### PR TITLE
mon: should not take non-tell commands as tell ones

### DIFF
--- a/src/mon/MonCommand.h
+++ b/src/mon/MonCommand.h
@@ -35,7 +35,7 @@ struct MonCommand {
   // in --help output.
   static const uint64_t FLAG_TELL       = (FLAG_NOFORWARD | FLAG_HIDDEN);
 
-  bool has_flag(uint64_t flag) const { return (flags & flag) != 0; }
+  bool has_flag(uint64_t flag) const { return (flags & flag) == flag; }
   void set_flag(uint64_t flag) { flags |= flag; }
   void unset_flag(uint64_t flag) { flags &= ~flag; }
 


### PR DESCRIPTION
this change addresses a regression introduced by a2c34794dc. in which, a
new flag, 'FLAG_TELL' was added. and it's used to check if a command is
"TELL" command. if it is, it's added to the tell/asok command registry
and monitor will handle the commands in this registry using asok hooks.

but there are some commands whose flag is "HIDDEN". and after
a2c34794dc, is_tell() takes HIDDEN commands as TELL command. that's why
`ceph_test_admin_socket_output --all` fails. because, "mds freeze" is
now wrongly considered as a TELL command. but monitor is not able to
handle is using the asok hooks.

after this change, is_tell() will not mistake "mds freeze" as a TELL
command anymore.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
