### PR TITLE
Windows support [part 8]

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2681,7 +2681,7 @@ bool Client::ms_dispatch2(const MessageRef &m)
   if (is_unmounting()) {
     ldout(cct, 10) << "unmounting: trim pass, size was " << lru.lru_get_size() 
              << "+" << inode_map.size() << dendl;
-    long unsigned size = lru.lru_get_size() + inode_map.size();
+    uint64_t size = lru.lru_get_size() + inode_map.size();
     trim_cache();
     if (size < lru.lru_get_size() + inode_map.size()) {
       ldout(cct, 10) << "unmounting: trim pass, cache shrank, poking unmount()" << dendl;
@@ -7164,8 +7164,8 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
     return -EROFS;
   }
   if ((mask & CEPH_SETATTR_SIZE) &&
-      (unsigned long)stx->stx_size > in->size &&
-      is_quota_bytes_exceeded(in, (unsigned long)stx->stx_size - in->size,
+      (uint64_t)stx->stx_size > in->size &&
+      is_quota_bytes_exceeded(in, (uint64_t)stx->stx_size - in->size,
 			      perms)) {
     return -EDQUOT;
   }
@@ -7323,7 +7323,7 @@ force_request:
       CEPH_CAP_FILE_WR;
   }
   if (mask & CEPH_SETATTR_SIZE) {
-    if ((unsigned long)stx->stx_size < mdsmap->get_max_filesize()) {
+    if ((uint64_t)stx->stx_size < mdsmap->get_max_filesize()) {
       req->head.args.setattr.size = stx->stx_size;
       ldout(cct,10) << "changing size to " << stx->stx_size << dendl;
     } else { //too big!
@@ -8088,7 +8088,7 @@ int Client::opendir(const char *relpath, dir_result_t **dirpp, const UserPerm& p
   r = _opendir(in.get(), dirpp, perms);
   /* if ENOTDIR, dirpp will be an uninitialized point and it's very dangerous to access its value */
   if (r != -ENOTDIR)
-      tout(cct) << (unsigned long)*dirpp << std::endl;
+      tout(cct) << (uintptr_t)*dirpp << std::endl;
   return r;
 }
 
@@ -8106,7 +8106,7 @@ int Client::_opendir(Inode *in, dir_result_t **dirpp, const UserPerm& perms)
 int Client::closedir(dir_result_t *dir) 
 {
   tout(cct) << __func__ << std::endl;
-  tout(cct) << (unsigned long)dir << std::endl;
+  tout(cct) << (uintptr_t)dir << std::endl;
 
   ldout(cct, 3) << __func__ << "(" << dir << ") = 0" << dendl;
   std::scoped_lock lock(client_lock);
@@ -13441,7 +13441,7 @@ int Client::ll_opendir(Inode *in, int flags, dir_result_t** dirpp,
   }
 
   int r = _opendir(in, dirpp, perms);
-  tout(cct) << (unsigned long)*dirpp << std::endl;
+  tout(cct) << (uintptr_t)*dirpp << std::endl;
 
   ldout(cct, 3) << "ll_opendir " << vino << " = " << r << " (" << *dirpp << ")"
 		<< dendl;
@@ -13456,7 +13456,7 @@ int Client::ll_releasedir(dir_result_t *dirp)
 
   ldout(cct, 3) << "ll_releasedir " << dirp << dendl;
   tout(cct) << "ll_releasedir" << std::endl;
-  tout(cct) << (unsigned long)dirp << std::endl;
+  tout(cct) << (uintptr_t)dirp << std::endl;
 
   std::scoped_lock lock(client_lock);
 
@@ -13472,7 +13472,7 @@ int Client::ll_fsyncdir(dir_result_t *dirp)
 
   ldout(cct, 3) << "ll_fsyncdir " << dirp << dendl;
   tout(cct) << "ll_fsyncdir" << std::endl;
-  tout(cct) << (unsigned long)dirp << std::endl;
+  tout(cct) << (uintptr_t)dirp << std::endl;
 
   std::scoped_lock lock(client_lock);
   return _fsync(dirp->inode.get(), false);
@@ -13509,7 +13509,7 @@ int Client::ll_open(Inode *in, int flags, Fh **fhp, const UserPerm& perms)
   if (fhptr) {
     ll_unclosed_fh_set.insert(fhptr);
   }
-  tout(cct) << (unsigned long)fhptr << std::endl;
+  tout(cct) << (uintptr_t)fhptr << std::endl;
   ldout(cct, 3) << "ll_open " << vino << " " << ceph_flags_sys2wire(flags) <<
       " = " << r << " (" << fhptr << ")" << dendl;
   return r;
@@ -13588,7 +13588,7 @@ out:
       ino = inode->ino;
   }
 
-  tout(cct) << (unsigned long)*fhp << std::endl;
+  tout(cct) << (uintptr_t)*fhp << std::endl;
   tout(cct) << ino << std::endl;
   ldout(cct, 8) << "_ll_create " << vparent << " " << name << " 0" << oct <<
     mode << dec << " " << ceph_flags_sys2wire(flags) << " = " << r << " (" <<
@@ -13679,7 +13679,7 @@ int Client::ll_read(Fh *fh, loff_t off, loff_t len, bufferlist *bl)
 
   ldout(cct, 3) << "ll_read " << fh << " " << fh->inode->ino << " " << " " << off << "~" << len << dendl;
   tout(cct) << "ll_read" << std::endl;
-  tout(cct) << (unsigned long)fh << std::endl;
+  tout(cct) << (uintptr_t)fh << std::endl;
   tout(cct) << off << std::endl;
   tout(cct) << len << std::endl;
 
@@ -13815,7 +13815,7 @@ int Client::ll_write(Fh *fh, loff_t off, loff_t len, const char *data)
   ldout(cct, 3) << "ll_write " << fh << " " << fh->inode->ino << " " << off <<
     "~" << len << dendl;
   tout(cct) << "ll_write" << std::endl;
-  tout(cct) << (unsigned long)fh << std::endl;
+  tout(cct) << (uintptr_t)fh << std::endl;
   tout(cct) << off << std::endl;
   tout(cct) << len << std::endl;
 
@@ -13861,7 +13861,7 @@ int Client::ll_flush(Fh *fh)
 
   ldout(cct, 3) << "ll_flush " << fh << " " << fh->inode->ino << " " << dendl;
   tout(cct) << "ll_flush" << std::endl;
-  tout(cct) << (unsigned long)fh << std::endl;
+  tout(cct) << (uintptr_t)fh << std::endl;
 
   std::scoped_lock lock(client_lock);
   return _flush(fh);
@@ -13875,7 +13875,7 @@ int Client::ll_fsync(Fh *fh, bool syncdataonly)
 
   ldout(cct, 3) << "ll_fsync " << fh << " " << fh->inode->ino << " " << dendl;
   tout(cct) << "ll_fsync" << std::endl;
-  tout(cct) << (unsigned long)fh << std::endl;
+  tout(cct) << (uintptr_t)fh << std::endl;
 
   std::scoped_lock lock(client_lock);
   int r = _fsync(fh, syncdataonly);
@@ -13894,7 +13894,7 @@ int Client::ll_sync_inode(Inode *in, bool syncdataonly)
 
   ldout(cct, 3) << "ll_sync_inode " << *in << " " << dendl;
   tout(cct) << "ll_sync_inode" << std::endl;
-  tout(cct) << (unsigned long)in << std::endl;
+  tout(cct) << (uintptr_t)in << std::endl;
 
   std::scoped_lock lock(client_lock);
   return _fsync(in, syncdataonly);
@@ -14041,7 +14041,7 @@ int Client::ll_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
 
   ldout(cct, 3) << __func__ << " " << fh << " " << fh->inode->ino << " " << dendl;
   tout(cct) << __func__ << " " << mode << " " << offset << " " << length << std::endl;
-  tout(cct) << (unsigned long)fh << std::endl;
+  tout(cct) << (uintptr_t)fh << std::endl;
 
   std::scoped_lock lock(client_lock);
   return _fallocate(fh, mode, offset, length);
@@ -14075,7 +14075,7 @@ int Client::ll_release(Fh *fh)
   ldout(cct, 3) << __func__ << " (fh)" << fh << " " << fh->inode->ino << " " <<
     dendl;
   tout(cct) << __func__ << " (fh)" << std::endl;
-  tout(cct) << (unsigned long)fh << std::endl;
+  tout(cct) << (uintptr_t)fh << std::endl;
 
   std::scoped_lock lock(client_lock);
 
@@ -14091,7 +14091,7 @@ int Client::ll_getlk(Fh *fh, struct flock *fl, uint64_t owner)
     return -ENOTCONN;
 
   ldout(cct, 3) << "ll_getlk (fh)" << fh << " " << fh->inode->ino << dendl;
-  tout(cct) << "ll_getk (fh)" << (unsigned long)fh << std::endl;
+  tout(cct) << "ll_getk (fh)" << (uintptr_t)fh << std::endl;
 
   std::scoped_lock lock(client_lock);
   return _getlk(fh, fl, owner);
@@ -14104,7 +14104,7 @@ int Client::ll_setlk(Fh *fh, struct flock *fl, uint64_t owner, int sleep)
     return -ENOTCONN;
 
   ldout(cct, 3) << __func__ << "  (fh) " << fh << " " << fh->inode->ino << dendl;
-  tout(cct) << __func__ << " (fh)" << (unsigned long)fh << std::endl;
+  tout(cct) << __func__ << " (fh)" << (uintptr_t)fh << std::endl;
 
   std::scoped_lock lock(client_lock);
   return _setlk(fh, fl, owner, sleep);
@@ -14117,7 +14117,7 @@ int Client::ll_flock(Fh *fh, int cmd, uint64_t owner)
     return -ENOTCONN;
 
   ldout(cct, 3) << __func__ << "  (fh) " << fh << " " << fh->inode->ino << dendl;
-  tout(cct) << __func__ << " (fh)" << (unsigned long)fh << std::endl;
+  tout(cct) << __func__ << " (fh)" << (uintptr_t)fh << std::endl;
 
   std::scoped_lock lock(client_lock);
   return _flock(fh, cmd, owner);

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -135,6 +135,8 @@ elseif(SUN)
   list(APPEND common_srcs solaris_errno.cc)
 elseif(AIX)
   list(APPEND common_srcs aix_errno.cc)
+elseif(WIN32)
+  list(APPEND common_srcs win32_errno.c)
 endif()
 
 if(WITH_EVENTTRACE)

--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -134,8 +134,13 @@ int ConfFile::parse_file(const std::string &fname,
     }
   }
   std::ifstream ifs{fname};
-  const std::string buffer{std::istreambuf_iterator<char>(ifs),
-			   std::istreambuf_iterator<char>()};
+  std::string buffer{std::istreambuf_iterator<char>(ifs),
+			               std::istreambuf_iterator<char>()};
+  #ifdef _WIN32
+    // We'll need to ensure that there's a new line at the end of the file,
+    // otherwise the config parsing will fail.
+    buffer.append("\n");
+  #endif
   if (parse_buffer(buffer, warnings)) {
     return 0;
   } else {

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -694,6 +694,19 @@ bool AdminSocket::init(const std::string& path)
 {
   ldout(m_cct, 5) << "init " << path << dendl;
 
+  #ifdef _WIN32
+  OSVERSIONINFOEXW ver = {0};
+  ver.dwOSVersionInfoSize = sizeof(ver);
+  get_windows_version(&ver);
+
+  if (std::tie(ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber) <
+      std::make_tuple(10, 0, 17063)) {
+    ldout(m_cct, 5) << "Unix sockets require Windows 10.0.17063 or later. "
+                    << "The admin socket will not be available." << dendl;
+    return false;
+  }
+  #endif
+
   /* Set up things for the new thread */
   std::string err;
   int pipe_rd = -1, pipe_wr = -1;

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -131,7 +131,7 @@ std::string AdminSocket::create_wakeup_pipe(int *pipe_rd, int *pipe_wr)
   #else
   if (pipe_cloexec(pipefd, O_NONBLOCK) < 0) {
   #endif
-    int e = errno;
+    int e = ceph_sock_errno();
     ostringstream oss;
     oss << "AdminSocket::create_wakeup_pipe error: " << cpp_strerror(e);
     return oss.str();
@@ -146,14 +146,10 @@ std::string AdminSocket::destroy_wakeup_pipe()
 {
   // Send a byte to the wakeup pipe that the thread is listening to
   char buf[1] = { 0x0 };
-  #ifdef _WIN32
-  int ret = send(m_wakeup_wr_fd, buf, sizeof(buf), 0) != 1;
-  #else
-  int ret = safe_write(m_wakeup_wr_fd, buf, sizeof(buf));
-  #endif
+  int ret = safe_send(m_wakeup_wr_fd, buf, sizeof(buf));
 
   // Close write end
-  retry_sys_call(::close, m_wakeup_wr_fd);
+  retry_sys_call(::compat_closesocket, m_wakeup_wr_fd);
   m_wakeup_wr_fd = -1;
 
   if (ret != 0) {
@@ -167,7 +163,7 @@ std::string AdminSocket::destroy_wakeup_pipe()
 
   // Close read end. Doing this before join() blocks the listenter and prevents
   // joining.
-  retry_sys_call(::close, m_wakeup_rd_fd);
+  retry_sys_call(::compat_closesocket, m_wakeup_rd_fd);
   m_wakeup_rd_fd = -1;
 
   return "";
@@ -188,7 +184,7 @@ std::string AdminSocket::bind_and_listen(const std::string &sock_path, int *fd)
   }
   int sock_fd = socket_cloexec(PF_UNIX, SOCK_STREAM, 0);
   if (sock_fd < 0) {
-    int err = errno;
+    int err = ceph_sock_errno();
     ostringstream oss;
     oss << "AdminSocket::bind_and_listen: "
 	<< "failed to create socket: " << cpp_strerror(err);
@@ -201,7 +197,7 @@ std::string AdminSocket::bind_and_listen(const std::string &sock_path, int *fd)
 	   "%s", sock_path.c_str());
   if (::bind(sock_fd, (struct sockaddr*)&address,
 	   sizeof(struct sockaddr_un)) != 0) {
-    int err = errno;
+    int err = ceph_sock_errno();
     if (err == EADDRINUSE) {
       AdminSocketClient client(sock_path);
       bool ok;
@@ -216,7 +212,7 @@ std::string AdminSocket::bind_and_listen(const std::string &sock_path, int *fd)
 		 sizeof(struct sockaddr_un)) == 0) {
 	  err = 0;
 	} else {
-	  err = errno;
+	  err = ceph_sock_errno();
 	}
       }
     }
@@ -230,7 +226,7 @@ std::string AdminSocket::bind_and_listen(const std::string &sock_path, int *fd)
     }
   }
   if (listen(sock_fd, 5) != 0) {
-    int err = errno;
+    int err = ceph_sock_errno();
     ostringstream oss;
     oss << "AdminSocket::bind_and_listen: "
 	  << "failed to listen to socket: " << cpp_strerror(err);
@@ -257,7 +253,7 @@ void AdminSocket::entry() noexcept
     ldout(m_cct,20) << __func__ << " waiting" << dendl;
     int ret = poll(fds, 2, -1);
     if (ret < 0) {
-      int err = errno;
+      int err = ceph_sock_errno();
       if (err == EINTR) {
 	continue;
       }
@@ -274,9 +270,9 @@ void AdminSocket::entry() noexcept
     if (fds[1].revents & POLLIN) {
       // read off one byte
       char buf;
-      auto s = ::read(m_wakeup_rd_fd, &buf, 1);
+      auto s = safe_recv(m_wakeup_rd_fd, &buf, 1);
       if (s == -1) {
-        int e = errno;
+        int e = ceph_sock_errno();
         ldout(m_cct, 5) << "AdminSocket: (ignoring) read(2) error: '"
 		        << cpp_strerror(e) << dendl;
       }
@@ -322,7 +318,7 @@ void AdminSocket::do_accept()
   int connection_fd = accept_cloexec(m_sock_fd, (struct sockaddr*) &address,
 			     &address_length);
   if (connection_fd < 0) {
-    int err = errno;
+    int err = ceph_sock_errno();
     lderr(m_cct) << "AdminSocket: do_accept error: '"
 			   << cpp_strerror(err) << dendl;
     return;
@@ -333,13 +329,13 @@ void AdminSocket::do_accept()
   unsigned pos = 0;
   string c;
   while (1) {
-    int ret = safe_read(connection_fd, &cmd[pos], 1);
+    int ret = safe_recv(connection_fd, &cmd[pos], 1);
     if (ret <= 0) {
       if (ret < 0) {
         lderr(m_cct) << "AdminSocket: error reading request code: "
 		     << cpp_strerror(ret) << dendl;
       }
-      retry_sys_call(::close, connection_fd);
+      retry_sys_call(::compat_closesocket, connection_fd);
       return;
     }
     if (cmd[0] == '\0') {
@@ -373,7 +369,7 @@ void AdminSocket::do_accept()
     }
     if (++pos >= sizeof(cmd)) {
       lderr(m_cct) << "AdminSocket: error reading request too long" << dendl;
-      retry_sys_call(::close, connection_fd);
+      retry_sys_call(::compat_closesocket, connection_fd);
       return;
     }
   }
@@ -396,17 +392,18 @@ void AdminSocket::do_accept()
     out.claim_append(o);
   }
   uint32_t len = htonl(out.length());
-  int ret = safe_write(connection_fd, &len, sizeof(len));
+  int ret = safe_send(connection_fd, &len, sizeof(len));
   if (ret < 0) {
     lderr(m_cct) << "AdminSocket: error writing response length "
 		 << cpp_strerror(ret) << dendl;
   } else {
-    if (out.write_fd(connection_fd) < 0) {
+    int r = out.send_fd(connection_fd);
+    if (r < 0) {
       lderr(m_cct) << "AdminSocket: error writing response payload "
 		   << cpp_strerror(ret) << dendl;
     }
   }
-  retry_sys_call(::close, connection_fd);
+  retry_sys_call(::compat_closesocket, connection_fd);
 }
 
 void AdminSocket::do_tell_queue()
@@ -753,7 +750,7 @@ void AdminSocket::shutdown()
     lderr(m_cct) << "AdminSocket::shutdown: error: " << err << dendl;
   }
 
-  retry_sys_call(::close, m_sock_fd);
+  retry_sys_call(::compat_closesocket, m_sock_fd);
 
   unregister_commands(version_hook.get());
   version_hook.reset();
@@ -772,10 +769,6 @@ void AdminSocket::wakeup()
 {
   // Send a byte to the wakeup pipe that the thread is listening to
   char buf[1] = { 0x0 };
-  #ifdef _WIN32
-  int r = send(m_wakeup_wr_fd, buf, sizeof(buf), 0);
-  #else
-  int r = safe_write(m_wakeup_wr_fd, buf, sizeof(buf));
-  #endif
+  int r = safe_send(m_wakeup_wr_fd, buf, sizeof(buf));
   (void)r;
 }

--- a/src/common/admin_socket_client.cc
+++ b/src/common/admin_socket_client.cc
@@ -35,6 +35,11 @@ const char* get_rand_socket_path()
   if (g_socket_path == NULL) {
     char buf[512];
     const char *tdir = getenv("TMPDIR");
+    #ifdef _WIN32
+    if (tdir == NULL) {
+      tdir = getenv("TEMP");
+    }
+    #endif /* _WIN32 */
     if (tdir == NULL) {
       tdir = "/tmp";
     }
@@ -50,7 +55,7 @@ static std::string asok_connect(const std::string &path, int *fd)
 {
   int socket_fd = socket_cloexec(PF_UNIX, SOCK_STREAM, 0);
   if(socket_fd < 0) {
-    int err = errno;
+    int err = ceph_sock_errno();
     ostringstream oss;
     oss << "socket(PF_UNIX, SOCK_STREAM, 0) failed: " << cpp_strerror(err);
     return oss.str();
@@ -64,10 +69,10 @@ static std::string asok_connect(const std::string &path, int *fd)
 
   if (::connect(socket_fd, (struct sockaddr *) &address, 
 	sizeof(struct sockaddr_un)) != 0) {
-    int err = errno;
+    int err = ceph_sock_errno();
     ostringstream oss;
     oss << "connect(" << socket_fd << ") failed: " << cpp_strerror(err);
-    close(socket_fd);
+    compat_closesocket(socket_fd);
     return oss.str();
   }
 
@@ -75,21 +80,21 @@ static std::string asok_connect(const std::string &path, int *fd)
   timer.tv_sec = 10;
   timer.tv_usec = 0;
   if (::setsockopt(socket_fd, SOL_SOCKET, SO_RCVTIMEO, (SOCKOPT_VAL_TYPE)&timer, sizeof(timer))) {
-    int err = errno;
+    int err = ceph_sock_errno();
     ostringstream oss;
     oss << "setsockopt(" << socket_fd << ", SO_RCVTIMEO) failed: "
 	<< cpp_strerror(err);
-    close(socket_fd);
+    compat_closesocket(socket_fd);
     return oss.str();
   }
   timer.tv_sec = 10;
   timer.tv_usec = 0;
   if (::setsockopt(socket_fd, SOL_SOCKET, SO_SNDTIMEO, (SOCKOPT_VAL_TYPE)&timer, sizeof(timer))) {
-    int err = errno;
+    int err = ceph_sock_errno();
     ostringstream oss;
     oss << "setsockopt(" << socket_fd << ", SO_SNDTIMEO) failed: "
 	<< cpp_strerror(err);
-    close(socket_fd);
+    compat_closesocket(socket_fd);
     return oss.str();
   }
 
@@ -99,7 +104,7 @@ static std::string asok_connect(const std::string &path, int *fd)
 
 static std::string asok_request(int socket_fd, std::string request)
 {
-  ssize_t res = safe_write(socket_fd, request.c_str(), request.length() + 1);
+  ssize_t res = safe_send(socket_fd, request.c_str(), request.length() + 1);
   if (res < 0) {
     int err = res;
     ostringstream oss;
@@ -138,30 +143,30 @@ std::string AdminSocketClient::do_request(std::string request, std::string *resu
   if (!err.empty()) {
     goto done;
   }
-  res = safe_read_exact(socket_fd, &message_size_raw,
+  res = safe_recv_exact(socket_fd, &message_size_raw,
 				sizeof(message_size_raw));
   if (res < 0) {
     int e = res;
     ostringstream oss;
-    oss << "safe_read(" << socket_fd << ") failed to read message size: "
+    oss << "safe_recv(" << socket_fd << ") failed to read message size: "
 	<< cpp_strerror(e);
     err = oss.str();
     goto done;
   }
   message_size = ntohl(message_size_raw);
   buffer.resize(message_size, 0);
-  res = safe_read_exact(socket_fd, &buffer[0], message_size);
+  res = safe_recv_exact(socket_fd, &buffer[0], message_size);
   if (res < 0) {
     int e = res;
     ostringstream oss;
-    oss << "safe_read(" << socket_fd << ") failed: " << cpp_strerror(e);
+    oss << "safe_recv(" << socket_fd << ") failed: " << cpp_strerror(e);
     err = oss.str();
     goto done;
   }
   //printf("MESSAGE FROM SERVER: %s\n", buffer.c_str());
   std::swap(*result, buffer);
 done:
-  close(socket_fd);
+  compat_closesocket(socket_fd);
  out:
   return err;
 }

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1685,7 +1685,7 @@ void buffer::list::decode_base64(buffer::list& e)
 
 ssize_t buffer::list::pread_file(const char *fn, uint64_t off, uint64_t len, std::string *error)
 {
-  int fd = TEMP_FAILURE_RETRY(::open(fn, O_RDONLY|O_CLOEXEC));
+  int fd = TEMP_FAILURE_RETRY(::open(fn, O_RDONLY|O_CLOEXEC|O_BINARY));
   if (fd < 0) {
     int err = errno;
     std::ostringstream oss;
@@ -1745,7 +1745,7 @@ ssize_t buffer::list::pread_file(const char *fn, uint64_t off, uint64_t len, std
 
 int buffer::list::read_file(const char *fn, std::string *error)
 {
-  int fd = TEMP_FAILURE_RETRY(::open(fn, O_RDONLY|O_CLOEXEC));
+  int fd = TEMP_FAILURE_RETRY(::open(fn, O_RDONLY|O_CLOEXEC|O_BINARY));
   if (fd < 0) {
     int err = errno;
     std::ostringstream oss;
@@ -1812,7 +1812,7 @@ ssize_t buffer::list::recv_fd(int fd, size_t len)
 
 int buffer::list::write_file(const char *fn, int mode)
 {
-  int fd = TEMP_FAILURE_RETRY(::open(fn, O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, mode));
+  int fd = TEMP_FAILURE_RETRY(::open(fn, O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC|O_BINARY, mode));
   if (fd < 0) {
     int err = errno;
     cerr << "bufferlist::write_file(" << fn << "): failed to open file: "

--- a/src/common/compat.cc
+++ b/src/common/compat.cc
@@ -287,7 +287,7 @@ int pipe(int pipefd[2]) {
 long int lrand48(void) {
   long int val;
   val = (long int) rand();
-  val << 16;
+  val <<= 16;
   val += (long int) rand();
   return val;
 }
@@ -385,7 +385,7 @@ int &alloc_tls() {
   return tlsvar;
 }
 
-int apply_tls_workaround() {
+void apply_tls_workaround() {
   // Workaround for the following Mingw bugs:
   // https://sourceforge.net/p/mingw-w64/bugs/727/
   // https://sourceforge.net/p/mingw-w64/bugs/527/

--- a/src/common/compat.cc
+++ b/src/common/compat.cc
@@ -232,6 +232,17 @@ char *ceph_strerror_r(int errnum, char *buf, size_t buflen)
 #endif
 }
 
+int ceph_memzero_s(void *dest, size_t destsz, size_t count) {
+#ifdef __STDC_LIB_EXT1__
+    return memset_s(dest, destsz, 0, count);
+#elif defined(_WIN32)
+    SecureZeroMemory(dest, count);
+#else
+    explicit_bzero(dest, count);
+#endif
+    return 0;
+}
+
 #ifdef _WIN32
 
 #include <iomanip>

--- a/src/common/compat.cc
+++ b/src/common/compat.cc
@@ -23,6 +23,8 @@
 #include <thread>
 #ifndef _WIN32
 #include <sys/mount.h>
+#else
+#include <stdlib.h>
 #endif
 #include <sys/param.h>
 #include <sys/socket.h>
@@ -279,6 +281,10 @@ long int lrand48(void) {
   return val;
 }
 
+int random() {
+  return rand();
+}
+
 int fsync(int fd) {
   HANDLE handle = (HANDLE*)_get_osfhandle(fd);
   if (handle == INVALID_HANDLE_VALUE)
@@ -455,6 +461,25 @@ int win_socketpair(int socks[2])
     closesocket(socks[1]);
     errno = e;
     return SOCKET_ERROR;
+}
+
+unsigned get_page_size() {
+  SYSTEM_INFO system_info;
+  GetSystemInfo(&system_info);
+  return system_info.dwPageSize;
+}
+
+int setenv(const char *name, const char *value, int overwrite) {
+  if (!overwrite && getenv(name)) {
+    return 0;
+  }
+  return _putenv_s(name, value);
+}
+
+#else
+
+unsigned get_page_size() {
+  return sysconf(_SC_PAGESIZE);
 }
 
 #endif /* _WIN32 */

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -461,7 +461,7 @@ std::string md_config_t::get_cluster_name(const char* conffile)
     // If cluster name is not set yet, use the prefix of the
     // basename of configuration file as cluster name.
     if (fs::path path{conffile}; path.extension() == ".conf") {
-      return path.stem();
+      return path.stem().string();
     } else {
       // If the configuration file does not follow $cluster.conf
       // convention, we do the last try and assign the cluster to

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -63,6 +63,8 @@ using ceph::Formatter;
 static const char *CEPH_CONF_FILE_DEFAULT = "$data_dir/config,/etc/ceph/$cluster.conf,$home/.ceph/$cluster.conf,$cluster.conf"
 #if defined(__FreeBSD__)
     ",/usr/local/etc/ceph/$cluster.conf"
+#elif defined(_WIN32)
+    ",$programdata/ceph/$cluster.conf"
 #endif
     ;
 
@@ -1226,7 +1228,10 @@ Option::value_t md_config_t::_expand_meta(
       } else if (var == "home") {
 	const char *home = getenv("HOME");
 	out = home ? std::string(home) : std::string();
-      } else {
+      } else if (var == "programdata") {
+        const char *home = getenv("ProgramData");
+        out = home ? std::string(home) : std::string();
+      }else {
 	if (var == "data_dir") {
 	  var = data_dir_option;
 	}

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -60,9 +60,9 @@ using ceph::decode;
 using ceph::encode;
 using ceph::Formatter;
 
-static const char *CEPH_CONF_FILE_DEFAULT = "$data_dir/config, /etc/ceph/$cluster.conf, $home/.ceph/$cluster.conf, $cluster.conf"
+static const char *CEPH_CONF_FILE_DEFAULT = "$data_dir/config,/etc/ceph/$cluster.conf,$home/.ceph/$cluster.conf,$cluster.conf"
 #if defined(__FreeBSD__)
-    ", /usr/local/etc/ceph/$cluster.conf"
+    ",/usr/local/etc/ceph/$cluster.conf"
 #endif
     ;
 
@@ -87,7 +87,7 @@ int ceph_resolve_file_search(const std::string& filename_list,
 			     std::string& result)
 {
   list<string> ls;
-  get_str_list(filename_list, ls);
+  get_str_list(filename_list, ";,", ls);
 
   int ret = -ENOENT;
   list<string>::iterator iter;
@@ -440,7 +440,7 @@ md_config_t::get_conffile_paths(const ConfigValues& values,
   }
 
   std::list<std::string> paths;
-  get_str_list(conf_files_str, paths);
+  get_str_list(conf_files_str, ";,", paths);
   for (auto i = paths.begin(); i != paths.end(); ) {
     string& path = *i;
     if (path.find("$data_dir") != path.npos &&

--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -324,6 +324,9 @@ public:
   bool has_parse_error() const {
     return !config.parse_error.empty();
   }
+  std::string get_parse_error() {
+    return config.parse_error;
+  }
   void complain_about_parse_error(CephContext *cct) {
     return config.complain_about_parse_error(cct);
   }

--- a/src/common/fork_function.h
+++ b/src/common/fork_function.h
@@ -18,13 +18,12 @@
 #include "include/ceph_assert.h"
 #include "common/errno.h"
 
+#ifndef _WIN32
 static void _fork_function_dummy_sighandler(int sig) {}
 
 // Run a function post-fork, with a timeout.  Function can return
 // int8_t only due to unix exit code limitations.  Returns -ETIMEDOUT
 // if timeout is reached.
-
-#ifndef _WIN32
 static inline int fork_function(
   int timeout,
   std::ostream& errstr,

--- a/src/common/ifaddrs_win32.cc
+++ b/src/common/ifaddrs_win32.cc
@@ -4,6 +4,7 @@
 #include <iphlpapi.h>
 #include <ws2tcpip.h>
 #include <ifaddrs.h>
+#include <stdio.h>
 
 #include "include/compat.h"
 

--- a/src/common/module.c
+++ b/src/common/module.c
@@ -82,11 +82,6 @@ int module_load(const char *module, const char *options)
 #else
 
 // We're stubbing out those functions, for now.
-static int run_command(const char *command)
-{
-	return -1;
-}
-
 int module_has_param(const char *module, const char *param)
 {
 	return -1;

--- a/src/common/safe_io.c
+++ b/src/common/safe_io.c
@@ -21,6 +21,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <sys/socket.h>
 
 ssize_t safe_read(int fd, void *buf, size_t count)
 {
@@ -43,6 +44,39 @@ ssize_t safe_read(int fd, void *buf, size_t count)
 	return cnt;
 }
 
+#ifdef _WIN32
+// "read" doesn't work with Windows sockets.
+ssize_t safe_recv(int fd, void *buf, size_t count)
+{
+  size_t cnt = 0;
+
+  while (cnt < count) {
+    ssize_t r = recv(fd, (SOCKOPT_VAL_TYPE)buf, count - cnt, 0);
+    if (r <= 0) {
+      if (r == 0) {
+        // EOF
+        return cnt;
+      }
+      int err = ceph_sock_errno();
+      if (err == EAGAIN || err == EINTR) {
+        continue;
+      }
+      return -err;
+    }
+    cnt += r;
+    buf = (char *)buf + r;
+  }
+  return cnt;
+}
+#else
+ssize_t safe_recv(int fd, void *buf, size_t count)
+{
+  // We'll use "safe_read" so that this can work with any type of
+  // file descriptor.
+  return safe_read(fd, buf, count);
+}
+#endif /* _WIN32 */
+
 ssize_t safe_read_exact(int fd, void *buf, size_t count)
 {
         ssize_t ret = safe_read(fd, buf, count);
@@ -52,7 +86,17 @@ ssize_t safe_read_exact(int fd, void *buf, size_t count)
 		return -EDOM;
 	return 0;
 }
- 
+
+ssize_t safe_recv_exact(int fd, void *buf, size_t count)
+{
+        ssize_t ret = safe_recv(fd, buf, count);
+  if (ret < 0)
+    return ret;
+  if ((size_t)ret != count)
+    return -EDOM;
+  return 0;
+}
+
 ssize_t safe_write(int fd, const void *buf, size_t count)
 {
 	while (count > 0) {
@@ -67,6 +111,30 @@ ssize_t safe_write(int fd, const void *buf, size_t count)
 	}
 	return 0;
 }
+
+#ifdef _WIN32
+ssize_t safe_send(int fd, const void *buf, size_t count)
+{
+  while (count > 0) {
+    ssize_t r = send(fd, (SOCKOPT_VAL_TYPE)buf, count, 0);
+    if (r < 0) {
+      int err = ceph_sock_errno();
+      if (err == EINTR || err == EAGAIN) {
+        continue;
+      }
+      return -err;
+    }
+    count -= r;
+    buf = (char *)buf + r;
+  }
+  return 0;
+}
+#else
+ssize_t safe_send(int fd, const void *buf, size_t count)
+{
+  return safe_write(fd, buf, count);
+}
+#endif /* _WIN32 */
 
 ssize_t safe_pread(int fd, void *buf, size_t count, off_t offset)
 {

--- a/src/common/safe_io.c
+++ b/src/common/safe_io.c
@@ -237,7 +237,7 @@ int safe_write_file(const char *base, const char *file,
 
   snprintf(fn, sizeof(fn), "%s/%s", base, file);
   snprintf(tmp, sizeof(tmp), "%s/%s.tmp", base, file);
-  fd = open(tmp, O_WRONLY|O_CREAT|O_TRUNC, mode);
+  fd = open(tmp, O_WRONLY|O_CREAT|O_TRUNC|O_BINARY, mode);
   if (fd < 0) {
     ret = errno;
     return -ret;
@@ -262,7 +262,7 @@ int safe_write_file(const char *base, const char *file,
     return ret;
   }
 
-  fd = open(base, O_RDONLY);
+  fd = open(base, O_RDONLY|O_BINARY);
   if (fd < 0) {
     ret = -errno;
     return ret;
@@ -281,7 +281,7 @@ int safe_read_file(const char *base, const char *file,
   int fd, len;
 
   snprintf(fn, sizeof(fn), "%s/%s", base, file);
-  fd = open(fn, O_RDONLY);
+  fd = open(fn, O_RDONLY|O_BINARY);
   if (fd < 0) {
     return -errno;
   }

--- a/src/common/safe_io.h
+++ b/src/common/safe_io.h
@@ -26,10 +26,16 @@ extern "C" {
    * Safe functions wrapping the raw read() and write() libc functions.
    * These retry on EINTR, and on error return -errno instead of returning
    * -1 and setting errno).
+   *
+   * On Windows, only recv/send work with sockets.
    */
   ssize_t safe_read(int fd, void *buf, size_t count)
       WARN_UNUSED_RESULT;
   ssize_t safe_write(int fd, const void *buf, size_t count)
+      WARN_UNUSED_RESULT;
+  ssize_t safe_recv(int fd, void *buf, size_t count)
+      WARN_UNUSED_RESULT;
+  ssize_t safe_send(int fd, const void *buf, size_t count)
       WARN_UNUSED_RESULT;
   ssize_t safe_pread(int fd, void *buf, size_t count, off_t offset)
       WARN_UNUSED_RESULT;
@@ -53,6 +59,8 @@ extern "C" {
    * number of bytes can be read.
    */
   ssize_t safe_read_exact(int fd, void *buf, size_t count)
+      WARN_UNUSED_RESULT;
+  ssize_t safe_recv_exact(int fd, void *buf, size_t count)
       WARN_UNUSED_RESULT;
   ssize_t safe_pread_exact(int fd, void *buf, size_t count, off_t offset)
       WARN_UNUSED_RESULT;

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -249,7 +249,7 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
   get_windows_version(&ver);
 
   char version_str[64];
-  snprintf(version_str, 64, "%d.%d (%d)",
+  snprintf(version_str, 64, "%lu.%lu (%lu)",
            ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber);
 
   char hostname[64];
@@ -257,7 +257,7 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
   GetComputerNameA(hostname, &hostname_sz);
 
   SYSTEM_INFO sys_info;
-  char* arch_str;
+  const char* arch_str;
   GetNativeSystemInfo(&sys_info);
 
   switch (sys_info.wProcessorArchitecture) {

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -159,7 +159,8 @@ void global_pre_init(
   }
   else if (ret) {
     cct->_log->flush();
-    cerr << "global_init: error reading config file." << std::endl;
+    cerr << "global_init: error reading config file. "
+         << conf.get_parse_error() << std::endl;
     _exit(1);
   }
 

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -495,7 +495,7 @@ void global_init_daemonize(CephContext *cct)
 
 int reopen_as_null(CephContext *cct, int fd)
 {
-  int newfd = open("/dev/null", O_RDONLY|O_CLOEXEC);
+  int newfd = open(DEV_NULL, O_RDONLY | O_CLOEXEC);
   if (newfd < 0) {
     int err = errno;
     lderr(cct) << __func__ << " failed to open /dev/null: " << cpp_strerror(err)

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -1165,9 +1165,11 @@ struct error_code;
     ssize_t pread_file(const char *fn, uint64_t off, uint64_t len, std::string *error);
     int read_file(const char *fn, std::string *error);
     ssize_t read_fd(int fd, size_t len);
+    ssize_t recv_fd(int fd, size_t len);
     int write_file(const char *fn, int mode=0644);
     int write_fd(int fd) const;
     int write_fd(int fd, uint64_t offset) const;
+    int send_fd(int fd) const;
     template<typename VectorT>
     void prepare_iov(VectorT *piov) const {
 #ifdef __CEPH__

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -214,6 +214,7 @@ int ceph_memzero_s(void *dest, size_t destsz, size_t count);
 #include "include/win32/winsock_compat.h"
 
 #include <windows.h>
+#include <time.h>
 
 #include "include/win32/win32_errno.h"
 

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -200,6 +200,7 @@ extern "C" {
 
 int pipe_cloexec(int pipefd[2], int flags);
 char *ceph_strerror_r(int errnum, char *buf, size_t buflen);
+unsigned get_page_size();
 
 #ifdef __cplusplus
 }
@@ -220,6 +221,10 @@ char *ceph_strerror_r(int errnum, char *buf, size_t buflen);
 
 #define WIN32_ERROR 0
 #undef ERROR
+
+#ifndef uint
+typedef unsigned int uint;
+#endif
 
 typedef _sigset_t sigset_t;
 
@@ -262,6 +267,10 @@ struct iovec {
 #define ENODATA 120
 #endif
 
+#ifndef EDQUOT
+#define EDQUOT ENOSPC
+#endif
+
 #define ESHUTDOWN ECONNABORTED
 #define ESTALE 256
 #define EREMOTEIO 257
@@ -280,6 +289,7 @@ ssize_t pread(int fd, void *buf, size_t count, off_t offset);
 ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
 
 long int lrand48(void);
+int random();
 
 int pipe(int pipefd[2]);
 
@@ -290,8 +300,14 @@ char *strptime(const char *s, const char *format, struct tm *tm);
 int chown(const char *path, uid_t owner, gid_t group);
 int fchown(int fd, uid_t owner, gid_t group);
 int lchown(const char *path, uid_t owner, gid_t group);
+int setenv(const char *name, const char *value, int overwrite);
+#define unsetenv(name) _putenv_s(name, "")
 
 int win_socketpair(int socks[2]);
+
+#ifdef __MINGW32__
+extern _CRTIMP errno_t __cdecl _putenv_s(const char *_Name,const char *_Value);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -203,6 +203,8 @@ int pipe_cloexec(int pipefd[2], int flags);
 char *ceph_strerror_r(int errnum, char *buf, size_t buflen);
 unsigned get_page_size();
 
+int ceph_memzero_s(void *dest, size_t destsz, size_t count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -355,4 +355,11 @@ static inline int ceph_sock_errno() {
 #endif
 }
 
+// Needed on Windows when handling binary files. Without it, line
+// endings will be replaced and certain characters can be treated as
+// EOF.
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
 #endif /* !CEPH_COMPAT_H */

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -15,6 +15,7 @@
 #include "acconfig.h"
 #include <sys/types.h>
 #include <errno.h>
+#include <unistd.h>
 
 #if defined(__linux__)
 #define PROCPREFIX
@@ -212,6 +213,8 @@ unsigned get_page_size();
 
 #include <windows.h>
 
+#include "include/win32/win32_errno.h"
+
 // There are a few name collisions between Windows headers and Ceph.
 // Updating Ceph definitions would be the prefferable fix in order to avoid
 // confussion, unless it requires too many changes, in which case we're going
@@ -262,19 +265,6 @@ struct iovec {
 #define SIGKILL 9
 #endif
 
-#ifndef ENODATA
-// mingw doesn't define this, the Windows SDK does.
-#define ENODATA 120
-#endif
-
-#ifndef EDQUOT
-#define EDQUOT ENOSPC
-#endif
-
-#define ESHUTDOWN ECONNABORTED
-#define ESTALE 256
-#define EREMOTEIO 257
-
 #define IOV_MAX 1024
 
 #ifdef __cplusplus
@@ -313,6 +303,7 @@ extern _CRTIMP errno_t __cdecl _putenv_s(const char *_Name,const char *_Value);
 }
 #endif
 
+#define compat_closesocket closesocket
 // Use "aligned_free" when freeing memory allocated using posix_memalign or
 // _aligned_malloc. Using "free" will crash.
 #define aligned_free(ptr) _aligned_free(ptr)
@@ -328,6 +319,9 @@ extern _CRTIMP errno_t __cdecl _putenv_s(const char *_Name,const char *_Value);
 #define SOCKOPT_VAL_TYPE void*
 
 #define aligned_free(ptr) free(ptr)
+static inline int compat_closesocket(int fildes) {
+  return close(fildes);
+}
 
 #endif /* WIN32 */
 

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -316,6 +316,8 @@ extern _CRTIMP errno_t __cdecl _putenv_s(const char *_Name,const char *_Value);
 #define O_CLOEXEC 0
 #define SOCKOPT_VAL_TYPE char*
 
+#define DEV_NULL "nul"
+
 #else /* WIN32 */
 
 #define SOCKOPT_VAL_TYPE void*
@@ -324,6 +326,8 @@ extern _CRTIMP errno_t __cdecl _putenv_s(const char *_Name,const char *_Value);
 static inline int compat_closesocket(int fildes) {
   return close(fildes);
 }
+
+#define DEV_NULL "/dev/null"
 
 #endif /* WIN32 */
 

--- a/src/include/coredumpctl.h
+++ b/src/include/coredumpctl.h
@@ -49,8 +49,8 @@ public:
 };
 
 #else
-#include <sys/resource.h>
 #ifdef RLIMIT_CORE
+#include <sys/resource.h>
 #include <iostream>
 #include <sys/resource.h>
 #include "common/errno.h"

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -118,7 +118,7 @@ private:
     ::snprintf(fn, sizeof(fn),
 	       ENCODE_STRINGIFY(ENCODE_DUMP_PATH) "/%s__%d.%x", name,
 	       getpid(), i++);
-    int fd = ::open(fn, O_WRONLY|O_TRUNC|O_CREAT|O_CLOEXEC, 0644);
+    int fd = ::open(fn, O_WRONLY|O_TRUNC|O_CREAT|O_CLOEXEC|O_BINARY, 0644);
     if (fd < 0) {
       return;
     }

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -171,7 +171,7 @@ WRITE_FLTTYPE_ENCODER(double, uint64_t, le64)
       break;								\
     char fn[PATH_MAX];							\
     snprintf(fn, sizeof(fn), ENCODE_STRINGIFY(ENCODE_DUMP_PATH) "/%s__%d.%x", #cl, getpid(), i++); \
-    int fd = ::open(fn, O_WRONLY|O_TRUNC|O_CREAT|O_CLOEXEC, 0644);		\
+    int fd = ::open(fn, O_WRONLY|O_TRUNC|O_CREAT|O_CLOEXEC|O_BINARY, 0644);		\
     if (fd >= 0) {							\
       ::ceph::bufferlist sub;						\
       sub.substr_of(bl, pre_off, bl.length() - pre_off);		\

--- a/src/include/random.h
+++ b/src/include/random.h
@@ -20,6 +20,15 @@
 #include <type_traits>
 #include <boost/optional.hpp>
 
+// Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85494
+#ifdef __MINGW32__
+#include <boost/random/random_device.hpp>
+
+using random_device_t = boost::random::random_device;
+#else
+using random_device_t = std::random_device;
+#endif
+
 // Basic random number facility (see N3551 for inspiration):
 namespace ceph::util {
 
@@ -91,7 +100,7 @@ void randomize_rng(const SeedT seed, MutexT& m, EngineT& e)
 template <typename MutexT, typename EngineT>
 void randomize_rng(MutexT& m, EngineT& e)
 {
-  std::random_device rd;
+  random_device_t rd;
  
   std::lock_guard<MutexT> lg(m);
   e.seed(rd());
@@ -107,7 +116,7 @@ void randomize_rng(const SeedT n)
 template <typename EngineT = std::default_random_engine>
 void randomize_rng()
 {
-  std::random_device rd;
+  random_device_t rd;
   detail::engine<EngineT>().seed(rd());
 }
 
@@ -232,7 +241,7 @@ template <typename NumberT>
 class random_number_generator final
 {
   std::mutex l;
-  std::random_device rd;
+  random_device_t rd;
   std::default_random_engine e;
 
   using seed_type = typename decltype(e)::result_type;

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -524,9 +524,12 @@ WRITE_EQ_OPERATORS_1(shard_id_t, id)
 WRITE_CMP_OPERATORS_1(shard_id_t, id)
 std::ostream &operator<<(std::ostream &lhs, const shard_id_t &rhs);
 
-#if defined(__sun) || defined(_AIX) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__sun) || defined(_AIX) || defined(__APPLE__) || \
+    defined(__FreeBSD__) || defined(_WIN32)
+extern "C" {
 __s32  ceph_to_hostos_errno(__s32 e);
 __s32  hostos_to_ceph_errno(__s32 e);
+}
 #else
 #define  ceph_to_hostos_errno(e) (e)
 #define  hostos_to_ceph_errno(e) (e)

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -79,6 +79,11 @@ int get_cgroup_memory_limit(uint64_t *limit);
 /// collect info from @p uname(2), @p /proc/meminfo and @p /proc/cpuinfo
 void collect_sys_info(std::map<std::string, std::string> *m, CephContext *cct);
 
+#ifdef _WIN32
+/// Retrieve the actual Windows version, regardless of the app manifest.
+int get_windows_version(POSVERSIONINFOEXW ver);
+#endif
+
 /// dump service ids grouped by their host to the specified formatter
 /// @param f formatter for the output
 /// @param services a map from hostname to a list of service id hosted by this host

--- a/src/include/uuid.h
+++ b/src/include/uuid.h
@@ -7,6 +7,7 @@
  */
 
 #include "encoding.h"
+#include "random.h"
 
 #include <ostream>
 #include <random>
@@ -32,7 +33,7 @@ struct uuid_d {
   }
 
   void generate_random() {
-    std::random_device rng;
+    random_device_t rng;
     boost::uuids::basic_random_generator gen(rng);
     uuid = gen();
   }

--- a/src/librbd/Utils.cc
+++ b/src/librbd/Utils.cc
@@ -5,6 +5,7 @@
 #include <boost/lexical_cast.hpp>
 
 #include "librbd/Utils.h"
+#include "include/random.h"
 #include "include/rbd_types.h"
 #include "include/stringify.h"
 #include "include/neorados/RADOS.hpp"
@@ -55,7 +56,7 @@ std::string generate_image_id(librados::IoCtx &ioctx) {
   librados::Rados rados(ioctx);
 
   uint64_t bid = rados.get_instance_id();
-  std::mt19937 generator{std::random_device{}()};
+  std::mt19937 generator{random_device_t{}()};
   std::uniform_int_distribution<uint32_t> distribution{0, 0xFFFFFFFF};
   uint32_t extra = distribution(generator);
 

--- a/src/librbd/crypto/openssl/DataCryptor.cc
+++ b/src/librbd/crypto/openssl/DataCryptor.cc
@@ -5,6 +5,7 @@
 #include <openssl/err.h>
 #include <string.h>
 #include "include/ceph_assert.h"
+#include "include/compat.h"
 
 namespace librbd {
 namespace crypto {
@@ -46,7 +47,8 @@ int DataCryptor::init(const char* cipher_name, const unsigned char* key,
 
 DataCryptor::~DataCryptor() {
   if (m_key != nullptr) {
-    explicit_bzero(m_key, EVP_CIPHER_key_length(m_cipher));
+    ceph_memzero_s(m_key, EVP_CIPHER_key_length(m_cipher),
+                   EVP_CIPHER_key_length(m_cipher));
     delete m_key;
     m_key = nullptr;
   }

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -375,7 +375,7 @@ void Log::dump_recent()
   {
     char pthread_name[16] = {0}; //limited by 16B include terminating null byte.
     ceph_pthread_getname(pthread_id, pthread_name, sizeof(pthread_name));
-    snprintf(buf, sizeof(buf), "  %lx / %s", pthread_id, pthread_name);
+    snprintf(buf, sizeof(buf), "  %llx / %s", pthread_id, pthread_name);
     _log_message(buf, true);
   }
 

--- a/src/log/LogClock.h
+++ b/src/log/LogClock.h
@@ -112,9 +112,15 @@ public:
   static timeval to_timeval(time_point t) {
     auto rep = t.time_since_epoch().count();
     timespan ts(rep.count);
+    #ifndef _WIN32
     return { static_cast<time_t>(std::chrono::duration_cast<std::chrono::seconds>(ts).count()),
              static_cast<suseconds_t>(std::chrono::duration_cast<std::chrono::microseconds>(
                ts % std::chrono::seconds(1)).count()) };
+    #else
+    return { static_cast<long>(std::chrono::duration_cast<std::chrono::seconds>(ts).count()),
+             static_cast<long>(std::chrono::duration_cast<std::chrono::microseconds>(
+               ts % std::chrono::seconds(1)).count()) };
+    #endif
   }
 private:
   static time_point coarse_now() {

--- a/src/log/LogClock.h
+++ b/src/log/LogClock.h
@@ -134,7 +134,8 @@ inline int append_time(const log_time& t, char *out, int outlen) {
   bool coarse = t.time_since_epoch().count().coarse;
   auto tv = log_clock::to_timeval(t);
   std::tm bdt;
-  localtime_r((time_t*)&tv.tv_sec, &bdt);
+  time_t t_sec = tv.tv_sec;
+  localtime_r(&t_sec, &bdt);
   char tz[32] = { 0 };
   strftime(tz, sizeof(tz), "%z", &bdt);
 

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -21,6 +21,7 @@
 #include <boost/range/algorithm_ext/copy_n.hpp>
 #include "common/weighted_shuffle.h"
 
+#include "include/random.h"
 #include "include/scope_guard.h"
 #include "include/stringify.h"
 
@@ -792,7 +793,7 @@ void MonClient::_add_conns(uint64_t global_id)
       auto rank_name = monmap.get_name(i);
       weights.push_back(monmap.get_weight(rank_name));
     }
-    std::random_device rd;
+    random_device_t rd;
     if (std::accumulate(begin(weights), end(weights), 0u) == 0) {
       std::shuffle(begin(ranks), end(ranks), std::mt19937{rd()});
     } else {

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -283,7 +283,7 @@ void Message::encode(uint64_t features, int crcflags, bool skip_header_crc)
       snprintf(fn, sizeof(fn), ENCODE_STRINGIFY(ENCODE_DUMP) "/%s__%d.%x",
 	       abi::__cxa_demangle(typeid(*this).name(), 0, 0, &status),
 	       getpid(), i++);
-      int fd = ::open(fn, O_WRONLY|O_TRUNC|O_CREAT|O_CLOEXEC, 0644);
+      int fd = ::open(fn, O_WRONLY|O_TRUNC|O_CREAT|O_CLOEXEC|O_BINARY, 0644);
       if (fd >= 0) {
 	bl.write_fd(fd);
 	::close(fd);

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -189,9 +189,9 @@ EventCenter::~EventCenter()
   //assert(time_events.empty());
 
   if (notify_receive_fd >= 0)
-    ::close(notify_receive_fd);
+    compat_closesocket(notify_receive_fd);
   if (notify_send_fd >= 0)
-    ::close(notify_send_fd);
+    compat_closesocket(notify_send_fd);
 
   delete driver;
   if (notify_handler)

--- a/src/msg/async/EventSelect.cc
+++ b/src/msg/async/EventSelect.cc
@@ -26,8 +26,10 @@
 
 int SelectDriver::init(EventCenter *c, int nevent)
 {
+  #ifndef _WIN32
   ldout(cct, 0) << "Select isn't suitable for production env, just avoid "
                 << "compiling error or special purpose" << dendl;
+  #endif
   FD_ZERO(&rfds);
   FD_ZERO(&wfds);
   max_fd = 0;

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -204,7 +204,7 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
     ::shutdown(_fd, SHUT_RDWR);
   }
   void close() override {
-    ::close(_fd);
+    compat_closesocket(_fd);
   }
   int fd() const override {
     return _fd;

--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -53,7 +53,7 @@ int NetHandler::create_socket(int domain, bool reuse_addr)
       r = ceph_sock_errno();
       lderr(cct) << __func__ << " setsockopt SO_REUSEADDR failed: "
                  << strerror(r) << dendl;
-      close(s);
+      compat_closesocket(s);
       return -r;
     }
   }
@@ -178,7 +178,7 @@ int NetHandler::generic_connect(const entity_addr_t& addr, const entity_addr_t &
   if (nonblock) {
     ret = set_nonblock(s);
     if (ret < 0) {
-      close(s);
+      compat_closesocket(s);
       return ret;
     }
   }
@@ -193,7 +193,7 @@ int NetHandler::generic_connect(const entity_addr_t& addr, const entity_addr_t &
       if (ret < 0) {
         ret = ceph_sock_errno();
         ldout(cct, 2) << __func__ << " client bind error " << ", " << cpp_strerror(ret) << dendl;
-        close(s);
+        compat_closesocket(s);
         return -ret;
       }
     }
@@ -207,7 +207,7 @@ int NetHandler::generic_connect(const entity_addr_t& addr, const entity_addr_t &
       return s;
 
     ldout(cct, 10) << __func__ << " connect: " << cpp_strerror(ret) << dendl;
-    close(s);
+    compat_closesocket(s);
     return -ret;
   }
 

--- a/src/rbd_replay/Replayer.cc
+++ b/src/rbd_replay/Replayer.cc
@@ -214,7 +214,7 @@ void Replayer::run(const std::string& replay_file) {
       m_rbd = new librbd::RBD();
       map<thread_id_t, Worker*> workers;
 
-      int fd = open(replay_file.c_str(), O_RDONLY);
+      int fd = open(replay_file.c_str(), O_RDONLY|O_BINARY);
       if (fd < 0) {
         std::cerr << "Failed to open " << replay_file << ": "
                   << cpp_strerror(errno) << std::endl;

--- a/src/rbd_replay/rbd-replay-prep.cc
+++ b/src/rbd_replay/rbd-replay-prep.cc
@@ -15,6 +15,7 @@
 // This code assumes that IO IDs and timestamps are related monotonically.
 // In other words, (a.id < b.id) == (a.timestamp < b.timestamp) for all IOs a and b.
 
+#include "include/compat.h"
 #include "common/errno.h"
 #include "rbd_replay/ActionTypes.h"
 #include <babeltrace/babeltrace.h>
@@ -198,7 +199,7 @@ public:
 
     struct bt_iter *bt_itr = bt_ctf_get_iter(itr);
 
-    int fd = open(output_file_name.c_str(), O_WRONLY | O_CREAT | O_EXCL, 0644);
+    int fd = open(output_file_name.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_BINARY, 0644);
     ASSERT_EXIT(fd >= 0, "Error opening output file " << output_file_name <<
                          ": " << cpp_strerror(errno));
     BOOST_SCOPE_EXIT( (fd) ) {

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -134,6 +134,7 @@ add_executable(unittest_random
   test_random.cc
   )
 add_ceph_unittest(unittest_random)
+target_link_libraries(unittest_random Boost::random)
 
 # unittest_throttle
 add_executable(unittest_throttle

--- a/src/tools/ceph-dencoder/ceph_dencoder.cc
+++ b/src/tools/ceph-dencoder/ceph_dencoder.cc
@@ -185,7 +185,7 @@ int main(int argc, const char **argv)
 	cerr << "expecting filename" << std::endl;
 	exit(1);
       }
-      int fd = ::open(*i, O_WRONLY|O_CREAT|O_TRUNC, 0644);
+      int fd = ::open(*i, O_WRONLY|O_CREAT|O_TRUNC|O_BINARY, 0644);
       if (fd < 0) {
 	cerr << "error opening " << *i << " for write: " << cpp_strerror(errno) << std::endl;
 	exit(1);

--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -43,7 +43,7 @@ class TraceIter {
   MonitorDBStore::TransactionRef t;
 public:
   explicit TraceIter(string fname) : fd(-1), idx(-1) {
-    fd = ::open(fname.c_str(), O_RDONLY);
+    fd = ::open(fname.c_str(), O_RDONLY|O_BINARY);
     t.reset(new MonitorDBStore::Transaction);
   }
   bool valid() {
@@ -879,7 +879,7 @@ int main(int argc, char **argv) {
 
     int fd = STDOUT_FILENO;
     if (!outpath.empty()){
-      fd = ::open(outpath.c_str(), O_WRONLY|O_CREAT|O_TRUNC, 0666);
+      fd = ::open(outpath.c_str(), O_WRONLY|O_CREAT|O_TRUNC|O_BINARY, 0666);
       if (fd < 0) {
         std::cerr << "error opening output file: "
           << cpp_strerror(errno) << std::endl;

--- a/src/tools/cephfs/Dumper.cc
+++ b/src/tools/cephfs/Dumper.cc
@@ -104,7 +104,7 @@ int Dumper::dump(const char *dump_file)
 
   cout << "journal is " << start << "~" << len << std::endl;
 
-  int fd = ::open(dump_file, O_WRONLY|O_CREAT|O_TRUNC, 0644);
+  int fd = ::open(dump_file, O_WRONLY|O_CREAT|O_TRUNC|O_BINARY, 0644);
   if (fd >= 0) {
     // include an informative header
     uuid_d fsid = monc->get_fsid();
@@ -213,7 +213,7 @@ int Dumper::undump(const char *dump_file, bool force)
     derr << "recover_journal failed, try to get header from dump file " << dendl;
   }
 
-  int fd = ::open(dump_file, O_RDONLY);
+  int fd = ::open(dump_file, O_RDONLY|O_BINARY);
   if (fd < 0) {
     r = errno;
     derr << "couldn't open " << dump_file << ": " << cpp_strerror(r) << dendl;

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -18,6 +18,7 @@
 #include "common/ceph_argparse.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
+#include "include/random.h"
 #include "mon/health_check.h"
 #include <time.h>
 #include <algorithm>
@@ -423,7 +424,7 @@ int main(int argc, const char **argv)
     int r = clock_gettime(CLOCK_MONOTONIC, &round_start);
     assert(r == 0);
     do {
-      std::random_device rd;
+      random_device_t rd;
       std::shuffle(pools.begin(), pools.end(), std::mt19937{rd()});
       cout << "pools ";
       for (auto& i: pools)

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -445,7 +445,7 @@ static int dump_data(std::string const &filename, bufferlist const &data)
   if (filename == "-") {
     fd = STDOUT_FILENO;
   } else {
-    fd = TEMP_FAILURE_RETRY(::open(filename.c_str(), O_WRONLY|O_CREAT|O_TRUNC, 0644));
+    fd = TEMP_FAILURE_RETRY(::open(filename.c_str(), O_WRONLY|O_CREAT|O_TRUNC|O_BINARY, 0644));
     if (fd < 0) {
       int err = errno;
       cerr << "failed to open file: " << cpp_strerror(err) << std::endl;
@@ -471,7 +471,7 @@ static int do_get(IoCtx& io_ctx, const char *objname, const char *outfile, unsig
   if (strcmp(outfile, "-") == 0) {
     fd = STDOUT_FILENO;
   } else {
-    fd = TEMP_FAILURE_RETRY(::open(outfile, O_WRONLY|O_CREAT|O_TRUNC, 0644));
+    fd = TEMP_FAILURE_RETRY(::open(outfile, O_WRONLY|O_CREAT|O_TRUNC|O_BINARY, 0644));
     if (fd < 0) {
       int err = errno;
       cerr << "failed to open file: " << cpp_strerror(err) << std::endl;
@@ -568,7 +568,7 @@ static int do_put(IoCtx& io_ctx,
   int ret = 0;
   int fd = STDIN_FILENO;
   if (!stdio)
-    fd = open(infile, O_RDONLY);
+    fd = open(infile, O_RDONLY|O_BINARY);
   if (fd < 0) {
     cerr << "error reading input file " << infile << ": " << cpp_strerror(errno) << std::endl;
     return 1;
@@ -629,7 +629,7 @@ static int do_append(IoCtx& io_ctx,
   int ret = 0;
   int fd = STDIN_FILENO;
   if (!stdio)
-    fd = open(infile, O_RDONLY);
+    fd = open(infile, O_RDONLY|O_BINARY);
   if (fd < 0) {
     cerr << "error reading input file " << infile << ": " << cpp_strerror(errno) << std::endl;
     return 1;
@@ -3855,7 +3855,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     if (nargs.size() < 2 || std::string(nargs[1]) == "-") {
       file_fd = STDOUT_FILENO;
     } else {
-      file_fd = open(nargs[1], O_WRONLY|O_CREAT|O_TRUNC, 0666);
+      file_fd = open(nargs[1], O_WRONLY|O_CREAT|O_TRUNC|O_BINARY, 0666);
       if (file_fd < 0) {
         cerr << "Error opening '" << nargs[1] << "': "
           << cpp_strerror(file_fd) << std::endl;
@@ -3904,7 +3904,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     if (filename == "-") {
       file_fd = STDIN_FILENO;
     } else {
-      file_fd = open(filename.c_str(), O_RDONLY);
+      file_fd = open(filename.c_str(), O_RDONLY|O_BINARY);
       if (file_fd < 0) {
         cerr << "Error opening '" << filename << "': "
           << cpp_strerror(file_fd) << std::endl;

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -960,7 +960,7 @@ std::string timestr(time_t t) {
   localtime_r(&t, &tm);
 
   char buf[32];
-  strftime(buf, sizeof(buf), "%F %T", &tm);
+  strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &tm);
 
   return buf;
 }

--- a/src/tools/rbd/action/Export.cc
+++ b/src/tools/rbd/action/Export.cc
@@ -229,7 +229,7 @@ int do_export_diff(librbd::Image& image, const char *fromsnapname,
   if (strcmp(path, "-") == 0)
     fd = STDOUT_FILENO;
   else
-    fd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0644);
+    fd = open(path, O_WRONLY | O_CREAT | O_EXCL | O_BINARY, 0644);
   if (fd < 0)
     return -errno;
 
@@ -565,7 +565,7 @@ static int do_export(librbd::Image& image, const char *path, bool no_progress,
   if (to_stdout) {
     fd = STDOUT_FILENO;
   } else {
-    fd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0644);
+    fd = open(path, O_WRONLY | O_CREAT | O_EXCL | O_BINARY, 0644);
     if (fd < 0) {
       return -errno;
     }

--- a/src/tools/rbd/action/Import.cc
+++ b/src/tools/rbd/action/Import.cc
@@ -449,7 +449,7 @@ int do_import_diff(librados::Rados &rados, librbd::Image &image,
   if (strcmp(path, "-") == 0) {
     fd = STDIN_FILENO;
   } else {
-    fd = open(path, O_RDONLY);
+    fd = open(path, O_RDONLY|O_BINARY);
     if (fd < 0) {
       r = -errno;
       std::cerr << "rbd: error opening " << path << std::endl;
@@ -843,7 +843,7 @@ static int do_import(librados::Rados &rados, librbd::RBD &rbd,
     fd = STDIN_FILENO;
     size = 1ULL << order;
   } else {
-    if ((fd = open(path, O_RDONLY)) < 0) {
+    if ((fd = open(path, O_RDONLY|O_BINARY)) < 0) {
       r = -errno;
       std::cerr << "rbd: error opening " << path << std::endl;
       goto done2;

--- a/src/tools/rbd/action/Journal.cc
+++ b/src/tools/rbd/action/Journal.cc
@@ -709,7 +709,7 @@ static int do_export_journal(librados::IoCtx& io_ctx,
   if (to_stdout) {
     fd = STDOUT_FILENO;
   } else {
-    fd = open(path.c_str(), O_WRONLY | O_CREAT | O_EXCL, 0644);
+    fd = open(path.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_BINARY, 0644);
     if (fd < 0) {
       r = -errno;
       std::cerr << "rbd: error creating " << path << std::endl;
@@ -920,7 +920,7 @@ static int do_import_journal(librados::IoCtx& io_ctx,
   if (from_stdin) {
     fd = STDIN_FILENO;
   } else {
-    if ((fd = open(path.c_str(), O_RDONLY)) < 0) {
+    if ((fd = open(path.c_str(), O_RDONLY|O_BINARY)) < 0) {
       r = -errno;
       std::cerr << "rbd: error opening " << path << std::endl;
       return r;

--- a/src/tools/rbd/action/MergeDiff.cc
+++ b/src/tools/rbd/action/MergeDiff.cc
@@ -173,7 +173,7 @@ static int do_merge_diff(const char *first, const char *second,
   if (first_stdin) {
     fd = STDIN_FILENO;
   } else {
-    fd = open(first, O_RDONLY);
+    fd = open(first, O_RDONLY|O_BINARY);
     if (fd < 0) {
       r = -errno;
       std::cerr << "rbd: error opening " << first << std::endl;
@@ -181,7 +181,7 @@ static int do_merge_diff(const char *first, const char *second,
     }
   }
 
-  sd = open(second, O_RDONLY);
+  sd = open(second, O_RDONLY|O_BINARY);
   if (sd < 0) {
     r = -errno;
     std::cerr << "rbd: error opening " << second << std::endl;
@@ -191,7 +191,7 @@ static int do_merge_diff(const char *first, const char *second,
   if (strcmp(path, "-") == 0) {
     pd = 1;
   } else {
-    pd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0644);
+    pd = open(path, O_WRONLY | O_CREAT | O_EXCL | O_BINARY, 0644);
     if (pd < 0) {
       r = -errno;
       std::cerr << "rbd: error create " << path << std::endl;

--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -911,7 +911,7 @@ int execute_peer_bootstrap_import(
 
   int fd = STDIN_FILENO;
   if (token_path != "-") {
-    fd = open(token_path.c_str(), O_RDONLY);
+    fd = open(token_path.c_str(), O_RDONLY|O_BINARY);
     if (fd < 0) {
       r = -errno;
       std::cerr << "rbd: error opening " << token_path << std::endl;


### PR DESCRIPTION
Windows support [part 8]

This PR series intends to set the ground for the upcoming Windows port effort.
For now, we're mostly interested in the client side, allowing Windows hosts
to consume rados, rbd and cephfs resources.

Those PRs should be reviewed and merged in order. Each PR depends on the previous one from the series (in fact it includes the previous commits as well).

~~Part 1: #31981~~
~~Part 2: #32704~~
~~Part 3: #32705~~
~~Part 4: #32707~~
~~Part 5: #32780~~
~~Part 6: #32779~~
~~Part 7: #32778~~ 
**Part 8: #32777**
Part 9: #32776
Part 10: #33750
Part 11: #34858
Part 12: #34859

Related but independent PRs:
https://github.com/ceph/ceph/pull/32027
~~https://github.com/ceph/fmt/pull/2~~
~~https://github.com/ceph/rocksdb/pull/42~~

For more details about the build process and current status, please check the
README.windows.rst file. Worth mentioning that the resulted binaries can
connect to ceph clusters and consume pools: http://paste.openstack.org/raw/787534/

Here are some test results as well:
[test_results.zip](https://github.com/ceph/ceph/files/4077517/test_results.zip)

Any feedback is highly appreciated.

Signed-off-by: Lucian Petrut lpetrut@cloudbasesolutions.com
Signed-off-by: Alin Gabriel Serdean aserdean@cloudbasesolutions.com
