### PR TITLE
qa: ignore slow ops for ffsb workunit

### DIFF
--- a/qa/cephfs/tasks/cfuse_workunit_suites_ffsb.yaml
+++ b/qa/cephfs/tasks/cfuse_workunit_suites_ffsb.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-whitelist:
+    - SLOW_OPS
     conf:
       osd:
         filestore flush min: 0

--- a/qa/suites/kcephfs/cephfs/tasks/kclient_workunit_suites_ffsb.yaml
+++ b/qa/suites/kcephfs/cephfs/tasks/kclient_workunit_suites_ffsb.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+    - SLOW_OPS
 tasks:
 - workunit:
     clients:

--- a/qa/suites/kcephfs/thrash/workloads/kclient_workunit_suites_ffsb.yaml
+++ b/qa/suites/kcephfs/thrash/workloads/kclient_workunit_suites_ffsb.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-whitelist:
+    - SLOW_OPS
     conf:
       osd:
         filestore flush min: 0


### PR DESCRIPTION
EC pools typically cause this.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
