### PR TITLE
osd/OSDMap: fix calc_pg_role

### DIFF
--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -713,11 +713,8 @@ seastar::future<Ref<PG>> OSD::handle_pg_create_info(
 	  startmap->pg_to_up_acting_osds(
 	    info->pgid.pgid, &up, &up_primary, &acting, &acting_primary);
 
-	  int role = startmap->calc_pg_role(whoami, acting, acting.size());
-	  if (!pp->is_replicated() && role != info->pgid.shard) {
-	    role = -1;
-	  }
-
+	  int role = startmap->calc_pg_role(pg_shard_t(whoami, info->pgid.shard),
+					    acting);
 
 	  create_pg_collection(
 	    rctx.transaction,

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -316,11 +316,8 @@ seastar::future<> PG::read_state(crimson::os::FuturizedStore* store)
 	acting,
 	up_primary,
 	primary);
-    int rr = OSDMap::calc_pg_role(pg_whoami.osd, acting);
-    if (peering_state.get_pool().info.is_replicated() || rr == pg_whoami.shard)
-	peering_state.set_role(rr);
-    else
-	peering_state.set_role(-1);
+    int rr = OSDMap::calc_pg_role(pg_whoami, acting);
+    peering_state.set_role(rr);
 
     epoch_t epoch = get_osdmap_epoch();
     shard_services.start_operation<LocalPeeringEvent>(

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4868,7 +4868,7 @@ bool OSD::maybe_wait_for_max_pg(const OSDMapRef& osdmap,
   if (is_mon_create) {
     pending_creates_from_mon++;
   } else {
-    bool is_primary = osdmap->get_pg_acting_rank(pgid.pgid, whoami) == 0;
+    bool is_primary = osdmap->get_pg_acting_role(pgid, whoami) == 0;
     pending_creates_from_osd.emplace(pgid, is_primary);
   }
   dout(1) << __func__ << " withhold creation of pg " << pgid
@@ -8725,7 +8725,7 @@ void OSD::consume_map()
     std::lock_guard l(pending_creates_lock);
     for (auto pg = pending_creates_from_osd.begin();
 	 pg != pending_creates_from_osd.end();) {
-      if (osdmap->get_pg_acting_rank(pg->first.pgid, whoami) < 0) {
+      if (osdmap->get_pg_acting_role(pg->first, whoami) < 0) {
 	dout(10) << __func__ << " pg " << pg->first << " doesn't map here, "
 		 << "discarding pending_create_from_osd" << dendl;
 	pg = pending_creates_from_osd.erase(pg);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1766,7 +1766,7 @@ protected:
   std::atomic<size_t> num_pgs = {0};
 
   std::mutex pending_creates_lock;
-  using create_from_osd_t = std::pair<pg_t, bool /* is primary*/>;
+  using create_from_osd_t = std::pair<spg_t, bool /* is primary*/>;
   std::set<create_from_osd_t> pending_creates_from_osd;
   unsigned pending_creates_from_mon = 0;
 

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2639,7 +2639,7 @@ void OSDMap::_pg_to_up_acting_osds(
     *acting_primary = _acting_primary;
 }
 
-int OSDMap::calc_pg_rank(int osd, const vector<int>& acting, int nrep)
+int OSDMap::calc_pg_role(int osd, const vector<int>& acting, int nrep)
 {
   if (!nrep)
     nrep = acting.size();
@@ -2647,11 +2647,6 @@ int OSDMap::calc_pg_rank(int osd, const vector<int>& acting, int nrep)
     if (acting[i] == osd)
       return i;
   return -1;
-}
-
-int OSDMap::calc_pg_role(int osd, const vector<int>& acting, int nrep)
-{
-  return calc_pg_rank(osd, acting, nrep);
 }
 
 bool OSDMap::primary_changed(
@@ -2666,8 +2661,8 @@ bool OSDMap::primary_changed(
     return true;     // was empty, now not, or vice versa
   if (oldprimary != newprimary)
     return true;     // primary changed
-  if (calc_pg_rank(oldprimary, oldacting) !=
-      calc_pg_rank(newprimary, newacting))
+  if (calc_pg_role(oldprimary, oldacting) !=
+      calc_pg_role(newprimary, newacting))
     return true;
   return false;      // same primary (tho replicas may have changed)
 }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2649,6 +2649,23 @@ int OSDMap::calc_pg_role(int osd, const vector<int>& acting, int nrep)
   return -1;
 }
 
+int OSDMap::calc_pg_role(pg_shard_t who, const vector<int>& acting)
+{
+  int nrep = acting.size();
+  if (who.shard == shard_id_t::NO_SHARD) {
+    for (int i=0; i<nrep; i++) {
+      if (acting[i] == who.osd) {
+	return i;
+      }
+    }
+  } else {
+    if (who.shard < nrep && acting[who.shard] == who.osd) {
+      return who.shard;
+    }
+  }
+  return -1;
+}
+
 bool OSDMap::primary_changed(
   int oldprimary,
   const vector<int> &oldacting,

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2639,8 +2639,11 @@ void OSDMap::_pg_to_up_acting_osds(
     *acting_primary = _acting_primary;
 }
 
-int OSDMap::calc_pg_role(int osd, const vector<int>& acting, int nrep)
+int OSDMap::calc_pg_role_broken(int osd, const vector<int>& acting, int nrep)
 {
+  // This implementation is broken for EC PGs since the osd may appear
+  // multiple times in the acting set.  See
+  // https://tracker.ceph.com/issues/43213
   if (!nrep)
     nrep = acting.size();
   for (int i=0; i<nrep; i++) 
@@ -2666,7 +2669,7 @@ int OSDMap::calc_pg_role(pg_shard_t who, const vector<int>& acting)
   return -1;
 }
 
-bool OSDMap::primary_changed(
+bool OSDMap::primary_changed_broken(
   int oldprimary,
   const vector<int> &oldacting,
   int newprimary,
@@ -2678,8 +2681,8 @@ bool OSDMap::primary_changed(
     return true;     // was empty, now not, or vice versa
   if (oldprimary != newprimary)
     return true;     // primary changed
-  if (calc_pg_role(oldprimary, oldacting) !=
-      calc_pg_role(newprimary, newacting))
+  if (calc_pg_role_broken(oldprimary, oldacting) !=
+      calc_pg_role_broken(newprimary, newacting))
     return true;
   return false;      // same primary (tho replicas may have changed)
 }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1397,10 +1397,10 @@ public:
     const std::vector<int> &newacting);
   
   /* rank is -1 (stray), 0 (primary), 1,2,3,... (replica) */
-  int get_pg_acting_rank(pg_t pg, int osd) const {
+  int get_pg_acting_role(spg_t pg, int osd) const {
     std::vector<int> group;
-    pg_to_acting_osds(pg, group);
-    return calc_pg_role(osd, group, group.size());
+    pg_to_acting_osds(pg.pgid, group);
+    return calc_pg_role(pg_shard_t(osd, pg.shard), group);
   }
 
   bool osd_is_valid_op_target(pg_t pg, int osd) const {

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1402,12 +1402,6 @@ public:
     pg_to_acting_osds(pg, group);
     return calc_pg_role(osd, group, group.size());
   }
-  /* role is -1 (stray), 0 (primary), 1 (replica) */
-  int get_pg_acting_role(const pg_t& pg, int osd) const {
-    std::vector<int> group;
-    pg_to_acting_osds(pg, group);
-    return calc_pg_role(osd, group, group.size());
-  }
 
   bool osd_is_valid_op_target(pg_t pg, int osd) const {
     int primary;

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1380,15 +1380,9 @@ public:
   bool is_up_acting_osd_shard(spg_t pg, int osd) const {
     std::vector<int> up, acting;
     _pg_to_up_acting_osds(pg.pgid, &up, NULL, &acting, NULL, false);
-    if (pg.shard == shard_id_t::NO_SHARD) {
-      if (calc_pg_role(osd, acting, acting.size()) >= 0 ||
-	  calc_pg_role(osd, up, up.size()) >= 0)
-	return true;
-    } else {
-      if (pg.shard < (int)acting.size() && acting[pg.shard] == osd)
-	return true;
-      if (pg.shard < (int)up.size() && up[pg.shard] == osd)
-	return true;
+    if (calc_pg_role(pg_shard_t(osd, pg.shard), acting) >= 0 ||
+	calc_pg_role(pg_shard_t(osd, pg.shard), up) >= 0) {
+      return true;
     }
     return false;
   }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1394,8 +1394,6 @@ public:
   }
 
 
-  /* what replica # is a given osd? 0 primary, -1 for none. */
-  static int calc_pg_rank(int osd, const std::vector<int>& acting, int nrep=0);
   static int calc_pg_role(int osd, const std::vector<int>& acting, int nrep=0);
   static bool primary_changed(
     int oldprimary,
@@ -1407,7 +1405,7 @@ public:
   int get_pg_acting_rank(pg_t pg, int osd) const {
     std::vector<int> group;
     pg_to_acting_osds(pg, group);
-    return calc_pg_rank(osd, group, group.size());
+    return calc_pg_role(osd, group, group.size());
   }
   /* role is -1 (stray), 0 (primary), 1 (replica) */
   int get_pg_acting_role(const pg_t& pg, int osd) const {

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1395,6 +1395,7 @@ public:
 
 
   static int calc_pg_role(int osd, const std::vector<int>& acting, int nrep=0);
+  static int calc_pg_role(pg_shard_t who, const std::vector<int>& acting);
   static bool primary_changed(
     int oldprimary,
     const std::vector<int> &oldacting,

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1403,18 +1403,6 @@ public:
     return calc_pg_role(pg_shard_t(osd, pg.shard), group);
   }
 
-  bool osd_is_valid_op_target(pg_t pg, int osd) const {
-    int primary;
-    std::vector<int> group;
-    pg_to_acting_osds(pg, &group, &primary);
-    if (osd == primary)
-      return true;
-    if (pg_is_ec(pg))
-      return false;
-
-    return calc_pg_role(osd, group, group.size()) >= 0;
-  }
-
   bool try_pg_upmap(
     CephContext *cct,
     pg_t pg,                       ///< pg to potentially remap

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1388,9 +1388,9 @@ public:
   }
 
 
-  static int calc_pg_role(int osd, const std::vector<int>& acting, int nrep=0);
+  static int calc_pg_role_broken(int osd, const std::vector<int>& acting, int nrep=0);
   static int calc_pg_role(pg_shard_t who, const std::vector<int>& acting);
-  static bool primary_changed(
+  static bool primary_changed_broken(
     int oldprimary,
     const std::vector<int> &oldacting,
     int newprimary,

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1153,11 +1153,7 @@ void PG::read_state(ObjectStore *store)
       acting,
       up_primary,
       primary);
-    int rr = OSDMap::calc_pg_role(osd->whoami, acting);
-    if (pool.info.is_replicated() || rr == pg_whoami.shard)
-      recovery_state.set_role(rr);
-    else
-      recovery_state.set_role(-1);
+    recovery_state.set_role(OSDMap::calc_pg_role(pg_whoami, acting));
   }
 
   // init pool options

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -580,11 +580,8 @@ void PeeringState::start_peering_interval(
   else
     state_clear(PG_STATE_REMAPPED);
 
-  int role = osdmap->calc_pg_role(pg_whoami.osd, acting, acting.size());
-  if (pool.info.is_replicated() || role == pg_whoami.shard)
-    set_role(role);
-  else
-    set_role(-1);
+  int role = osdmap->calc_pg_role(pg_whoami, acting);
+  set_role(role);
 
   // did acting, up, primary|acker change?
   if (!lastmap) {
@@ -2931,7 +2928,7 @@ void PeeringState::split_into(
     newacting,
     up_primary,
     primary);
-  child->role = OSDMap::calc_pg_role(pg_whoami.osd, child->acting);
+  child->role = OSDMap::calc_pg_role(pg_whoami, child->acting);
 
   // this comparison includes primary rank via pg_shard_t
   if (get_primary() != child->get_primary())

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -6950,9 +6950,9 @@ void PeeringState::PeeringMachine::log_exit(const char *state_name, utime_t ente
 
 ostream &operator<<(ostream &out, const PeeringState &ps) {
   out << "pg[" << ps.info
-      << " " << ps.up;
+      << " " << pg_vector_string(ps.up);
   if (ps.acting != ps.up)
-    out << "/" << ps.acting;
+    out << "/" << pg_vector_string(ps.acting);
   if (ps.is_ec_pg())
     out << "p" << ps.get_primary();
   if (!ps.async_recovery_targets.empty())

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -737,6 +737,9 @@ void PeeringState::on_new_interval()
       continue;
     upacting_features &= osdmap->get_xinfo(*p).features;
   }
+  psdout(20) << __func__ << " upacting_features 0x" << std::hex
+	     << upacting_features << std::dec
+	     << " from " << acting << "+" << up << dendl;
 
   psdout(20) << __func__ << " checking missing set deletes flag. missing = "
 	     << get_pg_log().get_missing() << dendl;
@@ -1129,9 +1132,13 @@ void PeeringState::send_lease()
 void PeeringState::proc_lease(const pg_lease_t& l)
 {
   if (!HAVE_FEATURE(upacting_features, SERVER_OCTOPUS)) {
+    psdout(20) << __func__ << " no-op, upacting_features 0x" << std::hex
+	       << upacting_features << std::dec
+	       << " does not include SERVER_OCTOPUS" << dendl;
     return;
   }
   if (!is_nonprimary()) {
+    psdout(20) << __func__ << " no-op, !nonprimary" << dendl;
     return;
   }
   psdout(10) << __func__ << " " << l << dendl;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2640,7 +2640,7 @@ bool Objecter::is_pg_changed(
   const vector<int>& newacting,
   bool any_change)
 {
-  if (OSDMap::primary_changed(
+  if (OSDMap::primary_changed_broken( // https://tracker.ceph.com/issues/43213
 	oldprimary,
 	oldacting,
 	newprimary,


### PR DESCRIPTION
The old implementation would take a int osd, but for EC PGs the OSD may appear multiple times in the acting set.  This meant that all but the first shard would incorrectly end up with a role of -1.

Lots of cleanup to resolve this.

Fixes https://tracker.ceph.com/issues/43189

There is still a remaining problem in the Objecter with the primary role change detection for such PGs; see https://tracker.ceph.com/issues/43213.  (This will require a much larger cleanup that changes all of the OSDMap calc functions to specify primary has a pg_shard_t instead of int.)