### PR TITLE
doc/cephfs/client-auth: description and example are inconsistent

### DIFF
--- a/doc/cephfs/client-auth.rst
+++ b/doc/cephfs/client-auth.rst
@@ -36,9 +36,9 @@ directory while creating key for a client using the following syntax. ::
 
  ceph fs authorize *file_system_name* client.*client_name* /*specified_directory* rw
 
-For example, to restrict client ``foo`` to writing only in the ``bar`` directory of file system ``cephfs``, use ::
+For example, to restrict client ``foo`` to writing only in the ``bar`` directory of file system ``cephfs_a``, use ::
 
- ceph fs authorize cephfs client.foo / r /bar rw
+ ceph fs authorize cephfs_a client.foo / r /bar rw
 
  results in:
 
@@ -51,7 +51,7 @@ For example, to restrict client ``foo`` to writing only in the ``bar`` directory
 To completely restrict the client to the ``bar`` directory, omit the
 root directory ::
 
- ceph fs authorize cephfs client.foo /bar rw
+ ceph fs authorize cephfs_a client.foo /bar rw
 
 Note that if a client's read access is restricted to a path, they will only
 be able to mount the file system when specifying a readable path in the


### PR DESCRIPTION
According to the path restriction example, the filesystem name
should be cephfs_a, not cephfs.  Converge on cephfs_a to avoid it
being confused with with the pool tag, which is always cephfs.

This was introduced in 160c4bfeb811 ("mon/AuthMonitor: Use new osd
auth caps for ceph fs authorize").

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>