### PR TITLE
doc/bootstrap: fixed default --keyring target

### DIFF
--- a/doc/bootstrap.rst
+++ b/doc/bootstrap.rst
@@ -50,7 +50,7 @@ To create a new cluster, you need to know:
 
 To bootstrap the cluster run the following command::
 
-  [node 1] $ sudo cephadm bootstrap --mon-ip *<mon-ip>*
+  [node 1] $ sudo ./cephadm bootstrap --mon-ip *<mon-ip>*
 
 This command does a few things:
 
@@ -69,7 +69,7 @@ Interacting with the cluster
 To interact with your cluster, start up a container that has all of 
 the Ceph packages installed::
 
-  [any node] $ sudo cephadm shell --config ceph.conf --keyring ceph.keyring
+  [any node] $ sudo ./cephadm shell --config ceph.conf --keyring ceph.client.admin.keyring
 
 The ``--config`` and ``--keyring`` arguments will bind those local
 files to the default locations in ``/etc/ceph`` inside the container


### PR DESCRIPTION
Changed target from 'ceph.keyring' to 'ceph.client.admin.keyring'.

Signed-off-by: Yaarit Hatuka <yaarit@redhat.com>