### PR TITLE
mgr/dashboard: fix failing user test

### DIFF
--- a/qa/tasks/mgr/dashboard/test_user.py
+++ b/qa/tasks/mgr/dashboard/test_user.py
@@ -341,7 +341,7 @@ class UserTest(DashboardTestCase):
         self.assertError(code='pwd_past_expiration_date', component='user')
 
     def test_create_with_default_expiration_date(self):
-        future_date_1 = datetime.utcnow() + timedelta(days=10)
+        future_date_1 = datetime.utcnow() + timedelta(days=9)
         future_date_1 = int(time.mktime(future_date_1.timetuple()))
         future_date_2 = datetime.utcnow() + timedelta(days=11)
         future_date_2 = int(time.mktime(future_date_2.timetuple()))
@@ -375,6 +375,7 @@ class UserTest(DashboardTestCase):
         user_1 = self._get('/api/user/user1')
         self.assertStatus(200)
 
+        time.sleep(10)
         self.login('user1', 'mypassword10#')
         self._post('/api/user/user1/change_password', {
             'old_password': 'mypassword10#',
@@ -383,9 +384,9 @@ class UserTest(DashboardTestCase):
         self.assertStatus(200)
         self._reset_login_to_admin()
 
-        user_2 = self._get('/api/user/user1')
+        user_1_pwd_changed = self._get('/api/user/user1')
         self.assertStatus(200)
-        self.assertLess(user_1['pwdExpirationDate'], user_2['pwdExpirationDate'])
+        self.assertLess(user_1['pwdExpirationDate'], user_1_pwd_changed['pwdExpirationDate'])
 
         self._delete('/api/user/user1')
         self._ceph_cmd(['dashboard', 'set-user-pwd-expiration-span', '0'])


### PR DESCRIPTION
Choose another future_date_1 date (9 days instead of 10) to make sure the expiration date will be between future_date_1 and future_date_2. Otherwise the expiration date might be equal to future_date_1.

Fixes: https://tracker.ceph.com/issues/43431
Signed-off-by: Tatjana Dehler <tdehler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
