### PR TITLE
mgr/orchestrator_cli: Fix NFS

### DIFF
--- a/src/pybind/mgr/orchestrator_cli/__init__.py
+++ b/src/pybind/mgr/orchestrator_cli/__init__.py
@@ -1,10 +1,3 @@
 from __future__ import absolute_import
-import os
 
-if 'UNITTEST' not in os.environ:
-    from .module import OrchestratorCli
-else:
-    import sys
-    import mock
-    sys.path.append("..")
-    sys.modules['ceph_module'] = mock.Mock()
+from .module import OrchestratorCli

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -528,10 +528,18 @@ Usage:
         'orchestrator nfs add',
         "name=svc_arg,type=CephString "
         "name=pool,type=CephString "
-        "name=namespace,type=CephString,req=false",
+        "name=namespace,type=CephString,req=false "
+        'name=num,type=CephInt,req=false '
+        'name=hosts,type=CephString,n=N,req=false '
+        'name=label,type=CephString,req=false',
         'Create an NFS service')
-    def _nfs_add(self, svc_arg, pool, namespace=None):
-        spec = orchestrator.NFSServiceSpec(svc_arg, pool=pool, namespace=namespace)
+    def _nfs_add(self, svc_arg, pool, namespace=None, num=None, label=None, hosts=[]):
+        spec = orchestrator.NFSServiceSpec(
+            svc_arg,
+            pool=pool,
+            namespace=namespace,
+            placement=orchestrator.PlacementSpec(label=label, hosts=hosts, count=num),
+        )
         spec.validate_add()
         completion = self.add_nfs(spec)
         self._orchestrator_wait([completion])
@@ -541,10 +549,16 @@ Usage:
     @orchestrator._cli_write_command(
         'orchestrator nfs update',
         "name=svc_id,type=CephString "
-        "name=num,type=CephInt",
+        'name=num,type=CephInt,req=false '
+        'name=hosts,type=CephString,n=N,req=false '
+        'name=label,type=CephString,req=false',
         'Scale an NFS service')
-    def _nfs_update(self, svc_id, num):
-        spec = orchestrator.NFSServiceSpec(svc_id, count=num)
+    def _nfs_update(self, svc_id, num=None, label=None, hosts=[]):
+        # type: (str, Optional[int], Optional[str], List[str]) -> HandleCommandResult
+        spec = orchestrator.NFSServiceSpec(
+            svc_id,
+            placement=orchestrator.PlacementSpec(label=label, hosts=hosts, count=num),
+        )
         completion = self.update_nfs(spec)
         self._orchestrator_wait([completion])
         return HandleCommandResult(stdout=completion.result_str())

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -32,7 +32,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
             'runtime': True,
         },
     ]
-    NATIVE_OPTIONS = []
+    NATIVE_OPTIONS = []  # type: List[dict]
 
     def __init__(self, *args, **kwargs):
         super(OrchestratorCli, self).__init__(*args, **kwargs)
@@ -226,7 +226,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
         "name=refresh,type=CephBool,req=false",
         'List devices on a node')
     def _list_devices(self, host=None, format='plain', refresh=False):
-        # type: (List[str], str, bool) -> HandleCommandResult
+        # type: (Optional[List[str]], str, bool) -> HandleCommandResult
         """
         Provide information about storage devices present in cluster hosts
 
@@ -255,11 +255,11 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
             table._align['SIZE'] = 'r'
             table.left_padding_width = 0
             table.right_padding_width = 1
-            for host in completion.result: # type: orchestrator.InventoryNode
-                for d in host.devices.devices:  # type: Device
+            for host_ in completion.result: # type: orchestrator.InventoryNode
+                for d in host_.devices.devices:  # type: Device
                     table.add_row(
                         (
-                            host.name,
+                            host_.name,
                             d.path,
                             d.human_readable_type,
                             format_bytes(d.sys_api.get('size', 0), 5, colored=False),
@@ -330,7 +330,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
         "name=svc_arg,type=CephString,req=false",
         'Create an OSD service. Either --svc_arg=host:drives or -i <drive_group>')
     def _create_osd(self, svc_arg=None, inbuf=None):
-        # type: (str, str) -> HandleCommandResult
+        # type: (Optional[str], Optional[str]) -> HandleCommandResult
         """Create one or more OSDs"""
 
         usage = """
@@ -722,16 +722,16 @@ Usage:
         assert self._select_orchestrator() is None
         self._set_backend(old_orch)
 
-        e = self.remote('selftest', 'remote_from_orchestrator_cli_self_test', "ZeroDivisionError")
+        e1 = self.remote('selftest', 'remote_from_orchestrator_cli_self_test', "ZeroDivisionError")
         try:
-            orchestrator.raise_if_exception(e)
+            orchestrator.raise_if_exception(e1)
             assert False
         except ZeroDivisionError as e:
             assert e.args == ('hello', 'world')
 
-        e = self.remote('selftest', 'remote_from_orchestrator_cli_self_test', "OrchestratorError")
+        e2 = self.remote('selftest', 'remote_from_orchestrator_cli_self_test', "OrchestratorError")
         try:
-            orchestrator.raise_if_exception(e)
+            orchestrator.raise_if_exception(e2)
             assert False
         except orchestrator.OrchestratorError as e:
             assert e.args == ('hello', 'world')

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -12,4 +12,4 @@ basepython = python3
 deps =
     -r requirements.txt
     mypy
-commands = mypy --config-file=../../mypy.ini orchestrator.py cephadm/module.py rook/module.py ansible/module.py
+commands = mypy --config-file=../../mypy.ini orchestrator.py cephadm/module.py rook/module.py ansible/module.py orchestrator_cli/module.py


### PR DESCRIPTION
* pybind/mgr: Add orchestrator_cli to modules tested with mypy
* `count` was removed from `NFSServiceSpec`

- [x] Will conflict with #32149


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
