### PR TITLE
qa/workunits/cephadm/test_cephadm: drop stray 'exit 0'

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -180,8 +180,6 @@ for u in ceph-$FSID@mgr.y; do
     systemctl is-active $u
 done
 
-exit 0
-
 for f in `seq 1 30`; do
     if $CEPHADM shell --fsid $FSID \
 	     --config $CONFIG --keyring $KEYRING -- \


### PR DESCRIPTION
Introduced in 40b70c632d22dbd4cf68f8ad0df1b30ee28b9f19

Signed-off-by: Sage Weil <sage@redhat.com>