### PR TITLE
mgr/dashboard: Typo in module command

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -557,7 +557,7 @@ in order to manage silences.
 
    #. Recreate from expired silence
 
-   #. Update a silence (which will recreate and expire it (default Alertmanager behaviour))
+   #. Update a silence (which will recreate and expire it (default Alertmanager behavior))
 
    To use it, specify the host and port of the Alertmanager server::
 
@@ -817,21 +817,21 @@ Disable the redirection
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 If the dashboard is behind a load-balancing proxy like `HAProxy <https://www.haproxy.org/>`_
-you might want to disable the redirection behaviour to prevent situations that
+you might want to disable the redirection behavior to prevent situations that
 internal (unresolvable) URL's are published to the frontend client. Use the
 following command to get the dashboard to respond with a HTTP error (500 by default)
 instead of redirecting to the active dashboard::
 
-  $ ceph config set mgr mgr/dashboard/standby_behaviour "error"
+  $ ceph config set mgr mgr/dashboard/standby_behavior "error"
 
-To reset the setting to the default redirection behaviour, use the following command::
+To reset the setting to the default redirection behavior, use the following command::
 
-  $ ceph config set mgr mgr/dashboard/standby_behaviour "redirect"
+  $ ceph config set mgr mgr/dashboard/standby_behavior "redirect"
 
 Configure the error status code
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When the redirection behaviour is disabled, then you want to customize the HTTP status
+When the redirection behavior is disabled, then you want to customize the HTTP status
 code of standby dashboards. To do so you need to run the command::
 
   $ ceph config set mgr mgr/dashboard/standby_error_status_code 503
@@ -848,7 +848,7 @@ If the dashboard fails over, the front-end client might receive a HTTP redirect
 the failover occurs during two HAProxy health checks. In this situation the
 previously active dashboard node will now respond with a 303 which points to
 the new active node. To prevent that situation you should consider to disable
-the redirection behaviour on standby nodes.
+the redirection behavior on standby nodes.
 
 ::
 
@@ -898,7 +898,7 @@ If enabled, the following parameters are logged per each request:
 * user - The name of the user, otherwise 'None'
 
 The logging of the request payload (the arguments and their values) is enabled
-by default. Execute the following command to disable this behaviour::
+by default. Execute the following command to disable this behavior::
 
   $ ceph dashboard set-audit-api-log-payload <true|false>
 

--- a/qa/tasks/mgr/test_dashboard.py
+++ b/qa/tasks/mgr/test_dashboard.py
@@ -22,7 +22,7 @@ class TestDashboard(MgrTestCase):
 
     def tearDown(self):
         self.mgr_cluster.mon_manager.raw_cluster_cmd("config", "set", "mgr",
-                                                     "mgr/dashboard/standby_behaviour",
+                                                     "mgr/dashboard/standby_behavior",
                                                      "redirect")
         self.mgr_cluster.mon_manager.raw_cluster_cmd("config", "set", "mgr",
                                                      "mgr/dashboard/standby_error_status_code",
@@ -63,7 +63,7 @@ class TestDashboard(MgrTestCase):
 
     def test_standby_disable_redirect(self):
         self.mgr_cluster.mon_manager.raw_cluster_cmd("config", "set", "mgr",
-                                                     "mgr/dashboard/standby_behaviour",
+                                                     "mgr/dashboard/standby_behavior",
                                                      "error")
 
         original_active_id = self.mgr_cluster.get_active_id()

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -257,7 +257,7 @@ class Module(MgrModule, CherryPyConfig):
         Option(name='key_file', type='str', default=''),
         Option(name='crt_file', type='str', default=''),
         Option(name='ssl', type='bool', default=True),
-        Option(name='standby_behaviour', type='str', default='redirect',
+        Option(name='standby_behavior', type='str', default='redirect',
                enum_allowed=['redirect', 'error']),
         Option(name='standby_error_status_code', type='int', default=500,
                min=400, max=599)
@@ -453,7 +453,7 @@ class StandbyModule(MgrStandbyModule, CherryPyConfig):
         class Root(object):
             @cherrypy.expose
             def default(self, *args, **kwargs):
-                if module.get_module_option('standby_behaviour', 'redirect') == 'redirect':
+                if module.get_module_option('standby_behavior', 'redirect') == 'redirect':
                     active_uri = module.get_active_uri()
                     if active_uri:
                         module.log.info("Redirecting to active '%s'", active_uri)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43535

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
