### PR TITLE
doc: change "monitor" to "node in bootstrap.rst

### DIFF
--- a/doc/bootstrap.rst
+++ b/doc/bootstrap.rst
@@ -7,9 +7,9 @@ node, and then adding additional nodes and daemons via the CLI or GUI
 dashboard.
 
 The following example installs a basic three-node cluster. Each
-node will be identified by its prompt. For example, "[monitor 1]"
-identifies the first monitor, "[monitor 2]" identifies the second
-monitor, and "[monitor 3]" identifies the third monitor. This
+node will be identified by its prompt. For example, "[node 1]"
+identifies the first node, "[node 2]" identifies the second
+node, and "[node 3]" identifies the third node. This
 information is provided in order to make clear which commands
 should be issued on which systems.
 
@@ -26,16 +26,16 @@ The ``cephadm`` utility is used to bootstrap a new Ceph Cluster.
 
 Use curl to fetch the standalone script::
 
-  [monitor 1] # curl --silent --remote-name --location https://github.com/ceph/ceph/raw/master/src/cephadm/cephadm
-  [monitor 1] # chmod +x cephadm
+  [node 1] # curl --silent --remote-name --location https://github.com/ceph/ceph/raw/master/src/ceph-daemon/ceph-daemon
+  [node 1] # chmod +x ceph-daemon
   
 You can also get the utility by installing a package provided by
 your Linux distribution::
 
-   [monitor 1] # apt install -y cephadm   # or
-   [monitor 1] # dnf install -y cephadm   # or
-   [monitor 1] # yum install -y cephadm   # or
-   [monitor 1] # zypper install -y cephadm
+   [node 1] # apt install -y ceph-daemon   # or
+   [node 1] # dnf install -y ceph-daemon   # or
+   [node 1] # yum install -y ceph-daemon   # or
+   [node 1] # zypper install -y ceph-daemon
 
 
 Bootstrap a new cluster


### PR DESCRIPTION
This commit changes prompts that read "monitor" to prompts
that read "node" in commands issued before nodes have become
monitors. (I had thought that this was already done, but
I suspect that in fact I had not understood Sage's email to
me on this subject until sometime after I had read it, and
having understood it just assumed that it was done.) Anyway,
the commands that acquire and run ceph-daemon have now been
situated after prompts that read "node", in order to avoid
making it look chicken-or-egg-like in our documentation as
though a monitor can be prior to itself.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
