### PR TITLE
doc: s/#/$ sudo/ -- working around Sphinx's policy on hashes (#)

### DIFF
--- a/doc/bootstrap.rst
+++ b/doc/bootstrap.rst
@@ -24,16 +24,16 @@ The ``ceph-daemon`` utility is used to bootstrap a new Ceph Cluster.
 
 Use curl to fetch the standalone script::
 
-  [monitor 1] # curl --silent --remote-name --location https://github.com/ceph/ceph/raw/master/src/ceph-daemon/ceph-daemon
-  [monitor 1] # chmod +x ceph-daemon
+  [monitor 1] $ sudo curl --silent --remote-name --location https://github.com/ceph/ceph/raw/master/src/ceph-daemon/ceph-daemon
+  [monitor 1] $ sudo chmod +x ceph-daemon
   
 You can also get the utility by installing a package provided by
 your Linux distribution::
 
-   [monitor 1] # apt install -y ceph-daemon   # or
-   [monitor 1] # dnf install -y ceph-daemon   # or
-   [monitor 1] # yum install -y ceph-daemon   # or
-   [monitor 1] # zypper install -y ceph-daemon
+   [monitor 1] $ sudo apt install -y ceph-daemon   # or
+   [monitor 1] $ sudo dnf install -y ceph-daemon   # or
+   [monitor 1] $ sudo yum install -y ceph-daemon   # or
+   [monitor 1] $ sudo zypper install -y ceph-daemon
 
 
 Bootstrap a new cluster
@@ -74,7 +74,7 @@ files to the default locations in ``/etc/ceph`` inside the container
 to allow the ``ceph`` CLI utility to work without additional
 arguments.  Inside the container, you can check the cluster status with::
 
-  [ceph: root@monitor_1_hostname /]# ceph status
+  [ceph: root@monitor_1_hostname /] $ sudo ceph status
 
 In order to interact with the Ceph cluster outside of a container
 (that is, from the command line), install the Ceph
@@ -96,11 +96,11 @@ For each new host you'd like to add to the cluster, you need to do two things:
 #. Install the cluster's public SSH key in the new host's root user's
    ``authorized_keys`` file.  For example,::
 
-     [monitor 1] # cat ceph.pub | ssh root@*newhost* tee -a /root/.ssh/authorized_keys
+     [monitor 1] $ sudo cat ceph.pub | ssh root@*newhost* tee -a /root/.ssh/authorized_keys
 
 #. Tell Ceph that the new node is part of the cluster::
 
-     [monitor 1] # ceph orchestrator host add *newhost*
+     [monitor 1] $ sudo ceph orchestrator host add *newhost*
 
 Deploying additional monitors
 =============================
@@ -112,12 +112,12 @@ either as a simple IP address or as a CIDR network name.
 
 To deploy additional monitors,::
 
-  [monitor 1] # ceph orchestrator mon update *<new-num-monitors>* *<host1:network1> [<host1:network2>...]*
+  [monitor 1] $ sudo ceph orchestrator mon update *<new-num-monitors>* *<host1:network1> [<host1:network2>...]*
 
 For example, to deploy a second monitor on ``newhost`` using an IP
 address in network ``10.1.2.0/24``,::
 
-  [monitor 1] # ceph orchestrator mon update 2 newhost:10.1.2.0/24
+  [monitor 1] $ sudo ceph orchestrator mon update 2 newhost:10.1.2.0/24
 
 Deploying OSDs
 ==============
@@ -125,11 +125,11 @@ Deploying OSDs
 To add an OSD to the cluster, you need to know the device name for the
 block device (hard disk or SSD) that will be used.  Then,::
 
-  [monitor 1] # ceph orchestrator osd create *<host>*:*<path-to-device>*
+  [monitor 1] $ sudo ceph orchestrator osd create *<host>*:*<path-to-device>*
 
 For example, to deploy an OSD on host *newhost*'s SSD,::
 
-  [monitor 1] # ceph orchestrator osd create newhost:/dev/disk/by-id/ata-WDC_WDS200T2B0A-00SM50_182294800028
+  [monitor 1] $ sudo ceph orchestrator osd create newhost:/dev/disk/by-id/ata-WDC_WDS200T2B0A-00SM50_182294800028
 
 Deploying manager daemons
 =========================
@@ -137,7 +137,7 @@ Deploying manager daemons
 It is a good idea to have at least one backup manager daemon.  To
 deploy one or more new manager daemons,::
 
-  [monitor 1] # ceph orchestrator mgr update *<new-num-mgrs>* [*<host1>* ...]
+  [monitor 1] $ sudo ceph orchestrator mgr update *<new-num-mgrs>* [*<host1>* ...]
 
 Deploying MDSs
 ==============


### PR DESCRIPTION
This commit changes "#" to "$ sudo", because when hash (#) appears
near the beginning of a line in an .rst file and then that file is
parsed by Sphinx, the material after the hash appears blue and in
italics. This blue, italicized text is undesriable and it is my
opinion that it might lead a reader to think that the authors of
the document are trying to impart some kind of information by
means of the color and italics. So: goobye hashes, hello sudo
commands.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
