### PR TITLE
mgr/restful: allow users to disable http authentication

### DIFF
--- a/src/pybind/mgr/restful/decorators.py
+++ b/src/pybind/mgr/restful/decorators.py
@@ -13,6 +13,9 @@ from . import context
 def auth(f):
     @wraps(f)
     def decorated(*args, **kwargs):
+        if not context.instance.enable_auth:
+            return f(*args, **kwargs)
+            
         if not request.authorization:
             response.status = 401
             response.headers['WWW-Authenticate'] = 'Basic realm="Login Required"'

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -198,6 +198,7 @@ class Module(MgrModule):
         {'name': 'server_addr'},
         {'name': 'server_port'},
         {'name': 'key_file'},
+        {'name': 'enable_auth', 'type': 'bool', 'default': True},
     ]
 
     COMMANDS = [
@@ -236,7 +237,7 @@ class Module(MgrModule):
         self.requests_lock = threading.RLock()
 
         self.keys = {}
-        self.disable_auth = False
+        self.enable_auth = True
 
         self.server = None
 
@@ -302,6 +303,8 @@ class Module(MgrModule):
         else:
             pkey_fname = self.get_localized_module_option('key_file')
 
+        self.enable_auth = self.get_localized_module_option('enable_auth', True)
+        
         if not cert_fname or not pkey_fname:
             raise CannotServe('no certificate configured')
         if not os.path.isfile(cert_fname):
@@ -384,6 +387,9 @@ class Module(MgrModule):
         except StopIteration:
             # the command was not issued by me
             pass
+
+    def config_notify(self):
+        self.enable_auth = self.get_localized_module_option('enable_auth', True)
 
 
     def create_self_signed_cert(self):


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

~added ceph restful disable-http-auth and ceph restful enable-http-auth commands to allow users to define whether to enable HTTP authentication.~

add the restful module parameter to allow users to disable http authentication with the following command:

```bash
$ ceph config set mgr mgr/restful/enable_auth false
```

## Checklist
- [x] References tracker ticket: https://tracker.ceph.com/issues/43323
- [x] Updates documentation if necessary: https://github.com/ceph/ceph/commit/63d24fd97bd794a994f259443827443438f7c058

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
