### PR TITLE
mds: Reorganize class members in SnapServer header

### DIFF
--- a/src/mds/SnapServer.h
+++ b/src/mds/SnapServer.h
@@ -24,23 +24,62 @@ class MDSRank;
 class MonClient;
 
 class SnapServer : public MDSTableServer {
+public:
+  SnapServer(MDSRank *m, MonClient *monc)
+    : MDSTableServer(m, TABLE_SNAP), mon_client(monc) {}
+  SnapServer() : MDSTableServer(NULL, TABLE_SNAP) {}
+
+  void handle_remove_snaps(const cref_t<MRemoveSnaps> &m);
+
+  void reset_state() override;
+
+  bool upgrade_format() {
+    // upgraded from old filesystem
+    ceph_assert(is_active());
+    ceph_assert(last_snap > 0);
+    bool upgraded = false;
+    if (get_version() == 0) {
+      // version 0 confuses snapclient code
+      reset();
+      upgraded = true;
+    }
+    if (snaprealm_v2_since == CEPH_NOSNAP) {
+      // new snapshots will have new format snaprealms
+      snaprealm_v2_since = last_snap + 1;
+      upgraded = true;
+    }
+    return upgraded;
+  }
+
+  void check_osd_map(bool force);
+
+  void mark_base_recursively_scrubbed(inodeno_t ino) {
+    if (ino ==  MDS_INO_ROOT)
+      root_scrubbed = true;
+    else if (ino == MDS_INO_MDSDIR(rank))
+      mdsdir_scrubbed = true;
+    else
+      ceph_abort();
+  }
+  bool can_allow_multimds_snaps() const {
+    return (root_scrubbed && mdsdir_scrubbed) ||
+	   snaps.empty() || snaps.begin()->first >= snaprealm_v2_since;
+  }
+
+  void encode(bufferlist& bl) const {
+    encode_server_state(bl);
+  }
+  void decode(bufferlist::const_iterator& bl) {
+    decode_server_state(bl);
+  }
+
+  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<SnapServer*>& ls);
+
+  bool force_update(snapid_t last, snapid_t v2_since,
+		    map<snapid_t, SnapInfo>& _snaps);
+
 protected:
-  MonClient *mon_client = nullptr;
-  snapid_t last_snap = 0;
-  snapid_t last_created, last_destroyed;
-  snapid_t snaprealm_v2_since;
-  map<snapid_t, SnapInfo> snaps;
-  map<int, set<snapid_t> > need_to_purge;
-  
-  map<version_t, SnapInfo> pending_update;
-  map<version_t, pair<snapid_t,snapid_t> > pending_destroy; // (removed_snap, seq)
-  set<version_t>           pending_noop;
-
-  version_t last_checked_osdmap;
-
-  bool root_scrubbed = false; // all snaprealms under root are converted?
-  bool mdsdir_scrubbed = false; // all snaprealms under ~mds0 are converted?
-
   void encode_server_state(bufferlist& bl) const override {
     ENCODE_START(5, 3, bl);
     encode(last_snap, bl);
@@ -93,61 +132,21 @@ protected:
   bool _notify_prep(version_t tid) override;
   void handle_query(const cref_t<MMDSTableRequest> &m) override;
 
-public:
-  void handle_remove_snaps(const cref_t<MRemoveSnaps> &m);
+  MonClient *mon_client = nullptr;
+  snapid_t last_snap = 0;
+  snapid_t last_created, last_destroyed;
+  snapid_t snaprealm_v2_since;
+  map<snapid_t, SnapInfo> snaps;
+  map<int, set<snapid_t> > need_to_purge;
 
-public:
-  SnapServer(MDSRank *m, MonClient *monc)
-    : MDSTableServer(m, TABLE_SNAP), mon_client(monc), last_checked_osdmap(0) {}
-  SnapServer() : MDSTableServer(NULL, TABLE_SNAP), last_checked_osdmap(0) {}
+  map<version_t, SnapInfo> pending_update;
+  map<version_t, pair<snapid_t,snapid_t> > pending_destroy; // (removed_snap, seq)
+  set<version_t> pending_noop;
 
-  void reset_state() override;
+  version_t last_checked_osdmap = 0;
 
-  bool upgrade_format() {
-    // upgraded from old filesystem
-    ceph_assert(is_active());
-    ceph_assert(last_snap > 0);
-    bool upgraded = false;
-    if (get_version() == 0) {
-      // version 0 confuses snapclient code
-      reset();
-      upgraded = true;
-    }
-    if (snaprealm_v2_since == CEPH_NOSNAP) {
-      // new snapshots will have new format snaprealms
-      snaprealm_v2_since = last_snap + 1;
-      upgraded = true;
-    }
-    return upgraded;
-  }
-
-  void check_osd_map(bool force);
-
-  void mark_base_recursively_scrubbed(inodeno_t ino) {
-    if (ino ==  MDS_INO_ROOT)
-      root_scrubbed = true;
-    else if (ino == MDS_INO_MDSDIR(rank))
-      mdsdir_scrubbed = true;
-    else
-      ceph_abort();
-  }
-  bool can_allow_multimds_snaps() const {
-    return (root_scrubbed && mdsdir_scrubbed) ||
-	   snaps.empty() || snaps.begin()->first >= snaprealm_v2_since;
-  }
-
-  void encode(bufferlist& bl) const {
-    encode_server_state(bl);
-  }
-  void decode(bufferlist::const_iterator& bl) {
-    decode_server_state(bl);
-  }
-
-  void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<SnapServer*>& ls);
-
-  bool force_update(snapid_t last, snapid_t v2_since,
-		    map<snapid_t, SnapInfo>& _snaps);
+  bool root_scrubbed = false; // all snaprealms under root are converted?
+  bool mdsdir_scrubbed = false; // all snaprealms under ~mds0 are converted?
 };
 WRITE_CLASS_ENCODER(SnapServer)
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43387
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
