### PR TITLE
mgr/cephadm: Fix Vagrant box

### DIFF
--- a/src/pybind/mgr/cephadm/HACKING.rst
+++ b/src/pybind/mgr/cephadm/HACKING.rst
@@ -35,7 +35,8 @@ From within the `src/pybind/mgr/cephadm` directory.
 
 ::
 
-   # vagrant up
+   # vagrant up osd0 mon0
+   # vagrant up mgr0
 
 This will spawn three machines.
 mon0, mgr0, osd0

--- a/src/pybind/mgr/cephadm/Vagrantfile
+++ b/src/pybind/mgr/cephadm/Vagrantfile
@@ -5,7 +5,8 @@ NUM_DAEMONS = ENV["NUM_DAEMONS"] ? ENV["NUM_DAEMONS"].to_i : 1
 Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.network "private_network", type: "dhcp"
-  config.vm.box = "centos/7"
+  # config.vm.box = "centos/7"
+  config.vm.box = "opensuse/Tumbleweed.x86_64"
 
   (0..NUM_DAEMONS - 1).each do |i|
     config.vm.define "mon#{i}" do |mon|
@@ -29,12 +30,22 @@ Vagrant.configure("2") do |config|
     sudo cp -r /home/vagrant/.ssh /root/.ssh
   SHELL
 
-  config.vm.provision "shell", inline: <<-SHELL
-    sudo yum install -y yum-utils
-    sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    sudo rpm --import 'https://download.ceph.com/keys/release.asc'
-    curl -L https://shaman.ceph.com/api/repos/ceph/master/latest/centos/7/repo/ | sudo tee /etc/yum.repos.d/shaman.repo
-    sudo yum install -y python36 podman ceph
-    sudo ln -s /usr/bin/python36 /usr/bin/python3 || true
-  SHELL
+  if config.vm.box == "centos/7"
+    config.vm.provision "shell", inline: <<-SHELL
+      sudo yum install -y yum-utils
+      sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+      sudo rpm --import 'https://download.ceph.com/keys/release.asc'
+      curl -L https://shaman.ceph.com/api/repos/ceph/master/latest/centos/7/repo/ | sudo tee /etc/yum.repos.d/shaman.repo
+      sudo yum install -y python36 podman ceph
+      sudo ln -s /usr/bin/python36 /usr/bin/python3 || true
+    SHELL
+  end
+  if config.vm.box == "opensuse/Tumbleweed.x86_64"
+    config.vm.provision "shell", inline: <<-SHELL
+      sudo systemctl enable systemd-timesyncd.service
+      sudo systemctl start systemd-timesyncd.service
+      sudo zypper --non-interactive refresh
+      sudo zypper --non-interactive install -y podman ceph
+    SHELL
+  end
 end

--- a/src/pybind/mgr/cephadm/Vagrantfile
+++ b/src/pybind/mgr/cephadm/Vagrantfile
@@ -8,6 +8,10 @@ Vagrant.configure("2") do |config|
   # config.vm.box = "centos/7"
   config.vm.box = "opensuse/Tumbleweed.x86_64"
 
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.memory = "1024"
+  end
+
   (0..NUM_DAEMONS - 1).each do |i|
     config.vm.define "mon#{i}" do |mon|
       mon.vm.hostname = "mon#{i}"
@@ -40,12 +44,32 @@ Vagrant.configure("2") do |config|
       sudo ln -s /usr/bin/python36 /usr/bin/python3 || true
     SHELL
   end
+
   if config.vm.box == "opensuse/Tumbleweed.x86_64"
     config.vm.provision "shell", inline: <<-SHELL
+      sudo systemctl restart systemd-timesyncd.service
       sudo systemctl enable systemd-timesyncd.service
-      sudo systemctl start systemd-timesyncd.service
-      sudo zypper --non-interactive refresh
-      sudo zypper --non-interactive install -y podman ceph
+      sudo zypper addrepo https://download.opensuse.org/repositories/filesystems:ceph:master:upstream/openSUSE_Tumbleweed/filesystems:ceph:master:upstream.repo
+      sudo zypper --non-interactive --gpg-auto-import-keys refresh
+      sudo zypper --non-interactive install -y nano podman ceph salt-minion || true
+      sudo echo "master: mgr0" > /etc/salt/minion
+      sudo systemctl restart salt-minion
+      sudo systemctl enable salt-minion
     SHELL
+
+    config.vm.define "mgr0" do |mgr|
+      mgr.vm.provision "shell", inline: <<-SHELL
+        sudo zypper --non-interactive install -y ceph-bootstrap || true
+        sudo systemctl restart salt-master
+        sudo systemctl enable salt-master
+        sleep 20
+        sudo salt-key -y -A || true
+        sleep 5
+        sudo ceph-bootstrap config /Cluster/Minions add \*
+        sudo ceph-bootstrap config /Cluster/Roles/Mon add mon\*
+        sudo ceph-bootstrap config /Cluster/Roles/Mgr add mgr\*
+        sudo ceph-bootstrap deploy
+      SHELL
+    end
   end
 end


### PR DESCRIPTION
The Vagrant box is using CentOS7 at the moment, but switching to CentOS8 does not help to get this Vagrant box installed because Fedora EPEL nor CentOS8 repositories contain all required packages (e.g. leveldb, python3-cherrypy or python3-pecan) to deploy Ceph.

Because of that this PR will switch to openSUSE/Tumbleweed by default which contains all packages to successfully deploy a Ceph cluster to test the Ceph orchestrator.

# How to test:
If Vagrant fails to download the box automatically, the please do the following:
- Download latest [box](http://download.opensuse.org/tumbleweed/appliances/Tumbleweed.x86_64-1.0-libvirt-Snapshot20200125.vagrant.libvirt.box) from http://download.opensuse.org/tumbleweed/appliances/.
- Execute `vagrant box add --name "opensuse/Tumbleweed.x86_64" "<PATH_TO_BOX_FILE>"`

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
