### PR TITLE
nautilus: mds: fix revoking caps after after stale->resume circle

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5162,7 +5162,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
 		<< " mds." << mds << " seq " << m->get_seq()
 		<< " caps now " << ccap_string(new_caps)
 		<< " was " << ccap_string(cap->issued)
-		<< (was_stale ? "" : " (stale)") << dendl;
+		<< (was_stale ? " (stale)" : "") << dendl;
 
   if (was_stale)
       cap->issued = cap->implemented = CEPH_CAP_PIN;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43343

---

backport of https://github.com/ceph/ceph/pull/31662
parent tracker: https://tracker.ceph.com/issues/42826

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh