### PR TITLE
mgr/orchestrator_cli: _update_mons require host spec only

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1148,6 +1148,10 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
         """
         Adjust the number of cluster managers.
         """
+        if not spec.placement.hosts and not spec.placement.label:
+            # Improve Error message. Point to parse_host_spec examples
+            raise orchestrator.OrchestratorValidationError("Mons need a host spec. (host, network, name(opt))")
+
         spec = NodeAssignment(spec=spec, get_hosts_func=self._get_hosts, service_type='mon').load()
         return self._update_mons(spec)
 

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -622,15 +622,10 @@ Usage:
         "name=label,type=CephString,req=false",
         'Update the number of monitor instances')
     def _update_mons(self, num=None, hosts=[], label=None):
-
-        if hosts or label:
-            placement = orchestrator.PlacementSpec(label=label, count=num, hosts=hosts)
-        else:
+        if not num and not hosts and not label:
             # Improve Error message. Point to parse_host_spec examples
-            raise orchestrator.OrchestratorValidationError("Mons need a host spec. (host, network, name(opt))")
-            # TODO: Scaling without a HostSpec doesn't work right now.
-            # we need network autodetection for that.
-            # placement = orchestrator.PlacementSpec(count=num)
+            raise orchestrator.OrchestratorValidationError("Mons need a placement spec. (num, host, network, name(opt))")
+        placement = orchestrator.PlacementSpec(label=label, count=num, hosts=hosts)
         placement.validate()
 
         spec = orchestrator.StatefulServiceSpec(placement=placement)

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -338,8 +338,9 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         )
 
     def update_mons(self, spec):
-        if spec.placement.nodes:
-            raise RuntimeError("Host list is not supported by rook.")
+        # type: (orchestrator.StatefulServiceSpec) -> RookCompletion
+        if spec.placement.hosts or spec.placement.label:
+            raise RuntimeError("Host list or label is not supported by rook.")
 
         return write_completion(
             lambda: self.rook_cluster.update_mon_count(spec.placement.count),

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -304,14 +304,17 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         )
 
     def add_mds(self, spec):
+        # type: (orchestrator.StatelessServiceSpec) -> RookCompletion
         return self._service_add_decorate('MDS', spec,
                                        self.rook_cluster.add_filesystem)
 
     def add_rgw(self, spec):
+        # type: (orchestrator.RGWSpec) -> RookCompletion
         return self._service_add_decorate('RGW', spec,
                                        self.rook_cluster.add_objectstore)
 
     def add_nfs(self, spec):
+        # type: (orchestrator.NFSServiceSpec) -> RookCompletion
         return self._service_add_decorate("NFS", spec,
                                           self.rook_cluster.add_nfsgw)
 
@@ -349,6 +352,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         )
 
     def update_mds(self, spec):
+        # type: (orchestrator.StatelessServiceSpec) -> RookCompletion
         num = spec.count
         return write_completion(
             lambda: self.rook_cluster.update_mds_count(spec.name, num),
@@ -357,6 +361,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         )
 
     def update_nfs(self, spec):
+        # type: (orchestrator.NFSServiceSpec) -> RookCompletion
         num = spec.count
         return write_completion(
             lambda: self.rook_cluster.update_nfs_count(spec.name, num),

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -336,6 +336,7 @@ class RookCluster(object):
                 raise
 
     def add_filesystem(self, spec):
+        # type: (orchestrator.StatelessServiceSpec) -> None
         # TODO use spec.placement
         # TODO warn if spec.extended has entries we don't kow how
         #      to action.


### PR DESCRIPTION
* `mgr/cephadm` requres a host spec right now
* `mgr/rook` only supports `spec.count` right now

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
