### PR TITLE
luminous: rbd-mirror: fix 'rbd mirror status' asok command output

### DIFF
--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -318,6 +318,12 @@ void Mirror::print_status(Formatter *f, stringstream *ss)
   }
 
   m_image_deleter->print_status(f, ss);
+
+  if (f) {
+    f->close_section();
+    f->close_section();
+    f->flush(*ss);
+  }
 }
 
 void Mirror::start()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43626

---

backport of https://github.com/ceph/ceph/pull/32447
parent tracker: https://tracker.ceph.com/issues/43429

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh