### PR TITLE
qa/rgw: s3a-hadoop task defaults to maven-version 3.6.3

### DIFF
--- a/qa/suites/rgw/hadoop-s3a/hadoop/trunk.yaml
+++ b/qa/suites/rgw/hadoop-s3a/hadoop/trunk.yaml
@@ -1,3 +1,0 @@
-overrides:
-  s3a-hadoop:
-    hadoop-version: 'trunk'

--- a/qa/suites/rgw/hadoop-s3a/hadoop/v28.yaml
+++ b/qa/suites/rgw/hadoop-s3a/hadoop/v28.yaml
@@ -1,3 +1,0 @@
-overrides:
-  s3a-hadoop:
-    hadoop-version: '2.8.5'

--- a/qa/tasks/s3a_hadoop.py
+++ b/qa/tasks/s3a_hadoop.py
@@ -14,8 +14,8 @@ def task(ctx, config):
       -tasks:
          ceph-ansible:
          s3a-hadoop:
-           maven-version: '3.3.9' (default)
-           hadoop-version: '2.7.3'
+           maven-version: '3.6.3' (default)
+           hadoop-version: '2.9.2'
            bucket-name: 's3atest' (default)
            access-key: 'anykey' (uses a default value)
            secret-key: 'secretkey' ( uses a default value)
@@ -40,7 +40,7 @@ def task(ctx, config):
 
     # get versions
     maven_major = config.get('maven-major', 'maven-3')
-    maven_version = config.get('maven-version', '3.6.2')
+    maven_version = config.get('maven-version', '3.6.3')
     hadoop_ver = config.get('hadoop-version', '2.9.2')
     bucket_name = config.get('bucket-name', 's3atest')
     access_key = config.get('access-key', 'EGAQRD2ULOIFKFSKCT4F')


### PR DESCRIPTION
all of the s3a-hadoop tests are failing because binaries for maven v3.6.2 are no longer available under http://www-us.apache.org/dist/maven/maven-3/

```
> cd /home/ubuntu/cephtest && wget http://www-us.apache.org/dist/maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.tar.gz && tar -xvf apache-maven-3.6.2-bin.tar.gz && git clone https://github.com/apache/hadoop && cd hadoop && git checkout -b hadoop-3.2.0 rel/release-3.2.0
--2020-01-13 17:58:42--  http://www-us.apache.org/dist/maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.tar.gz
Resolving www-us.apache.org (www-us.apache.org)... 40.79.78.1
Connecting to www-us.apache.org (www-us.apache.org)|40.79.78.1|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2020-01-13 17:58:42 ERROR 404: Not Found.
```