### PR TITLE
mimic: doc: wrong datatype describing crush_rule

### DIFF
--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -351,7 +351,7 @@ You may set values for the following keys:
 ``crush_rule``
 
 :Description: The rule to use for mapping object placement in the cluster.
-:Type: Integer
+:Type: String
 
 .. _allow_ec_overwrites:
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43315

---

parent tracker: https://tracker.ceph.com/issues/41389

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh