### PR TITLE
nautilus: rgw: fix a bug that bucket instance obj can't be removed after resharding completed

### DIFF
--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -345,7 +345,7 @@ int RGWBucketReshard::cancel()
 class BucketInfoReshardUpdate
 {
   RGWRados *store;
-  RGWBucketInfo bucket_info;
+  RGWBucketInfo& bucket_info;
   std::map<string, bufferlist> bucket_attrs;
 
   bool in_progress{false};


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43576

---

backport of https://github.com/ceph/ceph/pull/31483
parent tracker: https://tracker.ceph.com/issues/42691

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh