### PR TITLE
mgr: better error handling when reading option

### DIFF
--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -399,13 +399,23 @@ ceph_option_get(BaseMgrModule *self, PyObject *args)
   const Option *opt = g_conf().find_option(string(what));
   if (opt) {
     std::string value;
-    int r = g_conf().get_val(string(what), &value);
-    assert(r >= 0);
+    switch (int r = g_conf().get_val(string(what), &value); r) {
+    case -ENOMEM:
+      PyErr_NoMemory();
+      return nullptr;
+    case -ENAMETOOLONG:
+      PyErr_SetString(PyExc_ValueError, "value too long");
+      return nullptr;
+    default:
+      ceph_assert(r == 0);
+      break;
+    }
     dout(10) << "ceph_option_get " << what << " found: " << value << dendl;
     return get_python_typed_option_value(opt->type, value);
   } else {
     dout(4) << "ceph_option_get " << what << " not found " << dendl;
-    Py_RETURN_NONE;
+    PyErr_Format(PyExc_KeyError, "option not found: %s", what);
+    return nullptr;
   }
 }
 


### PR DESCRIPTION
this also silences the warning of
```
src/mgr/BaseMgrModule.cc:402:9: warning: unused variable 'r' [-Wunused-variable]
     int r = g_conf().get_val(string(what), &value);
         ^
```
Signed-off-by: Kefu Chai <kchai@redhat.com>