### PR TITLE
ceph.spec.in: Add %{_libdir}/ceph to library search path

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1266,6 +1266,8 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rgw
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-mgr
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rbd
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rbd-mirror
+mkdir -p %{buildroot}%{_sysconfdir}/ld.so.conf.d/
+echo %{_libdir}/ceph > %{buildroot}%{_sysconfdir}/ld.so.conf.d/ceph.conf
 
 %if 0%{?suse_version}
 # create __pycache__ directories and their contents
@@ -1997,6 +1999,7 @@ fi
 
 %files -n librados2
 %{_libdir}/librados.so.*
+%{_sysconfdir}/ld.so.conf.d/ceph.conf
 %dir %{_libdir}/ceph
 %{_libdir}/ceph/libceph-common.so.*
 %if %{with lttng}


### PR DESCRIPTION
Add `%{_libdir}/ceph` to library search path
so that `libceph-common.so.N` is found for `ceph-fuse`.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket - does https://bugzilla.opensuse.org/show_bug.cgi?id=1161212 count?
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>