### PR TITLE
cephadm: fix logging defaults

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -748,12 +748,17 @@ def get_daemon_args(fsid, daemon_type, daemon_id):
 
     if daemon_type in Ceph.daemons:
         r += [
+            '--setuser', 'ceph',
+            '--setgroup', 'ceph',
             '--default-log-to-file=false',
             '--default-log-to-stderr=true',
-            '--setuser', 'ceph',
-            '--setgroup', 'ceph'
+            '--default-log-stderr-prefix=debug\ ',
         ]
-
+        if daemon_type == 'mon':
+            r += [
+                '--default-mon-cluster-log-to-file=false',
+                '--default-mon-cluster-log-to-stderr=true',
+            ]
     elif daemon_type in Monitoring.components:
         component = Monitoring.components[daemon_type]  # type: ignore
         metadata = component.get('image', list())  # type: ignore


### PR DESCRIPTION
- prefix stderr log lines with 'debug '
- send cluster log to stderr (only affects mons)
- default to sending cluser log to stderr only (not to file)

This aligns things with the container-y way, as we do
with rook.  It means that if you want legacy behavior (log files),
you have *2* settings to change:

 log_to_file = true
 mon_cluster_log_to_file = true

We could default this to leave cluster log to file by default
since they aren't that big (and we do have log rotation), but
it's not as clean as it could be...




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>