### PR TITLE
mimic: ceph-volume: check if we run in an selinux environment

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_system.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_system.py
@@ -4,6 +4,7 @@ import getpass
 import pytest
 from textwrap import dedent
 from ceph_volume.util import system
+from mock.mock import patch
 
 
 class TestMkdirP(object):
@@ -260,8 +261,9 @@ class TestSetContext(object):
         system.set_context('/tmp/foo')
         assert len(fake_run.calls)
 
-    def test_selinuxenabled_doesnt_exist(self, stub_call, fake_run):
-        stub_call(('', 'command not found: selinuxenabled', 127))
+    @patch('ceph_volume.process.call')
+    def test_selinuxenabled_doesnt_exist(self, mocked_call, fake_run):
+        mocked_call.side_effect = FileNotFoundError()
         system.set_context('/tmp/foo')
         assert fake_run.calls == []
 

--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -297,7 +297,13 @@ def set_context(path, recursive=False):
         )
         return
 
-    stdout, stderr, code = process.call(['selinuxenabled'], verbose_on_failure=False)
+    try:
+        stdout, stderr, code = process.call(['selinuxenabled'],
+                                            verbose_on_failure=False)
+    except FileNotFoundError:
+        logger.info('No SELinux found, skipping call to restorecon')
+        return
+
     if code != 0:
         logger.info('SELinux is not enabled, will not call restorecon')
         return


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42966

---

backport of https://github.com/ceph/ceph/pull/31809
parent tracker: https://tracker.ceph.com/issues/42957

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh