### PR TITLE
cephadm: flag dashboard user to change password

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2005,10 +2005,10 @@ def command_bootstrap():
 
         logger.info('Creating initial admin user...')
         password = args.initial_dashboard_password or generate_password()
-        cli(['dashboard', 'ac-user-create',
-             args.initial_dashboard_user, password,
-             'administrator',
-             '--force-password'])
+        cmd = ['dashboard', 'ac-user-create', args.initial_dashboard_user, password, 'administrator', '--force-password']
+        if not args.dashboard_password_noupdate:
+            cmd.append('--pwd-update-required')
+        cli(cmd)   
         logger.info('Fetching dashboard port number...')
         out = cli(['config', 'get', 'mgr', 'mgr/dashboard/ssl_server_port'])
         port = int(out)
@@ -3395,6 +3395,10 @@ def _get_parser():
         '--skip-dashboard',
         action='store_true',
         help='do not enable the Ceph Dashboard')
+    parser_bootstrap.add_argument(
+        '--dashboard-password-noupdate',
+        action='store_true',
+        help='stop forced dashboard password change')
     parser_bootstrap.add_argument(
         '--no-minimize-config',
         action='store_true',


### PR DESCRIPTION
As the generated password is printed to stdout, users should change their password.
Should be possible to disable this behavior, as it is inconvenient for developers.

Fixes: tracker.ceph.com/issues/43694

dependent on #32680 

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>