### PR TITLE
luminous: rbd-mirror: make logrotate work

### DIFF
--- a/src/logrotate.conf
+++ b/src/logrotate.conf
@@ -5,6 +5,7 @@
     sharedscripts
     postrotate
         killall -q -1 ceph-mon ceph-mgr ceph-mds ceph-osd ceph-fuse radosgw || true
+        killall -q -1 ceph-mon ceph-mgr ceph-mds ceph-osd ceph-fuse radosgw rbd-mirror || true
     endscript
     missingok
     notifempty

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <signal.h>
+
 #include <boost/range/adaptor/map.hpp>
 
 #include "common/Formatter.h"
@@ -216,10 +218,26 @@ Mirror::~Mirror()
 
 void Mirror::handle_signal(int signum)
 {
-  m_stopping = true;
-  {
-    Mutex::Locker l(m_lock);
+  dout(20) << signum << dendl;
+
+  Mutex::Locker l(m_lock);
+
+  switch (signum) {
+  case SIGHUP:
+    for (auto &it : m_pool_replayers) {
+      it.second->reopen_logs();
+    }
+    g_ceph_context->reopen_logs();
+    break;
+
+  case SIGINT:
+  case SIGTERM:
+    m_stopping = true;
     m_cond.Signal();
+    break;
+
+  default:
+    ceph_abort();
   }
 }
 

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -254,6 +254,8 @@ bool PoolReplayer::is_running() const {
 
 void PoolReplayer::init()
 {
+  Mutex::Locker l(m_lock);
+
   assert(!m_pool_replayer_thread.is_started());
 
   // reset state
@@ -511,6 +513,18 @@ void PoolReplayer::run()
   }
 
   m_instance_replayer->stop();
+}
+
+void PoolReplayer::reopen_logs()
+{
+  Mutex::Locker l(m_lock);
+
+  if (m_local_rados) {
+    reinterpret_cast<CephContext *>(m_local_rados->cct())->reopen_logs();
+  }
+  if (m_remote_rados) {
+    reinterpret_cast<CephContext *>(m_remote_rados->cct())->reopen_logs();
+  }
 }
 
 void PoolReplayer::print_status(Formatter *f, stringstream *ss)

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -383,8 +383,6 @@ int PoolReplayer::init_rados(const std::string &cluster_name,
 			     const std::string &description,
 			     RadosRef *rados_ref,
                              bool strip_cluster_overrides) {
-  rados_ref->reset(new librados::Rados());
-
   // NOTE: manually bootstrap a CephContext here instead of via
   // the librados API to avoid mixing global singletons between
   // the librados shared library and the daemon
@@ -467,6 +465,8 @@ int PoolReplayer::init_rados(const std::string &cluster_name,
   cct->_conf->set_val_or_die("rbd_cache", "false");
   cct->_conf->apply_changes(nullptr);
   cct->_conf->complain_about_parse_errors(cct);
+
+  rados_ref->reset(new librados::Rados());
 
   r = (*rados_ref)->init_with_context(cct);
   assert(r == 0);

--- a/src/tools/rbd_mirror/PoolReplayer.h
+++ b/src/tools/rbd_mirror/PoolReplayer.h
@@ -64,6 +64,7 @@ public:
   void restart();
   void flush();
   void release_leader();
+  void reopen_logs();
 
 private:
   struct PoolWatcherListener : public PoolWatcher<>::Listener {

--- a/src/tools/rbd_mirror/main.cc
+++ b/src/tools/rbd_mirror/main.cc
@@ -54,7 +54,7 @@ int main(int argc, const char **argv)
   common_init_finish(g_ceph_context);
 
   init_async_signal_handler();
-  register_async_signal_handler(SIGHUP, sighup_handler);
+  register_async_signal_handler(SIGHUP, handle_signal);
   register_async_signal_handler_oneshot(SIGINT, handle_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_signal);
 
@@ -74,7 +74,7 @@ int main(int argc, const char **argv)
   mirror->run();
 
  cleanup:
-  unregister_async_signal_handler(SIGHUP, sighup_handler);
+  unregister_async_signal_handler(SIGHUP, handle_signal);
   unregister_async_signal_handler(SIGINT, handle_signal);
   unregister_async_signal_handler(SIGTERM, handle_signal);
   shutdown_async_signal_handler();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43499

---

backport of https://github.com/ceph/ceph/pull/32456
parent tracker: https://tracker.ceph.com/issues/43428

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh