### PR TITLE
tool/rados: implement the export-object/import-object functionality

### DIFF
--- a/src/tools/rados/PoolDump.h
+++ b/src/tools/rados/PoolDump.h
@@ -24,6 +24,8 @@ class PoolDump : public RadosDump
   public:
     explicit PoolDump(int file_fd_) : RadosDump(file_fd_, false) {}
     int dump(librados::IoCtx *io_ctx);
+    int export_object(librados::IoCtx *io_ctx, std::string oid, std::string nspace, std::string oloc);
+    int dump_object(librados::IoCtx *io_ctx, std::string oid, std::string nspace, std::string oloc);
 };
 
 #endif // POOL_DUMP_H_

--- a/src/tools/rados/RadosImport.h
+++ b/src/tools/rados/RadosImport.h
@@ -37,7 +37,7 @@ class RadosImport : public RadosDump
     RadosImport(int file_fd_, uint64_t align_, bool dry_run_)
       : RadosDump(file_fd_, dry_run_), align(align_)
     {}
-
+    int import_object(librados::IoCtx &ioctx, bool no_overwrite);
     int import(std::string pool, bool no_overwrite);
     int import(librados::IoCtx &io_ctx, bool no_overwrite);
 };


### PR DESCRIPTION
rados can support pool level export/import, but it didn't support object level.
With this patch we can export an object and able to import them back without breaking anything.
This is very useful when we want to delete a bunch of suspicious orphaned objects (eg. the result from "radosgw-admin orphans find").  With two two options, we can backport those objects first and perform the deletion later, if something went wrong, we can always import them back. 
usage:
"rados -p <pool-name> --export-object <object name> <file name>"
"rados -p <pool-name> --import <file name>"

Signed-off-by: dongdong tao <dongdong.tao@canonical.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
