### PR TITLE
mgr/volumes: cleanup on fs create error

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -129,10 +129,10 @@ class TestVolumes(CephFSTestCase):
         volname = self._generate_random_volume_name()
         self._fs_cmd("volume", "create", volname)
         volumels = json.loads(self._fs_cmd("volume", "ls"))
-        try:
-            if (not (volname in ([volume['name'] for volume in volumels]))):
-                raise RuntimeError("Error creating volume '{0}'".format(volname))
-        finally:
+
+        if not (volname in ([volume['name'] for volume in volumels])):
+            raise RuntimeError("Error creating volume '{0}'".format(volname))
+        else:
             # clean up
             self._fs_cmd("volume", "rm", volname, "--yes-i-really-mean-it")
 

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -249,9 +249,6 @@ class VolumeClient(object):
         # create the given pool
         command = {'prefix': 'osd pool create', 'pool': pool_name}
         r, outb, outs = self.mgr.mon_command(command)
-        if r != 0:
-            return r, outb, outs
-
         return r, outb, outs
 
     def remove_pool(self, pool_name):
@@ -304,11 +301,16 @@ class VolumeClient(object):
             return r, outb, outs
         r, outb, outs = self.create_pool(data_pool)
         if r != 0:
+            #cleanup
+            self.remove_pool(metadata_pool)
             return r, outb, outs
         # create filesystem
         r, outb, outs = self.create_filesystem(volname, metadata_pool, data_pool)
         if r != 0:
             log.error("Filesystem creation error: {0} {1} {2}".format(r, outb, outs))
+            #cleanup
+            self.remove_pool(data_pool)
+            self.remove_pool(metadata_pool)
             return r, outb, outs
         # create mds
         return self.create_mds(volname)

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -201,8 +201,6 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return handler(inbuf, cmd)
 
     def _cmd_fs_volume_create(self, inbuf, cmd):
-        # TODO: validate name against any rules for pool/fs names
-        # (...are there any?)
         vol_id = cmd['name']
         return self.vc.create_volume(vol_id)
 


### PR DESCRIPTION
Fixes:
```
$ ./bin/ceph osd lspools
1 cephfs.a.meta
2 cephfs.a.data
$ ./bin/ceph fs volume create jcollin
Error EINVAL: Creation of multiple filesystems is disabled.  To enable this experimental feature, use 'ceph fs flag set enable_multiple true'
[jcollin@stratocaster build]$ ./bin/ceph fs volume create jcollin1
Error EINVAL: Creation of multiple filesystems is disabled.  To enable this experimental feature, use 'ceph fs flag set enable_multiple true'
$ ./bin/ceph fs volume create jcollin12
Error EINVAL: Creation of multiple filesystems is disabled.  To enable this experimental feature, use 'ceph fs flag set enable_multiple true'
$ ./bin/ceph fs volume create jcollin123
Error EINVAL: Creation of multiple filesystems is disabled.  To enable this experimental feature, use 'ceph fs flag set enable_multiple true'
$ ./bin/ceph osd lspools
1 cephfs.a.meta
2 cephfs.a.data
3 cephfs.jcollin.meta
4 cephfs.jcollin.data
5 cephfs.jcollin1.meta
6 cephfs.jcollin1.data
7 cephfs.jcollin12.meta
8 cephfs.jcollin12.data
9 cephfs.jcollin123.meta
10 cephfs.jcollin123.data
```