### PR TITLE
mgr/rook: Added Mypy static type checking

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -26,7 +26,8 @@ from mgr_util import format_bytes
 
 try:
     from ceph.deployment.drive_group import DriveGroupSpec
-    from typing import TypeVar, Generic, List, Optional, Union, Tuple, Iterator, Callable, Any, Type
+    from typing import TypeVar, Generic, List, Optional, Union, Tuple, Iterator, Callable, Any, \
+        Type, Sequence
 except ImportError:
     pass
 
@@ -606,7 +607,7 @@ class Completion(_Promise):
 
 
 def pretty_print(completions):
-    # type: (List[Completion]) -> str
+    # type: (Sequence[Completion]) -> str
     return ', '.join(c.pretty_print() for c in completions)
 
 

--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -2,3 +2,4 @@ pytest-cov==2.7.1
 mock; python_version <= '3.3'
 ipaddress; python_version < '3.3'
 ../../python-common
+kubernetes

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -20,11 +20,17 @@ from urllib3.exceptions import ProtocolError
 from mgr_util import merge_dicts
 
 try:
+    from typing import Optional
+except ImportError:
+    pass  # just for type annotations
+
+try:
     from kubernetes.client.rest import ApiException
     from kubernetes.client import V1ListMeta, CoreV1Api, V1Pod
     from kubernetes import watch
 except ImportError:
-    class ApiException(Exception): pass
+    class ApiException(Exception):  # type: ignore
+        status = 0
 
 
 import orchestrator
@@ -85,7 +91,7 @@ class KubernetesResource(object):
 
         # ``_items`` is accessed by different threads. I assume assignment is atomic.
         self._items = dict()
-        self.thread = None  # type: threading.Thread
+        self.thread = None  # type: Optional[threading.Thread]
         self.exception = None
         if not _urllib3_supports_read_chunked:
             logging.info('urllib3 is too old. Fallback to full fetches')
@@ -115,7 +121,7 @@ class KubernetesResource(object):
             if _urllib3_supports_read_chunked:
                 # Start a thread which will use the kubernetes watch client against a resource
                 log.debug("Attaching resource watcher for k8s {}".format(self.api_func))
-                self.thread = self._watch(resource_version)  # type: threading.Thread
+                self.thread = self._watch(resource_version)
 
         return self._items.values()
 
@@ -376,7 +382,7 @@ class RookCluster(object):
         }
 
         if spec.namespace:
-            rook_nfsgw["spec"]["rados"]["namespace"] = spec.namespace
+            rook_nfsgw["spec"]["rados"]["namespace"] = spec.namespace  # type: ignore
 
         with self.ignore_409("NFS cluster '{0}' already exists".format(spec.name)):
             self.rook_api_post("cephnfses/", body=rook_nfsgw)
@@ -525,7 +531,7 @@ class RookCluster(object):
             if directories:
                 pd["directories"] = [{'path': p} for p in directories]
 
-            patch.append({ "op": "add", "path": "/spec/storage/nodes/-", "value": pd })
+            patch.append({ "op": "add", "path": "/spec/storage/nodes/-", "value": pd })  # type: ignore
         else:
             # Extend existing node
             node_idx = None
@@ -544,7 +550,7 @@ class RookCluster(object):
                 patch.append({
                     "op": "add",
                     "path": "/spec/storage/nodes/{0}/devices/-".format(node_idx),
-                    "value": {'name': n}
+                    "value": {'name': n}  # type: ignore
                 })
 
             new_dirs = list(set(directories) - set(current_node['directories']))
@@ -552,7 +558,7 @@ class RookCluster(object):
                 patch.append({
                     "op": "add",
                     "path": "/spec/storage/nodes/{0}/directories/-".format(node_idx),
-                    "value": {'path': p}
+                    "value": {'path': p}  # type: ignore
                 })
 
         if len(patch) == 0:

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -12,4 +12,4 @@ basepython = python3
 deps =
     -r requirements.txt
     mypy
-commands = mypy --config-file=../../mypy.ini orchestrator.py ssh/module.py
+commands = mypy --config-file=../../mypy.ini orchestrator.py ssh/module.py rook/module.py


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
