### PR TITLE
doc: quick-start-preflight.rst default to luminous

### DIFF
--- a/doc/install/ceph-deploy/quick-start-preflight.rst
+++ b/doc/install/ceph-deploy/quick-start-preflight.rst
@@ -26,11 +26,9 @@ For Debian and Ubuntu distributions, perform the following steps:
 
 	wget -q -O- 'https://download.ceph.com/keys/release.asc' | sudo apt-key add -
 
-#. Add the Ceph packages to your repository. Use the command below and
-   replace ``{ceph-stable-release}`` with a stable Ceph release (e.g.,
-   ``luminous``.)  For example::
+#. Add the Ceph packages to your repository. For example::
 
-	echo deb https://download.ceph.com/debian-{ceph-stable-release}/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
+	echo deb https://download.ceph.com/debian-luminous/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
 
 #. Update your repository and install ``ceph-deploy``::
 


### PR DESCRIPTION
eg should not have placeholders

Signed-off-by: Tim <elatllat@gmail.com>

- `jenkins test docs`
- `jenkins render docs`