### PR TITLE
luminous: common/util: handle long lines in /proc/cpuinfo

### DIFF
--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -173,7 +173,7 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
   // processor
   f = fopen(PROCPREFIX "/proc/cpuinfo", "r");
   if (f) {
-    char buf[100];
+    char buf[1024];
     while (!feof(f)) {
       char *line = fgets(buf, sizeof(buf), f);
       if (!line)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/39474

---

backport of https://github.com/ceph/ceph/pull/27707
parent tracker: https://tracker.ceph.com/issues/38296

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh