### PR TITLE
os/kstore: introduces mempool to kstore, and trim onode cache periodically

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4638,6 +4638,14 @@ std::vector<Option> get_global_options() {
     .set_default(65536)
     .set_description(""),
 
+    Option("kstore_cache_trim_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(3)
+    .set_description("How frequently we trim the kstore cache"),
+
+    Option("kstore_onode_cache_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    .set_default(50)
+    .set_description("How many kstore onode cached per collection"),
+
     // ---------------------
     // filestore
 

--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -146,26 +146,28 @@ namespace mempool {
 // define memory pools
 
 #define DEFINE_MEMORY_POOLS_HELPER(f) \
-  f(bloom_filter)		      \
-  f(bluestore_alloc)		      \
-  f(bluestore_cache_data)	      \
-  f(bluestore_cache_onode)	      \
-  f(bluestore_cache_other)	      \
-  f(bluestore_fsck)		      \
-  f(bluestore_txc)		      \
-  f(bluestore_writing_deferred)	      \
-  f(bluestore_writing)		      \
-  f(bluefs)			      \
-  f(buffer_anon)		      \
-  f(buffer_meta)		      \
-  f(osd)			      \
-  f(osd_mapbl)			      \
-  f(osd_pglog)			      \
-  f(osdmap)			      \
-  f(osdmap_mapping)		      \
-  f(pgmap)			      \
-  f(mds_co)			      \
-  f(unittest_1)			      \
+  f(bloom_filter)                     \
+  f(bluestore_alloc)                  \
+  f(bluestore_cache_data)             \
+  f(bluestore_cache_onode)            \
+  f(bluestore_cache_other)            \
+  f(bluestore_fsck)                   \
+  f(bluestore_txc)                    \
+  f(bluestore_writing_deferred)       \
+  f(bluestore_writing)                \
+  f(bluefs)                           \
+  f(kstore_cache_onode)               \
+  f(kstore_cache_other)               \
+  f(buffer_anon)                      \
+  f(buffer_meta)                      \
+  f(osd)                              \
+  f(osd_mapbl)                        \
+  f(osd_pglog)                        \
+  f(osdmap)                           \
+  f(osdmap_mapping)                   \
+  f(pgmap)                            \
+  f(mds_co)                           \
+  f(unittest_1)                       \
   f(unittest_2)
 
 

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -57,6 +57,7 @@ public:
 
   /// an in-memory object
   struct Onode {
+    MEMPOOL_CLASS_HELPERS();
     CephContext* cct;
     std::atomic_int nref;  ///< reference count
 
@@ -87,6 +88,17 @@ public:
         tail_offset(0) {
     }
 
+    Onode(CephContext* cct, const ghobject_t& o, const mempool::kstore_cache_other::string& k)
+      : cct(cct),
+	nref(0),
+	oid(o),
+	key(k),
+	dirty(false),
+	exists(false),
+	tail_offset(0) {
+    }
+
+
     void flush();
     void get() {
       ++nref;
@@ -116,7 +128,7 @@ public:
 	&Onode::lru_item> > lru_list_t;
 
     std::mutex lock;
-    ceph::unordered_map<ghobject_t,OnodeRef> onode_map;  ///< forward lookups
+    mempool::kstore_cache_other::unordered_map<ghobject_t,OnodeRef> onode_map;  ///< forward lookups
     lru_list_t lru;                                      ///< lru
 
     OnodeHashLRU(CephContext* cct) : cct(cct) {}


### PR DESCRIPTION
Signed-off-by: Chang Liu <liuchang0812@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
