### PR TITLE
mon/ConfigMonitor: prefix all global config options with global/

### DIFF
--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -174,6 +174,7 @@ bool ConfigMap::parse_mask(
   for (unsigned j = 0; j < split.size(); ++j) {
     auto& i = split[j];
     if (i == "global") {
+      *section = "global";
       continue;
     }
     size_t delim = i.find(':');

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -779,6 +779,13 @@ void ConfigMonitor::load_config()
 	       << dendl;
       pending_cleanup[key] = boost::none;
     } else {
+      if (section_name.empty()) {
+	// we prefer global/$option instead of just $option
+	derr << __func__ << " adding global/ prefix to key '" << key << "'"
+	     << dendl;
+	pending_cleanup[key] = boost::none;
+	pending_cleanup["global/"s + key] = it->value();
+      }
       Section *section = &config_map.global;;
       if (section_name.size()) {
 	if (section_name.find('.') != std::string::npos) {

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -540,6 +540,8 @@ bool ConfigMonitor::prepare_command(MonOpRequestRef op)
     string key;
     if (section.size()) {
       key += section + "/";
+    } else {
+      key += "global/";
     }
     string mask_str = mask.to_str();
     if (mask_str.size()) {

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -66,11 +66,14 @@ void ConfigMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   dout(10) << " " << (version+1) << dendl;
   put_last_committed(t, version+1);
 
-  for (auto& key : need_clean_options) {
-    derr << __func__ << " removing bad config key '" << key << "'" << dendl;
-    t->erase(CONFIG_PREFIX, key);
+  for (auto& [key, value] : pending_cleanup) {
+    if (pending.count(key) == 0) {
+      derr << __func__ << " repair: adjusting config key '" << key << "'"
+	   << dendl;
+      pending[key] = value;
+    }
   }
-  need_clean_options.clear();
+  pending_cleanup.clear();
 
   // TODO: record changed sections (osd, mds.foo, rack:bar, ...)
 
@@ -704,7 +707,7 @@ void ConfigMonitor::tick()
   }
   dout(10) << __func__ << dendl;
   bool changed = false;
-  if (!need_clean_options.empty()) {
+  if (!pending_cleanup.empty()) {
     changed = true;
   }
   if (changed) {
@@ -723,7 +726,7 @@ void ConfigMonitor::load_config()
   it->lower_bound(KEY_PREFIX);
   config_map.clear();
   current.clear();
-  need_clean_options.clear();
+  pending_cleanup.clear();
   while (it->valid() &&
 	 it->key().compare(0, KEY_PREFIX.size(), KEY_PREFIX) == 0) {
     string key = it->key().substr(KEY_PREFIX.size());
@@ -767,12 +770,12 @@ void ConfigMonitor::load_config()
     if (who.size() &&
 	!ConfigMap::parse_mask(who, &section_name, &mopt.mask)) {
       derr << __func__ << " invalid mask for key " << key << dendl;
-      need_clean_options.push_back(KEY_PREFIX + key);
+      pending_cleanup[key] = boost::none;
     } else if (opt->has_flag(Option::FLAG_NO_MON_UPDATE)) {
       dout(10) << __func__ << " NO_MON_UPDATE option '"
 	       << name << "' = '" << value << "' for " << name
 	       << dendl;
-      need_clean_options.push_back(KEY_PREFIX + key);
+      pending_cleanup[key] = boost::none;
     } else {
       Section *section = &config_map.global;;
       if (section_name.size()) {

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -787,7 +787,7 @@ void ConfigMonitor::load_config()
 	pending_cleanup["global/"s + key] = it->value();
       }
       Section *section = &config_map.global;;
-      if (section_name.size()) {
+      if (section_name.size() && section_name != "global") {
 	if (section_name.find('.') != std::string::npos) {
 	  section = &config_map.by_id[section_name];
 	} else {

--- a/src/mon/ConfigMonitor.h
+++ b/src/mon/ConfigMonitor.h
@@ -16,7 +16,7 @@ class ConfigMonitor : public PaxosService
   ConfigMap config_map;
   map<string,boost::optional<bufferlist>> pending;
   string pending_description;
-  list<string> need_clean_options;
+  map<string,boost::optional<bufferlist>> pending_cleanup;
 
   map<string,bufferlist> current;
 


### PR DESCRIPTION
This removes some ambiguity in the config-key parsing.  It also 
normalizes things, and fixes an inconsistency/bug with assimilate-conf.

Fixes https://tracker.ceph.com/issues/43296