### PR TITLE
nautilus: rgw: data sync markers include timestamp from datalog entry

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -902,6 +902,7 @@ public:
   RGWCoroutine *store_marker(const string& new_marker, uint64_t index_pos, const real_time& timestamp) override {
     sync_marker.marker = new_marker;
     sync_marker.pos = index_pos;
+    sync_marker.timestamp = timestamp;
 
     tn->log(20, SSTR("updating marker marker_oid=" << marker_oid << " marker=" << new_marker));
     RGWRados *store = sync_env->store;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43373

---

backport of https://github.com/ceph/ceph/pull/32309
parent tracker: https://tracker.ceph.com/issues/43359

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh