### PR TITLE
nautilus: os/bluestore: default bluestore_block_size 1T -> 100G

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4422,7 +4422,7 @@ std::vector<Option> get_global_options() {
     .set_description("Path to block device/file"),
 
     Option("bluestore_block_size", Option::TYPE_SIZE, Option::LEVEL_DEV)
-    .set_default(10_G)
+    .set_default(100_G)
     .set_flag(Option::FLAG_CREATE)
     .set_description("Size of file to create for backing bluestore"),
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/42913


This makes vstart *way* faster.  This option is only really relevant
for dev test environments.  We bumped it up back in dbdd1d9b6ec286982b5e86d4c51f831cc16afc12
from 10G just to make ENOSPC less common in dev/test.  Let's see if 100G
is a better balance.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 57890fce7064811780823e298b31e7fced2fa0e3)

 Conflicts:
	src/common/options.cc: we did not cherry-pick
        dbdd1d9b6ec286982b5e86d4c51f831cc16afc12 to nautilus, so we'll directly
        go from 10G->100G
