### PR TITLE
mds: remove empty directory checks and re-export during migration

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6655,7 +6655,6 @@ std::pair<bool, uint64_t> MDCache::trim(uint64_t count)
 	    dir->is_freezing() || dir->is_frozen())
 	  continue;
 
-	migrator->export_empty_import(dir);
         ++trimmed;
       }
     } else {

--- a/src/mds/Migrator.h
+++ b/src/mds/Migrator.h
@@ -187,7 +187,6 @@ public:
   // exporter
   void dispatch_export_dir(MDRequestRef& mdr, int count);
   void export_dir(CDir *dir, mds_rank_t dest);
-  void export_empty_import(CDir *dir);
 
   void export_dir_nicely(CDir *dir, mds_rank_t dest);
   void maybe_do_queued_export();


### PR DESCRIPTION
Currently when directories are migrated they get checked by the importer if they are empty and if so then re-exported back to the exporter. This is an unnecessary optimization and affects the overall distribution of metadata.

Fixes: https://tracker.ceph.com/issues/43644
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
