### PR TITLE
mgr/cephadm: fix type of timeout options

### DIFF
--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -21,7 +21,7 @@ class Alerts(MgrModule):
     MODULE_OPTIONS = [
         {
             'name': 'interval',
-            'type': 'seconds',
+            'type': 'secs',
             'default': 60,
             'desc': 'How frequently to reexamine health status',
             'runtime': True,

--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -29,6 +29,7 @@ class Alerts(MgrModule):
         # smtp
         {
             'name': 'smtp_host',
+            'default': '',
             'desc': 'SMTP server',
             'runtime': True,
         },
@@ -155,6 +156,8 @@ class Alerts(MgrModule):
             if r:
                 for code, alert in r.items():
                     checks[code] = alert
+        else:
+            self.log.warn('Alert is not sent because smtp_host is not configured')
         self.set_health_checks(checks)
 
     def serve(self):

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -268,13 +268,13 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
         },
         {
             'name': 'inventory_cache_timeout',
-            'type': 'seconds',
+            'type': 'secs',
             'default': 10 * 60,
             'desc': 'seconds to cache device inventory',
         },
         {
             'name': 'service_cache_timeout',
-            'type': 'seconds',
+            'type': 'secs',
             'default': 60,
             'desc': 'seconds to cache service (daemon) inventory',
         },


### PR DESCRIPTION
The timeout options need to be in `secs` type. Then the input values
will be checked and converted into integer before use.

Fixes: https://tracker.ceph.com/issues/43363
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
