### PR TITLE
os/kstore: protects onode'pending stripes with rwlock

### DIFF
--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -75,6 +75,7 @@ public:
     uint64_t tail_offset;
     bufferlist tail_bl;
 
+    ceph::shared_mutex stripes_lock;
     map<uint64_t,bufferlist> pending_stripes;  ///< unwritten stripes
 
     Onode(CephContext* cct, const ghobject_t& o, const string& k)
@@ -84,7 +85,8 @@ public:
 	key(k),
 	dirty(false),
 	exists(false),
-        tail_offset(0) {
+        tail_offset(0),
+	stripes_lock("KStore::Onode::stripes_lock(" + stringify(this) + ")") {
     }
 
     void flush();
@@ -101,6 +103,7 @@ public:
       tail_bl.clear();
     }
     void clear_pending_stripes() {
+      std::unique_lock l{stripes_lock};
       pending_stripes.clear();
     }
   };


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/43520

Signed-off-by: Chang Liu <liuchang0812@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
