### PR TITLE
RFC: mgr/cephadm: osd_remove: wait, till ok-to-destroy

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -3,6 +3,7 @@ import time
 from contextlib import contextmanager
 
 from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection
+from mgr_module import HandleCommandResult
 
 try:
     from typing import Any
@@ -31,7 +32,7 @@ def _run_cephadm(ret):
     return foo
 
 def mon_command(*args, **kwargs):
-    return 0, '', ''
+    return HandleCommandResult(0, '', '')
 
 
 class TestCephadm(object):
@@ -162,7 +163,9 @@ class TestCephadm(object):
             )
         ])
     ))
-    def test_remove_osds(self, cephadm_module):
+    @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
+    @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
+    def test_remove_osds(self, send_command_, cephadm_module):
         cephadm_module._cluster_fsid = "fsid"
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.remove_osds(['0'])

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -70,8 +70,9 @@ class CommandResult(object):
         self.ev.set()
 
     def wait(self):
+        # type: () -> HandleCommandResult
         self.ev.wait()
-        return self.r, self.outb, self.outs
+        return HandleCommandResult(self.r, self.outb, self.outs)
 
 
 class HandleCommandResult(namedtuple('HandleCommandResult', ['retval', 'stdout', 'stderr'])):
@@ -988,6 +989,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         return self._ceph_get_daemon_status(svc_type, svc_id)
 
     def mon_command(self, cmd_dict):
+        # type: (dict) -> HandleCommandResult
         """
         Helper for modules that do simple, synchronous mon command
         execution.

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -886,8 +886,8 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def remove_osds(self, osd_ids):
-        # type: (List[str]) -> Completion
+    def remove_osds(self, osd_ids, destroy=False):
+        # type: (List[str], bool) -> Completion
         """
         :param osd_ids: list of OSD IDs
         :param destroy: marks the OSD as being destroyed. See :ref:`orchestrator-osd-replace`


### PR DESCRIPTION
Properly remove osds when calling `remove_osd()`:

* call `ok-to-destroy`, `osd purge` etc.
* also implement the removal part of replace OSDs

**Notice**: I've never actually executed this code. Thus it's more like pseudo-code at this stage.

**TODO**:

- [ ] Move the loop into `serve()`

See also: https://github.com/rook/rook/pull/3954

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
