### PR TITLE
mgr/dashboard: Reload all CephFS directories

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/package-lock.json
+++ b/src/pybind/mgr/dashboard/frontend/package-lock.json
@@ -3236,6 +3236,17 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "angular-tree-component": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/angular-tree-component/-/angular-tree-component-8.5.2.tgz",
+      "integrity": "sha512-3NwMB+vLq1+WHz2UVgsZA73E1LmIIWJlrrasCKXbLJ3S7NmY9O/wKcolji3Vp2W//5KQ33RXu1jiPXCOQdRzVA==",
+      "requires": {
+        "lodash": "^4.17.11",
+        "mobx": "^5.14.2",
+        "mobx-angular": "3.0.3",
+        "opencollective-postinstall": "^2.0.2"
+      }
+    },
     "ansi-colors": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
@@ -11224,6 +11235,16 @@
           "dev": true
         }
       }
+    },
+    "mobx": {
+      "version": "5.15.2",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.2.tgz",
+      "integrity": "sha512-eVmHGuSYd0ZU6x8gYMdgLEnCC9kfBJaf7/qJt+/yIxczVVUiVzHvTBjZH3xEa5FD5VJJSh1/Ba4SThE4ErEGjw=="
+    },
+    "mobx-angular": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/mobx-angular/-/mobx-angular-3.0.3.tgz",
+      "integrity": "sha512-mZuuose70V+Sd0hMWDElpRe3mA6GhYjSQN3mHzqk2XWXRJ+eWQa/f3Lqhw+Me/Xd2etWsGR1hnRa1BfQ2ZDtpw=="
     },
     "moment": {
       "version": "2.24.0",

--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -90,6 +90,7 @@
     "@auth0/angular-jwt": "2.1.1",
     "@ngx-translate/i18n-polyfill": "1.0.0",
     "@swimlane/ngx-datatable": "15.0.2",
+    "angular-tree-component": "8.5.2",
     "async-mutex": "0.1.4",
     "bootstrap": "4.3.1",
     "chart.js": "2.8.0",

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.html
@@ -1,12 +1,33 @@
 <div class="row">
-  <div class="col-sm-4">
-    <tree [tree]="tree"
-          (nodeSelected)="onNodeSelected($event)">
-      <ng-template let-node>
-        <span class="node-name"
-              [innerHTML]="node.value"></span>
-      </ng-template>
-    </tree>
+  <div class="col-sm-4 pr-0">
+    <div class="card">
+      <div class="card-header">
+        <button type="button"
+                [class.disabled]="loadingIndicator"
+                class="btn btn-light pull-right"
+                (click)="refreshAllDirectories()">
+          <i [ngClass]="[icons.large, icons.refresh]"
+             [class.fa-spin]="loadingIndicator"></i>
+        </button>
+      </div>
+      <div class="card-body">
+        <!--
+          ng2-tree can't be used here as it cannot handle the reloading of all nodes
+          without loosing all states of the current tree. The difference of both tree components is
+          that ng2-tree is defined and configured by each node where as angular-tree
+          is configured by a tree structure and consist of nodes that mainly hold data.
+          Angular-tree is a lot better for dynamically loaded trees. The downside is that it's not
+          possible to set individual icons for each node.
+        -->
+        <tree-root *ngIf="nodes"
+                   [nodes]="nodes"
+                   [options]="treeOptions">
+          <ng-template #loadingTemplate>
+            <i [ngClass]="[icons.spinner, icons.spin]"></i>
+          </ng-template>
+        </tree-root>
+      </div>
+    </div>
   </div>
   <!-- Selection details -->
   <div class="col-sm-8 metadata"
@@ -16,23 +37,25 @@
         {{ selectedDir.path }}
       </div>
       <div class="card-body">
-        <legend i18n>Quotas</legend>
-        <cd-table [data]="settings"
-                  [columns]="quota.columns"
-                  [limit]="0"
-                  [footer]="false"
-                  selectionType="single"
-                  (updateSelection)="quota.updateSelection($event)"
-                  [onlyActionHeader]="true"
-                  identifier="quotaKey"
-                  [forceIdentifier]="true"
-                  [toolHeader]="false">
-          <cd-table-actions class="only-table-actions"
-                            [permission]="permission"
-                            [selection]="quota.selection"
-                            [tableActions]="quota.tableActions">
-          </cd-table-actions>
-        </cd-table>
+        <ng-container *ngIf="selectedDir.path !== '/'">
+          <legend i18n>Quotas</legend>
+          <cd-table [data]="settings"
+                    [columns]="quota.columns"
+                    [limit]="0"
+                    [footer]="false"
+                    selectionType="single"
+                    (updateSelection)="quota.updateSelection($event)"
+                    [onlyActionHeader]="true"
+                    identifier="quotaKey"
+                    [forceIdentifier]="true"
+                    [toolHeader]="false">
+            <cd-table-actions class="only-table-actions"
+                              [permission]="permission"
+                              [selection]="quota.selection"
+                              [tableActions]="quota.tableActions">
+            </cd-table-actions>
+          </cd-table>
+        </ng-container>
 
         <legend i18n>Snapshots</legend>
         <cd-table [data]="selectedDir.snapshots"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.scss
@@ -1,4 +1,12 @@
-@import 'ng2-tree.scss';
+// Angular2-Tree Component
+::ng-deep tree-root {
+  tree-viewport {
+    padding-bottom: 1.5em;
+  }
+  .tree-children {
+    overflow: inherit;
+  }
+}
 
 .quota-origin {
   &:hover {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
@@ -42,7 +42,6 @@ describe('CephfsDirectoriesComponent', () => {
   let maxValidator: jasmine.Spy;
   let minBinaryValidator: jasmine.Spy;
   let maxBinaryValidator: jasmine.Spy;
-  let originalDate: any;
   let modal: any;
 
   // Get's private attributes or functions
@@ -67,12 +66,11 @@ describe('CephfsDirectoriesComponent', () => {
     snapshots: (dirPath: string, howMany: number): CephfsSnapshot[] => {
       const name = 'someSnapshot';
       const snapshots = [];
+      const oneDay = 3600 * 24 * 1000;
       for (let i = 0; i < howMany; i++) {
         const snapName = `${name}${i + 1}`;
         const path = `${dirPath}/.snap/${snapName}`;
-        const created = new Date(
-          +new Date() - 3600 * 24 * 1000 * howMany * (howMany - i)
-        ).toString();
+        const created = new Date(+new Date() - oneDay * i).toString();
         snapshots.push({ name: snapName, path, created });
       }
       return snapshots;
@@ -147,7 +145,6 @@ describe('CephfsDirectoriesComponent', () => {
       modal = modalServiceShow(comp, init);
       return modal.ref;
     },
-    date: (arg: string) => (arg ? new originalDate(arg) : new Date('2022-02-22T00:00:00')),
     getControllerByPath: (path: string) => {
       return {
         expand: () => mockLib.expand(path),
@@ -357,8 +354,6 @@ describe('CephfsDirectoriesComponent', () => {
       deletedSnaps: [],
       updatedQuotas: {}
     };
-    originalDate = Date;
-    spyOn(global, 'Date').and.callFake(mockLib.date);
 
     cephfsService = TestBed.get(CephfsService);
     lsDirSpy = spyOn(cephfsService, 'lsDir').and.callFake(mockLib.lsDir);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
@@ -1,13 +1,14 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Type } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Validators } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { TREE_ACTIONS, TreeComponent, TreeModule } from 'angular-tree-component';
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
-import { NodeEvent, Tree, TreeModel, TreeModule } from 'ng2-tree';
 import { BsModalRef, BsModalService, ModalModule } from 'ngx-bootstrap/modal';
 import { ToastrModule } from 'ngx-toastr';
-import { of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 import {
   configureTestBed,
@@ -35,6 +36,7 @@ describe('CephfsDirectoriesComponent', () => {
   let component: CephfsDirectoriesComponent;
   let fixture: ComponentFixture<CephfsDirectoriesComponent>;
   let cephfsService: CephfsService;
+  let noAsyncUpdate: boolean;
   let lsDirSpy: jasmine.Spy;
   let modalShowSpy: jasmine.Spy;
   let notificationShowSpy: jasmine.Spy;
@@ -53,11 +55,12 @@ describe('CephfsDirectoriesComponent', () => {
 
   // Object contains mock data that will be reset before each test.
   let mockData: {
-    nodes: TreeModel[];
-    parent: Tree;
+    nodes: any;
+    parent: any;
     createdSnaps: CephfsSnapshot[] | any[];
     deletedSnaps: CephfsSnapshot[] | any[];
     updatedQuotas: { [path: string]: CephfsQuotas };
+    createdDirs: CephfsDir[];
   };
 
   // Object contains mock functions
@@ -101,16 +104,18 @@ describe('CephfsDirectoriesComponent', () => {
     },
     // Only used inside other mocks
     lsSingleDir: (path = ''): CephfsDir[] => {
-      if (path.includes('b')) {
+      const customDirs = mockData.createdDirs.filter((d) => d.parent === path);
+      const isCustomDir = mockData.createdDirs.some((d) => d.path === path);
+      if (isCustomDir || path.includes('b')) {
         // 'b' has no sub directories
-        return [];
+        return customDirs;
       }
-      return [
+      return customDirs.concat([
         // Directories are not sorted!
         mockLib.dir(path, 'c', 3),
         mockLib.dir(path, 'a', 1),
         mockLib.dir(path, 'b', 2)
-      ];
+      ]);
     },
     lsDir: (_id: number, path = ''): Observable<CephfsDir[]> => {
       // will return 2 levels deep
@@ -119,6 +124,14 @@ describe('CephfsDirectoriesComponent', () => {
       paths.forEach((pathL2) => {
         data = data.concat(mockLib.lsSingleDir(pathL2));
       });
+      if (path === '' || path === '/') {
+        // Adds root directory on ls of '/' to the directories list.
+        const root = mockLib.dir(path, '/', 1);
+        root.path = '/';
+        root.parent = undefined;
+        root.quotas = undefined;
+        data = [root].concat(data);
+      }
       return of(data);
     },
     mkSnapshot: (_id: any, path: string, name: string): Observable<string> => {
@@ -145,46 +158,55 @@ describe('CephfsDirectoriesComponent', () => {
       modal = modalServiceShow(comp, init);
       return modal.ref;
     },
-    getControllerByPath: (path: string) => {
-      return {
-        expand: () => mockLib.expand(path),
-        select: () => component.onNodeSelected(mockLib.getNodeEvent(path))
-      };
+    getNodeById: (path: string) => {
+      return mockLib.useNode(path);
     },
-    // Only used inside other mocks to mock "tree.expand" of every node
-    expand: (path: string) => {
-      component.updateDirectory(path, (nodes) => {
+    updateNodes: (path: string) => {
+      const p: Promise<any[]> = component.treeOptions.getChildren({ id: path });
+      return noAsyncUpdate ? () => p : mockLib.asyncNodeUpdate(p);
+    },
+    asyncNodeUpdate: fakeAsync((p: Promise<any[]>) => {
+      p.then((nodes) => {
         mockData.nodes = mockData.nodes.concat(nodes);
       });
-    },
-    getNodeEvent: (path: string): NodeEvent => {
-      const tree = mockData.nodes.find((n) => n.id === path) as Tree;
-      if (mockData.parent) {
-        tree.parent = mockData.parent;
-      } else {
-        const dir = get.nodeIds()[path];
-        const parentNode = mockData.nodes.find((n) => n.id === dir.parent);
-        tree.parent = parentNode as Tree;
-      }
-      return { node: tree } as NodeEvent;
-    },
+      tick();
+    }),
     changeId: (id: number) => {
+      // For some reason this spy has to be renewed after usage
+      spyOn(global, 'setTimeout').and.callFake((fn) => fn());
       component.id = id;
       component.ngOnChanges();
-      mockData.nodes = [component.tree].concat(component.tree.children);
+      mockData.nodes = component.nodes.concat(mockData.nodes);
     },
     selectNode: (path: string) => {
-      mockLib.getControllerByPath(path).select();
+      component.treeOptions.actionMapping.mouse.click(undefined, mockLib.useNode(path), undefined);
+    },
+    // Creates TreeNode with parents until root
+    useNode: (path: string): { id: string; parent: any; data: any; loadNodeChildren: Function } => {
+      const parentPath = path.split('/');
+      parentPath.pop();
+      const parentIsRoot = parentPath.length === 1;
+      const parent = parentIsRoot ? { id: '/' } : mockLib.useNode(parentPath.join('/'));
+      return {
+        id: path,
+        parent,
+        data: {},
+        loadNodeChildren: () => mockLib.updateNodes(path)
+      };
+    },
+    treeActions: {
+      toggleActive: (_a: any, node: any, _b: any) => {
+        return mockLib.updateNodes(node.id);
+      }
     },
     mkDir: (path: string, name: string, maxFiles: number, maxBytes: number) => {
       const dir = mockLib.dir(path, name, 3);
       dir.quotas.max_bytes = maxBytes * 1024;
       dir.quotas.max_files = maxFiles;
+      mockData.createdDirs.push(dir);
+      // Below is needed for quota tests only where 4 dirs are mocked
       get.nodeIds()[dir.path] = dir;
-      mockData.nodes.push({
-        id: dir.path,
-        value: name
-      });
+      mockData.nodes.push({ id: dir.path });
     },
     createSnapshotThroughModal: (name: string) => {
       component.createSnapshot();
@@ -214,7 +236,7 @@ describe('CephfsDirectoriesComponent', () => {
       let path = '';
       quotas.forEach((quota, index) => {
         index += 1;
-        mockLib.mkDir(path, index.toString(), quota[0], quota[1]);
+        mockLib.mkDir(path === '' ? '/' : path, index.toString(), quota[0], quota[1]);
         path += '/' + index;
       });
       mockData.parent = {
@@ -229,7 +251,7 @@ describe('CephfsDirectoriesComponent', () => {
             parent: { value: '/', id: '/' }
           }
         }
-      } as Tree;
+      };
       mockLib.selectNode('/1/2/3/4');
     }
   };
@@ -239,6 +261,10 @@ describe('CephfsDirectoriesComponent', () => {
     dirLength: (n: number) => expect(get.dirs().length).toBe(n),
     nodeLength: (n: number) => expect(mockData.nodes.length).toBe(n),
     lsDirCalledTimes: (n: number) => expect(lsDirSpy).toHaveBeenCalledTimes(n),
+    lsDirHasBeenCalledWith: (id: number, paths: string[]) => {
+      paths.forEach((path) => expect(lsDirSpy).toHaveBeenCalledWith(id, path));
+      assert.lsDirCalledTimes(paths.length);
+    },
     requestedPaths: (expected: string[]) => expect(get.requestedPaths()).toEqual(expected),
     snapshotsByName: (snaps: string[]) =>
       expect(component.selectedDir.snapshots.map((s) => s.name)).toEqual(snaps),
@@ -337,7 +363,7 @@ describe('CephfsDirectoriesComponent', () => {
       HttpClientTestingModule,
       SharedModule,
       RouterTestingModule,
-      TreeModule,
+      TreeModule.forRoot(),
       NgBootstrapFormValidationModule.forRoot(),
       ToastrModule.forRoot(),
       ModalModule.forRoot()
@@ -347,11 +373,13 @@ describe('CephfsDirectoriesComponent', () => {
   });
 
   beforeEach(() => {
+    noAsyncUpdate = false;
     mockData = {
-      nodes: undefined,
+      nodes: [],
       parent: undefined,
       createdSnaps: [],
       deletedSnaps: [],
+      createdDirs: [],
       updatedQuotas: {}
     };
 
@@ -368,9 +396,12 @@ describe('CephfsDirectoriesComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
 
-    spyOn(component.treeComponent, 'getControllerByNodeId').and.callFake((id) =>
-      mockLib.getControllerByPath(id)
-    );
+    spyOn(TREE_ACTIONS, 'TOGGLE_ACTIVE').and.callFake(mockLib.treeActions.toggleActive);
+
+    component.treeComponent = {
+      sizeChanged: () => null,
+      treeModel: { getNodeById: mockLib.getNodeById, update: () => null }
+    } as TreeComponent;
   });
 
   it('should create', () => {
@@ -474,7 +505,6 @@ describe('CephfsDirectoriesComponent', () => {
   });
 
   it('calls lsDir only if an id exits', () => {
-    component.ngOnChanges();
     assert.lsDirCalledTimes(0);
 
     mockLib.changeId(1);
@@ -501,7 +531,9 @@ describe('CephfsDirectoriesComponent', () => {
     it('expands first level', () => {
       // Tree will only show '*' if nor 'loadChildren' or 'children' are defined
       expect(
-        mockData.nodes.map((node) => ({ [node.id]: Boolean(node.loadChildren || node.children) }))
+        mockData.nodes.map((node: any) => ({
+          [node.id]: node.hasChildren || node.isExpanded || Boolean(node.children)
+        }))
       ).toEqual([{ '/': true }, { '/a': true }, { '/b': false }, { '/c': true }]);
     });
 
@@ -519,7 +551,7 @@ describe('CephfsDirectoriesComponent', () => {
        * */
       assert.requestedPaths(['/', '/a']);
       assert.nodeLength(7);
-      assert.dirLength(15);
+      assert.dirLength(16);
       expect(component.selectedDir).toBeDefined();
 
       mockLib.changeId(undefined);
@@ -536,7 +568,7 @@ describe('CephfsDirectoriesComponent', () => {
       assert.quotaIsNotInherited('bytes', '1 KiB', 0);
     });
 
-    it('should extend the list by subdirectories when expanding and omit already called path', () => {
+    it('should extend the list by subdirectories when expanding', () => {
       mockLib.selectNode('/a');
       mockLib.selectNode('/a/c');
       /**
@@ -554,8 +586,17 @@ describe('CephfsDirectoriesComponent', () => {
        * */
       assert.lsDirCalledTimes(3);
       assert.requestedPaths(['/', '/a', '/a/c']);
-      assert.dirLength(21);
+      assert.dirLength(22);
       assert.nodeLength(10);
+    });
+
+    it('should update the tree after each selection', () => {
+      const spy = spyOn(component.treeComponent, 'sizeChanged').and.callThrough();
+      expect(spy).toHaveBeenCalledTimes(0);
+      mockLib.selectNode('/a');
+      expect(spy).toHaveBeenCalledTimes(1);
+      mockLib.selectNode('/a/c');
+      expect(spy).toHaveBeenCalledTimes(2);
     });
 
     it('should select parent by path', () => {
@@ -566,7 +607,7 @@ describe('CephfsDirectoriesComponent', () => {
       expect(component.selectedDir.path).toBe('/a');
     });
 
-    it('should omit call for directories that have no sub directories', () => {
+    it('should refresh directories with no sub directories as they could have some now', () => {
       mockLib.selectNode('/b');
       /**
        * Tree looks like this:
@@ -575,8 +616,8 @@ describe('CephfsDirectoriesComponent', () => {
        *   * b <- Selected
        *   > c
        * */
-      assert.lsDirCalledTimes(1);
-      assert.requestedPaths(['/']);
+      assert.lsDirCalledTimes(2);
+      assert.requestedPaths(['/', '/b']);
       assert.nodeLength(4);
     });
 
@@ -906,6 +947,100 @@ describe('CephfsDirectoriesComponent', () => {
           actions: [],
           primary: { multiple: '', executing: '', single: '', no: '' }
         }
+      });
+    });
+  });
+
+  describe('reload all', () => {
+    const calledPaths = ['/', '/a', '/a/c', '/a/c/a', '/a/c/a/b'];
+
+    const dirsByPath = (): string[] => get.dirs().map((d) => d.path);
+
+    beforeEach(() => {
+      mockLib.changeId(1);
+      mockLib.selectNode('/a');
+      mockLib.selectNode('/a/c');
+      mockLib.selectNode('/a/c/a');
+      mockLib.selectNode('/a/c/a/b');
+    });
+
+    it('should reload all requested paths', () => {
+      assert.lsDirHasBeenCalledWith(1, calledPaths);
+      lsDirSpy.calls.reset();
+      assert.lsDirHasBeenCalledWith(1, []);
+      component.refreshAllDirectories();
+      assert.lsDirHasBeenCalledWith(1, calledPaths);
+    });
+
+    it('should reload all requested paths if not selected anything', () => {
+      lsDirSpy.calls.reset();
+      mockLib.changeId(2);
+      assert.lsDirHasBeenCalledWith(2, ['/']);
+      lsDirSpy.calls.reset();
+      component.refreshAllDirectories();
+      assert.lsDirHasBeenCalledWith(2, ['/']);
+    });
+
+    it('should add new directories', () => {
+      // Create two new directories in preparation
+      const dirsBeforeRefresh = dirsByPath();
+      expect(dirsBeforeRefresh.includes('/a/c/has_dir_now')).toBe(false);
+      mockLib.mkDir('/a/c', 'has_dir_now', 0, 0);
+      mockLib.mkDir('/a/c/a/b', 'has_dir_now_too', 0, 0);
+      // Now the new directories will be fetched
+      component.refreshAllDirectories();
+      const dirsAfterRefresh = dirsByPath();
+      expect(dirsAfterRefresh.length - dirsBeforeRefresh.length).toBe(2);
+      expect(dirsAfterRefresh.includes('/a/c/has_dir_now')).toBe(true);
+      expect(dirsAfterRefresh.includes('/a/c/a/b/has_dir_now_too')).toBe(true);
+    });
+
+    it('should remove deleted directories', () => {
+      // Create one new directory and refresh in order to have it added to the directories list
+      mockLib.mkDir('/a/c', 'will_be_removed_shortly', 0, 0);
+      component.refreshAllDirectories();
+      const dirsBeforeRefresh = dirsByPath();
+      expect(dirsBeforeRefresh.includes('/a/c/will_be_removed_shortly')).toBe(true);
+      mockData.createdDirs = []; // Mocks the deletion of the directory
+      // Now the deleted directory will be missing on refresh
+      component.refreshAllDirectories();
+      const dirsAfterRefresh = dirsByPath();
+      expect(dirsAfterRefresh.length - dirsBeforeRefresh.length).toBe(-1);
+      expect(dirsAfterRefresh.includes('/a/c/will_be_removed_shortly')).toBe(false);
+    });
+
+    describe('loading indicator', () => {
+      beforeEach(() => {
+        noAsyncUpdate = true;
+      });
+
+      it('should have set loading indicator to false after refreshing all dirs', fakeAsync(() => {
+        component.refreshAllDirectories();
+        expect(component.loadingIndicator).toBe(true);
+        tick(3000); // To resolve all promises
+        expect(component.loadingIndicator).toBe(false);
+      }));
+
+      it('should only update the tree once and not on every call', fakeAsync(() => {
+        const spy = spyOn(component.treeComponent, 'sizeChanged').and.callThrough();
+        component.refreshAllDirectories();
+        expect(spy).toHaveBeenCalledTimes(0);
+        tick(3000); // To resolve all promises
+        // Called during the interval and at the end of timeout
+        expect(spy).toHaveBeenCalledTimes(2);
+      }));
+
+      it('should have set all loaded dirs as attribute names of "indicators"', () => {
+        noAsyncUpdate = false;
+        component.refreshAllDirectories();
+        expect(Object.keys(component.loading).sort()).toEqual(calledPaths);
+      });
+
+      it('should set an indicator to true during load', () => {
+        lsDirSpy.and.callFake(() => Observable.create((): null => null));
+        component.refreshAllDirectories();
+        expect(Object.values(component.loading).every((b) => b)).toBe(true);
+        expect(component.loadingIndicator).toBe(true);
       });
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
@@ -112,7 +112,7 @@ describe('CephfsDirectoriesComponent', () => {
         mockLib.dir(path, 'b', 2)
       ];
     },
-    lsDir: (_id: number, path = '') => {
+    lsDir: (_id: number, path = ''): Observable<CephfsDir[]> => {
       // will return 2 levels deep
       let data = mockLib.lsSingleDir(path);
       const paths = data.map((dir) => dir.path);
@@ -121,7 +121,7 @@ describe('CephfsDirectoriesComponent', () => {
       });
       return of(data);
     },
-    mkSnapshot: (_id: any, path: string, name: string) => {
+    mkSnapshot: (_id: any, path: string, name: string): Observable<string> => {
       mockData.createdSnaps.push({
         name,
         path,
@@ -129,7 +129,7 @@ describe('CephfsDirectoriesComponent', () => {
       });
       return of(name);
     },
-    rmSnapshot: (_id: any, path: string, name: string) => {
+    rmSnapshot: (_id: any, path: string, name: string): Observable<string> => {
       mockData.deletedSnaps.push({
         name,
         path,
@@ -137,11 +137,11 @@ describe('CephfsDirectoriesComponent', () => {
       });
       return of(name);
     },
-    updateQuota: (_id: any, path: string, updated: CephfsQuotas) => {
+    updateQuota: (_id: any, path: string, updated: CephfsQuotas): Observable<string> => {
       mockData.updatedQuotas[path] = Object.assign(mockData.updatedQuotas[path] || {}, updated);
       return of('Response');
     },
-    modalShow: (comp: any, init: any) => {
+    modalShow: (comp: Type<any>, init: any): any => {
       modal = modalServiceShow(comp, init);
       return modal.ref;
     },
@@ -834,10 +834,7 @@ describe('CephfsDirectoriesComponent', () => {
   describe('table actions', () => {
     let actions: CdTableAction[];
 
-    const empty = (): CdTableSelection => {
-      const selection = new CdTableSelection();
-      return selection;
-    };
+    const empty = (): CdTableSelection => new CdTableSelection();
 
     const select = (value: number): CdTableSelection => {
       const selection = new CdTableSelection();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.ts
@@ -2,9 +2,15 @@ import { Component, Input, OnChanges, OnInit, TemplateRef, ViewChild } from '@an
 import { Validators } from '@angular/forms';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
+import {
+  ITreeOptions,
+  TREE_ACTIONS,
+  TreeComponent,
+  TreeModel,
+  TreeNode
+} from 'angular-tree-component';
 import * as _ from 'lodash';
 import * as moment from 'moment';
-import { NodeEvent, Tree, TreeComponent, TreeModel } from 'ng2-tree';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 
 import { CephfsService } from '../../../shared/api/cephfs.service';
@@ -51,7 +57,7 @@ class QuotaSetting {
   styleUrls: ['./cephfs-directories.component.scss']
 })
 export class CephfsDirectoriesComponent implements OnInit, OnChanges {
-  @ViewChild(TreeComponent, { static: true })
+  @ViewChild(TreeComponent, { static: false })
   treeComponent: TreeComponent;
   @ViewChild('origin', { static: true })
   originTmpl: TemplateRef<any>;
@@ -63,7 +69,23 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
   private dirs: CephfsDir[];
   private nodeIds: { [path: string]: CephfsDir };
   private requestedPaths: string[];
-  private selectedNode: Tree;
+  private loadingTimeout: any;
+
+  icons = Icons;
+  loadingIndicator = false;
+  loading = {};
+  treeOptions: ITreeOptions = {
+    useVirtualScroll: true,
+    getChildren: (node: TreeNode): Promise<any[]> => {
+      return this.updateDirectory(node.id);
+    },
+    actionMapping: {
+      mouse: {
+        click: this.selectAndShowNode.bind(this),
+        expanderClick: this.selectAndShowNode.bind(this)
+      }
+    }
+  };
 
   permission: Permission;
   selectedDir: CephfsDir;
@@ -80,7 +102,7 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
     tableActions: CdTableAction[];
     updateSelection: Function;
   };
-  tree: TreeModel;
+  nodes: any[];
 
   constructor(
     private authStorageService: AuthStorageService,
@@ -92,6 +114,20 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
     private notificationService: NotificationService,
     private dimlessBinaryPipe: DimlessBinaryPipe
   ) {}
+
+  private selectAndShowNode(tree: TreeModel, node: TreeNode, $event: any) {
+    TREE_ACTIONS.TOGGLE_EXPANDED(tree, node, $event);
+    this.selectNode(node);
+  }
+
+  private selectNode(node: TreeNode) {
+    TREE_ACTIONS.TOGGLE_ACTIVE(undefined, node, undefined);
+    this.selectedDir = this.getDirectory(node);
+    if (node.id === '/') {
+      return;
+    }
+    this.setSettings(node);
+  }
 
   ngOnInit() {
     this.permission = this.authStorageService.getPermissions().cephfs;
@@ -203,96 +239,82 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
     this.dirs = [];
     this.requestedPaths = [];
     this.nodeIds = {};
-    if (_.isUndefined(this.id)) {
-      this.setRootNode([]);
-    } else {
+    if (this.id) {
+      this.setRootNode();
       this.firstCall();
     }
   }
 
-  private setRootNode(nodes: TreeModel[]) {
-    const tree: TreeModel = {
-      value: '/',
-      id: '/',
-      settings: {
-        selectionAllowed: false,
-        static: true
+  private setRootNode() {
+    this.nodes = [
+      {
+        name: '/',
+        id: '/',
+        isExpanded: true
       }
-    };
-    if (nodes.length > 0) {
-      tree.children = nodes;
-    }
-    this.tree = tree;
+    ];
   }
 
   private firstCall() {
-    this.updateDirectory('/', (nodes) => this.setRootNode(nodes));
+    const path = '/';
+    setTimeout(() => {
+      this.getNode(path).loadNodeChildren();
+    }, 10);
   }
 
-  updateDirectory(path: string, callback: (x: any[]) => void) {
-    if (
-      !this.requestedPaths.includes(path) &&
-      (path === '/' || this.getSubDirectories(path).length > 0)
-    ) {
+  updateDirectory(path: string): Promise<any[]> {
+    this.unsetLoadingIndicator();
+    if (!this.requestedPaths.includes(path)) {
       this.requestedPaths.push(path);
-      this.cephfsService
-        .lsDir(this.id, path)
-        .subscribe((data) => this.loadDirectory(data, path, callback));
-    } else {
-      this.getChildren(path, callback);
+    } else if (this.loading[path] === true) {
+      return undefined; // Path is currently fetched.
     }
+    return new Promise((resolve) => {
+      this.setLoadingIndicator(path, true);
+      this.cephfsService.lsDir(this.id, path).subscribe((dirs) => {
+        this.updateTreeStructure(dirs);
+        this.updateQuotaTable();
+        this.updateTree();
+        resolve(this.getChildren(path));
+        this.setLoadingIndicator(path, false);
+      });
+    });
+  }
+
+  private setLoadingIndicator(path: string, loading: boolean) {
+    this.loading[path] = loading;
+    this.unsetLoadingIndicator();
   }
 
   private getSubDirectories(path: string, tree: CephfsDir[] = this.dirs): CephfsDir[] {
     return tree.filter((d) => d.parent === path);
   }
 
-  private loadDirectory(data: CephfsDir[], path: string, callback: (x: any[]) => void) {
-    if (path !== '/') {
-      // As always to levels are loaded all sub-directories of the current called path are
-      // already loaded, that's why they are filtered out.
-      data = data.filter((dir) => dir.parent !== path);
-    }
-    this.dirs = this.dirs.concat(data);
-    this.getChildren(path, callback);
+  private getChildren(path: string): any[] {
+    const subTree = this.getSubTree(path);
+    return _.sortBy(this.getSubDirectories(path), 'path').map((dir) =>
+      this.createNode(dir, subTree)
+    );
   }
 
-  private getChildren(path: string, callback: (x: any[]) => void) {
-    const subTree = this.getSubTree(path);
-    const nodes = _.sortBy(this.getSubDirectories(path), 'path').map((d) => {
-      this.nodeIds[d.path] = d;
-      const newNode: TreeModel = {
-        value: d.name,
-        id: d.path,
-        settings: { static: true }
-      };
-      if (this.getSubDirectories(d.path, subTree).length > 0) {
-        // LoadChildren will be triggered if a node is expanded
-        newNode.loadChildren = (treeCallback) => this.updateDirectory(d.path, treeCallback);
-      }
-      return newNode;
-    });
-    callback(nodes);
+  private createNode(dir: CephfsDir, subTree?: CephfsDir[]): any {
+    this.nodeIds[dir.path] = dir;
+    if (!subTree) {
+      this.getSubTree(dir.parent);
+    }
+    return {
+      name: dir.name,
+      id: dir.path,
+      hasChildren: this.getSubDirectories(dir.path, subTree).length > 0
+    };
   }
 
   private getSubTree(path: string): CephfsDir[] {
-    return this.dirs.filter((d) => d.parent.startsWith(path));
+    return this.dirs.filter((d) => d.parent && d.parent.startsWith(path));
   }
 
-  selectOrigin(path: string) {
-    this.treeComponent.getControllerByNodeId(path).select();
-  }
-
-  onNodeSelected(e: NodeEvent) {
-    const node = e.node;
-    this.treeComponent.getControllerByNodeId(node.id).expand();
-    this.setSettings(node);
-    this.selectedDir = this.getDirectory(node);
-    this.selectedNode = node;
-  }
-
-  private setSettings(node: Tree) {
-    const readable = (value: number, fn?: (number: number) => number | string): number | string =>
+  private setSettings(node: TreeNode) {
+    const readable = (value: number, fn?: (arg0: number) => number | string): number | string =>
       value ? (fn ? fn(value) : value) : '';
 
     this.settings = [
@@ -304,7 +326,7 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
   }
 
   private getQuota(
-    tree: Tree,
+    tree: TreeNode,
     quotaKey: string,
     valueConvertFn: (number: number) => number | string
   ): QuotaSetting {
@@ -318,7 +340,7 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
     let nextMaxValue = value;
     let nextMaxPath = dir.path;
     if (tree.id === currentPath) {
-      if (tree.parent.value === '/') {
+      if (tree.parent.id === '/') {
         // The value will never inherit any other value, so it has no maximum.
         nextMaxValue = 0;
       } else {
@@ -355,8 +377,8 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
    * | /a (10)       |     4th    |       10 => true      |   /a   |
    *
    */
-  private getOrigin(tree: Tree, quotaSetting: string): Tree {
-    if (tree.parent.value !== '/') {
+  private getOrigin(tree: TreeNode, quotaSetting: string): TreeNode {
+    if (tree.parent && tree.parent.id !== '/') {
       const current = this.getQuotaFromTree(tree, quotaSetting);
 
       // Get the next used quota and node above the current one (until it hits the root directory)
@@ -370,13 +392,21 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
     return tree;
   }
 
-  private getQuotaFromTree(tree: Tree, quotaSetting: string): number {
+  private getQuotaFromTree(tree: TreeNode, quotaSetting: string): number {
     return this.getDirectory(tree).quotas[quotaSetting];
   }
 
-  private getDirectory(node: Tree): CephfsDir {
+  private getDirectory(node: TreeNode): CephfsDir {
     const path = node.id as string;
     return this.nodeIds[path];
+  }
+
+  selectOrigin(path: string) {
+    this.selectNode(this.getNode(path));
+  }
+
+  private getNode(path: string): TreeNode {
+    return this.treeComponent.treeModel.getNodeById(path);
   }
 
   updateQuotaModal() {
@@ -544,15 +574,101 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
    * As all nodes point by their path on an directory object, the easiest way is to update
    * the objects by merge with their latest change.
    */
-  private forceDirRefresh() {
-    const path = this.selectedNode.parent.id as string;
-    this.cephfsService.lsDir(this.id, path).subscribe((data) => {
-      data.forEach((d) => {
-        Object.assign(this.dirs.find((sub) => sub.path === d.path), d);
+  private forceDirRefresh(path?: string) {
+    if (!path) {
+      const dir = this.selectedDir;
+      if (!dir) {
+        throw new Error('This function can only be called without path if an selection was made');
+      }
+      // Parent has to be called in order to update the object referring
+      // to the current selected directory
+      path = dir.parent ? dir.parent : dir.path;
+    }
+    const node = this.getNode(path);
+    node.loadNodeChildren();
+  }
+
+  private updateTreeStructure(dirs: CephfsDir[]) {
+    const getChildrenAndPaths = (
+      directories: CephfsDir[],
+      parent: string
+    ): { children: CephfsDir[]; paths: string[] } => {
+      const children = directories.filter((d) => d.parent === parent);
+      const paths = children.map((d) => d.path);
+      return { children, paths };
+    };
+
+    const parents = _.uniq(dirs.map((d) => d.parent).sort());
+    parents.forEach((p) => {
+      const received = getChildrenAndPaths(dirs, p);
+      const cached = getChildrenAndPaths(this.dirs, p);
+
+      cached.children.forEach((d) => {
+        if (!received.paths.includes(d.path)) {
+          this.removeOldDirectory(d);
+        }
       });
-      // Now update quotas
-      this.setSettings(this.selectedNode);
+      received.children.forEach((d) => {
+        if (cached.paths.includes(d.path)) {
+          this.updateExistingDirectory(cached.children, d);
+        } else {
+          this.addNewDirectory(d);
+        }
+      });
     });
+  }
+
+  private removeOldDirectory(rmDir: CephfsDir) {
+    const path = rmDir.path;
+    // Remove directory from local variables
+    _.remove(this.dirs, (d) => d.path === path);
+    delete this.nodeIds[path];
+    this.updateDirectoriesParentNode(rmDir);
+  }
+
+  private updateDirectoriesParentNode(dir: CephfsDir) {
+    const parent = dir.parent;
+    if (!parent) {
+      return;
+    }
+    const node = this.getNode(parent);
+    if (!node) {
+      // Node will not be found for new sub sub directories - this is the intended behaviour
+      return;
+    }
+    const children = this.getChildren(parent);
+    node.data.children = children;
+    node.data.hasChildren = children.length > 0;
+    this.treeComponent.treeModel.update();
+  }
+
+  private addNewDirectory(newDir: CephfsDir) {
+    this.dirs.push(newDir);
+    this.nodeIds[newDir.path] = newDir;
+    this.updateDirectoriesParentNode(newDir);
+  }
+
+  private updateExistingDirectory(source: CephfsDir[], updatedDir: CephfsDir) {
+    const currentDirObject = source.find((sub) => sub.path === updatedDir.path);
+    Object.assign(currentDirObject, updatedDir);
+  }
+
+  private updateQuotaTable() {
+    const node = this.selectedDir ? this.getNode(this.selectedDir.path) : undefined;
+    if (node && node.id !== '/') {
+      this.setSettings(node);
+    }
+  }
+
+  private updateTree(force: boolean = false) {
+    if (this.loadingIndicator && !force) {
+      // In order to make the page scrollable during load, the render cycle for each node
+      // is omitted and only be called if all updates were loaded.
+      return;
+    }
+    this.treeComponent.treeModel.update();
+    this.nodes = [...this.nodes];
+    this.treeComponent.sizeChanged();
   }
 
   deleteSnapshotModal() {
@@ -583,5 +699,35 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
     });
     this.modalRef.hide();
     this.forceDirRefresh();
+  }
+
+  refreshAllDirectories() {
+    // In order to make the page scrollable during load, the render cycle for each node
+    // is omitted and only be called if all updates were loaded.
+    this.loadingIndicator = true;
+    this.requestedPaths.map((path) => this.forceDirRefresh(path));
+    const interval = setInterval(() => {
+      this.updateTree(true);
+      if (!this.loadingIndicator) {
+        clearInterval(interval);
+      }
+    }, 3000);
+  }
+
+  unsetLoadingIndicator() {
+    if (!this.loadingIndicator) {
+      return;
+    }
+    clearTimeout(this.loadingTimeout);
+    this.loadingTimeout = setTimeout(() => {
+      const loading = Object.values(this.loading).some((l) => l);
+      if (loading) {
+        return this.unsetLoadingIndicator();
+      }
+      this.loadingIndicator = false;
+      this.updateTree();
+      // The problem is that we can't subscribe to an useful updated tree event and the time
+      // between fetching all calls and rebuilding the tree can take some time
+    }, 3000);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.html
@@ -16,8 +16,10 @@
     </cd-cephfs-clients>
   </tab>
   <tab i18n-heading
+       (selectTab)="directoriesSelected = true"
        heading="Directories">
-    <cd-cephfs-directories [id]="id">
+    <cd-cephfs-directories *ngIf="directoriesSelected"
+                           [id]="id">
     </cd-cephfs-directories>
   </tab>
   <tab i18n-heading

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.spec.ts
@@ -2,8 +2,8 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { TreeModule } from 'angular-tree-component';
 import * as _ from 'lodash';
-import { TreeModule } from 'ng2-tree';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.ts
@@ -39,6 +39,9 @@ export class CephfsTabsComponent implements OnChanges, OnDestroy {
     name: ''
   };
 
+  // Directories
+  directoriesSelected = false;
+
   private data: any;
   private reloadSubscriber: Subscription;
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
@@ -1,8 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { TreeModule } from 'angular-tree-component';
 import { ChartsModule } from 'ng2-charts';
-import { TreeModule } from 'ng2-tree';
 import { ProgressbarModule } from 'ngx-bootstrap/progressbar';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
@@ -21,7 +21,7 @@ import { CephfsTabsComponent } from './cephfs-tabs/cephfs-tabs.component';
     SharedModule,
     AppRoutingModule,
     ChartsModule,
-    TreeModule,
+    TreeModule.forRoot(),
     ProgressbarModule.forRoot(),
     TabsModule.forRoot()
   ],

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
@@ -58,10 +58,10 @@ describe('CephfsService', () => {
 
   it('should call lsDir', () => {
     service.lsDir(1).subscribe();
-    const req = httpTesting.expectOne('api/cephfs/1/ls_dir?depth=2');
+    const req = httpTesting.expectOne('ui-api/cephfs/1/ls_dir?depth=2');
     expect(req.request.method).toBe('GET');
     service.lsDir(2, '/some/path').subscribe();
-    httpTesting.expectOne('api/cephfs/2/ls_dir?depth=2&path=%252Fsome%252Fpath');
+    httpTesting.expectOne('ui-api/cephfs/2/ls_dir?depth=2&path=%252Fsome%252Fpath');
   });
 
   it('should call mkSnapshot', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
@@ -14,6 +14,7 @@ import { ApiModule } from './api.module';
 })
 export class CephfsService {
   baseURL = 'api/cephfs';
+  baseUiURL = 'ui-api/cephfs';
 
   constructor(private http: HttpClient) {}
 
@@ -22,7 +23,7 @@ export class CephfsService {
   }
 
   lsDir(id: number, path?: string): Observable<CephfsDir[]> {
-    let apiPath = `${this.baseURL}/${id}/ls_dir?depth=2`;
+    let apiPath = `${this.baseUiURL}/${id}/ls_dir?depth=2`;
     if (path) {
       apiPath += `&path=${encodeURIComponent(path)}`;
     }

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -1,6 +1,9 @@
 /* You can add global styles to this file, and also import other style files */
 @import 'defaults';
 
+// Angular2-Tree Component
+@import '~angular-tree-component/dist/angular-tree-component.css';
+
 // Fork-Awesome
 $fa-font-path: '~fork-awesome/fonts';
 $font-family-icon: 'ForkAwesome';


### PR DESCRIPTION
Now angular tree is used instead of ng2-tree, as it provides a better
way to dynamically load children and it provides a way to update all
children without losing all track of everything.

The loading icon will rotate now on any fetch.

The tree will detect new directories and removed directories.

Fixes: https://tracker.ceph.com/issues/42617
Signed-off-by: Stephan Müller <smueller@suse.com>

---
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>

---

![directories-reload-all](https://user-images.githubusercontent.com/16167865/72070990-1a68ca80-32eb-11ea-8919-52d865843b04.gif)
