### PR TITLE
mimic: ceph-volume: minor clean-up of "simple scan" subcommand help

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/simple/scan.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/scan.py
@@ -294,7 +294,7 @@ class Scan(object):
         For an OSD ID of 0 with fsid of ``a9d50838-e823-43d6-b01f-2f8d0a77afc2``
         that could mean a scan command that looks like::
 
-            ceph-volume lvm scan /var/lib/ceph/osd/ceph-0
+            ceph-volume simple scan /var/lib/ceph/osd/ceph-0
 
         Which would store the metadata in a JSON file at::
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43023

---

backport of https://github.com/ceph/ceph/pull/31821
parent tracker: https://tracker.ceph.com/issues/43017

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh