### PR TITLE
cephadm: use `journalctl` for container logs

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2002,12 +2002,28 @@ def command_logs():
     # type: () -> None
     if not args.fsid:
         raise Error('must pass --fsid to specify cluster')
-    cmd = [str(container_path), 'logs'] # type: List[str]
-    if args.follow:
-        cmd.append('-f')
-    if args.tail:
-        cmd.append('--tail=' + str(args.tail))
-    cmd.append('ceph-%s-%s' % (args.fsid, args.name))
+
+    (daemon_type, daemon_id) = args.name.split('.', 1)
+    unit_name = get_unit_name(args.fsid, daemon_type, daemon_id)
+
+    cmd = []
+    if args.logger == 'journald':
+        cmd.extend([find_program('journalctl')])
+        cmd.append('--no-pager')
+        if args.follow:
+            cmd.append('-f')
+        if args.tail:
+            cmd.extend(['-n', args.tail])
+        cmd.extend(['-u', unit_name])
+    elif args.logger == 'docker' or args.logger == 'podman':
+        cmd.extend([str(container_path), 'logs'])
+        if args.follow:
+            cmd.append('-f')
+        if args.tail:
+            cmd.extend(['--tail', args.tail])
+        cmd.append('ceph-%s-%s' % (args.fsid, args.name))
+    else:
+        raise Error('logger type \'%s\' not recognized' % (args.logger))
 
     # call this directly, without our wrapper, so that we get an unmolested
     # stdout with logger prefixing.
@@ -2542,6 +2558,10 @@ def _get_parser():
     parser_logs.add_argument(
         '--tail',
         help='Output the specified number of lines at the end of the log')
+    parser_logs.add_argument(
+        '--logger',
+        default='journald',
+        help='Specifies the logger. Can be one of \'docker\', \'podman\', or \'journald\'')
 
     parser_bootstrap = subparsers.add_parser(
         'bootstrap', help='bootstrap a cluster (mon + mgr daemons)')


### PR DESCRIPTION
`podman logs` does not give any context when the container is stopped/crashed.

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
