### PR TITLE
mgr: close restful socket after exec

### DIFF
--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -13,6 +13,7 @@ import threading
 import traceback
 import six
 import socket
+import fcntl
 
 from . import common
 from . import context
@@ -331,6 +332,10 @@ class Module(MgrModule):
             ),
             ssl_context=(cert_fname, pkey_fname),
         )
+        sock_fd_flag = fcntl.fcntl(self.server.socket.fileno(), fcntl.F_GETFD)
+        if not (sock_fd_flag & fcntl.FD_CLOEXEC):
+            self.log.debug("set server socket close-on-exec")
+            fcntl.fcntl(self.server.socket.fileno(), fcntl.F_SETFD, sock_fd_flag | fcntl.FD_CLOEXEC)
         if self.stop_server:
             self.log.debug('made server, but stop flag set')
         else:


### PR DESCRIPTION
This PR fixes the bug that mgr did not close the socket after the restful module executed the [respawn](https://github.com/ceph/ceph/blob/v15.0.0/src/mgr/MgrStandby.cc#L303), which would cause the restful mgr module that mgr could not operate correctly after executing [execv](https://github.com/ceph/ceph/blob/v15.0.0/src/mgr/MgrStandby.cc#L343) operation.

Signed-off-by: liushi <liu.shi@navercorp.com>
Fixes: https://tracker.ceph.com/issues/43383

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
