### PR TITLE
luminous: telemetry module for mgr

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -5,6 +5,44 @@
   python3.6 as the native python3. see the `announcement <https://lists.fedoraproject.org/archives/list/epel-announce@lists.fedoraproject.org/message/EGUMKAIMPK2UD5VSHXM53BH2MBDGDWMO/>_`
   for more details on the background of this change.
 
+* We now have telemetry support via a ceph-mgr module. The telemetry module is
+  absolutely on an opt-in basis, and is meant to collect generic cluster
+  information and push it to a central endpoint. By default, we're pushing it
+  to a project endpoint at https://telemetry.ceph.com/report, but this is
+  customizable using by setting the 'url' config option with::
+
+    ceph telemetry config-set url '<your url>'
+
+  You will have to opt-in on sharing your information with::
+
+    ceph telemetry on
+
+  You can view exactly what information will be reported first with::
+
+    ceph telemetry show
+
+  Should you opt-in, your information will be licensed under the
+  Community Data License Agreement - Sharing - Version 1.0, which you can
+  read at https://cdla.io/sharing-1-0/
+
+  The telemetry module reports information about CephFS file systems,
+  including:
+
+    - how many MDS daemons (in total and per file system)
+    - which features are (or have been) enabled
+    - how many data pools
+    - approximate file system age (year + month of creation)
+    - how much metadata is being cached per file system
+
+  As well as:
+
+    - whether IPv4 or IPv6 addresses are used for the monitors
+    - whether RADOS cache tiering is enabled (and which mode)
+    - whether pools are replicated or erasure coded, and
+      which erasure code profile plugin and parameters are in use
+    - how many RGW daemons, zones, and zonegroups are present; which RGW frontends are in use
+    - aggregate stats about the CRUSH map, like which algorithms are used, how big buckets are, how many rules are defined, and what tunables are in use
+
 12.2.12
 -------
 * In 12.2.9 and earlier releases, keyring caps were not checked for validity,

--- a/doc/mgr/index.rst
+++ b/doc/mgr/index.rst
@@ -34,4 +34,5 @@ sensible.
     Zabbix plugin <zabbix>
     Prometheus plugin <prometheus>
     Influx plugin <influx>
+    Telemetry plugin <telemetry>
 

--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -1,0 +1,36 @@
+Telemetry plugin
+================
+The telemetry plugin sends anonymous data about the cluster, in which it is running, back to the Ceph project.
+
+The data being sent back to the project does not contain any sensitive data like pool names, object names, object contents or hostnames.
+
+It contains counters and statistics on how the cluster has been deployed, the version of Ceph, the distribition of the hosts and other parameters which help the project to gain a better understanding of the way Ceph is used.
+
+Data is sent over HTTPS to *telemetry.ceph.com*
+
+Enabling
+--------
+
+The *telemetry* module is enabled with::
+
+  ceph mgr module enable telemetry
+
+
+Interval
+--------
+The module compiles and sends a new report every 72 hours by default.
+
+Contact and Description
+-----------------------
+A contact and description can be added to the report, this is optional.
+
+  ceph telemetry config-set contact 'John Doe <john.doe@example.com>'
+  ceph telemetry config-set description 'My first Ceph cluster'
+
+Show report
+-----------
+The report is sent in JSON format, and can be printed::
+
+  ceph telemetry show
+
+So you can inspect the content if you have privacy concerns.

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -584,3 +584,36 @@ happen if they are misplaced or degraded (see *PG_AVAILABILITY* and
 You can manually initiate a scrub of a clean PG with::
 
   ceph pg deep-scrub <pgid>
+
+
+Miscellaneous
+-------------
+
+TELEMETRY_CHANGED
+_________________
+
+Telemetry has been enabled, but the contents of the telemetry report
+have changed since that time, so telemetry reports will not be sent.
+
+The Ceph developers periodically revise the telemetry feature to
+include new and useful information, or to remove information found to
+be useless or sensitive.  If any new information is included in the
+report, Ceph will require the administrator to re-enable telemetry to
+ensure they have an opportunity to (re)review what information will be
+shared.
+
+To review the contents of the telemetry report,::
+
+  ceph telemetry show
+
+Note that the telemetry report consists of several optional channels
+that may be independently enabled or disabled.  For more information, see
+:ref:`telemetry`.
+
+To re-enable telemetry (and make this warning go away),::
+
+  ceph telemetry on
+
+To disable telemetry (and make this warning go away),::
+
+  ceph telemetry off

--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -41,6 +41,9 @@ class TestModuleSelftest(MgrTestCase):
         self._load_module("selftest")
         self.mgr_cluster.mon_manager.raw_cluster_cmd("mgr", "self-test", "run")
 
+    def test_telemetry(self):
+        self._selftest_plugin("telemetry")
+
     def test_selftest_command_spam(self):
         # Use the selftest module to stress the mgr daemon
         self._load_module("selftest")

--- a/src/pybind/mgr/telemetry/__init__.py
+++ b/src/pybind/mgr/telemetry/__init__.py
@@ -1,0 +1,1 @@
+from .module import Module

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -46,6 +46,7 @@ REVISION = 2
 #
 # Version 3:
 #   - added CephFS metadata (how many MDSs, fs features, how many data pools)
+#   - remove crush_rule
 
 class Module(MgrModule):
     config = dict()
@@ -323,8 +324,7 @@ class Module(MgrModule):
                         'pg_num': pool['pg_num'],
                         'pgp_num': pool['pg_placement_num'],
                         'size': pool['size'],
-                        'min_size': pool['min_size'],
-                        'crush_rule': pool['crush_rule']
+                        'min_size': pool['min_size']
                     }
                 )
 

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -297,9 +297,19 @@ class Module(MgrModule):
 
             report['created'] = mon_map['created']
 
+            ipv4_mons = 0
+            ipv6_mons = 0
+            for mon in mon_map['mons']:
+                if mon['public_addr'].startswith('['):
+                    ipv6_mons += 1
+                else:
+                    ipv4_mons += 1
+
             report['mon'] = {
                 'count': len(mon_map['mons']),
-                'features': mon_map['features']
+                'features': mon_map['features'],
+                'ipv4_addr_mons': ipv4_mons,
+                'ipv6_addr_mons': ipv6_mons,
             }
 
             num_pg = 0

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -50,6 +50,7 @@ REVISION = 2
 #   - added CephFS metadata (how many MDSs, fs features, how many data pools,
 #     how much metadata is cached)
 #   - added more pool metadata (rep vs ec, cache tiering mode, ec profile)
+#   - rgw daemons, zones, zonegroups; which rgw frontends
 
 class Module(MgrModule):
     config = dict()
@@ -424,6 +425,36 @@ class Module(MgrModule):
             report['services'] = defaultdict(int)
             for key, value in service_map['services'].items():
                 report['services'][key] += 1
+                if key == 'rgw':
+                    report['rgw'] = {
+                        'count': 0,
+                    }
+                    zones = set()
+                    realms = set()
+                    zonegroups = set()
+                    frontends = set()
+                    d = value.get('daemons', dict())
+
+                    for k,v in d.items():
+                        if k == 'summary' and v:
+                            report['rgw'][k] = v
+                        elif isinstance(v, dict) and 'metadata' in v:
+                            report['rgw']['count'] += 1
+                            zones.add(v['metadata']['zone_id'])
+                            zonegroups.add(v['metadata']['zonegroup_id'])
+                            frontends.add(v['metadata']['frontend_type#0'])
+
+                            # we could actually iterate over all the keys of
+                            # the dict and check for how many frontends there
+                            # are, but it is unlikely that one would be running
+                            # more than 2 supported ones
+                            f2 = v['metadata'].get('frontend_type#1', None)
+                            if f2:
+                                frontends.add(f2)
+
+                    report['rgw']['zones'] = len(zones)
+                    report['rgw']['zonegroups'] = len(zonegroups)
+                    report['rgw']['frontends'] = list(frontends)  # sets aren't json-serializable
 
         return report
 

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -29,7 +29,7 @@ LAST_REVISION_RE_OPT_IN = 2
 
 # Latest revision of the telemetry report.  Bump this each time we make
 # *any* change.
-REVISION = 2
+REVISION = 3
 
 # History of revisions
 # --------------------

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -336,7 +336,7 @@ class Module(MgrModule):
         self.event.wait(10)
 
         while self.run:
-            if self.config['enabled']:
+            if not self.config['enabled']:
                 self.log.info('Not sending report until configured to do so')
                 self.event.wait(1800)
                 continue

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -22,6 +22,27 @@ LICENSE='sharing-1-0'
 LICENSE_NAME='Community Data License Agreement - Sharing - Version 1.0'
 LICENSE_URL='https://cdla.io/sharing-1-0/'
 
+# If the telemetry revision has changed since this point, re-require
+# an opt-in.  This should happen each time we add new information to
+# the telemetry report.
+LAST_REVISION_RE_OPT_IN = 2
+
+# Latest revision of the telemetry report.  Bump this each time we make
+# *any* change.
+REVISION = 2
+
+# History of revisions
+# --------------------
+#
+# Version 1:
+#   Mimic and/or nautilus are lumped together here, since
+#   we didn't track revisions yet.
+#
+# Version 2:
+#   - added revision tracking, nagging, etc.
+#   - added config option changes
+#   - added channels
+#   - added explicit license acknowledgement to the opt-in process
 
 class Module(MgrModule):
     config = dict()
@@ -45,6 +66,11 @@ class Module(MgrModule):
         {
             'name': 'enabled',
             'default': False
+        },
+        {
+            'name': 'last_opt_revision',
+            'type': 'int',
+            'default': 1,
         },
         {
             'name': 'leaderboard',
@@ -349,9 +375,11 @@ class Module(MgrModule):
             if command.get('license') != LICENSE:
                 return -errno.EPERM, '', "Telemetry data is licensed under the " + LICENSE_NAME + " (" + LICENSE_URL + ").\nTo enable, add '--license " + LICENSE + "' to the 'ceph telemetry on' command."
             self.set_config('enabled', True)
+            self.set_config('last_opt_revision', REVISION)
             return 0, '', ''
         elif command['prefix'] == 'telemetry off':
             self.set_config('enabled', False)
+            self.set_config('last_opt_revision', REVISION)
             return 0, '', ''
         elif command['prefix'] == 'telemetry send':
             self.last_report = self.compile_report()

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -315,10 +315,10 @@ class Module(MgrModule):
             self.set_config(key, value)
             return 0, 'Configuration option {0} updated'.format(key), ''
         elif command['prefix'] == 'telemetry on':
-            self.set_config('active', True)
+            self.set_config('enabled', True)
             return 0, '', ''
         elif command['prefix'] == 'telemetry off':
-            self.set_config('active', False)
+            self.set_config('enabled', False)
             return 0, '', ''
         elif command['prefix'] == 'telemetry send':
             self.last_report = self.compile_report()

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -265,7 +265,6 @@ class Module(MgrModule):
         report['usage'] = {
             'pools': len(df['pools']),
             'pg_num:': num_pg,
-            'total_objects': df['stats']['total_objects'],
             'total_used_bytes': df['stats']['total_used_bytes'],
             'total_bytes': df['stats']['total_bytes'],
             'total_avail_bytes': df['stats']['total_avail_bytes']

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 
 from mgr_module import MgrModule
 
-ALL_CHANNELS = ['basic']
+ALL_CHANNELS = ['basic', 'ident']
 
 class Module(MgrModule):
     config = dict()
@@ -71,6 +71,12 @@ class Module(MgrModule):
             'default': True,
             'description': 'Share basic cluster information (size, version)',
         },
+        {
+            'name': 'channel_ident',
+            'type': 'bool',
+            'default': False,
+            'description': 'Share a user-provided description and/or contact email for the cluster',
+        }
     ]
 
     COMMANDS = [
@@ -241,11 +247,11 @@ class Module(MgrModule):
             'channels_available': ALL_CHANNELS,
         }
 
-        if self.str_to_bool(self.config['leaderboard']):
-            report['leaderboard'] = True
-
-        for option in ['description', 'contact', 'organization']:
-            report[option] = self.config.get(option, None)
+        if 'ident' in channels:
+            if self.config['leaderboard']:
+                report['leaderboard'] = True
+            for option in ['description', 'contact', 'organization']:
+                report[option] = self.config.get(option, None)
 
         if 'basic' in channels:
             mon_map = self.get('mon_map')

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 
 from mgr_module import MgrModule
 
+ALL_CHANNELS = ['basic']
 
 class Module(MgrModule):
     config = dict()
@@ -90,7 +91,8 @@ class Module(MgrModule):
             "perm": "rw"
         },
         {
-            "cmd": "telemetry show",
+            "cmd": "telemetry show "
+                   "name=channels,type=CephString,n=N,req=False",
             "desc": "Show last report or report to be sent",
             "perm": "r"
         },
@@ -227,13 +229,16 @@ class Module(MgrModule):
             r.append('basic')
         return r
 
-    def compile_report(self):
+    def compile_report(self, channels=[]):
+        if not channels:
+            channels = self.get_active_channels()
         report = {
             'leaderboard': False,
             'report_version': 1,
             'report_timestamp': datetime.utcnow().isoformat(),
             'report_id': self.report_id,
-            'channels': self.get_active_channels(),
+            'channels': channels,
+            'channels_available': ALL_CHANNELS,
         }
 
         if self.str_to_bool(self.config['leaderboard']):
@@ -242,7 +247,7 @@ class Module(MgrModule):
         for option in ['description', 'contact', 'organization']:
             report[option] = self.config.get(option, None)
 
-        if self.config['channel_basic']:
+        if 'basic' in channels:
             mon_map = self.get('mon_map')
             osd_map = self.get('osd_map')
             service_map = self.get('service_map')
@@ -346,7 +351,9 @@ class Module(MgrModule):
                 resp.text
             )
         elif command['prefix'] == 'telemetry show':
-            report = self.compile_report()
+            report = self.compile_report(
+                channels=command.get('channels', None)
+            )
             return 0, json.dumps(report, indent=4), ''
         elif command['prefix'] == 'telemetry self-test':
             self.self_test()

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -62,7 +62,7 @@ class Module(MgrModule):
         },
         {
             'name': 'interval',
-            'default': 72
+            'default': 24
         }
     ]
 

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -92,6 +92,16 @@ class Module(MgrModule):
             "cmd": "telemetry self-test",
             "desc": "Perform a self-test",
             "perm": "r"
+        },
+        {
+            "cmd": "telemetry on",
+            "desc": "Enable telemetry reports from this cluster",
+            "perm": "rw",
+        },
+        {
+            "cmd": "telemetry off",
+            "desc": "Disable telemetry reports from this cluster",
+            "perm": "rw",
         }
     ]
 
@@ -299,6 +309,12 @@ class Module(MgrModule):
             self.set_config_option(key, value)
             self.set_config(key, value)
             return 0, 'Configuration option {0} updated'.format(key), ''
+        elif command['prefix'] == 'telemetry on':
+            self.set_config('active', True)
+            return 0, '', ''
+        elif command['prefix'] == 'telemetry off':
+            self.set_config('active', False)
+            return 0, '', ''
         elif command['prefix'] == 'telemetry send':
             self.last_report = self.compile_report()
             self.send(self.last_report)

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -436,6 +436,8 @@ class Module(MgrModule):
         self.event.wait(10)
 
         while self.run:
+            self.event.clear()
+
             self.refresh_health_checks()
 
             if self.last_opt_revision < LAST_REVISION_RE_OPT_IN:

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -18,6 +18,11 @@ from mgr_module import MgrModule
 
 ALL_CHANNELS = ['basic', 'ident']
 
+LICENSE='sharing-1-0'
+LICENSE_NAME='Community Data License Agreement - Sharing - Version 1.0'
+LICENSE_URL='https://cdla.io/sharing-1-0/'
+
+
 class Module(MgrModule):
     config = dict()
 
@@ -108,7 +113,7 @@ class Module(MgrModule):
             "perm": "r"
         },
         {
-            "cmd": "telemetry on",
+            "cmd": "telemetry on name=license,type=CephString,req=false",
             "desc": "Enable telemetry reports from this cluster",
             "perm": "rw",
         },
@@ -245,6 +250,7 @@ class Module(MgrModule):
             'report_id': self.report_id,
             'channels': channels,
             'channels_available': ALL_CHANNELS,
+            'license': LICENSE,
         }
 
         if 'ident' in channels:
@@ -340,6 +346,8 @@ class Module(MgrModule):
             self.set_config(key, value)
             return 0, 'Configuration option {0} updated'.format(key), ''
         elif command['prefix'] == 'telemetry on':
+            if command.get('license') != LICENSE:
+                return -errno.EPERM, '', "Telemetry data is licensed under the " + LICENSE_NAME + " (" + LICENSE_URL + ").\nTo enable, add '--license " + LICENSE + "' to the 'ceph telemetry on' command."
             self.set_config('enabled', True)
             return 0, '', ''
         elif command['prefix'] == 'telemetry off':

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -137,10 +137,6 @@ class Module(MgrModule):
 
         return False
 
-    @staticmethod
-    def parse_timestamp(timestamp):
-        return datetime.strptime(timestamp, '%Y-%m-%d %H:%M:%S.%f')
-
     def set_config_option(self, option, value):
         if option not in self.config_keys.keys():
             raise RuntimeError('{0} is a unknown configuration '
@@ -239,7 +235,7 @@ class Module(MgrModule):
         df = self.get('df')
 
         report['report_id'] = self.report_id
-        report['created'] = self.parse_timestamp(mon_map['created']).isoformat()
+        report['created'] = mon_map['created']
 
         report['mon'] = {
             'count': len(mon_map['mons']),

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -346,9 +346,7 @@ class Module(MgrModule):
                 resp.text
             )
         elif command['prefix'] == 'telemetry show':
-            report = self.last_report
-            if not report:
-                report = self.compile_report()
+            report = self.compile_report()
             return 0, json.dumps(report, indent=4), ''
         elif command['prefix'] == 'telemetry self-test':
             self.self_test()

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -38,7 +38,7 @@ class Module(MgrModule):
         },
         {
             'name': 'enabled',
-            'default': True
+            'default': False
         },
         {
             'name': 'leaderboard',

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1,0 +1,374 @@
+"""
+Telemetry module for ceph-mgr
+
+Collect statistics from Ceph cluster and send this back to the Ceph project
+when user has opted-in
+"""
+import errno
+import json
+import re
+import requests
+import uuid
+import time
+from datetime import datetime
+from threading import Event
+from collections import defaultdict
+
+from mgr_module import MgrModule
+
+
+class Module(MgrModule):
+    config = dict()
+
+    metadata_keys = [
+            "arch",
+            "ceph_version",
+            "os",
+            "cpu",
+            "kernel_description",
+            "kernel_version",
+            "distro_description",
+            "distro"
+    ]
+
+    OPTIONS = [
+        {
+            'name': 'url',
+            'default': 'https://telemetry.ceph.com/report'
+        },
+        {
+            'name': 'enabled',
+            'default': True
+        },
+        {
+            'name': 'leaderboard',
+            'default': False
+        },
+        {
+            'name': 'description',
+            'default': None
+        },
+        {
+            'name': 'contact',
+            'default': None
+        },
+        {
+            'name': 'organization',
+            'default': None
+        },
+        {
+            'name': 'proxy',
+            'default': None
+        },
+        {
+            'name': 'interval',
+            'default': 72
+        }
+    ]
+
+    COMMANDS = [
+        {
+            "cmd": "telemetry config-set name=key,type=CephString "
+                   "name=value,type=CephString",
+            "desc": "Set a configuration value",
+            "perm": "rw"
+        },
+        {
+            "cmd": "telemetry config-show",
+            "desc": "Show current configuration",
+            "perm": "r"
+        },
+        {
+            "cmd": "telemetry send",
+            "desc": "Force sending data to Ceph telemetry",
+            "perm": "rw"
+        },
+        {
+            "cmd": "telemetry show",
+            "desc": "Show last report or report to be sent",
+            "perm": "r"
+        },
+        {
+            "cmd": "telemetry self-test",
+            "desc": "Perform a self-test",
+            "perm": "r"
+        }
+    ]
+
+    @property
+    def config_keys(self):
+        return dict((o['name'], o.get('default', None)) for o in self.OPTIONS)
+
+    def __init__(self, *args, **kwargs):
+        super(Module, self).__init__(*args, **kwargs)
+        self.event = Event()
+        self.run = False
+        self.last_upload = None
+        self.last_report = dict()
+        self.report_id = None
+
+    @staticmethod
+    def str_to_bool(string):
+        return str(string).lower() in ['true', 'yes', 'on']
+
+    @staticmethod
+    def is_valid_email(email):
+        regexp = "^.+@([?)[a-zA-Z0-9-.]+.([a-zA-Z]{2,3}|[0-9]{1,3})(]?))$"
+        try:
+            if len(email) <= 7 or len(email) > 255:
+                return False
+
+            if not re.match(regexp, email):
+                return False
+
+            return True
+        except:
+            pass
+
+        return False
+
+    @staticmethod
+    def parse_timestamp(timestamp):
+        return datetime.strptime(timestamp, '%Y-%m-%d %H:%M:%S.%f')
+
+    def set_config_option(self, option, value):
+        if option not in self.config_keys.keys():
+            raise RuntimeError('{0} is a unknown configuration '
+                               'option'.format(option))
+
+        if option == 'interval':
+            try:
+                value = int(value)
+            except (ValueError, TypeError):
+                raise RuntimeError('invalid interval. Please provide a valid '
+                                   'integer')
+
+            if value < 24:
+                raise RuntimeError('interval should be set to at least 24 hours')
+
+        if option in ['leaderboard', 'enabled']:
+            value = self.str_to_bool(value)
+
+        if option == 'contact':
+            if value and not self.is_valid_email(value):
+                raise RuntimeError('%s is not a valid e-mail address as a '
+                                   'contact', value)
+
+        if option in ['description', 'organization']:
+            if value and len(value) > 256:
+                raise RuntimeError('%s should be limited to 256 '
+                                   'characters', option)
+
+        self.config[option] = value
+        return True
+
+    def init_module_config(self):
+        for key, default in self.config_keys.items():
+            self.set_config_option(key, self.get_config(key, default))
+
+        self.last_upload = self.get_config('last_upload', None)
+        if self.last_upload is not None:
+            self.last_upload = int(self.last_upload)
+
+        self.report_id = self.get_config('report_id', None)
+        if self.report_id is None:
+            self.report_id = str(uuid.uuid4())
+            self.set_config('report_id', self.report_id)
+
+    def gather_osd_metadata(self, osd_map):
+        keys = ["osd_objectstore", "rotational"]
+        keys += self.metadata_keys
+
+        metadata = dict()
+        for key in keys:
+            metadata[key] = defaultdict(int)
+
+        for osd in osd_map['osds']:
+            for k, v in self.get_metadata('osd', str(osd['osd'])).items():
+                if k not in keys:
+                    continue
+
+                metadata[k][v] += 1
+
+        return metadata
+
+    def gather_mon_metadata(self, mon_map):
+        keys = list()
+        keys += self.metadata_keys
+
+        metadata = dict()
+        for key in keys:
+            metadata[key] = defaultdict(int)
+
+        for mon in mon_map['mons']:
+            for k, v in self.get_metadata('mon', mon['name']).items():
+                if k not in keys:
+                    continue
+
+                metadata[k][v] += 1
+
+        return metadata
+
+    def compile_report(self):
+        report = {'leaderboard': False, 'report_version': 1}
+
+        if self.str_to_bool(self.config['leaderboard']):
+            report['leaderboard'] = True
+
+        for option in ['description', 'contact', 'organization']:
+            report[option] = self.config.get(option, None)
+
+        mon_map = self.get('mon_map')
+        osd_map = self.get('osd_map')
+        service_map = self.get('service_map')
+        fs_map = self.get('fs_map')
+        df = self.get('df')
+
+        report['report_id'] = self.report_id
+        report['created'] = self.parse_timestamp(mon_map['created']).isoformat()
+
+        report['mon'] = {
+            'count': len(mon_map['mons']),
+            'features': mon_map['features']
+        }
+
+        num_pg = 0
+        report['pools'] = list()
+        for pool in osd_map['pools']:
+            num_pg += pool['pg_num']
+            report['pools'].append(
+                {
+                    'pool': pool['pool'],
+                    'type': pool['type'],
+                    'pg_num': pool['pg_num'],
+                    'pgp_num': pool['pg_placement_num'],
+                    'size': pool['size'],
+                    'min_size': pool['min_size'],
+                    'crush_rule': pool['crush_rule']
+                }
+            )
+
+        report['osd'] = {
+            'count': len(osd_map['osds']),
+            'require_osd_release': osd_map['require_osd_release'],
+            'require_min_compat_client': osd_map['require_min_compat_client']
+        }
+
+        report['fs'] = {
+            'count': len(fs_map['filesystems'])
+        }
+
+        report['metadata'] = dict()
+        report['metadata']['osd'] = self.gather_osd_metadata(osd_map)
+        report['metadata']['mon'] = self.gather_mon_metadata(mon_map)
+
+        report['usage'] = {
+            'pools': len(df['pools']),
+            'pg_num:': num_pg,
+            'total_objects': df['stats']['total_objects'],
+            'total_used_bytes': df['stats']['total_used_bytes'],
+            'total_bytes': df['stats']['total_bytes'],
+            'total_avail_bytes': df['stats']['total_avail_bytes']
+        }
+
+        report['services'] = defaultdict(int)
+        for key, value in service_map['services'].items():
+            report['services'][key] += 1
+
+        return report
+
+    def send(self, report):
+        self.log.info('Upload report to: %s', self.config['url'])
+        proxies = dict()
+        if 'proxy' in self.config:
+            self.log.info('Using HTTP(S) proxy: %s', self.config['proxy'])
+            proxies['http'] = self.config['proxy']
+            proxies['https'] = self.config['proxy']
+
+        requests.put(url=self.config['url'], json=report, proxies=proxies)
+
+    def handle_command(self, command):
+        if command['prefix'] == 'telemetry config-show':
+            return 0, json.dumps(self.config), ''
+        elif command['prefix'] == 'telemetry config-set':
+            key = command['key']
+            value = command['value']
+            if not value:
+                return -errno.EINVAL, '', 'Value should not be empty or None'
+
+            self.log.debug('Setting configuration option %s to %s', key, value)
+            self.set_config_option(key, value)
+            self.set_config(key, value)
+            return 0, 'Configuration option {0} updated'.format(key), ''
+        elif command['prefix'] == 'telemetry send':
+            self.last_report = self.compile_report()
+            self.send(self.last_report)
+            return 0, 'Report send to {0}'.format(self.config['url']), ''
+        elif command['prefix'] == 'telemetry show':
+            report = self.last_report
+            if not report:
+                report = self.compile_report()
+            return 0, json.dumps(report), ''
+        elif command['prefix'] == 'telemetry self-test':
+            self.self_test()
+            return 0, 'Self-test succeeded', ''
+        else:
+            return (-errno.EINVAL, '',
+                    "Command not found '{0}'".format(command['prefix']))
+
+    def self_test(self):
+        report = self.compile_report()
+        if len(report) == 0:
+            raise RuntimeError('Report is empty')
+
+        if 'report_id' not in report:
+            raise RuntimeError('report_id not found in report')
+
+    def shutdown(self):
+        self.run = False
+        self.event.set()
+
+    def serve(self):
+        self.init_module_config()
+        self.run = True
+
+        self.log.debug('Waiting for mgr to warm up')
+        self.event.wait(10)
+
+        while self.run:
+            if self.config['enabled']:
+                self.log.info('Not sending report until configured to do so')
+                self.event.wait(1800)
+                continue
+
+            now = int(time.time())
+            if not self.last_upload or (now - self.last_upload) > \
+                            self.config['interval'] * 3600:
+                self.log.info('Compiling and sending report to %s',
+                              self.config['url'])
+
+                try:
+                    self.last_report = self.compile_report()
+                except:
+                    self.log.exception('Exception while compiling report:')
+
+                try:
+                    self.send(self.last_report)
+                    self.last_upload = now
+                    self.set_config('last_upload', str(now))
+                except:
+                    self.log.exception('Exception while sending report:')
+            else:
+                self.log.info('Interval for sending new report has not expired')
+
+            sleep = 3600
+            self.log.debug('Sleeping for %d seconds', sleep)
+            self.event.wait(sleep)
+
+    def self_test(self):
+        self.compile_report()
+        return True
+
+    @staticmethod
+    def can_run():
+        return True, ''

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -220,7 +220,11 @@ class Module(MgrModule):
         return metadata
 
     def compile_report(self):
-        report = {'leaderboard': False, 'report_version': 1}
+        report = {
+            'leaderboard': False,
+            'report_version': 1,
+            'report_timestamp': datetime.utcnow().isoformat()
+        }
 
         if self.str_to_bool(self.config['leaderboard']):
             report['leaderboard'] = True

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -335,7 +335,7 @@ class Module(MgrModule):
             report = self.last_report
             if not report:
                 report = self.compile_report()
-            return 0, json.dumps(report), ''
+            return 0, json.dumps(report, indent=4), ''
         elif command['prefix'] == 'telemetry self-test':
             self.self_test()
             return 0, 'Self-test succeeded', ''

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -425,7 +425,7 @@ class Module(MgrModule):
 
         while self.run:
             if not self.config['enabled']:
-                self.log.info('Not sending report until configured to do so')
+                self.log.debug('Not sending report until configured to do so')
                 self.event.wait(1800)
                 continue
 
@@ -450,7 +450,7 @@ class Module(MgrModule):
                 except:
                     self.log.exception('Exception while sending report:')
             else:
-                self.log.info('Interval for sending new report has not expired')
+                self.log.debug('Interval for sending new report has not expired')
 
             sleep = 3600
             self.log.debug('Sleeping for %d seconds', sleep)


### PR DESCRIPTION
This is essentially a compilation of patches, backported to luminous, with some necessary adjustments to have them working. There's some creative executive decisions while backporting these, especially when it came to revisions -- given there's some information missing in luminous, and other that is, we kept the highest revision possible regardless of the missing info. And, for what it's worth, this revision does not seem to be shared with the server anyway, and simply to keep track of the user's explicit consent to data sharing.

We also dropped the telemetry server from the initial telemetry patch. Not only because it was a very rudimentary version, but mostly because the `ceph-telemetry` project is the way to go.

`Signed-off-by: Joao Eduardo Luis <joao@suse.com>`
<!--
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
-->