### PR TITLE
mon/MDSMonitor: handle standby already without fscid

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -1057,10 +1057,10 @@ void FSMap::adjust_standby_fscid(mds_gid_t standby_gid,
   standby_daemon_fscid.at(standby_gid) = fscid;
 }
 
-void FSMap::clear_standby_fscid(mds_gid_t standby_gid)
+std::size_t FSMap::clear_standby_fscid(mds_gid_t standby_gid)
 {
   auto count = standby_daemon_fscid.erase(standby_gid);
-  ceph_assert(count);
+  return count;
 }
 
 std::vector<mds_gid_t> FSMap::stop(mds_gid_t who)

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -186,7 +186,7 @@ public:
    */
   void adjust_standby_fscid(mds_gid_t standby_gid,
 			    fs_cluster_id_t fscid);
-  void clear_standby_fscid(mds_gid_t standby_gid);
+  std::size_t clear_standby_fscid(mds_gid_t standby_gid);
 
   /**
    * Assign an MDS cluster standby replay rank to a standby daemon


### PR DESCRIPTION
If prepare_beacon is called on an existing standby's beacon, then it
will handle any changes to get_fs() but if there's not been a change to
the empty case, the MDSMonitor will assert.

Fixes: https://tracker.ceph.com/issues/43542
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
