### PR TITLE
qa: fix package excludes for upgrade/nautilus-x[-singleton]

### DIFF
--- a/qa/suites/upgrade/nautilus-x-singleton/1-install/nautilus.yaml
+++ b/qa/suites/upgrade/nautilus-x-singleton/1-install/nautilus.yaml
@@ -10,13 +10,8 @@ tasks:
 - install:
     branch: nautilus
     exclude_packages:
-      - librados3
-      - ceph-mgr-dashboard
-      - ceph-mgr-diskprediction-local
-      - ceph-mgr-rook
       - ceph-mgr-cephadm
       - cephadm
-    extra_packages: ['librados2']
 - print: "**** done install nautilus"
 - ceph:
 - print: "**** done ceph"

--- a/qa/suites/upgrade/nautilus-x/parallel/1-ceph-install/nautilus.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/1-ceph-install/nautilus.yaml
@@ -5,6 +5,9 @@ meta:
    upgrade the client node
 tasks:
 - install:
+    exclude_packages:
+      - ceph-mgr-cephadm
+      - cephadm
     branch: nautilus
 - print: "**** done installing nautilus"
 - ceph:

--- a/qa/suites/upgrade/nautilus-x/stress-split/1-ceph-install/nautilus.yaml
+++ b/qa/suites/upgrade/nautilus-x/stress-split/1-ceph-install/nautilus.yaml
@@ -2,6 +2,9 @@ meta:
 - desc: install ceph/nautilus latest
 tasks:
 - install:
+    exclude_packages:
+      - ceph-mgr-cephadm
+      - cephadm
     branch: nautilus
 - print: "**** done install nautilus"
 - ceph:


### PR DESCRIPTION
cephadm is not in nautilus, other packages previously excluded are.