### PR TITLE
nautilus: msg/async: perform the v2 resets in proper EventCenter

### DIFF
--- a/cmake/modules/FindSanitizers.cmake
+++ b/cmake/modules/FindSanitizers.cmake
@@ -20,7 +20,7 @@ foreach(component ${Sanitizers_FIND_COMPONENTS})
     elseif(NOT CMAKE_POSITION_INDEPENDENT_CODE)
       message(SEND_ERROR "TSan requires all code to be position independent")
     endif()
-    set(Sanitizers_Thread_COMPILE_OPTIONS "-fsanitize=thread")
+    set(Sanitizers_thread_COMPILE_OPTIONS "-fsanitize=thread")
   elseif(component STREQUAL "undefined_behavior")
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88684
     set(Sanitizers_undefined_behavior_COMPILE_OPTIONS "-fsanitize=undefined;-fno-sanitize=vptr")

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -170,7 +170,7 @@ class AsyncConnection : public Connection {
   DispatchQueue *dispatch_queue;
 
   // lockfree, only used in own thread
-  bufferlist outcoming_bl;
+  bufferlist outgoing_bl;
   bool open_write = false;
 
   std::mutex write_lock;

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -310,7 +310,6 @@ AsyncMessenger::~AsyncMessenger()
 {
   delete reap_handler;
   ceph_assert(!did_bind); // either we didn't bind or we shut down the Processor
-  local_connection->mark_down();
   for (auto &&p : processors)
     delete p;
 }
@@ -344,6 +343,7 @@ int AsyncMessenger::shutdown()
   mark_down_all();
   // break ref cycles on the loopback connection
   local_connection->set_priv(NULL);
+  local_connection->mark_down();
   did_bind = false;
   lock.Lock();
   stop_cond.Signal();

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -363,8 +363,8 @@ void ProtocolV1::write_event() {
       if (left) {
         ceph_le64 s;
         s = in_seq;
-        connection->outcoming_bl.append(CEPH_MSGR_TAG_ACK);
-        connection->outcoming_bl.append((char *)&s, sizeof(s));
+        connection->outgoing_bl.append(CEPH_MSGR_TAG_ACK);
+        connection->outgoing_bl.append((char *)&s, sizeof(s));
         ldout(cct, 10) << __func__ << " try send msg ack, acked " << left
                        << " messages" << dendl;
         ack_left -= left;
@@ -552,16 +552,16 @@ void ProtocolV1::append_keepalive_or_ack(bool ack, utime_t *tp) {
     ceph_assert(tp);
     struct ceph_timespec ts;
     tp->encode_timeval(&ts);
-    connection->outcoming_bl.append(CEPH_MSGR_TAG_KEEPALIVE2_ACK);
-    connection->outcoming_bl.append((char *)&ts, sizeof(ts));
+    connection->outgoing_bl.append(CEPH_MSGR_TAG_KEEPALIVE2_ACK);
+    connection->outgoing_bl.append((char *)&ts, sizeof(ts));
   } else if (connection->has_feature(CEPH_FEATURE_MSGR_KEEPALIVE2)) {
     struct ceph_timespec ts;
     utime_t t = ceph_clock_now();
     t.encode_timeval(&ts);
-    connection->outcoming_bl.append(CEPH_MSGR_TAG_KEEPALIVE2);
-    connection->outcoming_bl.append((char *)&ts, sizeof(ts));
+    connection->outgoing_bl.append(CEPH_MSGR_TAG_KEEPALIVE2);
+    connection->outgoing_bl.append((char *)&ts, sizeof(ts));
   } else {
-    connection->outcoming_bl.append(CEPH_MSGR_TAG_KEEPALIVE);
+    connection->outgoing_bl.append(CEPH_MSGR_TAG_KEEPALIVE);
   }
 }
 
@@ -1060,9 +1060,9 @@ void ProtocolV1::session_reset() {
 
   connection->dispatch_queue->discard_queue(connection->conn_id);
   discard_out_queue();
-  // note: we need to clear outcoming_bl here, but session_reset may be
+  // note: we need to clear outgoing_bl here, but session_reset may be
   // called by other thread, so let caller clear this itself!
-  // outcoming_bl.clear();
+  // outgoing_bl.clear();
 
   connection->dispatch_queue->queue_remote_reset(connection);
 
@@ -1118,8 +1118,8 @@ ssize_t ProtocolV1::write_message(Message *m, bufferlist &bl, bool more) {
     }
   }
 
-  connection->outcoming_bl.append(CEPH_MSGR_TAG_MSG);
-  connection->outcoming_bl.append((char *)&header, sizeof(header));
+  connection->outgoing_bl.append(CEPH_MSGR_TAG_MSG);
+  connection->outgoing_bl.append((char *)&header, sizeof(header));
 
   ldout(cct, 20) << __func__ << " sending message type=" << header.type
                  << " src " << entity_name_t(header.src)
@@ -1128,17 +1128,17 @@ ssize_t ProtocolV1::write_message(Message *m, bufferlist &bl, bool more) {
 
   if ((bl.length() <= ASYNC_COALESCE_THRESHOLD) && (bl.buffers().size() > 1)) {
     for (const auto &pb : bl.buffers()) {
-      connection->outcoming_bl.append((char *)pb.c_str(), pb.length());
+      connection->outgoing_bl.append((char *)pb.c_str(), pb.length());
     }
   } else {
-    connection->outcoming_bl.claim_append(bl);
+    connection->outgoing_bl.claim_append(bl);
   }
 
   // send footer; if receiver doesn't support signatures, use the old footer
   // format
   ceph_msg_footer_old old_footer;
   if (connection->has_feature(CEPH_FEATURE_MSG_AUTH)) {
-    connection->outcoming_bl.append((char *)&footer, sizeof(footer));
+    connection->outgoing_bl.append((char *)&footer, sizeof(footer));
   } else {
     if (messenger->crcflags & MSG_CRC_HEADER) {
       old_footer.front_crc = footer.front_crc;
@@ -1150,20 +1150,20 @@ ssize_t ProtocolV1::write_message(Message *m, bufferlist &bl, bool more) {
     old_footer.data_crc =
         messenger->crcflags & MSG_CRC_DATA ? footer.data_crc : 0;
     old_footer.flags = footer.flags;
-    connection->outcoming_bl.append((char *)&old_footer, sizeof(old_footer));
+    connection->outgoing_bl.append((char *)&old_footer, sizeof(old_footer));
   }
 
   m->trace.event("async writing message");
   ldout(cct, 20) << __func__ << " sending " << m->get_seq() << " " << m
                  << dendl;
-  ssize_t total_send_size = connection->outcoming_bl.length();
+  ssize_t total_send_size = connection->outgoing_bl.length();
   ssize_t rc = connection->_try_send(more);
   if (rc < 0) {
     ldout(cct, 1) << __func__ << " error sending " << m << ", "
                   << cpp_strerror(rc) << dendl;
   } else {
     connection->logger->inc(
-        l_msgr_send_bytes, total_send_size - connection->outcoming_bl.length());
+        l_msgr_send_bytes, total_send_size - connection->outgoing_bl.length());
     ldout(cct, 10) << __func__ << " sending " << m
                    << (rc ? " continuely." : " done.") << dendl;
   }
@@ -1602,7 +1602,7 @@ CtPtr ProtocolV1::handle_connect_reply_2() {
     connect_seq = 0;
 
     // see session_reset
-    connection->outcoming_bl.clear();
+    connection->outgoing_bl.clear();
 
     return CONTINUE(send_connect_message);
   }
@@ -2290,7 +2290,7 @@ CtPtr ProtocolV1::replace(AsyncConnectionRef existing,
             std::lock_guard<std::mutex> l(existing->lock);
             existing->write_lock.lock();
             exproto->requeue_sent();
-            existing->outcoming_bl.clear();
+            existing->outgoing_bl.clear();
             existing->open_write = false;
             existing->write_lock.unlock();
             if (exproto->state == NONE) {

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -9,6 +9,8 @@
 #include "AsyncMessenger.h"
 #include "common/EventTrace.h"
 #include "include/random.h"
+#include "auth/AuthClient.h"
+#include "auth/AuthServer.h"
 
 #define dout_subsys ceph_subsys_ms
 #undef dout_prefix
@@ -72,7 +74,6 @@ ProtocolV1::ProtocolV1(AsyncConnection *connection)
       once_ready(false),
       state(NONE),
       global_seq(0),
-      authorizer(nullptr),
       wait_for_seq(false) {
   temp_buffer = new char[4096];
 }
@@ -82,20 +83,12 @@ ProtocolV1::~ProtocolV1() {
   ceph_assert(sent.empty());
 
   delete[] temp_buffer;
-
-  if (authorizer) {
-    delete authorizer;
-  }
 }
 
 void ProtocolV1::connect() {
   this->state = START_CONNECT;
 
   // reset connect state variables
-  if (authorizer) {
-    delete authorizer;
-    authorizer = nullptr;
-  }
   authorizer_buf.clear();
   // FIPS zeroization audit 20191115: these memsets are not security related.
   memset(&connect_msg, 0, sizeof(connect_msg));
@@ -1240,14 +1233,12 @@ void ProtocolV1::discard_out_queue() {
   write_in_progress = false;
 }
 
-void ProtocolV1::reset_recv_state() {
+void ProtocolV1::reset_recv_state()
+{
   // clean up state internal variables and states
-  if (state == CONNECTING_SEND_CONNECT_MSG) {
-    if (authorizer) {
-      delete authorizer;
-    }
-    authorizer = nullptr;
-  }
+  auth_meta.reset(new AuthConnectionMeta);
+  authorizer_more.clear();
+  session_security.reset();
 
   // clean read and write callbacks
   connection->pendingReadLen.reset();
@@ -1439,13 +1430,37 @@ CtPtr ProtocolV1::handle_my_addr_write(int r) {
   return CONTINUE(send_connect_message);
 }
 
-CtPtr ProtocolV1::send_connect_message() {
+CtPtr ProtocolV1::send_connect_message()
+{
   state = CONNECTING_SEND_CONNECT_MSG;
 
   ldout(cct, 20) << __func__ << dendl;
+  ceph_assert(messenger->auth_client);
 
-  if (!authorizer) {
-    authorizer = messenger->ms_deliver_get_authorizer(connection->peer_type);
+  bufferlist auth_bl;
+  vector<uint32_t> preferred_modes;
+
+  if (connection->peer_type != CEPH_ENTITY_TYPE_MON) {
+    if (authorizer_more.length()) {
+      ldout(cct,10) << __func__ << " using augmented (challenge) auth payload"
+		    << dendl;
+      auth_bl = authorizer_more;
+    } else {
+      auto am = auth_meta;
+      authorizer_more.clear();
+      connection->lock.unlock();
+      int r = messenger->auth_client->get_auth_request(
+	connection, am.get(),
+	&am->auth_method, &preferred_modes, &auth_bl);
+      connection->lock.lock();
+      if (r < 0) {
+	return _fault();
+      }
+      if (state != CONNECTING_SEND_CONNECT_MSG) {
+	ldout(cct, 1) << __func__ << " state changed!" << dendl;
+	return _fault();
+      }
+    }
   }
 
   ceph_msg_connect connect;
@@ -1455,13 +1470,15 @@ CtPtr ProtocolV1::send_connect_message() {
   connect.connect_seq = connect_seq;
   connect.protocol_version =
       messenger->get_proto_version(connection->peer_type, true);
-  connect.authorizer_protocol = authorizer ? authorizer->protocol : 0;
-  connect.authorizer_len = authorizer ? authorizer->bl.length() : 0;
-
-  if (authorizer) {
+  if (auth_bl.length()) {
     ldout(cct, 10) << __func__
-                   << " connect_msg.authorizer_len=" << connect.authorizer_len
-                   << " protocol=" << connect.authorizer_protocol << dendl;
+                   << " connect_msg.authorizer_len=" << auth_bl.length()
+                   << " protocol=" << auth_meta->auth_method << dendl;
+    connect.authorizer_protocol = auth_meta->auth_method;
+    connect.authorizer_len = auth_bl.length();
+  } else {
+    connect.authorizer_protocol = 0;
+    connect.authorizer_len = 0;
   }
 
   connect.flags = 0;
@@ -1472,8 +1489,8 @@ CtPtr ProtocolV1::send_connect_message() {
 
   bufferlist bl;
   bl.append((char *)&connect, sizeof(connect));
-  if (authorizer) {
-    bl.append(authorizer->bl.c_str(), authorizer->bl.length());
+  if (auth_bl.length()) {
+    bl.append(auth_bl.c_str(), auth_bl.length());
   }
 
   ldout(cct, 10) << __func__ << " connect sending gseq=" << global_seq
@@ -1555,17 +1572,37 @@ CtPtr ProtocolV1::handle_connect_reply_auth(char *buffer, int r) {
   bufferlist authorizer_reply;
   authorizer_reply.append(buffer, connect_reply.authorizer_len);
 
-  if (connect_reply.tag == CEPH_MSGR_TAG_CHALLENGE_AUTHORIZER) {
-    ldout(cct, 10) << __func__ << " connect got auth challenge" << dendl;
-    authorizer->add_challenge(cct, authorizer_reply);
-    return CONTINUE(send_connect_message);
-  }
-
-  auto iter = authorizer_reply.cbegin();
-  if (authorizer && !authorizer->verify_reply(iter,
-					      nullptr /* connection_secret */)) {
-    ldout(cct, 0) << __func__ << " failed verifying authorize reply" << dendl;
-    return _fault();
+  if (connection->peer_type != CEPH_ENTITY_TYPE_MON) {
+    auto am = auth_meta;
+    bool more = (connect_reply.tag == CEPH_MSGR_TAG_CHALLENGE_AUTHORIZER);
+    bufferlist auth_retry_bl;
+    int r;
+    connection->lock.unlock();
+    if (more) {
+      r = messenger->auth_client->handle_auth_reply_more(
+	connection, am.get(), authorizer_reply, &auth_retry_bl);
+    } else {
+      // these aren't used for v1
+      CryptoKey skey;
+      string con_secret;
+      r = messenger->auth_client->handle_auth_done(
+	connection, am.get(),
+	0 /* global id */, 0 /* con mode */,
+	authorizer_reply,
+	&skey, &con_secret);
+    }
+    connection->lock.lock();
+    if (state != CONNECTING_SEND_CONNECT_MSG) {
+      ldout(cct, 1) << __func__ << " state changed" << dendl;
+      return _fault();
+    }
+    if (r < 0) {
+      return _fault();
+    }
+    if (more && r == 0) {
+      authorizer_more = auth_retry_bl;
+      return CONTINUE(send_connect_message);
+    }
   }
 
   return handle_connect_reply_2();
@@ -1593,6 +1630,7 @@ CtPtr ProtocolV1::handle_connect_reply_2() {
 
   if (connect_reply.tag == CEPH_MSGR_TAG_BADAUTHORIZER) {
     ldout(cct, 0) << __func__ << " connect got BADAUTHORIZER" << dendl;
+    authorizer_more.clear();
     return _fault();
   }
 
@@ -1714,12 +1752,12 @@ CtPtr ProtocolV1::client_ready() {
 
   // If we have an authorizer, get a new AuthSessionHandler to deal with
   // ongoing security of the connection.  PLR
-  if (authorizer != NULL) {
+  if (auth_meta->authorizer) {
     ldout(cct, 10) << __func__ << " setting up session_security with auth "
-		   << authorizer << dendl;
+		   << auth_meta->authorizer.get() << dendl;
     session_security.reset(get_auth_session_handler(
-        cct, authorizer->protocol,
-	authorizer->session_key,
+        cct, auth_meta->authorizer->protocol,
+	auth_meta->session_key,
         connection->get_features()));
   } else {
     // We have no authorizer, so we shouldn't be applying security to messages
@@ -1946,41 +1984,43 @@ CtPtr ProtocolV1::handle_connect_message_2() {
   }
 
   bufferlist auth_bl_copy = authorizer_buf;
+  auto am = auth_meta;
+  am->auth_method = connect_msg.authorizer_protocol;
   connection->lock.unlock();
   ldout(cct,10) << __func__ << " authorizor_protocol "
 		<< connect_msg.authorizer_protocol
 		<< " len " << auth_bl_copy.length()
 		<< dendl;
-  bool authorizer_valid;
-  bool need_challenge = HAVE_FEATURE(connect_msg.features, CEPHX_V2);
-  bool had_challenge = (bool)authorizer_challenge;
-  if (!messenger->ms_deliver_verify_authorizer(
-          connection, connection->peer_type, connect_msg.authorizer_protocol,
-          auth_bl_copy, authorizer_reply, authorizer_valid, session_key,
-	  nullptr /* connection_secret */,
-          need_challenge ? &authorizer_challenge : nullptr) ||
-      !authorizer_valid) {
+  bool more = (bool)auth_meta->authorizer_challenge;
+  int r = messenger->auth_server->handle_auth_request(
+    connection,
+    am.get(),
+    more,
+    am->auth_method,
+    auth_bl_copy,
+    &authorizer_reply);
+  if (r < 0) {
     connection->lock.lock();
     if (state != ACCEPTING_WAIT_CONNECT_MSG_AUTH) {
-      ldout(cct, 1) << __func__
-		    << " state changed while accept, it must be mark_down"
-		    << dendl;
-      ceph_assert(state == CLOSED);
+      ldout(cct, 1) << __func__ << " state changed" << dendl;
       return _fault();
     }
-
-    if (need_challenge && !had_challenge && authorizer_challenge) {
-      ldout(cct, 10) << __func__ << ": challenging authorizer" << dendl;
-      ceph_assert(authorizer_reply.length());
-      return send_connect_message_reply(CEPH_MSGR_TAG_CHALLENGE_AUTHORIZER,
-                                        reply, authorizer_reply);
-    } else {
-      ldout(cct, 0) << __func__ << ": got bad authorizer, auth_reply_len="
-                    << authorizer_reply.length() << dendl;
-      session_security.reset();
-      return send_connect_message_reply(CEPH_MSGR_TAG_BADAUTHORIZER, reply,
-                                        authorizer_reply);
+    ldout(cct, 0) << __func__ << ": got bad authorizer, auth_reply_len="
+		  << authorizer_reply.length() << dendl;
+    session_security.reset();
+    return send_connect_message_reply(CEPH_MSGR_TAG_BADAUTHORIZER, reply,
+				      authorizer_reply);
+  }
+  if (r == 0) {
+    connection->lock.lock();
+    if (state != ACCEPTING_WAIT_CONNECT_MSG_AUTH) {
+      ldout(cct, 1) << __func__ << " state changed" << dendl;
+      return _fault();
     }
+    ldout(cct, 10) << __func__ << ": challenging authorizer" << dendl;
+    ceph_assert(authorizer_reply.length());
+    return send_connect_message_reply(CEPH_MSGR_TAG_CHALLENGE_AUTHORIZER,
+				      reply, authorizer_reply);
   }
 
   // We've verified the authorizer for this AsyncConnection, so set up the
@@ -1994,10 +2034,7 @@ CtPtr ProtocolV1::handle_connect_message_2() {
 
   connection->lock.lock();
   if (state != ACCEPTING_WAIT_CONNECT_MSG_AUTH) {
-    ldout(cct, 1) << __func__
-                  << " state changed while accept, it must be mark_down"
-                  << dendl;
-    ceph_assert(state == CLOSED);
+    ldout(cct, 1) << __func__ << " state changed" << dendl;
     return _fault();
   }
 
@@ -2280,8 +2317,6 @@ CtPtr ProtocolV1::replace(AsyncConnectionRef existing,
     // there shouldn't exist any buffer
     ceph_assert(connection->recv_start == connection->recv_end);
 
-    exproto->authorizer_challenge.reset();
-
     auto deactivate_existing = std::bind(
         [existing, new_worker, new_center, exproto, reply,
          authorizer_reply](ConnectedSocket &cs) mutable {
@@ -2400,9 +2435,9 @@ CtPtr ProtocolV1::open(ceph_msg_connect_reply &reply,
 		 << connect_msg.authorizer_protocol << dendl;
 
   session_security.reset(
-      get_auth_session_handler(cct, connect_msg.authorizer_protocol,
-                               session_key,
-			       connection->get_features()));
+    get_auth_session_handler(cct, auth_meta->auth_method,
+			     auth_meta->session_key,
+			     connection->get_features()));
 
   bufferlist reply_bl;
   reply_bl.append((char *)&reply, sizeof(reply));

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -1235,10 +1235,24 @@ void ProtocolV1::discard_out_queue() {
 
 void ProtocolV1::reset_recv_state()
 {
-  // clean up state internal variables and states
-  auth_meta.reset(new AuthConnectionMeta);
-  authorizer_more.clear();
-  session_security.reset();
+  ldout(cct, 5) << __func__ << dendl;
+
+  // execute in the same thread that uses the `session_security`.
+  // We need to do the warp because holding `write_lock` is not
+  // enough as `write_event()` releases it just before calling
+  // `write_message()`. `submit_to()` here is NOT blocking.
+  connection->center->submit_to(connection->center->get_id(), [this] {
+    ldout(cct, 5) << "reset_recv_state reseting security handlers" << dendl;
+
+    // Possibly unnecessary. See the comment in `deactivate_existing`.
+    std::lock_guard<std::mutex> l(connection->lock);
+    std::lock_guard<std::mutex> wl(connection->write_lock);
+
+    // clean up state internal variables and states
+    auth_meta.reset(new AuthConnectionMeta);
+    authorizer_more.clear();
+    session_security.reset();
+  }, /* nowait = */true);
 
   // clean read and write callbacks
   connection->pendingReadLen.reset();

--- a/src/msg/async/ProtocolV1.h
+++ b/src/msg/async/ProtocolV1.h
@@ -115,14 +115,13 @@ protected:
   std::atomic<uint64_t> out_seq{0};
   std::atomic<uint64_t> ack_left{0};
 
-  CryptoKey session_key;
   std::shared_ptr<AuthSessionHandler> session_security;
-  std::unique_ptr<AuthAuthorizerChallenge> authorizer_challenge;  // accept side
 
   // Open state
   ceph_msg_connect connect_msg;
   ceph_msg_connect_reply connect_reply;
-  bufferlist authorizer_buf;
+  bufferlist authorizer_buf;  // auth(orizer) payload read off the wire
+  bufferlist authorizer_more;  // connect-side auth retry (we added challenge)
 
   utime_t backoff;  // backoff time
   utime_t recv_stamp;
@@ -227,7 +226,6 @@ public:
   // Client Protocol
 private:
   int global_seq;
-  AuthAuthorizer *authorizer;
 
   CONTINUATION_DECL(ProtocolV1, send_client_banner);
   WRITE_HANDLER_CONTINUATION_DECL(ProtocolV1, handle_client_banner_write);

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -221,12 +221,27 @@ uint64_t ProtocolV2::discard_requeued_up_to(uint64_t out_seq, uint64_t seq) {
   return count;
 }
 
+// it's expected the `write_lock` is held while calling this method.
 void ProtocolV2::reset_recv_state() {
-  auth_meta.reset(new AuthConnectionMeta);
-  session_stream_handlers.tx.reset(nullptr);
-  session_stream_handlers.rx.reset(nullptr);
-  pre_auth.txbuf.clear();
-  pre_auth.rxbuf.clear();
+  ldout(cct, 5) << __func__ << dendl;
+
+  // execute in the same thread that uses the rx/tx handlers. We need
+  // to do the warp because holding `write_lock` is not enough as
+  // `write_event()` unlocks it just before calling `write_message()`.
+  // `submit_to()` here is NOT blocking.
+  connection->center->submit_to(connection->center->get_id(), [this] {
+    ldout(cct, 5) << "reset_recv_state reseting crypto handlers" << dendl;
+
+    // Possibly unnecessary. See the comment in `deactivate_existing`.
+    std::lock_guard<std::mutex> l(connection->lock);
+    std::lock_guard<std::mutex> wl(connection->write_lock);
+
+    auth_meta.reset(new AuthConnectionMeta);
+    session_stream_handlers.rx.reset(nullptr);
+    session_stream_handlers.tx.reset(nullptr);
+    pre_auth.rxbuf.clear();
+    pre_auth.txbuf.clear();
+  }, /* nowait = */true);
 
   // clean read and write callbacks
   connection->pendingReadLen.reset();
@@ -2658,15 +2673,18 @@ CtPtr ProtocolV2::reuse_connection(AsyncConnectionRef existing,
   }
   exproto->peer_global_seq = peer_global_seq;
 
+  ceph_assert(connection->center->in_thread());
   auto temp_cs = std::move(connection->cs);
   EventCenter *new_center = connection->center;
   Worker *new_worker = connection->worker;
+  // we can steal the session_stream_handlers under the assumption
+  // this happens in the event center's thread as there should be
+  // no user outside its boundaries (simlarly to e.g. outgoing_bl).
+  auto temp_stream_handlers = std::move(session_stream_handlers);
+  exproto->auth_meta = auth_meta;
 
   ldout(messenger->cct, 5) << __func__ << " stop myself to swap existing"
                            << dendl;
-
-  std::swap(exproto->session_stream_handlers, session_stream_handlers);
-  exproto->auth_meta = auth_meta;
 
   // avoid _stop shutdown replacing socket
   // queue a reset on the new connection, which we're dumping for the old
@@ -2688,14 +2706,25 @@ CtPtr ProtocolV2::reuse_connection(AsyncConnectionRef existing,
   ceph_assert(connection->recv_start == connection->recv_end);
 
   auto deactivate_existing = std::bind(
-      [existing, new_worker, new_center, exproto](ConnectedSocket &cs) mutable {
+      [ existing,
+        new_worker,
+        new_center,
+        exproto,
+        temp_stream_handlers=std::move(temp_stream_handlers)
+      ](ConnectedSocket &cs) mutable {
         // we need to delete time event in original thread
         {
           std::lock_guard<std::mutex> l(existing->lock);
           existing->write_lock.lock();
           exproto->requeue_sent();
+          // XXX: do we really need the locking for `outgoing_bl`? There is
+          // a comment just above its definition saying "lockfree, only used
+          // in own thread". I'm following lockfull schema just in the case.
+          // From performance point of view it should be fine – this happens
+          // far away from hot paths.
           existing->outgoing_bl.clear();
           existing->open_write = false;
+          exproto->session_stream_handlers = std::move(temp_stream_handlers);
           existing->write_lock.unlock();
           if (exproto->state == NONE) {
             existing->shutdown_socket();

--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -16,6 +16,8 @@
 #include "test/librados/test.h"
 #include "test/librados/TestCase.h"
 #include "gtest/gtest.h"
+#include <sys/time.h>
+#include <sys/resource.h>
 
 #include <errno.h>
 #include <map>
@@ -307,4 +309,37 @@ TEST_F(LibRadosMisc, MinCompatClient) {
 
   ASSERT_LE(-1, require_min_compat_client);
   ASSERT_GT(CEPH_RELEASE_MAX, require_min_compat_client);
+}
+
+static void shutdown_racer_func()
+{
+  const int niter = 32;
+  rados_t rad;
+  int i;
+
+  for (i = 0; i < niter; ++i) {
+    ASSERT_EQ("", connect_cluster(&rad));
+    rados_shutdown(rad);
+  }
+}
+
+// See trackers #20988 and #42026
+TEST_F(LibRadosMisc, ShutdownRace)
+{
+  const int nthreads = 128;
+  std::thread threads[nthreads];
+
+  // Need a bunch of fd's for this test
+  struct rlimit rold, rnew;
+  ASSERT_EQ(getrlimit(RLIMIT_NOFILE, &rold), 0);
+  rnew = rold;
+  rnew.rlim_cur = rnew.rlim_max;
+  ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &rnew), 0);
+
+  for (int i = 0; i < nthreads; ++i)
+    threads[i] = std::thread(shutdown_racer_func);
+
+  for (int i = 0; i < nthreads; ++i)
+    threads[i].join();
+  ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &rold), 0);
 }


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/42856
* https://tracker.ceph.com/issues/43775
* https://tracker.ceph.com/issues/43832

---

backport of 

* https://github.com/ceph/ceph/pull/27094
* https://github.com/ceph/ceph/pull/30717
* https://github.com/ceph/ceph/pull/32352
* https://github.com/ceph/ceph/pull/32732

parent trackers:

* https://tracker.ceph.com/issues/42026
* https://tracker.ceph.com/issues/43070
* https://tracker.ceph.com/issues/43667

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh