### PR TITLE
qa/distros: Add openSUSE Leap 15.2 as distro

### DIFF
--- a/qa/distros/all/opensuse_15.2.yaml
+++ b/qa/distros/all/opensuse_15.2.yaml
@@ -1,0 +1,2 @@
+os_type: opensuse
+os_version: "15.2"


### PR DESCRIPTION
There is a FOG image available now so add the distro here.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>