### PR TITLE
qa/tasks/mgr: set mgr module option with --force

### DIFF
--- a/qa/tasks/mgr/mgr_test_case.py
+++ b/qa/tasks/mgr/mgr_test_case.py
@@ -49,11 +49,13 @@ class MgrCluster(CephCluster):
                                              module, key
                                          ), val)
 
-    def set_module_localized_conf(self, module, mgr_id, key, val):
-        self.mon_manager.raw_cluster_cmd("config", "set", "mgr",
-                                         "mgr/{0}/{1}/{2}".format(
-                                             module, mgr_id, key
-                                         ), val)
+    def set_module_localized_conf(self, module, mgr_id, key, val, force):
+        cmd = ["config", "set", "mgr",
+               "/".join(["mgr", module, mgr_id, key]),
+               val]
+        if force:
+            cmd.append("--force")
+        self.mon_manager.raw_cluster_cmd(*cmd)
 
 
 class MgrTestCase(CephTestCase):
@@ -199,7 +201,8 @@ class MgrTestCase(CephTestCase):
             ))
             cls.mgr_cluster.set_module_localized_conf(module_name, mgr_id,
                                                       config_name,
-                                                      str(assign_port))
+                                                      str(assign_port),
+                                                      force=True)
             assign_port += 1
 
         for mgr_id in cls.mgr_cluster.mgr_ids:


### PR DESCRIPTION
if mgr is not active, monitor will refuse to set any option consumed by
mgr modules.

the reason the tests pass somtimes is that, we have a racing here:

1. stop all mgr daemons
2. MgrMonitor gets updated and updates its mgr_module_options
accordingly.
3. in TestDashboard.setUp(), we reset the port number for dashboard
using "ceph config set mgr mgr/dashboard/y/ssl_server_port 7789"
4. restart all mgr daemons

but the 2nd step and 3rd step could race with each other, if the 2nd
step happens after 3rd step, the test passes. otherwise it fails.

in this change, "--force" is passed to the "ceph config set" command,
so ConfigMonitor can bypass the sanity test for the option, and just
set this option.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
