### PR TITLE
mon/MgrMonitor.cc: add always_on_modules to the output of "ceph mgr module ls"

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -928,6 +928,11 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
   } else if (prefix == "mgr module ls") {
     f->open_object_section("modules");
     {
+      f->open_array_section("always_on_modules");
+      for (auto& p : map.get_always_on_modules()) {
+        f->dump_string("module", p);
+      }
+      f->close_section();
       f->open_array_section("enabled_modules");
       for (auto& p : map.modules) {
         if (map.get_always_on_modules().count(p) > 0)


### PR DESCRIPTION
Makes it easier to know what the always_on_modules for each release are, without
having to look at the code.

Signed-off-by: Neha Ojha <nojha@redhat.com>

Sample output:
```
 {
    "always_on_modules": [
        "balancer",
        "crash",
        "devicehealth",
        "orchestrator_cli",
        "pg_autoscaler",
        "progress",
        "rbd_support",
        "status",
        "telemetry",
        "volumes"
    ],
    "enabled_modules": [
        "dashboard",
        "iostat",
        "restful"
    ],
    "disabled_modules": [
        ..
```