### PR TITLE
nautilus: rgw: Select the std::bitset to resolv ambiguity

### DIFF
--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
-#include <bitset>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/container/flat_map.hpp>
@@ -128,7 +127,7 @@ static constexpr std::uint64_t stsAll = 79;
 static constexpr std::uint64_t s3Count = s3BypassGovernanceRetention + 1;
 static constexpr std::uint64_t allCount = stsAll + 1;
 
-using Action_t = bitset<allCount>;
+using Action_t = std::bitset<allCount>;
 using NotAction_t = Action_t;
 
 static const Action_t None(0);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43477

---

backport of https://github.com/ceph/ceph/pull/31126
parent tracker: https://tracker.ceph.com/issues/42471

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh