### PR TITLE
pybind/ceph_argparse: fix thread is_alive() detection

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -21,6 +21,7 @@ import socket
 import stat
 import sys
 import threading
+import time
 import uuid
 
 # Flags are from MonCommand.h
@@ -1332,6 +1333,13 @@ def run_in_thread(func, *args, **kwargs):
     # strictly guaranteed is that *some* thread that has the signal
     # unblocked will receive it).  But there doesn't seem to be
     # any interface to create a thread with SIGINT blocked.
+
+    # Apparently the thread my not have fully exited after join returns,
+    # so implement a try-loop with backoff before claiming to timeout.
+    for i in range(0,100):
+        if not t.is_alive():
+           break
+        time.sleep(float(i) / 100)
     if t.is_alive():
         raise Exception("timed out")
     elif t.exception:


### PR DESCRIPTION
This PR implements a limited sleep loop with backoff to fix an issue where python's join() method may return before a thread has fully exited.  IE calling is_alive() immediately after join() may return true even though the thread is in the process of exiting.  It appears this may be a new regression with python 3.6 as I never saw it happen after many thousands of tests with python 2 on the same platform.

This fixes https://tracker.ceph.com/issues/43402

Signed-off-by: Mark Nelson <mnelson@redhat.com>

- [X] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
