### PR TITLE
qa/tasks/mgr/test_orchestrator_cli: fix service action tests

### DIFF
--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -72,12 +72,12 @@ class TestOrchestratorCli(MgrTestCase):
 
 
     def test_service_action(self):
-        self._orch_cmd("service", "reload", "mds", "cephfs")
+        self._orch_cmd("service", "restart", "mds", "cephfs")
         self._orch_cmd("service", "stop", "mds", "cephfs")
         self._orch_cmd("service", "start", "mds", "cephfs")
 
     def test_service_instance_action(self):
-        self._orch_cmd("service-instance", "reload", "mds", "a")
+        self._orch_cmd("service-instance", "restart", "mds", "a")
         self._orch_cmd("service-instance", "stop", "mds", "a")
         self._orch_cmd("service-instance", "start", "mds", "a")
 


### PR DESCRIPTION
in b77f0c74a5213ee57de19d21c930b2f3c872a1c4, "reload"
service[-instance] action was dropped. so replace "reload" with
"restart" in the related tests.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
