### PR TITLE
mgr/dashboard: Fix notification sidebar e2e failure

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/e2e/ui/notification.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/ui/notification.e2e-spec.ts
@@ -15,12 +15,12 @@ describe('Notification page', () => {
 
     if (await notification.getCloseBtn().isPresent()) {
       await notification.waitClickableAndClick(notification.getCloseBtn());
-      await notification.waitStaleness(notification.getSidebar());
+      await notification.waitInvisibility(notification.getSidebar());
     }
   });
 
   it('should open notification sidebar', async () => {
-    await notification.waitStaleness(notification.getSidebar());
+    await notification.waitInvisibility(notification.getSidebar());
     await notification.open();
     await notification.waitVisibility(notification.getSidebar());
   });


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43593

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
