### PR TITLE
mgr/dashboard: Fix modals for Identifying Device and Editing O…

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -344,7 +344,7 @@ export class OsdListComponent implements OnInit {
         }),
         fields: [
           {
-            type: 'inputText',
+            type: 'text',
             name: 'deviceClass',
             value: selectedOsd.tree.device_class,
             label: this.i18n('Device class'),

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
@@ -30,7 +30,7 @@
                      [name]="field.name"
                      [formControlName]="field.name"
                      cdDimlessBinary>
-              <select *ngIf="field.name === 'select'"
+              <select *ngIf="field.type === 'select'"
                       class="form-control custom-select"
                       [id]="field.name"
                       [formControlName]="field.name">
@@ -43,7 +43,7 @@
                   {{ option.text }}
                 </option>
               </select>
-              <span *ngIf="formGroup.showError(field.name,formDir)"
+              <span *ngIf="formGroup.showError(field.name, formDir)"
                     class="invalid-feedback">
                 {{ getError(field) }}
               </span>


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43544

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
