### PR TITLE
rbd-mirror: register pool replayer only if init succeeded

### DIFF
--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -713,7 +713,10 @@ void Mirror::update_pool_replayers(const PoolPeers &pool_peers,
                                m_args));
 
         // TODO: make async
-        pool_replayer->init(site_name);
+        int r = pool_replayer->init(site_name);
+        if (r < 0) {
+          continue;
+        }
         m_pool_replayers.emplace(pool_peer, std::move(pool_replayer));
       }
     }

--- a/src/tools/rbd_mirror/PoolReplayer.h
+++ b/src/tools/rbd_mirror/PoolReplayer.h
@@ -53,7 +53,7 @@ public:
   bool is_leader() const;
   bool is_running() const;
 
-  void init(const std::string& site_name);
+  int init(const std::string& site_name);
   void shut_down();
 
   void run();


### PR DESCRIPTION
So if the init failed it could be retried after refresh
interval. The init error may be temporary, e.g. because the
remote pool is not created yet.

This also fixes a potential crash after a failed pool replayer
was added and then 'rbd mirror status' asok command was executed,
trying to access the pool replayer's uninitialized objects.

Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
