### PR TITLE
librbd: fix build on freebsd

### DIFF
--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -1797,7 +1797,7 @@ int Mirror<I>::image_info_list(
       mirror_image_info_t info;
       r = image_get_info(io_ctx, op_work_queue, image_id, &info);
       if (r >= 0) {
-        (*entries)[image_id] = {mode, info};
+        (*entries)[image_id] = std::make_pair(mode, info);
       }
     }
 


### PR DESCRIPTION
Signed-off-by: Mykola Golub <mgolub@suse.com>

FreeBSD 13.0-CURRENT 
FreeBSD clang version 9.0.1 (git@github.com:llvm/llvm-project.git c1a0a213378a458fbea1a5c77b315c7dce08fd05) (based on LLVM 9.0.1)

It fails with:
```
[100%] Linking CXX executable ../../../bin/unittest_librbd
/usr/local/bin/ld: ../../../lib/librbd_internal.a(Mirror.cc.o): in function `librbd::api::Mirror<librbd::ImageCtx>::image_info_list(librados::v14_2_0::IoCtx&, rbd_mirror_image_mode_t*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned long, std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::pair<rbd_mirror_image_mode_t, librbd::mirror_image_info_t>, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::pair<rbd_mirror_image_mode_t, librbd::mirror_image_info_t> > > >*)':
/home/mgolub/ceph/ceph/src/librbd/api/Mirror.cc:1800: undefined reference to `std::__1::pair<rbd_mirror_image_mode_t, librbd::mirror_image_info_t>::~pair()'
/usr/local/bin/ld: /home/mgolub/ceph/ceph/src/librbd/api/Mirror.cc:1800: undefined reference to `std::__1::pair<rbd_mirror_image_mode_t, librbd::mirror_image_info_t>::~pair()'
c++: error: linker command failed with exit code 1 (use -v to see invocation)
--- bin/unittest_librbd ---
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
