### PR TITLE
[RFC] cmake/CheckCxxAtomic: set HAVE_CXX11_ATOMIC to FALSE

### DIFF
--- a/cmake/modules/CheckCxxAtomic.cmake
+++ b/cmake/modules/CheckCxxAtomic.cmake
@@ -30,6 +30,7 @@ cmake_push_check_state()
 check_cxx_atomics(HAVE_CXX11_ATOMIC)
 cmake_pop_check_state()
 
+set(HAVE_CXX11_ATOMIC FALSE)
 if(NOT HAVE_CXX11_ATOMIC)
   cmake_push_check_state()
   set(CMAKE_REQUIRED_LIBRARIES "atomic")


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43747

NOTE: marking this as RFC because, although it fixes the issue (FTBFS on s390x) without breaking the x86_64 build, it *seems* like there should be a better way...