### PR TITLE
mds: Reorganize structure members in inode_backtrace header

### DIFF
--- a/src/mds/inode_backtrace.h
+++ b/src/mds/inode_backtrace.h
@@ -22,11 +22,7 @@ namespace ceph {
  *   newer.
  */
 struct inode_backpointer_t {
-  inodeno_t dirino;    // containing directory ino
-  string dname;        // linking dentry name
-  version_t version;   // child's version at time of backpointer creation
-
-  inode_backpointer_t() : version(0) {}
+  inode_backpointer_t() {}
   inode_backpointer_t(inodeno_t i, std::string_view d, version_t v) : dirino(i), dname(d), version(v) {}
 
   void encode(bufferlist& bl) const;
@@ -34,6 +30,10 @@ struct inode_backpointer_t {
   void decode_old(bufferlist::const_iterator &bl);
   void dump(Formatter *f) const;
   static void generate_test_instances(std::list<inode_backpointer_t*>& ls);
+
+  inodeno_t dirino;    // containing directory ino
+  string dname;        // linking dentry name
+  version_t version = 0;   // child's version at time of backpointer creation
 };
 WRITE_CLASS_ENCODER(inode_backpointer_t)
 
@@ -51,13 +51,7 @@ inline ostream& operator<<(ostream& out, const inode_backpointer_t& ib) {
  * an xattr on an object).
  */
 struct inode_backtrace_t {
-  inodeno_t ino;       // my ino
-  vector<inode_backpointer_t> ancestors;
-  int64_t pool;
-  // we use a set for old_pools to avoid duplicate entries, e.g. setlayout 0, 1, 0
-  set<int64_t> old_pools;
-
-  inode_backtrace_t() : pool(-1) {}
+  inode_backtrace_t() {}
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator &bl);
@@ -78,6 +72,12 @@ struct inode_backtrace_t {
    */
   int compare(const inode_backtrace_t& other,
                bool *equivalent, bool *divergent) const;
+
+  inodeno_t ino;       // my ino
+  vector<inode_backpointer_t> ancestors;
+  int64_t pool = -1;
+  // we use a set for old_pools to avoid duplicate entries, e.g. setlayout 0, 1, 0
+  set<int64_t> old_pools;
 };
 WRITE_CLASS_ENCODER(inode_backtrace_t)
 
@@ -94,4 +94,3 @@ inline bool operator==(const inode_backtrace_t& l,
 }
 
 #endif
-


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43424
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
