### PR TITLE
include, common: make ceph::bufferlist 32 bytes long on x86

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1898,7 +1898,7 @@ int buffer::list::write_fd(int fd, uint64_t offset) const
   iovec iov[IOV_MAX];
 
   auto p = std::cbegin(_buffers);
-  uint64_t left_pbrs = std::size(_buffers);
+  uint64_t left_pbrs = get_num_buffers();
   while (left_pbrs) {
     ssize_t bytes = 0;
     unsigned iovlen = 0;

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -263,29 +263,6 @@ static ceph::spinlock debug_lock;
     }
   };
 
-  class buffer::raw_unshareable : public buffer::raw {
-  public:
-    MEMPOOL_CLASS_HELPERS();
-
-    explicit raw_unshareable(unsigned l) : raw(l) {
-      if (len)
-	data = new char[len];
-      else
-	data = 0;
-    }
-    raw_unshareable(unsigned l, char *b) : raw(b, l) {
-    }
-    raw* clone_empty() override {
-      return new raw_char(len);
-    }
-    bool is_shareable() const override {
-      return false; // !shareable, will force make_shareable()
-    }
-    ~raw_unshareable() override {
-      delete[] data;
-    }
-  };
-
   class buffer::raw_static : public buffer::raw {
   public:
     MEMPOOL_CLASS_HELPERS();
@@ -380,10 +357,6 @@ static ceph::spinlock debug_lock;
     } else {
       return create_aligned(len, CEPH_PAGE_SIZE);
     }
-  }
-
-  ceph::unique_leakable_ptr<buffer::raw> buffer::create_unshareable(unsigned len) {
-    return ceph::unique_leakable_ptr<buffer::raw>(new raw_unshareable(len));
   }
 
   buffer::ptr::ptr(ceph::unique_leakable_ptr<raw> r)
@@ -2221,8 +2194,6 @@ MEMPOOL_DEFINE_OBJECT_FACTORY(buffer::raw_posix_aligned,
 			      buffer_raw_posix_aligned, buffer_meta);
 MEMPOOL_DEFINE_OBJECT_FACTORY(buffer::raw_char, buffer_raw_char, buffer_meta);
 MEMPOOL_DEFINE_OBJECT_FACTORY(buffer::raw_claimed_char, buffer_raw_claimed_char,
-			      buffer_meta);
-MEMPOOL_DEFINE_OBJECT_FACTORY(buffer::raw_unshareable, buffer_raw_unshareable,
 			      buffer_meta);
 MEMPOOL_DEFINE_OBJECT_FACTORY(buffer::raw_static, buffer_raw_static,
 			      buffer_meta);

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1262,21 +1262,17 @@ static ceph::spinlock debug_lock;
   }
 
   // sort-of-like-assignment-op
-  void buffer::list::claim(list& bl, unsigned int flags)
+  void buffer::list::claim(list& bl)
   {
     // free my buffers
     clear();
-    claim_append(bl, flags);
+    claim_append(bl);
   }
 
-  void buffer::list::claim_append(list& bl, unsigned int flags)
+  void buffer::list::claim_append(list& bl)
   {
     // steal the other guy's buffers
     _len += bl._len;
-    if (!(flags & CLAIM_ALLOW_NONSHAREABLE)) {
-      // NOP for now.
-      // TODO: kill CLAIM_ALLOW_NONSHAREABLE
-    }
     _buffers.splice_back(bl._buffers);
     bl._carriage = &always_empty_bptr;
     bl._buffers.clear_and_dispose();

--- a/src/common/buffer_seastar.cc
+++ b/src/common/buffer_seastar.cc
@@ -74,7 +74,7 @@ ptr::operator seastar::temporary_buffer<char>() &&
 list::operator seastar::net::packet() &&
 {
   seastar::net::packet p;
-  p.reserve(_buffers.size());
+  p.reserve(_num);
   for (auto& ptr : _buffers) {
     // append each ptr as a temporary_buffer
     p = seastar::net::packet(std::move(p), std::move(ptr));

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -166,7 +166,6 @@ inline namespace v14_2_0 {
   ceph::unique_leakable_ptr<raw> create_aligned_in_mempool(unsigned len, unsigned align, int mempool);
   ceph::unique_leakable_ptr<raw> create_page_aligned(unsigned len);
   ceph::unique_leakable_ptr<raw> create_small_page_aligned(unsigned len);
-  ceph::unique_leakable_ptr<raw> create_unshareable(unsigned len);
   ceph::unique_leakable_ptr<raw> claim_buffer(unsigned len, char *buf, deleter del);
 
 #ifdef HAVE_SEASTAR

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -443,6 +443,12 @@ inline namespace v14_2_0 {
       ptr_hook* _tail;
       std::size_t _size;
 
+      // the presence size() is our implementation detail; we don't
+      // expose it via bufferlist::buffers()::size(). Client should
+      // use buffferlist::get_num_buffers() instead.
+      std::size_t size() const { return _size; }
+      friend list;
+
     public:
       template <class T>
       class buffers_iterator {
@@ -582,7 +588,6 @@ inline namespace v14_2_0 {
 	other._size = 0;
       }
 
-      std::size_t size() const { return _size; }
       bool empty() const { return _tail == &_root; }
 
       const_iterator begin() const {

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -674,7 +674,6 @@ inline namespace v14_2_0 {
     // he expects it won't change.
     ptr* _carriage;
     unsigned _len;
-    unsigned _memcopy_count; //the total of memcopy using rebuild().
 
     template <bool is_const>
     class CEPH_BUFFER_API iterator_impl {
@@ -954,22 +953,19 @@ inline namespace v14_2_0 {
     // cons/des
     list()
       : _carriage(&always_empty_bptr),
-        _len(0),
-        _memcopy_count(0) {
+        _len(0) {
     }
     // cppcheck-suppress noExplicitConstructor
     // cppcheck-suppress noExplicitConstructor
     list(unsigned prealloc)
       : _carriage(&always_empty_bptr),
-        _len(0),
-        _memcopy_count(0) {
+        _len(0) {
       reserve(prealloc);
     }
 
     list(const list& other)
       : _carriage(&always_empty_bptr),
-        _len(other._len),
-        _memcopy_count(other._memcopy_count) {
+        _len(other._len) {
       _buffers.clone_from(other._buffers);
     }
     list(list&& other) noexcept;
@@ -990,7 +986,6 @@ inline namespace v14_2_0 {
       _buffers = std::move(other._buffers);
       _carriage = other._carriage;
       _len = other._len;
-      _memcopy_count = other._memcopy_count;
       other.clear();
       return *this;
     }
@@ -1008,7 +1003,6 @@ inline namespace v14_2_0 {
       return _carriage->unused_tail_length();
     }
 
-    unsigned get_memcopy_count() const {return _memcopy_count; }
     const buffers_t& buffers() const { return _buffers; }
     void swap(list& other) noexcept;
     unsigned length() const {
@@ -1047,7 +1041,6 @@ inline namespace v14_2_0 {
       _carriage = &always_empty_bptr;
       _buffers.clear_and_dispose();
       _len = 0;
-      _memcopy_count = 0;
     }
     void push_back(const ptr& bp) {
       if (bp.length() == 0)

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -1090,12 +1090,8 @@ inline namespace v14_2_0 {
 
     void reserve(size_t prealloc);
 
-    // assignment-op with move semantics
-    const static unsigned int CLAIM_DEFAULT = 0;
-    const static unsigned int CLAIM_ALLOW_NONSHAREABLE = 1;
-
-    void claim(list& bl, unsigned int flags = CLAIM_DEFAULT);
-    void claim_append(list& bl, unsigned int flags = CLAIM_DEFAULT);
+    void claim(list& bl);
+    void claim_append(list& bl);
     // only for bl is bufferlist::page_aligned_appender
     void claim_append_piecewise(list& bl);
 

--- a/src/include/buffer_raw.h
+++ b/src/include/buffer_raw.h
@@ -93,12 +93,6 @@ public:
       memcpy(c->data, data, len);
       return ceph::unique_leakable_ptr<raw>(c);
     }
-    virtual bool is_shareable() const {
-      // true if safe to reference/share the existing buffer copy
-      // false if it is not safe to share the buffer, e.g., due to special
-      // and/or registered memory that is scarce
-      return true;
-    }
     bool get_crc(const std::pair<size_t, size_t> &fromto,
 		 std::pair<uint32_t, uint32_t> *crc) const {
       std::lock_guard lg(crc_spinlock);

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -899,7 +899,7 @@ void RocksDBStore::RocksDBTransactionImpl::put_bat(
 			   to_set_bl.length()));
   } else {
     rocksdb::Slice key_slice(key);
-    vector<rocksdb::Slice> value_slices(to_set_bl.buffers().size());
+    vector<rocksdb::Slice> value_slices(to_set_bl.get_num_buffers());
     bat.Put(cf,
 	    rocksdb::SliceParts(&key_slice, 1),
             prepare_sliceparts(to_set_bl, &value_slices));
@@ -1055,7 +1055,7 @@ void RocksDBStore::RocksDBTransactionImpl::merge(
     } else {
       // make a copy
       rocksdb::Slice key_slice(k);
-      vector<rocksdb::Slice> value_slices(to_set_bl.buffers().size());
+      vector<rocksdb::Slice> value_slices(to_set_bl.get_num_buffers());
       bat.Merge(cf, rocksdb::SliceParts(&key_slice, 1),
 		prepare_sliceparts(to_set_bl, &value_slices));
     }
@@ -1070,7 +1070,7 @@ void RocksDBStore::RocksDBTransactionImpl::merge(
     } else {
       // make a copy
       rocksdb::Slice key_slice(key);
-      vector<rocksdb::Slice> value_slices(to_set_bl.buffers().size());
+      vector<rocksdb::Slice> value_slices(to_set_bl.get_num_buffers());
       bat.Merge(
 	db->default_cf,
 	rocksdb::SliceParts(&key_slice, 1),

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -396,7 +396,7 @@ public:
   void set_payload(ceph::buffer::list& bl) {
     if (byte_throttler)
       byte_throttler->put(payload.length());
-    payload.claim(bl, ceph::buffer::list::CLAIM_ALLOW_NONSHAREABLE);
+    payload.claim(bl);
     if (byte_throttler)
       byte_throttler->take(payload.length());
   }
@@ -404,7 +404,7 @@ public:
   void set_middle(ceph::buffer::list& bl) {
     if (byte_throttler)
       byte_throttler->put(middle.length());
-    middle.claim(bl, ceph::buffer::list::CLAIM_ALLOW_NONSHAREABLE);
+    middle.claim(bl);
     if (byte_throttler)
       byte_throttler->take(middle.length());
   }
@@ -420,11 +420,10 @@ public:
 
   const ceph::buffer::list& get_data() const { return data; }
   ceph::buffer::list& get_data() { return data; }
-  void claim_data(ceph::buffer::list& bl,
-		  unsigned int flags = ceph::buffer::list::CLAIM_DEFAULT) {
+  void claim_data(ceph::buffer::list& bl) {
     if (byte_throttler)
       byte_throttler->put(data.length());
-    bl.claim(data, flags);
+    bl.claim(data);
   }
   off_t get_data_len() const { return data.length(); }
 

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -109,7 +109,7 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
   ssize_t send(bufferlist &bl, bool more) override {
     size_t sent_bytes = 0;
     auto pb = std::cbegin(bl.buffers());
-    uint64_t left_pbrs = std::size(bl.buffers());
+    uint64_t left_pbrs = bl.get_num_buffers();
     while (left_pbrs) {
       struct msghdr msg;
       struct iovec msgvec[IOV_MAX];

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -1134,7 +1134,7 @@ ssize_t ProtocolV1::write_message(Message *m, bufferlist &bl, bool more) {
                  << " front=" << header.front_len << " data=" << header.data_len
                  << " off " << header.data_off << dendl;
 
-  if ((bl.length() <= ASYNC_COALESCE_THRESHOLD) && (bl.buffers().size() > 1)) {
+  if ((bl.length() <= ASYNC_COALESCE_THRESHOLD) && (bl.get_num_buffers() > 1)) {
     for (const auto &pb : bl.buffers()) {
       connection->outgoing_bl.append((char *)pb.c_str(), pb.length());
     }

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -345,7 +345,7 @@ ssize_t RDMAConnectedSocketImpl::submit(bool more)
   std::lock_guard l{lock};
   size_t bytes = pending_bl.length();
   ldout(cct, 20) << __func__ << " we need " << bytes << " bytes. iov size: "
-                 << pending_bl.buffers().size() << dendl;
+                 << pending_bl.get_num_buffers() << dendl;
   if (!bytes)
     return 0;
 
@@ -388,7 +388,7 @@ ssize_t RDMAConnectedSocketImpl::submit(bool more)
   }
 
   ldout(cct, 20) << __func__ << " left bytes: " << pending_bl.length() << " in buffers "
-                 << pending_bl.buffers().size() << " tx chunks " << tx_buffers.size() << dendl;
+                 << pending_bl.get_num_buffers() << " tx chunks " << tx_buffers.size() << dendl;
 
   int r = post_work_request(tx_buffers);
   if (r < 0)

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1579,7 +1579,7 @@ int FileJournal::prepare_entry(vector<ObjectStore::Transaction>& tls, bufferlist
     ebl.push_back(buffer::create_static(h.pre_pad, zero_buf));
   }
   // payload
-  ebl.claim_append(bl, buffer::list::CLAIM_ALLOW_NONSHAREABLE); // potential zero-copy
+  ebl.claim_append(bl);
   if (h.post_pad) {
     ebl.push_back(buffer::create_static(h.post_pad, zero_buf));
   }

--- a/src/os/filestore/FileJournal.h
+++ b/src/os/filestore/FileJournal.h
@@ -64,7 +64,7 @@ public:
     ZTracer::Trace trace;
     write_item(uint64_t s, bufferlist& b, int ol, TrackedOpRef opref) :
       seq(s), orig_len(ol), tracked_op(opref) {
-      bl.claim(b, buffer::list::CLAIM_ALLOW_NONSHAREABLE); // potential zero-copy
+      bl.claim(b);
     }
     write_item() : seq(0), orig_len(0) {}
   };

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1714,7 +1714,7 @@ TEST(BufferList, push_back) {
     bufferptr ptr;
     bl.push_back(std::move(ptr));
     EXPECT_EQ((unsigned)0, bl.length());
-    EXPECT_EQ((unsigned)0, bl.buffers().size());
+    EXPECT_EQ((unsigned)0, bl.get_num_buffers());
   }
   {
     bufferlist bl;
@@ -1723,7 +1723,7 @@ TEST(BufferList, push_back) {
     ptr.c_str()[0] = 'B';
     bl.push_back(std::move(ptr));
     EXPECT_EQ((unsigned)(1 + len), bl.length());
-    EXPECT_EQ((unsigned)2, bl.buffers().size());
+    EXPECT_EQ((unsigned)2, bl.get_num_buffers());
     EXPECT_EQ('B', bl.buffers().back()[0]);
     EXPECT_FALSE(static_cast<instrumented_bptr&>(ptr).get_raw());
   }
@@ -2047,18 +2047,18 @@ TEST(BufferList, append) {
   //
   {
     bufferlist bl;
-    EXPECT_EQ((unsigned)0, bl.buffers().size());
+    EXPECT_EQ((unsigned)0, bl.get_num_buffers());
     EXPECT_EQ((unsigned)0, bl.length());
     {
       bufferptr ptr;
       bl.append(std::move(ptr));
-      EXPECT_EQ((unsigned)0, bl.buffers().size());
+      EXPECT_EQ((unsigned)0, bl.get_num_buffers());
       EXPECT_EQ((unsigned)0, bl.length());
     }
     {
       bufferptr ptr(3);
       bl.append(std::move(ptr));
-      EXPECT_EQ((unsigned)1, bl.buffers().size());
+      EXPECT_EQ((unsigned)1, bl.get_num_buffers());
       EXPECT_EQ((unsigned)3, bl.length());
       EXPECT_FALSE(static_cast<instrumented_bptr&>(ptr).get_raw());
     }


### PR DESCRIPTION
The four last commits of this PR shrink size of `ceph::bufferlist` from 40 to 32 bytes which is exactly half of modern x86's cache line. The idea is to recycle the space occupied by `memcopy_count` – which seems to be rather a debug facility – and use these 4 bytes to store number-of-buffers as `bufferlist::_num`. The freshly introduced field allows in turn to drop `size_t`-typed `_size` member from the underlying, low-level list `ceph::bufferlist` is built upon.

Also, the patchset removes the redundancy in the API for retrieving the number of buffers in `bufferlist` instance.

Other commits, including the `last_p` removal (72 bytes -> 40 bytes), are pulled just as dependency. Possibly many of them could be squeezed if necessary.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
