### PR TITLE
qa/suites/rados/rest: run restful test on el8

### DIFF
--- a/qa/suites/rados/rest/centos_latest.yaml
+++ b/qa/suites/rados/rest/centos_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/centos_latest.yaml

--- a/qa/suites/rados/rest/supported-random-distro$
+++ b/qa/suites/rados/rest/supported-random-distro$
@@ -1,1 +1,0 @@
-../basic/supported-random-distro$


### PR DESCRIPTION
For some reason the requests library has trouble connecting from
ubuntu 18.04.  I reproduced this locally on my 18.04 desktop, although
there it fails on the first API request instead of the last (as in QA).

In any case, this appears to be a client library problem.

Fixes: https://tracker.ceph.com/issues/43720
Signed-off-by: Sage Weil <sage@redhat.com>