### PR TITLE
rbd-mirror: rename per-image replication perf counters

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7465,6 +7465,15 @@ static std::vector<Option> get_rbd_mirror_options() {
     .set_min_max((int64_t)PerfCountersBuilder::PRIO_DEBUGONLY,
                  (int64_t)PerfCountersBuilder::PRIO_CRITICAL + 1),
 
+    Option("rbd_mirror_image_perf_stats_prio", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default((int64_t)PerfCountersBuilder::PRIO_USEFUL)
+    .set_description("Priority level for mirror daemon per-image replication perf counters")
+    .set_long_description("The daemon will send per-image perf counter data to the "
+                          "manager daemon if the priority is not lower than "
+                          "mgr_stats_threshold.")
+    .set_min_max((int64_t)PerfCountersBuilder::PRIO_DEBUGONLY,
+                 (int64_t)PerfCountersBuilder::PRIO_CRITICAL + 1),
+
     Option("rbd_mirror_memory_autotune", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(true)
     .add_see_also("rbd_mirror_memory_target")

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -817,11 +817,11 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
 
         if daemon.startswith('rbd-mirror.'):
             match = re.match(
-                r'^rbd_mirror_([^/]+)/(?:(?:([^/]+)/)?)(.*)\.(replay(?:_bytes|_latency)?)$',
+                r'^rbd_mirror_image_([^/]+)/(?:(?:([^/]+)/)?)(.*)\.(replay(?:_bytes|_latency)?)$',
                 path
             )
             if match:
-                path = 'rbd_mirror_' + match.group(4)
+                path = 'rbd_mirror_image_' + match.group(4)
                 pool = match.group(1)
                 namespace = match.group(2) or ''
                 image = match.group(3)

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -1740,7 +1740,7 @@ void ImageReplayer<I>::register_admin_socket_hook() {
       m_asok_hook = asok_hook;
 
       CephContext *cct = static_cast<CephContext *>(m_local_io_ctx.cct());
-      auto prio = cct->_conf.get_val<int64_t>("rbd_mirror_perf_stats_prio");
+      auto prio = cct->_conf.get_val<int64_t>("rbd_mirror_image_perf_stats_prio");
       PerfCountersBuilder plb(g_ceph_context, "rbd_mirror_image_" + m_name,
                               l_rbd_mirror_first, l_rbd_mirror_last);
       plb.add_u64_counter(l_rbd_mirror_replay, "replay", "Replays", "r", prio);

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -1741,7 +1741,7 @@ void ImageReplayer<I>::register_admin_socket_hook() {
 
       CephContext *cct = static_cast<CephContext *>(m_local_io_ctx.cct());
       auto prio = cct->_conf.get_val<int64_t>("rbd_mirror_perf_stats_prio");
-      PerfCountersBuilder plb(g_ceph_context, "rbd_mirror_" + m_name,
+      PerfCountersBuilder plb(g_ceph_context, "rbd_mirror_image_" + m_name,
                               l_rbd_mirror_first, l_rbd_mirror_last);
       plb.add_u64_counter(l_rbd_mirror_replay, "replay", "Replays", "r", prio);
       plb.add_u64_counter(l_rbd_mirror_replay_bytes, "replay_bytes",


### PR DESCRIPTION
The same names for aggregated and per image counters cause
problems for prometheus.

Fixes: https://tracker.ceph.com/issues/43004
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
