### PR TITLE
crimson: remove some attributes from lambda

### DIFF
--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -479,7 +479,7 @@ private:
       return this->then_wrapped(
         [ valfunc = std::forward<ValueFuncT>(valfunc),
           errfunc = std::forward<ErrorVisitorT>(errfunc)
-        ] (auto&& future) mutable noexcept [[gnu::always_inline]] {
+        ] (auto&& future) mutable noexcept {
           if (__builtin_expect(future.failed(), false)) {
             return _safe_then_handle_errors<futurator_t>(
               std::move(future), std::forward<ErrorVisitorT>(errfunc));
@@ -528,7 +528,7 @@ private:
 
       return this->then_wrapped(
 	[ func = std::forward<FuncT>(func)
-	] (auto&& future) mutable noexcept [[gnu::always_inline]] {
+	] (auto&& future) mutable noexcept {
 	  return futurator_t::apply(std::forward<FuncT>(func)).safe_then(
 	    [future = std::forward<decltype(future)>(future)]() mutable {
 	      return std::move(future);
@@ -572,7 +572,7 @@ private:
         typename return_errorator_t::template futurize<::seastar::future<ValuesT...>>;
       return this->then_wrapped(
         [ errfunc = std::forward<ErrorVisitorT>(errfunc)
-        ] (auto&& future) mutable noexcept [[gnu::always_inline]] {
+        ] (auto&& future) mutable noexcept {
           if (__builtin_expect(future.failed(), false)) {
             return _safe_then_handle_errors<futurator_t>(
               std::move(future), std::forward<ErrorVisitorT>(errfunc));


### PR DESCRIPTION
There seems to be no "universally accepted" way to declare a lambda as
[[always_inline]]. "Universally accepted" here meaning: accepted with
no error or warning by gcc8, gcc9 and clang.

See for example: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60503

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
