### PR TITLE
cmake: do not include global_context.cc multiple times

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -300,6 +300,7 @@ endif()
 set(libcommon_files
   ${CMAKE_BINARY_DIR}/src/include/ceph_ver.h
   ceph_ver.c
+  global/global_context.cc
   xxHash/xxhash.c
   log/Log.cc
   mon/MonCap.cc
@@ -342,7 +343,6 @@ set(ceph_common_objs
   $<TARGET_OBJECTS:compressor_objs>
   $<TARGET_OBJECTS:common-objs>
   $<TARGET_OBJECTS:common_mountcephfs_objs>
-  $<TARGET_OBJECTS:global_common_objs>
   $<TARGET_OBJECTS:crush_objs>)
 set(ceph_common_deps
   json_spirit erasure_code arch crc32

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(crimson-common STATIC
   ${PROJECT_SOURCE_DIR}/src/common/HeartbeatMap.cc
   ${PROJECT_SOURCE_DIR}/src/common/PluginRegistry.cc
   ${PROJECT_SOURCE_DIR}/src/common/RefCountedObj.cc
+  ${PROJECT_SOURCE_DIR}/src/global/global_context.cc
   ${PROJECT_SOURCE_DIR}/src/global/pidfile.cc
   ${PROJECT_SOURCE_DIR}/src/librbd/Features.cc
   ${PROJECT_SOURCE_DIR}/src/log/Log.cc
@@ -96,8 +97,7 @@ add_library(crimson-common STATIC
   $<TARGET_OBJECTS:crimson-auth>
   $<TARGET_OBJECTS:common_buffer_obj>
   $<TARGET_OBJECTS:common_mountcephfs_objs>
-  $<TARGET_OBJECTS:crimson-crush>
-  $<TARGET_OBJECTS:global_common_objs>)
+  $<TARGET_OBJECTS:crimson-crush>)
 
 target_compile_definitions(crimson-common PRIVATE
   "CEPH_LIBDIR=\"${CMAKE_INSTALL_FULL_LIBDIR}\""

--- a/src/global/CMakeLists.txt
+++ b/src/global/CMakeLists.txt
@@ -2,17 +2,12 @@ set(libglobal_srcs
   global_init.cc
   pidfile.cc
   signal_handler.cc)
-set(global_common_files
-  global_context.cc)
-add_library(global_common_objs OBJECT ${global_common_files})
 add_library(libglobal_objs OBJECT ${libglobal_srcs})
 
 add_library(global-static STATIC
-  $<TARGET_OBJECTS:libglobal_objs>
-  $<TARGET_OBJECTS:global_common_objs>)
+  $<TARGET_OBJECTS:libglobal_objs>)
 target_link_libraries(global-static common)
 
 add_library(global STATIC
-  $<TARGET_OBJECTS:libglobal_objs>
-  $<TARGET_OBJECTS:global_common_objs>)
+  $<TARGET_OBJECTS:libglobal_objs>)
 target_link_libraries(global ceph-common ${EXTRALIBS})

--- a/src/global/global_context.cc
+++ b/src/global/global_context.cc
@@ -12,10 +12,13 @@
  *
  */
 
-#include "common/ceph_context.h"
 #include "global/global_context.h"
 
 #include <string.h>
+#include "common/ceph_context.h"
+#ifdef WITH_SEASTAR
+#include "crimson/common/config_proxy.h"
+#endif
 
 
 /*
@@ -24,7 +27,7 @@
 CephContext *g_ceph_context = NULL;
 ConfigProxy& g_conf() {
 #ifdef WITH_SEASTAR
-  return ceph::common::local_conf();
+  return crimson::common::local_conf();
 #else
   return g_ceph_context->_conf;
 #endif

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -43,8 +43,7 @@ if(HAS_VTA)
   set_source_files_properties(osdcap.cc
     PROPERTIES COMPILE_FLAGS -fno-var-tracking-assignments)
 endif()
-add_library(osd STATIC ${osd_srcs}
-  $<TARGET_OBJECTS:global_common_objs>)
+add_library(osd STATIC ${osd_srcs})
 target_link_libraries(osd
   PUBLIC dmclock::dmclock
   PRIVATE os heap_profiler cpu_profiler ${CMAKE_DL_LIBS})


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
