### PR TITLE
doc: add "mds map" to list of ceph monitor assets

### DIFF
--- a/doc/start/intro.rst
+++ b/doc/start/intro.rst
@@ -17,11 +17,11 @@ required when running Ceph File System clients.
 
 - **Monitors**: A :term:`Ceph Monitor` (``ceph-mon``) maintains maps
   of the cluster state, including the monitor map, manager map, the
-  OSD map, and the CRUSH map.  These maps are critical cluster state
-  required for Ceph daemons to coordinate with each other.  Monitors
-  are also responsible for managing authentication between daemons and
-  clients.  At least three monitors are normally required for
-  redundancy and high availability.
+  OSD map, the MDS map, and the CRUSH map.  These maps are critical 
+  cluster state required for Ceph daemons to coordinate with each other.  
+  Monitors are also responsible for managing authentication between 
+  daemons and clients.  At least three monitors are normally required 
+  for redundancy and high availability.
 
 - **Managers**: A :term:`Ceph Manager` daemon (``ceph-mgr``) is
   responsible for keeping track of runtime metrics and the current


### PR DESCRIPTION
This small change adds "mds map" to a list of things that the
Ceph monitor keeps track of, and this PR satisfies the issue here:

Fixes: https://tracker.ceph.com/issues/14251
Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
