### PR TITLE
common:solve the issue that the osd can't restart after seting a virtual local loopback IP

### DIFF
--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -3,6 +3,7 @@
 #include <ifaddrs.h>
 #include <stdlib.h>
 #include <string.h>
+#include<regex>
 #if defined(__FreeBSD__)
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -12,7 +13,6 @@
 #include "include/ipaddr.h"
 #include "msg/msg_types.h"
 #include "common/pick_address.h"
-#include<regex>
 void netmask_ipv4(const struct in_addr *addr,
 			 unsigned int prefix_len,
 			 struct in_addr *out) {


### PR DESCRIPTION
This will solve the issue that the osd can't restart after seting a virtual local loopback IP
Fixed:https://tracker.ceph.com/issues/43417
Signed-off-by: 1797702937@qq.com
Reviewed-by: chenyupeng@chinatelecom.cn
Reviewed-by: chenxiaowei@chinatelecom.cn