### PR TITLE
rados bench: fix the delayed checking of completed ops

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -1115,7 +1115,7 @@ protected:
   }
 
   bool completion_is_done(int slot) override {
-    return completions[slot]->is_complete();
+    return completions[slot] && completions[slot]->is_complete();
   }
 
   int completion_wait(int slot) override {


### PR DESCRIPTION
## Bug Description

rados bench may delay the checking of completed ops because the [checking runs sequentially](https://github.com/ceph/ceph/blob/master/src/common/obj_bencher.cc#L546) and could be blocked by some recently added ops while some old ops in the completion slots may have already been completed. The result is that the average latency of all ops in a test is prolonged.


## How to Reproduce

1. add `objecter_inflight_op_bytes = 536870912` to ceph.conf
2. launch ceph: `MON=1 OSD=1 MDS=0 MGR=1 RGW=0 ../src/vstart.sh -d -x`
3. create a pool named rados: `bin/ceph osd pool create rados 128`
4. run rados bench: `bin/rados bench -p rados 10 write -b 4M -t 128 --show-time --write-object --no-hints`

Here is an example output from running ceph on a HDD:
```
hints = 0
2020-01-30T18:55:04.687964-0700 Maintaining 128 concurrent writes of 4194304 bytes to objects of size 4194304 for up to 10 seconds or 0 objects
2020-01-30T18:55:04.687993-0700 Object prefix: benchmark_data_node-0.rados-bench.ucsc-cmps1_8144
2020-01-30T18:55:05.270604-0700   sec Cur ops   started  finished  avg MB/s  cur MB/s last lat(s)  avg lat(s)
2020-01-30T18:55:05.270604-0700     0       0         0         0         0         0           -           0
2020-01-30T18:55:06.270788-0700     1     128       135         7   27.9975        28    0.992613    0.868404
2020-01-30T18:55:07.270962-0700     2     128       150        22   43.9942        60     1.99371     1.37955
2020-01-30T18:55:08.271134-0700     3     128       167        39   51.9924        68     2.83227     1.85842
2020-01-30T18:55:09.271323-0700     4     128       187        59   58.9908        80     3.87153     2.42283
2020-01-30T18:55:10.271493-0700     5     128       201        73   58.3907        56      4.8478      2.8125
2020-01-30T18:55:11.271627-0700     6     128       222        94    62.657        84     5.87121     3.38456
2020-01-30T18:55:12.271795-0700     7     128       239       111   63.4186        68     6.91063     3.79397
2020-01-30T18:55:13.271973-0700     8     128       257       129   64.4897        72     5.11479     4.17667
2020-01-30T18:55:14.272166-0700     9     128       277       149   66.2114        80     6.09044     4.55332
2020-01-30T18:55:15.272302-0700    10     128       291       163   65.1895        56     5.85408     4.80099
2020-01-30T18:55:16.272468-0700    11     128       292       164   59.6268         4     5.25381     4.80375
2020-01-30T18:55:17.272634-0700    12     128       292       164   54.6578         0           -     4.80375
2020-01-30T18:55:18.272800-0700    13     126       292       166   51.0687         4     8.64637      4.8526
2020-01-30T18:55:19.272969-0700    14     126       292       166   47.4209         0           -      4.8526
2020-01-30T18:55:20.273135-0700    15     126       292       166   44.2595         0           -      4.8526
2020-01-30T18:55:21.273311-0700    16     126       292       166   41.4932         0           -      4.8526
2020-01-30T18:55:22.273558-0700 Total time run:         16.8569
Total writes made:      292
Write size:             4194304
Object size:            4194304
Bandwidth (MB/sec):     69.289
Stddev Bandwidth:       34.4006
Max bandwidth (MB/sec): 84
Min bandwidth (MB/sec): 0
Average IOPS:           17
Stddev IOPS:            8.60015
Max IOPS:               21
Min IOPS:               0
Average Latency(s):     7.35454
Stddev Latency(s):      3.68156
Max latency(s):         15.8641
Min latency(s):         0.816889
```
There are multiple lines with 0 `cur MB/s` at the end of the output. The reason is that the final reaping process for submitted ops was blocking by some new ops without knowning others may have been completed.

With this PR applied, the result is
```
hints = 0
2020-01-30T19:02:49.945007-0700 Maintaining 128 concurrent writes of 4194304 bytes to objects of size 4194304 for up to 10 seconds or 0 objects
2020-01-30T19:02:49.945033-0700 Object prefix: benchmark_data_node-0.rados-bench.ucsc-cmps1_18993
2020-01-30T19:02:50.274784-0700   sec Cur ops   started  finished  avg MB/s  cur MB/s last lat(s)  avg lat(s)
2020-01-30T19:02:50.274784-0700     0       0         0         0         0         0           -           0
2020-01-30T19:02:51.274933-0700     1     128       131         3   11.9982        12    0.745512    0.673135
2020-01-30T19:02:52.275101-0700     2     128       153        25    49.992        88     1.88869     1.36072
2020-01-30T19:02:53.275288-0700     3     128       174        46    61.323        84     2.96703     1.91538
2020-01-30T19:02:54.275428-0700     4     128       194        66   65.9893        80     3.84272     2.40573
2020-01-30T19:02:55.275583-0700     5     128       216        88   70.3887        88     4.99898     2.90928
2020-01-30T19:02:56.275767-0700     6     128       239       111   73.9878        92     3.05543     3.35437
2020-01-30T19:02:57.275940-0700     7     128       253       125   71.4167        56     6.93346     3.68387
2020-01-30T19:02:58.276102-0700     8     128       269       141   70.4883        64     6.17849     3.98811
2020-01-30T19:02:59.276243-0700     9     128       290       162   71.9883        84     5.84943     4.34379
2020-01-30T19:03:00.276385-0700    10     128       312       184   73.5882        88     7.24474     4.62051
2020-01-30T19:03:01.276537-0700    11     108       312       204     74.17        80     6.46688     4.81243
2020-01-30T19:03:02.276704-0700    12      87       312       225    74.988        84     5.89965     4.94982
2020-01-30T19:03:03.276855-0700    13      57       312       255    78.449       120     4.96182     5.04913
2020-01-30T19:03:04.276981-0700    14      34       312       278   79.4161        92     4.74756     5.11966
2020-01-30T19:03:05.277140-0700    15      15       312       297   79.1875        76      6.8449     5.22369
2020-01-30T19:03:06.277360-0700 Total time run:         15.2931
Total writes made:      312
Write size:             4194304
Object size:            4194304
Bandwidth (MB/sec):     81.6055
Stddev Bandwidth:       23.2846
Max bandwidth (MB/sec): 120
Min bandwidth (MB/sec): 12
Average IOPS:           20
Stddev IOPS:            5.82114
Max IOPS:               30
Min IOPS:               3
Average Latency(s):     5.25832
Stddev Latency(s):      1.93903
Max latency(s):         8.48391
Min latency(s):         0.540758
```

Note that the difference of the final "Average Latency(s)" between these two results is significant.

Signed-off-by: Jianshen Liu <jliu120@ucsc.edu>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
