### PR TITLE
mgr/dashboard: fix badges of SSD devices in inventory page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.ts
@@ -99,7 +99,7 @@ export class InventoryDevicesComponent implements OnInit, OnChanges {
         customTemplateConfig: {
           map: {
             hdd: { value: 'HDD', class: 'badge-hdd' },
-            'ssd/nvme': { value: 'SSD', class: 'badge-ssd' }
+            ssd: { value: 'SSD', class: 'badge-ssd' }
           }
         }
       },


### PR DESCRIPTION
The original type `ssd/nvme` reported from Orchestrator had been changed
after https://github.com/ceph/ceph/pull/32279. Adapt the change to fix
the SSD badges.

Fixes: https://tracker.ceph.com/issues/43439
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

## Before
![ssd](https://user-images.githubusercontent.com/1691518/71615675-5914cb80-2bed-11ea-9395-709e8cf30d20.png)

## After
![ssd2](https://user-images.githubusercontent.com/1691518/71615676-5c0fbc00-2bed-11ea-97c9-096fb93174c4.png)

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
