### PR TITLE
librbd: fix some edge cases for snapshot mirror mode promote

### DIFF
--- a/src/test/librbd/mirror/snapshot/test_mock_PromoteRequest.cc
+++ b/src/test/librbd/mirror/snapshot/test_mock_PromoteRequest.cc
@@ -275,12 +275,12 @@ TEST_F(TestMockMirrorSnapshotPromoteRequest, Success) {
 
   expect_refresh_image(mock_image_ctx, true, 0);
   MockUtils mock_utils;
-  expect_can_create_primary_snapshot(mock_utils, force, CEPH_NOSNAP, true);
+  expect_can_create_primary_snapshot(mock_utils, true, CEPH_NOSNAP, true);
   MockCreatePrimaryRequest mock_create_primary_request;
   expect_create_promote_snapshot(mock_image_ctx, mock_create_primary_request,
                                  0);
   C_SaferCond ctx;
-  auto req = new MockPromoteRequest(&mock_image_ctx, false, &ctx);
+  auto req = new MockPromoteRequest(&mock_image_ctx, force, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -305,14 +305,14 @@ TEST_F(TestMockMirrorSnapshotPromoteRequest, SuccessRollback) {
 
   expect_refresh_image(mock_image_ctx, true, 0);
   MockUtils mock_utils;
-  expect_can_create_primary_snapshot(mock_utils, force, 123, true);
+  expect_can_create_primary_snapshot(mock_utils, true, 123, true);
   MockCreateNonPrimaryRequest mock_create_non_primary_request;
   expect_create_orphan_snapshot(mock_image_ctx, mock_create_non_primary_request,
                                 0);
   MockListWatchersRequest mock_list_watchers_request;
   expect_list_watchers(mock_image_ctx, mock_list_watchers_request, {}, 0);
   expect_acquire_lock(mock_image_ctx, 0);
-  
+
   SnapInfo snap_info = {"snap", cls::rbd::MirrorPrimarySnapshotNamespace{}, 0,
                         {}, 0, 0, {}};
   expect_rollback(mock_image_ctx, 123, &snap_info, 0);
@@ -360,7 +360,7 @@ TEST_F(TestMockMirrorSnapshotPromoteRequest, ErrorCannotRollback) {
 
   expect_refresh_image(mock_image_ctx, true, 0);
   MockUtils mock_utils;
-  expect_can_create_primary_snapshot(mock_utils, force, CEPH_NOSNAP, false);
+  expect_can_create_primary_snapshot(mock_utils, true, CEPH_NOSNAP, false);
 
   C_SaferCond ctx;
   auto req = new MockPromoteRequest(&mock_image_ctx, force, &ctx);


### PR DESCRIPTION
- don't skip `can_create_primary_snapshot` check when refresh is
  not required;

- always call `can_create_primary_snapshot` with force in order
  not to fail whith "trying to create primary snapshot without
  force when previous primary snapshot is demoted".

Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
