### PR TITLE
os/kstore: do not cache in-fight stripes on read ops to avoid memory …

### DIFF
--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -1233,7 +1233,7 @@ int KStore::read(
   if (offset == length && offset == 0)
     length = o->onode.size;
 
-  r = _do_read(o, offset, length, bl, op_flags);
+  r = _do_read(o, offset, length, bl, false, op_flags);
 
  out:
   dout(10) << __func__ << " " << ch->cid << " " << oid
@@ -1247,6 +1247,7 @@ int KStore::_do_read(
     uint64_t offset,
     size_t length,
     bufferlist& bl,
+    bool do_cache,
     uint32_t op_flags)
 {
   int r = 0;
@@ -1274,7 +1275,7 @@ int KStore::_do_read(
   stripe_off = offset % stripe_size;
   while (length > 0) {
     bufferlist stripe;
-    _do_read_stripe(o, offset - stripe_off, &stripe);
+    _do_read_stripe(o, offset - stripe_off, &stripe, do_cache);
     dout(30) << __func__ << " stripe " << offset - stripe_off << " got "
 	     << stripe.length() << dendl;
     unsigned swant = std::min<unsigned>(stripe_size - stripe_off, length);
@@ -2593,8 +2594,15 @@ void KStore::_dump_onode(OnodeRef o)
   }
 }
 
-void KStore::_do_read_stripe(OnodeRef o, uint64_t offset, bufferlist *pbl)
+void KStore::_do_read_stripe(OnodeRef o, uint64_t offset, bufferlist *pbl, bool do_cache)
 {
+  if (!do_cache) {
+    string key;
+    get_data_key(o->onode.nid, offset, &key);
+    db->get(PREFIX_DATA, key, pbl);
+    return;
+  }
+ 
   map<uint64_t,bufferlist>::iterator p = o->pending_stripes.find(offset);
   if (p == o->pending_stripes.end()) {
     string key;
@@ -2664,7 +2672,7 @@ int KStore::_do_write(TransContext *txc,
     }
     uint64_t stripe_off = offset - offset_rem;
     bufferlist prev;
-    _do_read_stripe(o, stripe_off, &prev);
+    _do_read_stripe(o, stripe_off, &prev, true);
     dout(20) << __func__ << " read previous stripe " << stripe_off
 	     << ", got " << prev.length() << dendl;
     bufferlist bl;
@@ -2755,7 +2763,7 @@ int KStore::_zero(TransContext *txc,
     while (pos < offset + length) {
       if (stripe_off || end - pos < stripe_size) {
 	bufferlist stripe;
-	_do_read_stripe(o, pos - stripe_off, &stripe);
+	_do_read_stripe(o, pos - stripe_off, &stripe, true);
 	dout(30) << __func__ << " stripe " << pos - stripe_off << " got "
 		 << stripe.length() << dendl;
 	bufferlist bl;
@@ -2812,7 +2820,7 @@ int KStore::_do_truncate(TransContext *txc, OnodeRef o, uint64_t offset)
     while (pos < o->onode.size) {
       if (stripe_off) {
 	bufferlist stripe;
-	_do_read_stripe(o, pos - stripe_off, &stripe);
+	_do_read_stripe(o, pos - stripe_off, &stripe, true);
 	dout(30) << __func__ << " stripe " << pos - stripe_off << " got "
 		 << stripe.length() << dendl;
 	bufferlist t;
@@ -3149,7 +3157,7 @@ int KStore::_clone(TransContext *txc,
   // data
   oldo->flush();
 
-  r = _do_read(oldo, 0, oldo->onode.size, bl, 0);
+  r = _do_read(oldo, 0, oldo->onode.size, bl, true, 0);
   if (r < 0)
     goto out;
 
@@ -3219,7 +3227,7 @@ int KStore::_clone_range(TransContext *txc,
   newo->exists = true;
   _assign_nid(txc, newo);
 
-  r = _do_read(oldo, srcoff, length, bl, 0);
+  r = _do_read(oldo, srcoff, length, bl, true, 0);
   if (r < 0)
     goto out;
 

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -392,7 +392,7 @@ private:
     kv_stop = false;
   }
 
-  void _do_read_stripe(OnodeRef o, uint64_t offset, bufferlist *pbl);
+  void _do_read_stripe(OnodeRef o, uint64_t offset, bufferlist *pbl, bool do_cache);
   void _do_write_stripe(TransContext *txc, OnodeRef o,
 			uint64_t offset, bufferlist& bl);
   void _do_remove_stripe(TransContext *txc, OnodeRef o, uint64_t offset);
@@ -478,6 +478,7 @@ public:
     uint64_t offset,
     size_t len,
     bufferlist& bl,
+    bool do_cache,
     uint32_t op_flags = 0);
 
   using ObjectStore::fiemap;


### PR DESCRIPTION
…leaks

Fixes: http://tracker.ceph.com/issues/39665

Signed-off-by: Chang Liu <liuchang0812@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
