### PR TITLE
msg/async: mark down local_connection before draining the stack.

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -314,7 +314,6 @@ AsyncMessenger::~AsyncMessenger()
 {
   delete reap_handler;
   ceph_assert(!did_bind); // either we didn't bind or we shut down the Processor
-  local_connection->mark_down();
   for (auto &&p : processors)
     delete p;
 }
@@ -348,6 +347,7 @@ int AsyncMessenger::shutdown()
   mark_down_all();
   // break ref cycles on the loopback connection
   local_connection->set_priv(NULL);
+  local_connection->mark_down();
   did_bind = false;
   lock.lock();
   stop_cond.notify_all();

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -346,7 +346,7 @@ int AsyncMessenger::shutdown()
     p->stop();
   mark_down_all();
   // break ref cycles on the loopback connection
-  local_connection->set_priv(NULL);
+  local_connection->clear_priv();
   local_connection->mark_down();
   did_bind = false;
   lock.lock();


### PR DESCRIPTION
`AsyncMessenger` has `local_connection` – an instance of `AsyncConnection` used to send messages to itself (loop back). Connections are handled by `EventCenter` in its dedicated thread. When shutting down a messenger, it must be ensured there is no task left in the `EventCenter`'s queue. Otherwise a use-after-free can happen. That's the reason why `shutdown()` of `AsyncMessenger` does `mark_down_all()` on connections **before** draining the stack. The latter actually injects a task into all `EventCenter` instances and waits for its completion (synchronization barrier).
    
However, that's not the case for `local_connection`. Without the patch it's marked down by the messenger's destructor far **after** the synchronization barrier. This behavior is dangerous when an implementation of `mark_down()` creates a new task to be executed inside the boundaries of corresponding `EventCenter` instance.
    
The fix unifies handling of `local_connection` with other connections in the aspect of the shutdown phase.
    
Fixes: https://tracker.ceph.com/issues/43667
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
