### PR TITLE
qa/tasks/cephfs_test_runner: setattr to class not instance

### DIFF
--- a/qa/tasks/cephfs_test_runner.py
+++ b/qa/tasks/cephfs_test_runner.py
@@ -22,7 +22,11 @@ class DecoratingLoader(loader.TestLoader):
 
     def _apply_params(self, obj):
         for k, v in self._params.items():
-            setattr(obj, k, v)
+            if obj.__class__ is type:
+                cls = obj
+            else:
+                cls = obj.__class__
+            setattr(cls, k, v)
 
     def loadTestsFromTestCase(self, testCaseClass):
         self._apply_params(testCaseClass)


### PR DESCRIPTION
before this change, `setattr()` sets the instance specialized with a certain method
of test case, so in `MgrTestCase.setUpClass()`

assert cls.mgr_cluster is not None

fails,

after this change, instead of test case, the class of test suite is updated with the
specified params, even if we pass a certain test to test runner.
so we can

./run-backend-api-tests.sh tasks.mgr.test_dashboard.TestDashboard.test_standby

now. before this change, we can only:

./run-backend-api-tests.sh tasks.mgr.test_dashboard.TestDashboard

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
