### PR TITLE
ceph.spec.in: Use pkgconfig() style BuildRequires for udev/libudev-devel

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -168,7 +168,7 @@ BuildRequires:	libaio-devel
 BuildRequires:	libblkid-devel >= 2.17
 BuildRequires:	libcurl-devel
 BuildRequires:	libcap-ng-devel
-BuildRequires:	libudev-devel
+BuildRequires:	pkgconfig(libudev)
 BuildRequires:	libnl3-devel
 BuildRequires:	liboath-devel
 BuildRequires:	libtool
@@ -184,7 +184,7 @@ BuildRequires:	python%{python3_pkgversion}
 BuildRequires:	python%{python3_pkgversion}-devel
 BuildRequires:	snappy-devel
 BuildRequires:	sudo
-BuildRequires:	udev
+BuildRequires:	pkgconfig(udev)
 BuildRequires:	util-linux
 BuildRequires:	valgrind-devel
 BuildRequires:	which


### PR DESCRIPTION
pkgconfig() is cross-distro and allows to 'not having to care' for distro specific
packaging names. On openSUSE/SUSE distros, for udev/libudev, we gain the
benefit of being able to -mini flavors which are sooner in the build queues.

Signed-off-by: Dominique Leuenberger <dimstar@opensuse.org>


