### PR TITLE
qa/workunits/rados/test_crash.sh: suppress core files

### DIFF
--- a/qa/suites/rados/singleton/all/test-crash.yaml
+++ b/qa/suites/rados/singleton/all/test-crash.yaml
@@ -13,3 +13,6 @@ tasks:
          client.0:
            - rados/test_crash.sh
   - ceph.restart: [osd.*]
+  - exec:
+      mon.a:
+        - rm $TESTDIR/archive/coredump/*


### PR DESCRIPTION
The cores will make teuthology fail the job--and we don't want them for
this test, where we are deliberately causing crashes.

Signed-off-by: Sage Weil <sage@redhat.com>