### PR TITLE
mimic: osd: backfill_toofull seen on cluster where the most full OSD is at 1%

### DIFF
--- a/src/messages/MBackfillReserve.h
+++ b/src/messages/MBackfillReserve.h
@@ -27,7 +27,7 @@ public:
   enum {
     REQUEST = 0,   // primary->replica: please reserve a slot
     GRANT = 1,     // replica->primary: ok, i reserved it
-    REJECT = 2,    // replica->primary: sorry, try again later (*)
+    REJECT_TOOFULL = 2,    // replica->primary: too full, sorry, try again later (*)
     RELEASE = 3,   // primary->replcia: release the slot i reserved before
     REVOKE_TOOFULL = 4,   // replica->primary: too full, stop backfilling
     REVOKE = 5,    // replica->primary: i'm taking back the slot i gave you
@@ -58,7 +58,7 @@ public:
 	query_epoch,
 	query_epoch,
 	RemoteBackfillReserved());
-    case REJECT:
+    case REJECT_TOOFULL:
       // NOTE: this is replica -> primary "i reject your request"
       //      and also primary -> replica "cancel my previously-granted request"
       //                                  (for older peers)
@@ -67,7 +67,7 @@ public:
       return new PGPeeringEvent(
 	query_epoch,
 	query_epoch,
-	RemoteReservationRejected());
+	RemoteReservationRejectedTooFull());
     case RELEASE:
       return new PGPeeringEvent(
 	query_epoch,
@@ -110,8 +110,8 @@ public:
     case GRANT:
       out << "GRANT";
       break;
-    case REJECT:
-      out << "REJECT ";
+    case REJECT_TOOFULL:
+      out << "REJECT_TOOFULL";
       break;
     case RELEASE:
       out << "RELEASE";
@@ -144,7 +144,7 @@ public:
       encode(pgid.pgid, payload);
       encode(query_epoch, payload);
       encode((type == RELEASE || type == REVOKE_TOOFULL || type == REVOKE) ?
-	       REJECT : type, payload);
+	       REJECT_TOOFULL : type, payload);
       encode(priority, payload);
       encode(pgid.shard, payload);
       return;

--- a/src/messages/MBackfillReserve.h
+++ b/src/messages/MBackfillReserve.h
@@ -29,7 +29,7 @@ public:
     GRANT = 1,     // replica->primary: ok, i reserved it
     REJECT = 2,    // replica->primary: sorry, try again later (*)
     RELEASE = 3,   // primary->replcia: release the slot i reserved before
-    TOOFULL = 4,   // replica->primary: too full, stop backfilling
+    REVOKE_TOOFULL = 4,   // replica->primary: too full, stop backfilling
     REVOKE = 5,    // replica->primary: i'm taking back the slot i gave you
     // (*) NOTE: prior to luminous, REJECT was overloaded to also mean release
   };
@@ -73,7 +73,7 @@ public:
 	query_epoch,
 	query_epoch,
 	RemoteReservationCanceled());
-    case TOOFULL:
+    case REVOKE_TOOFULL:
       return new PGPeeringEvent(
 	query_epoch,
 	query_epoch,
@@ -116,8 +116,8 @@ public:
     case RELEASE:
       out << "RELEASE";
       break;
-    case TOOFULL:
-      out << "TOOFULL";
+    case REVOKE_TOOFULL:
+      out << "REVOKE_TOOFULL";
       break;
     case REVOKE:
       out << "REVOKE";
@@ -143,7 +143,7 @@ public:
       header.compat_version = 3;
       encode(pgid.pgid, payload);
       encode(query_epoch, payload);
-      encode((type == RELEASE || type == TOOFULL || type == REVOKE) ?
+      encode((type == RELEASE || type == REVOKE_TOOFULL || type == REVOKE) ?
 	       REJECT : type, payload);
       encode(priority, payload);
       encode(pgid.shard, payload);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7585,7 +7585,7 @@ PG::RecoveryState::RepRecovering::react(const BackfillTooFull &)
   pg->osd->send_message_osd_cluster(
     pg->primary.osd,
     new MBackfillReserve(
-      MBackfillReserve::TOOFULL,
+      MBackfillReserve::REVOKE_TOOFULL,
       spg_t(pg->info.pgid.pgid, pg->primary.shard),
       pg->get_osdmap()->get_epoch()),
     pg->get_osdmap()->get_epoch());

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4293,7 +4293,7 @@ void PG::reject_reservation()
   osd->send_message_osd_cluster(
     primary.osd,
     new MBackfillReserve(
-      MBackfillReserve::REJECT,
+      MBackfillReserve::REJECT_TOOFULL,
       spg_t(info.pgid.pgid, primary.shard),
       get_osdmap()->get_epoch()),
     get_osdmap()->get_epoch());
@@ -7266,7 +7266,7 @@ void PG::RecoveryState::WaitRemoteBackfillReserved::retry()
 }
 
 boost::statechart::result
-PG::RecoveryState::WaitRemoteBackfillReserved::react(const RemoteReservationRejected &evt)
+PG::RecoveryState::WaitRemoteBackfillReserved::react(const RemoteReservationRejectedTooFull &evt)
 {
   PG *pg = context< RecoveryMachine >().pg;
   pg->state_set(PG_STATE_BACKFILL_TOOFULL);
@@ -7326,7 +7326,7 @@ PG::RecoveryState::NotBackfilling::react(const RemoteBackfillReserved &evt)
 }
 
 boost::statechart::result
-PG::RecoveryState::NotBackfilling::react(const RemoteReservationRejected &evt)
+PG::RecoveryState::NotBackfilling::react(const RemoteReservationRejectedTooFull &evt)
 {
   return discard_event();
 }
@@ -7368,11 +7368,11 @@ PG::RecoveryState::RepNotRecovering::RepNotRecovering(my_context ctx)
 }
 
 boost::statechart::result
-PG::RecoveryState::RepNotRecovering::react(const RejectRemoteReservation &evt)
+PG::RecoveryState::RepNotRecovering::react(const RejectTooFullRemoteReservation &evt)
 {
   PG *pg = context< RecoveryMachine >().pg;
   pg->reject_reservation();
-  post_event(RemoteReservationRejected());
+  post_event(RemoteReservationRejectedTooFull());
   return discard_event();
 }
 
@@ -7439,12 +7439,12 @@ PG::RecoveryState::RepNotRecovering::react(const RequestBackfillPrio &evt)
       (rand()%1000 < (pg->cct->_conf->osd_debug_reject_backfill_probability*1000.0))) {
     ldout(pg->cct, 10) << "backfill reservation rejected: failure injection"
 		       << dendl;
-    post_event(RejectRemoteReservation());
+    post_event(RejectTooFullRemoteReservation());
   } else if (!pg->cct->_conf->osd_debug_skip_full_check_in_backfill_reservation &&
       pg->osd->check_backfill_full(pg)) {
     ldout(pg->cct, 10) << "backfill reservation rejected: backfill full"
 		       << dendl;
-    post_event(RejectRemoteReservation());
+    post_event(RejectTooFullRemoteReservation());
   } else {
     Context *preempt = nullptr;
     if (HAVE_FEATURE(pg->upacting_features, RECOVERY_RESERVATION_2)) {
@@ -7508,13 +7508,13 @@ PG::RecoveryState::RepWaitBackfillReserved::react(const RemoteBackfillReserved &
       (rand()%1000 < (pg->cct->_conf->osd_debug_reject_backfill_probability*1000.0))) {
     ldout(pg->cct, 10) << "backfill reservation rejected after reservation: "
 		       << "failure injection" << dendl;
-    post_event(RejectRemoteReservation());
+    post_event(RejectTooFullRemoteReservation());
     return discard_event();
   } else if (!pg->cct->_conf->osd_debug_skip_full_check_in_backfill_reservation &&
 	     pg->osd->check_backfill_full(pg)) {
     ldout(pg->cct, 10) << "backfill reservation rejected after reservation: backfill full"
 		       << dendl;
-    post_event(RejectRemoteReservation());
+    post_event(RejectTooFullRemoteReservation());
     return discard_event();
   } else {
     pg->osd->send_message_osd_cluster(
@@ -7530,17 +7530,17 @@ PG::RecoveryState::RepWaitBackfillReserved::react(const RemoteBackfillReserved &
 
 boost::statechart::result
 PG::RecoveryState::RepWaitBackfillReserved::react(
-  const RejectRemoteReservation &evt)
+  const RejectTooFullRemoteReservation &evt)
 {
   PG *pg = context< RecoveryMachine >().pg;
   pg->reject_reservation();
-  post_event(RemoteReservationRejected());
+  post_event(RemoteReservationRejectedTooFull());
   return discard_event();
 }
 
 boost::statechart::result
 PG::RecoveryState::RepWaitBackfillReserved::react(
-  const RemoteReservationRejected &evt)
+  const RemoteReservationRejectedTooFull &evt)
 {
   PG *pg = context< RecoveryMachine >().pg;
   pg->osd->remote_reserver.cancel_reservation(pg->info.pgid);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7260,7 +7260,6 @@ void PG::RecoveryState::WaitRemoteBackfillReserved::retry()
   }
 
   pg->state_clear(PG_STATE_BACKFILL_WAIT);
-  pg->state_set(PG_STATE_BACKFILL_TOOFULL);
   pg->publish_stats_to_osd();
 
   pg->schedule_backfill_retry(pg->cct->_conf->osd_backfill_retry_interval);
@@ -7269,6 +7268,8 @@ void PG::RecoveryState::WaitRemoteBackfillReserved::retry()
 boost::statechart::result
 PG::RecoveryState::WaitRemoteBackfillReserved::react(const RemoteReservationRejected &evt)
 {
+  PG *pg = context< RecoveryMachine >().pg;
+  pg->state_set(PG_STATE_BACKFILL_TOOFULL);
   retry();
   return transit<NotBackfilling>();
 }

--- a/src/osd/PGPeeringEvent.h
+++ b/src/osd/PGPeeringEvent.h
@@ -161,7 +161,7 @@ struct RequestRecoveryPrio : boost::statechart::event< RequestRecoveryPrio > {
 
 TrivialEvent(NullEvt)
 TrivialEvent(RemoteBackfillReserved)
-TrivialEvent(RemoteReservationRejected)
+TrivialEvent(RemoteReservationRejectedTooFull)
 TrivialEvent(RemoteReservationRevokedTooFull)
 TrivialEvent(RemoteReservationRevoked)
 TrivialEvent(RemoteReservationCanceled)


### PR DESCRIPTION
Backport 
#29857

Parent tracker
https://tracker.ceph.com/issues/41255

Backport tracker
https://tracker.ceph.com/issues/41584

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
