### PR TITLE
mgr/dashboard: Explicitly set/change the device class of an OSD

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -103,6 +103,19 @@ class Osd(RESTController):
             'histogram': histogram,
         }
 
+    def set(self, svc_id, device_class):
+        old_device_class = CephService.send_command('mon', 'osd crush get-device-class',
+                                                    ids=[svc_id])
+        old_device_class = old_device_class[0]['device_class']
+        if old_device_class != device_class:
+            CephService.send_command('mon', 'osd crush rm-device-class',
+                                     ids=[svc_id])
+            if device_class:
+                CephService.send_command('mon', 'osd crush set-device-class', **{
+                    'class': device_class,
+                    'ids': [svc_id]
+                })
+
     @RESTController.Resource('POST', query_params=['deep'])
     @UpdatePermission
     def scrub(self, svc_id, deep=False):

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -7,6 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import * as _ from 'lodash';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { TabsModule } from 'ngx-bootstrap/tabs';
+import { ToastrModule } from 'ngx-toastr';
 import { EMPTY, of } from 'rxjs';
 
 import {
@@ -18,6 +19,7 @@ import { CoreModule } from '../../../../core/core.module';
 import { OsdService } from '../../../../shared/api/osd.service';
 import { ConfirmationModalComponent } from '../../../../shared/components/confirmation-modal/confirmation-modal.component';
 import { CriticalConfirmationModalComponent } from '../../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
+import { FormModalComponent } from '../../../../shared/components/form-modal/form-modal.component';
 import { TableActionsComponent } from '../../../../shared/datatable/table-actions/table-actions.component';
 import { CdTableAction } from '../../../../shared/models/cd-table-action';
 import { CdTableSelection } from '../../../../shared/models/cd-table-selection';
@@ -47,8 +49,8 @@ describe('OsdListComponent', () => {
 
   const setFakeSelection = () => {
     // Default data and selection
-    const selection = [{ id: 1 }];
-    const data = [{ id: 1 }];
+    const selection = [{ id: 1, tree: { device_class: 'ssd' } }];
+    const data = [{ id: 1, tree: { device_class: 'ssd' } }];
 
     // Table data and selection
     component.selection = new CdTableSelection();
@@ -78,6 +80,7 @@ describe('OsdListComponent', () => {
       HttpClientTestingModule,
       PerformanceCounterModule,
       TabsModule.forRoot(),
+      ToastrModule.forRoot(),
       CephModule,
       ReactiveFormsModule,
       RouterTestingModule,
@@ -119,6 +122,9 @@ describe('OsdListComponent', () => {
     const createOsd = (n: number) => ({
       in: 'in',
       up: 'up',
+      tree: {
+        device_class: 'ssd'
+      },
       stats_history: {
         op_out_bytes: [[n, n], [n * 2, n * 2]],
         op_in_bytes: [[n * 3, n * 3], [n * 4, n * 4]]
@@ -239,6 +245,7 @@ describe('OsdListComponent', () => {
       'create,update,delete': {
         actions: [
           'Create',
+          'Edit',
           'Scrub',
           'Deep Scrub',
           'Reweight',
@@ -249,11 +256,20 @@ describe('OsdListComponent', () => {
           'Purge',
           'Destroy'
         ],
-        primary: { multiple: 'Scrub', executing: 'Scrub', single: 'Scrub', no: 'Create' }
+        primary: { multiple: 'Scrub', executing: 'Edit', single: 'Edit', no: 'Create' }
       },
       'create,update': {
-        actions: ['Create', 'Scrub', 'Deep Scrub', 'Reweight', 'Mark Out', 'Mark In', 'Mark Down'],
-        primary: { multiple: 'Scrub', executing: 'Scrub', single: 'Scrub', no: 'Create' }
+        actions: [
+          'Create',
+          'Edit',
+          'Scrub',
+          'Deep Scrub',
+          'Reweight',
+          'Mark Out',
+          'Mark In',
+          'Mark Down'
+        ],
+        primary: { multiple: 'Scrub', executing: 'Edit', single: 'Edit', no: 'Create' }
       },
       'create,delete': {
         actions: ['Create', 'Mark Lost', 'Purge', 'Destroy'],
@@ -270,6 +286,7 @@ describe('OsdListComponent', () => {
       },
       'update,delete': {
         actions: [
+          'Edit',
           'Scrub',
           'Deep Scrub',
           'Reweight',
@@ -280,11 +297,11 @@ describe('OsdListComponent', () => {
           'Purge',
           'Destroy'
         ],
-        primary: { multiple: 'Scrub', executing: 'Scrub', single: 'Scrub', no: 'Scrub' }
+        primary: { multiple: 'Scrub', executing: 'Edit', single: 'Edit', no: 'Edit' }
       },
       update: {
-        actions: ['Scrub', 'Deep Scrub', 'Reweight', 'Mark Out', 'Mark In', 'Mark Down'],
-        primary: { multiple: 'Scrub', executing: 'Scrub', single: 'Scrub', no: 'Scrub' }
+        actions: ['Edit', 'Scrub', 'Deep Scrub', 'Reweight', 'Mark Out', 'Mark In', 'Mark Down'],
+        primary: { multiple: 'Scrub', executing: 'Edit', single: 'Edit', no: 'Edit' }
       },
       delete: {
         actions: ['Mark Lost', 'Purge', 'Destroy'],
@@ -348,6 +365,10 @@ describe('OsdListComponent', () => {
 
     it('opens the reweight modal', () => {
       expectOpensModal('Reweight', OsdReweightModalComponent);
+    });
+
+    it('opens the form modal', () => {
+      expectOpensModal('Edit', FormModalComponent);
     });
 
     it('opens all confirmation modals', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
@@ -88,6 +88,13 @@ describe('OsdService', () => {
     expect(req.request.body).toEqual({ weight: 0.5 });
   });
 
+  it('should update OSD', () => {
+    service.update(1, 'hdd').subscribe();
+    const req = httpTesting.expectOne('api/osd/1');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ device_class: 'hdd' });
+  });
+
   it('should mark an OSD lost', () => {
     service.markLost(1).subscribe();
     const req = httpTesting.expectOne('api/osd/1/mark_lost');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
@@ -234,6 +234,10 @@ export class OsdService {
     return this.http.post(`${this.path}/${id}/reweight`, { weight: weight });
   }
 
+  update(id: number, deviceClass: string) {
+    return this.http.put(`${this.path}/${id}`, { device_class: deviceClass });
+  }
+
   markLost(id: number) {
     return this.http.post(`${this.path}/${id}/mark_lost`, null);
   }


### PR DESCRIPTION
**Screenshots:**
![Screenshot from 2019-12-10 15-27-27](https://user-images.githubusercontent.com/14297426/70543005-aad3b400-1b61-11ea-9856-d360e649afa5.png)

![Screenshot from 2019-12-10 15-27-42](https://user-images.githubusercontent.com/14297426/70543034-b626df80-1b61-11ea-8574-ed77831770e9.png)

**Equivalent to:**
```
$ ceph osd crush get-device-class osd.2
$ ceph osd crush rm-device-class osd.2 
$ ceph osd crush set-device-class ssd osd.2
```

Fixes: https://tracker.ceph.com/issues/43197

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
