### PR TITLE
mgr/dashboard: Unable to remove an iSCSI gateway that is alrea…

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -16,6 +16,7 @@ from ..rest_client import RequestException
 from ..security import Scope
 from ..services.iscsi_client import IscsiClient
 from ..services.iscsi_cli import IscsiGatewaysConfig
+from ..services.iscsi_config import IscsiGatewayDoesNotExist
 from ..services.rbd import format_bitmask
 from ..services.tcmu_service import TcmuService
 from ..exceptions import DashboardException
@@ -848,7 +849,7 @@ class IscsiTarget(RESTController):
         for portal in target['portals']:
             try:
                 IscsiClient.instance(gateway_name=portal['host']).ping()
-            except RequestException:
+            except (IscsiGatewayDoesNotExist, RequestException):
                 return
         gateway_name = target['portals'][0]['host']
         try:

--- a/src/pybind/mgr/dashboard/services/iscsi_cli.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_cli.py
@@ -8,7 +8,7 @@ from mgr_module import CLIReadCommand, CLIWriteCommand
 
 from .iscsi_client import IscsiClient
 from .iscsi_config import IscsiGatewaysConfig, IscsiGatewayAlreadyExists, InvalidServiceUrl, \
-    ManagedByOrchestratorException, IscsiGatewayDoesNotExist, IscsiGatewayInUse
+    ManagedByOrchestratorException, IscsiGatewayDoesNotExist
 from ..rest_client import RequestException
 
 
@@ -41,16 +41,8 @@ def add_iscsi_gateway(_, service_url):
                  'Remove iSCSI gateway configuration')
 def remove_iscsi_gateway(_, name):
     try:
-        try:
-            iscsi_config = IscsiClient.instance(gateway_name=name).get_config()
-            if name in iscsi_config['gateways']:
-                raise IscsiGatewayInUse(name)
-        except RequestException:
-            pass
         IscsiGatewaysConfig.remove_gateway(name)
         return 0, 'Success', ''
-    except IscsiGatewayInUse as ex:
-        return -errno.EBUSY, '', str(ex)
     except IscsiGatewayDoesNotExist as ex:
         return -errno.ENOENT, '', str(ex)
     except ManagedByOrchestratorException as ex:

--- a/src/pybind/mgr/dashboard/services/iscsi_config.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_config.py
@@ -27,12 +27,6 @@ class IscsiGatewayDoesNotExist(Exception):
             "iSCSI gateway '{}' does not exist".format(hostname))
 
 
-class IscsiGatewayInUse(Exception):
-    def __init__(self, hostname):
-        super(IscsiGatewayInUse, self).__init__(
-            "iSCSI gateway '{}' is in use".format(hostname))
-
-
 class InvalidServiceUrl(Exception):
     def __init__(self, service_url):
         super(InvalidServiceUrl, self).__init__(


### PR DESCRIPTION
Dashboard will now gracefully handle the scenario where `ceph-iscsi` configuration contains gateways that are not configured in Dashboard (`ceph dashboard iscsi-gateway-list`).

Users will always be able to see all targets in the UI, but will not be able to edit or delete targets that have "unknown" portals.

Fixes: https://tracker.ceph.com/issues/43900

Signed-off-by: Ricardo Marques <rimarques@suse.com>




<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
