### PR TITLE
mimic: ceph-volume: add proper size attribute to partitions

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -706,7 +706,8 @@ def get_partitions_facts(sys_block_path):
                 if not part['sectorsize']:
                     part['sectorsize'] = get_file_contents(
                         part_sys_block_path + "/queue/hw_sector_size", 512)
-                part['size'] = human_readable_size(float(part['sectors']) * 512)
+                part['size'] = float(part['sectors']) * 512
+                part['human_readable_size'] = human_readable_size(float(part['sectors']) * 512)
                 part['holders'] = []
                 for holder in os.listdir(part_sys_block_path + '/holders'):
                     part['holders'].append(holder)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42752

---

backport of https://github.com/ceph/ceph/pull/31492
parent tracker: https://tracker.ceph.com/issues/42710

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh