### PR TITLE
nautilus: rgw: fix opslog operation field as per Amazon s3

### DIFF
--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -391,7 +391,7 @@ int rgw_log_op(RGWRados *store, RGWREST* const rest, struct req_state *s,
 
   entry.uri = std::move(uri);
 
-  set_param_str(s, "REQUEST_METHOD", entry.op);
+  entry.op = op_name;
 
   /* custom header logging */
   if (rest) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43789

---

backport of https://github.com/ceph/ceph/pull/30539
parent tracker: https://tracker.ceph.com/issues/20978

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh