### PR TITLE
crimson: CLANG-related fixes to errorator.h

### DIFF
--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -79,7 +79,7 @@ public:
 template <class ErrorT, ErrorT ErrorV>
 struct unthrowable_wrapper : error_t<unthrowable_wrapper<ErrorT, ErrorV>> {
   unthrowable_wrapper(const unthrowable_wrapper&) = delete;
-  static constexpr unthrowable_wrapper instance{};
+  static const unthrowable_wrapper instance;
   [[nodiscard]] static const auto& make() {
     return instance;
   }
@@ -123,6 +123,8 @@ private:
 
   friend class error_t<unthrowable_wrapper<ErrorT, ErrorV>>;
 };
+template <class ErrorT, ErrorT ErrorV>
+const inline unthrowable_wrapper<ErrorT, ErrorV> unthrowable_wrapper<ErrorT, ErrorV>::instance{};
 
 template <class ErrorT, ErrorT ErrorV>
 std::exception_ptr unthrowable_wrapper<ErrorT, ErrorV>::carrier_instance = \
@@ -356,9 +358,9 @@ private:
 
     using base_t::base_t;
 
-    template <class Futurator, class ErrorVisitor>
+    template <class Futurator, class Future, class ErrorVisitor>
     [[gnu::noinline]]
-    static auto _safe_then_handle_errors(auto&& future,
+    static auto _safe_then_handle_errors(Future&& future,
                                          ErrorVisitor&& errfunc) {
       maybe_handle_error_t<ErrorVisitor, Futurator> maybe_handle_error(
         std::forward<ErrorVisitor>(errfunc),

--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -123,6 +123,7 @@ private:
 
   friend class error_t<unthrowable_wrapper<ErrorT, ErrorV>>;
 };
+
 template <class ErrorT, ErrorT ErrorV>
 const inline unthrowable_wrapper<ErrorT, ErrorV> unthrowable_wrapper<ErrorT, ErrorV>::instance{};
 
@@ -481,7 +482,7 @@ private:
       return this->then_wrapped(
         [ valfunc = std::forward<ValueFuncT>(valfunc),
           errfunc = std::forward<ErrorVisitorT>(errfunc)
-        ] (auto&& future) mutable [[gnu::always_inline]] noexcept {
+        ] (auto&& future) mutable noexcept [[gnu::always_inline]] {
           if (__builtin_expect(future.failed(), false)) {
             return _safe_then_handle_errors<futurator_t>(
               std::move(future), std::forward<ErrorVisitorT>(errfunc));
@@ -530,7 +531,7 @@ private:
 
       return this->then_wrapped(
 	[ func = std::forward<FuncT>(func)
-	] (auto&& future) mutable [[gnu::always_inline]] noexcept {
+	] (auto&& future) mutable noexcept [[gnu::always_inline]] {
 	  return futurator_t::apply(std::forward<FuncT>(func)).safe_then(
 	    [future = std::forward<decltype(future)>(future)]() mutable {
 	      return std::move(future);
@@ -574,7 +575,7 @@ private:
         typename return_errorator_t::template futurize<::seastar::future<ValuesT...>>;
       return this->then_wrapped(
         [ errfunc = std::forward<ErrorVisitorT>(errfunc)
-        ] (auto&& future) mutable [[gnu::always_inline]] noexcept {
+        ] (auto&& future) mutable noexcept [[gnu::always_inline]] {
           if (__builtin_expect(future.failed(), false)) {
             return _safe_then_handle_errors<futurator_t>(
               std::move(future), std::forward<ErrorVisitorT>(errfunc));


### PR DESCRIPTION

Clang is pedantic re 
- order of attributes,
- no 'auto' in function parameters,
- ref'ing class name when declaring objects within the class

