### PR TITLE
nautilus: cmake: remove seastar tests from "make check"

### DIFF
--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -1,15 +1,12 @@
 add_executable(unittest_seastar_buffer
   test_buffer.cc)
-add_ceph_unittest(unittest_seastar_buffer)
 target_link_libraries(unittest_seastar_buffer ceph-common crimson)
 
 add_executable(unittest_seastar_denc
   test_denc.cc)
-add_ceph_unittest(unittest_seastar_denc)
 target_link_libraries(unittest_seastar_denc crimson GTest::Main)
 
 add_executable(unittest_seastar_messenger test_messenger.cc)
-add_ceph_unittest(unittest_seastar_messenger)
 target_link_libraries(unittest_seastar_messenger ceph-common crimson)
 
 add_executable(perf_crimson_msgr perf_crimson_msgr.cc)
@@ -25,7 +22,6 @@ target_link_libraries(unittest_async_echo ceph-common global)
 
 add_executable(unittest_seastar_thread_pool
   test_thread_pool.cc)
-add_ceph_unittest(unittest_seastar_thread_pool)
 target_link_libraries(unittest_seastar_thread_pool crimson)
 
 add_executable(unittest_seastar_config
@@ -38,11 +34,9 @@ target_link_libraries(unittest_seastar_monc crimson)
 
 add_executable(unittest_seastar_perfcounters
   test_perfcounters.cc)
-add_ceph_unittest(unittest_seastar_perfcounters)
 target_link_libraries(unittest_seastar_perfcounters crimson)
 
 add_executable(unittest_seastar_lru
   test_lru.cc)
-add_ceph_unittest(unittest_seastar_lru)
 target_link_libraries(unittest_seastar_lru crimson GTest::Main)
 


### PR DESCRIPTION
because crimson is released yet, it does not make sense to run seaetar
based tests in LTS branches.

Signed-off-by: Kefu Chai <kchai@redhat.com>

Conflicts: this change is not cherry-picked from master. as explained
  in the commit message above. we need to use these seastar based
  tests to verify that the crimson facilities are not broken in master.
  but it does not help to run them in nautilus.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
