### PR TITLE
rgw: relax es zone validity check

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -2995,10 +2995,13 @@ int RGWMetadataHandlerPut_BucketInstance::put_check()
     bci.info.bucket.name = bucket_name;
     bci.info.bucket.bucket_id = bucket_instance;
     bci.info.bucket.tenant = tenant_name;
-    ret = bihandler->svc.zone->select_bucket_location_by_rule(bci.info.placement_rule, &rule_info);
-    if (ret < 0) {
-      ldout(cct, 0) << "ERROR: select_bucket_placement() returned " << ret << dendl;
-      return ret;
+    // if the sync module never writes data, don't require the zone to specify all placement targets
+    if (bihandler->svc.zone->sync_module_supports_writes()) {
+      ret = bihandler->svc.zone->select_bucket_location_by_rule(bci.info.placement_rule, &rule_info);
+      if (ret < 0) {
+        ldout(cct, 0) << "ERROR: select_bucket_placement() returned " << ret << dendl;
+        return ret;
+      }
     }
     bci.info.index_type = rule_info.index_type;
   } else {

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -841,6 +841,11 @@ bool RGWSI_Zone::zone_is_writeable()
   return writeable_zone && !get_zone().is_read_only();
 }
 
+bool RGWSI_Zone::sync_module_supports_writes() const
+{
+  return writeable_zone;
+}
+
 uint32_t RGWSI_Zone::get_zone_short_id() const
 {
   return zone_short_id;

--- a/src/rgw/services/svc_zone.h
+++ b/src/rgw/services/svc_zone.h
@@ -77,6 +77,7 @@ public:
   bool zone_is_writeable();
   bool zone_syncs_from(const RGWZone& target_zone, const RGWZone& source_zone) const;
   bool get_redirect_zone_endpoint(string *endpoint);
+  bool sync_module_supports_writes() const;
 
   RGWRESTConn *get_master_conn() {
     return rest_master_conn;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43350

Signed-off-by: jiahuizeng <jhzeng93@foxmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
