### PR TITLE
Revert "mgr/DaemonServer: safe-to-destroy - do not consider irrelevant pgs"

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1425,33 +1425,6 @@ bool DaemonServer::_handle_command(
 	    safe_to_destroy.insert(osd);
 	    continue;  // clearly safe to destroy
 	  }
-          set<int64_t> pools;
-          osdmap.get_pool_ids_by_osd(g_ceph_context, osd, &pools);
-          if (pools.empty()) {
-            // osd does not belong to any pools yet
-            safe_to_destroy.insert(osd);
-            continue;
-          }
-          if (osdmap.is_down(osd) && osdmap.is_out(osd)) {
-            // if osd is down&out and all relevant pools are active+clean,
-            // then should be safe to destroy
-            bool all_osd_pools_active_clean = true;
-            for (auto &ps: pg_map.pg_stat) {
-              auto& pg = ps.first;
-              auto state = ps.second.state;
-              if (!pools.count(pg.pool()))
-                continue;
-              if ((state & (PG_STATE_ACTIVE | PG_STATE_CLEAN)) !=
-                           (PG_STATE_ACTIVE | PG_STATE_CLEAN)) {
-                all_osd_pools_active_clean = false;
-                break;
-              }
-            }
-            if (all_osd_pools_active_clean) {
-              safe_to_destroy.insert(osd);
-              continue;
-            }
-          }
 	  auto q = pg_map.num_pg_by_osd.find(osd);
 	  if (q != pg_map.num_pg_by_osd.end()) {
 	    if (q->second.acting > 0 || q->second.up_not_acting > 0) {


### PR DESCRIPTION
This reverts commit ba8dd78236eec2c70b9bdc335d847c5762d4b6d4.

We use OSD device class to separate pools. Hence removing
the device class of an osd may cause mgr mistakenly approve
an invalid safe-to-destroy request, e.g., because that osd now
belongs to no pool while data migration could be still in-progress..

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
