### PR TITLE
mgr/dashboard: Unit test does not do the mentioned thing

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -718,10 +718,7 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
         })
 
     def test_load_v2(self):
-        """
-        The `enabled` and `pwdExpirationDate` attributes of a user have been added in v2
-        """
-        self.CONFIG_KEY_DICT['accessdb_v1'] = '''
+        self.CONFIG_KEY_DICT['accessdb_v2'] = '''
             {{
                 "users": {{
                     "admin": {{
@@ -746,7 +743,7 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
                         }}
                     }}
                 }},
-                "version": 1
+                "version": 2
             }}
         '''.format(int(round(time.time())), Scope.ISCSI, Permission.READ,
                    Permission.UPDATE, Scope.POOL, Permission.CREATE)


### PR DESCRIPTION
The unit test AccessControlTest::test_load_v2() is testing a v1 database instead of a v2.

The current implementation of test_load_v2() loads a v1 user database which already contains the fields 'enabled' and 'pwdExpirationDate' that are added with v2. It's not possible that such a data structure exists. The loading and migration of a v1 database is tested in AccessControlTest::test_load_v1().

Fixes: https://tracker.ceph.com/issues/43760

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
