### PR TITLE
common: skip interfaces starting with "lo" in find_ipv{4,6}_in_subnet()

### DIFF
--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -3,6 +3,7 @@
 #include <ifaddrs.h>
 #include <stdlib.h>
 #include <string.h>
+#include <boost/algorithm/string/predicate.hpp>
 #if defined(__FreeBSD__)
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -50,13 +51,12 @@ const struct ifaddrs *find_ipv4_in_subnet(const struct ifaddrs *addrs,
   struct in_addr want, temp;
 
   netmask_ipv4(&net->sin_addr, prefix_len, &want);
-
   for (; addrs != NULL; addrs = addrs->ifa_next) {
 
     if (addrs->ifa_addr == NULL)
       continue;
 
-    if (strcmp(addrs->ifa_name, "lo") == 0)
+    if (boost::starts_with(addrs->ifa_name, "lo"))
       continue;
 
     if (numa_node >= 0 && !match_numa_node(addrs->ifa_name, numa_node))
@@ -98,13 +98,12 @@ const struct ifaddrs *find_ipv6_in_subnet(const struct ifaddrs *addrs,
   struct in6_addr want, temp;
 
   netmask_ipv6(&net->sin6_addr, prefix_len, &want);
-
   for (; addrs != NULL; addrs = addrs->ifa_next) {
 
     if (addrs->ifa_addr == NULL)
       continue;
 
-    if (strcmp(addrs->ifa_name, "lo") == 0)
+    if (boost::starts_with(addrs->ifa_name, "lo"))
       continue;
 
     if (numa_node >= 0 && !match_numa_node(addrs->ifa_name, numa_node))


### PR DESCRIPTION
This will solve the issue that the osd can't restart after seting a virtual local loopback IP.
In find_ipv4_in_subnet() and find_ipv6_in_subnet(), I use boost::starts_with(addrs->ifa_name, "lo") to ship the interfaces starting with "lo".
Fixed:https://tracker.ceph.com/issues/43417
Signed-off-by: lijiawei1@chinatelecom.cn
Reviewed-by: chenyupeng@chinatelecom.cn
Reviewed-by: chenxiaowei@chinatelecom.cn