### PR TITLE
rbd-mirror: ensure deterministic ordering of method calls

### DIFF
--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -965,10 +965,10 @@ TEST_F(TestMockImageReplayer, ReplayerInterrupted) {
     .WillOnce(Return(false));
   EXPECT_CALL(mock_journal_replayer, is_replaying())
     .WillOnce(Return(false));
-  EXPECT_CALL(mock_journal_replayer, get_error_description())
-    .WillOnce(Return("INVALID"));
   EXPECT_CALL(mock_journal_replayer, get_error_code())
     .WillOnce(Return(-EINVAL));
+  EXPECT_CALL(mock_journal_replayer, get_error_description())
+    .WillOnce(Return("INVALID"));
   expect_shut_down(mock_journal_replayer, 0);
   expect_mirror_image_status_exists(false);
   mock_journal_replayer.replayer_listener->handle_notification();

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -1078,9 +1078,12 @@ void ImageReplayer<I>::handle_replayer_notification() {
   }
 
   if (!m_replayer->is_replaying()) {
-    dout(10) << "replay interrupted" << dendl;
-    on_stop_journal_replay(m_replayer->get_error_code(),
-                           m_replayer->get_error_description());
+    auto error_code = m_replayer->get_error_code();
+    auto error_description = m_replayer->get_error_description();
+    dout(10) << "replay interrupted: "
+             << "r=" << error_code << ", "
+             << "error=" << error_description << dendl;
+    on_stop_journal_replay(error_code, error_description);
     return;
   }
 


### PR DESCRIPTION
The mock tests will require method calls in a known order. Previously
different environments could evaluate the parameters in different
orders resulting in out-of-order method calls.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
