### PR TITLE
cephadm: show contextual message when port is in use

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -121,10 +121,12 @@ def attempt_bind(s, address, port):
     try:
         s.bind((address, port))
     except (socket.error, OSError) as e:  # py2 and py3
+        msg = 'Cannot bind to IP %s port %d: %s' % (address, port, e)
+        logger.warning(msg)
         if e.errno == errno.EADDRINUSE:
-            raise OSError
+            raise OSError(msg)
         elif e.errno == errno.EADDRNOTAVAIL:
-            return
+            pass
     finally:
         s.close()
 
@@ -138,7 +140,6 @@ def port_in_use(port_num):
 
         s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
         attempt_bind(s, '::', port_num)
-
     except OSError:
         return True
     else:
@@ -146,7 +147,7 @@ def port_in_use(port_num):
 
 def check_ip_port(ip, port):
     if not args.skip_ping_check:
-        logger.info('Verifying IP %s port %d is not in use...' % (ip, port))
+        logger.info('Verifying IP %s port %d ...' % (ip, port))
         if ip.startswith('[') or '::' in ip:
             s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
         else:
@@ -154,8 +155,7 @@ def check_ip_port(ip, port):
         try:
             attempt_bind(s, ip, port)
         except OSError as e:
-            raise Error('Unable to bind to IP %s port %d: %s' % (ip, port,
-                                                                 str(e)))
+            raise Error(e)
 
 ##################################
 


### PR DESCRIPTION
- OSError raised during a failed bind did not include exception cause
- Log warning for other potental failure cases (e.g. EADDRNOTAVAIL, etc)

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
