### PR TITLE
do_cmake.sh: fedora-32 (rawhide) build with python-3.8

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -16,8 +16,9 @@ if [ -r /etc/os-release ]; then
   source /etc/os-release
   case "$ID" in
       fedora)
-          if [ "$VERSION_ID" -ge "29" ] ; then
-              PYBUILD="3.7"
+          PYBUILD="3.7"
+          if [ "$VERSION_ID" -ge "32" ] ; then
+              PYBUILD="3.8"
           fi
           ;;
       rhel|centos)


### PR DESCRIPTION
do_cmake.sh: fedora-32 (rawhide) build with python-3.8
    
Fedora-32 now has python-3.8.
    
Fedora-29 is EOL. All non-EOL versions of Fedora have python-3.7, except
Fedora-32
    
(Unclear to me why PYBUILD="3" isn't used, like Ubuntu and FreeBSD. That would eliminate breakage when pyhon versions change in Rawhide.)
 
Fixes: https://tracker.ceph.com/issues/43457

Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
