### PR TITLE
mount.ceph: give a hint message when no mds is up or cluster is laggy

### DIFF
--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -508,6 +508,9 @@ int main(int argc, char *argv[])
 		case ENODEV:
 			fprintf(stderr, "mount error: ceph filesystem not supported by the system\n");
 			break;
+		case EHOSTUNREACH:
+			fprintf(stderr, "mount error: no mds server is up or the cluster is laggy\n");
+			break;
 		default:
 			fprintf(stderr, "mount error %d = %s\n",errno,strerror(errno));
 		}


### PR DESCRIPTION
When the cluster is laggy or no MDS is up the mount may time out with
errno == EHOSTUNREACH for the first time to do the mounting, and will
just return the same errno without waiting for the following retries.

Tracker: https://tracker.ceph.com/issues/43294

Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
