### PR TITLE
rgw: ReplaceKeyPrefixWith and ReplaceKeyWith can not set at the same …

### DIFF
--- a/src/rgw/rgw_xml_enc.cc
+++ b/src/rgw/rgw_xml_enc.cc
@@ -40,14 +40,24 @@ void RGWBWRedirectInfo::dump_xml(Formatter *f) const
   }
 }
 
+#define WEBSITE_HTTP_REDIRECT_CODE_MIN      300
+#define WEBSITE_HTTP_REDIRECT_CODE_MAX      400
 void RGWBWRedirectInfo::decode_xml(XMLObj *obj) {
   RGWXMLDecoder::decode_xml("Protocol", redirect.protocol, obj);
   RGWXMLDecoder::decode_xml("HostName", redirect.hostname, obj);
   int code = 0;
-  RGWXMLDecoder::decode_xml("HttpRedirectCode", code, obj);
+  bool has_http_redirect_code = RGWXMLDecoder::decode_xml("HttpRedirectCode", code, obj);
+  if (has_http_redirect_code &&
+      !(code > WEBSITE_HTTP_REDIRECT_CODE_MIN &&
+        code < WEBSITE_HTTP_REDIRECT_CODE_MAX)) {
+    throw RGWXMLDecoder::err("The provided HTTP redirect code is not valid. Valid codes are 3XX except 300.");
+  }
   redirect.http_redirect_code = code;
-  RGWXMLDecoder::decode_xml("ReplaceKeyPrefixWith", replace_key_prefix_with, obj);
-  RGWXMLDecoder::decode_xml("ReplaceKeyWith", replace_key_with, obj);
+  bool has_replace_key_prefix_with = RGWXMLDecoder::decode_xml("ReplaceKeyPrefixWith", replace_key_prefix_with, obj);
+  bool has_replace_key_with = RGWXMLDecoder::decode_xml("ReplaceKeyWith", replace_key_with, obj);
+  if (has_replace_key_prefix_with && has_replace_key_with) {
+    throw RGWXMLDecoder::err("You can only define ReplaceKeyPrefix or ReplaceKey but not both.");
+  }
 }
 
 void RGWBWRoutingRuleCondition::dump_xml(Formatter *f) const
@@ -60,10 +70,17 @@ void RGWBWRoutingRuleCondition::dump_xml(Formatter *f) const
   }
 }
 
+#define WEBSITE_HTTP_ERROR_CODE_RETURNED_EQUALS_MIN      400
+#define WEBSITE_HTTP_ERROR_CODE_RETURNED_EQUALS_MAX      600
 void RGWBWRoutingRuleCondition::decode_xml(XMLObj *obj) {
   RGWXMLDecoder::decode_xml("KeyPrefixEquals", key_prefix_equals, obj);
   int code = 0;
-  RGWXMLDecoder::decode_xml("HttpErrorCodeReturnedEquals", code, obj);
+  bool has_http_error_code_returned_equals = RGWXMLDecoder::decode_xml("HttpErrorCodeReturnedEquals", code, obj);
+  if (has_http_error_code_returned_equals &&
+      !(code >= WEBSITE_HTTP_ERROR_CODE_RETURNED_EQUALS_MIN &&
+        code < WEBSITE_HTTP_ERROR_CODE_RETURNED_EQUALS_MAX)) {
+    throw RGWXMLDecoder::err("The provided HTTP redirect code is not valid. Valid codes are 4XX or 5XX.");
+  }
   http_error_code_returned_equals = code;
 }
 


### PR DESCRIPTION
in 

> https://docs.aws.amazon.com/AmazonS3/latest/API/API_Redirect.html#AmazonS3-Type-Redirect-ReplaceKeyPrefixWith

```
ReplaceKeyPrefixWith
The object key prefix to use in the redirect request. For example, to redirect requests for all pages with prefix docs/ (objects in the docs/ folder) to documents/, you can set a condition block with KeyPrefixEquals set to docs/ and in the Redirect set ReplaceKeyPrefixWith to /documents. Not required if one of the siblings is present. Can be present only if ReplaceKeyWith is not provided.

Type: String

Required: No

ReplaceKeyWith
The specific object key to use in the redirect request. For example, redirect request to error.html. Not required if one of the siblings is present. Can be present only if ReplaceKeyPrefixWith is not provided.

Type: String

Required: No
```