### PR TITLE
qa/tasks/ceph_manager: add --log-early to raw_cluster_cmd

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1346,6 +1346,7 @@ class CephManager:
                 'ceph',
                 '--cluster',
                 self.cluster,
+                '--log-early',
             ]
             ceph_args.extend(args)
             proc = self.controller.run(


### PR DESCRIPTION
This is harmless if logging is low, but adds useful info when it is turned
up.

Hunting bug https://tracker.ceph.com/issues/43914

Signed-off-by: Sage Weil <sage@redhat.com>