### PR TITLE
nautilus: rgw/rgw_rest_conn.h: fix build with clang

### DIFF
--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -438,7 +438,7 @@ public:
   int wait(T *dest, E *err_result = nullptr);
 };
 
-template <class T, class E=int>
+template <class T, class E>
 int RGWRESTSendResource::wait(T *dest, E *err_result)
 {
   int ret = req.wait();


### PR DESCRIPTION
Building with clang requires this little fix for

```
[ 60%] Building CXX object src/rgw/CMakeFiles/rgw_common.dir/services/svc_zone.cc.o
cd /<<PKGBUILDDIR>>/obj-arm-linux-gnueabihf/src/rgw && /usr/bin/clang++  -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D__linux__ -I/<<PKGBUILDDIR>>/obj-arm-linux-gnueabihf/src/include -I/<<PKGBUILDDIR>>/src -I/usr/include/nss -I/usr/include/nspr -I/<<PKGBUILDDIR>>/src/dmclock/support/src -isystem /<<PKGBUILDDIR>>/obj-arm-linux-gnueabihf/include -isystem /<<PKGBUILDDIR>>/src/xxHash -isystem /<<PKGBUILDDIR>>/src/rapidjson/include -isystem /<<PKGBUILDDIR>>/src/rgw/services  -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -Wall -Wtype-limits -Wignored-qualifiers -Winit-self -Wpointer-arith -Werror=format-security -fno-strict-aliasing -fsigned-char -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-local-typedef -Wno-varargs -Wno-gnu-designator -Wno-missing-braces -Wno-parentheses -Wno-deprecated-register -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -ftemplate-depth-1024 -Wnon-virtual-dtor -Wno-unknown-pragmas -Wno-ignored-qualifiers -Wno-inconsistent-missing-override -Wno-mismatched-tags -Wno-unused-private-field -Wno-address-of-packed-member -fdiagnostics-color=auto -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fPIC   -DHAVE_CONFIG_H -D__CEPH__ -D_REENTRANT -D_THREAD_SAFE -D__STDC_FORMAT_MACROS -std=c++17 -o CMakeFiles/rgw_common.dir/services/svc_zone.cc.o -c /<<PKGBUILDDIR>>/src/rgw/services/svc_zone.cc
In file included from /<<PKGBUILDDIR>>/src/rgw/services/svc_zone.cc:7:
/<<PKGBUILDDIR>>/src/rgw/rgw_rest_conn.h:441:28: error: template parameter redefines default argument
template <class T, class E=int>
                           ^
/<<PKGBUILDDIR>>/src/rgw/rgw_rest_conn.h:437:32: note: previous default template argument defined here
  template <class T, class E = int>
                               ^
1 error generated.
```

This fixes the backport in 16aacb8a7ffeef7a22e4c654dc6a5475d606080d
    
Fixes: 16aacb8a7ffeef7a22e4c654dc6a5475d606080d

Fixes: https://tracker.ceph.com/issues/43437
Signed-off-by: Bernd Zeimetz <bernd@bzed.de>


## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
