### PR TITLE
nautilus: rgw: build_linked_oids_for_bucket and build_buckets_instance_index should return negative value if it fails

### DIFF
--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -375,7 +375,7 @@ int RGWOrphanSearch::build_buckets_instance_index()
   int ret = store->meta_mgr->list_keys_init(section, &handle);
   if (ret < 0) {
     lderr(store->ctx()) << "ERROR: can't get key: " << cpp_strerror(-ret) << dendl;
-    return -ret;
+    return ret;
   }
 
   map<int, list<string> > instances;
@@ -392,7 +392,7 @@ int RGWOrphanSearch::build_buckets_instance_index()
     ret = store->meta_mgr->list_keys_next(handle, max, keys, &truncated);
     if (ret < 0) {
       lderr(store->ctx()) << "ERROR: lists_keys_next(): " << cpp_strerror(-ret) << dendl;
-      return -ret;
+      return ret;
     }
 
     for (list<string>::iterator iter = keys.begin(); iter != keys.end(); ++iter) {
@@ -556,7 +556,7 @@ int RGWOrphanSearch::build_linked_oids_for_bucket(const string& bucket_instance_
                                &result, nullptr, &truncated);
     if (ret < 0) {
       cerr << "ERROR: store->list_objects(): " << cpp_strerror(-ret) << std::endl;
-      return -ret;
+      return ret;
     }
 
     for (vector<rgw_bucket_dir_entry>::iterator iter = result.begin(); iter != result.end(); ++iter) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43571

---

backport of https://github.com/ceph/ceph/pull/31346
parent tracker: https://tracker.ceph.com/issues/43452

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh