### PR TITLE
luminous: qa: install build dependencies for cfuse_workunit_kernel_untar_build.yaml

### DIFF
--- a/qa/suites/powercycle/osd/powercycle/default.yaml
+++ b/qa/suites/powercycle/osd/powercycle/default.yaml
@@ -1,5 +1,8 @@
 tasks:
 - install:
+    extra_system_packages:
+      deb: ['bison', 'flex', 'libelf-dev', 'libssl-dev']
+      rpm: ['bison', 'flex', 'elfutils-libelf-devel', 'openssl-devel']
 - ceph:
 - thrashosds:
     chance_down: 1.0


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/36076
Signed-off-by: Neha Ojha <nojha@redhat.com>
(cherry picked from commit 38ef3da8d27e24576193cbf3f9238f2c5b586c09)
