### PR TITLE
Windows support [part 2]

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -408,6 +408,7 @@ endif()
 
 if(WIN32)
   list(APPEND ceph_common_deps ws2_32 mswsock)
+  list(APPEND ceph_common_deps dlfcn_win32)
 endif()
 
 if(WITH_BLUESTORE_PMEM OR WITH_RBD_RWL)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -7,6 +7,10 @@ add_library(common_texttable_obj OBJECT
 add_library(common_prioritycache_obj OBJECT
   PriorityCache.cc)
 
+if(WIN32)
+  add_library(dlfcn_win32 STATIC dlfcn_win32.cc)
+endif()
+
 set(common_srcs
   AsyncOpTracker.cc
   BackTrace.cc

--- a/src/common/PluginRegistry.cc
+++ b/src/common/PluginRegistry.cc
@@ -20,15 +20,10 @@
 #include "common/ceph_context.h"
 #include "common/errno.h"
 #include "common/debug.h"
-
-#include <dlfcn.h>
+#include "include/dlfcn_compat.h"
 
 #define PLUGIN_PREFIX "libceph_"
-#ifdef __APPLE__
-#define PLUGIN_SUFFIX ".dylib"
-#else
-#define PLUGIN_SUFFIX ".so"
-#endif
+#define PLUGIN_SUFFIX SHARED_LIB_SUFFIX
 #define PLUGIN_INIT_FUNCTION "__ceph_plugin_init"
 #define PLUGIN_VERSION_FUNCTION "__ceph_plugin_version"
 

--- a/src/common/TracepointProvider.h
+++ b/src/common/TracepointProvider.h
@@ -7,7 +7,7 @@
 #include "common/ceph_context.h"
 #include "common/config_obs.h"
 #include "common/ceph_mutex.h"
-#include <dlfcn.h>
+#include "include/dlfcn_compat.h"
 
 class TracepointProvider : public md_config_obs_t {
 public:

--- a/src/common/dlfcn_win32.cc
+++ b/src/common/dlfcn_win32.cc
@@ -1,0 +1,57 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <sstream>
+#include <windows.h>
+
+#include "include/dlfcn_compat.h"
+
+
+void* dlopen(const char *filename, int flags) {
+  return LoadLibrary(filename);
+}
+
+int dlclose(void* handle) {
+  //FreeLibrary returns 0 on error, as opposed to dlclose.
+  return !FreeLibrary(handle);
+}
+
+void* dlsym(void* handle, const char* symbol) {
+  return (void*)GetProcAddress(handle, symbol);
+}
+
+dl_errmsg_t dlerror() {
+  DWORD err_code = ::GetLastError();
+  // As opposed to dlerror messages, this has to be freed.
+  LPSTR msg = NULL;
+  DWORD msg_len = FormatMessageA(
+    FORMAT_MESSAGE_ALLOCATE_BUFFER |
+    FORMAT_MESSAGE_FROM_SYSTEM |
+    FORMAT_MESSAGE_IGNORE_INSERTS,
+    NULL,
+    err_code,
+    0,
+    (LPSTR) &msg,
+    0,
+    NULL);
+  if (!msg_len) {
+    std::ostringstream msg_stream;
+    msg_stream << "Unknown error (" << err_code << ").";
+    return msg_stream.str();
+  }
+  std::string msg_s(msg);
+  LocalFree(msg);
+  return msg_s;
+}
+

--- a/src/erasure-code/ErasureCodePlugin.cc
+++ b/src/erasure-code/ErasureCodePlugin.cc
@@ -16,22 +16,18 @@
  */
 
 #include <errno.h>
-#include <dlfcn.h>
 
 #include "ceph_ver.h"
 #include "ErasureCodePlugin.h"
 #include "common/errno.h"
+#include "include/dlfcn_compat.h"
 #include "include/str_list.h"
 #include "include/ceph_assert.h"
 
 using namespace std;
 
 #define PLUGIN_PREFIX "libec_"
-#if defined(__APPLE__)
-#define PLUGIN_SUFFIX ".dylib"
-#else
-#define PLUGIN_SUFFIX ".so"
-#endif
+#define PLUGIN_SUFFIX SHARED_LIB_SUFFIX
 #define PLUGIN_INIT_FUNCTION "__erasure_code_init"
 #define PLUGIN_VERSION_FUNCTION "__erasure_code_version"
 

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -345,4 +345,7 @@
 /* Define if RWL is enabled */
 #cmakedefine WITH_RBD_RWL
 
+/* Shared library extension, such as .so, .dll or .dylib */
+#cmakedefine CMAKE_SHARED_LIBRARY_SUFFIX "@CMAKE_SHARED_LIBRARY_SUFFIX@"
+
 #endif /* CONFIG_H */

--- a/src/include/dlfcn_compat.h
+++ b/src/include/dlfcn_compat.h
@@ -1,0 +1,48 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef DLFCN_COMPAT_H
+#define DLFCN_COMPAT_H
+
+#include "acconfig.h"
+
+#define SHARED_LIB_SUFFIX CMAKE_SHARED_LIBRARY_SUFFIX
+
+#ifdef _WIN32
+  #include <string>
+
+  using dl_errmsg_t = std::string;
+
+  // The load mode flags will be ignored on Windows. We keep the same
+  // values for debugging purposes though.
+  #define RTLD_LAZY       0x00001
+  #define RTLD_NOW        0x00002
+  #define RTLD_BINDING_MASK   0x3
+  #define RTLD_NOLOAD     0x00004
+  #define RTLD_DEEPBIND   0x00008
+  #define RTLD_GLOBAL     0x00100
+  #define RTLD_LOCAL      0
+  #define RTLD_NODELETE   0x01000
+
+  void* dlopen(const char *filename, int flags);
+  int dlclose(void* handle);
+  dl_errmsg_t dlerror();
+  void* dlsym(void* handle, const char* symbol);
+#else
+  #include <dlfcn.h>
+
+  using dl_errmsg_t = char*;
+#endif /* _WIN32 */
+
+#endif /* DLFCN_H */

--- a/src/osd/ClassHandler.cc
+++ b/src/osd/ClassHandler.cc
@@ -5,8 +5,7 @@
 #include "ClassHandler.h"
 #include "common/errno.h"
 #include "common/ceph_context.h"
-
-#include <dlfcn.h>
+#include "include/dlfcn_compat.h"
 
 #include <map>
 
@@ -23,7 +22,7 @@
 
 
 #define CLS_PREFIX "libcls_"
-#define CLS_SUFFIX ".so"
+#define CLS_SUFFIX SHARED_LIB_SUFFIX
 
 using std::map;
 using std::set;


### PR DESCRIPTION
Windows support [part 2]

This PR series intends to set the ground for the upcoming Windows port effort.
For now, we're mostly interested in the client side, allowing Windows hosts
to consume rados, rbd and cephfs resources.

Those PRs should be reviewed and merged in order. Each PR depends on the previous one from the series (in fact it includes the previous commits as well).

~~Part 1: #31981~~
**Part 2**: #32704
Part 3: #32705
Part 4: #32707
Part 5: #32780 
Part 6: #32779
Part 7: #32778 
Part 8: #32777 
Part 9: #32776
Part 10: #33750

Related but independent PRs:
https://github.com/ceph/ceph/pull/32027
https://github.com/ceph/fmt/pull/2
https://github.com/ceph/rocksdb/pull/42

For more details about the build process and current status, please check the
README.windows.rst file. Worth mentioning that the resulted binaries can
connect to ceph clusters and consume pools: http://paste.openstack.org/raw/787534/

Here are some test results as well:
[test_results.zip](https://github.com/ceph/ceph/files/4077517/test_results.zip)

Any feedback is highly appreciated.

Signed-off-by: Lucian Petrut lpetrut@cloudbasesolutions.com
Signed-off-by: Alin Gabriel Serdean aserdean@cloudbasesolutions.com