### PR TITLE
nautilus: rpm: add rpm-build to SUSE-specific make check deps

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -296,6 +296,7 @@ BuildRequires:	python%{_python_buildid}-PyJWT
 BuildRequires:	python%{_python_buildid}-Routes
 BuildRequires:	python%{_python_buildid}-Werkzeug
 BuildRequires:	python%{_python_buildid}-numpy-devel
+BuildRequires:	rpm-build
 BuildRequires:  xmlsec1-devel
 %endif
 %endif

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -376,6 +376,10 @@ else
         echo "Using zypper to install dependencies"
         zypp_install="zypper --gpg-auto-import-keys --non-interactive install --no-recommends"
         $SUDO $zypp_install systemd-rpm-macros rpm-build || exit 1
+        if [ -e /usr/bin/python2 ] ; then
+            # see https://tracker.ceph.com/issues/23981
+            $SUDO $zypp_install python2-virtualenv python2-devel || exit 1
+        fi
         munge_ceph_spec_in $for_make_check $DIR/ceph.spec
         $SUDO $zypp_install $(rpmspec -q --buildrequires $DIR/ceph.spec) || exit 1
         $SUDO $zypp_install libxmlsec1-1 libxmlsec1-nss1 libxmlsec1-openssl1 xmlsec1-devel xmlsec1-openssl-devel

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -375,7 +375,7 @@ else
     opensuse*|suse|sles)
         echo "Using zypper to install dependencies"
         zypp_install="zypper --gpg-auto-import-keys --non-interactive install --no-recommends"
-        $SUDO $zypp_install systemd-rpm-macros
+        $SUDO $zypp_install systemd-rpm-macros rpm-build || exit 1
         munge_ceph_spec_in $for_make_check $DIR/ceph.spec
         $SUDO $zypp_install $(rpmspec -q --buildrequires $DIR/ceph.spec) || exit 1
         $SUDO $zypp_install libxmlsec1-1 libxmlsec1-nss1 libxmlsec1-openssl1 xmlsec1-devel xmlsec1-openssl-devel


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/43280
* https://tracker.ceph.com/issues/43288

---

backport of

* https://github.com/ceph/ceph/pull/32083
* https://github.com/ceph/ceph/pull/32153

parent trackers:

* https://tracker.ceph.com/issues/23981
* https://tracker.ceph.com/issues/42612

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh