### PR TITLE
nautilus: mgr/dashboard: KeyError on dashboard reload

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/summary.py
+++ b/src/pybind/mgr/dashboard/controllers/summary.py
@@ -63,9 +63,9 @@ class Summary(BaseController):
         return result
 
     def _get_host(self):
-        mgr_map = mgr.get('mgr_map')
-        services = mgr_map['services']
-        return services['dashboard']
+        # type: () -> str
+        services = mgr.get('mgr_map')['services']
+        return services['dashboard'] if 'dashboard' in services else ''
 
     @Endpoint()
     def __call__(self):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43159

---

backport of https://github.com/ceph/ceph/pull/31469
parent tracker: https://tracker.ceph.com/issues/42684

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh