### PR TITLE
mimic: selinux: Allow ceph to read udev db

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -90,6 +90,8 @@ logging_send_syslog_msg(ceph_t)
 
 sysnet_dns_name_resolve(ceph_t)
 
+udev_read_db(ceph_t)
+
 allow ceph_t nvme_device_t:blk_file { getattr ioctl open read write };
 
 # basis for future security review


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43244

---

backport of https://github.com/ceph/ceph/pull/29071
parent tracker: https://tracker.ceph.com/issues/43064

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh