### PR TITLE
qa: fix output check to not be sensitive to debugging

### DIFF
--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -334,43 +334,40 @@ class TestSnapshots(TestCephFSShell):
         # create the snapshot - must pass
         o = self.get_cephfs_shell_cmd_output("snap create snap1 /data_dir")
         log.info("cephfs-shell output:\n{}".format(o))
-        assert(o == "")
+        self.assertEqual("", o)
         o = self.mount_a.stat(sdn)
         log.info("mount_a output:\n{}".format(o))
-        assert(('st_mode' in str(o)) == True)
+        self.assertIn('st_mode', o)
 
         # create the same snapshot again - must fail with an error message
         o = self.get_cephfs_shell_cmd_error("snap create snap1 /data_dir")
         log.info("cephfs-shell output:\n{}".format(o))
-        o = o.split('\n')
-        assert(o[0] == "ERROR: snapshot 'snap1' already exists")
+        self.assertIn("snapshot 'snap1' already exists", o)
         o = self.mount_a.stat(sdn)
         log.info("mount_a output:\n{}".format(o))
-        assert(('st_mode' in str(o)) == True)
+        self.assertIn('st_mode', o)
 
         # delete the snapshot - must pass
         o = self.get_cephfs_shell_cmd_output("snap delete snap1 /data_dir")
         log.info("cephfs-shell output:\n{}".format(o))
-        assert(o == "")
+        self.assertEqual("", o)
         try:
             o = self.mount_a.stat(sdn)
         except:
             # snap dir should not exist anymore
             pass
         log.info("mount_a output:\n{}".format(o))
-        assert(('st_mode' in str(o)) == False)
+        self.assertNotIn('st_mode', o)
 
         # delete the same snapshot again - must fail with an error message
         o = self.get_cephfs_shell_cmd_error("snap delete snap1 /data_dir")
-        o = o.strip()
-        o = o.split('\n')
-        assert(o[0] == "ERROR: 'snap1': no such snapshot")
+        self.assertIn("'snap1': no such snapshot", o)
         try:
             o = self.mount_a.stat(sdn)
         except:
             pass
         log.info("mount_a output:\n{}".format(o))
-        assert(('st_mode' in str(o)) == False)
+        self.assertNotIn('st_mode', o)
 
 class TestCD(TestCephFSShell):
     CLIENTS_REQUIRED = 1
@@ -740,7 +737,6 @@ class TestMisc(TestCephFSShell):
         log.info("output:\n{}".format(o))
 
 class TestConfReading(TestCephFSShell):
-
     def test_reading_conf_opt(self):
         """
         Read conf without duplicate sections/options.


### PR DESCRIPTION
The traceback would screw up the equality checks.

Also, use unittest asserts so we can easily see the assert values.

Fixes: https://tracker.ceph.com/issues/43247
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
