### PR TITLE
mgr/cephadm: health alert for stray services or hosts

### DIFF
--- a/doc/mgr/cephadm.rst
+++ b/doc/mgr/cephadm.rst
@@ -37,3 +37,44 @@ To clear this value use the command:
 ::
 
     # ceph cephadm clear-ssh-config
+
+Health checks
+-------------
+
+CEPHADM_STRAY_HOST
+^^^^^^^^^^^^^^^^^^
+
+One or more hosts have running Ceph daemons but are not registered as
+hosts managed by *cephadm*.  This means that those services cannot
+currently be managed by cephadm (e.g., restarted, upgraded, included
+in `ceph orchestrator service ls`).
+
+You can manage the host(s) with::
+
+  ceph orchestrator host add *<hostname>*
+
+Note that you may need to configure SSH access to the remote host
+before this will work.
+
+Alternatively, you can manually connect to the host and ensure that
+services on that host are removed and/or migrated to a host that is
+managed by *cephadm*.
+
+You can also disable this warning entirely with::
+
+  ceph config set mgr mgr/cephadm/warn_on_stray_hosts false
+
+CEPHADM_STRAY_SERVICE
+^^^^^^^^^^^^^^^^^^^^^
+
+One or more Ceph daemons are running but not are not managed by
+*cephadm*, perhaps because they were deploy using a different tool, or
+were started manually.  This means that those services cannot
+currently be managed by cephadm (e.g., restarted, upgraded, included
+in `ceph orchestrator service ls`).
+
+**FIXME:** We need to implement and document an adopt procedure here.
+
+You can also disable this warning entirely with::
+
+  ceph config set mgr mgr/cephadm/warn_on_stray_services false


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43714

example:
```
HEALTH_WARN 1 stray host(s) with 4 service(s) not managed by cephadm; 4 stray service(s) not managed by cephadm
[WRN] CEPHADM_STRAY_HOST: 1 stray host(s) with 4 service(s) not managed by cephadm
    stray host gnit has 4 stray daemons: ['mds.bar.klgdmy', 'mgr.x', 'mon.a', 'osd.0']
[WRN] CEPHADM_STRAY_SERVICE: 4 stray service(s) not managed by cephadm
    stray service mds.bar.klgdmy on host gnit not managed by cephadm
    stray service mgr.x on host gnit not managed by cephadm
    stray service mon.a on host gnit not managed by cephadm
    stray service osd.0 on host gnit not managed by cephadm
```
or when gnit is added back,
```
HEALTH_WARN 3 stray service(s) not managed by cephadm
[WRN] CEPHADM_STRAY_SERVICE: 3 stray service(s) not managed by cephadm
    stray service mgr.x on host gnit not managed by cephadm
    stray service mon.a on host gnit not managed by cephadm
    stray service osd.0 on host gnit not managed by cephadm
```
(those are the vstart daemons)