### PR TITLE
qa/suites/upgrade: all upgrades to octopus on ubuntu only

### DIFF
--- a/qa/suites/upgrade/mimic-x-singleton/supported-random-distro$
+++ b/qa/suites/upgrade/mimic-x-singleton/supported-random-distro$
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/upgrade/mimic-x-singleton/ubuntu_latest.yaml
+++ b/qa/suites/upgrade/mimic-x-singleton/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/ubuntu_latest.yaml

--- a/qa/suites/upgrade/mimic-x/parallel/supported-all-distro
+++ b/qa/suites/upgrade/mimic-x/parallel/supported-all-distro
@@ -1,1 +1,0 @@
-../../../../../qa/distros/supported-all-distro/

--- a/qa/suites/upgrade/mimic-x/parallel/ubuntu_latest.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/ubuntu_latest.yaml

--- a/qa/suites/upgrade/mimic-x/stress-split-erasure-code/supported-all-distro
+++ b/qa/suites/upgrade/mimic-x/stress-split-erasure-code/supported-all-distro
@@ -1,1 +1,0 @@
-../../../../../qa/distros/supported-all-distro/

--- a/qa/suites/upgrade/mimic-x/stress-split-erasure-code/ubuntu_latest.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split-erasure-code/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/ubuntu_latest.yaml

--- a/qa/suites/upgrade/mimic-x/stress-split/supported-all-distro
+++ b/qa/suites/upgrade/mimic-x/stress-split/supported-all-distro
@@ -1,1 +1,0 @@
-../../../../../qa/distros/supported-all-distro/

--- a/qa/suites/upgrade/mimic-x/stress-split/ubuntu_latest.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/ubuntu_latest.yaml

--- a/qa/suites/upgrade/nautilus-x-singleton/supported-random-distro$
+++ b/qa/suites/upgrade/nautilus-x-singleton/supported-random-distro$
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$

--- a/qa/suites/upgrade/nautilus-x-singleton/ubuntu_latest.yaml
+++ b/qa/suites/upgrade/nautilus-x-singleton/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/ubuntu_latest.yaml

--- a/qa/suites/upgrade/nautilus-x/parallel/supported-all-distro
+++ b/qa/suites/upgrade/nautilus-x/parallel/supported-all-distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-all-distro

--- a/qa/suites/upgrade/nautilus-x/parallel/ubuntu_latest.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/ubuntu_latest.yaml

--- a/qa/suites/upgrade/nautilus-x/stress-split-erasure-code/supported-all-distro
+++ b/qa/suites/upgrade/nautilus-x/stress-split-erasure-code/supported-all-distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-all-distro

--- a/qa/suites/upgrade/nautilus-x/stress-split-erasure-code/ubuntu_latest.yaml
+++ b/qa/suites/upgrade/nautilus-x/stress-split-erasure-code/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/ubuntu_latest.yaml

--- a/qa/suites/upgrade/nautilus-x/stress-split/supported-all-distro
+++ b/qa/suites/upgrade/nautilus-x/stress-split/supported-all-distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-all-distro

--- a/qa/suites/upgrade/nautilus-x/stress-split/ubuntu_latest.yaml
+++ b/qa/suites/upgrade/nautilus-x/stress-split/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/ubuntu_latest.yaml


### PR DESCRIPTION
We cannot do a traditional upgrade (install old package, start cluster,
install new package, ...) because nautilus is el7-only and octopus is
el8-only.

So, do these tests on ubuntu.

Signed-off-by: Sage Weil <sage@redhat.com>