### PR TITLE
nautilus: osd: Use physical ratio for nearfull (doesn't include backfill resserve)

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -740,7 +740,7 @@ OSDService::s_names OSDService::recalc_full_state(float ratio, float pratio, str
     return FULL;
   } else if (ratio > backfillfull_ratio) {
     return BACKFILLFULL;
-  } else if (ratio > nearfull_ratio) {
+  } else if (pratio > nearfull_ratio) {
     return NEARFULL;
   }
    return NONE;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43246

---

backport of https://github.com/ceph/ceph/pull/31954
parent tracker: https://tracker.ceph.com/issues/42346

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh