### PR TITLE
qa/rgw: remove failing radosgw_admin_rest from multisite suite

### DIFF
--- a/qa/suites/rgw/multisite/tasks/test_multi.yaml
+++ b/qa/suites/rgw/multisite/tasks/test_multi.yaml
@@ -24,4 +24,3 @@ tasks:
 - rgw-multisite-tests:
     config:
       reconfigure_delay: 60
-- radosgw_admin_rest: [c2.client.0]


### PR DESCRIPTION
this was added to test that admin apis forward relevent requests to the
master zone, but radosgw_admin_rest.py tries to create an admin user
with 'radosgw-admin user create'. this fails with:

> Please run the command on master zone. Performing this operation on
non-master zone leads to inconsistent metadata between zones
Are you sure you want to go ahead? (requires --yes-i-really-mean-it)