### PR TITLE
[qa] cephfs-shell is only available as a package on Ubuntu so removing for RHEL

### DIFF
--- a/qa/suites/fs/basic_functional/tasks/cephfs-shell.yaml
+++ b/qa/suites/fs/basic_functional/tasks/cephfs-shell.yaml
@@ -1,8 +1,0 @@
-# Right now, cephfs-shell is only available as a package on Ubuntu
-# This overrides the random distribution that's chosen in the other yaml fragments.
-os_type: ubuntu
-os_version: "18.04"
-tasks:
-  - cephfs_test_runner:
-      modules:
-        - tasks.cephfs.test_cephfs_shell


### PR DESCRIPTION
cephfs-shell is only available as a package on Ubuntu so test case as its not applicable to RHEL

Signed-off-by: Rachanaben Patel <racpatel@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
