### PR TITLE
cephadm: add reconfig service action

### DIFF
--- a/qa/suites/rados/cephadm/start.yaml
+++ b/qa/suites/rados/cephadm/start.yaml
@@ -1,3 +1,7 @@
 tasks:
 - install:
 - cephadm:
+    conf:
+      mgr:
+        debug ms: 1
+        debug mgr: 20

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -418,20 +418,18 @@ def ceph_mons(ctx, config):
                             break
 
         # refresh ceph.conf files for all mons + first mgr
-        """
         for remote, roles in ctx.cluster.remotes.items():
             for mon in [r for r in roles
                         if teuthology.is_type('mon', cluster_name)(r)]:
                 c_, _, id_ = teuthology.split_role(mon)
                 _shell(ctx, cluster_name, remote, [
-                    'ceph', 'orchestrator', 'service', 'redeploy',
+                    'ceph', 'orchestrator', 'service-instance', 'reconfig',
                     'mon', id_,
                 ])
         _shell(ctx, cluster_name, ctx.ceph[cluster_name].bootstrap_remote, [
-            'ceph', 'orchestrator', 'service', 'redeploy',
+            'ceph', 'orchestrator', 'service-instance', 'reconfig',
             'mgr', ctx.ceph[cluster_name].first_mgr,
         ])
-        """
 
         yield
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1621,7 +1621,7 @@ def command_bootstrap():
     if not args.skip_ssh:
         logger.info('Enabling cephadm module...')
         cli(['mgr', 'module', 'enable', 'cephadm'])
-        logger.info('Setting orchestrator backend to ssh...')
+        logger.info('Setting orchestrator backend to cephadm...')
         cli(['orchestrator', 'set', 'backend', 'cephadm'])
 
         logger.info('Generating ssh key...')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1711,18 +1711,6 @@ def command_deploy():
 
     if daemon_type in Ceph.daemons:
         (config, keyring, crash_keyring) = get_config_and_both_keyrings()
-        if daemon_type == 'mon':
-            if args.mon_ip:
-                config += '[mon.%s]\n\tpublic_addr = %s\n' % (daemon_id, args.mon_ip)
-            elif args.mon_addrv:
-                config += '[mon.%s]\n\tpublic_addrv = %s\n' % (daemon_id,
-                                                            args.mon_addrv)
-            elif args.mon_network:
-                config += '[mon.%s]\n\tpublic_network = %s\n' % (daemon_id,
-                                                                args.mon_network)
-            else:
-                raise Error('must specify --mon-ip or --mon-network')
-
         (uid, gid) = extract_uid_gid()
         c = get_container(args.fsid, daemon_type, daemon_id)
         deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid,
@@ -2542,15 +2530,6 @@ def _get_parser():
     parser_deploy.add_argument(
         '--config-and-keyrings',
         help='JSON file with config and keyrings for the daemon and crash agent')
-    parser_deploy.add_argument(
-        '--mon-ip',
-        help='mon IP')
-    parser_deploy.add_argument(
-        '--mon-addrv',
-        help='mon IPs (e.g., [v2:localipaddr:3300,v1:localipaddr:6789])')
-    parser_deploy.add_argument(
-        '--mon-network',
-        help='mon network (CIDR)')
     parser_deploy.add_argument(
         '--osd-fsid',
         help='OSD uuid, if creating an OSD container')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -977,10 +977,18 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
             fsid, daemon_type, daemon_id,
             uid, gid,
             config, keyring)
+
     if not reconfig:
         deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
                             osd_fsid=osd_fsid)
+
     update_firewalld(daemon_type)
+
+    if reconfig and daemon_type not in Ceph.daemons:
+        # ceph daemons do not need a restart; others (presumably) do to pick
+        # up the new config
+        call_throws(['systemctl', 'restart',
+                     get_unit_name(fsid, daemon_type, daemon_id)])
 
 def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
                         enable=True, start=True,

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -707,8 +707,9 @@ def get_daemon_args(fsid, daemon_type, daemon_id):
     return r
 
 def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
-                       config=None, keyring=None):
-    # type: (str, str, Union[int, str], int, int, str, str) ->  None
+                       config=None, keyring=None,
+                       reconfig=False):
+    # type: (str, str, Union[int, str], int, int, Optional[str], Optional[str], Optional[bool]) ->  None
     data_dir = make_data_dir(fsid, daemon_type, daemon_id, uid=uid, gid=gid)
     make_log_dir(fsid, uid=uid, gid=gid)
 
@@ -929,10 +930,13 @@ def extract_uid_gid(img='', file_path='/var/lib/ceph'):
 
 def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
                   config=None, keyring=None,
-                  osd_fsid=None):
-    # type: (str, str, Union[int, str], CephContainer, int, int, Optional[str], Optional[str], Optional[str]) -> None
-    if daemon_type == 'mon' and not os.path.exists(
-            get_data_dir(fsid, 'mon', daemon_id)):
+                  osd_fsid=None,
+                  reconfig=False):
+    # type: (str, str, Union[int, str], CephContainer, int, int, Optional[str], Optional[str], Optional[str], Optional[bool]) -> None
+    data_dir = get_data_dir(fsid, daemon_type, daemon_id)
+    if reconfig and not os.path.exists(data_dir):
+        raise Error('cannot reconfig, data path %s does not exist' % data_dir)
+    if daemon_type == 'mon' and not os.path.exists(data_dir):
         assert config
         assert keyring
         # tmp keyring file
@@ -973,9 +977,9 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
             fsid, daemon_type, daemon_id,
             uid, gid,
             config, keyring)
-
-    deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
-                        osd_fsid=osd_fsid)
+    if not reconfig:
+        deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
+                            osd_fsid=osd_fsid)
     update_firewalld(daemon_type)
 
 def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
@@ -1723,9 +1727,10 @@ def command_deploy():
         c = get_container(args.fsid, daemon_type, daemon_id)
         deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid,
                       config, keyring,
-                      osd_fsid=args.osd_fsid)
+                      osd_fsid=args.osd_fsid,
+                      reconfig=args.reconfig)
 
-        if crash_keyring:
+        if crash_keyring and not args.reconfig:
             deploy_crash(args.fsid, uid, gid, config, crash_keyring)
     else:
         # monitoring daemon - prometheus, grafana, alertmanager
@@ -1758,7 +1763,8 @@ def command_deploy():
             raise Error("{} not implemented in command_deploy function".format(daemon_type))
 
         c = get_container(args.fsid, daemon_type, daemon_id, container_args=monitoring_args)
-        deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid)
+        deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid,
+                      reconfig=args.reconfig)
 
 ##################################
 
@@ -2552,6 +2558,10 @@ def _get_parser():
         '--skip-firewalld',
         action='store_true',
         help='Do not configure firewalld')
+    parser_deploy.add_argument(
+        '--reconfig',
+        action='store_true',
+        help='Reconfigure a previously deployed daemon')
 
     parser_check_host = subparsers.add_parser(
         'check-host', help='check host configuration')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1053,13 +1053,15 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
         return self._remove_daemon(args)
 
     def _create_daemon(self, daemon_type, daemon_id, host, keyring,
-                       extra_args=[]):
+                       extra_args=[], extra_config=None):
         name = '%s.%s' % (daemon_type, daemon_id)
 
         # generate config
         ret, config, err = self.mon_command({
             "prefix": "config generate-minimal-conf",
         })
+        if extra_config:
+            config += extra_config
 
         ret, crash_keyring, err = self.mon_command({
             'prefix': 'auth get-or-create',
@@ -1129,17 +1131,18 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
         })
 
         # infer whether this is a CIDR network, addrvec, or plain IP
+        extra_config = '[mon.%s]\n' % name
         if '/' in network:
-            extra_args = ['--mon-network', network]
+            extra_config += 'public network = %s\n' % network
         elif network.startswith('[v') and network.endswith(']'):
-            extra_args = ['--mon-addrv', network]
+            extra_config += 'public addrv = %s\n' % network
         elif ':' not in network:
-            extra_args = ['--mon-ip', network]
+            extra_config += 'public addr = %s\n' % network
         else:
             raise RuntimeError('Must specify a CIDR network, ceph addrvec, or plain IP: \'%s\'' % network)
 
         return self._create_daemon('mon', name or host, host, keyring,
-                                   extra_args=extra_args)
+                                   extra_config=extra_config)
 
     def update_mons(self, spec):
         # type: (orchestrator.StatefulServiceSpec) -> orchestrator.Completion

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -833,8 +833,6 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
                        service_id=None):
         self.log.debug('service_action action %s type %s name %s id %s' % (
             action, service_type, service_name, service_id))
-        if action == 'reload':
-            return trivial_result(["Reload is a no-op"])
 
         def _proc_daemons(daemons):
             if service_name is None and service_id is None:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1044,8 +1044,10 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
         return self._remove_daemon(args)
 
     def _create_daemon(self, daemon_type, daemon_id, host, keyring,
-                       extra_args=[], extra_config=None,
+                       extra_args=None, extra_config=None,
                        reconfig=False):
+        if not extra_args:
+            extra_args = []
         name = '%s.%s' % (daemon_type, daemon_id)
 
         # generate config

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -111,7 +111,7 @@ class TestCephadm(object):
         cephadm_module.service_cache_timeout = 10
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.service_action('redeploy', 'rgw', service_id='myrgw.foobar')
-            assert self._wait(cephadm_module, c) == ["(Re)deployed rgw.myrgw.foobar on host 'test'"]
+            assert self._wait(cephadm_module, c) == ["Deployed rgw.myrgw.foobar on host 'test'"]
 
             for what in ('start', 'stop', 'restart'):
                 c = cephadm_module.service_action(what, 'rgw', service_id='myrgw.foobar')
@@ -126,7 +126,7 @@ class TestCephadm(object):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test:0.0.0.0=a'], count=1)
             c = cephadm_module.update_mons(StatefulServiceSpec(placement=ps))
-            assert self._wait(cephadm_module, c) == ["(Re)deployed mon.a on host 'test'"]
+            assert self._wait(cephadm_module, c) == ["Deployed mon.a on host 'test'"]
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
@@ -137,7 +137,7 @@ class TestCephadm(object):
             ps = PlacementSpec(hosts=['test:0.0.0.0=a'], count=1)
             c = cephadm_module.update_mgrs(StatefulServiceSpec(placement=ps))
             [out] = self._wait(cephadm_module, c)
-            assert "(Re)deployed mgr." in out
+            assert "Deployed mgr." in out
             assert " on host 'test'" in out
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
@@ -178,7 +178,7 @@ class TestCephadm(object):
             ps = PlacementSpec(hosts=['test'], count=1)
             c = cephadm_module.add_mds(StatelessServiceSpec('name', placement=ps))
             [out] = self._wait(cephadm_module, c)
-            assert "(Re)deployed mds.name." in out
+            assert "Deployed mds.name." in out
             assert " on host 'test'" in out
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
@@ -190,7 +190,7 @@ class TestCephadm(object):
             ps = PlacementSpec(hosts=['test'], count=1)
             c = cephadm_module.add_rgw(RGWSpec('realm', 'zone', placement=ps))
             [out] = self._wait(cephadm_module, c)
-            assert "(Re)deployed rgw.realm.zone." in out
+            assert "Deployed rgw.realm.zone." in out
             assert " on host 'test'" in out
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm(
@@ -221,7 +221,7 @@ class TestCephadm(object):
             ps = PlacementSpec(hosts=['test'], count=1)
             c = cephadm_module.add_rbd_mirror(StatelessServiceSpec(name='name', placement=ps))
             [out] = self._wait(cephadm_module, c)
-            assert "(Re)deployed rbd-mirror." in out
+            assert "Deployed rbd-mirror." in out
             assert " on host 'test'" in out
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -857,7 +857,7 @@ class Orchestrator(object):
         * If using service_id, perform the action on a single specific daemon
           instance.
 
-        :param action: one of "start", "stop", "reload", "restart", "redeploy"
+        :param action: one of "start", "stop", "restart", "redeploy"
         :param service_type: e.g. "mds", "rgw", ...
         :param service_name: name of logical service ("cephfs", "us-east", ...)
         :param service_id: service daemon instance (usually a short hostname)

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -857,7 +857,7 @@ class Orchestrator(object):
         * If using service_id, perform the action on a single specific daemon
           instance.
 
-        :param action: one of "start", "stop", "restart", "redeploy"
+        :param action: one of "start", "stop", "restart", "redeploy", "reconfig"
         :param service_type: e.g. "mds", "rgw", ...
         :param service_name: name of logical service ("cephfs", "us-east", ...)
         :param service_id: service daemon instance (usually a short hostname)

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -575,10 +575,10 @@ Usage:
 
     @orchestrator._cli_write_command(
         'orchestrator service',
-        "name=action,type=CephChoices,strings=start|stop|reload|restart|redeploy "
+        "name=action,type=CephChoices,strings=start|stop|restart|redeploy "
         "name=svc_type,type=CephString "
         "name=svc_name,type=CephString",
-        'Start, stop or reload an entire service (i.e. all daemons)')
+        'Start, stop, restart, redeploy an entire service (i.e. all daemons)')
     def _service_action(self, action, svc_type, svc_name):
         completion = self.service_action(action, svc_type, service_name=svc_name)
         self._orchestrator_wait([completion])
@@ -587,10 +587,10 @@ Usage:
 
     @orchestrator._cli_write_command(
         'orchestrator service-instance',
-        "name=action,type=CephChoices,strings=start|stop|reload|restart|redeploy "
+        "name=action,type=CephChoices,strings=start|stop|restart|redeploy "
         "name=svc_type,type=CephString "
         "name=svc_id,type=CephString",
-        'Start, stop or reload a specific service instance')
+        'Start, stop, restart, or redeploy a specific service instance')
     def _service_instance_action(self, action, svc_type, svc_id):
         completion = self.service_action(action, svc_type, service_id=svc_id)
         self._orchestrator_wait([completion])

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -575,10 +575,10 @@ Usage:
 
     @orchestrator._cli_write_command(
         'orchestrator service',
-        "name=action,type=CephChoices,strings=start|stop|restart|redeploy "
+        "name=action,type=CephChoices,strings=start|stop|restart|redeploy|reconfig "
         "name=svc_type,type=CephString "
         "name=svc_name,type=CephString",
-        'Start, stop, restart, redeploy an entire service (i.e. all daemons)')
+        'Start, stop, restart, redeploy, or reconfig an entire service (i.e. all daemons)')
     def _service_action(self, action, svc_type, svc_name):
         completion = self.service_action(action, svc_type, service_name=svc_name)
         self._orchestrator_wait([completion])
@@ -587,10 +587,10 @@ Usage:
 
     @orchestrator._cli_write_command(
         'orchestrator service-instance',
-        "name=action,type=CephChoices,strings=start|stop|restart|redeploy "
+        "name=action,type=CephChoices,strings=start|stop|restart|redeploy|reconfig "
         "name=svc_type,type=CephString "
         "name=svc_id,type=CephString",
-        'Start, stop, restart, or redeploy a specific service instance')
+        'Start, stop, restart, redeploy, or reconfig a specific service instance')
     def _service_instance_action(self, action, svc_type, svc_id):
         completion = self.service_action(action, svc_type, service_id=svc_id)
         self._orchestrator_wait([completion])

--- a/test_cephadm.sh
+++ b/test_cephadm.sh
@@ -43,16 +43,16 @@ $CEPHADM $A \
     --allow-overwrite
 chmod 644 k c
 
-if [ -n "$ip2" ]; then
-    # mon.b
-    $CEPHADM $A \
-    --image $image \
-    deploy --name mon.b \
-    --fsid $fsid \
-    --mon-addrv "[v2:$ip2:3300,v1:$ip2:6789]" \
-    --keyring /var/lib/ceph/$fsid/mon.a/keyring \
-    --config c
-fi
+# mon.b
+cp c c.mon
+echo "public addrv = [v2:$ip:3301,v1:$ip:6790]" >> c.mon
+$CEPHADM $A \
+	 --image $image \
+	 deploy --name mon.b \
+	 --fsid $fsid \
+	 --keyring /var/lib/ceph/$fsid/mon.a/keyring \
+	 --config c.mon
+rm c.mon
 
 # mgr.b
 bin/ceph -c c -k k auth get-or-create mgr.y \


### PR DESCRIPTION
- refresh ceph.conf and/or keyring without touching running container
- refresh configs inside prom container
- restart non-ceph containers/daemons