### PR TITLE
ceph.spec.in: use python3 to bytecompile .py files

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -84,7 +84,9 @@
 %{!?python3_pkgversion: %global python3_pkgversion 3}
 %{!?python3_version_nodots: %global python3_version_nodots 3}
 %{!?python3_version: %global python3_version 3}
-
+%if 0%{?rhel} == 7
+%define __python %{__python3}
+%endif
 # unify libexec for all targets
 %global _libexecdir %{_exec_prefix}/lib
 
@@ -1567,6 +1569,9 @@ fi
 %{_datadir}/ceph/mgr/test_orchestrator
 %{_datadir}/ceph/mgr/volumes
 %{_datadir}/ceph/mgr/zabbix
+%if 0%{?rhel} == 7
+%{_datadir}/ceph/mgr/__pycache__
+%endif
 %{_unitdir}/ceph-mgr@.service
 %{_unitdir}/ceph-mgr.target
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/mgr


### PR DESCRIPTION
per
https://fedoraproject.org/wiki/Changes/No_more_automagic_Python_bytecompilation#Status_quo,
`brp-python-bytecompile` script bytecompile .py files automatically, the
.py files under interpreter-specific directories, such as `/usr/lib/python3.6/`,
are compiled using the appropriate compiler. but the mgr modules are
located under `/usr/share/ceph/mgr/`. they are compiled using
`${__python}`, which is still python2 in RHEL/CentOS 7. since we've
dropped the support of python2 in octopus. we should either stop
bytecompiling the .py source files or start using python3 to compile
them. otherwise python2 will fail to compile source files using python3
specific syntax like:

```
Compiling /home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos7/DIST/centos7/MACHINE_SIZE/huge/release/15.0.0-9242-g400d98b/rpm/el7/BUILDROOT/ceph-15.0.0-9242.g400d98b.el7.x86_64/usr/share/ceph/mgr/telemetry/module.py
...
  File "/usr/share/ceph/mgr/telemetry/module.py", line 387
    anon_devid = f"{devid.rsplit('_', 1)[0]}_{uuid.uuid1()}"
                                                           ^
SyntaxError: invalid syntax

error: Bad exit status from /var/tmp/rpm-tmp.4oRsox (%install)
```

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
