### PR TITLE
src/: use transparent comparator

### DIFF
--- a/src/common/map_cacher.hpp
+++ b/src/common/map_cacher.hpp
@@ -27,7 +27,7 @@ class Transaction {
 public:
   /// Set keys according to map
   virtual void set_keys(
-    const std::map<K, V> &keys ///< [in] keys/values to set
+    const std::map<K, V, std::less<>> &keys ///< [in] keys/values to set
     ) = 0;
 
   /// Remove keys
@@ -51,7 +51,7 @@ public:
   /// Returns requested key values
   virtual int get_keys(
     const std::set<K> &keys,   ///< [in] keys requested
-    std::map<K, V> *got  ///< [out] values for keys obtained
+    std::map<K, V, std::less<>> *got  ///< [out] values for keys obtained
     ) = 0; ///< @return error value
 
   /// Returns next key
@@ -123,15 +123,13 @@ public:
 
   /// Adds operation setting keys to Transaction
   void set_keys(
-    const map<K, V> &keys,  ///< [in] keys/values to set
+    const map<K, V, less<>> &keys,  ///< [in] keys/values to set
     Transaction<K, V> *t    ///< [out] transaction to use
     ) {
     std::set<VPtr> vptrs;
-    for (typename map<K, V>::const_iterator i = keys.begin();
-	 i != keys.end();
-	 ++i) {
-      VPtr ip = in_progress.lookup_or_create(i->first, i->second);
-      *ip = i->second;
+    for (const auto& [k, v] :  keys) {
+      VPtr ip = in_progress.lookup_or_create(k, v);
+      *ip = v;
       vptrs.insert(ip);
     }
     t->set_keys(keys);
@@ -162,7 +160,7 @@ public:
     map<K, V> *got             ///< [out] keys gotten
     ) {
     set<K> to_get;
-    map<K, V> _got;
+    map<K, V, less<>> _got;
     for (typename set<K>::const_iterator i = keys_to_get.begin();
 	 i != keys_to_get.end();
 	 ++i) {

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -342,7 +342,7 @@ string cleanbin(bufferlist &bl, bool &base64, bool show)
 
 // If non-printable characters found then convert to "Base64:" followed by
 // base64 encoding
-string cleanbin(string &str)
+string cleanbin(const string &str)
 {
   bool base64;
   bufferlist bl;

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -266,7 +266,7 @@ void PG::prepare_write(pg_info_t &info,
 		       bool need_write_epoch,
 		       ceph::os::Transaction &t)
 {
-  std::map<string,bufferlist> km;
+  std::map<std::string, bufferlist, std::less<>> km;
   std::string key_to_remove;
   if (dirty_big_info || dirty_info) {
     int ret = prepare_info_keymap(

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -424,6 +424,7 @@ inline namespace v14_2_0 {
      * @param map [in] keys and values to set
      */
     void omap_set(const std::map<std::string, bufferlist> &map);
+    void omap_set(const std::map<std::string, bufferlist, std::less<>> &map);
 
     /**
      * set header
@@ -542,6 +543,7 @@ inline namespace v14_2_0 {
     void stat2(uint64_t *psize, struct timespec *pts, int *prval);
     void getxattr(const char *name, bufferlist *pbl, int *prval);
     void getxattrs(std::map<std::string, bufferlist> *pattrs, int *prval);
+    void getxattrs(std::map<std::string, bufferlist, std::less<>> *pattrs, int *prval);
     void read(size_t off, uint64_t len, bufferlist *pbl, int *prval);
     void checksum(rados_checksum_type_t type, const bufferlist &init_value_bl,
 		  uint64_t off, size_t len, size_t chunk_size, bufferlist *pbl,
@@ -585,6 +587,12 @@ inline namespace v14_2_0 {
       std::map<std::string, bufferlist> *out_vals,
       bool *pmore,
       int *prval);
+    void omap_get_vals2(
+      const std::string &start_after,
+      uint64_t max_return,
+      std::map<std::string, bufferlist, std::less<>> *out_vals,
+      bool *pmore,
+      int *prval);
 
     /**
      * omap_get_vals: keys and values from the object omap
@@ -621,6 +629,13 @@ inline namespace v14_2_0 {
       const std::string &filter_prefix,
       uint64_t max_return,
       std::map<std::string, bufferlist> *out_vals,
+      bool *pmore,
+      int *prval);
+    void omap_get_vals2(
+      const std::string &start_after,
+      const std::string &filter_prefix,
+      uint64_t max_return,
+      std::map<std::string, bufferlist, std::less<>> *out_vals,
       bool *pmore,
       int *prval);
 
@@ -674,6 +689,9 @@ inline namespace v14_2_0 {
      */
     void omap_get_vals_by_keys(const std::set<std::string> &keys,
 			       std::map<std::string, bufferlist> *map,
+			       int *prval);
+    void omap_get_vals_by_keys(const std::set<std::string> &keys,
+                   std::map<std::string, bufferlist, std::less<>> *map,
 			       int *prval);
 
     /**
@@ -826,6 +844,7 @@ inline namespace v14_2_0 {
     int cmpext(const std::string& o, uint64_t off, bufferlist& cmp_bl);
     int sparse_read(const std::string& o, std::map<uint64_t,uint64_t>& m, bufferlist& bl, size_t len, uint64_t off);
     int getxattr(const std::string& oid, const char *name, bufferlist& bl);
+    int getxattrs(const std::string& oid, std::map<std::string, bufferlist, std::less<>>& attrset);
     int getxattrs(const std::string& oid, std::map<std::string, bufferlist>& attrset);
     int setxattr(const std::string& oid, const char *name, bufferlist& bl);
     int rmxattr(const std::string& oid, const char *name);
@@ -848,6 +867,11 @@ inline namespace v14_2_0 {
 		       const std::string& start_after,
 		       uint64_t max_return,
 		       std::map<std::string, bufferlist> *out_vals,
+		       bool *pmore);
+    int omap_get_vals2(const std::string& oid,
+		       const std::string& start_after,
+		       uint64_t max_return,
+               std::map<std::string, bufferlist, std::less<>> *out_vals,
 		       bool *pmore);
     int omap_get_vals(const std::string& oid,
                       const std::string& start_after,
@@ -876,6 +900,8 @@ inline namespace v14_2_0 {
                               std::map<std::string, bufferlist> *vals);
     int omap_set(const std::string& oid,
                  const std::map<std::string, bufferlist>& map);
+    int omap_set(const std::string& oid,
+                 const std::map<std::string, bufferlist, std::less<>>& map);
     int omap_set_header(const std::string& oid,
                         const bufferlist& bl);
     int omap_clear(const std::string& oid);
@@ -1107,6 +1133,7 @@ inline namespace v14_2_0 {
     int aio_flush_async(AioCompletion *c);
     int aio_getxattr(const std::string& oid, AioCompletion *c, const char *name, bufferlist& bl);
     int aio_getxattrs(const std::string& oid, AioCompletion *c, std::map<std::string, bufferlist>& attrset);
+    int aio_getxattrs(const std::string& oid, AioCompletion *c, std::map<std::string, bufferlist, std::less<>>& attrset);
     int aio_setxattr(const std::string& oid, AioCompletion *c, const char *name, bufferlist& bl);
     int aio_rmxattr(const std::string& oid, AioCompletion *c, const char *name);
     int aio_stat(const std::string& oid, AioCompletion *c, uint64_t *psize, time_t *pmtime);

--- a/src/include/radosstriper/libradosstriper.hpp
+++ b/src/include/radosstriper/libradosstriper.hpp
@@ -126,7 +126,9 @@ namespace libradosstriper
      * Start iterating over xattrs on a striped object.
      */
     int getxattrs(const std::string& oid,
-                  std::map<std::string, ceph::bufferlist>& attrset); 
+                  std::map<std::string, ceph::bufferlist>& attrset);
+    int getxattrs(const std::string& oid,
+                  std::map<std::string, ceph::bufferlist, std::less<>>& attrset);
     
     /**
      * synchronously write to the striped object at the specified offset.

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -94,7 +94,7 @@ void dump_services(ceph::Formatter* f, const std::map<std::string,
 		   std::list<std::string> >& services, const char* type);
 
 std::string cleanbin(ceph::buffer::list &bl, bool &b64, bool show = false);
-std::string cleanbin(std::string &str);
+std::string cleanbin(const std::string &str);
 
 namespace ceph::util {
 

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -181,14 +181,14 @@ public:
   virtual int get(
     const std::string &prefix,               ///< [in] Prefix/CF for key
     const std::set<std::string> &key,        ///< [in] Key to retrieve
-    std::map<std::string, ceph::buffer::list> *out   ///< [out] Key value retrieved
+    std::map<std::string, ceph::buffer::list, std::less<>> *out   ///< [out] Key value retrieved
     ) = 0;
   virtual int get(const std::string &prefix, ///< [in] prefix or CF name
 		  const std::string &key,    ///< [in] key
 		  ceph::buffer::list *value) {       ///< [out] value
     std::set<std::string> ks;
     ks.insert(key);
-    std::map<std::string,ceph::buffer::list> om;
+    std::map<std::string,ceph::buffer::list,std::less<>> om;
     int r = get(prefix, ks, &om);
     if (om.find(key) != om.end()) {
       *value = std::move(om[key]);

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -301,7 +301,7 @@ void LevelDBStore::LevelDBTransactionImpl::rm_range_keys(const string &prefix, c
 int LevelDBStore::get(
     const string &prefix,
     const std::set<string> &keys,
-    std::map<string, bufferlist> *out)
+    std::map<string, bufferlist, std::less<>> *out)
 {
   utime_t start = ceph_clock_now();
   for (std::set<string>::const_iterator i = keys.begin();

--- a/src/kv/LevelDBStore.h
+++ b/src/kv/LevelDBStore.h
@@ -223,7 +223,7 @@ public:
   int get(
     const string &prefix,
     const std::set<string> &key,
-    std::map<string, bufferlist> *out
+    std::map<string, bufferlist, std::less<>> *out
     ) override;
 
   int get(const string &prefix, 

--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -434,7 +434,7 @@ int MemDB::get(const string &prefix, const std::string& key,
 }
 
 int MemDB::get(const string &prefix, const std::set<string> &keys,
-    std::map<string, bufferlist> *out)
+    std::map<string, bufferlist, std::less<>> *out)
 {
   utime_t start = ceph_clock_now();
 

--- a/src/kv/MemDB.h
+++ b/src/kv/MemDB.h
@@ -144,7 +144,7 @@ public:
   int submit_transaction_sync(Transaction) override;
 
   int get(const std::string &prefix, const std::set<std::string> &key,
-    std::map<std::string, bufferlist> *out) override;
+    std::map<std::string, bufferlist, std::less<>> *out) override;
 
   int get(const std::string &prefix, const std::string &key,
           bufferlist *out) override;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1082,7 +1082,7 @@ void RocksDBStore::RocksDBTransactionImpl::merge(
 int RocksDBStore::get(
     const string &prefix,
     const std::set<string> &keys,
-    std::map<string, bufferlist> *out)
+    std::map<string, bufferlist, std::less<>> *out)
 {
   utime_t start = ceph_clock_now();
   auto cf = get_cf_handle(prefix);

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -352,7 +352,7 @@ public:
   int get(
     const string &prefix,
     const std::set<string> &key,
-    std::map<string, bufferlist> *out
+    std::map<string, bufferlist, std::less<>> *out
     ) override;
   int get(
     const string &prefix,

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -149,7 +149,7 @@ struct librados::IoCtxImpl {
 
   int getxattr(const object_t& oid, const char *name, bufferlist& bl);
   int setxattr(const object_t& oid, const char *name, bufferlist& bl);
-  int getxattrs(const object_t& oid, map<string, bufferlist>& attrset);
+  int getxattrs(const object_t& oid, map<string, bufferlist, less<>>& attrset);
   int rmxattr(const object_t& oid, const char *name);
 
   int operate(const object_t& oid, ::ObjectOperation *o, ceph::real_time *pmtime, int flags=0);
@@ -219,7 +219,7 @@ struct librados::IoCtxImpl {
   int aio_setxattr(const object_t& oid, AioCompletionImpl *c,
 		   const char *name, bufferlist& bl);
   int aio_getxattrs(const object_t& oid, AioCompletionImpl *c,
-		    map<string, bufferlist>& attrset);
+		    map<string, bufferlist, less<>>& attrset);
   int aio_rmxattr(const object_t& oid, AioCompletionImpl *c,
 		  const char *name);
   int aio_cancel(AioCompletionImpl *c);

--- a/src/librados/RadosXattrIter.h
+++ b/src/librados/RadosXattrIter.h
@@ -29,8 +29,8 @@ namespace librados {
   struct RadosXattrsIter {
     RadosXattrsIter();
     ~RadosXattrsIter();
-    std::map<std::string, bufferlist> attrset;
-    std::map<std::string, bufferlist>::iterator i;
+    std::map<std::string, bufferlist, std::less<>> attrset;
+    std::map<std::string, bufferlist, std::less<>>::iterator i;
     char *val;
   };
 };

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -3382,7 +3382,7 @@ extern "C" void _rados_write_op_omap_set(rados_write_op_t write_op,
                                          size_t num)
 {
   tracepoint(librados, rados_write_op_omap_set_enter, write_op, num);
-  std::map<std::string, bufferlist> entries;
+  std::map<std::string, bufferlist, less<>> entries;
   for (size_t i = 0; i < num; ++i) {
     tracepoint(librados, rados_write_op_omap_set_entry, keys[i], vals[i], lens[i]);
     bufferlist bl(lens[i]);
@@ -3402,7 +3402,7 @@ extern "C" void _rados_write_op_omap_set2(rados_write_op_t write_op,
                                           size_t num)
 {
   tracepoint(librados, rados_write_op_omap_set_enter, write_op, num);
-  std::map<std::string, bufferlist> entries;
+  std::map<std::string, bufferlist, std::less<>> entries;
   for (size_t i = 0; i < num; ++i) {
     bufferlist bl(val_lens[i]);
     bl.append(vals[i], val_lens[i]);
@@ -3790,8 +3790,8 @@ extern "C" void _rados_read_op_exec_user_buf(rados_read_op_t read_op,
 LIBRADOS_C_API_BASE_DEFAULT(rados_read_op_exec_user_buf);
 
 struct RadosOmapIter {
-  std::map<std::string, bufferlist> values;
-  std::map<std::string, bufferlist>::iterator i;
+  std::map<std::string, bufferlist, std::less<>> values;
+  std::map<std::string, bufferlist, std::less<>>::iterator i;
 };
 
 class C_OmapIter : public Context {

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -255,7 +255,9 @@ void librados::ObjectReadOperation::omap_get_vals(
 {
   ceph_assert(impl);
   ::ObjectOperation *o = &impl->o;
-  o->omap_get_vals(start_after, filter_prefix, max_return, out_vals, nullptr,
+  o->omap_get_vals(start_after, filter_prefix, max_return,
+		   reinterpret_cast<std::map<std::string, bufferlist, std::less<>>*>(out_vals),
+		   nullptr,
 		   prval);
 }
 
@@ -264,6 +266,20 @@ void librados::ObjectReadOperation::omap_get_vals2(
   const std::string &filter_prefix,
   uint64_t max_return,
   std::map<std::string, bufferlist> *out_vals,
+  bool *pmore,
+  int *prval)
+{
+  omap_get_vals2(
+    start_after, filter_prefix, max_return,
+    reinterpret_cast<std::map<std::string, bufferlist, std::less<>>*>(out_vals),
+    pmore, prval);
+}
+
+void librados::ObjectReadOperation::omap_get_vals2(
+  const std::string &start_after,
+  const std::string &filter_prefix,
+  uint64_t max_return,
+  std::map<std::string, bufferlist, std::less<>> *out_vals,
   bool *pmore,
   int *prval)
 {
@@ -281,13 +297,27 @@ void librados::ObjectReadOperation::omap_get_vals(
 {
   ceph_assert(impl);
   ::ObjectOperation *o = &impl->o;
-  o->omap_get_vals(start_after, "", max_return, out_vals, nullptr, prval);
+  o->omap_get_vals(start_after, "", max_return,
+		   reinterpret_cast<std::map<std::string, bufferlist, std::less<>>*>(out_vals),
+		   nullptr, prval);
 }
 
 void librados::ObjectReadOperation::omap_get_vals2(
   const std::string &start_after,
   uint64_t max_return,
   std::map<std::string, bufferlist> *out_vals,
+  bool *pmore,
+  int *prval)
+{
+  omap_get_vals2(start_after, max_return,
+		 reinterpret_cast<std::map<std::string, bufferlist, std::less<>>*>(out_vals),
+		 pmore, prval);
+}
+
+void librados::ObjectReadOperation::omap_get_vals2(
+  const std::string &start_after,
+  uint64_t max_return,
+  std::map<std::string, bufferlist, std::less<>> *out_vals,
   bool *pmore,
   int *prval)
 {
@@ -325,10 +355,19 @@ void librados::ObjectReadOperation::omap_get_header(bufferlist *bl, int *prval)
   ::ObjectOperation *o = &impl->o;
   o->omap_get_header(bl, prval);
 }
-
 void librados::ObjectReadOperation::omap_get_vals_by_keys(
   const std::set<std::string> &keys,
   std::map<std::string, bufferlist> *map,
+  int *prval)
+{
+  omap_get_vals_by_keys(keys,
+			reinterpret_cast<std::map<std::string, bufferlist, std::less<>>*>(map),
+			prval);
+}
+
+void librados::ObjectReadOperation::omap_get_vals_by_keys(
+  const std::set<std::string> &keys,
+  std::map<std::string, bufferlist, std::less<>> *map,
   int *prval)
 {
   ceph_assert(impl);
@@ -430,6 +469,11 @@ int librados::IoCtx::omap_get_vals2(
 }
 
 void librados::ObjectReadOperation::getxattrs(map<string, bufferlist> *pattrs, int *prval)
+{
+  getxattrs(reinterpret_cast<map<string, bufferlist, std::less<>>*>(pattrs), prval);
+}
+
+void librados::ObjectReadOperation::getxattrs(map<string, bufferlist, std::less<>> *pattrs, int *prval)
 {
   ceph_assert(impl);
   ::ObjectOperation *o = &impl->o;
@@ -546,7 +590,13 @@ void librados::ObjectWriteOperation::setxattr(const char *name,
 }
 
 void librados::ObjectWriteOperation::omap_set(
-  const map<string, bufferlist> &map)
+  const std::map<string, bufferlist> &map)
+{
+  omap_set(reinterpret_cast<const std::map<string, bufferlist, less<>>&>(map));
+}
+
+void librados::ObjectWriteOperation::omap_set(
+  const map<string, bufferlist, less<>> &map)
 {
   ceph_assert(impl);
   ::ObjectOperation *o = &impl->o;
@@ -1323,6 +1373,12 @@ int librados::IoCtx::getxattr(const std::string& oid, const char *name, bufferli
 
 int librados::IoCtx::getxattrs(const std::string& oid, map<std::string, bufferlist>& attrset)
 {
+  return getxattrs(oid, reinterpret_cast<map<std::string, bufferlist, std::less<>>&>(attrset));
+}
+
+int librados::IoCtx::getxattrs(const std::string& oid,
+			       map<std::string, bufferlist, std::less<>>& attrset)
+{
   object_t obj(oid);
   return io_ctx_impl->getxattrs(obj, attrset);
 }
@@ -1377,6 +1433,19 @@ int librados::IoCtx::omap_get_vals2(
   const std::string& start_after,
   uint64_t max_return,
   std::map<std::string, bufferlist> *out_vals,
+  bool *pmore)
+{
+  return omap_get_vals2(
+    oid, start_after, max_return,
+    reinterpret_cast<std::map<string, bufferlist, less<>>*>(out_vals),
+    pmore);
+}
+
+int librados::IoCtx::omap_get_vals2(
+  const std::string& oid,
+  const std::string& start_after,
+  uint64_t max_return,
+  std::map<std::string, bufferlist, std::less<>> *out_vals,
   bool *pmore)
 {
   ObjectReadOperation op;
@@ -1476,6 +1545,12 @@ int librados::IoCtx::omap_get_vals_by_keys(const std::string& oid,
 
 int librados::IoCtx::omap_set(const std::string& oid,
                               const map<string, bufferlist>& m)
+{
+  return omap_set(oid, reinterpret_cast<const map<string, bufferlist, less<>>&>(m));
+}
+
+int librados::IoCtx::omap_set(const std::string& oid,
+                              const map<string, bufferlist, less<>>& m)
 {
   ObjectWriteOperation op;
   op.omap_set(m);
@@ -2023,6 +2098,13 @@ int librados::IoCtx::aio_getxattr(const std::string& oid, librados::AioCompletio
 
 int librados::IoCtx::aio_getxattrs(const std::string& oid, AioCompletion *c,
 				   map<std::string, bufferlist>& attrset)
+{
+  return aio_getxattrs(oid, c,
+    reinterpret_cast<map<std::string, bufferlist, std::less<>>&>(attrset));
+}
+
+int librados::IoCtx::aio_getxattrs(const std::string& oid, AioCompletion *c,
+				   map<std::string, bufferlist, std::less<>>& attrset)
 {
   object_t obj(oid);
   return io_ctx_impl->aio_getxattrs(obj, c->pc, attrset);

--- a/src/libradosstriper/RadosStriperImpl.cc
+++ b/src/libradosstriper/RadosStriperImpl.cc
@@ -507,7 +507,7 @@ int libradosstriper::RadosStriperImpl::setxattr(const object_t& soid,
 }
 
 int libradosstriper::RadosStriperImpl::getxattrs(const object_t& soid,
-                                                 map<string, bufferlist>& attrset)
+                                                 map<string, bufferlist, less<>>& attrset)
 {
   std::string firstObjOid = getObjectId(soid, 0);
   int rc = m_ioCtx.getxattrs(firstObjOid, attrset);

--- a/src/libradosstriper/RadosStriperImpl.h
+++ b/src/libradosstriper/RadosStriperImpl.h
@@ -61,7 +61,7 @@ struct RadosStriperImpl {
   // xattrs
   int getxattr(const object_t& soid, const char *name, bufferlist& bl);
   int setxattr(const object_t& soid, const char *name, bufferlist& bl);
-  int getxattrs(const object_t& soid, map<string, bufferlist>& attrset);
+  int getxattrs(const object_t& soid, map<string, bufferlist, less<>>& attrset);
   int rmxattr(const object_t& soid, const char *name);
 
   // io

--- a/src/libradosstriper/libradosstriper.cc
+++ b/src/libradosstriper/libradosstriper.cc
@@ -196,6 +196,13 @@ int libradosstriper::RadosStriper::rmxattr(const std::string& oid, const char *n
 int libradosstriper::RadosStriper::getxattrs(const std::string& oid,
 					     std::map<std::string, bufferlist>& attrset)
 {
+  return rados_striper_impl->getxattrs(oid,
+    reinterpret_cast<std::map<std::string, bufferlist, std::less<>>&>(attrset));
+}
+
+int libradosstriper::RadosStriper::getxattrs(const std::string& oid,
+					     std::map<std::string, bufferlist, std::less<>>& attrset)
+{
   return rados_striper_impl->getxattrs(oid, attrset);
 }
 

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1578,8 +1578,8 @@ class C_IO_Dir_OMAP_FetchedMore : public CDirIOContext {
 public:
   bufferlist hdrbl;
   bool more = false;
-  map<string, bufferlist> omap;      ///< carry-over from before
-  map<string, bufferlist> omap_more; ///< new batch
+  map<string, bufferlist, less<>> omap;      ///< carry-over from before
+  map<string, bufferlist, less<>> omap_more; ///< new batch
   int ret;
   C_IO_Dir_OMAP_FetchedMore(CDir *d, MDSContext *f) :
     CDirIOContext(d), fin(f), ret(0) { }
@@ -1608,7 +1608,7 @@ class C_IO_Dir_OMAP_Fetched : public CDirIOContext {
 public:
   bufferlist hdrbl;
   bool more = false;
-  map<string, bufferlist> omap;
+  map<string, bufferlist, less<>> omap;
   bufferlist btbl;
   int ret1, ret2, ret3;
 
@@ -1668,7 +1668,7 @@ void CDir::_omap_fetch(MDSContext *c, const std::set<dentry_key_t>& keys)
 
 void CDir::_omap_fetch_more(
   bufferlist& hdrbl,
-  map<string, bufferlist>& omap,
+  map<string, bufferlist, less<>>& omap,
   MDSContext *c)
 {
   // we have more omap keys to fetch!
@@ -1887,7 +1887,7 @@ CDentry *CDir::_load_dentry(
   return dn;
 }
 
-void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
+void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist, less<>>& omap,
 			 bool complete, int r)
 {
   LogChannelRef clog = cache->mds->clog;
@@ -2163,7 +2163,7 @@ void CDir::_omap_commit(int op_prio)
   }
 
   set<string> to_remove;
-  map<string, bufferlist> to_set;
+  map<string, bufferlist, less<>> to_set;
 
   C_GatherBuilder gather(g_ceph_context,
 			 new C_OnFinisher(new C_IO_Dir_Committed(this,

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -634,7 +634,7 @@ protected:
 
   void _omap_fetch(MDSContext *fin, const std::set<dentry_key_t>& keys);
   void _omap_fetch_more(
-    bufferlist& hdrbl, std::map<std::string, bufferlist>& omap,
+    bufferlist& hdrbl, std::map<std::string, bufferlist, std::less<>>& omap,
     MDSContext *fin);
   CDentry *_load_dentry(
       std::string_view key,
@@ -660,7 +660,7 @@ protected:
    */
   void go_bad(bool complete);
 
-  void _omap_fetched(bufferlist& hdrbl, std::map<std::string, bufferlist>& omap,
+  void _omap_fetched(bufferlist& hdrbl, std::map<std::string, bufferlist, std::less<>>& omap,
 		     bool complete, int r);
 
   // -- commit --

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -99,7 +99,7 @@ protected:
   void _load_finish(int op_r, int header_r, int values_r,
 		    unsigned idx, bool first, bool more,
                     bufferlist &header_bl,
-		    std::map<std::string, bufferlist> &values);
+		    std::map<std::string, bufferlist, std::less<>> &values);
   void _recover_finish(int r);
 
   void _open_ino_finish(inodeno_t ino, int r);

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -103,7 +103,7 @@ public:
   int header_r;  //< Return value from OMAP header read
   int values_r;  //< Return value from OMAP value read
   bufferlist header_bl;
-  std::map<std::string, bufferlist> session_vals;
+  std::map<std::string, bufferlist, std::less<>> session_vals;
   bool more_session_vals = false;
 
   C_IO_SM_Load(SessionMap *cm, const bool f)
@@ -144,7 +144,7 @@ void SessionMapStore::encode_header(
  * Decode and insert some serialized OMAP values.  Call this
  * repeatedly to insert batched loads.
  */
-void SessionMapStore::decode_values(std::map<std::string, bufferlist> &session_vals)
+void SessionMapStore::decode_values(std::map<std::string, bufferlist, std::less<>> &session_vals)
 {
   for (std::map<std::string, bufferlist>::iterator i = session_vals.begin();
        i != session_vals.end(); ++i) {
@@ -176,7 +176,7 @@ void SessionMap::_load_finish(
     int values_r,
     bool first,
     bufferlist &header_bl,
-    std::map<std::string, bufferlist> &session_vals,
+    std::map<std::string, bufferlist, std::less<>> &session_vals,
     bool more_session_vals)
 {
   if (operation_r < 0) {
@@ -408,7 +408,7 @@ void SessionMap::save(MDSContext *onsave, version_t needv)
   }
 
   dout(20) << " updating keys:" << dendl;
-  map<string, bufferlist> to_set;
+  map<string, bufferlist, less<>> to_set;
   for(std::set<entity_name_t>::iterator i = dirty_sessions.begin();
       i != dirty_sessions.end(); ++i) {
     const entity_name_t name = *i;
@@ -841,7 +841,7 @@ void SessionMap::save_if_dirty(const std::set<entity_name_t> &tgt_sessions,
 
   // Batch writes into mds_sessionmap_keys_per_op
   const uint32_t kpo = g_conf()->mds_sessionmap_keys_per_op;
-  map<string, bufferlist> to_set;
+  map<string, bufferlist, less<>> to_set;
   for (uint32_t i = 0; i < write_sessions.size(); ++i) {
     const entity_name_t &session_id = write_sessions[i];
     Session *session = session_map[session_id];

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -533,7 +533,7 @@ public:
 
   virtual void encode_header(bufferlist *header_bl);
   virtual void decode_header(bufferlist &header_bl);
-  virtual void decode_values(std::map<std::string, bufferlist> &session_vals);
+  virtual void decode_values(std::map<std::string, bufferlist, std::less<>> &session_vals);
   virtual void decode_legacy(bufferlist::const_iterator& blp);
   void dump(Formatter *f) const;
 
@@ -724,7 +724,7 @@ public:
       int values_r,
       bool first,
       bufferlist &header_bl,
-      std::map<std::string, bufferlist> &session_vals,
+      std::map<std::string, bufferlist, std::less<>> &session_vals,
       bool more_session_vals);
 
   void load_legacy();

--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -352,7 +352,7 @@ static int os_getattr(const char *path, struct stat *stbuf)
 	return -ENOENT;
       set<string> k;
       k.insert(key);
-      map<string,bufferlist> v;
+      map<string,bufferlist,less<>> v;
       fs->store->omap_get_values(ch, oid, k, &v);
       if (!v.count(key)) {
 	return -ENOENT;
@@ -535,7 +535,7 @@ static int os_readdir(const char *path,
 
   case FN_OBJECT_ATTR:
     {
-      map<string,bufferptr> aset;
+      map<string,bufferptr,less<>> aset;
       fs->store->getattrs(ch, oid, aset);
       unsigned skip = offset;
       for (auto a : aset) {
@@ -684,7 +684,7 @@ static int os_open(const char *path, struct fuse_file_info *fi)
 	[&](bufferlist *pbl) {
 	  set<string> k;
 	  k.insert(key);
-	  map<string,bufferlist> v;
+	  map<string,bufferlist,less<>> v;
 	  int r = fs->store->omap_get_values(ch, oid, k, &v);
 	  if (r < 0)
 	    return r;
@@ -835,10 +835,10 @@ static int os_create(const char *path, mode_t mode, struct fuse_file_info *fi)
       pbl = new bufferlist;
       set<string> k;
       k.insert(key);
-      map<string,bufferlist> v;
+      map<string,bufferlist,less<>> v;
       fs->store->omap_get_values(ch, oid, k, &v);
       if (v.count(key) == 0) {
-	map<string,bufferlist> aset;
+	map<string,bufferlist,less<>> aset;
 	aset[key] = bufferlist();
 	t.omap_setkeys(cid, oid, aset);
       } else {
@@ -967,7 +967,7 @@ int os_flush(const char *path, struct fuse_file_info *fi)
 
   case FN_OBJECT_OMAP_VAL:
     {
-      map<string,bufferlist> aset;
+      map<string,bufferlist,less<>> aset;
       aset[key] = o->bl;
       t.omap_setkeys(cid, oid, aset);
       break;

--- a/src/os/ObjectMap.h
+++ b/src/os/ObjectMap.h
@@ -75,7 +75,7 @@ public:
   virtual int get(
     const ghobject_t &oid,             ///< [in] object containing map
     ceph::buffer::list *header,                ///< [out] Returned Header
-    std::map<std::string, ceph::buffer::list> *out       ///< [out] Returned keys and values
+    std::map<std::string, ceph::buffer::list, std::less<>> *out       ///< [out] Returned keys and values
     ) = 0;
 
   /// Get values for supplied keys
@@ -88,7 +88,7 @@ public:
   virtual int get_values(
     const ghobject_t &oid,             ///< [in] object containing map
     const std::set<std::string> &keys,           ///< [in] Keys to get
-    std::map<std::string, ceph::buffer::list> *out       ///< [out] Returned keys and values
+    std::map<std::string, ceph::buffer::list, std::less<>> *out       ///< [out] Returned keys and values
     ) = 0;
 
   /// Check key existence
@@ -102,7 +102,7 @@ public:
   virtual int get_xattrs(
     const ghobject_t &oid,             ///< [in] object
     const std::set<std::string> &to_get,         ///< [in] keys to get
-    std::map<std::string, ceph::buffer::list> *out       ///< [out] subset of attrs/vals defined
+    std::map<std::string, ceph::buffer::list, std::less<>> *out       ///< [out] subset of attrs/vals defined
     ) = 0;
 
   /// Get all xattrs

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -598,7 +598,7 @@ public:
    * @returns 0 on success, negative error code on failure.
    */
   virtual int getattrs(CollectionHandle &c, const ghobject_t& oid,
-		       std::map<std::string,ceph::buffer::ptr>& aset) = 0;
+		       std::map<std::string,ceph::buffer::ptr,std::less<>>& aset) = 0;
 
   /**
    * getattrs -- get all of the xattrs of an object
@@ -609,11 +609,11 @@ public:
    * @returns 0 on success, negative error code on failure.
    */
   int getattrs(CollectionHandle &c, const ghobject_t& oid,
-	       std::map<std::string,ceph::buffer::list>& aset) {
-    std::map<std::string,ceph::buffer::ptr> bmap;
+	       std::map<std::string, ceph::buffer::list, std::less<>>& aset) {
+    std::map<std::string, ceph::buffer::ptr, std::less<>> bmap;
     int r = getattrs(c, oid, bmap);
-    for (auto i = bmap.begin(); i != bmap.end(); ++i) {
-      aset[i->first].append(i->second);
+    for (auto& [key, val] : bmap) {
+      aset[key].append(std::move(val));
     }
     return r;
   }
@@ -680,7 +680,7 @@ public:
     CollectionHandle &c,     ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     ceph::buffer::list *header,      ///< [out] omap header
-    std::map<std::string, ceph::buffer::list> *out /// < [out] Key to value std::map
+    std::map<std::string, ceph::buffer::list, std::less<>> *out /// < [out] Key to value std::map
     ) = 0;
 
   /// Get omap header
@@ -703,7 +703,7 @@ public:
     CollectionHandle &c,         ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
     const std::set<std::string> &keys,     ///< [in] Keys to get
-    std::map<std::string, ceph::buffer::list> *out ///< [out] Returned keys and values
+    std::map<std::string, ceph::buffer::list, std::less<>> *out ///< [out] Returned keys and values
     ) = 0;
 
   /// Filters keys into out which are defined on oid

--- a/src/os/Transaction.cc
+++ b/src/os/Transaction.cc
@@ -544,7 +544,7 @@ void Transaction::generate_test_instances(list<Transaction*>& o)
 
   t = new Transaction;
   t->setattr(c, o1, "key", bl);
-  map<string,bufferptr> m;
+  map<string,bufferptr,less<>> m;
   m["a"] = buffer::copy("this", 4);
   m["b"] = buffer::copy("that", 4);
   t->setattrs(c, o1, m);

--- a/src/os/Transaction.h
+++ b/src/os/Transaction.h
@@ -905,7 +905,8 @@ public:
     data.ops = data.ops + 1;
   }
   /// Set multiple xattrs of an object
-  void setattrs(const coll_t& cid, const ghobject_t& oid, const std::map<std::string,ceph::buffer::ptr>& attrset) {
+  void setattrs(const coll_t& cid, const ghobject_t& oid,
+		const std::map<std::string,ceph::buffer::ptr,std::less<>>& attrset) {
     using ceph::encode;
     Op* _op = _get_next_op();
     _op->op = OP_SETATTRS;
@@ -915,7 +916,8 @@ public:
     data.ops = data.ops + 1;
   }
   /// Set multiple xattrs of an object
-  void setattrs(const coll_t& cid, const ghobject_t& oid, const std::map<std::string,ceph::buffer::list>& attrset) {
+  void setattrs(const coll_t& cid, const ghobject_t& oid,
+		const std::map<std::string,ceph::buffer::list,std::less<>>& attrset) {
     using ceph::encode;
     Op* _op = _get_next_op();
     _op->op = OP_SETATTRS;
@@ -1079,7 +1081,7 @@ public:
   void omap_setkeys(
     const coll_t& cid,                           ///< [in] Collection containing oid
     const ghobject_t &oid,                ///< [in] Object to update
-    const std::map<std::string, ceph::buffer::list> &attrset ///< [in] Replacement keys and values
+    const std::map<std::string, ceph::buffer::list, std::less<>> &attrset ///< [in] Replacement keys and values
     ) {
     using ceph::encode;
     Op* _op = _get_next_op();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7929,7 +7929,7 @@ void BlueStore::_fsck_check_objects(FSCKDepth depth,
             used_omap_head->erase(o->onode.nid);
             used_per_pool_omap_head->insert(o->onode.nid);
             bufferlist h;
-            map<string, bufferlist> kv;
+            map<string, bufferlist, less<>> kv;
             int r = _omap_get(c.get(), oid, &h, &kv);
             if (r < 0) {
               derr << " got " << r << " " << cpp_strerror(r) << dendl;
@@ -10215,7 +10215,7 @@ int BlueStore::getattr(
 int BlueStore::getattrs(
   CollectionHandle &c_,
   const ghobject_t& oid,
-  map<string,bufferptr>& aset)
+  map<string,bufferptr,less<>>& aset)
 {
   Collection *c = static_cast<Collection *>(c_.get());
   dout(15) << __func__ << " " << c->cid << " " << oid << dendl;
@@ -10440,7 +10440,7 @@ int BlueStore::omap_get(
   CollectionHandle &c_,    ///< [in] Collection containing oid
   const ghobject_t &oid,   ///< [in] Object containing omap
   bufferlist *header,      ///< [out] omap header
-  map<string, bufferlist> *out /// < [out] Key to value map
+  map<string, bufferlist, less<>> *out /// < [out] Key to value map
   )
 {
   Collection *c = static_cast<Collection *>(c_.get());
@@ -10451,7 +10451,7 @@ int BlueStore::_omap_get(
   Collection *c,    ///< [in] Collection containing oid
   const ghobject_t &oid,   ///< [in] Object containing omap
   bufferlist *header,      ///< [out] omap header
-  map<string, bufferlist> *out /// < [out] Key to value map
+  map<string, bufferlist, less<>> *out /// < [out] Key to value map
   )
 {
   dout(15) << __func__ << " " << c->get_cid() << " oid " << oid << dendl;
@@ -10583,7 +10583,7 @@ int BlueStore::omap_get_values(
   CollectionHandle &c_,        ///< [in] Collection containing oid
   const ghobject_t &oid,       ///< [in] Object containing omap
   const set<string> &keys,     ///< [in] Keys to get
-  map<string, bufferlist> *out ///< [out] Returned keys and values
+  map<string, bufferlist, less<>> *out ///< [out] Returned keys and values
   )
 {
   Collection *c = static_cast<Collection *>(c_.get());

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2706,7 +2706,7 @@ public:
 	      bufferptr& value) override;
 
   int getattrs(CollectionHandle &c, const ghobject_t& oid,
-	       map<string,bufferptr>& aset) override;
+	       map<string,bufferptr,less<>>& aset) override;
 
   int list_collections(vector<coll_t>& ls) override;
 
@@ -2729,13 +2729,13 @@ public:
     CollectionHandle &c,     ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
-    map<string, bufferlist> *out /// < [out] Key to value map
+    map<string, bufferlist, less<>> *out /// < [out] Key to value map
     ) override;
   int _omap_get(
     Collection *c,     ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
-    map<string, bufferlist> *out /// < [out] Key to value map
+    map<string, bufferlist, less<>> *out /// < [out] Key to value map
     );
 
   /// Get omap header
@@ -2758,7 +2758,7 @@ public:
     CollectionHandle &c,         ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
     const set<string> &keys,     ///< [in] Keys to get
-    map<string, bufferlist> *out ///< [out] Returned keys and values
+    map<string, bufferlist, less<>> *out ///< [out] Returned keys and values
     ) override;
 
   /// Filters keys into out which are defined on oid

--- a/src/os/filestore/DBObjectMap.cc
+++ b/src/os/filestore/DBObjectMap.cc
@@ -113,7 +113,7 @@ int DBObjectMap::check(std::ostream &out, bool repair, bool force)
 	break;
 
       set<string> to_get;
-      map<string, bufferlist> got;
+      map<string, bufferlist, less<>> got;
       to_get.insert(HEADER_KEY);
       db->get(sys_parent_prefix(header), to_get, &got);
       if (got.empty()) {
@@ -568,7 +568,7 @@ int DBObjectMap::get_header(const ghobject_t &oid,
 int DBObjectMap::_get_header(Header header,
 			     bufferlist *bl)
 {
-  map<string, bufferlist> out;
+  map<string, bufferlist, less<>> out;
   while (true) {
     out.clear();
     set<string> to_get;
@@ -727,7 +727,7 @@ int DBObjectMap::clear_keys_header(const ghobject_t &oid,
 
 int DBObjectMap::get(const ghobject_t &oid,
 		     bufferlist *_header,
-		     map<string, bufferlist> *out)
+		     map<string, bufferlist, less<>> *out)
 {
   MapHeaderLock hl(this, oid);
   Header header = lookup_map_header(hl, oid);
@@ -762,7 +762,7 @@ int DBObjectMap::get_keys(const ghobject_t &oid,
 int DBObjectMap::scan(Header header,
 		      const set<string> &in_keys,
 		      set<string> *out_keys,
-		      map<string, bufferlist> *out_values)
+		      map<string, bufferlist, less<>> *out_values)
 {
   ObjectMapIterator db_iter = _get_iterator(header);
   for (set<string>::const_iterator key_iter = in_keys.begin();
@@ -783,7 +783,7 @@ int DBObjectMap::scan(Header header,
 
 int DBObjectMap::get_values(const ghobject_t &oid,
 			    const set<string> &keys,
-			    map<string, bufferlist> *out)
+			    map<string, bufferlist, less<>> *out)
 {
   MapHeaderLock hl(this, oid);
   Header header = lookup_map_header(hl, oid);
@@ -805,7 +805,7 @@ int DBObjectMap::check_keys(const ghobject_t &oid,
 
 int DBObjectMap::get_xattrs(const ghobject_t &oid,
 			    const set<string> &to_get,
-			    map<string, bufferlist> *out)
+			    map<string, bufferlist, less<>> *out)
 {
   MapHeaderLock hl(this, oid);
   Header header = lookup_map_header(hl, oid);
@@ -1051,7 +1051,7 @@ void DBObjectMap::set_state()
 
 int DBObjectMap::get_state()
 {
-  map<string, bufferlist> result;
+  map<string, bufferlist, less<>> result;
   set<string> to_get;
   to_get.insert(GLOBAL_STATE_KEY);
   int r = db->get(SYS_PREFIX, to_get, &result);
@@ -1203,7 +1203,7 @@ DBObjectMap::Header DBObjectMap::lookup_parent(Header input)
 {
   std::unique_lock l{header_lock};
   header_cond.wait(l, [&input, this] { return !in_use.count(input->parent); });
-  map<string, bufferlist> out;
+  map<string, bufferlist, less<>> out;
   set<string> keys;
   keys.insert(HEADER_KEY);
 
@@ -1346,7 +1346,7 @@ int DBObjectMap::list_object_headers(vector<_Header> *out)
     out->push_back(header);
     while (header.parent) {
       set<string> to_get;
-      map<string, bufferlist> got;
+      map<string, bufferlist, less<>> got;
       to_get.insert(HEADER_KEY);
       db->get(sys_parent_prefix(header), to_get, &got);
       if (got.empty()) {

--- a/src/os/filestore/DBObjectMap.h
+++ b/src/os/filestore/DBObjectMap.h
@@ -156,7 +156,7 @@ public:
   int get(
     const ghobject_t &oid,
     bufferlist *header,
-    map<string, bufferlist> *out
+    map<string, bufferlist, less<>> *out
     ) override;
 
   int get_keys(
@@ -167,7 +167,7 @@ public:
   int get_values(
     const ghobject_t &oid,
     const set<string> &keys,
-    map<string, bufferlist> *out
+    map<string, bufferlist, less<>> *out
     ) override;
 
   int check_keys(
@@ -179,7 +179,7 @@ public:
   int get_xattrs(
     const ghobject_t &oid,
     const set<string> &to_get,
-    map<string, bufferlist> *out
+    map<string, bufferlist, less<>> *out
     ) override;
 
   int get_all_xattrs(
@@ -529,7 +529,7 @@ private:
   int scan(Header header,
 	   const set<string> &in_keys,
 	   set<string> *out_keys,
-	   map<string, bufferlist> *out_values);
+	   map<string, bufferlist, less<>> *out_values);
 
   /// Remove header and all related prefixes
   int _clear(Header header,

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -3840,7 +3840,7 @@ int FileStore::_clone(const coll_t& cid, const ghobject_t& oldoid, const ghobjec
 
   {
     char buf[2];
-    map<string, bufferptr> aset;
+    map<string, bufferptr, less<>> aset;
     r = _fgetattrs(**o, aset);
     if (r < 0)
       goto out3;
@@ -4448,7 +4448,7 @@ int FileStore::_fgetattr(int fd, const char *name, bufferptr& bp)
   return l;
 }
 
-int FileStore::_fgetattrs(int fd, map<string,bufferptr>& aset)
+int FileStore::_fgetattrs(int fd, map<string,bufferptr,less<>>& aset)
 {
   // get attr list
   char names1[100];
@@ -4499,7 +4499,7 @@ int FileStore::_fgetattrs(int fd, map<string,bufferptr>& aset)
   return 0;
 }
 
-int FileStore::_fsetattrs(int fd, map<string, bufferptr> &aset)
+int FileStore::_fsetattrs(int fd, map<string, bufferptr, less<>> &aset)
 {
   for (map<string, bufferptr>::iterator p = aset.begin();
        p != aset.end();
@@ -4580,7 +4580,7 @@ int FileStore::getattr(CollectionHandle& ch, const ghobject_t& oid, const char *
   r = _fgetattr(**fd, n, bp);
   lfn_close(fd);
   if (r == -ENODATA) {
-    map<string, bufferlist> got;
+    map<string, bufferlist, less<>> got;
     set<string> to_get;
     to_get.insert(string(name));
     Index index;
@@ -4614,12 +4614,13 @@ int FileStore::getattr(CollectionHandle& ch, const ghobject_t& oid, const char *
   }
 }
 
-int FileStore::getattrs(CollectionHandle& ch, const ghobject_t& oid, map<string,bufferptr>& aset)
+int FileStore::getattrs(CollectionHandle& ch, const ghobject_t& oid,
+			std::map<string,bufferptr,std::less<>>& aset)
 {
   tracepoint(objectstore, getattrs_enter, ch->cid.c_str());
   const coll_t& cid = !_need_temp_object_collection(ch->cid, oid) ? ch->cid : ch->cid.get_temp();
   set<string> omap_attrs;
-  map<string, bufferlist> omap_aset;
+  map<string, bufferlist, less<>> omap_aset;
   Index index;
   dout(15) << __FUNC__ << ": " << cid << "/" << oid << dendl;
 
@@ -4697,8 +4698,8 @@ int FileStore::_setattrs(const coll_t& cid, const ghobject_t& oid, map<string,bu
 {
   map<string, bufferlist> omap_set;
   set<string> omap_remove;
-  map<string, bufferptr> inline_set;
-  map<string, bufferptr> inline_to_set;
+  map<string, bufferptr, less<>> inline_set;
+  map<string, bufferptr, less<>> inline_to_set;
   FDRef fd;
   int spill_out = -1;
   bool incomplete_inline = false;
@@ -4841,7 +4842,7 @@ int FileStore::_rmattrs(const coll_t& cid, const ghobject_t& oid,
 {
   dout(15) << __FUNC__ << ": " << cid << "/" << oid << dendl;
 
-  map<string,bufferptr> aset;
+  map<string,bufferptr,less<>> aset;
   FDRef fd;
   set<string> omap_attrs;
   Index index;
@@ -4860,7 +4861,7 @@ int FileStore::_rmattrs(const coll_t& cid, const ghobject_t& oid,
 
   r = _fgetattrs(**fd, aset);
   if (r >= 0) {
-    for (map<string,bufferptr>::iterator p = aset.begin(); p != aset.end(); ++p) {
+    for (auto p = aset.begin(); p != aset.end(); ++p) {
       char n[CHAIN_XATTR_MAX_NAME_LEN];
       get_attrname(p->first.c_str(), n, CHAIN_XATTR_MAX_NAME_LEN);
       r = chain_fremovexattr(**fd, n);
@@ -5202,7 +5203,7 @@ int FileStore::collection_list(const coll_t& c,
 
 int FileStore::omap_get(CollectionHandle& ch, const ghobject_t &hoid,
 			bufferlist *header,
-			map<string, bufferlist> *out)
+			map<string, bufferlist, less<>> *out)
 {
   tracepoint(objectstore, omap_get_enter, ch->cid.c_str());
   const coll_t& c = !_need_temp_object_collection(ch->cid, hoid) ? ch->cid : ch->cid.get_temp();
@@ -5295,7 +5296,7 @@ int FileStore::omap_get_keys(CollectionHandle& ch, const ghobject_t &hoid, set<s
 
 int FileStore::omap_get_values(CollectionHandle& ch, const ghobject_t &hoid,
 			       const set<string> &keys,
-			       map<string, bufferlist> *out)
+			       map<string, bufferlist, less<>> *out)
 {
   tracepoint(objectstore, omap_get_values_enter, ch->cid.c_str());
   const coll_t& c = !_need_temp_object_collection(ch->cid, hoid) ? ch->cid : ch->cid.get_temp();

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -642,8 +642,8 @@ public:
   int _remove(const coll_t& cid, const ghobject_t& oid, const SequencerPosition &spos);
 
   int _fgetattr(int fd, const char *name, bufferptr& bp);
-  int _fgetattrs(int fd, map<string,bufferptr>& aset);
-  int _fsetattrs(int fd, map<string, bufferptr> &aset);
+  int _fgetattrs(int fd, map<string,bufferptr,less<>>& aset);
+  int _fsetattrs(int fd, map<string, bufferptr, less<>> &aset);
 
   void do_force_sync();
   void start_sync(Context *onsafe);
@@ -688,7 +688,8 @@ public:
   using ObjectStore::getattr;
   using ObjectStore::getattrs;
   int getattr(CollectionHandle& c, const ghobject_t& oid, const char *name, bufferptr &bp) override;
-  int getattrs(CollectionHandle& c, const ghobject_t& oid, map<string,bufferptr>& aset) override;
+  int getattrs(CollectionHandle& c, const ghobject_t& oid,
+	       std::map<std::string,bufferptr,std::less<>>& aset) override;
 
   int _setattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& aset,
 		const SequencerPosition &spos);
@@ -727,7 +728,7 @@ public:
   // omap (see ObjectStore.h for documentation)
   using ObjectStore::omap_get;
   int omap_get(CollectionHandle& c, const ghobject_t &oid, bufferlist *header,
-	       map<string, bufferlist> *out) override;
+	       std::map<std::string, bufferlist, std::less<>> *out) override;
   using ObjectStore::omap_get_header;
   int omap_get_header(
     CollectionHandle& c,
@@ -738,7 +739,7 @@ public:
   int omap_get_keys(CollectionHandle& c, const ghobject_t &oid, set<string> *keys) override;
   using ObjectStore::omap_get_values;
   int omap_get_values(CollectionHandle& c, const ghobject_t &oid, const set<string> &keys,
-		      map<string, bufferlist> *out) override;
+		      map<string, bufferlist, std::less<>> *out) override;
   using ObjectStore::omap_check_keys;
   int omap_check_keys(CollectionHandle& c, const ghobject_t &oid, const set<string> &keys,
 		      set<string> *out) override;

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -1398,7 +1398,7 @@ int KStore::getattr(
 int KStore::getattrs(
   CollectionHandle& ch,
   const ghobject_t& oid,
-  map<string,bufferptr>& aset)
+  map<string,bufferptr,less<>>& aset)
 {
   dout(15) << __func__ << " " << ch->cid << " " << oid << dendl;
   Collection *c = static_cast<Collection*>(ch.get());
@@ -1675,7 +1675,7 @@ int KStore::omap_get(
   CollectionHandle& ch,                ///< [in] Collection containing oid
   const ghobject_t &oid,   ///< [in] Object containing omap
   bufferlist *header,      ///< [out] omap header
-  map<string, bufferlist> *out /// < [out] Key to value map
+  map<string, bufferlist, less<>> *out /// < [out] Key to value map
   )
 {
   dout(15) << __func__ << " " << ch->cid << " oid " << oid << dendl;
@@ -1799,7 +1799,7 @@ int KStore::omap_get_values(
   CollectionHandle& ch,                    ///< [in] Collection containing oid
   const ghobject_t &oid,       ///< [in] Object containing omap
   const set<string> &keys,     ///< [in] Keys to get
-  map<string, bufferlist> *out ///< [out] Returned keys and values
+  map<string, bufferlist, less<>> *out ///< [out] Returned keys and values
   )
 {
   dout(15) << __func__ << " " << ch->cid << " oid " << oid << dendl;

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -487,7 +487,8 @@ public:
   using ObjectStore::getattr;
   int getattr(CollectionHandle& c, const ghobject_t& oid, const char *name, bufferptr& value) override;
   using ObjectStore::getattrs;
-  int getattrs(CollectionHandle& c, const ghobject_t& oid, map<string,bufferptr>& aset) override;
+  int getattrs(CollectionHandle& c, const ghobject_t& oid,
+	       map<string,bufferptr,less<>>& aset) override;
 
   int list_collections(vector<coll_t>& ls) override;
   bool collection_exists(const coll_t& c) override;
@@ -503,7 +504,7 @@ public:
     CollectionHandle& c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
-    map<string, bufferlist> *out /// < [out] Key to value map
+    map<string, bufferlist, less<>> *out /// < [out] Key to value map
     ) override;
 
   using ObjectStore::omap_get_header;
@@ -529,7 +530,7 @@ public:
     CollectionHandle& c,                    ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
     const set<string> &keys,     ///< [in] Keys to get
-    map<string, bufferlist> *out ///< [out] Returned keys and values
+    map<string, bufferlist, less<>> *out ///< [out] Returned keys and values
     ) override;
 
   using ObjectStore::omap_check_keys;

--- a/src/os/kstore/kstore_types.h
+++ b/src/os/kstore/kstore_types.h
@@ -41,7 +41,7 @@ WRITE_CLASS_ENCODER(kstore_cnode_t)
 struct kstore_onode_t {
   uint64_t nid;                        ///< numeric id (locally unique)
   uint64_t size;                       ///< object size
-  map<string, bufferptr> attrs;        ///< attrs
+  map<string, bufferptr, less<>> attrs;        ///< attrs
   uint64_t omap_head;                  ///< id for omap root node
   uint32_t stripe_size;                ///< stripe size
 

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -385,7 +385,7 @@ int MemStore::getattr(CollectionHandle &c_, const ghobject_t& oid,
 }
 
 int MemStore::getattrs(CollectionHandle &c_, const ghobject_t& oid,
-		       map<string,bufferptr>& aset)
+		       map<string,bufferptr,less<>>& aset)
 {
   Collection *c = static_cast<Collection*>(c_.get());
   dout(10) << __func__ << " " << c->cid << " " << oid << dendl;
@@ -468,7 +468,7 @@ int MemStore::omap_get(
   CollectionHandle& ch,                ///< [in] Collection containing oid
   const ghobject_t &oid,   ///< [in] Object containing omap
   bufferlist *header,      ///< [out] omap header
-  map<string, bufferlist> *out /// < [out] Key to value map
+  map<string, bufferlist, less<>> *out /// < [out] Key to value map
   )
 {
   dout(10) << __func__ << " " << ch->cid << " " << oid << dendl;
@@ -523,7 +523,7 @@ int MemStore::omap_get_values(
   CollectionHandle& ch,                    ///< [in] Collection containing oid
   const ghobject_t &oid,       ///< [in] Object containing omap
   const set<string> &keys,     ///< [in] Keys to get
-  map<string, bufferlist> *out ///< [out] Returned keys and values
+  map<string, bufferlist, less<>> *out ///< [out] Returned keys and values
   )
 {
   dout(10) << __func__ << " " << ch->cid << " " << oid << dendl;

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -32,9 +32,9 @@ public:
   struct Object : public RefCountedObject {
     ceph::mutex xattr_mutex{ceph::make_mutex("MemStore::Object::xattr_mutex")};
     ceph::mutex omap_mutex{ceph::make_mutex("MemStore::Object::omap_mutex")};
-    map<string,bufferptr> xattr;
+    map<string,bufferptr,less<>> xattr;
     bufferlist omap_header;
-    map<string,bufferlist> omap;
+    map<string,bufferlist,less<>> omap;
 
     using Ref = ceph::ref_t<Object>;
 
@@ -318,7 +318,7 @@ public:
   int getattr(CollectionHandle &c, const ghobject_t& oid, const char *name,
 	      bufferptr& value) override;
   int getattrs(CollectionHandle &c, const ghobject_t& oid,
-	       map<string,bufferptr>& aset) override;
+	       map<string,bufferptr,std::less<>>& aset) override;
 
   int list_collections(vector<coll_t>& ls) override;
 
@@ -343,7 +343,7 @@ public:
     CollectionHandle& c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
-    map<string, bufferlist> *out /// < [out] Key to value map
+    map<string, bufferlist, less<>> *out /// < [out] Key to value map
     ) override;
 
   using ObjectStore::omap_get_header;
@@ -369,7 +369,7 @@ public:
     CollectionHandle& c,                    ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
     const set<string> &keys,     ///< [in] Keys to get
-    map<string, bufferlist> *out ///< [out] Returned keys and values
+    map<string, bufferlist, less<>> *out ///< [out] Returned keys and values
     ) override;
 
   using ObjectStore::omap_check_keys;

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -279,7 +279,7 @@ private:
 
     // must be filled if state == WRITING
     map<int, bufferlist> returned_data;
-    map<string, bufferlist> xattrs;
+    map<string, bufferlist, less<>> xattrs;
     ECUtil::HashInfoRef hinfo;
     ObjectContextRef obc;
     set<pg_shard_t> waiting_on_pushes;
@@ -301,8 +301,8 @@ private:
   friend struct OnRecoveryReadComplete;
   void handle_recovery_read_complete(
     const hobject_t &hoid,
-    boost::tuple<uint64_t, uint64_t, map<pg_shard_t, bufferlist> > &to_read,
-    std::optional<map<string, bufferlist> > attrs,
+    boost::tuple<uint64_t, uint64_t, map<pg_shard_t, bufferlist, less<>>> &to_read,
+    std::optional<map<string, bufferlist, less<>>> attrs,
     RecoveryMessages *m);
   void handle_recovery_push(
     const PushOp &op,
@@ -344,10 +344,10 @@ public:
   struct read_result_t {
     int r;
     map<pg_shard_t, int> errors;
-    std::optional<map<string, bufferlist> > attrs;
+    std::optional<map<string, bufferlist, less<>> > attrs;
     list<
       boost::tuple<
-	uint64_t, uint64_t, map<pg_shard_t, bufferlist> > > returned;
+	uint64_t, uint64_t, map<pg_shard_t, bufferlist, less<>> > > returned;
     read_result_t() : r(0) {}
   };
   struct read_request_t {
@@ -408,7 +408,7 @@ public:
 	    boost::make_tuple(
 	      extent.get<0>(),
 	      extent.get<1>(),
-	      map<pg_shard_t, bufferlist>()));
+	      map<pg_shard_t, bufferlist, less<>>()));
 	}
       }
     }
@@ -634,7 +634,7 @@ public:
   /// If modified, ensure that the ref is held until the update is applied
   SharedPtrRegistry<hobject_t, ECUtil::HashInfo> unstable_hashinfo_registry;
   ECUtil::HashInfoRef get_hash_info(const hobject_t &hoid, bool checks = true,
-				    const map<string,bufferptr> *attr = NULL);
+				    const map<string,bufferptr, less<>> *attr = NULL);
 
 public:
   ECBackend(
@@ -665,7 +665,7 @@ public:
 
   int objects_get_attrs(
     const hobject_t &hoid,
-    map<string, bufferlist> *out) override;
+    map<string, bufferlist, less<>> *out) override;
 
   void rollback_append(
     const hobject_t &hoid,

--- a/src/osd/ECMsgTypes.h
+++ b/src/osd/ECMsgTypes.h
@@ -119,7 +119,7 @@ struct ECSubReadReply {
   pg_shard_t from;
   ceph_tid_t tid;
   std::map<hobject_t, std::list<std::pair<uint64_t, ceph::buffer::list> >> buffers_read;
-  std::map<hobject_t, std::map<string, ceph::buffer::list>> attrs_read;
+  std::map<hobject_t, std::map<string, ceph::buffer::list, std::less<>>> attrs_read;
   std::map<hobject_t, int> errors;
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -319,7 +319,7 @@ void ECTransaction::generate_transactions(
       ceph_assert(op.omap_updates.empty());
 
       if (!op.attr_updates.empty()) {
-	map<string, bufferlist> to_set;
+	map<string, bufferlist, less<>> to_set;
 	for (auto &&j: op.attr_updates) {
 	  if (j.second) {
 	    to_set[j.first] = *(j.second);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5985,7 +5985,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
     ObjectStore::Transaction t;
 
     if (command == "setomapval") {
-      map<string, bufferlist> newattrs;
+      map<string, bufferlist, less<>> newattrs;
       bufferlist val;
       string key, valstr;
       cmd_getval(service->cct, cmdmap, "key", key);
@@ -6024,7 +6024,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
     } else if (command == "getomap") {
       //Debug: Output entire omap
       bufferlist hdrbl;
-      map<string, bufferlist> keyvals;
+      map<string, bufferlist, less<>> keyvals;
       auto ch = store->open_collection(coll_t(pgid));
       if (!ch) {
 	ss << "unable to open collection for " << pgid;
@@ -6033,10 +6033,10 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
 	r = store->omap_get(ch, ghobject_t(obj), &hdrbl, &keyvals);
 	if (r >= 0) {
           ss << "header=" << string(hdrbl.c_str(), hdrbl.length());
-          for (map<string, bufferlist>::iterator it = keyvals.begin();
-	       it != keyvals.end(); ++it)
-            ss << " key=" << (*it).first << " val="
-               << string((*it).second.c_str(), (*it).second.length());
+          for (auto& [key,val] : keyvals) {
+            ss << " key=" << key << " val="
+               << string_view(val.c_str(), val.length());
+	  }
 	} else {
           ss << "error=" << r;
 	}

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -915,7 +915,7 @@ void PG::upgrade(ObjectStore *store)
 
   // update infover_key
   if (info_struct_v < pg_latest_struct_v) {
-    map<string,bufferlist> v;
+    map<string,bufferlist,less<>> v;
     __u8 ver = pg_latest_struct_v;
     encode(ver, v[string(infover_key)]);
     t.omap_setkeys(coll, pgmeta_oid, v);
@@ -953,7 +953,7 @@ void PG::prepare_write(
 {
   info.stats.stats.add(unstable_stats);
   unstable_stats.clear();
-  map<string,bufferlist> km;
+  map<string,bufferlist,less<>> km;
   string key_to_remove;
   if (dirty_big_info || dirty_info) {
     int ret = prepare_info_keymap(
@@ -992,7 +992,7 @@ bool PG::_has_removal_flag(ObjectStore *store,
   // first try new way
   set<string> keys;
   keys.insert("_remove");
-  map<string,bufferlist> values;
+  map<string,bufferlist,less<>> values;
   auto ch = store->open_collection(coll);
   ceph_assert(ch);
   if (store->omap_get_values(ch, pgmeta_oid, keys, &values) == 0 &&
@@ -1018,7 +1018,7 @@ int PG::peek_map_epoch(ObjectStore *store,
   set<string> keys;
   keys.insert(string(infover_key));
   keys.insert(string(epoch_key));
-  map<string,bufferlist> values;
+  map<string,bufferlist,less<>> values;
   auto ch = store->open_collection(coll);
   ceph_assert(ch);
   int r = store->omap_get_values(ch, pgmeta_oid, keys, &values);
@@ -1081,7 +1081,7 @@ int PG::read_info(
   keys.insert(string(biginfo_key));
   keys.insert(string(fastinfo_key));
   ghobject_t pgmeta_oid(pgid.make_pgmeta_oid());
-  map<string,bufferlist> values;
+  map<string,bufferlist,less<>> values;
   auto ch = store->open_collection(coll);
   ceph_assert(ch);
   int r = store->omap_get_values(ch, pgmeta_oid, keys, &values);

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -428,7 +428,7 @@ int PGBackend::objects_get_attr(
 
 int PGBackend::objects_get_attrs(
   const hobject_t &hoid,
-  map<string, bufferlist> *out)
+  map<string, bufferlist, less<>> *out)
 {
   return store->getattrs(
     ch,
@@ -440,7 +440,7 @@ void PGBackend::rollback_setattrs(
   const hobject_t &hoid,
   map<string, std::optional<bufferlist> > &old_attrs,
   ObjectStore::Transaction *t) {
-  map<string, bufferlist> to_set;
+  map<string, bufferlist, less<>> to_set;
   ceph_assert(!hoid.is_temp());
   for (map<string, std::optional<bufferlist> >::iterator i = old_attrs.begin();
        i != old_attrs.end();

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -212,7 +212,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
 
      virtual ObjectContextRef get_obc(
        const hobject_t &hoid,
-       const map<string, bufferlist> &attrs) = 0;
+       const map<string, bufferlist, less<>> &attrs) = 0;
 
      virtual bool try_lock_for_read(
        const hobject_t &hoid,
@@ -556,7 +556,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
 
    virtual int objects_get_attrs(
      const hobject_t &hoid,
-     map<string, bufferlist> *out);
+     map<string, bufferlist, less<>> *out);
 
    virtual int objects_read_sync(
      const hobject_t &hoid,

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -616,7 +616,7 @@ void PGLog::check() {
 // non-static
 void PGLog::write_log_and_missing(
   ObjectStore::Transaction& t,
-  map<string,bufferlist> *km,
+  map<string,bufferlist,less<>> *km,
   const coll_t& coll,
   const ghobject_t &log_oid,
   bool require_rollback)
@@ -655,7 +655,7 @@ void PGLog::write_log_and_missing(
 // static
 void PGLog::write_log_and_missing_wo_missing(
     ObjectStore::Transaction& t,
-    map<string,bufferlist> *km,
+    map<string,bufferlist,less<>> *km,
     pg_log_t &log,
     const coll_t& coll, const ghobject_t &log_oid,
     map<eversion_t, hobject_t> &divergent_priors,
@@ -672,7 +672,7 @@ void PGLog::write_log_and_missing_wo_missing(
 // static
 void PGLog::write_log_and_missing(
     ObjectStore::Transaction& t,
-    map<string,bufferlist> *km,
+    map<string,bufferlist,less<>> *km,
     pg_log_t &log,
     const coll_t& coll,
     const ghobject_t &log_oid,
@@ -698,7 +698,7 @@ void PGLog::write_log_and_missing(
 // static
 void PGLog::_write_log_and_missing_wo_missing(
   ObjectStore::Transaction& t,
-  map<string,bufferlist> *km,
+  map<string,bufferlist,less<>> *km,
   pg_log_t &log,
   const coll_t& coll, const ghobject_t &log_oid,
   map<eversion_t, hobject_t> &divergent_priors,
@@ -813,7 +813,7 @@ void PGLog::_write_log_and_missing_wo_missing(
 // static
 void PGLog::_write_log_and_missing(
   ObjectStore::Transaction& t,
-  map<string,bufferlist>* km,
+  map<string,bufferlist,less<>>* km,
   pg_log_t &log,
   const coll_t& coll, const ghobject_t &log_oid,
   eversion_t dirty_to,

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1265,14 +1265,14 @@ public:
 
   void write_log_and_missing(
     ObjectStore::Transaction& t,
-    map<string,bufferlist> *km,
+    map<string,bufferlist,less<>> *km,
     const coll_t& coll,
     const ghobject_t &log_oid,
     bool require_rollback);
 
   static void write_log_and_missing_wo_missing(
     ObjectStore::Transaction& t,
-    map<string,bufferlist>* km,
+    map<string,bufferlist,less<>>* km,
     pg_log_t &log,
     const coll_t& coll,
     const ghobject_t &log_oid, map<eversion_t, hobject_t> &divergent_priors,
@@ -1280,7 +1280,7 @@ public:
 
   static void write_log_and_missing(
     ObjectStore::Transaction& t,
-    map<string,bufferlist>* km,
+    map<string,bufferlist,less<>>* km,
     pg_log_t &log,
     const coll_t& coll,
     const ghobject_t &log_oid,
@@ -1290,7 +1290,7 @@ public:
 
   static void _write_log_and_missing_wo_missing(
     ObjectStore::Transaction& t,
-    map<string,bufferlist>* km,
+    map<string,bufferlist,less<>>* km,
     pg_log_t &log,
     const coll_t& coll, const ghobject_t &log_oid,
     map<eversion_t, hobject_t> &divergent_priors,
@@ -1308,7 +1308,7 @@ public:
 
   static void _write_log_and_missing(
     ObjectStore::Transaction& t,
-    map<string,bufferlist>* km,
+    map<string,bufferlist,less<>>* km,
     pg_log_t &log,
     const coll_t& coll, const ghobject_t &log_oid,
     eversion_t dirty_to,

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -136,7 +136,7 @@ public:
     ceph_tid_t objecter_tid2;
 
     object_copy_cursor_t cursor;
-    map<string,bufferlist> attrs;
+    map<string,bufferlist,less<>> attrs;
     bufferlist data;
     bufferlist omap_header;
     bufferlist omap_data;
@@ -401,7 +401,7 @@ public:
 
   ObjectContextRef get_obc(
     const hobject_t &hoid,
-    const map<string, bufferlist> &attrs) override {
+    const map<string, bufferlist, less<>> &attrs) override {
     return get_object_context(hoid, true, &attrs);
   }
 
@@ -1064,7 +1064,7 @@ protected:
   ObjectContextRef get_object_context(
     const hobject_t& soid,
     bool can_create,
-    const map<string, bufferlist> *attrs = 0
+    const map<string, bufferlist, less<>> *attrs = 0
     );
 
   void context_registry_on_change();
@@ -1084,7 +1084,7 @@ protected:
   SnapSetContext *get_snapset_context(
     const hobject_t& oid,
     bool can_create,
-    const map<string, bufferlist> *attrs = 0,
+    const map<string, bufferlist, less<>> *attrs = 0,
     bool oid_existed = true //indicate this oid whether exsited in backend
     );
   void register_snapset_context(SnapSetContext *ssc) {
@@ -1970,7 +1970,7 @@ public:
     bufferlist *val);
   int getattrs_maybe_cache(
     ObjectContextRef obc,
-    map<string, bufferlist> *out);
+    map<string, bufferlist, less<>> *out);
 
 public:
   void set_dynamic_perf_stats_queries(

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -368,7 +368,7 @@ void generate_transaction(
       }
 
       if (!op.attr_updates.empty()) {
-	map<string, bufferlist> attrs;
+	map<string, bufferlist, less<>> attrs;
 	for (auto &&p: op.attr_updates) {
 	  if (p.second)
 	    attrs[p.first] = *(p.second);
@@ -1583,8 +1583,8 @@ void ReplicatedBackend::submit_push_data(
   const interval_set<uint64_t> &intervals_included,
   bufferlist data_included,
   bufferlist omap_header,
-  const map<string, bufferlist> &attrs,
-  const map<string, bufferlist> &omap_entries,
+  const map<string, bufferlist, less<>> &attrs,
+  const map<string, bufferlist, less<>> &omap_entries,
   ObjectStore::Transaction *t)
 {
   hobject_t target_oid;

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -280,8 +280,8 @@ private:
 			const interval_set<uint64_t> &intervals_included,
 			bufferlist data_included,
 			bufferlist omap_header,
-			const map<string, bufferlist> &attrs,
-			const map<string, bufferlist> &omap_entries,
+			const map<string, bufferlist, less<>> &attrs,
+			const map<string, bufferlist, less<>> &omap_entries,
 			ObjectStore::Transaction *t);
   void submit_push_complete(const ObjectRecoveryInfo &recovery_info,
 			    ObjectStore::Transaction *t);

--- a/src/osd/ScrubStore.h
+++ b/src/osd/ScrubStore.h
@@ -48,7 +48,7 @@ private:
   // scrubbing
   OSDriver driver;
   MapCacher::MapCacher<std::string, bufferlist> backend;
-  map<string, bufferlist> results;
+  map<string, bufferlist, less<>> results;
 };
 }
 

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -62,7 +62,7 @@ const char *SnapMapper::PURGED_SNAP_PREFIX = "PSN_";
 
 int OSDriver::get_keys(
   const std::set<std::string> &keys,
-  std::map<std::string, bufferlist> *out)
+  std::map<std::string, bufferlist, std::less<>> *out)
 {
   return os->omap_get_values(ch, hoid, keys, out);
 }
@@ -215,7 +215,7 @@ void SnapMapper::set_snaps(
   MapCacher::Transaction<std::string, bufferlist> *t)
 {
   ceph_assert(check(oid));
-  map<string, bufferlist> to_set;
+  map<string, bufferlist, less<>> to_set;
   bufferlist bl;
   encode(in, bl);
   to_set[to_object_key(oid)] = bl;
@@ -291,7 +291,7 @@ void SnapMapper::add_oid(
   object_snaps _snaps(oid, snaps);
   set_snaps(oid, _snaps, t);
 
-  map<string, bufferlist> to_add;
+  map<string, bufferlist, less<>> to_add;
   for (set<snapid_t>::iterator i = snaps.begin();
        i != snaps.end();
        ++i) {
@@ -413,7 +413,7 @@ string SnapMapper::make_purged_snap_key(int64_t pool, snapid_t last)
 }
 
 void SnapMapper::make_purged_snap_key_value(
-  int64_t pool, snapid_t begin, snapid_t end, map<string,bufferlist> *m)
+  int64_t pool, snapid_t begin, snapid_t end, map<string,bufferlist,less<>> *m)
 {
   string k = make_purged_snap_key(pool, end - 1);
   auto& v = (*m)[k];
@@ -467,7 +467,7 @@ void SnapMapper::record_purged_snaps(
   map<epoch_t,mempool::osdmap::map<int64_t,snap_interval_set_t>> purged_snaps)
 {
   dout(10) << __func__ << " purged_snaps " << purged_snaps << dendl;
-  map<string,bufferlist> m;
+  map<string,bufferlist, less<>> m;
   set<string> rm;
   for (auto& [epoch, bypool] : purged_snaps) {
     // index by (pool, snap)
@@ -663,7 +663,7 @@ int SnapMapper::convert_legacy(
   auto start = ceph::mono_clock::now();
 
   iter->upper_bound(SnapMapper::LEGACY_MAPPING_PREFIX);
-  map<string,bufferlist> to_set;
+  map<string,bufferlist,less<>> to_set;
   while (iter->valid()) {
     bool valid = SnapMapper::is_legacy_mapping(iter->key());
     if (valid) {

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -46,7 +46,7 @@ public:
       : cid(cid), hoid(hoid), t(t) {}
   public:
     void set_keys(
-      const std::map<std::string, bufferlist> &to_set) override {
+	   const std::map<std::string, bufferlist, std::less<>> &to_set) override {
       t->omap_setkeys(cid, hoid, to_set);
     }
     void remove_keys(
@@ -71,7 +71,7 @@ public:
   }
   int get_keys(
     const std::set<std::string> &keys,
-    std::map<std::string, bufferlist> *out) override;
+    std::map<std::string, bufferlist, std::less<>> *out) override;
   int get_next(
     const std::string &key,
     pair<std::string, bufferlist> *next) override;
@@ -205,7 +205,7 @@ private:
     snapid_t *begin, snapid_t *end);
   static void make_purged_snap_key_value(
     int64_t pool, snapid_t begin,
-    snapid_t end, map<string,bufferlist> *m);
+    snapid_t end, map<string,bufferlist,less<>> *m);
   static string make_purged_snap_key(int64_t pool, snapid_t last);
 
 

--- a/src/osd/osd_internal_types.h
+++ b/src/osd/osd_internal_types.h
@@ -41,7 +41,7 @@ public:
   map<pair<uint64_t, entity_name_t>, WatchRef> watchers;
 
   // attr cache
-  map<string, bufferlist> attr_cache;
+  map<string, bufferlist, less<>> attr_cache;
 
   RWState rwstate;
   std::list<OpRequestRef> waiters;  ///< ops waiting on state change

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -6839,7 +6839,7 @@ void OSDOp::clear_data(vector<OSDOp>& ops)
 
 int prepare_info_keymap(
   CephContext* cct,
-  map<string,bufferlist> *km,
+  map<string,bufferlist,less<>> *km,
   string *key_to_remove,
   epoch_t epoch,
   pg_info_t &info,
@@ -6939,7 +6939,7 @@ void init_pg_ondisk(
 
   ghobject_t pgmeta_oid(pgid.make_pgmeta_oid());
   t.touch(coll, pgmeta_oid);
-  map<string,bufferlist> values;
+  map<string,bufferlist,less<>> values;
   __u8 struct_v = pg_latest_struct_v;
   encode(struct_v, values[string(infover_key)]);
   t.omap_setkeys(coll, pgmeta_oid, values);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -5132,7 +5132,7 @@ struct object_copy_data_t {
   utime_t mtime;
   uint32_t data_digest, omap_digest;
   uint32_t flags;
-  std::map<std::string, ceph::buffer::list> attrs;
+  std::map<std::string, ceph::buffer::list, std::less<>> attrs;
   ceph::buffer::list data;
   ceph::buffer::list omap_header;
   ceph::buffer::list omap_data;
@@ -5749,8 +5749,8 @@ struct PushOp {
   ceph::buffer::list data;
   interval_set<uint64_t> data_included;
   ceph::buffer::list omap_header;
-  std::map<std::string, ceph::buffer::list> omap_entries;
-  std::map<std::string, ceph::buffer::list> attrset;
+  std::map<std::string, ceph::buffer::list, std::less<>> omap_entries;
+  std::map<std::string, ceph::buffer::list, std::less<>> attrset;
 
   ObjectRecoveryInfo recovery_info;
   ObjectRecoveryProgress before_progress;
@@ -5773,7 +5773,7 @@ std::ostream& operator<<(std::ostream& out, const PushOp &op);
  */
 struct ScrubMap {
   struct object {
-    std::map<std::string, ceph::buffer::ptr> attrs;
+    std::map<std::string, ceph::buffer::ptr, std::less<>> attrs;
     uint64_t size;
     __u32 omap_digest;         ///< omap crc32c
     __u32 digest;              ///< data crc32c
@@ -6235,7 +6235,7 @@ static const __u8 pg_compat_struct_v = 10;
 
 int prepare_info_keymap(
   CephContext* cct,
-  map<string,bufferlist> *km,
+  map<string,bufferlist,less<>> *km,
   string *key_to_remove,
   epoch_t epoch,
   pg_info_t &info,

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -436,10 +436,11 @@ struct ObjectOperation {
   struct C_ObjectOperation_decodevals : public Context {
     uint64_t max_entries;
     ceph::buffer::list bl;
-    std::map<std::string,ceph::buffer::list> *pattrs;
+    std::map<std::string,ceph::buffer::list,std::less<>> *pattrs;
     bool *ptruncated;
     int *prval;
-    C_ObjectOperation_decodevals(uint64_t m, std::map<std::string,ceph::buffer::list> *pa,
+    C_ObjectOperation_decodevals(uint64_t m,
+				 std::map<std::string,ceph::buffer::list,std::less<>> *pa,
 				 bool *pt, int *pr)
       : max_entries(m), pattrs(pa), ptruncated(pt), prval(pr) {
       if (ptruncated) {
@@ -454,7 +455,7 @@ struct ObjectOperation {
 	  if (pattrs)
 	    decode(*pattrs, p);
 	  if (ptruncated) {
-	    std::map<std::string,ceph::buffer::list> ignore;
+	    std::map<std::string,ceph::buffer::list,std::less<>> ignore;
 	    if (!pattrs) {
 	      decode(ignore, p);
 	      pattrs = &ignore;
@@ -588,7 +589,7 @@ struct ObjectOperation {
       }
     }
   };
-  void getxattrs(std::map<std::string,ceph::buffer::list> *pattrs, int *prval) {
+  void getxattrs(std::map<std::string,ceph::buffer::list,std::less<>> *pattrs, int *prval) {
     add_op(CEPH_OSD_OP_GETXATTRS);
     if (pattrs || prval) {
       unsigned p = ops.size() - 1;
@@ -660,7 +661,7 @@ struct ObjectOperation {
   void omap_get_vals(const std::string &start_after,
 		     const std::string &filter_prefix,
 		     uint64_t max_to_get,
-		     std::map<std::string, ceph::buffer::list> *out_set,
+		     std::map<std::string, ceph::buffer::list, std::less<>> *out_set,
 		     bool *ptruncated,
 		     int *prval) {
     using ceph::encode;
@@ -683,7 +684,7 @@ struct ObjectOperation {
   }
 
   void omap_get_vals_by_keys(const std::set<std::string> &to_get,
-			    std::map<std::string, ceph::buffer::list> *out_set,
+			    std::map<std::string, ceph::buffer::list, std::less<>> *out_set,
 			    int *prval) {
     using ceph::encode;
     OSDOp &op = add_op(CEPH_OSD_OP_OMAPGETVALSBYKEYS);
@@ -722,7 +723,7 @@ struct ObjectOperation {
     object_copy_cursor_t *cursor;
     uint64_t *out_size;
     ceph::real_time *out_mtime;
-    std::map<std::string,ceph::buffer::list> *out_attrs;
+    std::map<std::string,ceph::buffer::list,std::less<>> *out_attrs;
     ceph::buffer::list *out_data, *out_omap_header, *out_omap_data;
     std::vector<snapid_t> *out_snaps;
     snapid_t *out_snap_seq;
@@ -737,7 +738,7 @@ struct ObjectOperation {
     C_ObjectOperation_copyget(object_copy_cursor_t *c,
 			      uint64_t *s,
 			      ceph::real_time *m,
-			      std::map<std::string,ceph::buffer::list> *a,
+			      std::map<std::string,ceph::buffer::list,std::less<>> *a,
 			      ceph::buffer::list *d, ceph::buffer::list *oh,
 			      ceph::buffer::list *o,
 			      std::vector<snapid_t> *osnaps,
@@ -816,7 +817,7 @@ struct ObjectOperation {
 		uint64_t max,
 		uint64_t *out_size,
 		ceph::real_time *out_mtime,
-		std::map<std::string,ceph::buffer::list> *out_attrs,
+		std::map<std::string,ceph::buffer::list,std::less<>> *out_attrs,
 		ceph::buffer::list *out_data,
 		ceph::buffer::list *out_omap_header,
 		ceph::buffer::list *out_omap_data,
@@ -981,7 +982,7 @@ struct ObjectOperation {
     out_rval[p] = prval;
   }
 
-  void omap_set(const std::map<std::string, ceph::buffer::list>& map) {
+  void omap_set(const std::map<std::string, ceph::buffer::list, std::less<>>& map) {
     using ceph::encode;
     ceph::buffer::list bl;
     encode(map, bl);

--- a/src/test/ObjectMap/KeyValueDBMemory.cc
+++ b/src/test/ObjectMap/KeyValueDBMemory.cc
@@ -157,7 +157,7 @@ public:
 
 int KeyValueDBMemory::get(const string &prefix,
 			  const std::set<string> &key,
-			  map<string, bufferlist> *out) {
+			  map<string, bufferlist, less<>> *out) {
   if (!exists_prefix(prefix))
     return 0;
 

--- a/src/test/ObjectMap/KeyValueDBMemory.h
+++ b/src/test/ObjectMap/KeyValueDBMemory.h
@@ -31,7 +31,7 @@ public:
   int get(
     const string &prefix,
     const std::set<string> &key,
-    std::map<string, bufferlist> *out
+    std::map<string, bufferlist, std::less<>> *out
     ) override;
   using KeyValueDB::get;
 

--- a/src/test/ObjectMap/test_object_map.cc
+++ b/src/test/ObjectMap/test_object_map.cc
@@ -132,7 +132,7 @@ public:
 		string key, string *value) {
     set<string> to_get;
     to_get.insert(key);
-    map<string, bufferlist> got;
+    map<string, bufferlist, less<>> got;
     db->get_xattrs(hoid, to_get, &got);
     if (!got.empty()) {
       *value = string(got.begin()->second.c_str(),
@@ -152,7 +152,7 @@ public:
 	      string key, string *value) {
     set<string> to_get;
     to_get.insert(key);
-    map<string, bufferlist> got;
+    map<string, bufferlist, less<>> got;
     db->get_values(hoid, to_get, &got);
     if (!got.empty()) {
       if (value) {
@@ -682,7 +682,7 @@ TEST_F(ObjectMapTest, CreateOneObject) {
   to_set.insert(make_pair(key, bl));
   ASSERT_EQ(db->set_keys(hoid, to_set), 0);
 
-  map<string, bufferlist> got;
+  map<string, bufferlist, less<>> got;
   set<string> to_get;
   to_get.insert(key);
   to_get.insert("not there");
@@ -765,7 +765,7 @@ TEST_F(ObjectMapTest, CloneOneObject) {
   r = tester.get_key(hoid, "foo2", &result);
   ASSERT_EQ(r, 0);
 
-  map<string, bufferlist> got;
+  map<string, bufferlist, less<>> got;
   bufferlist header;
 
   got.clear();

--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -743,8 +743,8 @@ enum fio_q_status fio_ceph_os_queue(thread_data* td, io_u* u)
     bl.push_back(buffer::copy(reinterpret_cast<char*>(u->xfer_buf),
                               u->xfer_buflen ) );
 
-    map<string,bufferptr> attrset;
-    map<string, bufferlist> omaps;
+    map<string,bufferptr,less<>> attrset;
+    map<string,bufferlist,less<>> omaps;
     // enqueue a write transaction on the collection's handle
     ObjectStore::Transaction t;
     char ver_key[64];
@@ -827,7 +827,7 @@ enum fio_q_status fio_ceph_os_queue(thread_data* td, io_u* u)
       }
     }
 
-    if (attrset.size()) {
+    if (!attrset.empty()) {
       t.setattrs(coll.cid, object.oid, attrset);
     }
     t.write(coll.cid, object.oid, u->offset, u->xfer_buflen, bl, flags);
@@ -849,7 +849,7 @@ enum fio_q_status fio_ceph_os_queue(thread_data* td, io_u* u)
       t.omap_rmkeys(coll.cid, pgmeta_oid, rmkeys);
     }
 
-    if (omaps.size()) {
+    if (!omaps.empty()) {
       ghobject_t pgmeta_oid(coll.pg.make_pgmeta_oid());
       t.omap_setkeys(coll.cid, pgmeta_oid, omaps);
     }

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -1766,7 +1766,8 @@ TEST_F(TestInternal, MissingDataPool) {
   bufferlist bl;
   using ceph::encode;
   encode(pool_id, bl);
-  ASSERT_EQ(0, m_ioctx.omap_set(header_oid, {{"data_pool_id", bl}}));
+  std::map<std::string, bufferlist, std::less<>> omap{{"data_pool_id", bl}};
+  ASSERT_EQ(0, m_ioctx.omap_set(header_oid, omap));
 
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -2464,7 +2464,7 @@ public:
     hoid.pool = 1;
     hoid.oid = "log";
     ghobject_t log_oid(hoid);
-    map<string, bufferlist> km;
+    map<string, bufferlist, less<>> km;
     write_log_and_missing(t, &km, test_coll, log_oid, false);
     if (!km.empty()) {
       t.omap_setkeys(test_coll, log_oid, km);

--- a/src/tools/RadosDump.h
+++ b/src/tools/RadosDump.h
@@ -219,15 +219,14 @@ struct data_section {
 };
 
 struct attr_section {
-  map<string,bufferlist> data;
-  explicit attr_section(const map<string,bufferlist> &data) : data(data) { }
-  explicit attr_section(map<string, bufferptr> &data_)
+  map<string,bufferlist,less<>> data;
+  explicit attr_section(const map<string,bufferlist,less<>> &data) : data(data) { }
+  explicit attr_section(map<string, bufferptr, less<>> &data_)
   {
-    for (std::map<std::string, bufferptr>::iterator i = data_.begin();
-         i != data_.end(); ++i) {
+    for (auto& [k, v] : data) {
       bufferlist bl;
-      bl.push_back(i->second);
-      data[i->first] = bl;
+      bl.append(v);
+      data[k] = bl;
     }
   }
 
@@ -263,8 +262,8 @@ struct omap_hdr_section {
 };
 
 struct omap_section {
-  map<string, bufferlist> omap;
-  explicit omap_section(const map<string, bufferlist> &omap) :
+  map<string, bufferlist, less<>> omap;
+  explicit omap_section(const map<string, bufferlist, less<>> &omap) :
     omap(omap) { }
   omap_section() { }
 

--- a/src/tools/kvstore_tool.cc
+++ b/src/tools/kvstore_tool.cc
@@ -135,7 +135,7 @@ bufferlist StoreTool::get(const string& prefix,
 {
   ceph_assert(!prefix.empty() && !key.empty());
 
-  map<string,bufferlist> result;
+  map<string,bufferlist,less<>> result;
   std::set<std::string> keys;
   keys.insert(key);
   db->get(prefix, keys, &result);

--- a/src/tools/rados/PoolDump.cc
+++ b/src/tools/rados/PoolDump.cc
@@ -95,7 +95,7 @@ int PoolDump::dump(IoCtx *io_ctx)
     // Compose TYPE_ATTRS chunk
     // ========================
     std::map<std::string, bufferlist> raw_xattrs;
-    std::map<std::string, bufferlist> xattrs;
+    std::map<std::string, bufferlist, std::less<>> xattrs;
     r = io_ctx->getxattrs(oid, raw_xattrs);
     if (r < 0) {
       cerr << "error getting xattr set " << oid << ": " << cpp_strerror(r)
@@ -130,9 +130,9 @@ int PoolDump::dump(IoCtx *io_ctx)
     // Compose TYPE_OMAP
     int MAX_READ = 512;
     string last_read = "";
-    do {
-      map<string, bufferlist> values;
-      r = io_ctx->omap_get_vals(oid, last_read, MAX_READ, &values);
+    for (bool more = true; more;) {
+      map<string, bufferlist, less<>> values;
+      r = io_ctx->omap_get_vals2(oid, last_read, MAX_READ, &values, &more);
       if (r < 0) {
 	cerr << "error getting omap keys " << oid << ": "
 	     << cpp_strerror(r) << std::endl;
@@ -149,7 +149,7 @@ int PoolDump::dump(IoCtx *io_ctx)
         return r;
       }
       r = values.size();
-    } while (r == MAX_READ);
+    }
 
     // Close object
     // =============


### PR DESCRIPTION
use transparent comparator whenever appropriate. transparent comparator
allows us to do heterogeneous lookup. which avoid the overhead to create
a temporary object just for compare it. for instance, we use std::string
for key, without transparent comparator, we will have to create a
std::string instance even if we have a string_view already. after this
change, we can just use a string_view as key when looking up it in the
map<string,val_type>.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
