### PR TITLE
doc: emphasize the importance of require-osd-release nautilus

### DIFF
--- a/doc/releases/nautilus.rst
+++ b/doc/releases/nautilus.rst
@@ -1333,6 +1333,8 @@ Instructions
 
      # ceph osd require-osd-release nautilus
 
+   .. important:: This step is mandatory. Failure to execute this step will make it impossible for OSDs to communicate after msgrv2 is enabled.
+
 #. If you set ``noout`` at the beginning, be sure to clear it with::
 
      # ceph osd unset noout
@@ -1374,6 +1376,13 @@ Instructions
 
    and verify that each monitor has both a ``v2:`` and ``v1:`` address
    listed.
+
+   .. important:: 
+      Before this step is run, the following command must already have been run:
+
+      # ceph osd require-osd-release nautilus
+
+      If this command (step 10 in this procedure) has not been run, OSDs will lose the ability to communicate.
 
 #. For each host that has been upgraded, you should update your
    ``ceph.conf`` file so that it either specifies no monitor port (if


### PR DESCRIPTION
This commit adds a red warning (in an "important" admonition)
directing the reader to make certain to run "ceph osd
require-osd-release nautilus" before enabling the v2 network
protocol. This change applies only to the procedure that
explains how to upgrade to Nautilus from Mimic or Luminous.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
