### PR TITLE
nautilus: update s3-test download code for s3-test tasks

### DIFF
--- a/qa/suites/rados/basic/tasks/rgw_snaps.yaml
+++ b/qa/suites/rados/basic/tasks/rgw_snaps.yaml
@@ -28,6 +28,7 @@ tasks:
     - default.rgw.log
 - s3readwrite:
     client.0:
+      force-branch: ceph-nautilus
       rgw_server: client.0
       readwrite:
         bucket: rwtest

--- a/qa/suites/rgw/multifs/tasks/rgw_readwrite.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_readwrite.yaml
@@ -4,6 +4,7 @@ tasks:
 - rgw: [client.0]
 - s3readwrite:
     client.0:
+      force-branch: ceph-nautilus
       rgw_server: client.0
       readwrite:
         bucket: rwtest

--- a/qa/suites/rgw/multifs/tasks/rgw_roundtrip.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_roundtrip.yaml
@@ -4,6 +4,7 @@ tasks:
 - rgw: [client.0]
 - s3roundtrip:
     client.0:
+      force-branch: ceph-nautilus
       rgw_server: client.0
       roundtrip:
         bucket: rttest

--- a/qa/suites/rgw/thrash/workload/rgw_readwrite.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_readwrite.yaml
@@ -1,6 +1,7 @@
 tasks:
 - s3readwrite:
     client.0:
+      force-branch: ceph-nautilus
       rgw_server: client.0
       readwrite:
         bucket: rwtest

--- a/qa/suites/rgw/thrash/workload/rgw_roundtrip.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_roundtrip.yaml
@@ -1,6 +1,7 @@
 tasks:
 - s3roundtrip:
     client.0:
+      force-branch: ceph-nautilus
       rgw_server: client.0
       roundtrip:
         bucket: rttest

--- a/qa/suites/smoke/basic/tasks/rgw_ec_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/rgw_ec_s3tests.yaml
@@ -9,6 +9,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
+      force-branch: ceph-nautilus
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/smoke/basic/tasks/rgw_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/rgw_s3tests.yaml
@@ -5,6 +5,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
+      force-branch: ceph-nautilus
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/teuthology/rgw/tasks/s3tests-civetweb.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests-civetweb.yaml
@@ -11,7 +11,7 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-      force-branch: master
+      force-branch: ceph-nautilus
 overrides:
   ceph:
     fs: xfs

--- a/qa/suites/teuthology/rgw/tasks/s3tests-fastcgi.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests-fastcgi.yaml
@@ -11,7 +11,7 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-      force-branch: master
+      force-branch: ceph-nautilus
 overrides:
   ceph:
     fs: xfs

--- a/qa/suites/teuthology/rgw/tasks/s3tests-fcgi.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests-fcgi.yaml
@@ -12,7 +12,7 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-      force-branch: master
+      force-branch: ceph-nautilus
 overrides:
   ceph:
     fs: xfs

--- a/qa/tasks/s3readwrite.py
+++ b/qa/tasks/s3readwrite.py
@@ -18,29 +18,32 @@ from teuthology.orchestra.connection import split_user
 
 log = logging.getLogger(__name__)
 
-
 @contextlib.contextmanager
 def download(ctx, config):
     """
     Download the s3 tests from the git builder.
     Remove downloaded s3 file upon exit.
-    
+
     The context passed in should be identical to the context
     passed in to the main task.
     """
     assert isinstance(config, dict)
     log.info('Downloading s3-tests...')
     testdir = teuthology.get_testdir(ctx)
-    for (client, cconf) in config.items():
-        branch = cconf.get('force-branch', None)
-        if not branch:
-            branch = cconf.get('branch', 'master')
-        sha1 = cconf.get('sha1')
+    for (client, client_config) in config.items():
+        s3tests_branch = client_config.get('force-branch', None)
+        if not s3tests_branch:
+            raise ValueError(
+                "Could not determine what branch to use for s3-tests. Please add 'force-branch: {s3-tests branch name}' to the .yaml config for this s3readwrite task.")
+
+        log.info("Using branch '%s' for s3tests", s3tests_branch)
+        sha1 = client_config.get('sha1')
+        git_remote = client_config.get('git_remote', teuth_config.ceph_git_base_url)
         ctx.cluster.only(client).run(
             args=[
                 'git', 'clone',
-                '-b', branch,
-                teuth_config.ceph_git_base_url + 's3-tests.git',
+                '-b', s3tests_branch,
+                git_remote + 's3-tests.git',
                 '{tdir}/s3-tests'.format(tdir=testdir),
                 ],
             )
@@ -242,6 +245,7 @@ def task(ctx, config):
         - ceph:
         - rgw:
         - s3readwrite:
+            force-branch: ceph-nautilus
 
     To restrict testing to particular clients::
 
@@ -257,6 +261,7 @@ def task(ctx, config):
         - rgw: [client.1]
         - s3readwrite:
             client.0:
+              force-branch: ceph-nautilus
               rgw_server: client.1
 
     To pass extra test arguments
@@ -266,6 +271,7 @@ def task(ctx, config):
         - rgw: [client.0]
         - s3readwrite:
             client.0:
+              force-branch: ceph-nautilus
               readwrite:
                 bucket: mybucket
                 readers: 10
@@ -285,6 +291,7 @@ def task(ctx, config):
         - rgw: [client.0]
         - s3readwrite:
             client.0:
+              force-branch: ceph-nautilus
               s3:
                 user_id: myuserid
                 display_name: myname

--- a/qa/tasks/s3roundtrip.py
+++ b/qa/tasks/s3roundtrip.py
@@ -18,35 +18,48 @@ from teuthology.orchestra.connection import split_user
 
 log = logging.getLogger(__name__)
 
-
 @contextlib.contextmanager
 def download(ctx, config):
     """
     Download the s3 tests from the git builder.
     Remove downloaded s3 file upon exit.
-    
+
     The context passed in should be identical to the context
     passed in to the main task.
     """
     assert isinstance(config, dict)
     log.info('Downloading s3-tests...')
     testdir = teuthology.get_testdir(ctx)
-    for (client, cconf) in config.iteritems():
-        branch = cconf.get('force-branch', None)
-        if not branch:
-            branch = cconf.get('branch', 'master')
+    for (client, client_config) in config.items():
+        s3tests_branch = client_config.get('force-branch', None)
+        if not s3tests_branch:
+            raise ValueError(
+                "Could not determine what branch to use for s3-tests. Please add 'force-branch: {s3-tests branch name}' to the .yaml config for this s3roundtrip task.")
+
+        log.info("Using branch '%s' for s3tests", s3tests_branch)
+        sha1 = client_config.get('sha1')
+        git_remote = client_config.get('git_remote', teuth_config.ceph_git_base_url)
         ctx.cluster.only(client).run(
             args=[
                 'git', 'clone',
-                '-b', branch,
-                teuth_config.ceph_git_base_url + 's3-tests.git',
+                '-b', s3tests_branch,
+                git_remote + 's3-tests.git',
                 '{tdir}/s3-tests'.format(tdir=testdir),
                 ],
             )
+        if sha1 is not None:
+            ctx.cluster.only(client).run(
+                args=[
+                    'cd', '{tdir}/s3-tests'.format(tdir=testdir),
+                    run.Raw('&&'),
+                    'git', 'reset', '--hard', sha1,
+                    ],
+                )
     try:
         yield
     finally:
         log.info('Removing s3-tests...')
+        testdir = teuthology.get_testdir(ctx)
         for client in config:
             ctx.cluster.only(client).run(
                 args=[
@@ -55,6 +68,7 @@ def download(ctx, config):
                     '{tdir}/s3-tests'.format(tdir=testdir),
                     ],
                 )
+
 
 def _config_user(s3tests_conf, section, user):
     """
@@ -211,13 +225,16 @@ def task(ctx, config):
         - ceph:
         - rgw:
         - s3roundtrip:
+            force-branch: ceph-nautilus
 
     To restrict testing to particular clients::
 
         tasks:
         - ceph:
         - rgw: [client.0]
-        - s3roundtrip: [client.0]
+        - s3roundtrip:
+            client.0:
+              force-branch: ceph-nautilus
 
     To run against a server on client.1::
 
@@ -226,6 +243,7 @@ def task(ctx, config):
         - rgw: [client.1]
         - s3roundtrip:
             client.0:
+              force-branch: ceph-nautilus
               rgw_server: client.1
 
     To pass extra test arguments
@@ -235,6 +253,7 @@ def task(ctx, config):
         - rgw: [client.0]
         - s3roundtrip:
             client.0:
+              force-branch: ceph-nautilus
               roundtrip:
                 bucket: mybucket
                 readers: 10
@@ -253,6 +272,7 @@ def task(ctx, config):
         - ceph:
         - rgw: [client.0]
         - s3roundtrip:
+            force-branch: ceph-nautilus
             client.0:
               s3:
                 user_id: myuserid


### PR DESCRIPTION
- Ensure the download code for all tasks running
s3-tests is consistent.
- Simplify download code to only use the config
variable 'force-branch' for the branch being
cloned.
- Make ceph-luminous the force-branch for all
suites using s3-tests.
- Add force-branch to suites running s3readwrite
& s3roundtrip tasks

Signed-off-by: Ali Maredia <amaredia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
