### PR TITLE
osd: flush cache tier PG cyclic

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -585,6 +585,7 @@ void OSDService::agent_entry()
       agent_valid_iterator = true;
     }
     PGRef pg = *agent_queue_pos;
+    agent_queue_pos++;
     dout(10) << "high_count " << flush_mode_high_count
 	     << " agent_ops " << agent_ops
 	     << " flush_quota " << agent_flush_quota << dendl;


### PR DESCRIPTION
OSD use a map to save the priority of PG pending in cache tier,
the PGs in the same priority will be handled one by one. This
will lead to pressure for backend pool when cache tier use ssds
and backend pool uses satas.
So we handle PGs in the same priority level cyclic in this commit.

Signed-off-by: liangmingyuan liangmingyuan@baidu.com
