### PR TITLE
qa/tasks/s3tests_java: move to gradle 6.0.1

### DIFF
--- a/qa/tasks/s3tests_java.py
+++ b/qa/tasks/s3tests_java.py
@@ -314,7 +314,7 @@ class S3tests_java(Task):
             args = ['cd',
                     '{tdir}/s3-tests-java'.format(tdir=testdir),
                     run.Raw('&&'),
-                    '/opt/gradle/gradle-4.7/bin/gradle', 'clean', 'test',
+                    '/opt/gradle/gradle/bin/gradle', 'clean', 'test',
                     '--rerun-tasks', '--no-build-cache',
                     ]
             extra_args = []


### PR DESCRIPTION
https://github.com/ceph/java_s3tests/pull/6

This makes the s3tests_java gradle test pass on master.  The good news is that these tests are new in master, so we don't have to worry about breaking nautilus or older tests!