### PR TITLE
mgr/orchestrator: Raise more expressive Error, if completion already …

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -318,6 +318,9 @@ class _Promise(object):
         Sets the whole completion to be faild with this exception and end the
         evaluation.
         """
+        if self._state == self.FINISHED:
+            raise ValueError(
+                'Invalid State: called fail, but Completion is already finished: {}'.format(str(e)))
         assert self._state in (self.INITIALIZED, self.RUNNING)
         logger.exception('_Promise failed')
         self._exception = e

--- a/src/pybind/mgr/tests/test_orchestrator.py
+++ b/src/pybind/mgr/tests/test_orchestrator.py
@@ -228,6 +228,11 @@ def test_fail():
     c._first_promise.fail(KeyError())
     assert isinstance(c.exception, KeyError)
 
+    with pytest.raises(ValueError,
+                  match='Invalid State: called fail, but Completion is already finished: {}'.format(
+                      str(ZeroDivisionError()))):
+        c._first_promise.fail(ZeroDivisionError())
+
 
 def test_pretty_print():
     mgr = mock.MagicMock()


### PR DESCRIPTION
…finished

Eases debugging of tracebacks. (See #32198 )

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
