### PR TITLE
Windows support [part 3]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,13 @@ include_directories(
   ${PROJECT_BINARY_DIR}/src/include
   ${PROJECT_SOURCE_DIR}/src)
 
+if(WIN32)
+  include_directories(
+  ${PROJECT_SOURCE_DIR}/src/include/win32)
+  # Boost complains if winsock2.h (or windows.h) is included before asio.hpp.
+  add_definitions(-include winsock_wrapper.h)
+endif()
+
 if(OFED_PREFIX)
   include_directories(SYSTEM ${OFED_PREFIX}/include)
   link_directories(${OFED_PREFIX}/lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -544,7 +544,9 @@ endif()
 
 add_subdirectory(kv)
 add_subdirectory(os)
+if(NOT WIN32)
 add_subdirectory(blk)
+endif()
 
 add_subdirectory(osd)
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -45,7 +45,6 @@ set(common_srcs
   admin_socket_client.cc
   assert.cc
   bit_str.cc
-  blkdev.cc
   bloom_filter.cc
   ceph_argparse.cc
   ceph_context.cc
@@ -64,7 +63,6 @@ set(common_srcs
   condition_variable_debug.cc
   config.cc
   config_values.cc
-  dns_resolve.cc
   dout.cc
   entity_name.cc
   environment.cc
@@ -76,9 +74,7 @@ set(common_srcs
   histogram.cc
   hobject.cc
   hostname.cc
-  ipaddr.cc
   iso_8601.cc
-  linux_version.c
   lockdep.cc
   mempool.cc
   mime.c
@@ -93,7 +89,6 @@ set(common_srcs
   pick_address.cc
   random_string.cc
   reverse.c
-  run_cmd.cc
   scrub_types.cc
   shared_mutex_debug.cc
   signal.cc
@@ -107,6 +102,19 @@ set(common_srcs
   utf8.c
   util.cc
   version.cc)
+
+if(WIN32)
+  list(APPEND common_srcs
+    blkdev_win32.cc
+    dns_resolve_win32.cc)
+else()
+  list(APPEND common_srcs
+    blkdev.cc
+    dns_resolve.cc
+    ipaddr.cc
+    linux_version.c
+    run_cmd.cc)
+endif()
 
 set_source_files_properties(${CMAKE_SOURCE_DIR}/src/common/version.cc
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_BINARY_DIR}/src/include/ceph_ver.h)

--- a/src/common/SubProcess.cc
+++ b/src/common/SubProcess.cc
@@ -102,6 +102,7 @@ void SubProcess::close_stderr() {
   close(stderr_pipe_in_fd);
 }
 
+#ifndef _WIN32
 void SubProcess::kill(int signo) const {
   ceph_assert(is_spawned());
 
@@ -273,6 +274,7 @@ int SubProcess::join() {
   errstr << cmd << ": waitpid: unknown status returned\n";
   return EXIT_FAILURE;
 }
+#endif /* _WIN32 */
 
 SubProcessTimed::SubProcessTimed(const char *cmd, std_fd_op stdin_op,
 				 std_fd_op stdout_op, std_fd_op stderr_op,
@@ -288,6 +290,7 @@ void timeout_sighandler(int sig) {
 }
 static void dummy_sighandler(int sig) {}
 
+#ifndef _WIN32
 void SubProcessTimed::exec() {
   ceph_assert(is_child());
 
@@ -392,3 +395,22 @@ void SubProcessTimed::exec() {
 fail_exit:
   _exit(EXIT_FAILURE);
 }
+
+#else
+int SubProcess::join() {
+  return EXIT_FAILURE;
+}
+
+void SubProcess::kill(int signo) const {
+}
+
+int SubProcess::spawn() {
+  return EXIT_FAILURE;
+}
+
+void SubProcess::exec() {
+}
+
+void SubProcessTimed::exec() {
+}
+#endif /* _WIN32 */

--- a/src/common/SubProcess.h
+++ b/src/common/SubProcess.h
@@ -21,7 +21,9 @@
 #include <signal.h>
 #endif
 
+#ifndef _WIN32
 #include <sys/wait.h>
+#endif
 #include <sstream>
 #include <vector>
 

--- a/src/common/Thread.cc
+++ b/src/common/Thread.cc
@@ -125,6 +125,8 @@ int Thread::try_create(size_t stacksize)
   // the set of signals we want to block.  (It's ok to block signals more
   // signals than usual for a little while-- they will just be delivered to
   // another thread or delieverd to this thread later.)
+
+  #ifndef _WIN32
   sigset_t old_sigset;
   if (g_code_env == CODE_ENVIRONMENT_LIBRARY) {
     block_signals(NULL, &old_sigset);
@@ -135,6 +137,9 @@ int Thread::try_create(size_t stacksize)
   }
   r = pthread_create(&thread_id, thread_attr, _entry_func, (void*)this);
   restore_sigset(&old_sigset);
+  #else
+  r = pthread_create(&thread_id, thread_attr, _entry_func, (void*)this);
+  #endif
 
   if (thread_attr) {
     pthread_attr_destroy(thread_attr);	

--- a/src/common/admin_socket_client.cc
+++ b/src/common/admin_socket_client.cc
@@ -16,6 +16,7 @@
 #include <fcntl.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <unistd.h>
 
 #include "common/admin_socket.h"
 #include "common/errno.h"

--- a/src/common/blkdev_win32.cc
+++ b/src/common/blkdev_win32.cc
@@ -1,0 +1,137 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <errno.h>
+#include "blkdev.h"
+
+int get_device_by_path(const char *path, char* partition, char* device,
+               size_t max)
+{
+  return -EOPNOTSUPP;
+}
+
+
+BlkDev::BlkDev(int f)
+  : fd(f)
+{}
+
+BlkDev::BlkDev(const std::string& devname)
+  : devname(devname)
+{}
+
+int BlkDev::get_devid(dev_t *id) const
+{
+  return -EOPNOTSUPP;
+}
+
+const char *BlkDev::sysfsdir() const {
+  assert(false);  // Should never be called on Windows
+  return "";
+}
+
+int BlkDev::dev(char *dev, size_t max) const
+{
+  return -EOPNOTSUPP;
+}
+
+int BlkDev::get_size(int64_t *psize) const
+{
+  return -EOPNOTSUPP;
+}
+
+bool BlkDev::support_discard() const
+{
+  return false;
+}
+
+int BlkDev::discard(int64_t offset, int64_t len) const
+{
+  return -EOPNOTSUPP;
+}
+
+bool BlkDev::is_rotational() const
+{
+  return false;
+}
+
+int BlkDev::model(char *model, size_t max) const
+{
+  return -EOPNOTSUPP;
+}
+
+int BlkDev::serial(char *serial, size_t max) const
+{
+  return -EOPNOTSUPP;
+}
+
+int BlkDev::partition(char *partition, size_t max) const
+{
+  return -EOPNOTSUPP;
+}
+
+int BlkDev::wholedisk(char *wd, size_t max) const
+{
+  return -EOPNOTSUPP;
+}
+
+void get_dm_parents(const std::string& dev, std::set<std::string> *ls)
+{
+}
+
+void get_raw_devices(const std::string& in,
+             std::set<std::string> *ls)
+{
+}
+
+int get_vdo_stats_handle(const char *devname, std::string *vdo_name)
+{
+  return -1;
+}
+
+int64_t get_vdo_stat(int fd, const char *property)
+{
+  return 0;
+}
+
+bool get_vdo_utilization(int fd, uint64_t *total, uint64_t *avail)
+{
+  return false;
+}
+
+std::string get_device_id(const std::string& devname,
+              std::string *err)
+{
+  if (err) {
+    *err = "not implemented";
+  }
+  return std::string();
+}
+
+int block_device_run_smartctl(const char *device, int timeout,
+                  std::string *result)
+{
+  return -EOPNOTSUPP;
+}
+
+int block_device_get_metrics(const std::string& devname, int timeout,
+                             json_spirit::mValue *result)
+{
+  return -EOPNOTSUPP;
+}
+
+int block_device_run_nvme(const char *device, const char *vendor, int timeout,
+            std::string *result)
+{
+  return -EOPNOTSUPP;
+}

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -29,6 +29,7 @@
 
 #include "include/any.h"
 #include "include/common_fwd.h"
+#include "include/compat.h"
 
 #include "common/cmdparse.h"
 #include "common/code_environment.h"

--- a/src/common/compat.cc
+++ b/src/common/compat.cc
@@ -148,6 +148,9 @@ int socketpair_cloexec(int domain, int type, int protocol, int sv[2])
 {
 #ifdef SOCK_CLOEXEC
   return socketpair(domain, type|SOCK_CLOEXEC, protocol, sv);
+#elif _WIN32
+  /* TODO */
+  return -ENOTSUP;
 #else
   int rc = socketpair(domain, type, protocol, sv);
   if (rc == -1)
@@ -207,3 +210,21 @@ char *ceph_strerror_r(int errnum, char *buf, size_t buflen)
   return buf;
 #endif
 }
+
+#ifdef _WIN32
+
+// chown is not available on Windows. Plus, changing file owners is not
+// a common practice on Windows.
+int chown(const char *path, uid_t owner, gid_t group) {
+  return 0;
+}
+
+int fchown(int fd, uid_t owner, gid_t group) {
+  return 0;
+}
+
+int lchown(const char *path, uid_t owner, gid_t group) {
+  return 0;
+}
+
+#endif /* _WIN32 */

--- a/src/common/dns_resolve.h
+++ b/src/common/dns_resolve.h
@@ -139,11 +139,13 @@ class DNSResolver {
     void put_state(res_state s);
 #endif
 
+#ifndef _WIN32
     /* this private function allows to reuse the res_state structure used
      * by other function of this class
      */
     int resolve_ip_addr(CephContext *cct, res_state *res,
         const std::string& hostname, entity_addr_t *addr);
+#endif
 
     std::string srv_protocol_to_str(SRV_Protocol proto) {
       switch (proto) {

--- a/src/common/dns_resolve_win32.cc
+++ b/src/common/dns_resolve_win32.cc
@@ -1,0 +1,65 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "include/scope_guard.h"
+#include "dns_resolve.h"
+#include "common/debug.h"
+
+#define dout_subsys ceph_subsys_
+
+
+namespace ceph {
+
+int ResolvHWrapper::res_query(const char *hostname, int cls,
+    int type, u_char *buf, int bufsz) {
+  return -1;
+}
+
+int ResolvHWrapper::res_search(const char *hostname, int cls,
+    int type, u_char *buf, int bufsz) {
+  return -1;
+}
+
+DNSResolver::~DNSResolver()
+{
+  delete resolv_h;
+}
+
+int DNSResolver::resolve_cname(CephContext *cct, const string& hostname,
+    string *cname, bool *found)
+{
+  return -ENOTSUP;
+}
+
+int DNSResolver::resolve_ip_addr(CephContext *cct, const string& hostname,
+    entity_addr_t *addr)
+{
+  return -ENOTSUP;
+}
+
+int DNSResolver::resolve_srv_hosts(CephContext *cct, const string& service_name,
+    const SRV_Protocol trans_protocol,
+    map<string, DNSResolver::Record> *srv_hosts)
+{
+  return this->resolve_srv_hosts(cct, service_name, trans_protocol, "", srv_hosts);
+}
+
+int DNSResolver::resolve_srv_hosts(CephContext *cct, const string& service_name,
+    const SRV_Protocol trans_protocol, const string& domain,
+    map<string, DNSResolver::Record> *srv_hosts)
+{
+  return -ENOTSUP;
+}
+
+}

--- a/src/common/fd.cc
+++ b/src/common/fd.cc
@@ -16,6 +16,7 @@
 #include "debug.h"
 #include "errno.h"
 
+#ifndef _WIN32
 void dump_open_fds(CephContext *cct)
 {
 #ifdef __APPLE__
@@ -51,3 +52,8 @@ void dump_open_fds(CephContext *cct)
 
   closedir(d);
 }
+#else
+void dump_open_fds(CephContext *cct)
+{
+}
+#endif

--- a/src/common/fork_function.h
+++ b/src/common/fork_function.h
@@ -10,7 +10,9 @@
 #include <ostream>
 
 #include <signal.h>
+#ifndef _WIN32
 #include <sys/wait.h>
+#endif
 #include <sys/types.h>
 
 #include "include/ceph_assert.h"
@@ -22,6 +24,7 @@ static void _fork_function_dummy_sighandler(int sig) {}
 // int8_t only due to unix exit code limitations.  Returns -ETIMEDOUT
 // if timeout is reached.
 
+#ifndef _WIN32
 static inline int fork_function(
   int timeout,
   std::ostream& errstr,
@@ -162,3 +165,13 @@ static inline int fork_function(
 fail_exit:
   _exit(EXIT_FAILURE);
 }
+#else
+static inline int fork_function(
+  int timeout,
+  std::ostream& errstr,
+  std::function<int8_t(void)> f)
+{
+  errstr << "Forking is not available on Windows.\n";
+  return -1;
+}
+#endif

--- a/src/common/hostname.cc
+++ b/src/common/hostname.cc
@@ -16,6 +16,8 @@
 
 #include <unistd.h>
 
+#include "include/compat.h"
+
 std::string ceph_get_hostname()
 {
   // are we in a container?  if so we would prefer the *real* hostname.

--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -36,7 +36,7 @@ void netmask_ipv4(const struct in_addr *addr,
 
 static bool match_numa_node(const string& if_name, int numa_node)
 {
-#ifdef WITH_SEASTAR
+#if defined(WITH_SEASTAR) || defined(_WIN32)
   return true;
 #else
   int if_node = -1;

--- a/src/common/module.c
+++ b/src/common/module.c
@@ -20,6 +20,7 @@
 #include <sys/wait.h>
 #endif 
 
+#ifndef _WIN32
 /*
  * TODO: Switch to libkmod when we abandon older platforms.  The APIs
  * we want are:
@@ -77,3 +78,23 @@ int module_load(const char *module, const char *options)
 
 	return run_command(command);
 }
+
+#else
+
+// We're stubbing out those functions, for now.
+static int run_command(const char *command)
+{
+	return -1;
+}
+
+int module_has_param(const char *module, const char *param)
+{
+	return -1;
+}
+
+int module_load(const char *module, const char *options)
+{
+	return -1;
+}
+
+#endif /* _WIN32 */

--- a/src/common/numa.cc
+++ b/src/common/numa.cc
@@ -188,8 +188,7 @@ int set_cpu_affinity_all_threads(size_t cpu_set_size, cpu_set_t *cpu_set)
   return 0;
 }
 
-#elif defined(__FreeBSD__)
-
+#else
 int parse_cpu_set_list(const char *s,
 		       size_t *cpu_set_size,
 		       cpu_set_t *cpu_set)

--- a/src/common/signal.cc
+++ b/src/common/signal.cc
@@ -30,6 +30,7 @@
 
 using namespace std::literals;
 
+#ifndef _WIN32
 std::string signal_mask_to_str()
 {
   sigset_t old_sigset;
@@ -83,3 +84,14 @@ void unblock_all_signals(sigset_t *old_sigset)
   int ret = pthread_sigmask(SIG_UNBLOCK, &sigset, old_sigset);
   ceph_assert(ret == 0);
 }
+#else
+std::string signal_mask_to_str()
+{
+  return "(unsupported signal)";
+}
+
+// Windows provides limited signal functionality.
+void block_signals(const int *siglist, sigset_t *old_sigset) {}
+void restore_sigset(const sigset_t *old_sigset) {}
+void unblock_all_signals(sigset_t *old_sigset) {}
+#endif /* _WIN32 */

--- a/src/crush/CrushCompiler.cc
+++ b/src/crush/CrushCompiler.cc
@@ -7,6 +7,10 @@
 #define EBADE ECORRUPT
 #endif
 
+#if defined(_WIN32)
+#define EBADE EINVAL
+#endif
+
 #ifndef EBADE
 #define EBADE EFTYPE
 #endif

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -34,7 +34,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#ifndef __CYGWIN__
+#if !defined(__CYGWIN__) && !defined(_WIN32)
 # include <sys/mman.h>
 #endif
 

--- a/src/include/ceph_assert.h
+++ b/src/include/ceph_assert.h
@@ -4,12 +4,12 @@
 #include <cstdlib>
 #include <string>
 
-#if defined(__linux__)
-#include <features.h>
-
 #ifndef __STRING
 # define __STRING(x) #x
 #endif
+
+#if defined(__linux__)
+#include <features.h>
 
 #elif defined(__FreeBSD__)
 #include <sys/cdefs.h>

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -206,6 +206,8 @@ char *ceph_strerror_r(int errnum, char *buf, size_t buflen);
 
 #if defined(_WIN32)
 
+#include "include/win32/winsock_compat.h"
+
 typedef _sigset_t sigset_t;
 
 typedef int uid_t;

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -219,6 +219,14 @@ typedef long nlink_t;
 
 typedef long long loff_t;
 
+#define CPU_SETSIZE (sizeof(size_t)*8)
+
+typedef union
+{
+  char cpuset[CPU_SETSIZE/8];
+  size_t _align;
+} cpu_set_t;
+
 #define SHUT_RD SD_RECEIVE
 #define SHUT_WR SD_SEND
 #define SHUT_RDWR SD_BOTH
@@ -244,6 +252,18 @@ typedef long long loff_t;
 // with subprocesses unless explicitly requested, we'll define this
 // flag as a no-op.
 #define O_CLOEXEC 0
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int chown(const char *path, uid_t owner, gid_t group);
+int fchown(int fd, uid_t owner, gid_t group);
+int lchown(const char *path, uid_t owner, gid_t group);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* WIN32 */
 

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -103,15 +103,15 @@ int sched_setaffinity(pid_t pid, size_t cpusetsize,
 #define XATTR_CREATE 1
 #endif
 
+#endif /* __APPLE__ */
+
 #ifndef HOST_NAME_MAX
 #ifdef MAXHOSTNAMELEN 
 #define HOST_NAME_MAX MAXHOSTNAMELEN 
 #else
 #define HOST_NAME_MAX 255
 #endif
-#endif
-
-#endif /* __APPLE__ */
+#endif /* HOST_NAME_MAX */
 
 /* O_LARGEFILE is not defined/required on OSX/FreeBSD */
 #ifndef O_LARGEFILE
@@ -193,16 +193,56 @@ int sched_setaffinity(pid_t pid, size_t cpusetsize,
 
 int ceph_posix_fallocate(int fd, off_t offset, off_t len);
 
-int pipe_cloexec(int pipefd[2], int flags);
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+int pipe_cloexec(int pipefd[2], int flags);
 char *ceph_strerror_r(int errnum, char *buf, size_t buflen);
 
 #ifdef __cplusplus
 }
 #endif
+
+#if defined(_WIN32)
+
+typedef _sigset_t sigset_t;
+
+typedef int uid_t;
+typedef int gid_t;
+
+typedef long blksize_t;
+typedef long blkcnt_t;
+typedef long nlink_t;
+
+typedef long long loff_t;
+
+#define SHUT_RD SD_RECEIVE
+#define SHUT_WR SD_SEND
+#define SHUT_RDWR SD_BOTH
+
+#ifndef SIGINT
+#define SIGINT 2
+#endif
+
+#ifndef SIGKILL
+#define SIGKILL 9
+#endif
+
+#ifndef ENODATA
+// mingw doesn't define this, the Windows SDK does.
+#define ENODATA 120
+#endif
+
+#define ESHUTDOWN ECONNABORTED
+#define ESTALE 256
+#define EREMOTEIO 257
+
+// O_CLOEXEC is not defined on Windows. Since handles aren't inherited
+// with subprocesses unless explicitly requested, we'll define this
+// flag as a no-op.
+#define O_CLOEXEC 0
+
+#endif /* WIN32 */
 
 #endif /* !CEPH_COMPAT_H */

--- a/src/include/statlite.h
+++ b/src/include/statlite.h
@@ -11,6 +11,8 @@ extern "C" {
 #include <unistd.h>
 #include <dirent.h>
 
+#include "include/compat.h"
+
 struct statlite {
   dev_t         st_dev;      /* device */
   ino_t         st_ino;      /* inode */

--- a/src/include/win32/arpa/inet.h
+++ b/src/include/win32/arpa/inet.h
@@ -1,0 +1,1 @@
+#include "winsock_compat.h"

--- a/src/include/win32/netdb.h
+++ b/src/include/win32/netdb.h
@@ -1,0 +1,1 @@
+#include "winsock_compat.h"

--- a/src/include/win32/netinet/in.h
+++ b/src/include/win32/netinet/in.h
@@ -1,0 +1,1 @@
+#include "winsock_compat.h"

--- a/src/include/win32/poll.h
+++ b/src/include/win32/poll.h
@@ -1,0 +1,1 @@
+#include "winsock_compat.h"

--- a/src/include/win32/sys/errno.h
+++ b/src/include/win32/sys/errno.h
@@ -1,0 +1,1 @@
+#include <errno.h>

--- a/src/include/win32/sys/socket.h
+++ b/src/include/win32/sys/socket.h
@@ -1,0 +1,1 @@
+#include "winsock_compat.h"

--- a/src/include/win32/sys/un.h
+++ b/src/include/win32/sys/un.h
@@ -1,0 +1,1 @@
+#include "include/win32/winsock_compat.h"

--- a/src/include/win32/syslog.h
+++ b/src/include/win32/syslog.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013, 2015 Cloudbase Solutions Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef SYSLOG_H
+#define SYSLOG_H 1
+
+#define LOG_EMERG       0       /* system is unusable */
+#define LOG_ALERT       1       /* action must be taken immediately */
+#define LOG_CRIT        2       /* critical conditions */
+#define LOG_ERR         3       /* error conditions */
+#define LOG_WARNING     4       /* warning conditions */
+#define LOG_NOTICE      5       /* normal but significant condition */
+#define LOG_INFO        6       /* informational */
+#define LOG_DEBUG       7       /* debug-level messages */
+#define LOG_NDELAY      8       /* don't delay open */
+
+#define LOG_KERN      (0<<3)  /* kernel messages */
+#define LOG_USER      (1<<3)  /* user-level messages */
+#define LOG_MAIL      (2<<3)  /* mail system */
+#define LOG_DAEMON    (3<<3)  /* system daemons */
+#define LOG_AUTH      (4<<3)  /* security/authorization messages */
+#define LOG_SYSLOG    (5<<3)  /* messages generated internally by syslogd */
+#define LOG_LPR       (6<<3)  /* line printer subsystem */
+#define LOG_NEWS      (7<<3)  /* network news subsystem */
+#define LOG_UUCP      (8<<3)  /* UUCP subsystem */
+#define LOG_CRON      (9<<3)  /* clock daemon */
+#define LOG_AUTHPRIV  (10<<3) /* security/authorization messages */
+#define LOG_FTP       (11<<3) /* FTP daemon */
+
+#define LOG_LOCAL0      (16<<3) /* reserved for local use */
+#define LOG_LOCAL1      (17<<3) /* reserved for local use */
+#define LOG_LOCAL2      (18<<3) /* reserved for local use */
+#define LOG_LOCAL3      (19<<3) /* reserved for local use */
+#define LOG_LOCAL4      (20<<3) /* reserved for local use */
+#define LOG_LOCAL5      (21<<3) /* reserved for local use */
+#define LOG_LOCAL6      (22<<3) /* reserved for local use */
+#define LOG_LOCAL7      (23<<3) /* reserved for local use */
+
+static inline void
+openlog(const char *ident, int option, int facility)
+{
+}
+
+static inline void
+syslog(int priority, const char *format, ...)
+{
+}
+
+#endif /* syslog.h */

--- a/src/include/win32/winsock_compat.h
+++ b/src/include/win32/winsock_compat.h
@@ -1,0 +1,39 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef WINSOCK_COMPAT_H
+#define WINSOCK_COMPAT_H 1
+
+#include "winsock_wrapper.h"
+
+#ifndef poll
+#define poll WSAPoll
+#endif
+
+// afunix.h is available starting with Windows SDK 17063. Still, it wasn't
+// picked up by mingw yet, for which reason we're going to define sockaddr_un
+// here.
+#ifndef _AFUNIX_
+#define UNIX_PATH_MAX 108
+
+typedef struct sockaddr_un
+{
+     ADDRESS_FAMILY sun_family;     /* AF_UNIX */
+     char sun_path[UNIX_PATH_MAX];  /* pathname */
+} SOCKADDR_UN, *PSOCKADDR_UN;
+
+#define SIO_AF_UNIX_GETPEERPID _WSAIOR(IOC_VENDOR, 256)
+#endif /* _AFUNIX */
+
+#endif /* WINSOCK_COMPAT_H */

--- a/src/include/win32/winsock_wrapper.h
+++ b/src/include/win32/winsock_wrapper.h
@@ -1,0 +1,27 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef WINSOCK_WRAPPER_H
+#define WINSOCK_WRAPPER_H 1
+
+#ifdef __cplusplus
+// Boost complains if winsock2.h (or windows.h) is included before asio.hpp.
+#include <boost/asio.hpp>
+#endif
+
+#include <winsock2.h>
+#include <ws2ipdef.h>
+#include <ws2tcpip.h>
+
+#endif /* WINSOCK_WRAPPER_H */

--- a/src/log/LogClock.h
+++ b/src/log/LogClock.h
@@ -12,6 +12,10 @@
 #include "include/ceph_assert.h"
 #include "common/ceph_time.h"
 
+#ifndef suseconds_t
+typedef long suseconds_t;
+#endif
+
 namespace ceph {
 namespace logging {
 namespace _logclock {
@@ -130,7 +134,7 @@ inline int append_time(const log_time& t, char *out, int outlen) {
   bool coarse = t.time_since_epoch().count().coarse;
   auto tv = log_clock::to_timeval(t);
   std::tm bdt;
-  localtime_r(&tv.tv_sec, &bdt);
+  localtime_r((time_t*)&tv.tv_sec, &bdt);
   char tz[32] = { 0 };
   strftime(tz, sizeof(tz), "%z", &bdt);
 

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -32,7 +32,7 @@
 #include <vector>
 #include <map>
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__sun)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__sun) || defined(_WIN32)
 #include <sys/statvfs.h>
 #else
 #include <sys/vfs.h>    /* or <sys/statfs.h> */

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -16,7 +16,7 @@ else()
 endif()
 install(TARGETS rados DESTINATION bin)
 
-if(WITH_BOOST_CONTEXT)
+if(WITH_BOOST_CONTEXT AND NOT WIN32)
 set(neorados_srcs
   neorados.cc)
 add_executable(neorados ${neorados_srcs})

--- a/src/tools/rbd/action/Nbd.cc
+++ b/src/tools/rbd/action/Nbd.cc
@@ -21,6 +21,10 @@ namespace po = boost::program_options;
 static int call_nbd_cmd(const po::variables_map &vm,
                         const std::vector<std::string> &args,
                         const std::vector<std::string> &ceph_global_init_args) {
+  #ifdef _WIN32
+  std::cerr << "rbd: nbd device is not supported" << std::endl;
+  return -EOPNOTSUPP;
+  #else
   char exe_path[PATH_MAX];
   ssize_t exe_path_bytes = readlink("/proc/self/exe", exe_path,
 				    sizeof(exe_path) - 1);
@@ -53,6 +57,7 @@ static int call_nbd_cmd(const po::variables_map &vm,
   }
 
   return 0;
+  #endif
 }
 
 int get_image_or_snap_spec(const po::variables_map &vm, std::string *spec) {
@@ -99,7 +104,7 @@ int parse_options(const std::vector<std::string> &options,
 
 int execute_list(const po::variables_map &vm,
                  const std::vector<std::string> &ceph_global_init_args) {
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(_WIN32)
   std::cerr << "rbd: nbd device is not supported" << std::endl;
   return -EOPNOTSUPP;
 #endif
@@ -120,7 +125,7 @@ int execute_list(const po::variables_map &vm,
 
 int execute_map(const po::variables_map &vm,
                 const std::vector<std::string> &ceph_global_init_args) {
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(_WIN32)
   std::cerr << "rbd: nbd device is not supported" << std::endl;
   return -EOPNOTSUPP;
 #endif
@@ -163,7 +168,7 @@ int execute_map(const po::variables_map &vm,
 
 int execute_unmap(const po::variables_map &vm,
                   const std::vector<std::string> &ceph_global_init_args) {
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(_WIN32)
   std::cerr << "rbd: nbd device is not supported" << std::endl;
   return -EOPNOTSUPP;
 #endif


### PR DESCRIPTION
Windows support [part 3]

This PR series intends to set the ground for the upcoming Windows port effort.
For now, we're mostly interested in the client side, allowing Windows hosts
to consume rados, rbd and cephfs resources.

Those PRs should be reviewed and merged in order. Each PR depends on the previous one from the series (in fact it includes the previous commits as well).

~~Part 1: https://github.com/ceph/ceph/pull/31981~~
~~Part 2: https://github.com/ceph/ceph/pull/32704~~
**Part 3**: https://github.com/ceph/ceph/pull/32705
Part 4: https://github.com/ceph/ceph/pull/32707
Part 5: #32780 
Part 6: #32779
Part 7: #32778 
Part 8: #32777 
Part 9: #32776
Part 10: #33750
Part 11: #34858
Part 12: #34859

Related but independent PRs:
https://github.com/ceph/ceph/pull/32027
https://github.com/ceph/fmt/pull/2
https://github.com/ceph/rocksdb/pull/42

For more details about the build process and current status, please check the
README.windows.rst file. Worth mentioning that the resulted binaries can
connect to ceph clusters and consume pools: http://paste.openstack.org/raw/787534/

Here are some test results as well:
[test_results.zip](https://github.com/ceph/ceph/files/4077517/test_results.zip)

Any feedback is highly appreciated.

Signed-off-by: Lucian Petrut lpetrut@cloudbasesolutions.com
Signed-off-by: Alin Gabriel Serdean aserdean@cloudbasesolutions.com
