### PR TITLE
mds: throttle scrub start for multiple active MDS

### DIFF
--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -105,6 +105,8 @@ public:
    */
   std::string_view scrub_summary();
 
+  bool is_scrubbing() const { return !inode_stack.empty(); }
+
   MDCache *mdcache;
 
 protected:


### PR DESCRIPTION
- add check to "scrub start" command handler to dishonor request if multiple MDS are "active" for a recursive scrub request
- add check to MDSRank::handle_mds_map() to see if scrubbing is in progress and max_mds is greater than 1, if so then scrubbing is aborted. This is supposed to take care of the condition when scrubbing has been started with max_mds == 1 and then bumped to a higher value

Fixes: https://tracker.ceph.com/issues/43483
Signed-off-by: Milind Changire <mchangir@redhat.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>