### PR TITLE
mgr/dashboard: Throw a more meaningful exception

### DIFF
--- a/qa/tasks/mgr/dashboard/test_host.py
+++ b/qa/tasks/mgr/dashboard/test_host.py
@@ -85,3 +85,17 @@ class HostControllerTest(DashboardTestCase):
             'devid': str,
             'location': JList(JObj({'host': str, 'dev': str}))
         })))
+
+
+class HostControllerNoOrchestratorTest(DashboardTestCase):
+    def test_host_create(self):
+        self._post('/api/host?hostname=foo')
+        self.assertStatus(503)
+        self.assertError(code='orchestrator_status_unavailable',
+                         component='orchestrator')
+
+    def test_host_delete(self):
+        self._delete('/api/host/bar')
+        self.assertStatus(503)
+        self.assertError(code='orchestrator_status_unavailable',
+                         component='orchestrator')

--- a/src/pybind/mgr/dashboard/controllers/orchestrator.py
+++ b/src/pybind/mgr/dashboard/controllers/orchestrator.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import
 
 import time
 
-import cherrypy
-
 try:
     from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupValidationError
 except ImportError:
@@ -63,7 +61,10 @@ def raise_if_no_orchestrator(method):
     def inner(self, *args, **kwargs):
         orch = OrchClient.instance()
         if not orch.available():
-            raise cherrypy.HTTPError(503)
+            raise DashboardException(code='orchestrator_status_unavailable',
+                                     msg='Orchestrator is unavailable',
+                                     component='orchestrator',
+                                     http_status_code=503)
         return method(self, *args, **kwargs)
     return inner
 


### PR DESCRIPTION
When the orchestrator is not available, a HTTP 503 error was thrown. This results in a non meaningful error message in the UI. Because of that this PR will throw a 503 with a description that will help the user to understand the problem.

After:
![Bildschirmfoto vom 2019-12-13 11-15-22](https://user-images.githubusercontent.com/1897962/70793149-ff15a880-1d9a-11ea-9072-fc91341b6233.png)

Before:
![Bildschirmfoto vom 2019-12-13 11-08-04](https://user-images.githubusercontent.com/1897962/70793159-03da5c80-1d9b-11ea-87b9-9ae0e2b07d89.png)

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
