### PR TITLE
mimic: nautilus: rbd-mirror: fix 'rbd mirror status' asok command output

### DIFF
--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -292,6 +292,8 @@ void Mirror::print_status(Formatter *f, stringstream *ss)
 
   if (f) {
     f->close_section();
+    f->close_section();
+    f->flush(*ss);
   }
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43625

---

backport of https://github.com/ceph/ceph/pull/32447
parent tracker: https://tracker.ceph.com/issues/43429

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh