### PR TITLE
ceph-daemon: combine SUDO and ARGS into a single var

### DIFF
--- a/qa/standalone/test_ceph_daemon.sh
+++ b/qa/standalone/test_ceph_daemon.sh
@@ -57,9 +57,16 @@ if [ -z "$PYTHON_KLUDGE" ]; then
    exit 0
 fi
 
+# add image to args
+CEPH_DAEMON_ARGS="$CEPH_DAEMON_ARGS --image $IMAGE_MASTER"
+
+# combine into a single var
+CEPH_DAEMON_BIN="$CEPH_DAEMON"
+CEPH_DAEMON="$SUDO $CEPH_DAEMON_BIN $CEPH_DAEMON_ARGS"
+
 # clean up previous run(s)?
-$SUDO $CEPH_DAEMON rm-cluster --fsid $FSID --force
-$SUDO $CEPH_DAEMON rm-cluster --fsid $FSID_LEGACY --force
+$CEPH_DAEMON rm-cluster --fsid $FSID --force
+$CEPH_DAEMON rm-cluster --fsid $FSID_LEGACY --force
 vgchange -an $OSD_VG_NAME || true
 loopdev=$($SUDO losetup -a | grep $(basename $OSD_IMAGE_NAME) | awk -F : '{print $1}')
 if ! [ "$loopdev" = "" ]; then
@@ -79,18 +86,18 @@ function expect_false()
 $SUDO $CEPH_DAEMON check-host
 
 ## version + --image
-$SUDO CEPH_DAEMON_IMAGE=$IMAGE_NAUTILUS $CEPH_DAEMON version \
+$SUDO CEPH_DAEMON_IMAGE=$IMAGE_NAUTILUS $CEPH_DAEMON_BIN version \
     | grep 'ceph version 14'
-$SUDO $CEPH_DAEMON --image $IMAGE_MIMIC version \
+$SUDO $CEPH_DAEMON_BIN --image $IMAGE_MIMIC version \
     | grep 'ceph version 13'
-$SUDO $CEPH_DAEMON --image $IMAGE_MASTER version | grep 'ceph version'
+$SUDO $CEPH_DAEMON_BIN --image $IMAGE_MASTER version | grep 'ceph version'
 
 # try force docker; this won't work if docker isn't installed
-which docker && ( $SUDO $CEPH_DAEMON --docker version | grep 'ceph version' )
+which docker && ( $CEPH_DAEMON --docker version | grep 'ceph version' )
 
 ## test shell before bootstrap, when crash dir isn't (yet) present on this host
-$SUDO $CEPH_DAEMON shell -- ceph -v | grep 'ceph version'
-$SUDO $CEPH_DAEMON shell --fsid $FSID -- ceph -v | grep 'ceph version'
+$CEPH_DAEMON shell -- ceph -v | grep 'ceph version'
+$CEPH_DAEMON shell --fsid $FSID -- ceph -v | grep 'ceph version'
 
 ## bootstrap
 ORIG_CONFIG=`mktemp -p $TMPDIR`
@@ -101,7 +108,7 @@ cat <<EOF > $ORIG_CONFIG
 [global]
 log to file = true
 EOF
-$SUDO $CEPH_DAEMON --image $IMAGE_MASTER bootstrap \
+$CEPH_DAEMON bootstrap \
       --mon-id a \
       --mgr-id x \
       --mon-ip $IP \
@@ -127,18 +134,18 @@ done
 systemctl | grep system-ceph | grep -q .slice  # naming is escaped and annoying
 
 # check ceph -s works (via shell w/ passed config/keyring)
-$SUDO $CEPH_DAEMON shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
+$CEPH_DAEMON shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
       ceph -s | grep $FSID
 
 ## ls
-$SUDO $CEPH_DAEMON ls | jq '.[]' | jq 'select(.name == "mon.a").fsid' \
+$CEPH_DAEMON ls | jq '.[]' | jq 'select(.name == "mon.a").fsid' \
     | grep $FSID
-$SUDO $CEPH_DAEMON ls | jq '.[]' | jq 'select(.name == "mgr.x").fsid' \
+$CEPH_DAEMON ls | jq '.[]' | jq 'select(.name == "mgr.x").fsid' \
     | grep $FSID
 
 ## deploy
 # add mon.b
-$SUDO $CEPH_DAEMON --image $IMAGE_MASTER deploy --name mon.b \
+$CEPH_DAEMON deploy --name mon.b \
       --fsid $FSID \
       --mon-ip $IP:3301 \
       --keyring /var/lib/ceph/$FSID/mon.a/keyring \
@@ -149,12 +156,12 @@ for u in ceph-$FSID@mon.b; do
 done
 
 # add mgr.y
-$SUDO $CEPH_DAEMON shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
+$CEPH_DAEMON shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
       ceph auth get-or-create mgr.y \
       mon 'allow profile mgr' \
       osd 'allow *' \
       mds 'allow *' > $TMPDIR/keyring.mgr.y
-$SUDO $CEPH_DAEMON --image $IMAGE_MASTER deploy --name mgr.y \
+$CEPH_DAEMON deploy --name mgr.y \
       --fsid $FSID \
       --keyring $TMPDIR/keyring.mgr.y \
       --config $CONFIG
@@ -163,13 +170,13 @@ for u in ceph-$FSID@mgr.y; do
     systemctl is-active $u
 done
 for f in `seq 1 30`; do
-    if $SUDO $CEPH_DAEMON shell --fsid $FSID \
+    if $CEPH_DAEMON shell --fsid $FSID \
 	     --config $CONFIG --keyring $KEYRING -- \
 	  ceph -s -f json-pretty \
 	| jq '.mgrmap.num_standbys' | grep -q 1 ; then break; fi
     sleep 1
 done
-$SUDO $CEPH_DAEMON shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
+$CEPH_DAEMON shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
       ceph -s -f json-pretty \
     | jq '.mgrmap.num_standbys' | grep -q 1
 
@@ -181,7 +188,7 @@ $SUDO losetup $loop_dev $TMPDIR/$OSD_IMAGE_NAME
 $SUDO pvcreate $loop_dev && $SUDO vgcreate $OSD_VG_NAME $loop_dev
 for id in `seq 0 $((--OSD_TO_CREATE))`; do
     $SUDO lvcreate -l $((100/$OSD_TO_CREATE))%VG -n $OSD_LV_NAME.$id $OSD_VG_NAME
-    $SUDO $CEPH_DAEMON shell --config $CONFIG --keyring $KEYRING -- \
+    $CEPH_DAEMON shell --config $CONFIG --keyring $KEYRING -- \
             ceph orchestrator osd create \
                 $(hostname):/dev/$OSD_VG_NAME/$OSD_LV_NAME.$id
 done
@@ -193,61 +200,61 @@ done
 for tarball in $TEST_TARS; do
     TMP_TAR_DIR=`mktemp -d -p $TMPDIR`
     $SUDO tar xzvf $tarball -C $TMP_TAR_DIR
-    NAMES=$($SUDO $CEPH_DAEMON ls --legacy-dir $TMP_TAR_DIR | jq -r '.[].name')
+    NAMES=$($CEPH_DAEMON ls --legacy-dir $TMP_TAR_DIR | jq -r '.[].name')
     for name in $NAMES; do
         # TODO: skip osd test for now
         if [[ $name =~ "osd" ]]; then
            continue
         fi
-        $SUDO $CEPH_DAEMON --image $IMAGE_MASTER adopt \
-                           --style legacy \
-                           --legacy-dir $TMP_TAR_DIR \
-                           --name $name
+        $CEPH_DAEMON adopt \
+                --style legacy \
+                --legacy-dir $TMP_TAR_DIR \
+                --name $name
         # validate after adopt
-        out=$($SUDO $CEPH_DAEMON ls | jq '.[]' \
-                                    | jq 'select(.name == "'$name'")')
+        out=$($CEPH_DAEMON ls | jq '.[]' \
+                              | jq 'select(.name == "'$name'")')
         echo $out | jq -r '.style' | grep 'ceph-daemon'
         echo $out | jq -r '.fsid' | grep $FSID_LEGACY
     done
     # clean-up before next iter
-    $SUDO $CEPH_DAEMON rm-cluster --fsid $FSID_LEGACY --force
+    $CEPH_DAEMON rm-cluster --fsid $FSID_LEGACY --force
     $SUDO rm -rf $TMP_TAR_DIR
 done
 
 ## unit
-$SUDO $CEPH_DAEMON unit --fsid $FSID --name mon.a -- is-enabled
-$SUDO $CEPH_DAEMON unit --fsid $FSID --name mon.a -- is-active
-expect_false $SUDO $CEPH_DAEMON unit --fsid $FSID --name mon.xyz -- is-active
-$SUDO $CEPH_DAEMON unit --fsid $FSID --name mon.a -- disable
-expect_false $SUDO $CEPH_DAEMON unit --fsid $FSID --name mon.a -- is-enabled
-$SUDO $CEPH_DAEMON unit --fsid $FSID --name mon.a -- enable
-$SUDO $CEPH_DAEMON unit --fsid $FSID --name mon.a -- is-enabled
+$CEPH_DAEMON unit --fsid $FSID --name mon.a -- is-enabled
+$CEPH_DAEMON unit --fsid $FSID --name mon.a -- is-active
+expect_false $CEPH_DAEMON unit --fsid $FSID --name mon.xyz -- is-active
+$CEPH_DAEMON unit --fsid $FSID --name mon.a -- disable
+expect_false $CEPH_DAEMON unit --fsid $FSID --name mon.a -- is-enabled
+$CEPH_DAEMON unit --fsid $FSID --name mon.a -- enable
+$CEPH_DAEMON unit --fsid $FSID --name mon.a -- is-enabled
 
 ## shell
-$SUDO $CEPH_DAEMON --image $IMAGE_MASTER shell -- true
-$SUDO $CEPH_DAEMON --image $IMAGE_MASTER shell --fsid $FSID -- test -d /var/log/ceph
+$CEPH_DAEMON shell -- true
+$CEPH_DAEMON shell --fsid $FSID -- test -d /var/log/ceph
 
 ## enter
-expect_false $SUDO $CEPH_DAEMON enter
-$SUDO $CEPH_DAEMON enter --fsid $FSID --name mon.a -- test -d /var/lib/ceph/mon/ceph-a
-$SUDO $CEPH_DAEMON enter --fsid $FSID --name mgr.x -- test -d /var/lib/ceph/mgr/ceph-x
-$SUDO $CEPH_DAEMON enter --fsid $FSID --name mon.a -- pidof ceph-mon
-expect_false $SUDO $CEPH_DAEMON enter --fsid $FSID --name mgr.x -- pidof ceph-mon
-$SUDO $CEPH_DAEMON enter --fsid $FSID --name mgr.x -- pidof ceph-mgr
+expect_false $CEPH_DAEMON enter
+$CEPH_DAEMON enter --fsid $FSID --name mon.a -- test -d /var/lib/ceph/mon/ceph-a
+$CEPH_DAEMON enter --fsid $FSID --name mgr.x -- test -d /var/lib/ceph/mgr/ceph-x
+$CEPH_DAEMON enter --fsid $FSID --name mon.a -- pidof ceph-mon
+expect_false $CEPH_DAEMON enter --fsid $FSID --name mgr.x -- pidof ceph-mon
+$CEPH_DAEMON enter --fsid $FSID --name mgr.x -- pidof ceph-mgr
 
 ## ceph-volume
-$SUDO $CEPH_DAEMON --image $IMAGE_MASTER ceph-volume --fsid $FSID -- inventory --format=json \
+$CEPH_DAEMON ceph-volume --fsid $FSID -- inventory --format=json \
       | jq '.[]'
 
 ## rm-daemon
 # mon and osd require --force
-expect_false $SUDO $CEPH_DAEMON rm-daemon --fsid $FSID --name mon.a
+expect_false $CEPH_DAEMON rm-daemon --fsid $FSID --name mon.a
 # mgr does not
-$SUDO $CEPH_DAEMON rm-daemon --fsid $FSID --name mgr.x
+$CEPH_DAEMON rm-daemon --fsid $FSID --name mgr.x
 
 ## rm-cluster
-expect_false $SUDO $CEPH_DAEMON rm-cluster --fsid $FSID
-$SUDO $CEPH_DAEMON rm-cluster --fsid $FSID --force
+expect_false $CEPH_DAEMON rm-cluster --fsid $FSID
+$CEPH_DAEMON rm-cluster --fsid $FSID --force
 
 rm -rf $TMPDIR
 echo PASS


### PR DESCRIPTION
- reduce the amount of typing/noise for each CEPH_DAEMON invocation
- ensure the `--image` param is passed to each test invocation
- allow passing additional args to ceph-daemon via CEPH_DAEMON_ARGS

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
