### PR TITLE
os/bluestore/Blue(FS|Store): uint64_t alloc_size

### DIFF
--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -72,7 +72,7 @@ public:
    * @params
    * alloc_size - allocation unit size to check
    */
-  virtual size_t available_freespace(uint64_t alloc_size) = 0;
+  virtual uint64_t available_freespace(uint64_t alloc_size) = 0;
 };
 
 class BlueFSVolumeSelector {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5872,12 +5872,12 @@ int BlueStore::allocate_bluefs_freespace(
   return 0;
 }
 
-size_t BlueStore::available_freespace(uint64_t alloc_size) {
-  size_t total = 0;
-  auto iterated_allocation = [&](size_t off, size_t len) {
+uint64_t BlueStore::available_freespace(uint64_t alloc_size) {
+  uint64_t total = 0;
+  auto iterated_allocation = [&](uint64_t off, uint64_t len) {
     //only count in size that is alloc_size aligned
-    size_t dist_to_alignment;
-    size_t offset_in_block = off & (alloc_size - 1);
+    uint64_t dist_to_alignment;
+    uint64_t offset_in_block = off & (alloc_size - 1);
     if (offset_in_block == 0)
       dist_to_alignment = 0;
     else

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3207,7 +3207,7 @@ private:
     PExtentVector& extents) override {
     return allocate_bluefs_freespace(min_size, size, &extents);
   };
-  size_t available_freespace(uint64_t alloc_size) override;
+  uint64_t available_freespace(uint64_t alloc_size) override;
   inline bool _use_rotational_settings();
 
 public:


### PR DESCRIPTION
Compiling on Debian's 32bit architectures failed with

```
<<PKGBUILDDIR>>/src/os/bluestore/BlueStore.cc:5539:37: error: no matching function for call to ‘p2align(size_t&, uint64_t&)’
 5539 |     total += p2align(len, alloc_size);
      |                                     ^
In file included from /<<PKGBUILDDIR>>/src/include/denc.h:42,
                 from /<<PKGBUILDDIR>>/src/include/encoding.h:40,
                 from /<<PKGBUILDDIR>>/src/include/compact_map.h:16,
                 from /<<PKGBUILDDIR>>/src/include/mempool.h:32,
                 from /<<PKGBUILDDIR>>/src/os/bluestore/BlueStore.h:36,
                 from /<<PKGBUILDDIR>>/src/os/bluestore/BlueStore.cc:25:
/<<PKGBUILDDIR>>/src/include/intarith.h:57:20: note: candidate: ‘template<class T> constexpr T p2align(T, T)’
   57 | constexpr inline T p2align(T x, T align) {
      |                    ^~~~~~~
/<<PKGBUILDDIR>>/src/include/intarith.h:57:20: note:   template argument deduction/substitution failed:
/<<PKGBUILDDIR>>/src/os/bluestore/BlueStore.cc:5539:37: note:   deduced conflicting types for parameter ‘T’ (‘unsigned int’ and ‘long long unsigned int’)
 5539 |     total += p2align(len, alloc_size);
```

As far as I understand it the available_freespace should at least be
able to return the same number as alloc_size, so we should use uint64_t
instead of size_t here, similar to
10a953afc8f803e50c96354470fb114b33e62599

Fixes: https://tracker.ceph.com/issues/43451
Signed-off-by: Bernd Zeimetz <bernd@bzed.de>


## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
