### PR TITLE
rgw: Add subuser to OPA request

### DIFF
--- a/doc/radosgw/opa.rst
+++ b/doc/radosgw/opa.rst
@@ -46,6 +46,7 @@ Example request::
    {
        "input": {
            "method": "GET",
+           "subuser": "subuser",
            "user_info": {
                "user_id": "john",
                "display_name": "John"  

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -92,6 +92,10 @@ transform_old_authinfo(CephContext* const cct,
       return {};
     }
 
+    string get_subuser() const override {
+      return {};
+    }
+
     void to_str(std::ostream& out) const override {
       out << "RGWDummyIdentityApplier(auth_id=" << id
           << ", perm_mask=" << perm_mask

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -76,6 +76,9 @@ public:
 
   /* Name of Account */
   virtual string get_acct_name() const = 0;
+
+  /* Subuser of Account */
+  virtual string get_subuser() const = 0;
 };
 
 inline std::ostream& operator<<(std::ostream& out,
@@ -410,6 +413,10 @@ public:
     return token_claims.user_name;
   }
 
+  string get_subuser() const override {
+    return {};
+  }
+
   struct Factory {
     virtual ~Factory() {}
 
@@ -541,6 +548,7 @@ public:
   void load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo& user_info) const override; /* out */
   uint32_t get_identity_type() const override { return info.acct_type; }
   string get_acct_name() const override { return info.acct_name; }
+  string get_subuser() const override { return {}; }
 
   struct Factory {
     virtual ~Factory() {}
@@ -602,6 +610,7 @@ public:
   void load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo& user_info) const override; /* out */
   uint32_t get_identity_type() const override { return TYPE_RGW; }
   string get_acct_name() const override { return {}; }
+  string get_subuser() const override { return subuser; }
 
   struct Factory {
     virtual ~Factory() {}
@@ -646,6 +655,7 @@ public:
   void load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo& user_info) const override; /* out */
   uint32_t get_identity_type() const override { return TYPE_ROLE; }
   string get_acct_name() const override { return {}; }
+  string get_subuser() const override { return {}; }
   void modify_request_state(const DoutPrefixProvider* dpp, req_state* s) const override;
 
   struct Factory {

--- a/src/rgw/rgw_auth_filters.h
+++ b/src/rgw/rgw_auth_filters.h
@@ -88,6 +88,10 @@ public:
     return get_decoratee().get_acct_name();
   }
 
+  string get_subuser() const override {
+    return get_decoratee().get_subuser();
+  }
+
   bool is_identity(
     const boost::container::flat_set<Principal>& ids) const override {
     return get_decoratee().is_identity(ids);

--- a/src/rgw/rgw_opa.cc
+++ b/src/rgw/rgw_opa.cc
@@ -45,6 +45,7 @@ int rgw_opa_authorize(RGWOp *& op,
   jf.dump_string("params", s->info.request_params.c_str());
   jf.dump_string("request_uri_aws4", s->info.request_uri_aws4.c_str());
   jf.dump_string("object_name", s->object.name.c_str());
+  jf.dump_string("subuser", s->auth.identity->get_subuser().c_str());
   jf.dump_object("user_info", s->user->get_info());
   jf.dump_object("bucket_info", s->bucket_info);
   jf.close_section();

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -128,6 +128,11 @@ public:
     return 0;
   }
 
+  string get_subuser() const override {
+    abort();
+    return 0;
+  }
+
   void to_str(std::ostream& out) const override {
     out << id;
   }


### PR DESCRIPTION
Add auth s3_postobj_creds object to OPA erquest for managing multi keys in OPA server. So that if user has multiple keys, OPA server can defined which key from user is requesting.

Fixes: https://tracker.ceph.com/issues/44179
Signed-off-by: Seena Fallah <seenafallah@gmail.com>