### PR TITLE
nautilus: rgw: GET/HEAD and PUT operations on buckets w/lifecycle expiration configured do not return x-amz-expiration header

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -31,6 +31,7 @@
 #include "common/async/yield_context.h"
 #include "rgw_website.h"
 #include "rgw_object_lock.h"
+#include "rgw_tag.h"
 #include "cls/version/cls_version_types.h"
 #include "cls/user/cls_user_types.h"
 #include "cls/rgw/cls_rgw_types.h"
@@ -2081,6 +2082,8 @@ struct req_state : DoutPrefixProvider {
   string req_id;
   string trans_id;
   uint64_t id;
+
+  RGWObjTags tagset;
 
   bool mfa_verified{false};
 

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1604,12 +1604,21 @@ std::string s3_expiration_header(
     }
 
     if (filter.has_tags()) {
-      bool tag_match = true;
+      bool tag_match = false;
       const RGWObjTags& rule_tagset = filter.get_tags();
       for (auto& tag : rule_tagset.get_tags()) {
-	if (obj_tag_map.find(tag.first) == obj_tag_map.end()) {
-	  tag_match = false;
-	  break;
+	/* remember, S3 tags are {key,value} tuples */
+	auto ma1 = obj_tag_map.find(tag.first);
+	if (ma1 != obj_tag_map.end()) {
+	  if (tag.second == ma1->second) {
+	    ldpp_dout(dpp, 10) << "tag match obj_key=" << obj_key
+			       << " rule_id=" << id
+			       << " tag=" << tag
+			       << " (ma=" << *ma1 << ")"
+			       << dendl;
+	    tag_match = true;
+	    break;
+	  }
 	}
       }
       if (! tag_match)

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1535,7 +1535,7 @@ std::string s3_expiration_header(
   const std::map<std::string, buffer::list>& bucket_attrs)
 {
   CephContext* cct = dpp->get_cct();
-  RGWLifecycleConfiguration config(cct); // TODO: save in bucket info
+  RGWLifecycleConfiguration config(cct);
   std::string hdr{""};
 
   const auto& aiter = bucket_attrs.find(RGW_ATTR_LC);
@@ -1638,8 +1638,7 @@ std::string s3_expiration_header(
     // update earliest expiration
     if (rule_expiration_date) {
       if ((! expiration_date) ||
-	  ((expiration_date &&
-	    (*expiration_date < *rule_expiration_date)))) {
+	  (*expiration_date < *rule_expiration_date)) {
       expiration_date =
 	boost::optional<ceph::real_time>(rule_expiration_date);
       }

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1552,6 +1552,16 @@ std::string s3_expiration_header(
       return hdr;
   } /* catch */
 
+  /* dump tags at debug level 16 */
+  RGWObjTags::tag_map_t obj_tag_map = obj_tagset.get_tags();
+  if (cct->_conf->subsys.should_gather(ceph_subsys_rgw, 16)) {
+    for (const auto& elt : obj_tag_map) {
+      ldout(cct, 16) << __func__
+		     <<  "() key=" << elt.first << " val=" << elt.second
+		     << dendl;
+    }
+  }
+
   boost::optional<ceph::real_time> expiration_date;
   boost::optional<std::string> rule_id;
 
@@ -1596,7 +1606,6 @@ std::string s3_expiration_header(
     if (filter.has_tags()) {
       bool tag_match = true;
       const RGWObjTags& rule_tagset = filter.get_tags();
-      RGWObjTags::tag_map_t obj_tag_map = obj_tagset.get_tags();
       for (auto& tag : rule_tagset.get_tags()) {
 	if (obj_tag_map.find(tag.first) == obj_tag_map.end()) {
 	  tag_match = false;

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1651,7 +1651,7 @@ std::string s3_expiration_header(
     char exp_buf[100];
     time_t exp = ceph::real_clock::to_time_t(*expiration_date);
     if (std::strftime(exp_buf, sizeof(exp_buf),
-		      "%c", std::gmtime(&exp))) {
+		      "%a, %d %b %Y %T %Z", std::gmtime(&exp))) {
       hdr = fmt::format("expiry-date=\"{0}\", rule-id=\"{1}\"", exp_buf,
 			*rule_id);
     } else {

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -23,6 +23,7 @@
 #include "rgw_tag.h"
 
 #include <atomic>
+#include <tuple>
 
 #define HASH_PRIME 7877
 #define MAX_ID_LEN 255
@@ -210,8 +211,6 @@ class LCFilter
   void dump(Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(LCFilter)
-
-
 
 class LCRule
 {
@@ -515,6 +514,13 @@ namespace rgw::lc {
 
 int fix_lc_shard_entry(RGWRados *store, const RGWBucketInfo& bucket_info,
 		       const map<std::string,bufferlist>& battrs);
+
+std::string s3_expiration_header(
+  DoutPrefixProvider* dpp,
+  const rgw_obj_key& obj_key,
+  const RGWObjTags& obj_tagset,
+  const ceph::real_time& mtime,
+  const std::map<std::string, buffer::list>& bucket_attrs);
 
 } // namespace rgw::lc
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -798,7 +798,7 @@ void rgw_add_to_iam_environment(rgw::IAM::Environment& e, std::string_view key, 
 }
 
 static int rgw_iam_add_tags_from_bl(struct req_state* s, bufferlist& bl){
-  RGWObjTags tagset;
+  RGWObjTags& tagset = s->tagset;
   try {
     auto bliter = bl.cbegin();
     tagset.decode(bliter);

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -95,6 +95,14 @@ void rgw_get_errno_s3(rgw_http_error *e , int err_no)
   }
 }
 
+static inline std::string get_s3_expiration_header(
+  struct req_state* s,
+  const ceph::real_time& mtime)
+{
+  return rgw::lc::s3_expiration_header(
+    s, s->object, s->tagset, mtime, s->bucket_attrs);
+}
+
 struct response_attr_param {
   const char *param;
   const char *http_attr;
@@ -187,6 +195,8 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs,
   map<string, string>::iterator riter;
   bufferlist metadata_bl;
 
+  string expires = get_s3_expiration_header(s, lastmod);
+
   if (sent_header)
     goto send_data;
 
@@ -258,6 +268,8 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs,
   dump_content_length(s, total_len);
   dump_last_modified(s, lastmod);
   dump_header_if_nonempty(s, "x-amz-version-id", version_id);
+  dump_header_if_nonempty(s, "x-amz-expiration", expires);
+
   if (attrs.find(RGW_ATTR_APPEND_PART_NUM) != attrs.end()) {
     dump_header(s, "x-rgw-object-type", "Appendable");
     dump_header(s, "x-rgw-next-append-position", s->obj_size);
@@ -1782,16 +1794,21 @@ void RGWPutObj_ObjStore_S3::send_response()
 	s->cct->_conf->rgw_s3_success_create_obj_status);
       set_req_state_err(s, op_ret);
     }
+
+    string expires = get_s3_expiration_header(s, mtime);
+
     if (copy_source.empty()) {
       dump_errno(s);
       dump_etag(s, etag);
       dump_content_length(s, 0);
       dump_header_if_nonempty(s, "x-amz-version-id", version_id);
+      dump_header_if_nonempty(s, "x-amz-expiration", expires);
       for (auto &it : crypt_http_responses)
         dump_header(s, it.first, it.second);
     } else {
       dump_errno(s);
       dump_header_if_nonempty(s, "x-amz-version-id", version_id);
+      dump_header_if_nonempty(s, "x-amz-expiration", expires);
       end_header(s, this, "application/xml");
       dump_start(s);
       struct tm tmp;

--- a/src/rgw/rgw_tag.cc
+++ b/src/rgw/rgw_tag.cc
@@ -8,6 +8,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include "rgw_tag.h"
+#include "rgw_common.h"
 
 static constexpr uint32_t MAX_OBJ_TAGS=10;
 static constexpr uint32_t MAX_TAG_KEY_SIZE=128;

--- a/src/rgw/rgw_tag.h
+++ b/src/rgw/rgw_tag.h
@@ -8,16 +8,16 @@
 #include <include/types.h>
 #include <boost/container/flat_map.hpp>
 
-#include "rgw_common.h"
-
 class RGWObjTags
 {
- protected:
+public:
   using tag_map_t = boost::container::flat_map <std::string, std::string>;
+
+protected:
   tag_map_t tag_map;
  public:
-  RGWObjTags() {}
-  ~RGWObjTags() {}
+  RGWObjTags() = default;
+  ~RGWObjTags() = default;
 
   void encode(bufferlist& bl) const {
     ENCODE_START(1,1,bl);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41122
possibly a backport of https://github.com/ceph/ceph/pull/26160
parent tracker: https://tracker.ceph.com/issues/38055

---

original PR body:

Fixes: https://tracker.ceph.com/issues/41122



Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>



This is similar PR to: https://github.com/ceph/ceph/pull/30020

---

updated using ceph-backport.sh version 15.0.0.6950
