### PR TITLE
luminous: rgw: lc: continue past get_obj_state() failure

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -421,7 +421,8 @@ int RGWLC::bucket_lc_process(string& shard_id)
             RGWObjState *state;
             int ret = store->get_obj_state(&rctx, bucket_info, obj, &state, false);
             if (ret < 0) {
-              return ret;
+	      ldout(cct,5) << "ERROR: get_obj_state() failed for key=" << key << dendl;
+	      continue;
             }
             if (state->mtime != obj_iter->meta.mtime)//Check mtime again to avoid delete a recently update object as much as possible
               continue;
@@ -526,7 +527,7 @@ int RGWLC::bucket_lc_process(string& shard_id)
               RGWObjState *state;
               int ret = store->get_obj_state(&rctx, bucket_info, obj, &state, false);
               if (ret < 0) {
-                return ret;
+		ldout(cct,5) << "ERROR: get_obj_state() failed for key=" << obj_iter->key << dendl;
               }
               if (state->mtime != obj_iter->meta.mtime)//Check mtime again to avoid delete a recently update object as much as possible
                 continue;


### PR DESCRIPTION
The get_obj_state() failure in particular could indicate a race with
an object being deleted, so likely is non-fatal.  By returning, lifecycle
processing for the current bi-shard would not resume until re-scheduled,
likely in 24 hours.

Fixes: https://tracker.ceph.com/issues/43269

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
