### PR TITLE
mgr/cephadm: add drivegroup support; workaround c-v batch shortcoming

### DIFF
--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -576,13 +576,14 @@ def ceph_osds(ctx, config):
             devs = devs_by_remote[remote]
             assert devs   ## FIXME ##
             dev = devs.pop()
+            short_dev = dev.replace('/dev/', '')
             log.info('Deploying %s on %s with %s...' % (
                 osd, remote.shortname, dev))
             _shell(ctx, cluster_name, remote, [
                 'ceph-volume', 'lvm', 'zap', dev])
             _shell(ctx, cluster_name, remote, [
                 'ceph', 'orchestrator', 'osd', 'create',
-                remote.shortname + ':' + dev
+                remote.shortname + ':' + short_dev
             ])
             ctx.daemons.register_daemon(
                 remote, 'osd', id_,

--- a/src/pybind/mgr/ansible/module.py
+++ b/src/pybind/mgr/ansible/module.py
@@ -348,30 +348,33 @@ class Module(MgrModule, orchestrator.Orchestrator):
 
         return op
 
-    def create_osds(self, drive_group):
+    def create_osds(self, drive_groups):
         """Create one or more OSDs within a single Drive Group.
         If no host provided the operation affects all the host in the OSDS role
 
 
-        :param drive_group: (ceph.deployment.drive_group.DriveGroupSpec),
+        :param drive_groups: (ceph.deployment.drive_group.DriveGroupSpec),
                             Drive group with the specification of drives to use
         """
 
         # Transform drive group specification to Ansible playbook parameters
-        host, osd_spec = dg_2_ansible(drive_group)
+        ops = []
+        for drive_group in drive_groups:
+            host, osd_spec = dg_2_ansible(drive_group)
 
-        # Create a new read completion object for execute the playbook
-        op = playbook_operation(client=self.ar_client,
-                                playbook=ADD_OSD_PLAYBOOK,
-                                result_pattern="",
-                                params=osd_spec,
-                                querystr_dict={"limit": host},
-                                output_wizard=ProcessPlaybookResult(self.ar_client),
-                                event_filter_list=["playbook_on_stats"])
+            # Create a new read completion object for execute the playbook
+            op = playbook_operation(client=self.ar_client,
+                                    playbook=ADD_OSD_PLAYBOOK,
+                                    result_pattern="",
+                                    params=osd_spec,
+                                    querystr_dict={"limit": host},
+                                    output_wizard=ProcessPlaybookResult(self.ar_client),
+                                    event_filter_list=["playbook_on_stats"])
 
-        self._launch_operation(op)
+            self._launch_operation(op)
+            ops.append(op)
 
-        return op
+        return ops
 
     def remove_osds(self, osd_ids, destroy=False):
         """Remove osd's.

--- a/src/pybind/mgr/cephadm/Vagrantfile
+++ b/src/pybind/mgr/cephadm/Vagrantfile
@@ -17,8 +17,8 @@ Vagrant.configure("2") do |config|
     config.vm.define "osd#{i}" do |osd|
       osd.vm.hostname = "osd#{i}"
       osd.vm.provider :libvirt do |libvirt|
-        libvirt.storage :file, :size => '5G'
-        libvirt.storage :file, :size => '5G'
+        libvirt.storage :file, :size => '20G'
+        libvirt.storage :file, :size => '20G'
       end
     end
   end

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -21,7 +21,9 @@ import multiprocessing.pool
 import shutil
 import subprocess
 
-from ceph.deployment import inventory
+from ceph.deployment import inventory, translate
+from ceph.deployment.drive_selection import selector
+
 from mgr_module import MgrModule
 import mgr_util
 import orchestrator
@@ -1287,15 +1289,49 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             r[str(o['osd'])] = o['uuid']
         return r
 
-    @async_completion
-    def _create_osd(self, all_hosts_, drive_group):
-        all_hosts = orchestrator.InventoryNode.get_host_names(all_hosts_)
-        assert len(drive_group.hosts(all_hosts)) == 1
-        assert len(drive_group.data_devices.paths) > 0
-        assert all(map(lambda p: isinstance(p, six.string_types),
-            drive_group.data_devices.paths))
+    def call_inventory(self, hosts, drive_groups):
+        def call_create(inventory):
+            return self._prepare_deployment(hosts, drive_groups, inventory)
 
-        host = drive_group.hosts(all_hosts)[0]
+        return self.get_inventory().then(call_create)
+
+    def create_osds(self, drive_groups):
+        return self.get_hosts().then(lambda hosts: self.call_inventory(hosts, drive_groups))
+
+
+    def _prepare_deployment(self, all_hosts, drive_groups, inventory_list):
+        # type: (List[orchestrator.InventoryNode], List[orchestrator.DriveGroupSpecs], List[orchestrator.InventoryNode] -> orchestrator.Completion
+
+        for drive_group in drive_groups:
+            self.log.info("Processing DriveGroup {}".format(drive_group))
+            # 1) use fn_filter to determine matching_hosts
+            matching_hosts = drive_group.hosts([x.name for x in all_hosts])
+            # 2) Map the inventory to the InventoryNode object
+            # FIXME: lazy-load the inventory from a InventoryNode object;
+            #        this would save one call to the inventory(at least externally)
+
+            def _find_inv_for_host(hostname, inventory_list):
+                # This is stupid and needs to be loaded with the host
+                for _inventory in inventory_list:
+                    if _inventory.name == hostname:
+                        return _inventory
+
+            cmds = []
+            # 3) iterate over matching_host and call DriveSelection and to_ceph_volume
+            for host in matching_hosts:
+                inventory_for_host = _find_inv_for_host(host, inventory_list)
+                drive_selection = selector.DriveSelection(drive_group, inventory_for_host.devices)
+                cmd = translate.ToCephVolume(drive_group, drive_selection).run()
+                if not cmd:
+                    self.log.info("No data_devices, skipping DriveGroup: {}".format(drive_group.name))
+                    continue
+                cmds.append((host, cmd))
+
+        return self._create_osd(cmds)
+
+    @async_map_completion
+    def _create_osd(self, host, cmd):
+
         self._require_hosts(host)
 
         # get bootstrap key
@@ -1314,20 +1350,14 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             'keyring': keyring,
         })
 
-        devices = drive_group.data_devices.paths
-        for device in devices:
-            out, err, code = self._run_cephadm(
-                host, 'osd', 'ceph-volume',
-                [
-                    '--config-and-keyring', '-',
-                    '--',
-                    'lvm', 'prepare',
-                    "--cluster-fsid", self._cluster_fsid,
-                    "--{}".format(drive_group.objectstore),
-                    "--data", device,
-                ],
-                stdin=j)
-            self.log.debug('ceph-volume prepare: %s' % out)
+        split_cmd = cmd.split(' ')
+        _cmd = ['--config-and-keyring', '-', '--']
+        _cmd.extend(split_cmd)
+        out, code = self._run_ceph_daemon(
+            host, 'osd', 'ceph-volume',
+            _cmd,
+            stdin=j)
+        self.log.debug('ceph-volume prepare: %s' % out)
 
         # check result
         out, err, code = self._run_cephadm(
@@ -1346,9 +1376,6 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                 if osd['tags']['ceph.cluster_fsid'] != fsid:
                     self.log.debug('mismatched fsid, skipping %s' % osd)
                     continue
-                if len(list(set(devices) & set(osd['devices']))) == 0 and osd.get('lv_path') not in devices:
-                    self.log.debug('mismatched devices, skipping %s' % osd)
-                    continue
                 if osd_id not in osd_uuid_map:
                     self.log.debug('osd id %d does not exist in cluster' % osd_id)
                     continue
@@ -1364,22 +1391,6 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                     osd_uuid_map=osd_uuid_map)
 
         return "Created osd(s) on host '{}'".format(host)
-
-    def create_osds(self, drive_group):
-        """
-        Create a new osd.
-
-        The orchestrator CLI currently handles a narrow form of drive
-        specification defined by a single block device using bluestore.
-
-        :param drive_group: osd specification
-
-        TODO:
-          - support full drive_group specification
-          - support batch creation
-        """
-
-        return self.get_hosts().then(lambda hosts: self._create_osd(hosts, drive_group))
 
     @with_services('osd')
     def remove_osds(self, osd_ids, services):

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1319,7 +1319,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                 for _inventory in inventory_list:
                     if _inventory.name == hostname:
                         return _inventory
-                    raise OrchestratorError("No inventory found for host: {}".format(hostname))
+                raise OrchestratorError("No inventory found for host: {}".format(hostname))
 
             cmds = []
             # 3) iterate over matching_host and call DriveSelection and to_ceph_volume
@@ -2109,4 +2109,3 @@ class NodeAssignment(object):
             logger.info('Assigning nodes to spec: {}'.format(candidates))
             self.spec.placement.set_hosts(candidates)
             return None
-

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1355,6 +1355,8 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             'keyring': keyring,
         })
 
+        before_osd_uuid_map = self.get_osd_uuid_map()
+
         split_cmd = cmd.split(' ')
         _cmd = ['--config-and-keyring', '-', '--']
         _cmd.extend(split_cmd)
@@ -1380,6 +1382,9 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             for osd in osds:
                 if osd['tags']['ceph.cluster_fsid'] != fsid:
                     self.log.debug('mismatched fsid, skipping %s' % osd)
+                    continue
+                if osd_id in before_osd_uuid_map:
+                    # this osd existed before we ran prepare
                     continue
                 if osd_id not in osd_uuid_map:
                     self.log.debug('osd id %d does not exist in cluster' % osd_id)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -22,6 +22,7 @@ import shutil
 import subprocess
 
 from ceph.deployment import inventory, translate
+from ceph.deployment.drive_group import DriveGroupSpecs
 from ceph.deployment.drive_selection import selector
 
 from mgr_module import MgrModule
@@ -1298,9 +1299,12 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
     def create_osds(self, drive_groups):
         return self.get_hosts().then(lambda hosts: self.call_inventory(hosts, drive_groups))
 
-
-    def _prepare_deployment(self, all_hosts, drive_groups, inventory_list):
-        # type: (List[orchestrator.InventoryNode], List[orchestrator.DriveGroupSpecs], List[orchestrator.InventoryNode] -> orchestrator.Completion
+    def _prepare_deployment(self,
+                            all_hosts,  # type: List[orchestrator.InventoryNode]
+                            drive_groups,  # type: List[DriveGroupSpecs]
+                            inventory_list  # type: List[orchestrator.InventoryNode]
+                            ):
+        # type: (...) -> orchestrator.Completion
 
         for drive_group in drive_groups:
             self.log.info("Processing DriveGroup {}".format(drive_group))
@@ -1315,13 +1319,14 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                 for _inventory in inventory_list:
                     if _inventory.name == hostname:
                         return _inventory
+                    raise OrchestratorError("No inventory found for host: {}".format(hostname))
 
             cmds = []
             # 3) iterate over matching_host and call DriveSelection and to_ceph_volume
             for host in matching_hosts:
                 inventory_for_host = _find_inv_for_host(host, inventory_list)
                 drive_selection = selector.DriveSelection(drive_group, inventory_for_host.devices)
-                cmd = translate.ToCephVolume(drive_group, drive_selection).run()
+                cmd = translate.to_ceph_volume(drive_group, drive_selection).run()
                 if not cmd:
                     self.log.info("No data_devices, skipping DriveGroup: {}".format(drive_group.name))
                     continue
@@ -1353,7 +1358,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         split_cmd = cmd.split(' ')
         _cmd = ['--config-and-keyring', '-', '--']
         _cmd.extend(split_cmd)
-        out, code = self._run_ceph_daemon(
+        out, err, code = self._run_cephadm(
             host, 'osd', 'ceph-volume',
             _cmd,
             stdin=j)

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -124,9 +124,9 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
     def test_create_osds(self, _send_command, _get_connection, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
-            dg = DriveGroupSpec('test', DeviceSelection(paths=['']))
-            c = cephadm_module.create_osds(dg)
-            assert wait(cephadm_module, c) == "Created osd(s) on host 'test'"
+            dg = DriveGroupSpec('test', data_devices=DeviceSelection(paths=['']))
+            c = cephadm_module.create_osds([dg])
+            assert wait(cephadm_module, c) == ["Created osd(s) on host 'test'"]
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm(
         json.dumps([

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -1,6 +1,7 @@
 import datetime
 import errno
 import json
+import yaml
 from functools import wraps
 
 from ceph.deployment.inventory import Device
@@ -15,7 +16,7 @@ except ImportError:
 
 
 from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupValidationError, \
-    DeviceSelection
+    DeviceSelection, DriveGroupSpecs
 from mgr_module import MgrModule, CLICommand, HandleCommandResult
 
 import orchestrator
@@ -342,13 +343,15 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
 
         usage = """
 Usage:
-  ceph orchestrator osd create -i <json_file>
+  ceph orchestrator osd create -i <json_file/yaml_file>
   ceph orchestrator osd create host:device1,device2,...
 """
 
+        # TODO: try if inbuf file is yaml of json
         if inbuf:
             try:
-                drive_group = DriveGroupSpec.from_json(json.loads(inbuf))
+                dgs = DriveGroupSpecs(json.loads(inbuf))
+                drive_groups = dgs.drive_groups
             except ValueError as e:
                 msg = 'Failed to read JSON input: {}'.format(str(e)) + usage
                 return HandleCommandResult(-errno.EINVAL, stderr=msg)
@@ -362,14 +365,13 @@ Usage:
                 return HandleCommandResult(-errno.EINVAL, stderr=msg)
 
             devs = DeviceSelection(paths=block_devices)
-            drive_group = DriveGroupSpec(node_name, data_devices=devs)
+            drive_groups = [DriveGroupSpec(node_name, data_devices=devs)]
         else:
             return HandleCommandResult(-errno.EINVAL, stderr=usage)
 
-        completion = self.create_osds(drive_group)
+        completion = self.create_osds(drive_groups)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
-        self.log.warning(str(completion.result))
         return HandleCommandResult(stdout=completion.result_str())
 
     @orchestrator._cli_write_command(

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -347,10 +347,9 @@ Usage:
   ceph orchestrator osd create host:device1,device2,...
 """
 
-        # TODO: try if inbuf file is yaml of json
         if inbuf:
             try:
-                dgs = DriveGroupSpecs(json.loads(inbuf))
+                dgs = DriveGroupSpecs(yaml.load(inbuf))
                 drive_groups = dgs.drive_groups
             except ValueError as e:
                 msg = 'Failed to read JSON input: {}'.format(str(e)) + usage

--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -4,3 +4,4 @@ ipaddress; python_version < '3.3'
 ../../python-common
 kubernetes
 requests-mock
+pyyaml

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -369,8 +369,22 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             mgr=self
         )
 
-    def create_osds(self, drive_group):
+    def create_osds(self, drive_groups):
         # type: (List[DriveGroupSpec]) -> RookCompletion
+        """ Creates OSDs from a drive group specification.
+
+        Caveat: Currently limited to a single DriveGroup.
+        The orchestrator_cli expects a single completion which
+        ideally represents a set of operations. This orchestrator
+        doesn't support this notion, yet. Hence it's only accepting
+        a single DriveGroup for now.
+        You can work around it by invoking:
+
+        $: ceph orchestrator osd create -i <dg.file>
+
+        multiple times. The drivegroup file must only contain one spec at a time.
+        """
+        drive_group = drive_groups[0]
 
         targets = []  # type: List[str]
         if drive_group.data_devices:

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -370,7 +370,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         )
 
     def create_osds(self, drive_group):
-        # type: (DriveGroupSpec) -> RookCompletion
+        # type: (List[DriveGroupSpec]) -> RookCompletion
 
         targets = []  # type: List[str]
         if drive_group.data_devices:

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -13,6 +13,7 @@ except ImportError:
 import six
 
 from ceph.deployment import inventory
+from ceph.deployment.drive_group import DriveGroupSpec
 from mgr_module import CLICommand, HandleCommandResult
 from mgr_module import MgrModule
 
@@ -183,8 +184,23 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         return result
 
-    def create_osds(self, drive_group):
-        # type: (orchestrator.DriveGroupSpec) -> TestCompletion
+    def create_osds(self, drive_groups):
+        # type: (List[DriveGroupSpec]) -> TestCompletion
+        """ Creates OSDs from a drive group specification.
+
+        Caveat: Currently limited to a single DriveGroup.
+        The orchestrator_cli expects a single completion which
+        ideally represents a set of operations. This orchestrator
+        doesn't support this notion, yet. Hence it's only accepting
+        a single DriveGroup for now.
+        You can work around it by invoking:
+
+        $: ceph orchestrator osd create -i <dg.file>
+
+        multiple times. The drivegroup file must only contain one spec at a time.
+        """
+        drive_group = drive_groups[0]
+
         def run(all_hosts):
             drive_group.validate(orchestrator.InventoryNode.get_host_names(all_hosts))
         return self.get_hosts().then(run).then(

--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -23,11 +23,13 @@ class DriveSelection(object):
         self.disks = disks.copy()
         self.spec = spec
 
-        if self.spec.data_devices.paths:
-            self._data = self.spec.data_devices.paths
-            self._db = []
-            self._wal = []
-            self._journal = []
+        if self.spec.data_devices.paths:  # type: ignore
+            # re: type: ignore there is *always* a path attribute assigned to DeviceSelection
+            # it's just None if actual drivegroups are used
+            self._data = self.spec.data_devices.paths  # type: ignore
+            self._db = []  # type: List
+            self._wal = []  # type: List
+            self._journal = []  # type: List
         else:
             self._data = self.assign_devices(self.spec.data_devices)
             self._wal = self.assign_devices(self.spec.wal_devices)

--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -23,10 +23,16 @@ class DriveSelection(object):
         self.disks = disks.copy()
         self.spec = spec
 
-        self._data = self.assign_devices(self.spec.data_devices)
-        self._wal = self.assign_devices(self.spec.wal_devices)
-        self._db = self.assign_devices(self.spec.db_devices)
-        self._jornal = self.assign_devices(self.spec.journal_devices)
+        if self.spec.data_devices.paths:
+            self._data = self.spec.data_devices.paths
+            self._db = []
+            self._wal = []
+            self._journal = []
+        else:
+            self._data = self.assign_devices(self.spec.data_devices)
+            self._wal = self.assign_devices(self.spec.wal_devices)
+            self._db = self.assign_devices(self.spec.db_devices)
+            self._journal = self.assign_devices(self.spec.journal_devices)
 
     def data_devices(self):
         # type: () -> List[Device]
@@ -42,7 +48,7 @@ class DriveSelection(object):
 
     def journal_devices(self):
         # type: () -> List[Device]
-        return self._jornal
+        return self._journal
 
     @staticmethod
     def _limit_reached(device_filter, len_devices,
@@ -95,7 +101,7 @@ class DriveSelection(object):
 
         return a sorted(by path) list of devices
         """
-        if device_filter is None:
+        if not device_filter and not self.spec.data_devices.paths:
             logger.debug('device_filter is None')
             return []
         devices = list()  # type: List[Device]
@@ -111,6 +117,12 @@ class DriveSelection(object):
 
                 # continue criterias
                 assert _filter.matcher is not None
+
+                if not disk.available:
+                    logger.debug(
+                        "Ignoring disk {}. Disk is not available".format(disk.path))
+                    continue
+
                 if not _filter.matcher.compare(disk):
                     logger.debug(
                         "Ignoring disk {}. Filter did not match".format(

--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -79,7 +79,7 @@ class DriveSelection(object):
     @staticmethod
     def _has_mandatory_idents(disk):
         # type: (Device) -> bool
-        """ Check for mandatory indentification fields
+        """ Check for mandatory identification fields
         """
         if disk.path:
             logger.debug("Found matching disk: {}".format(disk.path))
@@ -117,7 +117,7 @@ class DriveSelection(object):
             for disk in self.disks.devices:
                 logger.debug("Processing disk {}".format(disk.path))
 
-                # continue criterias
+                # continue criteria
                 assert _filter.matcher is not None
 
                 if not disk.available:

--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -103,9 +103,15 @@ class DriveSelection(object):
 
         return a sorted(by path) list of devices
         """
-        if not device_filter and not self.spec.data_devices.paths:
+
+        if not device_filter:
             logger.debug('device_filter is None')
             return []
+
+        if not self.spec.data_devices:
+            logger.debug('data_devices is None')
+            return []
+
         devices = list()  # type: List[Device]
         for _filter in FilterGenerator(device_filter):
             if not _filter.is_matchable:

--- a/src/python-common/ceph/deployment/translate.py
+++ b/src/python-common/ceph/deployment/translate.py
@@ -5,7 +5,7 @@ from ceph.deployment.drive_selection.selector import DriveSelection
 logger = logging.getLogger(__name__)
 
 
-class ToCephVolume(object):
+class to_ceph_volume(object):
 
     def __init__(self,
                  spec,  # type: DriveGroupSpec

--- a/src/python-common/ceph/deployment/translate.py
+++ b/src/python-common/ceph/deployment/translate.py
@@ -1,0 +1,70 @@
+import logging
+from ceph.deployment.drive_group import DriveGroupSpec
+from ceph.deployment.drive_selection.selector import DriveSelection
+
+logger = logging.getLogger(__name__)
+
+
+class ToCephVolume(object):
+
+    def __init__(self,
+                 spec,  # type: DriveGroupSpec
+                 selection  # type: DriveSelection
+                 ):
+
+        self.spec = spec
+        self.selection = selection
+
+    def run(self):
+        """ Generate ceph-volume commands based on the DriveGroup filters """
+        try:
+            data_devices = [x.path for x in self.selection.data_devices()]
+        except AttributeError:
+            data_devices = [x for x in self.selection.data_devices()]
+        db_devices = [x.path for x in self.selection.db_devices()]
+        wal_devices = [x.path for x in self.selection.wal_devices()]
+        journal_devices = [x.path for x in self.selection.journal_devices()]
+
+        if not data_devices:
+            return None
+
+        if self.spec.objectstore == 'filestore':
+            cmd = "lvm batch --no-auto"
+
+            cmd += " {}".format(" ".join(data_devices))
+
+            if self.spec.journal_size:
+                cmd += " --journal-size {}".format(self.spec.journal_size)
+
+            if journal_devices:
+                cmd += " --journal-devices {}".format(
+                    ' '.join(journal_devices))
+
+            cmd += " --filestore"
+
+        if self.spec.objectstore == 'bluestore':
+
+            cmd = "lvm batch --no-auto {}".format(" ".join(data_devices))
+
+            if db_devices:
+                cmd += " --db-devices {}".format(" ".join(db_devices))
+
+            if wal_devices:
+                cmd += " --wal-devices {}".format(" ".join(wal_devices))
+
+            if self.spec.block_wal_size:
+                cmd += " --block-wal-size {}".format(self.spec.block_wal_size)
+
+            if self.spec.block_db_size:
+                cmd += " --block-db-size {}".format(self.spec.block_db_size)
+
+        if self.spec.encrypted:
+            cmd += " --dmcrypt"
+
+        if self.spec.osds_per_device:
+            cmd += " --osds-per-device {}".format(self.spec.osds_per_device)
+
+        cmd += " --yes"
+        cmd += " --no-systemd"
+
+        return cmd

--- a/src/python-common/ceph/deployment/translate.py
+++ b/src/python-common/ceph/deployment/translate.py
@@ -42,6 +42,16 @@ class to_ceph_volume(object):
 
             cmd += " --filestore"
 
+        # HORRIBLE HACK
+        if self.spec.objectstore == 'bluestore' and \
+           not self.spec.encrypted and \
+           not self.spec.osds_per_device and \
+           len(data_devices) == 1 and \
+           not db_devices and \
+           not wal_devices:
+            cmd = "lvm prepare --bluestore --data %s --no-systemd" % (' '.join(data_devices))
+            return cmd
+
         if self.spec.objectstore == 'bluestore':
 
             cmd = "lvm batch --no-auto {}".format(" ".join(data_devices))

--- a/src/python-common/ceph/tests/test_disk_selector.py
+++ b/src/python-common/ceph/tests/test_disk_selector.py
@@ -11,6 +11,7 @@ except ImportError:
 
 from ceph.deployment import drive_selection
 from ceph.tests.factories import InventoryFactory
+from ceph.tests.utils import _mk_inventory, _mk_device
 
 
 class TestMatcher(object):
@@ -672,39 +673,6 @@ class TestFilter(object):
         assert ret.is_matchable is False
 
 
-def _mk_device(rotational=True, locked=False):
-    return [Device(
-        path='??',
-        sys_api={
-            "rotational": '1' if rotational else '0',
-            "vendor": "Vendor",
-            "human_readable_size": "394.27 GB",
-            "partitions": {},
-            "locked": int(locked),
-            "sectorsize": "512",
-            "removable": "0",
-            "path": "??",
-            "support_discard": "",
-            "model": "Model",
-            "ro": "0",
-            "nr_requests": "128",
-            "size": 423347879936
-        },
-        available=not locked,
-        rejected_reasons=['locked'] if locked else [],
-        lvs=[],
-        device_id="Model-Vendor-foobar"
-    )]
-
-
-def _mk_inventory(devices):
-    devs = []
-    for dev_, name in zip(devices, map(chr, range(ord('a'), ord('z')))):
-        dev = Device.from_json(dev_.to_json())
-        dev.path = '/dev/sd' + name
-        dev.sys_api = dict(dev_.sys_api, path='/dev/sd' + name)
-        devs.append(dev)
-    return Devices(devices=devs)
 
 
 class TestDriveSelection(object):

--- a/src/python-common/ceph/tests/test_disk_selector.py
+++ b/src/python-common/ceph/tests/test_disk_selector.py
@@ -673,8 +673,6 @@ class TestFilter(object):
         assert ret.is_matchable is False
 
 
-
-
 class TestDriveSelection(object):
 
     testdata = [

--- a/src/python-common/ceph/tests/utils.py
+++ b/src/python-common/ceph/tests/utils.py
@@ -1,0 +1,38 @@
+from ceph.deployment.inventory import Devices, Device
+
+
+def _mk_device(rotational=True,
+               locked=False,
+               size="394.27 GB"):
+    return [Device(
+        path='??',
+        sys_api={
+            "rotational": '1' if rotational else '0',
+            "vendor": "Vendor",
+            "human_readable_size": size,
+            "partitions": {},
+            "locked": int(locked),
+            "sectorsize": "512",
+            "removable": "0",
+            "path": "??",
+            "support_discard": "",
+            "model": "Model",
+            "ro": "0",
+            "nr_requests": "128",
+            "size": 423347879936  # ignore coversion from human_readable_size
+        },
+        available=not locked,
+        rejected_reasons=['locked'] if locked else [],
+        lvs=[],
+        device_id="Model-Vendor-foobar"
+    )]
+
+
+def _mk_inventory(devices):
+    devs = []
+    for dev_, name in zip(devices, map(chr, range(ord('a'), ord('z')))):
+        dev = Device.from_json(dev_.to_json())
+        dev.path = '/dev/sd' + name
+        dev.sys_api = dict(dev_.sys_api, path='/dev/sd' + name)
+        devs.append(dev)
+    return Devices(devices=devs)


### PR DESCRIPTION
Key commit is 614c0eb77eb44dd74165613c7fe818b8330cf7ba which does a regular old prepare if the drivegroup is "trivial" (single device, no odd options).

This is a kludgey workaround but it is enough to make the teuthology tests pass when using preexisting LVs: http://pulpito.ceph.com/sage-2020-01-29_20:15:33-rados-wip-sage4-testing-2020-01-29-1143-distro-basic-smithi/