### PR TITLE
mgr/telemetry: fix device serial number anonymization

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -382,10 +382,9 @@ class Module(MgrModule):
                 rep['host_id'] = anon_host
 
             # anonymize device id
-            (vendor, model, serial) = devid.split('_')
             anon_devid = self.get_store('devid-id/%s' % devid)
             if not anon_devid:
-                anon_devid = '%s_%s_%s' % (vendor, model, uuid.uuid1())
+                anon_devid = f"{devid.rsplit('_', 1)[0]}_{uuid.uuid1()}"
                 self.set_store('devid-id/%s' % devid, anon_devid)
             self.log.info('devid %s / %s, host %s / %s' % (devid, anon_devid,
                                                            host, anon_host))
@@ -511,7 +510,7 @@ class Module(MgrModule):
             for osd in osd_map['osds']:
                 if osd['up'] and not cluster_network:
                     front_ip = osd['public_addrs']['addrvec'][0]['addr'].split(':')[0]
-                    back_ip = osd['public_addrs']['addrvec'][0]['addr'].split(':')[0]
+                    back_ip = osd['cluster_addrs']['addrvec'][0]['addr'].split(':')[0]
                     if front_ip != back_ip:
                         cluster_network = True
             report['osd'] = {
@@ -605,7 +604,7 @@ class Module(MgrModule):
 
             report['usage'] = {
                 'pools': len(df['pools']),
-                'pg_num:': num_pg,
+                'pg_num': num_pg,
                 'total_used_bytes': df['stats']['total_used_bytes'],
                 'total_bytes': df['stats']['total_bytes'],
                 'total_avail_bytes': df['stats']['total_avail_bytes']


### PR DESCRIPTION
- Model names sometimes have underscores in them, hence it is
not safe to split the string <vendor>_<model>_<serial> by '_' and expect
the correct corresponding tuple.
For now we'll take the string after the last '_' as the serial.

- Fixed back_ip to be retrieved from cluster_addrs instead of
public_addrs.

- Omitted the ':' from 'pg_num:' key. This won't break the telemetry
server since it does not extract this key, but calculates it from 'pools'.

Signed-off-by: Yaarit Hatuka <yaarit@redhat.com>