### PR TITLE
forcing tests to start using python3 in virtualenv

### DIFF
--- a/qa/tasks/nfs_ganesha_rgw_v2.py
+++ b/qa/tasks/nfs_ganesha_rgw_v2.py
@@ -111,7 +111,7 @@ def task(ctx, config):
             'source',
             'venv/bin/activate',
             run.Raw(';'),
-            run.Raw('pip install --upgrade setuptools'),
+            run.Raw('pip3 install --upgrade setuptools'),
             run.Raw(';'),
             'deactivate'])
 
@@ -120,7 +120,7 @@ def task(ctx, config):
             'source',
             'venv/bin/activate',
             run.Raw(';'),
-            run.Raw('pip install boto boto3 names PyYaml psutil ConfigParser'),
+            run.Raw('pip3 install boto boto3 names PyYaml psutil ConfigParser'),
             run.Raw(';'),
             'deactivate'])
 

--- a/qa/tasks/nfs_ganesha_rgw_v2.py
+++ b/qa/tasks/nfs_ganesha_rgw_v2.py
@@ -104,7 +104,7 @@ def task(ctx, config):
 
     rgw[0].run(args=['cd', 'nfs_ganesha_rgw/ceph-qe-scripts', run.Raw(';'), 'git', 'checkout', '%s' % branch])
 
-    rgw[0].run(args=['virtualenv', 'venv'])
+    rgw[0].run(args=['python3', '-m', 'venv', 'venv'])
 
     rgw[0].run(
         args=[
@@ -156,7 +156,7 @@ def task(ctx, config):
 
     rgw[0].run(
         args=[run.Raw(
-            'sudo venv/bin/python2.7 nfs_ganesha_rgw/ceph-qe-scripts/rgw/v2/tests/nfs_ganesha/%s '
+            'sudo venv/bin/python3 nfs_ganesha_rgw/ceph-qe-scripts/rgw/v2/tests/nfs_ganesha/%s '
             '-r nfs_ganesha_rgw/ceph-qe-scripts/rgw/v2/tests/nfs_ganesha/config/rgw_user.yaml '
             '-c nfs_ganesha_rgw/ceph-qe-scripts/rgw/v2/tests/nfs_ganesha/config/%s ' % (script_name, test_name))])
 

--- a/qa/tasks/rgw_longrunning.py
+++ b/qa/tasks/rgw_longrunning.py
@@ -162,7 +162,7 @@ def task(ctx, config):
             'source',
             'venv/bin/activate',
             run.Raw(';'),
-            run.Raw('pip install boto boto3 names PyYaml ConfigParser'),
+            run.Raw('pip3 install boto boto3 names PyYaml ConfigParser'),
             run.Raw(';'),
             'deactivate'])
     time.sleep(60)

--- a/qa/tasks/rgw_longrunning.py
+++ b/qa/tasks/rgw_longrunning.py
@@ -156,7 +156,7 @@ def task(ctx, config):
                                                    DIR[config.get('test_version', 'v2')]['config'])])
     clients[0].run(args=['cat', config_file])
     # os.remove(local_file)
-    clients[0].run(args=['virtualenv', 'venv'])
+    clients[0].run(args=['python3', '-m', 'venv', 'venv'])
     clients[0].run(
         args=[
             'source',
@@ -172,7 +172,7 @@ def task(ctx, config):
     time.sleep(60)
     clients[0].run(
         args=[run.Raw(
-            'sudo venv/bin/python2.7 %s -c %s ' % (script, config_file))])
+            'sudo venv/bin/python3 %s -c %s ' % (script, config_file))])
     try:
         yield
     finally:

--- a/qa/tasks/rgw_system_test.py
+++ b/qa/tasks/rgw_system_test.py
@@ -95,7 +95,7 @@ def task(ctx, config):
                                                        DIR[config.get('test_version', 'v2')]['config'])])
             remote.run(args=['cat', config_file])
             # os.remove(local_file)
-        remote.run(args=['virtualenv', 'venv'])
+        remote.run(args=['python3', '-m', 'venv', 'venv'])
         remote.run(
             args=[
                 'source',
@@ -112,7 +112,7 @@ def task(ctx, config):
         time.sleep(60)
         remote.run(
             args=[run.Raw(
-                'sudo venv/bin/python2.7 %s -c %s ' % (script, config_file))])
+                'sudo venv/bin/python3 %s -c %s ' % (script, config_file))])
     try:
         yield
     finally:

--- a/qa/tasks/rgw_system_test.py
+++ b/qa/tasks/rgw_system_test.py
@@ -101,7 +101,7 @@ def task(ctx, config):
                 'source',
                 'venv/bin/activate',
                 run.Raw(';'),
-                run.Raw('pip install boto boto3 names PyYaml ConfigParser'),
+                run.Raw('pip3 install boto boto3 names PyYaml ConfigParser'),
                 run.Raw(';'),
                 'deactivate'])
 


### PR DESCRIPTION
since ceph-qe-scripts have moved to python3, we should be creating virtualenv using python3 and start the tests using the same. 

Signed-off-by: rakeshgm <rakeshgm014@gmail.com>
