### PR TITLE
cephadm: SO_REUSEADDR when doing bind check

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -119,6 +119,7 @@ class Monitoring(object):
 def attempt_bind(s, address, port):
     # type (str) -> None
     try:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         s.bind((address, port))
     except (socket.error, OSError) as e:  # py2 and py3
         if e.errno == errno.EADDRINUSE:


### PR DESCRIPTION
This is what the ceph daemons use; our check should do it too.

Signed-off-by: Sage Weil <sage@redhat.com>