### PR TITLE
Windows support [part 6]

### DIFF
--- a/README.windows.rst
+++ b/README.windows.rst
@@ -30,7 +30,6 @@ DEPS_DIR      The directory where the Ceph     $CEPH_DIR/build.deps
               dependencies will be built.
 NUM_WORKERS   The number of workers to use     The number of vcpus
               when building Ceph.              available
-NINJA_BUILD   Use Ninja instead of make.
 CLEAN_BUILD   Clean the build directory.
 SKIP_BUILD    Run cmake without actually
               performing the build.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -437,7 +437,7 @@ if(WITH_DPDK)
 endif()
 
 if(WIN32)
-  list(APPEND ceph_common_deps ws2_32 mswsock bcrypt)
+  list(APPEND ceph_common_deps ws2_32 mswsock iphlpapi bcrypt)
   list(APPEND ceph_common_deps dlfcn_win32)
 endif()
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -33,7 +33,6 @@ set(common_srcs
   Readahead.cc
   RefCountedObj.cc
   SloppyCRCMap.cc
-  SubProcess.cc
   Thread.cc
   Throttle.cc
   Timer.cc
@@ -89,6 +88,7 @@ set(common_srcs
   pick_address.cc
   random_string.cc
   reverse.c
+  run_cmd.cc
   scrub_types.cc
   shared_mutex_debug.cc
   signal.cc
@@ -106,14 +106,15 @@ set(common_srcs
 if(WIN32)
   list(APPEND common_srcs
     blkdev_win32.cc
-    dns_resolve_win32.cc)
+    dns_resolve_win32.cc
+    SubProcess_win32.cc)
 else()
   list(APPEND common_srcs
     blkdev.cc
     dns_resolve.cc
     ipaddr.cc
     linux_version.c
-    run_cmd.cc)
+    SubProcess.cc)
 endif()
 
 set_source_files_properties(${CMAKE_SOURCE_DIR}/src/common/version.cc

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -73,6 +73,7 @@ set(common_srcs
   histogram.cc
   hobject.cc
   hostname.cc
+  ipaddr.cc
   iso_8601.cc
   lockdep.cc
   mempool.cc
@@ -107,12 +108,12 @@ if(WIN32)
   list(APPEND common_srcs
     blkdev_win32.cc
     dns_resolve_win32.cc
-    SubProcess_win32.cc)
+    SubProcess_win32.cc
+    ifaddrs_win32.c)
 else()
   list(APPEND common_srcs
     blkdev.cc
     dns_resolve.cc
-    ipaddr.cc
     linux_version.c
     SubProcess.cc)
 endif()

--- a/src/common/SubProcess.cc
+++ b/src/common/SubProcess.cc
@@ -102,7 +102,6 @@ void SubProcess::close_stderr() {
   close(stderr_pipe_in_fd);
 }
 
-#ifndef _WIN32
 void SubProcess::kill(int signo) const {
   ceph_assert(is_spawned());
 
@@ -274,7 +273,6 @@ int SubProcess::join() {
   errstr << cmd << ": waitpid: unknown status returned\n";
   return EXIT_FAILURE;
 }
-#endif /* _WIN32 */
 
 SubProcessTimed::SubProcessTimed(const char *cmd, std_fd_op stdin_op,
 				 std_fd_op stdout_op, std_fd_op stderr_op,
@@ -290,7 +288,6 @@ void timeout_sighandler(int sig) {
 }
 static void dummy_sighandler(int sig) {}
 
-#ifndef _WIN32
 void SubProcessTimed::exec() {
   ceph_assert(is_child());
 
@@ -395,22 +392,3 @@ void SubProcessTimed::exec() {
 fail_exit:
   _exit(EXIT_FAILURE);
 }
-
-#else
-int SubProcess::join() {
-  return EXIT_FAILURE;
-}
-
-void SubProcess::kill(int signo) const {
-}
-
-int SubProcess::spawn() {
-  return EXIT_FAILURE;
-}
-
-void SubProcess::exec() {
-}
-
-void SubProcessTimed::exec() {
-}
-#endif /* _WIN32 */

--- a/src/common/SubProcess.h
+++ b/src/common/SubProcess.h
@@ -27,6 +27,8 @@
 #include <sstream>
 #include <vector>
 
+#include "include/compat.h"
+
 /**
  * SubProcess:
  * A helper class to spawn a subprocess.
@@ -85,8 +87,11 @@ protected:
   bool is_child() const { return pid == 0; }
   virtual void exec();
 
-private:
   void close(int &fd);
+
+#ifdef _WIN32
+  void close_h(HANDLE &handle);
+#endif
 
 protected:
   std::string cmd;
@@ -99,6 +104,10 @@ protected:
   int stderr_pipe_in_fd;
   int pid;
   std::ostringstream errstr;
+
+#ifdef _WIN32
+  HANDLE proc_handle = INVALID_HANDLE_VALUE;
+#endif
 };
 
 class SubProcessTimed : public SubProcess {
@@ -107,12 +116,21 @@ public:
 		  std_fd_op stdout_op = CLOSE, std_fd_op stderr_op = CLOSE,
 		  int timeout = 0, int sigkill = SIGKILL);
 
+#ifdef _WIN32
+  int spawn() override;
+  int join() override;
+#endif
+
 protected:
   void exec() override;
 
 private:
   int timeout;
   int sigkill;
+
+#ifdef _WIN32
+  std::thread waiter;
+#endif
 };
 
 void timeout_sighandler(int sig);

--- a/src/common/SubProcess_win32.cc
+++ b/src/common/SubProcess_win32.cc
@@ -1,0 +1,293 @@
+#include "SubProcess.h"
+
+#include <stdarg.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <iostream>
+#include <iomanip>
+
+#include "common/errno.h"
+#include "include/ceph_assert.h"
+#include "include/compat.h"
+
+SubProcess::SubProcess(const char *cmd_, std_fd_op stdin_op_, std_fd_op stdout_op_, std_fd_op stderr_op_) :
+  cmd(cmd_),
+  cmd_args(),
+  stdin_op(stdin_op_),
+  stdout_op(stdout_op_),
+  stderr_op(stderr_op_),
+  stdin_pipe_out_fd(-1),
+  stdout_pipe_in_fd(-1),
+  stderr_pipe_in_fd(-1),
+  pid(0),
+  errstr() {
+}
+
+SubProcess::~SubProcess() {
+  ceph_assert(!is_spawned());
+  ceph_assert(stdin_pipe_out_fd == -1);
+  ceph_assert(stdout_pipe_in_fd == -1);
+  ceph_assert(stderr_pipe_in_fd == -1);
+}
+
+void SubProcess::add_cmd_args(const char *arg, ...) {
+  ceph_assert(!is_spawned());
+
+  va_list ap;
+  va_start(ap, arg);
+  const char *p = arg;
+  do {
+    add_cmd_arg(p);
+    p = va_arg(ap, const char*);
+  } while (p != NULL);
+  va_end(ap);
+}
+
+void SubProcess::add_cmd_arg(const char *arg) {
+  ceph_assert(!is_spawned());
+
+  cmd_args.push_back(arg);
+}
+
+int SubProcess::get_stdin() const {
+  ceph_assert(is_spawned());
+  ceph_assert(stdin_op == PIPE);
+
+  return stdin_pipe_out_fd;
+}
+
+int SubProcess::get_stdout() const {
+  ceph_assert(is_spawned());
+  ceph_assert(stdout_op == PIPE);
+
+  return stdout_pipe_in_fd;
+}
+
+int SubProcess::get_stderr() const {
+  ceph_assert(is_spawned());
+  ceph_assert(stderr_op == PIPE);
+
+  return stderr_pipe_in_fd;
+}
+
+void SubProcess::close(int &fd) {
+  if (fd == -1)
+    return;
+
+  ::close(fd);
+  fd = -1;
+}
+
+void SubProcess::close_stdin() {
+  ceph_assert(is_spawned());
+  ceph_assert(stdin_op == PIPE);
+
+  close(stdin_pipe_out_fd);
+}
+
+void SubProcess::close_stdout() {
+  ceph_assert(is_spawned());
+  ceph_assert(stdout_op == PIPE);
+
+  close(stdout_pipe_in_fd);
+}
+
+void SubProcess::close_stderr() {
+  ceph_assert(is_spawned());
+  ceph_assert(stderr_op == PIPE);
+
+  close(stderr_pipe_in_fd);
+}
+
+const std::string SubProcess::err() const {
+  return errstr.str();
+}
+
+SubProcessTimed::SubProcessTimed(const char *cmd, std_fd_op stdin_op,
+                 std_fd_op stdout_op, std_fd_op stderr_op,
+                 int timeout_, int sigkill_) :
+  SubProcess(cmd, stdin_op, stdout_op, stderr_op),
+  timeout(timeout_),
+  sigkill(sigkill_) {
+}
+
+static bool timedout = false;
+void timeout_sighandler(int sig) {
+  timedout = true;
+}
+
+void SubProcess::close_h(HANDLE &handle) {
+  if (handle == INVALID_HANDLE_VALUE)
+    return;
+
+  CloseHandle(handle);
+  handle = INVALID_HANDLE_VALUE;
+}
+
+int SubProcess::join() {
+  ceph_assert(is_spawned());
+
+  close(stdin_pipe_out_fd);
+  close(stdout_pipe_in_fd);
+  close(stderr_pipe_in_fd);
+
+  DWORD status = 0;
+
+  if (WaitForSingleObject(proc_handle, INFINITE) != WAIT_FAILED) {
+    if (!GetExitCodeProcess(proc_handle, &status)) {
+      errstr << cmd << ": Could not get exit code: " << pid
+             << ". Error code: " << GetLastError();
+    } else if (status) {
+      errstr << cmd << ": exit status: " << status;
+    }
+  } else {
+    errstr << cmd << ": Waiting for child process failed: " << pid
+           << ". Error code: " << GetLastError();
+  }
+
+  close_h(proc_handle);
+  pid = 0;
+  return status;
+}
+
+void SubProcess::kill(int signo) const {
+  ceph_assert(is_spawned());
+  ceph_assert(TerminateProcess(proc_handle, 128 + SIGTERM));
+}
+
+int SubProcess::spawn() {
+  std::ostringstream cmdline;
+  cmdline << cmd;
+  for (auto& arg : cmd_args) {
+    cmdline << " " << std::quoted(arg);
+  }
+
+  STARTUPINFO si = {0};
+  PROCESS_INFORMATION pi = {0};
+  SECURITY_ATTRIBUTES sa = {0};
+
+  sa.nLength = sizeof(SECURITY_ATTRIBUTES);
+  sa.bInheritHandle = TRUE;
+  sa.lpSecurityDescriptor = NULL;
+
+  HANDLE stdin_r = INVALID_HANDLE_VALUE, stdin_w = INVALID_HANDLE_VALUE,
+         stdout_r = INVALID_HANDLE_VALUE, stdout_w = INVALID_HANDLE_VALUE,
+         stderr_r = INVALID_HANDLE_VALUE, stderr_w = INVALID_HANDLE_VALUE;
+
+  if ((stdin_op == PIPE && !CreatePipe(&stdin_r, &stdin_w, &sa, 0)) ||
+      (stdout_op == PIPE && !CreatePipe(&stdout_r, &stdout_w, &sa, 0)) ||
+      (stderr_op == PIPE && !CreatePipe(&stderr_r, &stderr_w, &sa, 0))) {
+    errstr << cmd << ": CreatePipe failed: " << GetLastError();
+    return -1;
+  }
+
+  // The following handles will be used by the parent process and
+  // must be marked as non-inheritable.
+  if ((stdin_op == PIPE && !SetHandleInformation(stdin_w, HANDLE_FLAG_INHERIT, 0)) ||
+      (stdout_op == PIPE && !SetHandleInformation(stdout_r, HANDLE_FLAG_INHERIT, 0)) ||
+      (stderr_op == PIPE && !SetHandleInformation(stderr_r, HANDLE_FLAG_INHERIT, 0))) {
+    errstr << cmd << ": SetHandleInformation failed: "
+           << GetLastError();
+    goto fail;
+  }
+
+  si.cb = sizeof(STARTUPINFO);
+  si.hStdInput = stdin_op == KEEP ? GetStdHandle(STD_INPUT_HANDLE) : stdin_r;
+  si.hStdOutput = stdout_op == KEEP ? GetStdHandle(STD_OUTPUT_HANDLE) : stdout_w;
+  si.hStdError = stderr_op == KEEP ? GetStdHandle(STD_ERROR_HANDLE) : stderr_w;
+  si.dwFlags |= STARTF_USESTDHANDLES;
+
+  stdin_pipe_out_fd = stdin_op == PIPE ? _open_osfhandle((intptr_t)stdin_w, 0) : -1;
+  stdout_pipe_in_fd = stdout_op == PIPE ? _open_osfhandle((intptr_t)stdout_r, _O_RDONLY) : - 1;
+  stderr_pipe_in_fd = stderr_op == PIPE ? _open_osfhandle((intptr_t)stderr_r, _O_RDONLY) : -1;
+
+  if (stdin_op == PIPE && stdin_pipe_out_fd == -1 ||
+      stdout_op == PIPE && stdout_pipe_in_fd == -1 ||
+      stderr_op == PIPE && stderr_pipe_in_fd == -1) {
+    errstr << cmd << ": _open_osfhandle failed: " << GetLastError();
+    goto fail;
+  }
+
+  // We've transfered ownership from those handles.
+  stdin_w = stdout_r = stderr_r = INVALID_HANDLE_VALUE;
+
+  if (!CreateProcess(
+      NULL, const_cast<char*>(cmdline.str().c_str()),
+      NULL, NULL, /* No special security attributes */
+      1, /* Inherit handles marked as inheritable */
+      0, /* No special flags */
+      NULL, /* Use the same environment variables */
+      NULL, /* use the same cwd */
+      &si, &pi)) {
+    errstr << cmd << ": CreateProcess failed: " << GetLastError();
+    goto fail;
+  }
+
+  proc_handle = pi.hProcess;
+  pid = GetProcessId(proc_handle);
+  if (!pid) {
+    errstr << cmd << ": Could not get child process id.";
+    goto fail;
+  }
+
+  // The following are used by the subprocess.
+  CloseHandle(stdin_r);
+  CloseHandle(stdout_w);
+  CloseHandle(stderr_w);
+  CloseHandle(pi.hThread);
+  return 0;
+
+fail:
+  // fd copies
+  close(stdin_pipe_out_fd);
+  close(stdout_pipe_in_fd);
+  close(stderr_pipe_in_fd);
+
+  // the original handles
+  close_h(stdin_r);
+  close_h(stdin_w);
+  close_h(stdout_r);
+  close_h(stdout_w);
+  close_h(stderr_r);
+  close_h(stderr_w);
+
+  // We may consider mapping some of the Windows errors.
+  return -1;
+}
+
+void SubProcess::exec() {
+}
+
+int SubProcessTimed::spawn() {
+  if (auto ret = SubProcess::spawn(); ret < 0) {
+    return ret;
+  }
+
+  if (timeout > 0) {
+    waiter = std::thread([&](){
+      DWORD wait_status = WaitForSingleObject(proc_handle, timeout * 1000);
+      ceph_assert(wait_status != WAIT_FAILED);
+      if (wait_status == WAIT_TIMEOUT) {
+        // 128 + sigkill is just the return code, which is expected by
+        // the unit tests and possibly by other code. We can't pick a
+        // termination signal unless we use window events.
+        ceph_assert(TerminateProcess(proc_handle, 128 + sigkill));
+        timedout = 1;
+      }
+    });
+  }
+  return 0;
+}
+
+int SubProcessTimed::join() {
+  ceph_assert(is_spawned());
+
+  if (waiter.joinable()) {
+    waiter.join();
+  }
+
+  return SubProcess::join();;
+}
+
+void SubProcessTimed::exec() {
+}

--- a/src/common/dns_resolve.h
+++ b/src/common/dns_resolve.h
@@ -15,7 +15,9 @@
 #define CEPH_DNS_RESOLVE_H
 
 #include <netinet/in.h>
+#ifndef _WIN32
 #include <resolv.h>
+#endif
 
 #include "common/ceph_mutex.h"
 #include "msg/msg_types.h"		// for entity_addr_t

--- a/src/common/ifaddrs_win32.cc
+++ b/src/common/ifaddrs_win32.cc
@@ -1,0 +1,108 @@
+#include <errno.h>
+#include <winsock2.h>
+#include <wincrypt.h>
+#include <iphlpapi.h>
+#include <ws2tcpip.h>
+#include <ifaddrs.h>
+
+#include "include/compat.h"
+
+int getifaddrs(struct ifaddrs **ifap)
+{
+  int ret = 0;
+
+  DWORD size, res = 0;
+  res = GetAdaptersAddresses(
+    AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX,
+    NULL, NULL, &size);
+  if (res != ERROR_BUFFER_OVERFLOW) {
+    errno = ENOMEM;
+    return -1;
+  }
+
+  PIP_ADAPTER_ADDRESSES adapter_addrs = (PIP_ADAPTER_ADDRESSES)malloc(size);
+  res = GetAdaptersAddresses(
+    AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX,
+    NULL, adapter_addrs, &size);
+  if (res != ERROR_SUCCESS) {
+    errno = ENOMEM;
+    return -1;
+  }
+
+  struct ifaddrs *out_list_head = NULL;
+  struct ifaddrs *out_list_curr;
+
+  for (PIP_ADAPTER_ADDRESSES curr_addrs = adapter_addrs;
+       curr_addrs != NULL;
+       curr_addrs = curr_addrs->Next) {
+    if (curr_addrs->OperStatus != 1)
+      continue;
+
+    for (PIP_ADAPTER_UNICAST_ADDRESS unicast_addrs = curr_addrs->FirstUnicastAddress;
+         unicast_addrs != NULL;
+         unicast_addrs = unicast_addrs->Next) {
+      SOCKADDR* unicast_sockaddr = unicast_addrs->Address.lpSockaddr;
+      if (unicast_sockaddr->sa_family != AF_INET &&
+          unicast_sockaddr->sa_family != AF_INET6)
+        continue;
+      out_list_curr = calloc(sizeof(*out_list_curr), 1);
+      if (!out_list_curr) {
+        errno = ENOMEM;
+        ret = -1;
+        goto out;
+      }
+
+      out_list_curr->ifa_next = out_list_head;
+      out_list_head = out_list_curr;
+
+      out_list_curr->ifa_flags = IFF_UP;
+      if (curr_addrs->IfType == IF_TYPE_SOFTWARE_LOOPBACK)
+        out_list_curr->ifa_flags |= IFF_LOOPBACK;
+
+      out_list_curr->ifa_addr = (struct sockaddr *) &out_list_curr->in_addrs;
+      out_list_curr->ifa_netmask = (struct sockaddr *) &out_list_curr->in_netmasks;
+      out_list_curr->ifa_name = out_list_curr->ad_name;
+
+      if (unicast_sockaddr->sa_family == AF_INET) {
+        ULONG subnet_mask = 0;
+        if (ConvertLengthToIpv4Mask(unicast_addrs->OnLinkPrefixLength, &subnet_mask)) {
+          errno = ENODATA;
+          ret = -1;
+          goto out;
+        }
+        struct sockaddr_in *addr4 = (struct sockaddr_in *) &out_list_curr->in_addrs;
+        struct sockaddr_in *netmask4 = (struct sockaddr_in *) &out_list_curr->in_netmasks;
+        netmask4->sin_family = unicast_sockaddr->sa_family;
+        addr4->sin_family = unicast_sockaddr->sa_family;
+        netmask4->sin_addr.S_un.S_addr = subnet_mask;
+        addr4->sin_addr = ((struct sockaddr_in*) unicast_sockaddr)->sin_addr;
+      } else {
+        struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *) &out_list_curr->in_addrs;
+        (*addr6) = *(struct sockaddr_in6 *) unicast_sockaddr;
+      }
+      out_list_curr->speed = curr_addrs->TransmitLinkSpeed;
+      // TODO maybe use friendly name instead of adapter GUID
+      sprintf_s(out_list_curr->ad_name,
+                sizeof(out_list_curr->ad_name),
+                curr_addrs->AdapterName);
+    }
+  }
+  ret = 0;
+out:
+  free(adapter_addrs);
+  if (ret && out_list_head)
+    free(out_list_head);
+  else if (ifap)
+    *ifap = out_list_head;
+
+  return ret;
+}
+
+void freeifaddrs(struct ifaddrs *ifa)
+{
+  while (ifa) {
+    struct ifaddrs *next = ifa->ifa_next;
+    free(ifa);
+    ifa = next;
+  }
+}

--- a/src/compressor/lz4/CMakeLists.txt
+++ b/src/compressor/lz4/CMakeLists.txt
@@ -5,7 +5,8 @@ set(lz4_sources
 )
 
 add_library(ceph_lz4 SHARED ${lz4_sources})
-target_link_libraries(ceph_lz4 PRIVATE LZ4::LZ4 compressor)
+target_link_libraries(ceph_lz4
+  PRIVATE LZ4::LZ4 compressor $<$<PLATFORM_ID:Windows>:ceph-common>)
 set_target_properties(ceph_lz4 PROPERTIES
   VERSION 2.0.0
   SOVERSION 2

--- a/src/compressor/snappy/CMakeLists.txt
+++ b/src/compressor/snappy/CMakeLists.txt
@@ -5,7 +5,8 @@ set(snappy_sources
 )
 
 add_library(ceph_snappy SHARED ${snappy_sources})
-target_link_libraries(ceph_snappy PRIVATE snappy::snappy compressor)
+target_link_libraries(ceph_snappy
+  PRIVATE snappy::snappy compressor $<$<PLATFORM_ID:Windows>:ceph-common>)
 set_target_properties(ceph_snappy PROPERTIES
   VERSION 2.0.0
   SOVERSION 2

--- a/src/compressor/zlib/CMakeLists.txt
+++ b/src/compressor/zlib/CMakeLists.txt
@@ -49,7 +49,7 @@ else(HAVE_INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64 AND (NOT APPLE))
 endif(HAVE_INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64 AND (NOT APPLE))
 
 add_library(ceph_zlib SHARED ${zlib_sources})
-target_link_libraries(ceph_zlib ZLIB::ZLIB compressor)
+target_link_libraries(ceph_zlib ZLIB::ZLIB compressor $<$<PLATFORM_ID:Windows>:ceph-common>)
 target_include_directories(ceph_zlib SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/isa-l/include")
 set_target_properties(ceph_zlib PROPERTIES
   VERSION 2.0.0

--- a/src/compressor/zstd/CMakeLists.txt
+++ b/src/compressor/zstd/CMakeLists.txt
@@ -28,7 +28,7 @@ set(zstd_sources
 )
 
 add_library(ceph_zstd SHARED ${zstd_sources})
-target_link_libraries(ceph_zstd PRIVATE zstd)
+target_link_libraries(ceph_zstd PRIVATE zstd $<$<PLATFORM_ID:Windows>:ceph-common>)
 set_target_properties(ceph_zstd PROPERTIES
   VERSION 2.0.0
   SOVERSION 2

--- a/src/crypto/openssl/CMakeLists.txt
+++ b/src/crypto/openssl/CMakeLists.txt
@@ -5,7 +5,9 @@ set(openssl_crypto_plugin_srcs
   openssl_crypto_plugin.cc)
 
 add_library(ceph_crypto_openssl SHARED ${openssl_crypto_plugin_srcs})
-target_link_libraries(ceph_crypto_openssl PRIVATE crypto)
+target_link_libraries(ceph_crypto_openssl
+    PRIVATE OpenSSL::Crypto
+    $<$<PLATFORM_ID:Windows>:ceph-common>)
 target_include_directories(ceph_crypto_openssl PRIVATE ${OPENSSL_INCLUDE_DIR})
 add_dependencies(crypto_plugins ceph_crypto_openssl)
 set_target_properties(ceph_crypto_openssl PROPERTIES INSTALL_RPATH "")

--- a/src/erasure-code/CMakeLists.txt
+++ b/src/erasure-code/CMakeLists.txt
@@ -28,7 +28,8 @@ if(HAVE_BETTER_YASM_ELF64 OR HAVE_ARMV8_SIMD)
 endif()
 
 add_library(erasure_code STATIC ErasureCodePlugin.cc)
-target_link_libraries(erasure_code ${CMAKE_DL_LIBS})
+target_link_libraries(erasure_code $<$<PLATFORM_ID:Windows>:dlfcn_win32>
+                      ${CMAKE_DL_LIBS})
 
 add_library(erasure_code_objs OBJECT ErasureCode.cc)
 

--- a/src/include/win32/ifaddrs.h
+++ b/src/include/win32/ifaddrs.h
@@ -1,0 +1,39 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2002-2016 Free Software Foundation, Inc.
+ * Copyright (C) 2019 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef IFADDRS_H
+#define IFADDRS_H
+
+#include "winsock_compat.h"
+#include <ifdef.h>
+
+struct ifaddrs {
+  struct ifaddrs  *ifa_next;    /* Next item in list */
+  char            *ifa_name;    /* Name of interface */
+  unsigned int     ifa_flags;   /* Flags from SIOCGIFFLAGS */
+  struct sockaddr *ifa_addr;    /* Address of interface */
+  struct sockaddr *ifa_netmask; /* Netmask of interface */
+
+  struct sockaddr_storage in_addrs;
+  struct sockaddr_storage in_netmasks;
+
+  char             ad_name[IF_MAX_STRING_SIZE];
+  size_t           speed;
+};
+
+int getifaddrs(struct ifaddrs **ifap);
+void freeifaddrs(struct ifaddrs *ifa);
+
+#endif

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -262,7 +262,7 @@ if(ENABLE_SHARED)
     SOVERSION 1
     CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN ON)
-    if(NOT APPLE)
+    if(NOT APPLE AND NOT WIN32)
       set_property(TARGET librbd APPEND_STRING PROPERTY
         LINK_FLAGS " -Wl,--exclude-libs,ALL")
     endif()

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -206,7 +206,7 @@ if(WITH_EVENTTRACE)
   add_dependencies(rbd_internal eventtrace_tp)
 endif()
 target_link_libraries(rbd_internal PRIVATE
-  osdc)
+  osdc rbd_types)
 
 if(WITH_RBD_RWL)
   target_link_libraries(rbd_internal
@@ -222,7 +222,7 @@ set(rbd_plugin_parent_cache_srcs
 add_library(librbd_plugin_parent_cache SHARED
   ${rbd_plugin_parent_cache_srcs})
 target_link_libraries(librbd_plugin_parent_cache PRIVATE
-  ceph_immutable_object_cache_lib
+  ceph_immutable_object_cache_lib ceph-common librbd
   librados)
 set_target_properties(librbd_plugin_parent_cache PROPERTIES
   OUTPUT_NAME ceph_librbd_parent_cache
@@ -236,7 +236,6 @@ add_library(librbd ${CEPH_SHARED}
 if(WITH_LTTNG)
   add_dependencies(librbd librbd-tp)
 endif()
-add_dependencies(librbd librbd_plugins)
 
 target_link_libraries(librbd PRIVATE
   rbd_internal


### PR DESCRIPTION
Windows support [part 6]

This PR series intends to set the ground for the upcoming Windows port effort.
For now, we're mostly interested in the client side, allowing Windows hosts
to consume rados, rbd and cephfs resources.

Those PRs should be reviewed and merged in order. Each PR depends on the previous one from the series (in fact it includes the previous commits as well).

~~Part 1: #31981~~
~~Part 2: #32704~~
~~Part 3: #32705~~
~~Part 4: #32707~~
Part 5: #32780 
**Part 6: #32779**
Part 7: #32778 
Part 8: #32777 
Part 9: #32776
Part 10: #33750
Part 11: #34858
Part 12: #34859

Related but independent PRs:
https://github.com/ceph/ceph/pull/32027
https://github.com/ceph/fmt/pull/2
https://github.com/ceph/rocksdb/pull/42

For more details about the build process and current status, please check the
README.windows.rst file. Worth mentioning that the resulted binaries can
connect to ceph clusters and consume pools: http://paste.openstack.org/raw/787534/

Here are some test results as well:
[test_results.zip](https://github.com/ceph/ceph/files/4077517/test_results.zip)

Individual PR commits:

```
cmake: Set missing dependencies
common: ifaddrs compatibility layer
cmake: allow building CLI tools on Windows
common: implement win32 subprocess helpers
```

Any feedback is highly appreciated.

Signed-off-by: Lucian Petrut lpetrut@cloudbasesolutions.com
Signed-off-by: Alin Gabriel Serdean aserdean@cloudbasesolutions.com
