### PR TITLE
cephadm: Read ceph version from io.ceph.version label if set

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2218,18 +2218,19 @@ def list_daemons(detail=True, legacy_dir=None):
                         out, err, code = call(
                             [
                                 container_path, 'inspect',
-                                '--format', '{{.Id}},{{.Config.Image}},{{%s}}' % image_field,
+                                '--format', '{{.Id}},{{.Config.Image}},{{%s}},{{index .Config.Labels "io.ceph.version"}}' % image_field,
                                 'ceph-%s-%s' % (fsid, j)
                             ],
                             verbose_on_failure=False)
                         if not code:
-                            (container_id, image_name, image_id) = out.strip().split(',')
+                            (container_id, image_name, image_id, version) = out.strip().split(',')
                             image_id = normalize_container_id(image_id)
-                            out, err, code = call(
-                                [container_path, 'exec', container_id,
-                                 'ceph', '-v'])
-                            if not code and out.startswith('ceph version '):
-                                version = out.split(' ')[2]
+                            if not version:
+                                out, err, code = call(
+                                    [container_path, 'exec', container_id,
+                                     'ceph', '-v'])
+                                if not code and out.startswith('ceph version '):
+                                    version = out.split(' ')[2]
                         i['container_id'] = container_id
                         i['container_image_name'] = image_name
                         i['container_image_id'] = image_id

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1454,7 +1454,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         found = list(zip(*args))[0] if args else []
         not_found = {osd_id for osd_id in osd_ids if 'osd.%s' % osd_id not in found}
         if not_found:
-            raise OrchestratorError('Unable to find ODS: %s' % not_found)
+            raise OrchestratorError('Unable to find OSD: %s' % not_found)
         return self._remove_daemon(args)
 
     def _create_daemon(self, daemon_type, daemon_id, host,


### PR DESCRIPTION
Currently the cephadm code reads the ceph version by calling `ceph -v` in the container. If there is a label set on the container with the ceph version, this call can be avoided.

This patch looks for a label called `io.ceph.version` and reads the version there, falling back to calling `ceph -v` if unset or set to the empty string.

See also: ceph/ceph-container#1508
See also: https://tracker.ceph.com/issues/43678

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
