### PR TITLE
nautilus: mds/OpenFileTable: match MAX_ITEMS_PER_OBJ to osd_deep_scrub_large_omap_object_key_threshold

### DIFF
--- a/qa/suites/fs/basic_functional/tasks/openfiletable.yaml
+++ b/qa/suites/fs/basic_functional/tasks/openfiletable.yaml
@@ -1,0 +1,5 @@
+
+tasks:
+  - cephfs_test_runner:
+      modules:
+        - tasks.cephfs.test_openfiletable

--- a/qa/tasks/cephfs/test_openfiletable.py
+++ b/qa/tasks/cephfs/test_openfiletable.py
@@ -1,0 +1,41 @@
+import time
+from cephfs_test_case import CephFSTestCase
+from teuthology.exceptions import CommandFailedError
+from tasks.cephfs.cephfs_test_case import CephFSTestCase, for_teuthology
+
+class OpenFileTable(CephFSTestCase):
+    CLIENTS_REQUIRED = 1
+    MDSS_REQUIRED = 1
+
+    def test_max_items_per_obj(self):
+        """
+        The maximum number of openfiles omap objects keys are now equal to
+        osd_deep_scrub_large_omap_object_key_threshold option.
+        """
+        self.set_conf("mds", "osd_deep_scrub_large_omap_object_key_threshold", "5")
+
+        self.fs.mds_restart()
+        self.fs.wait_for_daemons()
+
+        # Write some bytes to a file
+        size_mb = 1
+
+        # Hold the file open
+        file_count = 8
+        for i in xrange(0, file_count):
+            filename = "open_file{}".format(i)
+            p = self.mount_a.open_background(filename)
+            self.mount_a.write_n_mb(filename, size_mb)
+
+        time.sleep(10)
+
+        """
+        With osd_deep_scrub_large_omap_object_key_threshold value as 5 and
+        opening 8 files we should have a new rados object with name
+        mds0_openfiles.1 to hold the extra keys.
+        """
+
+        stat_out = self.fs.rados(["stat", "mds0_openfiles.1"])
+
+        # Now close the file
+        self.mount_a.kill_background(p)

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -71,8 +71,8 @@ protected:
   friend class C_IO_OFT_Journal;
   friend class C_OFT_OpenInoFinish;
 
-  static const unsigned MAX_ITEMS_PER_OBJ = 1024 * 1024;
-  static const unsigned MAX_OBJECTS = 1024; // billion items at most
+  uint64_t MAX_ITEMS_PER_OBJ = g_conf().get_val<uint64_t>("osd_deep_scrub_large_omap_object_key_threshold");
+  static const unsigned MAX_OBJECTS = 1024; // (1024 * osd_deep_scrub_large_omap_object_key_threshold) items at most
 
   static const int DIRTY_NEW	= -1;
   static const int DIRTY_UNDEF	= -2;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43784

---

backport of https://github.com/ceph/ceph/pull/31232
parent tracker: https://tracker.ceph.com/issues/42515

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh