### PR TITLE
mgr: re-enable mds `scrub status` info in ceph status

### DIFF
--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -32,7 +32,9 @@ class TestScrubControls(CephFSTestCase):
         return self.fs.rank_tell(["scrub", "status"])
     def _check_task_status(self, expected_status):
         task_status = self.fs.get_task_status("scrub status")
-        self.assertTrue(task_status['0'].startswith(expected_status))
+        active = self.fs.get_active_names()
+        log.debug("current active={0}".format(active))
+        self.assertTrue(task_status[active[0]].startswith(expected_status))
 
     def test_scrub_abort(self):
         test_dir = "scrub_control_test_path"

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -964,6 +964,10 @@ bool DaemonServer::_handle_command(
     // only include state from services that are in the persisted service map
     f->open_object_section("service_status");
     for (auto& [type, service] : pending_service_map.services) {
+      if (ServiceMap::is_normal_ceph_entity(type)) {
+        continue;
+      }
+
       f->open_object_section(type.c_str());
       for (auto& q : service.daemons) {
 	f->open_object_section(q.first.c_str());
@@ -2741,6 +2745,10 @@ void DaemonServer::got_service_map()
   // cull missing daemons, populate new ones
   std::set<std::string> types;
   for (auto& [type, service] : pending_service_map.services) {
+    if (ServiceMap::is_normal_ceph_entity(type)) {
+      continue;
+    }
+
     types.insert(type);
 
     std::set<std::string> names;

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -145,6 +145,8 @@ private:
     }
   };
 
+  void update_task_status(DaemonKey key, const ref_t<MMgrReport>& m);
+
 public:
   int init(uint64_t gid, entity_addrvec_t client_addrs);
   void shutdown();

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -144,7 +144,6 @@ class DaemonState
   bool service_daemon = false;
   utime_t service_status_stamp;
   std::map<std::string, std::string> service_status;
-  std::map<std::string, std::string> task_status;
   utime_t last_service_beacon;
 
   // running config

--- a/src/mgr/ServiceMap.h
+++ b/src/mgr/ServiceMap.h
@@ -138,6 +138,18 @@ struct ServiceMap {
     }
     return true;
   }
+
+  static inline bool is_normal_ceph_entity(std::string_view type) {
+    if (type == "osd" ||
+        type == "client" ||
+        type == "mon" ||
+        type == "mds" ||
+        type == "mgr") {
+      return true;
+    }
+
+    return false;
+  }
 };
 WRITE_CLASS_ENCODER_FEATURES(ServiceMap)
 WRITE_CLASS_ENCODER_FEATURES(ServiceMap::Service)

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2963,11 +2963,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
       for (auto& p : service_map.services) {
         const std::string &service = p.first;
         // filter out normal ceph entity types
-        if (service == "osd" ||
-            service == "client" ||
-            service == "mon" ||
-            service == "mds" ||
-            service == "mgr") {
+        if (ServiceMap::is_normal_ceph_entity(service)) {
           continue;
         }
 	ss << "    " << p.first << ": " << string(maxlen - p.first.size(), ' ')
@@ -3797,7 +3793,11 @@ void Monitor::handle_command(MonOpRequestRef op)
     f->close_section();
 
     for (auto& p : mgrstatmon()->get_service_map().services) {
-      f->open_object_section(p.first.c_str());
+      auto &service = p.first;
+      if (ServiceMap::is_normal_ceph_entity(service)) {
+        continue;
+      }
+      f->open_object_section(service.c_str());
       map<string,int> m;
       p.second.count_metadata("ceph_version", &m);
       for (auto& q : m) {


### PR DESCRIPTION
@tchaikov @batrick 

MDS does not register with the manager for service updates and is not a service daemon. This pr adjusts `task status` update logic for that. One thing to note here is that the MDS (in the form of `<service>.<name>`)  gets added to the service map though it's not a service daemon. Would that cause any side effects?

@batrick -- right now I haven't changed the way MDS constantly sends scrub updates even when idle ("idle" status). I'll get to that once the approach here seems ok.