### PR TITLE
cmake: silence messages when cppcheck/IWYU is not found

### DIFF
--- a/cmake/modules/FindCppCheck.cmake
+++ b/cmake/modules/FindCppCheck.cmake
@@ -25,6 +25,4 @@ if(CPPCHECK_BIN)
     )
 
   message(STATUS "Found cppcheck. To perform static analysis using cppcheck, use: \"make cppcheck\". Results will be stored in \"cppcheck.txt\".")
-else()
-  message(STATUS "Could not find cppcheck. To perform static analysis using cppcheck install the tool (e.g. \"yum install cppcheck\").")
 endif()

--- a/cmake/modules/FindIWYU.cmake
+++ b/cmake/modules/FindIWYU.cmake
@@ -9,7 +9,7 @@ if(IWYU_BIN)
   endif()
 
   if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    message(STATUS "Found IWYU, but clang++ is not used used. To enable IWYU, set CMAKE_C_COMPILER to \"clang\" and CMAKE_CXX_COMPILER to \"clang++\" and build again.")
+    message(STATUS "Found IWYU, but clang++ is not used. To enable IWYU, set CMAKE_C_COMPILER to \"clang\" and CMAKE_CXX_COMPILER to \"clang++\" and build again.")
     return()
   endif()
 
@@ -22,6 +22,4 @@ if(IWYU_BIN)
     )
 
   message(STATUS "Found IWYU. To perform header analysis using IWYU, use: \"make iwyu\". Results will be stored in \"iwyu.txt\".")
-else()
-  message(STATUS "Could not find IWYU. To perform header analysis using IWYU install the tool (e.g. \"yum install iwyu\").")
 endif()


### PR DESCRIPTION
* remove messages spit when these tools are not found
  they are not necessary for building Ceph. and the messages in the cmake
  output are distracting.
* fix a typo

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
