### PR TITLE
crimson: fix lambda captures of non-variables

### DIFF
--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -134,7 +134,8 @@ int main(int argc, char* argv[])
   using crimson::common::sharded_conf;
   using crimson::common::sharded_perf_coll;
   try {
-    return app.run_deprecated(app_args.size(), const_cast<char**>(app_args.data()), [&] {
+    return app.run_deprecated(app_args.size(), const_cast<char**>(app_args.data()),
+      [&, &ceph_args=ceph_args] {
       auto& config = app.configuration();
       return seastar::async([&] {
 	if (config.count("debug")) {

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -467,8 +467,8 @@ public:
     F &&f) {
     auto [oid, type] = get_oid_and_lock(*m, op_info);
     return get_locked_obc(op, oid, type)
-      .safe_then([this, f=std::forward<F>(f), type](auto obc) {
-	return f(obc).finally([this, obc, type] {
+      .safe_then([this, f=std::forward<F>(f), type=type](auto obc) {
+	return f(obc).finally([this, obc, type=type] {
 	  obc->put_lock_type(type);
 	  return load_obc_ertr::now();
 	});

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -81,7 +81,8 @@ seastar::future<> ShardServices::dispatch_context_messages(
     [this](auto& osd_messages) {
       auto& [peer, messages] = osd_messages;
       logger().debug("dispatch_context_messages sending messages to {}", peer);
-      return seastar::parallel_for_each(std::move(messages), [=](auto& m) {
+      return seastar::parallel_for_each(
+        std::move(messages), [=, peer=peer](auto& m) {
         return send_to_osd(peer, m, osdmap->get_epoch());
       });
     });


### PR DESCRIPTION
One cannot just capture a structured binding "non-variable".
(From the C++ standard, $8.4.5.2:
"If a lambda-expression [...] captures a structured binding (explicitly or implicitly),
the program is ill-formed.")

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
