### PR TITLE
mgr/pg_autoscaler: calculate pool_pg_target using pool size

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -303,7 +303,7 @@ class PgAutoscaler(MgrModule):
             final_ratio = max(capacity_ratio, target_ratio)
 
             # So what proportion of pg allowance should we be using?
-            pool_pg_target = (final_ratio * root_map[root_id].pg_target) / raw_used_rate * bias
+            pool_pg_target = (final_ratio * root_map[root_id].pg_target) / p['size'] * bias
 
             final_pg_target = max(p['options'].get('pg_num_min', PG_NUM_MIN),
                                   nearest_power_of_two(pool_pg_target))


### PR DESCRIPTION
Using raw_used_rate to calculate the pool_pg_target results in too
many PGs for erasure coded pools (e.g. EC 4+2 has raw_used_rate=1.5
but size is 6, so there will be 4x too many PGs). Calculate using
p['size'] instead.

Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>
Fixes: https://tracker.ceph.com/issues/43546