### PR TITLE
gcc-10: a couple of small fixes to build with gcc-10

### DIFF
--- a/src/common/bit_str.h
+++ b/src/common/bit_str.h
@@ -15,6 +15,9 @@
 #define CEPH_COMMON_BIT_STR_H
 
 #include <functional>
+#include <ostream>
+#include <cstdint>
+#include <iosfwd>
 
 namespace ceph {
   class Formatter;

--- a/src/librbd/api/PoolMetadata.h
+++ b/src/librbd/api/PoolMetadata.h
@@ -8,6 +8,7 @@
 #include "include/rados/librados_fwd.hpp"
 
 #include <map>
+#include <string>
 
 namespace librbd {
 


### PR DESCRIPTION
a couple of small fixes to build with gcc-10 (20191229 snapshot)

gcc-10 is stricter about certain things than gcc-9.

More info about gcc-10 changes at https://gcc.gnu.org/gcc-10/changes.html

Apparently there's still a decent chance that gcc-10 will make it into
Fedora-32 despite having missed the cut-off of 2019-12-31.

Fixes: https://tracker.ceph.com/issues/43456

Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
