### PR TITLE
rgwlc: enable thread-parallelism in RGWLC

### DIFF
--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -947,7 +947,7 @@ int cls_rgw_lc_list(IoCtx& io_ctx, const string& oid,
 	    [](const cls_rgw_lc_entry& a, const cls_rgw_lc_entry& b)
 	      { return a.bucket < b.bucket; });
   entries = std::move(ret.entries);
- return r;
+  return r;
 }
 
 void cls_rgw_reshard_add(librados::ObjectWriteOperation& op, const cls_rgw_reshard_entry& entry)

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -847,7 +847,8 @@ int cls_rgw_lc_put_head(IoCtx& io_ctx, const string& oid, cls_rgw_lc_obj_head& h
   return r;
 }
 
-int cls_rgw_lc_get_next_entry(IoCtx& io_ctx, const string& oid, string& marker, pair<string, int>& entry)
+int cls_rgw_lc_get_next_entry(IoCtx& io_ctx, const string& oid, string& marker,
+			      cls_rgw_lc_entry& entry)
 {
   bufferlist in, out;
   cls_rgw_lc_get_next_entry_op call;
@@ -869,7 +870,8 @@ int cls_rgw_lc_get_next_entry(IoCtx& io_ctx, const string& oid, string& marker, 
  return r;
 }
 
-int cls_rgw_lc_rm_entry(IoCtx& io_ctx, const string& oid, const pair<string, int>& entry)
+int cls_rgw_lc_rm_entry(IoCtx& io_ctx, const string& oid,
+			const cls_rgw_lc_entry& entry)
 {
   bufferlist in, out;
   cls_rgw_lc_rm_entry_op call;
@@ -879,7 +881,8 @@ int cls_rgw_lc_rm_entry(IoCtx& io_ctx, const string& oid, const pair<string, int
  return r;
 }
 
-int cls_rgw_lc_set_entry(IoCtx& io_ctx, const string& oid, const pair<string, int>& entry)
+int cls_rgw_lc_set_entry(IoCtx& io_ctx, const string& oid,
+			 const cls_rgw_lc_entry& entry)
 {
   bufferlist in, out;
   cls_rgw_lc_set_entry_op call;
@@ -889,7 +892,8 @@ int cls_rgw_lc_set_entry(IoCtx& io_ctx, const string& oid, const pair<string, in
   return r;
 }
 
-int cls_rgw_lc_get_entry(IoCtx& io_ctx, const string& oid, const std::string& marker, rgw_lc_entry_t& entry)
+int cls_rgw_lc_get_entry(IoCtx& io_ctx, const string& oid,
+			 const std::string& marker, cls_rgw_lc_entry& entry)
 {
   bufferlist in, out;
   cls_rgw_lc_get_entry_op call{marker};;
@@ -915,7 +919,7 @@ int cls_rgw_lc_get_entry(IoCtx& io_ctx, const string& oid, const std::string& ma
 int cls_rgw_lc_list(IoCtx& io_ctx, const string& oid,
                     const string& marker,
                     uint32_t max_entries,
-                    map<string, int>& entries)
+                    vector<cls_rgw_lc_entry>& entries)
 {
   bufferlist in, out;
   cls_rgw_lc_list_entries_op op;
@@ -938,8 +942,11 @@ int cls_rgw_lc_list(IoCtx& io_ctx, const string& oid,
   } catch (ceph::buffer::error& err) {
     return -EIO;
   }
-  entries.insert(ret.entries.begin(),ret.entries.end());
 
+  std::sort(std::begin(ret.entries), std::end(ret.entries),
+	    [](const cls_rgw_lc_entry& a, const cls_rgw_lc_entry& b)
+	      { return a.bucket < b.bucket; });
+  entries = std::move(ret.entries);
  return r;
 }
 

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -606,14 +606,13 @@ int cls_rgw_gc_list(librados::IoCtx& io_ctx, std::string& oid, std::string& mark
 #ifndef CLS_CLIENT_HIDE_IOCTX
 int cls_rgw_lc_get_head(librados::IoCtx& io_ctx, const std::string& oid, cls_rgw_lc_obj_head& head);
 int cls_rgw_lc_put_head(librados::IoCtx& io_ctx, const std::string& oid, cls_rgw_lc_obj_head& head);
-int cls_rgw_lc_get_next_entry(librados::IoCtx& io_ctx, const std::string& oid, std::string& marker, std::pair<std::string, int>& entry);
-int cls_rgw_lc_rm_entry(librados::IoCtx& io_ctx, const std::string& oid, const std::pair<std::string, int>& entry);
-int cls_rgw_lc_set_entry(librados::IoCtx& io_ctx, const std::string& oid, const std::pair<std::string, int>& entry);
-int cls_rgw_lc_get_entry(librados::IoCtx& io_ctx, const std::string& oid, const std::string& marker, rgw_lc_entry_t& entry);
+int cls_rgw_lc_get_next_entry(librados::IoCtx& io_ctx, const std::string& oid, string& marker, cls_rgw_lc_entry& entry);
+int cls_rgw_lc_rm_entry(librados::IoCtx& io_ctx, const std::string& oid, const cls_rgw_lc_entry& entry);
+int cls_rgw_lc_set_entry(librados::IoCtx& io_ctx, const std::string& oid, const cls_rgw_lc_entry& entry);
+int cls_rgw_lc_get_entry(librados::IoCtx& io_ctx, const std::string& oid, const std::string& marker, cls_rgw_lc_entry& entry);
 int cls_rgw_lc_list(librados::IoCtx& io_ctx, const std::string& oid,
-                    const std::string& marker,
-                    uint32_t max_entries,
-                    std::map<std::string, int>& entries);
+		    const std::string& marker, uint32_t max_entries,
+                    vector<cls_rgw_lc_entry>& entries);
 #endif
 
 /* resharding */

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1194,14 +1194,14 @@ struct cls_rgw_lc_list_entries_op {
   cls_rgw_lc_list_entries_op() {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(marker, bl);
     encode(max_entries, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     compat_v = struct_v;
     decode(marker, bl);
     decode(max_entries, bl);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1030,21 +1030,26 @@ struct cls_rgw_lc_get_next_entry_op {
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_get_next_entry_op)
 
-using rgw_lc_entry_t = std::pair<std::string, int>;
-
 struct cls_rgw_lc_get_next_entry_ret {
-  rgw_lc_entry_t entry;
+  cls_rgw_lc_entry entry;
+
   cls_rgw_lc_get_next_entry_ret() {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 2, bl);
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
-    decode(entry, bl);
+    DECODE_START(2, bl);
+    if (struct_v < 1) {
+      std::pair<std::string, int> oe;
+      decode(oe, bl);
+      entry = {oe.first, 0 /* start */, uint32_t(oe.second)};
+    } else {
+      decode(entry, bl);
+    }
     DECODE_FINISH(bl);
   }
 
@@ -1071,9 +1076,11 @@ struct cls_rgw_lc_get_entry_op {
 WRITE_CLASS_ENCODER(cls_rgw_lc_get_entry_op)
 
 struct cls_rgw_lc_get_entry_ret {
-  rgw_lc_entry_t entry;
+  cls_rgw_lc_entry entry;
+
   cls_rgw_lc_get_entry_ret() {}
-  cls_rgw_lc_get_entry_ret(rgw_lc_entry_t&& _entry) : entry(std::move(_entry)) {}
+  cls_rgw_lc_get_entry_ret(cls_rgw_lc_entry&& _entry)
+    : entry(std::move(_entry)) {}
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
@@ -1090,38 +1097,49 @@ struct cls_rgw_lc_get_entry_ret {
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_get_entry_ret)
 
-
 struct cls_rgw_lc_rm_entry_op {
-  rgw_lc_entry_t entry;
+  cls_rgw_lc_entry entry;
   cls_rgw_lc_rm_entry_op() {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 2, bl);
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
-    decode(entry, bl);
+    DECODE_START(2, bl);
+    if (struct_v < 1) {
+      std::pair<std::string, int> oe;
+      decode(oe, bl);
+      entry = {oe.first, 0 /* start */, uint32_t(oe.second)};
+    } else {
+      decode(entry, bl);
+    }
     DECODE_FINISH(bl);
   }
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_rm_entry_op)
 
 struct cls_rgw_lc_set_entry_op {
-  rgw_lc_entry_t entry;
+  cls_rgw_lc_entry entry;
   cls_rgw_lc_set_entry_op() {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 2, bl);
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
-    decode(entry, bl);
+    DECODE_START(2, bl);
+    if (struct_v < 1) {
+      std::pair<std::string, int> oe;
+      decode(oe, bl);
+      entry = {oe.first, 0 /* start */, uint32_t(oe.second)};
+    } else {
+      decode(entry, bl);
+    }
     DECODE_FINISH(bl);
   }
 };
@@ -1171,18 +1189,20 @@ WRITE_CLASS_ENCODER(cls_rgw_lc_get_head_ret)
 struct cls_rgw_lc_list_entries_op {
   std::string marker;
   uint32_t max_entries = 0;
+  uint8_t compat_v{0};
 
   cls_rgw_lc_list_entries_op() {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(marker, bl);
     encode(max_entries, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
+    compat_v = struct_v;
     decode(marker, bl);
     decode(max_entries, bl);
     DECODE_FINISH(bl);
@@ -1192,27 +1212,46 @@ struct cls_rgw_lc_list_entries_op {
 WRITE_CLASS_ENCODER(cls_rgw_lc_list_entries_op)
 
 struct cls_rgw_lc_list_entries_ret {
-  std::map<std::string, int> entries;
+  vector<cls_rgw_lc_entry> entries;
   bool is_truncated{false};
+  uint8_t compat_v;
 
-  cls_rgw_lc_list_entries_ret() {}
+cls_rgw_lc_list_entries_ret(uint8_t compat_v = 3)
+  : compat_v(compat_v) {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(2, 1, bl);
-    encode(entries, bl);
+    ENCODE_START(compat_v, 1, bl);
+    if (compat_v <= 2) {
+      map<string, int> oes;
+      std::for_each(entries.begin(), entries.end(),
+                   [&oes](const cls_rgw_lc_entry& elt)
+                     {oes.insert({elt.bucket, elt.status});});
+      encode(oes, bl);
+    } else {
+      encode(entries, bl);
+    }
     encode(is_truncated, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(2, bl);
-    decode(entries, bl);
+    DECODE_START(3, bl);
+    compat_v = struct_v;
+    if (struct_v <= 2) {
+      map<string, int> oes;
+      decode(oes, bl);
+      std::for_each(oes.begin(), oes.end(),
+		    [this](const std::pair<string, int>& oe)
+		      {entries.push_back({oe.first, 0 /* start */,
+					  uint32_t(oe.second)});});
+    } else {
+      decode(entries, bl);
+    }
     if (struct_v >= 2) {
       decode(is_truncated, bl);
     }
     DECODE_FINISH(bl);
   }
-
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_list_entries_ret)
 

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -1212,6 +1212,37 @@ struct cls_rgw_lc_obj_head
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_obj_head)
 
+struct cls_rgw_lc_entry {
+  std::string bucket;
+  uint64_t start_time; // if in_progress
+  uint32_t status;
+
+  cls_rgw_lc_entry()
+    : start_time(0), status(0) {}
+
+  cls_rgw_lc_entry(const cls_rgw_lc_entry& rhs) = default;
+
+  cls_rgw_lc_entry(const std::string& b, uint64_t t, uint32_t s)
+    : bucket(b), start_time(t), status(s) {};
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(bucket, bl);
+    encode(start_time, bl);
+    encode(status, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(bucket, bl);
+    decode(start_time, bl);
+    decode(status, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_rgw_lc_entry);
+
 struct cls_rgw_reshard_entry
 {
   ceph::real_time time;

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1275,6 +1275,11 @@ OPTION(rgw_enable_quota_threads, OPT_BOOL)
 OPTION(rgw_enable_gc_threads, OPT_BOOL)
 OPTION(rgw_enable_lc_threads, OPT_BOOL)
 
+/* overrides for librgw/nfs */
+OPTION(rgw_nfs_run_gc_threads, OPT_BOOL)
+OPTION(rgw_nfs_run_lc_threads, OPT_BOOL)
+OPTION(rgw_nfs_run_quota_threads, OPT_BOOL)
+OPTION(rgw_nfs_run_sync_thread, OPT_BOOL)
 
 OPTION(rgw_data, OPT_STR)
 OPTION(rgw_enable_apis, OPT_STR)

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1289,6 +1289,7 @@ OPTION(rgw_service_provider_name, OPT_STR) //service provider name which is cont
 OPTION(rgw_content_length_compat, OPT_BOOL) // Check both HTTP_CONTENT_LENGTH and CONTENT_LENGTH in fcgi env
 OPTION(rgw_lifecycle_work_time, OPT_STR) //job process lc  at 00:00-06:00s
 OPTION(rgw_lc_lock_max_time, OPT_INT)  // total run time for a single lc processor work
+OPTION(rgw_lc_max_worker, OPT_INT)// number of (parellized) LCWorker threads
 OPTION(rgw_lc_max_objs, OPT_INT)
 OPTION(rgw_lc_max_rules, OPT_U32)  // Max rules set on one bucket
 OPTION(rgw_lc_debug_interval, OPT_INT)  // Debug run interval, in seconds

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1290,6 +1290,7 @@ OPTION(rgw_content_length_compat, OPT_BOOL) // Check both HTTP_CONTENT_LENGTH an
 OPTION(rgw_lifecycle_work_time, OPT_STR) //job process lc  at 00:00-06:00s
 OPTION(rgw_lc_lock_max_time, OPT_INT)  // total run time for a single lc processor work
 OPTION(rgw_lc_max_worker, OPT_INT)// number of (parellized) LCWorker threads
+OPTION(rgw_lc_max_wp_worker, OPT_INT)// number of per-LCWorker pool threads
 OPTION(rgw_lc_max_objs, OPT_INT)
 OPTION(rgw_lc_max_rules, OPT_U32)  // Max rules set on one bucket
 OPTION(rgw_lc_debug_interval, OPT_INT)  // Debug run interval, in seconds

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5548,7 +5548,7 @@ std::vector<Option> get_rgw_options() {
     .set_long_description("Local time window in which the lifecycle maintenance thread can work."),
 
     Option("rgw_lc_lock_max_time", Option::TYPE_INT, Option::LEVEL_DEV)
-    .set_default(60)
+    .set_default(90)
     .set_description(""),
 
     Option("rgw_lc_thread_delay", Option::TYPE_INT, Option::LEVEL_ADVANCED)
@@ -5559,16 +5559,23 @@ std::vector<Option> get_rgw_options() {
     .set_default(3)
     .set_description("Number of LCWorker tasks that will be run in parallel")
     .set_long_description(
-      "Number of LCWorker tasks that will be run in parallel--used to permit >1 bucket/index shards "
-      "to be processed simultaneously"),
+      "Number of LCWorker tasks that will run in parallel--used to permit >1 "
+      "bucket/index shards to be processed simultaneously"),
+
+    Option("rgw_lc_max_wp_worker", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(3)
+    .set_description("Number of workpool threads per LCWorker")
+    .set_long_description(
+      "Number of threads in per-LCWorker workpools--used to accelerate "
+      "per-bucket processing"),
 
     Option("rgw_lc_max_objs", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(32)
     .set_description("Number of lifecycle data shards")
     .set_long_description(
-          "Number of RADOS objects to use for storing lifecycle index. This can affect "
-          "concurrency of lifecycle maintenance, but requires multiple RGW processes "
-          "running on the zone to be utilized."),
+          "Number of RADOS objects to use for storing lifecycle index. This "
+	  "affects concurrency of lifecycle maintenance, as shards can be "
+          "processed in parallel."),
 
     Option("rgw_lc_max_rules", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(1000)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5555,6 +5555,13 @@ std::vector<Option> get_rgw_options() {
     .set_default(0)
     .set_description("Delay after processing of bucket listing chunks (i.e., per 1000 entries) in milliseconds"),
 
+    Option("rgw_lc_max_worker", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(3)
+    .set_description("Number of LCWorker tasks that will be run in parallel")
+    .set_long_description(
+      "Number of LCWorker tasks that will be run in parallel--used to permit >1 bucket/index shards "
+      "to be processed simultaneously"),
+
     Option("rgw_lc_max_objs", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(32)
     .set_description("Number of lifecycle data shards")

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5936,6 +5936,22 @@ std::vector<Option> get_rgw_options() {
     .set_long_description("use fast S3 attrs from bucket index (assumes NFS "
 			  "mounts are immutable)"),
 
+    Option("rgw_nfs_run_gc_threads", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("run GC threads in librgw (default off)"),
+
+    Option("rgw_nfs_run_lc_threads", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("run lifecycle threads in librgw (default off)"),
+
+    Option("rgw_nfs_run_quota_threads", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("run quota threads in librgw (default off)"),
+
+    Option("rgw_nfs_run_sync_thread", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("run sync thread in librgw (default off)"),
+
     Option("rgw_rados_pool_autoscale_bias", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(4.0)
     .set_min_max(0.01, 100000.0)

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -508,11 +508,27 @@ namespace rgw {
     rgw::curl::setup_curl(boost::none);
     rgw_http_client_init(g_ceph_context);
 
+    auto run_gc =
+      g_conf()->rgw_enable_gc_threads &&
+      g_conf()->rgw_nfs_run_gc_threads;
+
+    auto run_lc =
+      g_conf()->rgw_enable_lc_threads &&
+      g_conf()->rgw_nfs_run_lc_threads;
+
+    auto run_quota =
+      g_conf()->rgw_enable_quota_threads &&
+      g_conf()->rgw_nfs_run_quota_threads;
+
+    auto run_sync =
+      g_conf()->rgw_run_sync_thread &&
+      g_conf()->rgw_nfs_run_sync_thread;
+
     store = RGWStoreManager::get_storage(g_ceph_context,
-					 g_conf()->rgw_enable_gc_threads,
-					 g_conf()->rgw_enable_lc_threads,
-					 g_conf()->rgw_enable_quota_threads,
-					 g_conf()->rgw_run_sync_thread,
+					 run_gc,
+					 run_lc,
+					 run_quota,
+					 run_sync,
 					 g_conf().get_val<bool>("rgw_dynamic_resharding"));
 
     if (!store) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7185,13 +7185,14 @@ next:
     formatter->open_array_section("lifecycle_list");
     vector<cls_rgw_lc_entry> bucket_lc_map;
     string marker;
+    int index{0};
 #define MAX_LC_LIST_ENTRIES 100
     if (max_entries < 0) {
       max_entries = MAX_LC_LIST_ENTRIES;
     }
     do {
       int ret = store->getRados()->list_lc_progress(marker, max_entries,
-						    bucket_lc_map);
+						    bucket_lc_map, index);
       if (ret < 0) {
         cerr << "ERROR: failed to list objs: " << cpp_strerror(-ret)
 	     << std::endl;
@@ -7211,7 +7212,6 @@ next:
         formatter->dump_string("status", lc_status);
         formatter->close_section(); // objs
         formatter->flush(cout);
-        marker = entry.bucket;
       }
     } while (!bucket_lc_map.empty());
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7183,27 +7183,35 @@ next:
 
   if (opt_cmd == OPT::LC_LIST) {
     formatter->open_array_section("lifecycle_list");
-    map<string, int> bucket_lc_map;
+    vector<cls_rgw_lc_entry> bucket_lc_map;
     string marker;
 #define MAX_LC_LIST_ENTRIES 100
     if (max_entries < 0) {
       max_entries = MAX_LC_LIST_ENTRIES;
     }
     do {
-      int ret = store->getRados()->list_lc_progress(marker, max_entries, &bucket_lc_map);
+      int ret = store->getRados()->list_lc_progress(marker, max_entries,
+						    bucket_lc_map);
       if (ret < 0) {
-        cerr << "ERROR: failed to list objs: " << cpp_strerror(-ret) << std::endl;
+        cerr << "ERROR: failed to list objs: " << cpp_strerror(-ret)
+	     << std::endl;
         return 1;
       }
-      map<string, int>::iterator iter;
-      for (iter = bucket_lc_map.begin(); iter != bucket_lc_map.end(); ++iter) {
+      for (const auto& entry : bucket_lc_map) {
         formatter->open_object_section("bucket_lc_info");
-        formatter->dump_string("bucket", iter->first);
-        string lc_status = LC_STATUS[iter->second];
+        formatter->dump_string("bucket", entry.bucket);
+	char exp_buf[100];
+	time_t t{time_t(entry.start_time)};
+	if (std::strftime(
+	      exp_buf, sizeof(exp_buf),
+	      "%a, %d %b %Y %T %Z", std::gmtime(&t))) {
+	  formatter->dump_string("started", exp_buf);
+	}
+        string lc_status = LC_STATUS[entry.status];
         formatter->dump_string("status", lc_status);
         formatter->close_section(); // objs
         formatter->flush(cout);
-        marker = iter->first;
+        marker = entry.bucket;
       }
     } while (!bucket_lc_map.empty());
 

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -431,6 +431,7 @@ public:
       store(_store), bucket_info(_bucket_info),
       target(store->getRados(), bucket_info), list_op(&target) {
     list_op.params.list_versions = bucket_info.versioned();
+    list_op.params.allow_unordered = true;
     delay_ms = store->ctx()->_conf.get_val<int64_t>("rgw_lc_thread_delay");
   }
 

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -775,6 +775,12 @@ public:
       ix(0)
     {}
 
+  ~WorkPool() {
+    for (auto& wq : wqs) {
+      wq.join();
+    }
+  }
+
   void setf(WorkQ::work_f _f) {
     for (auto& wq : wqs) {
       wq.setf(_f);

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -493,15 +493,16 @@ public:
     ++obj_iter;
   }
 
-  bool next_has_same_name()
-  {
-    if ((obj_iter + 1) == objs.end()) {
+  boost::optional<std::string> next_key_name() {
+    if (obj_iter == objs.end() ||
+	(obj_iter + 1) == objs.end()) {
       /* this should have been called after get_obj() was called, so this should
        * only happen if is_truncated is false */
-      return false;
+      return boost::none;
     }
-    return (obj_iter->key.name.compare((obj_iter + 1)->key.name) == 0);
+    return ((obj_iter + 1)->key.name);
   }
+
 }; /* LCObjsLister */
 
 struct op_env {
@@ -581,8 +582,15 @@ static int remove_expired_obj(lc_op_ctx& oc, bool remove_indeed)
 } /* remove_expired_obj */
 
 class LCOpAction {
+protected:
+  boost::optional<std::string> next_key_name;
 public:
   virtual ~LCOpAction() {}
+
+  bool next_has_same_name(const std::string& key_name) {
+    return (next_key_name && key_name.compare(
+	      boost::get<std::string>(next_key_name)) == 0);
+  }
 
   virtual bool check(lc_op_ctx& oc, ceph::real_time *exp_time) {
     return false;
@@ -983,6 +991,10 @@ public:
 
 class LCOpAction_CurrentExpiration : public LCOpAction {
 public:
+  LCOpAction_CurrentExpiration(op_env& env) {
+    next_key_name = env.ol.next_key_name();
+  }
+
   bool check(lc_op_ctx& oc, ceph::real_time *exp_time) override {
     auto& o = oc.o;
     if (!o.is_current()) {
@@ -992,8 +1004,8 @@ public:
       return false;
     }
     if (o.is_delete_marker()) {
-      if (oc.ol.next_has_same_name()) {
-        return false;
+      if (next_has_same_name(o.key.name)) {
+	return false;
       } else {
         *exp_time = real_clock::now();
         return true;
@@ -1045,7 +1057,13 @@ public:
 };
 
 class LCOpAction_NonCurrentExpiration : public LCOpAction {
+protected:
+  ceph::real_time mtime;
 public:
+  LCOpAction_NonCurrentExpiration(op_env& env)
+    : mtime(env.ol.get_prev_obj().meta.mtime)
+    {}
+
   bool check(lc_op_ctx& oc, ceph::real_time *exp_time) override {
     auto& o = oc.o;
     if (o.is_current()) {
@@ -1055,7 +1073,6 @@ public:
       return false;
     }
 
-    auto mtime = oc.ol.get_prev_obj().meta.mtime;
     int expiration = oc.op.noncur_expiration;
     bool is_expired = obj_has_expired(oc.cct, mtime, expiration, exp_time);
 
@@ -1086,6 +1103,10 @@ public:
 
 class LCOpAction_DMExpiration : public LCOpAction {
 public:
+  LCOpAction_DMExpiration(op_env& env) {
+    next_key_name = env.ol.next_key_name();
+  }
+
   bool check(lc_op_ctx& oc, ceph::real_time *exp_time) override {
     auto& o = oc.o;
     if (!o.is_delete_marker()) {
@@ -1094,8 +1115,7 @@ public:
 			<< oc.wq->thr_name() << dendl;
       return false;
     }
-
-    if (oc.ol.next_has_same_name()) {
+    if (next_has_same_name(o.key.name)) {
       ldout(oc.cct, 20) << __func__ << "(): key=" << o.key
 			<< ": next is same object, skipping "
 			<< oc.wq->thr_name() << dendl;
@@ -1230,16 +1250,21 @@ public:
 
 class LCOpAction_NonCurrentTransition : public LCOpAction_Transition {
 protected:
+  ceph::real_time effective_mtime;
+
   bool check_current_state(bool is_current) override {
     return !is_current;
   }
 
   ceph::real_time get_effective_mtime(lc_op_ctx& oc) override {
-    return oc.ol.get_prev_obj().meta.mtime;
+    return effective_mtime;
   }
 public:
-  LCOpAction_NonCurrentTransition(const transition_action& _transition)
-    : LCOpAction_Transition(_transition) {}
+  LCOpAction_NonCurrentTransition(op_env& env,
+				  const transition_action& _transition)
+    : LCOpAction_Transition(_transition),
+      effective_mtime(env.ol.get_prev_obj().meta.mtime)
+    {}
 };
 
 void LCOpRule::build()
@@ -1250,15 +1275,15 @@ void LCOpRule::build()
 
   if (op.expiration > 0 ||
       op.expiration_date != boost::none) {
-    actions.emplace_back(new LCOpAction_CurrentExpiration);
+    actions.emplace_back(new LCOpAction_CurrentExpiration(env));
   }
 
   if (op.dm_expiration) {
-    actions.emplace_back(new LCOpAction_DMExpiration);
+    actions.emplace_back(new LCOpAction_DMExpiration(env));
   }
 
   if (op.noncur_expiration > 0) {
-    actions.emplace_back(new LCOpAction_NonCurrentExpiration);
+    actions.emplace_back(new LCOpAction_NonCurrentExpiration(env));
   }
 
   for (auto& iter : op.transitions) {
@@ -1266,7 +1291,7 @@ void LCOpRule::build()
   }
 
   for (auto& iter : op.noncur_transitions) {
-    actions.emplace_back(new LCOpAction_NonCurrentTransition(iter.second));
+    actions.emplace_back(new LCOpAction_NonCurrentTransition(env, iter.second));
   }
 }
 

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -781,14 +781,14 @@ RGWLC::LCWorker::LCWorker(const DoutPrefixProvider* dpp, CephContext *cct,
   workpool = new WorkPool(this, wpw, 512);
 }
 
-static inline bool worker_should_stop(time_t stop_at)
+static inline bool worker_should_stop(time_t stop_at, bool once)
 {
-  return stop_at < time(nullptr);
+  return !once && stop_at < time(nullptr);
 }
 
 int RGWLC::handle_multipart_expiration(
   RGWRados::Bucket *target, const multimap<string, lc_op>& prefix_map,
-  LCWorker* worker, time_t stop_at)
+  LCWorker* worker, time_t stop_at, bool once)
 {
   MultipartMetaFilter mp_filter;
   vector<rgw_bucket_dir_entry> objs;
@@ -837,7 +837,7 @@ int RGWLC::handle_multipart_expiration(
   for (auto prefix_iter = prefix_map.begin(); prefix_iter != prefix_map.end();
        ++prefix_iter) {
 
-    if (worker_should_stop(stop_at)) {
+    if (worker_should_stop(stop_at, once)) {
       ldout(cct, 5) << __func__ << " interval budget EXPIRED worker "
 		     << worker->ix
 		     << dendl;
@@ -1334,7 +1334,7 @@ int LCOpRule::process(rgw_bucket_dir_entry& o,
 }
 
 int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
-			     time_t stop_at)
+			     time_t stop_at, bool once)
 {
   RGWLifecycleConfiguration  config(cct);
   RGWBucketInfo bucket_info;
@@ -1412,7 +1412,7 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
   for(auto prefix_iter = prefix_map.begin(); prefix_iter != prefix_map.end();
       ++prefix_iter) {
 
-    if (worker_should_stop(stop_at)) {
+    if (worker_should_stop(stop_at, once)) {
       ldout(cct, 5) << __func__ << " interval budget EXPIRED worker "
 		     << worker->ix
 		     << dendl;
@@ -1455,7 +1455,7 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
     worker->workpool->drain();
   }
 
-  ret = handle_multipart_expiration(&target, prefix_map, worker, stop_at);
+  ret = handle_multipart_expiration(&target, prefix_map, worker, stop_at, once);
   return ret;
 }
 
@@ -1648,7 +1648,8 @@ int RGWLC::process(int index, int max_lock_secs, LCWorker* worker,
       }
     }
 
-    if(!if_already_run_today(head.start_date)) {
+    if(!if_already_run_today(head.start_date) ||
+       once) {
       head.start_date = now;
       head.marker.clear();
       ret = bucket_lc_prepare(index, worker);
@@ -1701,7 +1702,7 @@ int RGWLC::process(int index, int max_lock_secs, LCWorker* worker,
 	    << dendl;
 
     l.unlock(&store->getRados()->lc_pool_ctx, obj_names[index]);
-    ret = bucket_lc_process(entry.bucket, worker, thread_stop_at());
+    ret = bucket_lc_process(entry.bucket, worker, thread_stop_at(), once);
     bucket_lc_post(index, max_lock_secs, entry, ret, worker);
   } while(1 && !once);
 

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -26,6 +26,7 @@
 #include "rgw_zone.h"
 #include "rgw_string.h"
 #include "rgw_multi.h"
+#include "rgw_sal.h"
 
 // this seems safe to use, at least for now--arguably, we should
 // prefer header-only fmt, in general
@@ -288,8 +289,7 @@ bool RGWLC::if_already_run_today(time_t& start_date)
 
 int RGWLC::bucket_lc_prepare(int index, LCWorker* worker)
 {
-  map<string, int > entries;
-
+  vector<cls_rgw_lc_entry> entries;
   string marker;
 
 #define MAX_LC_LIST_ENTRIES 100
@@ -298,20 +298,22 @@ int RGWLC::bucket_lc_prepare(int index, LCWorker* worker)
 			      marker, MAX_LC_LIST_ENTRIES, entries);
     if (ret < 0)
       return ret;
-    map<string, int>::iterator iter;
-    for (iter = entries.begin(); iter != entries.end(); ++iter) {
-      pair<string, int > entry(iter->first, lc_uninitial);
+
+    for (auto& entry : entries) {
+      entry.start_time = ceph_clock_now();
+      entry.status = lc_uninitial; // lc_uninitial? really?
       ret = cls_rgw_lc_set_entry(store->getRados()->lc_pool_ctx,
-				 obj_names[index],  entry);
+				 obj_names[index], entry);
       if (ret < 0) {
-        ldpp_dout(this, 0) << "RGWLC::bucket_lc_prepare() failed to set entry on "
-            << obj_names[index] << dendl;
+        ldpp_dout(this, 0)
+	  << "RGWLC::bucket_lc_prepare() failed to set entry on "
+	  << obj_names[index] << dendl;
         return ret;
       }
     }
 
-    if (!entries.empty()) {
-      marker = std::move(entries.rbegin()->first);
+    if (! entries.empty()) {
+      marker = std::move(entries.back().bucket);
     }
   } while (!entries.empty());
 
@@ -1332,7 +1334,7 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker)
 }
 
 int RGWLC::bucket_lc_post(int index, int max_lock_sec,
-			  pair<string, int>& entry, int& result,
+			  cls_rgw_lc_entry& entry, int& result,
 			  LCWorker* worker)
 {
   utime_t lock_duration(cct->_conf->rgw_lc_lock_max_time, 0);
@@ -1340,6 +1342,10 @@ int RGWLC::bucket_lc_post(int index, int max_lock_sec,
   rados::cls::lock::Lock l(lc_index_lock_name);
   l.set_cookie(cookie);
   l.set_duration(lock_duration);
+
+  dout(5) << "RGWLC::bucket_lc_post(): POST " << entry
+	  << " index: " << index << " worker ix: " << worker->ix
+	  << dendl;
 
   do {
     int ret = l.lock_exclusive(
@@ -1362,9 +1368,9 @@ int RGWLC::bucket_lc_post(int index, int max_lock_sec,
       }
       goto clean;
     } else if (result < 0) {
-      entry.second = lc_failed;
+      entry.status = lc_failed;
     } else {
-      entry.second = lc_complete;
+      entry.status = lc_complete;
     }
 
     ret = cls_rgw_lc_set_entry(store->getRados()->lc_pool_ctx,
@@ -1381,15 +1387,13 @@ clean:
 }
 
 int RGWLC::list_lc_progress(const string& marker, uint32_t max_entries,
-			    map<string, int>* progress_map)
+			    vector<cls_rgw_lc_entry>& progress_map)
 {
   int index = 0;
-  progress_map->clear();
   for(; index <max_objs; index++) {
-    map<string, int > entries;
     int ret =
       cls_rgw_lc_list(store->getRados()->lc_pool_ctx, obj_names[index], marker,
-		      max_entries, entries);
+		      max_entries, progress_map);
     if (ret < 0) {
       if (ret == -ENOENT) {
         ldpp_dout(this, 10) << __func__ << "() ignoring unfound lc object="
@@ -1398,10 +1402,6 @@ int RGWLC::list_lc_progress(const string& marker, uint32_t max_entries,
       } else {
         return ret;
       }
-    }
-    map<string, int>::iterator iter;
-    for (iter = entries.begin(); iter != entries.end(); ++iter) {
-      progress_map->insert(*iter);
     }
   }
   return 0;
@@ -1439,7 +1439,8 @@ int RGWLC::process(int index, int max_lock_secs, LCWorker* worker)
   rados::cls::lock::Lock l(lc_index_lock_name);
   do {
     utime_t now = ceph_clock_now();
-    pair<string, int > entry;//string = bucket_name:bucket_id ,int = LC_BUCKET_STATUS
+    //string = bucket_name:bucket_id ,int = LC_BUCKET_STATUS
+    cls_rgw_lc_entry entry;
     if (max_lock_secs <= 0)
       return -EAGAIN;
 
@@ -1466,6 +1467,18 @@ int RGWLC::process(int index, int max_lock_secs, LCWorker* worker)
       goto exit;
     }
 
+    if (! (cct->_conf->rgw_lc_lock_max_time == 9969)) {
+      ret = cls_rgw_lc_get_entry(store->getRados()->lc_pool_ctx,
+				 obj_names[index], head.marker, entry);
+      if ((entry.status == lc_processing) &&
+	  (true /* XXXX expired epoch! */)) {
+	dout(5) << "RGWLC::process(): ACTIVE entry: " << entry
+		<< " index: " << index << " worker ix: " << worker->ix
+		<< dendl;
+	goto exit;
+      }
+    }
+
     if(!if_already_run_today(head.start_date)) {
       head.start_date = now;
       head.marker.clear();
@@ -1488,32 +1501,38 @@ int RGWLC::process(int index, int max_lock_secs, LCWorker* worker)
     }
 
     /* termination condition (eof) */
-    if (entry.first.empty())
+    if (entry.bucket.empty())
       goto exit;
 
-    entry.second = lc_processing;
+    ldpp_dout(this, 5) << "RGWLC::process(): START entry 1: " << entry
+	    << " index: " << index << " worker ix: " << worker->ix
+	    << dendl;
+
+    entry.status = lc_processing;
     ret = cls_rgw_lc_set_entry(store->getRados()->lc_pool_ctx,
-			       obj_names[index],  entry);
+			       obj_names[index], entry);
     if (ret < 0) {
       ldpp_dout(this, 0) << "RGWLC::process() failed to set obj entry "
-			 << obj_names[index]
-			 << " (" << entry.first << ","
-			 << entry.second << ")"
-			 << dendl;
+	      << obj_names[index] << entry.bucket << entry.status << dendl;
       goto exit;
     }
 
-    head.marker = entry.first;
-    ret = cls_rgw_lc_put_head(store->getRados()->lc_pool_ctx, obj_names[index],
-			      head);
+    head.marker = entry.bucket;
+    ret = cls_rgw_lc_put_head(store->getRados()->lc_pool_ctx,
+			      obj_names[index],  head);
     if (ret < 0) {
       ldpp_dout(this, 0) << "RGWLC::process() failed to put head "
 			 << obj_names[index]
-			 << dendl;
+	      << dendl;
       goto exit;
     }
+
+    ldpp_dout(this, 5) << "RGWLC::process(): START entry 2: " << entry
+	    << " index: " << index << " worker ix: " << worker->ix
+	    << dendl;
+
     l.unlock(&store->getRados()->lc_pool_ctx, obj_names[index]);
-    ret = bucket_lc_process(entry.first, worker);
+    ret = bucket_lc_process(entry.bucket, worker);
     bucket_lc_post(index, max_lock_secs, entry, ret, worker);
   } while(1);
 
@@ -1653,9 +1672,9 @@ static std::string get_lc_shard_name(const rgw_bucket& bucket){
 }
 
 template<typename F>
-static int guard_lc_modify(
-  rgw::sal::RGWRadosStore* store, const rgw_bucket& bucket,
-  const string& cookie, const F& f) {
+static int guard_lc_modify(rgw::sal::RGWRadosStore* store,
+			   const rgw_bucket& bucket, const string& cookie,
+			   const F& f) {
   CephContext *cct = store->ctx();
 
   string shard_id = get_lc_shard_name(bucket);
@@ -1663,7 +1682,10 @@ static int guard_lc_modify(
   string oid; 
   get_lc_oid(cct, shard_id, &oid);
 
-  pair<string, int> entry(shard_id, lc_uninitial);
+  /* XXX it makes sense to take shard_id for a bucket_id? */
+  cls_rgw_lc_entry entry;
+  entry.bucket = shard_id;
+  entry.status = lc_uninitial;
   int max_lock_secs = cct->_conf->rgw_lc_lock_max_time;
 
   rados::cls::lock::Lock l(lc_index_lock_name); 
@@ -1716,9 +1738,10 @@ int RGWLC::set_bucket_config(RGWBucketInfo& bucket_info,
 
   rgw_bucket& bucket = bucket_info.bucket;
 
+
   ret = guard_lc_modify(store, bucket, cookie,
 			[&](librados::IoCtx *ctx, const string& oid,
-			    const pair<string, int>& entry) {
+			    const cls_rgw_lc_entry& entry) {
     return cls_rgw_lc_set_entry(*ctx, oid, entry);
   });
 
@@ -1745,7 +1768,7 @@ int RGWLC::remove_bucket_config(RGWBucketInfo& bucket_info,
 
   ret = guard_lc_modify(store, bucket, cookie,
 			[&](librados::IoCtx *ctx, const string& oid,
-			    const pair<string, int>& entry) {
+			    const cls_rgw_lc_entry& entry) {
     return cls_rgw_lc_rm_entry(*ctx, oid, entry);
   });
 
@@ -1773,7 +1796,7 @@ int fix_lc_shard_entry(rgw::sal::RGWRadosStore* store,
   std::string lc_oid;
   get_lc_oid(store->ctx(), shard_name, &lc_oid);
 
-  rgw_lc_entry_t entry;
+  cls_rgw_lc_entry entry;
   // There are multiple cases we need to encounter here
   // 1. entry exists and is already set to marker, happens in plain buckets & newly resharded buckets
   // 2. entry doesn't exist, which usually happens when reshard has happened prior to update and next LC process has already dropped the update
@@ -1797,8 +1820,9 @@ int fix_lc_shard_entry(rgw::sal::RGWRadosStore* store,
 
     ret = guard_lc_modify(
       store, bucket_info.bucket, cookie,
-      [&lc_pool_ctx, &lc_oid](librados::IoCtx *ctx, const string& oid,
-			      const pair<string, int>& entry) {
+      [&lc_pool_ctx, &lc_oid](librados::IoCtx* ctx,
+			      const string& oid,
+			      const cls_rgw_lc_entry& entry) {
 	return cls_rgw_lc_set_entry(*lc_pool_ctx, lc_oid, entry);
       });
 

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1540,14 +1540,16 @@ clean:
   } while (true);
 }
 
-int RGWLC::list_lc_progress(const string& marker, uint32_t max_entries,
-			    vector<cls_rgw_lc_entry>& progress_map)
+int RGWLC::list_lc_progress(string& marker, uint32_t max_entries,
+			    vector<cls_rgw_lc_entry>& progress_map,
+			    int& index)
 {
-  int index = 0;
-  for(; index <max_objs; index++) {
+  progress_map.clear();
+  for(; index < max_objs; index++, marker="") {
+    vector<cls_rgw_lc_entry> entries;
     int ret =
       cls_rgw_lc_list(store->getRados()->lc_pool_ctx, obj_names[index], marker,
-		      max_entries, progress_map);
+		      max_entries, entries);
     if (ret < 0) {
       if (ret == -ENOENT) {
         ldpp_dout(this, 10) << __func__ << "() ignoring unfound lc object="
@@ -1557,6 +1559,15 @@ int RGWLC::list_lc_progress(const string& marker, uint32_t max_entries,
         return ret;
       }
     }
+    progress_map.reserve(progress_map.size() + entries.size());
+    progress_map.insert(progress_map.end(), entries.begin(), entries.end());
+
+    /* update index, marker tuple */
+    if (progress_map.size() > 0)
+      marker = progress_map.back().bucket;
+
+    if (progress_map.size() >= max_entries)
+      break;
   }
   return 0;
 }

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -13,6 +13,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/variant.hpp>
 
+#include "include/scope_guard.h"
 #include "common/Formatter.h"
 #include "common/containers.h"
 #include <common/errno.h>
@@ -215,7 +216,8 @@ void *RGWLC::LCWorker::entry() {
       ldpp_dout(dpp, 2) << "life cycle: start" << dendl;
       int r = lc->process(this);
       if (r < 0) {
-        ldpp_dout(dpp, 0) << "ERROR: do life cycle process() returned error r=" << r << dendl;
+        ldpp_dout(dpp, 0) << "ERROR: do life cycle process() returned error r="
+			  << r << dendl;
       }
       ldpp_dout(dpp, 2) << "life cycle: stop" << dendl;
     }
@@ -227,7 +229,8 @@ void *RGWLC::LCWorker::entry() {
     utime_t next;
     next.set_from_double(end + secs);
 
-    ldpp_dout(dpp, 5) << "schedule life cycle next start time: " << rgw_to_asctime(next) << dendl;
+    ldpp_dout(dpp, 5) << "schedule life cycle next start time: "
+		      << rgw_to_asctime(next) << dendl;
 
     std::unique_lock l{lock};
     cond.wait_for(l, std::chrono::seconds(secs));
@@ -263,7 +266,7 @@ void RGWLC::finalize()
   delete[] obj_names;
 }
 
-bool RGWLC::if_already_run_today(time_t& start_date)
+bool RGWLC::if_already_run_today(time_t start_date)
 {
   struct tm bdt;
   time_t begin_of_day;
@@ -287,10 +290,25 @@ bool RGWLC::if_already_run_today(time_t& start_date)
     return false;
 }
 
+static inline std::ostream& operator<<(std::ostream &os, cls_rgw_lc_entry& ent) {
+  os << "<ent: bucket=";
+  os << ent.bucket;
+  os << "; start_time=";
+  os << rgw_to_asctime(utime_t(time_t(ent.start_time), 0));
+  os << "; status=";
+    os << ent.status;
+    os << ">";
+    return os;
+}
+
 int RGWLC::bucket_lc_prepare(int index, LCWorker* worker)
 {
   vector<cls_rgw_lc_entry> entries;
   string marker;
+
+  dout(5) << "RGWLC::bucket_lc_prepare(): PREPARE "
+	  << "index: " << index << " worker ix: " << worker->ix
+	  << dendl;
 
 #define MAX_LC_LIST_ENTRIES 100
   do {
@@ -368,7 +386,8 @@ static bool pass_object_lock_check(RGWRados *store, RGWBucketInfo& bucket_info,
       try {
         decode(retention, iter->second);
       } catch (buffer::error& err) {
-        ldout(store->ctx(), 0) << "ERROR: failed to decode RGWObjectRetention" << dendl;
+        ldout(store->ctx(), 0) << "ERROR: failed to decode RGWObjectRetention"
+			       << dendl;
         return false;
       }
       if (ceph::real_clock::to_time_t(retention.get_retain_until_date()) >
@@ -382,7 +401,8 @@ static bool pass_object_lock_check(RGWRados *store, RGWBucketInfo& bucket_info,
       try {
         decode(obj_legal_hold, iter->second);
       } catch (buffer::error& err) {
-        ldout(store->ctx(), 0) << "ERROR: failed to decode RGWObjectLegalHold" << dendl;
+        ldout(store->ctx(), 0) << "ERROR: failed to decode RGWObjectLegalHold"
+			       << dendl;
         return false;
       }
       if (obj_legal_hold.is_enabled()) {
@@ -501,6 +521,7 @@ struct op_env {
 }; /* op_env */
 
 class LCRuleOp;
+class WorkQ;
 
 struct lc_op_ctx {
   CephContext *cct;
@@ -515,12 +536,14 @@ struct lc_op_ctx {
   rgw_obj obj;
   RGWObjectCtx rctx;
   const DoutPrefixProvider *dpp;
+  WorkQ* wq;
 
-  lc_op_ctx(op_env& _env, rgw_bucket_dir_entry& _o,
-	    const DoutPrefixProvider *_dpp)
-    : cct(_env.store->ctx()), env(_env), o(_o),
+  lc_op_ctx(op_env& env, rgw_bucket_dir_entry& o,
+	    const DoutPrefixProvider *dpp, WorkQ* wq)
+    : cct(env.store->ctx()), env(env), o(o),
       store(env.store), bucket_info(env.bucket_info), op(env.op), ol(env.ol),
-      obj(env.bucket_info.bucket, o.key), rctx(env.store), dpp(_dpp) {}
+      obj(env.bucket_info.bucket, o.key), rctx(env.store), dpp(dpp), wq(wq)
+    {}
 }; /* lc_op_ctx */
 
 static int remove_expired_obj(lc_op_ctx& oc, bool remove_indeed)
@@ -605,7 +628,8 @@ public:
   LCOpRule(op_env& _env) : env(_env) {}
 
   void build();
-  int process(rgw_bucket_dir_entry& o, const DoutPrefixProvider *dpp);
+  int process(rgw_bucket_dir_entry& o, const DoutPrefixProvider *dpp,
+	      WorkQ* wq);
 }; /* LCOpRule */
 
 using WorkItem =
@@ -620,24 +644,36 @@ class WorkQ : public Thread
 {
 public:
   using unique_lock = std::unique_lock<std::mutex>;
-  using work_f = std::function<void(RGWLC::LCWorker*, WorkItem&)>;
+  using work_f = std::function<void(RGWLC::LCWorker*, WorkQ*, WorkItem&)>;
   using dequeue_result = boost::variant<void*, WorkItem>;
 
+  static constexpr uint32_t FLAG_NONE =        0x0000;
+  static constexpr uint32_t FLAG_EWAIT_SYNC =  0x0001;
+  static constexpr uint32_t FLAG_DWAIT_SYNC =  0x0002;
+  static constexpr uint32_t FLAG_EDRAIN_SYNC = 0x0004;
+
 private:
-  const work_f bsf = [](RGWLC::LCWorker* wk, WorkItem& wi) {};
+  const work_f bsf = [](RGWLC::LCWorker* wk, WorkQ* wq, WorkItem& wi) {};
   RGWLC::LCWorker* wk;
   uint32_t qmax;
+  int ix;
   std::mutex mtx;
   std::condition_variable cv;
+  uint32_t flags;
   vector<WorkItem> items;
   work_f f;
 
 public:
   WorkQ(RGWLC::LCWorker* wk, uint32_t ix, uint32_t qmax)
-    : wk(wk), qmax(qmax), f(bsf)
+    : wk(wk), qmax(qmax), ix(ix), flags(FLAG_NONE), f(bsf)
     {
-      create((string{"workpool_thr_"} + to_string(ix)).c_str());
+      create(thr_name().c_str());
     }
+
+  std::string thr_name() {
+    return std::string{"wp_thrd: "}
+    + std::to_string(wk->ix) + ", " + std::to_string(ix);
+  }
 
   void setf(work_f _f) {
     f = _f;
@@ -647,15 +683,20 @@ public:
     unique_lock uniq(mtx);
     while ((!wk->get_lc()->going_down()) &&
 	   (items.size() > qmax)) {
+      flags |= FLAG_EWAIT_SYNC;
       cv.wait_for(uniq, 200ms);
     }
     items.push_back(item);
+    if (flags & FLAG_DWAIT_SYNC) {
+      flags &= ~FLAG_DWAIT_SYNC;
+      cv.notify_one();
+    }
   }
 
   void drain() {
     unique_lock uniq(mtx);
-    while ((!wk->get_lc()->going_down()) &&
-	   (items.size() > 0)) {
+    flags |= FLAG_EDRAIN_SYNC;
+    while (flags & FLAG_EDRAIN_SYNC) {
       cv.wait_for(uniq, 200ms);
     }
   }
@@ -665,11 +706,20 @@ private:
     unique_lock uniq(mtx);
     while ((!wk->get_lc()->going_down()) &&
 	   (items.size() == 0)) {
+      /* clear drain state, as we are NOT doing work and qlen==0 */
+      if (flags & FLAG_EDRAIN_SYNC) {
+	flags &= ~FLAG_EDRAIN_SYNC;
+      }
+      flags |= FLAG_DWAIT_SYNC;
       cv.wait_for(uniq, 200ms);
     }
     if (items.size() > 0) {
       auto item = items.back();
       items.pop_back();
+      if (flags & FLAG_EWAIT_SYNC) {
+	flags &= ~FLAG_EWAIT_SYNC;
+	cv.notify_one();
+      }
       return {item};
     }
     return nullptr;
@@ -682,7 +732,7 @@ private:
 	/* going down */
 	break;
       }
-      f(wk, boost::get<WorkItem>(item));
+      f(wk, this, boost::get<WorkItem>(item));
     }
     return nullptr;
   }
@@ -723,17 +773,22 @@ public:
   }
 }; /* WorkPool */
 
-RGWLC::LCWorker::LCWorker(const DoutPrefixProvider* _dpp, CephContext *_cct,
-			  RGWLC *_lc)
-  : dpp(_dpp), cct(_cct), lc(_lc)
+RGWLC::LCWorker::LCWorker(const DoutPrefixProvider* dpp, CephContext *cct,
+			  RGWLC *lc, int ix)
+  : dpp(dpp), cct(cct), lc(lc), ix(ix)
 {
   auto wpw = cct->_conf.get_val<int64_t>("rgw_lc_max_wp_worker");
   workpool = new WorkPool(this, wpw, 512);
 }
 
+static inline bool worker_should_stop(time_t stop_at)
+{
+  return stop_at < time(nullptr);
+}
+
 int RGWLC::handle_multipart_expiration(
   RGWRados::Bucket *target, const multimap<string, lc_op>& prefix_map,
-  LCWorker* worker)
+  LCWorker* worker, time_t stop_at)
 {
   MultipartMetaFilter mp_filter;
   vector<rgw_bucket_dir_entry> objs;
@@ -750,7 +805,7 @@ int RGWLC::handle_multipart_expiration(
   list_op.params.ns = RGW_OBJ_NS_MULTIPART;
   list_op.params.filter = &mp_filter;
 
-  auto pf = [&](RGWLC::LCWorker* wk, WorkItem& wi) {
+  auto pf = [&](RGWLC::LCWorker* wk, WorkQ* wq, WorkItem& wi) {
     auto wt = boost::get<std::tuple<const lc_op&, rgw_bucket_dir_entry>>(wi);
     auto& [rule, obj] = wt;
     RGWMPObj mp_obj;
@@ -764,11 +819,13 @@ int RGWLC::handle_multipart_expiration(
       if (ret < 0 && ret != -ERR_NO_SUCH_UPLOAD) {
 	ldpp_dout(wk->get_lc(), 0)
 	  << "ERROR: abort_multipart_upload failed, ret=" << ret
+	  << wq->thr_name()
 	  << ", meta:" << obj.key
 	  << dendl;
       } else if (ret == -ERR_NO_SUCH_UPLOAD) {
 	ldpp_dout(wk->get_lc(), 5)
 	  << "ERROR: abort_multipart_upload failed, ret=" << ret
+	  << wq->thr_name()
 	  << ", meta:" << obj.key
 	  << dendl;
       }
@@ -779,6 +836,14 @@ int RGWLC::handle_multipart_expiration(
 
   for (auto prefix_iter = prefix_map.begin(); prefix_iter != prefix_map.end();
        ++prefix_iter) {
+
+    if (worker_should_stop(stop_at)) {
+      ldout(cct, 5) << __func__ << " interval budget EXPIRED worker "
+		     << worker->ix
+		     << dendl;
+      return 0;
+    }
+
     if (!prefix_iter->second.status || prefix_iter->second.mp_expiration <= 0) {
       continue;
     }
@@ -799,7 +864,6 @@ int RGWLC::handle_multipart_expiration(
 	  {prefix_iter->second, *obj_iter};
 	worker->workpool->enqueue(WorkItem{t1});
 	if (going_down()) {
-	  worker->workpool->drain();
 	  return 0;
 	}
       } /* for objs */
@@ -864,7 +928,8 @@ static int check_tags(lc_op_ctx& oc, bool *skip)
 			    oc.rctx, tags_bl);
     if (ret < 0) {
       if (ret != -ENODATA) {
-        ldout(oc.cct, 5) << "ERROR: read_obj_tags returned r=" << ret << dendl;
+        ldout(oc.cct, 5) << "ERROR: read_obj_tags returned r="
+			 << ret << " " << oc.wq->thr_name() << dendl;
       }
       return 0;
     }
@@ -873,12 +938,16 @@ static int check_tags(lc_op_ctx& oc, bool *skip)
       auto iter = tags_bl.cbegin();
       dest_obj_tags.decode(iter);
     } catch (buffer::error& err) {
-      ldout(oc.cct,0) << "ERROR: caught buffer::error, couldn't decode TagSet" << dendl;
+      ldout(oc.cct,0) << "ERROR: caught buffer::error, couldn't decode TagSet "
+		      << oc.wq->thr_name() << dendl;
       return -EIO;
     }
 
     if (! has_all_tags(op, dest_obj_tags)) {
-      ldout(oc.cct, 20) << __func__ << "() skipping obj " << oc.obj << " as tags do not match in rule: " << op.id << dendl;
+      ldout(oc.cct, 20) << __func__ << "() skipping obj " << oc.obj
+			<< " as tags do not match in rule: "
+			<< op.id << " "
+			<< oc.wq->thr_name() << dendl;
       return 0;
     }
   }
@@ -902,7 +971,9 @@ public:
       if (ret == -ENOENT) {
         return false;
       }
-      ldout(oc.cct, 0) << "ERROR: check_tags on obj=" << oc.obj << " returned ret=" << ret << dendl;
+      ldout(oc.cct, 0) << "ERROR: check_tags on obj=" << oc.obj
+		       << " returned ret=" << ret << " "
+		       << oc.wq->thr_name() << dendl;
       return false;
     }
 
@@ -915,7 +986,9 @@ public:
   bool check(lc_op_ctx& oc, ceph::real_time *exp_time) override {
     auto& o = oc.o;
     if (!o.is_current()) {
-      ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": not current, skipping" << dendl;
+      ldout(oc.cct, 20) << __func__ << "(): key=" << o.key
+			<< ": not current, skipping "
+			<< oc.wq->thr_name() << dendl;
       return false;
     }
     if (o.is_delete_marker()) {
@@ -932,7 +1005,9 @@ public:
     auto& op = oc.op;
     if (op.expiration <= 0) {
       if (op.expiration_date == boost::none) {
-        ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": no expiration set in rule, skipping" << dendl;
+        ldout(oc.cct, 20) << __func__ << "(): key=" << o.key
+			  << ": no expiration set in rule, skipping "
+			  << oc.wq->thr_name() << dendl;
         return false;
       }
       is_expired = ceph_clock_now() >=
@@ -942,7 +1017,9 @@ public:
       is_expired = obj_has_expired(oc.cct, mtime, op.expiration, exp_time);
     }
 
-    ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": is_expired=" << (int)is_expired << dendl;
+    ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": is_expired="
+		      << (int)is_expired << " "
+		      << oc.wq->thr_name() << dendl;
     return is_expired;
   }
 
@@ -956,11 +1033,13 @@ public:
     }
     if (r < 0) {
       ldout(oc.cct, 0) << "ERROR: remove_expired_obj " 
-      << oc.bucket_info.bucket << ":" << o.key 
-      << " " << cpp_strerror(r) << dendl;
+		       << oc.bucket_info.bucket << ":" << o.key 
+		       << " " << cpp_strerror(r) << " "
+		       << oc.wq->thr_name() << dendl;
       return r;
     }
-    ldout(oc.cct, 2) << "DELETED:" << oc.bucket_info.bucket << ":" << o.key << dendl;
+    ldout(oc.cct, 2) << "DELETED:" << oc.bucket_info.bucket << ":" << o.key
+		     << " " << oc.wq->thr_name() << dendl;
     return 0;
   }
 };
@@ -970,7 +1049,9 @@ public:
   bool check(lc_op_ctx& oc, ceph::real_time *exp_time) override {
     auto& o = oc.o;
     if (o.is_current()) {
-      ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": current version, skipping" << dendl;
+      ldout(oc.cct, 20) << __func__ << "(): key=" << o.key
+			<< ": current version, skipping "
+			<< oc.wq->thr_name() << dendl;
       return false;
     }
 
@@ -978,7 +1059,9 @@ public:
     int expiration = oc.op.noncur_expiration;
     bool is_expired = obj_has_expired(oc.cct, mtime, expiration, exp_time);
 
-    ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": is_expired=" << is_expired << dendl;
+    ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": is_expired="
+		      << is_expired << " "
+		      << oc.wq->thr_name() << dendl;
     return is_expired &&
       pass_object_lock_check(oc.store->getRados(),
 			     oc.bucket_info, oc.obj, oc.rctx);
@@ -989,11 +1072,14 @@ public:
     int r = remove_expired_obj(oc, true);
     if (r < 0) {
       ldout(oc.cct, 0) << "ERROR: remove_expired_obj (non-current expiration) " 
-      << oc.bucket_info.bucket << ":" << o.key 
-      << " " << cpp_strerror(r) << dendl;
+		       << oc.bucket_info.bucket << ":" << o.key 
+		       << " " << cpp_strerror(r)
+		       << " " << oc.wq->thr_name() << dendl;
       return r;
     }
-    ldout(oc.cct, 2) << "DELETED:" << oc.bucket_info.bucket << ":" << o.key << " (non-current expiration)" << dendl;
+    ldout(oc.cct, 2) << "DELETED:" << oc.bucket_info.bucket << ":" << o.key
+		     << " (non-current expiration) "
+		     << oc.wq->thr_name() << dendl;
     return 0;
   }
 };
@@ -1003,12 +1089,16 @@ public:
   bool check(lc_op_ctx& oc, ceph::real_time *exp_time) override {
     auto& o = oc.o;
     if (!o.is_delete_marker()) {
-      ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": not a delete marker, skipping" << dendl;
+      ldout(oc.cct, 20) << __func__ << "(): key=" << o.key
+			<< ": not a delete marker, skipping "
+			<< oc.wq->thr_name() << dendl;
       return false;
     }
 
     if (oc.ol.next_has_same_name()) {
-      ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": next is same object, skipping" << dendl;
+      ldout(oc.cct, 20) << __func__ << "(): key=" << o.key
+			<< ": next is same object, skipping "
+			<< oc.wq->thr_name() << dendl;
       return false;
     }
 
@@ -1022,11 +1112,15 @@ public:
     int r = remove_expired_obj(oc, true);
     if (r < 0) {
       ldout(oc.cct, 0) << "ERROR: remove_expired_obj (delete marker expiration) "
-      << oc.bucket_info.bucket << ":" << o.key
-      << " " << cpp_strerror(r) << dendl;
+		       << oc.bucket_info.bucket << ":" << o.key
+		       << " " << cpp_strerror(r)
+		       << " " << oc.wq->thr_name()
+		       << dendl;
       return r;
     }
-    ldout(oc.cct, 2) << "DELETED:" << oc.bucket_info.bucket << ":" << o.key << " (delete marker expiration)" << dendl;
+    ldout(oc.cct, 2) << "DELETED:" << oc.bucket_info.bucket << ":" << o.key
+		     << " (delete marker expiration) "
+		     << oc.wq->thr_name() << dendl;
     return 0;
   }
 };
@@ -1057,7 +1151,9 @@ public:
     bool is_expired;
     if (transition.days < 0) {
       if (transition.date == boost::none) {
-        ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": no transition day/date set in rule, skipping" << dendl;
+        ldout(oc.cct, 20) << __func__ << "(): key=" << o.key
+			  << ": no transition day/date set in rule, skipping "
+			  << oc.wq->thr_name() << dendl;
         return false;
       }
       is_expired = ceph_clock_now() >=
@@ -1067,7 +1163,9 @@ public:
       is_expired = obj_has_expired(oc.cct, mtime, transition.days, exp_time);
     }
 
-    ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": is_expired=" << is_expired << dendl;
+    ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": is_expired="
+		      << is_expired << " "
+		      << oc.wq->thr_name() << dendl;
 
     need_to_process =
       (rgw_placement_rule::get_canonical_storage_class(o.meta.storage_class) !=
@@ -1089,9 +1187,11 @@ public:
 
     if (!oc.store->svc()->zone->get_zone_params().
 	valid_placement(target_placement)) {
-      ldpp_dout(oc.dpp, 0) << "ERROR: non existent dest placement: " << target_placement
+      ldpp_dout(oc.dpp, 0) << "ERROR: non existent dest placement: "
+			   << target_placement
                            << " bucket="<< oc.bucket_info.bucket
-                           << " rule_id=" << oc.op.id << dendl;
+                           << " rule_id=" << oc.op.id
+			   << " " << oc.wq->thr_name() << dendl;
       return -EINVAL;
     }
 
@@ -1100,12 +1200,16 @@ public:
       o.versioned_epoch, oc.dpp, null_yield);
     if (r < 0) {
       ldpp_dout(oc.dpp, 0) << "ERROR: failed to transition obj " 
-      << oc.bucket_info.bucket << ":" << o.key 
-      << " -> " << transition.storage_class 
-      << " " << cpp_strerror(r) << dendl;
+			   << oc.bucket_info.bucket << ":" << o.key 
+			   << " -> " << transition.storage_class 
+			   << " " << cpp_strerror(r)
+			   << " " << oc.wq->thr_name() << dendl;
       return r;
     }
-    ldpp_dout(oc.dpp, 2) << "TRANSITIONED:" << oc.bucket_info.bucket << ":" << o.key << " -> " << transition.storage_class << dendl;
+    ldpp_dout(oc.dpp, 2) << "TRANSITIONED:" << oc.bucket_info.bucket
+			 << ":" << o.key << " -> "
+			 << transition.storage_class
+			 << " " << oc.wq->thr_name() << dendl;
     return 0;
   }
 };
@@ -1166,9 +1270,11 @@ void LCOpRule::build()
   }
 }
 
-int LCOpRule::process(rgw_bucket_dir_entry& o, const DoutPrefixProvider *dpp)
+int LCOpRule::process(rgw_bucket_dir_entry& o,
+		      const DoutPrefixProvider *dpp,
+		      WorkQ* wq)
 {
-  lc_op_ctx ctx(env, o, dpp);
+  lc_op_ctx ctx(env, o, dpp, wq);
 
   unique_ptr<LCOpAction> *selected = nullptr;
   real_time exp;
@@ -1205,25 +1311,30 @@ int LCOpRule::process(rgw_bucket_dir_entry& o, const DoutPrefixProvider *dpp)
     }
 
     if (!cont) {
-      ldpp_dout(dpp, 20) << __func__ << "(): key=" << o.key << ": no rule match, skipping" << dendl;
+      ldpp_dout(dpp, 20) << __func__ << "(): key=" << o.key
+			 << ": no rule match, skipping "
+			 << " " << wq->thr_name() << dendl;
       return 0;
     }
 
     int r = (*selected)->process(ctx);
     if (r < 0) {
       ldpp_dout(dpp, 0) << "ERROR: remove_expired_obj " 
-      << env.bucket_info.bucket << ":" << o.key
-      << " " << cpp_strerror(r) << dendl;
+			<< env.bucket_info.bucket << ":" << o.key
+			<< " " << cpp_strerror(r)
+			<< " " << wq->thr_name() << dendl;
       return r;
     }
-    ldpp_dout(dpp, 20) << "processed:" << env.bucket_info.bucket << ":" << o.key << dendl;
+    ldpp_dout(dpp, 20) << "processed:" << env.bucket_info.bucket << ":"
+		       << o.key << " " << wq->thr_name() << dendl;
   }
 
   return 0;
 
 }
 
-int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker)
+int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
+			     time_t stop_at)
 {
   RGWLifecycleConfiguration  config(cct);
   RGWBucketInfo bucket_info;
@@ -1239,13 +1350,22 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker)
     store->svc(), bucket_tenant, bucket_name, bucket_info, NULL, null_yield,
     &bucket_attrs);
   if (ret < 0) {
-    ldpp_dout(this, 0) << "LC:get_bucket_info for " << bucket_name << " failed" << dendl;
+    ldpp_dout(this, 0) << "LC:get_bucket_info for " << bucket_name
+		       << " failed" << dendl;
     return ret;
   }
 
+  auto stack_guard = make_scope_guard(
+    [&worker, &bucket_info]
+      {
+	worker->workpool->drain();
+      }
+    );
+
   if (bucket_info.bucket.marker != bucket_marker) {
-    ldpp_dout(this, 1) << "LC: deleting stale entry found for bucket=" << bucket_tenant
-                       << ":" << bucket_name << " cur_marker=" << bucket_info.bucket.marker
+    ldpp_dout(this, 1) << "LC: deleting stale entry found for bucket="
+		       << bucket_tenant << ":" << bucket_name
+		       << " cur_marker=" << bucket_info.bucket.marker
                        << " orig_marker=" << bucket_marker << dendl;
     return -ENOENT;
   }
@@ -1260,21 +1380,23 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker)
   try {
       config.decode(iter);
     } catch (const buffer::error& e) {
-      ldpp_dout(this, 0) << __func__ <<  "() decode life cycle config failed" << dendl;
+      ldpp_dout(this, 0) << __func__ <<  "() decode life cycle config failed"
+			 << dendl;
       return -1;
     }
 
-  auto pf = [](RGWLC::LCWorker* wk, WorkItem& wi) {
+  auto pf = [](RGWLC::LCWorker* wk, WorkQ* wq, WorkItem& wi) {
     auto wt =
       boost::get<std::tuple<LCOpRule&, rgw_bucket_dir_entry>>(wi);
     auto& [op_rule, o] = wt;
     ldpp_dout(wk->get_lc(), 20)
-      << __func__ << "(): key=" << o.key << dendl;
-    std::cout << "KEY2: " << o.key << std::endl;
-    int ret = op_rule.process(o, wk->dpp);
+      << __func__ << "(): key=" << o.key << wq->thr_name() 
+      << dendl;
+    int ret = op_rule.process(o, wk->dpp, wq);
     if (ret < 0) {
       ldpp_dout(wk->get_lc(), 20)
 	<< "ERROR: orule.process() returned ret=" << ret
+	<< wq->thr_name() 
 	<< dendl;
     }
   };
@@ -1289,11 +1411,20 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker)
   rgw_obj_key next_marker;
   for(auto prefix_iter = prefix_map.begin(); prefix_iter != prefix_map.end();
       ++prefix_iter) {
+
+    if (worker_should_stop(stop_at)) {
+      ldout(cct, 5) << __func__ << " interval budget EXPIRED worker "
+		     << worker->ix
+		     << dendl;
+      return 0;
+    }
+
     auto& op = prefix_iter->second;
     if (!is_valid_op(op)) {
       continue;
     }
-    ldpp_dout(this, 20) << __func__ << "(): prefix=" << prefix_iter->first << dendl;
+    ldpp_dout(this, 20) << __func__ << "(): prefix=" << prefix_iter->first
+			<< dendl;
     if (prefix_iter != prefix_map.begin() && 
         (prefix_iter->first.compare(0, prev(prefix_iter)->first.length(),
 				    prev(prefix_iter)->first) == 0)) {
@@ -1316,11 +1447,6 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker)
     op_env oenv(op, store, worker, bucket_info, ol);
     LCOpRule orule(oenv);
     orule.build(); // why can't ctor do it?
-#if 0
-    /* would permit passing o by reference, removes fetch overlap */
-    auto fetch_barrier = [&worker]()
-			   { worker->workpool->drain(); };
-#endif
     rgw_bucket_dir_entry* o{nullptr};
     for (; ol.get_obj(&o /* , fetch_barrier */); ol.next()) {
       std::tuple<LCOpRule&, rgw_bucket_dir_entry> t1 = {orule, *o};
@@ -1329,7 +1455,7 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker)
     worker->workpool->drain();
   }
 
-  ret = handle_multipart_expiration(&target, prefix_map, worker);
+  ret = handle_multipart_expiration(&target, prefix_map, worker, stop_at);
   return ret;
 }
 
@@ -1350,15 +1476,17 @@ int RGWLC::bucket_lc_post(int index, int max_lock_sec,
   do {
     int ret = l.lock_exclusive(
       &store->getRados()->lc_pool_ctx, obj_names[index]);
-    if (ret == -EBUSY || ret == -EEXIST) { /* already locked by another lc processor */
+    if (ret == -EBUSY || ret == -EEXIST) {
+      /* already locked by another lc processor */
       ldpp_dout(this, 0) << "RGWLC::bucket_lc_post() failed to acquire lock on "
-          << obj_names[index] << ", sleep 5, try again" << dendl;
+			 << obj_names[index] << ", sleep 5, try again " << dendl;
       sleep(5);
       continue;
     }
     if (ret < 0)
       return 0;
-    ldpp_dout(this, 20) << "RGWLC::bucket_lc_post() lock " << obj_names[index] << dendl;
+    ldpp_dout(this, 20) << "RGWLC::bucket_lc_post() lock " << obj_names[index]
+			<< dendl;
     if (result ==  -ENOENT) {
       ret = cls_rgw_lc_rm_entry(store->getRados()->lc_pool_ctx,
 				obj_names[index],  entry);
@@ -1381,7 +1509,8 @@ int RGWLC::bucket_lc_post(int index, int max_lock_sec,
     }
 clean:
     l.unlock(&store->getRados()->lc_pool_ctx, obj_names[index]);
-    ldpp_dout(this, 20) << "RGWLC::bucket_lc_post() unlock " << obj_names[index] << dendl;
+    ldpp_dout(this, 20) << "RGWLC::bucket_lc_post() unlock "
+			<< obj_names[index] << dendl;
     return 0;
   } while (true);
 }
@@ -1434,12 +1563,42 @@ int RGWLC::process(LCWorker* worker)
   return 0;
 }
 
+bool RGWLC::expired_session(time_t started)
+{
+  time_t interval = (cct->_conf->rgw_lc_debug_interval > 0)
+    ? cct->_conf->rgw_lc_debug_interval
+    : 24*60*60;
+
+  auto now = time(nullptr);
+
+  dout(16) << "RGWLC::expired_session"
+	   << " started: " << started
+	   << " interval: " << interval << "(*2==" << 2*interval << ")"
+	   << " now: " << now
+	   << dendl;
+
+  return (started + 2*interval < now);
+}
+
+time_t RGWLC::thread_stop_at()
+{
+  uint64_t interval = (cct->_conf->rgw_lc_debug_interval > 0)
+    ? cct->_conf->rgw_lc_debug_interval
+    : 24*60*60;
+
+  return time(nullptr) + interval;
+}
+
 int RGWLC::process(int index, int max_lock_secs, LCWorker* worker)
 {
+  dout(5) << "RGWLC::process(): ENTER: "
+	  << "index: " << index << " worker ix: " << worker->ix
+	  << dendl;
+
   rados::cls::lock::Lock l(lc_index_lock_name);
   do {
     utime_t now = ceph_clock_now();
-    //string = bucket_name:bucket_id ,int = LC_BUCKET_STATUS
+    //string = bucket_name:bucket_id, start_time, int = LC_BUCKET_STATUS
     cls_rgw_lc_entry entry;
     if (max_lock_secs <= 0)
       return -EAGAIN;
@@ -1449,7 +1608,8 @@ int RGWLC::process(int index, int max_lock_secs, LCWorker* worker)
 
     int ret = l.lock_exclusive(&store->getRados()->lc_pool_ctx,
 			       obj_names[index]);
-    if (ret == -EBUSY || ret == -EEXIST) { /* already locked by another lc processor */
+    if (ret == -EBUSY || ret == -EEXIST) {
+      /* already locked by another lc processor */
       ldpp_dout(this, 0) << "RGWLC::process() failed to acquire lock on "
           << obj_names[index] << ", sleep 5, try again" << dendl;
       sleep(5);
@@ -1470,12 +1630,20 @@ int RGWLC::process(int index, int max_lock_secs, LCWorker* worker)
     if (! (cct->_conf->rgw_lc_lock_max_time == 9969)) {
       ret = cls_rgw_lc_get_entry(store->getRados()->lc_pool_ctx,
 				 obj_names[index], head.marker, entry);
-      if ((entry.status == lc_processing) &&
-	  (true /* XXXX expired epoch! */)) {
-	dout(5) << "RGWLC::process(): ACTIVE entry: " << entry
-		<< " index: " << index << " worker ix: " << worker->ix
-		<< dendl;
-	goto exit;
+      if (ret >= 0) {
+	if (entry.status == lc_processing) {
+	  if (expired_session(entry.start_time)) {
+	    dout(5) << "RGWLC::process(): STALE lc session found for: " << entry
+		    << " index: " << index << " worker ix: " << worker->ix
+		    << " (clearing)"
+		    << dendl;
+	  } else {
+	    dout(5) << "RGWLC::process(): ACTIVE entry: " << entry
+		    << " index: " << index << " worker ix: " << worker->ix
+		  << dendl;
+	    goto exit;
+	  }
+	}
       }
     }
 
@@ -1532,7 +1700,7 @@ int RGWLC::process(int index, int max_lock_secs, LCWorker* worker)
 	    << dendl;
 
     l.unlock(&store->getRados()->lc_pool_ctx, obj_names[index]);
-    ret = bucket_lc_process(entry.bucket, worker);
+    ret = bucket_lc_process(entry.bucket, worker, thread_stop_at());
     bucket_lc_post(index, max_lock_secs, entry, ret, worker);
   } while(1);
 
@@ -1547,7 +1715,7 @@ void RGWLC::start_processor()
   workers.reserve(maxw);
   for (int ix = 0; ix < maxw; ++ix) {
     auto worker  =
-      std::make_unique<RGWLC::LCWorker>(this /* dpp */, cct, this);
+      std::make_unique<RGWLC::LCWorker>(this /* dpp */, cct, this, ix);
     worker->create((string{"lifecycle_thr_"} + to_string(ix)).c_str());
     workers.emplace_back(std::move(worker));
   }

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -431,7 +431,6 @@ public:
       store(_store), bucket_info(_bucket_info),
       target(store->getRados(), bucket_info), list_op(&target) {
     list_op.params.list_versions = bucket_info.versioned();
-    list_op.params.allow_unordered = true;
     delay_ms = store->ctx()->_conf.get_val<int64_t>("rgw_lc_thread_delay");
   }
 
@@ -500,6 +499,7 @@ public:
        * only happen if is_truncated is false */
       return boost::none;
     }
+
     return ((obj_iter + 1)->key.name);
   }
 
@@ -509,7 +509,7 @@ struct op_env {
 
   using LCWorker = RGWLC::LCWorker;
 
-  lc_op& op;
+  lc_op op;
   rgw::sal::RGWRadosStore *store;
   LCWorker* worker;
   RGWBucketInfo& bucket_info;
@@ -526,12 +526,14 @@ class WorkQ;
 
 struct lc_op_ctx {
   CephContext *cct;
-  op_env& env;
-  rgw_bucket_dir_entry& o;
+  op_env env;
+  rgw_bucket_dir_entry o;
+  boost::optional<std::string> next_key_name;
+  ceph::real_time dm_effective_mtime;
 
   rgw::sal::RGWRadosStore *store;
   RGWBucketInfo& bucket_info;
-  lc_op& op;
+  lc_op& op; // ok--refers to expanded env.op
   LCObjsLister& ol;
 
   rgw_obj obj;
@@ -540,11 +542,19 @@ struct lc_op_ctx {
   WorkQ* wq;
 
   lc_op_ctx(op_env& env, rgw_bucket_dir_entry& o,
+	    boost::optional<std::string> next_key_name,
+	    ceph::real_time dem,
 	    const DoutPrefixProvider *dpp, WorkQ* wq)
-    : cct(env.store->ctx()), env(env), o(o),
+    : cct(env.store->ctx()), env(env), o(o), next_key_name(next_key_name),
       store(env.store), bucket_info(env.bucket_info), op(env.op), ol(env.ol),
       obj(env.bucket_info.bucket, o.key), rctx(env.store), dpp(dpp), wq(wq)
     {}
+
+  bool next_has_same_name(const std::string& key_name) {
+    return (next_key_name && key_name.compare(
+	      boost::get<std::string>(next_key_name)) == 0);
+  }
+
 }; /* lc_op_ctx */
 
 static int remove_expired_obj(lc_op_ctx& oc, bool remove_indeed)
@@ -582,19 +592,12 @@ static int remove_expired_obj(lc_op_ctx& oc, bool remove_indeed)
 } /* remove_expired_obj */
 
 class LCOpAction {
-protected:
-  boost::optional<std::string> next_key_name;
 public:
   virtual ~LCOpAction() {}
 
-  bool next_has_same_name(const std::string& key_name) {
-    return (next_key_name && key_name.compare(
-	      boost::get<std::string>(next_key_name)) == 0);
-  }
-
   virtual bool check(lc_op_ctx& oc, ceph::real_time *exp_time) {
     return false;
-  };
+  }
 
   /* called after check(). Check should tell us whether this action
    * is applicable. If there are multiple actions, we'll end up executing
@@ -614,6 +617,8 @@ public:
   virtual int process(lc_op_ctx& oc) {
     return 0;
   }
+
+  friend class LCOpRule;
 }; /* LCOpAction */
 
 class LCOpFilter {
@@ -627,15 +632,22 @@ virtual ~LCOpFilter() {}
 class LCOpRule {
   friend class LCOpAction;
 
-  op_env& env;
+  op_env env;
+  boost::optional<std::string> next_key_name;
+  ceph::real_time dm_effective_mtime;
 
-  std::vector<unique_ptr<LCOpFilter> > filters;
-  std::vector<unique_ptr<LCOpAction> > actions;
+  std::vector<shared_ptr<LCOpFilter> > filters; // n.b., sharing ovhd
+  std::vector<shared_ptr<LCOpAction> > actions;
 
 public:
   LCOpRule(op_env& _env) : env(_env) {}
 
+  boost::optional<std::string> get_next_key_name() {
+    return next_key_name;
+  }
+
   void build();
+  void update();
   int process(rgw_bucket_dir_entry& o, const DoutPrefixProvider *dpp,
 	      WorkQ* wq);
 }; /* LCOpRule */
@@ -643,9 +655,9 @@ public:
 using WorkItem =
   boost::variant<void*,
 		 /* out-of-line delete */
-		 std::tuple<LCOpRule&, rgw_bucket_dir_entry>,
+		 std::tuple<LCOpRule, rgw_bucket_dir_entry>,
 		 /* uncompleted MPU expiration */
-		 std::tuple<const lc_op&, rgw_bucket_dir_entry>,
+		 std::tuple<lc_op, rgw_bucket_dir_entry>,
 		 rgw_bucket_dir_entry>;
 
 class WorkQ : public Thread
@@ -814,7 +826,7 @@ int RGWLC::handle_multipart_expiration(
   list_op.params.filter = &mp_filter;
 
   auto pf = [&](RGWLC::LCWorker* wk, WorkQ* wq, WorkItem& wi) {
-    auto wt = boost::get<std::tuple<const lc_op&, rgw_bucket_dir_entry>>(wi);
+    auto wt = boost::get<std::tuple<lc_op, rgw_bucket_dir_entry>>(wi);
     auto& [rule, obj] = wt;
     RGWMPObj mp_obj;
     if (obj_has_expired(cct, obj.meta.mtime, rule.mp_expiration)) {
@@ -868,7 +880,7 @@ int RGWLC::handle_multipart_expiration(
       }
 
       for (auto obj_iter = objs.begin(); obj_iter != objs.end(); ++obj_iter) {
-	std::tuple<const lc_op&, rgw_bucket_dir_entry> t1 =
+	std::tuple<lc_op, rgw_bucket_dir_entry> t1 =
 	  {prefix_iter->second, *obj_iter};
 	worker->workpool->enqueue(WorkItem{t1});
 	if (going_down()) {
@@ -991,9 +1003,7 @@ public:
 
 class LCOpAction_CurrentExpiration : public LCOpAction {
 public:
-  LCOpAction_CurrentExpiration(op_env& env) {
-    next_key_name = env.ol.next_key_name();
-  }
+  LCOpAction_CurrentExpiration(op_env& env) {}
 
   bool check(lc_op_ctx& oc, ceph::real_time *exp_time) override {
     auto& o = oc.o;
@@ -1004,9 +1014,17 @@ public:
       return false;
     }
     if (o.is_delete_marker()) {
-      if (next_has_same_name(o.key.name)) {
+      std::string nkn;
+      if (oc.next_key_name) nkn = *oc.next_key_name;
+      if (oc.next_has_same_name(o.key.name)) {
+	ldout(oc.cct, 7) << __func__ << "(): dm-check SAME: key=" << o.key
+		       << " next_key_name: %%" << nkn << "%% "
+		       << oc.wq->thr_name() << dendl;
 	return false;
       } else {
+	ldout(oc.cct, 7) << __func__ << "(): dm-check DELE: key=" << o.key
+			 << " next_key_name: %%" << nkn << "%% "
+			 << oc.wq->thr_name() << dendl;
         *exp_time = real_clock::now();
         return true;
       }
@@ -1040,18 +1058,29 @@ public:
     int r;
     if (o.is_delete_marker()) {
       r = remove_expired_obj(oc, true);
-    } else {
-      r = remove_expired_obj(oc, !oc.bucket_info.versioned());
-    }
-    if (r < 0) {
-      ldout(oc.cct, 0) << "ERROR: remove_expired_obj " 
-		       << oc.bucket_info.bucket << ":" << o.key 
-		       << " " << cpp_strerror(r) << " "
-		       << oc.wq->thr_name() << dendl;
+      if (r < 0) {
+	ldout(oc.cct, 0) << "ERROR: current is-dm remove_expired_obj "
+			 << oc.bucket_info.bucket << ":" << o.key
+			 << " " << cpp_strerror(r) << " "
+			 << oc.wq->thr_name() << dendl;
       return r;
+      }
+      ldout(oc.cct, 2) << "DELETED: current is-dm "
+		       << oc.bucket_info.bucket << ":" << o.key
+		       << " " << oc.wq->thr_name() << dendl;
+    } else {
+      /* ! o.is_delete_marker() */
+      r = remove_expired_obj(oc, !oc.bucket_info.versioned());
+      if (r < 0) {
+	ldout(oc.cct, 0) << "ERROR: remove_expired_obj "
+			 << oc.bucket_info.bucket << ":" << o.key
+			 << " " << cpp_strerror(r) << " "
+			 << oc.wq->thr_name() << dendl;
+	return r;
+      }
+      ldout(oc.cct, 2) << "DELETED:" << oc.bucket_info.bucket << ":" << o.key
+		       << " " << oc.wq->thr_name() << dendl;
     }
-    ldout(oc.cct, 2) << "DELETED:" << oc.bucket_info.bucket << ":" << o.key
-		     << " " << oc.wq->thr_name() << dendl;
     return 0;
   }
 };
@@ -1103,9 +1132,7 @@ public:
 
 class LCOpAction_DMExpiration : public LCOpAction {
 public:
-  LCOpAction_DMExpiration(op_env& env) {
-    next_key_name = env.ol.next_key_name();
-  }
+  LCOpAction_DMExpiration(op_env& env) {}
 
   bool check(lc_op_ctx& oc, ceph::real_time *exp_time) override {
     auto& o = oc.o;
@@ -1115,7 +1142,7 @@ public:
 			<< oc.wq->thr_name() << dendl;
       return false;
     }
-    if (next_has_same_name(o.key.name)) {
+    if (oc.next_has_same_name(o.key.name)) {
       ldout(oc.cct, 20) << __func__ << "(): key=" << o.key
 			<< ": next is same object, skipping "
 			<< oc.wq->thr_name() << dendl;
@@ -1250,20 +1277,17 @@ public:
 
 class LCOpAction_NonCurrentTransition : public LCOpAction_Transition {
 protected:
-  ceph::real_time effective_mtime;
-
   bool check_current_state(bool is_current) override {
     return !is_current;
   }
 
   ceph::real_time get_effective_mtime(lc_op_ctx& oc) override {
-    return effective_mtime;
+    return oc.dm_effective_mtime;
   }
 public:
   LCOpAction_NonCurrentTransition(op_env& env,
 				  const transition_action& _transition)
-    : LCOpAction_Transition(_transition),
-      effective_mtime(env.ol.get_prev_obj().meta.mtime)
+    : LCOpAction_Transition(_transition)
     {}
 };
 
@@ -1295,13 +1319,18 @@ void LCOpRule::build()
   }
 }
 
+void LCOpRule::update()
+{
+  next_key_name = env.ol.next_key_name();
+  dm_effective_mtime = env.ol.get_prev_obj().meta.mtime;
+}
+
 int LCOpRule::process(rgw_bucket_dir_entry& o,
 		      const DoutPrefixProvider *dpp,
 		      WorkQ* wq)
 {
-  lc_op_ctx ctx(env, o, dpp, wq);
-
-  unique_ptr<LCOpAction> *selected = nullptr;
+  lc_op_ctx ctx(env, o, next_key_name, dm_effective_mtime, dpp, wq);
+  shared_ptr<LCOpAction> *selected = nullptr; // n.b., req'd by sharing
   real_time exp;
 
   for (auto& a : actions) {
@@ -1412,8 +1441,9 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
 
   auto pf = [](RGWLC::LCWorker* wk, WorkQ* wq, WorkItem& wi) {
     auto wt =
-      boost::get<std::tuple<LCOpRule&, rgw_bucket_dir_entry>>(wi);
+      boost::get<std::tuple<LCOpRule, rgw_bucket_dir_entry>>(wi);
     auto& [op_rule, o] = wt;
+
     ldpp_dout(wk->get_lc(), 20)
       << __func__ << "(): key=" << o.key << wq->thr_name() 
       << dendl;
@@ -1474,7 +1504,8 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
     orule.build(); // why can't ctor do it?
     rgw_bucket_dir_entry* o{nullptr};
     for (; ol.get_obj(&o /* , fetch_barrier */); ol.next()) {
-      std::tuple<LCOpRule&, rgw_bucket_dir_entry> t1 = {orule, *o};
+      orule.update();
+      std::tuple<LCOpRule, rgw_bucket_dir_entry> t1 = {orule, *o};
       worker->workpool->enqueue(WorkItem{t1});
     }
     worker->workpool->drain();
@@ -1864,7 +1895,7 @@ void get_lc_oid(CephContext *cct, const string& shard_id, string *oid)
   int max_objs =
     (cct->_conf->rgw_lc_max_objs > HASH_PRIME ? HASH_PRIME :
      cct->_conf->rgw_lc_max_objs);
-  /* XXXX oh noes!!! */
+  /* n.b. review hash algo */
   int index = ceph_str_hash_linux(shard_id.c_str(),
 				  shard_id.size()) % HASH_PRIME % max_objs;
   *oid = lc_oid_prefix;

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <iostream>
 #include <map>
+#include <algorithm>
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string.hpp>
@@ -14,6 +15,7 @@
 #include "include/random.h"
 #include "cls/rgw/cls_rgw_client.h"
 #include "cls/lock/cls_lock_client.h"
+#include "rgw_perf_counters.h"
 #include "rgw_common.h"
 #include "rgw_bucket.h"
 #include "rgw_lc.h"
@@ -48,11 +50,13 @@ bool LCRule::valid() const
   if (id.length() > MAX_ID_LEN) {
     return false;
   }
-  else if(expiration.empty() && noncur_expiration.empty() && mp_expiration.empty() && !dm_expiration &&
+  else if(expiration.empty() && noncur_expiration.empty() &&
+	  mp_expiration.empty() && !dm_expiration &&
           transitions.empty() && noncur_transitions.empty()) {
     return false;
   }
-  else if (!expiration.valid() || !noncur_expiration.valid() || !mp_expiration.valid()) {
+  else if (!expiration.valid() || !noncur_expiration.valid() ||
+	   !mp_expiration.valid()) {
     return false;
   }
   if (!transitions.empty()) {
@@ -78,7 +82,8 @@ bool LCRule::valid() const
   return true;
 }
 
-void LCRule::init_simple_days_rule(std::string_view _id, std::string_view _prefix, int num_days)
+void LCRule::init_simple_days_rule(std::string_view _id,
+				   std::string_view _prefix, int num_days)
 {
   id = _id;
   prefix = _prefix;
@@ -118,7 +123,8 @@ bool RGWLifecycleConfiguration::_add_rule(const LCRule& rule)
     } else {
       action.date = ceph::from_iso_8601(elem.second.get_date());
     }
-    action.storage_class = rgw_placement_rule::get_canonical_storage_class(elem.first);
+    action.storage_class
+      = rgw_placement_rule::get_canonical_storage_class(elem.first);
     op.transitions.emplace(elem.first, std::move(action));
   }
   for (const auto &elem : rule.get_noncur_transitions()) {
@@ -151,7 +157,8 @@ int RGWLifecycleConfiguration::check_and_add_rule(const LCRule& rule)
   if (rule_map.find(id) != rule_map.end()) {  //id shouldn't be the same 
     return -EINVAL;
   }
-  if (rule.get_filter().has_tags() && (rule.get_dm_expiration() || !rule.get_mp_expiration().empty())) {
+  if (rule.get_filter().has_tags() && (rule.get_dm_expiration() ||
+				       !rule.get_mp_expiration().empty())) {
     return -ERR_INVALID_REQUEST;
   }
   rule_map.insert(pair<string, LCRule>(id, rule));
@@ -162,7 +169,8 @@ int RGWLifecycleConfiguration::check_and_add_rule(const LCRule& rule)
   return 0;
 }
 
-bool RGWLifecycleConfiguration::has_same_action(const lc_op& first, const lc_op& second) {
+bool RGWLifecycleConfiguration::has_same_action(const lc_op& first,
+						const lc_op& second) {
   if ((first.expiration > 0 || first.expiration_date != boost::none) && 
     (second.expiration > 0 || second.expiration_date != boost::none)) {
     return true;
@@ -176,9 +184,11 @@ bool RGWLifecycleConfiguration::has_same_action(const lc_op& first, const lc_op&
         return true;
       }
     }
-  } else if (!first.noncur_transitions.empty() && !second.noncur_transitions.empty()) {
+  } else if (!first.noncur_transitions.empty() &&
+	     !second.noncur_transitions.empty()) {
     for (auto &elem : first.noncur_transitions) {
-      if (second.noncur_transitions.find(elem.first) != second.noncur_transitions.end()) {
+      if (second.noncur_transitions.find(elem.first) !=
+	  second.noncur_transitions.end()) {
         return true;
       }
     }
@@ -193,12 +203,16 @@ bool RGWLifecycleConfiguration::valid()
   return true;
 }
 
+RGWLC::LCWorker::LCWorker(const DoutPrefixProvider* _dpp, CephContext *_cct,
+			  RGWLC *_lc)
+  : dpp(_dpp), cct(_cct), lc(_lc) {}
+
 void *RGWLC::LCWorker::entry() {
   do {
     utime_t start = ceph_clock_now();
     if (should_work(start)) {
       ldpp_dout(dpp, 2) << "life cycle: start" << dendl;
-      int r = lc->process();
+      int r = lc->process(this);
       if (r < 0) {
         ldpp_dout(dpp, 0) << "ERROR: do life cycle process() returned error r=" << r << dendl;
       }
@@ -272,7 +286,7 @@ bool RGWLC::if_already_run_today(time_t& start_date)
     return false;
 }
 
-int RGWLC::bucket_lc_prepare(int index)
+int RGWLC::bucket_lc_prepare(int index, LCWorker* worker)
 {
   map<string, int > entries;
 
@@ -280,13 +294,15 @@ int RGWLC::bucket_lc_prepare(int index)
 
 #define MAX_LC_LIST_ENTRIES 100
   do {
-    int ret = cls_rgw_lc_list(store->getRados()->lc_pool_ctx, obj_names[index], marker, MAX_LC_LIST_ENTRIES, entries);
+    int ret = cls_rgw_lc_list(store->getRados()->lc_pool_ctx, obj_names[index],
+			      marker, MAX_LC_LIST_ENTRIES, entries);
     if (ret < 0)
       return ret;
     map<string, int>::iterator iter;
     for (iter = entries.begin(); iter != entries.end(); ++iter) {
       pair<string, int > entry(iter->first, lc_uninitial);
-      ret = cls_rgw_lc_set_entry(store->getRados()->lc_pool_ctx, obj_names[index],  entry);
+      ret = cls_rgw_lc_set_entry(store->getRados()->lc_pool_ctx,
+				 obj_names[index],  entry);
       if (ret < 0) {
         ldpp_dout(this, 0) << "RGWLC::bucket_lc_prepare() failed to set entry on "
             << obj_names[index] << dendl;
@@ -302,7 +318,8 @@ int RGWLC::bucket_lc_prepare(int index)
   return 0;
 }
 
-static bool obj_has_expired(CephContext *cct, ceph::real_time mtime, int days, ceph::real_time *expire_time = nullptr)
+static bool obj_has_expired(CephContext *cct, ceph::real_time mtime, int days,
+			    ceph::real_time *expire_time = nullptr)
 {
   double timediff, cmp;
   utime_t base_time;
@@ -325,7 +342,8 @@ static bool obj_has_expired(CephContext *cct, ceph::real_time mtime, int days, c
   return (timediff >= cmp);
 }
 
-static bool pass_object_lock_check(RGWRados *store, RGWBucketInfo& bucket_info, rgw_obj& obj, RGWObjectCtx& ctx)
+static bool pass_object_lock_check(RGWRados *store, RGWBucketInfo& bucket_info,
+				   rgw_obj& obj, RGWObjectCtx& ctx)
 {
   if (!bucket_info.obj_lock_enabled()) {
     return true;
@@ -351,7 +369,8 @@ static bool pass_object_lock_check(RGWRados *store, RGWBucketInfo& bucket_info, 
         ldout(store->ctx(), 0) << "ERROR: failed to decode RGWObjectRetention" << dendl;
         return false;
       }
-      if (ceph::real_clock::to_time_t(retention.get_retain_until_date()) > ceph_clock_now()) {
+      if (ceph::real_clock::to_time_t(retention.get_retain_until_date()) >
+	  ceph_clock_now()) {
         return false;
       }
     }
@@ -385,12 +404,13 @@ int RGWLC::handle_multipart_expiration(
   auto delay_ms = cct->_conf.get_val<int64_t>("rgw_lc_thread_delay");
   list_op.params.list_versions = false;
   /* lifecycle processing does not depend on total order, so can
-   * take advantage of unorderd listing optimizations--such as
+   * take advantage of unordered listing optimizations--such as
    * operating on one shard at a time */
   list_op.params.allow_unordered = true;
   list_op.params.ns = RGW_OBJ_NS_MULTIPART;
   list_op.params.filter = &mp_filter;
-  for (auto prefix_iter = prefix_map.begin(); prefix_iter != prefix_map.end(); ++prefix_iter) {
+  for (auto prefix_iter = prefix_map.begin(); prefix_iter != prefix_map.end();
+       ++prefix_iter) {
     if (!prefix_iter->second.status || prefix_iter->second.mp_expiration <= 0) {
       continue;
     }
@@ -407,12 +427,14 @@ int RGWLC::handle_multipart_expiration(
       }
 
       for (auto obj_iter = objs.begin(); obj_iter != objs.end(); ++obj_iter) {
-        if (obj_has_expired(cct, obj_iter->meta.mtime, prefix_iter->second.mp_expiration)) {
+        if (obj_has_expired(cct, obj_iter->meta.mtime,
+			    prefix_iter->second.mp_expiration)) {
           rgw_obj_key key(obj_iter->key);
           if (!mp_obj.from_meta(key.name)) {
             continue;
           }
           RGWObjectCtx rctx(store);
+	  /* XXXX where is this defined? */
           ret = abort_multipart_upload(store, cct, &rctx, bucket_info, mp_obj);
           if (ret < 0 && ret != -ERR_NO_SUCH_UPLOAD) {
             ldpp_dout(this, 0) << "ERROR: abort_multipart_upload failed, ret=" << ret << ", meta:" << obj_iter->key << dendl;
@@ -429,7 +451,8 @@ int RGWLC::handle_multipart_expiration(
   return 0;
 }
 
-static int read_obj_tags(RGWRados *store, RGWBucketInfo& bucket_info, rgw_obj& obj, RGWObjectCtx& ctx, bufferlist& tags_bl)
+static int read_obj_tags(RGWRados *store, RGWBucketInfo& bucket_info,
+			 rgw_obj& obj, RGWObjectCtx& ctx, bufferlist& tags_bl)
 {
   RGWRados::Object op_target(store, bucket_info, ctx, obj);
   RGWRados::Object::Read read_op(&op_target);
@@ -500,7 +523,8 @@ public:
   }
 
   int fetch() {
-    int ret = list_op.list_objects(1000, &objs, NULL, &is_truncated, null_yield);
+    int ret = list_op.list_objects(
+      1000, &objs, NULL, &is_truncated, null_yield);
     if (ret < 0) {
       return ret;
     }
@@ -556,15 +580,20 @@ public:
 
 
 struct op_env {
+
+  using LCWorker = RGWLC::LCWorker;
+
   lc_op& op;
   rgw::sal::RGWRadosStore *store;
-  RGWLC *lc;
+  LCWorker* worker;
   RGWBucketInfo& bucket_info;
   LCObjsLister& ol;
 
-  op_env(lc_op& _op, rgw::sal::RGWRadosStore *_store, RGWLC *_lc, RGWBucketInfo& _bucket_info,
-         LCObjsLister& _ol) : op(_op), store(_store), lc(_lc), bucket_info(_bucket_info), ol(_ol) {}
-};
+  op_env(lc_op& _op, rgw::sal::RGWRadosStore *_store, LCWorker* _worker,
+	 RGWBucketInfo& _bucket_info, LCObjsLister& _ol)
+    : op(_op), store(_store), worker(_worker), bucket_info(_bucket_info),
+      ol(_ol) {}
+}; /* op_env */
 
 class LCRuleOp;
 
@@ -582,10 +611,12 @@ struct lc_op_ctx {
   RGWObjectCtx rctx;
   const DoutPrefixProvider *dpp;
 
-  lc_op_ctx(op_env& _env, rgw_bucket_dir_entry& _o, const DoutPrefixProvider *_dpp) : cct(_env.store->ctx()), env(_env), o(_o),
-                 store(env.store), bucket_info(env.bucket_info), op(env.op), ol(env.ol),
-                 obj(env.bucket_info.bucket, o.key), rctx(env.store), dpp(_dpp) {}
-};
+  lc_op_ctx(op_env& _env, rgw_bucket_dir_entry& _o,
+	    const DoutPrefixProvider *_dpp)
+    : cct(_env.store->ctx()), env(_env), o(_o),
+      store(env.store), bucket_info(env.bucket_info), op(env.op), ol(env.ol),
+      obj(env.bucket_info.bucket, o.key), rctx(env.store), dpp(_dpp) {}
+}; /* lc_op_ctx */
 
 static int remove_expired_obj(lc_op_ctx& oc, bool remove_indeed)
 {
@@ -613,6 +644,10 @@ static int remove_expired_obj(lc_op_ctx& oc, bool remove_indeed)
   del_op.params.versioning_status = bucket_info.versioning_status();
   del_op.params.obj_owner = obj_owner;
   del_op.params.unmod_since = meta.mtime;
+
+  if (perfcounter) {
+    perfcounter->inc(l_rgw_lc_remove_expired, 1);
+  }
 
   return del_op.delete_obj(null_yield);
 }
@@ -676,7 +711,8 @@ static int check_tags(lc_op_ctx& oc, bool *skip)
     *skip = true;
 
     bufferlist tags_bl;
-    int ret = read_obj_tags(oc.store->getRados(), oc.bucket_info, oc.obj, oc.rctx, tags_bl);
+    int ret = read_obj_tags(oc.store->getRados(), oc.bucket_info, oc.obj,
+			    oc.rctx, tags_bl);
     if (ret < 0) {
       if (ret != -ENODATA) {
         ldout(oc.cct, 5) << "ERROR: read_obj_tags returned r=" << ret << dendl;
@@ -750,7 +786,8 @@ public:
         ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": no expiration set in rule, skipping" << dendl;
         return false;
       }
-      is_expired = ceph_clock_now() >= ceph::real_clock::to_time_t(*op.expiration_date);
+      is_expired = ceph_clock_now() >=
+	ceph::real_clock::to_time_t(*op.expiration_date);
       *exp_time = *op.expiration_date;
     } else {
       is_expired = obj_has_expired(oc.cct, mtime, op.expiration, exp_time);
@@ -793,7 +830,9 @@ public:
     bool is_expired = obj_has_expired(oc.cct, mtime, expiration, exp_time);
 
     ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": is_expired=" << is_expired << dendl;
-    return is_expired && pass_object_lock_check(oc.store->getRados(), oc.bucket_info, oc.obj, oc.rctx);
+    return is_expired &&
+      pass_object_lock_check(oc.store->getRados(),
+			     oc.bucket_info, oc.obj, oc.rctx);
   }
 
   int process(lc_op_ctx& oc) {
@@ -851,7 +890,8 @@ protected:
   virtual bool check_current_state(bool is_current) = 0;
   virtual ceph::real_time get_effective_mtime(lc_op_ctx& oc) = 0;
 public:
-  LCOpAction_Transition(const transition_action& _transition) : transition(_transition) {}
+  LCOpAction_Transition(const transition_action& _transition)
+    : transition(_transition) {}
 
   bool check(lc_op_ctx& oc, ceph::real_time *exp_time) override {
     auto& o = oc.o;
@@ -871,7 +911,8 @@ public:
         ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": no transition day/date set in rule, skipping" << dendl;
         return false;
       }
-      is_expired = ceph_clock_now() >= ceph::real_clock::to_time_t(*transition.date);
+      is_expired = ceph_clock_now() >=
+	ceph::real_clock::to_time_t(*transition.date);
       *exp_time = *transition.date;
     } else {
       is_expired = obj_has_expired(oc.cct, mtime, transition.days, exp_time);
@@ -879,7 +920,9 @@ public:
 
     ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": is_expired=" << is_expired << dendl;
 
-    need_to_process = (rgw_placement_rule::get_canonical_storage_class(o.meta.storage_class) != transition.storage_class);
+    need_to_process =
+      (rgw_placement_rule::get_canonical_storage_class(o.meta.storage_class) !=
+       transition.storage_class);
 
     return is_expired;
   }
@@ -895,15 +938,17 @@ public:
     target_placement.inherit_from(oc.bucket_info.placement_rule);
     target_placement.storage_class = transition.storage_class;
 
-    if (!oc.store->svc()->zone->get_zone_params().valid_placement(target_placement)) {
+    if (!oc.store->svc()->zone->get_zone_params().
+	valid_placement(target_placement)) {
       ldpp_dout(oc.dpp, 0) << "ERROR: non existent dest placement: " << target_placement
                            << " bucket="<< oc.bucket_info.bucket
                            << " rule_id=" << oc.op.id << dendl;
       return -EINVAL;
     }
 
-    int r = oc.store->getRados()->transition_obj(oc.rctx, oc.bucket_info, oc.obj,
-                                     target_placement, o.meta.mtime, o.versioned_epoch, oc.dpp, null_yield);
+    int r = oc.store->getRados()->transition_obj(
+      oc.rctx, oc.bucket_info, oc.obj, target_placement, o.meta.mtime,
+      o.versioned_epoch, oc.dpp, null_yield);
     if (r < 0) {
       ldpp_dout(oc.dpp, 0) << "ERROR: failed to transition obj " 
       << oc.bucket_info.bucket << ":" << o.key 
@@ -926,7 +971,8 @@ protected:
     return oc.o.meta.mtime;
   }
 public:
-  LCOpAction_CurrentTransition(const transition_action& _transition) : LCOpAction_Transition(_transition) {}
+  LCOpAction_CurrentTransition(const transition_action& _transition)
+    : LCOpAction_Transition(_transition) {}
 };
 
 class LCOpAction_NonCurrentTransition : public LCOpAction_Transition {
@@ -939,7 +985,8 @@ protected:
     return oc.ol.get_prev_obj().meta.mtime;
   }
 public:
-  LCOpAction_NonCurrentTransition(const transition_action& _transition) : LCOpAction_Transition(_transition) {}
+  LCOpAction_NonCurrentTransition(const transition_action& _transition)
+    : LCOpAction_Transition(_transition) {}
 };
 
 void LCOpRule::build()
@@ -1027,7 +1074,7 @@ int LCOpRule::process(rgw_bucket_dir_entry& o, const DoutPrefixProvider *dpp)
 
 }
 
-int RGWLC::bucket_lc_process(string& shard_id)
+int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker)
 {
   RGWLifecycleConfiguration  config(cct);
   RGWBucketInfo bucket_info;
@@ -1039,7 +1086,9 @@ int RGWLC::bucket_lc_process(string& shard_id)
   string bucket_tenant = result[0];
   string bucket_name = result[1];
   string bucket_marker = result[2];
-  int ret = store->getRados()->get_bucket_info(store->svc(), bucket_tenant, bucket_name, bucket_info, NULL, null_yield, &bucket_attrs);
+  int ret = store->getRados()->get_bucket_info(
+    store->svc(), bucket_tenant, bucket_name, bucket_info, NULL, null_yield,
+    &bucket_attrs);
   if (ret < 0) {
     ldpp_dout(this, 0) << "LC:get_bucket_info for " << bucket_name << " failed" << dendl;
     return ret;
@@ -1074,14 +1123,16 @@ int RGWLC::bucket_lc_process(string& shard_id)
 
   rgw_obj_key pre_marker;
   rgw_obj_key next_marker;
-  for(auto prefix_iter = prefix_map.begin(); prefix_iter != prefix_map.end(); ++prefix_iter) {
+  for(auto prefix_iter = prefix_map.begin(); prefix_iter != prefix_map.end();
+      ++prefix_iter) {
     auto& op = prefix_iter->second;
     if (!is_valid_op(op)) {
       continue;
     }
     ldpp_dout(this, 20) << __func__ << "(): prefix=" << prefix_iter->first << dendl;
     if (prefix_iter != prefix_map.begin() && 
-        (prefix_iter->first.compare(0, prev(prefix_iter)->first.length(), prev(prefix_iter)->first) == 0)) {
+        (prefix_iter->first.compare(0, prev(prefix_iter)->first.length(),
+				    prev(prefix_iter)->first) == 0)) {
       next_marker = pre_marker;
     } else {
       pre_marker = next_marker;
@@ -1099,7 +1150,7 @@ int RGWLC::bucket_lc_process(string& shard_id)
       return ret;
     }
 
-    op_env oenv(op, store, this, bucket_info, ol);
+    op_env oenv(op, store, worker, bucket_info, ol);
 
     LCOpRule orule(oenv);
 
@@ -1126,7 +1177,9 @@ int RGWLC::bucket_lc_process(string& shard_id)
   return ret;
 }
 
-int RGWLC::bucket_lc_post(int index, int max_lock_sec, pair<string, int >& entry, int& result)
+int RGWLC::bucket_lc_post(int index, int max_lock_sec,
+			  pair<string, int>& entry, int& result,
+			  LCWorker* worker)
 {
   utime_t lock_duration(cct->_conf->rgw_lc_lock_max_time, 0);
 
@@ -1135,7 +1188,8 @@ int RGWLC::bucket_lc_post(int index, int max_lock_sec, pair<string, int >& entry
   l.set_duration(lock_duration);
 
   do {
-    int ret = l.lock_exclusive(&store->getRados()->lc_pool_ctx, obj_names[index]);
+    int ret = l.lock_exclusive(
+      &store->getRados()->lc_pool_ctx, obj_names[index]);
     if (ret == -EBUSY || ret == -EEXIST) { /* already locked by another lc processor */
       ldpp_dout(this, 0) << "RGWLC::bucket_lc_post() failed to acquire lock on "
           << obj_names[index] << ", sleep 5, try again" << dendl;
@@ -1146,7 +1200,8 @@ int RGWLC::bucket_lc_post(int index, int max_lock_sec, pair<string, int >& entry
       return 0;
     ldpp_dout(this, 20) << "RGWLC::bucket_lc_post() lock " << obj_names[index] << dendl;
     if (result ==  -ENOENT) {
-      ret = cls_rgw_lc_rm_entry(store->getRados()->lc_pool_ctx, obj_names[index],  entry);
+      ret = cls_rgw_lc_rm_entry(store->getRados()->lc_pool_ctx,
+				obj_names[index],  entry);
       if (ret < 0) {
         ldpp_dout(this, 0) << "RGWLC::bucket_lc_post() failed to remove entry "
             << obj_names[index] << dendl;
@@ -1158,7 +1213,8 @@ int RGWLC::bucket_lc_post(int index, int max_lock_sec, pair<string, int >& entry
       entry.second = lc_complete;
     }
 
-    ret = cls_rgw_lc_set_entry(store->getRados()->lc_pool_ctx, obj_names[index],  entry);
+    ret = cls_rgw_lc_set_entry(store->getRados()->lc_pool_ctx,
+			       obj_names[index],  entry);
     if (ret < 0) {
       ldpp_dout(this, 0) << "RGWLC::process() failed to set entry on "
           << obj_names[index] << dendl;
@@ -1170,13 +1226,16 @@ clean:
   } while (true);
 }
 
-int RGWLC::list_lc_progress(const string& marker, uint32_t max_entries, map<string, int> *progress_map)
+int RGWLC::list_lc_progress(const string& marker, uint32_t max_entries,
+			    map<string, int>* progress_map)
 {
   int index = 0;
   progress_map->clear();
   for(; index <max_objs; index++) {
     map<string, int > entries;
-    int ret = cls_rgw_lc_list(store->getRados()->lc_pool_ctx, obj_names[index], marker, max_entries, entries);
+    int ret =
+      cls_rgw_lc_list(store->getRados()->lc_pool_ctx, obj_names[index], marker,
+		      max_entries, entries);
     if (ret < 0) {
       if (ret == -ENOENT) {
         ldpp_dout(this, 10) << __func__ << "() ignoring unfound lc object="
@@ -1194,15 +1253,26 @@ int RGWLC::list_lc_progress(const string& marker, uint32_t max_entries, map<stri
   return 0;
 }
 
-int RGWLC::process()
+static inline vector<int> random_sequence(uint32_t n)
+{
+  vector<int> v(n-1, 0);
+  std::generate(v.begin(), v.end(),
+    [ix = 0]() mutable {
+      return ix++;
+    });
+  std::random_shuffle(v.begin(), v.end());
+  return v;
+}
+
+int RGWLC::process(LCWorker* worker)
 {
   int max_secs = cct->_conf->rgw_lc_lock_max_time;
 
-  const int start = ceph::util::generate_random_number(0, max_objs - 1);
-
-  for (int i = 0; i < max_objs; i++) {
-    int index = (i + start) % max_objs;
-    int ret = process(index, max_secs);
+  /* generate an index-shard sequence unrelated to any other
+   * that might be running in parallel */
+  vector<int> shard_seq = random_sequence(max_objs);
+  for (auto index : shard_seq) {
+    int ret = process(index, max_secs, worker);
     if (ret < 0)
       return ret;
   }
@@ -1210,7 +1280,7 @@ int RGWLC::process()
   return 0;
 }
 
-int RGWLC::process(int index, int max_lock_secs)
+int RGWLC::process(int index, int max_lock_secs, LCWorker* worker)
 {
   rados::cls::lock::Lock l(lc_index_lock_name);
   do {
@@ -1222,7 +1292,8 @@ int RGWLC::process(int index, int max_lock_secs)
     utime_t time(max_lock_secs, 0);
     l.set_duration(time);
 
-    int ret = l.lock_exclusive(&store->getRados()->lc_pool_ctx, obj_names[index]);
+    int ret = l.lock_exclusive(&store->getRados()->lc_pool_ctx,
+			       obj_names[index]);
     if (ret == -EBUSY || ret == -EEXIST) { /* already locked by another lc processor */
       ldpp_dout(this, 0) << "RGWLC::process() failed to acquire lock on "
           << obj_names[index] << ", sleep 5, try again" << dendl;
@@ -1233,7 +1304,8 @@ int RGWLC::process(int index, int max_lock_secs)
       return 0;
 
     cls_rgw_lc_obj_head head;
-    ret = cls_rgw_lc_get_head(store->getRados()->lc_pool_ctx, obj_names[index], head);
+    ret = cls_rgw_lc_get_head(store->getRados()->lc_pool_ctx, obj_names[index],
+			      head);
     if (ret < 0) {
       ldpp_dout(this, 0) << "RGWLC::process() failed to get obj head "
           << obj_names[index] << ", ret=" << ret << dendl;
@@ -1243,42 +1315,53 @@ int RGWLC::process(int index, int max_lock_secs)
     if(!if_already_run_today(head.start_date)) {
       head.start_date = now;
       head.marker.clear();
-      ret = bucket_lc_prepare(index);
+      ret = bucket_lc_prepare(index, worker);
       if (ret < 0) {
       ldpp_dout(this, 0) << "RGWLC::process() failed to update lc object "
-          << obj_names[index] << ", ret=" << ret << dendl;
+			 << obj_names[index]
+			 << ", ret=" << ret
+			 << dendl;
       goto exit;
       }
     }
 
-    ret = cls_rgw_lc_get_next_entry(store->getRados()->lc_pool_ctx, obj_names[index], head.marker, entry);
+    ret = cls_rgw_lc_get_next_entry(store->getRados()->lc_pool_ctx,
+				    obj_names[index], head.marker, entry);
     if (ret < 0) {
       ldpp_dout(this, 0) << "RGWLC::process() failed to get obj entry "
           << obj_names[index] << dendl;
       goto exit;
     }
 
+    /* termination condition (eof) */
     if (entry.first.empty())
       goto exit;
 
     entry.second = lc_processing;
-    ret = cls_rgw_lc_set_entry(store->getRados()->lc_pool_ctx, obj_names[index],  entry);
+    ret = cls_rgw_lc_set_entry(store->getRados()->lc_pool_ctx,
+			       obj_names[index],  entry);
     if (ret < 0) {
-      ldpp_dout(this, 0) << "RGWLC::process() failed to set obj entry " << obj_names[index]
-          << " (" << entry.first << "," << entry.second << ")" << dendl;
+      ldpp_dout(this, 0) << "RGWLC::process() failed to set obj entry "
+			 << obj_names[index]
+			 << " (" << entry.first << ","
+			 << entry.second << ")"
+			 << dendl;
       goto exit;
     }
 
     head.marker = entry.first;
-    ret = cls_rgw_lc_put_head(store->getRados()->lc_pool_ctx, obj_names[index],  head);
+    ret = cls_rgw_lc_put_head(store->getRados()->lc_pool_ctx, obj_names[index],
+			      head);
     if (ret < 0) {
-      ldpp_dout(this, 0) << "RGWLC::process() failed to put head " << obj_names[index] << dendl;
+      ldpp_dout(this, 0) << "RGWLC::process() failed to put head "
+			 << obj_names[index]
+			 << dendl;
       goto exit;
     }
     l.unlock(&store->getRados()->lc_pool_ctx, obj_names[index]);
-    ret = bucket_lc_process(entry.first);
-    bucket_lc_post(index, max_lock_secs, entry, ret);
-  }while(1);
+    ret = bucket_lc_process(entry.first, worker);
+    bucket_lc_post(index, max_lock_secs, entry, ret, worker);
+  } while(1);
 
 exit:
     l.unlock(&store->getRados()->lc_pool_ctx, obj_names[index]);
@@ -1287,21 +1370,25 @@ exit:
 
 void RGWLC::start_processor()
 {
-  worker = new LCWorker(this, cct, this);
-  worker->create("lifecycle_thr");
+  auto maxw = cct->_conf->rgw_lc_max_worker;
+  workers.reserve(maxw);
+  for (int ix = 0; ix < maxw; ++ix) {
+    auto worker  =
+      std::make_unique<RGWLC::LCWorker>(this /* dpp */, cct, this);
+    worker->create((string{"lifecycle_thr_"} + to_string(ix)).c_str());
+    workers.emplace_back(std::move(worker));
+  }
 }
 
 void RGWLC::stop_processor()
 {
   down_flag = true;
-  if (worker) {
+  for (auto& worker : workers) {
     worker->stop();
     worker->join();
   }
-  delete worker;
-  worker = NULL;
+  workers.clear();
 }
-
 
 unsigned RGWLC::get_subsys() const
 {
@@ -1331,7 +1418,8 @@ bool RGWLC::LCWorker::should_work(utime_t& now)
   int end_hour;
   int end_minute;
   string worktime = cct->_conf->rgw_lifecycle_work_time;
-  sscanf(worktime.c_str(),"%d:%d-%d:%d",&start_hour, &start_minute, &end_hour, &end_minute);
+  sscanf(worktime.c_str(),"%d:%d-%d:%d",&start_hour, &start_minute,
+	 &end_hour, &end_minute);
   struct tm bdt;
   time_t tt = now.sec();
   localtime_r(&tt, &bdt);
@@ -1364,7 +1452,8 @@ int RGWLC::LCWorker::schedule_next_start_time(utime_t &start, utime_t& now)
   int end_hour;
   int end_minute;
   string worktime = cct->_conf->rgw_lifecycle_work_time;
-  sscanf(worktime.c_str(),"%d:%d-%d:%d",&start_hour, &start_minute, &end_hour, &end_minute);
+  sscanf(worktime.c_str(),"%d:%d-%d:%d",&start_hour, &start_minute, &end_hour,
+	 &end_minute);
   struct tm bdt;
   time_t tt = now.sec();
   time_t nt;
@@ -1378,15 +1467,20 @@ int RGWLC::LCWorker::schedule_next_start_time(utime_t &start, utime_t& now)
   return secs>0 ? secs : secs+24*60*60;
 }
 
-void RGWLifecycleConfiguration::generate_test_instances(list<RGWLifecycleConfiguration*>& o)
+void RGWLifecycleConfiguration::generate_test_instances(
+  list<RGWLifecycleConfiguration*>& o)
 {
   o.push_back(new RGWLifecycleConfiguration);
 }
 
 void get_lc_oid(CephContext *cct, const string& shard_id, string *oid)
 {
-  int max_objs = (cct->_conf->rgw_lc_max_objs > HASH_PRIME ? HASH_PRIME : cct->_conf->rgw_lc_max_objs);
-  int index = ceph_str_hash_linux(shard_id.c_str(), shard_id.size()) % HASH_PRIME % max_objs;
+  int max_objs =
+    (cct->_conf->rgw_lc_max_objs > HASH_PRIME ? HASH_PRIME :
+     cct->_conf->rgw_lc_max_objs);
+  /* XXXX oh noes!!! */
+  int index = ceph_str_hash_linux(shard_id.c_str(),
+				  shard_id.size()) % HASH_PRIME % max_objs;
   *oid = lc_oid_prefix;
   char buf[32];
   snprintf(buf, 32, ".%d", index);
@@ -1394,14 +1488,14 @@ void get_lc_oid(CephContext *cct, const string& shard_id, string *oid)
   return;
 }
 
-
-
 static std::string get_lc_shard_name(const rgw_bucket& bucket){
   return string_join_reserve(':', bucket.tenant, bucket.name, bucket.marker);
 }
 
 template<typename F>
-static int guard_lc_modify(rgw::sal::RGWRadosStore* store, const rgw_bucket& bucket, const string& cookie, const F& f) {
+static int guard_lc_modify(
+  rgw::sal::RGWRadosStore* store, const rgw_bucket& bucket,
+  const string& cookie, const F& f) {
   CephContext *cct = store->ctx();
 
   string shard_id = get_lc_shard_name(bucket);
@@ -1454,17 +1548,17 @@ int RGWLC::set_bucket_config(RGWBucketInfo& bucket_info,
 
   attrs[RGW_ATTR_LC] = std::move(lc_bl);
 
-  int ret = store->ctl()->bucket->set_bucket_instance_attrs(bucket_info, attrs,
-							 &bucket_info.objv_tracker,
-							 null_yield);
+  int ret =
+    store->ctl()->bucket->set_bucket_instance_attrs(
+      bucket_info, attrs, &bucket_info.objv_tracker, null_yield);
   if (ret < 0)
     return ret;
 
   rgw_bucket& bucket = bucket_info.bucket;
 
-
-  ret = guard_lc_modify(store, bucket, cookie, [&](librados::IoCtx *ctx, const string& oid,
-                                                   const pair<string, int>& entry) {
+  ret = guard_lc_modify(store, bucket, cookie,
+			[&](librados::IoCtx *ctx, const string& oid,
+			    const pair<string, int>& entry) {
     return cls_rgw_lc_set_entry(*ctx, oid, entry);
   });
 
@@ -1476,9 +1570,9 @@ int RGWLC::remove_bucket_config(RGWBucketInfo& bucket_info,
 {
   map<string, bufferlist> attrs = bucket_attrs;
   attrs.erase(RGW_ATTR_LC);
-  int ret = store->ctl()->bucket->set_bucket_instance_attrs(bucket_info, attrs,
-							 &bucket_info.objv_tracker,
-							 null_yield);
+  int ret =
+    store->ctl()->bucket->set_bucket_instance_attrs(
+      bucket_info, attrs, &bucket_info.objv_tracker, null_yield);
 
   rgw_bucket& bucket = bucket_info.bucket;
 
@@ -1489,8 +1583,9 @@ int RGWLC::remove_bucket_config(RGWBucketInfo& bucket_info,
   }
 
 
-  ret = guard_lc_modify(store, bucket, cookie, [&](librados::IoCtx *ctx, const string& oid,
-                                                   const pair<string, int>& entry) {
+  ret = guard_lc_modify(store, bucket, cookie,
+			[&](librados::IoCtx *ctx, const string& oid,
+			    const pair<string, int>& entry) {
     return cls_rgw_lc_rm_entry(*ctx, oid, entry);
   });
 
@@ -1499,7 +1594,8 @@ int RGWLC::remove_bucket_config(RGWBucketInfo& bucket_info,
 
 namespace rgw::lc {
 
-int fix_lc_shard_entry(rgw::sal::RGWRadosStore* store, const RGWBucketInfo& bucket_info,
+int fix_lc_shard_entry(rgw::sal::RGWRadosStore* store,
+		       const RGWBucketInfo& bucket_info,
 		       const map<std::string,bufferlist>& battrs)
 {
   if (auto aiter = battrs.find(RGW_ATTR_LC);
@@ -1533,12 +1629,12 @@ int fix_lc_shard_entry(rgw::sal::RGWRadosStore* store, const RGWBucketInfo& buck
     gen_rand_alphanumeric(store->ctx(), cookie_buf, sizeof(cookie_buf) - 1);
     std::string cookie = cookie_buf;
 
-    ret = guard_lc_modify(store, bucket_info.bucket, cookie,
-			  [&lc_pool_ctx, &lc_oid](librados::IoCtx *ctx, const string& oid,
-					    const pair<string, int>& entry) {
-			    return cls_rgw_lc_set_entry(*lc_pool_ctx,
-							lc_oid, entry);
-			  });
+    ret = guard_lc_modify(
+      store, bucket_info.bucket, cookie,
+      [&lc_pool_ctx, &lc_oid](librados::IoCtx *ctx, const string& oid,
+			      const pair<string, int>& entry) {
+	return cls_rgw_lc_set_entry(*lc_pool_ctx, lc_oid, entry);
+      });
 
   }
 

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -508,7 +508,8 @@ public:
   int list_lc_progress(const string& marker, uint32_t max_entries,
 		       vector<cls_rgw_lc_entry>&);
   int bucket_lc_prepare(int index, LCWorker* worker);
-  int bucket_lc_process(string& shard_id, LCWorker* worker, time_t stop_at);
+  int bucket_lc_process(string& shard_id, LCWorker* worker, time_t stop_at,
+			bool once);
   int bucket_lc_post(int index, int max_lock_sec,
 		     cls_rgw_lc_entry& entry, int& result, LCWorker* worker);
   bool going_down();
@@ -528,8 +529,7 @@ public:
 
   int handle_multipart_expiration(RGWRados::Bucket *target,
 				  const multimap<string, lc_op>& prefix_map,
-				  LCWorker* worker,
-				  time_t stop_at);
+				  LCWorker* worker, time_t stop_at, bool once);
 };
 
 namespace rgw::lc {

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -505,8 +505,8 @@ public:
   bool if_already_run_today(time_t start_date);
   bool expired_session(time_t started);
   time_t thread_stop_at();
-  int list_lc_progress(const string& marker, uint32_t max_entries,
-		       vector<cls_rgw_lc_entry>&);
+  int list_lc_progress(string& marker, uint32_t max_entries,
+		       vector<cls_rgw_lc_entry>&, int& index);
   int bucket_lc_prepare(int index, LCWorker* worker);
   int bucket_lc_process(string& shard_id, LCWorker* worker, time_t stop_at,
 			bool once);

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -500,8 +500,8 @@ public:
   void initialize(CephContext *_cct, rgw::sal::RGWRadosStore *_store);
   void finalize();
 
-  int process(LCWorker* worker);
-  int process(int index, int max_secs, LCWorker* worker);
+  int process(LCWorker* worker, bool once);
+  int process(int index, int max_secs, LCWorker* worker, bool once);
   bool if_already_run_today(time_t start_date);
   bool expired_session(time_t started);
   time_t thread_stop_at();

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -467,6 +467,7 @@ public:
     const DoutPrefixProvider *dpp;
     CephContext *cct;
     RGWLC *lc;
+    int ix;
     ceph::mutex lock = ceph::make_mutex("LCWorker");
     ceph::condition_variable cond;
     WorkPool* workpool{nullptr};
@@ -497,10 +498,12 @@ public:
   int process(LCWorker* worker);
   int process(int index, int max_secs, LCWorker* worker);
   bool if_already_run_today(time_t& start_date);
-  int list_lc_progress(const string& marker, uint32_t max_entries, map<string, int> *progress_map);
+  int list_lc_progress(const string& marker, uint32_t max_entries,
+		       vector<cls_rgw_lc_entry>&);
   int bucket_lc_prepare(int index, LCWorker* worker);
   int bucket_lc_process(string& shard_id, LCWorker* worker);
-  int bucket_lc_post(int index, int max_lock_sec, pair<string, int >& entry, int& result, LCWorker* worker);
+  int bucket_lc_post(int index, int max_lock_sec,
+		     cls_rgw_lc_entry& entry, int& result, LCWorker* worker);
   bool going_down();
   void start_processor();
   void stop_processor();

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -458,6 +458,7 @@ class RGWLC : public DoutPrefixProvider {
   std::atomic<bool> down_flag = { false };
   string cookie;
 
+public:
   class LCWorker : public Thread {
     const DoutPrefixProvider *dpp;
     CephContext *cct;
@@ -466,16 +467,20 @@ class RGWLC : public DoutPrefixProvider {
     ceph::condition_variable cond;
 
   public:
-    LCWorker(const DoutPrefixProvider* _dpp, CephContext *_cct, RGWLC *_lc) : dpp(_dpp), cct(_cct), lc(_lc) {}
+    LCWorker(const DoutPrefixProvider* _dpp, CephContext *_cct, RGWLC *_lc);
+    RGWLC* get_lc() { return lc; }
     void *entry() override;
     void stop();
     bool should_work(utime_t& now);
     int schedule_next_start_time(utime_t& start, utime_t& now);
-  };
-  
-  public:
-  LCWorker *worker;
-  RGWLC() : cct(NULL), store(NULL), worker(NULL) {}
+    friend class RGWRados;
+  }; /* LCWorker */
+
+  friend class RGWRados;
+
+  std::vector<std::unique_ptr<RGWLC::LCWorker>> workers;
+
+  RGWLC() : cct(nullptr), store(nullptr) {}
   ~RGWLC() {
     stop_processor();
     finalize();
@@ -484,13 +489,13 @@ class RGWLC : public DoutPrefixProvider {
   void initialize(CephContext *_cct, rgw::sal::RGWRadosStore *_store);
   void finalize();
 
-  int process();
-  int process(int index, int max_secs);
+  int process(LCWorker* worker);
+  int process(int index, int max_secs, LCWorker* worker);
   bool if_already_run_today(time_t& start_date);
   int list_lc_progress(const string& marker, uint32_t max_entries, map<string, int> *progress_map);
-  int bucket_lc_prepare(int index);
-  int bucket_lc_process(string& shard_id);
-  int bucket_lc_post(int index, int max_lock_sec, pair<string, int >& entry, int& result);
+  int bucket_lc_prepare(int index, LCWorker* worker);
+  int bucket_lc_process(string& shard_id, LCWorker* worker);
+  int bucket_lc_post(int index, int max_lock_sec, pair<string, int >& entry, int& result, LCWorker* worker);
   bool going_down();
   void start_processor();
   void stop_processor();

--- a/src/rgw/rgw_perf_counters.cc
+++ b/src/rgw/rgw_perf_counters.cc
@@ -35,6 +35,7 @@ int rgw_perf_start(CephContext *cct)
   plb.add_u64_counter(l_rgw_keystone_token_cache_miss, "keystone_token_cache_miss", "Keystone token cache miss");
 
   plb.add_u64_counter(l_rgw_gc_retire, "gc_retire_object", "GC object retires");
+  plb.add_u64_counter(l_rgw_lc_remove_expired, "lc_remove_expired", "LC removed objects");
 
   plb.add_u64_counter(l_rgw_pubsub_event_triggered, "pubsub_event_triggered", "Pubsub events with at least one topic");
   plb.add_u64_counter(l_rgw_pubsub_event_lost, "pubsub_event_lost", "Pubsub events lost");

--- a/src/rgw/rgw_perf_counters.h
+++ b/src/rgw/rgw_perf_counters.h
@@ -32,6 +32,7 @@ enum {
   l_rgw_keystone_token_cache_miss,
 
   l_rgw_gc_retire,
+  l_rgw_lc_remove_expired,
 
   l_rgw_pubsub_event_triggered,
   l_rgw_pubsub_event_lost,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8040,10 +8040,11 @@ int RGWRados::process_gc(bool expired_only)
   return gc->process(expired_only);
 }
 
-int RGWRados::list_lc_progress(const string& marker, uint32_t max_entries,
-			       vector<cls_rgw_lc_entry>& progress_map)
+int RGWRados::list_lc_progress(string& marker, uint32_t max_entries,
+			       vector<cls_rgw_lc_entry>& progress_map,
+			       int& index)
 {
-  return lc->list_lc_progress(marker, max_entries, progress_map);
+  return lc->list_lc_progress(marker, max_entries, progress_map, index);
 }
 
 int RGWRados::process_lc()

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8047,7 +8047,7 @@ int RGWRados::list_lc_progress(const string& marker, uint32_t max_entries, map<s
 
 int RGWRados::process_lc()
 {
-  return lc->process();
+  return lc->process(nullptr);
 }
 
 bool RGWRados::process_expire_objects()

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8048,7 +8048,12 @@ int RGWRados::list_lc_progress(const string& marker, uint32_t max_entries,
 
 int RGWRados::process_lc()
 {
-  return lc->process(nullptr);
+  RGWLC lc;
+  lc.initialize(cct, this->store);
+  RGWLC::LCWorker worker(&lc, cct, &lc, 0);
+  auto ret = lc.process(&worker, true /* once */);
+  lc.stop_processor(); // sets down_flag, but returns immediately
+  return ret;
 }
 
 bool RGWRados::process_expire_objects()

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8040,7 +8040,8 @@ int RGWRados::process_gc(bool expired_only)
   return gc->process(expired_only);
 }
 
-int RGWRados::list_lc_progress(const string& marker, uint32_t max_entries, map<string, int> *progress_map)
+int RGWRados::list_lc_progress(const string& marker, uint32_t max_entries,
+			       vector<cls_rgw_lc_entry>& progress_map)
 {
   return lc->list_lc_progress(marker, max_entries, progress_map);
 }

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1444,9 +1444,9 @@ public:
   int defer_gc(void *ctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y);
 
   int process_lc();
-  int list_lc_progress(const string& marker, uint32_t max_entries,
-		       vector<cls_rgw_lc_entry>& progress_map);
-  
+  int list_lc_progress(string& marker, uint32_t max_entries,
+		       vector<cls_rgw_lc_entry>& progress_map, int& index);
+
   int bucket_check_index(RGWBucketInfo& bucket_info,
                          map<RGWObjCategory, RGWStorageStats> *existing_stats,
                          map<RGWObjCategory, RGWStorageStats> *calculated_stats);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1444,7 +1444,8 @@ public:
   int defer_gc(void *ctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y);
 
   int process_lc();
-  int list_lc_progress(const string& marker, uint32_t max_entries, map<string, int> *progress_map);
+  int list_lc_progress(const string& marker, uint32_t max_entries,
+		       vector<cls_rgw_lc_entry>& progress_map);
   
   int bucket_check_index(RGWBucketInfo& bucket_info,
                          map<RGWObjCategory, RGWStorageStats> *existing_stats,


### PR DESCRIPTION
Allow RGWLC to spawn >1 LCWorker threads, controlled by option
rgw_lc_max_worker (default to 3).

LCWorker parallelism exactly resembles previous cross-instance
parallelism (and extends it), with no new locking.

Fixes: https://tracker.ceph.com/issues/43841

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
