### PR TITLE
test: Fix wait_for_state() to wait for a PG to get into a state

### DIFF
--- a/qa/standalone/osd/osd-backfill-space.sh
+++ b/qa/standalone/osd/osd-backfill-space.sh
@@ -49,7 +49,7 @@ function get_num_in_state() {
 }
 
 
-function wait_for_state() {
+function wait_for_not_state() {
     local state=$1
     local num_in_state=-1
     local cur_in_state
@@ -78,15 +78,15 @@ function wait_for_state() {
 }
 
 
-function wait_for_backfill() {
+function wait_for_not_backfilling() {
     local timeout=$1
-    wait_for_state backfilling $timeout
+    wait_for_not_state backfilling $timeout
 }
 
 
-function wait_for_active() {
+function wait_for_not_activating() {
     local timeout=$1
-    wait_for_state activating $timeout
+    wait_for_not_state activating $timeout
 }
 
 # All tests are created in an environment which has fake total space
@@ -149,8 +149,8 @@ function TEST_backfill_test_simple() {
     done
     sleep 30
 
-    wait_for_backfill 240 || return 1
-    wait_for_active 60 || return 1
+    wait_for_not_backfilling 240 || return 1
+    wait_for_not_activating 60 || return 1
 
     ERRORS=0
     if [ "$(ceph pg dump pgs | grep +backfill_toofull | wc -l)" != "1" ];
@@ -228,8 +228,8 @@ function TEST_backfill_test_multi() {
     done
     sleep 30
 
-    wait_for_backfill 240 || return 1
-    wait_for_active 60 || return 1
+    wait_for_not_backfilling 240 || return 1
+    wait_for_not_activating 60 || return 1
 
     ERRORS=0
     full="$(ceph pg dump pgs | grep +backfill_toofull | wc -l)"
@@ -380,8 +380,8 @@ function TEST_backfill_test_sametarget() {
     ceph osd pool set $pool2 size 2
     sleep 30
 
-    wait_for_backfill 240 || return 1
-    wait_for_active 60 || return 1
+    wait_for_not_backfilling 240 || return 1
+    wait_for_not_activating 60 || return 1
 
     ERRORS=0
     if [ "$(ceph pg dump pgs | grep +backfill_toofull | wc -l)" != "1" ];
@@ -512,8 +512,8 @@ function TEST_backfill_multi_partial() {
     ceph osd in osd.$fillosd
     sleep 30
 
-    wait_for_backfill 240 || return 1
-    wait_for_active 60 || return 1
+    wait_for_not_backfilling 240 || return 1
+    wait_for_not_activating 60 || return 1
 
     flush_pg_stats || return 1
     ceph pg dump pgs
@@ -695,8 +695,8 @@ function TEST_ec_backfill_simple() {
 
     ceph pg dump pgs
 
-    wait_for_backfill 240 || return 1
-    wait_for_active 60 || return 1
+    wait_for_not_backfilling 240 || return 1
+    wait_for_not_activating 60 || return 1
 
     ceph pg dump pgs
 
@@ -819,8 +819,8 @@ function TEST_ec_backfill_multi() {
 
     sleep 30
 
-    wait_for_backfill 240 || return 1
-    wait_for_active 60 || return 1
+    wait_for_not_backfilling 240 || return 1
+    wait_for_not_activating 60 || return 1
 
     ceph pg dump pgs
 
@@ -958,8 +958,8 @@ function SKIP_TEST_ec_backfill_multi_partial() {
     sleep 30
     ceph pg dump pgs
 
-    wait_for_backfill 240 || return 1
-    wait_for_active 60 || return 1
+    wait_for_not_backfilling 240 || return 1
+    wait_for_not_activating 60 || return 1
 
     ceph pg dump pgs
 
@@ -1066,8 +1066,8 @@ function SKIP_TEST_ec_backfill_multi_partial() {
     ceph osd in osd.$fillosd
     sleep 30
 
-    wait_for_backfill 240 || return 1
-    wait_for_active 60 || return 1
+    wait_for_not_backfilling 240 || return 1
+    wait_for_not_activating 60 || return 1
 
     ERRORS=0
     if [ "$(ceph pg dump pgs | grep -v "^1.0" | grep +backfill_toofull | wc -l)" != "1" ];

--- a/qa/standalone/osd/osd-recovery-space.sh
+++ b/qa/standalone/osd/osd-recovery-space.sh
@@ -49,7 +49,6 @@ function get_num_in_state() {
 
 function wait_for_state() {
     local state=$1
-    local num_in_state=-1
     local cur_in_state
     local -a delays=($(get_timeout_delays $2 5))
     local -i loop=0
@@ -61,11 +60,8 @@ function wait_for_state() {
 
     while true ; do
         cur_in_state=$(get_num_in_state ${state})
-        test $cur_in_state = "0" && break
-        if test $cur_in_state != $num_in_state ; then
-            loop=0
-            num_in_state=$cur_in_state
-        elif (( $loop >= ${#delays[*]} )) ; then
+        test $cur_in_state -gt 0 && break
+        if (( $loop >= ${#delays[*]} )) ; then
             ceph pg dump pgs
             return 1
         fi


### PR DESCRIPTION
To avoid confusion fix function names in osd-backfill-space.sh for how
they actually work.

Fixes: https://tracker.ceph.com/issues/43592

Signed-off-by: David Zafman <dzafman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
