### PR TITLE
mimic: ceph-volume/lvm/activate.py: clarify error message: fsid refers to osd_fsid

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -248,7 +248,7 @@ class Activate(object):
         elif osd_fsid and not osd_id:
             lvs.filter(lv_tags={'ceph.osd_fsid': osd_fsid})
         if not lvs:
-            raise RuntimeError('could not find osd.%s with fsid %s' % (osd_id, osd_fsid))
+            raise RuntimeError('could not find osd.%s with osd_fsid %s' % (osd_id, osd_fsid))
         # This argument is only available when passed in directly or via
         # systemd, not when ``create`` is being used
         if getattr(args, 'auto_detect_objectstore', False):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43463

---

backport of https://github.com/ceph/ceph/pull/32351
parent tracker: https://tracker.ceph.com/issues/43442

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh