### PR TITLE
mgr/dashbaord: Fix E2E pools page failure

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/e2e/block/images.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/block/images.po.ts
@@ -18,8 +18,7 @@ export class ImagesPageHelper extends PageHelper {
     await element(by.id('name')).sendKeys(name); // Enter in image name
 
     // Select image pool
-    await element(by.id('pool')).click();
-    await element(by.cssContainingText('select[name=pool] option', pool)).click();
+    await this.selectOption('pool', pool);
     await $(getPoolName).click();
     await expect(element(by.id('pool')).getAttribute('class')).toContain('ng-valid'); // check if selected
 

--- a/src/pybind/mgr/dashboard/frontend/e2e/block/mirroring.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/block/mirroring.po.ts
@@ -20,8 +20,7 @@ export class MirroringPageHelper extends PageHelper {
     await this.waitClickableAndClick(editModeButton);
     // Clicks the drop down in the edit pop-up, then clicks the Update button
     await this.waitVisibility($('.modal-content'));
-    await element(by.id('mirrorMode')).click(); // Mode select box
-    await element(by.cssContainingText('select[name=mirrorMode] option', option)).click();
+    await this.selectOption('mirrorMode', option);
 
     // Clicks update button and checks if the mode has been changed
     await element(by.cssContainingText('button', 'Update')).click();

--- a/src/pybind/mgr/dashboard/frontend/e2e/page-helper.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/page-helper.po.ts
@@ -144,6 +144,24 @@ export abstract class PageHelper {
   }
 
   /**
+   * Helper method to select an option inside a select element.
+   * This method will also expect that the option was set.
+   */
+  async selectOption(selectionName: string, option: string) {
+    await element(by.cssContainingText(`select[name=${selectionName}] option`, option)).click();
+    return this.expectSelectOption(selectionName, option);
+  }
+
+  /**
+   * Helper method to expect a set option inside a select element.
+   */
+  async expectSelectOption(selectionName: string, option: string) {
+    return expect(
+      element(by.css(`select[name=${selectionName}] option:checked`)).getText()
+    ).toContain(option);
+  }
+
+  /**
    * Returns the cell with the content given in `content`. Will not return a rejected Promise if the
    * table cell hasn't been found. It behaves this way to enable to wait for
    * visibility/invisibility/presence of the returned element.

--- a/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.po.ts
@@ -38,6 +38,8 @@ export class PoolPageHelper extends PageHelper {
     await nameInput.sendKeys(name);
     await this.selectOption('poolType', 'replicated');
 
+    await this.expectSelectOption('pgAutoscaleMode', 'on');
+    await this.selectOption('pgAutoscaleMode', 'off'); // To show pgNum field
     await $('input[name=pgNum]').sendKeys(
       protractor.Key.CONTROL,
       'a',

--- a/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.po.ts
@@ -36,11 +36,8 @@ export class PoolPageHelper extends PageHelper {
       return Promise.reject(`Placement groups ${placement_groups} are not a power of 2`);
     }
     await nameInput.sendKeys(name);
-    await element(by.cssContainingText('select[name=poolType] option', 'replicated')).click();
+    await this.selectOption('poolType', 'replicated');
 
-    await expect(element(by.css('select[name=poolType] option:checked')).getText()).toBe(
-      ' replicated '
-    );
     await $('input[name=pgNum]').sendKeys(
       protractor.Key.CONTROL,
       'a',

--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -55,13 +55,6 @@ if [ "$BASE_URL" == "" ]; then
     # Set SSL verify to False
     ./bin/ceph dashboard set-rgw-api-ssl-verify False
 
-    # Disable PG autoscaling for new pools. This is a temporary workaround.
-    # e2e tests for pools should be adapted to remove this workaround after
-    # these issues are resolved:
-    # - https://tracker.ceph.com/issues/38227
-    # - https://tracker.ceph.com/issues/42638
-    ./bin/ceph config set global osd_pool_default_pg_autoscale_mode off
-
     BASE_URL=$(./bin/ceph mgr services | jq -r .dashboard)
 fi
 


### PR DESCRIPTION
The problem was that pg autoscaling is set to "on" by default. Therefore
the pg_num field is hidden, which caused the error. Now the test sets
the pg autoscaling to "off" revealing the pg_num field to make the tests
pass.

Fixes: https://tracker.ceph.com/issues/43594
Fixes: https://tracker.ceph.com/issues/43102
Signed-off-by: Stephan Müller <smueller@suse.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
