### PR TITLE
crimson/net: configure seastar to accept on a fixed core

### DIFF
--- a/src/crimson/mgr/client.cc
+++ b/src/crimson/mgr/client.cc
@@ -72,14 +72,11 @@ seastar::future<> Client::reconnect()
       return seastar::now();
     }
     auto peer = mgrmap.get_active_addrs().front();
-    return msgr.connect(peer, CEPH_ENTITY_TYPE_MGR).then(
-      [this](auto _conn) {
-        conn = _conn;
-        // ask for the mgrconfigure message
-        auto m = ceph::make_message<MMgrOpen>();
-        m->daemon_name = local_conf()->name.get_id();
-        return conn->send(std::move(m));
-      });
+    conn = msgr.connect(peer, CEPH_ENTITY_TYPE_MGR);
+    // ask for the mgrconfigure message
+    auto m = ceph::make_message<MMgrOpen>();
+    m->daemon_name = local_conf()->name.get_id();
+    return conn->send(std::move(m));
   });
 }
 

--- a/src/crimson/mgr/client.cc
+++ b/src/crimson/mgr/client.cc
@@ -73,8 +73,8 @@ seastar::future<> Client::reconnect()
     }
     auto peer = mgrmap.get_active_addrs().front();
     return msgr.connect(peer, CEPH_ENTITY_TYPE_MGR).then(
-      [this](auto xconn) {
-        conn = xconn->release();
+      [this](auto _conn) {
+        conn = _conn;
         // ask for the mgrconfigure message
         auto m = ceph::make_message<MMgrOpen>();
         m->daemon_name = local_conf()->name.get_id();

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -943,11 +943,7 @@ seastar::future<> Client::reopen_session(int rank)
     auto peer = monmap.get_addrs(rank).front();
     logger().info("connecting to mon.{}", rank);
     return msgr.connect(peer, CEPH_ENTITY_TYPE_MON).then(
-      [this] (auto xconn) -> seastar::future<Connection::AuthResult> {
-      // sharded-messenger compatible mode assumes all connections running
-      // in one shard.
-      ceph_assert((*xconn)->shard_id() == seastar::engine().cpu_id());
-      crimson::net::ConnectionRef conn = xconn->release();
+      [this] (auto conn) -> seastar::future<Connection::AuthResult> {
       auto& mc = pending_conns.emplace_back(
 	std::make_unique<Connection>(auth_registry, conn, &keyring));
       if (conn->get_peer_addr().is_msgr2()) {

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -942,8 +942,9 @@ seastar::future<> Client::reopen_session(int rank)
 #warning fixme
     auto peer = monmap.get_addrs(rank).front();
     logger().info("connecting to mon.{}", rank);
-    return msgr.connect(peer, CEPH_ENTITY_TYPE_MON).then(
-      [this] (auto conn) -> seastar::future<Connection::AuthResult> {
+    return seastar::futurize_apply(
+        [peer, this] () -> seastar::future<Connection::AuthResult> {
+      auto conn = msgr.connect(peer, CEPH_ENTITY_TYPE_MON);
       auto& mc = pending_conns.emplace_back(
 	std::make_unique<Connection>(auth_registry, conn, &keyring));
       if (conn->get_peer_addr().is_msgr2()) {

--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -110,9 +110,6 @@ class Connection : public seastar::enable_shared_from_this<Connection> {
   // will wait for all connections closed
   virtual seastar::future<> close() = 0;
 
-  /// which shard id the connection lives
-  virtual seastar::shard_id shard_id() const = 0;
-
   virtual void print(ostream& out) const = 0;
 
   void set_last_keepalive(clock_t::time_point when) {

--- a/src/crimson/net/Dispatcher.h
+++ b/src/crimson/net/Dispatcher.h
@@ -53,11 +53,6 @@ class Dispatcher {
 		       bufferlist&) {
     return seastar::make_ready_future<msgr_tag_t, bufferlist>(0, bufferlist{});
   }
-
-  // get the local dispatcher shard if it is accessed by another core
-  virtual Dispatcher* get_local_shard() {
-    return this;
-  }
 };
 
 } // namespace crimson::net

--- a/src/crimson/net/Errors.cc
+++ b/src/crimson/net/Errors.cc
@@ -35,102 +35,12 @@ const std::error_category& net_category()
           return "negotiation failure";
         case error::read_eof:
           return "read eof";
-        case error::connection_aborted:
-          return "connection aborted";
-        case error::connection_refused:
-          return "connection refused";
-        case error::connection_reset:
-          return "connection reset";
         case error::corrupted_message:
           return "corrupted message";
-        case error::invalid_argument:
-          return "invalid argument";
-        case error::address_in_use:
-          return "address in use";
-        case error::broken_pipe:
-          return "broken pipe";
         case error::protocol_aborted:
           return "protocol aborted";
         default:
           return "unknown";
-      }
-    }
-
-    // unfortunately, seastar throws connection errors with the system category,
-    // rather than the generic category that would match their counterparts
-    // in std::errc. we add our own errors for them, so we can match either
-    std::error_condition default_error_condition(int ev) const noexcept override {
-      switch (static_cast<error>(ev)) {
-        case error::connection_aborted:
-          return std::errc::connection_aborted;
-        case error::connection_refused:
-          return std::errc::connection_refused;
-        case error::connection_reset:
-          return std::errc::connection_reset;
-        case error::invalid_argument:
-          return std::errc::invalid_argument;
-        case error::address_in_use:
-          return std::errc::address_in_use;
-        case error::broken_pipe:
-          return std::errc::broken_pipe;
-        default:
-          return std::error_condition(ev, *this);
-      }
-    }
-
-    bool equivalent(int code, const std::error_condition& cond) const noexcept override {
-      if (error_category::equivalent(code, cond)) {
-        return true;
-      }
-      switch (static_cast<error>(code)) {
-        case error::connection_aborted:
-          return cond == std::errc::connection_aborted
-              || cond == std::error_condition(ECONNABORTED, std::system_category());
-        case error::connection_refused:
-          return cond == std::errc::connection_refused
-              || cond == std::error_condition(ECONNREFUSED, std::system_category());
-        case error::connection_reset:
-          return cond == std::errc::connection_reset
-              || cond == std::error_condition(ECONNRESET, std::system_category());
-        case error::invalid_argument:
-          return cond == std::errc::invalid_argument
-              || cond == std::error_condition(EINVAL, std::system_category());
-        case error::address_in_use:
-          return cond == std::errc::address_in_use
-              || cond == std::error_condition(EADDRINUSE, std::system_category());
-        case error::broken_pipe:
-          return cond == std::errc::broken_pipe
-              || cond == std::error_condition(EPIPE, std::system_category());
-        default:
-          return false;
-      }
-    }
-
-    bool equivalent(const std::error_code& code, int cond) const noexcept override {
-      if (error_category::equivalent(code, cond)) {
-        return true;
-      }
-      switch (static_cast<error>(cond)) {
-        case error::connection_aborted:
-          return code == std::errc::connection_aborted
-              || code == std::error_code(ECONNABORTED, std::system_category());
-        case error::connection_refused:
-          return code == std::errc::connection_refused
-              || code == std::error_code(ECONNREFUSED, std::system_category());
-        case error::connection_reset:
-          return code == std::errc::connection_reset
-              || code == std::error_code(ECONNRESET, std::system_category());
-        case error::invalid_argument:
-          return code == std::errc::invalid_argument
-              || code == std::error_code(EINVAL, std::system_category());
-        case error::address_in_use:
-          return code == std::errc::address_in_use
-              || code == std::error_code(EADDRINUSE, std::system_category());
-        case error::broken_pipe:
-          return code == std::errc::broken_pipe
-              || code == std::error_code(EPIPE, std::system_category());
-        default:
-          return false;
       }
     }
   };

--- a/src/crimson/net/Errors.h
+++ b/src/crimson/net/Errors.h
@@ -25,13 +25,7 @@ enum class error {
   bad_peer_address,
   negotiation_failure,
   read_eof,
-  connection_aborted,
-  connection_refused,
-  connection_reset,
   corrupted_message,
-  invalid_argument,
-  address_in_use,
-  broken_pipe,
   protocol_aborted,
 };
 

--- a/src/crimson/net/Messenger.cc
+++ b/src/crimson/net/Messenger.cc
@@ -12,10 +12,15 @@ Messenger::create(const entity_name_t& name,
                   const uint64_t nonce,
                   const int master_sid)
 {
-  return create_sharded<SocketMessenger>(name, lname, nonce, master_sid)
-    .then([](Messenger *msgr) {
-      return msgr;
-    });
+  // enforce the messenger to a specific core (master_sid)
+  // TODO: drop the cross-core feature and cleanup the related interfaces in
+  // the future.
+  ceph_assert(master_sid >= 0);
+  return create_sharded<SocketMessenger>(
+      name, lname, nonce, static_cast<seastar::shard_id>(master_sid)
+  ).then([](Messenger *msgr) {
+    return msgr;
+  });
 }
 
 } // namespace crimson::net

--- a/src/crimson/net/Messenger.cc
+++ b/src/crimson/net/Messenger.cc
@@ -6,21 +6,12 @@
 
 namespace crimson::net {
 
-seastar::future<Messenger*>
+MessengerRef
 Messenger::create(const entity_name_t& name,
                   const std::string& lname,
-                  const uint64_t nonce,
-                  const int master_sid)
+                  const uint64_t nonce)
 {
-  // enforce the messenger to a specific core (master_sid)
-  // TODO: drop the cross-core feature and cleanup the related interfaces in
-  // the future.
-  ceph_assert(master_sid >= 0);
-  return create_sharded<SocketMessenger>(
-      name, lname, nonce, static_cast<seastar::shard_id>(master_sid)
-  ).then([](Messenger *msgr) {
-    return msgr;
-  });
+  return seastar::make_shared<SocketMessenger>(name, lname, nonce);
 }
 
 } // namespace crimson::net

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -76,7 +76,7 @@ public:
 
   /// either return an existing connection to the peer,
   /// or a new pending connection
-  virtual seastar::future<ConnectionXRef>
+  virtual seastar::future<ConnectionRef>
   connect(const entity_addr_t& peer_addr,
           const entity_type_t& peer_type) = 0;
 
@@ -106,11 +106,6 @@ public:
     auth_server = as;
   }
 
-  // get the local messenger shard if it is accessed by another core
-  virtual Messenger* get_local_shard() {
-    return this;
-  }
-
   virtual void print(ostream& out) const = 0;
 
   virtual SocketPolicy get_policy(entity_type_t peer_type) const = 0;
@@ -131,11 +126,10 @@ public:
   void set_require_authorizer(bool r) {
     require_authorizer = r;
   }
-  static seastar::future<Messenger*>
+  static MessengerRef
   create(const entity_name_t& name,
          const std::string& lname,
-         const uint64_t nonce,
-         const int master_sid=-1);
+         const uint64_t nonce);
 };
 
 inline ostream& operator<<(ostream& out, const Messenger& msgr) {

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -76,7 +76,7 @@ public:
 
   /// either return an existing connection to the peer,
   /// or a new pending connection
-  virtual seastar::future<ConnectionRef>
+  virtual ConnectionRef
   connect(const entity_addr_t& peer_addr,
           const entity_type_t& peer_type) = 0;
 

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -257,8 +257,8 @@ seastar::future<> Protocol::do_write_dispatch_sweep()
       ceph_assert(false);
     }
   }).handle_exception_type([this] (const std::system_error& e) {
-    if (e.code() != error::broken_pipe &&
-        e.code() != error::connection_reset &&
+    if (e.code() != std::errc::broken_pipe &&
+        e.code() != std::errc::connection_reset &&
         e.code() != error::negotiation_failure) {
       logger().error("{} write_event(): unexpected error at {} -- {}",
                      conn, get_state_name(write_state), e);

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -32,7 +32,7 @@ class Protocol {
   virtual void start_connect(const entity_addr_t& peer_addr,
                              const entity_type_t& peer_type) = 0;
 
-  virtual void start_accept(SocketFRef&& socket,
+  virtual void start_accept(SocketRef&& socket,
                             const entity_addr_t& peer_addr) = 0;
 
  protected:
@@ -58,7 +58,7 @@ class Protocol {
   Dispatcher &dispatcher;
   SocketConnection &conn;
 
-  SocketFRef socket;
+  SocketRef socket;
   seastar::gate pending_dispatch;
   AuthConnectionMetaRef auth_meta;
 

--- a/src/crimson/net/ProtocolV1.cc
+++ b/src/crimson/net/ProtocolV1.cc
@@ -324,7 +324,7 @@ void ProtocolV1::start_connect(const entity_addr_t& _peer_addr,
           socket = std::move(sock);
           if (state == state_t::closing) {
             return socket->close().then([] {
-              throw std::system_error(make_error_code(error::connection_aborted));
+              throw std::system_error(make_error_code(error::protocol_aborted));
             });
           }
           return seastar::now();
@@ -878,7 +878,7 @@ seastar::future<> ProtocolV1::handle_tags()
             return handle_keepalive2_ack();
           case CEPH_MSGR_TAG_CLOSE:
             logger().info("{} got tag close", conn);
-            throw std::system_error(make_error_code(error::connection_aborted));
+            throw std::system_error(make_error_code(error::protocol_aborted));
           default:
             logger().error("{} got unknown msgr tag {}",
                            conn, static_cast<int>(buf[0]));
@@ -899,8 +899,8 @@ void ProtocolV1::execute_open()
       return handle_tags()
         .handle_exception_type([this] (const std::system_error& e) {
           logger().warn("{} open fault: {}", conn, e);
-          if (e.code() == error::connection_aborted ||
-              e.code() == error::connection_reset) {
+          if (e.code() == error::protocol_aborted ||
+              e.code() == std::errc::connection_reset) {
             return dispatcher.ms_handle_reset(
                 seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()))
               .then([this] {

--- a/src/crimson/net/ProtocolV1.cc
+++ b/src/crimson/net/ProtocolV1.cc
@@ -320,7 +320,7 @@ void ProtocolV1::start_connect(const entity_addr_t& _peer_addr,
     seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()));
   (void) seastar::with_gate(pending_dispatch, [this] {
       return Socket::connect(conn.peer_addr)
-        .then([this](SocketFRef sock) {
+        .then([this](SocketRef sock) {
           socket = std::move(sock);
           if (state == state_t::closing) {
             return socket->close().then([] {
@@ -600,7 +600,7 @@ seastar::future<stop_t> ProtocolV1::repeat_handle_connect()
     });
 }
 
-void ProtocolV1::start_accept(SocketFRef&& sock,
+void ProtocolV1::start_accept(SocketRef&& sock,
                               const entity_addr_t& _peer_addr)
 {
   ceph_assert(state == state_t::none);

--- a/src/crimson/net/ProtocolV1.h
+++ b/src/crimson/net/ProtocolV1.h
@@ -21,7 +21,7 @@ class ProtocolV1 final : public Protocol {
   void start_connect(const entity_addr_t& peer_addr,
                      const entity_type_t& peer_type) override;
 
-  void start_accept(SocketFRef&& socket,
+  void start_accept(SocketRef&& socket,
                     const entity_addr_t& peer_addr) override;
 
   void trigger_close() override;

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -129,7 +129,7 @@ namespace crimson::net {
 
 #ifdef UNIT_TESTS_BUILT
 void intercept(Breakpoint bp, bp_type_t type,
-               SocketConnection& conn, SocketFRef& socket) {
+               SocketConnection& conn, SocketRef& socket) {
   if (conn.interceptor) {
     auto action = conn.interceptor->intercept(conn, Breakpoint(bp));
     socket->set_trap(type, action, &conn.interceptor->blocker);
@@ -203,7 +203,7 @@ void ProtocolV2::start_connect(const entity_addr_t& _peer_addr,
   execute_connecting();
 }
 
-void ProtocolV2::start_accept(SocketFRef&& sock,
+void ProtocolV2::start_accept(SocketRef&& sock,
                               const entity_addr_t& _peer_addr)
 {
   ceph_assert(state == state_t::NONE);
@@ -923,7 +923,7 @@ void ProtocolV2::execute_connecting()
           }
           INTERCEPT_N_RW(custom_bp_t::SOCKET_CONNECTING);
           return Socket::connect(conn.peer_addr);
-        }).then([this](SocketFRef sock) {
+        }).then([this](SocketRef sock) {
           logger().debug("{} socket connected", conn);
           if (unlikely(state != state_t::CONNECTING)) {
             logger().debug("{} triggered {} during Socket::connect()",
@@ -1739,7 +1739,7 @@ ProtocolV2::send_server_ident()
 
 void ProtocolV2::trigger_replacing(bool reconnect,
                                    bool do_reset,
-                                   SocketFRef&& new_socket,
+                                   SocketRef&& new_socket,
                                    AuthConnectionMetaRef&& new_auth_meta,
                                    ceph::crypto::onwire::rxtx_t new_rxtx,
                                    uint64_t new_peer_global_seq,

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -22,7 +22,7 @@ class ProtocolV2 final : public Protocol {
   void start_connect(const entity_addr_t& peer_addr,
                      const entity_type_t& peer_type) override;
 
-  void start_accept(SocketFRef&& socket,
+  void start_accept(SocketRef&& socket,
                     const entity_addr_t& peer_addr) override;
 
   void trigger_close() override;
@@ -182,7 +182,7 @@ class ProtocolV2 final : public Protocol {
   // REPLACING (server)
   void trigger_replacing(bool reconnect,
                          bool do_reset,
-                         SocketFRef&& new_socket,
+                         SocketRef&& new_socket,
                          AuthConnectionMetaRef&& new_auth_meta,
                          ceph::crypto::onwire::rxtx_t new_rxtx,
                          uint64_t new_peer_global_seq,

--- a/src/crimson/net/Socket.cc
+++ b/src/crimson/net/Socket.cc
@@ -115,8 +115,8 @@ static inline seastar::future<>
 close_and_handle_errors(seastar::output_stream<char>& out)
 {
   return out.close().handle_exception_type([] (const std::system_error& e) {
-    if (e.code() != error::broken_pipe &&
-        e.code() != error::connection_reset) {
+    if (e.code() != std::errc::broken_pipe &&
+        e.code() != std::errc::connection_reset) {
       logger().error("Socket::close(): unexpected error {}", e);
       ceph_abort();
     }

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -3,12 +3,16 @@
 
 #pragma once
 
+#include <seastar/core/gate.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/net/packet.hh>
 
 #include "include/buffer.h"
 #include "msg/msg_types.h"
+
+#include "crimson/common/log.h"
+#include "Errors.h"
 
 #ifdef UNIT_TESTS_BUILT
 #include "Interceptor.h"
@@ -17,7 +21,8 @@
 namespace crimson::net {
 
 class Socket;
-using SocketFRef = seastar::foreign_ptr<std::unique_ptr<Socket>>;
+using SocketRef = std::unique_ptr<Socket>;
+using SocketFRef = seastar::foreign_ptr<SocketRef>;
 
 class Socket
 {
@@ -137,6 +142,158 @@ class Socket
  public:
   void set_trap(bp_type_t type, bp_action_t action, socket_blocker* blocker_);
 #endif
+};
+
+class FixedCPUServerSocket
+    : public seastar::peering_sharded_service<FixedCPUServerSocket> {
+  const seastar::shard_id cpu;
+  entity_addr_t addr;
+  std::optional<seastar::server_socket> listener;
+  seastar::gate shutdown_gate;
+
+  using sharded_service_t = seastar::sharded<FixedCPUServerSocket>;
+  std::unique_ptr<sharded_service_t> service;
+
+  struct construct_tag {};
+
+  static seastar::logger& logger() {
+    return crimson::get_logger(ceph_subsys_ms);
+  }
+
+  seastar::future<> reset() {
+    return container().invoke_on_all([] (auto& ss) {
+      assert(ss.shutdown_gate.is_closed());
+      ss.shutdown_gate = seastar::gate();
+      ss.addr = entity_addr_t();
+      ss.listener.reset();
+    });
+  }
+
+public:
+  FixedCPUServerSocket(seastar::shard_id cpu, construct_tag) : cpu{cpu} {}
+  ~FixedCPUServerSocket() {
+    assert(!listener);
+    // detect whether user have called destroy() properly
+    ceph_assert(!service);
+  }
+
+  FixedCPUServerSocket(FixedCPUServerSocket&&) = delete;
+  FixedCPUServerSocket(const FixedCPUServerSocket&) = delete;
+  FixedCPUServerSocket& operator=(const FixedCPUServerSocket&) = delete;
+
+  seastar::future<> listen(entity_addr_t addr) {
+    assert(seastar::engine().cpu_id() == cpu);
+    logger().trace("FixedCPUServerSocket::listen({})...", addr);
+    return container().invoke_on_all([addr] (auto& ss) {
+      ss.addr = addr;
+      seastar::socket_address s_addr(addr.in4_addr());
+      seastar::listen_options lo;
+      lo.reuse_address = true;
+      lo.set_fixed_cpu(ss.cpu);
+      ss.listener = seastar::listen(s_addr, lo);
+    }).handle_exception_type([addr] (const std::system_error& e) {
+      if (e.code() == error::address_in_use) {
+        logger().trace("FixedCPUServerSocket::listen({}): address in use", addr);
+        throw;
+      } else {
+        logger().error("FixedCPUServerSocket::listen({}): "
+                       "got unexpeted error {}", addr, e);
+        ceph_abort();
+      }
+    });
+  }
+
+  // fn_accept should be a nothrow function of type
+  // seastar::future<>(SocketRef, entity_addr_t)
+  template <typename Func>
+  seastar::future<> accept(Func&& fn_accept) {
+    assert(seastar::engine().cpu_id() == cpu);
+    logger().trace("FixedCPUServerSocket({})::accept()...", addr);
+    return container().invoke_on_all(
+        [fn_accept = std::move(fn_accept)] (auto& ss) mutable {
+      assert(ss.listener);
+      // gate accepting
+      // FixedCPUServerSocket::shutdown() will drain the continuations in the gate
+      // so ignore the returned future
+      std::ignore = seastar::with_gate(ss.shutdown_gate,
+          [&ss, fn_accept = std::move(fn_accept)] () mutable {
+        return seastar::keep_doing([&ss, fn_accept = std::move(fn_accept)] () mutable {
+          return Socket::accept(*ss.listener
+          ).then([&ss, fn_accept = std::move(fn_accept)]
+                 (auto socket, entity_addr_t peer_addr) mutable {
+            // assert seastar::listen_options::set_fixed_cpu() works
+            assert(seastar::engine().cpu_id() == ss.cpu);
+            SocketRef _socket = socket.release();
+            std::ignore = seastar::with_gate(ss.shutdown_gate,
+                [socket = std::move(_socket), peer_addr,
+                 &ss, fn_accept = std::move(fn_accept)] () mutable {
+              logger().trace("FixedCPUServerSocket({})::accept(): "
+                             "accepted peer {}", ss.addr, peer_addr);
+              return fn_accept(std::move(socket), peer_addr
+              ).handle_exception([&ss, peer_addr] (auto eptr) {
+                logger().error("FixedCPUServerSocket({})::accept(): "
+                               "fn_accept(s, {}) got unexpected exception {}",
+                               ss.addr, peer_addr, eptr);
+                ceph_abort();
+              });
+            });
+          });
+        }).handle_exception_type([&ss] (const std::system_error& e) {
+          if (e.code() == error::connection_aborted ||
+              e.code() == error::invalid_argument) {
+            logger().trace("FixedCPUServerSocket({})::accept(): stopped ({})",
+                           ss.addr, e);
+          } else {
+            throw;
+          }
+        }).handle_exception([&ss] (auto eptr) {
+          logger().error("FixedCPUServerSocket({})::accept(): "
+                         "got unexpected exception {}", ss.addr, eptr);
+          ceph_abort();
+        });
+      });
+    });
+  }
+
+  seastar::future<> shutdown() {
+    assert(seastar::engine().cpu_id() == cpu);
+    logger().trace("FixedCPUServerSocket({})::shutdown()...", addr);
+    return container().invoke_on_all([] (auto& ss) {
+      if (ss.listener) {
+        ss.listener->abort_accept();
+      }
+      return ss.shutdown_gate.close();
+    }).then([this] {
+      return reset();
+    });
+  }
+
+  seastar::future<> destroy() {
+    assert(seastar::engine().cpu_id() == cpu);
+    return shutdown().then([this] {
+      // we should only construct/stop shards on #0
+      return container().invoke_on(0, [] (auto& ss) {
+        assert(ss.service);
+        return ss.service->stop().finally([cleanup = std::move(ss.service)] {});
+      });
+    });
+  }
+
+  static seastar::future<FixedCPUServerSocket*> create() {
+    auto cpu = seastar::engine().cpu_id();
+    // we should only construct/stop shards on #0
+    return seastar::smp::submit_to(0, [cpu] {
+      auto service = std::make_unique<sharded_service_t>();
+      return service->start(cpu, construct_tag{}
+      ).then([service = std::move(service)] () mutable {
+        auto p_shard = service.get();
+        p_shard->local().service = std::move(service);
+        return p_shard;
+      });
+    }).then([] (auto p_shard) {
+      return &p_shard->local();
+    });
+  }
 };
 
 } // namespace crimson::net

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -178,7 +178,7 @@ public:
       lo.set_fixed_cpu(ss.cpu);
       ss.listener = seastar::listen(s_addr, lo);
     }).handle_exception_type([addr] (const std::system_error& e) {
-      if (e.code() == error::address_in_use) {
+      if (e.code() == std::errc::address_in_use) {
         logger().trace("FixedCPUServerSocket::listen({}): address in use", addr);
         throw;
       } else {
@@ -230,8 +230,8 @@ public:
             });
           });
         }).handle_exception_type([&ss] (const std::system_error& e) {
-          if (e.code() == error::connection_aborted ||
-              e.code() == error::invalid_argument) {
+          if (e.code() == std::errc::connection_aborted ||
+              e.code() == std::errc::invalid_argument) {
             logger().trace("FixedCPUServerSocket({})::accept(): stopped ({})",
                            ss.addr, e);
           } else {

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -119,7 +119,7 @@ SocketConnection::start_connect(const entity_addr_t& _peer_addr,
 }
 
 void
-SocketConnection::start_accept(SocketFRef&& sock,
+SocketConnection::start_accept(SocketRef&& sock,
                                const entity_addr_t& _peer_addr)
 {
   protocol->start_accept(std::move(sock), _peer_addr);

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -30,7 +30,6 @@ SocketConnection::SocketConnection(SocketMessenger& messenger,
                                    bool is_msgr2)
   : messenger(messenger)
 {
-  ceph_assert(&messenger.container().local() == &messenger);
   if (is_msgr2) {
     protocol = std::make_unique<ProtocolV2>(dispatcher, *this, messenger);
   } else {
@@ -53,14 +52,14 @@ SocketConnection::get_messenger() const {
 
 bool SocketConnection::is_connected() const
 {
-  ceph_assert(seastar::engine().cpu_id() == shard_id());
+  assert(seastar::engine().cpu_id() == shard_id());
   return protocol->is_connected();
 }
 
 #ifdef UNIT_TESTS_BUILT
 bool SocketConnection::is_closed() const
 {
-  ceph_assert(seastar::engine().cpu_id() == shard_id());
+  assert(seastar::engine().cpu_id() == shard_id());
   return protocol->is_closed();
 }
 
@@ -72,23 +71,19 @@ bool SocketConnection::peer_wins() const
 
 seastar::future<> SocketConnection::send(MessageRef msg)
 {
-  // Cannot send msg from another core now, its ref counter can be contaminated!
-  ceph_assert(seastar::engine().cpu_id() == shard_id());
-  return seastar::smp::submit_to(shard_id(), [this, msg=std::move(msg)] {
-    return protocol->send(std::move(msg));
-  });
+  assert(seastar::engine().cpu_id() == shard_id());
+  return protocol->send(std::move(msg));
 }
 
 seastar::future<> SocketConnection::keepalive()
 {
-  return seastar::smp::submit_to(shard_id(), [this] {
-    return protocol->keepalive();
-  });
+  assert(seastar::engine().cpu_id() == shard_id());
+  return protocol->keepalive();
 }
 
 seastar::future<> SocketConnection::close()
 {
-  ceph_assert(seastar::engine().cpu_id() == shard_id());
+  assert(seastar::engine().cpu_id() == shard_id());
   return protocol->close();
 }
 

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -98,7 +98,7 @@ class SocketConnection : public Connection {
                      const entity_type_t& peer_type);
   /// start a handshake from the server's perspective,
   /// only call when SocketConnection first construct
-  void start_accept(SocketFRef&& socket,
+  void start_accept(SocketRef&& socket,
                     const entity_addr_t& peer_addr);
 
   bool is_server_side() const {

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -64,6 +64,8 @@ class SocketConnection : public Connection {
   // messages sent, but not yet acked by peer
   std::deque<MessageRef> sent;
 
+  seastar::shard_id shard_id() const;
+
  public:
   SocketConnection(SocketMessenger& messenger,
                    Dispatcher& dispatcher,
@@ -87,8 +89,6 @@ class SocketConnection : public Connection {
   seastar::future<> keepalive() override;
 
   seastar::future<> close() override;
-
-  seastar::shard_id shard_id() const override;
 
   void print(ostream& out) const override;
 

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -125,8 +125,7 @@ seastar::future<> SocketMessenger::start(Dispatcher *disp) {
       assert(seastar::engine().cpu_id() == master_sid);
       SocketConnectionRef conn = seastar::make_shared<SocketConnection>(
           *this, *dispatcher, get_myaddr().is_msgr2());
-      // TODO: use SocketRef
-      conn->start_accept(seastar::make_foreign(std::move(socket)), peer_addr);
+      conn->start_accept(std::move(socket), peer_addr);
       return seastar::now();
     });
   }

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -99,7 +99,7 @@ SocketMessenger::try_bind(const entity_addrvec_t& addrs,
         logger().info("{} try_bind: done", *this);
         return stop_t::yes;
       }).handle_exception_type([this, max_port, &port] (const std::system_error& e) {
-        assert(e.code() == error::address_in_use);
+        assert(e.code() == std::errc::address_in_use);
         logger().trace("{} try_bind: {} already used", *this, port);
         if (port == max_port) {
           throw;

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -131,7 +131,7 @@ seastar::future<> SocketMessenger::start(Dispatcher *disp) {
   return seastar::now();
 }
 
-seastar::future<crimson::net::ConnectionRef>
+crimson::net::ConnectionRef
 SocketMessenger::connect(const entity_addr_t& peer_addr, const entity_type_t& peer_type)
 {
   assert(seastar::engine().cpu_id() == master_sid);
@@ -141,12 +141,12 @@ SocketMessenger::connect(const entity_addr_t& peer_addr, const entity_type_t& pe
   ceph_assert(peer_addr.get_port() > 0);
 
   if (auto found = lookup_conn(peer_addr); found) {
-    return seastar::make_ready_future<ConnectionRef>(found->shared_from_this());
+    return found->shared_from_this();
   }
   SocketConnectionRef conn = seastar::make_shared<SocketConnection>(
       *this, *dispatcher, peer_addr.is_msgr2());
   conn->start_connect(peer_addr, peer_type);
-  return seastar::make_ready_future<ConnectionRef>(conn->shared_from_this());
+  return conn->shared_from_this();
 }
 
 seastar::future<> SocketMessenger::shutdown()

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -33,42 +33,50 @@ namespace crimson::net {
 SocketMessenger::SocketMessenger(const entity_name_t& myname,
                                  const std::string& logic_name,
                                  uint32_t nonce,
-                                 int master_sid)
+                                 seastar::shard_id master_sid)
   : Messenger{myname},
     master_sid{master_sid},
-    sid{seastar::engine().cpu_id()},
     logic_name{logic_name},
     nonce{nonce}
 {}
 
 seastar::future<> SocketMessenger::set_myaddrs(const entity_addrvec_t& addrs)
 {
+  assert(seastar::engine().cpu_id() == master_sid);
   auto my_addrs = addrs;
   for (auto& addr : my_addrs.v) {
     addr.nonce = nonce;
   }
-  return container().invoke_on_all([my_addrs](auto& msgr) {
-      return msgr.Messenger::set_myaddrs(my_addrs);
-    });
+  return Messenger::set_myaddrs(my_addrs);
+}
+
+seastar::future<> SocketMessenger::do_bind(const entity_addrvec_t& addrs)
+{
+  assert(seastar::engine().cpu_id() == master_sid);
+  ceph_assert(addrs.front().get_family() == AF_INET);
+  return set_myaddrs(addrs).then([this] {
+    if (!listener) {
+      return FixedCPUServerSocket::create().then([this] (auto _listener) {
+        listener = _listener;
+      });
+    } else {
+      return seastar::now();
+    }
+  }).then([this] {
+    auto listen_addr = get_myaddr();
+    logger().debug("{} do_bind: try listen {}...", *this, listen_addr.in4_addr());
+    if (!listener) {
+      logger().warn("{} do_bind: listener doesn't exist", *this);
+      return seastar::now();
+    }
+    return listener->listen(listen_addr);
+  });
 }
 
 seastar::future<> SocketMessenger::bind(const entity_addrvec_t& addrs)
 {
-  ceph_assert(addrs.front().get_family() == AF_INET);
-  auto my_addrs = addrs;
-  for (auto& addr : my_addrs.v) {
-    addr.nonce = nonce;
-  }
-  logger().info("{} listening on {}", *this, my_addrs.front().in4_addr());
-  return container().invoke_on_all([my_addrs](auto& msgr) {
-    msgr.do_bind(my_addrs);
-  }).handle_exception_type([this] (const std::system_error& e) {
-    if (e.code() == error::address_in_use) {
-      throw e;
-    } else {
-      logger().error("{} bind: unexpected error {}", *this, e);
-      ceph_abort();
-    }
+  return do_bind(addrs).then([this] {
+    logger().info("{} bind: done", *this);
   });
 }
 
@@ -78,221 +86,163 @@ SocketMessenger::try_bind(const entity_addrvec_t& addrs,
 {
   auto addr = addrs.front();
   if (addr.get_port() != 0) {
-    return bind(addrs);
+    return do_bind(addrs).then([this] {
+      logger().info("{} try_bind: done", *this);
+    });
   }
   ceph_assert(min_port <= max_port);
   return seastar::do_with(uint32_t(min_port),
-    [this, max_port, addr] (auto& port) {
-      return seastar::repeat([this, max_port, addr, &port] {
-          auto to_bind = addr;
-          to_bind.set_port(port);
-          return bind(entity_addrvec_t{to_bind})
-            .then([this] {
-              logger().info("{}: try_bind: done", *this);
-              return stop_t::yes;
-            }).handle_exception_type([this, max_port, &port] (const std::system_error& e) {
-              ceph_assert(e.code() == error::address_in_use);
-              logger().trace("{}: try_bind: {} already used", *this, port);
-              if (port == max_port) {
-                throw e;
-              }
-              ++port;
-              return stop_t::no;
-            });
-        });
+                          [this, max_port, addr] (auto& port) {
+    return seastar::repeat([this, max_port, addr, &port] {
+      auto to_bind = addr;
+      to_bind.set_port(port);
+      return do_bind(entity_addrvec_t{to_bind}).then([this] {
+        logger().info("{} try_bind: done", *this);
+        return stop_t::yes;
+      }).handle_exception_type([this, max_port, &port] (const std::system_error& e) {
+        assert(e.code() == error::address_in_use);
+        logger().trace("{} try_bind: {} already used", *this, port);
+        if (port == max_port) {
+          throw;
+        }
+        ++port;
+        return stop_t::no;
+      });
     });
+  });
 }
 
 seastar::future<> SocketMessenger::start(Dispatcher *disp) {
-  return container().invoke_on_all([disp](auto& msgr) {
-      return msgr.do_start(disp->get_local_shard());
-    });
-}
+  assert(seastar::engine().cpu_id() == master_sid);
 
-seastar::future<crimson::net::ConnectionXRef>
-SocketMessenger::connect(const entity_addr_t& peer_addr, const entity_type_t& peer_type)
-{
-  // make sure we connect to a valid peer_addr
-  ceph_assert(peer_addr.is_legacy() || peer_addr.is_msgr2());
-  ceph_assert(peer_addr.get_port() > 0);
-
-  auto shard = locate_shard(peer_addr);
-  return container().invoke_on(shard, [peer_addr, peer_type](auto& msgr) {
-      return msgr.do_connect(peer_addr, peer_type);
-    }).then([](seastar::foreign_ptr<ConnectionRef>&& conn) {
-      return seastar::make_lw_shared<seastar::foreign_ptr<ConnectionRef>>(std::move(conn));
-    });
-}
-
-seastar::future<> SocketMessenger::stop()
-{
-  return do_shutdown();
-}
-
-seastar::future<> SocketMessenger::shutdown()
-{
-  return container().invoke_on_all([](auto& msgr) {
-      return msgr.do_shutdown();
-    }).finally([this] {
-      return container().invoke_on_all([](auto& msgr) {
-          msgr.shutdown_promise.set_value();
-        });
-    });
-}
-
-void SocketMessenger::do_bind(const entity_addrvec_t& addrs)
-{
-  // safe to discard an immediate ready future
-  (void) Messenger::set_myaddrs(addrs);
-
-  // TODO: v2: listen on multiple addresses
-  seastar::socket_address address(addrs.front().in4_addr());
-  seastar::listen_options lo;
-  lo.reuse_address = true;
-  listener = seastar::listen(address, lo);
-}
-
-seastar::future<> SocketMessenger::do_start(Dispatcher *disp)
-{
-  dispatcher = disp;
-  started = true;
-
-  // start listening if bind() was called
+  dispatcher = disp->get_local_shard();
   if (listener) {
     // make sure we have already bound to a valid address
     ceph_assert(get_myaddr().is_legacy() || get_myaddr().is_msgr2());
     ceph_assert(get_myaddr().get_port() > 0);
 
-    // forwarded to accepting_complete
-    (void) seastar::keep_doing([this] {
-        return Socket::accept(*listener)
-          .then([this] (SocketFRef socket,
-                        entity_addr_t peer_addr) {
-            auto shard = locate_shard(peer_addr);
-#warning fixme
-            // we currently do dangerous i/o from a Connection core, different from the Socket core.
-            return container().invoke_on(shard,
-              [sock = std::move(socket), peer_addr, this](auto& msgr) mutable {
-                SocketConnectionRef conn = seastar::make_shared<SocketConnection>(
-                    msgr, *msgr.dispatcher, get_myaddr().is_msgr2());
-                conn->start_accept(std::move(sock), peer_addr);
-              });
-          });
-      }).handle_exception_type([this] (const std::system_error& e) {
-        // stop gracefully on connection_aborted and invalid_argument
-        if (e.code() != error::connection_aborted &&
-            e.code() != error::invalid_argument) {
-          logger().error("{} unexpected error during accept: {}", *this, e);
-          ceph_abort();
-        }
-      }).handle_exception([this] (auto eptr) {
-        logger().error("{} unexpected exception during accept: {}", *this, eptr);
-        ceph_abort();
-      }).then([this] () { return accepting_complete.set_value(); });
-  } else {
-    accepting_complete.set_value();
+    return listener->accept([this] (SocketRef socket, entity_addr_t peer_addr) {
+      assert(seastar::engine().cpu_id() == master_sid);
+      SocketConnectionRef conn = seastar::make_shared<SocketConnection>(
+          *this, *dispatcher, get_myaddr().is_msgr2());
+      // TODO: use SocketRef
+      conn->start_accept(seastar::make_foreign(std::move(socket)), peer_addr);
+      return seastar::now();
+    });
   }
   return seastar::now();
 }
 
-seastar::foreign_ptr<crimson::net::ConnectionRef>
-SocketMessenger::do_connect(const entity_addr_t& peer_addr, const entity_type_t& peer_type)
+seastar::future<crimson::net::ConnectionXRef>
+SocketMessenger::connect(const entity_addr_t& peer_addr, const entity_type_t& peer_type)
 {
+  assert(seastar::engine().cpu_id() == master_sid);
+
+  // make sure we connect to a valid peer_addr
+  ceph_assert(peer_addr.is_legacy() || peer_addr.is_msgr2());
+  ceph_assert(peer_addr.get_port() > 0);
+
+  // TODO: use ConnectionRef
   if (auto found = lookup_conn(peer_addr); found) {
-    return seastar::make_foreign(found->shared_from_this());
+    return seastar::make_ready_future<ConnectionXRef>(
+      seastar::make_lw_shared<seastar::foreign_ptr<ConnectionRef>>(
+        seastar::make_foreign(found->shared_from_this())));
   }
   SocketConnectionRef conn = seastar::make_shared<SocketConnection>(
       *this, *dispatcher, peer_addr.is_msgr2());
   conn->start_connect(peer_addr, peer_type);
-  return seastar::make_foreign(conn->shared_from_this());
+  return seastar::make_ready_future<ConnectionXRef>(
+    seastar::make_lw_shared<seastar::foreign_ptr<ConnectionRef>>(
+      seastar::make_foreign(conn->shared_from_this())));
 }
 
-seastar::future<> SocketMessenger::do_shutdown()
+seastar::future<> SocketMessenger::shutdown()
 {
-  if (!started) {
-    return seastar::now();
-  }
-
-  if (listener) {
-    listener->abort_accept();
-  }
+  assert(seastar::engine().cpu_id() == master_sid);
+  return seastar::futurize_apply([this] {
+    if (listener) {
+      auto d_listener = listener;
+      listener = nullptr;
+      return d_listener->destroy();
+    } else {
+      return seastar::now();
+    }
   // close all connections
-  return seastar::parallel_for_each(accepting_conns, [] (auto conn) {
+  }).then([this] {
+    return seastar::parallel_for_each(accepting_conns, [] (auto conn) {
       return conn->close();
-    }).then([this] {
-      ceph_assert(accepting_conns.empty());
-      return seastar::parallel_for_each(connections, [] (auto conn) {
-          return conn.second->close();
-        });
-    }).then([this] {
-      return accepting_complete.get_shared_future();
-    }).finally([this] {
-      ceph_assert(connections.empty());
     });
+  }).then([this] {
+    ceph_assert(accepting_conns.empty());
+    return seastar::parallel_for_each(connections, [] (auto conn) {
+      return conn.second->close();
+    });
+  }).then([this] {
+    ceph_assert(connections.empty());
+    shutdown_promise.set_value();
+  });
 }
 
 seastar::future<> SocketMessenger::learned_addr(const entity_addr_t &peer_addr_for_me, const SocketConnection& conn)
 {
-  // make sure we there's no racing to learn address from peer
-  return container().invoke_on(0, [peer_addr_for_me, &conn] (auto& msgr) {
-    if (!msgr.need_addr) {
-      if ((!msgr.get_myaddr().is_any() &&
-           msgr.get_myaddr().get_type() != peer_addr_for_me.get_type()) ||
-          msgr.get_myaddr().get_family() != peer_addr_for_me.get_family() ||
-          !msgr.get_myaddr().is_same_host(peer_addr_for_me)) {
-        logger().warn("{} peer_addr_for_me {} type/family/IP doesn't match myaddr {}",
-                      conn, peer_addr_for_me, msgr.get_myaddr());
-        throw std::system_error(
-            make_error_code(crimson::net::error::bad_peer_address));
-      }
+  assert(seastar::engine().cpu_id() == master_sid);
+  if (!need_addr) {
+    if ((!get_myaddr().is_any() &&
+         get_myaddr().get_type() != peer_addr_for_me.get_type()) ||
+        get_myaddr().get_family() != peer_addr_for_me.get_family() ||
+        !get_myaddr().is_same_host(peer_addr_for_me)) {
+      logger().warn("{} peer_addr_for_me {} type/family/IP doesn't match myaddr {}",
+                    conn, peer_addr_for_me, get_myaddr());
+      throw std::system_error(
+          make_error_code(crimson::net::error::bad_peer_address));
+    }
+    return seastar::now();
+  }
+  need_addr = false;
+
+  if (get_myaddr().get_type() == entity_addr_t::TYPE_NONE) {
+    // Not bound
+    entity_addr_t addr = peer_addr_for_me;
+    addr.set_type(entity_addr_t::TYPE_ANY);
+    addr.set_port(0);
+    return set_myaddrs(entity_addrvec_t{addr}
+    ).then([this, &conn, peer_addr_for_me] {
+      logger().info("{} learned myaddr={} (unbound) from {}",
+                    conn, get_myaddr(), peer_addr_for_me);
+    });
+  } else {
+    // Already bound
+    if (!get_myaddr().is_any() &&
+        get_myaddr().get_type() != peer_addr_for_me.get_type()) {
+      logger().warn("{} peer_addr_for_me {} type doesn't match myaddr {}",
+                    conn, peer_addr_for_me, get_myaddr());
+      throw std::system_error(
+          make_error_code(crimson::net::error::bad_peer_address));
+    }
+    if (get_myaddr().get_family() != peer_addr_for_me.get_family()) {
+      logger().warn("{} peer_addr_for_me {} family doesn't match myaddr {}",
+                    conn, peer_addr_for_me, get_myaddr());
+      throw std::system_error(
+          make_error_code(crimson::net::error::bad_peer_address));
+    }
+    if (get_myaddr().is_blank_ip()) {
+      entity_addr_t addr = peer_addr_for_me;
+      addr.set_type(get_myaddr().get_type());
+      addr.set_port(get_myaddr().get_port());
+      return set_myaddrs(entity_addrvec_t{addr}
+      ).then([this, &conn, peer_addr_for_me] {
+        logger().info("{} learned myaddr={} (blank IP) from {}",
+                      conn, get_myaddr(), peer_addr_for_me);
+      });
+    } else if (!get_myaddr().is_same_host(peer_addr_for_me)) {
+      logger().warn("{} peer_addr_for_me {} IP doesn't match myaddr {}",
+                    conn, peer_addr_for_me, get_myaddr());
+      throw std::system_error(
+          make_error_code(crimson::net::error::bad_peer_address));
+    } else {
       return seastar::now();
     }
-    msgr.need_addr = false;
-
-    if (msgr.get_myaddr().get_type() == entity_addr_t::TYPE_NONE) {
-      // Not bound
-      entity_addr_t addr = peer_addr_for_me;
-      addr.set_type(entity_addr_t::TYPE_ANY);
-      addr.set_port(0);
-      return msgr.set_myaddrs(entity_addrvec_t{addr}
-      ).then([&msgr, &conn, peer_addr_for_me] {
-        logger().info("{} learned myaddr={} (unbound) from {}",
-                      conn, msgr.get_myaddr(), peer_addr_for_me);
-      });
-    } else {
-      // Already bound
-      if (!msgr.get_myaddr().is_any() &&
-          msgr.get_myaddr().get_type() != peer_addr_for_me.get_type()) {
-        logger().warn("{} peer_addr_for_me {} type doesn't match myaddr {}",
-                      conn, peer_addr_for_me, msgr.get_myaddr());
-        throw std::system_error(
-            make_error_code(crimson::net::error::bad_peer_address));
-      }
-      if (msgr.get_myaddr().get_family() != peer_addr_for_me.get_family()) {
-        logger().warn("{} peer_addr_for_me {} family doesn't match myaddr {}",
-                      conn, peer_addr_for_me, msgr.get_myaddr());
-        throw std::system_error(
-            make_error_code(crimson::net::error::bad_peer_address));
-      }
-      if (msgr.get_myaddr().is_blank_ip()) {
-        entity_addr_t addr = peer_addr_for_me;
-        addr.set_type(msgr.get_myaddr().get_type());
-        addr.set_port(msgr.get_myaddr().get_port());
-        return msgr.set_myaddrs(entity_addrvec_t{addr}
-        ).then([&msgr, &conn, peer_addr_for_me] {
-          logger().info("{} learned myaddr={} (blank IP) from {}",
-                        conn, msgr.get_myaddr(), peer_addr_for_me);
-        });
-      } else if (!msgr.get_myaddr().is_same_host(peer_addr_for_me)) {
-        logger().warn("{} peer_addr_for_me {} IP doesn't match myaddr {}",
-                      conn, peer_addr_for_me, msgr.get_myaddr());
-        throw std::system_error(
-            make_error_code(crimson::net::error::bad_peer_address));
-      } else {
-        return seastar::now();
-      }
-    }
-  });
+  }
 }
 
 SocketPolicy SocketMessenger::get_policy(entity_type_t peer_type) const
@@ -323,19 +273,6 @@ void SocketMessenger::set_policy_throttler(entity_type_t peer_type,
   policy_set.set_throttlers(peer_type, throttle, nullptr);
 }
 
-seastar::shard_id SocketMessenger::locate_shard(const entity_addr_t& addr)
-{
-  ceph_assert(addr.get_family() == AF_INET);
-  if (master_sid >= 0) {
-    return master_sid;
-  }
-  std::size_t seed = 0;
-  boost::hash_combine(seed, addr.u.sin.sin_addr.s_addr);
-  //boost::hash_combine(seed, addr.u.sin.sin_port);
-  //boost::hash_combine(seed, addr.nonce);
-  return seed % seastar::smp::count;
-}
-
 crimson::net::SocketConnectionRef SocketMessenger::lookup_conn(const entity_addr_t& addr)
 {
   if (auto found = connections.find(addr);
@@ -358,9 +295,6 @@ void SocketMessenger::unaccept_conn(SocketConnectionRef conn)
 
 void SocketMessenger::register_conn(SocketConnectionRef conn)
 {
-  if (master_sid >= 0) {
-    ceph_assert(static_cast<int>(sid) == master_sid);
-  }
   auto [i, added] = connections.emplace(conn->get_peer_addr(), conn);
   std::ignore = i;
   ceph_assert(added);
@@ -378,12 +312,10 @@ void SocketMessenger::unregister_conn(SocketConnectionRef conn)
 seastar::future<uint32_t>
 SocketMessenger::get_global_seq(uint32_t old)
 {
-  return container().invoke_on(0, [old] (auto& msgr) {
-    if (old > msgr.global_seq) {
-      msgr.global_seq = old;
-    }
-    return ++msgr.global_seq;
-  });
+  if (old > global_seq) {
+    global_seq = old;
+  }
+  return seastar::make_ready_future<uint32_t>(++global_seq);
 }
 
 } // namespace crimson::net

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -29,7 +29,7 @@ namespace crimson::net {
 
 class FixedCPUServerSocket;
 
-class SocketMessenger final : public Messenger, public seastar::peering_sharded_service<SocketMessenger> {
+class SocketMessenger final : public Messenger {
   const seastar::shard_id master_sid;
   seastar::promise<> shutdown_promise;
 
@@ -51,8 +51,7 @@ class SocketMessenger final : public Messenger, public seastar::peering_sharded_
  public:
   SocketMessenger(const entity_name_t& myname,
                   const std::string& logic_name,
-                  uint32_t nonce,
-                  seastar::shard_id master_sid);
+                  uint32_t nonce);
   ~SocketMessenger() override { ceph_assert(!listener); }
 
   seastar::future<> set_myaddrs(const entity_addrvec_t& addr) override;
@@ -66,8 +65,8 @@ class SocketMessenger final : public Messenger, public seastar::peering_sharded_
 
   seastar::future<> start(Dispatcher *dispatcher) override;
 
-  seastar::future<ConnectionXRef> connect(const entity_addr_t& peer_addr,
-                                          const entity_type_t& peer_type) override;
+  seastar::future<ConnectionRef> connect(const entity_addr_t& peer_addr,
+                                         const entity_type_t& peer_type) override;
   // can only wait once
   seastar::future<> wait() override {
     assert(seastar::engine().cpu_id() == master_sid);
@@ -75,10 +74,6 @@ class SocketMessenger final : public Messenger, public seastar::peering_sharded_
   }
 
   seastar::future<> shutdown() override;
-
-  Messenger* get_local_shard() override {
-    return &container().local();
-  }
 
   void print(ostream& out) const override {
     out << get_myname()

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -27,12 +27,13 @@
 
 namespace crimson::net {
 
+class FixedCPUServerSocket;
+
 class SocketMessenger final : public Messenger, public seastar::peering_sharded_service<SocketMessenger> {
-  const int master_sid;
-  const seastar::shard_id sid;
+  const seastar::shard_id master_sid;
   seastar::promise<> shutdown_promise;
 
-  std::optional<seastar::server_socket> listener;
+  FixedCPUServerSocket* listener = nullptr;
   Dispatcher *dispatcher = nullptr;
   std::map<entity_addr_t, SocketConnectionRef> connections;
   std::set<SocketConnectionRef> accepting_conns;
@@ -43,30 +44,16 @@ class SocketMessenger final : public Messenger, public seastar::peering_sharded_
   // specifying we haven't learned our addr; set false when we find it.
   bool need_addr = true;
   uint32_t global_seq = 0;
-
-  seastar::future<> accept(seastar::connected_socket socket,
-                           seastar::socket_address paddr);
-
-  void do_bind(const entity_addrvec_t& addr);
-
   bool started = false;
-  seastar::shared_promise<> accepting_complete;
-  seastar::future<> do_start(Dispatcher *disp);
-  seastar::foreign_ptr<ConnectionRef> do_connect(const entity_addr_t& peer_addr,
-                                                 const entity_type_t& peer_type);
-  seastar::future<> do_shutdown();
-  // conn sharding options:
-  // 0. Compatible (master_sid >= 0): place all connections to one master shard
-  // 1. Simplest (master_sid < 0): sharded by ip only
-  // 2. Balanced (not implemented): sharded by ip + port + nonce,
-  //        but, need to move SocketConnection between cores.
-  seastar::shard_id locate_shard(const entity_addr_t& addr);
+
+  seastar::future<> do_bind(const entity_addrvec_t& addr);
 
  public:
   SocketMessenger(const entity_name_t& myname,
                   const std::string& logic_name,
                   uint32_t nonce,
-                  int master_sid);
+                  seastar::shard_id master_sid);
+  ~SocketMessenger() override { ceph_assert(!listener); }
 
   seastar::future<> set_myaddrs(const entity_addrvec_t& addr) override;
 
@@ -83,6 +70,7 @@ class SocketMessenger final : public Messenger, public seastar::peering_sharded_
                                           const entity_type_t& peer_type) override;
   // can only wait once
   seastar::future<> wait() override {
+    assert(seastar::engine().cpu_id() == master_sid);
     return shutdown_promise.get_future();
   }
 
@@ -118,12 +106,9 @@ class SocketMessenger final : public Messenger, public seastar::peering_sharded_
   void unaccept_conn(SocketConnectionRef);
   void register_conn(SocketConnectionRef);
   void unregister_conn(SocketConnectionRef);
-
-  // required by sharded<>
-  seastar::future<> stop();
-
   seastar::shard_id shard_id() const {
-    return sid;
+    assert(seastar::engine().cpu_id() == master_sid);
+    return master_sid;
   }
 };
 

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -65,8 +65,8 @@ class SocketMessenger final : public Messenger {
 
   seastar::future<> start(Dispatcher *dispatcher) override;
 
-  seastar::future<ConnectionRef> connect(const entity_addr_t& peer_addr,
-                                         const entity_type_t& peer_type) override;
+  ConnectionRef connect(const entity_addr_t& peer_addr,
+                        const entity_type_t& peer_type) override;
   // can only wait once
   seastar::future<> wait() override {
     assert(seastar::engine().cpu_id() == master_sid);

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -71,7 +71,8 @@ Heartbeat::start_messenger(crimson::net::Messenger& msgr,
 
 seastar::future<> Heartbeat::stop()
 {
-  return seastar::now();
+  return seastar::when_all_succeed(front_msgr.shutdown(),
+                                   back_msgr.shutdown());
 }
 
 const entity_addrvec_t& Heartbeat::get_front_addrs() const

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -93,7 +93,7 @@ void Heartbeat::set_require_authorizer(bool require_authorizer)
   }
 }
 
-seastar::future<> Heartbeat::add_peer(osd_id_t peer, epoch_t epoch)
+void Heartbeat::add_peer(osd_id_t peer, epoch_t epoch)
 {
   auto [peer_info, added] = peers.try_emplace(peer);
   auto& info = peer_info->second;
@@ -102,17 +102,10 @@ seastar::future<> Heartbeat::add_peer(osd_id_t peer, epoch_t epoch)
     logger().info("add_peer({})", peer);
     auto osdmap = service.get_osdmap_service().get_map();
     // TODO: use addrs
-    return seastar::when_all_succeed(
-        front_msgr->connect(osdmap->get_hb_front_addrs(peer).front(),
-                            CEPH_ENTITY_TYPE_OSD),
-        back_msgr->connect(osdmap->get_hb_back_addrs(peer).front(),
-                           CEPH_ENTITY_TYPE_OSD))
-      .then([&info=peer_info->second] (auto con_front, auto con_back) {
-        info.con_front = con_front;
-        info.con_back = con_back;
-      });
-  } else {
-    return seastar::now();
+    peer_info->second.con_front = front_msgr->connect(
+        osdmap->get_hb_front_addrs(peer).front(), CEPH_ENTITY_TYPE_OSD);
+    peer_info->second.con_back = back_msgr->connect(
+        osdmap->get_hb_back_addrs(peer).front(), CEPH_ENTITY_TYPE_OSD);
   }
 }
 
@@ -143,7 +136,7 @@ seastar::future<Heartbeat::osds_t> Heartbeat::remove_down_peers()
     });
 }
 
-seastar::future<> Heartbeat::add_reporter_peers(int whoami)
+void Heartbeat::add_reporter_peers(int whoami)
 {
   auto osdmap = service.get_osdmap_service().get_map();
   // include next and previous up osds to ensure we have a fully-connected set
@@ -160,20 +153,18 @@ seastar::future<> Heartbeat::add_reporter_peers(int whoami)
   auto subtree = local_conf().get_val<string>("mon_osd_reporter_subtree_level");
   osdmap->get_random_up_osds_by_subtree(
     whoami, subtree, min_down, want, &want);
-  return seastar::parallel_for_each(
-    std::move(want),
-    [epoch=osdmap->get_epoch(), this](int osd) {
-      return add_peer(osd, epoch);
-  });
+  auto epoch = osdmap->get_epoch();
+  for (int osd : want) {
+    add_peer(osd, epoch);
+  };
 }
 
 seastar::future<> Heartbeat::update_peers(int whoami)
 {
   const auto min_peers = static_cast<size_t>(
     local_conf().get_val<int64_t>("osd_heartbeat_min_peers"));
-  return add_reporter_peers(whoami).then([this] {
-    return remove_down_peers();
-  }).then([=](osds_t&& extra) {
+  add_reporter_peers(whoami);
+  return remove_down_peers().then([=](osds_t&& extra) {
     // too many?
     struct iteration_state {
       osds_t::const_iterator where;
@@ -197,11 +188,10 @@ seastar::future<> Heartbeat::update_peers(int whoami)
       next = osdmap->get_next_up_osd_after(next)) {
       want.push_back(next);
     }
-    return seastar::parallel_for_each(
-      std::move(want),
-      [epoch=osdmap->get_epoch(), this](int osd) {
-        return add_peer(osd, epoch);
-    });
+    auto epoch = osdmap->get_epoch();
+    for (int osd : want) {
+      add_peer(osd, epoch);
+    }
   });
 }
 
@@ -242,7 +232,7 @@ seastar::future<> Heartbeat::ms_handle_reset(crimson::net::ConnectionRef conn)
   const auto peer = found->first;
   const auto epoch = found->second.epoch;
   return remove_peer(peer).then([peer, epoch, this] {
-    return add_peer(peer, epoch);
+    add_peer(peer, epoch);
   });
 }
 

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -27,8 +27,8 @@ public:
 
   Heartbeat(const crimson::osd::ShardServices& service,
 	    crimson::mon::Client& monc,
-	    crimson::net::Messenger& front_msgr,
-	    crimson::net::Messenger& back_msgr);
+	    crimson::net::MessengerRef front_msgr,
+	    crimson::net::MessengerRef back_msgr);
 
   seastar::future<> start(entity_addrvec_t front,
 			  entity_addrvec_t back);
@@ -74,8 +74,8 @@ private:
 private:
   const crimson::osd::ShardServices& service;
   crimson::mon::Client& monc;
-  crimson::net::Messenger& front_msgr;
-  crimson::net::Messenger& back_msgr;
+  crimson::net::MessengerRef front_msgr;
+  crimson::net::MessengerRef back_msgr;
 
   seastar::timer<seastar::lowres_clock> timer;
   // use real_clock so it can be converted to utime_t

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -34,7 +34,7 @@ public:
 			  entity_addrvec_t back);
   seastar::future<> stop();
 
-  seastar::future<> add_peer(osd_id_t peer, epoch_t epoch);
+  void add_peer(osd_id_t peer, epoch_t epoch);
   seastar::future<> update_peers(int whoami);
   seastar::future<> remove_peer(osd_id_t peer);
 
@@ -67,7 +67,7 @@ private:
   /// @return peers not needed in this epoch
   seastar::future<osds_t> remove_down_peers();
   /// add enough reporters for fast failure detection
-  seastar::future<> add_reporter_peers(int whoami);
+  void add_reporter_peers(int whoami);
 
   seastar::future<> start_messenger(crimson::net::Messenger& msgr,
 				    const entity_addrvec_t& addrs);

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -401,6 +401,10 @@ seastar::future<> OSD::stop()
   }).then([this] {
     return monc->stop();
   }).then([this] {
+    return when_all_succeed(
+      public_msgr.shutdown(),
+      cluster_msgr.shutdown());
+  }).then([this] {
     return store->umount();
   }).handle_exception([](auto ep) {
     logger().error("error while stopping osd: {}", ep);

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -54,22 +54,22 @@ using crimson::os::FuturizedStore;
 namespace crimson::osd {
 
 OSD::OSD(int id, uint32_t nonce,
-         crimson::net::Messenger& cluster_msgr,
-         crimson::net::Messenger& public_msgr,
-         crimson::net::Messenger& hb_front_msgr,
-         crimson::net::Messenger& hb_back_msgr)
+         crimson::net::MessengerRef cluster_msgr,
+         crimson::net::MessengerRef public_msgr,
+         crimson::net::MessengerRef hb_front_msgr,
+         crimson::net::MessengerRef hb_back_msgr)
   : whoami{id},
     nonce{nonce},
     // do this in background
     beacon_timer{[this] { (void)send_beacon(); }},
     cluster_msgr{cluster_msgr},
     public_msgr{public_msgr},
-    monc{new crimson::mon::Client{public_msgr, *this}},
-    mgrc{new crimson::mgr::Client{public_msgr, *this}},
+    monc{new crimson::mon::Client{*public_msgr, *this}},
+    mgrc{new crimson::mgr::Client{*public_msgr, *this}},
     store{crimson::os::FuturizedStore::create(
       local_conf().get_val<std::string>("osd_objectstore"),
       local_conf().get_val<std::string>("osd_data"))},
-    shard_services{*this, cluster_msgr, public_msgr, *monc, *mgrc, *store},
+    shard_services{*this, *cluster_msgr, *public_msgr, *monc, *mgrc, *store},
     heartbeat{new Heartbeat{shard_services, *monc, hb_front_msgr, hb_back_msgr}},
     // do this in background
     heartbeat_timer{[this] { (void)update_heartbeat_peers(); }},
@@ -78,8 +78,8 @@ OSD::OSD(int id, uint32_t nonce,
   osdmaps[0] = boost::make_local_shared<OSDMap>();
   for (auto msgr : {std::ref(cluster_msgr), std::ref(public_msgr),
                     std::ref(hb_front_msgr), std::ref(hb_back_msgr)}) {
-    msgr.get().set_auth_server(monc.get());
-    msgr.get().set_auth_client(monc.get());
+    msgr.get()->set_auth_server(monc.get());
+    msgr.get()->set_auth_client(monc.get());
   }
 
   if (local_conf()->osd_open_classes_on_start) {
@@ -224,34 +224,34 @@ seastar::future<> OSD::start()
       CEPH_FEATURE_OSDENC;
     using crimson::net::SocketPolicy;
 
-    public_msgr.set_default_policy(SocketPolicy::stateless_server(0));
-    public_msgr.set_policy(entity_name_t::TYPE_MON,
-                           SocketPolicy::lossy_client(osd_required));
-    public_msgr.set_policy(entity_name_t::TYPE_MGR,
-                           SocketPolicy::lossy_client(osd_required));
-    public_msgr.set_policy(entity_name_t::TYPE_OSD,
-                           SocketPolicy::stateless_server(0));
-
-    cluster_msgr.set_default_policy(SocketPolicy::stateless_server(0));
-    cluster_msgr.set_policy(entity_name_t::TYPE_MON,
-                            SocketPolicy::lossy_client(0));
-    cluster_msgr.set_policy(entity_name_t::TYPE_OSD,
-                            SocketPolicy::lossless_peer(osd_required));
-    cluster_msgr.set_policy(entity_name_t::TYPE_CLIENT,
+    public_msgr->set_default_policy(SocketPolicy::stateless_server(0));
+    public_msgr->set_policy(entity_name_t::TYPE_MON,
+                            SocketPolicy::lossy_client(osd_required));
+    public_msgr->set_policy(entity_name_t::TYPE_MGR,
+                            SocketPolicy::lossy_client(osd_required));
+    public_msgr->set_policy(entity_name_t::TYPE_OSD,
                             SocketPolicy::stateless_server(0));
+
+    cluster_msgr->set_default_policy(SocketPolicy::stateless_server(0));
+    cluster_msgr->set_policy(entity_name_t::TYPE_MON,
+                             SocketPolicy::lossy_client(0));
+    cluster_msgr->set_policy(entity_name_t::TYPE_OSD,
+                             SocketPolicy::lossless_peer(osd_required));
+    cluster_msgr->set_policy(entity_name_t::TYPE_CLIENT,
+                             SocketPolicy::stateless_server(0));
 
     dispatchers.push_front(this);
     dispatchers.push_front(monc.get());
     dispatchers.push_front(mgrc.get());
     return seastar::when_all_succeed(
-      cluster_msgr.try_bind(pick_addresses(CEPH_PICK_ADDRESS_CLUSTER),
+      cluster_msgr->try_bind(pick_addresses(CEPH_PICK_ADDRESS_CLUSTER),
+                             local_conf()->ms_bind_port_min,
+                             local_conf()->ms_bind_port_max)
+        .then([this] { return cluster_msgr->start(&dispatchers); }),
+      public_msgr->try_bind(pick_addresses(CEPH_PICK_ADDRESS_PUBLIC),
                             local_conf()->ms_bind_port_min,
                             local_conf()->ms_bind_port_max)
-        .then([this] { return cluster_msgr.start(&dispatchers); }),
-      public_msgr.try_bind(pick_addresses(CEPH_PICK_ADDRESS_PUBLIC),
-                           local_conf()->ms_bind_port_min,
-                           local_conf()->ms_bind_port_max)
-        .then([this] { return public_msgr.start(&dispatchers); }));
+        .then([this] { return public_msgr->start(&dispatchers); }));
   }).then([this] {
     return seastar::when_all_succeed(monc->start(),
                                      mgrc->start());
@@ -264,15 +264,15 @@ seastar::future<> OSD::start()
     return monc->renew_subs();
   }).then([this] {
     if (auto [addrs, changed] =
-        replace_unknown_addrs(cluster_msgr.get_myaddrs(),
-                              public_msgr.get_myaddrs()); changed) {
-      return cluster_msgr.set_myaddrs(addrs);
+        replace_unknown_addrs(cluster_msgr->get_myaddrs(),
+                              public_msgr->get_myaddrs()); changed) {
+      return cluster_msgr->set_myaddrs(addrs);
     } else {
       return seastar::now();
     }
   }).then([this] {
-    return heartbeat->start(public_msgr.get_myaddrs(),
-                            cluster_msgr.get_myaddrs());
+    return heartbeat->start(public_msgr->get_myaddrs(),
+                            cluster_msgr->get_myaddrs());
   }).then([this] {
     return start_boot();
   });
@@ -325,13 +325,13 @@ seastar::future<> OSD::_send_boot()
 
   logger().info("hb_back_msgr: {}", heartbeat->get_back_addrs());
   logger().info("hb_front_msgr: {}", heartbeat->get_front_addrs());
-  logger().info("cluster_msgr: {}", cluster_msgr.get_myaddr());
+  logger().info("cluster_msgr: {}", cluster_msgr->get_myaddr());
   auto m = make_message<MOSDBoot>(superblock,
                                   osdmap->get_epoch(),
                                   osdmap->get_epoch(),
                                   heartbeat->get_back_addrs(),
                                   heartbeat->get_front_addrs(),
-                                  cluster_msgr.get_myaddrs(),
+                                  cluster_msgr->get_myaddrs(),
                                   CEPH_FEATURES_ALL);
   return monc->send_message(m);
 }
@@ -402,8 +402,8 @@ seastar::future<> OSD::stop()
     return monc->stop();
   }).then([this] {
     return when_all_succeed(
-      public_msgr.shutdown(),
-      cluster_msgr.shutdown());
+      public_msgr->shutdown(),
+      cluster_msgr->shutdown());
   }).then([this] {
     return store->umount();
   }).handle_exception([](auto ep) {
@@ -833,7 +833,7 @@ seastar::future<> OSD::committed_osd_maps(version_t first,
       shard_services.update_map(osdmap);
       if (up_epoch != 0 &&
           osdmap->is_up(whoami) &&
-          osdmap->get_addrs(whoami) == public_msgr.get_myaddrs()) {
+          osdmap->get_addrs(whoami) == public_msgr->get_myaddrs()) {
         up_epoch = osdmap->get_epoch();
         if (!boot_epoch) {
           boot_epoch = osdmap->get_epoch();
@@ -842,7 +842,7 @@ seastar::future<> OSD::committed_osd_maps(version_t first,
     });
   }).then([m, this] {
     if (osdmap->is_up(whoami) &&
-        osdmap->get_addrs(whoami) == public_msgr.get_myaddrs() &&
+        osdmap->get_addrs(whoami) == public_msgr->get_myaddrs() &&
         bind_epoch < osdmap->get_up_from(whoami)) {
       if (state.is_booting()) {
         logger().info("osd.{}: activating...", whoami);
@@ -924,17 +924,17 @@ bool OSD::should_restart() const
     logger().info("map e {} marked osd.{} down",
                   osdmap->get_epoch(), whoami);
     return true;
-  } else if (osdmap->get_addrs(whoami) != public_msgr.get_myaddrs()) {
+  } else if (osdmap->get_addrs(whoami) != public_msgr->get_myaddrs()) {
     logger().error("map e {} had wrong client addr ({} != my {})",
                    osdmap->get_epoch(),
                    osdmap->get_addrs(whoami),
-                   public_msgr.get_myaddrs());
+                   public_msgr->get_myaddrs());
     return true;
-  } else if (osdmap->get_cluster_addrs(whoami) != cluster_msgr.get_myaddrs()) {
+  } else if (osdmap->get_cluster_addrs(whoami) != cluster_msgr->get_myaddrs()) {
     logger().error("map e {} had wrong cluster addr ({} != my {})",
                    osdmap->get_epoch(),
                    osdmap->get_cluster_addrs(whoami),
-                   cluster_msgr.get_myaddrs());
+                   cluster_msgr->get_myaddrs());
     return true;
   } else {
     return false;

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -68,9 +68,9 @@ class OSD final : public crimson::net::Dispatcher,
   const uint32_t nonce;
   seastar::timer<seastar::lowres_clock> beacon_timer;
   // talk with osd
-  crimson::net::Messenger& cluster_msgr;
+  crimson::net::MessengerRef cluster_msgr;
   // talk with client/mon/mgr
-  crimson::net::Messenger& public_msgr;
+  crimson::net::MessengerRef public_msgr;
   ChainedDispatchers dispatchers;
   std::unique_ptr<crimson::mon::Client> monc;
   std::unique_ptr<crimson::mgr::Client> mgrc;
@@ -117,10 +117,10 @@ class OSD final : public crimson::net::Dispatcher,
 
 public:
   OSD(int id, uint32_t nonce,
-      crimson::net::Messenger& cluster_msgr,
-      crimson::net::Messenger& client_msgr,
-      crimson::net::Messenger& hb_front_msgr,
-      crimson::net::Messenger& hb_back_msgr);
+      crimson::net::MessengerRef cluster_msgr,
+      crimson::net::MessengerRef client_msgr,
+      crimson::net::MessengerRef hb_front_msgr,
+      crimson::net::MessengerRef hb_back_msgr);
   ~OSD() final;
 
   seastar::future<> mkfs(uuid_d osd_uuid, uuid_d cluster_fsid);

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -57,11 +57,9 @@ seastar::future<> ShardServices::send_to_osd(
 		    osdmap->get_info(peer).up_from, from_epoch);
     return seastar::now();
   } else {
-    return cluster_msgr.connect(osdmap->get_cluster_addrs(peer).front(),
-      CEPH_ENTITY_TYPE_OSD)
-      .then([m, this] (auto conn) {
-	      return conn->send(m);
-	    });
+    auto conn = cluster_msgr.connect(
+        osdmap->get_cluster_addrs(peer).front(), CEPH_ENTITY_TYPE_OSD);
+    return conn->send(m);
   }
 }
 

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -59,8 +59,8 @@ seastar::future<> ShardServices::send_to_osd(
   } else {
     return cluster_msgr.connect(osdmap->get_cluster_addrs(peer).front(),
       CEPH_ENTITY_TYPE_OSD)
-      .then([m, this] (auto xconn) {
-	      return (*xconn)->send(m);
+      .then([m, this] (auto conn) {
+	      return conn->send(m);
 	    });
   }
 }

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -10,6 +10,8 @@ add_ceph_unittest(unittest_seastar_denc)
 target_link_libraries(unittest_seastar_denc crimson GTest::Main)
 
 add_executable(unittest_seastar_socket test_socket.cc)
+add_ceph_test(unittest_seastar_socket
+  unittest_seastar_socket --memory 256M --smp 2)
 target_link_libraries(unittest_seastar_socket crimson)
 
 add_executable(unittest_seastar_messenger test_messenger.cc)

--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -187,9 +187,9 @@ seastar_echo(const entity_addr_t addr, echo_role role, unsigned count)
       client.msgr->set_require_authorizer(false);
       client.msgr->set_auth_client(&client.dummy_auth);
       client.msgr->set_auth_server(&client.dummy_auth);
-      return client.msgr->start(&client.dispatcher).then([addr, &client] {
-        return client.msgr->connect(addr, entity_name_t::TYPE_OSD);
-      }).then([&disp=client.dispatcher, count](crimson::net::ConnectionRef conn) {
+      return client.msgr->start(&client.dispatcher).then(
+          [addr, &client, &disp=client.dispatcher, count] {
+        auto conn = client.msgr->connect(addr, entity_name_t::TYPE_OSD);
         return seastar::do_until(
           [&disp,count] { return disp.count >= count; },
           [&disp,conn] {

--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -37,7 +37,7 @@ struct DummyAuthAuthorizer : public AuthAuthorizer {
 
 struct Server {
   crimson::thread::Throttle byte_throttler;
-  crimson::net::Messenger& msgr;
+  crimson::net::MessengerRef msgr;
   crimson::auth::DummyAuthClientServer dummy_auth;
   struct ServerDispatcher : crimson::net::Dispatcher {
     unsigned count = 0;
@@ -59,18 +59,18 @@ struct Server {
           0, bufferlist{});
     }
   } dispatcher;
-  Server(crimson::net::Messenger& msgr)
+  Server(crimson::net::MessengerRef msgr)
     : byte_throttler(crimson::net::conf.osd_client_message_size_cap),
       msgr{msgr}
   {
-    msgr.set_crc_header();
-    msgr.set_crc_data();
+    msgr->set_crc_header();
+    msgr->set_crc_data();
   }
 };
 
 struct Client {
   crimson::thread::Throttle byte_throttler;
-  crimson::net::Messenger& msgr;
+  crimson::net::MessengerRef msgr;
   crimson::auth::DummyAuthClientServer dummy_auth;
   struct ClientDispatcher : crimson::net::Dispatcher {
     unsigned count = 0;
@@ -83,12 +83,12 @@ struct Client {
       return seastar::now();
     }
   } dispatcher;
-  Client(crimson::net::Messenger& msgr)
+  Client(crimson::net::MessengerRef msgr)
     : byte_throttler(crimson::net::conf.osd_client_message_size_cap),
       msgr{msgr}
   {
-    msgr.set_crc_header();
-    msgr.set_crc_data();
+    msgr->set_crc_header();
+    msgr->set_crc_data();
   }
 };
 } // namespace seastar_pingpong
@@ -151,60 +151,58 @@ seastar_echo(const entity_addr_t addr, echo_role role, unsigned count)
 {
   std::cout << "seastar/";
   if (role == echo_role::as_server) {
-    return crimson::net::Messenger::create(entity_name_t::OSD(0), "server",
-                                        addr.get_nonce(), 0)
-      .then([addr, count] (auto msgr) {
-        return seastar::do_with(seastar_pingpong::Server{*msgr},
-          [addr, count](auto& server) mutable {
-            std::cout << "server listening at " << addr << std::endl;
-            // bind the server
-            server.msgr.set_default_policy(crimson::net::SocketPolicy::stateless_server(0));
-            server.msgr.set_policy_throttler(entity_name_t::TYPE_OSD,
-                                             &server.byte_throttler);
-            server.msgr.set_require_authorizer(false);
-            server.msgr.set_auth_client(&server.dummy_auth);
-            server.msgr.set_auth_server(&server.dummy_auth);
-            return server.msgr.bind(entity_addrvec_t{addr})
-              .then([&server] {
-                return server.msgr.start(&server.dispatcher);
-              }).then([&dispatcher=server.dispatcher, count] {
-                return dispatcher.on_reply.wait([&dispatcher, count] {
-                  return dispatcher.count >= count;
-                });
-              }).finally([&server] {
-                std::cout << "server shutting down" << std::endl;
-                return server.msgr.shutdown();
-              });
-          });
+    return seastar::do_with(
+        seastar_pingpong::Server{crimson::net::Messenger::create(
+            entity_name_t::OSD(0), "server", addr.get_nonce())},
+        [addr, count](auto& server) mutable {
+      std::cout << "server listening at " << addr << std::endl;
+      // bind the server
+      server.msgr->set_default_policy(crimson::net::SocketPolicy::stateless_server(0));
+      server.msgr->set_policy_throttler(entity_name_t::TYPE_OSD,
+                                        &server.byte_throttler);
+      server.msgr->set_require_authorizer(false);
+      server.msgr->set_auth_client(&server.dummy_auth);
+      server.msgr->set_auth_server(&server.dummy_auth);
+      return server.msgr->bind(entity_addrvec_t{addr}
+      ).then([&server] {
+        return server.msgr->start(&server.dispatcher);
+      }).then([&dispatcher=server.dispatcher, count] {
+        return dispatcher.on_reply.wait([&dispatcher, count] {
+          return dispatcher.count >= count;
+        });
+      }).finally([&server] {
+        std::cout << "server shutting down" << std::endl;
+        return server.msgr->shutdown();
       });
+    });
   } else {
-    return crimson::net::Messenger::create(entity_name_t::OSD(1), "client",
-                                        addr.get_nonce(), 0)
-      .then([addr, count] (auto msgr) {
-        return seastar::do_with(seastar_pingpong::Client{*msgr},
-          [addr, count](auto& client) {
-            std::cout << "client sending to " << addr << std::endl;
-            client.msgr.set_default_policy(crimson::net::SocketPolicy::lossy_client(0));
-            client.msgr.set_policy_throttler(entity_name_t::TYPE_OSD,
-                                             &client.byte_throttler);
-            client.msgr.set_require_authorizer(false);
-            client.msgr.set_auth_client(&client.dummy_auth);
-            client.msgr.set_auth_server(&client.dummy_auth);
-            return client.msgr.start(&client.dispatcher)
-              .then([addr, &client] {
-                return client.msgr.connect(addr, entity_name_t::TYPE_OSD);
-              }).then([&disp=client.dispatcher, count](crimson::net::ConnectionXRef conn) {
-                return seastar::do_until(
-                  [&disp,count] { return disp.count >= count; },
-                  [&disp,conn] { return (*conn)->send(make_message<MPing>())
-                                   .then([&] { return disp.on_reply.wait(); });
-                });
-              }).finally([&client] {
-                std::cout << "client shutting down" << std::endl;
-                return client.msgr.shutdown();
-              });
-          });
+    return seastar::do_with(
+        seastar_pingpong::Client{crimson::net::Messenger::create(
+            entity_name_t::OSD(1), "client", addr.get_nonce())},
+        [addr, count](auto& client) {
+      std::cout << "client sending to " << addr << std::endl;
+      client.msgr->set_default_policy(crimson::net::SocketPolicy::lossy_client(0));
+      client.msgr->set_policy_throttler(entity_name_t::TYPE_OSD,
+                                        &client.byte_throttler);
+      client.msgr->set_require_authorizer(false);
+      client.msgr->set_auth_client(&client.dummy_auth);
+      client.msgr->set_auth_server(&client.dummy_auth);
+      return client.msgr->start(&client.dispatcher).then([addr, &client] {
+        return client.msgr->connect(addr, entity_name_t::TYPE_OSD);
+      }).then([&disp=client.dispatcher, count](crimson::net::ConnectionRef conn) {
+        return seastar::do_until(
+          [&disp,count] { return disp.count >= count; },
+          [&disp,conn] {
+            return conn->send(make_message<MPing>()).then([&] {
+              return disp.on_reply.wait();
+            });
+          }
+        );
+      }).finally([&client] {
+        std::cout << "client shutting down" << std::endl;
+        return client.msgr->shutdown();
       });
+    });
   }
 }
 

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -67,7 +67,7 @@ static seastar::future<> test_echo(unsigned rounds,
                              const std::string& lname,
                              const uint64_t nonce,
                              const entity_addr_t& addr) {
-        auto&& fut = crimson::net::Messenger::create(name, lname, nonce);
+        auto&& fut = crimson::net::Messenger::create(name, lname, nonce, 0);
         return fut.then([this, addr](crimson::net::Messenger *messenger) {
             return container().invoke_on_all([messenger](auto& server) {
                 server.msgr = messenger->get_local_shard();
@@ -156,7 +156,7 @@ static seastar::future<> test_echo(unsigned rounds,
       seastar::future<> init(const entity_name_t& name,
                              const std::string& lname,
                              const uint64_t nonce) {
-        return crimson::net::Messenger::create(name, lname, nonce)
+        return crimson::net::Messenger::create(name, lname, nonce, 0)
           .then([this](crimson::net::Messenger *messenger) {
             return container().invoke_on_all([messenger](auto& client) {
                 client.msgr = messenger->get_local_shard();

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -3715,6 +3715,9 @@ int main(int argc, char** argv)
       return test_v2_protocol(v2_test_addr, v2_testpeer_addr, v2_testpeer_islocal);
     }).then([] {
       std::cout << "All tests succeeded" << std::endl;
+      // Seastar has bugs to have events undispatched during shutdown,
+      // which will result in memory leak and thus fail LeakSanitizer.
+      return seastar::sleep(100ms);
     }).handle_exception([] (auto eptr) {
       std::cout << "Test failure" << std::endl;
       return seastar::make_exception_future<>(eptr);

--- a/src/test/crimson/test_monc.cc
+++ b/src/test/crimson/test_monc.cc
@@ -39,29 +39,26 @@ static seastar::future<> test_monc()
   }).then([] {
     return crimson::common::sharded_perf_coll().start();
   }).then([] {
-    return crimson::net::Messenger::create(entity_name_t::OSD(0), "monc", 0,
-                                        seastar::engine().cpu_id())
-        .then([] (crimson::net::Messenger *msgr) {
-      auto& conf = crimson::common::local_conf();
-      if (conf->ms_crc_data) {
-        msgr->set_crc_data();
-      }
-      if (conf->ms_crc_header) {
-        msgr->set_crc_header();
-      }
-      msgr->set_require_authorizer(false);
-      return seastar::do_with(MonClient{*msgr, dummy_handler},
-                              [msgr](auto& monc) {
-        return msgr->start(&monc).then([&monc] {
-          return seastar::with_timeout(
-            seastar::lowres_clock::now() + std::chrono::seconds{10},
-            monc.start());
-        }).then([&monc] {
-          return monc.stop();
-        });
-      }).finally([msgr] {
-        return msgr->shutdown();
+    auto msgr = crimson::net::Messenger::create(entity_name_t::OSD(0), "monc", 0);
+    auto& conf = crimson::common::local_conf();
+    if (conf->ms_crc_data) {
+      msgr->set_crc_data();
+    }
+    if (conf->ms_crc_header) {
+      msgr->set_crc_header();
+    }
+    msgr->set_require_authorizer(false);
+    return seastar::do_with(MonClient{*msgr, dummy_handler},
+                            [msgr](auto& monc) {
+      return msgr->start(&monc).then([&monc] {
+        return seastar::with_timeout(
+          seastar::lowres_clock::now() + std::chrono::seconds{10},
+          monc.start());
+      }).then([&monc] {
+        return monc.stop();
       });
+    }).finally([msgr] {
+      return msgr->shutdown();
     });
   }).finally([] {
     return crimson::common::sharded_perf_coll().stop().then([] {

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -43,7 +43,7 @@ future<> test_refused() {
   return socket_connect().discard_result().then([] {
     ceph_abort_msg("connection is not refused");
   }).handle_exception_type([] (const std::system_error& e) {
-    if (e.code() != error::connection_refused) {
+    if (e.code() != std::errc::connection_refused) {
       logger.error("test_refused() got unexpeted error {}", e);
       ceph_abort();
     } else {
@@ -69,7 +69,7 @@ future<> test_bind_same() {
         }).finally([pss2] {
           return pss2->destroy();
         }).handle_exception_type([] (const std::system_error& e) {
-          if (e.code() != error::address_in_use) {
+          if (e.code() != std::errc::address_in_use) {
             logger.error("test_bind_same() got unexpeted error {}", e);
             ceph_abort();
           } else {
@@ -246,8 +246,8 @@ class Connection {
     ).then([] {
       ceph_abort();
     }).handle_exception_type([this] (const std::system_error& e) {
-      if (e.code() != error::broken_pipe &&
-          e.code() != error::connection_reset) {
+      if (e.code() != std::errc::broken_pipe &&
+          e.code() != std::errc::connection_reset) {
         logger.error("dispatch_write_unbounded(): "
                      "unexpected error {}", e);
         throw;
@@ -305,7 +305,7 @@ class Connection {
       ceph_abort();
     }).handle_exception_type([this] (const std::system_error& e) {
       if (e.code() != error::read_eof
-       && e.code() != error::connection_reset) {
+       && e.code() != std::errc::connection_reset) {
         logger.error("dispatch_read_unbounded(): "
                      "unexpected error {}", e);
         throw;

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -434,6 +434,9 @@ int main(int argc, char** argv)
       return test_preemptive_down();
     }).then([] {
       logger.info("All tests succeeded");
+      // Seastar has bugs to have events undispatched during shutdown,
+      // which will result in memory leak and thus fail LeakSanitizer.
+      return seastar::sleep(100ms);
     }).handle_exception([] (auto eptr) {
       std::cout << "Test failure" << std::endl;
       return seastar::make_exception_future<>(eptr);

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -18,9 +18,10 @@ using seastar::future;
 using crimson::net::error;
 using crimson::net::FixedCPUServerSocket;
 using crimson::net::Socket;
-using crimson::net::SocketFRef;
 using crimson::net::SocketRef;
 using crimson::net::stop_t;
+
+using SocketFRef = seastar::foreign_ptr<SocketRef>;
 
 static seastar::logger logger{"crimsontest"};
 static entity_addr_t server_addr = [] {
@@ -33,7 +34,7 @@ future<SocketRef> socket_connect() {
   logger.debug("socket_connect()...");
   return Socket::connect(server_addr).then([] (auto socket) {
     logger.debug("socket_connect() connected");
-    return socket.release();
+    return socket;
   });
 }
 

--- a/src/tools/crimson/perf_crimson_msgr.cc
+++ b/src/tools/crimson/perf_crimson_msgr.cc
@@ -11,6 +11,7 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/core/smp.hh>
 
 #include "common/ceph_time.h"
 #include "messages/MOSDOp.h"
@@ -30,6 +31,23 @@ using Ref = boost::intrusive_ptr<Message>;
 
 seastar::logger& logger() {
   return crimson::get_logger(ceph_subsys_ms);
+}
+
+template <typename T, typename... Args>
+seastar::future<T*> create_sharded(Args... args) {
+  // seems we should only construct/stop shards on #0
+  return seastar::smp::submit_to(0, [=] {
+    auto sharded_obj = seastar::make_lw_shared<seastar::sharded<T>>();
+    return sharded_obj->start(args...).then([sharded_obj]() {
+      seastar::engine().at_exit([sharded_obj]() {
+          return sharded_obj->stop().finally([sharded_obj] {});
+        });
+      return sharded_obj.get();
+    });
+  }).then([] (seastar::sharded<T> *ptr_shard) {
+    // return the pointer valid for the caller CPU
+    return &ptr_shard->local();
+  });
 }
 
 enum class perf_mode_t {
@@ -114,32 +132,26 @@ static seastar::future<> run(
     const server_config& server_conf)
 {
   struct test_state {
+    struct Server;
+    using ServerFRef = seastar::foreign_ptr<std::unique_ptr<Server>>;
+
     struct Server final
-        : public crimson::net::Dispatcher,
-          public seastar::peering_sharded_service<Server> {
-      crimson::net::Messenger *msgr = nullptr;
+        : public crimson::net::Dispatcher {
+      crimson::net::MessengerRef msgr;
       crimson::auth::DummyAuthClientServer dummy_auth;
-      const seastar::shard_id sid;
       const seastar::shard_id msgr_sid;
       std::string lname;
       unsigned msg_len;
       bufferlist msg_data;
 
-      Server(unsigned msgr_core, unsigned msg_len)
-        : sid{seastar::engine().cpu_id()},
-          msgr_sid{msgr_core},
+      Server(unsigned msg_len)
+        : msgr_sid{seastar::engine().cpu_id()},
           msg_len{msg_len} {
         lname = "server#";
-        lname += std::to_string(sid);
+        lname += std::to_string(msgr_sid);
         msg_data.append_zero(msg_len);
       }
 
-      Dispatcher* get_local_shard() override {
-        return &(container().local());
-      }
-      seastar::future<> stop() {
-        return seastar::make_ready_future<>();
-      }
       seastar::future<> ms_dispatch(crimson::net::Connection* c,
                                     MessageRef m) override {
         ceph_assert(m->get_type() == CEPH_MSG_OSD_OP);
@@ -158,34 +170,38 @@ static seastar::future<> run(
       }
 
       seastar::future<> init(bool v1_crc_enabled, const entity_addr_t& addr) {
-        return container().invoke_on(msgr_sid, [v1_crc_enabled, addr] (auto& server) {
+        return seastar::smp::submit_to(msgr_sid, [v1_crc_enabled, addr, this] {
           // server msgr is always with nonce 0
-          auto&& fut = crimson::net::Messenger::create(entity_name_t::OSD(server.sid), server.lname, 0, server.sid);
-          return fut.then(
-            [&server, addr, v1_crc_enabled](crimson::net::Messenger *messenger) {
-              return server.container().invoke_on_all(
-                [messenger, v1_crc_enabled](auto& server) {
-                  server.msgr = messenger->get_local_shard();
-                  server.msgr->set_default_policy(crimson::net::SocketPolicy::stateless_server(0));
-                  server.msgr->set_auth_client(&server.dummy_auth);
-                  server.msgr->set_auth_server(&server.dummy_auth);
-                  if (v1_crc_enabled) {
-                    server.msgr->set_crc_header();
-                    server.msgr->set_crc_data();
-                  }
-                }).then([messenger, addr] {
-                  return messenger->bind(entity_addrvec_t{addr});
-                }).then([&server, messenger] {
-                  return messenger->start(&server);
-                });
-            });
+          msgr = crimson::net::Messenger::create(entity_name_t::OSD(msgr_sid), lname, 0);
+          msgr->set_default_policy(crimson::net::SocketPolicy::stateless_server(0));
+          msgr->set_auth_client(&dummy_auth);
+          msgr->set_auth_server(&dummy_auth);
+          if (v1_crc_enabled) {
+            msgr->set_crc_header();
+            msgr->set_crc_data();
+          }
+          return msgr->bind(entity_addrvec_t{addr}).then([this] {
+            return msgr->start(this);
+          });
         });
       }
       seastar::future<> shutdown() {
         logger().info("{} shutdown...", lname);
-        return container().invoke_on(msgr_sid, [] (auto& server) {
-          ceph_assert(server.msgr);
-          return server.msgr->shutdown();
+        return seastar::smp::submit_to(msgr_sid, [this] {
+          ceph_assert(msgr);
+          return msgr->shutdown();
+        });
+      }
+      seastar::future<> wait() {
+        return seastar::smp::submit_to(msgr_sid, [this] {
+          ceph_assert(msgr);
+          return msgr->wait();
+        });
+      }
+
+      static seastar::future<ServerFRef> create(seastar::shard_id msgr_sid, unsigned msg_len) {
+        return seastar::smp::submit_to(msgr_sid, [msg_len] {
+          return seastar::make_foreign(std::make_unique<Server>(msg_len));
         });
       }
     };
@@ -250,7 +266,7 @@ static seastar::future<> run(
       std::string lname;
 
       const unsigned jobs;
-      crimson::net::Messenger *msgr = nullptr;
+      crimson::net::MessengerRef msgr;
       const unsigned msg_len;
       bufferlist msg_data;
       const unsigned nr_depth;
@@ -281,12 +297,6 @@ static seastar::future<> run(
         return nr_depth - depth.current();
       }
 
-      Dispatcher* get_local_shard() override {
-        return &(container().local());
-      }
-      seastar::future<> stop() {
-        return seastar::now();
-      }
       seastar::future<> ms_handle_connect(crimson::net::ConnectionRef conn) override {
         conn_stats.connected_time = mono_clock::now();
         return seastar::now();
@@ -323,19 +333,16 @@ static seastar::future<> run(
       seastar::future<> init(bool v1_crc_enabled) {
         return container().invoke_on_all([v1_crc_enabled] (auto& client) {
           if (client.is_active()) {
-            return crimson::net::Messenger::create(entity_name_t::OSD(client.sid), client.lname, client.sid, client.sid)
-            .then([&client, v1_crc_enabled] (crimson::net::Messenger *messenger) {
-              client.msgr = messenger;
-              client.msgr->set_default_policy(crimson::net::SocketPolicy::lossy_client(0));
-              client.msgr->set_require_authorizer(false);
-              client.msgr->set_auth_client(&client.dummy_auth);
-              client.msgr->set_auth_server(&client.dummy_auth);
-              if (v1_crc_enabled) {
-                client.msgr->set_crc_header();
-                client.msgr->set_crc_data();
-              }
-              return client.msgr->start(&client);
-            });
+            client.msgr = crimson::net::Messenger::create(entity_name_t::OSD(client.sid), client.lname, client.sid);
+            client.msgr->set_default_policy(crimson::net::SocketPolicy::lossy_client(0));
+            client.msgr->set_require_authorizer(false);
+            client.msgr->set_auth_client(&client.dummy_auth);
+            client.msgr->set_auth_server(&client.dummy_auth);
+            if (v1_crc_enabled) {
+              client.msgr->set_crc_header();
+              client.msgr->set_crc_data();
+            }
+            return client.msgr->start(&client);
           }
           return seastar::now();
         });
@@ -359,9 +366,9 @@ static seastar::future<> run(
           // start clients in active cores (#1 ~ #jobs)
           if (client.is_active()) {
             mono_time start_time = mono_clock::now();
-            return client.msgr->connect(peer_addr, entity_name_t::TYPE_OSD)
-            .then([&client] (auto conn) {
-              client.active_conn = conn->release();
+            return client.msgr->connect(peer_addr, entity_name_t::TYPE_OSD
+            ).then([&client] (auto conn) {
+              client.active_conn = conn;
               // make sure handshake won't hurt the performance
               return seastar::sleep(1s);
             }).then([&client, start_time] {
@@ -638,57 +645,57 @@ static seastar::future<> run(
   };
 
   return seastar::when_all_succeed(
-      crimson::net::create_sharded<test_state::Server>(server_conf.core, server_conf.block_size),
-      crimson::net::create_sharded<test_state::Client>(client_conf.jobs,
-						       client_conf.block_size, client_conf.depth))
-    .then([=](test_state::Server *server,
-              test_state::Client *client) {
-      if (mode == perf_mode_t::both) {
-          logger().info("\nperf settings:\n  {}\n  {}\n",
-                        client_conf.str(), server_conf.str());
-          ceph_assert(seastar::smp::count >= 1+client_conf.jobs);
-          ceph_assert(client_conf.jobs > 0);
-          ceph_assert(seastar::smp::count >= 1+server_conf.core);
-          ceph_assert(server_conf.core == 0 || server_conf.core > client_conf.jobs);
-          return seastar::when_all_succeed(
-              server->init(server_conf.v1_crc_enabled, server_conf.addr),
-              client->init(client_conf.v1_crc_enabled))
-            .then([client, addr = client_conf.server_addr] {
-              return client->connect_wait_verify(addr);
-            }).then([client, ramptime = client_conf.ramptime,
-                     msgtime = client_conf.msgtime] {
-              return client->dispatch_with_timer(ramptime, msgtime);
-            }).finally([client] {
-              return client->shutdown();
-            }).finally([server] {
-              return server->shutdown();
-            });
-      } else if (mode == perf_mode_t::client) {
-          logger().info("\nperf settings:\n  {}\n", client_conf.str());
-          ceph_assert(seastar::smp::count >= 1+client_conf.jobs);
-          ceph_assert(client_conf.jobs > 0);
-          return client->init(client_conf.v1_crc_enabled)
-            .then([client, addr = client_conf.server_addr] {
-              return client->connect_wait_verify(addr);
-            }).then([client, ramptime = client_conf.ramptime,
-                     msgtime = client_conf.msgtime] {
-              return client->dispatch_with_timer(ramptime, msgtime);
-            }).finally([client] {
-              return client->shutdown();
-            });
-      } else { // mode == perf_mode_t::server
-          ceph_assert(seastar::smp::count >= 1+server_conf.core);
-          logger().info("\nperf settings:\n  {}\n", server_conf.str());
-          return server->init(server_conf.v1_crc_enabled, server_conf.addr)
-          // dispatch ops
-            .then([server] {
-              return server->msgr->wait();
-          // shutdown
-            }).finally([server] {
-              return server->shutdown();
-            });
-      }
-    });
+      test_state::Server::create(server_conf.core, server_conf.block_size),
+      create_sharded<test_state::Client>(client_conf.jobs, client_conf.block_size, client_conf.depth)
+  ).then([=](test_state::ServerFRef fp_server,
+             test_state::Client *client) {
+    test_state::Server* server = fp_server.get();
+    if (mode == perf_mode_t::both) {
+      logger().info("\nperf settings:\n  {}\n  {}\n",
+                    client_conf.str(), server_conf.str());
+      ceph_assert(seastar::smp::count >= 1+client_conf.jobs);
+      ceph_assert(client_conf.jobs > 0);
+      ceph_assert(seastar::smp::count >= 1+server_conf.core);
+      ceph_assert(server_conf.core == 0 || server_conf.core > client_conf.jobs);
+      return seastar::when_all_succeed(
+        server->init(server_conf.v1_crc_enabled, server_conf.addr),
+        client->init(client_conf.v1_crc_enabled)
+      ).then([client, addr = client_conf.server_addr] {
+        return client->connect_wait_verify(addr);
+      }).then([client, ramptime = client_conf.ramptime,
+               msgtime = client_conf.msgtime] {
+        return client->dispatch_with_timer(ramptime, msgtime);
+      }).finally([client] {
+        return client->shutdown();
+      }).finally([server, fp_server = std::move(fp_server)] () mutable {
+        return server->shutdown().then([cleanup = std::move(fp_server)] {});
+      });
+    } else if (mode == perf_mode_t::client) {
+      logger().info("\nperf settings:\n  {}\n", client_conf.str());
+      ceph_assert(seastar::smp::count >= 1+client_conf.jobs);
+      ceph_assert(client_conf.jobs > 0);
+      return client->init(client_conf.v1_crc_enabled
+      ).then([client, addr = client_conf.server_addr] {
+        return client->connect_wait_verify(addr);
+      }).then([client, ramptime = client_conf.ramptime,
+               msgtime = client_conf.msgtime] {
+        return client->dispatch_with_timer(ramptime, msgtime);
+      }).finally([client] {
+        return client->shutdown();
+      });
+    } else { // mode == perf_mode_t::server
+      ceph_assert(seastar::smp::count >= 1+server_conf.core);
+      logger().info("\nperf settings:\n  {}\n", server_conf.str());
+      return server->init(server_conf.v1_crc_enabled, server_conf.addr
+      // dispatch ops
+      ).then([server] {
+        return server->wait();
+      // shutdown
+      }).finally([server, fp_server = std::move(fp_server)] () mutable {
+        return server->shutdown().then([cleanup = std::move(fp_server)] {});
+      });
+    }
+  });
 }
 
 }

--- a/src/tools/crimson/perf_crimson_msgr.cc
+++ b/src/tools/crimson/perf_crimson_msgr.cc
@@ -366,12 +366,9 @@ static seastar::future<> run(
           // start clients in active cores (#1 ~ #jobs)
           if (client.is_active()) {
             mono_time start_time = mono_clock::now();
-            return client.msgr->connect(peer_addr, entity_name_t::TYPE_OSD
-            ).then([&client] (auto conn) {
-              client.active_conn = conn;
-              // make sure handshake won't hurt the performance
-              return seastar::sleep(1s);
-            }).then([&client, start_time] {
+            client.active_conn = client.msgr->connect(peer_addr, entity_name_t::TYPE_OSD);
+            // make sure handshake won't hurt the performance
+            return seastar::sleep(1s).then([&client, start_time] {
               if (client.conn_stats.connected_time == mono_clock::zero()) {
                 logger().error("\n{} not connected after 1s!\n", client.lname);
                 ceph_assert(false);


### PR DESCRIPTION
In posix-stack, `seastar::pollable_fd` will unregister itself from epoll on the original core during destruction. This means we cannot "move" our `Socket` across cores, create `seastar::input/output_stream` there, and start polling on the different core. It is the root cause of intermittent ASAN error in our unit tests.

To address this, we need to modify seastar to implement a new load-balance policy in `seastar::listen_option`, see https://github.com/ceph/seastar/pull/12.

Note this PR won't compile until the seastar PR merged.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
