### PR TITLE
Windows support [part 4]

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -434,7 +434,7 @@ if(WITH_DPDK)
 endif()
 
 if(WIN32)
-  list(APPEND ceph_common_deps ws2_32 mswsock)
+  list(APPEND ceph_common_deps ws2_32 mswsock bcrypt)
   list(APPEND ceph_common_deps dlfcn_win32)
 endif()
 

--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -84,8 +84,26 @@ void CryptoRandom::get_bytes(char *buf, int len)
   }
 }
 
-#else // !HAVE_GETENTROPY
+#elif defined(_WIN32) // !HAVE_GETENTROPY
 
+#include <bcrypt.h>
+
+CryptoRandom::CryptoRandom() : fd(0) {}
+CryptoRandom::~CryptoRandom() = default;
+
+void CryptoRandom::get_bytes(char *buf, int len)
+{
+  auto ret = BCryptGenRandom (
+    NULL,
+    (unsigned char*)buf,
+    len,
+    BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+  if (ret != 0) {
+    throw std::system_error(ret, std::system_category());
+  }
+}
+
+#else // !HAVE_GETENTROPY && !_WIN32
 // open /dev/urandom once on construction and reuse the fd for all reads
 CryptoRandom::CryptoRandom()
   : fd{open_urandom()}

--- a/src/cls/lock/cls_lock_client.cc
+++ b/src/cls/lock/cls_lock_client.cc
@@ -213,52 +213,52 @@ namespace rados {
 
       void Lock::assert_locked_shared(ObjectOperation *op)
       {
-        assert_locked(op, name, LOCK_SHARED, cookie, tag);
+        assert_locked(op, name, ClsLockType::SHARED, cookie, tag);
       }
 
       void Lock::assert_locked_exclusive(ObjectOperation *op)
       {
-        assert_locked(op, name, LOCK_EXCLUSIVE, cookie, tag);
+        assert_locked(op, name, ClsLockType::EXCLUSIVE, cookie, tag);
       }
 
       void Lock::assert_locked_exclusive_ephemeral(ObjectOperation *op)
       {
-        assert_locked(op, name, LOCK_EXCLUSIVE_EPHEMERAL, cookie, tag);
+        assert_locked(op, name, ClsLockType::EXCLUSIVE_EPHEMERAL, cookie, tag);
       }
 
       void Lock::lock_shared(ObjectWriteOperation *op)
       {
-        lock(op, name, LOCK_SHARED,
+        lock(op, name, ClsLockType::SHARED,
              cookie, tag, description, duration, flags);
       }
 
       int Lock::lock_shared(IoCtx *ioctx, const std::string& oid)
       {
-        return lock(ioctx, oid, name, LOCK_SHARED,
+        return lock(ioctx, oid, name, ClsLockType::SHARED,
                     cookie, tag, description, duration, flags);
       }
 
       void Lock::lock_exclusive(ObjectWriteOperation *op)
       {
-        lock(op, name, LOCK_EXCLUSIVE,
+        lock(op, name, ClsLockType::EXCLUSIVE,
              cookie, tag, description, duration, flags);
       }
 
       int Lock::lock_exclusive(IoCtx *ioctx, const std::string& oid)
       {
-        return lock(ioctx, oid, name, LOCK_EXCLUSIVE,
+        return lock(ioctx, oid, name, ClsLockType::EXCLUSIVE,
                     cookie, tag, description, duration, flags);
       }
 
       void Lock::lock_exclusive_ephemeral(ObjectWriteOperation *op)
       {
-        lock(op, name, LOCK_EXCLUSIVE_EPHEMERAL,
+        lock(op, name, ClsLockType::EXCLUSIVE_EPHEMERAL,
              cookie, tag, description, duration, flags);
       }
 
       int Lock::lock_exclusive_ephemeral(IoCtx *ioctx, const std::string& oid)
       {
-        return lock(ioctx, oid, name, LOCK_EXCLUSIVE_EPHEMERAL,
+        return lock(ioctx, oid, name, ClsLockType::EXCLUSIVE_EPHEMERAL,
                     cookie, tag, description, duration, flags);
       }
 

--- a/src/cls/lock/cls_lock_ops.cc
+++ b/src/cls/lock/cls_lock_ops.cc
@@ -40,7 +40,7 @@ void cls_lock_lock_op::generate_test_instances(list<cls_lock_lock_op*>& o)
 {
   cls_lock_lock_op *i = new cls_lock_lock_op;
   i->name = "name";
-  i->type = LOCK_SHARED;
+  i->type = ClsLockType::SHARED;
   i->cookie = "cookie";
   i->tag = "tag";
   i->description = "description";
@@ -130,7 +130,7 @@ void cls_lock_get_info_reply::dump(Formatter *f) const
 void cls_lock_get_info_reply::generate_test_instances(list<cls_lock_get_info_reply*>& o)
 {
   cls_lock_get_info_reply *i = new cls_lock_get_info_reply;
-  i->lock_type = LOCK_SHARED;
+  i->lock_type = ClsLockType::SHARED;
   i->tag = "tag";
   locker_id_t id1, id2;
   entity_addr_t addr1, addr2;
@@ -180,7 +180,7 @@ void cls_lock_assert_op::generate_test_instances(list<cls_lock_assert_op*>& o)
 {
   cls_lock_assert_op *i = new cls_lock_assert_op;
   i->name = "name";
-  i->type = LOCK_SHARED;
+  i->type = ClsLockType::SHARED;
   i->cookie = "cookie";
   i->tag = "tag";
   o.push_back(i);
@@ -200,7 +200,7 @@ void cls_lock_set_cookie_op::generate_test_instances(list<cls_lock_set_cookie_op
 {
   cls_lock_set_cookie_op *i = new cls_lock_set_cookie_op;
   i->name = "name";
-  i->type = LOCK_SHARED;
+  i->type = ClsLockType::SHARED;
   i->cookie = "cookie";
   i->tag = "tag";
   i->new_cookie = "new cookie";

--- a/src/cls/lock/cls_lock_ops.h
+++ b/src/cls/lock/cls_lock_ops.h
@@ -18,7 +18,7 @@ struct cls_lock_lock_op
   utime_t duration;
   uint8_t flags;
 
-  cls_lock_lock_op() : type(LOCK_NONE), flags(0) {}
+  cls_lock_lock_op() : type(ClsLockType::NONE), flags(0) {}
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
@@ -128,7 +128,7 @@ struct cls_lock_get_info_reply
   ClsLockType lock_type;
   std::string tag;
 
-  cls_lock_get_info_reply() : lock_type(LOCK_NONE) {}
+  cls_lock_get_info_reply() : lock_type(ClsLockType::NONE) {}
 
   void encode(ceph::buffer::list &bl, uint64_t features) const {
     ENCODE_START(1, 1, bl);
@@ -180,7 +180,7 @@ struct cls_lock_assert_op
   std::string cookie;
   std::string tag;
 
-  cls_lock_assert_op() : type(LOCK_NONE) {}
+  cls_lock_assert_op() : type(ClsLockType::NONE) {}
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
@@ -214,7 +214,7 @@ struct cls_lock_set_cookie_op
   std::string tag;
   std::string new_cookie;
 
-  cls_lock_set_cookie_op() : type(LOCK_NONE) {}
+  cls_lock_set_cookie_op() : type(ClsLockType::NONE) {}
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);

--- a/src/cls/lock/cls_lock_types.cc
+++ b/src/cls/lock/cls_lock_types.cc
@@ -69,7 +69,7 @@ void locker_info_t::generate_test_instances(std::list<locker_info_t*>& o)
 
 void lock_info_t::dump(ceph::Formatter *f) const
 {
-  f->dump_int("lock_type", lock_type);
+  f->dump_int("lock_type", static_cast<int>(lock_type));
   f->dump_string("tag", tag);
   f->open_array_section("lockers");
   for (auto &i : lockers) {
@@ -91,7 +91,7 @@ void lock_info_t::generate_test_instances(std::list<lock_info_t *>& o)
   generate_test_addr(info.addr, 1, 2);
   info.description = "description";
   i->lockers[id] = info;
-  i->lock_type = LOCK_EXCLUSIVE;
+  i->lock_type = ClsLockType::EXCLUSIVE;
   i->tag = "tag";
   o.push_back(i);
   o.push_back(new lock_info_t);

--- a/src/cls/lock/cls_lock_types.h
+++ b/src/cls/lock/cls_lock_types.h
@@ -13,23 +13,23 @@
 #define LOCK_FLAG_MAY_RENEW 0x1    /* idempotent lock acquire */
 #define LOCK_FLAG_MUST_RENEW 0x2   /* lock must already be acquired */
 
-enum ClsLockType {
-  LOCK_NONE                = 0,
-  LOCK_EXCLUSIVE           = 1,
-  LOCK_SHARED              = 2,
-  LOCK_EXCLUSIVE_EPHEMERAL = 3, /* lock object is removed @ unlock */
+enum class ClsLockType {
+  NONE                = 0,
+  EXCLUSIVE           = 1,
+  SHARED              = 2,
+  EXCLUSIVE_EPHEMERAL = 3, /* lock object is removed @ unlock */
 };
 
 inline const char *cls_lock_type_str(ClsLockType type)
 {
     switch (type) {
-      case LOCK_NONE:
+      case ClsLockType::NONE:
 	return "none";
-      case LOCK_EXCLUSIVE:
+      case ClsLockType::EXCLUSIVE:
 	return "exclusive";
-      case LOCK_SHARED:
+      case ClsLockType::SHARED:
 	return "shared";
-      case LOCK_EXCLUSIVE_EPHEMERAL:
+      case ClsLockType::EXCLUSIVE_EPHEMERAL:
 	return "exclusive-ephemeral";
       default:
 	return "<unknown>";
@@ -37,17 +37,17 @@ inline const char *cls_lock_type_str(ClsLockType type)
 }
 
 inline bool cls_lock_is_exclusive(ClsLockType type) {
-  return LOCK_EXCLUSIVE == type || LOCK_EXCLUSIVE_EPHEMERAL == type;
+  return ClsLockType::EXCLUSIVE == type || ClsLockType::EXCLUSIVE_EPHEMERAL == type;
 }
 
 inline bool cls_lock_is_ephemeral(ClsLockType type) {
-  return LOCK_EXCLUSIVE_EPHEMERAL == type;
+  return ClsLockType::EXCLUSIVE_EPHEMERAL == type;
 }
 
 inline bool cls_lock_is_valid(ClsLockType type) {
-  return LOCK_SHARED == type ||
-    LOCK_EXCLUSIVE == type ||
-    LOCK_EXCLUSIVE_EPHEMERAL == type;
+  return ClsLockType::SHARED == type ||
+    ClsLockType::EXCLUSIVE == type ||
+    ClsLockType::EXCLUSIVE_EPHEMERAL == type;
 }
 
 namespace rados {
@@ -161,7 +161,8 @@ namespace rados {
           decode(tag, bl);
           DECODE_FINISH(bl);
         }
-        lock_info_t() : lock_type(LOCK_NONE) {}
+
+        lock_info_t() : lock_type(ClsLockType::NONE) {}
         void dump(ceph::Formatter *f) const;
         static void generate_test_instances(std::list<lock_info_t *>& o);
       };

--- a/src/common/HeartbeatMap.cc
+++ b/src/common/HeartbeatMap.cc
@@ -12,6 +12,7 @@
  * 
  */
 
+#include <utime.h>
 #include <signal.h>
 
 #include "HeartbeatMap.h"
@@ -173,7 +174,7 @@ void HeartbeatMap::check_touch_file()
   if (path.length() && is_healthy()) {
     int fd = ::open(path.c_str(), O_WRONLY|O_CREAT|O_CLOEXEC, 0644);
     if (fd >= 0) {
-      ::utimes(path.c_str(), NULL);
+      ::utime(path.c_str(), NULL);
       ::close(fd);
     } else {
       ldout(m_cct, 0) << "unable to touch " << path << ": "

--- a/src/common/admin_socket_client.cc
+++ b/src/common/admin_socket_client.cc
@@ -74,7 +74,7 @@ static std::string asok_connect(const std::string &path, int *fd)
   struct timeval timer;
   timer.tv_sec = 10;
   timer.tv_usec = 0;
-  if (::setsockopt(socket_fd, SOL_SOCKET, SO_RCVTIMEO, &timer, sizeof(timer))) {
+  if (::setsockopt(socket_fd, SOL_SOCKET, SO_RCVTIMEO, (SOCKOPT_VAL_TYPE)&timer, sizeof(timer))) {
     int err = errno;
     ostringstream oss;
     oss << "setsockopt(" << socket_fd << ", SO_RCVTIMEO) failed: "
@@ -84,7 +84,7 @@ static std::string asok_connect(const std::string &path, int *fd)
   }
   timer.tv_sec = 10;
   timer.tv_usec = 0;
-  if (::setsockopt(socket_fd, SOL_SOCKET, SO_SNDTIMEO, &timer, sizeof(timer))) {
+  if (::setsockopt(socket_fd, SOL_SOCKET, SO_SNDTIMEO, (SOCKOPT_VAL_TYPE)&timer, sizeof(timer))) {
     int err = errno;
     ostringstream oss;
     oss << "setsockopt(" << socket_fd << ", SO_SNDTIMEO) failed: "

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -193,7 +193,7 @@ static ceph::spinlock debug_lock;
     raw_hack_aligned(unsigned l, unsigned _align) : raw(l) {
       align = _align;
       realdata = new char[len+align-1];
-      unsigned off = ((unsigned)realdata) & (align-1);
+      unsigned off = ((uintptr_t)realdata) & (align-1);
       if (off)
 	data = realdata + align - off;
       else
@@ -201,7 +201,7 @@ static ceph::spinlock debug_lock;
       //cout << "hack aligned " << (unsigned)data
       //<< " in raw " << (unsigned)realdata
       //<< " off " << off << std::endl;
-      ceph_assert(((unsigned)data & (align-1)) == 0);
+      ceph_assert(((uintptr_t)data & (align-1)) == 0);
     }
     ~raw_hack_aligned() {
       delete[] realdata;

--- a/src/common/compat.cc
+++ b/src/common/compat.cc
@@ -213,6 +213,9 @@ char *ceph_strerror_r(int errnum, char *buf, size_t buflen)
 
 #ifdef _WIN32
 
+#include <iomanip>
+#include <ctime>
+
 // chown is not available on Windows. Plus, changing file owners is not
 // a common practice on Windows.
 int chown(const char *path, uid_t owner, gid_t group) {
@@ -225,6 +228,119 @@ int fchown(int fd, uid_t owner, gid_t group) {
 
 int lchown(const char *path, uid_t owner, gid_t group) {
   return 0;
+}
+
+int posix_memalign(void **memptr, size_t alignment, size_t size) {
+  *memptr = _aligned_malloc(size, alignment);
+  return *memptr ? 0 : errno;
+}
+
+char *strptime(const char *s, const char *format, struct tm *tm) {
+  std::istringstream input(s);
+  input.imbue(std::locale(setlocale(LC_ALL, nullptr)));
+  input >> std::get_time(tm, format);
+  if (input.fail()) {
+    return nullptr;
+  }
+  return (char*)(s + input.tellg());
+}
+
+int pipe(int pipefd[2]) {
+  // We'll use the same pipe size as Linux (64kb).
+  return _pipe(pipefd, 0x10000, O_NOINHERIT);
+}
+
+// lrand48 is not available on Windows. We'll generate a pseudo-random
+// value in the 0 - 2^31 range by calling rand twice.
+long int lrand48(void) {
+  long int val;
+  val = (long int) rand();
+  val << 16;
+  val += (long int) rand();
+  return val;
+}
+
+int fsync(int fd) {
+  HANDLE handle = (HANDLE*)_get_osfhandle(fd);
+  if (handle == INVALID_HANDLE_VALUE)
+    return -1;
+  if (!FlushFileBuffers(handle))
+    return -1;
+  return 0;
+}
+
+ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset) {
+  DWORD bytes_written = 0;
+
+  HANDLE handle = (HANDLE*)_get_osfhandle(fd);
+  if (handle == INVALID_HANDLE_VALUE)
+    return -1;
+
+  OVERLAPPED overlapped = { 0 };
+  ULARGE_INTEGER offsetUnion;
+  offsetUnion.QuadPart = offset;
+
+  overlapped.Offset = offsetUnion.LowPart;
+  overlapped.OffsetHigh = offsetUnion.HighPart;
+
+  if (!WriteFile(handle, buf, count, &bytes_written, &overlapped))
+    // we may consider mapping error codes, although that may
+    // not be exhaustive.
+    return -1;
+
+  return bytes_written;
+}
+
+ssize_t pread(int fd, void *buf, size_t count, off_t offset) {
+  DWORD bytes_read = 0;
+
+  HANDLE handle = (HANDLE*)_get_osfhandle(fd);
+  if (handle == INVALID_HANDLE_VALUE)
+    return -1;
+
+  OVERLAPPED overlapped = { 0 };
+  ULARGE_INTEGER offsetUnion;
+  offsetUnion.QuadPart = offset;
+
+  overlapped.Offset = offsetUnion.LowPart;
+  overlapped.OffsetHigh = offsetUnion.HighPart;
+
+  if (!ReadFile(handle, buf, count, &bytes_read, &overlapped)) {
+    if (GetLastError() != ERROR_HANDLE_EOF)
+      return -1;
+  }
+
+  return bytes_read;
+}
+
+ssize_t preadv(int fd, const struct iovec *iov, int iov_cnt) {
+  ssize_t read = 0;
+
+  for (int i = 0; i < iov_cnt; i++) {
+    int r = ::read(fd, iov[i].iov_base, iov[i].iov_len);
+    if (r < 0)
+      return r;
+    read += r;
+    if (r < iov[i].iov_len)
+      break;
+  }
+
+  return read;
+}
+
+ssize_t writev(int fd, const struct iovec *iov, int iov_cnt) {
+  ssize_t written = 0;
+
+  for (int i = 0; i < iov_cnt; i++) {
+    int r = ::write(fd, iov[i].iov_base, iov[i].iov_len);
+    if (r < 0)
+      return r;
+    written += r;
+    if (r < iov[i].iov_len)
+      break;
+  }
+
+  return written;
 }
 
 #endif /* _WIN32 */

--- a/src/common/compat.cc
+++ b/src/common/compat.cc
@@ -201,7 +201,10 @@ int sched_setaffinity(pid_t pid, size_t cpusetsize,
 
 char *ceph_strerror_r(int errnum, char *buf, size_t buflen)
 {
-#ifdef STRERROR_R_CHAR_P
+#ifdef _WIN32
+  strerror_s(buf, buflen, errnum);
+  return buf;
+#elif defined(STRERROR_R_CHAR_P)
   return strerror_r(errnum, buf, buflen);
 #else
   if (strerror_r(errnum, buf, buflen)) {

--- a/src/common/page.cc
+++ b/src/common/page.cc
@@ -1,5 +1,9 @@
 #include <unistd.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 namespace ceph {
 
   // page size crap, see page.h
@@ -12,7 +16,17 @@ namespace ceph {
     return n;
   }
 
+  #ifdef _WIN32
+  unsigned _get_page_size() {
+    SYSTEM_INFO system_info;
+    GetSystemInfo(&system_info);
+    return system_info.dwPageSize;
+  }
+
+  unsigned _page_size = _get_page_size();
+  #else
   unsigned _page_size = sysconf(_SC_PAGESIZE);
+  #endif
   unsigned long _page_mask = ~(unsigned long)(_page_size - 1);
   unsigned _page_shift = _get_bits_of(_page_size - 1);
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -267,7 +267,7 @@ struct error_code;
 
     // misc
     bool is_aligned(unsigned align) const {
-      return ((long)c_str() & (align-1)) == 0;
+      return ((uintptr_t)c_str() & (align-1)) == 0;
     }
     bool is_page_aligned() const { return is_aligned(CEPH_PAGE_SIZE); }
     bool is_n_align_sized(unsigned align) const

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -302,6 +302,11 @@ int lchown(const char *path, uid_t owner, gid_t group);
 // with subprocesses unless explicitly requested, we'll define this
 // flag as a no-op.
 #define O_CLOEXEC 0
+#define SOCKOPT_VAL_TYPE char*
+
+#else
+
+#define SOCKOPT_VAL_TYPE void*
 
 #define compat_mkdir(pathname, mode) mkdir(pathname, mode)
 

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -280,12 +280,18 @@ int lchown(const char *path, uid_t owner, gid_t group);
 
 #ifdef __cplusplus
 }
+
+// Windows' mkdir doesn't accept a mode argument.
+#define compat_mkdir(pathname, mode) mkdir(pathname)
+
 #endif
 
 // O_CLOEXEC is not defined on Windows. Since handles aren't inherited
 // with subprocesses unless explicitly requested, we'll define this
 // flag as a no-op.
 #define O_CLOEXEC 0
+
+#define compat_mkdir(pathname, mode) mkdir(pathname, mode)
 
 #endif /* WIN32 */
 

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -227,6 +227,11 @@ typedef union
   size_t _align;
 } cpu_set_t;
 
+struct iovec {
+  void *iov_base;
+  size_t iov_len;
+};
+
 #define SHUT_RD SD_RECEIVE
 #define SHUT_WR SD_SEND
 #define SHUT_RDWR SD_BOTH
@@ -248,14 +253,26 @@ typedef union
 #define ESTALE 256
 #define EREMOTEIO 257
 
-// O_CLOEXEC is not defined on Windows. Since handles aren't inherited
-// with subprocesses unless explicitly requested, we'll define this
-// flag as a no-op.
-#define O_CLOEXEC 0
+#define IOV_MAX 1024
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+ssize_t readv(int fd, const struct iovec *iov, int iov_cnt);
+ssize_t writev(int fd, const struct iovec *iov, int iov_cnt);
+
+int fsync(int fd);
+ssize_t pread(int fd, void *buf, size_t count, off_t offset);
+ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
+
+long int lrand48(void);
+
+int pipe(int pipefd[2]);
+
+int posix_memalign(void **memptr, size_t alignment, size_t size);
+
+char *strptime(const char *s, const char *format, struct tm *tm);
 
 int chown(const char *path, uid_t owner, gid_t group);
 int fchown(int fd, uid_t owner, gid_t group);
@@ -264,6 +281,11 @@ int lchown(const char *path, uid_t owner, gid_t group);
 #ifdef __cplusplus
 }
 #endif
+
+// O_CLOEXEC is not defined on Windows. Since handles aren't inherited
+// with subprocesses unless explicitly requested, we'll define this
+// flag as a no-op.
+#define O_CLOEXEC 0
 
 #endif /* WIN32 */
 

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -208,6 +208,18 @@ char *ceph_strerror_r(int errnum, char *buf, size_t buflen);
 
 #include "include/win32/winsock_compat.h"
 
+#include <windows.h>
+
+// There are a few name collisions between Windows headers and Ceph.
+// Updating Ceph definitions would be the prefferable fix in order to avoid
+// confussion, unless it requires too many changes, in which case we're going
+// to redefine Windows values by adding the "WIN32_" prefix.
+#define WIN32_DELETE 0x00010000L
+#undef DELETE
+
+#define WIN32_ERROR 0
+#undef ERROR
+
 typedef _sigset_t sigset_t;
 
 typedef int uid_t;

--- a/src/include/err.h
+++ b/src/include/err.h
@@ -8,6 +8,7 @@
 #define IS_ERR_VALUE(x) ((x) >= (unsigned long)-MAX_ERRNO)
 
 #include <errno.h>
+#include <stdint.h>
 
 /* this generates a warning in c++; caller can do the cast manually
 static inline void *ERR_PTR(long error)
@@ -18,12 +19,12 @@ static inline void *ERR_PTR(long error)
 
 static inline long PTR_ERR(const void *ptr)
 {
-  return (long) ptr;
+  return (uintptr_t) ptr;
 }
 
 static inline long IS_ERR(const void *ptr)
 {
-  return IS_ERR_VALUE((unsigned long)ptr);
+  return IS_ERR_VALUE((uintptr_t)ptr);
 }
 
 #endif

--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -31,6 +31,7 @@
 #include "include/ceph_assert.h"
 #include "include/compact_map.h"
 #include "include/compact_set.h"
+#include "include/compat.h"
 
 
 /*

--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -24,6 +24,7 @@
 #include <seastar/core/lowres_clock.hh>
 #endif
 
+#include "include/compat.h"
 #include "include/types.h"
 #include "include/timegm.h"
 #include "common/strtol.h"
@@ -466,11 +467,15 @@ public:
       }
     }
 
+    #ifndef _WIN32
     // apply the tm_gmtoff manually below, since none of mktime,
     // gmtime, and localtime seem to do it.  zero it out here just in
     // case some other libc *does* apply it.  :(
     auto gmtoff = tm.tm_gmtoff;
     tm.tm_gmtoff = 0;
+    #else
+    auto gmtoff = _timezone;
+    #endif /* _WIN32 */
 
     time_t t = internal_timegm(&tm);
     if (epoch)

--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -485,12 +485,12 @@ public:
 
     if (out_date) {
       char buf[32];
-      strftime(buf, sizeof(buf), "%F", &tm);
+      strftime(buf, sizeof(buf), "%Y-%m-%d", &tm);
       *out_date = buf;
     }
     if (out_time) {
       char buf[32];
-      strftime(buf, sizeof(buf), "%T", &tm);
+      strftime(buf, sizeof(buf), "%H:%M:%S", &tm);
       *out_time = buf;
     }
 

--- a/src/include/win32/sys/uio.h
+++ b/src/include/win32/sys/uio.h
@@ -1,0 +1,1 @@
+#include "include/compat.h"

--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -147,7 +147,7 @@ int MemDB::_init(bool create)
   int r;
   dout(1) << __func__ << dendl;
   if (create) {
-    r = ::mkdir(m_db_path.c_str(), 0700);
+    r = compat_mkdir(m_db_path.c_str(), 0700);
     if (r < 0) {
       r = -errno;
       if (r != -EEXIST) {

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -319,7 +319,7 @@ int RocksDBStore::create_db_dir()
     unique_ptr<rocksdb::Directory> dir;
     env->NewDirectory(path, &dir);
   } else {
-    int r = ::mkdir(path.c_str(), 0755);
+    int r = compat_mkdir(path.c_str(), 0755);
     if (r < 0)
       r = -errno;
     if (r < 0 && r != -EEXIST) {

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -1756,7 +1756,7 @@ int librados::IoCtx::lock_exclusive(const std::string &oid, const std::string &n
   if (duration)
     dur.set_from_timeval(duration);
 
-  return rados::cls::lock::lock(this, oid, name, LOCK_EXCLUSIVE, cookie, "",
+  return rados::cls::lock::lock(this, oid, name, ClsLockType::EXCLUSIVE, cookie, "",
 		  		description, dur, flags);
 }
 
@@ -1769,7 +1769,7 @@ int librados::IoCtx::lock_shared(const std::string &oid, const std::string &name
   if (duration)
     dur.set_from_timeval(duration);
 
-  return rados::cls::lock::lock(this, oid, name, LOCK_SHARED, cookie, tag,
+  return rados::cls::lock::lock(this, oid, name, ClsLockType::SHARED, cookie, tag,
 		  		description, dur, flags);
 }
 
@@ -1837,7 +1837,7 @@ int librados::IoCtx::list_lockers(const std::string &oid, const std::string &nam
   if (tag)
     *tag = tmp_tag;
   if (exclusive) {
-    if (tmp_type == LOCK_EXCLUSIVE)
+    if (tmp_type == ClsLockType::EXCLUSIVE)
       *exclusive = 1;
     else
       *exclusive = 0;

--- a/src/libradosstriper/RadosStriperImpl.cc
+++ b/src/libradosstriper/RadosStriperImpl.cc
@@ -1069,7 +1069,7 @@ int libradosstriper::RadosStriperImpl::trunc(const std::string& soid, uint64_t s
   op.assert_exists();
   std::string lockCookie = RadosStriperImpl::getUUID();
   utime_t dur = utime_t();
-  rados::cls::lock::lock(&op, RADOS_LOCK_NAME, LOCK_EXCLUSIVE, lockCookie, "", "", dur, 0);
+  rados::cls::lock::lock(&op, RADOS_LOCK_NAME, ClsLockType::EXCLUSIVE, lockCookie, "", "", dur, 0);
   int rc = m_ioCtx.operate(firstObjOid, &op);
   if (rc) return rc;
   // load layout and size
@@ -1342,7 +1342,7 @@ int libradosstriper::RadosStriperImpl::openStripedObjectForRead(
   op.assert_exists();
   *lockCookie = getUUID();
   utime_t dur = utime_t();
-  rados::cls::lock::lock(&op, RADOS_LOCK_NAME, LOCK_SHARED, *lockCookie, "Tag", "", dur, 0);
+  rados::cls::lock::lock(&op, RADOS_LOCK_NAME, ClsLockType::SHARED, *lockCookie, "Tag", "", dur, 0);
   std::string firstObjOid = getObjectId(soid, 0);
   int rc = m_ioCtx.operate(firstObjOid, &op);
   if (rc) {
@@ -1371,7 +1371,7 @@ int libradosstriper::RadosStriperImpl::openStripedObjectForWrite(const std::stri
   op.assert_exists();
   *lockCookie = getUUID();
   utime_t dur = utime_t();
-  rados::cls::lock::lock(&op, RADOS_LOCK_NAME, LOCK_SHARED, *lockCookie, "Tag", "", dur, 0);
+  rados::cls::lock::lock(&op, RADOS_LOCK_NAME, ClsLockType::SHARED, *lockCookie, "Tag", "", dur, 0);
   std::string firstObjOid = getObjectId(soid, 0);
   int rc = m_ioCtx.operate(firstObjOid, &op);
   if (rc) {

--- a/src/librbd/ManagedLock.cc
+++ b/src/librbd/ManagedLock.cc
@@ -286,8 +286,8 @@ int ManagedLock<I>::assert_header_locked() {
   {
     std::lock_guard locker{m_lock};
     rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME,
-                                    (m_mode == EXCLUSIVE ? LOCK_EXCLUSIVE :
-                                                           LOCK_SHARED),
+                                    (m_mode == EXCLUSIVE ? ClsLockType::EXCLUSIVE :
+                                                           ClsLockType::SHARED),
                                     m_cookie,
                                     managed_lock::util::get_watcher_lock_tag());
   }

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -234,7 +234,7 @@ void ObjectMap<I>::aio_save(Context *on_finish) {
 
   librados::ObjectWriteOperation op;
   if (m_snap_id == CEPH_NOSNAP) {
-    rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, LOCK_EXCLUSIVE, "", "");
+    rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, ClsLockType::EXCLUSIVE, "", "");
   }
   cls_client::object_map_save(&op, m_object_map);
 

--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -295,7 +295,7 @@ Context *RefreshRequest<I>::handle_v1_get_locks(int *result) {
     *result = rados::cls::lock::get_lock_info_finish(&it, &m_lockers,
                                                      &lock_type, &m_lock_tag);
     if (*result == 0) {
-      m_exclusive_locked = (lock_type == LOCK_EXCLUSIVE);
+      m_exclusive_locked = (lock_type == ClsLockType::EXCLUSIVE);
     }
   }
   if (*result < 0) {
@@ -389,11 +389,11 @@ Context *RefreshRequest<I>::handle_v2_get_mutable_metadata(int *result) {
   }
 
   if (*result >= 0) {
-    ClsLockType lock_type = LOCK_NONE;
+    ClsLockType lock_type = ClsLockType::NONE;
     *result = rados::cls::lock::get_lock_info_finish(&it, &m_lockers,
                                                      &lock_type, &m_lock_tag);
     if (*result == 0) {
-      m_exclusive_locked = (lock_type == LOCK_EXCLUSIVE);
+      m_exclusive_locked = (lock_type == ClsLockType::EXCLUSIVE);
     }
   }
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1394,7 +1394,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     {
       std::shared_lock locker{ictx->image_lock};
       r = rados::cls::lock::lock(&ictx->md_ctx, ictx->header_oid, RBD_LOCK_NAME,
-			         exclusive ? LOCK_EXCLUSIVE : LOCK_SHARED,
+			         exclusive ? ClsLockType::EXCLUSIVE : ClsLockType::SHARED,
 			         cookie, tag, "", utime_t(), 0);
       if (r < 0) {
         return r;

--- a/src/librbd/managed_lock/AcquireRequest.cc
+++ b/src/librbd/managed_lock/AcquireRequest.cc
@@ -109,7 +109,7 @@ void AcquireRequest<I>::send_lock() {
 
   librados::ObjectWriteOperation op;
   rados::cls::lock::lock(&op, RBD_LOCK_NAME,
-                         m_exclusive ? LOCK_EXCLUSIVE : LOCK_SHARED, m_cookie,
+                         m_exclusive ? ClsLockType::EXCLUSIVE : ClsLockType::SHARED, m_cookie,
                          util::get_watcher_lock_tag(), "", utime_t(), 0);
 
   using klass = AcquireRequest;

--- a/src/librbd/managed_lock/GetLockerRequest.cc
+++ b/src/librbd/managed_lock/GetLockerRequest.cc
@@ -58,7 +58,7 @@ void GetLockerRequest<I>::handle_get_lockers(int r) {
 
   std::map<rados::cls::lock::locker_id_t,
            rados::cls::lock::locker_info_t> lockers;
-  ClsLockType lock_type = LOCK_NONE;
+  ClsLockType lock_type = ClsLockType::NONE;
   std::string lock_tag;
   if (r == 0) {
     auto it = m_out_bl.cbegin();
@@ -84,11 +84,11 @@ void GetLockerRequest<I>::handle_get_lockers(int r) {
     return;
   }
 
-  if (m_exclusive && lock_type == LOCK_SHARED) {
+  if (m_exclusive && lock_type == ClsLockType::SHARED) {
     ldout(m_cct, 5) << "incompatible shared lock type detected" << dendl;
     finish(-EBUSY);
     return;
-  } else if (!m_exclusive && lock_type == LOCK_EXCLUSIVE) {
+  } else if (!m_exclusive && lock_type == ClsLockType::EXCLUSIVE) {
     ldout(m_cct, 5) << "incompatible exclusive lock type detected" << dendl;
     finish(-EBUSY);
     return;

--- a/src/librbd/managed_lock/ReacquireRequest.cc
+++ b/src/librbd/managed_lock/ReacquireRequest.cc
@@ -47,7 +47,7 @@ void ReacquireRequest<I>::set_cookie() {
 
   librados::ObjectWriteOperation op;
   rados::cls::lock::set_cookie(&op, RBD_LOCK_NAME,
-                               m_exclusive ? LOCK_EXCLUSIVE : LOCK_SHARED,
+                               m_exclusive ? ClsLockType::EXCLUSIVE : ClsLockType::SHARED,
                                m_old_cookie, util::get_watcher_lock_tag(),
                                m_new_cookie);
 

--- a/src/librbd/object_map/LockRequest.cc
+++ b/src/librbd/object_map/LockRequest.cc
@@ -35,7 +35,7 @@ void LockRequest<I>::send_lock() {
   ldout(cct, 10) << this << " " << __func__ << ": oid=" << oid << dendl;
 
   librados::ObjectWriteOperation op;
-  rados::cls::lock::lock(&op, RBD_LOCK_NAME, LOCK_EXCLUSIVE, "", "", "",
+  rados::cls::lock::lock(&op, RBD_LOCK_NAME, ClsLockType::EXCLUSIVE, "", "", "",
                            utime_t(), 0);
 
   using klass = LockRequest<I>;

--- a/src/librbd/object_map/RefreshRequest.cc
+++ b/src/librbd/object_map/RefreshRequest.cc
@@ -236,7 +236,7 @@ void RefreshRequest<I>::send_resize() {
 
   librados::ObjectWriteOperation op;
   if (m_snap_id == CEPH_NOSNAP) {
-    rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, LOCK_EXCLUSIVE, "", "");
+    rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, ClsLockType::EXCLUSIVE, "", "");
   }
   if (m_truncate_on_disk_object_map) {
     op.truncate(0);

--- a/src/librbd/object_map/ResizeRequest.cc
+++ b/src/librbd/object_map/ResizeRequest.cc
@@ -42,7 +42,7 @@ void ResizeRequest::send() {
 
   librados::ObjectWriteOperation op;
   if (m_snap_id == CEPH_NOSNAP) {
-    rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, LOCK_EXCLUSIVE, "", "");
+    rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, ClsLockType::EXCLUSIVE, "", "");
   }
   cls_client::object_map_resize(&op, m_num_objs, m_default_object_state);
 

--- a/src/librbd/object_map/SnapshotCreateRequest.cc
+++ b/src/librbd/object_map/SnapshotCreateRequest.cc
@@ -121,7 +121,7 @@ bool SnapshotCreateRequest::send_add_snapshot() {
   m_state = STATE_ADD_SNAPSHOT;
 
   librados::ObjectWriteOperation op;
-  rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, LOCK_EXCLUSIVE, "", "");
+  rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, ClsLockType::EXCLUSIVE, "", "");
   cls_client::object_map_snap_add(&op);
 
   librados::AioCompletion *rados_completion = create_callback_completion();

--- a/src/librbd/object_map/SnapshotRemoveRequest.cc
+++ b/src/librbd/object_map/SnapshotRemoveRequest.cc
@@ -91,7 +91,7 @@ void SnapshotRemoveRequest::remove_snapshot() {
 
   librados::ObjectWriteOperation op;
   if (m_next_snap_id == CEPH_NOSNAP) {
-    rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, LOCK_EXCLUSIVE, "", "");
+    rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, ClsLockType::EXCLUSIVE, "", "");
   }
   cls_client::object_map_snap_remove(&op, m_snap_object_map);
 

--- a/src/librbd/object_map/SnapshotRollbackRequest.cc
+++ b/src/librbd/object_map/SnapshotRollbackRequest.cc
@@ -104,7 +104,7 @@ void SnapshotRollbackRequest::send_write_map() {
   m_state = STATE_WRITE_MAP;
 
   librados::ObjectWriteOperation op;
-  rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, LOCK_EXCLUSIVE, "", "");
+  rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, ClsLockType::EXCLUSIVE, "", "");
   op.write_full(m_read_bl);
 
   librados::AioCompletion *rados_completion = create_callback_completion();

--- a/src/librbd/object_map/UpdateRequest.cc
+++ b/src/librbd/object_map/UpdateRequest.cc
@@ -52,7 +52,7 @@ void UpdateRequest<I>::update_object_map() {
 
   librados::ObjectWriteOperation op;
   if (m_snap_id == CEPH_NOSNAP) {
-    rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, LOCK_EXCLUSIVE, "", "");
+    rados::cls::lock::assert_locked(&op, RBD_LOCK_NAME, ClsLockType::EXCLUSIVE, "", "");
   }
   cls_client::object_map_update(&op, m_update_start_object_no,
                                 m_update_end_object_no, m_new_state,

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -30,7 +30,7 @@
 #include "MDSCacheObject.h"
 #include "MDSContext.h"
 #include "SimpleLock.h"
-#include "LocalLock.h"
+#include "LocalLockC.h"
 #include "ScrubHeader.h"
 
 class CInode;
@@ -344,7 +344,7 @@ public:
   static LockType versionlock_type;
 
   SimpleLock lock; // FIXME referenced containers not in mempool
-  LocalLock versionlock; // FIXME referenced containers not in mempool
+  LocalLockC versionlock; // FIXME referenced containers not in mempool
 
   mempool::mds_co::map<client_t,ClientLease*> client_lease_map;
   std::map<int, std::unique_ptr<BatchOp>> batch_ops;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -35,7 +35,7 @@
 #include "CDentry.h"
 #include "SimpleLock.h"
 #include "ScatterLock.h"
-#include "LocalLock.h"
+#include "LocalLockC.h"
 #include "Capability.h"
 #include "SnapRealm.h"
 #include "Mutation.h"
@@ -985,7 +985,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static LockType policylock_type;
 
   // FIXME not part of mempool
-  LocalLock  versionlock;
+  LocalLockC  versionlock;
   SimpleLock authlock;
   SimpleLock linklock;
   ScatterLock dirfragtreelock;

--- a/src/mds/LocalLockC.h
+++ b/src/mds/LocalLockC.h
@@ -18,9 +18,9 @@
 
 #include "SimpleLock.h"
 
-class LocalLock : public SimpleLock {
+class LocalLockC : public SimpleLock {
 public:
-  LocalLock(MDSCacheObject *o, LockType *t) : 
+  LocalLockC(MDSCacheObject *o, LockType *t) : 
     SimpleLock(o, t) {
     set_state(LOCK_LOCK); // always.
   }

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -1703,7 +1703,7 @@ void Locker::wrlock_force(SimpleLock *lock, MutationRef& mut)
 {
   if (lock->get_type() == CEPH_LOCK_IVERSION ||
       lock->get_type() == CEPH_LOCK_DVERSION)
-    return local_wrlock_grab(static_cast<LocalLock*>(lock), mut);
+    return local_wrlock_grab(static_cast<LocalLockC*>(lock), mut);
 
   dout(7) << "wrlock_force  on " << *lock
 	  << " on " << *lock->get_parent() << dendl;  
@@ -1750,7 +1750,7 @@ bool Locker::wrlock_start(const MutationImpl::LockOp &op, MDRequestRef& mut)
   SimpleLock *lock = op.lock;
   if (lock->get_type() == CEPH_LOCK_IVERSION ||
       lock->get_type() == CEPH_LOCK_DVERSION)
-    return local_wrlock_start(static_cast<LocalLock*>(lock), mut);
+    return local_wrlock_start(static_cast<LocalLockC*>(lock), mut);
 
   dout(10) << "wrlock_start " << *lock << " on " << *lock->get_parent() << dendl;
 
@@ -1893,7 +1893,7 @@ bool Locker::xlock_start(SimpleLock *lock, MDRequestRef& mut)
 {
   if (lock->get_type() == CEPH_LOCK_IVERSION ||
       lock->get_type() == CEPH_LOCK_DVERSION)
-    return local_xlock_start(static_cast<LocalLock*>(lock), mut);
+    return local_xlock_start(static_cast<LocalLockC*>(lock), mut);
 
   dout(7) << "xlock_start on " << *lock << " on " << *lock->get_parent() << dendl;
   client_t client = mut->get_client();
@@ -5194,7 +5194,7 @@ void Locker::scatter_tempsync(ScatterLock *lock, bool *need_issue)
 // ==========================================================================
 // local lock
 
-void Locker::local_wrlock_grab(LocalLock *lock, MutationRef& mut)
+void Locker::local_wrlock_grab(LocalLockC *lock, MutationRef& mut)
 {
   dout(7) << "local_wrlock_grab  on " << *lock
 	  << " on " << *lock->get_parent() << dendl;  
@@ -5207,7 +5207,7 @@ void Locker::local_wrlock_grab(LocalLock *lock, MutationRef& mut)
   ceph_assert(it->is_wrlock());
 }
 
-bool Locker::local_wrlock_start(LocalLock *lock, MDRequestRef& mut)
+bool Locker::local_wrlock_start(LocalLockC *lock, MDRequestRef& mut)
 {
   dout(7) << "local_wrlock_start  on " << *lock
 	  << " on " << *lock->get_parent() << dendl;  
@@ -5227,7 +5227,7 @@ bool Locker::local_wrlock_start(LocalLock *lock, MDRequestRef& mut)
 void Locker::local_wrlock_finish(const MutationImpl::lock_iterator& it, MutationImpl *mut)
 {
   ceph_assert(it->is_wrlock());
-  LocalLock *lock = static_cast<LocalLock*>(it->lock);
+  LocalLockC *lock = static_cast<LocalLockC*>(it->lock);
   dout(7) << "local_wrlock_finish  on " << *lock
 	  << " on " << *lock->get_parent() << dendl;  
   lock->put_wrlock();
@@ -5239,7 +5239,7 @@ void Locker::local_wrlock_finish(const MutationImpl::lock_iterator& it, Mutation
   }
 }
 
-bool Locker::local_xlock_start(LocalLock *lock, MDRequestRef& mut)
+bool Locker::local_xlock_start(LocalLockC *lock, MDRequestRef& mut)
 {
   dout(7) << "local_xlock_start  on " << *lock
 	  << " on " << *lock->get_parent() << dendl;  
@@ -5258,7 +5258,7 @@ bool Locker::local_xlock_start(LocalLock *lock, MDRequestRef& mut)
 void Locker::local_xlock_finish(const MutationImpl::lock_iterator& it, MutationImpl *mut)
 {
   ceph_assert(it->is_xlock());
-  LocalLock *lock = static_cast<LocalLock*>(it->lock);
+  LocalLockC *lock = static_cast<LocalLockC*>(it->lock);
   dout(7) << "local_xlock_finish  on " << *lock
 	  << " on " << *lock->get_parent() << dendl;  
   lock->put_xlock();

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -36,7 +36,7 @@ class CDentry;
 class Capability;
 class SimpleLock;
 class ScatterLock;
-class LocalLock;
+class LocalLockC;
 
 class Locker {
 public:
@@ -153,7 +153,7 @@ public:
   bool is_revoking_any_caps_from(client_t client);
 
   // local
-  void local_wrlock_grab(LocalLock *lock, MutationRef& mut);
+  void local_wrlock_grab(LocalLockC *lock, MutationRef& mut);
 
   // file
   void file_eval(ScatterLock *lock, bool *need_issue);
@@ -224,9 +224,9 @@ protected:
   void _do_cap_release(client_t client, inodeno_t ino, uint64_t cap_id, ceph_seq_t mseq, ceph_seq_t seq);
   void caps_tick();
 
-  bool local_wrlock_start(LocalLock *lock, MDRequestRef& mut);
+  bool local_wrlock_start(LocalLockC *lock, MDRequestRef& mut);
   void local_wrlock_finish(const MutationImpl::lock_iterator& it, MutationImpl *mut);
-  bool local_xlock_start(LocalLock *lock, MDRequestRef& mut);
+  bool local_xlock_start(LocalLockC *lock, MDRequestRef& mut);
   void local_xlock_finish(const MutationImpl::lock_iterator& it, MutationImpl *mut);
 
   void handle_file_lock(ScatterLock *lock, const cref_t<MLock> &m);

--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -67,6 +67,14 @@ int NetHandler::set_nonblock(int sd)
   int flags;
   int r = 0;
 
+  #ifdef _WIN32
+  ULONG mode = 1;
+  r = ioctlsocket(sd, FIONBIO, &mode);
+  if (r) {
+    lderr(cct) << __func__ << " ioctlsocket(FIONBIO) failed: " << r << dendl;
+    return -r;
+  }
+  #else
   /* Set the socket nonblocking.
    * Note that fcntl(2) for F_GETFL and F_SETFL can't be
    * interrupted by a signal. */
@@ -80,6 +88,7 @@ int NetHandler::set_nonblock(int sd)
     lderr(cct) << __func__ << " fcntl(F_SETFL,O_NONBLOCK): " << cpp_strerror(r) << dendl;
     return -r;
   }
+  #endif
 
   return 0;
 }

--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -49,7 +49,7 @@ int NetHandler::create_socket(int domain, bool reuse_addr)
    * will be able to close/open sockets a zillion of times */
   if (reuse_addr) {
     int on = 1;
-    if (::setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) == -1) {
+    if (::setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (SOCKOPT_VAL_TYPE)&on, sizeof(on)) == -1) {
       r = errno;
       lderr(cct) << __func__ << " setsockopt SO_REUSEADDR failed: "
                  << strerror(r) << dendl;
@@ -99,14 +99,14 @@ int NetHandler::set_socket_options(int sd, bool nodelay, int size)
   // disable Nagle algorithm?
   if (nodelay) {
     int flag = 1;
-    r = ::setsockopt(sd, IPPROTO_TCP, TCP_NODELAY, (char*)&flag, sizeof(flag));
+    r = ::setsockopt(sd, IPPROTO_TCP, TCP_NODELAY, (SOCKOPT_VAL_TYPE)&flag, sizeof(flag));
     if (r < 0) {
       r = errno;
       ldout(cct, 0) << "couldn't set TCP_NODELAY: " << cpp_strerror(r) << dendl;
     }
   }
   if (size) {
-    r = ::setsockopt(sd, SOL_SOCKET, SO_RCVBUF, (void*)&size, sizeof(size));
+    r = ::setsockopt(sd, SOL_SOCKET, SO_RCVBUF, (SOCKOPT_VAL_TYPE)&size, sizeof(size));
     if (r < 0)  {
       r = errno;
       ldout(cct, 0) << "couldn't set SO_RCVBUF to " << size << ": " << cpp_strerror(r) << dendl;
@@ -116,7 +116,7 @@ int NetHandler::set_socket_options(int sd, bool nodelay, int size)
   // block ESIGPIPE
 #ifdef CEPH_USE_SO_NOSIGPIPE
   int val = 1;
-  r = ::setsockopt(sd, SOL_SOCKET, SO_NOSIGPIPE, (void*)&val, sizeof(val));
+  r = ::setsockopt(sd, SOL_SOCKET, SO_NOSIGPIPE, (SOCKOPT_VAL_TYPE)&val, sizeof(val));
   if (r) {
     r = errno;
     ldout(cct,0) << "couldn't set SO_NOSIGPIPE: " << cpp_strerror(r) << dendl;
@@ -136,10 +136,10 @@ void NetHandler::set_priority(int sd, int prio, int domain)
   int iptos = IPTOS_CLASS_CS6;
   switch (domain) {
   case AF_INET:
-    r = ::setsockopt(sd, IPPROTO_IP, IP_TOS, &iptos, sizeof(iptos));
+    r = ::setsockopt(sd, IPPROTO_IP, IP_TOS, (SOCKOPT_VAL_TYPE)&iptos, sizeof(iptos));
     break;
   case AF_INET6:
-    r = ::setsockopt(sd, IPPROTO_IPV6, IPV6_TCLASS, &iptos, sizeof(iptos));
+    r = ::setsockopt(sd, IPPROTO_IPV6, IPV6_TCLASS, (SOCKOPT_VAL_TYPE)&iptos, sizeof(iptos));
     break;
   default:
     lderr(cct) << "couldn't set ToS of unknown family (" << domain << ")"
@@ -156,7 +156,7 @@ void NetHandler::set_priority(int sd, int prio, int domain)
   // setsockopt(IPTOS_CLASS_CS6) sets the priority of the socket as 0.
   // See http://goo.gl/QWhvsD and http://goo.gl/laTbjT
   // We need to call setsockopt(SO_PRIORITY) after it.
-  r = ::setsockopt(sd, SOL_SOCKET, SO_PRIORITY, &prio, sizeof(prio));
+  r = ::setsockopt(sd, SOL_SOCKET, SO_PRIORITY, (SOCKOPT_VAL_TYPE)&prio, sizeof(prio));
   if (r < 0) {
     r = errno;
     ldout(cct, 0) << __func__ << " couldn't set SO_PRIORITY to " << prio

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -193,9 +193,9 @@ static inline void encode(const sockaddr_storage& a, ceph::buffer::list& bl) {
   ::memcpy(dst, src, copy_size);
   encode(ss, bl);
 #else
-  ceph_sockaddr_storage ss{};
+  ceph_sockaddr_storage ss;
   ::memset(&ss, '\0', sizeof(ss));
-  ::memcpy(&wireaddr, &ss, std::min(sizeof(ss), sizeof(a)));
+  ::memcpy(&ss, &a, std::min(sizeof(ss), sizeof(a)));
   encode(ss, bl);
 #endif
 }

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -33,6 +33,7 @@
 #include "include/mempool.h"
 
 #include "msg/msg_types.h"
+#include "include/compat.h"
 #include "include/types.h"
 #include "include/utime.h"
 #include "include/CompatSet.h"

--- a/src/test/cls_lock/test_cls_lock.cc
+++ b/src/test/cls_lock/test_cls_lock.cc
@@ -33,7 +33,7 @@ using namespace rados::cls::lock;
 void lock_info(IoCtx *ioctx, string& oid, string& name, map<locker_id_t, locker_info_t>& lockers,
 	       ClsLockType *assert_type, string *assert_tag)
 {
-  ClsLockType lock_type = LOCK_NONE;
+  ClsLockType lock_type = ClsLockType::NONE;
   string tag;
   lockers.clear();
   ASSERT_EQ(0, get_lock_info(ioctx, oid, name, &lockers, &lock_type, &tag));
@@ -69,8 +69,8 @@ TEST(ClsLock, TestMultiLocking) {
   ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
   IoCtx ioctx;
   cluster.ioctx_create(pool_name.c_str(), ioctx);
-  ClsLockType lock_type_shared = LOCK_SHARED;
-  ClsLockType lock_type_exclusive = LOCK_EXCLUSIVE;
+  ClsLockType lock_type_shared = ClsLockType::SHARED;
+  ClsLockType lock_type_exclusive = ClsLockType::EXCLUSIVE;
 
 
   Rados cluster2;
@@ -357,39 +357,39 @@ TEST(ClsLock, TestSetCookie) {
   string cookie = "cookie";
   string new_cookie = "new cookie";
   librados::ObjectWriteOperation op1;
-  set_cookie(&op1, name, LOCK_SHARED, cookie, tag, new_cookie);
+  set_cookie(&op1, name, ClsLockType::SHARED, cookie, tag, new_cookie);
   ASSERT_EQ(-ENOENT, ioctx.operate(oid, &op1));
 
   librados::ObjectWriteOperation op2;
-  lock(&op2, name, LOCK_SHARED, cookie, tag, "", utime_t{}, 0);
+  lock(&op2, name, ClsLockType::SHARED, cookie, tag, "", utime_t{}, 0);
   ASSERT_EQ(0, ioctx.operate(oid, &op2));
 
   librados::ObjectWriteOperation op3;
-  lock(&op3, name, LOCK_SHARED, "cookie 2", tag, "", utime_t{}, 0);
+  lock(&op3, name, ClsLockType::SHARED, "cookie 2", tag, "", utime_t{}, 0);
   ASSERT_EQ(0, ioctx.operate(oid, &op3));
 
   librados::ObjectWriteOperation op4;
-  set_cookie(&op4, name, LOCK_SHARED, cookie, tag, cookie);
+  set_cookie(&op4, name, ClsLockType::SHARED, cookie, tag, cookie);
   ASSERT_EQ(-EBUSY, ioctx.operate(oid, &op4));
 
   librados::ObjectWriteOperation op5;
-  set_cookie(&op5, name, LOCK_SHARED, cookie, "wrong tag", new_cookie);
+  set_cookie(&op5, name, ClsLockType::SHARED, cookie, "wrong tag", new_cookie);
   ASSERT_EQ(-EBUSY, ioctx.operate(oid, &op5));
 
   librados::ObjectWriteOperation op6;
-  set_cookie(&op6, name, LOCK_SHARED, "wrong cookie", tag, new_cookie);
+  set_cookie(&op6, name, ClsLockType::SHARED, "wrong cookie", tag, new_cookie);
   ASSERT_EQ(-EBUSY, ioctx.operate(oid, &op6));
 
   librados::ObjectWriteOperation op7;
-  set_cookie(&op7, name, LOCK_EXCLUSIVE, cookie, tag, new_cookie);
+  set_cookie(&op7, name, ClsLockType::EXCLUSIVE, cookie, tag, new_cookie);
   ASSERT_EQ(-EBUSY, ioctx.operate(oid, &op7));
 
   librados::ObjectWriteOperation op8;
-  set_cookie(&op8, name, LOCK_SHARED, cookie, tag, "cookie 2");
+  set_cookie(&op8, name, ClsLockType::SHARED, cookie, tag, "cookie 2");
   ASSERT_EQ(-EBUSY, ioctx.operate(oid, &op8));
 
   librados::ObjectWriteOperation op9;
-  set_cookie(&op9, name, LOCK_SHARED, cookie, tag, new_cookie);
+  set_cookie(&op9, name, ClsLockType::SHARED, cookie, tag, new_cookie);
   ASSERT_EQ(0, ioctx.operate(oid, &op9));
 
   ASSERT_EQ(0, destroy_one_pool_pp(pool_name, cluster));

--- a/src/test/librbd/managed_lock/test_mock_AcquireRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_AcquireRequest.cc
@@ -91,7 +91,7 @@ MATCHER_P(IsLockType, exclusive, "") {
   bl.share(arg);
   auto iter = bl.cbegin();
   decode(op, iter);
-  return op.type == (exclusive ? LOCK_EXCLUSIVE : LOCK_SHARED);
+  return op.type == (exclusive ? ClsLockType::EXCLUSIVE : ClsLockType::SHARED);
 }
 
 } // anonymous namespace

--- a/src/test/librbd/managed_lock/test_mock_GetLockerRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_GetLockerRequest.cc
@@ -90,7 +90,7 @@ TEST_F(TestMockManagedLockGetLockerRequest, SuccessExclusive) {
   InSequence seq;
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", util::get_watcher_lock_tag(),
-                       LOCK_EXCLUSIVE);
+                       ClsLockType::EXCLUSIVE);
 
   C_SaferCond ctx;
   Locker locker;
@@ -117,7 +117,7 @@ TEST_F(TestMockManagedLockGetLockerRequest, SuccessShared) {
   InSequence seq;
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", util::get_watcher_lock_tag(),
-                       LOCK_SHARED);
+                       ClsLockType::SHARED);
 
   C_SaferCond ctx;
   Locker locker;
@@ -143,7 +143,7 @@ TEST_F(TestMockManagedLockGetLockerRequest, GetLockInfoError) {
 
   InSequence seq;
   expect_get_lock_info(mock_image_ctx, -EINVAL, entity_name_t::CLIENT(1), "",
-                       "", "", LOCK_EXCLUSIVE);
+                       "", "", ClsLockType::EXCLUSIVE);
 
   C_SaferCond ctx;
   Locker locker;
@@ -164,7 +164,7 @@ TEST_F(TestMockManagedLockGetLockerRequest, GetLockInfoEmpty) {
 
   InSequence seq;
   expect_get_lock_info(mock_image_ctx, -ENOENT, entity_name_t::CLIENT(1), "",
-                       "", "", LOCK_EXCLUSIVE);
+                       "", "", ClsLockType::EXCLUSIVE);
 
   C_SaferCond ctx;
   Locker locker;
@@ -185,7 +185,7 @@ TEST_F(TestMockManagedLockGetLockerRequest, GetLockInfoExternalTag) {
 
   InSequence seq;
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
-                       "auto 123", "external tag", LOCK_EXCLUSIVE);
+                       "auto 123", "external tag", ClsLockType::EXCLUSIVE);
 
   C_SaferCond ctx;
   Locker locker;
@@ -207,7 +207,7 @@ TEST_F(TestMockManagedLockGetLockerRequest, GetLockInfoIncompatibleShared) {
   InSequence seq;
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", util::get_watcher_lock_tag(),
-                       LOCK_SHARED);
+                       ClsLockType::SHARED);
 
   C_SaferCond ctx;
   Locker locker;
@@ -229,7 +229,7 @@ TEST_F(TestMockManagedLockGetLockerRequest, GetLockInfoIncompatibleExclusive) {
   InSequence seq;
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "auto 123", util::get_watcher_lock_tag(),
-                       LOCK_EXCLUSIVE);
+                       ClsLockType::EXCLUSIVE);
 
   C_SaferCond ctx;
   Locker locker;
@@ -251,7 +251,7 @@ TEST_F(TestMockManagedLockGetLockerRequest, GetLockInfoExternalCookie) {
   InSequence seq;
   expect_get_lock_info(mock_image_ctx, 0, entity_name_t::CLIENT(1), "1.2.3.4",
                        "external cookie", util::get_watcher_lock_tag(),
-                       LOCK_EXCLUSIVE);
+                       ClsLockType::EXCLUSIVE);
 
   C_SaferCond ctx;
   Locker locker;

--- a/src/test/librbd/managed_lock/test_mock_ReacquireRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_ReacquireRequest.cc
@@ -24,7 +24,7 @@ MATCHER_P(IsLockType, exclusive, "") {
   bl.share(arg);
   auto iter = bl.cbegin();
   decode(op, iter);
-  return op.type == (exclusive ? LOCK_EXCLUSIVE : LOCK_SHARED);
+  return op.type == (exclusive ? ClsLockType::EXCLUSIVE : ClsLockType::SHARED);
 }
 
 } // anonymous namespace

--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -339,7 +339,7 @@ TEST_F(TestImageWatcher, NotifyFlatten) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
         "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_FLATTEN, create_response_message(0)}};
@@ -373,7 +373,7 @@ TEST_F(TestImageWatcher, NotifyResize) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
         "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_RESIZE, create_response_message(0)}};
@@ -407,7 +407,7 @@ TEST_F(TestImageWatcher, NotifyRebuildObjectMap) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
         "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_REBUILD_OBJECT_MAP, create_response_message(0)}};
@@ -442,7 +442,7 @@ TEST_F(TestImageWatcher, NotifySnapCreate) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
         "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_SNAP_CREATE, create_response_message(0)}};
@@ -477,7 +477,7 @@ TEST_F(TestImageWatcher, NotifySnapCreateError) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
         "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_SNAP_CREATE, create_response_message(-EEXIST)}};
@@ -501,7 +501,7 @@ TEST_F(TestImageWatcher, NotifySnapRename) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
         "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_SNAP_RENAME, create_response_message(0)}};
@@ -523,7 +523,7 @@ TEST_F(TestImageWatcher, NotifySnapRenameError) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
         "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_SNAP_RENAME, create_response_message(-EEXIST)}};
@@ -545,7 +545,7 @@ TEST_F(TestImageWatcher, NotifySnapRemove) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
         "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_SNAP_REMOVE, create_response_message(0)}};
@@ -569,7 +569,7 @@ TEST_F(TestImageWatcher, NotifySnapProtect) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
         "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_SNAP_PROTECT, create_response_message(0)}};
@@ -593,7 +593,7 @@ TEST_F(TestImageWatcher, NotifySnapUnprotect) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
         "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_SNAP_UNPROTECT, create_response_message(0)}};
@@ -617,7 +617,7 @@ TEST_F(TestImageWatcher, NotifyRename) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
         "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_RENAME, create_response_message(0)}};
@@ -639,7 +639,7 @@ TEST_F(TestImageWatcher, NotifyAsyncTimedOut) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
         "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_FLATTEN, {}}};
@@ -659,7 +659,7 @@ TEST_F(TestImageWatcher, NotifyAsyncError) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
         "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_FLATTEN, create_response_message(-EIO)}};
@@ -679,7 +679,7 @@ TEST_F(TestImageWatcher, NotifyAsyncCompleteError) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
         "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_FLATTEN, create_response_message(0)}};
@@ -712,7 +712,7 @@ TEST_F(TestImageWatcher, NotifyAsyncRequestTimedOut) {
   ictx->config.set_val("rbd_request_timed_out_seconds", "0");
 
   ASSERT_EQ(0, register_image_watch(*ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE,
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
 			  "auto " + stringify(m_watch_ctx->get_handle())));
 
   m_notify_acks = {{NOTIFY_OP_FLATTEN, create_response_message(0)}};

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -229,7 +229,7 @@ TEST_F(TestInternal, ResizeFailsToLockImage) {
 
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE, "manually locked"));
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE, "manually locked"));
 
   librbd::NoOpProgressContext no_op;
   ASSERT_EQ(-EROFS, ictx->operations->resize(m_image_size >> 1, true, no_op));
@@ -258,7 +258,7 @@ TEST_F(TestInternal, SnapCreateFailsToLockImage) {
 
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE, "manually locked"));
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE, "manually locked"));
 
   ASSERT_EQ(-EROFS, snap_create(*ictx, "snap1"));
 }
@@ -289,7 +289,7 @@ TEST_F(TestInternal, SnapRollbackFailsToLockImage) {
 
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE, "manually locked"));
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE, "manually locked"));
 
   librbd::NoOpProgressContext no_op;
   ASSERT_EQ(-EROFS,
@@ -368,7 +368,7 @@ TEST_F(TestInternal, FlattenFailsToLockImage) {
   } BOOST_SCOPE_EXIT_END;
 
   ASSERT_EQ(0, open_image(clone_name, &ictx2));
-  ASSERT_EQ(0, lock_image(*ictx2, LOCK_EXCLUSIVE, "manually locked"));
+  ASSERT_EQ(0, lock_image(*ictx2, ClsLockType::EXCLUSIVE, "manually locked"));
 
   librbd::NoOpProgressContext no_op;
   ASSERT_EQ(-EROFS, ictx2->operations->flatten(no_op));
@@ -379,7 +379,7 @@ TEST_F(TestInternal, AioWriteRequestsLock) {
 
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE, "manually locked"));
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE, "manually locked"));
 
   std::string buffer(256, '1');
   Context *ctx = new DummyContext();
@@ -405,7 +405,7 @@ TEST_F(TestInternal, AioDiscardRequestsLock) {
 
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  ASSERT_EQ(0, lock_image(*ictx, LOCK_EXCLUSIVE, "manually locked"));
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE, "manually locked"));
 
   Context *ctx = new DummyContext();
   auto c = librbd::io::AioCompletion::create(ctx);

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -1179,7 +1179,7 @@ static int do_lock_cmd(std::vector<const char*> &nargs,
   string lock_cookie;
   string lock_description;
   int lock_duration = 0;
-  ClsLockType lock_type = LOCK_EXCLUSIVE;
+  ClsLockType lock_type = ClsLockType::EXCLUSIVE;
 
   map<string, string>::const_iterator i;
   i = opts.find("lock-tag");
@@ -1204,9 +1204,9 @@ static int do_lock_cmd(std::vector<const char*> &nargs,
   if (i != opts.end()) {
     const string& type_str = i->second;
     if (type_str.compare("exclusive") == 0) {
-      lock_type = LOCK_EXCLUSIVE;
+      lock_type = ClsLockType::EXCLUSIVE;
     } else if (type_str.compare("shared") == 0) {
-      lock_type = LOCK_SHARED;
+      lock_type = ClsLockType::SHARED;
     } else {
       cerr << "unknown lock type was specified, aborting" << std::endl;
       return -EINVAL;
@@ -1243,7 +1243,7 @@ static int do_lock_cmd(std::vector<const char*> &nargs,
 
   if (cmd.compare("info") == 0) {
     map<rados::cls::lock::locker_id_t, rados::cls::lock::locker_info_t> lockers;
-    ClsLockType type = LOCK_NONE;
+    ClsLockType type = ClsLockType::NONE;
     string tag;
     int ret = rados::cls::lock::get_lock_info(ioctx, oid, lock_name, &lockers, &type, &tag);
     if (ret < 0) {
@@ -1281,7 +1281,7 @@ static int do_lock_cmd(std::vector<const char*> &nargs,
     l.set_description(lock_description);
     int ret;
     switch (lock_type) {
-    case LOCK_SHARED:
+    case ClsLockType::SHARED:
       ret = l.lock_shared(ioctx, oid);
       break;
     default:

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -307,7 +307,7 @@ void add_verbose_option(boost::program_options::options_description *opt) {
 
 void add_no_error_option(boost::program_options::options_description *opt) {
   opt->add_options()
-    (NO_ERROR.c_str(), po::bool_switch(), "continue after error");
+    (NO_ERR.c_str(), po::bool_switch(), "continue after error");
 }
 
 void add_export_format_option(boost::program_options::options_description *opt) {

--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -79,7 +79,7 @@ static const std::string NO_PROGRESS("no-progress");
 static const std::string FORMAT("format");
 static const std::string PRETTY_FORMAT("pretty-format");
 static const std::string VERBOSE("verbose");
-static const std::string NO_ERROR("no-error");
+static const std::string NO_ERR("no-error");
 
 static const std::string LIMIT("limit");
 
@@ -87,7 +87,7 @@ static const std::string SKIP_QUIESCE("skip-quiesce");
 static const std::string IGNORE_QUIESCE_ERROR("ignore-quiesce-error");
 
 static const std::set<std::string> SWITCH_ARGUMENTS = {
-  WHOLE_OBJECT, NO_PROGRESS, PRETTY_FORMAT, VERBOSE, NO_ERROR, SKIP_QUIESCE,
+  WHOLE_OBJECT, NO_PROGRESS, PRETTY_FORMAT, VERBOSE, NO_ERR, SKIP_QUIESCE,
   IGNORE_QUIESCE_ERROR
 };
 

--- a/src/tools/rbd/action/Journal.cc
+++ b/src/tools/rbd/action/Journal.cc
@@ -1165,7 +1165,7 @@ int execute_export(const po::variables_map &vm,
     return r;
   }
 
-  r = do_export_journal(io_ctx, journal_name, path, vm[at::NO_ERROR].as<bool>(),
+  r = do_export_journal(io_ctx, journal_name, path, vm[at::NO_ERR].as<bool>(),
 			vm[at::VERBOSE].as<bool>());
   if (r < 0) {
     std::cerr << "rbd: journal export: " << cpp_strerror(r) << std::endl;
@@ -1208,7 +1208,7 @@ int execute_import(const po::variables_map &vm,
     return r;
   }
 
-  r = do_import_journal(io_ctx, journal_name, path, vm[at::NO_ERROR].as<bool>(),
+  r = do_import_journal(io_ctx, journal_name, path, vm[at::NO_ERR].as<bool>(),
 			vm[at::VERBOSE].as<bool>());
   if (r < 0) {
     std::cerr << "rbd: journal import: " << cpp_strerror(r) << std::endl;


### PR DESCRIPTION
Windows support [part 4]

This PR series intends to set the ground for the upcoming Windows port effort.
For now, we're mostly interested in the client side, allowing Windows hosts
to consume rados, rbd and cephfs resources.

Those PRs should be reviewed and merged in order. Each PR depends on the previous one from the series (in fact it includes the previous commits as well).

~~Part 1: #31981~~
~~Part 2: #32704~~
Part 3: #32705
**Part 4: #32707**
Part 5: #32780 
Part 6: #32779
Part 7: #32778 
Part 8: #32777 
Part 9: #32776
Part 10: #33750
Part 11: #34858
Part 12: #34859

Related but independent PRs:
https://github.com/ceph/ceph/pull/32027
https://github.com/ceph/fmt/pull/2
https://github.com/ceph/rocksdb/pull/42

For more details about the build process and current status, please check the
README.windows.rst file. Worth mentioning that the resulted binaries can
connect to ceph clusters and consume pools: http://paste.openstack.org/raw/787534/

Here are some test results as well:
[test_results.zip](https://github.com/ceph/ceph/files/4077517/test_results.zip)

Any feedback is highly appreciated.

Signed-off-by: Lucian Petrut lpetrut@cloudbasesolutions.com
Signed-off-by: Alin Gabriel Serdean aserdean@cloudbasesolutions.com
