### PR TITLE
nautilus: cephfs: qa: ignore slow ops for ffsb workunit

### DIFF
--- a/qa/cephfs/tasks/cfuse_workunit_suites_ffsb.yaml
+++ b/qa/cephfs/tasks/cfuse_workunit_suites_ffsb.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-whitelist:
+    - SLOW_OPS
     conf:
       osd:
         filestore flush min: 0

--- a/qa/suites/kcephfs/cephfs/tasks/kclient_workunit_suites_ffsb.yaml
+++ b/qa/suites/kcephfs/cephfs/tasks/kclient_workunit_suites_ffsb.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+    - SLOW_OPS
 tasks:
 - workunit:
     clients:

--- a/qa/suites/kcephfs/thrash/workloads/kclient_workunit_suites_ffsb.yaml
+++ b/qa/suites/kcephfs/thrash/workloads/kclient_workunit_suites_ffsb.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-whitelist:
+    - SLOW_OPS
     conf:
       osd:
         filestore flush min: 0


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43733

---

backport of https://github.com/ceph/ceph/pull/32668
parent tracker: https://tracker.ceph.com/issues/42637

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh