### PR TITLE
Revert "seastar: pickup change to fix cgroups V2 support"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,9 +40,6 @@
 	url = https://github.com/ceph/lua.git
 	branch = lua-5.3-ceph
 	ignore = dirty
-[submodule "src/dpdk"]
-	path = src/dpdk
-	url = https://github.com/ceph/dpdk
 [submodule "src/zstd"]
 	path = src/zstd
 	url = https://github.com/facebook/zstd


### PR DESCRIPTION
This reverts commit 7f79b47b0e12799f841a96450cb20474fa8ec69b.

Signed-off-by: Sage Weil <sage@redhat.com>