### PR TITLE
cephadm: python3 shebang

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -390,6 +390,7 @@ Base is the package that includes all the files shared amongst ceph servers
 Summary:        Utility to bootstrap Ceph clusters
 Requires:       podman
 Requires:       lvm2
+Requires:       python%{python3_pkgversion}
 %description -n cephadm
 Utility to bootstrap a Ceph cluster and manage Ceph daemons deployed 
 with systemd and podman.

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 DEFAULT_IMAGE='ceph/daemon-base:latest-master-devel'  # FIXME when octopus is ready!!!
 DATA_DIR='/var/lib/ceph'


### PR DESCRIPTION
We need to figure out if/how we can make this as tolerant as possible for
the curl users so that it can still run on a python2-only host.

Maybe.

Signed-off-by: Sage Weil <sage@redhat.com>