### PR TITLE
osdc/Objecter: debug pause/unpause transition

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2906,7 +2906,11 @@ int Objecter::_calc_target(op_target_t *t, Connection *con, bool any_change)
   if (t->paused && !should_be_paused) {
     unpaused = true;
   }
-  t->paused = should_be_paused;
+  if (t->paused != should_be_paused) {
+    ldout(cct, 10) << __func__ << " paused " << t->paused
+		   << " -> " << should_be_paused << dendl;
+    t->paused = should_be_paused;
+  }
 
   bool legacy_change =
     t->pgid != pgid ||


### PR DESCRIPTION
My only theory for https://tracker.ceph.com/issues/43813 is that
t->paused got set somehow, but I can't see how.  Add some debug output
when this happens (it should be pretty rare).

Signed-off-by: Sage Weil <sage@redhat.com>