### PR TITLE
test/rgw: fix test_rgw_reshard_wait with -DHAVE_BOOST_CONTEXT=OFF

### DIFF
--- a/src/test/rgw/test_rgw_reshard_wait.cc
+++ b/src/test/rgw/test_rgw_reshard_wait.cc
@@ -13,7 +13,9 @@
  */
 
 #include "rgw/rgw_reshard.h"
+#ifdef HAVE_BOOST_CONTEXT
 #include <spawn/spawn.hpp>
+#endif
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
This include, like the code which calls it, should have been
conditionalized in https://github.com/ceph/ceph/pull/31580 (commit 069dd7af3923cded76cbbd96f4b1020397ea6f11).

Fixes: https://tracker.ceph.com/issues/43739
Signed-off-by: Yaakov Selkowitz <yselkowi@redhat.com>
