### PR TITLE
qa/rgw: multisite checkpoints consider pubsub zone

### DIFF
--- a/src/test/rgw/rgw_multi/multisite.py
+++ b/src/test/rgw/rgw_multi/multisite.py
@@ -164,6 +164,9 @@ class Zone(SystemObject, SystemObject.CreateDelete, SystemObject.GetSet, SystemO
     def tier_type(self):
         raise NotImplementedError
 
+    def syncs_from(self, zone_name):
+        return zone_name != self.name
+
     def has_buckets(self):
         return True
 

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -354,7 +354,7 @@ def compare_bucket_status(target_zone, source_zone, bucket_name, log_status, syn
     return True
 
 def zone_data_checkpoint(target_zone, source_zone):
-    if target_zone == source_zone:
+    if not target_zone.syncs_from(source_zone):
         return
 
     log_status = data_source_log_status(source_zone)
@@ -384,7 +384,7 @@ def zonegroup_data_checkpoint(zonegroup_conns):
             zone_data_checkpoint(target_conn.zone, source_conn.zone)
 
 def zone_bucket_checkpoint(target_zone, source_zone, bucket_name):
-    if target_zone == source_zone:
+    if not target_zone.syncs_from(source_zone):
         return
 
     log_status = bucket_source_log_status(source_zone, bucket_name)

--- a/src/test/rgw/rgw_multi/zone_ps.py
+++ b/src/test/rgw/rgw_multi/zone_ps.py
@@ -49,6 +49,9 @@ class PSZone(Zone):  # pylint: disable=too-many-ancestors
     def tier_type(self):
         return "pubsub"
 
+    def syncs_from(self, zone_name):
+        return zone_name == self.master_zone.name
+
     def create(self, cluster, args=None, **kwargs):
         if args is None:
             args = ''


### PR DESCRIPTION
pubsub zones are configured to only sync_from the master zone, so bucket checkpoints should ignore its sync status with respect to other zones

Fixes: https://tracker.ceph.com/issues/43768