### PR TITLE
mgr/progress: Add integration to pybind/mgr/tox.ini

### DIFF
--- a/src/pybind/mgr/progress/__init__.py
+++ b/src/pybind/mgr/progress/__init__.py
@@ -2,10 +2,6 @@ import os
 if 'UNITTEST' not in os.environ:
     from .module import *
 else:
-    import sys
-    import mock
-    sys.modules['ceph_module'] = mock.Mock()
-    sys.modules['rados'] = mock.Mock()
-    from .module import *
-   
+    import tests
+
 

--- a/src/pybind/mgr/progress/test_progress.py
+++ b/src/pybind/mgr/progress/test_progress.py
@@ -2,7 +2,8 @@
 import unittest
 import os
 import sys
-from mock import Mock
+from tests import mock
+
 import pytest
 import json
 os.environ['UNITTEST'] = "1"
@@ -15,7 +16,7 @@ class TestPgRecoveryEvent(object):
     def setup(self):
         # Creating the class and Mocking 
         # a bunch of attributes for testing
-        module._module = Mock() # just so Event._refresh() works
+        module._module = mock.Mock() # just so Event._refresh() works
         self.test_event = module.PgRecoveryEvent(None, None, [module.PgId(1,i) for i in range(3)], [0], 30)
 
     def test_pg_update(self):
@@ -76,7 +77,7 @@ class TestPgRecoveryEvent(object):
         ]
         }
 
-        self.test_event.pg_update(pg_dump, Mock())
+        self.test_event.pg_update(pg_dump, mock.Mock())
         assert self.test_event._progress == 1.0
        
 class OSDMap: 
@@ -124,13 +125,13 @@ class TestModule(object):
         # Creating the class and Mocking a
         # bunch of attributes for testing
 
-        module.PgRecoveryEvent.pg_update = Mock()
+        module.PgRecoveryEvent.pg_update = mock.Mock()
         self.test_module = module.Module() # so we can see if an event gets created
-        self.test_module.log = Mock() # we don't need to log anything
-        self.test_module.get = Mock() # so we can call pg_update
-        self.test_module._complete = Mock() # we want just to see if this event gets called
-        self.test_module.get_osdmap = Mock() # so that self.get_osdmap().get_epoch() works
-        module._module = Mock() # so that Event.refresh() works
+        self.test_module.log = mock.Mock() # we don't need to log anything
+        self.test_module.get = mock.Mock() # so we can call pg_update
+        self.test_module._complete = mock.Mock() # we want just to see if this event gets called
+        self.test_module.get_osdmap = mock.Mock() # so that self.get_osdmap().get_epoch() works
+        module._module = mock.Mock() # so that Event.refresh() works
 
     def test_osd_in_out(self):
         # test for the correct event being

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -19,5 +19,6 @@ commands = mypy --config-file=../../mypy.ini \
            mgr_util.py \
            orchestrator.py \
            orchestrator_cli/module.py \
+           progress/module.py \
            rook/module.py \
            test_orchestrator/module.py

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -5,7 +5,7 @@ skipsdist = true
 [testenv]
 setenv = UNITTEST = true
 deps = -r requirements.txt
-commands = pytest -v --cov --cov-append --cov-report=term --doctest-modules {posargs:mgr_util.py tests/ cephadm/ ansible/}
+commands = pytest -v --cov --cov-append --cov-report=term --doctest-modules {posargs:mgr_util.py tests/ cephadm/ ansible/ progress/}
 
 [testenv:mypy]
 basepython = python3


### PR DESCRIPTION
## mgr/progress: Add test_progress.py to tox

`test_progress.py` was previously not integrated to `make check`. As we now have a tox.ini, we can trivially integrate it.

## mgr/progress: Add module to static type checking
(Taken from #26769 )

Some types in this module are not obvious. Half a year ago, adding those type hints really helped me to understand what is going on in this module. As we now have a tox integration, let's make use of it!

--- 
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
