### PR TITLE
mgr/cephadm: fix detection of just-created OSDs

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1314,6 +1314,8 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             'keyring': keyring,
         })
 
+        before_osd_uuid_map = self.get_osd_uuid_map()
+
         devices = drive_group.data_devices.paths
         for device in devices:
             out, err, code = self._run_cephadm(
@@ -1346,8 +1348,8 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                 if osd['tags']['ceph.cluster_fsid'] != fsid:
                     self.log.debug('mismatched fsid, skipping %s' % osd)
                     continue
-                if len(list(set(devices) & set(osd['devices']))) == 0 and osd.get('lv_path') not in devices:
-                    self.log.debug('mismatched devices, skipping %s' % osd)
+                if osd_id in before_osd_uuid_map:
+                    # this osd existed before we ran prepare
                     continue
                 if osd_id not in osd_uuid_map:
                     self.log.debug('osd id %d does not exist in cluster' % osd_id)


### PR DESCRIPTION
Don't match against the literal device names that were passed, as this
will fail if there is (1) an LV name or (2) non-canonical name like
/dev/disk/...

Instead, match any OSD we see that didn't exist before we ran c-v prepare.
This might include other OSDs created by a racing c-v incantation, but (1)
we shouldn't have any of those, and (2) even if they were, the OSD is new
and should be added.