### PR TITLE
cephadm: infer the fsid by name

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -630,23 +630,25 @@ def infer_fsid(func):
             logger.debug('Using specified fsid: %s' % args.fsid)
             return func()
 
-        fsid_list = []
-        if os.path.exists(args.data_dir):
-            for i in os.listdir(args.data_dir):
-                if is_fsid(i):
-                    fsid_list.append(i)
-        logger.debug('Found fsids %s' % str(fsid_list))
+        fsids = set()
+        daemon_list = list_daemons(detail=False)
+        for daemon in daemon_list:
+            if 'name' not in args or not args.name:
+                fsids.add(daemon['fsid'])
+            elif daemon['name'] == args.name:
+                fsids.add(daemon['fsid'])
+        fsids = list(fsids)
 
-        if not fsid_list:
-            # TODO: raise?
-            return func()
-
-        if len(fsid_list) > 1:
-            raise Error('cannot infer fsid, must specify --fsid')
-
-        logger.info('Inferring fsid %s' % fsid_list[0])
-        args.fsid = fsid_list[0]
+        if not fsids:
+            # some commands do not always require an fsid
+            pass
+        elif len(fsids) == 1:
+            logger.info('Inferring fsid %s' % fsids[0])
+            args.fsid = fsids[0]
+        else:
+            raise Error('Cannot infer an fsid, one must be specified: %s' % fsids)
         return func()
+
     return _infer_fsid
 
 def write_tmp(s, uid, gid):

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1988,6 +1988,10 @@ def command_shell():
     else:
         daemon_type = 'osd'  # get the most mounts
         daemon_id = None
+
+    if daemon_id and not args.fsid:
+        raise Error('must pass --fsid to specify cluster')
+
     mounts = get_container_mounts(args.fsid, daemon_type, daemon_id,
                                   no_config=True if args.config else False)
     if args.config:


### PR DESCRIPTION
Allow for the fsid to be inferred when a single fsid is found by name.

Old behavior:
```
host1:~ # cephadm enter --name mon.foo
ERROR: cannot infer fsid, must specify --fsid
host1:~ # cephadm enter --name mon.bar
ERROR: cannot infer fsid, must specify --fsid
```

New behavior:
```
host1:~ # cephadm enter --name mon.foo
INFO:cephadm:Found fsids ['3eb4399a-3d6f-11ea-ba23-8cdcd44b8f38']
INFO:cephadm:Inferring fsid 3eb4399a-3d6f-11ea-ba23-8cdcd44b8f38
[ceph: root@host1 /]# exit
exit
host1:~ # cephadm enter --name mon.bar
INFO:cephadm:Found fsids ['9f017fc8-3d70-11ea-afd8-8cdcd44b8f38']
INFO:cephadm:Inferring fsid 9f017fc8-3d70-11ea-afd8-8cdcd44b8f38
[ceph: root@host1 /]# exit
exit
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
