### PR TITLE
ceph.spec.in: add runtime deps for mgr-diskprediction-cloud

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -566,6 +566,13 @@ BuildArch:      noarch
 Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
+%if 0%{without python2}
+Requires:       python3-grpcio
+Requires:       python3-protobuf
+%else
+Requires:       python2-grpcio
+Requires:       python2-protobuf
+%endif
 %description mgr-diskprediction-cloud
 ceph-mgr-diskprediction-cloud is a ceph-mgr plugin that tries to predict
 disk failures using services in the Google cloud.

--- a/qa/packages/packages.yaml
+++ b/qa/packages/packages.yaml
@@ -38,7 +38,6 @@ ceph:
   - cephadm
   - ceph-mgr
   - ceph-mgr-dashboard
-  - ceph-mgr-diskprediction-cloud
   - ceph-mgr-diskprediction-local
   - ceph-mgr-rook
   - ceph-mgr-cephadm

--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/0-mimic.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/0-mimic.yaml
@@ -8,7 +8,6 @@ tasks:
       - librados3
       - ceph-mgr-dashboard
       - ceph-mgr-diskprediction-local
-      - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/0-mimic.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/0-mimic.yaml
@@ -8,7 +8,6 @@ tasks:
       - librados3
       - ceph-mgr-dashboard
       - ceph-mgr-diskprediction-local
-      - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm

--- a/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
@@ -18,7 +18,6 @@ tasks:
       - librados3
       - ceph-mgr-dashboard
       - ceph-mgr-diskprediction-local
-      - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
@@ -15,7 +15,6 @@ tasks:
       - librados3
       - ceph-mgr-dashboard
       - ceph-mgr-diskprediction-local
-      - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
@@ -14,7 +14,6 @@ tasks:
       - librados3
       - ceph-mgr-dashboard
       - ceph-mgr-diskprediction-local
-      - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
@@ -15,7 +15,6 @@ tasks:
       - librados3
       - ceph-mgr-dashboard
       - ceph-mgr-diskprediction-local
-      - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
@@ -14,7 +14,6 @@ tasks:
       - librados3
       - ceph-mgr-dashboard
       - ceph-mgr-diskprediction-local
-      - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
@@ -15,7 +15,6 @@ tasks:
       - librados3
       - ceph-mgr-dashboard
       - ceph-mgr-diskprediction-local
-      - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
@@ -15,7 +15,6 @@ tasks:
       - librados3
       - ceph-mgr-dashboard
       - ceph-mgr-diskprediction-local
-      - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm

--- a/qa/suites/upgrade/mimic-x-singleton/1-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x-singleton/1-install/mimic.yaml
@@ -13,7 +13,6 @@ tasks:
       - librados3
       - ceph-mgr-dashboard
       - ceph-mgr-diskprediction-local
-      - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm

--- a/qa/suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
@@ -10,7 +10,6 @@ tasks:
       - librados3
       - ceph-mgr-dashboard
       - ceph-mgr-diskprediction-local
-      - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm

--- a/qa/suites/upgrade/mimic-x/stress-split/1-ceph-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/1-ceph-install/mimic.yaml
@@ -7,7 +7,6 @@ tasks:
       - librados3
       - ceph-mgr-dashboard
       - ceph-mgr-diskprediction-local
-      - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm

--- a/qa/suites/upgrade/nautilus-x-singleton/1-install/nautilus.yaml
+++ b/qa/suites/upgrade/nautilus-x-singleton/1-install/nautilus.yaml
@@ -13,7 +13,6 @@ tasks:
       - librados3
       - ceph-mgr-dashboard
       - ceph-mgr-diskprediction-local
-      - ceph-mgr-diskprediction-cloud
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm


### PR DESCRIPTION
please note, these dependencies are not available in el7/el8, and
python2-{grpcio,protobuf} do not exist in fedora core. also, the
`google.api` module is still missing even with these dependencies
installed. so consider it as a partial fix.

See-also: https://tracker.ceph.com/issues/42655
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
