### PR TITLE
test/unittest_lockdep: do not start extra threads

### DIFF
--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -23,10 +23,9 @@ endif()
 
 # unittest_lockdep
 add_executable(unittest_lockdep
-  test_lockdep.cc
-  )
+  test_lockdep.cc)
 add_ceph_unittest(unittest_lockdep)
-target_link_libraries(unittest_lockdep ceph-common global)
+target_link_libraries(unittest_lockdep ceph-common)
 
 # FreeBSD only has shims to support NUMA, no functional code.
 if(LINUX)

--- a/src/test/common/test_lockdep.cc
+++ b/src/test/common/test_lockdep.cc
@@ -1,20 +1,45 @@
 // -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "common/ceph_context.h"
-#include "include/util.h"
 #include "gtest/gtest.h"
+
+#include "common/ceph_argparse.h"
+#include "common/ceph_context.h"
 #include "common/ceph_mutex.h"
-#include "global/global_context.h"
-#include "global/global_init.h"
+#include "common/common_init.h"
 #include "common/lockdep.h"
+#include "include/util.h"
 #include "include/coredumpctl.h"
 #include "log/Log.h"
 
-TEST(lockdep, abba)
+class lockdep : public ::testing::Test
 {
-  ASSERT_TRUE(g_lockdep);
+protected:
+  void SetUp() override {
+#ifdef CEPH_DEBUG_MUTEX
+    GTEST_SKIP() << "WARNING: CEPH_DEBUG_MUTEX is not defined, lockdep will not work";
+#endif
+    CephInitParameters params(CEPH_ENTITY_TYPE_CLIENT);
+    cct = common_preinit(params, CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+    cct->_conf->cluster = "ceph";
+    cct->_conf.set_val("lockdep", "true");
+    cct->_conf.apply_changes(nullptr);
+    ASSERT_TRUE(g_lockdep);
+  }
+  void TearDown() final
+  {
+    if (cct) {
+      cct->put();
+      cct = nullptr;
+    }
+  }
+protected:
+  CephContext *cct = nullptr;
+};
 
+TEST_F(lockdep, abba)
+{
   ceph::mutex a(ceph::make_mutex("a")), b(ceph::make_mutex("b"));
   a.lock();
   ASSERT_TRUE(ceph_mutex_is_locked(a));
@@ -31,10 +56,8 @@ TEST(lockdep, abba)
   b.unlock();
 }
 
-TEST(lockdep, recursive)
+TEST_F(lockdep, recursive)
 {
-  ASSERT_TRUE(g_lockdep);
-
   ceph::mutex a(ceph::make_mutex("a"));
   a.lock();
   PrCtl unset_dumpable;
@@ -48,31 +71,4 @@ TEST(lockdep, recursive)
   b.lock();
   b.unlock();
   b.unlock();
-}
-
-int main(int argc, char **argv) {
-#ifdef NDEBUG
-  cout << "NDEBUG is defined" << std::endl;
-#else
-  cout << "NDEBUG is NOT defined" << std::endl;
-#endif
-#ifndef CEPH_DEBUG_MUTEX
-  cerr << "WARNING: CEPH_DEBUG_MUTEX is not defined, lockdep will not work"
-       << std::endl;
-  exit(0);
-#endif
-  std::vector<const char*> args(argv, argv + argc);
-  args.push_back("--lockdep");
-  auto cct = global_init(NULL, args,
-			 CEPH_ENTITY_TYPE_CLIENT,
-			 CODE_ENVIRONMENT_UTILITY,
-			 CINIT_FLAG_NO_MON_CONFIG |
-			 CINIT_FLAG_NO_DAEMON_ACTIONS);
-  common_init_finish(g_ceph_context);
-
-  // stop logging thread
-  g_ceph_context->_log->stop();
-
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
