### PR TITLE
librados: fix leak in getxattr and getxattrs

### DIFF
--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -2544,6 +2544,7 @@ static void rados_aio_getxattr_complete(rados_completion_t c, void *arg) {
     }
   }
   cdata->user_completion.finish(rc);
+  ((librados::AioCompletionImpl*)c)->put();
   delete cdata;
 }
 
@@ -2597,6 +2598,7 @@ static void rados_aio_getxattrs_complete(rados_completion_t c, void *arg) {
     cdata->it = 0;
     cdata->user_completion.finish(0);
   }
+  ((librados::AioCompletionImpl*)c)->put();
   delete cdata;
 }
 


### PR DESCRIPTION
Issue was related to missing put() on AioCompletionImpl.
