### PR TITLE
luminous: os/bluestore: Revert "spdk: fix ceph-osd crash when activate SPDK"

### DIFF
--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -928,8 +928,6 @@ void NVMEDevice::close()
 {
   dout(1) << __func__ << dendl;
 
-  delete queue_t;
-  queue_t = nullptr;
   name.clear();
   driver->remove_device(this);
 


### PR DESCRIPTION
Actually, with this cherry-pick https://github.com/ceph/ceph/pull/22686, luminous branch cannot compile successfully when `WITH_SPDK=ON`.   

Because there is no autotest for SPDK enabling case in Ceph QA system, so the test results of https://github.com/ceph/ceph/pull/22686 didn't show any exceptions

Variable `queue_t` is not declared in NVMEDevice.cc file in luminous branch

![WeChatWorkScreenshot_84779c4d-df3d-4802-b840-def6e9f25b50 copy](https://user-images.githubusercontent.com/5844041/72602067-9ac5a600-3951-11ea-89da-8691f0905166.png)
