### PR TITLE
mgr/cephadm: remove redundant /dev when blinking device light

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -906,7 +906,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
                 'local-disk-%s-led-%s' % (
                     ident_fault,
                     'on' if on else 'off'),
-                '--path', '/dev/' + dev,
+                '--path', dev,
             ]
             out, err, code = self._run_cephadm(
                 host, 'osd', 'shell', ['--'] + cmd,


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43223
Signed-off-by: Sage Weil <sage@redhat.com>