### PR TITLE
nautilus: rgw_file: avoid string::front() on empty path

### DIFF
--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -510,7 +510,8 @@ namespace rgw {
 	if (pos > 1) {
 	  path += "/";
 	} else {
-	  if (!omit_bucket && (path.front() != '/')) // pretty-print
+	  if (!omit_bucket &&
+	      ((path.length() == 0) || (path.front() != '/')))
 	    path += "/";
 	}
 	path += *s;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43922

---

backport of https://github.com/ceph/ceph/pull/32596
parent tracker: https://tracker.ceph.com/issues/43548

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh