### PR TITLE
qa/tasks/ceph_manager: fix chmod on log dir during pg export copy

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -319,8 +319,15 @@ class OSDThrasher(Thrasher):
                     "exp.{pg}.{id}".format(
                         pg=pg,
                         id=exp_osd))
+                exp_host_path_dirs = [
+                    os.path.join(
+                        '/var/log/ceph',
+                        self.ceph_manager.ctx.ceph[self.ceph_manager.cluster].fsid),
+                    '/var/log/ceph',
+                ]
             else:
                 exp_host_path = exp_path
+                exp_host_path_dirs = ['/var/log/ceph']
 
             # export
             # Can't use new export-remove op since this is part of upgrade testing
@@ -375,8 +382,9 @@ class OSDThrasher(Thrasher):
                         self.log("Transfer export file from {srem} to {trem}".
                                  format(srem=exp_remote, trem=imp_remote))
                         # just in case an upgrade make /var/log/ceph unreadable by non-root,
-                        exp_remote.run(args=['sudo', 'chmod', '777', '/var/log/ceph'])
-                        imp_remote.run(args=['sudo', 'chmod', '777', '/var/log/ceph'])
+                        for d in exp_host_path_dirs:
+                            exp_remote.run(args=['sudo', 'chmod', '777', d])
+                            imp_remote.run(args=['sudo', 'chmod', '777', d])
                         tmpexport = Remote.get_file(exp_remote, exp_host_path)
                         Remote.put_file(imp_remote, tmpexport, exp_host_path)
                         os.remove(tmpexport)


### PR DESCRIPTION
With cephadm, we should chmod both /var/log/ceph and /var/log/ceph/$fsid.

Signed-off-by: Sage Weil <sage@redhat.com>