### PR TITLE
mgr/dashboard: pass a list of drive_group to create_osds

### DIFF
--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -95,7 +95,7 @@ class OsdManager(ResourceManager):
 
     @wait_api_result
     def create(self, drive_group):
-        return self.api.create_osds(drive_group)
+        return self.api.create_osds([drive_group])
 
 
 class OrchClient(object):

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -872,7 +872,7 @@ class Orchestrator(object):
         #assert not (service_name and service_id)
         raise NotImplementedError()
 
-    def create_osds(self, drive_group):
+    def create_osds(self, drive_groups):
         # type: (DriveGroupSpec) -> Completion
         """
         Create one or more OSDs within a single Drive Group.
@@ -882,7 +882,7 @@ class Orchestrator(object):
         finer-grained OSD feature enablement (choice of backing store,
         compression/encryption, etc).
 
-        :param drive_group: DriveGroupSpec
+        :param drive_groups: a list of DriveGroupSpec
         :param all_hosts: TODO, this is required because the orchestrator methods are not composable
                 Probably this parameter can be easily removed because each orchestrator can use
                 the "get_inventory" method and the "drive_group.host_pattern" attribute


### PR DESCRIPTION
as orchestrator backends expect a list of drive_groups.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
