### PR TITLE
mgr/dashboard: Cleanup feature toggle status output

### DIFF
--- a/src/pybind/mgr/dashboard/plugins/feature_toggles.py
+++ b/src/pybind/mgr/dashboard/plugins/feature_toggles.py
@@ -96,7 +96,7 @@ class FeatureToggles(I.CanMgr, I.Setupable, I.HasOptions,
             else:
                 for feature in features or [f.value for f in Features]:
                     enabled = mgr.get_module_option(self.OPTION_FMT.format(feature))
-                    msg += ["Feature '{}': '{}'".format(
+                    msg += ["Feature '{}': {}".format(
                         feature,
                         'enabled' if enabled else 'disabled')]
             return ret, '\n'.join(msg), ''


### PR DESCRIPTION
Modify status output from
```
Feature 'rbd': 'enabled'
Feature 'mirroring': 'enabled'
Feature 'iscsi': 'enabled'
Feature 'cephfs': 'enabled'
Feature 'rgw': 'enabled'
Feature 'nfs': 'disabled'
```
to
```
Feature 'rbd': enabled
Feature 'mirroring': enabled
Feature 'iscsi': enabled
Feature 'cephfs': enabled
Feature 'rgw': enabled
Feature 'nfs': disabled
```

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
