### PR TITLE
crimson: add support for watch / notify, part 1

### DIFF
--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -852,6 +852,7 @@ namespace ct_error {
   using operation_not_supported =
     ct_error_code<std::errc::operation_not_supported>;
   using not_connected = ct_error_code<std::errc::not_connected>;
+  using timed_out = ct_error_code<std::errc::timed_out>;
 }
 
 using stateful_errc = stateful_error_t<std::errc>;

--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -851,6 +851,7 @@ namespace ct_error {
   using permission_denied = ct_error_code<std::errc::permission_denied>;
   using operation_not_supported =
     ct_error_code<std::errc::operation_not_supported>;
+  using not_connected = ct_error_code<std::errc::not_connected>;
 }
 
 using stateful_errc = stateful_error_t<std::errc>;

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(crimson-osd
   ${PROJECT_SOURCE_DIR}/src/osd/MissingLoc.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PGLog.cc
   ${PROJECT_SOURCE_DIR}/src/osd/osd_perf_counters.cc
+  watch.cc
   )
 target_link_libraries(crimson-osd
   crimson-common crimson-os crimson fmt::fmt)

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <seastar/core/shared_future.hh>
+#include <seastar/core/shared_ptr.hh>
 
 #include <boost/intrusive_ptr.hpp>
 #include <boost/intrusive/list.hpp>
@@ -14,9 +15,10 @@
 #include "osd/object_state.h"
 #include "crimson/common/config_proxy.h"
 #include "crimson/osd/osd_operation.h"
-#include "crimson/osd/watch.h"
 
 namespace crimson::osd {
+
+class Watch;
 
 template <typename OBC>
 struct obc_to_hoid {
@@ -40,7 +42,7 @@ public:
   // frequented paths. std::map is used mostly because of developer's
   // convenience.
   using watch_key_t = std::pair<uint64_t, entity_name_t>;
-  std::map<watch_key_t, crimson::osd::WatchRef> watchers;
+  std::map<watch_key_t, seastar::shared_ptr<crimson::osd::Watch>> watchers;
 
   ObjectContext(const hobject_t &hoid) : obs(hoid), loaded(false) {}
 
@@ -229,4 +231,4 @@ public:
                           const std::set <std::string> &changed) final;
 };
 
-}
+} // namespace crimson::osd

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -14,6 +14,7 @@
 #include "osd/object_state.h"
 #include "crimson/common/config_proxy.h"
 #include "crimson/osd/osd_operation.h"
+#include "crimson/osd/watch.h"
 
 namespace crimson::osd {
 
@@ -35,6 +36,12 @@ public:
   ObjectState obs;
   std::optional<SnapSet> ss;
   bool loaded : 1;
+  // the watch / notify machinery rather stays away from the hot and
+  // frequented paths. std::map is used mostly because of developer's
+  // convenience.
+  using watch_key_t = std::pair<uint64_t, entity_name_t>;
+  std::map<watch_key_t, crimson::osd::WatchRef> watchers;
+
   ObjectContext(const hobject_t &hoid) : obs(hoid), loaded(false) {}
 
   const hobject_t &get_oid() const {

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -131,10 +131,12 @@ OpsExecuter::watch_errorator::future<> OpsExecuter::do_op_watch_subop_watch(
 {
   struct connect_ctx_t {
     ObjectContext::watch_key_t key;
+    crimson::net::ConnectionRef conn;
     watch_info_t info;
 
     connect_ctx_t(const OSDOp& osd_op, const MOSDOp& msg)
       : key(osd_op.op.watch.cookie, msg.get_reqid().name),
+        conn(msg.get_connection()),
         info(create_watch_info(osd_op, msg)) {
     }
   };
@@ -159,7 +161,7 @@ OpsExecuter::watch_errorator::future<> OpsExecuter::do_op_watch_subop_watch(
       } else {
         logger().info("op_effect: found existing watcher: {}", ctx.key);
       }
-      return it->second->connect(nullptr /* conn */, true /* will_ping */);
+      return it->second->connect(std::move(ctx.conn), true /* will_ping */);
     });
 }
 

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -372,11 +372,18 @@ OpsExecuter::watch_errorator::future<> OpsExecuter::do_op_notify_ack(
       return seastar::do_for_each(obc->watchers,
         [ctx=std::move(ctx)] (auto& kv) {
           const auto& [key, watchp] = kv;
+          static_assert(
+            std::is_same_v<std::decay_t<decltype(watchp)>,
+                           seastar::shared_ptr<crimson::osd::Watch>>);
           auto& [cookie, entity] = key;
           if (ctx.entity != entity) {
+            logger().debug("skipping watch {}; entity name {} != {}",
+                           key, entity, ctx.entity);
             return seastar::now();
           }
           if (ctx.watch_cookie != cookie) {
+            logger().debug("skipping watch {}; cookie {} != {}",
+                           key, ctx.watch_cookie, cookie);
             return seastar::now();
           }
           logger().info("acking notify on watch {}", key);

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -187,6 +187,8 @@ OpsExecuter::watch_errorator::future<> OpsExecuter::do_op_watch_subop_unwatch(
   ObjectState& os,
   ceph::os::Transaction& txn)
 {
+  logger().info("{}", __func__);
+
   struct disconnect_ctx_t {
     ObjectContext::watch_key_t key;
     bool send_disconnect{ false };

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -295,7 +295,15 @@ OpsExecuter::watch_errorator::future<> OpsExecuter::do_op_notify(
       return seastar::now();
     },
     [] (auto&& ctx, ObjectContextRef obc) {
-      return seastar::now();
+      auto alive_watchers = obc->watchers | boost::adaptors::map_values
+                                          | boost::adaptors::filtered(
+        [] (const auto& w) {
+          // FIXME: filter as for the `is_ping` in `Watch::start_notify`
+          return w->is_alive();
+        });
+      return crimson::osd::Notify::create_n_propagate(
+        std::begin(alive_watchers),
+        std::end(alive_watchers));
   });
 }
 

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -163,6 +163,21 @@ OpsExecuter::watch_errorator::future<> OpsExecuter::do_op_watch_subop_watch(
     });
 }
 
+OpsExecuter::watch_errorator::future<> OpsExecuter::do_op_watch_subop_reconnect(
+  OSDOp& osd_op,
+  ObjectState& os,
+  ceph::os::Transaction& txn)
+{
+  const entity_name_t& entity = get_message().get_reqid().name;
+  const auto& cookie = osd_op.op.watch.cookie;
+  if (!os.oi.watchers.count(std::make_pair(cookie, entity))) {
+    return crimson::ct_error::not_connected::make();
+  } else {
+    logger().info("found existing watch by {}", entity);
+    return do_op_watch_subop_watch(osd_op, os, txn);
+  }
+}
+
 OpsExecuter::watch_errorator::future<> OpsExecuter::do_op_watch_subop_unwatch(
   OSDOp& osd_op,
   ObjectState& os,
@@ -211,8 +226,7 @@ OpsExecuter::watch_errorator::future<> OpsExecuter::do_op_watch(
     case CEPH_OSD_WATCH_OP_WATCH:
       return do_op_watch_subop_watch(osd_op, os, txn);
     case CEPH_OSD_WATCH_OP_RECONNECT:
-      // TODO: implement reconnect
-      break;
+      return do_op_watch_subop_reconnect(osd_op, os, txn);
     case CEPH_OSD_WATCH_OP_PING:
       // TODO: implement ping
       break;

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -123,6 +123,9 @@ private:
   watch_errorator::future<> do_op_notify(
     class OSDOp& osd_op,
     const class ObjectState& os);
+  watch_errorator::future<> do_op_notify_ack(
+    class OSDOp& osd_op,
+    const class ObjectState& os);
 
   hobject_t &get_target() const {
     return obc->obs.oi.soid;

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -66,7 +66,8 @@ private:
   // the later on `submit_changes()` – after successfully processing main
   // stages of all involved operations. When any stage fails, none of all
   // scheduled effect-exposing stages will be executed.
-  // when operation requires this division, `with_effect()` should be used.
+  // when operation requires this division, some variant of `with_effect()`
+  // should be used.
   struct effect_t {
     virtual osd_op_errorator::future<> execute() = 0;
     virtual ~effect_t() = default;
@@ -87,7 +88,10 @@ private:
   seastar::chunked_fifo<std::unique_ptr<effect_t>> op_effects;
 
   template <class Context, class MainFunc, class EffectFunc>
-  auto with_effect(Context&& ctx, MainFunc&& main_func, EffectFunc&& effect_func);
+  auto with_effect_on_obc(
+    Context&& ctx,
+    MainFunc&& main_func,
+    EffectFunc&& effect_func);
 
   call_errorator::future<> do_op_call(class OSDOp& osd_op);
 
@@ -148,29 +152,35 @@ public:
 };
 
 template <class Context, class MainFunc, class EffectFunc>
-auto OpsExecuter::with_effect(
+auto OpsExecuter::with_effect_on_obc(
   Context&& ctx,
   MainFunc&& main_func,
   EffectFunc&& effect_func)
 {
   using context_t = std::decay_t<Context>;
   // the language offers implicit conversion to pointer-to-function for
-  // lambda only when it's closureless
-  static_assert(std::is_convertible_v<EffectFunc,
-                                      seastar::future<> (*)(context_t&&)>,
+  // lambda only when it's closureless. We enforce this restriction due
+  // the fact that `submit_changes()` std::moves many executer's parts.
+  using allowed_effect_func_t =
+    seastar::future<> (*)(context_t&&, ObjectContextRef);
+  static_assert(std::is_convertible_v<EffectFunc, allowed_effect_func_t>,
                 "with_effect function is not allowed to capture");
   struct task_t final : effect_t {
     context_t ctx;
     EffectFunc effect_func;
+    ObjectContextRef obc;
 
-    task_t(Context&& ctx, EffectFunc&& effect_func)
-       : ctx(std::move(ctx)), effect_func(std::move(effect_func)) {}
+    task_t(Context&& ctx, EffectFunc&& effect_func, ObjectContextRef obc)
+       : ctx(std::move(ctx)),
+         effect_func(std::move(effect_func)),
+         obc(std::move(obc)) {
+    }
     osd_op_errorator::future<> execute() final {
-      return std::move(effect_func)(std::move(ctx));
+      return std::move(effect_func)(std::move(ctx), std::move(obc));
     }
   };
   auto task =
-    std::make_unique<task_t>(std::move(ctx), std::move(effect_func));
+    std::make_unique<task_t>(std::move(ctx), std::move(effect_func), obc);
   auto& ctx_ref = task->ctx;
   op_effects.emplace_back(std::move(task));
   return std::forward<MainFunc>(main_func)(ctx_ref);

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -49,7 +49,8 @@ class OpsExecuter {
   using watch_errorator = crimson::errorator<
     crimson::ct_error::enoent,
     crimson::ct_error::invarg,
-    crimson::ct_error::not_connected>;
+    crimson::ct_error::not_connected,
+    crimson::ct_error::timed_out>;
 
 public:
   // because OpsExecuter is pretty heavy-weight object we want to ensure
@@ -112,6 +113,10 @@ private:
     class ObjectState& os,
     ceph::os::Transaction& txn);
   watch_errorator::future<> do_op_watch_subop_unwatch(
+    class OSDOp& osd_op,
+    class ObjectState& os,
+    ceph::os::Transaction& txn);
+  watch_errorator::future<> do_op_watch_subop_ping(
     class OSDOp& osd_op,
     class ObjectState& os,
     ceph::os::Transaction& txn);

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -48,7 +48,8 @@ class OpsExecuter {
   using get_attr_errorator = PGBackend::get_attr_errorator;
   using watch_errorator = crimson::errorator<
     crimson::ct_error::enoent,
-    crimson::ct_error::invarg>;
+    crimson::ct_error::invarg,
+    crimson::ct_error::not_connected>;
 
 public:
   // because OpsExecuter is pretty heavy-weight object we want to ensure
@@ -103,6 +104,10 @@ private:
     class ObjectState& os,
     ceph::os::Transaction& txn);
   watch_errorator::future<> do_op_watch_subop_watch(
+    class OSDOp& osd_op,
+    class ObjectState& os,
+    ceph::os::Transaction& txn);
+  watch_errorator::future<> do_op_watch_subop_reconnect(
     class OSDOp& osd_op,
     class ObjectState& os,
     ceph::os::Transaction& txn);

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -46,6 +46,9 @@ class OpsExecuter {
     crimson::ct_error::input_output_error>;
   using read_errorator = PGBackend::read_errorator;
   using get_attr_errorator = PGBackend::get_attr_errorator;
+  using watch_errorator = crimson::errorator<
+    crimson::ct_error::enoent,
+    crimson::ct_error::invarg>;
 
 public:
   // because OpsExecuter is pretty heavy-weight object we want to ensure
@@ -58,6 +61,7 @@ public:
     call_errorator,
     read_errorator,
     get_attr_errorator,
+    watch_errorator,
     PGBackend::stat_errorator>;
 
 private:
@@ -94,6 +98,18 @@ private:
     EffectFunc&& effect_func);
 
   call_errorator::future<> do_op_call(class OSDOp& osd_op);
+  watch_errorator::future<> do_op_watch(
+    class OSDOp& osd_op,
+    class ObjectState& os,
+    ceph::os::Transaction& txn);
+  watch_errorator::future<> do_op_watch_subop_watch(
+    class OSDOp& osd_op,
+    class ObjectState& os,
+    ceph::os::Transaction& txn);
+  watch_errorator::future<> do_op_watch_subop_unwatch(
+    class OSDOp& osd_op,
+    class ObjectState& os,
+    ceph::os::Transaction& txn);
 
   hobject_t &get_target() const {
     return obc->obs.oi.soid;

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -120,6 +120,9 @@ private:
     class OSDOp& osd_op,
     class ObjectState& os,
     ceph::os::Transaction& txn);
+  watch_errorator::future<> do_op_notify(
+    class OSDOp& osd_op,
+    const class ObjectState& os);
 
   hobject_t &get_target() const {
     return obc->obs.oi.soid;

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -1,0 +1,54 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "crimson/osd/watch.h"
+#include "messages/MWatchNotify.h"
+
+
+namespace {
+  seastar::logger& logger() {
+    return crimson::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace crimson::osd {
+
+bool Watch::NotifyCmp::operator()(NotifyRef lhs, NotifyRef rhs) const
+{
+  ceph_assert(lhs);
+  ceph_assert(rhs);
+  return lhs->get_id() < rhs->get_id();
+}
+
+seastar::future<> Watch::connect(crimson::net::ConnectionRef conn, bool)
+{
+  if (this->conn == conn) {
+    logger().debug("conn={} already connected", conn);
+  }
+
+  this->conn = std::move(conn);
+  return seastar::now();
+}
+
+seastar::future<> Watch::send_notify_msg(NotifyRef notify)
+{
+  logger().info("{} for notify(id={})", __func__, notify->ninfo.notify_id);
+  return conn->send(make_message<MWatchNotify>(
+    winfo.cookie,
+    notify->user_version,
+    notify->ninfo.notify_id,
+    CEPH_WATCH_EVENT_NOTIFY,
+    notify->ninfo.bl,
+    notify->client_gid));
+}
+
+seastar::future<> Watch::start_notify(NotifyRef notify)
+{
+  logger().info("{} adding &notify={}", __func__, notify.get());
+  auto [ it, emplaced ] = in_progress_notifies.emplace(std::move(notify));
+  ceph_assert(emplaced);
+  ceph_assert(is_alive());
+  return is_connected() ? send_notify_msg(*it) : seastar::now();
+}
+
+} // namespace crimson::osd

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -41,6 +41,13 @@ public:
     return seastar::now();
   }
 
+  /// Call when notify_ack received on notify_id
+  seastar::future<> notify_ack(
+    uint64_t notify_id, ///< [in] id of acked notify
+    const ceph::bufferlist& reply_bl) { ///< [in] notify reply buffer
+    return seastar::now();
+  }
+
   template <class... Args>
   static seastar::shared_ptr<Watch> create(Args&&... args) {
     return seastar::make_shared<Watch>(private_ctag_t{},

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -1,0 +1,53 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <seastar/core/shared_ptr.hh>
+
+#include "crimson/net/Connection.h"
+
+namespace crimson::osd {
+
+// NOTE: really need to have this public. Otherwise `shared_from_this()`
+// will abort. According to cppreference.com:
+//
+//   "The constructors of std::shared_ptr detect the presence
+//   of an unambiguous and accessible (ie. public inheritance
+//   is mandatory) (since C++17) enable_shared_from_this base".
+//
+// I expect the `seastar::shared_ptr` shares this behaviour.
+class Watch : public seastar::enable_shared_from_this<Watch> {
+  // this is a private tag for the public constructor that turns it into
+  // de facto private one. The motivation behind the hack is make_shared
+  // used by create().
+  struct private_ctag_t{};
+
+public:
+  Watch(private_ctag_t) {
+  }
+
+  seastar::future<> connect(crimson::net::ConnectionRef, bool) {
+    return seastar::now();
+  }
+  bool is_connected() const {
+    return true;
+  }
+  void got_ping(utime_t) {
+    // NOP
+  }
+
+  seastar::future<> remove(bool) {
+    return seastar::now();
+  }
+
+  template <class... Args>
+  static seastar::shared_ptr<Watch> create(Args&&... args) {
+    return seastar::make_shared<Watch>(private_ctag_t{},
+                                       std::forward<Args>(args)...);
+  };
+};
+
+using WatchRef = seastar::shared_ptr<Watch>;
+
+} // namespace crimson::osd

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -44,6 +44,8 @@ class Watch : public seastar::enable_shared_from_this<Watch> {
 
   seastar::future<> start_notify(NotifyRef);
   seastar::future<> send_notify_msg(NotifyRef);
+  seastar::future<> send_disconnect_msg();
+  void discard_state();
 
   friend Notify;
 
@@ -68,9 +70,7 @@ public:
     // NOP
   }
 
-  seastar::future<> remove(bool) {
-    return seastar::now();
-  }
+  seastar::future<> remove(bool send_disconnect);
 
   /// Call when notify_ack received on notify_id
   seastar::future<> notify_ack(
@@ -148,6 +148,7 @@ public:
     WatchIteratorT end,
     Args&&... args);
 
+  seastar::future<> remove_watcher(WatchRef watch);
   seastar::future<> complete_watcher(WatchRef watch,
                                      const ceph::bufferlist& reply_bl);
 };

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -4,12 +4,14 @@
 #pragma once
 
 #include <iterator>
+#include <map>
 #include <set>
 
 #include <seastar/core/shared_ptr.hh>
 
 #include "crimson/net/Connection.h"
 #include "crimson/osd/object_context.h"
+#include "include/denc.h"
 
 namespace crimson::osd {
 
@@ -38,6 +40,7 @@ class Watch : public seastar::enable_shared_from_this<Watch> {
   crimson::osd::ObjectContextRef obc;
 
   watch_info_t winfo;
+  entity_name_t entity_name;
 
   seastar::future<> start_notify(NotifyRef);
   seastar::future<> send_notify_msg(NotifyRef);
@@ -46,10 +49,12 @@ class Watch : public seastar::enable_shared_from_this<Watch> {
 
 public:
   Watch(private_ctag_t,
+        crimson::osd::ObjectContextRef obc,
         const watch_info_t& winfo,
-        crimson::osd::ObjectContextRef obc)
-    : winfo(winfo),
-      obc(std::move(obc)) {
+        const entity_name_t& entity_name)
+    : obc(std::move(obc)),
+      winfo(winfo),
+      entity_name(entity_name) {
   }
 
   seastar::future<> connect(crimson::net::ConnectionRef, bool);
@@ -70,31 +75,58 @@ public:
   /// Call when notify_ack received on notify_id
   seastar::future<> notify_ack(
     uint64_t notify_id, ///< [in] id of acked notify
-    const ceph::bufferlist& reply_bl) { ///< [in] notify reply buffer
-    return seastar::now();
-  }
+    const ceph::bufferlist& reply_bl); ///< [in] notify reply buffer
 
   template <class... Args>
   static seastar::shared_ptr<Watch> create(Args&&... args) {
     return seastar::make_shared<Watch>(private_ctag_t{},
                                        std::forward<Args>(args)...);
   };
+
+  uint64_t get_watcher_gid() const {
+    return entity_name.num();
+  }
+  uint64_t get_cookie() const {
+    return winfo.cookie;
+  }
 };
 
 using WatchRef = seastar::shared_ptr<Watch>;
 
+struct notify_reply_t {
+  uint64_t watcher_gid;
+  uint64_t watcher_cookie;
+  ceph::bufferlist bl;
+
+  bool operator<(const notify_reply_t& rhs) const;
+  DENC(notify_reply_t, v, p) {
+    DENC_START(1, 1, p);
+    denc(v.watcher_gid, p);
+    denc(v.watcher_cookie, p);
+    denc(v.bl, p);
+    DENC_FINISH(p);
+  }
+};
+
 class Notify {
   std::set<WatchRef> watchers;
   notify_info_t ninfo;
+  crimson::net::ConnectionRef conn;
   uint64_t client_gid;
   uint64_t user_version;
+  bool complete = false;
+  bool discarded = false;
+
+  /// (gid,cookie) -> reply_bl for everyone who acked the notify
+  std::multiset<notify_reply_t> notify_replies;
 
   uint64_t get_id() const { return ninfo.notify_id; }
-  seastar::future<> propagate() { return seastar::now(); }
+  seastar::future<> maybe_send_completion();
 
   template <class WatchIteratorT>
   Notify(WatchIteratorT begin,
          WatchIteratorT end,
+         crimson::net::ConnectionRef conn,
          const notify_info_t& ninfo,
          const uint64_t client_gid,
          const uint64_t user_version);
@@ -115,17 +147,22 @@ public:
     WatchIteratorT begin,
     WatchIteratorT end,
     Args&&... args);
+
+  seastar::future<> complete_watcher(WatchRef watch,
+                                     const ceph::bufferlist& reply_bl);
 };
 
 
 template <class WatchIteratorT>
 Notify::Notify(WatchIteratorT begin,
                WatchIteratorT end,
+               crimson::net::ConnectionRef conn,
                const notify_info_t& ninfo,
                const uint64_t client_gid,
                const uint64_t user_version)
   : watchers(begin, end),
     ninfo(ninfo),
+    conn(std::move(conn)),
     client_gid(client_gid),
     user_version(user_version) {
 }
@@ -147,8 +184,10 @@ seastar::future<> Notify::create_n_propagate(
   return seastar::do_for_each(begin, end, [=] (auto& watchref) {
     return watchref->start_notify(notify);
   }).then([notify = std::move(notify)] {
-    return notify->propagate();
+    return notify->maybe_send_completion();
   });
 }
 
 } // namespace crimson::osd
+
+WRITE_CLASS_DENC(crimson::osd::notify_reply_t)

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -3,11 +3,17 @@
 
 #pragma once
 
+#include <iterator>
+#include <set>
+
 #include <seastar/core/shared_ptr.hh>
 
 #include "crimson/net/Connection.h"
 
 namespace crimson::osd {
+
+class Notify;
+using NotifyRef = seastar::shared_ptr<Notify>;
 
 // NOTE: really need to have this public. Otherwise `shared_from_this()`
 // will abort. According to cppreference.com:
@@ -23,15 +29,27 @@ class Watch : public seastar::enable_shared_from_this<Watch> {
   // used by create().
   struct private_ctag_t{};
 
+  struct NotifyCmp {
+    inline bool operator()(NotifyRef lhs, NotifyRef rhs) const;
+  };
+  std::set<NotifyRef, NotifyCmp> in_progress_notifies;
+  crimson::net::ConnectionRef conn;
+
+  seastar::future<> start_notify(NotifyRef);
+  seastar::future<> send_notify_msg(NotifyRef);
+
+  friend Notify;
+
 public:
   Watch(private_ctag_t) {
   }
 
-  seastar::future<> connect(crimson::net::ConnectionRef, bool) {
-    return seastar::now();
+  seastar::future<> connect(crimson::net::ConnectionRef, bool);
+  bool is_alive() const {
+    return true;
   }
   bool is_connected() const {
-    return true;
+    return static_cast<bool>(conn);
   }
   void got_ping(utime_t) {
     // NOP
@@ -56,5 +74,53 @@ public:
 };
 
 using WatchRef = seastar::shared_ptr<Watch>;
+
+class Notify {
+  std::set<WatchRef> watchers;
+
+  uint64_t get_id() const { return 0; }
+  void propagate() {}
+
+  template <class WatchIteratorT>
+  Notify(WatchIteratorT begin, WatchIteratorT end);
+  // this is a private tag for the public constructor that turns it into
+  // de facto private one. The motivation behind the hack is make_shared
+  // used by create_n_propagate factory.
+  struct private_ctag_t{};
+
+  friend Watch;
+
+public:
+  template <class... Args>
+  Notify(private_ctag_t, Args&&... args) : Notify(std::forward<Args>(args)...) {
+  }
+
+  template <class WatchIteratorT>
+  static seastar::future<> create_n_propagate(
+    WatchIteratorT begin,
+    WatchIteratorT end);
+};
+
+
+template <class WatchIteratorT>
+Notify::Notify(WatchIteratorT begin, WatchIteratorT end)
+  : watchers(begin, end) {
+}
+
+template <class WatchIteratorT>
+seastar::future<> Notify::create_n_propagate(
+  WatchIteratorT begin,
+  WatchIteratorT end)
+{
+  static_assert(
+    std::is_same_v<typename std::iterator_traits<WatchIteratorT>::value_type,
+                   crimson::osd::WatchRef>);
+  auto notify = seastar::make_shared<Notify>(private_ctag_t{}, begin, end);
+  seastar::do_for_each(begin, end, [=] (auto& watchref) {
+    return watchref->start_notify(notify);
+  }).then([notify = std::move(notify)] {;
+    notify->propagate();
+  });
+}
 
 } // namespace crimson::osd

--- a/src/messages/MWatchNotify.h
+++ b/src/messages/MWatchNotify.h
@@ -35,7 +35,7 @@ private:
 
   MWatchNotify()
     : Message{CEPH_MSG_WATCH_NOTIFY, HEAD_VERSION, COMPAT_VERSION} { }
-  MWatchNotify(uint64_t c, uint64_t v, uint64_t i, uint8_t o, ceph::buffer::list b)
+  MWatchNotify(uint64_t c, uint64_t v, uint64_t i, uint8_t o, ceph::buffer::list b, uint64_t n=0)
     : Message{CEPH_MSG_WATCH_NOTIFY, HEAD_VERSION, COMPAT_VERSION},
       cookie(c),
       ver(v),
@@ -43,7 +43,7 @@ private:
       opcode(o),
       bl(b),
       return_code(0),
-      notifier_gid(0) { }
+      notifier_gid(n) { }
 private:
   ~MWatchNotify() override {}
 

--- a/src/osd/Watch.cc
+++ b/src/osd/Watch.cc
@@ -308,8 +308,6 @@ Watch::~Watch() {
   ceph_assert(!conn);
 }
 
-bool Watch::connected() { return !!conn; }
-
 Context *Watch::get_delayed_cb()
 {
   ceph_assert(!cb);
@@ -460,7 +458,7 @@ void Watch::start_notify(NotifyRef notif)
   dout(10) << "start_notify " << notif->notify_id << dendl;
   in_progress_notifies[notif->notify_id] = notif;
   notif->start_watcher(self.lock());
-  if (connected())
+  if (is_connected())
     send_notify(notif);
 }
 

--- a/src/osd/Watch.cc
+++ b/src/osd/Watch.cc
@@ -37,7 +37,8 @@ Notify::Notify(
   uint64_t notify_id,
   uint64_t version,
   OSDService *osd)
-  : client(client), client_gid(client_gid),
+  : client(client),
+    client_gid(client_gid),
     complete(false),
     discarded(false),
     timed_out(false),
@@ -47,7 +48,7 @@ Notify::Notify(
     notify_id(notify_id),
     version(version),
     osd(osd),
-    cb(NULL) {}
+    cb(nullptr) {}
 
 NotifyRef Notify::makeNotifyRef(
   ConnectionRef client,

--- a/src/osd/Watch.cc
+++ b/src/osd/Watch.cc
@@ -192,9 +192,13 @@ void Notify::maybe_complete_notify()
     encode(missed, bl);
 
     bufferlist empty;
-    MWatchNotify *reply(new MWatchNotify(cookie, version, notify_id,
-					 CEPH_WATCH_EVENT_NOTIFY_COMPLETE, empty));
-    reply->notifier_gid = client_gid;
+    auto* const reply = new MWatchNotify(
+      cookie,
+      version,
+      notify_id,
+      CEPH_WATCH_EVENT_NOTIFY_COMPLETE,
+      empty,
+      client_gid);
     reply->set_data(bl);
     if (timed_out)
       reply->return_code = -ETIMEDOUT;
@@ -473,9 +477,12 @@ void Watch::send_notify(NotifyRef notif)
 {
   dout(10) << "send_notify" << dendl;
   MWatchNotify *notify_msg = new MWatchNotify(
-    cookie, notif->version, notif->notify_id,
-    CEPH_WATCH_EVENT_NOTIFY, notif->payload);
-  notify_msg->notifier_gid = notif->client_gid;
+    cookie,
+    notif->version,
+    notif->notify_id,
+    CEPH_WATCH_EVENT_NOTIFY,
+    notif->payload,
+    notif->client_gid);
   conn->send_message(notify_msg);
 }
 

--- a/src/osd/Watch.h
+++ b/src/osd/Watch.h
@@ -192,6 +192,7 @@ public:
     return last_ping;
   }
 
+  /// True if currently connected
   bool is_connected() const {
     return conn.get() != NULL;
   }
@@ -226,9 +227,6 @@ public:
 
   /// Generates context for use if watch timeout is delayed by scrub or recovery
   Context *get_delayed_cb();
-
-  /// True if currently connected
-  bool connected();
 
   /// Transitions Watch to connected, unregister_cb, resends pending Notifies
   void connect(


### PR DESCRIPTION
This PR brings foundations of the RADOS watch / notify mechanism which is required by e.g. the exclusive lock feature of RBD. Currently, there is no support for timeouts nor glue code for recovery / scrub.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
