### PR TITLE
nautilus: mgr/dashboard: Standby Dashboards don't handle all requests properly

### DIFF
--- a/qa/tasks/mgr/test_dashboard.py
+++ b/qa/tasks/mgr/test_dashboard.py
@@ -49,8 +49,15 @@ class TestDashboard(MgrTestCase):
         self.assertNotEqual(original_uri, failed_over_uri)
 
         # The original active daemon should have come back up as a standby
-        # and be doing redirects to the new active daemon
+        # and be doing redirects to the new active daemon.
         r = requests.get(original_uri, allow_redirects=False, verify=False)
+        self.assertEqual(r.status_code, 303)
+        self.assertEqual(r.headers['Location'], failed_over_uri)
+
+        # Ensure that every URL redirects to the active daemon.
+        r = requests.get("{}/runtime.js".format(original_uri),
+                         allow_redirects=False,
+                         verify=False)
         self.assertEqual(r.status_code, 303)
         self.assertEqual(r.headers['Location'], failed_over_uri)
 

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -467,7 +467,7 @@ class StandbyModule(MgrStandbyModule, CherryPyConfig):
 
         class Root(object):
             @cherrypy.expose
-            def index(self):
+            def default(self, *args, **kwargs):
                 if module.get_module_option('standby_behaviour', 'redirect') == 'redirect':
                     active_uri = module.get_active_uri()
                     if active_uri:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42139

---

backport of https://github.com/ceph/ceph/pull/30478
parent tracker: https://tracker.ceph.com/issues/41930

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh