### PR TITLE
common/bl: carry the bufferlist::_carriage over std::moves

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -924,14 +924,6 @@ static ceph::spinlock debug_lock;
 
   // -- buffer::list --
 
-  buffer::list::list(list&& other) noexcept
-    : _buffers(std::move(other._buffers)),
-      _carriage(other._carriage),
-      _len(other._len),
-      _num(other._num) {
-    other.clear();
-  }
-
   void buffer::list::swap(list& other) noexcept
   {
     std::swap(_len, other._len);

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -926,7 +926,7 @@ static ceph::spinlock debug_lock;
 
   buffer::list::list(list&& other) noexcept
     : _buffers(std::move(other._buffers)),
-      _carriage(&always_empty_bptr),
+      _carriage(other._carriage),
       _len(other._len),
       _num(other._num) {
     other.clear();

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -953,7 +953,14 @@ inline namespace v14_2_0 {
         _num(other._num) {
       _buffers.clone_from(other._buffers);
     }
-    list(list&& other) noexcept;
+
+    list(list&& other) noexcept
+      : _buffers(std::move(other._buffers)),
+        _carriage(other._carriage),
+        _len(other._len),
+        _num(other._num) {
+      other.clear();
+    }
 
     ~list() {
       _buffers.clear_and_dispose();

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1310,6 +1310,18 @@ TEST(BufferList, constructors) {
   }
 }
 
+TEST(BufferList, append_after_move) {
+  bufferlist bl(6);
+  bl.append("ABC", 3);
+  EXPECT_EQ(1, bl.get_num_buffers());
+
+  bufferlist moved_to_bl(std::move(bl));
+  moved_to_bl.append("123", 3);
+  // it's expected that the list(list&&) ctor will preserve the _carriage
+  EXPECT_EQ(1, moved_to_bl.get_num_buffers());
+  EXPECT_EQ(0, ::memcmp("ABC123", moved_to_bl.c_str(), 6));
+}
+
 void bench_bufferlist_alloc(int size, int num, int per)
 {
   utime_t start = ceph_clock_now();


### PR DESCRIPTION
The two last commits improve the `bufferlist` move constructor:

* the first one fixes the unnecessary zeroization of `bufferlist::_carriage` preventing the carry the append space to new instance of `bufferlist` constructed by moving-from another one,
* the last one makes the move constructor inlineable which is pretty important for for crimson as we tend to move `seastar::future<ceph::bufferlist>` over the IO path.

Other commits are pulled just as dependency in development process. Possibly many of them could be squeezed if necessary.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
