### PR TITLE
nautilus: doc/_templates/page.html: redirect to etherpad

### DIFF
--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -13,7 +13,7 @@
 
 {%- if edit_on_github_url %}
   <div id="docubetter" align="right" style="display:none; padding: 15px; font-weight: bold;">
-    <a id="edit-on-github" href="{{ edit_on_github_url }}" rel="nofollow">{{ _('Edit on GitHub')}}</a> | <a href="https://github.com/ceph/ceph/projects/4">Report a Documentation Bug</a>
+    <a id="edit-on-github" href="{{ edit_on_github_url }}" rel="nofollow">{{ _('Edit on GitHub')}}</a> | <a href="https://pad.ceph.com/p/Report_Documentation_Bugs">Report a Documentation Bug</a>
   </div>
 {%- endif %}
 


### PR DESCRIPTION
This simplifies things for users who are not able to add cards to
https://github.com/ceph/ceph/projects/4 due to insufficient permissions.

Signed-off-by: Neha Ojha <nojha@redhat.com>
(cherry picked from commit 066981dedbca161fba85d368d86c8ca15bfe0fac)
