### PR TITLE
common: drop sharing of buffer::raw outside bufferlist.

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -99,12 +99,14 @@ static ceph::spinlock debug_lock;
 	alignment(align) {
     }
     raw* clone_empty() override {
-      return create(len, alignment);
+      return create(len, alignment).release();
     }
 
-    static raw_combined *create(unsigned len,
-				unsigned align,
-				int mempool = mempool::mempool_buffer_anon) {
+    static ceph::unique_leakable_ptr<buffer::raw>
+    create(unsigned len,
+	   unsigned align,
+	   int mempool = mempool::mempool_buffer_anon)
+    {
       if (!align)
 	align = sizeof(size_t);
       size_t rawlen = round_up_to(sizeof(buffer::raw_combined),
@@ -124,7 +126,8 @@ static ceph::spinlock debug_lock;
 
       // actual data first, since it has presumably larger alignment restriction
       // then put the raw_combined at the end
-      return new (ptr + datalen) raw_combined(ptr, len, align, mempool);
+      return ceph::unique_leakable_ptr<buffer::raw>(
+	new (ptr + datalen) raw_combined(ptr, len, align, mempool));
     }
 
     static void operator delete(void *ptr) {
@@ -314,27 +317,35 @@ static ceph::spinlock debug_lock;
   ceph::unique_leakable_ptr<buffer::raw> buffer::create(unsigned len) {
     return buffer::create_aligned(len, sizeof(size_t));
   }
-  ceph::unique_leakable_ptr<buffer::raw> buffer::create_in_mempool(unsigned len, int mempool) {
+  ceph::unique_leakable_ptr<buffer::raw>
+  buffer::create_in_mempool(unsigned len, int mempool) {
     return buffer::create_aligned_in_mempool(len, sizeof(size_t), mempool);
   }
-  buffer::raw* buffer::claim_char(unsigned len, char *buf) {
-    return new raw_claimed_char(len, buf);
+  ceph::unique_leakable_ptr<buffer::raw>
+  buffer::claim_char(unsigned len, char *buf) {
+    return ceph::unique_leakable_ptr<buffer::raw>(
+      new raw_claimed_char(len, buf));
   }
-  buffer::raw* buffer::create_malloc(unsigned len) {
-    return new raw_malloc(len);
+  ceph::unique_leakable_ptr<buffer::raw> buffer::create_malloc(unsigned len) {
+    return ceph::unique_leakable_ptr<buffer::raw>(new raw_malloc(len));
   }
-  buffer::raw* buffer::claim_malloc(unsigned len, char *buf) {
-    return new raw_malloc(len, buf);
+  ceph::unique_leakable_ptr<buffer::raw>
+  buffer::claim_malloc(unsigned len, char *buf) {
+    return ceph::unique_leakable_ptr<buffer::raw>(new raw_malloc(len, buf));
   }
-  buffer::raw* buffer::create_static(unsigned len, char *buf) {
-    return new raw_static(buf, len);
+  ceph::unique_leakable_ptr<buffer::raw>
+  buffer::create_static(unsigned len, char *buf) {
+    return ceph::unique_leakable_ptr<buffer::raw>(new raw_static(buf, len));
   }
-  buffer::raw* buffer::claim_buffer(unsigned len, char *buf, deleter del) {
-    return new raw_claim_buffer(buf, len, std::move(del));
+  ceph::unique_leakable_ptr<buffer::raw>
+  buffer::claim_buffer(unsigned len, char *buf, deleter del) {
+    return ceph::unique_leakable_ptr<buffer::raw>(
+      new raw_claim_buffer(buf, len, std::move(del)));
   }
 
   ceph::unique_leakable_ptr<buffer::raw> buffer::create_aligned_in_mempool(
-    unsigned len, unsigned align, int mempool) {
+    unsigned len, unsigned align, int mempool)
+  {
     // If alignment is a page multiple, use a separate buffer::raw to
     // avoid fragmenting the heap.
     //
@@ -352,8 +363,7 @@ static ceph::spinlock debug_lock;
       return ceph::unique_leakable_ptr<buffer::raw>(new raw_hack_aligned(len, align));
 #endif
     }
-    return ceph::unique_leakable_ptr<buffer::raw>(
-      raw_combined::create(len, align, mempool));
+    return raw_combined::create(len, align, mempool);
   }
   ceph::unique_leakable_ptr<buffer::raw> buffer::create_aligned(
     unsigned len, unsigned align) {
@@ -367,19 +377,15 @@ static ceph::spinlock debug_lock;
   ceph::unique_leakable_ptr<buffer::raw> buffer::create_small_page_aligned(unsigned len) {
     if (len < CEPH_PAGE_SIZE) {
       return create_aligned(len, CEPH_BUFFER_ALLOC_UNIT);
-    } else
+    } else {
       return create_aligned(len, CEPH_PAGE_SIZE);
+    }
   }
 
-  buffer::raw* buffer::create_unshareable(unsigned len) {
-    return new raw_unshareable(len);
+  ceph::unique_leakable_ptr<buffer::raw> buffer::create_unshareable(unsigned len) {
+    return ceph::unique_leakable_ptr<buffer::raw>(new raw_unshareable(len));
   }
 
-  buffer::ptr::ptr(raw* r) : _raw(r), _off(0), _len(r->len)   // no lock needed; this is an unref raw.
-  {
-    r->nref++;
-    bdout << "ptr " << this << " get " << _raw << bendl;
-  }
   buffer::ptr::ptr(ceph::unique_leakable_ptr<raw> r)
     : _raw(r.release()),
       _off(0),
@@ -2203,21 +2209,6 @@ buffer::ptr_node::create_hypercombined(ceph::unique_leakable_ptr<buffer::raw> r)
   // new to create ptr_node on buffer::raw::bptr_storage.
   return std::unique_ptr<buffer::ptr_node, buffer::ptr_node::disposer>(
     new ptr_node(std::move(r)));
-}
-
-std::unique_ptr<buffer::ptr_node, buffer::ptr_node::disposer>
-buffer::ptr_node::create_hypercombined(buffer::raw* const r)
-{
-  if (likely(r->nref == 0)) {
-    // FIXME: we don't currently hypercombine buffers due to crashes
-    // observed in the rados suite. After fixing we'll use placement
-    // new to create ptr_node on buffer::raw::bptr_storage.
-    return std::unique_ptr<buffer::ptr_node, buffer::ptr_node::disposer>(
-      new ptr_node(r));
-  } else {
-    return std::unique_ptr<buffer::ptr_node, buffer::ptr_node::disposer>(
-      new ptr_node(r));
-  }
 }
 
 buffer::ptr_node* buffer::ptr_node::copy_hypercombined(

--- a/src/common/buffer_seastar.cc
+++ b/src/common/buffer_seastar.cc
@@ -43,12 +43,14 @@ class raw_seastar_local_ptr : public raw {
 
 inline namespace v14_2_0 {
 
-raw* create_foreign(temporary_buffer&& buf) {
-  return new raw_seastar_foreign_ptr(std::move(buf));
+ceph::unique_leakable_ptr<buffer::raw> create_foreign(temporary_buffer&& buf) {
+  return ceph::unique_leakable_ptr<buffer::raw>(
+    new raw_seastar_foreign_ptr(std::move(buf)));
 }
 
-raw* create(temporary_buffer&& buf) {
-  return new raw_seastar_local_ptr(std::move(buf));
+ceph::unique_leakable_ptr<buffer::raw> create(temporary_buffer&& buf) {
+  return ceph::unique_leakable_ptr<buffer::raw>(
+    new raw_seastar_local_ptr(std::move(buf)));
 }
 
 } // inline namespace v14_2_0
@@ -99,8 +101,8 @@ public:
 
 buffer::ptr seastar_buffer_iterator::get_ptr(size_t len)
 {
-  buffer::raw* r = new raw_seastar_local_shared_ptr{buf};
-  buffer::ptr p{r};
+  buffer::ptr p{ceph::unique_leakable_ptr<buffer::raw>(
+    new raw_seastar_local_shared_ptr{buf})};
   p.set_length(len);
   return p;
 }

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -186,7 +186,6 @@ inline namespace v14_2_0 {
     friend class list;
   protected:
     raw *_raw;
-  public: // dirty hack for testing; if it works, this will be abstracted
     unsigned _off, _len;
   private:
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -183,6 +183,8 @@ inline namespace v14_2_0 {
    * a buffer pointer.  references (a subsequence of) a raw buffer.
    */
   class CEPH_BUFFER_API ptr {
+    friend class list;
+  protected:
     raw *_raw;
   public: // dirty hack for testing; if it works, this will be abstracted
     unsigned _off, _len;
@@ -306,7 +308,6 @@ inline namespace v14_2_0 {
     void try_assign_to_mempool(int pool);
 
     // accessors
-    raw *get_raw() const { return _raw; }
     const char *c_str() const;
     char *c_str();
     const char *end_c_str() const;

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -667,7 +667,8 @@ future<> MonMap::read_monmap(const std::string& monmap)
       return do_with(make_file_input_stream(f), [this, s](input_stream<char>& in) {
         return in.read_exactly(s).then([this](temporary_buffer<char> buf) {
           ceph::buffer::list bl;
-          bl.append(ceph::buffer::create(std::move(buf)));
+          bl.push_back(ceph::buffer::ptr_node::create(
+            ceph::buffer::create(std::move(buf))));
           decode(bl);
         });
       });

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -279,7 +279,7 @@ TEST(BufferPtr, assignment) {
   //
   {
     bufferptr original(len);
-    bufferptr same_raw(original.get_raw());
+    bufferptr same_raw(original);
     unsigned offset = 5;
     unsigned length = len - offset;
     original.set_offset(offset);
@@ -1630,20 +1630,6 @@ TEST(BufferList, push_back) {
     bufferptr ptr(len);
     ptr.c_str()[0] = 'B';
     bl.push_back(ptr);
-    EXPECT_EQ((unsigned)(1 + len), bl.length());
-    EXPECT_EQ((unsigned)2, bl.get_num_buffers());
-    EXPECT_EQ('B', bl.back()[0]);
-    EXPECT_EQ(ptr.get_raw(), bl.back().get_raw());
-  }
-  //
-  // void push_back(raw *r)
-  //
-  {
-    bufferlist bl;
-    bl.append('A');
-    bufferptr ptr(len);
-    ptr.c_str()[0] = 'B';
-    bl.push_back(ptr.get_raw());
     EXPECT_EQ((unsigned)(1 + len), bl.length());
     EXPECT_EQ((unsigned)2, bl.get_num_buffers());
     EXPECT_EQ('B', bl.back()[0]);


### PR DESCRIPTION
Before the changes clients of the buffer library were allowed to construct multiple instances of `buffer::ptr` from single underlying `buffer::raw` on their own. However, it looks the very sole user of this publicly exposed feature was the `bufferlist`'s unit test.

First commit switches all `raw` factories to return uniqueness-enforcing type over `raw`. It also paves the way to drop `buffer::ptr::get_raw()` entirely which is accomplished with the second patch. For the sake of `unittest_bufferlist` it introduces a concept of `instrumented_bptr` – a concept specific to the testing code and kept within.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
