### PR TITLE
qa/workunits/cephadm/test_cephadm: workunit test cleanup

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -77,7 +77,7 @@ CEPHADM="$SUDO $CEPHADM_BIN $CEPHADM_ARGS"
 # clean up previous run(s)?
 $CEPHADM rm-cluster --fsid $FSID --force
 $CEPHADM rm-cluster --fsid $FSID_LEGACY --force
-vgchange -an $OSD_VG_NAME || true
+$SUDO vgchange -an $OSD_VG_NAME || true
 loopdev=$($SUDO losetup -a | grep $(basename $OSD_IMAGE_NAME) | awk -F : '{print $1}')
 if ! [ "$loopdev" = "" ]; then
     $SUDO losetup -d $loopdev

--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -43,7 +43,7 @@ if [ -z "$PYTHON_KLUDGE" ]; then
     which python3 && PYTHONS="$PYTHONS python3"
     which python2 && PYTHONS="$PYTHONS python2"
     echo "PYTHONS $PYTHONS"
-    if [ -z $PYTHONS ]; then
+    if [ -z "$PYTHONS" ]; then
 	echo "No PYTHONS found!"
 	exit 1
     fi


### PR DESCRIPTION
misc fixups based on `wip-swagner-testing` of PR #32560

http://qa-proxy.ceph.com/teuthology/swagner-2020-01-13_10:20:46-rados-wip-swagner-testing-distro-basic-smithi/4664538/teuthology.log

* an error will not be produced if no python(s) are installed
* `vgchange -an` needs to be run as root

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
