### PR TITLE
rgw: fix copy object urlencoding

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4850,7 +4850,7 @@ bool RGWCopyObj::parse_copy_location(const boost::string_view& url_src,
     params_str = url_src.substr(pos + 1);
   }
 
-  boost::string_view dec_src{name_str};
+  boost::string_view dec_src{url_decode(name_str)};
   if (dec_src[0] == '/')
     dec_src.remove_prefix(1);
 
@@ -4858,8 +4858,11 @@ bool RGWCopyObj::parse_copy_location(const boost::string_view& url_src,
   if (pos == string::npos)
     return false;
 
-  bucket_name = url_decode(dec_src.substr(0, pos));
-  key.name = url_decode(dec_src.substr(pos + 1));
+  boost::string_view bn_view{dec_src.substr(0, pos)};
+  bucket_name = std::string{bn_view.data(), bn_view.size()};
+
+  boost::string_view kn_view{dec_src.substr(pos + 1)};
+  key.name = std::string{kn_view.data(), kn_view.size()};
 
   if (key.name.empty()) {
     return false;


### PR DESCRIPTION
Commit ea979b9 breaks parsing of urlencoded 'copy_source' field on S3 Copy operation.  
It's happen because in new version the field splitted by '/' before urldecode.  
Fixes: [#43259](https://tracker.ceph.com/issues/43259)
