### PR TITLE
mimic: ceph-volume: use correct extents if using db-devices and >1 osds_per_device

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -354,7 +354,7 @@ class MixedType(MixedStrategy):
         for osd in self.computed['osds']:
             data_path = osd['data']['path']
             data_vg = data_vgs[data_path]
-            data_lv_extents = data_vg.sizing(parts=1)['extents']
+            data_lv_extents = data_vg.sizing(parts=self.osds_per_device)['extents']
             data_lv = lvm.create_lv(
                 'osd-block', data_vg.name, extents=data_lv_extents, uuid_name=True
             )
@@ -536,4 +536,3 @@ class MixedType(MixedStrategy):
                 self.block_wal_size,
             )
             raise RuntimeError(msg)
-


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43322

---

backport of https://github.com/ceph/ceph/pull/32177
parent tracker: https://tracker.ceph.com/issues/39442

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh