### PR TITLE
nautilus: mds: note client features when rejecting client

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -541,8 +541,9 @@ void Server::handle_client_session(const MClientSession::const_ref &m)
 	stringstream ss;
 	ss << "missing required features '" << missing_features << "'";
 	send_reject_message(ss.str());
-	mds->clog->warn() << "client session lacks required features '"
-			  << missing_features << "' denied (" << session->info.inst << ")";
+	mds->clog->warn() << "client session (" << session->info.inst
+                          << ") lacks required features " << missing_features
+                          << "; client supports " << client_metadata.features;
 	session->clear();
 	break;
       }

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -433,6 +433,7 @@ void feature_bitset_t::decode(bufferlist::const_iterator &p) {
 void feature_bitset_t::print(ostream& out) const
 {
   std::ios_base::fmtflags f(out.flags());
+  out << "0x";
   for (int i = _vec.size() - 1; i >= 0; --i)
     out << std::setfill('0') << std::setw(sizeof(block_type) * 2)
         << std::hex << _vec[i];


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43624

---

backport of https://github.com/ceph/ceph/pull/32505
parent tracker: https://tracker.ceph.com/issues/43484

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh