### PR TITLE
Windows support [part 7]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,10 @@ if(WIN32)
   include_directories(
     ${PROJECT_SOURCE_DIR}/src/include/win32)
   # Boost complains if winsock2.h (or windows.h) is included before asio.hpp.
-  add_compile_options(-include winsock_wrapper.h)
+  add_definitions(-include winsock_wrapper.h)
+  # Boost is also defining some of the errno values, we'll have
+  # to avoid mismatches.
+  add_definitions(-include win32_errno.h)
 endif()
 
 if(FREEBSD)

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -126,7 +126,11 @@ AdminSocket::~AdminSocket()
 std::string AdminSocket::create_wakeup_pipe(int *pipe_rd, int *pipe_wr)
 {
   int pipefd[2];
+  #ifdef _WIN32
+  if (win_socketpair(pipefd) < 0) {
+  #else
   if (pipe_cloexec(pipefd, O_NONBLOCK) < 0) {
+  #endif
     int e = errno;
     ostringstream oss;
     oss << "AdminSocket::create_wakeup_pipe error: " << cpp_strerror(e);
@@ -142,7 +146,11 @@ std::string AdminSocket::destroy_wakeup_pipe()
 {
   // Send a byte to the wakeup pipe that the thread is listening to
   char buf[1] = { 0x0 };
+  #ifdef _WIN32
+  int ret = send(m_wakeup_wr_fd, buf, sizeof(buf), 0) != 1;
+  #else
   int ret = safe_write(m_wakeup_wr_fd, buf, sizeof(buf));
+  #endif
 
   // Close write end
   retry_sys_call(::close, m_wakeup_wr_fd);
@@ -764,6 +772,10 @@ void AdminSocket::wakeup()
 {
   // Send a byte to the wakeup pipe that the thread is listening to
   char buf[1] = { 0x0 };
+  #ifdef _WIN32
+  int r = send(m_wakeup_wr_fd, buf, sizeof(buf), 0);
+  #else
   int r = safe_write(m_wakeup_wr_fd, buf, sizeof(buf));
+  #endif
   (void)r;
 }

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -124,7 +124,7 @@ static ceph::spinlock debug_lock;
 
     static void operator delete(void *ptr) {
       raw_combined *raw = (raw_combined *)ptr;
-      ::free((void *)raw->data);
+      aligned_free((void *)raw->data);
     }
   };
 
@@ -176,7 +176,7 @@ static ceph::spinlock debug_lock;
 	    << " l=" << l << ", align=" << align << bendl;
     }
     ~raw_posix_aligned() override {
-      ::free(data);
+      aligned_free(data);
       bdout << "raw_posix_aligned " << this << " free " << (void *)data << bendl;
     }
     raw* clone_empty() override {

--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -30,6 +30,12 @@
 int clock_gettime(int clk_id, struct timespec *tp);
 #endif
 
+#ifdef _WIN32
+#define CLOCK_REALTIME_COARSE CLOCK_REALTIME
+#define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
+// MINGW uses the QueryPerformanceCounter API behind the scenes.
+#endif
+
 struct ceph_timespec;
 
 namespace ceph {

--- a/src/common/win32_errno.c
+++ b/src/common/win32_errno.c
@@ -1,0 +1,326 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+
+#include "include/int_types.h"
+#include "include/compat.h"
+
+// We're only converting errors defined in errno.h, not standard Windows
+// system error codes that are usually retrievied using GetLastErrorCode().
+// TODO: consider converting WinSock2 (WSA*) error codes, which are quite
+// similar to the errno.h ones.
+
+__u32 ceph_to_hostos_errno_unsigned(__u32 r)
+{
+  // using an array like like freebsd_errno.cc might be more readable but
+  // we have some large values defined by Boost.
+  switch(r) {
+    case 1: return EPERM;
+    case 2: return ENOENT;
+    case 3: return ESRCH;
+    case 4: return EINTR;
+    case 5: return EIO;
+    case 6: return ENXIO;
+    case 7: return E2BIG;
+    case 8: return ENOEXEC;
+    case 9: return EBADF;
+    case 10: return ECHILD;
+    // same as EWOULDBLOCK
+    case 11: return EAGAIN;
+    case 12: return ENOMEM;
+    case 13: return EACCES;
+    case 14: return EFAULT;
+    case 15: return ENOTBLK;
+    case 16: return EBUSY;
+    case 17: return EEXIST;
+    case 18: return EXDEV;
+    case 19: return ENODEV;
+    case 20: return ENOTDIR;
+    case 21: return EISDIR;
+    case 22: return EINVAL;
+    case 23: return ENFILE;
+    case 24: return EMFILE;
+    case 25: return ENOTTY;
+    case 26: return ETXTBSY;
+    case 27: return EFBIG;
+    case 28: return ENOSPC;
+    case 29: return ESPIPE;
+    case 30: return EROFS;
+    case 31: return EMLINK;
+    case 32: return EPIPE;
+    case 33: return EDOM;
+    case 34: return ERANGE;
+    // same as EDEADLK
+    case 35: return EDEADLOCK;
+    case 36: return ENAMETOOLONG;
+    case 37: return ENOLCK;
+    case 38: return ENOSYS;
+    case 39: return ENOTEMPTY;
+    case 40: return ELOOP;
+    case 42: return ENOMSG;
+    case 43: return EIDRM;
+    case 44: return ECHRNG;
+    case 45: return EL2NSYNC;
+    case 46: return EL3HLT;
+    case 47: return EL3RST;
+    case 48: return ELNRNG;
+    case 49: return EUNATCH;
+    case 50: return ENOCSI;
+    case 51: return EL2HLT;
+    case 52: return EBADE;
+    case 53: return EBADR;
+    case 54: return EXFULL;
+    case 55: return ENOANO;
+    case 56: return EBADRQC;
+    case 57: return EBADSLT;
+    case 59: return EBFONT;
+    case 60: return ENOSTR;
+    case 61: return ENODATA;
+    case 62: return ETIME;
+    case 63: return ENOSR;
+    case 64: return ENONET;
+    case 65: return ENOPKG;
+    case 66: return EREMOTE;
+    case 67: return ENOLINK;
+    case 68: return EADV;
+    case 69: return ESRMNT;
+    case 70: return ECOMM;
+    case 71: return EPROTO;
+    case 72: return EMULTIHOP;
+    case 73: return EDOTDOT;
+    case 74: return EBADMSG;
+    case 75: return EOVERFLOW;
+    case 76: return ENOTUNIQ;
+    case 77: return EBADFD;
+    case 78: return EREMCHG;
+    case 79: return ELIBACC;
+    case 80: return ELIBBAD;
+    case 81: return ELIBSCN;
+    case 82: return ELIBMAX;
+    case 83: return ELIBEXEC;
+    case 84: return EILSEQ;
+    case 85: return ERESTART;
+    case 86: return ESTRPIPE;
+    case 87: return EUSERS;
+    case 88: return ENOTSOCK;
+    case 89: return EDESTADDRREQ;
+    case 90: return EMSGSIZE;
+    case 91: return EPROTOTYPE;
+    case 92: return ENOPROTOOPT;
+    case 93: return EPROTONOSUPPORT;
+    case 94: return ESOCKTNOSUPPORT;
+    // same as ENOTSUP
+    case 95: return EOPNOTSUPP;
+    case 96: return EPFNOSUPPORT;
+    case 97: return EAFNOSUPPORT;
+    case 98: return EADDRINUSE;
+    case 99: return EADDRNOTAVAIL;
+    case 100: return ENETDOWN;
+    case 101: return ENETUNREACH;
+    case 102: return ENETRESET;
+    case 103: return ECONNABORTED;
+    case 104: return ECONNRESET;
+    case 105: return ENOBUFS;
+    case 106: return EISCONN;
+    case 107: return ENOTCONN;
+    case 108: return ESHUTDOWN;
+    case 109: return ETOOMANYREFS;
+    case 110: return ETIMEDOUT;
+    case 111: return ECONNREFUSED;
+    case 112: return EHOSTDOWN;
+    case 113: return EHOSTUNREACH;
+    case 114: return EALREADY;
+    case 115: return EINPROGRESS;
+    case 116: return ESTALE;
+    case 117: return EUCLEAN;
+    case 118: return ENOTNAM;
+    case 119: return ENAVAIL;
+    case 120: return EISNAM;
+    case 121: return EREMOTEIO;
+    case 122: return EDQUOT;
+    case 123: return ENOMEDIUM;
+    case 124: return EMEDIUMTYPE;
+    case 125: return ECANCELED;
+    case 126: return ENOKEY;
+    case 127: return EKEYEXPIRED;
+    case 128: return EKEYREVOKED;
+    case 129: return EKEYREJECTED;
+    case 130: return EOWNERDEAD;
+    case 131: return ENOTRECOVERABLE;
+    case 132: return ERFKILL;
+    case 133: return EHWPOISON;
+    default:
+      return r;
+  }
+}
+
+__u32 hostos_to_ceph_errno_unsigned(__u32 r) {
+  // Windows errno -> Linux errno
+  switch(r) {
+    case EPERM: return 1;
+    case ENOENT: return 2;
+    case ESRCH: return 3;
+    case EINTR: return 4;
+    case EIO: return 5;
+    case ENXIO: return 6;
+    case E2BIG: return 7;
+    case ENOEXEC: return 8;
+    case EBADF: return 9;
+    case ECHILD: return 10;
+    case EAGAIN: return 11;
+    case EWOULDBLOCK: return 11;
+    case ENOMEM: return 12;
+    case EACCES: return 13;
+    case EFAULT: return 14;
+    case ENOTBLK: return 15;
+    case EBUSY: return 16;
+    case EEXIST: return 17;
+    case EXDEV: return 18;
+    case ENODEV: return 19;
+    case ENOTDIR: return 20;
+    case EISDIR: return 21;
+    case EINVAL: return 22;
+    case ENFILE: return 23;
+    case EMFILE: return 24;
+    case ENOTTY: return 25;
+    case ETXTBSY: return 26;
+    case EFBIG: return 27;
+    case ENOSPC: return 28;
+    case ESPIPE: return 29;
+    case EROFS: return 30;
+    case EMLINK: return 31;
+    case EPIPE: return 32;
+    case EDOM: return 33;
+    case ERANGE: return 34;
+    // same as EDEADLOCK
+    // case EDEADLK: return 35;
+    case EDEADLOCK: return 35;
+    case ENAMETOOLONG: return 36;
+    case ENOLCK: return 37;
+    case ENOSYS: return 38;
+    case ENOTEMPTY: return 39;
+    case ELOOP: return 40;
+    case ENOMSG: return 42;
+    case EIDRM: return 43;
+    case ECHRNG: return 44;
+    case EL2NSYNC: return 45;
+    case EL3HLT: return 46;
+    case EL3RST: return 47;
+    case ELNRNG: return 48;
+    case EUNATCH: return 49;
+    case ENOCSI: return 50;
+    case EL2HLT: return 51;
+    case EBADE: return 52;
+    case EBADR: return 53;
+    case EXFULL: return 54;
+    case ENOANO: return 55;
+    case EBADRQC: return 56;
+    case EBADSLT: return 57;
+    case EBFONT: return 59;
+    case ENOSTR: return 60;
+    case ENODATA: return 61;
+    case ETIME: return 62;
+    case ENOSR: return 63;
+    case ENONET: return 64;
+    case ENOPKG: return 65;
+    case EREMOTE: return 66;
+    case ENOLINK: return 67;
+    case EADV: return 68;
+    case ESRMNT: return 69;
+    case ECOMM: return 70;
+    case EPROTO: return 71;
+    case EMULTIHOP: return 72;
+    case EDOTDOT: return 73;
+    case EBADMSG: return 74;
+    case EOVERFLOW: return 75;
+    case ENOTUNIQ: return 76;
+    case EBADFD: return 77;
+    case EREMCHG: return 78;
+    case ELIBACC: return 79;
+    case ELIBBAD: return 80;
+    case ELIBSCN: return 81;
+    case ELIBMAX: return 82;
+    case ELIBEXEC: return 83;
+    case EILSEQ: return 84;
+    // compat.h defines ERESTART as EINTR
+    // case ERESTART: return 85;
+    case ESTRPIPE: return 86;
+    case EUSERS: return 87;
+    case ENOTSOCK: return 88;
+    case EDESTADDRREQ: return 89;
+    case EMSGSIZE: return 90;
+    case EPROTOTYPE: return 91;
+    case ENOPROTOOPT: return 92;
+    case EPROTONOSUPPORT: return 93;
+    case ESOCKTNOSUPPORT: return 94;
+    case EOPNOTSUPP: return 95;
+    case ENOTSUP: return 95;
+    case EPFNOSUPPORT: return 96;
+    case EAFNOSUPPORT: return 97;
+    case EADDRINUSE: return 98;
+    case EADDRNOTAVAIL: return 99;
+    case ENETDOWN: return 100;
+    case ENETUNREACH: return 101;
+    case ENETRESET: return 102;
+    case ECONNABORTED: return 103;
+    case ECONNRESET: return 104;
+    case ENOBUFS: return 105;
+    case EISCONN: return 106;
+    case ENOTCONN: return 107;
+    case ESHUTDOWN: return 108;
+    case ETOOMANYREFS: return 109;
+    case ETIMEDOUT: return 110;
+    case ECONNREFUSED: return 111;
+    case EHOSTDOWN: return 112;
+    case EHOSTUNREACH: return 113;
+    case EALREADY: return 114;
+    case EINPROGRESS: return 115;
+    case ESTALE: return 116;
+    case EUCLEAN: return 117;
+    case ENOTNAM: return 118;
+    case ENAVAIL: return 119;
+    case EISNAM: return 120;
+    case EREMOTEIO: return 121;
+    case EDQUOT: return 122;
+    case ENOMEDIUM: return 123;
+    case EMEDIUMTYPE: return 124;
+    case ECANCELED: return 125;
+    case ENOKEY: return 126;
+    case EKEYEXPIRED: return 127;
+    case EKEYREVOKED: return 128;
+    case EKEYREJECTED: return 129;
+    case EOWNERDEAD: return 130;
+    case ENOTRECOVERABLE: return 131;
+    case ERFKILL: return 132;
+    case EHWPOISON: return 133;
+    default:
+      return r;
+ }
+}
+
+// converts from linux errno values to host values
+__s32 ceph_to_hostos_errno(__s32 r)
+{
+  int sign = (r < 0 ? -1 : 1);
+  return ceph_to_hostos_errno_unsigned(abs(r)) * sign;
+}
+
+// converts Host OS errno values to linux/Ceph values
+__s32 hostos_to_ceph_errno(__s32 r)
+{
+  int sign = (r < 0 ? -1 : 1);
+  return hostos_to_ceph_errno_unsigned(abs(r)) * sign;
+}

--- a/src/common/win32_errno.c
+++ b/src/common/win32_errno.c
@@ -311,6 +311,82 @@ __u32 hostos_to_ceph_errno_unsigned(__u32 r) {
  }
 }
 
+__s32 wsae_to_errno_unsigned(__s32 r)
+{
+  switch(r) {
+    case WSAEINTR: return EINTR;
+    case WSAEBADF: return EBADF;
+    case WSAEACCES: return EACCES;
+    case WSAEFAULT: return EFAULT;
+    case WSAEINVAL: return EINVAL;
+    case WSAEMFILE: return EMFILE;
+    // Linux defines WSAEWOULDBLOCK as EAGAIN, but not Windows headers.
+    // Since all ceph code uses EAGAIN instead of EWOULDBLOCK, we'll do
+    // the same here.
+    case WSAEWOULDBLOCK: return EAGAIN;
+    // Some functions (e.g. connect) can return WSAEWOULDBLOCK instead of
+    // EINPROGRESS.
+    case WSAEINPROGRESS: return EINPROGRESS;
+    case WSAEALREADY: return EALREADY;
+    case WSAENOTSOCK: return ENOTSOCK;
+    case WSAEDESTADDRREQ: return EDESTADDRREQ;
+    case WSAEMSGSIZE: return EMSGSIZE;
+    case WSAEPROTOTYPE: return EPROTOTYPE;
+    case WSAENOPROTOOPT: return ENOPROTOOPT;
+    case WSAEPROTONOSUPPORT: return EPROTONOSUPPORT;
+    case WSAESOCKTNOSUPPORT: return ESOCKTNOSUPPORT;
+    case WSAEOPNOTSUPP: return EOPNOTSUPP;
+    case WSAEPFNOSUPPORT: return EPFNOSUPPORT;
+    case WSAEAFNOSUPPORT: return EAFNOSUPPORT;
+    case WSAEADDRINUSE: return EADDRINUSE;
+    case WSAEADDRNOTAVAIL: return EADDRNOTAVAIL;
+    case WSAENETDOWN: return ENETDOWN;
+    case WSAENETUNREACH: return ENETUNREACH;
+    case WSAENETRESET: return ENETRESET;
+    case WSAECONNABORTED: return ECONNABORTED;
+    case WSAECONNRESET: return ECONNRESET;
+    case WSAENOBUFS: return ENOBUFS;
+    case WSAEISCONN: return EISCONN;
+    case WSAENOTCONN: return ENOTCONN;
+    case WSAESHUTDOWN: return ESHUTDOWN;
+    case WSAETOOMANYREFS: return ETOOMANYREFS;
+    case WSAETIMEDOUT: return ETIMEDOUT;
+    case WSAECONNREFUSED: return ECONNREFUSED;
+    case WSAELOOP: return ELOOP;
+    case WSAENAMETOOLONG: return ENAMETOOLONG;
+    case WSAEHOSTDOWN: return EHOSTDOWN;
+    case WSAEHOSTUNREACH: return EHOSTUNREACH;
+    case WSAENOTEMPTY: return ENOTEMPTY;
+    // case WSAEPROCLIM
+    case WSAEUSERS: return EUSERS;
+    case WSAEDQUOT: return EDQUOT;
+    case WSAESTALE: return ESTALE;
+    case WSAEREMOTE: return EREMOTE;
+    // case WSASYSNOTREADY
+    // case WSAVERNOTSUPPORTED
+    // case WSANOTINITIALISED
+    case WSAEDISCON: return ESHUTDOWN;
+    // case WSAENOMORE
+    case WSAECANCELLED: return ECANCELED;
+    // We might return EINVAL, but it's probably better if we propagate the
+    // original error code here.
+    // case WSAEINVALIDPROCTABLE
+    // case WSAEINVALIDPROVIDER
+    // case WSAEPROVIDERFAILEDINIT
+    // case WSASYSCALLFAILURE
+    // case WSASERVICE_NOT_FOUND:
+    // case WSATYPE_NOT_FOUND:
+    // case WSA_E_NO_MORE:
+    case WSA_E_CANCELLED: return ECANCELED;
+    case WSAEREFUSED: return ECONNREFUSED;
+    case WSAHOST_NOT_FOUND: return EHOSTUNREACH;
+    case WSATRY_AGAIN: return EAGAIN;
+    // case WSANO_RECOVERY
+    // case WSANO_DATA:
+    default: return r;
+  }
+}
+
 // converts from linux errno values to host values
 __s32 ceph_to_hostos_errno(__s32 r)
 {
@@ -323,4 +399,10 @@ __s32 hostos_to_ceph_errno(__s32 r)
 {
   int sign = (r < 0 ? -1 : 1);
   return hostos_to_ceph_errno_unsigned(abs(r)) * sign;
+}
+
+__s32 wsae_to_errno(__s32 r)
+{
+  int sign = (r < 0 ? -1 : 1);
+  return wsae_to_errno_unsigned(abs(r)) * sign;
 }

--- a/src/crush/CrushCompiler.cc
+++ b/src/crush/CrushCompiler.cc
@@ -7,10 +7,6 @@
 #define EBADE ECORRUPT
 #endif
 
-#if defined(_WIN32)
-#define EBADE EINVAL
-#endif
-
 #ifndef EBADE
 #define EBADE EFTYPE
 #endif

--- a/src/global/CMakeLists.txt
+++ b/src/global/CMakeLists.txt
@@ -1,7 +1,12 @@
 set(libglobal_srcs
   global_init.cc
-  pidfile.cc
-  signal_handler.cc)
+  pidfile.cc)
+if (WIN32)
+  list(APPEND libglobal_srcs signal_handler_win32.cc)
+else()
+  list(APPEND libglobal_srcs signal_handler.cc)
+endif()
+
 add_library(libglobal_objs OBJECT ${libglobal_srcs})
 
 add_library(global-static STATIC

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -12,6 +12,14 @@
  *
  */
 
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
 #include "common/async/context_pool.h"
 #include "common/ceph_argparse.h"
 #include "common/code_environment.h"
@@ -29,8 +37,10 @@
 #include "include/str_list.h"
 #include "mon/MonClient.h"
 
+#ifndef _WIN32
 #include <pwd.h>
 #include <grp.h>
+#endif
 #include <errno.h>
 
 #ifdef HAVE_SYS_PRCTL_H
@@ -68,6 +78,10 @@ static const char* c_str_or_null(const std::string &str)
 static int chown_path(const std::string &pathname, const uid_t owner, const gid_t group,
 		      const std::string &uid_str, const std::string &gid_str)
 {
+  #ifdef _WIN32
+  return 0;
+  #else
+
   const char *pathname_cstr = c_str_or_null(pathname);
 
   if (!pathname_cstr) {
@@ -83,6 +97,7 @@ static int chown_path(const std::string &pathname, const uid_t owner, const gid_
   }
 
   return r;
+  #endif
 }
 
 void global_pre_init(
@@ -194,9 +209,11 @@ global_init(const std::map<std::string,std::string> *defaults,
     g_ceph_context->set_init_flags(flags);
   }
 
+  #ifndef _WIN32
   // signal stuff
   int siglist[] = { SIGPIPE, 0 };
   block_signals(siglist, NULL);
+  #endif
 
   if (g_conf()->fatal_signal_handlers) {
     install_standard_sighandlers();
@@ -207,8 +224,9 @@ global_init(const std::map<std::string,std::string> *defaults,
     g_ceph_context->_log->set_flush_on_exit();
 
   // drop privileges?
-  std::ostringstream priv_ss;
- 
+  ostringstream priv_ss;
+
+  #ifndef _WIN32
   // consider --setuser root a no-op, even if we're not root
   if (getuid() != 0) {
     if (g_conf()->setuser.length()) {
@@ -318,6 +336,7 @@ global_init(const std::map<std::string,std::string> *defaults,
       priv_ss << "deferred set uid:gid to " << uid << ":" << gid << " (" << uid_string << ":" << gid_string << ")";
     }
   }
+  #endif /* _WIN32 */
 
 #if defined(HAVE_SYS_PRCTL_H)
   if (prctl(PR_SET_DUMPABLE, 1) == -1) {
@@ -361,9 +380,18 @@ global_init(const std::map<std::string,std::string> *defaults,
   if (g_conf()->run_dir.length() &&
       code_env == CODE_ENVIRONMENT_DAEMON &&
       !(flags & CINIT_FLAG_NO_DAEMON_ACTIONS)) {
-    int r = ::mkdir(g_conf()->run_dir.c_str(), 0755);
-    if (r < 0 && errno != EEXIST) {
-      cerr << "warning: unable to create " << g_conf()->run_dir << ": " << cpp_strerror(errno) << std::endl;
+
+    if (!fs::exists(g_conf()->run_dir.c_str())) {
+      std::error_code ec;
+      if (!fs::create_directory(g_conf()->run_dir, ec)) {
+       cerr << "warning: unable to create " << g_conf()->run_dir
+            << ec.message() << std::endl;
+      }
+      fs::permissions(
+        g_conf()->run_dir.c_str(),
+        fs::perms::owner_all |
+        fs::perms::group_read | fs::perms::group_exec |
+        fs::perms::others_read | fs::perms::others_exec);
     }
   }
 
@@ -449,7 +477,7 @@ void global_init_daemonize(CephContext *cct)
   if (global_init_prefork(cct) < 0)
     return;
 
-#if !defined(_AIX)
+#if !defined(_AIX) && !defined(_WIN32)
   int ret = daemon(1, 1);
   if (ret) {
     ret = errno;

--- a/src/global/pidfile.cc
+++ b/src/global/pidfile.cc
@@ -161,6 +161,9 @@ int pidfh::open(std::string_view pid_file)
   pf_dev = st.st_dev;
   pf_ino = st.st_ino;
 
+  // Default Windows file share flags prevent other processes from writing
+  // to this file.
+  #ifndef _WIN32
   struct flock l = {
     .l_type = F_WRLCK,
     .l_whence = SEEK_SET,
@@ -182,6 +185,7 @@ int pidfh::open(std::string_view pid_file)
     reset();
     return -lock_errno;
   }
+  #endif
   return 0;
 }
 

--- a/src/global/signal_handler_win32.cc
+++ b/src/global/signal_handler_win32.cc
@@ -1,0 +1,37 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (c) 2019 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "global/signal_handler.h"
+
+void install_sighandler(int signum, signal_handler_t handler, int flags) {}
+void sighup_handler(int signum) {}
+
+// Install the standard Ceph signal handlers
+void install_standard_sighandlers(void){}
+
+/// initialize async signal handler framework
+void init_async_signal_handler(){}
+
+/// shutdown async signal handler framework
+void shutdown_async_signal_handler(){}
+
+/// queue an async signal
+void queue_async_signal(int signum){}
+
+/// install a safe, async, callback for the given signal
+void register_async_signal_handler(int signum, signal_handler_t handler){}
+void register_async_signal_handler_oneshot(int signum, signal_handler_t handler){}
+
+/// uninstall a safe async signal callback
+void unregister_async_signal_handler(int signum, signal_handler_t handler){}

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -312,4 +312,23 @@ int lchown(const char *path, uid_t owner, gid_t group);
 
 #endif /* WIN32 */
 
+/* Supplies code to be run at startup time before invoking main().
+ * Use as:
+ *
+ *     CEPH_CONSTRUCTOR(my_constructor) {
+ *         ...some code...
+ *     }
+ */
+#ifdef _MSC_VER
+#pragma section(".CRT$XCU",read)
+#define CEPH_CONSTRUCTOR(f) \
+  static void __cdecl f(void); \
+  __declspec(allocate(".CRT$XCU")) static void (__cdecl*f##_)(void) = f; \
+  static void __cdecl f(void)
+#else
+#define CEPH_CONSTRUCTOR(f) \
+  static void f(void) __attribute__((constructor)); \
+  static void f(void)
+#endif
+
 #endif /* !CEPH_COMPAT_H */

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -14,6 +14,7 @@
 
 #include "acconfig.h"
 #include <sys/types.h>
+#include <errno.h>
 
 #if defined(__linux__)
 #define PROCPREFIX
@@ -290,6 +291,8 @@ int chown(const char *path, uid_t owner, gid_t group);
 int fchown(int fd, uid_t owner, gid_t group);
 int lchown(const char *path, uid_t owner, gid_t group);
 
+int win_socketpair(int socks[2]);
+
 #ifdef __cplusplus
 }
 #endif
@@ -330,5 +333,14 @@ int lchown(const char *path, uid_t owner, gid_t group);
   static void f(void) __attribute__((constructor)); \
   static void f(void)
 #endif
+
+/* This should only be used with the socket API. */
+static inline int ceph_sock_errno() {
+#ifdef _WIN32
+  return wsae_to_errno(WSAGetLastError());
+#else
+  return errno;
+#endif
+}
 
 #endif /* !CEPH_COMPAT_H */

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -292,8 +292,11 @@ int lchown(const char *path, uid_t owner, gid_t group);
 
 #ifdef __cplusplus
 }
-
 #endif
+
+// Use "aligned_free" when freeing memory allocated using posix_memalign or
+// _aligned_malloc. Using "free" will crash.
+#define aligned_free(ptr) _aligned_free(ptr)
 
 // O_CLOEXEC is not defined on Windows. Since handles aren't inherited
 // with subprocesses unless explicitly requested, we'll define this
@@ -301,9 +304,11 @@ int lchown(const char *path, uid_t owner, gid_t group);
 #define O_CLOEXEC 0
 #define SOCKOPT_VAL_TYPE char*
 
-#else
+#else /* WIN32 */
 
 #define SOCKOPT_VAL_TYPE void*
+
+#define aligned_free(ptr) free(ptr)
 
 #endif /* WIN32 */
 

--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -370,7 +370,7 @@ public:
     if (type) {
       type->items -= n;
     }
-    ::free(p);
+    aligned_free(p);
   }
 
   void destroy(T* p) {

--- a/src/include/win32/win32_errno.h
+++ b/src/include/win32/win32_errno.h
@@ -129,4 +129,14 @@
 
 #define ESHUTDOWN 312
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__s32 wsae_to_errno(__s32 r);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif // WIN32_ERRNO_H

--- a/src/include/win32/win32_errno.h
+++ b/src/include/win32/win32_errno.h
@@ -1,0 +1,132 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+// We're going to preserve the error numbers defined by the Windows SDK but not
+// by Mingw headers. For others, we're going to use numbers greater than 256 to
+// avoid unintended overlaps.
+
+#ifndef WIN32_ERRNO_H
+#define WIN32_ERRNO_H 1
+
+#include <errno.h>
+
+#ifndef EBADMSG
+#define EBADMSG 104
+#endif
+
+#ifndef ENODATA
+#define ENODATA 120
+#endif
+
+#ifndef ENOLINK
+#define ENOLINK 121
+#endif
+
+#ifndef ENOMSG
+#define ENOMSG 122
+#endif
+
+#ifndef ENOTRECOVERABLE
+#define ENOTRECOVERABLE 127
+#endif
+
+#ifndef ETIME
+#define ETIME 137
+#endif
+
+#ifndef ETXTBSY
+#define ETXTBSY 139
+#endif
+
+#ifndef ENODATA
+#define ENODATA 120
+#endif
+
+#define ESTALE 256
+#define EREMOTEIO 257
+
+#ifndef EBADE
+#define EBADE 258
+#endif
+
+#define EUCLEAN 259
+#define EREMCHG 260
+#define EKEYREJECTED 261
+#define EREMOTE 262
+
+// Not used at moment. Full coverage ensures that remote errors will be
+// converted and handled properly.
+#define EADV 263
+#define EBADFD 264
+#define EBADR 265
+#define EBADRQC 266
+#define EBADSLT 267
+#define EBFONT 268
+#define ECHRNG 269
+#define ECOMM 270
+#define EDOTDOT 271
+#define EHOSTDOWN 272
+#define EHWPOISON 273
+// Defined by Boost.
+#ifndef EIDRM
+#define EIDRM 274
+#endif
+#define EISNAM 275
+#define EKEYEXPIRED 276
+#define EKEYREVOKED 277
+#define EL2HLT 278
+#define EL2NSYNC 279
+#define EL3HLT 280
+#define EL3RST 281
+#define ELIBACC 282
+#define ELIBBAD 283
+#define ELIBEXEC 284
+#define ELIBMAX 285
+#define ELIBSCN 286
+#define ELNRNG 287
+#define EMEDIUMTYPE 288
+#define EMULTIHOP 289
+#define ENAVAIL 290
+#define ENOANO 291
+#define ENOCSI 292
+#define ENOKEY 293
+#define ENOMEDIUM 294
+#define ENONET 295
+#define ENOPKG 296
+#ifndef ENOSR
+#define ENOSR 297
+#endif
+#ifndef ENOSTR
+#define ENOSTR 298
+#endif
+#define ENOTNAM 299
+#define ENOTUNIQ 300
+#define EPFNOSUPPORT 301
+#define ERFKILL 302
+#define ESOCKTNOSUPPORT 303
+#define ESRMNT 304
+#define ESTRPIPE 305
+#define ETOOMANYREFS 306
+#define EUNATCH 307
+#define EUSERS 308
+#define EXFULL 309
+#define ENOTBLK 310
+
+#ifndef EDQUOT
+#define EDQUOT 311
+#endif
+
+#define ESHUTDOWN 312
+
+#endif // WIN32_ERRNO_H

--- a/src/kv/rocksdb_cache/BinnedLRUCache.cc
+++ b/src/kv/rocksdb_cache/BinnedLRUCache.cc
@@ -488,7 +488,7 @@ BinnedLRUCache::~BinnedLRUCache() {
   for (int i = 0; i < num_shards_; i++) {
     shards_[i].~BinnedLRUCacheShard();
   }
-  free(shards_);
+  aligned_free(shards_);
 }
 
 CacheShard* BinnedLRUCache::GetShard(int shard) {

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -289,7 +289,7 @@ ssize_t AsyncConnection::read_bulk(char *buf, unsigned len)
       goto again;
     } else {
       ldout(async_msgr->cct, 1) << __func__ << " reading from fd=" << cs.fd()
-                          << " : "<< strerror(nread) << dendl;
+                          << " : "<< nread << " " << strerror(nread) << dendl;
       return -1;
     }
   } else if (nread == 0) {

--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -71,7 +71,8 @@ int NetHandler::set_nonblock(int sd)
   ULONG mode = 1;
   r = ioctlsocket(sd, FIONBIO, &mode);
   if (r) {
-    lderr(cct) << __func__ << " ioctlsocket(FIONBIO) failed: " << r << dendl;
+    lderr(cct) << __func__ << " ioctlsocket(FIONBIO) failed: " << r
+                           << " " << WSAGetLastError() << dendl;
     return -r;
   }
   #else

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -240,18 +240,18 @@ int FileJournal::_open_file(int64_t oldsize, blksize_t blksize,
     for (; (i + write_size) <= (uint64_t)max_size; i += write_size) {
       ret = ::pwrite(fd, static_cast<void*>(buf), write_size, i);
       if (ret < 0) {
-	free(buf);
+	aligned_free(buf);
 	return -errno;
       }
     }
     if (i < (uint64_t)max_size) {
       ret = ::pwrite(fd, static_cast<void*>(buf), max_size - i, i);
       if (ret < 0) {
-	free(buf);
+	aligned_free(buf);
 	return -errno;
       }
     }
-    free(buf);
+    aligned_free(buf);
   }
 
 


### PR DESCRIPTION
Windows support [part 7]

This PR series intends to set the ground for the upcoming Windows port effort.
For now, we're mostly interested in the client side, allowing Windows hosts
to consume rados, rbd and cephfs resources.

Those PRs should be reviewed and merged in order. Each PR depends on the previous one from the series (in fact it includes the previous commits as well).

~~Part 1: #31981~~
~~Part 2: #32704~~
~~Part 3: #32705~~
~~Part 4: #32707~~
~~Part 5: #32780~~
~~Part 6: #32779~~
**Part 7: #32778** 
Part 8: #32777 
Part 9: #32776
Part 10: #33750
Part 11: #34858
Part 12: #34859

Related but independent PRs:
https://github.com/ceph/ceph/pull/32027
https://github.com/ceph/fmt/pull/2
https://github.com/ceph/rocksdb/pull/42

For more details about the build process and current status, please check the
README.windows.rst file. Worth mentioning that the resulted binaries can
connect to ceph clusters and consume pools: http://paste.openstack.org/raw/787534/

Here are some test results as well:
[test_results.zip](https://github.com/ceph/ceph/files/4077517/test_results.zip)

Individual PR commits:

```
msg: Use sockets instead of pipes for wakeup events on win32
common,msg: Initialize Windows WSA and TLS
common,os,kv: Define aligned_free
common: avoid CLOCK_*_COARSE warnings on win32
global: Windows support
```

Any feedback is highly appreciated.

Signed-off-by: Lucian Petrut lpetrut@cloudbasesolutions.com
Signed-off-by: Alin Gabriel Serdean aserdean@cloudbasesolutions.com
