### PR TITLE
pybind/mgr/*: fix config_notify handling of default values

### DIFF
--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -106,7 +106,7 @@ class Alerts(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_module_option(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']))
             self.log.debug(' mgr option %s = %s',
                            opt['name'], getattr(self, opt['name']))
         # Do the same for the native options.

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -591,7 +591,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],  # type: ignore
-                    self.get_module_option(opt['name']) or opt['default'])  # type: ignore
+                    self.get_module_option(opt['name']))  # type: ignore
             self.log.debug(' mgr option %s = %s',
                            opt['name'], getattr(self, opt['name']))  # type: ignore
         for opt in self.NATIVE_OPTIONS:

--- a/src/pybind/mgr/crash/module.py
+++ b/src/pybind/mgr/crash/module.py
@@ -56,7 +56,7 @@ class Module(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_module_option(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']))
             self.log.debug(' mgr option %s = %s',
                            opt['name'], getattr(self, opt['name']))
 

--- a/src/pybind/mgr/diskprediction_cloud/module.py
+++ b/src/pybind/mgr/diskprediction_cloud/module.py
@@ -142,7 +142,7 @@ class Module(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_module_option(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']))
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
         if not self._activated_cloud and self.get_ceph_option('device_failure_prediction_mode') == 'cloud':
             self._event.set()

--- a/src/pybind/mgr/diskprediction_local/module.py
+++ b/src/pybind/mgr/diskprediction_local/module.py
@@ -54,7 +54,7 @@ class Module(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_module_option(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']))
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
         if self.get_ceph_option('device_failure_prediction_mode') == 'local':
             self._event.set()

--- a/src/pybind/mgr/hello/module.py
+++ b/src/pybind/mgr/hello/module.py
@@ -83,7 +83,7 @@ class Hello(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_module_option(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']))
             self.log.debug(' mgr option %s = %s',
                            opt['name'], getattr(self, opt['name']))
         # Do the same for the native options.

--- a/src/pybind/mgr/k8sevents/module.py
+++ b/src/pybind/mgr/k8sevents/module.py
@@ -1079,7 +1079,7 @@ class Module(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_module_option(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']))
 
         if not self.kubernetes_control:
             # Populate the config

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -97,7 +97,7 @@ class PgAutoscaler(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_module_option(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']))
             self.log.debug(' mgr option %s = %s',
                            opt['name'], getattr(self, opt['name']))
 


### PR DESCRIPTION
The default values are handled by mgr_module.py's _get_module_option();
the or here means that we break any non-true (0, false, none) value and
override it with the default.

https://tracker.ceph.com/issues/43746
Signed-off-by: Sage Weil <sage@redhat.com>