### PR TITLE
bluestore/bluefs: allow bluefs files to r/w simultaneously

### DIFF
--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -125,6 +125,10 @@ public:
 
     void* vselector_hint = nullptr;
 
+    ceph::shared_mutex lock {
+      ceph::make_shared_mutex(std::string(), false, false, false)
+    };
+
   private:
     FRIEND_MAKE_REF(File);
     File()


### PR DESCRIPTION
Allow bluefs files to be written to (sequentially) and read at the same time.

Reading and writting the same file might stall each other a bit.
Small writes might not propagate, but once flush() and fsync() are done, changes are propagated.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>