### PR TITLE
librbd: remove pool objects when removing a namespace

### DIFF
--- a/src/librbd/api/Namespace.cc
+++ b/src/librbd/api/Namespace.cc
@@ -14,6 +14,20 @@
 namespace librbd {
 namespace api {
 
+namespace {
+
+const std::list<std::string> POOL_OBJECTS {
+  RBD_CHILDREN,
+  RBD_GROUP_DIRECTORY,
+  RBD_INFO,
+  RBD_MIRRORING,
+  RBD_TASK,
+  RBD_TRASH,
+  RBD_DIRECTORY
+};
+
+} // anonymous namespace
+
 template <typename I>
 int Namespace<I>::create(librados::IoCtx& io_ctx, const std::string& name)
 {
@@ -123,6 +137,15 @@ int Namespace<I>::remove(librados::IoCtx& io_ctx, const std::string& name)
     lderr(cct) << "failed to disable mirroring: " << cpp_strerror(r)
                << dendl;
     return r;
+  }
+
+  for (auto& oid : POOL_OBJECTS) {
+    r = ns_ctx.remove(oid);
+    if (r < 0 && r != -ENOENT) {
+      lderr(cct) << "failed to remove object '" << oid << "': "
+                 << cpp_strerror(r) << dendl;
+      return r;
+    }
   }
 
   r = cls_client::namespace_remove(&default_ns_ctx, name);


### PR DESCRIPTION
Avoid leaving RBD pool objects within a pool namespace that is
being deleted.

Fixes: https://tracker.ceph.com/issues/43378
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
