### PR TITLE
mgr/rook: provide full path for devices names in inventory

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -228,7 +228,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             devs = []
             for d in node_devs:
                 dev = inventory.Device(
-                    path=d['name'],
+                    path='/dev/' + d['name'],
                     sys_api=dict(
                         rotational='1' if d['rotational'] else '0',
                         size=d['size']


### PR DESCRIPTION
This matches the cephadm behavior.

Fixes: https://tracker.ceph.com/issues/43273
Signed-off-by: Sage Weil <sage@redhat.com>