### PR TITLE
nautilus: mon/Session: only index osd ids >= 0

### DIFF
--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -134,7 +134,8 @@ struct MonSessionMap {
     }
     s->sub_map.clear();
     s->item.remove_myself();
-    if (s->name.is_osd()) {
+    if (s->name.is_osd() &&
+	s->name.num() >= 0) {
       for (multimap<int,MonSession*>::iterator p = by_osd.find(s->name.num());
 	   p->first == s->name.num();
 	   ++p)
@@ -163,7 +164,8 @@ struct MonSessionMap {
   void add_session(MonSession *s) {
     sessions.push_back(&s->item);
     s->get();
-    if (s->name.is_osd()) {
+    if (s->name.is_osd() &&
+	s->name.num() >= 0) {
       by_osd.insert(pair<int,MonSession*>(s->name.num(), s));
     }
     if (s->con_features) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43821

---

backport of https://github.com/ceph/ceph/pull/32764
parent tracker: https://tracker.ceph.com/issues/43552

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh