### PR TITLE
nautilus: rbd:  creating thick-provision image progress percent info exceeds 100%

### DIFF
--- a/src/tools/rbd/action/Create.cc
+++ b/src/tools/rbd/action/Create.cc
@@ -151,6 +151,9 @@ int write_data(librbd::Image &image, librbd::ImageOptions &opts,
       }
       ++i;
       off += tpw.chunk_size;
+      if(off > image_size) {
+        off = image_size;
+      }
       pc.update_progress(off, image_size);
     }
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43508

---

backport of https://github.com/ceph/ceph/pull/30954
parent tracker: https://tracker.ceph.com/issues/42335

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh