### PR TITLE
test: Do not test unicode if boost::spirit >= 1.72

### DIFF
--- a/src/test/confutils.cc
+++ b/src/test/confutils.cc
@@ -231,6 +231,8 @@ const char illegal_conf4[] = "\
         keyring = osd_keyring          ; osd's keyring\n\
 ";
 
+#if BOOST_VERSION < 107200
+// Boost::spirit > 1.72 asserts on chars that are not < 0x7f
 // unicode config file
 const char unicode_config_1[] = "\
 [global]\n\
@@ -238,6 +240,7 @@ const char unicode_config_1[] = "\
         pid file =           foo-bar\n\
 [osd0]\n\
 ";
+#endif
 
 const char override_config_1[] = "\
 [global]\n\
@@ -363,12 +366,14 @@ TEST(ConfUtils, ReadFiles2) {
   ASSERT_EQ(cf1.read("global", "pid file", val), 0);
   ASSERT_EQ(val, "spork");
 
+#if BOOST_VERSION < 107200
   std::string unicode_config_1f(next_tempfile(unicode_config_1));
   ConfFile cf2;
   ASSERT_EQ(cf2.parse_file(unicode_config_1f.c_str(), &err), 0);
   ASSERT_EQ(err.tellp(), 0U);
   ASSERT_EQ(cf2.read("global", "log file", val), 0);
   ASSERT_EQ(val, "\x66\xd1\x86\xd1\x9d\xd3\xad\xd3\xae");
+#endif
 }
 
 TEST(ConfUtils, IllegalFiles) {


### PR DESCRIPTION
Testing with Boost 1.72 unittest_confutil crashes with:
```
[ RUN      ] ConfUtils.ReadFiles2
Assertion failed: (strict_ischar(ch)), function isblank, file /usr/local/include/boost/spirit/home/support/char_encoding/standard.hpp, line 129.
Abort
```

Which is due to the fact that in Boost 1.72 most of the character
testing has been garded with an assert to make sure char holds an
ascii char.
Like:
```
        static bool
        isblank BOOST_PREVENT_MACRO_SUBSTITUTION (int ch)
        {
            BOOST_ASSERT(strict_ischar(ch));
            return (ch == ' ' || ch == '\t');
        }
```
And ReadFile2 explicitly tests for strings with char value > 0x7f.
So that is certainly going to crash.

Now I can imagine that we would like to be able to have users use
different encodings for things like logfiles.
But for now that is not going to work with the boost:spirit parser

Fixes: https://tracker.ceph.com/issues/43406



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [X] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>