### PR TITLE
mgr/cephadm: fix section name for mon options in ceph.conf

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1131,7 +1131,10 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
         """
         Create a new monitor on the given host.
         """
-        self.log.info("create_mon({}:{}): starting".format(host, network))
+        name = name or host
+
+        self.log.info("create_mon({}:{}): starting mon.{}".format(
+            host, network, name))
 
         # get mon. key
         ret, keyring, err = self.mon_command({
@@ -1150,7 +1153,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.Orchestrator):
         else:
             raise RuntimeError('Must specify a CIDR network, ceph addrvec, or plain IP: \'%s\'' % network)
 
-        return self._create_daemon('mon', name or host, host, keyring,
+        return self._create_daemon('mon', name, host, keyring,
                                    extra_config=extra_config)
 
     def update_mons(self, spec):


### PR DESCRIPTION
If name is not explicitly specified, we were putting the options in
the [mon.] section instead of [mon.$name].

Signed-off-by: Sage Weil <sage@redhat.com>