### PR TITLE
common: remove dead code in {safe,mutable}_item_history.

### DIFF
--- a/src/common/item_history.h
+++ b/src/common/item_history.h
@@ -16,44 +16,6 @@ total lifetime.
 */
 
 template<class T>
-class mutable_item_history {
-private:
-  std::mutex lock;
-  std::list<T> history;
-  T *current = nullptr;
-
-public:
-  mutable_item_history() {
-    history.emplace_back(T());
-    current = &history.back();
-  }
-
-  // readers are lock-free
-  const T& operator*() const {
-    return *current;
-  }
-  const T *operator->() const {
-    return current;
-  }
-
-  // non-const variants (be careful!)
-  T& operator*() {
-    return *current;
-  }
-  T *operator->() {
-    return current;
-  }
-
-  // writes are serialized
-  const T& operator=(const T& other) {
-    std::lock_guard l(lock);
-    history.push_back(other);
-    current = &history.back();
-    return *current;
-  }
-};
-
-template<class T>
 class safe_item_history {
 private:
   std::mutex lock;

--- a/src/common/item_history.h
+++ b/src/common/item_history.h
@@ -13,9 +13,6 @@ the latest value and continue using it as long as they want.  This container
 is only appropriate for values that are updated a handful of times over their
 total lifetime.
 
-There is a prune() method to throw out old values, but it should only be used
-if the caller has some way of knowing all readers are done.
-
 */
 
 template<class T>
@@ -54,14 +51,6 @@ public:
     current = &history.back();
     return *current;
   }
-
-  void prune() {
-    // note: this is not necessarily thread-safe wrt readers
-    std::lock_guard l(lock);
-    while (history.size() > 1) {
-      history.pop_front();
-    }
-  }
 };
 
 template<class T>
@@ -93,11 +82,4 @@ public:
     return *current;
   }
 
-  void prune() {
-    // note: this is not necessarily thread-safe wrt readers
-    std::lock_guard l(lock);
-    while (history.size() > 1) {
-      history.pop_front();
-    }
-  }
 };


### PR DESCRIPTION
The presence of these never-used methods obscures bug investigation. For instance, `safe_item_history` is used to record all messenger's addresses. As we never lock reading from it in `_conn_prefix()`, we expect they live as long their corresponding messenger instances. When such an item becomes corrupted, presence of `prune()` imposes verification the method is never called – this effort could have been avoided if we hadn't have the dangerous method.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
