### PR TITLE
mgr/cephadm: prefix daemon ids with hostname

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -626,8 +626,8 @@ def get_fqdn():
 
 def generate_service_id():
     # type: () -> str
-    return ''.join(random.choice(string.ascii_lowercase)
-                   for _ in range(6))
+    return get_hostname() + '.' + ''.join(random.choice(string.ascii_lowercase)
+                                          for _ in range(6))
 
 def generate_password():
     # type: () -> str

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -45,9 +45,10 @@ class TestCephadm(object):
         existing = [
             ServiceDescription(service_instance='mon.a')
         ]
-        new_mon = cephadm_module.get_unique_name(existing, 'mon')
+        new_mon = cephadm_module.get_unique_name('myhost', existing, 'mon')
         assert new_mon.startswith('mon.')
         assert new_mon != 'mon.a'
+        assert '.myhost.' in new_mon
 
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))


### PR DESCRIPTION
We have two options here:

1. ``mds.fsname.host-abcdef``.  This is the current behavior.  It makes the "id" $host-$random, and uses - as a separator so that this does not pick up config settings in the ``mds.fsname.host`` section.  (Current behavior.)
2. ``mds.fsname.host.abcdef``.  This would let you set per-host options for daemons in this group.  I think it blurs things a bit, but I can also see that it could be a useful thing.

??