### PR TITLE
librbd: don't call refresh from mirror::GetInfoRequest state machine

### DIFF
--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -647,11 +647,26 @@ void Mirror<I>::image_get_info(I *ictx, mirror_image_info_t *mirror_image_info,
   CephContext *cct = ictx->cct;
   ldout(cct, 20) << "ictx=" << ictx << dendl;
 
-  auto ctx = new C_ImageGetInfo(mirror_image_info, nullptr, on_finish);
-  auto req = mirror::GetInfoRequest<I>::create(*ictx, &ctx->mirror_image,
-                                               &ctx->promotion_state,
-                                               ctx);
-  req->send();
+  auto on_refresh = new LambdaContext(
+    [ictx, mirror_image_info, on_finish](int r) {
+      if (r < 0) {
+        lderr(ictx->cct) << "refresh failed: " << cpp_strerror(r) << dendl;
+        on_finish->complete(r);
+        return;
+      }
+
+      auto ctx = new C_ImageGetInfo(mirror_image_info, nullptr, on_finish);
+      auto req = mirror::GetInfoRequest<I>::create(*ictx, &ctx->mirror_image,
+                                                   &ctx->promotion_state,
+                                                   ctx);
+      req->send();
+    });
+
+  if (ictx->state->is_refresh_required()) {
+    ictx->state->refresh(on_refresh);
+  } else {
+    on_refresh->complete(0);
+  }
 }
 
 template <typename I>

--- a/src/librbd/mirror/GetInfoRequest.cc
+++ b/src/librbd/mirror/GetInfoRequest.cc
@@ -23,35 +23,6 @@ using librbd::util::create_rados_callback;
 
 template <typename I>
 void GetInfoRequest<I>::send() {
-  refresh_image();
-}
-
-template <typename I>
-void GetInfoRequest<I>::refresh_image() {
-  if (!m_image_ctx.state->is_refresh_required()) {
-    get_mirror_image();
-    return;
-  }
-
-  CephContext *cct = m_image_ctx.cct;
-  ldout(cct, 20) << dendl;
-
-  auto ctx = create_context_callback<
-    GetInfoRequest<I>, &GetInfoRequest<I>::handle_refresh_image>(this);
-  m_image_ctx.state->refresh(ctx);
-}
-
-template <typename I>
-void GetInfoRequest<I>::handle_refresh_image(int r) {
-  CephContext *cct = m_image_ctx.cct;
-  ldout(cct, 20) << "r=" << r << dendl;
-
-  if (r < 0) {
-    lderr(cct) << "failed to refresh image: " << cpp_strerror(r) << dendl;
-    finish(r);
-    return;
-  }
-
   get_mirror_image();
 }
 

--- a/src/librbd/mirror/GetInfoRequest.h
+++ b/src/librbd/mirror/GetInfoRequest.h
@@ -43,9 +43,6 @@ private:
    * <start>
    *    |
    *    v
-   * REFRESH
-   *    |
-   *    v
    * GET_MIRROR_IMAGE
    *    |
    *    v
@@ -64,9 +61,6 @@ private:
 
   bufferlist m_out_bl;
   std::string m_mirror_uuid;
-
-  void refresh_image();
-  void handle_refresh_image(int r);
 
   void get_mirror_image();
   void handle_get_mirror_image(int r);


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43589
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
