### PR TITLE
nautilus: ceph-volume/test: patch VolumeGroups

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
@@ -61,6 +61,7 @@ class TestMixedType(object):
                        block_db_size=None, block_wal_size=None,
                        osd_ids=[])
         monkeypatch.setattr(lvm, 'VolumeGroup', lambda x, **kw: [])
+        monkeypatch.setattr(lvm, 'VolumeGroups', lambda: [])
         bluestore.MixedType(args, [], [db_dev], [])
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43275

---

backport of https://github.com/ceph/ceph/pull/31979
parent tracker: https://tracker.ceph.com/issues/43107

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh