### PR TITLE
nautilus: osd: set collection pool opts on collection create, pg load

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4757,6 +4757,8 @@ PGRef OSD::handle_pg_create_info(const OSDMapRef& osdmap,
     false,
     rctx.transaction);
 
+  pg->init_collection_pool_opts();
+
   if (pg->is_primary()) {
     Mutex::Locker locker(m_perf_queries_lock);
     pg->set_dynamic_perf_stats_queries(m_perf_queries);
@@ -9405,6 +9407,8 @@ void OSD::split_pgs(
       i->pgid,
       child,
       split_bits);
+
+    child->init_collection_pool_opts();
 
     child->finish_split_stats(*stat_iter, rctx->transaction);
     child->unlock();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4147,6 +4147,9 @@ void PG::read_state(ObjectStore *store)
       set_role(-1);
   }
 
+  // init pool options
+  store->set_collection_opts(ch, pool.info.opts);
+
   PG::RecoveryCtx rctx(0, 0, 0, new ObjectStore::Transaction);
   handle_initialize(&rctx);
   // note: we don't activate here because we know the OSD will advance maps
@@ -6992,12 +6995,17 @@ void PG::handle_query_state(Formatter *f)
   recovery_state.handle_event(q, 0);
 }
 
-void PG::update_store_with_options()
+void PG::init_collection_pool_opts()
 {
   auto r = osd->store->set_collection_opts(ch, pool.info.opts);
-  if(r < 0 && r != -EOPNOTSUPP) {
+  if (r < 0 && r != -EOPNOTSUPP) {
     derr << __func__ << " set_collection_opts returns error:" << r << dendl;
   }
+}
+
+void PG::update_store_with_options()
+{
+  init_collection_pool_opts();
 }
 
 struct C_DeleteMore : public Context {

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -3138,6 +3138,9 @@ protected:
   // abstract bits
   friend class FlushState;
 
+public:
+  void init_collection_pool_opts();
+protected:
   virtual void on_role_change() = 0;
   virtual void on_pool_change() = 0;
   virtual void on_change(ObjectStore::Transaction *t) = 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40891
backport of https://github.com/ceph/ceph/pull/29093
parent tracker: https://tracker.ceph.com/issues/40483

---

We need to tell the ObjectStore's Collections what the pool options are
for things like the bluestore compression mode and so on to take effect.

Apply these

- when we create new collections, due to a new pg or a split
- when we start up and open an existing collection

We already apply these changes when there is a pool change.

(This is a manual backport of 512d89af9ac0d19df44dedc67fe349022c656907).

Fixes: https://tracker.ceph.com/issues/40483
Signed-off-by: Sage Weil <sage@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
