### PR TITLE
osd: trim pg logs based on a per-osd budget

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -721,6 +721,7 @@ OPTION(osd_kill_backfill_at, OPT_INT)
 // Bounds how infrequently a new map epoch will be persisted for a pg
 OPTION(osd_pg_epoch_persisted_max_stale, OPT_U32) // make this < map_cache_size!
 
+OPTION(osd_target_pg_log_entries_per_osd, OPT_U32)
 OPTION(osd_min_pg_log_entries, OPT_U32)  // number of entries to keep in the pg log when trimming it
 OPTION(osd_max_pg_log_entries, OPT_U32) // max entries, say when degraded, before we trim
 OPTION(osd_pg_log_dups_tracked, OPT_U32) // how many versions back to track combined in both pglog's regular + dup logs

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3302,15 +3302,21 @@ std::vector<Option> get_global_options() {
     .set_default(40)
     .set_description(""),
 
+    Option("osd_target_pg_log_entries_per_osd", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(3000 * 100)
+    .set_description("target number of PG entries total on an OSD")
+    .add_see_also("osd_max_pg_log_entries")
+    .add_see_also("osd_min_pg_log_entries"),
+
     Option("osd_min_pg_log_entries", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(3000)
+    .set_default(250)
     .set_description("minimum number of entries to maintain in the PG log")
     .add_service("osd")
     .add_see_also("osd_max_pg_log_entries")
     .add_see_also("osd_pg_log_dups_tracked"),
 
     Option("osd_max_pg_log_entries", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(3000)
+    .set_default(10000)
     .set_description("maximum number of entries to maintain in the PG log when degraded before we trim")
     .add_service("osd")
     .add_see_also("osd_min_pg_log_entries")

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -416,6 +416,7 @@ seastar::future<> OSD::load_pgs()
         return load_pg(pgid).then([pgid, this](auto&& pg) {
           logger().info("load_pgs: loaded {}", pgid);
           pg_map.pg_loaded(pgid, std::move(pg));
+          shard_services.inc_pg_num();
           return seastar::now();
         });
       } else if (coll.is_temp(&pgid)) {

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -111,7 +111,6 @@ class OSD final : public crimson::net::Dispatcher,
 			     const AuthCapsInfo& caps) final;
 
   crimson::osd::ShardServices shard_services;
-  std::unordered_map<spg_t, Ref<PG>> pgs;
 
   std::unique_ptr<Heartbeat> heartbeat;
   seastar::timer<seastar::lowres_clock> heartbeat_timer;

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -76,6 +76,7 @@ seastar::future<> PGAdvanceMap::start()
 	  handle.exit();
 	  if (do_init) {
 	    osd.pg_map.pg_created(pg->get_pgid(), pg);
+	    osd.shard_services.inc_pg_num();
 	    logger().info("PGAdvanceMap::start new pg {}", *pg);
 	  }
 	  return seastar::when_all_succeed(

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -271,6 +271,12 @@ void PG::prepare_write(pg_info_t &info,
   }
 }
 
+void PG::do_delete_work(ceph::os::Transaction &t)
+{
+  // TODO
+  shard_services.dec_pg_num();
+}
+
 void PG::log_state_enter(const char *state) {
   logger().info("Entering state: {}", state);
 }

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -240,6 +240,8 @@ public:
 			    ceph::timespan delay) final;
   void recheck_readable() final;
 
+  unsigned get_target_pg_log_entries() const final;
+
   void on_pool_change() final {
     // Not needed yet
   }

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -268,9 +268,7 @@ public:
   void on_removal(ceph::os::Transaction &t) final {
     // TODO
   }
-  void do_delete_work(ceph::os::Transaction &t) final {
-    // TODO
-  }
+  void do_delete_work(ceph::os::Transaction &t) final;
 
   // merge/split not ready
   void clear_ready_to_merge() final {}

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -150,6 +150,16 @@ public:
   seastar::future<> send_pg_created();
   void prune_pg_created();
 
+  unsigned get_pg_num() const {
+    return num_pgs;
+  }
+  void inc_pg_num() {
+    ++num_pgs;
+  }
+  void dec_pg_num() {
+    --num_pgs;
+  }
+
   seastar::future<> osdmap_subscribe(version_t epoch, bool force_request);
 
   // Time state
@@ -161,6 +171,9 @@ public:
   std::map<int, HeartbeatStampsRef> heartbeat_stamps;
 
   crimson::osd::ObjectContextRegistry obc_registry;
+
+private:
+  unsigned num_pgs = 0;
 };
 
 }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -662,6 +662,9 @@ public:
 	return awaiting.second.get() == pg;
       });
   }
+
+  unsigned get_target_pg_log_entries() const;
+  
   // delayed pg activation
   void queue_for_recovery(PG *pg) {
     std::lock_guard l(recovery_lock);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -849,6 +849,11 @@ void PG::publish_stats_to_osd()
   }
 }
 
+unsigned PG::get_target_pg_log_entries() const
+{
+  return osd->get_target_pg_log_entries();
+}
+
 void PG::clear_publish_stats()
 {
   dout(15) << "clear_stats" << dendl;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -400,6 +400,7 @@ public:
   uint64_t get_snap_trimq_size() const override {
     return snap_trimq.size();
   }
+  unsigned get_target_pg_log_entries() const override;
 
   void clear_publish_stats() override;
   void clear_primary_state() override;

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -4050,7 +4050,7 @@ void PeeringState::calc_trim_to()
                  PG_STATE_BACKFILLING |
                  PG_STATE_BACKFILL_WAIT |
                  PG_STATE_BACKFILL_TOOFULL)) {
-    target = cct->_conf->osd_max_pg_log_entries;
+    target = pl->get_target_pg_log_entries();
   }
 
   eversion_t limit = std::min(
@@ -4092,7 +4092,7 @@ void PeeringState::calc_trim_to_aggressive()
 		 PG_STATE_BACKFILLING |
 		 PG_STATE_BACKFILL_WAIT |
 		 PG_STATE_BACKFILL_TOOFULL)) {
-    target = cct->_conf->osd_max_pg_log_entries;
+    target = pl->get_target_pg_log_entries();
   }
   // limit pg log trimming up to the can_rollback_to value
   eversion_t limit = std::min(

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -2484,7 +2484,8 @@ void PeeringState::activate(
 	  last_peering_reset /* epoch to create pg at */);
 
 	// send some recent log, so that op dup detection works well.
-	m->log.copy_up_to(cct, pg_log.get_log(), cct->_conf->osd_min_pg_log_entries);
+	m->log.copy_up_to(cct, pg_log.get_log(),
+			  cct->_conf->osd_max_pg_log_entries);
 	m->info.log_tail = m->log.tail;
 	pi.log_tail = m->log.tail;  // sigh...
 

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -4043,15 +4043,7 @@ void PeeringState::complete_write(eversion_t v, eversion_t lc)
 
 void PeeringState::calc_trim_to()
 {
-  size_t target = cct->_conf->osd_min_pg_log_entries;
-  if (is_degraded() ||
-      state_test(PG_STATE_RECOVERING |
-                 PG_STATE_RECOVERY_WAIT |
-                 PG_STATE_BACKFILLING |
-                 PG_STATE_BACKFILL_WAIT |
-                 PG_STATE_BACKFILL_TOOFULL)) {
-    target = pl->get_target_pg_log_entries();
-  }
+  size_t target = pl->get_target_pg_log_entries();
 
   eversion_t limit = std::min(
     min_last_complete_ondisk,
@@ -4085,15 +4077,8 @@ void PeeringState::calc_trim_to()
 
 void PeeringState::calc_trim_to_aggressive()
 {
-  size_t target = cct->_conf->osd_min_pg_log_entries;
-  if (is_degraded() ||
-      state_test(PG_STATE_RECOVERING |
-		 PG_STATE_RECOVERY_WAIT |
-		 PG_STATE_BACKFILLING |
-		 PG_STATE_BACKFILL_WAIT |
-		 PG_STATE_BACKFILL_TOOFULL)) {
-    target = pl->get_target_pg_log_entries();
-  }
+  size_t target = pl->get_target_pg_log_entries();
+
   // limit pg log trimming up to the can_rollback_to value
   eversion_t limit = std::min(
     pg_log.get_head(),

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -281,6 +281,8 @@ public:
     virtual void queue_check_readable(epoch_t lpr, ceph::timespan delay) = 0;
     virtual void recheck_readable() = 0;
 
+    virtual unsigned get_target_pg_log_entries() const = 0;
+
     // ============ Flush state ==================
     /**
      * try_flush_or_schedule_async()


### PR DESCRIPTION
Set the default budget based on the current defaults: 3000 per osd, and a
rule of thumb target of 100 PGs per OSD.  Set the per-PG trim target
by dividing the overall value by the number of PGs on the OSD.

Increase the max pg log length alone, so if the OSD has <100 PGs,
those PGs will get more entries.  Reduce the minimum to be smaller than
the max.  Use the min/max config options to bracket what is allocated to
a single PG.

Signed-off-by: Sage Weil <sage@redhat.com>