### PR TITLE
[RFC] cephadm: Let cmake zip cephadm

### DIFF
--- a/doc/bootstrap.rst
+++ b/doc/bootstrap.rst
@@ -26,7 +26,7 @@ The ``cephadm`` utility is used to bootstrap a new Ceph Cluster.
 
 Use curl to fetch the standalone script::
 
-  [monitor 1] # curl --silent --remote-name --location https://github.com/ceph/ceph/raw/master/src/cephadm/cephadm
+  [monitor 1] # curl --silent --remote-name --location http://whatever.ceph.com/whatever/cephadm
   [monitor 1] # chmod +x cephadm
   
 You can also get the utility by installing a package provided by

--- a/src/cephadm/.gitignore
+++ b/src/cephadm/.gitignore
@@ -1,0 +1,2 @@
+bulid
+cephadm

--- a/src/cephadm/CMakeLists.txt
+++ b/src/cephadm/CMakeLists.txt
@@ -2,3 +2,20 @@ if(WITH_TESTS)
   include(AddCephTest)
   add_tox_test(cephadm TOX_ENVS mypy)
 endif()
+
+add_custom_command(
+    OUTPUT "${CMAKE_SOURCE_DIR}/src/cephadm/cephadm"
+    DEPENDS "${CMAKE_SOURCE_DIR}/src/cephadm/cephadm.py"
+    COMMAND rm -rf build
+    COMMAND mkdir -p build/cephadm
+    COMMAND cp cephadm.py build/cephadm
+    COMMAND cd build && python3 -m zipapp cephadm -p /usr/bin/python3
+    COMMAND mv build/cephadm.pyz cephadm
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/cephadm
+    COMMENT "zipping cephadm"
+)
+
+add_custom_target(cephadm-cephadm
+  ALL
+  DEPENDS ${CMAKE_SOURCE_DIR}/src/cephadm/cephadm
+)

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -49,7 +49,7 @@ import tempfile
 import time
 import errno
 try:
-    from typing import Dict, List, Tuple, Optional, Union
+    from typing import Dict, List, Tuple, Optional, Union, Any
 except ImportError:
     pass
 import uuid
@@ -67,6 +67,8 @@ if sys.version_info >= (3, 2):
     from configparser import ConfigParser
 else:
     from ConfigParser import SafeConfigParser
+
+logger = logging.getLogger('cephadm')
 
 container_path = None
 
@@ -2631,8 +2633,9 @@ def _get_parser():
     return parser
 
 
-if __name__ == "__main__":
+def main():
     # allow argv to be injected
+    global args
     try:
         av = injected_argv # type: ignore
     except NameError:
@@ -2644,7 +2647,6 @@ if __name__ == "__main__":
         logging.basicConfig(level=logging.DEBUG)
     else:
         logging.basicConfig(level=logging.INFO)
-    logger = logging.getLogger('cephadm')
 
     # root?
     if os.geteuid() != 0:
@@ -2678,3 +2680,8 @@ if __name__ == "__main__":
     if not r:
         r = 0
     sys.exit(r)
+
+
+if __name__ == "__main__":
+    args = object()  # type: Any
+    main()

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1,17 +1,10 @@
 import argparse
 import mock
 import os
-import sys
 import unittest
 
 import pytest
-
-if sys.version_info >= (3, 3):
-    from importlib.machinery import SourceFileLoader
-    cd = SourceFileLoader('cephadm', 'cephadm').load_module()
-else:
-    import imp
-    cd = imp.load_source('cephadm', 'cephadm')
+import cephadm as cd
 
 class TestCephAdm(unittest.TestCase):
     def test_is_fsid(self):

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -12,4 +12,4 @@ commands=pytest {posargs}
 [testenv:mypy]
 basepython = python3
 deps = mypy
-commands = mypy {posargs:cephadm}
+commands = mypy {posargs:cephadm.py}


### PR DESCRIPTION
by having a compilation step, we're gaining the freedom
that the sources may differ from the `cephadm` executable. E.g.

* Proper python modularization
* Making use of files elsewhere in the ceph tree (e.g. logrotate.conf)

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

## Considerations

We already have exploited the fact that cephadm is not a proper python package:

* `mgr/cephadm` expects one single file that can be transferred to remote machines
* it's executed both via `./cephadm` and `python ./cephadm`

In combination they pretty much rule out pushing cephadm to pypi without duplicated effort.

Thoughts?

## TODO:

- [ ] Deal with additional stdin
- [ ] document that we now have to call `make cephadm-cephadm`

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
