### PR TITLE
luminous: rgw: enable 'qlen' and 'qactive' performance counters

### DIFF
--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -27,6 +27,9 @@ int ClientIO::init_env(CephContext *cct)
 {
   env.init(cct);
 
+  perfcounter->inc(l_rgw_qlen);
+  perfcounter->inc(l_rgw_qactive);
+
   const auto& request = parser.get();
   const auto& headers = request;
   for (auto header = headers.begin(); header != headers.end(); ++header) {
@@ -89,6 +92,8 @@ int ClientIO::init_env(CephContext *cct)
 
 size_t ClientIO::complete_request()
 {
+  perfcounter->inc(l_rgw_qlen, -1);
+  perfcounter->inc(l_rgw_qactive, -1);
   return 0;
 }
 

--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -75,6 +75,8 @@ void RGWCivetWeb::flush()
 
 size_t RGWCivetWeb::complete_request()
 {
+  perfcounter->inc(l_rgw_qlen, -1);
+  perfcounter->inc(l_rgw_qactive, -1);
   return 0;
 }
 
@@ -127,6 +129,9 @@ int RGWCivetWeb::init_env(CephContext *cct)
 
     env.set(buf, value);
   }
+
+  perfcounter->inc(l_rgw_qlen);
+  perfcounter->inc(l_rgw_qactive);
 
   env.set("REMOTE_ADDR", info->remote_addr);
   env.set("REQUEST_METHOD", info->request_method);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43482

---

backport of https://github.com/ceph/ceph/pull/20842
parent tracker: https://tracker.ceph.com/issues/23147

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh