### PR TITLE
mgr/cephadm: check-host on 'host add'

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -685,6 +685,11 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         :param host: host name
         """
+        out, err, code = self._run_cephadm(host, '', 'check-host', [],
+                                           error_ok=True, no_fsid=True)
+        if code:
+            raise OrchestratorError('New host %s failed check: %s' % (host, err))
+
         self.inventory[host] = {}
         self._save_inventory()
         self.inventory_cache[host] = orchestrator.OutdatableData()

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -73,7 +73,9 @@ class TestCephadm(object):
         assert new_mon.startswith('mon.')
         assert new_mon != 'mon.a'
 
-    def test_host(self, cephadm_module):
+    @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
+    def test_host(self, _get_connection, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             assert self._wait(cephadm_module, cephadm_module.get_hosts()) == [InventoryNode('test')]
         c = cephadm_module.get_hosts()


### PR DESCRIPTION
This patch breaks the unit test that does host_add because it passes in a fake hostname.  Should we... add a flag that skips the check?  Do something funky that make sthe test magically skip the check host step?