### PR TITLE
nautilus: mon/PGMap.h: disable network stats in dump_osd_stats

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -362,7 +362,7 @@ PyObject *ActivePyModules::get_python(const std::string &what)
     cluster_state.with_pgmap(
         [&f, &tstate](const PGMap &pg_map) {
       PyEval_RestoreThread(tstate);
-      pg_map.dump_osd_stats(&f);
+      pg_map.dump_osd_stats(&f, false);
     });
     return f.get();
   } else if (what == "osd_pool_stats") {

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1554,7 +1554,7 @@ void PGMap::dump_pool_stats(Formatter *f) const
   f->close_section();
 }
 
-void PGMap::dump_osd_stats(Formatter *f) const
+void PGMap::dump_osd_stats(Formatter *f, bool with_net) const
 {
   f->open_array_section("osd_stats");
   for (auto q = osd_stat.begin();
@@ -1562,7 +1562,7 @@ void PGMap::dump_osd_stats(Formatter *f) const
        ++q) {
     f->open_object_section("osd_stat");
     f->dump_int("osd", q->first);
-    q->second.dump(f);
+    q->second.dump(f, with_net);
     f->close_section();
   }
   f->close_section();

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -438,7 +438,7 @@ public:
   void dump_basic(Formatter *f) const;
   void dump_pg_stats(Formatter *f, bool brief) const;
   void dump_pool_stats(Formatter *f) const;
-  void dump_osd_stats(Formatter *f) const;
+  void dump_osd_stats(Formatter *f, bool with_net = true) const;
   void dump_delta(Formatter *f) const;
   void dump_filtered_pg_stats(Formatter *f, set<pg_t>& pgs) const;
   void dump_pool_stats_full(const OSDMap &osd_map, stringstream *ss,

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -438,7 +438,7 @@ public:
   void dump_basic(Formatter *f) const;
   void dump_pg_stats(Formatter *f, bool brief) const;
   void dump_pool_stats(Formatter *f) const;
-  void dump_osd_stats(Formatter *f, bool with_net = true) const;
+  void dump_osd_stats(Formatter *f, bool with_net = false) const;
   void dump_delta(Formatter *f) const;
   void dump_filtered_pg_stats(Formatter *f, set<pg_t>& pgs) const;
   void dump_pool_stats_full(const OSDMap &osd_map, stringstream *ss,

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -357,7 +357,7 @@ void objectstore_perf_stat_t::generate_test_instances(std::list<objectstore_perf
 }
 
 // -- osd_stat_t --
-void osd_stat_t::dump(Formatter *f) const
+void osd_stat_t::dump(Formatter *f, bool with_net) const
 {
   f->dump_unsigned("up_from", up_from);
   f->dump_unsigned("seq", seq);
@@ -393,6 +393,7 @@ void osd_stat_t::dump(Formatter *f) const
   f->open_array_section("alerts");
   ::dump(f, os_alerts);
   f->close_section();
+  if (with_net) {
   f->open_array_section("network_ping_times");
   for (auto &i : hb_pingtime) {
     f->open_object_section("entry");
@@ -448,6 +449,7 @@ void osd_stat_t::dump(Formatter *f) const
     f->close_section(); // entry
   }
   f->close_section(); // network_ping_time
+  }
 }
 
 void osd_stat_t::encode(bufferlist &bl, uint64_t features) const

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2411,7 +2411,7 @@ struct osd_stat_t {
       }
     }
   }
-  void dump(Formatter *f) const;
+  void dump(Formatter *f, bool with_net = true) const;
   void encode(bufferlist &bl, uint64_t features) const;
   void decode(bufferlist::const_iterator &bl);
   static void generate_test_instances(std::list<osd_stat_t*>& o);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43466
possibly a backport of https://github.com/ceph/ceph/pull/32406
parent tracker: https://tracker.ceph.com/issues/43364

---

original PR body:

Parent tracker: https://tracker.ceph.com/issues/43364

---

updated using ceph-backport.sh version 15.0.0.6950