### PR TITLE
ceph-daemon: don't deref symlinks during chown

### DIFF
--- a/src/ceph-daemon/ceph-daemon
+++ b/src/ceph-daemon/ceph-daemon
@@ -62,7 +62,7 @@ import uuid
 
 from distutils.spawn import find_executable
 from functools import wraps
-from glob import iglob
+from glob import glob
 
 
 container_path = None
@@ -311,46 +311,49 @@ def make_log_dir(fsid, uid=None, gid=None):
     makedirs(log_dir, uid, gid, LOG_DIR_MODE)
     return log_dir
 
-def copy_file(src, dst, uid=None, gid=None):
-    # type: (str, str, int, int) -> str
+def copy_files(src, dst, uid=None, gid=None):
+    # type: (List[str], str, int, int) -> None
     """
-    Copy a file from src to dst
-    """
-    if not uid or not gid:
-        (uid, gid) = extract_uid_gid()
-
-    if os.path.isdir(dst):
-        dst = os.path.join(dst, os.path.basename(src))
-
-    logger.debug('Copy \'%s\' -> \'%s\'' % (src, dst))
-    shutil.copyfile(src, dst)
-    os.chown(dst, uid, gid)
-
-    return dst
-
-def move_file(src, dst, uid=None, gid=None):
-    # type: (str, str, int, int) -> str
-    """
-    Move a file from src to dst
+    Copy a files from src to dst
     """
     if not uid or not gid:
         (uid, gid) = extract_uid_gid()
 
-    if os.path.isdir(dst):
-        dst = os.path.join(dst, os.path.basename(src))
+    for src_file in src:
+        dst_file = dst
+        if os.path.isdir(dst):
+            dst_file = os.path.join(dst, os.path.basename(src_file))
 
-    if os.path.islink(src):
-        # shutil.move() in python2 does not handle symlinks correctly
-        src_rl = os.readlink(src)
-        logger.debug('symlink \'%s\' -> \'%s\'' % (dst, src_rl))
-        os.symlink(src_rl, dst)
-        os.unlink(src)
-    else:
-        logger.debug('Move \'%s\' -> \'%s\'' % (src, dst))
-        shutil.move(src, dst)
-    os.chown(dst, uid, gid)
+        logger.debug('copy file \'%s\' -> \'%s\'' % (src_file, dst_file))
+        shutil.copyfile(src_file, dst_file)
 
-    return dst
+        logger.debug('chown %s:%s \'%s\'' % (uid, gid, dst_file))
+        os.chown(dst_file, uid, gid)
+
+def move_files(src, dst, uid=None, gid=None):
+    # type: (List[str], str, int, int) -> None
+    """
+    Move files from src to dst
+    """
+    if not uid or not gid:
+        (uid, gid) = extract_uid_gid()
+
+    for src_file in src:
+        dst_file = dst
+        if os.path.isdir(dst):
+            dst_file = os.path.join(dst, os.path.basename(src_file))
+
+        if os.path.islink(src_file):
+            # shutil.move() in py2 does not handle symlinks correctly
+            src_rl = os.readlink(src_file)
+            logger.debug("symlink '%s' -> '%s'" % (dst_file, src_rl))
+            os.symlink(src_rl, dst_file)
+            os.unlink(src_file)
+        else:
+            logger.debug("move file '%s' -> '%s'" % (src_file, dst_file))
+            shutil.move(src_file, dst_file)
+            logger.debug('chown %s:%s \'%s\'' % (uid, gid, dst_file))
+            os.chown(dst_file, uid, gid)
 
 def find_program(filename):
     # type: (str) -> str
@@ -444,7 +447,7 @@ def get_daemon_args(fsid, daemon_type, daemon_id):
 def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
                        config=None, keyring=None):
     # type: (str, str, Union[int, str], int, int, str, str) ->  None
-    data_dir = make_data_dir(fsid, daemon_type, daemon_id)
+    data_dir = make_data_dir(fsid, daemon_type, daemon_id, uid=uid, gid=gid)
     make_log_dir(fsid)
 
     if config:
@@ -1604,9 +1607,11 @@ def command_adopt():
         data_dir_src = ('/var/lib/ceph/%s/%s-%s' %
                         (daemon_type, args.cluster, daemon_id))
         data_dir_src = os.path.abspath(args.legacy_dir + data_dir_src)
-        data_dir_dst = make_data_dir(fsid, daemon_type, daemon_id)
-        for data_file in iglob(os.path.join(data_dir_src, '*')):
-            move_file(data_file, data_dir_dst, uid=uid, gid=gid)
+        data_dir_dst = make_data_dir(fsid, daemon_type, daemon_id,
+                                     uid=uid, gid=gid)
+        move_files(glob(os.path.join(data_dir_src, '*')),
+                   data_dir_dst,
+                   uid=uid, gid=gid)
         logger.debug('Remove dir \'%s\'' % (data_dir_src))
         if os.path.ismount(data_dir_src):
             call_throws(['umount', data_dir_src])
@@ -1616,7 +1621,7 @@ def command_adopt():
         config_src = '/etc/ceph/%s.conf' % (args.cluster)
         config_src = os.path.abspath(args.legacy_dir + config_src)
         config_dst = os.path.join(data_dir_dst, 'config')
-        copy_file(config_src, config_dst, uid=uid, gid=gid)
+        copy_files([config_src], config_dst, uid=uid, gid=gid)
 
         # logs
         logger.info('Moving logs...')
@@ -1624,8 +1629,9 @@ def command_adopt():
                         (args.cluster, daemon_type, daemon_id))
         log_dir_src = os.path.abspath(args.legacy_dir + log_dir_src)
         log_dir_dst = make_log_dir(fsid, uid=uid, gid=gid)
-        for log_file in iglob(log_dir_src):
-            move_file(log_file, log_dir_dst, uid=uid, gid=gid)
+        move_files(glob(log_dir_src),
+                   log_dir_dst,
+                   uid=uid, gid=gid)
 
         logger.info('Creating new units...')
         c = get_container(fsid, daemon_type, daemon_id)


### PR DESCRIPTION
- consolidate move/copy loop logic
- chown the actual file and not the symlink

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
