### PR TITLE
qa/suites/rados/thrash-old-clients: centos -> ubuntu

### DIFF
--- a/qa/suites/rados/thrash-old-clients/distro$/centos_latest.yaml
+++ b/qa/suites/rados/thrash-old-clients/distro$/centos_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/centos_latest.yaml

--- a/qa/suites/rados/thrash-old-clients/distro$/ubuntu_latest.yaml
+++ b/qa/suites/rados/thrash-old-clients/distro$/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/ubuntu_latest.yaml


### PR DESCRIPTION
We can't upgrade packages from el7 to el8, so do this on ubuntu 18.04.

Signed-off-by: Sage Weil <sage@redhat.com>