### PR TITLE
cephadm: bootstrap: avoid repeat chars in generated password

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1471,7 +1471,8 @@ def command_bootstrap():
         password = args.initial_dashboard_password or generate_password()
         cli(['dashboard', 'ac-user-create',
              args.initial_dashboard_user, password,
-             'administrator'])
+             'administrator',
+             '--force-password'])
         logger.info('Fetching dashboard port number...')
         out = cli(['config', 'get', 'mgr', 'mgr/dashboard/ssl_server_port'])
         port = int(out)


### PR DESCRIPTION
INFO:cephadm:Non-zero exit code 22 from /usr/bin/podman run --rm --net=host -e CONTAINER_IMAGE=ceph/daemon-base:latest-master-devel -e NODE_NAME=gnit -v /var/log/ceph/00000000-0000-0000-0000-0000deadbeef:/var/log/ceph:z -v /tmp/ceph-tmp6if8iaha:/etc/ceph/ceph.client.admin.keyring:z -v /tmp/ceph-tmp4vyvfiio:/etc/ceph/ceph.conf:z --entrypoint /usr/bin/ceph ceph/daemon-base:latest-master-devel dashboard ac-user-create admin oaaacwf4ul administrator
INFO:cephadm:/usr/bin/ceph:stderr Error EINVAL: Password cannot contain repetitive characters.

Signed-off-by: Sage Weil <sage@redhat.com>