### PR TITLE
qa/workunits/cephadm/test_cephadm.sh: re-enable `adopt` tests

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -196,7 +196,6 @@ done
 # WRITE ME
 
 ## adopt
-if false; then
 for tarball in $TEST_TARS; do
     TMP_TAR_DIR=`mktemp -d -p $TMPDIR`
     $SUDO tar xzvf $tarball -C $TMP_TAR_DIR
@@ -216,7 +215,6 @@ for tarball in $TEST_TARS; do
     $CEPHADM rm-cluster --fsid $FSID_LEGACY --force
     $SUDO rm -rf $TMP_TAR_DIR
 done
-fi
 
 ## unit
 $CEPHADM unit --fsid $FSID --name mon.a -- is-enabled


### PR DESCRIPTION
New corpus now places the blockdev sparse files in the corpus tarball under `/dev` instead of `/var/lib/ceph`.

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
