### PR TITLE
qa/workunits/rados/test_crash.sh: do not rm coredump

### DIFF
--- a/qa/suites/rados/singleton/all/test-crash.yaml
+++ b/qa/suites/rados/singleton/all/test-crash.yaml
@@ -15,4 +15,4 @@ tasks:
   - ceph.restart: [osd.*]
   - exec:
       mon.a:
-        - rm $TESTDIR/archive/coredump/*
+        - find $TESTDIR/archive/coredump -type f -exec rm -f {} \;

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -182,12 +182,12 @@ void RGWOp_User_Create::execute()
     op_state.set_key_type(key_type);
   }
 
-  if (max_buckets != default_max_buckets)
+  if (max_buckets != default_max_buckets) {
     if (max_buckets < 0) {
       max_buckets = -1;
     }
     op_state.set_max_buckets(max_buckets);
-
+  }
   if (s->info.args.exists("suspended"))
     op_state.set_suspension(suspended);
 
@@ -277,12 +277,12 @@ void RGWOp_User_Modify::execute()
   op_state.set_access_key(access_key);
   op_state.set_secret_key(secret_key);
 
-  if (quota_set)
+  if (quota_set) {
     if (max_buckets < 0 ) {
       max_buckets = -1;
     }
     op_state.set_max_buckets(max_buckets);
-
+  }
   if (gen_key)
     op_state.set_generate_key();
 


### PR DESCRIPTION
they are moved away by crash module already

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
