### PR TITLE
nautilus: mon/MgrMonitor.cc: add always_on_modules to the output of "ceph mgr module ls"

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -874,6 +874,11 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
   } else if (prefix == "mgr module ls") {
     f->open_object_section("modules");
     {
+      f->open_array_section("always_on_modules");
+      for (auto& p : map.get_always_on_modules()) {
+        f->dump_string("module", p);
+      }
+      f->close_section();
       f->open_array_section("enabled_modules");
       for (auto& p : map.modules) {
         if (map.get_always_on_modules().count(p) > 0)


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/32939

Makes it easier to know what the always_on_modules for each release are, without
having to look at the code.

Signed-off-by: Neha Ojha <nojha@redhat.com>
(cherry picked from commit 8aa3c65b56add413d3fba1cb1d0cf84a10bfcf3c)

