### PR TITLE
nautilus: mgr/dashboard: fix RGW subuser auto-generate key.

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
@@ -57,17 +57,34 @@ describe('RgwUserFormComponent', () => {
       expect(rgwUserService.addS3Key).not.toHaveBeenCalled();
     });
 
-    it('should set key', () => {
+    it('should set user defined key', () => {
       const key = new RgwUserS3Key();
       key.user = 'test1:subuser2';
+      key.access_key = 'my-access-key';
+      key.secret_key = 'my-secret-key';
       component.setS3Key(key);
       expect(component.s3Keys.length).toBe(1);
       expect(component.s3Keys[0].user).toBe('test1:subuser2');
       expect(rgwUserService.addS3Key).toHaveBeenCalledWith('test1', {
         subuser: 'subuser2',
         generate_key: 'false',
-        access_key: undefined,
-        secret_key: undefined
+        access_key: 'my-access-key',
+        secret_key: 'my-secret-key'
+      });
+    });
+
+    it('should set params for auto-generating key', () => {
+      const key = new RgwUserS3Key();
+      key.user = 'test1:subuser2';
+      key.generate_key = true;
+      key.access_key = 'my-access-key';
+      key.secret_key = 'my-secret-key';
+      component.setS3Key(key);
+      expect(component.s3Keys.length).toBe(1);
+      expect(component.s3Keys[0].user).toBe('test1:subuser2');
+      expect(rgwUserService.addS3Key).toHaveBeenCalledWith('test1', {
+        subuser: 'subuser2',
+        generate_key: 'true'
       });
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
@@ -390,10 +390,16 @@ export class RgwUserFormComponent implements OnInit {
       const uid = userMatches[1];
       const args = {
         subuser: userMatches[2] ? userMatches[3] : '',
-        generate_key: key.generate_key ? 'true' : 'false',
-        access_key: key.access_key,
-        secret_key: key.secret_key
+        generate_key: key.generate_key ? 'true' : 'false'
       };
+      if (args['generate_key'] === 'false') {
+        if (!_.isNil(key.access_key)) {
+          args['access_key'] = key.access_key;
+        }
+        if (!_.isNil(key.secret_key)) {
+          args['secret_key'] = key.secret_key;
+        }
+      }
       this.submitObservables.push(this.rgwUserService.addS3Key(uid, args));
       // If the access and the secret key are auto-generated, then visualize
       // this to the user by displaying a notification instead of the key.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43301

---

backport of https://github.com/ceph/ceph/pull/32186
parent tracker: https://tracker.ceph.com/issues/43263

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh