### PR TITLE
rpm/suse: refrain from setting -O? via RPM_OPT_FLAGS

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -21,6 +21,7 @@
 # bcond syntax!
 #################################################################################
 %bcond_with make_check
+%bcond_with cmake_verbose_logging
 %bcond_without ceph_test_package
 %ifarch s390 s390x
 %bcond_with tcmalloc
@@ -1189,8 +1190,16 @@ ${CMAKE} .. \
 %else
     -DWITH_RADOSGW_KAFKA_ENDPOINT=OFF \
 %endif
+%if 0%{with cmake_verbose_logging}
+    -DCMAKE_VERBOSE_LOGGING=ON \
+%endif
     -DBOOST_J=$CEPH_SMP_NCPUS \
     -DWITH_GRAFANA=ON
+
+%if %{with cmake_verbose_logging}
+cat ./CMakeFiles/CMakeOutput.log
+cat ./CMakeFiles/CMakeError.log
+%endif
 
 make "$CEPH_MFLAGS_JOBS"
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1092,6 +1092,8 @@ done
 %endif
 
 %if 0%{?suse_version}
+# remove any -O? from RPM_OPT_FLAGS: we rely on cmake to set the correct value
+RPM_OPT_FLAGS="$(echo "$RPM_OPT_FLAGS" | sed -e 's/\$-O[0-9] //' | sed -e 's/-O[0-9] //g' |sed -e 's/\-O[0-9]$//')"
 # the following setting fixed an OOM condition we once encountered in the OBS
 RPM_OPT_FLAGS="$RPM_OPT_FLAGS --param ggc-min-expand=20 --param ggc-min-heapsize=32768"
 %endif


### PR DESCRIPTION
Fixes s390x FTBFS in the OBS - see https://tracker.ceph.com/issues/43747 (many thanks to @uweigand for finding the root cause of this bug)

Adds cmake_verbose_logging bcond switch (defaults to off)