### PR TITLE
rgw: Increase the default number of RGW bucket shards

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -307,3 +307,12 @@
 * RGW S3: Support has been added for BlockPublicAccess set of APIs at a bucket
   level, currently blocking/ignoring public acls & policies are supported.
   User/Account level apis are planned to be added in the future
+
+* RGW: The default number of bucket index shards for new buckets was raised
+  from 1 to 11 to increase the amount of write throughput for small buckets
+  and delay the onset of dynamic resharding. This change only affects new
+  deployments/zones. To change this default value on existing deployments,
+  use 'radosgw-admin zonegroup modify --bucket-index-max-shards=11'.
+  If the zonegroup is part of a realm, the change must be committed with
+  'radosgw-admin period update --commit' - otherwise the change will take
+  effect after radosgws are restarted.

--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -728,6 +728,13 @@ Options
 
    Remove the zones from list of zones to sync from.
 
+.. option:: --bucket-index-max-shards
+
+   Override a zone's or zonegroup's default number of bucket index shards. This
+   option is accepted by the 'zone create', 'zone modify', 'zonegroup add',
+   and 'zonegroup modify' commands, and applies to buckets that are created
+   after the zone/zonegroup changes take effect.
+
 .. option:: --fix
 
 	Besides checking bucket index, will also fix it.

--- a/qa/rgw_bucket_sharding/many.yaml
+++ b/qa/rgw_bucket_sharding/many.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        rgw override bucket index max shards: 1999

--- a/qa/rgw_bucket_sharding/single.yaml
+++ b/qa/rgw_bucket_sharding/single.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        rgw override bucket index max shards: 1

--- a/qa/suites/rgw/verify/sharding$
+++ b/qa/suites/rgw/verify/sharding$
@@ -1,0 +1,1 @@
+.qa/rgw_bucket_sharding

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5391,7 +5391,10 @@ std::vector<Option> get_rgw_options() {
 
     Option("rgw_override_bucket_index_max_shards", Option::TYPE_UINT, Option::LEVEL_DEV)
     .set_default(0)
-    .set_description(""),
+    .set_description("The default number of bucket index shards for newly-created "
+        "buckets. This value overrides bucket_index_max_shards stored in the zone. "
+        "Setting this value in the zone is preferred, because it applies globally "
+        "to all radosgw daemons running in the zone."),
 
     Option("rgw_bucket_index_max_aio", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(128)

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -4569,15 +4569,8 @@ int main(int argc, const char **argv)
       break;
     case OPT::ZONEGROUP_MODIFY:
       {
-	RGWRealm realm(realm_id, realm_name);
-	int ret = realm.init(g_ceph_context, store->svc()->sysobj);
-	if (ret < 0) {
-	  cerr << "failed to init realm: " << cpp_strerror(-ret) << std::endl;
-	  return -ret;
-	}
-
 	RGWZoneGroup zonegroup(zonegroup_id, zonegroup_name);
-	ret = zonegroup.init(g_ceph_context, store->svc()->sysobj);
+	int ret = zonegroup.init(g_ceph_context, store->svc()->sysobj);
 	if (ret < 0) {
 	  cerr << "failed to init zonegroup: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -179,7 +179,8 @@ int RGWZoneGroup::equals(const string& other_zonegroup) const
 int RGWZoneGroup::add_zone(const RGWZoneParams& zone_params, bool *is_master, bool *read_only,
                            const list<string>& endpoints, const string *ptier_type,
                            bool *psync_from_all, list<string>& sync_from, list<string>& sync_from_rm,
-                           string *predirect_zone, RGWSyncModulesManager *sync_mgr)
+                           string *predirect_zone, std::optional<int> bucket_index_max_shards,
+                           RGWSyncModulesManager *sync_mgr)
 {
   auto& zone_id = zone_params.get_id();
   auto& zone_name = zone_params.get_name();
@@ -232,6 +233,10 @@ int RGWZoneGroup::add_zone(const RGWZoneParams& zone_params, bool *is_master, bo
 
   if (predirect_zone) {
     zone.redirect_zone = *predirect_zone;
+  }
+
+  if (bucket_index_max_shards) {
+    zone.bucket_index_max_shards = *bucket_index_max_shards;
   }
 
   for (auto add : sync_from) {

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -799,8 +799,9 @@ struct RGWZoneGroup : public RGWSystemMetaObj {
   int equals(const std::string& other_zonegroup) const;
   int add_zone(const RGWZoneParams& zone_params, bool *is_master, bool *read_only,
                const list<std::string>& endpoints, const std::string *ptier_type,
-               bool *psync_from_all, list<std::string>& sync_from, list<std::string>& sync_from_rm,
-               std::string *predirect_zone, RGWSyncModulesManager *sync_mgr);
+               bool *psync_from_all, list<std::string>& sync_from,
+               list<std::string>& sync_from_rm, std::string *predirect_zone,
+               std::optional<int> bucket_index_max_shards, RGWSyncModulesManager *sync_mgr);
   int remove_zone(const std::string& zone_id);
   int rename_zone(const RGWZoneParams& zone_params);
   rgw_pool get_pool(CephContext *cct) const override;

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -565,11 +565,18 @@ struct RGWZone {
  */
   uint32_t bucket_index_max_shards;
 
+  // pre-shard buckets on creation to enable some write-parallism by default,
+  // delay the need to reshard as the bucket grows, and (in multisite) get some
+  // bucket index sharding where dynamic resharding is not supported
+  static constexpr uint32_t default_bucket_index_max_shards = 11;
+
   bool sync_from_all;
   set<std::string> sync_from; /* list of zones to sync from */
 
-  RGWZone() : log_meta(false), log_data(false), read_only(false), bucket_index_max_shards(0),
-              sync_from_all(true) {}
+  RGWZone()
+    : log_meta(false), log_data(false), read_only(false),
+      bucket_index_max_shards(default_bucket_index_max_shards),
+      sync_from_all(true) {}
 
   void encode(bufferlist& bl) const {
     ENCODE_START(7, 1, bl);

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -245,6 +245,7 @@
                                set list of zones to sync from
      --sync-from-rm=[zone-name][,...]
                                remove zones from list of zones to sync from
+     --bucket-index-max-shards override a zone/zonegroup's default bucket index shard count
      --fix                     besides checking bucket index, will also fix it
      --check-objects           bucket check: rebuilds bucket index according to
                                actual objects state


### PR DESCRIPTION
each zone in the zonegroup has a "bucket_index_max_shards" field, but the only way to change it is by manually editing the json format using `radosgw-admin zonegroup get/set`

this change extends the `zone modify` and `zonegroup modify` commands to accept the `--max-bucket-index-shards` option to set this field - either for an individual zone, or for all zones in a given zonegroup

it also pulls in the change from https://github.com/ceph/ceph/pull/30875 to raise its default value to 11