### PR TITLE
ceph-volume: Dereference symlink in lvm list

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import argparse
 import json
 import logging
+import os.path
 from textwrap import dedent
 from ceph_volume import decorators
 from ceph_volume.util import disk
@@ -162,7 +163,14 @@ class List(object):
         this tool before and contain enough metadata.
         """
         if args.device:
-            return self.single_report(args.device, lvs)
+            # The `args.device` argument can be a logical volume name or a
+            # device path. If it's a path that exists, use the canonical path
+            # (in particular, dereference symlinks); otherwise, assume it's a
+            # logical volume name and use it as-is.
+            device = args.device
+            if os.path.exists(device):
+                device = os.path.realpath(device)
+            return self.single_report(device, lvs)
         else:
             return self.full_report(lvs)
 


### PR DESCRIPTION
This allows for a symlink to be passed to

```
ceph-volume lvm list <path>
```

which makes it possible to use `/dev/disk/by-path/*` devices, for
instance.

Fixes: https://tracker.ceph.com/issues/43497
Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
