### PR TITLE
mgr/dashboard: check if user has config-opt permissions

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.spec.ts
@@ -2,11 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
 import { AppModule } from '../../../app.module';
+import { PrometheusService } from '../../../shared/api/prometheus.service';
+import { Permissions } from '../../../shared/models/permissions';
+import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { NavigationComponent } from './navigation.component';
 
 describe('NavigationComponent', () => {
   let component: NavigationComponent;
   let fixture: ComponentFixture<NavigationComponent>;
+  let ifAlertmanagerConfiguredSpy: jasmine.Spy;
+  let ifPrometheusConfigured: jasmine.Spy;
 
   configureTestBed({
     imports: [AppModule],
@@ -14,12 +19,36 @@ describe('NavigationComponent', () => {
   });
 
   beforeEach(() => {
+    ifAlertmanagerConfiguredSpy = spyOn(
+      TestBed.get(PrometheusService),
+      'ifAlertmanagerConfigured'
+    ).and.stub();
+    ifPrometheusConfigured = spyOn(
+      TestBed.get(PrometheusService),
+      'ifPrometheusConfigured'
+    ).and.stub();
     fixture = TestBed.createComponent(NavigationComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create and PrometheusService methods should not have been called', () => {
     expect(component).toBeTruthy();
+    expect(ifAlertmanagerConfiguredSpy).toHaveBeenCalledTimes(0);
+    expect(ifPrometheusConfigured).toHaveBeenCalledTimes(0);
+  });
+
+  it('PrometheusService methods should have been called', () => {
+    const authStorageServiceSpy = spyOn(
+      TestBed.get(AuthStorageService),
+      'getPermissions'
+    ).and.returnValue(new Permissions({ 'config-opt': ['read'] }));
+    TestBed.overrideProvider(AuthStorageService, { useValue: authStorageServiceSpy });
+    fixture = TestBed.createComponent(NavigationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(ifAlertmanagerConfiguredSpy).toHaveBeenCalledTimes(1);
+    expect(ifPrometheusConfigured).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
@@ -50,13 +50,14 @@ export class NavigationComponent implements OnInit {
       }
       this.summaryData = data;
     });
-    this.prometheusService.ifAlertmanagerConfigured(() => {
-      this.isAlertmanagerConfigured = true;
-    });
-    this.prometheusService.ifPrometheusConfigured(() => {
-      this.isPrometheusConfigured = true;
-    });
-
+    if (this.permissions.configOpt.read) {
+      this.prometheusService.ifAlertmanagerConfigured(() => {
+        this.isAlertmanagerConfigured = true;
+      });
+      this.prometheusService.ifPrometheusConfigured(() => {
+        this.isPrometheusConfigured = true;
+      });
+    }
     this.authStorageService.isPwdDisplayed$.subscribe((isDisplayed) => {
       this.isPwdDisplayed = isDisplayed;
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.ts
@@ -59,7 +59,8 @@ export class NotificationsSidebarComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    if (this.authStorageService.getPermissions().prometheus.read) {
+    const permissions = this.authStorageService.getPermissions();
+    if (permissions.prometheus.read && permissions.configOpt.read) {
       this.triggerPrometheusAlerts();
       this.ngZone.runOutsideAngular(() => {
         this.interval = window.setInterval(() => {


### PR DESCRIPTION
Check if user has config-opt permissions before retrieving settings.

Fixes: https://tracker.ceph.com/issues/43595
Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
