### PR TITLE
common/bl: drop non-sharable buffer types to simplify bufferlist claiming

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -263,29 +263,6 @@ static ceph::spinlock debug_lock;
     }
   };
 
-  class buffer::raw_unshareable : public buffer::raw {
-  public:
-    MEMPOOL_CLASS_HELPERS();
-
-    explicit raw_unshareable(unsigned l) : raw(l) {
-      if (len)
-	data = new char[len];
-      else
-	data = 0;
-    }
-    raw_unshareable(unsigned l, char *b) : raw(b, l) {
-    }
-    raw* clone_empty() override {
-      return new raw_char(len);
-    }
-    bool is_shareable() const override {
-      return false; // !shareable, will force make_shareable()
-    }
-    ~raw_unshareable() override {
-      delete[] data;
-    }
-  };
-
   class buffer::raw_static : public buffer::raw {
   public:
     MEMPOOL_CLASS_HELPERS();
@@ -380,10 +357,6 @@ static ceph::spinlock debug_lock;
     } else {
       return create_aligned(len, CEPH_PAGE_SIZE);
     }
-  }
-
-  ceph::unique_leakable_ptr<buffer::raw> buffer::create_unshareable(unsigned len) {
-    return ceph::unique_leakable_ptr<buffer::raw>(new raw_unshareable(len));
   }
 
   buffer::ptr::ptr(ceph::unique_leakable_ptr<raw> r)
@@ -2221,8 +2194,6 @@ MEMPOOL_DEFINE_OBJECT_FACTORY(buffer::raw_posix_aligned,
 			      buffer_raw_posix_aligned, buffer_meta);
 MEMPOOL_DEFINE_OBJECT_FACTORY(buffer::raw_char, buffer_raw_char, buffer_meta);
 MEMPOOL_DEFINE_OBJECT_FACTORY(buffer::raw_claimed_char, buffer_raw_claimed_char,
-			      buffer_meta);
-MEMPOOL_DEFINE_OBJECT_FACTORY(buffer::raw_unshareable, buffer_raw_unshareable,
 			      buffer_meta);
 MEMPOOL_DEFINE_OBJECT_FACTORY(buffer::raw_static, buffer_raw_static,
 			      buffer_meta);

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1262,21 +1262,17 @@ static ceph::spinlock debug_lock;
   }
 
   // sort-of-like-assignment-op
-  void buffer::list::claim(list& bl, unsigned int flags)
+  void buffer::list::claim(list& bl)
   {
     // free my buffers
     clear();
-    claim_append(bl, flags);
+    claim_append(bl);
   }
 
-  void buffer::list::claim_append(list& bl, unsigned int flags)
+  void buffer::list::claim_append(list& bl)
   {
     // steal the other guy's buffers
     _len += bl._len;
-    if (!(flags & CLAIM_ALLOW_NONSHAREABLE)) {
-      // NOP for now.
-      // TODO: kill CLAIM_ALLOW_NONSHAREABLE
-    }
     _buffers.splice_back(bl._buffers);
     bl._carriage = &always_empty_bptr;
     bl._buffers.clear_and_dispose();

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -166,7 +166,6 @@ inline namespace v14_2_0 {
   ceph::unique_leakable_ptr<raw> create_aligned_in_mempool(unsigned len, unsigned align, int mempool);
   ceph::unique_leakable_ptr<raw> create_page_aligned(unsigned len);
   ceph::unique_leakable_ptr<raw> create_small_page_aligned(unsigned len);
-  ceph::unique_leakable_ptr<raw> create_unshareable(unsigned len);
   ceph::unique_leakable_ptr<raw> claim_buffer(unsigned len, char *buf, deleter del);
 
 #ifdef HAVE_SEASTAR

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -1090,12 +1090,8 @@ inline namespace v14_2_0 {
 
     void reserve(size_t prealloc);
 
-    // assignment-op with move semantics
-    const static unsigned int CLAIM_DEFAULT = 0;
-    const static unsigned int CLAIM_ALLOW_NONSHAREABLE = 1;
-
-    void claim(list& bl, unsigned int flags = CLAIM_DEFAULT);
-    void claim_append(list& bl, unsigned int flags = CLAIM_DEFAULT);
+    void claim(list& bl);
+    void claim_append(list& bl);
     // only for bl is bufferlist::page_aligned_appender
     void claim_append_piecewise(list& bl);
 

--- a/src/include/buffer_raw.h
+++ b/src/include/buffer_raw.h
@@ -93,12 +93,6 @@ public:
       memcpy(c->data, data, len);
       return ceph::unique_leakable_ptr<raw>(c);
     }
-    virtual bool is_shareable() const {
-      // true if safe to reference/share the existing buffer copy
-      // false if it is not safe to share the buffer, e.g., due to special
-      // and/or registered memory that is scarce
-      return true;
-    }
     bool get_crc(const std::pair<size_t, size_t> &fromto,
 		 std::pair<uint32_t, uint32_t> *crc) const {
       std::lock_guard lg(crc_spinlock);

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -396,7 +396,7 @@ public:
   void set_payload(ceph::buffer::list& bl) {
     if (byte_throttler)
       byte_throttler->put(payload.length());
-    payload.claim(bl, ceph::buffer::list::CLAIM_ALLOW_NONSHAREABLE);
+    payload.claim(bl);
     if (byte_throttler)
       byte_throttler->take(payload.length());
   }
@@ -404,7 +404,7 @@ public:
   void set_middle(ceph::buffer::list& bl) {
     if (byte_throttler)
       byte_throttler->put(middle.length());
-    middle.claim(bl, ceph::buffer::list::CLAIM_ALLOW_NONSHAREABLE);
+    middle.claim(bl);
     if (byte_throttler)
       byte_throttler->take(middle.length());
   }
@@ -420,11 +420,10 @@ public:
 
   const ceph::buffer::list& get_data() const { return data; }
   ceph::buffer::list& get_data() { return data; }
-  void claim_data(ceph::buffer::list& bl,
-		  unsigned int flags = ceph::buffer::list::CLAIM_DEFAULT) {
+  void claim_data(ceph::buffer::list& bl) {
     if (byte_throttler)
       byte_throttler->put(data.length());
-    bl.claim(data, flags);
+    bl.claim(data);
   }
   off_t get_data_len() const { return data.length(); }
 

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1579,7 +1579,7 @@ int FileJournal::prepare_entry(vector<ObjectStore::Transaction>& tls, bufferlist
     ebl.push_back(buffer::create_static(h.pre_pad, zero_buf));
   }
   // payload
-  ebl.claim_append(bl, buffer::list::CLAIM_ALLOW_NONSHAREABLE); // potential zero-copy
+  ebl.claim_append(bl);
   if (h.post_pad) {
     ebl.push_back(buffer::create_static(h.post_pad, zero_buf));
   }

--- a/src/os/filestore/FileJournal.h
+++ b/src/os/filestore/FileJournal.h
@@ -64,7 +64,7 @@ public:
     ZTracer::Trace trace;
     write_item(uint64_t s, bufferlist& b, int ol, TrackedOpRef opref) :
       seq(s), orig_len(ol), tracked_op(opref) {
-      bl.claim(b, buffer::list::CLAIM_ALLOW_NONSHAREABLE); // potential zero-copy
+      bl.claim(b);
     }
     write_item() : seq(0), orig_len(0) {}
   };


### PR DESCRIPTION
This  is also drops the virtual `buffer::raw::is_sharable()`.
Depends on: #32806, #32823, #32831.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
