### PR TITLE
crush/CrushWrapper: behave with empty weight vector

### DIFF
--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1577,8 +1577,9 @@ public:
     crush_init_workspace(crush, work);
     crush_choose_arg_map arg_map = choose_args_get_with_fallback(
       choose_args_index);
-    int numrep = crush_do_rule(crush, rule, x, rawout, maxout, &weight[0],
-			       weight.size(), work, arg_map.args);
+    int numrep = crush_do_rule(crush, rule, x, rawout, maxout,
+			       std::data(weight), std::size(weight),
+			       work, arg_map.args);
     if (numrep < 0)
       numrep = 0;
     out.resize(numrep);

--- a/src/test/crush/CMakeLists.txt
+++ b/src/test/crush/CMakeLists.txt
@@ -2,14 +2,12 @@
 add_executable(unittest_crush_wrapper
   CrushWrapper.cc)
 add_ceph_unittest(unittest_crush_wrapper)
-target_link_libraries(unittest_crush_wrapper global ${BLKID_LIBRARIES})
+target_link_libraries(unittest_crush_wrapper ceph-common)
 
 # unittest_crush
 add_executable(unittest_crush
-  crush.cc
-  $<TARGET_OBJECTS:unit-main>
-  )
+  crush.cc)
 add_ceph_unittest(unittest_crush parallel)
-target_link_libraries(unittest_crush global m ${BLKID_LIBRARIES})
+target_link_libraries(unittest_crush ceph-common)
 
 add_ceph_test(crush_weights.sh ${CMAKE_CURRENT_SOURCE_DIR}/crush_weights.sh)

--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -23,16 +23,34 @@
 #include <iostream>
 #include <gtest/gtest.h>
 
-#include "include/stringify.h"
 #include "common/ceph_argparse.h"
-#include "global/global_init.h"
-#include "global/global_context.h"
+#include "common/common_init.h"
+#include "include/stringify.h"
 #include "include/Context.h"
 #include "osd/osd_types.h"
 
 #include "crush/CrushWrapper.h"
 
-TEST(CrushWrapper, get_immediate_parent) {
+class CrushWrapperTest : public ::testing::Test
+{
+public:
+  void SetUp() final
+  {
+    CephInitParameters params(CEPH_ENTITY_TYPE_CLIENT);
+    cct = common_preinit(params, CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+    cct->_conf.set_val("debug_crush", "0");
+  }
+  void TearDown() final
+  {
+    cct->put();
+    cct = nullptr;
+  }
+protected:
+  CephContext *cct = nullptr;
+};
+
+TEST_F(CrushWrapperTest, get_immediate_parent) {
   std::unique_ptr<CrushWrapper> c(new CrushWrapper);
 
   const int ROOT_TYPE = 1;
@@ -56,7 +74,7 @@ TEST(CrushWrapper, get_immediate_parent) {
     map<string,string> loc;
     loc["root"] = "default";
 
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd.0", loc));
   }
 
@@ -66,7 +84,7 @@ TEST(CrushWrapper, get_immediate_parent) {
   EXPECT_EQ("default", loc.second);
 }
 
-TEST(CrushWrapper, move_bucket) {
+TEST_F(CrushWrapperTest, move_bucket) {
   std::unique_ptr<CrushWrapper> c(new CrushWrapper);
 
   const int ROOT_TYPE = 2;
@@ -87,7 +105,7 @@ TEST(CrushWrapper, move_bucket) {
     loc["host"] = "host0";
 
     int item = 0;
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd.0", loc));
   }
   int host0 = c->get_item_id("host0");
@@ -101,9 +119,9 @@ TEST(CrushWrapper, move_bucket) {
   loc["root"] = "root1";
 
   // 0 is not a valid bucket number, must be negative
-  EXPECT_EQ(-EINVAL, c->move_bucket(g_ceph_context, 0, loc));
+  EXPECT_EQ(-EINVAL, c->move_bucket(cct, 0, loc));
   // -100 is not an existing bucket
-  EXPECT_EQ(-ENOENT, c->move_bucket(g_ceph_context, -100, loc));
+  EXPECT_EQ(-ENOENT, c->move_bucket(cct, -100, loc));
   // move host0 from root0 to root1
   {
     pair <string,string> loc;
@@ -113,7 +131,7 @@ TEST(CrushWrapper, move_bucket) {
     EXPECT_EQ("root", loc.first);
     EXPECT_EQ("root0", loc.second);
   }
-  EXPECT_EQ(0, c->move_bucket(g_ceph_context, host0, loc));
+  EXPECT_EQ(0, c->move_bucket(cct, host0, loc));
   {
     pair <string,string> loc;
     int ret;
@@ -124,7 +142,7 @@ TEST(CrushWrapper, move_bucket) {
   }
 }
 
-TEST(CrushWrapper, swap_bucket) {
+TEST_F(CrushWrapperTest, swap_bucket) {
   std::unique_ptr<CrushWrapper> c(new CrushWrapper);
 
   const int ROOT_TYPE = 2;
@@ -150,20 +168,20 @@ TEST(CrushWrapper, swap_bucket) {
   {
     map<string,string> loc;
     loc["root"] = "root";
-    EXPECT_EQ(0, c->move_bucket(g_ceph_context, a, loc));
+    EXPECT_EQ(0, c->move_bucket(cct, a, loc));
   }
   {
     map<string,string> loc;
     loc["root"] = "root";
     loc["host"] = "a";
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, 0, 1.0, "osd.0", loc));
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, 1, 1.0, "osd.1", loc));
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, 2, 1.0, "osd.2", loc));
+    EXPECT_EQ(0, c->insert_item(cct, 0, 1.0, "osd.0", loc));
+    EXPECT_EQ(0, c->insert_item(cct, 1, 1.0, "osd.1", loc));
+    EXPECT_EQ(0, c->insert_item(cct, 2, 1.0, "osd.2", loc));
   }
   {
     map<string,string> loc;
     loc["host"] = "b";
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, 3, 1.0, "osd.3", loc));
+    EXPECT_EQ(0, c->insert_item(cct, 3, 1.0, "osd.3", loc));
   }
   ASSERT_EQ(0x30000, c->get_item_weight(a));
   ASSERT_EQ(string("a"), c->get_item_name(a));
@@ -176,9 +194,9 @@ TEST(CrushWrapper, swap_bucket) {
   ASSERT_EQ(3, c->get_bucket_item(b, 0));
 	
   // check if it can swap parent with child
-  ASSERT_EQ(-EINVAL, c->swap_bucket(g_ceph_context, root, a));
+  ASSERT_EQ(-EINVAL, c->swap_bucket(cct, root, a));
 
-  c->swap_bucket(g_ceph_context, a, b);
+  c->swap_bucket(cct, a, b);
   ASSERT_EQ(0x30000, c->get_item_weight(b));
   ASSERT_EQ(string("a"), c->get_item_name(b));
   ASSERT_EQ(0x10000, c->get_item_weight(a));
@@ -190,7 +208,7 @@ TEST(CrushWrapper, swap_bucket) {
   ASSERT_EQ(3, c->get_bucket_item(a, 0));
 }
 
-TEST(CrushWrapper, rename_bucket_or_item) {
+TEST_F(CrushWrapperTest, rename_bucket_or_item) {
   std::unique_ptr<CrushWrapper> c(new CrushWrapper);
 
   const int ROOT_TYPE = 2;
@@ -211,7 +229,7 @@ TEST(CrushWrapper, rename_bucket_or_item) {
     loc["root"] = "root0";
     loc["host"] = "host0";
 
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd.0", loc));
   }
   item++;
@@ -220,7 +238,7 @@ TEST(CrushWrapper, rename_bucket_or_item) {
     loc["root"] = "root0";
     loc["host"] = "host1";
 
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd.1", loc));
   }
 
@@ -257,7 +275,7 @@ TEST(CrushWrapper, rename_bucket_or_item) {
   EXPECT_EQ(osd0id, c->get_item_id("osd0renamed"));
 }
 
-TEST(CrushWrapper, check_item_loc) {
+TEST_F(CrushWrapperTest, check_item_loc) {
   std::unique_ptr<CrushWrapper> c(new CrushWrapper);
   int item = 0;
   float expected_weight = 1.0;
@@ -266,7 +284,7 @@ TEST(CrushWrapper, check_item_loc) {
   {
     float weight;
     map<string,string> loc;
-    EXPECT_FALSE(c->check_item_loc(g_ceph_context, item, loc, &weight));
+    EXPECT_FALSE(c->check_item_loc(cct, item, loc, &weight));
   }
 
   const int ROOT_TYPE = 2;
@@ -286,7 +304,7 @@ TEST(CrushWrapper, check_item_loc) {
     float weight;
     map<string,string> loc;
     loc["root"] = "default";
-    EXPECT_FALSE(c->check_item_loc(g_ceph_context, item, loc, &weight));
+    EXPECT_FALSE(c->check_item_loc(cct, item, loc, &weight));
   }
   // fail because the bucket name does not match an existing bucket
   {
@@ -295,13 +313,13 @@ TEST(CrushWrapper, check_item_loc) {
     loc["root"] = "default";
     const string HOST("host0");
     loc["host"] = HOST;
-    EXPECT_FALSE(c->check_item_loc(g_ceph_context, item, loc, &weight));
+    EXPECT_FALSE(c->check_item_loc(cct, item, loc, &weight));
   }
   const string OSD("osd.0");
   {
     map<string,string> loc;
     loc["root"] = "default";
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, expected_weight,
+    EXPECT_EQ(0, c->insert_item(cct, item, expected_weight,
 				OSD, loc));
   }
   // fail because osd.0 is not a bucket and must not be in loc, in
@@ -310,19 +328,19 @@ TEST(CrushWrapper, check_item_loc) {
     float weight;
     map<string,string> loc;
     loc["root"] = "osd.0";
-    EXPECT_FALSE(c->check_item_loc(g_ceph_context, item, loc, &weight));
+    EXPECT_FALSE(c->check_item_loc(cct, item, loc, &weight));
   }
   // succeed and retrieves the expected weight
   {
     float weight;
     map<string,string> loc;
     loc["root"] = "default";
-    EXPECT_TRUE(c->check_item_loc(g_ceph_context, item, loc, &weight));
+    EXPECT_TRUE(c->check_item_loc(cct, item, loc, &weight));
     EXPECT_EQ(expected_weight, weight);
   }
 }
 
-TEST(CrushWrapper, update_item) {
+TEST_F(CrushWrapperTest, update_item) {
   std::unique_ptr<CrushWrapper> c(new CrushWrapper);
 
   const int ROOT_TYPE = 2;
@@ -355,13 +373,13 @@ TEST(CrushWrapper, update_item) {
   {
     map<string,string> loc;
     loc["rack"] = "\001";
-    EXPECT_EQ(-EINVAL, c->update_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(-EINVAL, c->update_item(cct, item, 1.0,
 				      "osd." + stringify(item), loc));
   }
   // fail if invalid item name
   {
     map<string,string> loc;
-    EXPECT_EQ(-EINVAL, c->update_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(-EINVAL, c->update_item(cct, item, 1.0,
 				      "\005", loc));
   }
   const string OSD0("osd.0");
@@ -374,30 +392,30 @@ TEST(CrushWrapper, update_item) {
   loc["root"] = "default";
   loc["host"] = HOST0;
   EXPECT_GE(0.0, c->get_item_weightf(host0));
-  EXPECT_EQ(0, c->insert_item(g_ceph_context, item, original_weight,
+  EXPECT_EQ(0, c->insert_item(cct, item, original_weight,
 			      OSD0, loc));
 
   // updating nothing changes nothing
   EXPECT_EQ(OSD0, c->get_item_name(item));
   EXPECT_EQ(original_weight, c->get_item_weightf(item));
-  EXPECT_TRUE(c->check_item_loc(g_ceph_context, item, loc, &weight));
-  EXPECT_EQ(0, c->update_item(g_ceph_context, item, original_weight,
+  EXPECT_TRUE(c->check_item_loc(cct, item, loc, &weight));
+  EXPECT_EQ(0, c->update_item(cct, item, original_weight,
 			      OSD0, loc));
   EXPECT_EQ(OSD0, c->get_item_name(item));
   EXPECT_EQ(original_weight, c->get_item_weightf(item));
-  EXPECT_TRUE(c->check_item_loc(g_ceph_context, item, loc, &weight));
+  EXPECT_TRUE(c->check_item_loc(cct, item, loc, &weight));
 
   // update the name and weight of the item but not the location
   EXPECT_EQ(OSD0, c->get_item_name(item));
   EXPECT_EQ(original_weight, c->get_item_weightf(item));
-  EXPECT_TRUE(c->check_item_loc(g_ceph_context, item, loc, &weight));
-  EXPECT_EQ(1, c->update_item(g_ceph_context, item, modified_weight,
+  EXPECT_TRUE(c->check_item_loc(cct, item, loc, &weight));
+  EXPECT_EQ(1, c->update_item(cct, item, modified_weight,
 			      OSD1, loc));
   EXPECT_EQ(OSD1, c->get_item_name(item));
   EXPECT_EQ(modified_weight, c->get_item_weightf(item));
-  EXPECT_TRUE(c->check_item_loc(g_ceph_context, item, loc, &weight));
+  EXPECT_TRUE(c->check_item_loc(cct, item, loc, &weight));
   c->set_item_name(item, OSD0);
-  c->adjust_item_weightf(g_ceph_context, item, original_weight);
+  c->adjust_item_weightf(cct, item, original_weight);
 
   // update the name and weight of the item and change its location
   map<string,string> other_loc;
@@ -406,17 +424,17 @@ TEST(CrushWrapper, update_item) {
 
   EXPECT_EQ(OSD0, c->get_item_name(item));
   EXPECT_EQ(original_weight, c->get_item_weightf(item));
-  EXPECT_TRUE(c->check_item_loc(g_ceph_context, item, loc, &weight));
-  EXPECT_FALSE(c->check_item_loc(g_ceph_context, item, other_loc, &weight));
-  EXPECT_EQ(1, c->update_item(g_ceph_context, item, modified_weight,
+  EXPECT_TRUE(c->check_item_loc(cct, item, loc, &weight));
+  EXPECT_FALSE(c->check_item_loc(cct, item, other_loc, &weight));
+  EXPECT_EQ(1, c->update_item(cct, item, modified_weight,
 			      OSD1, other_loc));
   EXPECT_EQ(OSD1, c->get_item_name(item));
   EXPECT_EQ(modified_weight, c->get_item_weightf(item));
-  EXPECT_FALSE(c->check_item_loc(g_ceph_context, item, loc, &weight));
-  EXPECT_TRUE(c->check_item_loc(g_ceph_context, item, other_loc, &weight));
+  EXPECT_FALSE(c->check_item_loc(cct, item, loc, &weight));
+  EXPECT_TRUE(c->check_item_loc(cct, item, other_loc, &weight));
 }
 
-TEST(CrushWrapper, adjust_item_weight) {
+TEST_F(CrushWrapperTest, adjust_item_weight) {
   std::unique_ptr<CrushWrapper> c(new CrushWrapper);
 
   const int ROOT_TYPE = 2;
@@ -454,10 +472,10 @@ TEST(CrushWrapper, adjust_item_weight) {
     int bucket_id = 0;
 
     item = 0;
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd." + stringify(item), loc));
     item = 1;
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd." + stringify(item), loc));
 
     bucket_id = c->get_item_id("host0");
@@ -466,7 +484,7 @@ TEST(CrushWrapper, adjust_item_weight) {
 
     map<string,string> bloc;
     bloc["root"] = "default";
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, host0, host_weight,
+    EXPECT_EQ(0, c->insert_item(cct, host0, host_weight,
 				HOST0, bloc));
   }
 
@@ -477,10 +495,10 @@ TEST(CrushWrapper, adjust_item_weight) {
     int bucket_id = 0;
 
     item = 0;
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd." + stringify(item), loc));
     item = 1;
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd." + stringify(item), loc));
 
     bucket_id = c->get_item_id("fake");
@@ -489,7 +507,7 @@ TEST(CrushWrapper, adjust_item_weight) {
 
     map<string,string> bloc;
     bloc["root"] = "default";
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, hostfake, host_weight,
+    EXPECT_EQ(0, c->insert_item(cct, hostfake, host_weight,
 				FAKE, bloc));
   }
 
@@ -525,17 +543,17 @@ TEST(CrushWrapper, adjust_item_weight) {
   loc_two["host"] = "fake";
 
   item = 0;
-  EXPECT_EQ(2, c->adjust_item_weightf(g_ceph_context, item, modified_weight));
+  EXPECT_EQ(2, c->adjust_item_weightf(cct, item, modified_weight));
   EXPECT_EQ(modified_weight, c->get_item_weightf_in_loc(item, loc_one));
   EXPECT_EQ(modified_weight, c->get_item_weightf_in_loc(item, loc_two));
 
   item = 1;
-  EXPECT_EQ(1, c->adjust_item_weightf_in_loc(g_ceph_context, item, modified_weight, loc_two));
+  EXPECT_EQ(1, c->adjust_item_weightf_in_loc(cct, item, modified_weight, loc_two));
   EXPECT_EQ(original_weight, c->get_item_weightf_in_loc(item, loc_one));
   EXPECT_EQ(modified_weight, c->get_item_weightf_in_loc(item, loc_two));
 }
 
-TEST(CrushWrapper, adjust_subtree_weight) {
+TEST_F(CrushWrapperTest, adjust_subtree_weight) {
   std::unique_ptr<CrushWrapper> c(new CrushWrapper);
 
   const int ROOT_TYPE = 2;
@@ -573,10 +591,10 @@ TEST(CrushWrapper, adjust_subtree_weight) {
     int bucket_id = 0;
 
     item = 0;
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd." + stringify(item), loc));
     item = 1;
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd." + stringify(item), loc));
 
     bucket_id = c->get_item_id("host0");
@@ -585,7 +603,7 @@ TEST(CrushWrapper, adjust_subtree_weight) {
 
     map<string,string> bloc;
     bloc["root"] = "default";
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, host0, host_weight,
+    EXPECT_EQ(0, c->insert_item(cct, host0, host_weight,
 				HOST0, bloc));
   }
 
@@ -596,10 +614,10 @@ TEST(CrushWrapper, adjust_subtree_weight) {
     int bucket_id = 0;
 
     item = 0;
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd." + stringify(item), loc));
     item = 1;
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd." + stringify(item), loc));
 
     bucket_id = c->get_item_id("fake");
@@ -608,7 +626,7 @@ TEST(CrushWrapper, adjust_subtree_weight) {
 
     map<string,string> bloc;
     bloc["root"] = "default";
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, hostfake, host_weight,
+    EXPECT_EQ(0, c->insert_item(cct, hostfake, host_weight,
 				FAKE, bloc));
   }
 
@@ -617,7 +635,7 @@ TEST(CrushWrapper, adjust_subtree_weight) {
   ASSERT_EQ(c->get_bucket_weight(host0), 131072);
   ASSERT_EQ(c->get_bucket_weight(rootno), 262144);
 
-  int r = c->adjust_subtree_weightf(g_ceph_context, host0, 2.0);
+  int r = c->adjust_subtree_weightf(cct, host0, 2.0);
   ASSERT_EQ(r, 2); // 2 items changed
 
   //cout << "--------after---------" << std::endl;
@@ -628,7 +646,7 @@ TEST(CrushWrapper, adjust_subtree_weight) {
   ASSERT_EQ(c->get_bucket_weight(rootno), 262144 + 131072);
 }
 
-TEST(CrushWrapper, insert_item) {
+TEST_F(CrushWrapperTest, insert_item) {
   std::unique_ptr<CrushWrapper> c(new CrushWrapper);
 
   const int ROOT_TYPE = 2;
@@ -649,7 +667,7 @@ TEST(CrushWrapper, insert_item) {
   {
     map<string,string> loc;
     loc["host"] = "\001";
-    EXPECT_EQ(-EINVAL, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(-EINVAL, c->insert_item(cct, item, 1.0,
 				      "osd." + stringify(item), loc));
   }
 
@@ -659,10 +677,10 @@ TEST(CrushWrapper, insert_item) {
     loc["root"] = "default";
 
     item++;
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd." + stringify(item), loc));
     int another_item = item + 1;
-    EXPECT_EQ(-EEXIST, c->insert_item(g_ceph_context, another_item, 1.0,
+    EXPECT_EQ(-EEXIST, c->insert_item(cct, another_item, 1.0,
 				      "osd." + stringify(item), loc));
   }
   // implicit creation of a bucket 
@@ -673,7 +691,7 @@ TEST(CrushWrapper, insert_item) {
     loc["host"] = name;
 
     item++;
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd." + stringify(item), loc));
   }
   // adding to an existing item name that is not associated with a bucket
@@ -686,7 +704,7 @@ TEST(CrushWrapper, insert_item) {
     c->set_item_name(item, name);
 
     item++;
-    EXPECT_EQ(-EINVAL, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(-EINVAL, c->insert_item(cct, item, 1.0,
 				      "osd." + stringify(item), loc));
   }
   // 
@@ -708,14 +726,14 @@ TEST(CrushWrapper, insert_item) {
       loc["root"] = "default";
       loc["host"] = "host0";
 
-      EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+      EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				  "osd." + stringify(item), loc));
     }
     {
       map<string,string> loc;
       loc["root"] = "default";
 
-      EXPECT_EQ(-EINVAL, c->insert_item(g_ceph_context, item, 1.0,
+      EXPECT_EQ(-EINVAL, c->insert_item(cct, item, 1.0,
 					"osd." + stringify(item), loc));
     }
   }
@@ -733,7 +751,7 @@ TEST(CrushWrapper, insert_item) {
     map<string,string> loc;
     loc["host"] = "host0";
 
-    EXPECT_EQ(-ELOOP, c->insert_item(g_ceph_context, rootno, 1.0,
+    EXPECT_EQ(-ELOOP, c->insert_item(cct, rootno, 1.0,
 				     "default", loc));
   }
   // fail when mapping a bucket to the wrong type
@@ -750,19 +768,19 @@ TEST(CrushWrapper, insert_item) {
     loc["host"] = "myosd";
 
     item++;
-    EXPECT_EQ(-EINVAL, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(-EINVAL, c->insert_item(cct, item, 1.0,
 				      "osd." + stringify(item), loc));
   }
   // fail when no location 
   {
     map<string,string> loc;
     item++;
-    EXPECT_EQ(-EINVAL, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(-EINVAL, c->insert_item(cct, item, 1.0,
 				      "osd." + stringify(item), loc));
   }
 }
 
-TEST(CrushWrapper, remove_item) {
+TEST_F(CrushWrapperTest, remove_item) {
   std::unique_ptr<CrushWrapper> c(new CrushWrapper);
 
   const int ROOT_TYPE = 2;
@@ -792,19 +810,19 @@ TEST(CrushWrapper, remove_item) {
 			       {"host", "host0"}};
     string name{"osd."};
     for (int item = 0; item < num_osd; item++) {
-      ASSERT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+      ASSERT_EQ(0, c->insert_item(cct, item, 1.0,
 				  name + to_string(item), loc));
     }
   }
   const int item_to_remove = num_osd / 2;
   map<string, string> loc;
   loc.insert(c->get_immediate_parent(item_to_remove));
-  ASSERT_EQ(0, c->remove_item(g_ceph_context, item_to_remove, true));
+  ASSERT_EQ(0, c->remove_item(cct, item_to_remove, true));
   float weight;
-  EXPECT_FALSE(c->check_item_loc(g_ceph_context, item_to_remove, loc, &weight));
+  EXPECT_FALSE(c->check_item_loc(cct, item_to_remove, loc, &weight));
 }
 
-TEST(CrushWrapper, item_bucket_names) {
+TEST_F(CrushWrapperTest, item_bucket_names) {
   std::unique_ptr<CrushWrapper> c(new CrushWrapper);
   int index = 123;
   string name = "NAME";
@@ -816,7 +834,7 @@ TEST(CrushWrapper, item_bucket_names) {
   EXPECT_EQ(name, c->get_item_name(index));
 }
 
-TEST(CrushWrapper, bucket_types) {
+TEST_F(CrushWrapperTest, bucket_types) {
   std::unique_ptr<CrushWrapper> c(new CrushWrapper);
   int index = 123;
   string name = "NAME";
@@ -826,30 +844,30 @@ TEST(CrushWrapper, bucket_types) {
   EXPECT_EQ(name, c->get_type_name(index));
 }
 
-TEST(CrushWrapper, is_valid_crush_name) {
+TEST_F(CrushWrapperTest, is_valid_crush_name) {
   EXPECT_TRUE(CrushWrapper::is_valid_crush_name("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012456789-_"));
   EXPECT_FALSE(CrushWrapper::is_valid_crush_name(""));
   EXPECT_FALSE(CrushWrapper::is_valid_crush_name("\001"));
 }
 
-TEST(CrushWrapper, is_valid_crush_loc) {
+TEST_F(CrushWrapperTest, is_valid_crush_loc) {
   map<string,string> loc;
-  EXPECT_TRUE(CrushWrapper::is_valid_crush_loc(g_ceph_context, loc));
+  EXPECT_TRUE(CrushWrapper::is_valid_crush_loc(cct, loc));
   loc["good"] = "better";
-  EXPECT_TRUE(CrushWrapper::is_valid_crush_loc(g_ceph_context, loc));
+  EXPECT_TRUE(CrushWrapper::is_valid_crush_loc(cct, loc));
   {
     map<string,string> loc;
     loc["\005"] = "default";
-    EXPECT_FALSE(CrushWrapper::is_valid_crush_loc(g_ceph_context, loc));
+    EXPECT_FALSE(CrushWrapper::is_valid_crush_loc(cct, loc));
   }
   {
     map<string,string> loc;
     loc["host"] = "\003";
-    EXPECT_FALSE(CrushWrapper::is_valid_crush_loc(g_ceph_context, loc));
+    EXPECT_FALSE(CrushWrapper::is_valid_crush_loc(cct, loc));
   }
 }
 
-TEST(CrushWrapper, dump_rules) {
+TEST_F(CrushWrapperTest, dump_rules) {
   std::unique_ptr<CrushWrapper> c(new CrushWrapper);
 
   const int ROOT_TYPE = 1;
@@ -875,7 +893,7 @@ TEST(CrushWrapper, dump_rules) {
     map<string,string> loc;
     loc["root"] = root_name;
 
-    EXPECT_EQ(0, c->insert_item(g_ceph_context, item, 1.0,
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
 				"osd.0", loc));
   }
 
@@ -922,7 +940,7 @@ TEST(CrushWrapper, dump_rules) {
   ASSERT_TRUE(wm[0] == 1.0);
 }
 
-TEST(CrushWrapper, distance) {
+TEST_F(CrushWrapperTest, distance) {
   CrushWrapper c;
   c.create();
   c.set_type_name(1, "host");
@@ -944,25 +962,25 @@ TEST(CrushWrapper, distance) {
   loc["host"] = "a1";
   loc["rack"] = "a";
   loc["root"] = "default";
-  c.insert_item(g_ceph_context, 0, 1, "osd.0", loc);
+  c.insert_item(cct, 0, 1, "osd.0", loc);
 
   loc.clear();
   loc["host"] = "a2";
   loc["rack"] = "a";
   loc["root"] = "default";
-  c.insert_item(g_ceph_context, 1, 1, "osd.1", loc);
+  c.insert_item(cct, 1, 1, "osd.1", loc);
 
   loc.clear();
   loc["host"] = "b1";
   loc["rack"] = "b";
   loc["root"] = "default";
-  c.insert_item(g_ceph_context, 2, 1, "osd.2", loc);
+  c.insert_item(cct, 2, 1, "osd.2", loc);
 
   loc.clear();
   loc["host"] = "b2";
   loc["rack"] = "b";
   loc["root"] = "default";
-  c.insert_item(g_ceph_context, 3, 1, "osd.3", loc);
+  c.insert_item(cct, 3, 1, "osd.3", loc);
 
   vector<pair<string,string> > ol;
   c.get_full_location_ordered(3, ol);
@@ -978,20 +996,20 @@ TEST(CrushWrapper, distance) {
   p.insert(make_pair("host","b2"));
   p.insert(make_pair("rack","b"));
   p.insert(make_pair("root","default"));
-  ASSERT_EQ(3, c.get_common_ancestor_distance(g_ceph_context, 0, p));
-  ASSERT_EQ(3, c.get_common_ancestor_distance(g_ceph_context, 1, p));
-  ASSERT_EQ(2, c.get_common_ancestor_distance(g_ceph_context, 2, p));
-  ASSERT_EQ(1, c.get_common_ancestor_distance(g_ceph_context, 3, p));
-  ASSERT_EQ(-ENOENT, c.get_common_ancestor_distance(g_ceph_context, 123, p));
+  ASSERT_EQ(3, c.get_common_ancestor_distance(cct, 0, p));
+  ASSERT_EQ(3, c.get_common_ancestor_distance(cct, 1, p));
+  ASSERT_EQ(2, c.get_common_ancestor_distance(cct, 2, p));
+  ASSERT_EQ(1, c.get_common_ancestor_distance(cct, 3, p));
+  ASSERT_EQ(-ENOENT, c.get_common_ancestor_distance(cct, 123, p));
 
   // make sure a "multipath" location will reflect a minimal
   // distance for both paths
   p.insert(make_pair("host","b1"));
-  ASSERT_EQ(1, c.get_common_ancestor_distance(g_ceph_context, 2, p));
-  ASSERT_EQ(1, c.get_common_ancestor_distance(g_ceph_context, 3, p));
+  ASSERT_EQ(1, c.get_common_ancestor_distance(cct, 2, p));
+  ASSERT_EQ(1, c.get_common_ancestor_distance(cct, 3, p));
 }
 
-TEST(CrushWrapper, choose_args_compat) {
+TEST_F(CrushWrapperTest, choose_args_compat) {
   CrushWrapper c;
   c.create();
   c.set_type_name(1, "host");
@@ -1005,13 +1023,13 @@ TEST(CrushWrapper, choose_args_compat) {
   loc["rack"] = "r11";
   loc["root"] = "default";
   int item = 1;
-  c.insert_item(g_ceph_context, item, weight, "osd.1", loc);
+  c.insert_item(cct, item, weight, "osd.1", loc);
 
   loc["host"] = "b2";
   loc["rack"] = "r12";
   loc["root"] = "default";
   item = 2;
-  c.insert_item(g_ceph_context, item, weight, "osd.2", loc);
+  c.insert_item(cct, item, weight, "osd.2", loc);
 
   ceph_assert(c.add_simple_rule("rule1", "r11", "host", "",
 			   "firstn", pg_pool_t::TYPE_ERASURE) >= 0);
@@ -1064,7 +1082,7 @@ TEST(CrushWrapper, choose_args_compat) {
   }
 }
 
-TEST(CrushWrapper, remove_root) {
+TEST_F(CrushWrapperTest, remove_root) {
   CrushWrapper c;
   c.create();
   c.set_type_name(1, "host");
@@ -1078,25 +1096,25 @@ TEST(CrushWrapper, remove_root) {
   loc["rack"] = "r11";
   loc["root"] = "default";
   int item = 1;
-  c.insert_item(g_ceph_context, item, weight, "osd.1", loc);
+  c.insert_item(cct, item, weight, "osd.1", loc);
   item = 2;
   loc["host"] = "b2";
   loc["rack"] = "r12";
   loc["root"] = "default";
-  c.insert_item(g_ceph_context, item, weight, "osd.2", loc);
+  c.insert_item(cct, item, weight, "osd.2", loc);
 
   ceph_assert(c.add_simple_rule("rule1", "r11", "host", "",
 			   "firstn", pg_pool_t::TYPE_ERASURE) >= 0);
   ASSERT_TRUE(c.name_exists("default"));
   ASSERT_TRUE(c.name_exists("r11"));
   ASSERT_TRUE(c.name_exists("r12"));
-  ASSERT_EQ(c.remove_root(g_ceph_context, c.get_item_id("default")), 0);
+  ASSERT_EQ(c.remove_root(cct, c.get_item_id("default")), 0);
   ASSERT_FALSE(c.name_exists("default"));
   ASSERT_FALSE(c.name_exists("r11"));
   ASSERT_FALSE(c.name_exists("r12"));
 }
 
-TEST(CrushWrapper, trim_roots_with_class) {
+TEST_F(CrushWrapperTest, trim_roots_with_class) {
   CrushWrapper c;
   c.create();
   c.set_type_name(1, "root");
@@ -1106,7 +1124,7 @@ TEST(CrushWrapper, trim_roots_with_class) {
   loc["root"] = "default";
 
   int item = 1;
-  c.insert_item(g_ceph_context, item, weight, "osd.1", loc);
+  c.insert_item(cct, item, weight, "osd.1", loc);
   int cl = c.get_or_create_class_id("ssd");
   c.class_map[item] = cl;
 
@@ -1122,12 +1140,12 @@ TEST(CrushWrapper, trim_roots_with_class) {
 
   ASSERT_TRUE(c.name_exists("default"));
   ASSERT_TRUE(c.name_exists("default~ssd"));
-  c.trim_roots_with_class(g_ceph_context);
+  c.trim_roots_with_class(cct);
   ASSERT_TRUE(c.name_exists("default"));
   ASSERT_FALSE(c.name_exists("default~ssd"));
 }
 
-TEST(CrushWrapper, device_class_clone) {
+TEST_F(CrushWrapperTest, device_class_clone) {
   CrushWrapper c;
   c.create();
   c.set_type_name(1, "host");
@@ -1139,14 +1157,14 @@ TEST(CrushWrapper, device_class_clone) {
   int weight = 1;
 
   int item = 1;
-  c.insert_item(g_ceph_context, item, weight, "osd.1", loc);
+  c.insert_item(cct, item, weight, "osd.1", loc);
   int cl = c.get_or_create_class_id("ssd");
   c.class_map[item] = cl;
 
   int item_no_class = 2;
-  c.insert_item(g_ceph_context, item_no_class, weight, "osd.2", loc);
+  c.insert_item(cct, item_no_class, weight, "osd.2", loc);
 
-  c.reweight(g_ceph_context);
+  c.reweight(cct);
 
   map<int32_t, map<int32_t, int32_t>> old_class_bucket;
   map<int,map<int,vector<int>>> cmap_item_weight; // cargs -> bno -> weights
@@ -1174,7 +1192,7 @@ TEST(CrushWrapper, device_class_clone) {
 				 &other_clone_id, &cmap_item_weight), -EBADF);
 }
 
-TEST(CrushWrapper, split_id_class) {
+TEST_F(CrushWrapperTest, split_id_class) {
   CrushWrapper c;
   c.create();
   c.set_type_name(1, "root");
@@ -1184,7 +1202,7 @@ TEST(CrushWrapper, split_id_class) {
   loc["root"] = "default";
 
   int item = 1;
-  c.insert_item(g_ceph_context, item, weight, "osd.1", loc);
+  c.insert_item(cct, item, weight, "osd.1", loc);
   int class_id = c.get_or_create_class_id("ssd");
   c.class_map[item] = class_id;
 
@@ -1206,7 +1224,7 @@ TEST(CrushWrapper, split_id_class) {
   ASSERT_EQ(-1, retrieved_class_id);
 }
 
-TEST(CrushWrapper, populate_classes) {
+TEST_F(CrushWrapperTest, populate_classes) {
   CrushWrapper c;
   c.create();
   c.set_type_name(1, "root");
@@ -1216,7 +1234,7 @@ TEST(CrushWrapper, populate_classes) {
   loc["root"] = "default";
 
   int item = 1;
-  c.insert_item(g_ceph_context, item, weight, "osd.1", loc);
+  c.insert_item(cct, item, weight, "osd.1", loc);
   int class_id = c.get_or_create_class_id("ssd");
   c.class_map[item] = class_id;
 
@@ -1230,7 +1248,7 @@ TEST(CrushWrapper, populate_classes) {
   ASSERT_EQ(old_class_bucket, c.class_bucket);
 }
 
-TEST(CrushWrapper, remove_class_name) {
+TEST_F(CrushWrapperTest, remove_class_name) {
   CrushWrapper c;
   c.create();
 
@@ -1240,7 +1258,7 @@ TEST(CrushWrapper, remove_class_name) {
   ASSERT_EQ(-ENOENT, c.remove_class_name("ssd"));
 }
 
-TEST(CrushWrapper, try_remap_rule) {
+TEST_F(CrushWrapperTest, try_remap_rule) {
   // build a simple 2 level map
   CrushWrapper c;
   c.create();
@@ -1264,51 +1282,51 @@ TEST(CrushWrapper, try_remap_rule) {
   loc["host"] = "foo";
   loc["rack"] = "a";
   loc["root"] = "default";
-  c.insert_item(g_ceph_context, 0, 1, "osd.0", loc);
-  c.insert_item(g_ceph_context, 1, 1, "osd.1", loc);
-  c.insert_item(g_ceph_context, 2, 1, "osd.2", loc);
+  c.insert_item(cct, 0, 1, "osd.0", loc);
+  c.insert_item(cct, 1, 1, "osd.1", loc);
+  c.insert_item(cct, 2, 1, "osd.2", loc);
 
   loc.clear();
   loc["host"] = "bar";
   loc["rack"] = "a";
   loc["root"] = "default";
-  c.insert_item(g_ceph_context, 3, 1, "osd.3", loc);
-  c.insert_item(g_ceph_context, 4, 1, "osd.4", loc);
-  c.insert_item(g_ceph_context, 5, 1, "osd.5", loc);
+  c.insert_item(cct, 3, 1, "osd.3", loc);
+  c.insert_item(cct, 4, 1, "osd.4", loc);
+  c.insert_item(cct, 5, 1, "osd.5", loc);
 
   loc.clear();
   loc["host"] = "baz";
   loc["rack"] = "b";
   loc["root"] = "default";
-  c.insert_item(g_ceph_context, 6, 1, "osd.6", loc);
-  c.insert_item(g_ceph_context, 7, 1, "osd.7", loc);
-  c.insert_item(g_ceph_context, 8, 1, "osd.8", loc);
+  c.insert_item(cct, 6, 1, "osd.6", loc);
+  c.insert_item(cct, 7, 1, "osd.7", loc);
+  c.insert_item(cct, 8, 1, "osd.8", loc);
 
   loc.clear();
   loc["host"] = "qux";
   loc["rack"] = "b";
   loc["root"] = "default";
-  c.insert_item(g_ceph_context, 9, 1, "osd.9", loc);
-  c.insert_item(g_ceph_context, 10, 1, "osd.10", loc);
-  c.insert_item(g_ceph_context, 11, 1, "osd.11", loc);
+  c.insert_item(cct, 9, 1, "osd.9", loc);
+  c.insert_item(cct, 10, 1, "osd.10", loc);
+  c.insert_item(cct, 11, 1, "osd.11", loc);
   c.finalize();
 
   loc.clear();
   loc["host"] = "bif";
   loc["rack"] = "c";
   loc["root"] = "default";
-  c.insert_item(g_ceph_context, 12, 1, "osd.12", loc);
-  c.insert_item(g_ceph_context, 13, 1, "osd.13", loc);
-  c.insert_item(g_ceph_context, 14, 1, "osd.14", loc);
+  c.insert_item(cct, 12, 1, "osd.12", loc);
+  c.insert_item(cct, 13, 1, "osd.13", loc);
+  c.insert_item(cct, 14, 1, "osd.14", loc);
   c.finalize();
 
   loc.clear();
   loc["host"] = "pop";
   loc["rack"] = "c";
   loc["root"] = "default";
-  c.insert_item(g_ceph_context, 15, 1, "osd.15", loc);
-  c.insert_item(g_ceph_context, 16, 1, "osd.16", loc);
-  c.insert_item(g_ceph_context, 17, 1, "osd.17", loc);
+  c.insert_item(cct, 15, 1, "osd.15", loc);
+  c.insert_item(cct, 16, 1, "osd.16", loc);
+  c.insert_item(cct, 17, 1, "osd.17", loc);
   c.finalize();
 
   //c.dump(&jf);
@@ -1331,7 +1349,7 @@ TEST(CrushWrapper, try_remap_rule) {
     vector<int> underfull = { 0, 2, 5, 8, 11 };
     vector<int> more_underfull = {};
     vector<int> out;
-    int r = c.try_remap_rule(g_ceph_context, rule, 3,
+    int r = c.try_remap_rule(cct, rule, 3,
 			      overfull, underfull, more_underfull,
 			      orig, &out);
     cout << orig << " -> r = " << (int)r << " out " << out << std::endl;
@@ -1345,7 +1363,7 @@ TEST(CrushWrapper, try_remap_rule) {
     underfull = {9, 0, 2, 5};
     orig = {1, 3, 9};
 
-    r = c.try_remap_rule(g_ceph_context, rule, 3,
+    r = c.try_remap_rule(cct, rule, 3,
 			 overfull, underfull, more_underfull,
 			 orig, &out);
     cout << orig << " -> r = " << (int)r << " out " << out << std::endl;
@@ -1360,7 +1378,7 @@ TEST(CrushWrapper, try_remap_rule) {
     overfull = { 3, 9 };
     underfull = { 2 };
     more_underfull = { 5, 8, 11 };
-    r = c.try_remap_rule(g_ceph_context, rule, 3,
+    r = c.try_remap_rule(cct, rule, 3,
 			      overfull, underfull, more_underfull,
 			      orig, &out);
     cout << orig << " -> r = " << (int)r << " out " << out << std::endl;
@@ -1384,7 +1402,7 @@ TEST(CrushWrapper, try_remap_rule) {
     vector<int> underfull = { 0, 2, 5, 8, 11 };
     vector<int> more_underfull = { };
     vector<int> out;
-    int r = c.try_remap_rule(g_ceph_context, rule, 3,
+    int r = c.try_remap_rule(cct, rule, 3,
 			      overfull, underfull, more_underfull,
 			      orig, &out);
     cout << orig << " -> r = " << (int)r << " out " << out << std::endl;
@@ -1411,7 +1429,7 @@ TEST(CrushWrapper, try_remap_rule) {
     vector<int> underfull = { 6, 7, 9, 3, 0, 1, 15, 16, 13, 2, 5, 8, 11 };
     vector<int> more_underfull = { };
     vector<int> out;
-    int r = c.try_remap_rule(g_ceph_context, rule, 3,
+    int r = c.try_remap_rule(cct, rule, 3,
 			      overfull, underfull, more_underfull,
 			      orig, &out);
     cout << orig << " -> r = " << (int)r << " out " << out << std::endl;
@@ -1424,7 +1442,7 @@ TEST(CrushWrapper, try_remap_rule) {
 
     orig.pop_back();
     out.clear();
-    r = c.try_remap_rule(g_ceph_context, rule, 3,
+    r = c.try_remap_rule(cct, rule, 3,
 			 overfull, underfull, more_underfull,
 			 orig, &out);
     cout << orig << " -> r = " << (int)r << " out " << out << std::endl;
@@ -1436,20 +1454,6 @@ TEST(CrushWrapper, try_remap_rule) {
   }
 }
 
-int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
-
-  map<string,string> defaults = {
-    { "debug_crush", "0" }
-  };
-  auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
-			 CODE_ENVIRONMENT_UTILITY,
-			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
-  common_init_finish(g_ceph_context);
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
 // Local Variables:
 // compile-command: "cd ../../../build ; make -j4 unittest_crush_wrapper && valgrind --tool=memcheck bin/unittest_crush_wrapper"
 // End:

--- a/src/test/crush/crush.cc
+++ b/src/test/crush/crush.cc
@@ -8,16 +8,17 @@
  * LGPL-2.1 (see COPYING-LGPL2.1) or later
  */
 
+#include <gtest/gtest.h>
 #include <iostream>
 #include <memory>
-#include <gtest/gtest.h>
+#include <set>
 
+#include "common/ceph_argparse.h"
+#include "common/common_init.h"
 #include "include/stringify.h"
 
 #include "crush/CrushWrapper.h"
 #include "osd/osd_types.h"
-
-#include <set>
 
 std::unique_ptr<CrushWrapper> build_indep_map(CephContext *cct, int num_rack,
                               int num_host, int num_osd)
@@ -82,17 +83,35 @@ int get_num_dups(const vector<int>& v)
 {
   std::set<int> s;
   int dups = 0;
-  for (unsigned i=0; i<v.size(); ++i) {
-    if (s.count(v[i]))
+  for (auto n : v) {
+    if (s.count(n))
       ++dups;
-    else if (v[i] != CRUSH_ITEM_NONE)
-      s.insert(v[i]);
+    else if (n != CRUSH_ITEM_NONE)
+      s.insert(n);
   }
   return dups;
 }
 
-TEST(CRUSH, indep_toosmall) {
-  std::unique_ptr<CrushWrapper> c(build_indep_map(g_ceph_context, 1, 3, 1));
+class CRUSHTest : public ::testing::Test
+{
+public:
+  void SetUp() final
+  {
+    CephInitParameters params(CEPH_ENTITY_TYPE_CLIENT);
+    cct = common_preinit(params, CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  }
+  void TearDown() final
+  {
+    cct->put();
+    cct = nullptr;
+  }
+protected:
+  CephContext *cct = nullptr;
+};
+
+TEST_F(CRUSHTest, indep_toosmall) {
+  std::unique_ptr<CrushWrapper> c(build_indep_map(cct, 1, 3, 1));
   vector<__u32> weight(c->get_max_devices(), 0x10000);
   c->dump_tree(&cout, NULL);
 
@@ -110,8 +129,8 @@ TEST(CRUSH, indep_toosmall) {
   }
 }
 
-TEST(CRUSH, indep_basic) {
-  std::unique_ptr<CrushWrapper> c(build_indep_map(g_ceph_context, 3, 3, 3));
+TEST_F(CRUSHTest, indep_basic) {
+  std::unique_ptr<CrushWrapper> c(build_indep_map(cct, 3, 3, 3));
   vector<__u32> weight(c->get_max_devices(), 0x10000);
   c->dump_tree(&cout, NULL);
 
@@ -129,8 +148,8 @@ TEST(CRUSH, indep_basic) {
   }
 }
 
-TEST(CRUSH, indep_out_alt) {
-  std::unique_ptr<CrushWrapper> c(build_indep_map(g_ceph_context, 3, 3, 3));
+TEST_F(CRUSHTest, indep_out_alt) {
+  std::unique_ptr<CrushWrapper> c(build_indep_map(cct, 3, 3, 3));
   vector<__u32> weight(c->get_max_devices(), 0x10000);
 
   // mark a bunch of osds out
@@ -155,8 +174,8 @@ TEST(CRUSH, indep_out_alt) {
   }
 }
 
-TEST(CRUSH, indep_out_contig) {
-  std::unique_ptr<CrushWrapper> c(build_indep_map(g_ceph_context, 3, 3, 3));
+TEST_F(CRUSHTest, indep_out_contig) {
+  std::unique_ptr<CrushWrapper> c(build_indep_map(cct, 3, 3, 3));
   vector<__u32> weight(c->get_max_devices(), 0x10000);
 
   // mark a bunch of osds out
@@ -181,8 +200,8 @@ TEST(CRUSH, indep_out_contig) {
 }
 
 
-TEST(CRUSH, indep_out_progressive) {
-  std::unique_ptr<CrushWrapper> c(build_indep_map(g_ceph_context, 3, 3, 3));
+TEST_F(CRUSHTest, indep_out_progressive) {
+  std::unique_ptr<CrushWrapper> c(build_indep_map(cct, 3, 3, 3));
   c->set_choose_total_tries(100);
   vector<__u32> tweight(c->get_max_devices(), 0x10000);
   c->dump_tree(&cout, NULL);
@@ -244,7 +263,7 @@ TEST(CRUSH, indep_out_progressive) {
 
 }
 
-TEST(CRUSH, straw_zero) {
+TEST_F(CRUSHTest, straw_zero) {
   // zero weight items should have no effect on placement.
 
   std::unique_ptr<CrushWrapper> c(new CrushWrapper);
@@ -298,7 +317,7 @@ TEST(CRUSH, straw_zero) {
   }
 }
 
-TEST(CRUSH, straw_same) {
+TEST_F(CRUSHTest, straw_same) {
   // items with the same weight should map about the same as items
   // with very similar weights.
   //
@@ -492,7 +511,7 @@ double calc_straw2_stddev(int *weights, int n, bool verbose)
   return stddev;
 }
 
-TEST(CRUSH, straw2_stddev)
+TEST_F(CRUSHTest, straw2_stddev)
 {
   int n = 15;
   int weights[n];
@@ -509,7 +528,7 @@ TEST(CRUSH, straw2_stddev)
   }
 }
 
-TEST(CRUSH, straw2_reweight) {
+TEST_F(CRUSHTest, straw2_reweight) {
   // when we adjust the weight of an item in a straw2 bucket,
   // we should *only* see movement from or to that item, never
   // between other items.


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
