### PR TITLE
Changes to remove references to os_type "ubuntu" and "centos" hardcode   

### DIFF
--- a/qa/suites/rgw/multifs/tasks/rgw_bucket_quota.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_bucket_quota.yaml
@@ -1,5 +1,4 @@
 # Amazon/S3.pm (cpan) not available as an rpm
-os_type: ubuntu
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rgw/multifs/tasks/rgw_multipart_upload.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_multipart_upload.yaml
@@ -1,5 +1,4 @@
 # Amazon::S3 is not available on el7
-os_type: ubuntu
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rgw/multifs/tasks/rgw_user_quota.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_user_quota.yaml
@@ -1,5 +1,4 @@
 # Amazon/S3.pm (cpan) not available as an rpm
-os_type: ubuntu
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rgw/multisite/tasks/test_multi.yaml
+++ b/qa/suites/rgw/multisite/tasks/test_multi.yaml
@@ -1,5 +1,5 @@
 # see http://tracker.ceph.com/issues/20360 and http://tracker.ceph.com/issues/18126
-os_type: centos
+# os_type: centos
 
 tasks:
 - install:

--- a/qa/suites/rgw/multisite/valgrind.yaml
+++ b/qa/suites/rgw/multisite/valgrind.yaml
@@ -1,5 +1,5 @@
 # see http://tracker.ceph.com/issues/20360 and http://tracker.ceph.com/issues/18126
-os_type: centos
+# os_type: centos
 
 overrides:
   install:

--- a/qa/suites/rgw/tempest/distro/valgrind.yaml
+++ b/qa/suites/rgw/tempest/distro/valgrind.yaml
@@ -1,4 +1,4 @@
-os_type: centos
+# os_type: centos
 overrides:
   rgw:
     client.0:

--- a/qa/suites/rgw/thrash/workload/rgw_bucket_quota.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_bucket_quota.yaml
@@ -1,5 +1,5 @@
 # Amazon/S3.pm (cpan) not available as an rpm
-os_type: ubuntu
+#os_type: ubuntu
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rgw/thrash/workload/rgw_multipart_upload.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_multipart_upload.yaml
@@ -1,5 +1,5 @@
 # Amazon::S3 is not available on el7
-os_type: ubuntu
+#os_type: ubuntu
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rgw/thrash/workload/rgw_user_quota.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_user_quota.yaml
@@ -1,5 +1,5 @@
 # Amazon/S3.pm (cpan) not available as an rpm
-os_type: ubuntu
+#os_type: ubuntu
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rgw/verify/tasks/0-install.yaml
+++ b/qa/suites/rgw/verify/tasks/0-install.yaml
@@ -1,5 +1,5 @@
 # see http://tracker.ceph.com/issues/20360 and http://tracker.ceph.com/issues/18126
-os_type: centos
+# os_type: centos
 
 tasks:
 - install:

--- a/qa/suites/rgw/verify/validater/valgrind.yaml
+++ b/qa/suites/rgw/verify/validater/valgrind.yaml
@@ -1,5 +1,5 @@
 # see http://tracker.ceph.com/issues/20360 and http://tracker.ceph.com/issues/18126
-os_type: centos
+# os_type: centos
 
 overrides:
   install:


### PR DESCRIPTION



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
