### PR TITLE
cephfs-shell: Fix ls -l

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -808,16 +808,10 @@ class CephFSShell(Cmd):
                 is_dir = item.is_dir()
 
                 if args.long and args.H:
-                    print_long(cephfs.getcwd()
-                               + path
-                               + b'/'
-                               + filepath,
+                    print_long(os.path.join(cephfs.getcwd(), path, filepath),
                                is_dir, True)
                 elif args.long:
-                    print_long(cephfs.getcwd()
-                               + path
-                               + b'/'
-                               + filepath,
+                    print_long(os.path.join(cephfs.getcwd(), path, filepath),
                                is_dir, False)
                 elif is_dir:
                     values.append(colorama.Style.BRIGHT


### PR DESCRIPTION
"ls -l" fails with ENOENT when it's executed outside
root directory. This patch fixes the same.

Fixes: https://tracker.ceph.com/issues/43763
Signed-off-by: Kotresh HR <khiremat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
