### PR TITLE
rbd-mirror: continue to isolate journal replay logic

### DIFF
--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(unittest_rbd_mirror
   image_replayer/test_mock_GetMirrorImageIdRequest.cc
   image_replayer/test_mock_PrepareLocalImageRequest.cc
   image_replayer/test_mock_PrepareRemoteImageRequest.cc
+  image_replayer/journal/test_mock_CreateLocalImageRequest.cc
   image_replayer/journal/test_mock_EventPreprocessor.cc
   image_replayer/journal/test_mock_Replayer.cc
   image_sync/test_mock_SyncPointCreateRequest.cc

--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(unittest_rbd_mirror
   image_replayer/test_mock_PrepareLocalImageRequest.cc
   image_replayer/test_mock_PrepareRemoteImageRequest.cc
   image_replayer/journal/test_mock_CreateLocalImageRequest.cc
+  image_replayer/journal/test_mock_PrepareReplayRequest.cc
   image_replayer/journal/test_mock_EventPreprocessor.cc
   image_replayer/journal/test_mock_Replayer.cc
   image_sync/test_mock_SyncPointCreateRequest.cc

--- a/src/test/rbd_mirror/image_replayer/journal/test_mock_CreateLocalImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/journal/test_mock_CreateLocalImageRequest.cc
@@ -1,0 +1,362 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "librbd/journal/Types.h"
+#include "librbd/journal/TypeTraits.h"
+#include "tools/rbd_mirror/Threads.h"
+#include "tools/rbd_mirror/image_replayer/CreateImageRequest.h"
+#include "tools/rbd_mirror/image_replayer/journal/CreateLocalImageRequest.h"
+#include "test/journal/mock/MockJournaler.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/rbd_mirror/mock/MockContextWQ.h"
+#include "test/rbd_mirror/mock/MockSafeTimer.h"
+#include <boost/intrusive_ptr.hpp>
+
+namespace librbd {
+
+namespace {
+
+struct MockTestImageCtx : public librbd::MockImageCtx {
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
+    : librbd::MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+
+namespace journal {
+
+template <>
+struct TypeTraits<librbd::MockTestImageCtx> {
+  typedef ::journal::MockJournaler Journaler;
+};
+
+} // namespace journal
+
+namespace util {
+
+static std::string s_image_id;
+
+template <>
+std::string generate_image_id<MockTestImageCtx>(librados::IoCtx&) {
+  ceph_assert(!s_image_id.empty());
+  return s_image_id;
+}
+
+} // namespace util
+} // namespace librbd
+
+namespace rbd {
+namespace mirror {
+
+template <>
+struct Threads<librbd::MockTestImageCtx> {
+};
+
+namespace image_replayer {
+
+template<>
+struct CreateImageRequest<librbd::MockTestImageCtx> {
+  static CreateImageRequest* s_instance;
+  Context *on_finish = nullptr;
+
+  static CreateImageRequest* create(Threads<librbd::MockTestImageCtx>* threads,
+                                    librados::IoCtx &local_io_ctx,
+                                    const std::string &global_image_id,
+                                    const std::string &remote_mirror_uuid,
+                                    const std::string &local_image_name,
+				    const std::string &local_image_id,
+                                    librbd::MockTestImageCtx *remote_image_ctx,
+                                    Context *on_finish) {
+    ceph_assert(s_instance != nullptr);
+    s_instance->on_finish = on_finish;
+    s_instance->construct(local_image_id);
+    return s_instance;
+  }
+
+  CreateImageRequest() {
+    ceph_assert(s_instance == nullptr);
+    s_instance = this;
+  }
+  ~CreateImageRequest() {
+    s_instance = nullptr;
+  }
+
+  MOCK_METHOD1(construct, void(const std::string&));
+  MOCK_METHOD0(send, void());
+};
+
+CreateImageRequest<librbd::MockTestImageCtx>*
+  CreateImageRequest<librbd::MockTestImageCtx>::s_instance = nullptr;
+
+} // namespace image_replayer
+} // namespace mirror
+} // namespace rbd
+
+#include "tools/rbd_mirror/image_replayer/journal/CreateLocalImageRequest.cc"
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::WithArg;
+
+namespace rbd {
+namespace mirror {
+namespace image_replayer {
+namespace journal {
+
+class TestMockImageReplayerJournalCreateLocalImageRequest : public TestMockFixture {
+public:
+  typedef CreateLocalImageRequest<librbd::MockTestImageCtx> MockCreateLocalImageRequest;
+  typedef Threads<librbd::MockTestImageCtx> MockThreads;
+  typedef CreateImageRequest<librbd::MockTestImageCtx> MockCreateImageRequest;
+
+  void SetUp() override {
+    TestMockFixture::SetUp();
+
+    librbd::RBD rbd;
+    ASSERT_EQ(0, create_image(rbd, m_remote_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_remote_io_ctx, m_image_name, &m_remote_image_ctx));
+    m_mock_remote_image_ctx = new librbd::MockTestImageCtx(*m_remote_image_ctx);
+  }
+
+  void TearDown() override {
+    delete m_mock_remote_image_ctx;
+    TestMockFixture::TearDown();
+  }
+
+  void expect_journaler_register_client(
+      ::journal::MockJournaler& mock_journaler,
+      const librbd::journal::ClientData& client_data, int r) {
+    bufferlist bl;
+    encode(client_data, bl);
+
+    EXPECT_CALL(mock_journaler, register_client(ContentsEqual(bl), _))
+      .WillOnce(WithArg<1>(Invoke([this, r](Context *on_finish) {
+                                    m_threads->work_queue->queue(on_finish, r);
+                                  })));
+  }
+
+  void expect_journaler_unregister_client(
+      ::journal::MockJournaler& mock_journaler, int r) {
+    EXPECT_CALL(mock_journaler, unregister_client(_))
+      .WillOnce(Invoke([this, r](Context *on_finish) {
+                  m_threads->work_queue->queue(on_finish, r);
+                }));
+  }
+
+  void expect_journaler_update_client(
+      ::journal::MockJournaler& mock_journaler,
+      const librbd::journal::ClientData& client_data, int r) {
+    bufferlist bl;
+    encode(client_data, bl);
+
+    EXPECT_CALL(mock_journaler, update_client(ContentsEqual(bl), _))
+      .WillOnce(WithArg<1>(Invoke([this, r](Context *on_finish) {
+                                    m_threads->work_queue->queue(on_finish, r);
+                                  })));
+  }
+  void expect_create_image(MockCreateImageRequest& mock_create_image_request,
+                           const std::string& image_id, int r) {
+    EXPECT_CALL(mock_create_image_request, construct(image_id));
+    EXPECT_CALL(mock_create_image_request, send())
+      .WillOnce(Invoke([this, &mock_create_image_request, r]() {
+          m_threads->work_queue->queue(mock_create_image_request.on_finish, r);
+        }));
+  }
+
+  MockCreateLocalImageRequest* create_request(
+      MockThreads& mock_threads,
+      ::journal::MockJournaler& mock_journaler,
+      const std::string& global_image_id,
+      const std::string& remote_mirror_uuid,
+      librbd::journal::MirrorPeerClientMeta* mirror_peer_client_meta,
+      std::string* local_image_id, Context* on_finish) {
+    return new MockCreateLocalImageRequest(
+      &mock_threads, m_local_io_ctx, m_mock_remote_image_ctx,
+      &mock_journaler, global_image_id, remote_mirror_uuid,
+      mirror_peer_client_meta, nullptr, local_image_id, on_finish);
+  }
+
+  librbd::ImageCtx *m_remote_image_ctx;
+  librbd::MockTestImageCtx *m_mock_remote_image_ctx = nullptr;
+};
+
+TEST_F(TestMockImageReplayerJournalCreateLocalImageRequest, Success) {
+  InSequence seq;
+
+  // re-register the client
+  ::journal::MockJournaler mock_journaler;
+  expect_journaler_unregister_client(mock_journaler, 0);
+
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  librbd::util::s_image_id = "local image id";
+  mirror_peer_client_meta.image_id = "local image id";
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_SYNCING;
+  librbd::journal::ClientData client_data;
+  client_data.client_meta = mirror_peer_client_meta;
+  expect_journaler_register_client(mock_journaler, client_data, 0);
+
+  // create the missing local image
+  MockCreateImageRequest mock_create_image_request;
+  expect_create_image(mock_create_image_request, "local image id", 0);
+
+  C_SaferCond ctx;
+  MockThreads mock_threads;
+  std::string local_image_id;
+  auto request = create_request(
+    mock_threads, mock_journaler, "global image id", "remote mirror uuid",
+    &mirror_peer_client_meta, &local_image_id, &ctx);
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  ASSERT_EQ("local image id", local_image_id);
+  ASSERT_EQ("local image id", mirror_peer_client_meta.image_id);
+  ASSERT_EQ(librbd::journal::MIRROR_PEER_STATE_SYNCING,
+            mirror_peer_client_meta.state);
+}
+
+TEST_F(TestMockImageReplayerJournalCreateLocalImageRequest, UnregisterError) {
+  InSequence seq;
+
+  // re-register the client
+  ::journal::MockJournaler mock_journaler;
+  expect_journaler_unregister_client(mock_journaler, -EINVAL);
+
+  C_SaferCond ctx;
+  MockThreads mock_threads;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  std::string local_image_id;
+  auto request = create_request(
+    mock_threads, mock_journaler, "global image id", "remote mirror uuid",
+    &mirror_peer_client_meta, &local_image_id, &ctx);
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageReplayerJournalCreateLocalImageRequest, RegisterError) {
+  InSequence seq;
+
+  // re-register the client
+  ::journal::MockJournaler mock_journaler;
+  expect_journaler_unregister_client(mock_journaler, 0);
+
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  librbd::util::s_image_id = "local image id";
+  mirror_peer_client_meta.image_id = "local image id";
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_SYNCING;
+  librbd::journal::ClientData client_data;
+  client_data.client_meta = mirror_peer_client_meta;
+  expect_journaler_register_client(mock_journaler, client_data, -EINVAL);
+
+  C_SaferCond ctx;
+  MockThreads mock_threads;
+  std::string local_image_id;
+  auto request = create_request(
+    mock_threads, mock_journaler, "global image id", "remote mirror uuid",
+    &mirror_peer_client_meta, &local_image_id, &ctx);
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageReplayerJournalCreateLocalImageRequest, CreateImageError) {
+  InSequence seq;
+
+  // re-register the client
+  ::journal::MockJournaler mock_journaler;
+  expect_journaler_unregister_client(mock_journaler, 0);
+
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  librbd::util::s_image_id = "local image id";
+  mirror_peer_client_meta.image_id = "local image id";
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_SYNCING;
+  librbd::journal::ClientData client_data;
+  client_data.client_meta = mirror_peer_client_meta;
+  expect_journaler_register_client(mock_journaler, client_data, 0);
+
+  // create the missing local image
+  MockCreateImageRequest mock_create_image_request;
+  expect_create_image(mock_create_image_request, "local image id", -EINVAL);
+
+  C_SaferCond ctx;
+  MockThreads mock_threads;
+  std::string local_image_id;
+  auto request = create_request(
+    mock_threads, mock_journaler, "global image id", "remote mirror uuid",
+    &mirror_peer_client_meta, &local_image_id, &ctx);
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageReplayerJournalCreateLocalImageRequest, CreateImageDuplicate) {
+  InSequence seq;
+
+  // re-register the client
+  ::journal::MockJournaler mock_journaler;
+  expect_journaler_unregister_client(mock_journaler, 0);
+
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  librbd::util::s_image_id = "local image id";
+  mirror_peer_client_meta.image_id = "local image id";
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_SYNCING;
+  librbd::journal::ClientData client_data;
+  client_data.client_meta = mirror_peer_client_meta;
+  expect_journaler_register_client(mock_journaler, client_data, 0);
+
+  // create the missing local image
+  MockCreateImageRequest mock_create_image_request;
+  expect_create_image(mock_create_image_request, "local image id", -EBADF);
+
+  // update image id
+  expect_journaler_update_client(mock_journaler, client_data, 0);
+
+  // re-create the local image
+  expect_create_image(mock_create_image_request, "local image id", 0);
+
+  C_SaferCond ctx;
+  MockThreads mock_threads;
+  std::string local_image_id;
+  auto request = create_request(
+    mock_threads, mock_journaler, "global image id", "remote mirror uuid",
+    &mirror_peer_client_meta, &local_image_id, &ctx);
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageReplayerJournalCreateLocalImageRequest, UpdateClientImageError) {
+  InSequence seq;
+
+  // re-register the client
+  ::journal::MockJournaler mock_journaler;
+  expect_journaler_unregister_client(mock_journaler, 0);
+
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  librbd::util::s_image_id = "local image id";
+  mirror_peer_client_meta.image_id = "local image id";
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_SYNCING;
+  librbd::journal::ClientData client_data;
+  client_data.client_meta = mirror_peer_client_meta;
+  expect_journaler_register_client(mock_journaler, client_data, 0);
+
+  // create the missing local image
+  MockCreateImageRequest mock_create_image_request;
+  expect_create_image(mock_create_image_request, "local image id", -EBADF);
+
+  // update image id
+  expect_journaler_update_client(mock_journaler, client_data, -EINVAL);
+
+  C_SaferCond ctx;
+  MockThreads mock_threads;
+  std::string local_image_id;
+  auto request = create_request(
+    mock_threads, mock_journaler, "global image id", "remote mirror uuid",
+    &mirror_peer_client_meta, &local_image_id, &ctx);
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+} // namespace journal
+} // namespace image_replayer
+} // namespace mirror
+} // namespace rbd

--- a/src/test/rbd_mirror/image_replayer/journal/test_mock_PrepareReplayRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/journal/test_mock_PrepareReplayRequest.cc
@@ -1,0 +1,768 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "librbd/journal/Types.h"
+#include "librbd/journal/TypeTraits.h"
+#include "tools/rbd_mirror/Threads.h"
+#include "tools/rbd_mirror/image_replayer/journal/PrepareReplayRequest.h"
+#include "test/journal/mock/MockJournaler.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/librbd/mock/MockJournal.h"
+
+namespace librbd {
+
+namespace {
+
+struct MockTestImageCtx : public librbd::MockImageCtx {
+  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+    : librbd::MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+
+namespace journal {
+
+template <>
+struct TypeTraits<librbd::MockTestImageCtx> {
+  typedef ::journal::MockJournaler Journaler;
+};
+
+} // namespace journal
+} // namespace rbd
+
+// template definitions
+#include "tools/rbd_mirror/image_replayer/journal/PrepareReplayRequest.cc"
+
+namespace rbd {
+namespace mirror {
+namespace image_replayer {
+namespace journal {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+using ::testing::StrEq;
+using ::testing::WithArg;
+
+class TestMockImageReplayerJournalPrepareReplayRequest : public TestMockFixture {
+public:
+  typedef PrepareReplayRequest<librbd::MockTestImageCtx> MockPrepareReplayRequest;
+  typedef std::list<cls::journal::Tag> Tags;
+
+  void SetUp() override {
+    TestMockFixture::SetUp();
+
+    librbd::RBD rbd;
+    ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
+  }
+
+  void expect_journaler_get_client(::journal::MockJournaler &mock_journaler,
+                                   const std::string &client_id,
+                                   cls::journal::Client &client, int r) {
+    EXPECT_CALL(mock_journaler, get_client(StrEq(client_id), _, _))
+      .WillOnce(DoAll(WithArg<1>(Invoke([client](cls::journal::Client *out_client) {
+                                          *out_client = client;
+                                        })),
+                      WithArg<2>(Invoke([this, r](Context *on_finish) {
+                                          m_threads->work_queue->queue(on_finish, r);
+                                        }))));
+  }
+
+  void expect_journaler_update_client(::journal::MockJournaler &mock_journaler,
+                                      const librbd::journal::ClientData &client_data,
+                                      int r) {
+    bufferlist bl;
+    encode(client_data, bl);
+
+    EXPECT_CALL(mock_journaler, update_client(ContentsEqual(bl), _))
+      .WillOnce(WithArg<1>(Invoke([this, r](Context *on_finish) {
+                                    m_threads->work_queue->queue(on_finish, r);
+                                  })));
+  }
+
+  void expect_journaler_get_tags(::journal::MockJournaler &mock_journaler,
+                                 uint64_t tag_class, const Tags& tags,
+                                 int r) {
+    EXPECT_CALL(mock_journaler, get_tags(tag_class, _, _))
+      .WillOnce(DoAll(WithArg<1>(Invoke([tags](Tags *out_tags) {
+                                          *out_tags = tags;
+                                        })),
+                      WithArg<2>(Invoke([this, r](Context *on_finish) {
+                                          m_threads->work_queue->queue(on_finish, r);
+                                        }))));
+  }
+
+  void expect_journal_get_tag_tid(librbd::MockJournal &mock_journal,
+                                  uint64_t tag_tid) {
+    EXPECT_CALL(mock_journal, get_tag_tid()).WillOnce(Return(tag_tid));
+  }
+
+  void expect_journal_get_tag_data(librbd::MockJournal &mock_journal,
+                                   const librbd::journal::TagData &tag_data) {
+    EXPECT_CALL(mock_journal, get_tag_data()).WillOnce(Return(tag_data));
+  }
+
+  void expect_is_resync_requested(librbd::MockJournal &mock_journal,
+                                  bool do_resync, int r) {
+    EXPECT_CALL(mock_journal, is_resync_requested(_))
+      .WillOnce(DoAll(SetArgPointee<0>(do_resync),
+                      Return(r)));
+  }
+
+  bufferlist encode_tag_data(const librbd::journal::TagData &tag_data) {
+    bufferlist bl;
+    encode(tag_data, bl);
+    return bl;
+  }
+
+  MockPrepareReplayRequest* create_request(
+      librbd::MockTestImageCtx& mock_local_image_ctx,
+      ::journal::MockJournaler& mock_remote_journaler,
+      librbd::mirror::PromotionState remote_promotion_state,
+      const std::string& local_mirror_uuid,
+      const std::string& remote_mirror_uuid,
+      librbd::journal::MirrorPeerClientMeta* client_meta,
+      bool* resync_requested, bool* syncing, Context* on_finish) {
+    return new MockPrepareReplayRequest(
+      &mock_local_image_ctx, &mock_remote_journaler, remote_promotion_state,
+      local_mirror_uuid, remote_mirror_uuid, client_meta, nullptr,
+      resync_requested, syncing, on_finish);
+  }
+
+  librbd::ImageCtx *m_local_image_ctx = nullptr;
+};
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, Success) {
+  InSequence seq;
+
+  librbd::MockJournal mock_journal;
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  mock_local_image_ctx.journal = &mock_journal;
+
+  // check initial state
+  expect_is_resync_requested(mock_journal, false, 0);
+  expect_journal_get_tag_tid(mock_journal, 345);
+  expect_journal_get_tag_data(mock_journal, {"remote mirror uuid"});
+
+  // lookup remote image tag class
+  librbd::journal::ClientData client_data{
+    librbd::journal::ImageClientMeta{123}};
+  cls::journal::Client client;
+  encode(client_data, client.data);
+  ::journal::MockJournaler mock_remote_journaler;
+  expect_journaler_get_client(mock_remote_journaler,
+                              librbd::Journal<>::IMAGE_CLIENT_ID,
+                              client, 0);
+
+  // single promotion event
+  Tags tags = {
+    {2, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 344, 99})},
+  };
+  expect_journaler_get_tags(mock_remote_journaler, 123, tags, 0);
+
+  C_SaferCond ctx;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_FALSE(resync_requested);
+  ASSERT_FALSE(syncing);
+}
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, NoLocalJournal) {
+  InSequence seq;
+
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  C_SaferCond ctx;
+  ::journal::MockJournaler mock_remote_journaler;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, ResyncRequested) {
+  InSequence seq;
+
+  librbd::MockJournal mock_journal;
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  mock_local_image_ctx.journal = &mock_journal;
+
+  // check initial state
+  expect_is_resync_requested(mock_journal, true, 0);
+  expect_journal_get_tag_tid(mock_journal, 345);
+  expect_journal_get_tag_data(mock_journal, {"remote mirror uuid"});
+
+  C_SaferCond ctx;
+  ::journal::MockJournaler mock_remote_journaler;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_TRUE(resync_requested);
+  ASSERT_FALSE(syncing);
+}
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, ResyncRequestedError) {
+  InSequence seq;
+
+  librbd::MockJournal mock_journal;
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  mock_local_image_ctx.journal = &mock_journal;
+
+  // check initial state
+  expect_is_resync_requested(mock_journal, false, -EINVAL);
+
+  C_SaferCond ctx;
+  ::journal::MockJournaler mock_remote_journaler;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, UnlinkedRemoteNonPrimary) {
+  InSequence seq;
+
+  librbd::MockJournal mock_journal;
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  mock_local_image_ctx.journal = &mock_journal;
+
+  // check initial state
+  expect_is_resync_requested(mock_journal, false, 0);
+  expect_journal_get_tag_tid(mock_journal, 345);
+  expect_journal_get_tag_data(mock_journal, {"blah"});
+
+  C_SaferCond ctx;
+  ::journal::MockJournaler mock_remote_journaler;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_NON_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(-EREMOTEIO, ctx.wait());
+}
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, Syncing) {
+  InSequence seq;
+
+  librbd::MockJournal mock_journal;
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  mock_local_image_ctx.journal = &mock_journal;
+
+  // check initial state
+  expect_is_resync_requested(mock_journal, false, 0);
+  expect_journal_get_tag_tid(mock_journal, 345);
+  expect_journal_get_tag_data(mock_journal, {"remote mirror uuid"});
+
+  C_SaferCond ctx;
+  ::journal::MockJournaler mock_remote_journaler;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_SYNCING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_FALSE(resync_requested);
+  ASSERT_TRUE(syncing);
+}
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, GetRemoteTagClassError) {
+  InSequence seq;
+
+  librbd::MockJournal mock_journal;
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  mock_local_image_ctx.journal = &mock_journal;
+
+  // check initial state
+  expect_is_resync_requested(mock_journal, false, 0);
+  expect_journal_get_tag_tid(mock_journal, 345);
+  expect_journal_get_tag_data(mock_journal, {"remote mirror uuid"});
+
+  // lookup remote image tag class
+  librbd::journal::ClientData client_data{
+    librbd::journal::ImageClientMeta{123}};
+  cls::journal::Client client;
+  encode(client_data, client.data);
+  ::journal::MockJournaler mock_remote_journaler;
+  expect_journaler_get_client(mock_remote_journaler,
+                              librbd::Journal<>::IMAGE_CLIENT_ID,
+                              client, -EINVAL);
+
+  C_SaferCond ctx;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, GetRemoteTagsError) {
+  InSequence seq;
+
+  librbd::MockJournal mock_journal;
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  mock_local_image_ctx.journal = &mock_journal;
+
+  // check initial state
+  expect_is_resync_requested(mock_journal, false, 0);
+  expect_journal_get_tag_tid(mock_journal, 345);
+  expect_journal_get_tag_data(mock_journal, {"remote mirror uuid"});
+
+  // lookup remote image tag class
+  librbd::journal::ClientData client_data{
+    librbd::journal::ImageClientMeta{123}};
+  cls::journal::Client client;
+  encode(client_data, client.data);
+  ::journal::MockJournaler mock_remote_journaler;
+  expect_journaler_get_client(mock_remote_journaler,
+                              librbd::Journal<>::IMAGE_CLIENT_ID,
+                              client, 0);
+
+  // single promotion event
+  Tags tags = {
+    {2, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 344, 99})},
+  };
+  expect_journaler_get_tags(mock_remote_journaler, 123, tags, -EINVAL);
+
+  C_SaferCond ctx;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, LocalDemotedRemoteSyncingState) {
+  InSequence seq;
+
+  librbd::MockJournal mock_journal;
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  mock_local_image_ctx.journal = &mock_journal;
+
+  // check initial state
+  expect_is_resync_requested(mock_journal, false, 0);
+  expect_journal_get_tag_tid(mock_journal, 345);
+  expect_journal_get_tag_data(mock_journal, {librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                                             "remote mirror uuid", true, 4, 1});
+
+  // update client state
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta{
+    mock_local_image_ctx.id};
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  librbd::journal::ClientData client_data;
+  client_data.client_meta = mirror_peer_client_meta;
+  ::journal::MockJournaler mock_remote_journaler;
+  expect_journaler_update_client(mock_remote_journaler, client_data, 0);
+
+  // lookup remote image tag class
+  client_data = {librbd::journal::ImageClientMeta{123}};
+  cls::journal::Client client;
+  encode(client_data, client.data);
+  expect_journaler_get_client(mock_remote_journaler,
+                              librbd::Journal<>::IMAGE_CLIENT_ID,
+                              client, 0);
+
+  // remote demotion / promotion event
+  Tags tags = {
+    {2, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 1, 99})},
+    {3, 123, encode_tag_data({librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 2, 1})},
+    {4, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              true, 3, 1})},
+    {5, 123, encode_tag_data({librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 4, 1})},
+    {6, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              true, 5, 1})},
+    {7, 123, encode_tag_data({librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 6, 1})},
+    {8, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              true, 7, 1})}
+  };
+  expect_journaler_get_tags(mock_remote_journaler, 123, tags, 0);
+
+  C_SaferCond ctx;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_SYNCING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_FALSE(resync_requested);
+  ASSERT_FALSE(syncing);
+}
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, UpdateClientError) {
+  InSequence seq;
+
+  librbd::MockJournal mock_journal;
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  mock_local_image_ctx.journal = &mock_journal;
+
+  // check initial state
+  expect_is_resync_requested(mock_journal, false, 0);
+  expect_journal_get_tag_tid(mock_journal, 345);
+  expect_journal_get_tag_data(mock_journal, {"remote mirror uuid"});
+
+  // lookup remote image tag class
+  librbd::journal::ClientData client_data{
+    librbd::journal::ImageClientMeta{123}};
+  cls::journal::Client client;
+  encode(client_data, client.data);
+  ::journal::MockJournaler mock_remote_journaler;
+  expect_journaler_get_client(mock_remote_journaler,
+                              librbd::Journal<>::IMAGE_CLIENT_ID,
+                              client, 0);
+
+  // single promotion event
+  Tags tags = {
+    {2, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 344, 99})},
+  };
+  expect_journaler_get_tags(mock_remote_journaler, 123, tags, 0);
+
+  C_SaferCond ctx;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_FALSE(resync_requested);
+  ASSERT_FALSE(syncing);
+}
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, NonPrimaryRemoteNotTagOwner) {
+  InSequence seq;
+
+  librbd::MockJournal mock_journal;
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  mock_local_image_ctx.journal = &mock_journal;
+
+  // check initial state
+  expect_is_resync_requested(mock_journal, false, 0);
+  expect_journal_get_tag_tid(mock_journal, 345);
+  expect_journal_get_tag_data(mock_journal, {librbd::Journal<>::LOCAL_MIRROR_UUID,
+                                             librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                                             true, 344, 0});
+
+  C_SaferCond ctx;
+  ::journal::MockJournaler mock_remote_journaler;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_NON_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(-EREMOTEIO, ctx.wait());
+}
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, RemoteDemotePromote) {
+  InSequence seq;
+
+  librbd::MockJournal mock_journal;
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  mock_local_image_ctx.journal = &mock_journal;
+
+  // check initial state
+  expect_is_resync_requested(mock_journal, false, 0);
+  expect_journal_get_tag_tid(mock_journal, 345);
+  expect_journal_get_tag_data(mock_journal, {"remote mirror uuid"});
+
+  // lookup remote image tag class
+  librbd::journal::ClientData client_data{
+    librbd::journal::ImageClientMeta{123}};
+  cls::journal::Client client;
+  encode(client_data, client.data);
+  ::journal::MockJournaler mock_remote_journaler;
+  expect_journaler_get_client(mock_remote_journaler,
+                              librbd::Journal<>::IMAGE_CLIENT_ID,
+                              client, 0);
+
+  // remote demotion / promotion event
+  Tags tags = {
+    {2, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 1, 99})},
+    {3, 123, encode_tag_data({librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 2, 1})},
+    {4, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              true, 2, 1})},
+    {5, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              true, 4, 369})}
+  };
+  expect_journaler_get_tags(mock_remote_journaler, 123, tags, 0);
+
+  C_SaferCond ctx;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_FALSE(resync_requested);
+  ASSERT_FALSE(syncing);
+}
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, MultipleRemoteDemotePromotes) {
+  InSequence seq;
+
+  librbd::MockJournal mock_journal;
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  mock_local_image_ctx.journal = &mock_journal;
+
+  // check initial state
+  expect_is_resync_requested(mock_journal, false, 0);
+  expect_journal_get_tag_tid(mock_journal, 345);
+  expect_journal_get_tag_data(mock_journal, {librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                                             "remote mirror uuid", true, 4, 1});
+
+  // lookup remote image tag class
+  librbd::journal::ClientData client_data{
+    librbd::journal::ImageClientMeta{123}};
+  cls::journal::Client client;
+  encode(client_data, client.data);
+  ::journal::MockJournaler mock_remote_journaler;
+  expect_journaler_get_client(mock_remote_journaler,
+                              librbd::Journal<>::IMAGE_CLIENT_ID,
+                              client, 0);
+
+  // remote demotion / promotion event
+  Tags tags = {
+    {2, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 1, 99})},
+    {3, 123, encode_tag_data({librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 2, 1})},
+    {4, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              true, 3, 1})},
+    {5, 123, encode_tag_data({librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 4, 1})},
+    {6, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              true, 5, 1})},
+    {7, 123, encode_tag_data({librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 6, 1})},
+    {8, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              true, 7, 1})}
+  };
+  expect_journaler_get_tags(mock_remote_journaler, 123, tags, 0);
+
+  C_SaferCond ctx;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_FALSE(resync_requested);
+  ASSERT_FALSE(syncing);
+}
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, LocalDemoteRemotePromote) {
+  InSequence seq;
+
+  librbd::MockJournal mock_journal;
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  mock_local_image_ctx.journal = &mock_journal;
+
+  // check initial state
+  expect_is_resync_requested(mock_journal, false, 0);
+  expect_journal_get_tag_tid(mock_journal, 346);
+  expect_journal_get_tag_data(mock_journal,
+                              {librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                               librbd::Journal<>::LOCAL_MIRROR_UUID,
+                               true, 345, 1});
+
+  // lookup remote image tag class
+  librbd::journal::ClientData client_data{
+    librbd::journal::ImageClientMeta{123}};
+  cls::journal::Client client;
+  encode(client_data, client.data);
+  ::journal::MockJournaler mock_remote_journaler;
+  expect_journaler_get_client(mock_remote_journaler,
+                              librbd::Journal<>::IMAGE_CLIENT_ID,
+                              client, 0);
+
+  // remote demotion / promotion event
+  Tags tags = {
+    {2, 123, encode_tag_data({"local mirror uuid", "local mirror uuid",
+                              true, 344, 99})},
+    {3, 123, encode_tag_data({librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              "local mirror uuid", true, 345, 1})},
+    {4, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              true, 3, 1})}
+  };
+  expect_journaler_get_tags(mock_remote_journaler, 123, tags, 0);
+
+  C_SaferCond ctx;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_FALSE(resync_requested);
+  ASSERT_FALSE(syncing);
+}
+
+TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, SplitBrainForcePromote) {
+  InSequence seq;
+
+  librbd::MockJournal mock_journal;
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  mock_local_image_ctx.journal = &mock_journal;
+
+  // check initial state
+  expect_is_resync_requested(mock_journal, false, 0);
+  expect_journal_get_tag_tid(mock_journal, 345);
+  expect_journal_get_tag_data(mock_journal, {librbd::Journal<>::LOCAL_MIRROR_UUID,
+                                             librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                                             true, 344, 0});
+
+  // lookup remote image tag class
+  librbd::journal::ClientData client_data{
+    librbd::journal::ImageClientMeta{123}};
+  cls::journal::Client client;
+  encode(client_data, client.data);
+  ::journal::MockJournaler mock_remote_journaler;
+  expect_journaler_get_client(mock_remote_journaler,
+                              librbd::Journal<>::IMAGE_CLIENT_ID,
+                              client, 0);
+
+  // remote demotion / promotion event
+  Tags tags = {
+    {2, 123, encode_tag_data({librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 1, 99})},
+    {3, 123, encode_tag_data({librbd::Journal<>::ORPHAN_MIRROR_UUID,
+                              librbd::Journal<>::LOCAL_MIRROR_UUID,
+                              true, 2, 1})}
+  };
+  expect_journaler_get_tags(mock_remote_journaler, 123, tags, 0);
+
+  C_SaferCond ctx;
+  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
+  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  bool resync_requested;
+  bool syncing;
+  auto request = create_request(
+    mock_local_image_ctx, mock_remote_journaler,
+    librbd::mirror::PROMOTION_STATE_PRIMARY, "local mirror uuid",
+    "remote mirror uuid", &mirror_peer_client_meta, &resync_requested,
+    &syncing, &ctx);
+  request->send();
+  ASSERT_EQ(-EEXIST, ctx.wait());
+}
+
+} // namespace journal
+} // namespace image_replayer
+} // namespace mirror
+} // namespace rbd

--- a/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
@@ -503,16 +503,6 @@ TEST_F(TestMockImageReplayerBootstrapRequest, NonPrimaryRemoteSyncingState) {
 
   InSequence seq;
 
-  // lookup remote image tag class
-  cls::journal::Client client;
-  librbd::journal::ClientData client_data{
-    librbd::journal::ImageClientMeta{123}};
-  encode(client_data, client.data);
-  ::journal::MockJournaler mock_journaler;
-  expect_journaler_get_client(mock_journaler,
-                              librbd::Journal<>::IMAGE_CLIENT_ID,
-                              client, 0);
-
   // open the remote image
   librbd::MockJournal mock_journal;
   librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
@@ -532,7 +522,9 @@ TEST_F(TestMockImageReplayerBootstrapRequest, NonPrimaryRemoteSyncingState) {
   librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta{
     mock_local_image_ctx.id};
   mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  librbd::journal::ClientData client_data;
   client_data.client_meta = mirror_peer_client_meta;
+  ::journal::MockJournaler mock_journaler;
   expect_journaler_update_client(mock_journaler, client_data, 0);
 
   MockCloseImageRequest mock_close_image_request;
@@ -556,16 +548,6 @@ TEST_F(TestMockImageReplayerBootstrapRequest, NonPrimaryRemoteNotTagOwner) {
   create_local_image();
 
   InSequence seq;
-
-  // lookup remote image tag class
-  cls::journal::Client client;
-  librbd::journal::ClientData client_data{
-    librbd::journal::ImageClientMeta{123}};
-  encode(client_data, client.data);
-  ::journal::MockJournaler mock_journaler;
-  expect_journaler_get_client(mock_journaler,
-                              librbd::Journal<>::IMAGE_CLIENT_ID,
-                              client, 0);
 
   // open the remote image
   librbd::MockJournal mock_journal;
@@ -605,6 +587,7 @@ TEST_F(TestMockImageReplayerBootstrapRequest, NonPrimaryRemoteNotTagOwner) {
   librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta{
     mock_local_image_ctx.id};
   mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  ::journal::MockJournaler mock_journaler;
   MockBootstrapRequest *request = create_request(
     &mock_threads, &mock_instance_watcher, mock_journaler,
     mock_local_image_ctx.id, mock_remote_image_ctx.id, "global image id",
@@ -618,16 +601,6 @@ TEST_F(TestMockImageReplayerBootstrapRequest, RemoteDemotePromote) {
   create_local_image();
 
   InSequence seq;
-
-  // lookup remote image tag class
-  cls::journal::Client client;
-  librbd::journal::ClientData client_data{
-    librbd::journal::ImageClientMeta{123}};
-  encode(client_data, client.data);
-  ::journal::MockJournaler mock_journaler;
-  expect_journaler_get_client(mock_journaler,
-                              librbd::Journal<>::IMAGE_CLIENT_ID,
-                              client, 0);
 
   // open the remote image
   librbd::MockJournal mock_journal;
@@ -653,6 +626,16 @@ TEST_F(TestMockImageReplayerBootstrapRequest, RemoteDemotePromote) {
 
   expect_journal_get_tag_tid(mock_journal, 345);
   expect_journal_get_tag_data(mock_journal, {"remote mirror uuid"});
+
+  // lookup remote image tag class
+  cls::journal::Client client;
+  librbd::journal::ClientData client_data{
+    librbd::journal::ImageClientMeta{123}};
+  encode(client_data, client.data);
+  ::journal::MockJournaler mock_journaler;
+  expect_journaler_get_client(mock_journaler,
+                              librbd::Journal<>::IMAGE_CLIENT_ID,
+                              client, 0);
 
   // remote demotion / promotion event
   Tags tags = {
@@ -695,16 +678,6 @@ TEST_F(TestMockImageReplayerBootstrapRequest, MultipleRemoteDemotePromotes) {
 
   InSequence seq;
 
-  // lookup remote image tag class
-  cls::journal::Client client;
-  librbd::journal::ClientData client_data{
-    librbd::journal::ImageClientMeta{123}};
-  encode(client_data, client.data);
-  ::journal::MockJournaler mock_journaler;
-  expect_journaler_get_client(mock_journaler,
-                              librbd::Journal<>::IMAGE_CLIENT_ID,
-                              client, 0);
-
   // open the remote image
   librbd::MockJournal mock_journal;
   librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
@@ -730,6 +703,16 @@ TEST_F(TestMockImageReplayerBootstrapRequest, MultipleRemoteDemotePromotes) {
   expect_journal_get_tag_tid(mock_journal, 345);
   expect_journal_get_tag_data(mock_journal, {librbd::Journal<>::ORPHAN_MIRROR_UUID,
                                              "remote mirror uuid", true, 4, 1});
+
+  // lookup remote image tag class
+  cls::journal::Client client;
+  librbd::journal::ClientData client_data{
+    librbd::journal::ImageClientMeta{123}};
+  encode(client_data, client.data);
+  ::journal::MockJournaler mock_journaler;
+  expect_journaler_get_client(mock_journaler,
+                              librbd::Journal<>::IMAGE_CLIENT_ID,
+                              client, 0);
 
   // remote demotion / promotion event
   Tags tags = {
@@ -781,16 +764,6 @@ TEST_F(TestMockImageReplayerBootstrapRequest, LocalDemoteRemotePromote) {
 
   InSequence seq;
 
-  // lookup remote image tag class
-  cls::journal::Client client;
-  librbd::journal::ClientData client_data{
-    librbd::journal::ImageClientMeta{123}};
-  encode(client_data, client.data);
-  ::journal::MockJournaler mock_journaler;
-  expect_journaler_get_client(mock_journaler,
-                              librbd::Journal<>::IMAGE_CLIENT_ID,
-                              client, 0);
-
   // open the remote image
   librbd::MockJournal mock_journal;
   librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
@@ -818,6 +791,16 @@ TEST_F(TestMockImageReplayerBootstrapRequest, LocalDemoteRemotePromote) {
                               {librbd::Journal<>::ORPHAN_MIRROR_UUID,
                                librbd::Journal<>::LOCAL_MIRROR_UUID,
                                true, 345, 1});
+
+  // lookup remote image tag class
+  cls::journal::Client client;
+  librbd::journal::ClientData client_data{
+    librbd::journal::ImageClientMeta{123}};
+  encode(client_data, client.data);
+  ::journal::MockJournaler mock_journaler;
+  expect_journaler_get_client(mock_journaler,
+                              librbd::Journal<>::IMAGE_CLIENT_ID,
+                              client, 0);
 
   // remote demotion / promotion event
   Tags tags = {
@@ -855,16 +838,6 @@ TEST_F(TestMockImageReplayerBootstrapRequest, SplitBrainForcePromote) {
 
   InSequence seq;
 
-  // lookup remote image tag class
-  cls::journal::Client client;
-  librbd::journal::ClientData client_data{
-    librbd::journal::ImageClientMeta{123}};
-  encode(client_data, client.data);
-  ::journal::MockJournaler mock_journaler;
-  expect_journaler_get_client(mock_journaler,
-                              librbd::Journal<>::IMAGE_CLIENT_ID,
-                              client, 0);
-
   // open the remote image
   librbd::MockJournal mock_journal;
   librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
@@ -891,6 +864,16 @@ TEST_F(TestMockImageReplayerBootstrapRequest, SplitBrainForcePromote) {
   expect_journal_get_tag_data(mock_journal, {librbd::Journal<>::LOCAL_MIRROR_UUID,
                                              librbd::Journal<>::ORPHAN_MIRROR_UUID,
                                              true, 344, 0});
+
+  // lookup remote image tag class
+  cls::journal::Client client;
+  librbd::journal::ClientData client_data{
+    librbd::journal::ImageClientMeta{123}};
+  encode(client_data, client.data);
+  ::journal::MockJournaler mock_journaler;
+  expect_journaler_get_client(mock_journaler,
+                              librbd::Journal<>::IMAGE_CLIENT_ID,
+                              client, 0);
 
   // remote demotion / promotion event
   Tags tags = {
@@ -929,16 +912,6 @@ TEST_F(TestMockImageReplayerBootstrapRequest, ResyncRequested) {
 
   InSequence seq;
 
-  // lookup remote image tag class
-  cls::journal::Client client;
-  librbd::journal::ClientData client_data{
-    librbd::journal::ImageClientMeta{123}};
-  encode(client_data, client.data);
-  ::journal::MockJournaler mock_journaler;
-  expect_journaler_get_client(mock_journaler,
-                              librbd::Journal<>::IMAGE_CLIENT_ID,
-                              client, 0);
-
   // open the remote image
   librbd::MockJournal mock_journal;
   librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
@@ -976,6 +949,7 @@ TEST_F(TestMockImageReplayerBootstrapRequest, ResyncRequested) {
   librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta{
     mock_local_image_ctx.id};
   mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  ::journal::MockJournaler mock_journaler;
   MockBootstrapRequest *request = create_request(
     &mock_threads, &mock_instance_watcher, mock_journaler,
     mock_local_image_ctx.id, mock_remote_image_ctx.id, "global image id",
@@ -991,16 +965,6 @@ TEST_F(TestMockImageReplayerBootstrapRequest, PrimaryRemote) {
   create_local_image();
 
   InSequence seq;
-
-  // lookup remote image tag class
-  cls::journal::Client client;
-  librbd::journal::ClientData client_data{
-    librbd::journal::ImageClientMeta{123}};
-  encode(client_data, client.data);
-  ::journal::MockJournaler mock_journaler;
-  expect_journaler_get_client(mock_journaler,
-                              librbd::Journal<>::IMAGE_CLIENT_ID,
-                              client, 0);
 
   // open the remote image
   librbd::MockJournal mock_journal;
@@ -1024,9 +988,11 @@ TEST_F(TestMockImageReplayerBootstrapRequest, PrimaryRemote) {
   librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
   mirror_peer_client_meta.image_id = mock_local_image_ctx.id;
   mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_SYNCING;
+  librbd::journal::ClientData client_data;
   client_data.client_meta = mirror_peer_client_meta;
-  client.data.clear();
+  cls::journal::Client client;
   encode(client_data, client.data);
+  ::journal::MockJournaler mock_journaler;
   expect_journaler_update_client(mock_journaler, client_data, 0);
 
   // create the local image
@@ -1068,16 +1034,6 @@ TEST_F(TestMockImageReplayerBootstrapRequest, PrimaryRemoteLocalDeleted) {
 
   InSequence seq;
 
-  // lookup remote image tag class
-  cls::journal::Client client;
-  librbd::journal::ClientData client_data{
-    librbd::journal::ImageClientMeta{123}};
-  encode(client_data, client.data);
-  ::journal::MockJournaler mock_journaler;
-  expect_journaler_get_client(mock_journaler,
-                              librbd::Journal<>::IMAGE_CLIENT_ID,
-                              client, 0);
-
   // open the remote image
   librbd::MockJournal mock_journal;
   librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
@@ -1098,10 +1054,12 @@ TEST_F(TestMockImageReplayerBootstrapRequest, PrimaryRemoteLocalDeleted) {
                           "missing image id", nullptr, -ENOENT);
 
   // re-register the client
+  ::journal::MockJournaler mock_journaler;
   expect_journaler_unregister_client(mock_journaler, 0);
   librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
   mirror_peer_client_meta.image_id = "";
   mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  librbd::journal::ClientData client_data;
   client_data.client_meta = mirror_peer_client_meta;
   expect_journaler_register_client(mock_journaler, client_data, 0);
 
@@ -1119,7 +1077,7 @@ TEST_F(TestMockImageReplayerBootstrapRequest, PrimaryRemoteLocalDeleted) {
   mirror_peer_client_meta.image_id = mock_local_image_ctx.id;
   mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_SYNCING;
   client_data.client_meta = mirror_peer_client_meta;
-  client.data.clear();
+  cls::journal::Client client;
   encode(client_data, client.data);
   expect_journaler_update_client(mock_journaler, client_data, 0);
 
@@ -1161,16 +1119,6 @@ TEST_F(TestMockImageReplayerBootstrapRequest, LocalImageIdCollision) {
 
   InSequence seq;
 
-  // lookup remote image tag class
-  cls::journal::Client client;
-  librbd::journal::ClientData client_data{
-    librbd::journal::ImageClientMeta{123}};
-  encode(client_data, client.data);
-  ::journal::MockJournaler mock_journaler;
-  expect_journaler_get_client(mock_journaler,
-                              librbd::Journal<>::IMAGE_CLIENT_ID,
-                              client, 0);
-
   // open the remote image
   librbd::MockJournal mock_journal;
   librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
@@ -1193,9 +1141,11 @@ TEST_F(TestMockImageReplayerBootstrapRequest, LocalImageIdCollision) {
   librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
   mirror_peer_client_meta.image_id = mock_local_image_ctx.id;
   mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_SYNCING;
+  librbd::journal::ClientData client_data;
   client_data.client_meta = mirror_peer_client_meta;
-  client.data.clear();
+  cls::journal::Client client;
   encode(client_data, client.data);
+  ::journal::MockJournaler mock_journaler;
   expect_journaler_update_client(mock_journaler, client_data, 0);
 
   // create the local image

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -41,6 +41,7 @@ set(rbd_mirror_internal
   image_replayer/PrepareLocalImageRequest.cc
   image_replayer/PrepareRemoteImageRequest.cc
   image_replayer/Utils.cc
+  image_replayer/journal/CreateLocalImageRequest.cc
   image_replayer/journal/EventPreprocessor.cc
   image_replayer/journal/Replayer.cc
   image_replayer/journal/ReplayStatusFormatter.cc

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -43,6 +43,7 @@ set(rbd_mirror_internal
   image_replayer/Utils.cc
   image_replayer/journal/CreateLocalImageRequest.cc
   image_replayer/journal/EventPreprocessor.cc
+  image_replayer/journal/PrepareReplayRequest.cc
   image_replayer/journal/Replayer.cc
   image_replayer/journal/ReplayStatusFormatter.cc
   image_sync/SyncPointCreateRequest.cc

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -12,7 +12,6 @@
 #include "common/WorkQueue.h"
 #include "global/global_context.h"
 #include "journal/Journaler.h"
-#include "journal/Settings.h"
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
@@ -25,8 +24,6 @@
 #include "Threads.h"
 #include "tools/rbd_mirror/image_replayer/BootstrapRequest.h"
 #include "tools/rbd_mirror/image_replayer/CloseImageRequest.h"
-#include "tools/rbd_mirror/image_replayer/PrepareLocalImageRequest.h"
-#include "tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.h"
 #include "tools/rbd_mirror/image_replayer/ReplayerListener.h"
 #include "tools/rbd_mirror/image_replayer/Utils.h"
 #include "tools/rbd_mirror/image_replayer/journal/Replayer.h"
@@ -326,98 +323,6 @@ void ImageReplayer<I>::start(Context *on_finish, bool manual)
     return;
   }
 
-  prepare_local_image();
-}
-
-template <typename I>
-void ImageReplayer<I>::prepare_local_image() {
-  dout(10) << dendl;
-
-  m_local_image_id = "";
-  Context *ctx = create_context_callback<
-    ImageReplayer, &ImageReplayer<I>::handle_prepare_local_image>(this);
-  auto req = image_replayer::PrepareLocalImageRequest<I>::create(
-    m_local_io_ctx, m_global_image_id, &m_local_image_id, &m_local_image_name,
-    &m_local_image_tag_owner, m_threads->work_queue, ctx);
-  req->send();
-}
-
-template <typename I>
-void ImageReplayer<I>::handle_prepare_local_image(int r) {
-  dout(10) << "r=" << r << dendl;
-
-  if (r == -ENOENT) {
-    dout(10) << "local image does not exist" << dendl;
-  } else if (r < 0) {
-    on_start_fail(r, "error preparing local image for replay");
-    return;
-  } else {
-    // have the correct local image name now
-    reregister_admin_socket_hook();
-  }
-
-  prepare_remote_image();
-}
-
-template <typename I>
-void ImageReplayer<I>::prepare_remote_image() {
-  dout(10) << dendl;
-  if (m_peers.empty()) {
-    // technically nothing to bootstrap, but it handles the status update
-    bootstrap();
-    return;
-  }
-
-  // TODO need to support multiple remote images
-  ceph_assert(!m_peers.empty());
-  m_remote_image = {*m_peers.begin()};
-
-  auto cct = static_cast<CephContext *>(m_local_io_ctx.cct());
-  journal::Settings journal_settings;
-  journal_settings.commit_interval = cct->_conf.get_val<double>(
-    "rbd_mirror_journal_commit_age");
-
-  ceph_assert(m_remote_journaler == nullptr);
-
-  Context *ctx = create_context_callback<
-    ImageReplayer, &ImageReplayer<I>::handle_prepare_remote_image>(this);
-  auto req = image_replayer::PrepareRemoteImageRequest<I>::create(
-    m_threads, m_remote_image.io_ctx, m_global_image_id, m_local_mirror_uuid,
-    m_local_image_id, journal_settings, m_cache_manager_handler,
-    &m_remote_image.mirror_uuid, &m_remote_image.image_id, &m_remote_journaler,
-    &m_client_state, &m_client_meta, ctx);
-  req->send();
-}
-
-template <typename I>
-void ImageReplayer<I>::handle_prepare_remote_image(int r) {
-  dout(10) << "r=" << r << dendl;
-
-  ceph_assert(r < 0 ? m_remote_journaler == nullptr :
-                      m_remote_journaler != nullptr);
-  if (r < 0 && !m_local_image_id.empty() &&
-      m_local_image_tag_owner == librbd::Journal<>::LOCAL_MIRROR_UUID) {
-    // local image is primary -- fall-through
-  } else if (r == -ENOENT) {
-    dout(10) << "remote image does not exist" << dendl;
-
-    // TODO need to support multiple remote images
-    if (m_remote_image.image_id.empty() && !m_local_image_id.empty() &&
-        m_local_image_tag_owner == m_remote_image.mirror_uuid) {
-      // local image exists and is non-primary and linked to the missing
-      // remote image
-
-      m_delete_requested = true;
-      on_start_fail(0, "remote image no longer exists");
-    } else {
-      on_start_fail(-ENOENT, "remote image does not exist");
-    }
-    return;
-  } else if (r < 0) {
-    on_start_fail(r, "error retrieving remote image id");
-    return;
-  }
-
   bootstrap();
 }
 
@@ -425,38 +330,38 @@ template <typename I>
 void ImageReplayer<I>::bootstrap() {
   dout(10) << dendl;
 
-  if (!m_local_image_id.empty() &&
-      m_local_image_tag_owner == librbd::Journal<>::LOCAL_MIRROR_UUID) {
-    dout(5) << "local image is primary" << dendl;
-    on_start_fail(0, "local image is primary");
-    return;
-  } else if (m_peers.empty()) {
+  std::unique_lock locker{m_lock};
+  if (m_peers.empty()) {
+    locker.unlock();
+
     dout(5) << "no peer clusters" << dendl;
     on_start_fail(-ENOENT, "no peer clusters");
     return;
   }
 
-  image_replayer::BootstrapRequest<I> *request = nullptr;
-  {
-    std::lock_guard locker{m_lock};
-    if (on_start_interrupted(m_lock)) {
-      return;
-    }
+  // TODO need to support multiple remote images
+  ceph_assert(!m_peers.empty());
+  m_remote_image = {*m_peers.begin()};
 
-    auto ctx = create_context_callback<
-      ImageReplayer, &ImageReplayer<I>::handle_bootstrap>(this);
-    request = image_replayer::BootstrapRequest<I>::create(
-      m_threads, m_local_io_ctx, m_remote_image.io_ctx, m_instance_watcher,
-      &m_local_image_ctx, m_local_image_id, m_remote_image.image_id,
-      m_global_image_id, m_local_mirror_uuid, m_remote_image.mirror_uuid,
-      m_remote_journaler, &m_client_state, &m_client_meta, ctx,
-      &m_resync_requested, &m_progress_cxt);
-    request->get();
-    m_bootstrap_request = request;
+  if (on_start_interrupted(m_lock)) {
+    return;
   }
 
-  update_mirror_image_status(false, boost::none);
+  m_local_image_id = "";
+  auto ctx = create_context_callback<
+      ImageReplayer, &ImageReplayer<I>::handle_bootstrap>(this);
+  auto request = image_replayer::BootstrapRequest<I>::create(
+      m_threads, m_local_io_ctx, m_remote_image.io_ctx, m_instance_watcher,
+      m_remote_image.image_id, m_global_image_id, m_local_mirror_uuid,
+      m_cache_manager_handler, &m_progress_cxt, &m_local_image_ctx,
+      &m_local_image_id, &m_remote_image.mirror_uuid, &m_remote_journaler,
+      &m_resync_requested, ctx);
 
+  request->get();
+  m_bootstrap_request = request;
+  locker.unlock();
+
+  update_mirror_image_status(false, boost::none);
   request->send();
 }
 
@@ -474,14 +379,20 @@ void ImageReplayer<I>::handle_bootstrap(int r) {
 
   if (on_start_interrupted()) {
     return;
+  } else if (r == -ENOMSG) {
+    dout(5) << "local image is primary" << dendl;
+    on_start_fail(0, "local image is primary");
+    return;
   } else if (r == -EREMOTEIO) {
-    m_local_image_tag_owner = "";
     dout(5) << "remote image is non-primary" << dendl;
     on_start_fail(-EREMOTEIO, "remote image is non-primary");
     return;
   } else if (r == -EEXIST) {
-    m_local_image_tag_owner = "";
     on_start_fail(r, "split-brain detected");
+    return;
+  } else if (r == -ENOLINK) {
+    m_delete_requested = true;
+    on_start_fail(0, "remote image no longer exists");
     return;
   } else if (r < 0) {
     on_start_fail(r, "error bootstrapping replay");
@@ -1143,16 +1054,20 @@ void ImageReplayer<I>::unregister_admin_socket_hook() {
 
 template <typename I>
 void ImageReplayer<I>::reregister_admin_socket_hook() {
-  {
-    std::lock_guard locker{m_lock};
-
-    auto image_spec = image_replayer::util::compute_image_spec(
-      m_local_io_ctx, m_local_image_name);
-    if (m_asok_hook != nullptr && m_image_spec == image_spec) {
-      return;
-    }
-    m_image_spec = image_spec;
+  std::unique_lock locker{m_lock};
+  if (m_state == STATE_STARTING && m_bootstrap_request != nullptr) {
+    m_local_image_name = m_bootstrap_request->get_local_image_name();
   }
+
+  auto image_spec = image_replayer::util::compute_image_spec(
+    m_local_io_ctx, m_local_image_name);
+  if (m_asok_hook != nullptr && m_image_spec == image_spec) {
+    return;
+  }
+
+  m_image_spec = image_spec;
+  locker.unlock();
+
   unregister_admin_socket_hook();
   register_admin_socket_hook();
 }

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -131,12 +131,6 @@ protected:
    * <starting>                                             *
    *    |                                                   *
    *    v                                           (error) *
-   * PREPARE_LOCAL_IMAGE  * * * * * * * * * * * * * * * * * *
-   *    |                                                   *
-   *    v                                           (error) *
-   * PREPARE_REMOTE_IMAGE * * * * * * * * * * * * * * * * * *
-   *    |                                                   *
-   *    v                                           (error) *
    * BOOTSTRAP_IMAGE  * * * * * * * * * * * * * * * * * * * *
    *    |                                                   *
    *    v                                           (error) *
@@ -202,7 +196,8 @@ private:
     }
 
     void update_progress(const std::string &description,
-				 bool flush = true) override;
+                         bool flush = true) override;
+
   private:
     ImageReplayer<ImageCtxT> *replayer;
   };
@@ -237,7 +232,6 @@ private:
   bool m_resync_requested = false;
 
   ImageCtxT *m_local_image_ctx = nullptr;
-  std::string m_local_image_tag_owner;
 
   decltype(ImageCtxT::journal) m_local_journal = nullptr;
   Journaler* m_remote_journaler = nullptr;
@@ -253,10 +247,6 @@ private:
   AdminSocketHook *m_asok_hook = nullptr;
 
   image_replayer::BootstrapRequest<ImageCtxT> *m_bootstrap_request = nullptr;
-
-  cls::journal::ClientState m_client_state =
-    cls::journal::CLIENT_STATE_DISCONNECTED;
-  librbd::journal::MirrorPeerClientMeta m_client_meta;
 
   AsyncOpTracker m_in_flight_op_tracker;
 
@@ -277,12 +267,6 @@ private:
 
   void shut_down(int r);
   void handle_shut_down(int r);
-
-  void prepare_local_image();
-  void handle_prepare_local_image(int r);
-
-  void prepare_remote_image();
-  void handle_prepare_remote_image(int r);
 
   void bootstrap();
   void handle_bootstrap(int r);

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
@@ -479,7 +479,11 @@ void BootstrapRequest<I>::handle_image_sync(int r) {
   }
 
   if (r < 0) {
-    derr << "failed to sync remote image: " << cpp_strerror(r) << dendl;
+    if (r == -ECANCELED) {
+      dout(10) << "request canceled" << dendl;
+    } else {
+      derr << "failed to sync remote image: " << cpp_strerror(r) << dendl;
+    }
     m_ret_val = r;
   }
 

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
@@ -96,10 +96,7 @@ private:
    * <start>
    *    |
    *    v
-   * GET_REMOTE_TAG_CLASS * * * * * * * * * * * * * * * * * *
-   *    |                                                   * (error)
-   *    v                                                   *
-   * OPEN_REMOTE_IMAGE  * * * * * * * * * * * * * * * * * * *
+   * OPEN_REMOTE_IMAGE  * * * * * * * * * * * * * * * * * * * (error)
    *    |                                                   *
    *    |/--------------------------------------------------*---\
    *    v                                                   *   |
@@ -125,6 +122,9 @@ private:
    *    |         |             \-----------------------*---*---/
    *    |         |                                     *   *
    *    |         v (skip if not needed)                *   *
+   *    |      GET_REMOTE_TAG_CLASS * * * * *           *   *
+   *    |         |                         *           *   *
+   *    |         v (skip if not needed)    *           *   *
    *    |      GET_REMOTE_TAGS  * * * * * * *           *   *
    *    |         |                         *           *   *
    *    |         v (skip if not needed)    v           *   *
@@ -182,9 +182,6 @@ private:
 
   bufferlist m_out_bl;
 
-  void get_remote_tag_class();
-  void handle_get_remote_tag_class(int r);
-
   void open_remote_image();
   void handle_open_remote_image(int r);
 
@@ -208,6 +205,9 @@ private:
 
   void update_client_image();
   void handle_update_client_image(int r);
+
+  void get_remote_tag_class();
+  void handle_get_remote_tag_class(int r);
 
   void get_remote_tags();
   void handle_get_remote_tags(int r);

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
@@ -112,31 +112,31 @@ private:
    *    |         v                                     *   *   |
    *    | (remote image primary)                        *   *   |
    *    \----> OPEN_LOCAL_IMAGE * * * * * * * * * * * * *   *   |
-   *    |         |   .                                 *   *   |
-   *    |         |   . (image doesn't exist)           *   *   |
-   *    |         |   . . > UNREGISTER_CLIENT * * * * * *   *   |
-   *    |         |             |                       *   *   |
-   *    |         |             v                       *   *   |
-   *    |         |         REGISTER_CLIENT * * * * * * *   *   |
-   *    |         |             |                       *   *   |
-   *    |         |             \-----------------------*---*---/
-   *    |         |                                     *   *
-   *    |         v (skip if not needed)                *   *
-   *    |      GET_REMOTE_TAG_CLASS * * * * *           *   *
-   *    |         |                         *           *   *
-   *    |         v (skip if not needed)    *           *   *
-   *    |      GET_REMOTE_TAGS  * * * * * * *           *   *
-   *    |         |                         *           *   *
-   *    |         v (skip if not needed)    v           *   *
-   *    |      IMAGE_SYNC * * * > CLOSE_LOCAL_IMAGE     *   *
-   *    |         |                         |           *   *
-   *    |         \-----------------\ /-----/           *   *
-   *    |                            |                  *   *
-   *    |                            |                  *   *
-   *    | (skip if not needed)       |                  *   *
-   *    \----> UPDATE_CLIENT_STATE  *|* * * * * * * * * *   *
-   *                |                |                  *   *
-   *    /-----------/----------------/                  *   *
+   *              |   .                                 *   *   |
+   *              |   . (image doesn't exist)           *   *   |
+   *              |   . . > UNREGISTER_CLIENT * * * * * *   *   |
+   *              |             |                       *   *   |
+   *              |             v                       *   *   |
+   *              |         REGISTER_CLIENT * * * * * * *   *   |
+   *              |             |                       *   *   |
+   *              |             \-----------------------*---*---/
+   *              |                                     *   *
+   *              v (skip if not needed)                *   *
+   *           UPDATE_CLIENT_STATE                      *   *
+   *              |                                     *   *
+   *              v (skip if not needed)                *   *
+   *           GET_REMOTE_TAG_CLASS * * * * *           *   *
+   *              |                         *           *   *
+   *              v (skip if not needed)    *           *   *
+   *           GET_REMOTE_TAGS  * * * * * * *           *   *
+   *              |                         *           *   *
+   *              v (skip if not needed)    v           *   *
+   *           IMAGE_SYNC * * * > CLOSE_LOCAL_IMAGE     *   *
+   *              |                         |           *   *
+   *              \-----------------\ /-----/           *   *
+   *                                 |                  *   *
+   *                                 |                  *   *
+   *    /----------------------------/                  *   *
    *    |                                               *   *
    *    v                                               *   *
    * CLOSE_REMOTE_IMAGE < * * * * * * * * * * * * * * * *   *
@@ -188,9 +188,6 @@ private:
   void get_remote_mirror_info();
   void handle_get_remote_mirror_info(int r);
 
-  void update_client_state();
-  void handle_update_client_state(int r);
-
   void open_local_image();
   void handle_open_local_image(int r);
 
@@ -205,6 +202,9 @@ private:
 
   void update_client_image();
   void handle_update_client_image(int r);
+
+  void update_client_state();
+  void handle_update_client_state(int r);
 
   void get_remote_tag_class();
   void handle_get_remote_tag_class(int r);

--- a/src/tools/rbd_mirror/image_replayer/PrepareLocalImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/PrepareLocalImageRequest.cc
@@ -29,13 +29,13 @@ using librbd::util::create_rados_callback;
 
 template <typename I>
 void PrepareLocalImageRequest<I>::send() {
-  dout(20) << dendl;
+  dout(10) << dendl;
   get_local_image_id();
 }
 
 template <typename I>
 void PrepareLocalImageRequest<I>::get_local_image_id() {
-  dout(20) << dendl;
+  dout(10) << dendl;
 
   Context *ctx = create_context_callback<
     PrepareLocalImageRequest<I>,
@@ -47,7 +47,7 @@ void PrepareLocalImageRequest<I>::get_local_image_id() {
 
 template <typename I>
 void PrepareLocalImageRequest<I>::handle_get_local_image_id(int r) {
-  dout(20) << "r=" << r << ", "
+  dout(10) << "r=" << r << ", "
            << "local_image_id=" << *m_local_image_id << dendl;
 
   if (r < 0) {
@@ -60,7 +60,7 @@ void PrepareLocalImageRequest<I>::handle_get_local_image_id(int r) {
 
 template <typename I>
 void PrepareLocalImageRequest<I>::get_local_image_name() {
-  dout(20) << dendl;
+  dout(10) << dendl;
 
   librados::ObjectReadOperation op;
   librbd::cls_client::dir_get_name_start(&op, *m_local_image_id);
@@ -76,7 +76,7 @@ void PrepareLocalImageRequest<I>::get_local_image_name() {
 
 template <typename I>
 void PrepareLocalImageRequest<I>::handle_get_local_image_name(int r) {
-  dout(20) << "r=" << r << dendl;
+  dout(10) << "r=" << r << dendl;
 
   if (r == 0) {
     auto it = m_out_bl.cbegin();
@@ -96,7 +96,7 @@ void PrepareLocalImageRequest<I>::handle_get_local_image_name(int r) {
 
 template <typename I>
 void PrepareLocalImageRequest<I>::get_mirror_state() {
-  dout(20) << dendl;
+  dout(10) << dendl;
 
   librados::ObjectReadOperation op;
   librbd::cls_client::mirror_image_get_start(&op, *m_local_image_id);
@@ -112,7 +112,7 @@ void PrepareLocalImageRequest<I>::get_mirror_state() {
 
 template <typename I>
 void PrepareLocalImageRequest<I>::handle_get_mirror_state(int r) {
-  dout(20) << ": r=" << r << dendl;
+  dout(10) << ": r=" << r << dendl;
 
   cls::rbd::MirrorImage mirror_image;
   if (r == 0) {
@@ -141,7 +141,7 @@ void PrepareLocalImageRequest<I>::get_tag_owner() {
     typename std::remove_pointer<decltype(std::declval<I>().journal)>
     ::type>::type;
 
-  dout(20) << dendl;
+  dout(10) << dendl;
 
   Context *ctx = create_context_callback<
     PrepareLocalImageRequest<I>,
@@ -152,7 +152,7 @@ void PrepareLocalImageRequest<I>::get_tag_owner() {
 
 template <typename I>
 void PrepareLocalImageRequest<I>::handle_get_tag_owner(int r) {
-  dout(20) << "r=" << r << ", "
+  dout(10) << "r=" << r << ", "
            << "tag_owner=" << *m_tag_owner << dendl;
 
   if (r < 0) {
@@ -167,7 +167,7 @@ void PrepareLocalImageRequest<I>::handle_get_tag_owner(int r) {
 
 template <typename I>
 void PrepareLocalImageRequest<I>::finish(int r) {
-  dout(20) << "r=" << r << dendl;
+  dout(10) << "r=" << r << dendl;
 
   m_on_finish->complete(r);
   delete this;

--- a/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.cc
@@ -37,7 +37,7 @@ void PrepareRemoteImageRequest<I>::send() {
 
 template <typename I>
 void PrepareRemoteImageRequest<I>::get_remote_mirror_uuid() {
-  dout(20) << dendl;
+  dout(10) << dendl;
 
   librados::ObjectReadOperation op;
   librbd::cls_client::mirror_uuid_get_start(&op);
@@ -60,7 +60,7 @@ void PrepareRemoteImageRequest<I>::handle_get_remote_mirror_uuid(int r) {
     }
   }
 
-  dout(20) << "r=" << r << dendl;
+  dout(10) << "r=" << r << dendl;
   if (r < 0) {
     if (r == -ENOENT) {
       dout(5) << "remote mirror uuid missing" << dendl;
@@ -77,7 +77,7 @@ void PrepareRemoteImageRequest<I>::handle_get_remote_mirror_uuid(int r) {
 
 template <typename I>
 void PrepareRemoteImageRequest<I>::get_remote_image_id() {
-  dout(20) << dendl;
+  dout(10) << dendl;
 
   Context *ctx = create_context_callback<
     PrepareRemoteImageRequest<I>,
@@ -90,7 +90,7 @@ void PrepareRemoteImageRequest<I>::get_remote_image_id() {
 
 template <typename I>
 void PrepareRemoteImageRequest<I>::handle_get_remote_image_id(int r) {
-  dout(20) << "r=" << r << ", "
+  dout(10) << "r=" << r << ", "
            << "remote_image_id=" << *m_remote_image_id << dendl;
 
   if (r < 0) {
@@ -103,7 +103,7 @@ void PrepareRemoteImageRequest<I>::handle_get_remote_image_id(int r) {
 
 template <typename I>
 void PrepareRemoteImageRequest<I>::get_client() {
-  dout(20) << dendl;
+  dout(10) << dendl;
 
   ceph_assert(*m_remote_journaler == nullptr);
   *m_remote_journaler = new Journaler(m_threads->work_queue, m_threads->timer,
@@ -121,7 +121,7 @@ void PrepareRemoteImageRequest<I>::get_client() {
 
 template <typename I>
 void PrepareRemoteImageRequest<I>::handle_get_client(int r) {
-  dout(20) << "r=" << r << dendl;
+  dout(10) << "r=" << r << dendl;
 
   if (r == -ENOENT) {
     dout(10) << "client not registered" << dendl;
@@ -141,7 +141,7 @@ void PrepareRemoteImageRequest<I>::handle_get_client(int r) {
 
 template <typename I>
 void PrepareRemoteImageRequest<I>::register_client() {
-  dout(20) << dendl;
+  dout(10) << dendl;
 
   librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta{
     m_local_image_id};
@@ -160,7 +160,7 @@ void PrepareRemoteImageRequest<I>::register_client() {
 
 template <typename I>
 void PrepareRemoteImageRequest<I>::handle_register_client(int r) {
-  dout(20) << "r=" << r << dendl;
+  dout(10) << "r=" << r << dendl;
 
   if (r < 0) {
     derr << "failed to register with remote journal: " << cpp_strerror(r)
@@ -178,7 +178,7 @@ void PrepareRemoteImageRequest<I>::handle_register_client(int r) {
 
 template <typename I>
 void PrepareRemoteImageRequest<I>::finish(int r) {
-  dout(20) << "r=" << r << dendl;
+  dout(10) << "r=" << r << dendl;
 
   if (r < 0) {
     delete *m_remote_journaler;

--- a/src/tools/rbd_mirror/image_replayer/journal/CreateLocalImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/journal/CreateLocalImageRequest.cc
@@ -1,0 +1,194 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "CreateLocalImageRequest.h"
+#include "include/rados/librados.hpp"
+#include "common/debug.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "journal/Journaler.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+#include "tools/rbd_mirror/ProgressContext.h"
+#include "tools/rbd_mirror/image_replayer/CreateImageRequest.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::image_replayer::journal::" \
+                           << "CreateLocalImageRequest: " << this << " " \
+                           << __func__ << ": "
+
+namespace rbd {
+namespace mirror {
+namespace image_replayer {
+namespace journal {
+
+using librbd::util::create_context_callback;
+
+template <typename I>
+void CreateLocalImageRequest<I>::send() {
+  *m_local_image_id = "";
+  unregister_client();
+}
+
+template <typename I>
+void CreateLocalImageRequest<I>::unregister_client() {
+  dout(10) << dendl;
+  update_progress("UNREGISTER_CLIENT");
+
+  auto ctx = create_context_callback<
+    CreateLocalImageRequest<I>,
+    &CreateLocalImageRequest<I>::handle_unregister_client>(this);
+  m_remote_journaler->unregister_client(ctx);
+}
+
+template <typename I>
+void CreateLocalImageRequest<I>::handle_unregister_client(int r) {
+  dout(10) << "r=" << r << dendl;
+  if (r < 0 && r != -ENOENT) {
+    derr << "failed to unregister with remote journal: " << cpp_strerror(r)
+         << dendl;
+    finish(r);
+    return;
+  }
+
+  *m_client_meta = librbd::journal::MirrorPeerClientMeta{""};
+  register_client();
+}
+
+template <typename I>
+void CreateLocalImageRequest<I>::register_client() {
+  ceph_assert(m_local_image_id->empty());
+  *m_local_image_id = librbd::util::generate_image_id<I>(m_local_io_ctx);
+  dout(10) << "local_image_id=" << *m_local_image_id << dendl;
+  update_progress("REGISTER_CLIENT");
+
+  librbd::journal::MirrorPeerClientMeta client_meta{*m_local_image_id};
+  client_meta.state = librbd::journal::MIRROR_PEER_STATE_SYNCING;
+
+  librbd::journal::ClientData client_data{client_meta};
+  bufferlist client_data_bl;
+  encode(client_data, client_data_bl);
+
+  auto ctx = create_context_callback<
+    CreateLocalImageRequest<I>,
+    &CreateLocalImageRequest<I>::handle_register_client>(this);
+  m_remote_journaler->register_client(client_data_bl, ctx);
+}
+
+template <typename I>
+void CreateLocalImageRequest<I>::handle_register_client(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    derr << "failed to register with remote journal: " << cpp_strerror(r)
+         << dendl;
+    finish(r);
+    return;
+  }
+
+  *m_client_meta = librbd::journal::MirrorPeerClientMeta{*m_local_image_id};
+  m_client_meta->state = librbd::journal::MIRROR_PEER_STATE_SYNCING;
+
+  create_local_image();
+}
+
+template <typename I>
+void CreateLocalImageRequest<I>::create_local_image() {
+  dout(10) << "local_image_id=" << *m_local_image_id << dendl;
+  update_progress("CREATE_LOCAL_IMAGE");
+
+  m_remote_image_ctx->image_lock.lock_shared();
+  std::string image_name = m_remote_image_ctx->name;
+  m_remote_image_ctx->image_lock.unlock_shared();
+
+  auto ctx = create_context_callback<
+    CreateLocalImageRequest<I>,
+    &CreateLocalImageRequest<I>::handle_create_local_image>(this);
+  auto request = CreateImageRequest<I>::create(
+    m_threads, m_local_io_ctx, m_global_image_id, m_remote_mirror_uuid,
+    image_name, *m_local_image_id, m_remote_image_ctx, ctx);
+  request->send();
+}
+template <typename I>
+void CreateLocalImageRequest<I>::handle_create_local_image(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r == -EBADF) {
+    dout(5) << "image id " << *m_local_image_id << " already in-use" << dendl;
+    *m_local_image_id = "";
+    update_client_image();
+    return;
+  } else if (r < 0) {
+    if (r == -ENOENT) {
+      dout(10) << "parent image does not exist" << dendl;
+    } else {
+      derr << "failed to create local image: " << cpp_strerror(r) << dendl;
+    }
+    finish(r);
+    return;
+  }
+
+  finish(0);
+}
+
+template <typename I>
+void CreateLocalImageRequest<I>::update_client_image() {
+  ceph_assert(m_local_image_id->empty());
+  *m_local_image_id = librbd::util::generate_image_id<I>(m_local_io_ctx);
+
+  dout(10) << "local_image_id=" << *m_local_image_id << dendl;
+  update_progress("UPDATE_CLIENT_IMAGE");
+
+  librbd::journal::MirrorPeerClientMeta client_meta{*m_local_image_id};
+  client_meta.state = librbd::journal::MIRROR_PEER_STATE_SYNCING;
+
+  librbd::journal::ClientData client_data(client_meta);
+  bufferlist data_bl;
+  encode(client_data, data_bl);
+
+  auto ctx = create_context_callback<
+    CreateLocalImageRequest<I>,
+    &CreateLocalImageRequest<I>::handle_update_client_image>(this);
+  m_remote_journaler->update_client(data_bl, ctx);
+}
+
+template <typename I>
+void CreateLocalImageRequest<I>::handle_update_client_image(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    derr << "failed to update client: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  *m_client_meta = librbd::journal::MirrorPeerClientMeta{*m_local_image_id};
+  m_client_meta->state = librbd::journal::MIRROR_PEER_STATE_SYNCING;
+  create_local_image();
+}
+
+template <typename I>
+void CreateLocalImageRequest<I>::finish(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+template <typename I>
+void CreateLocalImageRequest<I>::update_progress(
+    const std::string& description) {
+  dout(15) << description << dendl;
+  if (m_progress_ctx != nullptr) {
+    m_progress_ctx->update_progress(description);
+  }
+}
+
+} // namespace journal
+} // namespace image_replayer
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::image_replayer::journal::CreateLocalImageRequest<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/image_replayer/journal/CreateLocalImageRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/journal/CreateLocalImageRequest.h
@@ -1,0 +1,122 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RBD_MIRROR_IMAGE_REPLAYER_JOURNAL_CREATE_LOCAL_IMAGE_REQUEST_H
+#define RBD_MIRROR_IMAGE_REPLAYER_JOURNAL_CREATE_LOCAL_IMAGE_REQUEST_H
+
+#include "include/rados/librados_fwd.hpp"
+#include "librbd/journal/Types.h"
+#include "librbd/journal/TypeTraits.h"
+#include <string>
+
+struct Context;
+namespace librbd { class ImageCtx; }
+
+namespace rbd {
+namespace mirror {
+
+class ProgressContext;
+template <typename> struct Threads;
+
+namespace image_replayer {
+namespace journal {
+
+template <typename ImageCtxT>
+class CreateLocalImageRequest {
+public:
+  typedef librbd::journal::MirrorPeerClientMeta MirrorPeerClientMeta;
+  typedef librbd::journal::TypeTraits<ImageCtxT> TypeTraits;
+  typedef typename TypeTraits::Journaler Journaler;
+  typedef rbd::mirror::ProgressContext ProgressContext;
+
+  static CreateLocalImageRequest* create(
+      Threads<ImageCtxT>* threads, librados::IoCtx& local_io_ctx,
+      ImageCtxT* remote_image_ctx, Journaler* remote_journaler,
+      const std::string& global_image_id,
+      const std::string& remote_mirror_uuid,
+      MirrorPeerClientMeta* client_meta, ProgressContext* progress_ctx,
+      std::string* local_image_id, Context* on_finish) {
+    return new CreateLocalImageRequest(threads, local_io_ctx, remote_image_ctx,
+                                       remote_journaler, global_image_id,
+                                       remote_mirror_uuid, client_meta,
+                                       progress_ctx, local_image_id, on_finish);
+  }
+
+  CreateLocalImageRequest(
+      Threads<ImageCtxT>* threads, librados::IoCtx& local_io_ctx,
+      ImageCtxT* remote_image_ctx, Journaler* remote_journaler,
+      const std::string& global_image_id,
+      const std::string& remote_mirror_uuid,
+      MirrorPeerClientMeta* client_meta, ProgressContext* progress_ctx,
+      std::string* local_image_id, Context* on_finish)
+    : m_threads(threads), m_local_io_ctx(local_io_ctx),
+      m_remote_image_ctx(remote_image_ctx),
+      m_remote_journaler(remote_journaler),
+      m_global_image_id(global_image_id),
+      m_remote_mirror_uuid(remote_mirror_uuid), m_client_meta(client_meta),
+      m_progress_ctx(progress_ctx), m_local_image_id(local_image_id),
+      m_on_finish(on_finish) {
+  }
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * UNREGISTER_CLIENT
+   *    |
+   *    v
+   * REGISTER_CLIENT
+   *    |
+   *    |     . . . . . . . . . UPDATE_CLIENT_IMAGE
+   *    |     .                         ^
+   *    v     v         (id exists)     *
+   * CREATE_LOCAL_IMAGE * * * * * * * * *
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+
+  Threads<ImageCtxT>* m_threads;
+  librados::IoCtx& m_local_io_ctx;
+  ImageCtxT* m_remote_image_ctx;
+  Journaler* m_remote_journaler;
+  std::string m_global_image_id;
+  std::string m_remote_mirror_uuid;
+  MirrorPeerClientMeta* m_client_meta;
+  ProgressContext* m_progress_ctx;
+  std::string* m_local_image_id;
+  Context* m_on_finish;
+
+  void unregister_client();
+  void handle_unregister_client(int r);
+
+  void register_client();
+  void handle_register_client(int r);
+
+  void create_local_image();
+  void handle_create_local_image(int r);
+
+  void update_client_image();
+  void handle_update_client_image(int r);
+
+  void finish(int r);
+
+  void update_progress(const std::string& description);
+
+};
+
+} // namespace journal
+} // namespace image_replayer
+} // namespace mirror
+} // namespace rbd
+
+extern template class rbd::mirror::image_replayer::journal::CreateLocalImageRequest<librbd::ImageCtx>;
+
+#endif // RBD_MIRROR_IMAGE_REPLAYER_JOURNAL_CREATE_LOCAL_IMAGE_REQUEST_H

--- a/src/tools/rbd_mirror/image_replayer/journal/PrepareReplayRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/journal/PrepareReplayRequest.cc
@@ -1,0 +1,315 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "PrepareReplayRequest.h"
+#include "common/debug.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "journal/Journaler.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Journal.h"
+#include "librbd/Utils.h"
+#include "tools/rbd_mirror/ProgressContext.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::image_replayer::journal::" \
+                           << "PrepareReplayRequest: " << this << " " \
+                           << __func__ << ": "
+
+namespace rbd {
+namespace mirror {
+namespace image_replayer {
+namespace journal {
+
+using librbd::util::create_context_callback;
+
+template <typename I>
+void PrepareReplayRequest<I>::send() {
+  *m_resync_requested = false;
+  *m_syncing = false;
+
+  std::shared_lock image_locker(m_local_image_ctx->image_lock);
+  if (m_local_image_ctx->journal == nullptr) {
+    image_locker.unlock();
+
+    derr << "local image does not support journaling" << dendl;
+    finish(-EINVAL);
+    return;
+  }
+
+  int r = m_local_image_ctx->journal->is_resync_requested(m_resync_requested);
+  if (r < 0) {
+    image_locker.unlock();
+
+    derr << "failed to check if a resync was requested" << dendl;
+    finish(r);
+    return;
+  }
+
+  m_local_tag_tid = m_local_image_ctx->journal->get_tag_tid();
+  m_local_tag_data = m_local_image_ctx->journal->get_tag_data();
+  dout(10) << "local tag=" << m_local_tag_tid << ", "
+           << "local tag data=" << m_local_tag_data << dendl;
+  image_locker.unlock();
+
+  if (m_local_tag_data.mirror_uuid != m_remote_mirror_uuid &&
+      m_remote_promotion_state != librbd::mirror::PROMOTION_STATE_PRIMARY) {
+    // if the local mirror is not linked to the (now) non-primary image,
+    // stop the replay. Otherwise, we ignore that the remote is non-primary
+    // so that we can replay the demotion
+    dout(5) << "remote image is not primary -- skipping image replay"
+            << dendl;
+    finish(-EREMOTEIO);
+    return;
+  }
+
+  if (*m_resync_requested) {
+    finish(0);
+    return;
+  } else if (m_client_meta->state ==
+               librbd::journal::MIRROR_PEER_STATE_SYNCING &&
+             m_local_tag_data.mirror_uuid == m_remote_mirror_uuid) {
+    // if the initial sync hasn't completed, we cannot replay
+    *m_syncing = true;
+    finish(0);
+    return;
+  }
+
+  update_client_state();
+}
+
+template <typename I>
+void PrepareReplayRequest<I>::update_client_state() {
+  if (m_client_meta->state != librbd::journal::MIRROR_PEER_STATE_SYNCING ||
+      m_local_tag_data.mirror_uuid == m_remote_mirror_uuid) {
+    get_remote_tag_class();
+    return;
+  }
+
+  // our local image is not primary, is flagged as syncing on the remote side,
+  // but is no longer tied to the remote -- this implies we were forced
+  // promoted and then demoted at some point
+  dout(15) << dendl;
+  update_progress("UPDATE_CLIENT_STATE");
+
+  librbd::journal::MirrorPeerClientMeta client_meta(*m_client_meta);
+  client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+
+  librbd::journal::ClientData client_data(client_meta);
+  bufferlist data_bl;
+  encode(client_data, data_bl);
+
+  auto ctx = create_context_callback<
+    PrepareReplayRequest<I>,
+    &PrepareReplayRequest<I>::handle_update_client_state>(this);
+  m_remote_journaler->update_client(data_bl, ctx);
+}
+
+template <typename I>
+void PrepareReplayRequest<I>::handle_update_client_state(int r) {
+  dout(15) << "r=" << r << dendl;
+  if (r < 0) {
+    derr << "failed to update client: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  m_client_meta->state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
+  get_remote_tag_class();
+}
+
+template <typename I>
+void PrepareReplayRequest<I>::get_remote_tag_class() {
+  dout(10) << dendl;
+  update_progress("GET_REMOTE_TAG_CLASS");
+
+  auto ctx = create_context_callback<
+    PrepareReplayRequest<I>,
+    &PrepareReplayRequest<I>::handle_get_remote_tag_class>(this);
+  m_remote_journaler->get_client(librbd::Journal<>::IMAGE_CLIENT_ID, &m_client,
+                                 ctx);
+}
+
+template <typename I>
+void PrepareReplayRequest<I>::handle_get_remote_tag_class(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    derr << "failed to retrieve remote client: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  librbd::journal::ClientData client_data;
+  auto it = m_client.data.cbegin();
+  try {
+    decode(client_data, it);
+  } catch (const buffer::error &err) {
+    derr << "failed to decode remote client meta data: " << err.what()
+         << dendl;
+    finish(-EBADMSG);
+    return;
+  }
+
+  librbd::journal::ImageClientMeta *client_meta =
+    boost::get<librbd::journal::ImageClientMeta>(&client_data.client_meta);
+  if (client_meta == nullptr) {
+    derr << "unknown remote client registration" << dendl;
+    finish(-EINVAL);
+    return;
+  }
+
+  m_remote_tag_class = client_meta->tag_class;
+  dout(10) << "remote tag class=" << m_remote_tag_class << dendl;
+
+  get_remote_tags();
+}
+
+template <typename I>
+void PrepareReplayRequest<I>::get_remote_tags() {
+  dout(10) << dendl;
+  update_progress("GET_REMOTE_TAGS");
+
+  auto ctx = create_context_callback<
+    PrepareReplayRequest<I>,
+    &PrepareReplayRequest<I>::handle_get_remote_tags>(this);
+  m_remote_journaler->get_tags(m_remote_tag_class, &m_remote_tags, ctx);
+}
+
+template <typename I>
+void PrepareReplayRequest<I>::handle_get_remote_tags(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    derr << "failed to retrieve remote tags: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  // At this point, the local image was existing, non-primary, and replaying;
+  // and the remote image is primary.  Attempt to link the local image's most
+  // recent tag to the remote image's tag chain.
+  bool remote_tag_data_valid = false;
+  librbd::journal::TagData remote_tag_data;
+  boost::optional<uint64_t> remote_orphan_tag_tid =
+    boost::make_optional<uint64_t>(false, 0U);
+  bool reconnect_orphan = false;
+
+  // decode the remote tags
+  for (auto &remote_tag : m_remote_tags) {
+    if (m_local_tag_data.predecessor.commit_valid &&
+        m_local_tag_data.predecessor.mirror_uuid == m_remote_mirror_uuid &&
+        m_local_tag_data.predecessor.tag_tid > remote_tag.tid) {
+      dout(10) << "skipping processed predecessor remote tag "
+               << remote_tag.tid << dendl;
+      continue;
+    }
+
+    try {
+      auto it = remote_tag.data.cbegin();
+      decode(remote_tag_data, it);
+      remote_tag_data_valid = true;
+    } catch (const buffer::error &err) {
+      derr << "failed to decode remote tag " << remote_tag.tid << ": "
+           << err.what() << dendl;
+      finish(-EBADMSG);
+      return;
+    }
+
+    dout(10) << "decoded remote tag " << remote_tag.tid << ": "
+             << remote_tag_data << dendl;
+
+    if (!m_local_tag_data.predecessor.commit_valid) {
+      // newly synced local image (no predecessor) replays from the first tag
+      if (remote_tag_data.mirror_uuid != librbd::Journal<>::LOCAL_MIRROR_UUID) {
+        dout(10) << "skipping non-primary remote tag" << dendl;
+        continue;
+      }
+
+      dout(10) << "using initial primary remote tag" << dendl;
+      break;
+    }
+
+    if (m_local_tag_data.mirror_uuid == librbd::Journal<>::ORPHAN_MIRROR_UUID) {
+      // demotion last available local epoch
+
+      if (remote_tag_data.mirror_uuid == m_local_tag_data.mirror_uuid &&
+          remote_tag_data.predecessor.commit_valid &&
+          remote_tag_data.predecessor.tag_tid ==
+            m_local_tag_data.predecessor.tag_tid) {
+        // demotion matches remote epoch
+
+        if (remote_tag_data.predecessor.mirror_uuid == m_local_mirror_uuid &&
+            m_local_tag_data.predecessor.mirror_uuid ==
+              librbd::Journal<>::LOCAL_MIRROR_UUID) {
+          // local demoted and remote has matching event
+          dout(10) << "found matching local demotion tag" << dendl;
+          remote_orphan_tag_tid = remote_tag.tid;
+          continue;
+        }
+
+        if (m_local_tag_data.predecessor.mirror_uuid == m_remote_mirror_uuid &&
+            remote_tag_data.predecessor.mirror_uuid ==
+              librbd::Journal<>::LOCAL_MIRROR_UUID) {
+          // remote demoted and local has matching event
+          dout(10) << "found matching remote demotion tag" << dendl;
+          remote_orphan_tag_tid = remote_tag.tid;
+          continue;
+        }
+      }
+
+      if (remote_tag_data.mirror_uuid == librbd::Journal<>::LOCAL_MIRROR_UUID &&
+          remote_tag_data.predecessor.mirror_uuid ==
+            librbd::Journal<>::ORPHAN_MIRROR_UUID &&
+          remote_tag_data.predecessor.commit_valid && remote_orphan_tag_tid &&
+          remote_tag_data.predecessor.tag_tid == *remote_orphan_tag_tid) {
+        // remote promotion tag chained to remote/local demotion tag
+        dout(10) << "found chained remote promotion tag" << dendl;
+        reconnect_orphan = true;
+        break;
+      }
+
+      // promotion must follow demotion
+      remote_orphan_tag_tid = boost::none;
+    }
+  }
+
+  if (remote_tag_data_valid &&
+      m_local_tag_data.mirror_uuid == m_remote_mirror_uuid) {
+    dout(10) << "local image is in clean replay state" << dendl;
+  } else if (reconnect_orphan) {
+    dout(10) << "remote image was demoted/promoted" << dendl;
+  } else {
+    derr << "split-brain detected -- skipping image replay" << dendl;
+    finish(-EEXIST);
+    return;
+  }
+
+  finish(0);
+}
+
+template <typename I>
+void PrepareReplayRequest<I>::finish(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+template <typename I>
+void PrepareReplayRequest<I>::update_progress(const std::string &description) {
+  dout(10) << description << dendl;
+
+  if (m_progress_ctx != nullptr) {
+    m_progress_ctx->update_progress(description);
+  }
+}
+
+} // namespace journal
+} // namespace image_replayer
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::image_replayer::journal::PrepareReplayRequest<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/image_replayer/journal/PrepareReplayRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/journal/PrepareReplayRequest.h
@@ -1,0 +1,124 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RBD_MIRROR_IMAGE_REPLAYER_JOURNAL_PREPARE_REPLAY_REQUEST_H
+#define RBD_MIRROR_IMAGE_REPLAYER_JOURNAL_PREPARE_REPLAY_REQUEST_H
+
+#include "include/int_types.h"
+#include "cls/journal/cls_journal_types.h"
+#include "librbd/journal/Types.h"
+#include "librbd/journal/TypeTraits.h"
+#include "librbd/mirror/Types.h"
+#include <list>
+#include <string>
+
+struct Context;
+namespace librbd { struct ImageCtx; }
+
+namespace rbd {
+namespace mirror {
+
+class ProgressContext;
+
+namespace image_replayer {
+namespace journal {
+
+template <typename ImageCtxT>
+class PrepareReplayRequest {
+public:
+  typedef librbd::journal::TypeTraits<ImageCtxT> TypeTraits;
+  typedef typename TypeTraits::Journaler Journaler;
+  typedef librbd::journal::MirrorPeerClientMeta MirrorPeerClientMeta;
+
+  static PrepareReplayRequest* create(
+      ImageCtxT* local_image_ctx, Journaler* remote_journaler,
+      librbd::mirror::PromotionState remote_promotion_state,
+      const std::string& local_mirror_uuid,
+      const std::string& remote_mirror_uuid,
+      MirrorPeerClientMeta* client_meta, ProgressContext* progress_ctx,
+      bool* resync_requested, bool* syncing, Context* on_finish) {
+    return new PrepareReplayRequest(
+      local_image_ctx, remote_journaler, remote_promotion_state,
+      local_mirror_uuid, remote_mirror_uuid, client_meta, progress_ctx,
+      resync_requested, syncing, on_finish);
+  }
+
+  PrepareReplayRequest(
+      ImageCtxT* local_image_ctx, Journaler* remote_journaler,
+      librbd::mirror::PromotionState remote_promotion_state,
+      const std::string& local_mirror_uuid,
+      const std::string& remote_mirror_uuid,
+      MirrorPeerClientMeta* client_meta, ProgressContext* progress_ctx,
+      bool* resync_requested, bool* syncing, Context* on_finish)
+    : m_local_image_ctx(local_image_ctx), m_remote_journaler(remote_journaler),
+      m_remote_promotion_state(remote_promotion_state),
+      m_local_mirror_uuid(local_mirror_uuid),
+      m_remote_mirror_uuid(remote_mirror_uuid), m_client_meta(client_meta),
+      m_progress_ctx(progress_ctx), m_resync_requested(resync_requested),
+      m_syncing(syncing), m_on_finish(on_finish) {
+  }
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * UPDATE_CLIENT_STATE
+   *    |
+   *    v
+   * GET_REMOTE_TAG_CLASS
+   *    |
+   *    v
+   * GET_REMOTE_TAGS
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+  typedef std::list<cls::journal::Tag> Tags;
+
+  ImageCtxT* m_local_image_ctx;
+  Journaler* m_remote_journaler;
+  librbd::mirror::PromotionState m_remote_promotion_state;
+  std::string m_local_mirror_uuid;
+  std::string m_remote_mirror_uuid;
+  MirrorPeerClientMeta* m_client_meta;
+  ProgressContext* m_progress_ctx;
+  bool* m_resync_requested;
+  bool* m_syncing;
+  Context* m_on_finish;
+
+  uint64_t m_local_tag_tid = 0;
+  librbd::journal::TagData m_local_tag_data;
+
+  uint64_t m_remote_tag_class = 0;
+  Tags m_remote_tags;
+  cls::journal::Client m_client;
+
+  void update_client_state();
+  void handle_update_client_state(int r);
+
+  void get_remote_tag_class();
+  void handle_get_remote_tag_class(int r);
+
+  void get_remote_tags();
+  void handle_get_remote_tags(int r);
+
+  void finish(int r);
+  void update_progress(const std::string& description);
+
+};
+
+} // namespace journal
+} // namespace image_replayer
+} // namespace mirror
+} // namespace rbd
+
+extern template class rbd::mirror::image_replayer::journal::PrepareReplayRequest<librbd::ImageCtx>;
+
+#endif // RBD_MIRROR_IMAGE_REPLAYER_JOURNAL_PREPARE_REPLAY_REQUEST_H

--- a/src/tools/rbd_mirror/image_replayer/journal/Replayer.cc
+++ b/src/tools/rbd_mirror/image_replayer/journal/Replayer.cc
@@ -596,8 +596,13 @@ void Replayer<I>::handle_wait_for_in_flight_ops(int r) {
   ReplayStatusFormatter<I>::destroy(m_replay_status_formatter);
   m_replay_status_formatter = nullptr;
 
-  ceph_assert(m_on_init_shutdown != nullptr);
-  m_on_init_shutdown->complete(m_error_code);
+  Context* on_init_shutdown = nullptr;
+  {
+    std::unique_lock locker{m_lock};
+    ceph_assert(m_on_init_shutdown != nullptr);
+    std::swap(m_on_init_shutdown, on_init_shutdown);
+  }
+  on_init_shutdown->complete(m_error_code);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_replayer/journal/Replayer.cc
+++ b/src/tools/rbd_mirror/image_replayer/journal/Replayer.cc
@@ -601,6 +601,7 @@ void Replayer<I>::handle_wait_for_in_flight_ops(int r) {
     std::unique_lock locker{m_lock};
     ceph_assert(m_on_init_shutdown != nullptr);
     std::swap(m_on_init_shutdown, on_init_shutdown);
+    m_state = STATE_COMPLETE;
   }
   on_init_shutdown->complete(m_error_code);
 }


### PR DESCRIPTION
There will be one additional PR after this one to remove all remaining traces of journal-only logic and variables from the shared image replaying state machines.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
