### PR TITLE
rgw: build radosgw daemon as a shared lib + small executable

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1846,12 +1846,14 @@ fi
 %{_bindir}/radosgw-token
 %{_bindir}/radosgw-es
 %{_bindir}/radosgw-object-expirer
+%{_libdir}/libradosgw.so*
 %{_mandir}/man8/radosgw.8*
 %dir %{_localstatedir}/lib/ceph/radosgw
 %{_unitdir}/ceph-radosgw@.service
 %{_unitdir}/ceph-radosgw.target
 
 %post radosgw
+/sbin/ldconfig
 %if 0%{?suse_version}
 if [ $1 -eq 1 ] ; then
   /usr/bin/systemctl preset ceph-radosgw@\*.service ceph-radosgw.target >/dev/null 2>&1 || :
@@ -1873,6 +1875,7 @@ fi
 %endif
 
 %postun radosgw
+/sbin/ldconfig
 %if 0%{?suse_version}
 DISABLE_RESTART_ON_UPDATE="yes"
 %service_del_postun ceph-radosgw@\*.service ceph-radosgw.target

--- a/debian/radosgw.install
+++ b/debian/radosgw.install
@@ -1,4 +1,5 @@
 lib/systemd/system/ceph-radosgw*
+lib/*/libradosgw.so*
 usr/bin/radosgw
 usr/bin/radosgw-es
 usr/bin/radosgw-object-expirer

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -266,21 +266,34 @@ if(WITH_RADOSGW_BEAST_FRONTEND)
     rgw_dmclock_async_scheduler.cc)
 endif()
 
-add_library(radosgw_a STATIC ${radosgw_srcs}
+add_library(radosgw SHARED ${radosgw_srcs} ${rgw_a_srcs} rgw_main.cc
   $<TARGET_OBJECTS:civetweb_common_objs>)
+
+add_dependencies(radosgw civetweb_h)
+
+target_compile_definitions(radosgw PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
+target_include_directories(radosgw PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src")
+target_include_directories(radosgw SYSTEM PUBLIC "../rapidjson/include")
+
+target_link_libraries(radosgw
+  PRIVATE ${rgw_libs} rgw_schedulers
+  PUBLIC dmclock::dmclock
+)
+if(WITH_RADOSGW_BEAST_FRONTEND AND WITH_RADOSGW_BEAST_OPENSSL)
+target_link_libraries(radosgw
+  # used by rgw_asio_frontend.cc
+  PRIVATE OpenSSL::SSL)
+endif()
+set_target_properties(radosgw PROPERTIES OUTPUT_NAME radosgw VERSION 2.0.0
+  SOVERSION 2)
+install(TARGETS radosgw DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
 add_library(rgw_schedulers STATIC ${rgw_schedulers_srcs})
 target_link_libraries(rgw_schedulers
   PUBLIC dmclock::dmclock)
-target_link_libraries(radosgw_a
-  PRIVATE ${rgw_libs} rgw_schedulers
-  PUBLIC dmclock::dmclock)
-if(WITH_RADOSGW_BEAST_FRONTEND AND WITH_RADOSGW_BEAST_OPENSSL)
-  # used by rgw_asio_frontend.cc
-  target_link_libraries(radosgw_a PRIVATE OpenSSL::SSL)
-endif()
 
-add_executable(radosgw rgw_main.cc)
-target_link_libraries(radosgw radosgw_a librados
+add_executable(radosgwd radosgw.cc)
+target_link_libraries(radosgwd radosgw librados
   cls_rgw_client cls_otp_client cls_lock_client cls_refcount_client
   cls_log_client cls_timeindex_client
   cls_version_client cls_user_client
@@ -288,7 +301,8 @@ target_link_libraries(radosgw radosgw_a librados
   ${FCGI_LIBRARY} ${LIB_RESOLV}
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES}
   ${ALLOC_LIBS})
-install(TARGETS radosgw DESTINATION bin)
+set_target_properties(radosgwd PROPERTIES OUTPUT_NAME radosgw)
+install(TARGETS radosgwd DESTINATION bin)
 
 set(radosgw_admin_srcs
   rgw_admin.cc

--- a/src/rgw/radosgw.cc
+++ b/src/rgw/radosgw.cc
@@ -1,0 +1,13 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+//
+
+extern int radosgw_Main(int, const char **);
+
+/*
+ * start up the RADOS connection and then handle HTTP messages as they come in
+ */
+int main(int argc, char **argv)
+{
+  return radosgw_Main(argc, const_cast<const char **>(argv));
+}

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -171,7 +171,7 @@ static RGWRESTMgr *rest_filter(RGWRados *store, int dialect, RGWRESTMgr *orig)
 /*
  * start up the RADOS connection and then handle HTTP messages as they come in
  */
-int main(int argc, const char **argv)
+int radosgw_Main(int argc, const char **argv)
 {
   // dout() messages will be sent to stderr, but FCGX wants messages on stdout
   // Redirect stderr to stdout.
@@ -627,3 +627,13 @@ int main(int argc, const char **argv)
 
   return 0;
 }
+
+extern "C" {
+
+int radosgw_main(int argc, const char** argv)
+{
+  return radosgw_Main(argc, argv);
+}
+
+} /* extern "C" */
+


### PR DESCRIPTION
rgw: radosgw (rgw) daemon as a shared lib

Majority of radosgw is contained in libradosgw.so. (/usr)/bin/radosgw
is now a few lines that calls radosgw_Main() in libradosgw.so.

The "zipper" work to modularize storage back-ends that will require
linking to the shared library to resolve the methods that they reference.

Putting the bulk of the implementation in a shared lib also allows for
unit testing to link with the shared lib for testing.

radosgw_Main() is the C++ implementation. For C linkage, radosgw_main()
is provided.

https://tracker.ceph.com/issues/43411

Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
