### PR TITLE
mgr/dashboard: monitoring: improve generic "Could not reach external API" message

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/prometheus.py
+++ b/src/pybind/mgr/dashboard/controllers/prometheus.py
@@ -27,22 +27,27 @@ class PrometheusReceiver(BaseController):
 
 class PrometheusRESTController(RESTController):
     def prometheus_proxy(self, method, path, params=None, payload=None):
+        # type (str, str, dict, dict)
         return self._proxy(self._get_api_url(Settings.PROMETHEUS_API_HOST),
-                           method, path, params, payload)
+                           method, path, 'Prometheus', params, payload)
 
     def alert_proxy(self, method, path, params=None, payload=None):
+        # type (str, str, dict, dict)
         return self._proxy(self._get_api_url(Settings.ALERTMANAGER_API_HOST),
-                           method, path, params, payload)
+                           method, path, 'Alertmanager', params, payload)
 
     def _get_api_url(self, host):
         return host.rstrip('/') + '/api/v1'
 
-    def _proxy(self, base_url, method, path, params=None, payload=None):
+    def _proxy(self, base_url, method, path, api_name, params=None, payload=None):
+        # type (str, str, str, str, dict, dict)
         try:
             response = requests.request(method, base_url + path, params=params, json=payload)
         except Exception:
-            raise DashboardException('Could not reach external API', http_status_code=404,
-                                     component='prometheus')
+            raise DashboardException(
+                "Could not reach {}'s API on {}".format(api_name, base_url),
+                http_status_code=404,
+                component='prometheus')
         content = json.loads(response.content)
         if content['status'] == 'success':
             if 'data' in content:


### PR DESCRIPTION
"Could not reach external API" could possibly mean that either the Prometheus API or the Alertmanager's API couldn't be reached. There's no way to find out the difference in the front-end. This makes it unnecessarily difficult for users to configure monitoring correctly in the dashboard.


**Before**
![before](https://user-images.githubusercontent.com/9606095/72427051-d8280900-3782-11ea-9000-c301765fd9de.png)

<hr>

**After**
![after](https://user-images.githubusercontent.com/9606095/72427285-5389ba80-3783-11ea-9689-c887ae168953.png)



Fixes: https://tracker.ceph.com/issues/43604

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
