### PR TITLE
doc: adds parallel construction to a list's items

### DIFF
--- a/doc/bootstrap.rst
+++ b/doc/bootstrap.rst
@@ -57,8 +57,8 @@ This command does a few things:
 * Creates a monitor and manager daemon for the new cluster on the
   local host.  A minimal configuration file needed to communicate with
   the new cluster is written to ``ceph.conf`` in the local directory.
-* A copy of the ``client.admin`` administrative (privileged!) secret
-  key is written to ``ceph.client.admin.keyring`` in the local directory.
+* Writes a copy of the ``client.admin`` administrative (privileged!) secret
+  key to ``ceph.client.admin.keyring`` in the local directory.
 * Generates a new SSH key, and adds the public key to the local root user's
   ``/root/.ssh/authorized_keys`` file.  A copy of the public key is written
   to ``ceph.pub`` in the local directory.


### PR DESCRIPTION
This commit brings into parallel construction the three items in
a list, so that the reader's cognitive load is diminished.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
