### PR TITLE
rpm: drop vim-specific header

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1,4 +1,3 @@
-# vim: set noexpandtab ts=8 sw=8 :
 #
 # spec file for package ceph
 #


### PR DESCRIPTION
The copyright notice should be the first thing in the file.

The line being dropped was added, perhaps unintentionally, by
unrelated commit c52eb995e0d9c3bbb6d0293f5dacaeb511f37f96
"Add initial SELinux support"

Signed-off-by: Nathan Cutler <ncutler@suse.com>