### PR TITLE
cephadm: remove `logs` command

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -253,12 +253,6 @@ $CEPHADM enter --fsid $FSID --name mgr.x -- pidof ceph-mgr
 expect_false $CEPHADM --timeout 1 enter --fsid $FSID --name mon.a -- sleep 10
 $CEPHADM --timeout 10 enter --fsid $FSID --name mon.a -- sleep 1
 
-## logs
-expect_false $CEPHADM logs
-expect_false $CEPHADM logs --fsid $FSID --name mon.z
-$CEPHADM logs --fsid $FSID --name mon.a
-expect_false $CEPHADM --timeout 1 logs --fsid $FSID --name mon.a -f
-
 ## ceph-volume
 $CEPHADM ceph-volume --fsid $FSID -- inventory --format=json \
       | jq '.[]'

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2134,24 +2134,6 @@ def command_unit():
 
 ##################################
 
-@infer_fsid
-def command_logs():
-    # type: () -> int
-    if not args.fsid:
-        raise Error('must pass --fsid to specify cluster')
-    cmd = [str(container_path), 'logs'] # type: List[str]
-    if args.follow:
-        cmd.append('-f')
-    if args.tail:
-        cmd.append('--tail=' + str(args.tail))
-    cmd.append('ceph-%s-%s' % (args.fsid, args.name))
-
-    # call this directly, without our wrapper, so that we get an unmolested
-    # stdout with logger prefixing.
-    return call_timeout(cmd, args.timeout)
-
-##################################
-
 def command_ls():
     # type: () -> None
     ls = list_daemons(detail=not args.no_detail,
@@ -2666,24 +2648,6 @@ def _get_parser():
         '--name', '-n',
         required=True,
         help='daemon name (type.id)')
-
-    parser_logs = subparsers.add_parser(
-        'logs', help='fetch the log for a daemon\'s container')
-    parser_logs.set_defaults(func=command_logs)
-    parser_logs.add_argument(
-        '--fsid',
-        help='cluster FSID')
-    parser_logs.add_argument(
-        '--name', '-n',
-        required=True,
-        help='daemon name (type.id)')
-    parser_logs.add_argument(
-        '-f', '--follow',
-        action='store_true',
-        help='Follow log output')
-    parser_logs.add_argument(
-        '--tail',
-        help='Output the specified number of lines at the end of the log')
 
     parser_bootstrap = subparsers.add_parser(
         'bootstrap', help='bootstrap a cluster (mon + mgr daemons)')


### PR DESCRIPTION
Remove the `cephadm logs` command:

* `podman logs` does not show the log for containers that are stopped/crashed
* `journalctl -f` does not exit when the container exits

Fixes: https://tracker.ceph.com/issues/43618
Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
