### PR TITLE
cephadm: use predefined Prometheus/Grafana/Node-Exporter image for deployment

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -134,7 +134,7 @@ class Monitoring(object):
                 "certs/cert_key",
             ],
         }
-    }
+    }  # type: Dict[str, dict]
 
 def attempt_bind(s, address, port):
     # type (str) -> None
@@ -1929,9 +1929,8 @@ def command_deploy():
         if port_in_use(daemon_port):
             raise Error("TCP Port '{}' required for {} is already in use".format(daemon_port, daemon_type))
 
-        # Monitoring metadata is nested dicts, so asking mypy to ignore
-        p = Monitoring.components[daemon_type]  # type: ignore
-        metadata = p.get('image', dict())  # type: ignore
+        p = Monitoring.components[daemon_type]
+        metadata = p.get('image', dict())
 
         # DEFAULT_IMAGE cannot be used for monitoring components
         if args.image == DEFAULT_IMAGE:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1928,8 +1928,17 @@ def command_deploy():
         daemon_port = Monitoring.port_map[daemon_type]
         if port_in_use(daemon_port):
             raise Error("TCP Port '{}' required for {} is already in use".format(daemon_port, daemon_type))
-        elif args.image == DEFAULT_IMAGE:
-            raise Error("--image parameter must be supplied for {}".format(daemon_type))
+
+        # Monitoring metadata is nested dicts, so asking mypy to ignore
+        p = Monitoring.components[daemon_type]  # type: ignore
+        metadata = p.get('image', dict())  # type: ignore
+
+        # DEFAULT_IMAGE cannot be used for monitoring components
+        if args.image == DEFAULT_IMAGE:
+            if metadata.get('image') != '':
+                args.image = metadata['image']
+            else:
+                raise Error("--image parameter must be supplied for {}".format(daemon_type))
 
         if daemon_type in ['prometheus', 'grafana'] and not args.config_json:
                 raise Error("config-json parameter is needed when deploying {} service".format(daemon_type))


### PR DESCRIPTION
if no CEPHADM_IMAGE environment variable has been defined.

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
