### PR TITLE
msg/async: open() should be called with connection locked

### DIFF
--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -2066,6 +2066,7 @@ CtPtr ProtocolV1::handle_connect_message_2() {
     // incoming lossy client, no need to register this connection
     // new session
     ldout(cct, 10) << __func__ << " accept new session" << dendl;
+    connection->lock.lock();
     return open(reply, authorizer_reply);
   }
 


### PR DESCRIPTION
open() function unlocks connection->lock and obviously expects it to
be locked. Usually double unlock can be stayed unnoticed, unless CPU
is intel with TSX support, which eventually ends up with pthread
__lll_unlock_elision call and `xend` instruction, which aborts an
entire application with a page fault with the following backtrace:

```
__lll_unlock_elision () from /lib64/libpthread.so.0
__gthread_mutex_unlock(pthread_mutex_t*) () from /root/devel/ceph-upstream/build/lib/libceph-common.so.2
std::mutex::unlock() () from /root/devel/ceph-upstream/build/lib/libceph-common.so.2
ProtocolV1::open(ceph_msg_connect_reply&, ceph::buffer::v14_2_0::list&) () from /root/devel/ceph-upstream/build/lib/libceph-common.so.2
ProtocolV1::handle_connect_message_2() () from /root/devel/ceph-upstream/build/lib/libceph-common.so.2
ProtocolV1::handle_connect_message_1(char*, int) () from /root/devel/ceph-upstream/build/lib/libceph-common.so.2
```

So be nice, don't let double unlock happen.
