### PR TITLE
qa/suites/rados/singleton/all/recovery-preemption: fix pg log length

### DIFF
--- a/qa/suites/rados/singleton/all/recovery-preemption.yaml
+++ b/qa/suites/rados/singleton/all/recovery-preemption.yaml
@@ -19,6 +19,7 @@ tasks:
         osd recovery sleep: .1
         osd min pg log entries: 10
         osd max pg log entries: 1000
+        osd_target_pg_log_entries_per_osd: 0
         osd pg log trim min: 10
     log-whitelist:
       - \(POOL_APP_NOT_ENABLED\)


### PR DESCRIPTION
This was broken by the variable PG log lengths in
9c69c2f7cc585b5e13e4d1b0432016d38135a3de.

Disable the new option to get (roughly) the old behavior, or at least the
short logs that we want to trigger some backfill.

https://tracker.ceph.com/issues/43810