### PR TITLE
mimic: ceph-volume: check if we run in an selinux environment, now also in py2

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_system.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_system.py
@@ -225,6 +225,13 @@ def stub_which(monkeypatch):
     return apply
 
 
+# python2 has no FileNotFoundError
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = OSError
+
+
 class TestSetContext(object):
 
     def setup(self):

--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -8,6 +8,12 @@ import uuid
 from ceph_volume import process, terminal
 from . import as_string
 
+# python2 has no FileNotFoundError
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = OSError
+
 logger = logging.getLogger(__name__)
 mlogger = terminal.MultiLogger(__name__)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42972

---

backport of https://github.com/ceph/ceph/pull/31814
parent tracker: https://tracker.ceph.com/issues/42967

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh