### PR TITLE
nautilus: build/ops: install-deps,rpm: enable devtoolset-8 on aarch64 also

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -149,11 +149,7 @@ BuildRequires:	fuse-devel
 %if 0%{?rhel} == 7
 # devtoolset offers newer make and valgrind-devel, but the old ones are good
 # enough.
-%ifarch x86_64
 BuildRequires:	devtoolset-8-gcc-c++ >= 8.2.1
-%else
-BuildRequires:	devtoolset-7-gcc-c++ >= 7.3.1-5.13
-%endif
 %else
 BuildRequires:	gcc-c++
 %endif

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -350,7 +350,7 @@ else
 			    $SUDO yum -y install centos-release-scl-rh
 			    $SUDO yum-config-manager --disable centos-sclo-rh
 			    $SUDO yum-config-manager --enable centos-sclo-rh-testing
-			    dts_ver=7
+			    dts_ver=8
 			    ;;
 		    esac
                 elif test $ID = rhel -a $MAJOR_VERSION = 7 ; then


### PR DESCRIPTION
in 5ae3b06e, we left aarch64 with devtoolset-7, but aarch64 builders are
also suffering from http://tracker.ceph.com/issues/38892. so i installed
devtoolset-8 on all aarch64 builders manually from the rpm packages
downloaded from koji builder:

- https://cbs.centos.org/koji/buildinfo?buildID=24923
- https://cbs.centos.org/koji/buildinfo?buildID=24931

libasan5, libubsan1 are not installed.

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 00f19923b4225c25480ddb3c09a898a2444fbeb9)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
