### PR TITLE
pyind/mgr: add mgr_module.py and mgr_util.py to mypy

### DIFF
--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -98,6 +98,7 @@ def merge_dicts(*args):
 
 
 def get_default_addr():
+    # type: () -> str
     def is_ipv6_enabled():
         try:
             sock = socket.socket(socket.AF_INET6)
@@ -119,6 +120,7 @@ class ServerConfigException(Exception):
     pass
 
 def verify_cacrt(cert_fname):
+    # type: (str) -> None
     """Basic validation of a ca cert"""
 
     if not cert_fname:
@@ -139,6 +141,7 @@ def verify_cacrt(cert_fname):
 
 
 def verify_tls_files(cert_fname, pkey_fname):
+    # type: (str, str) -> None
     """Basic checks for TLS certificate and key files
 
     Do some validations to the private key and certificate:

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -15,6 +15,8 @@ deps =
 commands = mypy --config-file=../../mypy.ini \
            ansible/module.py \
            cephadm/module.py \
+           mgr_module.py \
+           mgr_util.py \
            orchestrator.py \
            orchestrator_cli/module.py \
            rook/module.py \


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

... and yet another tiny step towards finding type errors earlier

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
