### PR TITLE
test: modify iam tests to use a function to set bits

### DIFF
--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -88,6 +88,7 @@ using rgw::IAM::iamCreateRole;
 using rgw::IAM::iamDeleteRole;
 using rgw::IAM::iamAll;
 using rgw::IAM::stsAll;
+using rgw::IAM::allCount;
 
 class FakeIdentity : public Identity {
   const Principal id;
@@ -1203,10 +1204,14 @@ TEST(MatchPolicy, String)
   EXPECT_TRUE(match_policy("a:*", "a:b:c", flag)); // can span segments
 }
 
-static const Action_t s3AllValuet("1111111111111111111111111111111111111111111111111111111111111");
-static const Action_t iamAllValuet("111111111111100000000000000000000000000000000000000000000000000000000000000");
-static const Action_t stsAllValuet("1110000000000000000000000000000000000000000000000000000000000000000000000000000");
-static const Action_t allValuet("11111111111111111111111111111111111111111111111111111111111111111111111111111111");
+Action_t set_range_bits(std::uint64_t start, std::uint64_t end)
+{
+  Action_t result;
+  for (uint64_t i = start; i < end; i++) {
+    result.set(i);
+  }
+  return result;
+}
 
 using rgw::IAM::s3AllValue;
 using rgw::IAM::stsAllValue;
@@ -1214,8 +1219,8 @@ using rgw::IAM::allValue;
 using rgw::IAM::iamAllValue;
 TEST(set_cont_bits, iamconsts)
 {
-  EXPECT_EQ(s3AllValue, s3AllValuet);
-  EXPECT_EQ(iamAllValue, iamAllValuet);
-  EXPECT_EQ(stsAllValue, stsAllValuet);
-  EXPECT_EQ(allValue , allValuet);
+  EXPECT_EQ(s3AllValue, set_range_bits(0, s3All));
+  EXPECT_EQ(iamAllValue, set_range_bits(s3All+1, iamAll));
+  EXPECT_EQ(stsAllValue, set_range_bits(iamAll+1, stsAll));
+  EXPECT_EQ(allValue , set_range_bits(0, allCount));
 }


### PR DESCRIPTION
This reduces the need for the tests to also always modify the binary string for every new addition in the bitfields

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
