### PR TITLE
mgr/dashboard: fix improper URL checking

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/home.py
+++ b/src/pybind/mgr/dashboard/controllers/home.py
@@ -115,6 +115,11 @@ class HomeController(BaseController, LanguageMixin):
 
         base_dir = self._language_dir(langs)
         full_path = os.path.join(base_dir, path)
+
+        # Block uplevel attacks
+        if not os.path.normpath(full_path).startswith(os.path.normpath(base_dir)):
+            raise cherrypy.HTTPError(403)  # Forbidden
+
         logger.debug("serving static content: %s", full_path)
         if 'Vary' in cherrypy.response.headers:
             cherrypy.response.headers['Vary'] = "{}, Accept-Language"

--- a/src/pybind/mgr/dashboard/tests/test_home.py
+++ b/src/pybind/mgr/dashboard/tests/test_home.py
@@ -45,6 +45,13 @@ class HomeTest(ControllerTestCase, FakeFsMixin):
     @mock.patch(FakeFsMixin.builtins_open, new=FakeFsMixin.f_open)
     @mock.patch('os.stat', new=FakeFsMixin.f_os.stat)
     @mock.patch('os.listdir', new=FakeFsMixin.f_os.listdir)
+    def test_home_uplevel_check(self):
+        self._get('/../../../../../../etc/shadow')
+        self.assertStatus(403)
+
+    @mock.patch(FakeFsMixin.builtins_open, new=FakeFsMixin.f_open)
+    @mock.patch('os.stat', new=FakeFsMixin.f_os.stat)
+    @mock.patch('os.listdir', new=FakeFsMixin.f_os.listdir)
     def test_home_en_us(self):
         self._get('/', headers=[('Accept-Language', 'en-US')])
         self.assertStatus(200)


### PR DESCRIPTION
This change disables up-level references beyond the HTTP base directory.

Can be tested with (`--path-as-is` is key to avoid curl from sanitizing `../`):
`curl --path-as-is -k https://<dashboard_address>/../../../../../../../../<any_root_fs_path>`

Fixes: CVE-2020-1699
Fixes: https://tracker.ceph.com/issues/43607
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
