### PR TITLE
nautilus: mgr/dashboard: Fix e2e chromedriver problem

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/protractor.conf.js
+++ b/src/pybind/mgr/dashboard/frontend/protractor.conf.js
@@ -12,7 +12,8 @@ exports.config = {
     'browserName': 'chrome',
     chromeOptions: {
       args: ['--no-sandbox', '--headless', '--window-size=1920x1080']
-    }
+    },
+    acceptInsecureCerts : true
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43302

---

backport of https://github.com/ceph/ceph/pull/32224
parent tracker: https://tracker.ceph.com/issues/43254

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh