### PR TITLE
mimic: ceph-volume: fix the integer overflow

### DIFF
--- a/src/ceph-volume/ceph_volume/systemd/main.py
+++ b/src/ceph-volume/ceph_volume/systemd/main.py
@@ -92,8 +92,8 @@ def main(args=None):
     logger.info('parsed sub-command: %s, extra data: %s', sub_command, extra_data)
     command = ['ceph-volume', sub_command, 'trigger', extra_data]
 
-    tries = os.environ.get('CEPH_VOLUME_SYSTEMD_TRIES', 30)
-    interval = os.environ.get('CEPH_VOLUME_SYSTEMD_INTERVAL', 5)
+    tries = int(os.environ.get('CEPH_VOLUME_SYSTEMD_TRIES', 30))
+    interval = int(os.environ.get('CEPH_VOLUME_SYSTEMD_INTERVAL', 5))
     while tries > 0:
         try:
             # don't log any output to the terminal, just rely on stderr/stdout


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43200

---

backport of https://github.com/ceph/ceph/pull/32106
parent tracker: https://tracker.ceph.com/issues/43186

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh