### PR TITLE
qa: enable CRB repo for RHEL8

### DIFF
--- a/qa/workunits/ceph-helpers-root.sh
+++ b/qa/workunits/ceph-helpers-root.sh
@@ -50,15 +50,6 @@ function install_one() {
     esac
 }
 
-function install_cmake3_on_centos7 {
-    source /etc/os-release
-    local MAJOR_VERSION="$(echo $VERSION_ID | cut -d. -f1)"
-    sudo yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/$MAJOR_VERSION/x86_64/
-    sudo yum install --nogpgcheck -y epel-release
-    sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$MAJOR_VERSION
-    sudo yum install -y cmake3
-}
-
 function install_cmake3_on_xenial {
     install_pkg_on_ubuntu \
 	ceph-cmake \

--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -31,15 +31,18 @@ case $(distro_id) in
         esac
 		;;
 	centos|fedora|rhel)
-	        # el8 needs PowerTools for snappy-devel
-	        test -x /usr/bin/dnf && sudo dnf config-manager --set-enabled PowerTools || true
-		install git gcc-c++.x86_64 snappy-devel zlib zlib-devel bzip2 bzip2-devel libradospp-devel.x86_64
-        if [ $(distro_id) = "fedora" ]; then
-            install cmake
-        else
-            install_cmake3_on_centos7
-        fi
-		;;
+        case $(distro_id) in
+            centos)
+                # centos needs PowerTools repo for snappy-devel
+                test -x /usr/bin/dnf && sudo dnf config-manager --set-enabled PowerTools || true
+                ;;
+            rhel)
+                # RHEL needs CRB repo for snappy-devel
+                sudo subscription-manager repos --enable "codeready-builder-for-rhel-8-x86_64-rpms"
+                ;;
+        esac
+        install git gcc-c++.x86_64 snappy-devel zlib zlib-devel bzip2 bzip2-devel libradospp-devel.x86_64 cmake
+        ;;
 	opensuse*|suse|sles)
 		install git gcc-c++ snappy-devel zlib-devel libbz2-devel libradospp-devel
 		;;


### PR DESCRIPTION
instead of enabling PowerTools repo, we need to enable CodeReady Builder
repo for RHEL8

also, since we are moving to RHEL8, there is no need to install cmake3
specifically for CentOS. CentOS 8 comes with cmake3.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
