### PR TITLE
librbd: when unlinking peer from mirror snaps do it in all namespaces

### DIFF
--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -15,6 +15,7 @@
 #include "librbd/Operations.h"
 #include "librbd/Utils.h"
 #include "librbd/api/Image.h"
+#include "librbd/api/Namespace.h"
 #include "librbd/mirror/DemoteRequest.h"
 #include "librbd/mirror/DisableRequest.h"
 #include "librbd/mirror/EnableRequest.h"
@@ -1306,71 +1307,93 @@ int Mirror<I>::peer_site_remove(librados::IoCtx& io_ctx,
     return r;
   }
 
-  std::set<std::string> image_ids;
-  r = list_mirror_images(io_ctx, image_ids);
+  vector<string> names;
+  r = Namespace<I>::list(io_ctx, &names);
   if (r < 0) {
-    lderr(cct) << "failed listing images: " << cpp_strerror(r) << dendl;
     return r;
   }
 
-  for (const auto& image_id : image_ids) {
-    cls::rbd::MirrorImage mirror_image;
-    r = cls_client::mirror_image_get(&io_ctx, image_id, &mirror_image);
+  names.push_back("");
+
+  librados::IoCtx ns_io_ctx;
+  ns_io_ctx.dup(io_ctx);
+
+  for (auto &name : names) {
+    ns_io_ctx.set_namespace(name);
+
+    std::set<std::string> image_ids;
+    r = list_mirror_images(ns_io_ctx, image_ids);
     if (r < 0) {
-      lderr(cct) << "error getting mirror info for image " << image_id
-                 << ": " << cpp_strerror(r) << dendl;
-      return r;
-    }
-
-    if (mirror_image.mode != cls::rbd::MIRROR_IMAGE_MODE_SNAPSHOT) {
-      continue;
-    }
-
-    // Snapshot based mirroring. Unlink the peer from mirroring snapshots.
-    // TODO: optimize.
-
-    I *img_ctx = I::create("", image_id, nullptr, io_ctx, false);
-    r = img_ctx->state->open(0);
-    if (r < 0) {
-      lderr(cct) << "error opening image " << image_id << ": "
+      lderr(cct) << "failed listing images in "
+                 << (name.empty() ? "default" : name) << " namespace : "
                  << cpp_strerror(r) << dendl;
       return r;
     }
 
-    std::list<uint64_t> snap_ids;
-    {
-      std::shared_lock image_locker{img_ctx->image_lock};
-      for (auto &it : img_ctx->snap_info) {
-        auto info = boost::get<cls::rbd::MirrorPrimarySnapshotNamespace>(
-          &it.second.snap_namespace);
-        if (info && info->mirror_peer_uuids.count(uuid)) {
-          snap_ids.push_back(it.first);
-        }
-      }
-    }
-    for (auto snap_id : snap_ids) {
-      C_SaferCond cond;
-      auto req = mirror::snapshot::UnlinkPeerRequest<I>::create(
-        img_ctx, snap_id, uuid, &cond);
-      req->send();
-      r = cond.wait();
+    for (const auto& image_id : image_ids) {
+      cls::rbd::MirrorImage mirror_image;
+      r = cls_client::mirror_image_get(&ns_io_ctx, image_id, &mirror_image);
       if (r == -ENOENT) {
-        r = 0;
+        continue;
       }
       if (r < 0) {
-        break;
+        lderr(cct) << "error getting mirror info for image " << image_id
+                   << ": " << cpp_strerror(r) << dendl;
+        return r;
       }
-    }
+      if (mirror_image.mode != cls::rbd::MIRROR_IMAGE_MODE_SNAPSHOT) {
+        continue;
+      }
 
-    int close_r = img_ctx->state->close();
-    if (r < 0) {
-      lderr(cct) << "error unlinking peer for image " << image_id << ": "
-                 << cpp_strerror(r) << dendl;
-      return r;
-    } else if (close_r < 0) {
-      lderr(cct) << "failed to close image " << image_id << ": "
-                 << cpp_strerror(close_r) << dendl;
-      return close_r;
+      // Snapshot based mirroring. Unlink the peer from mirroring snapshots.
+      // TODO: optimize.
+
+      I *img_ctx = I::create("", image_id, nullptr, ns_io_ctx, false);
+      r = img_ctx->state->open(0);
+      if (r == -ENOENT) {
+        continue;
+      }
+      if (r < 0) {
+        lderr(cct) << "error opening image " << image_id << ": "
+                   << cpp_strerror(r) << dendl;
+        return r;
+      }
+
+      std::list<uint64_t> snap_ids;
+      {
+        std::shared_lock image_locker{img_ctx->image_lock};
+        for (auto &it : img_ctx->snap_info) {
+          auto info = boost::get<cls::rbd::MirrorPrimarySnapshotNamespace>(
+            &it.second.snap_namespace);
+          if (info && info->mirror_peer_uuids.count(uuid)) {
+            snap_ids.push_back(it.first);
+          }
+        }
+      }
+      for (auto snap_id : snap_ids) {
+        C_SaferCond cond;
+        auto req = mirror::snapshot::UnlinkPeerRequest<I>::create(
+          img_ctx, snap_id, uuid, &cond);
+        req->send();
+        r = cond.wait();
+        if (r == -ENOENT) {
+          r = 0;
+        }
+        if (r < 0) {
+          break;
+        }
+      }
+
+      int close_r = img_ctx->state->close();
+      if (r < 0) {
+        lderr(cct) << "error unlinking peer for image " << image_id << ": "
+                   << cpp_strerror(r) << dendl;
+        return r;
+      } else if (close_r < 0) {
+        lderr(cct) << "failed to close image " << image_id << ": "
+                   << cpp_strerror(close_r) << dendl;
+        return close_r;
+      }
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
