### PR TITLE
ceph-volume: finer grained availability notion in inventory.

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -293,6 +293,8 @@ def device_info(monkeypatch, patch_bluestore_label):
             monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: lv)
         else:
             monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: None)
+            monkeypatch.setattr("ceph_volume.util.device.lvm.get_device_lvs",
+                                lambda path: [lv])
         monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv", lambda vg_name, lv_uuid: lv)
         monkeypatch.setattr("ceph_volume.util.device.disk.lsblk", lambda path: lsblk)
         monkeypatch.setattr("ceph_volume.util.device.disk.blkid", lambda path: blkid)


### PR DESCRIPTION
This is an alternative approach to #32527 and relates to the discussion there.

The idea is to have a more fine grained notion of a drive being available. For example a drive with a VG might be available for creating an lvm osd but it is not available to create a raw osd.

I kept the available property for backwards compatibility, it is just a conjunction of the finer grained availability properties.

Fixes: https://tracker.ceph.com/issues/43400