### PR TITLE
client: periodically send perf metrics to MDS

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3230,6 +3230,10 @@ void Client::put_cap_ref(Inode *in, int cap)
   }
 }
 
+// get caps for a given file handle -- the inode should have @need caps
+// issued by the mds and @want caps not revoked (or not under revocation).
+// this routine blocks till the cap requirement is satisfied. also account
+// (track) for capability hit when required (when cap requirement succeedes).
 int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
 {
   Inode *in = fh->inode.get();
@@ -3304,6 +3308,7 @@ int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
 	if ((revoking & want) == 0) {
 	  *phave = need | (have & want);
 	  in->get_cap_ref(need);
+	  cap_hit();
 	  return 0;
 	}
       }

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -732,6 +732,16 @@ public:
   void flush_cap_releases();
   void tick();
 
+  void cap_hit() {
+    ++cap_hits;
+  }
+  void cap_miss() {
+    ++cap_misses;
+  }
+  std::pair<uint64_t, uint64_t> get_cap_hit_rates() {
+    return std::make_pair(cap_hits, cap_misses);
+  }
+
   xlist<Inode*> &get_dirty_list() { return dirty_list; }
 
   SafeTimer timer;
@@ -1281,6 +1291,9 @@ private:
   int reclaim_errno = 0;
   epoch_t reclaim_osd_epoch = 0;
   entity_addrvec_t reclaim_target_addrs;
+
+  uint64_t cap_hits = 0;
+  uint64_t cap_misses = 0;
 };
 
 /**

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -30,6 +30,7 @@
 #include "include/types.h"
 #include "include/unordered_map.h"
 #include "include/unordered_set.h"
+#include "include/cephfs/metrics/Types.h"
 #include "mds/mdstypes.h"
 #include "msg/Dispatcher.h"
 #include "msg/MessageRef.h"
@@ -1190,6 +1191,8 @@ private:
   int _lookup_ino(inodeno_t ino, const UserPerm& perms, Inode **inode=NULL);
   bool _ll_forget(Inode *in, uint64_t count);
 
+  void collect_and_send_metrics();
+  void collect_and_send_global_metrics();
 
   uint32_t deleg_timeout = 0;
 

--- a/src/client/MetaSession.h
+++ b/src/client/MetaSession.h
@@ -19,10 +19,10 @@ struct MetaRequest;
 struct MetaSession {
   mds_rank_t mds_num;
   ConnectionRef con;
-  version_t seq;
-  uint64_t cap_gen;
+  version_t seq = 0;
+  uint64_t cap_gen = 0;
   utime_t cap_ttl, last_cap_renew_request;
-  uint64_t cap_renew_seq;
+  uint64_t cap_renew_seq = 0;
   entity_addrvec_t addrs;
   feature_bitset_t mds_features;
 
@@ -34,17 +34,17 @@ struct MetaSession {
     STATE_CLOSED,
     STATE_STALE,
     STATE_REJECTED,
-  } state;
+  } state = STATE_OPENING;
 
   enum {
     RECLAIM_NULL,
     RECLAIMING,
     RECLAIM_OK,
     RECLAIM_FAIL,
-  } reclaim_state;
+  } reclaim_state = RECLAIM_NULL;
 
-  int mds_state;
-  bool readonly;
+  int mds_state = MDSMap::STATE_NULL;
+  bool readonly = false;
 
   list<Context*> waiting_for_open;
 
@@ -56,13 +56,9 @@ struct MetaSession {
 
   ceph::ref_t<MClientCapRelease> release;
 
-  MetaSession(mds_rank_t mds_num, ConnectionRef con,
-	      const entity_addrvec_t& addrs)
-    : mds_num(mds_num), con(con),
-      seq(0), cap_gen(0), cap_renew_seq(0), addrs(addrs),
-      state(STATE_OPENING), reclaim_state(RECLAIM_NULL),
-      mds_state(MDSMap::STATE_NULL), readonly(false)
-  {}
+  MetaSession(mds_rank_t mds_num, ConnectionRef con, const entity_addrvec_t& addrs)
+    : mds_num(mds_num), con(con), addrs(addrs) {
+  }
 
   const char *get_state_name() const;
 

--- a/src/mds/cephfs_features.h
+++ b/src/mds/cephfs_features.h
@@ -15,6 +15,8 @@
 #ifndef CEPHFS_FEATURES_H
 #define CEPHFS_FEATURES_H
 
+#include "include/cephfs/metrics/Types.h"
+
 class feature_bitset_t;
 namespace ceph {
   class Formatter;
@@ -56,6 +58,13 @@ namespace ceph {
   CEPHFS_FEATURE_DELEG_INO,             \
   CEPHFS_FEATURE_OCTOPUS,               \
   CEPHFS_FEATURE_METRIC_COLLECT,        \
+}
+
+#define CEPHFS_METRIC_FEATURES_ALL {		\
+    CLIENT_METRIC_TYPE_CAP_INFO,		\
+    CLIENT_METRIC_TYPE_READ_LATENCY,		\
+    CLIENT_METRIC_TYPE_WRITE_LATENCY,		\
+    CLIENT_METRIC_TYPE_METADATA_LATENCY,	\
 }
 
 #define CEPHFS_FEATURES_MDS_SUPPORTED CEPHFS_FEATURES_ALL


### PR DESCRIPTION
Right now, send a handful of metrics (those which can be inferred without any fuss) -- cap hit ratio and read/write/metadata latency. We'd need to finalize on the default set and start sending those.

Needs pr #26004 and #29951 to compile and for the metrics to show up in `fs perf stats`

EDIT: Note that the metrics are send on `Client::tick()`. We may as well have a separate thread for thrad for that to avoid taking `client_lock`. That's a minor change.