### PR TITLE
doc/rbd: ceph auth get-or-create mgr doesn't accept pool parameter

### DIFF
--- a/doc/rbd/rados-rbd-cmds.rst
+++ b/doc/rbd/rados-rbd-cmds.rst
@@ -35,13 +35,13 @@ recommended that you utilize a more restricted user wherever possible.
 To `create a Ceph user`_, with ``ceph`` specify the ``auth get-or-create``
 command, user name, monitor caps, and OSD caps::
 
-        ceph auth get-or-create client.{ID} mon 'profile rbd' osd 'profile {profile name} [pool={pool-name}][, profile ...]' mgr 'profile rbd [pool={pool-name}]'
+        ceph auth get-or-create client.{ID} mon 'profile rbd' osd 'profile {profile name} [pool={pool-name}][, profile ...]' mgr 'profile rbd'
 
 For example, to create a user ID named ``qemu`` with read-write access to the
 pool ``vms`` and read-only access to the pool ``images``, execute the
 following::
 
-	ceph auth get-or-create client.qemu mon 'profile rbd' osd 'profile rbd pool=vms, profile rbd-read-only pool=images' mgr 'profile rbd pool=images'
+	ceph auth get-or-create client.qemu mon 'profile rbd' osd 'profile rbd pool=vms, profile rbd-read-only pool=images' mgr 'profile rbd'
 
 The output from the ``ceph auth get-or-create`` command will be the keyring for
 the specified user, which can be written to ``/etc/ceph/ceph.client.{ID}.keyring``.


### PR DESCRIPTION
Fix rados-rbd-cmds documentation; mgr doesn't accept pool parameter.
Will give Error EINVAL: mon capability parse failed, stopped at
'pool=images' of 'profile rbd pool=images'.

Fixes: documentation
Signed-off-by: Ethan Waldo ewaldo@healthetechs.com

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
