### PR TITLE
nautilus: rgw: fix bugs in listobjectsv1

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -742,18 +742,11 @@ return 0;
 
 void RGWListBucket_ObjStore_S3::send_common_versioned_response()
 {
-  
   if (!s->bucket_tenant.empty()) {
     s->formatter->dump_string("Tenant", s->bucket_tenant);
   }
   s->formatter->dump_string("Name", s->bucket_name);
   s->formatter->dump_string("Prefix", prefix);
-  s->formatter->dump_string("KeyMarker", marker.name);
-  s->formatter->dump_string("VersionIdMarker", marker.instance);
-  if (is_truncated && !next_marker.empty()) {
-    s->formatter->dump_string("NextKeyMarker", next_marker.name);
-    s->formatter->dump_string("NextVersionIdMarker", next_marker.instance);
-  }
   s->formatter->dump_int("MaxKeys", max);
   if (!delimiter.empty()) {
     s->formatter->dump_string("Delimiter", delimiter);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43300

---

backport of https://github.com/ceph/ceph/pull/28873
parent tracker: https://tracker.ceph.com/issues/40663

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh