### PR TITLE
qa/standalone/osd/osd-backfill-recovery-log.sh: fix TEST_backfill_log_[1, 2]

### DIFF
--- a/qa/standalone/osd/osd-backfill-recovery-log.sh
+++ b/qa/standalone/osd/osd-backfill-recovery-log.sh
@@ -110,7 +110,7 @@ function TEST_backfill_log_1() {
 function TEST_backfill_log_2() {
     local dir=$1
 
-    _common_test $dir "--osd_min_pg_log_entries=1 --osd_max_pg_log_entries=2" 1 149 150
+    _common_test $dir "--osd_min_pg_log_entries=1 --osd_max_pg_log_entries=2" 2 148 150
 }
 
 

--- a/qa/standalone/osd/osd-backfill-recovery-log.sh
+++ b/qa/standalone/osd/osd-backfill-recovery-log.sh
@@ -102,7 +102,7 @@ function _common_test() {
 function TEST_backfill_log_1() {
     local dir=$1
 
-    _common_test $dir "--osd_min_pg_log_entries=1 --osd_max_pg_log_entries=2 --osd_pg_log_dups_tracked=10" 1 9 150
+    _common_test $dir "--osd_min_pg_log_entries=1 --osd_max_pg_log_entries=2 --osd_pg_log_dups_tracked=10" 2 8 150
 }
 
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43807
Signed-off-by: Neha Ojha <nojha@redhat.com>
