### PR TITLE
install-deps.sh: install python2-{virtualenv,devel} on SUSE if needed

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -425,6 +425,10 @@ else
         echo "Using zypper to install dependencies"
         zypp_install="zypper --gpg-auto-import-keys --non-interactive install --no-recommends"
         $SUDO $zypp_install systemd-rpm-macros rpm-build || exit 1
+        if [ -e /usr/bin/python2 ] ; then
+            # see https://tracker.ceph.com/issues/23981
+            $SUDO $zypp_install python2-virtualenv python2-devel || exit 1
+        fi
         munge_ceph_spec_in $with_seastar $for_make_check $DIR/ceph.spec
         $SUDO $zypp_install $(rpmspec -q --buildrequires $DIR/ceph.spec) || exit 1
         ;;


### PR DESCRIPTION
Recent versions of openSUSE are fully Python 3 systems, but Python 2 can still
be installed on them. When Python 2 *and* Python 3 are installed, tox will try
to run unit tests ("make check" tests) on both. But the spec-file-based
mechanism used by install-deps.sh for determining "make check" dependencies only
installs python3-virtualenv and python3-devel.

Fixes: https://tracker.ceph.com/issues/23981
Signed-off-by: Nathan Cutler <ncutler@suse.com>