### PR TITLE
script/build-integration-branch: Add usage

### DIFF
--- a/src/script/build-integration-branch
+++ b/src/script/build-integration-branch
@@ -1,5 +1,23 @@
 #!/usr/bin/env python3
 
+"""
+Builds integration branches. Something similar to 
+  $ git checkout -b branch-name
+  $ for b in $(get-branches-from-github) ; do
+  $   git pull b
+
+Requires `~/.github_token`.
+
+
+Usage:
+  build-integration-branch <label> [--no-date]
+  build-integration-branch -h | --help
+
+Options:
+  -h --help   Show this screen.
+  --no-date   Don't add `{postfix}` to the branch name.
+"""
+
 from __future__ import print_function
 
 import json
@@ -13,8 +31,23 @@ try:
 except:
     from urlparse import urljoin
 
-label = sys.argv[1]
+TIME_FORMAT = '%Y-%m-%d-%H%M'
+postfix = "-" + time.strftime(TIME_FORMAT, time.localtime())
+
 repo = "ceph/ceph"
+
+try:
+  from docopt import docopt
+  arguments = docopt(__doc__.format(postfix=postfix))
+  print(arguments)
+  label = arguments['<label>']
+  branch = label if arguments['--no-date'] else label + prefix
+except ImportError:
+  # Fallback without docopt.
+  label = sys.argv[1]
+  assert len(sys.argv) == 2
+  branch = label + prefix
+
 
 with open(os.environ['HOME'] + '/.github_token', 'r') as myfile:
     token = myfile.readline().strip()
@@ -47,9 +80,6 @@ for issue in j:
     prtext.append(pr['html_url'] + ' - ' + pr['title'])
 print("--- queried %s prs" % len(prs))
 
-# name branch
-TIME_FORMAT = '%Y-%m-%d-%H%M'
-branch = label + "-" + time.strftime(TIME_FORMAT, time.localtime())
 print("branch %s" % branch)
 
 # assemble


### PR DESCRIPTION
Also add a --no-date to make it possible to re-use an existing branch name

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
