### PR TITLE
Documentation: Centos ceph-deploy's python dependencies

### DIFF
--- a/doc/start/quick-start-preflight.rst
+++ b/doc/start/quick-start-preflight.rst
@@ -71,6 +71,10 @@ For CentOS 7, perform the following steps:
      gpgkey=https://download.ceph.com/keys/release.asc
      EOM
 
+#. You may need to install python setuptools required by ceph-deploy:
+
+	sudo yum install python-setuptools
+	
 #. Update your repository and install ``ceph-deploy``::
 
 	sudo yum update


### PR DESCRIPTION
Documentation: Centos ceph-deploy's python dependencies

Following the current documentation on a freshly installed Centos system leads to a missing python module dependency:

```
[clement@ceph0 cluster]$ ceph-deploy new ceph0
Traceback (most recent call last):
  File "/usr/bin/ceph-deploy", line 18, in <module>
    from ceph_deploy.cli import main
  File "/usr/lib/python2.7/site-packages/ceph_deploy/cli.py", line 1, in <module>
    import pkg_resources
ImportError: No module named pkg_resources
``` 

This issue can be solved by installing `python-setuptools`.

Fixes: https://tracker.ceph.com/issues/43545
Signed-off-by: Clément Hampaï <clement.hampai@cypressxt.net>
