### PR TITLE
mgr/dashboard: Refactor handling of pwd expiration settings

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/settings.py
+++ b/src/pybind/mgr/dashboard/controllers/settings.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 import cherrypy
 
-from . import ApiController, RESTController, UiApiController
+from . import ApiController, RESTController
 from ..settings import Settings as SettingsModule, Options
 from ..security import Scope
 
@@ -85,13 +85,3 @@ class Settings(RESTController):
         with self._attribute_handler(kwargs) as data:
             for name, value in data.items():
                 setattr(SettingsModule, self._to_native(name), value)
-
-
-@UiApiController('/standard_settings')
-class StandardSettings(RESTController):
-    def list(self):
-        return {
-            'user_pwd_expiration_span': SettingsModule.USER_PWD_EXPIRATION_SPAN,
-            'user_pwd_expiration_warning_1': SettingsModule.USER_PWD_EXPIRATION_WARNING_1,
-            'user_pwd_expiration_warning_2': SettingsModule.USER_PWD_EXPIRATION_WARNING_2
-        }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
@@ -175,9 +175,9 @@ describe('UserFormComponent', () => {
       }
     ];
     const pwdExpirationSettings = {
-      user_pwd_expiration_warning_1: 10,
-      user_pwd_expiration_warning_2: 5,
-      user_pwd_expiration_span: 90
+      pwdExpirationSpan: 10,
+      pwdExpirationWarning1: 5,
+      pwdExpirationWarning2: 90
     };
 
     beforeEach(() => {
@@ -191,7 +191,9 @@ describe('UserFormComponent', () => {
       const req = httpTesting.expectOne('api/role');
       expect(req.request.method).toBe('GET');
       req.flush(roles);
-      httpTesting.expectOne('ui-api/standard_settings');
+      httpTesting.expectOne(
+        'api/settings?names=USER_PWD_EXPIRATION_SPAN,USER_PWD_EXPIRATION_WARNING_1,USER_PWD_EXPIRATION_WARNING_2'
+      );
     });
 
     afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
@@ -130,7 +130,7 @@ export class UserFormComponent implements OnInit {
           role.enabled = true;
           return role;
         });
-        this.pwdExpirationSettings = new CdPwdExpirationSettings(result[1]);
+        this.pwdExpirationSettings = result[1];
 
         if (this.mode === this.userFormMode.editing) {
           this.initEdit();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/settings.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/settings.service.ts
@@ -75,6 +75,19 @@ export class SettingsService {
   }
 
   pwdExpirationSettings(): Observable<CdPwdExpirationSettings> {
-    return this.http.get<CdPwdExpirationSettings>('ui-api/standard_settings');
+    return this.getValues([
+      'USER_PWD_EXPIRATION_SPAN',
+      'USER_PWD_EXPIRATION_WARNING_1',
+      'USER_PWD_EXPIRATION_WARNING_2'
+    ]).pipe(
+      map((resp: { [key: string]: any }) => {
+        const result = new CdPwdExpirationSettings(
+          resp['USER_PWD_EXPIRATION_SPAN'],
+          resp['USER_PWD_EXPIRATION_WARNING_1'],
+          resp['USER_PWD_EXPIRATION_WARNING_2']
+        );
+        return result;
+      })
+    );
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.spec.ts
@@ -42,9 +42,9 @@ describe('PwdExpirationNotificationComponent', () => {
       spyOn(authStorageService, 'getPwdExpirationDate').and.returnValue(1645488000);
       spyOn(settingsService, 'pwdExpirationSettings').and.returnValue(
         observableOf({
-          user_pwd_expiration_warning_1: 10,
-          user_pwd_expiration_warning_2: 5,
-          user_pwd_expiration_span: 90
+          pwdExpirationWarning1: 10,
+          pwdExpirationWarning2: 5,
+          pwdExpirationSpan: 90
         })
       );
       fixture = TestBed.createComponent(PwdExpirationNotificationComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.ts
@@ -21,7 +21,7 @@ export class PwdExpirationNotificationComponent implements OnInit {
 
   ngOnInit() {
     this.settingsService.pwdExpirationSettings().subscribe((pwdExpirationSettings) => {
-      this.pwdExpirationSettings = new CdPwdExpirationSettings(pwdExpirationSettings);
+      this.pwdExpirationSettings = pwdExpirationSettings;
       const pwdExpirationDate = this.authStorageService.getPwdExpirationDate();
       if (pwdExpirationDate) {
         this.expirationDays = this.getExpirationDays(pwdExpirationDate);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-pwd-expiration-settings.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-pwd-expiration-settings.ts
@@ -3,9 +3,13 @@ export class CdPwdExpirationSettings {
   pwdExpirationWarning1: number;
   pwdExpirationWarning2: number;
 
-  constructor(data: any) {
-    this.pwdExpirationSpan = data.user_pwd_expiration_span;
-    this.pwdExpirationWarning1 = data.user_pwd_expiration_warning_1;
-    this.pwdExpirationWarning2 = data.user_pwd_expiration_warning_2;
+  constructor(
+    pwdExpirationSpan: number,
+    pwdExpirationWarning1: number,
+    pwdExpirationWarning2: number
+  ) {
+    this.pwdExpirationSpan = pwdExpirationSpan;
+    this.pwdExpirationWarning1 = pwdExpirationWarning1;
+    this.pwdExpirationWarning2 = pwdExpirationWarning2;
   }
 }


### PR DESCRIPTION
* After the '/api/settings' REST API has been enhanced, it make sense to make use of it.
* Do some code cleanup.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
