### PR TITLE
nautilus: mgr/pg_autoscaler: default to pg_num[_min] = 32

### DIFF
--- a/doc/rados/configuration/pool-pg-config-ref.rst
+++ b/doc/rados/configuration/pool-pg-config-ref.rst
@@ -198,7 +198,7 @@ Ceph configuration file.
               value is the same as ``pg_num`` with ``mkpool``.
 
 :Type: 32-bit Integer
-:Default: ``16``
+:Default: ``32``
 
 
 ``osd pool default pgp num``

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -195,18 +195,18 @@ class PoolTest(DashboardTestCase):
             ['osd', 'erasure-code-profile', 'set', 'ecprofile', 'crush-failure-domain=osd'])
         pools = [{
             'pool': 'dashboard_pool1',
-            'pg_num': '10',
+            'pg_num': '32',
             'pool_type': 'replicated',
             'application_metadata': ['rbd', 'sth'],
         }, {
             'pool': 'dashboard_pool2',
-            'pg_num': '10',
+            'pg_num': '32',
             'pool_type': 'erasure',
             'erasure_code_profile': 'ecprofile',
             'crush_rule': 'ecrule',
         }, {
             'pool': 'dashboard_pool3',
-            'pg_num': '10',
+            'pg_num': '32',
             'pool_type': 'replicated',
             'compression_algorithm': 'zstd',
             'compression_mode': 'aggressive',
@@ -219,7 +219,7 @@ class PoolTest(DashboardTestCase):
     def test_update(self):
         pool = {
             'pool': 'dashboard_pool_update1',
-            'pg_num': '4',
+            'pg_num': '32',
             'pool_type': 'replicated',
             'compression_mode': 'passive',
             'compression_algorithm': 'snappy',

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2555,7 +2555,7 @@ std::vector<Option> get_global_options() {
     .add_service("mon"),
 
     Option("osd_pool_default_pg_num", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(16)
+    .set_default(32)
     .set_description("number of PGs for new pools")
     .set_flag(Option::FLAG_RUNTIME)
     .add_service("mon"),

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -25,7 +25,7 @@ Some terminology is made up for the purposes of this module:
 
 INTERVAL = 5
 
-PG_NUM_MIN = 16  # unless specified on a per-pool basis
+PG_NUM_MIN = 32  # unless specified on a per-pool basis
 
 def nearest_power_of_two(n):
     v = int(n)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43819

---

NOTE: follow-on backport for https://github.com/ceph/ceph/pull/32069#issuecomment-577275657

---

backport of https://github.com/ceph/ceph/pull/32788
parent tracker: https://tracker.ceph.com/issues/43757

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh