### PR TITLE
common/util: allow for a large /proc/cpuinfo

### DIFF
--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -268,7 +268,7 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
   // processor
   f = fopen(PROCPREFIX "/proc/cpuinfo", "r");
   if (f) {
-    char buf[1024];
+    char buf[1048576];
     while (!feof(f)) {
       char *line = fgets(buf, sizeof(buf), f);
       if (!line)


### PR DESCRIPTION
This file is frequently 10s of KB or more.

Fixes b02e81935c877eff4929c8aad714b0015db45201 (which didn't make the
buffer big enough for real-life systems).

Fixes: https://tracker.ceph.com/issues/43306
Signed-off-by: Sage Weil <sage@redhat.com>