### PR TITLE
ceph-volume: use correct extents if using db-devices and >1 osds_per_device

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -355,7 +355,7 @@ class MixedType(MixedStrategy):
         for osd in self.computed['osds']:
             data_path = osd['data']['path']
             data_vg = data_vgs[data_path]
-            data_lv_extents = data_vg.sizing(parts=1)['extents']
+            data_lv_extents = data_vg.sizing(parts=self.osds_per_device)['extents']
             data_uuid = system.generate_uuid()
             data_lv = lvm.create_lv(
                 'osd-block', data_uuid, vg=data_vg.name, extents=data_lv_extents)


### PR DESCRIPTION
Actual data size depending on osds_per_device needs to be calculated here. Otherwise, if osds_per_device is greater than 1, ceph-volume will allocate 100% of the device to the first osd and then fail to create the LV for the second because the volume group is already full.

Fixes: https://tracker.ceph.com/issues/39442
Signed-off-by: Fabian Niepelt <f.niepelt@mittwald.de>