### PR TITLE
gcc-10 has reorganized its C++ header files to avoid extraneous

### DIFF
--- a/src/common/bit_str.h
+++ b/src/common/bit_str.h
@@ -17,6 +17,8 @@
 #include <cstdint>
 #include <iosfwd>
 #include <functional>
+#include <cstdint>
+#include <ostream>
 
 namespace ceph {
   class Formatter;

--- a/src/librbd/api/PoolMetadata.h
+++ b/src/librbd/api/PoolMetadata.h
@@ -4,6 +4,9 @@
 #ifndef CEPH_LIBRBD_API_POOL_METADATA_H
 #define CEPH_LIBRBD_API_POOL_METADATA_H
 
+#include <string>
+#include <cstdint>
+
 #include "include/buffer_fwd.h"
 #include "include/rados/librados_fwd.hpp"
 


### PR DESCRIPTION
indirect #includes.  As a result some user code needs to include
headers that it previously didn't.

This patch is sufficient to get ceph building with gcc-10


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
