### PR TITLE
qa/cephfs: change deps for xfstests-dev on centos8

### DIFF
--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -119,6 +119,8 @@ class XFSTestsDev(CephFSTestCase):
             libacl1-dev libaio-dev xfsprogs libgdbm-dev gawk fio dbench \
             uuid-runtime python sqlite3""".split()
 
+            if version >= 19:
+                deps[deps.index('python')] ='python2'
             args = ['sudo', 'apt-get', 'install', '-y'] + deps
         else:
             raise RuntimeError('expected a yum based or a apt based system')

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -93,29 +93,33 @@ class XFSTestsDev(CephFSTestCase):
     def install_deps(self):
         from teuthology.misc import get_system_type
 
-        args = ['sudo', 'install', '-y']
+        distro, version = get_system_type(self.mount_a.client_remote,
+                                          distro=True, version=True)
+        distro = distro.lower()
+        version = int(version.split('.')[0]) # only keep major release number
 
         distro = get_system_type(self.mount_a.client_remote,
                                  distro=True).lower()
-        if distro in ('redhatenterpriseserver', 'redhatenterprise', 'fedora', 'centos'):
+        if distro in ('redhatenterpriseserver', 'redhatenterprise', 'fedora',
+                      'centos'):
             deps = """acl attr automake bc dbench dump e2fsprogs fio \
             gawk gcc indent libtool lvm2 make psmisc quota sed \
             xfsdump xfsprogs \
             libacl-devel libattr-devel libaio-devel libuuid-devel \
-            xfsprogs-devel btrfs-progs-devel python sqlite""".split()
-            deps_for_old_distros = "xfsprogs-qa-devel"
+            xfsprogs-devel btrfs-progs-devel python2 sqlite""".split()
+            deps_old_distros = ['xfsprogs-qa-devel']
 
-            args.insert(1, 'yum')
-            args.extend(deps)
-            args.append(deps_for_old_distros)
+            if distro == 'centos' and version > 7:
+                    deps.remove('btrfs-progs-devel')
+
+            args = ['sudo', 'yum', 'install', '-y'] + deps + deps_old_distros
         elif distro == 'ubuntu':
             deps = """xfslibs-dev uuid-dev libtool-bin \
             e2fsprogs automake gcc libuuid1 quota attr libattr1-dev make \
             libacl1-dev libaio-dev xfsprogs libgdbm-dev gawk fio dbench \
             uuid-runtime python sqlite3""".split()
 
-            args.insert(1, 'apt-get')
-            args.extend(deps)
+            args = ['sudo', 'apt-get', 'install', '-y'] + deps
         else:
             raise RuntimeError('expected a yum based or a apt based system')
 

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -391,6 +391,11 @@ class LocalRemote(object):
 
         return proc
 
+    def sh(self, command, log_limit=1024, cwd=None, env=None):
+        from teuthology.misc import sh as teuth_sh
+
+        return teuth_sh(command=command, log_limit=log_limit, cwd=cwd,
+                        env=env)
 
 class LocalDaemon(object):
     def __init__(self, daemon_type, daemon_id):


### PR DESCRIPTION
btrfs-progs-devel is not available anymore on CentOS 8, update
dependency for xfstests-dev in xfstests_dev.py accordingly.

Also, let's make minor changes to improve readability since we are 
around.

Fixes: https://tracker.ceph.com/issues/43486


The PR also adds a new method, vstart_runner.LocalRemote.sh, since              
teuthology.misc.get_system_type couldn't work with vstart cluster
otherwise.

Fixes: https://tracker.ceph.com/issues/43496

 qa/xfstests_dev: change deps for xfstests-dev on ubuntu

Rename python to python2 if Ubuntu distro release is 19 or later.

Fixes: https://tracker.ceph.com/issues/43522



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>