### PR TITLE
lvm/deactivate: add unit tests, remove --all

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_deactivate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_deactivate.py
@@ -1,0 +1,59 @@
+import pytest
+from mock.mock import patch
+from ceph_volume.api import lvm
+from ceph_volume.devices.lvm import deactivate
+
+class TestDeactivate(object):
+
+    @patch("ceph_volume.devices.lvm.deactivate.get_lvs_by_tag")
+    def test_no_osd(self, p_get_lvs):
+        p_get_lvs.return_value = []
+        with pytest.raises(StopIteration):
+            deactivate.deactivate_osd(0)
+
+    @patch("ceph_volume.devices.lvm.deactivate.get_lvs_by_tag")
+    @patch("ceph_volume.util.system.unmount_tmpfs")
+    def test_unmount_tmpfs_called_osd_id(self, p_u_tmpfs, p_get_lvs):
+        FooVolume = lvm.Volume(
+            lv_name='foo', lv_path='/dev/vg/foo',
+            lv_tags="ceph.osd_id=0,ceph.cluster_name=foo,ceph.type=data")
+        p_get_lvs.return_value = [FooVolume]
+
+        deactivate.deactivate_osd(0)
+        p_u_tmpfs.assert_called_with(
+            '/var/lib/ceph/osd/{}-{}'.format('foo', 0))
+
+    @patch("ceph_volume.devices.lvm.deactivate.get_lvs_by_tag")
+    @patch("ceph_volume.util.system.unmount_tmpfs")
+    def test_unmount_tmpfs_called_osd_uuid(self, p_u_tmpfs, p_get_lvs):
+        FooVolume = lvm.Volume(
+            lv_name='foo', lv_path='/dev/vg/foo',
+            lv_tags="ceph.osd_fsid=0,ceph.osd_id=1,ceph.cluster_name=foo,ceph.type=data")
+        p_get_lvs.return_value = [FooVolume]
+
+        deactivate.deactivate_osd(None, 0)
+        p_u_tmpfs.assert_called_with(
+            '/var/lib/ceph/osd/{}-{}'.format('foo', 1))
+
+    @patch("ceph_volume.devices.lvm.deactivate.get_lvs_by_tag")
+    @patch("ceph_volume.util.system.unmount_tmpfs")
+    @patch("ceph_volume.util.encryption.dmcrypt_close")
+    def test_no_crypt_no_dmclose(self, p_dm_close, p_u_tmpfs, p_get_lvs):
+        FooVolume = lvm.Volume(
+            lv_name='foo', lv_path='/dev/vg/foo',
+            lv_tags="ceph.osd_id=0,ceph.cluster_name=foo,ceph.type=data")
+        p_get_lvs.return_value = [FooVolume]
+
+        deactivate.deactivate_osd(0)
+
+    @patch("ceph_volume.devices.lvm.deactivate.get_lvs_by_tag")
+    @patch("ceph_volume.util.system.unmount_tmpfs")
+    @patch("ceph_volume.util.encryption.dmcrypt_close")
+    def test_crypt_dmclose(self, p_dm_close, p_u_tmpfs, p_get_lvs):
+        FooVolume = lvm.Volume(
+            lv_name='foo', lv_path='/dev/vg/foo', lv_uuid='123',
+            lv_tags="ceph.osd_id=0,ceph.encrypted=1,ceph.cluster_name=foo,ceph.type=data")
+        p_get_lvs.return_value = [FooVolume]
+
+        deactivate.deactivate_osd(0)
+        p_dm_close.assert_called_with('123')


### PR DESCRIPTION
Remove the --all flag until its actually implemented.

Fixes: https://tracker.ceph.com/issues/43330

Signed-off-by: Jan Fajerski <jfajerski@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
