### PR TITLE
Windows support [part 5] 

### DIFF
--- a/src/common/ceph_fs.cc
+++ b/src/common/ceph_fs.cc
@@ -76,8 +76,14 @@ int ceph_flags_sys2wire(int flags)
        ceph_sys2wire(O_CREAT);
        ceph_sys2wire(O_EXCL);
        ceph_sys2wire(O_TRUNC);
+
+       #ifndef _WIN32
        ceph_sys2wire(O_DIRECTORY);
        ceph_sys2wire(O_NOFOLLOW);
+       // In some cases, FILE_FLAG_BACKUP_SEMANTICS may be used instead
+       // of O_DIRECTORY. We may need some workarounds in order to handle
+       // the fact that those flags are not available on Windows.
+       #endif
 
 #undef ceph_sys2wire
 

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -12,7 +12,10 @@
  * 
  */
 
+#ifndef _WIN32
 #include <sys/utsname.h>
+#endif
+
 #include <fstream>
 #include <boost/algorithm/string.hpp>
 
@@ -46,6 +49,7 @@ using std::string;
 using ceph::bufferlist;
 using ceph::Formatter;
 
+#ifndef _WIN32
 int get_fs_stats(ceph_data_stats_t &stats, const char *path)
 {
   if (!path)
@@ -63,6 +67,24 @@ int get_fs_stats(ceph_data_stats_t &stats, const char *path)
   stats.avail_percent = (((float)stats.byte_avail/stats.byte_total)*100);
   return 0;
 }
+#else
+int get_fs_stats(ceph_data_stats_t &stats, const char *path)
+{
+  ULARGE_INTEGER avail_bytes, total_bytes, total_free_bytes;
+
+  if (!GetDiskFreeSpaceExA(path, &avail_bytes,
+                           &total_bytes, &total_free_bytes)) {
+    return -EINVAL;
+  }
+
+  stats.byte_total = total_bytes.QuadPart;
+  stats.byte_used = total_bytes.QuadPart - total_free_bytes.QuadPart;
+  // may not be equal to total_free_bytes due to quotas
+  stats.byte_avail = avail_bytes.QuadPart;
+  stats.avail_percent = ((float)stats.byte_avail / stats.byte_total) * 100;
+  return 0;
+}
+#endif
 
 static char* value_sanitize(char *value)
 {
@@ -145,6 +167,7 @@ static void distro_detect(map<string, string> *m, CephContext *cct)
 
 int get_cgroup_memory_limit(uint64_t *limit)
 {
+#ifndef _WIN32
   // /sys/fs/cgroup/memory/memory.limit_in_bytes
 
   // the magic value 9223372036854771712 or 0x7ffffffffffff000
@@ -172,8 +195,35 @@ int get_cgroup_memory_limit(uint64_t *limit)
 out:
   fclose(f);
   return ret;
+#else
+  return 0;
+#endif
 }
 
+#ifdef _WIN32
+int get_windows_version(POSVERSIONINFOEXW ver) {
+  using  get_version_func_t = DWORD (WINAPI *)(OSVERSIONINFOEXW*);
+
+  // We'll load the library directly to avoid depending on the NTDDK.
+  HMODULE ntdll_lib = LoadLibraryW(L"Ntdll.dll");
+  if (!ntdll_lib) {
+    return -EINVAL;
+  }
+
+  // The standard "GetVersion" returned values depend on the application
+  // manifest. We'll get the "real" version by using the Rtl* version.
+  auto get_version_func = (
+    get_version_func_t)GetProcAddress(ntdll_lib, "RtlGetVersion");
+  int ret = 0;
+  if (!get_version_func || get_version_func(ver)) {
+    // RtlGetVersion returns non-zero values in case of errors.
+    ret = -EINVAL;
+  }
+
+  FreeLibrary(ntdll_lib);
+  return ret;
+}
+#endif
 
 void collect_sys_info(map<string, string> *m, CephContext *cct)
 {
@@ -182,6 +232,7 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
   (*m)["ceph_version_short"] = ceph_version_to_str();
   (*m)["ceph_release"] = ceph_release_to_str();
 
+  #ifndef _WIN32
   // kernel info
   struct utsname u;
   int r = uname(&u);
@@ -192,6 +243,44 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
     (*m)["hostname"] = u.nodename;
     (*m)["arch"] = u.machine;
   }
+  #else
+  OSVERSIONINFOEXW ver = {0};
+  ver.dwOSVersionInfoSize = sizeof(ver);
+  get_windows_version(&ver);
+
+  char version_str[64];
+  snprintf(version_str, 64, "%d.%d (%d)",
+           ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber);
+
+  char hostname[64];
+  DWORD hostname_sz = sizeof(hostname);
+  GetComputerNameA(hostname, &hostname_sz);
+
+  SYSTEM_INFO sys_info;
+  char* arch_str;
+  GetNativeSystemInfo(&sys_info);
+
+  switch (sys_info.wProcessorArchitecture) {
+    case PROCESSOR_ARCHITECTURE_AMD64:
+      arch_str = "x86_64";
+      break;
+    case PROCESSOR_ARCHITECTURE_INTEL:
+      arch_str = "x86";
+      break;
+    case PROCESSOR_ARCHITECTURE_ARM:
+      arch_str = "arm";
+      break;
+    default:
+      arch_str = "unknown";
+      break;
+  }
+
+  (*m)["os"] = "Windows";
+  (*m)["kernel_version"] = version_str;
+  (*m)["kernel_description"] = version_str;
+  (*m)["hostname"] = hostname;
+  (*m)["arch"] = arch_str;
+  #endif
 
   // but wait, am i in a container?
   bool in_container = false;
@@ -210,7 +299,7 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
   }
   if (in_container) {
     if (const char *node_name = getenv("NODE_NAME")) {
-      (*m)["container_hostname"] = u.nodename;
+      (*m)["container_hostname"] = (*m)["hostname"];
       (*m)["hostname"] = node_name;
     }
     if (const char *ns = getenv("POD_NAMESPACE")) {
@@ -246,7 +335,7 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
       (*m)["cpu"] = buf;
     }
   }
-#else
+#elif !defined(_WIN32)
   // memory
   if (std::ifstream f{PROCPREFIX "/proc/meminfo"}; !f.fail()) {
     for (std::string line; std::getline(f, line); ) {

--- a/src/os/filestore/os_xattr.h
+++ b/src/os/filestore/os_xattr.h
@@ -24,6 +24,8 @@ extern "C" {
 # define ENOATTR ENODATA
 #endif
 
+#include <stddef.h>
+
 int ceph_os_setxattr(const char *path, const char *name,
                   const void *value, size_t size);
 int ceph_os_fsetxattr(int fd, const char *name, const void *value,

--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(CURSES_NEED_NCURSES TRUE)
-find_package(Curses REQUIRED)
+# libcurses may not be available on some platforms (e.g. Windows).
+find_package(Curses)
 
 set(rbd_srcs
   rbd.cc
@@ -61,8 +62,12 @@ target_link_libraries(rbd librbd
   journal
   libneorados
   librados
-  ceph-common global ${CURSES_LIBRARIES}
+  ceph-common global
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
+if(CURSES_FOUND)
+  target_compile_definitions(rbd PRIVATE HAVE_CURSES)
+  target_link_libraries(rbd ${CURSES_LIBRARIES})
+endif()
 if(WITH_KRBD)
   target_link_libraries(rbd 
     krbd)

--- a/src/tools/rbd/action/Perf.cc
+++ b/src/tools/rbd/action/Perf.cc
@@ -11,7 +11,9 @@
 #include "common/Formatter.h"
 #include "common/TextTable.h"
 #include "global/global_context.h"
+#ifdef HAVE_CURSES
 #include <ncurses.h>
+#endif
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/time.h>
@@ -338,6 +340,7 @@ void format(const ImageStats& image_stats, Formatter* f, bool global_search) {
 
 } // namespace iostat
 
+#ifdef HAVE_CURSES
 namespace iotop {
 
 class MainWindow {
@@ -560,6 +563,7 @@ private:
 };
 
 } // namespace iotop
+#endif // HAVE_CURSES
 
 
 void get_arguments_iostat(po::options_description *positional,
@@ -651,6 +655,7 @@ int execute_iostat(const po::variables_map &vm,
   return 0;
 }
 
+#ifdef HAVE_CURSES
 void get_arguments_iotop(po::options_description *positional,
                          po::options_description *options) {
   at::add_pool_options(positional, options, true);
@@ -688,13 +693,15 @@ int execute_iotop(const po::variables_map &vm,
   return 0;
 }
 
-Shell::Action stat_action(
-  {"perf", "image", "iostat"}, {}, "Display image IO statistics.", "",
-  &get_arguments_iostat, &execute_iostat);
 Shell::Action top_action(
   {"perf", "image", "iotop"}, {}, "Display a top-like IO monitor.", "",
   &get_arguments_iotop, &execute_iotop);
 
+#endif // HAVE_CURSES
+
+Shell::Action stat_action(
+  {"perf", "image", "iostat"}, {}, "Display image IO statistics.", "",
+  &get_arguments_iostat, &execute_iostat);
 } // namespace perf
 } // namespace action
 } // namespace rbd


### PR DESCRIPTION
Windows support [part 5]

This PR series intends to set the ground for the upcoming Windows port effort.
For now, we're mostly interested in the client side, allowing Windows hosts
to consume rados, rbd and cephfs resources.

Those PRs should be reviewed and merged in order. Each PR depends on the previous one from the series (in fact it includes the previous commits as well).

~~Part 1: #31981~~
~~Part 2: #32704~~
~~Part 3: #32705~~
~~Part 4: #32707~~
**Part 5: #32780** 
Part 6: #32779
Part 7: #32778 
Part 8: #32777 
Part 9: #32776
Part 10: #33750
Part 11: #34858
Part 12: #34859

Related but independent PRs:
https://github.com/ceph/ceph/pull/32027
https://github.com/ceph/fmt/pull/2
https://github.com/ceph/rocksdb/pull/42

For more details about the build process and current status, please check the
README.windows.rst file. Worth mentioning that the resulted binaries can
connect to ceph clusters and consume pools: http://paste.openstack.org/raw/787534/

Here are some test results as well:
[test_results.zip](https://github.com/ceph/ceph/files/4077517/test_results.zip)

Individual PR commits:

```
rbd: make libcurses optional
common: add Windows implementation for system info getter
common: add platform checks
common: skip undefined open flags on Windows
os: Add missing include
```

Any feedback is highly appreciated.

Signed-off-by: Lucian Petrut lpetrut@cloudbasesolutions.com
Signed-off-by: Alin Gabriel Serdean aserdean@cloudbasesolutions.com
