### PR TITLE
luminous: librbd: don't call refresh from mirror::GetInfoRequest state machine

### DIFF
--- a/src/librbd/mirror/GetInfoRequest.cc
+++ b/src/librbd/mirror/GetInfoRequest.cc
@@ -23,35 +23,6 @@ using librbd::util::create_rados_callback;
 
 template <typename I>
 void GetInfoRequest<I>::send() {
-  refresh_image();
-}
-
-template <typename I>
-void GetInfoRequest<I>::refresh_image() {
-  if (!m_image_ctx.state->is_refresh_required()) {
-    get_mirror_image();
-    return;
-  }
-
-  CephContext *cct = m_image_ctx.cct;
-  ldout(cct, 20) << dendl;
-
-  auto ctx = create_context_callback<
-    GetInfoRequest<I>, &GetInfoRequest<I>::handle_refresh_image>(this);
-  m_image_ctx.state->refresh(ctx);
-}
-
-template <typename I>
-void GetInfoRequest<I>::handle_refresh_image(int r) {
-  CephContext *cct = m_image_ctx.cct;
-  ldout(cct, 20) << "r=" << r << dendl;
-
-  if (r < 0) {
-    lderr(cct) << "failed to refresh image: " << cpp_strerror(r) << dendl;
-    finish(r);
-    return;
-  }
-
   get_mirror_image();
 }
 

--- a/src/librbd/mirror/GetInfoRequest.h
+++ b/src/librbd/mirror/GetInfoRequest.h
@@ -43,9 +43,6 @@ private:
    * <start>
    *    |
    *    v
-   * REFRESH
-   *    |
-   *    v
    * GET_MIRROR_IMAGE
    *    |
    *    v
@@ -64,9 +61,6 @@ private:
 
   bufferlist m_out_bl;
   std::string m_mirror_uuid;
-
-  void refresh_image();
-  void handle_refresh_image(int r);
 
   void get_mirror_image();
   void handle_get_mirror_image(int r);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43831

---

backport of https://github.com/ceph/ceph/pull/32734
parent tracker: https://tracker.ceph.com/issues/43589

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh