### PR TITLE
qa: add "path" to "device" output schema

### DIFF
--- a/qa/tasks/mgr/dashboard/test_host.py
+++ b/qa/tasks/mgr/dashboard/test_host.py
@@ -83,5 +83,9 @@ class HostControllerTest(DashboardTestCase):
         self.assertSchema(data, JList(JObj({
             'daemons': JList(str),
             'devid': str,
-            'location': JList(JObj({'host': str, 'dev': str}))
+            'location': JList(JObj({
+                'host': str,
+                'dev': str,
+                'path': str
+            }))
         })))

--- a/qa/tasks/mgr/dashboard/test_osd.py
+++ b/qa/tasks/mgr/dashboard/test_osd.py
@@ -140,7 +140,11 @@ class OsdTest(DashboardTestCase):
         self.assertSchema(data, JList(JObj({
             'daemons': JList(str),
             'devid': str,
-            'location': JList(JObj({'host': str, 'dev': str}))
+            'location': JList(JObj({
+                'host': str,
+                'dev': str,
+                'path': str
+            }))
         })))
 
 


### PR DESCRIPTION
"path" was added by 2c0fd7d86827aa76b8d923870018365cdae4a6ad, so update
the test accordingly

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
