### PR TITLE
mgr/cephadm: Add unittest for service_action

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -808,6 +808,8 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
             return trivial_result(["Reload is a no-op"])
 
         def _proc_daemons(daemons):
+            if service_name is None and service_id is None:
+                raise ValueError('service_name or service_id required')
             args = []
             for d in daemons:
                 args.append((d.service_type, d.service_instance,
@@ -858,7 +860,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
                 error_ok=True)
             self.service_cache.invalidate(host)
             self.log.debug('_service_action code %s out %s' % (code, out))
-        return trivial_result("{} {} from host '{}'".format(action, name, host))
+        return "{} {} from host '{}'".format(action, name, host)
 
     def get_inventory(self, node_filter=None, refresh=False):
         """


### PR DESCRIPTION
(That was missing previously)

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
