### PR TITLE
osd: Allow 64-char hostname to be added as the "host" in CRUSH

### DIFF
--- a/src/crush/CrushLocation.cc
+++ b/src/crush/CrushLocation.cc
@@ -105,7 +105,7 @@ int CrushLocation::init_on_startup()
 
   // start with a sane default
   char hostname[HOST_NAME_MAX + 1];
-  int r = gethostname(hostname, sizeof(hostname)-1);
+  int r = gethostname(hostname, sizeof(hostname));
   if (r < 0)
     strcpy(hostname, "unknown_host");
   // use short hostname


### PR DESCRIPTION
On Linux system it is possible to set 64 character length hostname when
HOST_NAME_MAX is set to 64. It means that if we execute gethostname
function we should expect HOST_NAME_MAX characters + 1 for null
character ending hostname string as described here:
http://man7.org/linux/man-pages/man2/sethostname.2.html

With the current code on host with 64 long hostname osd during start
updates crush map with host=unknown_host.

Signed-off-by: Michal Skalski <mskalski@juniper.net>

```
$ uname -r
3.10.0-957.27.2.el7.x86_64

$ cat /etc/redhat-release
Red Hat Enterprise Linux Server release 7.7 (Maipo)

$ getconf HOST_NAME_MAX
64

$ sudo hostname my64lengthhostname12345678912345678912345679.myexampledomain.net

$ echo -n $(hostname) | wc -c
64

$ cat ./test_ceph_hostname
#include <iostream>
#include <unistd.h>
#include <string.h>
#include <cerrno>
/*
 * https://github.com/ceph/ceph/blob/master/src/include/compat.h
 */
#include <sys/param.h>
#include <limits.h>

#ifndef HOST_NAME_MAX
#ifdef MAXHOSTNAMELEN
#define HOST_NAME_MAX MAXHOSTNAMELEN
#else
#define HOST_NAME_MAX 255
#endif
#endif

int main() {
  /*
   * https://github.com/ceph/ceph/blob/master/src/crush/CrushLocation.cc
   */
  char hostname[HOST_NAME_MAX + 1];
  int r = gethostname(hostname, sizeof(hostname)-1);
  if (r < 0) {
    strcpy(hostname, "unknown_host");
    // added for this example
    std::cout << "Error: ernno= " << errno << " msg: " << strerror(errno) << "\n";
  }
  // use short hostname
  // use short hostname
  for (unsigned i=0; hostname[i]; ++i) {
    if (hostname[i] == '.') {
      hostname[i] = '\0';
      break;
    }
  }
  std::cout << hostname << "\n";
}

$ ./test_ceph_hostname
Error: ernno= 36 msg: File name too long
unknown_host
```


with the proposed change:

```
$ ./test_ceph_hostname
my64lengthhostname12345678912345678912345679
```
