### PR TITLE
mgr/dashboard: "Promote" CRUSH options in pool form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -127,66 +127,6 @@
             </div>
           </div>
 
-          <!-- Crush ruleset selection -->
-          <div class="form-group row"
-               *ngIf="form.getValue('poolType') && current.rules.length > 0">
-            <label class="col-form-label col-sm-3"
-                   for="crushRule"
-                   i18n>Crush ruleset</label>
-            <div class="col-sm-9">
-              <div class="input-group">
-                <select class="form-control custom-select"
-                        id="crushRule"
-                        formControlName="crushRule"
-                        name="crushSet">
-                  <option [ngValue]="null"
-                          i18n>-- Select a crush rule --</option>
-                  <option *ngFor="let rule of current.rules"
-                          [ngValue]="rule">
-                    {{ rule.rule_name }}
-                  </option>
-                </select>
-                <span class="input-group-append">
-                  <button class="btn btn-light"
-                          [ngClass]="{'active': data.crushInfo}"
-                          id="crush-info-button"
-                          type="button"
-                          (click)="data.crushInfo = !data.crushInfo">
-                    <i [ngClass]="[icons.questionCircle]"
-                       aria-hidden="true"></i>
-                  </button>
-                </span>
-              </div>
-              <span class="form-text text-muted"
-                    id="crush-info-block"
-                    *ngIf="data.crushInfo && form.getValue('crushRule')">
-                <tabset>
-                  <tab i18n-heading
-                       heading="Crush rule"
-                       class="crush-rule-info">
-                    <cd-table-key-value [renderObjects]="true"
-                                        [data]="form.getValue('crushRule')"
-                                        [autoReload]="false">
-                    </cd-table-key-value>
-                  </tab>
-                  <tab i18n-heading
-                       heading="Crush steps"
-                       class="crush-rule-steps">
-                    <ol>
-                      <li *ngFor="let step of form.get('crushRule').value.steps">
-                        {{ describeCrushStep(step) }}
-                      </li>
-                    </ol>
-                  </tab>
-                </tabset>
-              </span>
-              <span class="invalid-feedback"
-                    *ngIf="form.showError('crushRule', formDir, 'tooFewOsds')"
-                    i18n>The rule can't be used in the current cluster as it has
-                to few OSDs to meet the minimum required OSD by this rule.</span>
-            </div>
-          </div>
-
           <!-- Replica Size -->
           <div class="form-group row"
                *ngIf="form.getValue('poolType') === 'replicated'">
@@ -216,6 +156,48 @@
                 {{ getMinSize() }} to {{ getMaxSize() }} is valid.</span>
             </div>
           </div>
+
+          <!-- Flags -->
+          <div class="form-group row"
+               *ngIf="info.is_all_bluestore && form.getValue('poolType') === 'erasure'">
+            <label i18n
+                   class="col-form-label col-sm-3">Flags</label>
+            <div class="col-sm-9">
+              <div class="custom-control custom-checkbox">
+                <input type="checkbox"
+                       class="custom-control-input"
+                       id="ec-overwrites"
+                       formControlName="ecOverwrites">
+                <label class="custom-control-label"
+                       for="ec-overwrites"
+                       i18n>EC Overwrites</label>
+              </div>
+            </div>
+          </div>
+
+        </div>
+        <!-- Applications -->
+        <div class="form-group row">
+          <label i18n
+                 class="col-sm-3 col-form-label"
+                 for="applications">Applications</label>
+          <div class="col-sm-9">
+            <cd-select-badges id="applications"
+                              [customBadges]="true"
+                              [customBadgeValidators]="data.applications.validators"
+                              [messages]="data.applications.messages"
+                              [data]="data.applications.selected"
+                              [options]="data.applications.available"
+                              [selectionLimit]="4"
+                              (selection)="appSelection()">
+            </cd-select-badges>
+          </div>
+        </div>
+
+        <!-- CRUSH -->
+        <div *ngIf="form.getValue('poolType')">
+
+          <legend i18n>CRUSH</legend>
 
           <!-- Erasure Profile select -->
           <div class="form-group row"
@@ -279,41 +261,74 @@
             </div>
           </div>
 
-          <!-- Flags -->
-          <div class="form-group row"
-               *ngIf="info.is_all_bluestore && form.getValue('poolType') === 'erasure'">
-            <label i18n
-                   class="col-form-label col-sm-3">Flags</label>
+          <!-- Crush ruleset selection -->
+          <div class="form-group row">
+            <label class="col-form-label col-sm-3"
+                   for="crushRule"
+                   i18n>Crush ruleset</label>
             <div class="col-sm-9">
-              <div class="custom-control custom-checkbox">
-                <input type="checkbox"
-                       class="custom-control-input"
-                       id="ec-overwrites"
-                       formControlName="ecOverwrites">
-                <label class="custom-control-label"
-                       for="ec-overwrites"
-                       i18n>EC Overwrites</label>
+              <ng-template #noRules>
+                <span class="form-text text-muted">
+                  <span i18n>There are no rules.</span>&nbsp;
+                  <span *ngIf="form.getValue('poolType') === 'erasure'"
+                        i18n>A new crush ruleset will be implicitly created.</span>
+                </span>
+              </ng-template>
+              <div *ngIf="current.rules.length > 0; else noRules">
+                <div class="input-group">
+                  <select class="form-control custom-select"
+                          id="crushRule"
+                          formControlName="crushRule"
+                          name="crushSet">
+                    <option [ngValue]="null"
+                            i18n>-- Select a crush rule --</option>
+                    <option *ngFor="let rule of current.rules"
+                            [ngValue]="rule">
+                      {{ rule.rule_name }}
+                    </option>
+                  </select>
+                  <span class="input-group-append">
+                    <button class="btn btn-light"
+                            [ngClass]="{'active': data.crushInfo}"
+                            id="crush-info-button"
+                            type="button"
+                            (click)="data.crushInfo = !data.crushInfo">
+                      <i [ngClass]="[icons.questionCircle]"
+                         aria-hidden="true"></i>
+                    </button>
+                  </span>
+                </div>
+                <span class="form-text text-muted"
+                      id="crush-info-block"
+                      *ngIf="data.crushInfo && form.getValue('crushRule')">
+                  <tabset>
+                    <tab i18n-heading
+                         heading="Crush rule"
+                         class="crush-rule-info">
+                      <cd-table-key-value [renderObjects]="true"
+                                          [data]="form.getValue('crushRule')"
+                                          [autoReload]="false">
+                      </cd-table-key-value>
+                    </tab>
+                    <tab i18n-heading
+                         heading="Crush steps"
+                         class="crush-rule-steps">
+                      <ol>
+                        <li *ngFor="let step of form.get('crushRule').value.steps">
+                          {{ describeCrushStep(step) }}
+                        </li>
+                      </ol>
+                    </tab>
+                  </tabset>
+                </span>
+                <span class="invalid-feedback"
+                      *ngIf="form.showError('crushRule', formDir, 'tooFewOsds')"
+                      i18n>The rule can't be used in the current cluster as it has
+                  too few OSDs to meet the minimum required OSD by this rule.</span>
               </div>
             </div>
           </div>
 
-        </div>
-        <!-- Applications -->
-        <div class="form-group row">
-          <label i18n
-                 class="col-sm-3 col-form-label"
-                 for="applications">Applications</label>
-          <div class="col-sm-9">
-            <cd-select-badges id="applications"
-                              [customBadges]="true"
-                              [customBadgeValidators]="data.applications.validators"
-                              [messages]="data.applications.messages"
-                              [data]="data.applications.selected"
-                              [options]="data.applications.available"
-                              [selectionLimit]="4"
-                              (selection)="appSelection()">
-            </cd-select-badges>
-          </div>
         </div>
 
         <!-- Compression -->

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -255,6 +255,7 @@ export class PoolFormComponent implements OnInit {
     this.data.pgs = this.form.getValue('pgNum');
     this.setAvailableApps(this.data.applications.default.concat(pool.application_metadata));
     this.data.applications.selected = pool.application_metadata;
+    this.rulesChange();
   }
 
   private setAvailableApps(apps: string[] = this.data.applications.default) {


### PR DESCRIPTION
CRUSH fields were moved to a dedicated "CRUSH" section.

Also, instead of hiding the "Crush ruleset" field when there are no rules, we are now showing a message that informs the user that a new "Crush ruleset" will be implicitly created.

![Screenshot from 2019-12-12 11-49-44](https://user-images.githubusercontent.com/14297426/70709857-d24b8d80-1cd5-11ea-8750-07760411f630.png)


Fixes: https://tracker.ceph.com/issues/43261

Signed-off-by: Ricardo Marques <rimarques@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
