### PR TITLE
nautilus: rgw: move forward marker even in case of many rgw.none indexes

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9145,10 +9145,11 @@ int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
 
   map<string, bufferlist> updates;
   uint32_t count = 0;
+  int pos = -1;
   while (count < num_entries && !candidates.empty()) {
     r = 0;
     // Select the next one
-    int pos = candidates.begin()->second;
+    pos = candidates.begin()->second;
     const string& name = vcurrents[pos]->first;
     struct rgw_bucket_dir_entry& dirent = vcurrents[pos]->second;
 
@@ -9204,8 +9205,9 @@ int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
       break;
     }
   }
-  if (!m.empty())
-    *last_entry = m.rbegin()->first;
+
+  if (pos >= 0)
+    *last_entry = std::move((--vcurrents[pos])->first);
 
   return 0;
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43728

---

backport of https://github.com/ceph/ceph/pull/32513
parent tracker: https://tracker.ceph.com/issues/43455

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh