### PR TITLE
mgr/pg_autoscaler: default to pg_num[_min] = 32

### DIFF
--- a/doc/rados/configuration/pool-pg-config-ref.rst
+++ b/doc/rados/configuration/pool-pg-config-ref.rst
@@ -198,7 +198,7 @@ Ceph configuration file.
               value is the same as ``pg_num`` with ``mkpool``.
 
 :Type: 32-bit Integer
-:Default: ``16``
+:Default: ``32``
 
 
 ``osd pool default pgp num``

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -61,7 +61,7 @@ class PoolTest(DashboardTestCase):
     def _create_pool(self, name, data):
         data = data or {
             'pool': name,
-            'pg_num': '16',
+            'pg_num': '32',
             'pool_type': 'replicated',
             'compression_algorithm': 'snappy',
             'compression_mode': 'passive',
@@ -217,7 +217,7 @@ class PoolTest(DashboardTestCase):
     def test_pool_create_with_two_applications(self):
         self.__yield_pool(None, {
             'pool': 'dashboard_pool1',
-            'pg_num': '16',
+            'pg_num': '32',
             'pool_type': 'replicated',
             'application_metadata': ['rbd', 'sth'],
         })
@@ -228,7 +228,7 @@ class PoolTest(DashboardTestCase):
             ['osd', 'erasure-code-profile', 'set', 'ecprofile', 'crush-failure-domain=osd'])
         self.__yield_pool(None, {
             'pool': 'dashboard_pool2',
-            'pg_num': '16',
+            'pg_num': '32',
             'pool_type': 'erasure',
             'application_metadata': ['rbd'],
             'erasure_code_profile': 'ecprofile',
@@ -239,7 +239,7 @@ class PoolTest(DashboardTestCase):
     def test_pool_create_with_compression(self):
         pool = {
             'pool': 'dashboard_pool3',
-            'pg_num': '16',
+            'pg_num': '32',
             'pool_type': 'replicated',
             'compression_algorithm': 'zstd',
             'compression_mode': 'aggressive',
@@ -269,7 +269,7 @@ class PoolTest(DashboardTestCase):
             {
                 'pool_data': {
                     'pool': 'dashboard_pool_quota1',
-                    'pg_num': '16',
+                    'pg_num': '32',
                     'pool_type': 'replicated',
                 },
                 'pool_quotas_to_check': {
@@ -280,7 +280,7 @@ class PoolTest(DashboardTestCase):
             {
                 'pool_data': {
                     'pool': 'dashboard_pool_quota2',
-                    'pg_num': '16',
+                    'pg_num': '32',
                     'pool_type': 'replicated',
                     'quota_max_objects': 1024,
                     'quota_max_bytes': 1000,

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2570,7 +2570,7 @@ std::vector<Option> get_global_options() {
     .add_service("mon"),
 
     Option("osd_pool_default_pg_num", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(16)
+    .set_default(32)
     .set_description("number of PGs for new pools")
     .set_flag(Option::FLAG_RUNTIME)
     .add_service("mon"),

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -24,7 +24,7 @@ Some terminology is made up for the purposes of this module:
 
 INTERVAL = 5
 
-PG_NUM_MIN = 16  # unless specified on a per-pool basis
+PG_NUM_MIN = 32  # unless specified on a per-pool basis
 
 def nearest_power_of_two(n):
     v = int(n)


### PR DESCRIPTION
78bf92448002eece7501da01b67f900a84207e70 increased the default to 16.
Increasing it further to 32 will provide enough parallelism to improve
out of the box performance for new users.

Fixes: https://tracker.ceph.com/issues/43757
Signed-off-by: Neha Ojha <nojha@redhat.com>