### PR TITLE
include/cpp-btree: drop btree::dump()

### DIFF
--- a/src/include/cpp-btree/btree.h
+++ b/src/include/cpp-btree/btree.h
@@ -51,7 +51,6 @@
 #include <cstring>
 #include <experimental/type_traits>
 #include <functional>
-#include <iosfwd>
 #include <iterator>
 #include <limits>
 #include <new>
@@ -1145,14 +1144,6 @@ class btree {
     return compare_result_as_less_than(key_comp()(x, y));
   }
 
-  // Dump the btree to the specified ostream. Requires that operator<< is
-  // defined for Key and Value.
-  void dump(std::ostream &os) const {
-    if (root() != NULL) {
-      internal_dump(os, root(), 0);
-    }
-  }
-
   // Verifies the structure of the btree.
   void verify() const;
 
@@ -1384,9 +1375,6 @@ class btree {
 
   // Deletes a node and all of its children.
   void internal_clear(node_type *node);
-
-  // Dumps a node and all of its children to the specified ostream.
-  void internal_dump(std::ostream &os, const node_type *node, int level) const;
 
   // Verifies the tree structure of node.
   int internal_verify(const node_type *node,
@@ -2523,23 +2511,6 @@ void btree<P>::internal_clear(node_type *node) {
     delete_internal_node(node);
   } else {
     delete_leaf_node(node);
-  }
-}
-
-template <typename P>
-void btree<P>::internal_dump(
-    std::ostream &os, const node_type *node, int level) const {
-  for (int i = 0; i < node->count(); ++i) {
-    if (!node->leaf()) {
-      internal_dump(os, node->child(i), level + 1);
-    }
-    for (int j = 0; j < level; ++j) {
-      os << "  ";
-    }
-    os << node->key(i) << " [" << level << "]\n";
-  }
-  if (!node->leaf()) {
-    internal_dump(os, node->child(node->count()), level + 1);
   }
 }
 

--- a/src/include/cpp-btree/btree_container.h
+++ b/src/include/cpp-btree/btree_container.h
@@ -142,7 +142,6 @@ class btree_container {
   void clear() { tree_.clear(); }
   void swap(btree_container &x) { tree_.swap(x.tree_); }
   void verify() const { tree_.verify(); }
-  void dump(std::ostream &os) const { tree_.dump(os); }
 
   // Size routines.
   size_type size() const { return tree_.size(); }
@@ -184,12 +183,6 @@ class btree_container {
  protected:
   Tree tree_;
 };
-
-template <typename T>
-inline std::ostream& operator<<(std::ostream &os, const btree_container<T> &b) {
-  b.dump(os);
-  return os;
-}
 
 // A common base class for btree_set and btree_map.
 template <typename Tree>


### PR DESCRIPTION
btree::dump() is a helper for printing out all the leaf nodes in a
btree, it's used by "operator<<()". but this operator is not used.
let's remove it.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
