### PR TITLE
nautilus: mount.ceph: give a hint message when no mds is up or cluster is laggy

### DIFF
--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -508,6 +508,9 @@ int main(int argc, char *argv[])
 		case ENODEV:
 			fprintf(stderr, "mount error: ceph filesystem not supported by the system\n");
 			break;
+		case EHOSTUNREACH:
+			fprintf(stderr, "mount error: no mds server is up or the cluster is laggy\n");
+			break;
 		default:
 			fprintf(stderr, "mount error %d = %s\n",errno,strerror(errno));
 		}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43503

---

backport of https://github.com/ceph/ceph/pull/32164
parent tracker: https://tracker.ceph.com/issues/43294

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh