### PR TITLE
mon: elector: return after triggering a new election

### DIFF
--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -147,8 +147,8 @@ void ElectionLogic::receive_propose(int from, epoch_t mepoch)
       elector->trigger_new_election();
     } else {
       ldout(cct, 5) << " ignoring old propose" << dendl;
-      return;
     }
+    return;
   }
 
   if (elector->get_my_rank() < from) {


### PR DESCRIPTION
When receiving an old propose, we were correctly triggering a new election
but not then returning out of receive_propose(), so we processed the
"should I defer" logic and perhaps sent out a deferal (in the current epoch!).

Fixes: https://tracker.ceph.com/issues/42977

Signed-off-by: Greg Farnum <gfarnum@redhat.com>