### PR TITLE
nautilus: mds: reject forward scrubs when cluster has multiple active MDS (more than one rank)

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2401,6 +2401,12 @@ void MDSRankDispatcher::handle_mds_map(
     purge_queue.update_op_limit(*mdsmap);
   }
 
+  if (scrubstack->is_scrubbing()) {
+    if (mdsmap->get_max_mds() > 1) {
+      auto c = new C_MDSInternalNoop;
+      scrubstack->scrub_abort(c);
+    }
+  }
   mdcache->handle_mdsmap(*mdsmap);
 }
 
@@ -2515,6 +2521,12 @@ bool MDSRankDispatcher::handle_asok_command(std::string_view command,
     vector<string> scrubop_vec;
     cmd_getval(g_ceph_context, cmdmap, "scrubops", scrubop_vec);
     cmd_getval(g_ceph_context, cmdmap, "path", path);
+
+    /* Multiple MDS scrub is not currently supported. See also: https://tracker.ceph.com/issues/12274 */
+    if (mdsmap->get_max_mds() > 1) {
+      ss << "Scrub is not currently supported for multiple active MDS. Please reduce max_mds to 1 and then scrub.";
+      return true;
+    }
 
     C_SaferCond cond;
     command_scrub_start(f, path, "", scrubop_vec, &cond);

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3610,6 +3610,13 @@ bool MDSRankDispatcher::handle_command(
     cmd_getval(g_ceph_context, cmdmap, "path", path);
     cmd_getval(g_ceph_context, cmdmap, "tag", tag);
 
+    /* Multiple MDS scrub is not currently supported. See also: https://tracker.ceph.com/issues/12274 */
+    if (mdsmap->get_max_mds() > 1) {
+      *ss << "Scrub is not currently supported for multiple active MDS. Please reduce max_mds to 1 and then scrub.";
+      *r = ENOTSUP;
+      return true;
+    }
+
     *need_reply = false;
     *run_later = create_async_exec_context(new C_ScrubExecAndReply
                                            (this, m, path, tag, scrubop_vec));

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -126,6 +126,8 @@ public:
    */
   void scrub_status(Formatter *f);
 
+  bool is_scrubbing() const { return !inode_stack.empty(); }
+
 private:
   // scrub abort is _not_ a state, rather it's an operation that's
   // performed after in-progress scrubs are finished.


### PR DESCRIPTION
https://tracker.ceph.com/issues/43558