### PR TITLE
mimic: ceph-volume: import mock.mock instead of unittest.mock (py2)

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from mock.mock import patch
 from ceph_volume import process, exceptions
 from ceph_volume.api import lvm as api
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43118

---

backport of https://github.com/ceph/ceph/pull/31816
parent tracker: https://tracker.ceph.com/issues/42970

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh