### PR TITLE
qa/workunit/rbd: fixed QoS throughput unit parsing

### DIFF
--- a/qa/workunits/rbd/qos.sh
+++ b/qa/workunits/rbd/qos.sh
@@ -21,12 +21,15 @@ rbd_bench() {
     fi
 
     # parse `rbd bench` output for string like this:
-    # elapsed:    25  ops:     2560  ops/sec:   100.08  bytes/sec: 409928.13
+    # elapsed:    25  ops:     2560  ops/sec:   100.08  bytes/sec: 409.13 MiB
     iops_bps=$(${timeout_cmd} rbd bench "${image}" \
                               --io-type ${type} --io-size 4K \
                               --io-total ${total} --rbd-cache=false \
                               --rbd_qos_${qos_type}_limit ${qos_limit} |
-                   awk '/elapsed:/ {print int($6) ":" int($8)}')
+                   awk '/elapsed:.* GiB/ {print int($6) ":" int($8) * 1024 * 1024 * 1024}
+                        /elapsed:.* MiB/ {print int($6) ":" int($8) * 1024 * 1024}
+                        /elapsed:.* KiB/ {print int($6) ":" int($8) * 1024}
+                        /elapsed:.* B/   {print int($6) ":" int($8)}')
     eval ${iops_var_name}=${iops_bps%:*}
     eval ${bps_var_name}=${iops_bps#*:}
 }
@@ -43,16 +46,16 @@ test "${iops_unlimited}" -ge 20 || exit 0
 io_total=$((bps_unlimited * 30))
 
 rbd_bench "${POOL}/${IMAGE}" write ${io_total} iops $((iops_unlimited / 2)) iops bps
-test "${iops}" -lt $((iops_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
+test "${iops}" -le $((iops_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
 
 rbd_bench "${POOL}/${IMAGE}" write ${io_total} write_iops $((iops_unlimited / 2)) iops bps
-test "${iops}" -lt $((iops_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
+test "${iops}" -le $((iops_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
 
 rbd_bench "${POOL}/${IMAGE}" write ${io_total} bps $((bps_unlimited / 2)) iops bps
-test "${bps}" -lt $((bps_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
+test "${bps}" -le $((bps_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
 
 rbd_bench "${POOL}/${IMAGE}" write ${io_total} write_bps $((bps_unlimited / 2)) iops bps
-test "${bps}" -lt $((bps_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
+test "${bps}" -le $((bps_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
 
 rbd_bench "${POOL}/${IMAGE}" read ${io_total} iops 0 iops bps
 iops_unlimited=$iops
@@ -63,24 +66,24 @@ test "${iops_unlimited}" -ge 20 || exit 0
 io_total=$((bps_unlimited * 30))
 
 rbd_bench "${POOL}/${IMAGE}" read ${io_total} iops $((iops_unlimited / 2)) iops bps
-test "${iops}" -lt $((iops_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
+test "${iops}" -le $((iops_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
 
 rbd_bench "${POOL}/${IMAGE}" read ${io_total} read_iops $((iops_unlimited / 2)) iops bps
-test "${iops}" -lt $((iops_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
+test "${iops}" -le $((iops_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
 
 rbd_bench "${POOL}/${IMAGE}" read ${io_total} bps $((bps_unlimited / 2)) iops bps
-test "${bps}" -lt $((bps_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
+test "${bps}" -le $((bps_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
 
 rbd_bench "${POOL}/${IMAGE}" read ${io_total} read_bps $((bps_unlimited / 2)) iops bps
-test "${bps}" -lt $((bps_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
+test "${bps}" -le $((bps_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
 
 # test a config override is applied
 rbd config image set "${POOL}/${IMAGE}" rbd_qos_iops_limit $((iops_unlimited / 4))
 rbd_bench "${POOL}/${IMAGE}" read ${io_total} iops $((iops_unlimited / 2)) iops bps
-test "${iops}" -lt $((iops_unlimited / 4 * (100 + TOLERANCE_PRCNT) / 100))
+test "${iops}" -le $((iops_unlimited / 4 * (100 + TOLERANCE_PRCNT) / 100))
 rbd config image remove "${POOL}/${IMAGE}" rbd_qos_iops_limit
 rbd_bench "${POOL}/${IMAGE}" read ${io_total} iops $((iops_unlimited / 2)) iops bps
-test "${iops}" -lt $((iops_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
+test "${iops}" -le $((iops_unlimited / 2 * (100 + TOLERANCE_PRCNT) / 100))
 
 rbd rm "${POOL}/${IMAGE}"
 


### PR DESCRIPTION
The 'rbd bench' command was recently modified to print IEC units
instead of bytes/sec. This broke the handling for QoS throughput
tests since it was incorrectly evaluating the available RBD
throughput. Additionally, the QoS tests should use a "<="
comparison operator since the QoS is the upper-bound limit.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
