### PR TITLE
qa/cephfs: make filelock_interrupt.py work with python3

### DIFF
--- a/qa/workunits/fs/misc/filelock_interrupt.py
+++ b/qa/workunits/fs/misc/filelock_interrupt.py
@@ -1,9 +1,24 @@
 #!/usr/bin/python3
 
+from contextlib import contextmanager
 import errno
 import fcntl
 import signal
 import struct
+
+@contextmanager
+def timeout(seconds):
+    def timeout_handler(signum, frame):
+        raise InterruptedError
+
+    orig_handler = signal.signal(signal.SIGALRM, timeout_handler)
+    try:
+        signal.alarm(seconds)
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, orig_handler)
+
 
 """
 introduced by Linux 3.15
@@ -11,10 +26,6 @@ introduced by Linux 3.15
 fcntl.F_OFD_GETLK = 36
 fcntl.F_OFD_SETLK = 37
 fcntl.F_OFD_SETLKW = 38
-
-
-def handler(signum, frame):
-    pass
 
 
 def main():
@@ -26,15 +37,13 @@ def main():
     """
     is flock interruptible?
     """
-    signal.signal(signal.SIGALRM, handler)
-    signal.alarm(5)
-    try:
-        fcntl.flock(f2, fcntl.LOCK_EX)
-    except IOError as e:
-        if e.errno != errno.EINTR:
-            raise
-    else:
-        raise RuntimeError("expect flock to block")
+    with timeout(5):
+        try:
+            fcntl.flock(f2, fcntl.LOCK_EX)
+        except InterruptedError:
+            pass
+        else:
+            raise RuntimeError("expect flock to block")
 
     fcntl.flock(f1, fcntl.LOCK_UN)
 
@@ -54,16 +63,14 @@ def main():
     """
     is posix lock interruptible?
     """
-    signal.signal(signal.SIGALRM, handler)
-    signal.alarm(5)
-    try:
-        lockdata = struct.pack('hhllhh', fcntl.F_WRLCK, 0, 0, 0, 0, 0)
-        fcntl.fcntl(f2, fcntl.F_OFD_SETLKW, lockdata)
-    except IOError as e:
-        if e.errno != errno.EINTR:
-            raise
-    else:
-        raise RuntimeError("expect posix lock to block")
+    with timeout(5):
+        try:
+            lockdata = struct.pack('hhllhh', fcntl.F_WRLCK, 0, 0, 0, 0, 0)
+            fcntl.fcntl(f2, fcntl.F_OFD_SETLKW, lockdata)
+        except InterruptedError:
+            pass
+        else:
+            raise RuntimeError("expect posix lock to block")
 
     """
     file handler 2 should still hold lock on 10~10


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43513
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
