### PR TITLE
mgr/dashboard: Change project name to "Ceph Dashboard"

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
@@ -4,7 +4,7 @@ import { I18n } from '@ngx-translate/i18n-polyfill';
 
 export class AppConstants {
   public static readonly organization = 'ceph';
-  public static readonly projectName = 'Ceph Manager Dashboard';
+  public static readonly projectName = 'Ceph Dashboard';
   public static readonly license = 'Free software (LGPL 2.1).';
 }
 


### PR DESCRIPTION
The Dashboard's "About" page still referred to the application as "Ceph Manager Dashboard". Changed the `projectName` constant to "Ceph Dashboard" to resolve this.

Before:
![Screenshot from 2020-01-28 09-25-19](https://user-images.githubusercontent.com/263427/73360496-f6215d80-429a-11ea-89e3-730b256fd4dc.png)

After:
![Screenshot from 2020-01-29 14-13-31](https://user-images.githubusercontent.com/263427/73360508-fc173e80-429a-11ea-9b66-d72bd8104997.png)


Fixes: https://tracker.ceph.com/issues/43840
Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
