### PR TITLE
unittest_lockdep: avoid any threads for death test

### DIFF
--- a/src/test/common/test_lockdep.cc
+++ b/src/test/common/test_lockdep.cc
@@ -9,6 +9,7 @@
 #include "global/global_init.h"
 #include "common/lockdep.h"
 #include "include/coredumpctl.h"
+#include "log/Log.h"
 
 TEST(lockdep, abba)
 {
@@ -65,8 +66,12 @@ int main(int argc, char **argv) {
   auto cct = global_init(NULL, args,
 			 CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
-			 CINIT_FLAG_NO_MON_CONFIG);
+			 CINIT_FLAG_NO_MON_CONFIG |
+			 CINIT_FLAG_NO_DAEMON_ACTIONS);
   common_init_finish(g_ceph_context);
+
+  // stop logging thread
+  g_ceph_context->_log->stop();
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
Heed the warning:

[WARNING] /home/sage/src/ceph/src/googletest/googletest/src/gtest-death-test.cc:1122:: Death tests use fork(), which is unsafe particularly in a threaded context. For this test, Google Test detected 4 threads. See https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#death-tests-and-threads for more explanation and suggested solutions, especially if this is the last message you see before your test times out.

Fixes: https://tracker.ceph.com/issues/43403
Signed-off-by: Sage Weil <sage@redhat.com>