### PR TITLE
build-integration-branch: s/prefix/postfix/

### DIFF
--- a/src/script/build-integration-branch
+++ b/src/script/build-integration-branch
@@ -4,7 +4,8 @@
 Builds integration branches. Something similar to 
   $ git checkout -b branch-name
   $ for b in $(get-branches-from-github) ; do
-  $   git pull b
+  >   git pull b
+  > done
 
 Requires `~/.github_token`.
 
@@ -39,14 +40,15 @@ repo = "ceph/ceph"
 try:
   from docopt import docopt
   arguments = docopt(__doc__.format(postfix=postfix))
-  print(arguments)
   label = arguments['<label>']
-  branch = label if arguments['--no-date'] else label + prefix
+  branch = label
+  if not arguments['--no-date']:
+      branch += postfix
 except ImportError:
   # Fallback without docopt.
   label = sys.argv[1]
   assert len(sys.argv) == 2
-  branch = label + prefix
+  branch = label + postfix
 
 
 with open(os.environ['HOME'] + '/.github_token', 'r') as myfile:


### PR DESCRIPTION
prefix is not defined.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
