### PR TITLE
common, *: kill the bl::last_p member. Use iterator instead.

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9430,20 +9430,16 @@ int64_t Client::_preadv_pwritev_locked(Fh *fh, const struct iovec *iov,
         if (r <= 0)
           return r;
 
-        int bufoff = 0;
+        auto iter = bl.cbegin();
         for (unsigned j = 0, resid = r; j < iovcnt && resid > 0; j++) {
                /*
                 * This piece of code aims to handle the case that bufferlist does not have enough data 
                 * to fill in the iov 
                 */
-               if (resid < iov[j].iov_len) {
-                    bl.copy(bufoff, resid, (char *)iov[j].iov_base);
-                    break;
-               } else {
-                    bl.copy(bufoff, iov[j].iov_len, (char *)iov[j].iov_base);
-               }
-               resid -= iov[j].iov_len;
-               bufoff += iov[j].iov_len;
+               const auto round_size = std::min<unsigned>(resid, iov[j].iov_len);
+               iter.copy(round_size, reinterpret_cast<char*>(iov[j].iov_base));
+               resid -= round_size;
+               /* iter is self-updating */
         }
         return r;  
     }
@@ -9580,7 +9576,7 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
       uint32_t len = in->inline_data.length();
 
       if (endoff < len)
-        in->inline_data.copy(endoff, len - endoff, bl);
+        in->inline_data.begin(endoff).copy(len - endoff, bl); // XXX
 
       if (offset < len)
         in->inline_data.splice(offset, len - offset);
@@ -13483,17 +13479,20 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
     if (in->inline_version < CEPH_INLINE_NONE &&
         (have & CEPH_CAP_FILE_BUFFER)) {
       bufferlist bl;
+      auto inline_iter = in->inline_data.cbegin();
       int len = in->inline_data.length();
       if (offset < len) {
         if (offset > 0)
-          in->inline_data.copy(0, offset, bl);
+          inline_iter.copy(offset, bl);
         int size = length;
         if (offset + size > len)
           size = len - offset;
         if (size > 0)
           bl.append_zero(size);
-        if (offset + size < len)
-          in->inline_data.copy(offset + size, len - offset - size, bl);
+        if (offset + size < len) {
+          inline_iter.advance(size);
+          inline_iter.copy(len - offset - size, bl);
+        }
         in->inline_data = bl;
         in->inline_version++;
       }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9063,7 +9063,7 @@ int Client::read(int fd, char *buf, loff_t size, loff_t offset)
   int r = _read(f, offset, size, &bl);
   ldout(cct, 3) << "read(" << fd << ", " << (void*)buf << ", " << size << ", " << offset << ") = " << r << dendl;
   if (r >= 0) {
-    bl.copy(0, bl.length(), buf);
+    bl.begin().copy(bl.length(), buf);
     r = bl.length();
   }
   return r;
@@ -13265,7 +13265,7 @@ int Client::ll_read_block(Inode *in, uint64_t blockid,
   client_lock.lock();
 
   if (r >= 0) {
-      bl.copy(0, bl.length(), buf);
+      bl.begin().copy(bl.length(), buf);
       r = bl.length();
   }
 

--- a/src/cls/queue/cls_queue_src.cc
+++ b/src/cls/queue/cls_queue_src.cc
@@ -303,7 +303,7 @@ int queue_list_entries(cls_method_context_t hctx, const cls_queue_list_op& op, c
     do {
       CLS_LOG(10, "INFO: queue_list_entries(): index: %u, size_to_process: %lu\n", index, size_to_process);
       cls_queue_entry entry;
-      it.seek(index);
+      ceph_assert(it.get_off() == index);
       //Populate offset if not done in previous iteration
       if (! offset_populated) {
         cls_queue_marker marker = {start_offset + index, gen};
@@ -346,11 +346,11 @@ int queue_list_entries(cls_method_context_t hctx, const cls_queue_list_op& op, c
       }
       // Data
       if (data_size <= size_to_process) {
-        bl_chunk.copy(index, data_size, entry.data);
+        it.copy(data_size, entry.data);
         index += entry.data.length();
         size_to_process -= entry.data.length();
       } else {
-        bl_chunk.copy(index, size_to_process, bl);
+        it.copy(size_to_process, bl);
         offset_populated = true;
         entry_start_processed = true;
         CLS_LOG(10, "INFO: queue_list_entries(): not enough data to read data, breaking out!\n");

--- a/src/common/bloom_filter.cc
+++ b/src/common/bloom_filter.cc
@@ -38,7 +38,7 @@ void bloom_filter::decode(bufferlist::const_iterator& p)
   delete[] bit_table_;
   if (table_size_) {
     bit_table_ = new cell_type[table_size_];
-    t.copy(0, table_size_, (char *)bit_table_);
+    t.begin().copy(table_size_, (char *)bit_table_);
   } else {
     bit_table_ = NULL;
   }

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1324,31 +1324,6 @@ static ceph::spinlock debug_lock;
     bl.clear();
   }
 
-  void buffer::list::copy(unsigned off, unsigned len, char *dest) const
-  {
-    begin(off).copy(len, dest);
-  }
-
-  void buffer::list::copy(unsigned off, unsigned len, list &dest) const
-  {
-    begin(off).copy(len, dest);
-  }
-
-  void buffer::list::copy(unsigned off, unsigned len, std::string& dest) const
-  {
-    begin(off).copy(len, dest);
-  }
-    
-  void buffer::list::copy_in(unsigned off, unsigned len, const char *src, bool crc_reset)
-  {
-    begin(off).copy_in(len, src, crc_reset);
-  }
-
-  void buffer::list::copy_in(unsigned off, unsigned len, const list& src)
-  {
-    begin(off).copy_in(len, src);
-  }
-
   void buffer::list::append(char c)
   {
     // put what we can into the existing append_buffer.

--- a/src/crush/CrushLocation.cc
+++ b/src/crush/CrushLocation.cc
@@ -89,7 +89,7 @@ int CrushLocation::update_from_hook()
     return ret;
 
   std::string out;
-  bl.copy(0, bl.length(), out);
+  bl.begin().copy(bl.length(), out);
   out.erase(out.find_last_not_of(" \n\r\t")+1);
   return _parse(out);
 }

--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -167,7 +167,7 @@ int ErasureCode::encode_prepare(const bufferlist &raw,
     unsigned remainder = raw.length() - (k - padded_chunks) * blocksize;
     bufferptr buf(buffer::create_aligned(blocksize, SIMD_ALIGN));
 
-    raw.copy((k - padded_chunks) * blocksize, remainder, buf.c_str());
+    raw.begin((k - padded_chunks) * blocksize).copy(remainder, buf.c_str());
     buf.zero(remainder, blocksize - remainder);
     encoded[chunk_index(k-padded_chunks)].push_back(std::move(buf));
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -1142,14 +1142,6 @@ inline namespace v14_2_0 {
       return const_iterator(this, _len, _buffers.end(), 0);
     }
 
-    // crope lookalikes.
-    // **** WARNING: this are horribly inefficient for large bufferlists. ****
-    void copy(unsigned off, unsigned len, char *dest) const;
-    void copy(unsigned off, unsigned len, list &dest) const;
-    void copy(unsigned off, unsigned len, std::string& dest) const;
-    void copy_in(unsigned off, unsigned len, const char *src, bool crc_reset = true);
-    void copy_in(unsigned off, unsigned len, const list& src);
-
     void append(char c);
     void append(const char *data, unsigned len);
     void append(std::string s) {

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -946,8 +946,6 @@ inline namespace v14_2_0 {
     }
 
   private:
-    mutable iterator last_p;
-
     // always_empty_bptr has no underlying raw but its _len is always 0.
     // This is useful for e.g. get_append_buffer_unused_tail_length() as
     // it allows to avoid conditionals on hot paths.
@@ -959,24 +957,21 @@ inline namespace v14_2_0 {
     list()
       : _carriage(&always_empty_bptr),
         _len(0),
-        _memcopy_count(0),
-        last_p(this) {
+        _memcopy_count(0) {
     }
     // cppcheck-suppress noExplicitConstructor
     // cppcheck-suppress noExplicitConstructor
     list(unsigned prealloc)
       : _carriage(&always_empty_bptr),
         _len(0),
-        _memcopy_count(0),
-	last_p(this) {
+        _memcopy_count(0) {
       reserve(prealloc);
     }
 
     list(const list& other)
       : _carriage(&always_empty_bptr),
         _len(other._len),
-        _memcopy_count(other._memcopy_count),
-        last_p(this) {
+        _memcopy_count(other._memcopy_count) {
       _buffers.clone_from(other._buffers);
     }
     list(list&& other) noexcept;
@@ -990,7 +985,6 @@ inline namespace v14_2_0 {
         _carriage = &always_empty_bptr;
         _buffers.clone_from(other._buffers);
         _len = other._len;
-        last_p = begin();
       }
       return *this;
     }
@@ -999,7 +993,6 @@ inline namespace v14_2_0 {
       _carriage = other._carriage;
       _len = other._len;
       _memcopy_count = other._memcopy_count;
-      last_p = begin();
       other.clear();
       return *this;
     }
@@ -1057,7 +1050,6 @@ inline namespace v14_2_0 {
       _buffers.clear_and_dispose();
       _len = 0;
       _memcopy_count = 0;
-      last_p = begin();
     }
     void push_back(const ptr& bp) {
       if (bp.length() == 0)
@@ -1133,18 +1125,18 @@ inline namespace v14_2_0 {
     operator seastar::net::packet() &&;
 #endif
 
-    iterator begin() {
-      return iterator(this, 0);
+    iterator begin(size_t offset=0) {
+      return iterator(this, offset);
     }
     iterator end() {
       return iterator(this, _len, _buffers.end(), 0);
     }
 
-    const_iterator begin() const {
-      return const_iterator(this, 0);
+    const_iterator begin(size_t offset=0) const {
+      return const_iterator(this, offset);
     }
-    const_iterator cbegin() const {
-      return begin();
+    const_iterator cbegin(size_t offset=0) const {
+      return begin(offset);
     }
     const_iterator end() const {
       return const_iterator(this, _len, _buffers.end(), 0);

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -673,25 +673,20 @@ template<class T, class Alloc, typename traits>
 inline std::enable_if_t<!traits::supported>
   encode(const std::list<T,Alloc>& ls, bufferlist& bl, uint64_t features)
 {
-  // should i pre- or post- count?
-  if (!ls.empty()) {
-    unsigned pos = bl.length();
-    unsigned n = 0;
-    encode(n, bl);
-    for (auto p = ls.begin(); p != ls.end(); ++p) {
-      n++;
-      encode(*p, bl, features);
-    }
-    ceph_le32 en;
-    en = n;
-    bl.copy_in(pos, sizeof(en), (char*)&en);
-  } else {
-    __u32 n = (__u32)(ls.size());    // FIXME: this is slow on a list.
-    encode(n, bl);
-    for (auto p = ls.begin(); p != ls.end(); ++p)
-      encode(*p, bl, features);
+  using counter_encode_t = ceph_le32;
+  unsigned n = 0;
+  auto filler = bl.append_hole(sizeof(counter_encode_t));
+  for (const auto& item : ls) {
+    // we count on our own because of buggy std::list::size() implementation
+    // which doesn't follow the O(1) complexity constraint C++11 has brought.
+    ++n;
+    encode(item, bl, features);
   }
+  counter_encode_t en;
+  en = n;
+  filler.copy_in(sizeof(en), reinterpret_cast<char*>(&en));
 }
+
 template<class T, class Alloc, typename traits>
 inline std::enable_if_t<!traits::supported>
   decode(std::list<T,Alloc>& ls, bufferlist::const_iterator& p)

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -1657,7 +1657,7 @@ extern "C" int ceph_ll_read(class ceph_mount_info *cmount, Fh* filehandle,
   r = cmount->get_client()->ll_read(filehandle, off, len, &bl);
   if (r >= 0)
     {
-      bl.copy(0, bl.length(), buf);
+      bl.begin().copy(bl.length(), buf);
       r = bl.length();
     }
   return r;

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -1956,7 +1956,7 @@ void librados::IoCtxImpl::C_aio_Complete::finish(int r)
       c->rval = -ERANGE;
     } else {
       if (c->out_buf && !c->blp->is_provided_buffer(c->out_buf))
-        c->blp->copy(0, c->blp->length(), c->out_buf);
+        c->blp->begin().copy(c->blp->length(), c->out_buf);
 
       c->rval = c->blp->length();
     }

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -1274,7 +1274,7 @@ extern "C" int _rados_read(rados_ioctx_t io, const char *o, char *buf, size_t le
       return -ERANGE;
     }
     if (!bl.is_provided_buffer(buf))
-      bl.copy(0, bl.length(), buf);
+      bl.begin().copy(bl.length(), buf);
     ret = bl.length();    // hrm :/
   }
 
@@ -1307,7 +1307,7 @@ extern "C" int _rados_checksum(rados_ioctx_t io, const char *o,
       return -ERANGE;
     }
 
-    checksum_bl.copy(0, checksum_bl.length(), pchecksum);
+    checksum_bl.begin().copy(checksum_bl.length(), pchecksum);
   }
   tracepoint(librados, rados_checksum_exit, retval, pchecksum, checksum_len);
   return retval;
@@ -1754,7 +1754,7 @@ extern "C" int _rados_getxattr(rados_ioctx_t io, const char *o, const char *name
       return -ERANGE;
     }
     if (!bl.is_provided_buffer(buf))
-      bl.copy(0, bl.length(), buf);
+      bl.begin().copy(bl.length(), buf);
     ret = bl.length();
   }
 
@@ -1947,7 +1947,7 @@ extern "C" int _rados_exec(rados_ioctx_t io, const char *o, const char *cls, con
 	tracepoint(librados, rados_exec_exit, -ERANGE, buf, 0);
 	return -ERANGE;
       }
-      outbl.copy(0, outbl.length(), buf);
+      outbl.begin().copy(outbl.length(), buf);
       ret = outbl.length();   // hrm :/
     }
   }
@@ -2539,7 +2539,7 @@ static void rados_aio_getxattr_complete(rados_completion_t c, void *arg) {
       rc = -ERANGE;
     } else {
       if (!cdata->bl.is_provided_buffer(cdata->user_buf))
-	cdata->bl.copy(0, cdata->bl.length(), cdata->user_buf);
+	cdata->bl.begin().copy(cdata->bl.length(), cdata->user_buf);
       rc = cdata->bl.length();
     }
   }
@@ -3691,7 +3691,7 @@ public:
     if (bytes_read)
       *bytes_read = out_bl.length();
     if (out_buf && !out_bl.is_provided_buffer(out_buf))
-      out_bl.copy(0, out_bl.length(), out_buf);
+      out_bl.begin().copy(out_bl.length(), out_buf);
   }
 };
 

--- a/src/libradosstriper/libradosstriper.cc
+++ b/src/libradosstriper/libradosstriper.cc
@@ -432,7 +432,7 @@ extern "C" int rados_striper_read(rados_striper_t striper,
     if (bl.length() > len)
       return -ERANGE;
     if (!bl.is_provided_buffer(buf))
-      bl.copy(0, bl.length(), buf);
+      bl.begin().copy(bl.length(), buf);
     ret = bl.length();    // hrm :/
   }
   return ret;
@@ -463,7 +463,7 @@ extern "C" int rados_striper_getxattr(rados_striper_t striper,
   if (ret >= 0) {
     if (bl.length() > len)
       return -ERANGE;
-    bl.copy(0, bl.length(), buf);
+    bl.begin().copy(bl.length(), buf);
     ret = bl.length();
   }
   return ret;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5772,7 +5772,7 @@ void Server::handle_client_setxattr(MDRequestRef& mdr)
   } else {
     bufferptr b = buffer::create(len);
     if (len)
-      req->get_data().copy(0, len, b.c_str());
+      req->get_data().begin().copy(len, b.c_str());
     auto em = px.emplace(std::piecewise_construct, std::forward_as_tuple(mempool::mds_co::string(name)), std::forward_as_tuple(b));
     if (!em.second)
       em.first->second = b;

--- a/src/mgr/ActivePyModule.cc
+++ b/src/mgr/ActivePyModule.cc
@@ -209,7 +209,7 @@ int ActivePyModule::handle_command(
   cmdmap_dump(cmdmap, &f);
   PyObject *py_cmd = f.get();
   string instr;
-  inbuf.copy(0, inbuf.length(), instr);
+  inbuf.begin().copy(inbuf.length(), instr);
 
   ceph_assert(m_session == nullptr);
   m_command_perms = module_command.perm;

--- a/src/os/Transaction.h
+++ b/src/os/Transaction.h
@@ -543,7 +543,7 @@ public:
     ceph::buffer::list other_op_bl;
     {
       ceph::buffer::ptr other_op_bl_ptr(other.op_bl.length());
-      other.op_bl.copy(0, other.op_bl.length(), other_op_bl_ptr.c_str());
+      other.op_bl.begin().copy(other.op_bl.length(), other_op_bl_ptr.c_str());
       other_op_bl.append(std::move(other_op_bl_ptr));
     }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12723,7 +12723,7 @@ void BlueStore::_pad_zeros(
     back_pad = chunk_size - back_copy;
     ceph_assert(back_copy <= length);
     bufferptr tail(chunk_size);
-    bl->copy(length - back_copy, back_copy, tail.c_str());
+    bl->begin(length - back_copy).copy(back_copy, tail.c_str());
     tail.zero(back_copy, back_pad, false);
     bufferlist old;
     old.swap(*bl);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12700,7 +12700,7 @@ void BlueStore::_pad_zeros(
     bufferptr z = buffer::create_small_page_aligned(chunk_size);
     z.zero(0, front_pad, false);
     pad_count += front_pad;
-    bl->copy(0, front_copy, z.c_str() + front_pad);
+    bl->begin().copy(front_copy, z.c_str() + front_pad);
     if (front_copy + front_pad < chunk_size) {
       back_pad = chunk_size - (length + front_pad);
       z.zero(front_pad + length, back_pad, false);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3025,8 +3025,9 @@ struct C_ProxyChunkRead : public Context {
 	} else {
 	  copy_offset = 0;
 	}
-	prdop->ops[op_index].outdata.copy_in(copy_offset, obj_op->ops[0].outdata.length(),
-					     obj_op->ops[0].outdata.c_str());
+	prdop->ops[op_index].outdata.begin(copy_offset).copy_in(
+          obj_op->ops[0].outdata.length(),
+          obj_op->ops[0].outdata.c_str());
       } 	
       
       pg->finish_proxy_read(oid, tid, r);

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -6816,20 +6816,18 @@ void OSDOp::clear_data(vector<OSDOp>& ops)
     if (ceph_osd_op_type_attr(op.op.op) &&
         op.op.xattr.name_len &&
 	op.indata.length() >= op.op.xattr.name_len) {
-      ceph::buffer::ptr bp(op.op.xattr.name_len);
       ceph::buffer::list bl;
-      bl.append(bp);
-      bl.copy_in(0, op.op.xattr.name_len, op.indata);
+      bl.push_back(ceph::buffer::ptr_node::create(op.op.xattr.name_len));
+      bl.begin().copy_in(op.op.xattr.name_len, op.indata);
       op.indata.claim(bl);
     } else if (ceph_osd_op_type_exec(op.op.op) &&
                op.op.cls.class_len &&
 	       op.indata.length() >
 	         (op.op.cls.class_len + op.op.cls.method_len)) {
       __u8 len = op.op.cls.class_len + op.op.cls.method_len;
-      ceph::buffer::ptr bp(len);
       ceph::buffer::list bl;
-      bl.append(bp);
-      bl.copy_in(0, len, op.indata);
+      bl.push_back(ceph::buffer::ptr_node::create(len));
+      bl.begin().copy_in(len, op.indata);
       op.indata.claim(bl);
     } else {
       op.indata.clear();

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3504,7 +3504,7 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
       ceph::buffer::list t;
       t.claim(*op->outbl);
       t.invalidate_crc();  // we're overwriting the raw buffers via c_str()
-      bl.copy(0, bl.length(), t.c_str());
+      bl.begin().copy(bl.length(), t.c_str());
       op->outbl->substr_of(t, 0, bl.length());
     } else {
       m->claim_data(*op->outbl);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -3104,12 +3104,17 @@ public:
 		  0, 0, op_flags);
     } else {
       C_GatherBuilder gcom(cct, oncommit);
+      auto it = bl.cbegin();
       for (auto p = extents.begin(); p != extents.end(); ++p) {
 	ceph::buffer::list cur;
 	for (auto bit = p->buffer_extents.begin();
 	     bit != p->buffer_extents.end();
-	     ++bit)
-	  bl.copy(bit->first, bit->second, cur);
+	     ++bit) {
+	  if (it.get_off() != bit->first) {
+	    it.seek(bit->first);
+	  }
+	  it.copy(bit->second, cur);
+	}
 	ceph_assert(cur.length() == p->length);
 	write_trunc(p->oid, p->oloc, p->offset, p->length,
 	      snapc, cur, mtime, flags, p->truncate_size, trunc_seq,

--- a/src/osdc/Striper.cc
+++ b/src/osdc/Striper.cc
@@ -474,11 +474,11 @@ void Striper::StripedReadResult::assemble_result(CephContext *cct, char *buffer,
     curr -= p->second.second;
     if (len < p->second.second) {
       if (len)
-	p->second.first.copy(0, len, buffer + curr);
+	p->second.first.begin().copy(len, buffer + curr);
       // FIPS zeroization audit 20191117: this memset is not security related.
       memset(buffer + curr + len, 0, p->second.second - len);
     } else {
-      p->second.first.copy(0, len, buffer + curr);
+      p->second.first.begin().copy(len, buffer + curr);
     }
     ++p;
   }

--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -98,7 +98,7 @@ int RGWGetObj_Decompress::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len
     return -EIO;
   }
   bufferlist out_bl, in_bl, temp_in_bl;
-  bl.copy(bl_ofs, bl_len, temp_in_bl); 
+  bl.begin(bl_ofs).copy(bl_len, temp_in_bl);
   bl_ofs = 0;
   int r = 0;
   if (waiting.length() != 0) {
@@ -110,17 +110,24 @@ int RGWGetObj_Decompress::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len
   }
   bl_len = in_bl.length();
   
+  auto iter_in_bl = in_bl.cbegin();
   while (first_block <= last_block) {
     bufferlist tmp;
     off_t ofs_in_bl = first_block->new_ofs - cur_ofs;
     if (ofs_in_bl + (off_t)first_block->len > bl_len) {
       // not complete block, put it to waiting
       unsigned tail = bl_len - ofs_in_bl;
-      in_bl.copy(ofs_in_bl, tail, waiting);
+      if (iter_in_bl.get_off() != ofs_in_bl) {
+        iter_in_bl.seek(ofs_in_bl);
+      }
+      iter_in_bl.copy(tail, waiting);
       cur_ofs -= tail;
       break;
     }
-    in_bl.copy(ofs_in_bl, first_block->len, tmp);
+    if (iter_in_bl.get_off() != ofs_in_bl) {
+      iter_in_bl.seek(ofs_in_bl);
+    }
+    iter_in_bl.copy(first_block->len, tmp);
     int cr = compressor->decompress(tmp, out_bl);
     if (cr < 0) {
       lderr(cct) << "Decompression failed with exit code " << cr << dendl;

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -472,7 +472,7 @@ int RGWGetObj_BlockDecrypt::process(bufferlist& in, size_t part_ofs, size_t size
 
 int RGWGetObj_BlockDecrypt::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len) {
   ldout(cct, 25) << "Decrypt " << bl_len << " bytes" << dendl;
-  bl.copy(bl_ofs, bl_len, cache);
+  bl.begin(bl_ofs).copy(bl_len, cache);
 
   int res = 0;
   size_t part_ofs = ofs;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3596,7 +3596,7 @@ public:
 int RGWPutObj::get_data_cb(bufferlist& bl, off_t bl_ofs, off_t bl_len)
 {
   bufferlist bl_tmp;
-  bl.copy(bl_ofs, bl_len, bl_tmp);
+  bl.begin(bl_ofs).copy(bl_len, bl_tmp);
 
   bl_aux.append(bl_tmp);
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5989,7 +5989,7 @@ int RGWRados::Object::Read::read(int64_t ofs, int64_t end, bufferlist& bl, optio
 
       if (ofs < astate->data.length()) {
         unsigned copy_len = std::min((uint64_t)astate->data.length() - ofs, len);
-        astate->data.copy(ofs, copy_len, bl);
+        astate->data.begin(ofs).copy(copy_len, bl);
         read_len -= copy_len;
         read_ofs += copy_len;
         if (!read_len)

--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -69,7 +69,7 @@ TEST(AES, Encrypt) {
   char cipher_s[sizeof(want_cipher)];
 
   ASSERT_EQ(sizeof(cipher_s), cipher.length());
-  cipher.copy(0, sizeof(cipher_s), &cipher_s[0]);
+  cipher.cbegin().copy(sizeof(cipher_s), &cipher_s[0]);
 
   int err;
   err = memcmp(cipher_s, want_cipher, sizeof(want_cipher));
@@ -153,7 +153,7 @@ TEST(AES, Decrypt) {
   ASSERT_EQ(error, "");
 
   ASSERT_EQ(sizeof(plaintext_s), plaintext.length());
-  plaintext.copy(0, sizeof(plaintext_s), &plaintext_s[0]);
+  plaintext.cbegin().copy(sizeof(plaintext_s), &plaintext_s[0]);
 
   int err;
   err = memcmp(plaintext_s, want_plaintext, sizeof(want_plaintext));

--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -867,7 +867,7 @@ enum fio_q_status fio_ceph_os_queue(thread_data* td, io_u* u)
       u->error = r;
       td_verror(td, u->error, "xfer");
     } else {
-      bl.copy(0, bl.length(), static_cast<char*>(u->xfer_buf));
+      bl.begin().copy(bl.length(), static_cast<char*>(u->xfer_buf));
       u->resid = u->xfer_buflen - r;
     }
     return FIO_Q_COMPLETED;

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -82,7 +82,7 @@ int TestMemIoCtxImpl::append(const std::string& oid, const bufferlist &bl,
   std::unique_lock l{file->lock};
   auto off = file->data.length();
   ensure_minimum_length(off + bl.length(), &file->data);
-  file->data.copy_in(off, bl.length(), bl);
+  file->data.begin(off).copy_in(bl.length(), bl);
   return 0;
 }
 
@@ -582,7 +582,7 @@ int TestMemIoCtxImpl::write(const std::string& oid, bufferlist& bl, size_t len,
   }
 
   ensure_minimum_length(off + len, &file->data);
-  file->data.copy_in(off, len, bl);
+  file->data.begin(off).copy_in(len, bl);
   return 0;
 }
 
@@ -613,7 +613,7 @@ int TestMemIoCtxImpl::write_full(const std::string& oid, bufferlist& bl,
 
   file->data.clear();
   ensure_minimum_length(bl.length(), &file->data);
-  file->data.copy_in(0, bl.length(), bl);
+  file->data.begin().copy_in(bl.length(), bl);
   return 0;
 }
 
@@ -645,7 +645,7 @@ int TestMemIoCtxImpl::writesame(const std::string& oid, bufferlist& bl, size_t l
 
   ensure_minimum_length(off + len, &file->data);
   while (len > 0) {
-    file->data.copy_in(off, bl.length(), bl);
+    file->data.begin(off).copy_in(bl.length(), bl);
     off += bl.length();
     len -= bl.length();
   }

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -4072,11 +4072,11 @@ public:
     } else {
       bufferlist value;
       ceph_assert(dstdata.length() > dstoff);
-      dstdata.copy(0, dstoff, value);
+      dstdata.cbegin().copy(dstoff, value);
       value.append(bl);
       if (value.length() < dstdata.length())
-        dstdata.copy(value.length(),
-		     dstdata.length() - value.length(), value);
+        dstdata.cbegin(value.length()).copy(
+          dstdata.length() - value.length(), value);
       value.swap(dstdata);
     }
 
@@ -4118,11 +4118,11 @@ public:
     } else {
       bufferlist value;
       ceph_assert(data.length() > offset);
-      data.copy(0, offset, value);
+      data.cbegin().copy(offset, value);
       value.append(bl);
       if (value.length() < data.length())
-        data.copy(value.length(),
-		  data.length()-value.length(), value);
+        data.cbegin(value.length()).copy(
+          data.length()-value.length(), value);
       value.swap(data);
     }
 
@@ -4159,7 +4159,7 @@ public:
       data.append_zero(len - data.length());
     } else {
       bufferlist bl;
-      data.copy(0, len, bl);
+      data.cbegin().copy(len, bl);
       bl.swap(data);
     }
 
@@ -4197,7 +4197,7 @@ public:
       n.substr_of(data, 0, offset);
       n.append_zero(len);
       if (data.length() > offset + len)
-	data.copy(offset + len, data.length() - offset - len, n);
+	data.cbegin(offset + len).copy(data.length() - offset - len, n);
       data.swap(n);
     }
 
@@ -4245,7 +4245,7 @@ public:
         len = max_len;
       ceph_assert(len == result.length());
       ASSERT_EQ(len, result.length());
-      expected.copy(offset, len, bl);
+      expected.cbegin(offset).copy(len, bl);
       ASSERT_EQ(r, (int)len);
       ASSERT_TRUE(bl_eq(bl, result));
     }

--- a/src/test/perf_local.cc
+++ b/src/test/perf_local.cc
@@ -246,7 +246,7 @@ double buffer_copy()
   char copy[10];
   uint64_t start = Cycles::rdtsc();
   for (int i = 0; i < count; i++) {
-    b.copy(2, 6, copy);
+    b.cbegin(2).copy(6, copy);
   }
   uint64_t stop = Cycles::rdtsc();
   return Cycles::to_seconds(stop - start)/count;

--- a/src/test/test_filejournal.cc
+++ b/src/test/test_filejournal.cc
@@ -300,14 +300,14 @@ TEST(TestFileJournal, ReplaySmall) {
     uint64_t seq = 0;
     ASSERT_EQ(true, fj.read_entry(inbl, seq));
     ASSERT_EQ(seq, 2ull);
-    inbl.copy(0, inbl.length(), v);
+    inbl.cbegin().copy(inbl.length(), v);
     ASSERT_EQ("small", v);
     inbl.clear();
     v.clear();
 
     ASSERT_EQ(true, fj.read_entry(inbl, seq));
     ASSERT_EQ(seq, 3ull);
-    inbl.copy(0, inbl.length(), v);
+    inbl.cbegin().copy(inbl.length(), v);
     ASSERT_EQ("small", v);
     inbl.clear();
     v.clear();
@@ -392,7 +392,7 @@ TEST(TestFileJournal, ReplayCorrupt) {
     uint64_t seq = 0;
     ASSERT_EQ(true, fj.read_entry(inbl, seq));
     ASSERT_EQ(seq, 2ull);
-    inbl.copy(0, inbl.length(), v);
+    inbl.cbegin().copy(inbl.length(), v);
     ASSERT_EQ(needle, v);
     inbl.clear();
     v.clear();

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -352,11 +352,11 @@ uint64_t EstimateDedupRatio::fixed_chunk(string oid, uint64_t offset)
     if (outdata.length() - c_offset > chunk_size) {
       bufferptr bptr(chunk_size);
       chunk.push_back(std::move(bptr));
-      chunk.copy_in(0, chunk_size, outdata.c_str());	  
+      chunk.begin().copy_in(chunk_size, outdata.c_str());
     } else {
       bufferptr bptr(outdata.length() - c_offset);
       chunk.push_back(std::move(bptr));
-      chunk.copy_in(0, outdata.length() - c_offset, outdata.c_str());	  
+      chunk.begin().copy_in(outdata.length() - c_offset, outdata.c_str());
     }
     add_chunk_fp_to_stat(chunk);
     c_offset = c_offset + chunk_size;
@@ -415,7 +415,7 @@ uint64_t EstimateDedupRatio::rabin_chunk(string oid, uint64_t offset)
     bufferptr c_data = buffer::create(p.second);
     c_data.zero();
     chunk.append(c_data);
-    chunk.copy_in(0, p.second, outdata.c_str() + p.first);
+    chunk.begin().copy_in(p.second, outdata.c_str() + p.first);
     add_chunk_fp_to_stat(chunk);
     cout << " oid: " << oid <<  " offset: " << p.first + offset << " length: " << p.second << std::endl;
   }

--- a/src/tools/cephfs/JournalScanner.cc
+++ b/src/tools/cephfs/JournalScanner.cc
@@ -201,7 +201,7 @@ int JournalScanner::scan_events()
       dout(4) << "Read 0x" << std::hex << this_object.length() << std::dec
               << " bytes from " << oid << " gap=" << gap << dendl;
       objects_valid.push_back(oid);
-      this_object.copy(0, this_object.length(), read_buf);
+      this_object.begin().copy(this_object.length(), read_buf);
     }
 
     if (gap) {


### PR DESCRIPTION
This PR is a resurrection of https://github.com/ceph/ceph/pull/24498 with one but important exception: instead of introducing a new *hint passing* mechanism to supersede `bufferlist::last_p`, it converts users of the `copy_in()` and `copy()` methods to the well-established `bufferlist::iterator` interface. Therefore,  they can be removed from `bufferlist` which is accomplished with the last commit.

The reasons for killing `last_p` are still:
  * https://github.com/ceph/ceph/pull/24498#issuecomment-428298876,
  * https://github.com/ceph/ceph/pull/24498#issuecomment-428587480.

There is also a new one: `last_p` is basically a caching mechanism, and thus brings the burden of `cache invalidation`. This was recently exercised in https://github.com/ceph/ceph/pull/32702.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
