### PR TITLE
librbd: look for mirror peers in default namespace

### DIFF
--- a/src/librbd/mirror/snapshot/CreatePrimaryRequest.h
+++ b/src/librbd/mirror/snapshot/CreatePrimaryRequest.h
@@ -5,6 +5,7 @@
 #define CEPH_LIBRBD_MIRROR_SNAPSHOT_CREATE_PRIMARY_REQUEST_H
 
 #include "include/buffer.h"
+#include "include/rados/librados.hpp"
 #include "cls/rbd/cls_rbd_types.h"
 
 #include <string>
@@ -30,10 +31,7 @@ public:
   }
 
   CreatePrimaryRequest(ImageCtxT *image_ctx, bool demoted, bool force,
-                       uint64_t *snap_id, Context *on_finish)
-    : m_image_ctx(image_ctx), m_demoted(demoted), m_force(force),
-      m_snap_id(snap_id), m_on_finish(on_finish) {
-  }
+                       uint64_t *snap_id, Context *on_finish);
 
   void send();
 
@@ -70,6 +68,7 @@ private:
   uint64_t *m_snap_id;
   Context *m_on_finish;
 
+  librados::IoCtx m_default_ns_ctx;
   std::set<std::string> m_mirror_peer_uuids;
   std::string m_snap_name;
 

--- a/src/test/librbd/mirror/snapshot/test_mock_CreatePrimaryRequest.cc
+++ b/src/test/librbd/mirror/snapshot/test_mock_CreatePrimaryRequest.cc
@@ -115,6 +115,14 @@ public:
                    SnapInfo{snap_name, ns, 0, {}, 0, 0, {}}}).second);
   }
 
+  void expect_clone_md_ctx(MockTestImageCtx &mock_image_ctx) {
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx), clone())
+      .WillOnce(Invoke([&mock_image_ctx]() {
+                         get_mock_io_ctx(mock_image_ctx.md_ctx).get();
+                         return &get_mock_io_ctx(mock_image_ctx.md_ctx);
+                       }));
+  }
+
   void expect_refresh_image(MockTestImageCtx &mock_image_ctx,
                             bool refresh_required, int r) {
     EXPECT_CALL(*mock_image_ctx.state, is_refresh_required())
@@ -216,6 +224,7 @@ TEST_F(TestMockMirrorSnapshotCreatePrimaryRequest, Success) {
 
   InSequence seq;
 
+  expect_clone_md_ctx(mock_image_ctx);
   expect_refresh_image(mock_image_ctx, true, 0);
   expect_get_mirror_image(
     mock_image_ctx, {cls::rbd::MIRROR_IMAGE_MODE_SNAPSHOT, "gid",
@@ -244,6 +253,7 @@ TEST_F(TestMockMirrorSnapshotCreatePrimaryRequest, RefreshError) {
 
   InSequence seq;
 
+  expect_clone_md_ctx(mock_image_ctx);
   expect_refresh_image(mock_image_ctx, true, -EINVAL);
 
   C_SaferCond ctx;
@@ -263,6 +273,7 @@ TEST_F(TestMockMirrorSnapshotCreatePrimaryRequest, GetMirrorImageError) {
 
   InSequence seq;
 
+  expect_clone_md_ctx(mock_image_ctx);
   expect_refresh_image(mock_image_ctx, false, 0);
   expect_get_mirror_image(
     mock_image_ctx, {cls::rbd::MIRROR_IMAGE_MODE_SNAPSHOT, "gid",
@@ -285,6 +296,7 @@ TEST_F(TestMockMirrorSnapshotCreatePrimaryRequest, CanNotError) {
 
   InSequence seq;
 
+  expect_clone_md_ctx(mock_image_ctx);
   expect_refresh_image(mock_image_ctx, true, 0);
   expect_get_mirror_image(
     mock_image_ctx, {cls::rbd::MIRROR_IMAGE_MODE_SNAPSHOT, "gid",
@@ -309,6 +321,7 @@ TEST_F(TestMockMirrorSnapshotCreatePrimaryRequest, GetMirrorPeersError) {
 
   InSequence seq;
 
+  expect_clone_md_ctx(mock_image_ctx);
   expect_refresh_image(mock_image_ctx, true, 0);
   expect_get_mirror_image(
     mock_image_ctx, {cls::rbd::MIRROR_IMAGE_MODE_SNAPSHOT, "gid",
@@ -336,6 +349,7 @@ TEST_F(TestMockMirrorSnapshotCreatePrimaryRequest, CreateSnapshotError) {
 
   InSequence seq;
 
+  expect_clone_md_ctx(mock_image_ctx);
   expect_refresh_image(mock_image_ctx, true, 0);
   expect_get_mirror_image(
     mock_image_ctx, {cls::rbd::MIRROR_IMAGE_MODE_SNAPSHOT, "gid",
@@ -369,6 +383,7 @@ TEST_F(TestMockMirrorSnapshotCreatePrimaryRequest, SuccessUnlinkPeer) {
 
   InSequence seq;
 
+  expect_clone_md_ctx(mock_image_ctx);
   expect_refresh_image(mock_image_ctx, true, 0);
   expect_get_mirror_image(
     mock_image_ctx, {cls::rbd::MIRROR_IMAGE_MODE_SNAPSHOT, "gid",


### PR DESCRIPTION
(when creating primary mirror snapshot)

Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
