### PR TITLE
mon/Session: only index osd ids >= 0

### DIFF
--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -139,7 +139,8 @@ struct MonSessionMap {
     }
     s->sub_map.clear();
     s->item.remove_myself();
-    if (s->name.is_osd()) {
+    if (s->name.is_osd() &&
+	s->name.num() >= 0) {
       for (auto p = by_osd.find(s->name.num());
 	   p->first == s->name.num();
 	   ++p)
@@ -168,7 +169,8 @@ struct MonSessionMap {
   void add_session(MonSession *s) {
     sessions.push_back(&s->item);
     s->get();
-    if (s->name.is_osd()) {
+    if (s->name.is_osd() &&
+	s->name.num() >= 0) {
       by_osd.insert(std::pair<int,MonSession*>(s->name.num(), s));
     }
     if (s->con_features) {


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/43552