### PR TITLE
ceph-daemon: `imp` module  DeprecationWarning

### DIFF
--- a/src/ceph-daemon/tests/test_ceph_daemon.py
+++ b/src/ceph-daemon/tests/test_ceph_daemon.py
@@ -1,11 +1,14 @@
-import imp
-import unittest
 import mock
 import os
+import sys
+import unittest
 
-
-cd = imp.load_source("ceph-daemon", "ceph-daemon")
-
+if sys.version_info >= (3, 3):
+    from importlib.machinery import SourceFileLoader
+    cd = SourceFileLoader('ceph-daemon', 'ceph-daemon').load_module()
+else:
+    import imp
+    cd = imp.load_source('ceph-daemon', 'ceph-daemon')
 
 class TestCephDaemon(unittest.TestCase):
     def test_is_fsid(self):


### PR DESCRIPTION
Fix DeprecationWarning while running py3 tox

```
py3 installed: attrs==19.3.0,importlib-metadata==1.2.0,mock==3.0.5,more-itertools==8.0.2,packaging==19.2,pluggy==0.13.1,py==1.8.0,pyparsing==2.4.5,pytest==5.3.1,six==1.13.0,wcwidth==0.1.7,zipp==0.6.0
py3 run-test-pre: PYTHONHASHSEED='2680360094'
py3 run-test: commands[0] | pytest
============================================================================================================================= test session starts =============================================================================================================================
platform linux -- Python 3.7.3, pytest-5.3.1, py-1.8.0, pluggy-0.13.1
cachedir: .tox/py3/.pytest_cache
rootdir: /root/src/github.com/mgfritch/ceph/src/ceph-daemon
collected 3 items

tests/test_ceph_daemon.py ...                                                                                                                                                                                                                                           [100%]

============================================================================================================================== warnings summary ===============================================================================================================================
tests/test_ceph_daemon.py:1
  /root/src/github.com/mgfritch/ceph/src/ceph-daemon/tests/test_ceph_daemon.py:1: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================================================================================================== 3 passed, 1 warning in 0.03s =========================================================================================================================                                                                                                                                                                                                                                                                                                                                                                                                                      
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
