### PR TITLE
rpm/cephadm: move HOMEDIR to /var/lib and make scriptlets idempotent on SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -405,11 +405,11 @@ Recommends:    chrony
 Base is the package that includes all the files shared amongst ceph servers
 
 %package -n cephadm
-Summary:        cephadm utility to bootstrap Ceph clusters
+Summary:        Utility to bootstrap Ceph clusters
 Requires:       podman
 %description -n cephadm
-cephadm utility to bootstrap a Ceph cluster and manage ceph daemons
-deployed with systemd and podman.
+Utility to bootstrap a Ceph cluster and manage Ceph daemons deployed 
+with systemd and podman.
 
 %package -n ceph-common
 Summary:	Ceph Common

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1354,6 +1354,12 @@ install -m 0644 -D COPYING %{buildroot}%{_docdir}/ceph/COPYING
 install -m 0644 -D etc/sysctl/90-ceph-osd.conf %{buildroot}%{_sysctldir}/90-ceph-osd.conf
 
 install -m 0755 src/cephadm/cephadm %{buildroot}%{_sbindir}/cephadm
+mkdir -p %{buildroot}%{_sharedstatedir}/cephadm
+chmod 0700 %{buildroot}%{_sharedstatedir}/cephadm
+mkdir -p %{buildroot}%{_sharedstatedir}/cephadm/.ssh
+chmod 0700 %{buildroot}%{_sharedstatedir}/cephadm/.ssh
+touch %{buildroot}%{_sharedstatedir}/cephadm/.ssh/authorized_keys
+chmod 0600 %{buildroot}%{_sharedstatedir}/cephadm/.ssh/authorized_keys
 
 # firewall templates and /sbin/mount.ceph symlink
 %if 0%{?suse_version}
@@ -1515,30 +1521,22 @@ if [ $1 -ge 1 ] ; then
 fi
 
 %pre -n cephadm
-# create user
-if ! getent passwd | grep -q '^cephadm:'; then
-   useradd -r -s /bin/bash -c "cephadm user for mgr/cephadm" -m cephadm
-fi
-# set up (initially empty) .ssh/authorized_keys file
-if ! test -d /home/cephadm/.ssh; then
-   mkdir /home/cephadm/.ssh
-   chown --reference /home/cephadm /home/cephadm/.ssh
-   chmod 0700 /home/cephadm/.ssh
-fi
-if ! test -e /home/cephadm/.ssh/authorized_keys; then
-   touch /home/cephadm/.ssh/authorized_keys
-   chown --reference /home/cephadm /home/cephadm/.ssh/authorized_keys
-   chmod 0600 /home/cephadm/.ssh/authorized_keys
-fi
+getent group cephadm >/dev/null || groupadd -r cephadm
+getent passwd cephadm >/dev/null || useradd -r -g cephadm -s /bin/bash -c "cephadm user for mgr/cephadm" -d %{_sharedstatedir}/cephadm cephadm
 exit 0
 
+%if ! 0%{?suse_version}
 %postun -n cephadm
 userdel -r cephadm || true
 exit 0
+%endif
 
 %files -n cephadm
 %{_sbindir}/cephadm
 %{_sysconfdir}/sudoers.d/cephadm
+%attr(0700,cephadm,cephadm) %dir %{_sharedstatedir}/cephadm
+%attr(0700,cephadm,cephadm) %dir %{_sharedstatedir}/cephadm/.ssh
+%attr(0600,cephadm,cephadm) %{_sharedstatedir}/cephadm/.ssh/authorized_keys
 
 %files common
 %dir %{_docdir}/ceph


### PR DESCRIPTION
Also introduce a cephadm group. Since the cephadm package does not
require ceph-common, the ceph group is not available to be used.

Drop the `-r` option to useradd, because cephadm does not qualify as a system
user.

Finally, fix the SUSE RPM build. SUSE RPM builds using "osc" implement a check
that compares the cephadm package's "before" and "after" file lists, to enforce
idempotency of the scriptlets. The "userdel cephadm" in the `%postun` breaks this
check, so omit it from the SUSE RPM builds.

Fixes: https://tracker.ceph.com/issues/43285
Signed-off-by: Nathan Cutler <ncutler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
