### PR TITLE
mgr/dashboard: Fix OSD IDs are not displayed when using cephadm backend

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/orchestrator.py
+++ b/src/pybind/mgr/dashboard/controllers/orchestrator.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import os.path
 
 import cherrypy
 from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupValidationError
@@ -83,7 +84,8 @@ class OrchestratorInventory(RESTController):
             node_osds = device_osd_map.get(inventory_node['name'])
             for device in inventory_node['devices']:
                 if node_osds:
-                    device['osd_ids'] = sorted(node_osds.get(device['path'], []))
+                    dev_name = os.path.basename(device['path'])
+                    device['osd_ids'] = sorted(node_osds.get(dev_name, []))
                 else:
                     device['osd_ids'] = []
         return inventory_nodes

--- a/src/pybind/mgr/dashboard/tests/test_orchestrator.py
+++ b/src/pybind/mgr/dashboard/tests/test_orchestrator.py
@@ -73,14 +73,14 @@ class OrchestratorControllerTest(ControllerTestCase):
                 'name': 'host-0',
                 'devices': [
                     {'path': 'nvme0n1'},
-                    {'path': 'sdb'},
-                    {'path': 'sdc'},
+                    {'path': '/dev/sdb'},
+                    {'path': '/dev/sdc'},
                 ]
             },
             {
                 'name': 'host-1',
                 'devices': [
-                    {'path': 'sda'},
+                    {'path': '/dev/sda'},
                     {'path': 'sdb'},
                 ]
             }


### PR DESCRIPTION
The basename of device path should be used for OSD mapping comparison.
e.g. `/dev/sda` -> `sda`.

Fixes: https://tracker.ceph.com/issues/43136
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
