### PR TITLE
osd/PeeringState.cc: don't let num_objects become negative

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3197,6 +3197,16 @@ void PeeringState::update_calc_stats()
   info.stats.avail_no_missing.clear();
   info.stats.object_location_counts.clear();
 
+  // We should never hit this condition, but if end up hitting it,
+  // make sure to update num_objects and set PG_STATE_INCONSISTENT.
+  if (info.stats.stats.sum.num_objects < 0) {
+    psdout(0) << __func__ << " negative num_objects = "
+              << info.stats.stats.sum.num_objects << " setting it to 0 "
+              << dendl;
+    info.stats.stats.sum.num_objects = 0;
+    state_set(PG_STATE_INCONSISTENT);
+  }
+
   if ((is_remapped() || is_undersized() || !is_clean()) &&
       (is_peered()|| is_activating())) {
     psdout(20) << __func__ << " actingset " << actingset << " upset "


### PR DESCRIPTION
If num_objects become negative, we may end up incorrectly setting
the PG_STATE_DEGRADED flag. Instead reset num_objects to zero and set
the PG_STATE_INCONSISTENT flag when this happens expecting scrub to fix
the inconsistency.

Fixes: https://tracker.ceph.com/issues/43308
Co-authored-by: David Zafman <dzafman@redhat.com>
Signed-off-by: Neha Ojha <nojha@redhat.com>
