### PR TITLE
qa/suites/rados/thrash-old-clients: use cephadm

### DIFF
--- a/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
@@ -34,6 +34,8 @@ tasks:
       - python3-rgw
       - python3-rbd
       - python3-cephfs
+      - rbd-mirror
+      - rbd-nbd
     extra_packages:
       - librados2
       - python-rados

--- a/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
@@ -28,7 +28,3 @@ tasks:
       - libcephfs-dev
       - libradospp-devel
     extra_packages: ['librados2']
-- install.upgrade:
-    mon.a:
-    mon.b:
-    mon.c:

--- a/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
@@ -30,4 +30,12 @@ tasks:
       - ceph-immutable-object-cache
       - ceph-base
       - librados-devel
-    extra_packages: ['librados2']
+      - python3-rados
+      - python3-rgw
+      - python3-rbd
+      - python3-cephfs
+    extra_packages:
+      - librados2
+      - python-rados
+      - python-rbd
+      - python-cephfs

--- a/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
@@ -27,4 +27,7 @@ tasks:
       - libcephfs-devel
       - libcephfs-dev
       - libradospp-devel
+      - ceph-immutable-object-cache
+      - ceph-base
+      - librados-devel
     extra_packages: ['librados2']

--- a/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    mon_bind_addrvec: false
     mon_bind_msgr2: false
     crush_tunables: hammer
     log-whitelist:

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    mon_bind_addrvec: false
     mon_bind_msgr2: false
     log-whitelist:
       - \(MON_DOWN\)

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
@@ -26,4 +26,12 @@ tasks:
       - ceph-immutable-object-cache
       - ceph-base
       - librados-devel
-    extra_packages: ['librados2']
+      - python3-rados
+      - python3-rgw
+      - python3-rbd
+      - python3-cephfs
+    extra_packages:
+      - librados2
+      - python-rados
+      - python-rbd
+      - python-cephfs

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
@@ -24,7 +24,3 @@ tasks:
       - libcephfs-devel
       - libcephfs-dev
     extra_packages: ['librados2']
-- install.upgrade:
-    mon.a:
-    mon.b:
-    mon.c:

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
@@ -23,4 +23,7 @@ tasks:
       - libcephfs2
       - libcephfs-devel
       - libcephfs-dev
+      - ceph-immutable-object-cache
+      - ceph-base
+      - librados-devel
     extra_packages: ['librados2']

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    mon_bind_addrvec: false
     mon_bind_msgr2: false
     log-whitelist:
       - \(MON_DOWN\)

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
@@ -25,4 +25,12 @@ tasks:
       - ceph-immutable-object-cache
       - ceph-base
       - librados-devel
-    extra_packages: ['librados2']
+      - python3-rados
+      - python3-rgw
+      - python3-rbd
+      - python3-cephfs
+    extra_packages:
+      - librados2
+      - python-rados
+      - python-rbd
+      - python-cephfs

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
@@ -22,4 +22,7 @@ tasks:
       - libcephfs2
       - libcephfs-devel
       - libcephfs-dev
+      - ceph-immutable-object-cache
+      - ceph-base
+      - librados-devel
     extra_packages: ['librados2']

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
@@ -23,7 +23,3 @@ tasks:
       - libcephfs-devel
       - libcephfs-dev
     extra_packages: ['librados2']
-- install.upgrade:
-    mon.a:
-    mon.b:
-    mon.c:

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
@@ -19,4 +19,6 @@ tasks:
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm
+      - ceph-immutable-object-cache
+      - ceph-base
     extra_packages: ['librados2']

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
@@ -20,7 +20,3 @@ tasks:
       - ceph-mgr-cephadm
       - cephadm
     extra_packages: ['librados2']
-- install.upgrade:
-    mon.a:
-    mon.b:
-    mon.c:

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
@@ -1,7 +1,6 @@
 overrides:
   ceph:
     mon_bind_msgr2: false
-    mon_bind_addrvec: false
     log-whitelist:
       - \(MON_DOWN\)
     conf:

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
@@ -21,4 +21,14 @@ tasks:
       - cephadm
       - ceph-immutable-object-cache
       - ceph-base
-    extra_packages: ['librados2']
+      - python3-rados
+      - python3-rgw
+      - python3-rbd
+      - python3-cephfs
+      - librados-devel
+    extra_packages:
+      - librados2
+      - python-rados
+      - python-rgw
+      - python-rbd
+      - python-cephfs

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
@@ -20,4 +20,14 @@ tasks:
       - cephadm
       - ceph-immutable-object-cache
       - ceph-base
-    extra_packages: ['librados2']
+      - python3-rados
+      - python3-rgw
+      - python3-rbd
+      - python3-cephfs
+      - librados-devel
+    extra_packages:
+      - librados2
+      - python-rados
+      - python-rgw
+      - python-rbd
+      - python-cephfs

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
@@ -18,4 +18,6 @@ tasks:
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm
+      - ceph-immutable-object-cache
+      - ceph-base
     extra_packages: ['librados2']

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    mon_bind_addrvec: false
     mon_bind_msgr2: false
     log-whitelist:
       - \(MON_DOWN\)

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
@@ -19,7 +19,3 @@ tasks:
       - ceph-mgr-cephadm
       - cephadm
     extra_packages: ['librados2']
-- install.upgrade:
-    mon.a:
-    mon.b:
-    mon.c:

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
@@ -19,4 +19,6 @@ tasks:
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm
+      - ceph-immutable-object-cache
+      - ceph-base
     extra_packages: ['librados2']

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
@@ -20,7 +20,3 @@ tasks:
       - ceph-mgr-cephadm
       - cephadm
     extra_packages: ['librados2']
-- install.upgrade:
-    mon.a:
-    mon.b:
-    mon.c:

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    mon_bind_addrvec: false
     mon_bind_msgr2: false
     log-whitelist:
       - \(MON_DOWN\)

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
@@ -21,4 +21,14 @@ tasks:
       - cephadm
       - ceph-immutable-object-cache
       - ceph-base
-    extra_packages: ['librados2']
+      - python3-rados
+      - python3-rgw
+      - python3-rbd
+      - python3-cephfs
+      - librados-devel
+    extra_packages:
+      - librados2
+      - python-rados
+      - python-rgw
+      - python-rbd
+      - python-cephfs

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
@@ -19,4 +19,6 @@ tasks:
       - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm
+      - ceph-immutable-object-cache
+      - ceph-base
     extra_packages: ['librados2']

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
@@ -20,7 +20,3 @@ tasks:
       - ceph-mgr-cephadm
       - cephadm
     extra_packages: ['librados2']
-- install.upgrade:
-    mon.a:
-    mon.b:
-    mon.c:

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    mon_bind_addrvec: false
     mon_bind_msgr2: false
     log-whitelist:
       - \(MON_DOWN\)

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
@@ -21,4 +21,14 @@ tasks:
       - cephadm
       - ceph-immutable-object-cache
       - ceph-base
-    extra_packages: ['librados2']
+      - python3-rados
+      - python3-rgw
+      - python3-rbd
+      - python3-cephfs
+      - librados-devel
+    extra_packages:
+      - librados2
+      - python-rados
+      - python-rgw
+      - python-rbd
+      - python-cephfs

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus-v1only.yaml
@@ -13,7 +13,3 @@ tasks:
     branch: nautilus
     exclude_packages:
       - cephadm
-- install.upgrade:
-    mon.a:
-    mon.b:
-    mon.c:

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus-v1only.yaml
@@ -1,7 +1,6 @@
 overrides:
   ceph:
     mon_bind_msgr2: false
-    mon_bind_addrvec: false
     log-whitelist:
       - \(MON_DOWN\)
     conf:

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus-v1only.yaml
@@ -13,3 +13,6 @@ tasks:
     branch: nautilus
     exclude_packages:
       - cephadm
+      - ceph-mgr-cephadm
+      - ceph-immutable-object-cache
+      

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus-v1only.yaml
@@ -15,4 +15,12 @@ tasks:
       - cephadm
       - ceph-mgr-cephadm
       - ceph-immutable-object-cache
-      
+      - python3-rados
+      - python3-rgw
+      - python3-rbd
+      - python3-cephfs
+    extra_packages:
+      - python-rados
+      - python-rgw
+      - python-rbd
+      - python-cephfs

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus-v2only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus-v2only.yaml
@@ -12,3 +12,5 @@ tasks:
     branch: nautilus
     exclude_packages:
       - cephadm
+      - ceph-mgr-cephadm
+      - ceph-immutable-object-cache

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus-v2only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus-v2only.yaml
@@ -12,7 +12,3 @@ tasks:
     branch: nautilus
     exclude_packages:
       - cephadm
-- install.upgrade:
-    mon.a:
-    mon.b:
-    mon.c:

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus-v2only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus-v2only.yaml
@@ -14,3 +14,12 @@ tasks:
       - cephadm
       - ceph-mgr-cephadm
       - ceph-immutable-object-cache
+      - python3-rados
+      - python3-rgw
+      - python3-rbd
+      - python3-cephfs
+    extra_packages:
+      - python-rados
+      - python-rgw
+      - python-rbd
+      - python-cephfs

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus.yaml
@@ -9,3 +9,12 @@ tasks:
       - cephadm
       - ceph-mgr-cephadm
       - ceph-immutable-object-cache
+      - python3-rados
+      - python3-rgw
+      - python3-rbd
+      - python3-cephfs
+    extra_packages:
+      - python-rados
+      - python-rgw
+      - python-rbd
+      - python-cephfs

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus.yaml
@@ -7,7 +7,3 @@ tasks:
     branch: nautilus
     exclude_packages:
       - cephadm
-- install.upgrade:
-    mon.a:
-    mon.b:
-    mon.c:

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus.yaml
@@ -7,3 +7,5 @@ tasks:
     branch: nautilus
     exclude_packages:
       - cephadm
+      - ceph-mgr-cephadm
+      - ceph-immutable-object-cache

--- a/qa/suites/rados/thrash-old-clients/ceph.yaml
+++ b/qa/suites/rados/thrash-old-clients/ceph.yaml
@@ -1,2 +1,2 @@
 tasks:
-- ceph:
+- cephadm:

--- a/qa/suites/rados/thrash-old-clients/clusters/three-plus-one.yaml
+++ b/qa/suites/rados/thrash-old-clients/clusters/three-plus-one.yaml
@@ -1,8 +1,7 @@
 roles:
 - [mon.a, mgr.y, osd.0, osd.1, osd.2, osd.3, client.0]
 - [mon.b, mgr.x, osd.4, osd.5, osd.6, osd.7, client.1]
-- [mon.c, osd.8, osd.9, osd.10, osd.11]
-- [client.2]
+- [mon.c, osd.8, osd.9, osd.10, osd.11, client.2]
 openstack:
 - volumes: # attached to each instance
     count: 4

--- a/qa/suites/rados/thrash-old-clients/distro$/centos_7.6.yaml
+++ b/qa/suites/rados/thrash-old-clients/distro$/centos_7.6.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/centos_7.6.yaml

--- a/qa/suites/rados/thrash-old-clients/distro$/ubuntu_latest.yaml
+++ b/qa/suites/rados/thrash-old-clients/distro$/ubuntu_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/ubuntu_latest.yaml

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1530,6 +1530,18 @@ class CephManager:
         """
         if stdout is None:
             stdout = StringIO()
+
+        if self.cephadm:
+            return shell(
+                self.ctx, self.cluster, self.controller,
+                args=[
+                    'ceph', 'daemon', '%s.%s' % (service_type, service_id),
+                ] + command,
+                stdout=stdout,
+                wait=True,
+                check_status=check_status,
+            )
+
         testdir = teuthology.get_testdir(self.ctx)
         remote = self.find_remote(service_type, service_id)
         args = [

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -814,6 +814,9 @@ def task(ctx, config):
     cluster_name = config['cluster']
     ctx.ceph[cluster_name] = argparse.Namespace()
 
+    ctx.ceph[cluster_name].thrashers = []
+    # fixme: setup watchdog, ala ceph.py
+
     # cephadm mode?
     if 'cephadm_mode' not in config:
         config['cephadm_mode'] = 'root'

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -297,6 +297,7 @@ def ceph_bootstrap(ctx, config):
             path='{}/seed.{}.conf'.format(testdir, cluster_name),
             data=conf_fp.getvalue())
         log.debug('Final config:\n' + conf_fp.getvalue())
+        ctx.ceph[cluster_name].conf = seed_config
 
         # bootstrap
         log.info('Bootstrapping...')

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -197,7 +197,7 @@ def ceph_log(ctx, config):
                     args=[
                         'sudo',
                         'find',
-                        '/var/log/ceph/' + fsid,
+                        '/var/log/ceph',   # all logs, not just for the cluster
                         '-name',
                         '*.log',
                         '-print0',
@@ -226,7 +226,7 @@ def ceph_log(ctx, config):
                     os.makedirs(sub)
                 except OSError:
                     pass
-                teuthology.pull_directory(remote, '/var/log/ceph/' + fsid,
+                teuthology.pull_directory(remote, '/var/log/ceph',  # everything
                                           os.path.join(sub, 'log'))
 
 @contextlib.contextmanager

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -388,7 +388,17 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
       if (i != mon->monmap->mon_info.begin()) {
 	conf << " ";
       }
-      conf << i->second.public_addrs;
+      if (i->second.public_addrs.size() == 1 &&
+	  i->second.public_addrs.front().is_legacy() &&
+	  i->second.public_addrs.front().get_port() == CEPH_MON_PORT_LEGACY) {
+	// if this is a legacy addr on the legacy default port, then
+	// use the legacy-compatible formatting so that old clients
+	// can use this config.  new code will see the :6789 and correctly
+	// interpret this as a v1 address.
+	conf << i->second.public_addrs.get_legacy_str();
+      } else {
+	conf << i->second.public_addrs;
+      }
     }
     conf << "\n";
     conf << config_map.global.get_minimal_conf();


### PR DESCRIPTION
- deploy cluster with cephadm so we can run a octopus+ cluster and also
  install client packages that are ancient.
- move client.2 back onto the third node, since packages no longer
  conflict.

Signed-off-by: Sage Weil <sage@redhat.com>