### PR TITLE
nautilus: mon: elector: return after triggering a new election

### DIFF
--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -288,8 +288,8 @@ void Elector::handle_propose(MonOpRequestRef op)
       mon->start_election();
     } else {
       dout(5) << " ignoring old propose" << dendl;
-      return;
     }
+    return;
   }
 
   if (mon->rank < from) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43928

---

backport of https://github.com/ceph/ceph/pull/32981
parent tracker: https://tracker.ceph.com/issues/42977

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh