### PR TITLE
nautilus: mgr/dashboard: Using wrong identifiers in RGW user/bucket datatables

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.html
@@ -5,7 +5,7 @@
           columnMode="flex"
           selectionType="multi"
           (updateSelection)="updateSelection($event)"
-          identifier="bucket"
+          identifier="bid"
           (fetchData)="getBucketList($event)">
   <cd-table-actions class="table-actions"
                     [permission]="permission"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.html
@@ -5,7 +5,7 @@
           columnMode="flex"
           selectionType="multi"
           (updateSelection)="updateSelection($event)"
-          identifier="user_id"
+          identifier="uid"
           (fetchData)="getUserList($event)">
   <cd-table-actions class="table-actions"
                     [permission]="permission"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42033

---

backport of https://github.com/ceph/ceph/pull/30492
parent tracker: https://tracker.ceph.com/issues/41940

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh