### PR TITLE
qa/standalone/mon/osd-create-pool: fix utf-8 grep LANG

### DIFF
--- a/qa/standalone/mon/osd-pool-create.sh
+++ b/qa/standalone/mon/osd-pool-create.sh
@@ -200,12 +200,15 @@ function TEST_utf8_cli() {
     # the fix for http://tracker.ceph.com/issues/7387.  If it turns out
     # to not be OK (when is the default encoding *not* UTF-8?), maybe
     # the character '黄' can be replaced with the escape $'\xe9\xbb\x84'
+    OLDLANG="$LANG"
+    export LANG=en_US.UTF-8
     ceph osd pool create 黄 16 || return 1
     ceph osd lspools 2>&1 | \
         grep "黄" || return 1
     ceph -f json-pretty osd dump | \
         python3 -c "import json; import sys; json.load(sys.stdin)" || return 1
     ceph osd pool delete 黄 黄 --yes-i-really-really-mean-it
+    export LANG="$OLDLANG"
 }
 
 function TEST_pool_create_rep_expected_num_objects() {


### PR DESCRIPTION
This needs en_US.UTF-8... en_US does not work.

Fixes: https://tracker.ceph.com/issues/43422
Signed-off-by: Sage Weil <sage@redhat.com>