### PR TITLE
test: Get coredumps on systemd-coredump distros

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -170,11 +170,11 @@ function teardown() {
     fi
     local cores="no"
     local pattern="$(sysctl -n $KERNCORE)"
+    local sysd_dir="/var/lib/systemd/coredump"
     # See if we have apport core handling
     if [ "${pattern:0:1}" = "|" ]; then
-      # TODO: Where can we get the dumps?
-      # Not sure where the dumps really are so this will look in the CWD
-      pattern=""
+      pattern="$sysd_dir/core.xxxx"
+      MOVECORE=yes
     fi
     # Local we start with core and teuthology ends with core
     if ls $(dirname "$pattern") | grep -q '^core\|core$' ; then
@@ -184,6 +184,9 @@ function teardown() {
 	    for i in $(ls $(dirname $(sysctl -n $KERNCORE)) | grep '^core\|core$'); do
 		mv $i /tmp/cores.$$
 	    done
+	elif [ -n "$MOVECORE" ]; then
+	    # Move cores to where Teuthology will archive it
+	    cp -r $sysd_dir $TESTDIR/archive
         fi
     fi
     if [ "$cores" = "yes" -o "$dumplogs" = "1" ]; then


### PR DESCRIPTION
https://tracker.ceph.com/issues/43602

Signed-off-by: David Zafman <dzafman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
