### PR TITLE
osd/scheduler/OpSchedulerItem: schedule backoffs as client ops

### DIFF
--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -244,7 +244,9 @@ public:
   }
 
   op_scheduler_class get_scheduler_class() const final {
-    if (maybe_get_mosd_op()) {
+    auto type = op->get_req()->get_type();
+    if (type == CEPH_MSG_OSD_OP ||
+	type == CEPH_MSG_OSD_BACKOFF) {
       return op_scheduler_class::client;
     } else {
       return op_scheduler_class::immediate;


### PR DESCRIPTION
http://pulpito.ceph.com/sjust-2019-12-20_06:42:20-rados-wip-sjust-testing-2019-12-19-distro-basic-smithi/

Failures appear unrelated/similar to other master runs.