### PR TITLE
test: fix unused assert's variable in ceph_test_osd_stale_read.cc

### DIFF
--- a/src/test/osd/ceph_test_osd_stale_read.cc
+++ b/src/test/osd/ceph_test_osd_stale_read.cc
@@ -36,8 +36,10 @@ int get_primary_osd(Rados& rados, const string& pool_name,
     + oid
     + string("\",\"format\": \"json\"}");
   bufferlist outbl;
-  int r = rados.mon_command(cmd, inbl, &outbl, NULL);
-  assert(r >= 0);
+  if (int r = rados.mon_command(cmd, inbl, &outbl, nullptr);
+      r < 0) {
+    return r;
+  }
   string outstr(outbl.c_str(), outbl.length());
   json_spirit::Value v;
   if (!json_spirit::read(outstr, v)) {


### PR DESCRIPTION
This rectifies:
```
ceph_test_osd_stale_read.cc:39:7: warning: unused variable ‘r’ [-Wunused-variable]
   int r = rados.mon_command(cmd, inbl, &outbl, NULL);
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
