### PR TITLE
cephadm: simplify Monitoring.components structure

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -96,37 +96,31 @@ class Monitoring(object):
 
     components = {
         "prometheus": {
-            "image": {
-                "image": "prom/prometheus:latest",
-                "cpus": '2',
-                "memory": '4GB',
-                "args": [
-                    "--config.file=/etc/prometheus/prometheus.yml",
-                    "--storage.tsdb.path=/prometheus",
-                    "--web.listen-address=:{}".format(port_map['prometheus']),
-                ]
-            },
+            "image": "prom/prometheus:latest",
+            "cpus": '2',
+            "memory": '4GB',
+            "args": [
+                "--config.file=/etc/prometheus/prometheus.yml",
+                "--storage.tsdb.path=/prometheus",
+                "--web.listen-address=:{}".format(port_map['prometheus']),
+            ],
             "config-json": [
                 "prometheus.yml",
             ],
         },
         "node-exporter": {
-            "image": {
-                "image": "prom/node-exporter",
-                "cpus": "1",
-                "memory": "1GB",
-                "args": [
-                    "--no-collector.timex",
-                ],
-            }
+            "image": "prom/node-exporter",
+            "cpus": "1",
+            "memory": "1GB",
+            "args": [
+                "--no-collector.timex",
+            ],
         },
         "grafana": {
-            "image": {
-                "image": "pcuzner/ceph-grafana-el8:latest",
-                "cpus": "2",
-                "memory": "4GB",
-                "args": [],
-            },
+            "image": "pcuzner/ceph-grafana-el8:latest",
+            "cpus": "2",
+            "memory": "4GB",
+            "args": [],
             "config-json": [
                 "grafana.ini",
                 "provisioning/datasources/ceph-dashboard.yml",
@@ -885,8 +879,7 @@ def get_daemon_args(fsid, daemon_type, daemon_id):
                 '--default-mon-cluster-log-to-stderr=true',
             ]
     elif daemon_type in Monitoring.components:
-        component = Monitoring.components[daemon_type]
-        metadata = component.get('image', list())
+        metadata = Monitoring.components[daemon_type]
         r += metadata.get('args', list())
     return r
 
@@ -1986,10 +1979,9 @@ def command_deploy():
             uid, gid = extract_uid_gid(file_path='/var/lib/grafana')
         else:
             raise Error("{} not implemented yet".format(daemon_type))
-        
+
         # Monitoring metadata is nested dicts, so asking mypy to ignore
-        m = Monitoring.components[daemon_type]
-        metadata = m.get('image', dict())
+        metadata = Monitoring.components[daemon_type]
         monitoring_args = [
             '--user',
             str(uid),

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -134,7 +134,7 @@ class Monitoring(object):
                 "certs/cert_key",
             ],
         }
-    }
+    }  # type: Dict[str, dict]
 
 def attempt_bind(s, address, port):
     # type (str) -> None
@@ -885,9 +885,9 @@ def get_daemon_args(fsid, daemon_type, daemon_id):
                 '--default-mon-cluster-log-to-stderr=true',
             ]
     elif daemon_type in Monitoring.components:
-        component = Monitoring.components[daemon_type]  # type: ignore
-        metadata = component.get('image', list())  # type: ignore
-        r += metadata.get('args', list())  # type: ignore
+        component = Monitoring.components[daemon_type]
+        metadata = component.get('image', list())
+        r += metadata.get('args', list())
     return r
 
 def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
@@ -911,7 +911,7 @@ def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
     if daemon_type in Monitoring.components.keys():
 
         received_config = get_parm(args.config_json)
-        required_config = Monitoring.components[daemon_type].get('config-json', list())  # type: ignore
+        required_config = Monitoring.components[daemon_type].get('config-json', list())
         if required_config:
             if not received_config or not all(c in received_config.keys() for c in required_config):
                 raise Error("{} deployment requires config-json which must "
@@ -1988,15 +1988,15 @@ def command_deploy():
             raise Error("{} not implemented yet".format(daemon_type))
         
         # Monitoring metadata is nested dicts, so asking mypy to ignore
-        m = Monitoring.components[daemon_type]  # type: ignore
-        metadata = m.get('image', dict())  # type: ignore
+        m = Monitoring.components[daemon_type]
+        metadata = m.get('image', dict())
         monitoring_args = [
             '--user',
             str(uid),
             '--cpus',
-            metadata.get('cpus', '2'),  # type: ignore
+            metadata.get('cpus', '2'),
             '--memory',
-            metadata.get('memory', '4GB')  # type: ignore
+            metadata.get('memory', '4GB')
         ]
 
         c = get_container(args.fsid, daemon_type, daemon_id, container_args=monitoring_args)

--- a/src/cephadm/samples/grafana.json
+++ b/src/cephadm/samples/grafana.json
@@ -12,7 +12,7 @@
             "  cert_file = /etc/grafana/certs/cert_file",
             "  cert_key = /etc/grafana/certs/cert_key",
             "  http_port = 3000",
-            "  http_addr = 10.90.90.150",
+            "  http_addr = localhost",
             "[security]",
             "  admin_user = admin",
             "  admin_password = admin",
@@ -28,7 +28,7 @@
             "    type: 'prometheus'",
             "    access: 'proxy'",
             "    orgId: 1",
-            "    url: 'http://10.90.90.150:9095'",
+            "    url: 'http://localhost:9095'",
             "    basicAuth: false",
             "    isDefault: true",
             "    editable: false"


### PR DESCRIPTION
Minor clean-up and simplification of the `Monitoring.components` dictionary. 

* Simplify Monitoring.components by removing nested dict type
* re-enable and fix tox for the Monitoring.components dict type
* add missing tests for node-exporter, prometheus, and grafana

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
