### PR TITLE
include: fix interval_set const_iterator call operator type

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -630,9 +630,6 @@ OPTION(osd_ignore_stale_divergent_priors, OPT_BOOL) // do not assert on divergen
 // decode the object, any error will be reported.
 OPTION(osd_read_ec_check_for_errors, OPT_BOOL) // return error if any ec shard has an error
 
-// Only use clone_overlap for recovery if there are fewer than
-// osd_recover_clone_overlap_limit entries in the overlap set
-OPTION(osd_recover_clone_overlap_limit, OPT_INT)
 OPTION(osd_debug_feed_pullee, OPT_INT)
 
 OPTION(osd_backfill_scan_min, OPT_INT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2922,9 +2922,12 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
-    Option("osd_recover_clone_overlap_limit", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    // Only use clone_overlap for recovery if there are fewer than
+    // osd_recover_clone_overlap_limit entries in the overlap set
+    Option("osd_recover_clone_overlap_limit", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(10)
-    .set_description(""),
+    .set_description("")
+    .set_flag(Option::FLAG_RUNTIME),
 
     Option("osd_debug_feed_pullee", Option::TYPE_INT, Option::LEVEL_DEV)
     .set_default(-1)

--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -160,7 +160,7 @@ class interval_set {
   };
 
   interval_set() : _size(0) {}
-  interval_set(Map& other) {
+  interval_set(Map&& other) {
     m.swap(other);
     _size = 0;
     for (auto& i : m) {

--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -720,8 +720,8 @@ class interval_set {
    * Move contents of m into another Map. Use that instead of
    * encoding interval_set into bufferlist then decoding it back into Map.
    */
-  void move_into(Map& other) {
-    other = std::move(m);
+  Map detach() && {
+    return std::move(m);
   }
 
 private:

--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -34,6 +34,9 @@ template<typename T, typename Map = std::map<T,T>>
 class interval_set {
  public:
   using value_type = T;
+  using interval_type = typename Map::value_type;
+  using interval_const_type = const interval_type;
+  using size_type = typename Map::size_type;
 
   class const_iterator;
 
@@ -56,41 +59,42 @@ class interval_set {
         }
 
         // Dereference this iterator to get a pair.
-        std::pair < T, T > &operator*() {
-                return *_iter;
+        interval_type& operator*() const {
+          return *_iter;
         }
 
         // Return the interval start.
-        T get_start() const {
-                return _iter->first;
+        value_type get_start() const {
+          return _iter->first;
         }
 
         // Return the interval length.
-        T get_len() const {
-                return _iter->second;
+        value_type get_len() const {
+          return _iter->second;
         }
-        T get_end() const {
-                return _iter->first + _iter->second;
+
+        value_type get_end() const {
+          return _iter->first + _iter->second;
         }
 
         // Set the interval length.
-        void set_len(T len) {
-                _iter->second = len;
+        void set_len(const value_type& len) {
+          _iter->second = len;
         }
 
         // Preincrement
-        iterator &operator++()
+        iterator& operator++()
         {
-                ++_iter;
-                return *this;
+          ++_iter;
+          return *this;
         }
 
         // Postincrement
         iterator operator++(int)
         {
-                iterator prev(_iter);
-                ++_iter;
-                return prev;
+          iterator prev(_iter);
+          ++_iter;
+          return prev;
         }
 
     friend class interval_set<T,Map>::const_iterator;
@@ -123,84 +127,83 @@ class interval_set {
         }
 
         // Dereference this iterator to get a pair.
-        std::pair < T, T > operator*() const {
-                return *_iter;
+        interval_const_type& operator*() const {
+          return *_iter;
         }
 
         // Return the interval start.
-        T get_start() const {
-                return _iter->first;
+        value_type get_start() const {
+          return _iter->first;
         }
-        T get_end() const {
-                return _iter->first + _iter->second;
+        value_type get_end() const {
+          return _iter->first + _iter->second;
         }
 
         // Return the interval length.
-        T get_len() const {
-                return _iter->second;
+        value_type get_len() const {
+          return _iter->second;
         }
 
         // Preincrement
-        const_iterator &operator++()
+        const_iterator& operator++()
         {
-                ++_iter;
-                return *this;
+          ++_iter;
+          return *this;
         }
 
         // Postincrement
         const_iterator operator++(int)
         {
-                const_iterator prev(_iter);
-                ++_iter;
-                return prev;
+          const_iterator prev(_iter);
+          ++_iter;
+          return prev;
         }
 
     protected:
         typename Map::const_iterator _iter;
   };
 
-  interval_set() : _size(0) {}
+  interval_set() = default;
   interval_set(Map&& other) {
     m.swap(other);
-    _size = 0;
-    for (auto& i : m) {
-      _size += i.second;
+    for (const auto& p : m) {
+      _size += p.second;
     }
   }
 
-  int num_intervals() const
+  size_type num_intervals() const
   {
     return m.size();
   }
 
-  typename interval_set<T,Map>::iterator begin() {
-    return typename interval_set<T,Map>::iterator(m.begin());
+  iterator begin() {
+    return iterator(m.begin());
   }
 
-  typename interval_set<T,Map>::iterator lower_bound(T start) {
-    return typename interval_set<T,Map>::iterator(find_inc_m(start));
+  iterator lower_bound(T start) {
+    return iterator(find_inc_m(start));
   }
 
-  typename interval_set<T,Map>::iterator end() {
-    return typename interval_set<T,Map>::iterator(m.end());
+  iterator end() {
+    return iterator(m.end());
   }
 
-  typename interval_set<T,Map>::const_iterator begin() const {
-    return typename interval_set<T,Map>::const_iterator(m.begin());
+  const_iterator begin() const {
+    return const_iterator(m.begin());
   }
 
-  typename interval_set<T,Map>::const_iterator lower_bound(T start) const {
-    return typename interval_set<T,Map>::const_iterator(find_inc(start));
+  const_iterator lower_bound(T start) const {
+    return const_iterator(find_inc(start));
   }
 
-  typename interval_set<T,Map>::const_iterator end() const {
-    return typename interval_set<T,Map>::const_iterator(m.end());
+  const_iterator end() const {
+    return const_iterator(m.end());
   }
 
   // helpers
  private:
-  typename Map::const_iterator find_inc(T start) const {
-    typename Map::const_iterator p = m.lower_bound(start);  // p->first >= start
+  auto find_inc(T start) const {
+    auto p = m.lower_bound(start);  // p->first >= start
     if (p != m.begin() &&
         (p == m.end() || p->first > start)) {
       p--;   // might overlap?
@@ -210,8 +213,8 @@ class interval_set {
     return p;
   }
   
-  typename Map::iterator find_inc_m(T start) {
-    typename Map::iterator p = m.lower_bound(start);
+  auto find_inc_m(T start) {
+    auto p = m.lower_bound(start);
     if (p != m.begin() &&
         (p == m.end() || p->first > start)) {
       p--;   // might overlap?
@@ -221,8 +224,8 @@ class interval_set {
     return p;
   }
   
-  typename Map::const_iterator find_adj(T start) const {
-    typename Map::const_iterator p = m.lower_bound(start);
+  auto find_adj(T start) const {
+    auto p = m.lower_bound(start);
     if (p != m.begin() &&
         (p == m.end() || p->first > start)) {
       p--;   // might touch?
@@ -232,8 +235,8 @@ class interval_set {
     return p;
   }
   
-  typename Map::iterator find_adj_m(T start) {
-    typename Map::iterator p = m.lower_bound(start);
+  auto find_adj_m(T start) {
+    auto p = m.lower_bound(start);
     if (p != m.begin() &&
         (p == m.end() || p->first > start)) {
       p--;   // might touch?
@@ -244,16 +247,16 @@ class interval_set {
   }
 
   void intersection_size_asym(const interval_set &s, const interval_set &l) {
-    typename decltype(m)::const_iterator ps = s.m.begin(), pl;
+    auto ps = s.m.begin();
     ceph_assert(ps != s.m.end());
-    T offset = ps->first;
+    auto offset = ps->first;
     bool first = true;
-    typename decltype(m)::iterator mi = m.begin();
+    auto mi = m.begin();
 
     while (1) {
       if (first)
         first = false;
-      pl = l.find_inc(offset);
+      auto pl = l.find_inc(offset);
       if (pl == l.m.end())
         break;
       while (ps != s.m.end() && ps->first + ps->second <= pl->first)
@@ -279,10 +282,10 @@ class interval_set {
         continue;
       }
 
-      T start = std::max<T>(ps->first, pl->first);
-      T en = std::min<T>(ps->first + ps->second, offset);
+      auto start = std::max<T>(ps->first, pl->first);
+      auto en = std::min<T>(ps->first + ps->second, offset);
       ceph_assert(en > start);
-      typename decltype(m)::value_type i{start, en - start};
+      auto i = interval_type{start, en - start};
       mi = m.insert(mi, i);
       _size += i.second;
       if (ps->first + ps->second <= offset) {
@@ -344,15 +347,15 @@ class interval_set {
   void decode(ceph::buffer::ptr::const_iterator& p) {
     denc(m, p);
     _size = 0;
-    for (const auto& i : m) {
-      _size += i.second;
+    for (const auto& p : m) {
+      _size += p.second;
     }
   }
   void decode(ceph::buffer::list::iterator& p) {
     denc(m, p);
     _size = 0;
-    for (const auto& i : m) {
-      _size += i.second;
+    for (const auto& p : m) {
+      _size += p.second;
     }
   }
 
@@ -362,8 +365,8 @@ class interval_set {
   void decode_nohead(int n, ceph::buffer::ptr::const_iterator& p) {
     denc_traits<Map>::decode_nohead(n, m, p);
     _size = 0;
-    for (const auto& i : m) {
-      _size += i.second;
+    for (const auto& p : m) {
+      _size += p.second;
     }
   }
 
@@ -373,7 +376,7 @@ class interval_set {
   }
 
   bool contains(T i, T *pstart=0, T *plen=0) const {
-    typename Map::const_iterator p = find_inc(i);
+    auto p = find_inc(i);
     if (p == m.end()) return false;
     if (p->first > i) return false;
     if (p->first+p->second <= i) return false;
@@ -385,7 +388,7 @@ class interval_set {
     return true;
   }
   bool contains(T start, T len) const {
-    typename Map::const_iterator p = find_inc(start);
+    auto p = find_inc(start);
     if (p == m.end()) return false;
     if (p->first > start) return false;
     if (p->first+p->second <= start) return false;
@@ -406,14 +409,14 @@ class interval_set {
   bool empty() const {
     return m.empty();
   }
-  T range_start() const {
+  value_type range_start() const {
     ceph_assert(!empty());
-    typename Map::const_iterator p = m.begin();
+    auto p = m.begin();
     return p->first;
   }
-  T range_end() const {
+  value_type range_end() const {
     ceph_assert(!empty());
-    typename Map::const_iterator p = m.end();
+    auto p = m.end();
     p--;
     return p->first+p->second;
   }
@@ -421,20 +424,20 @@ class interval_set {
   // interval start after p (where p not in set)
   bool starts_after(T i) const {
     ceph_assert(!contains(i));
-    typename Map::const_iterator p = find_inc(i);
+    auto p = find_inc(i);
     if (p == m.end()) return false;
     return true;
   }
-  T start_after(T i) const {
+  value_type start_after(T i) const {
     ceph_assert(!contains(i));
-    typename Map::const_iterator p = find_inc(i);
+    auto p = find_inc(i);
     return p->first;
   }
 
   // interval end that contains start
-  T end_after(T start) const {
+  value_type end_after(T start) const {
     ceph_assert(contains(start));
-    typename Map::const_iterator p = find_inc(start);
+    auto p = find_inc(start);
     return p->first+p->second;
   }
   
@@ -446,7 +449,7 @@ class interval_set {
     //cout << "insert " << start << "~" << len << endl;
     ceph_assert(len > 0);
     _size += len;
-    typename Map::iterator p = find_adj_m(start);
+    auto p = find_adj_m(start);
     if (p == m.end()) {
       m[start] = len;                  // new interval
       if (pstart)
@@ -463,7 +466,7 @@ class interval_set {
         
         p->second += len;               // append to end
         
-        typename Map::iterator n = p;
+        auto n = p;
         n++;
 	if (pstart)
 	  *pstart = p->first;
@@ -515,7 +518,7 @@ class interval_set {
 
   void erase(T start, T len, 
     std::function<bool(T, T)> claim = {}) {
-    typename Map::iterator p = find_inc_m(start);
+    auto p = find_inc_m(start);
 
     _size -= len;
     ceph_assert(_size >= 0);
@@ -546,17 +549,15 @@ class interval_set {
   }
 
   void subtract(const interval_set &a) {
-    for (typename Map::const_iterator p = a.m.begin();
-         p != a.m.end();
-         p++)
-      erase(p->first, p->second);
+    for (const auto& [start, len] : a.m) {
+      erase(start, len);
+    }
   }
 
   void insert(const interval_set &a) {
-    for (typename Map::const_iterator p = a.m.begin();
-         p != a.m.end();
-         p++)
-      insert(p->first, p->second);
+    for (const auto& [start, len] : a.m) {
+      insert(start, len);
+    }
   }
 
 
@@ -588,9 +589,9 @@ class interval_set {
       return;
     }
 
-    typename Map::const_iterator pa = a.m.begin();
-    typename Map::const_iterator pb = b.m.begin();
-    typename decltype(m)::iterator mi = m.begin();
+    auto pa = a.m.begin();
+    auto pb = b.m.begin();
+    auto mi = m.begin();
 
     while (pa != a.m.end() && pb != b.m.end()) {
       // passing?
@@ -612,7 +613,7 @@ class interval_set {
       T start = std::max(pa->first, pb->first);
       T en = std::min(pa->first+pa->second, pb->first+pb->second);
       ceph_assert(en > start);
-      typename decltype(m)::value_type i{start, en - start};
+      auto i = interval_type{start, en - start};
       mi = m.insert(mi, i);
       _size += i.second;
       if (pa->first+pa->second > pb->first+pb->second)
@@ -674,10 +675,9 @@ class interval_set {
     if (big.size() / size() < 10)
       return subset_size_sym(big);
 
-    for (typename Map::const_iterator i = m.begin();
-         i != m.end();
-         i++) 
-      if (!big.contains(i->first, i->second)) return false;
+    for (const auto& [start, len] : m) {
+      if (!big.contains(start, len)) return false;
+    }
     return true;
   }  
 
@@ -688,7 +688,7 @@ class interval_set {
    */
   void span_of(const interval_set &other, T start, T len) {
     clear();
-    typename Map::const_iterator p = other.find_inc(start);
+    auto p = other.find_inc(start);
     if (p == other.m.end())
       return;
     if (p->first < start) {
@@ -726,7 +726,7 @@ class interval_set {
 
 private:
   // data
-  uint64_t _size;
+  uint64_t _size = 0;
   Map m;   // map start -> len
 };
 
@@ -767,13 +767,11 @@ struct denc_traits<interval_set<T,Map>> {
 template<class T, typename Map>
 inline std::ostream& operator<<(std::ostream& out, const interval_set<T,Map> &s) {
   out << "[";
-  const char *prequel = "";
-  for (typename interval_set<T,Map>::const_iterator i = s.begin();
-       i != s.end();
-       ++i)
-  {
-    out << prequel << i.get_start() << "~" << i.get_len();
-    prequel = ",";
+  bool first = true;
+  for (const auto& [start, len] : s) {
+    if (!first) out << ",";
+    out << start << "~" << len;
+    first = false;
   }
   out << "]";
   return out;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9961,7 +9961,7 @@ int BlueStore::fiemap(
   interval_set<uint64_t> m;
   int r = _fiemap(c_, oid, offset, length, m);
   if (r >= 0) {
-    m.move_into(destmap);
+    destmap = std::move(m).detach();
   }
   return r;
 }

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -565,7 +565,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
 
    virtual int objects_readv_sync(
      const hobject_t &hoid,
-     map<uint64_t, uint64_t>& m,
+     map<uint64_t, uint64_t>&& m,
      uint32_t op_flags,
      bufferlist *bl) {
      return -EOPNOTSUPP;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5574,7 +5574,7 @@ int PrimaryLogPG::do_sparse_read(OpContext *ctx, OSDOp& osd_op) {
     }
 
     bufferlist data_bl;
-    r = pgbackend->objects_readv_sync(soid, m, op.flags, &data_bl);
+    r = pgbackend->objects_readv_sync(soid, std::move(m), op.flags, &data_bl);
     if (r == -EIO) {
       r = rep_repair_primary_object(soid, ctx);
     }

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -264,7 +264,7 @@ int ReplicatedBackend::objects_readv_sync(
   interval_set<uint64_t> im(m);
   auto r = store->readv(ch, ghobject_t(hoid), im, *bl, op_flags);
   if (r >= 0) {
-    im.move_into(m);
+    m = std::move(im).detach();
   }
   return r;
 }

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -257,11 +257,11 @@ int ReplicatedBackend::objects_read_sync(
 
 int ReplicatedBackend::objects_readv_sync(
   const hobject_t &hoid,
-  map<uint64_t, uint64_t>& m,
+  map<uint64_t, uint64_t>&& m,
   uint32_t op_flags,
   bufferlist *bl)
 {
-  interval_set<uint64_t> im(m);
+  interval_set<uint64_t> im(std::move(m));
   auto r = store->readv(ch, ghobject_t(hoid), im, *bl, op_flags);
   if (r >= 0) {
     m = std::move(im).detach();
@@ -2081,7 +2081,7 @@ int ReplicatedBackend::build_push_op(const ObjectRecoveryInfo &recovery_info,
       int r = store->fiemap(ch, ghobject_t(recovery_info.soid), 0,
                             copy_subset.range_end(), m);
       if (r >= 0)  {
-        interval_set<uint64_t> fiemap_included(m);
+        interval_set<uint64_t> fiemap_included(std::move(m));
         copy_subset.intersection_of(fiemap_included);
       } else {
         // intersection of copy_subset and empty interval_set would be empty anyway

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1213,7 +1213,7 @@ void ReplicatedBackend::calc_head_subsets(
     return;
   }
 
-  if (cloning.num_intervals() > cct->_conf->osd_recover_clone_overlap_limit) {
+  if (cloning.num_intervals() > g_conf().get_val<uint64_t>("osd_recover_clone_overlap_limit")) {
     dout(10) << "skipping clone, too many holes" << dendl;
     get_parent()->release_locks(manager);
     clone_subsets.clear();
@@ -1303,7 +1303,7 @@ void ReplicatedBackend::calc_clone_subsets(
 	     << " overlap " << next << dendl;
   }
 
-  if (cloning.num_intervals() > cct->_conf->osd_recover_clone_overlap_limit) {
+  if (cloning.num_intervals() > g_conf().get_val<uint64_t>("osd_recover_clone_overlap_limit")) {
     dout(10) << "skipping clone, too many holes" << dendl;
     get_parent()->release_locks(manager);
     clone_subsets.clear();

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -151,7 +151,7 @@ public:
 
   int objects_readv_sync(
     const hobject_t &hoid,
-    map<uint64_t, uint64_t>& m,
+    map<uint64_t, uint64_t>&& m,
     uint32_t op_flags,
     bufferlist *bl) override;
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -4488,9 +4488,9 @@ void ObjectModDesc::decode(ceph::buffer::list::const_iterator &_bl)
   DECODE_FINISH(_bl);
 }
 
-std::atomic<int32_t> ObjectCleanRegions::max_num_intervals = {10};
+std::atomic<uint32_t> ObjectCleanRegions::max_num_intervals = {10};
 
-void ObjectCleanRegions::set_max_num_intervals(int32_t num)
+void ObjectCleanRegions::set_max_num_intervals(uint32_t num)
 {
   max_num_intervals = num;
 }

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -3887,7 +3887,7 @@ private:
   bool new_object;
   bool clean_omap;
   interval_set<uint64_t> clean_offsets;
-  static std::atomic<int32_t> max_num_intervals;
+  static std::atomic<uint32_t> max_num_intervals;
 
   /**
    * trim the number of intervals if clean_offsets.num_intervals()
@@ -3909,7 +3909,7 @@ public:
   bool operator==(const ObjectCleanRegions &orc) const {
     return new_object == orc.new_object && clean_omap == orc.clean_omap && clean_offsets == orc.clean_offsets;
   }
-  static void set_max_num_intervals(int32_t num);
+  static void set_max_num_intervals(uint32_t num);
   void merge(const ObjectCleanRegions &other);
   void mark_data_region_dirty(uint64_t offset, uint64_t len);
   void mark_omap_dirty();

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1269,7 +1269,12 @@ TEST(GarbageCollector, BasicTest)
     ASSERT_EQ(saving, 1);
     auto& to_collect = gc.get_extents_to_collect();
     ASSERT_EQ(to_collect.num_intervals(), 1u);
-    ASSERT_EQ(*to_collect.begin(), std::make_pair(100ul, 10ul));
+    {
+      auto it = to_collect.begin();
+      using p = decltype(*it);
+      auto v = p{100ul, 10ul};
+      ASSERT_EQ(*it, v);
+    }
 
     em.clear();
     old_extents.clear();
@@ -1339,10 +1344,21 @@ TEST(GarbageCollector, BasicTest)
     ASSERT_EQ(saving, 2);
     auto& to_collect = gc.get_extents_to_collect();
     ASSERT_EQ(to_collect.num_intervals(), 2u);
-    ASSERT_TRUE((*to_collect.begin()) == std::make_pair(0x0ul ,0x8000ul) ||
-		  *(++to_collect.begin()) == std::make_pair(0x0ul, 0x8000ul));
-    ASSERT_TRUE((*to_collect.begin()) == std::make_pair(0x3f000ul, 0x1000ul) ||
-		  *(++to_collect.begin()) == std::make_pair(0x3f000ul, 0x1000ul));
+    {
+      auto it1 = to_collect.begin();
+      auto it2 = ++to_collect.begin();
+      using p = decltype(*it1);
+      {
+        auto v1 = p{0x0ul ,0x8000ul};
+        auto v2 = p{0x0ul, 0x8000ul};
+        ASSERT_TRUE(*it1 == v1 || *it2 == v2);
+      }
+      {
+        auto v1 = p{0x3f000ul, 0x1000ul};
+        auto v2 = p{0x3f000ul, 0x1000ul};
+        ASSERT_TRUE(*it1 == v1 || *it2 == v2);
+      }
+    }
 
     em.clear();
     old_extents.clear();
@@ -1460,10 +1476,21 @@ TEST(GarbageCollector, BasicTest)
     ASSERT_EQ(saving, 2);
     auto& to_collect = gc.get_extents_to_collect();
     ASSERT_EQ(to_collect.num_intervals(), 2u);
-    ASSERT_TRUE(*to_collect.begin() == std::make_pair(0x0ul, 0x8000ul) ||
-		  *(++to_collect.begin()) == std::make_pair(0x0ul, 0x8000ul));
-    ASSERT_TRUE(*to_collect.begin() == std::make_pair(0x3f000ul, 0x1000ul) ||
-		  *(++to_collect.begin()) == std::make_pair(0x3f000ul, 0x1000ul));
+    {
+      auto it1 = to_collect.begin();
+      auto it2 = ++to_collect.begin();
+      using p = decltype(*it1);
+      {
+        auto v1 = p{0x0ul, 0x8000ul};
+        auto v2 = p{0x0ul, 0x8000ul};
+        ASSERT_TRUE(*it1 == v1 || *it2  == v2);
+      }
+      {
+        auto v1 = p{0x3f000ul, 0x1000ul};
+        auto v2 = p{0x3f000ul, 0x1000ul};
+        ASSERT_TRUE(*it1 == v1 || *it2 == v2);
+      }
+    }
 
     em.clear();
     old_extents.clear();


### PR DESCRIPTION
This also updates the header to use `auto` for type deduction for
simplifying the code.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
