### PR TITLE
mgr/dashboard: Fix e2e chromedriver problem

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/protractor.conf.js
+++ b/src/pybind/mgr/dashboard/frontend/protractor.conf.js
@@ -21,7 +21,8 @@ const config = {
     browserName: 'chrome',
     chromeOptions: {
       args: ['--no-sandbox', '--headless', '--window-size=1920x1080']
-    }
+    },
+    acceptInsecureCerts : true
   },
   directConnect: true,
   baseUrl: process.env.BASE_URL || 'http://localhost:4200/',


### PR DESCRIPTION
New version of Chrome/ChromeDriver seems to have a problem with insecure
certificates.

Since we use a vStart cluster with no real certificate,
we always face this problem when running e2e tests.

This will fix the current problem and hopefully any future problems related to
certificates.

Fixes: https://tracker.ceph.com/issues/43254

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
