### PR TITLE
Revert "qa/workunits/rados/test_crash.sh: suppress core files"

### DIFF
--- a/qa/suites/rados/singleton/all/test-crash.yaml
+++ b/qa/suites/rados/singleton/all/test-crash.yaml
@@ -13,6 +13,3 @@ tasks:
          client.0:
            - rados/test_crash.sh
   - ceph.restart: [osd.*]
-  - exec:
-      mon.a:
-        - rm $TESTDIR/archive/coredump/*


### PR DESCRIPTION
This reverts commit 290992e5195d8959a4d9b9f175f46f41aedbf81f.

The qa/workunits/rados/test_crash.sh cleans up the core file.  The
original problem was that gdb was missing on el8, preventing that
cleanup.

Signed-off-by: Sage Weil <sage@redhat.com>