### PR TITLE
qa/suites/rados/perf: run on ubuntu

### DIFF
--- a/qa/suites/rados/perf/supported-random-distro$
+++ b/qa/suites/rados/perf/supported-random-distro$
@@ -1,1 +1,0 @@
-../basic/supported-random-distro$

--- a/qa/suites/rados/perf/ubuntu_latest.yaml
+++ b/qa/suites/rados/perf/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/ubuntu_latest.yaml


### PR DESCRIPTION
pdsh and collectl packages don't seem to exist on el8.

Signed-off-by: Sage Weil <sage@redhat.com>