### PR TITLE
doc: clarify difference between fs and kcephfs suite

### DIFF
--- a/doc/dev/developer_guide/index.rst
+++ b/doc/dev/developer_guide/index.rst
@@ -945,6 +945,9 @@ all the integration tests, for all the Ceph components.
 `krbd <https://github.com/ceph/ceph/tree/master/qa/suites/krbd>`_
   test the RBD kernel module
 
+`multimds <https://github.com/ceph/ceph/tree/master/qa/suites/multimds>`_
+  test CephFS with multiple MDSs
+
 `powercycle <https://github.com/ceph/ceph/tree/master/qa/suites/powercycle>`_
   verify the Ceph cluster behaves when machines are powered off
   and on again

--- a/doc/dev/developer_guide/index.rst
+++ b/doc/dev/developer_guide/index.rst
@@ -937,10 +937,10 @@ all the integration tests, for all the Ceph components.
   verify the `integration testing`_ infrastructure works as expected)
 
 `fs <https://github.com/ceph/ceph/tree/master/qa/suites/fs>`_
-  test CephFS
+  test CephFS mounted using FUSE
 
 `kcephfs <https://github.com/ceph/ceph/tree/master/qa/suites/kcephfs>`_
-  test the CephFS kernel module
+  test CephFS mounted using kernel
 
 `krbd <https://github.com/ceph/ceph/tree/master/qa/suites/krbd>`_
   test the RBD kernel module


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43220
Fixes: https://tracker.ceph.com/issues/43222



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>