### PR TITLE
mon/ConfigMonitor: only propose if leader

### DIFF
--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -704,7 +704,7 @@ update:
 
 void ConfigMonitor::tick()
 {
-  if (!is_active()) {
+  if (!is_active() || !mon->is_leader()) {
     return;
   }
   dout(10) << __func__ << dendl;


### PR DESCRIPTION
Introduced by 08fcf01c040e0caaf5b418d300f774bf8c3033da, which activated
this (broken) code path.

Fixes: https://tracker.ceph.com/issues/43892
Signed-off-by: Sage Weil <sage@redhat.com>