### PR TITLE
os/bluestore: Fix unnecessary onode cache rm/add during split_cache

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3737,7 +3737,6 @@ void BlueStore::Collection::split_cache(
       o->c = dest;
       dest->onode_map.cache->_add(o, 1);
       dest->onode_map.onode_map[o->oid] = o;
-      dest->onode_map.cache = dest->onode_map.cache;
 
       // move over shared blobs and buffers.  cover shared blobs from
       // both extent map and spanning blob map (the full extent map

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3731,13 +3731,13 @@ void BlueStore::Collection::split_cache(
       ldout(store->cct, 20) << __func__ << " moving " << o << " " << o->oid
 			    << dendl;
 
-      onode_map.cache->_rm(p->second);
       p = onode_map.onode_map.erase(p);
-
       o->c = dest;
-      dest->onode_map.cache->_add(o, 1);
       dest->onode_map.onode_map[o->oid] = o;
-
+      if (dest->cache != cache) {
+        onode_map.cache->_rm(p->second);
+        dest->onode_map.cache->_add(o, 1);
+      }
       // move over shared blobs and buffers.  cover shared blobs from
       // both extent map and spanning blob map (the full extent map
       // may not be faulted in)


### PR DESCRIPTION
This PR adds a check in split_cache so that when we are splitting a collection such that both of the new collections are within the same cache shard, we don't actually remove and re-add the onode to that shard.  This should both be a slight efficiency gain and also may resolve a segfault that is hit when removing the onode from the shard causes the reference count to go to zero and the onode is destroyed (and thus can't safely be re-added).  Strangely, this has only appeared to happen so far when both of the resulting collections are on the same cache shard.  If the issue continues, we can optionally further ensure that the ref count doesn't drop or simply avoid adding the onode to the new cache shard at this time.

See:
https://tracker.ceph.com/issues/43131
https://tracker.ceph.com/issues/43147

## Checklist
- [X] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
