### PR TITLE
nautilus: rgw: the http response code of delete bucket should not be 204-no-content

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1566,15 +1566,6 @@ void RGWDeleteBucket_ObjStore_S3::send_response()
   set_req_state_err(s, r);
   dump_errno(s);
   end_header(s, this);
-
-  if (s->system_request) {
-    JSONFormatter f; /* use json formatter for system requests output */
-
-    f.open_object_section("info");
-    encode_json("object_ver", objv_tracker.read_version, &f);
-    f.close_section();
-    rgw_flush_formatter_and_reset(s, &f);
-  }
 }
 
 static inline void map_qs_metadata(struct req_state* s)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43786

---

backport of https://github.com/ceph/ceph/pull/30471
parent tracker: https://tracker.ceph.com/issues/41925

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh