### PR TITLE
qa/workunits/cephadm/test_cephadm.sh: skip docker when service is disabled

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -102,7 +102,7 @@ $SUDO $CEPHADM_BIN --image $IMAGE_MIMIC version \
 $SUDO $CEPHADM_BIN --image $IMAGE_MASTER version | grep 'ceph version'
 
 # try force docker; this won't work if docker isn't installed
-which docker && ( $CEPHADM --docker version | grep 'ceph version' )
+systemctl status docker && ( $CEPHADM --docker version | grep 'ceph version' )
 
 ## test shell before bootstrap, when crash dir isn't (yet) present on this host
 $CEPHADM shell --fsid $FSID -- ceph -v | grep 'ceph version'


### PR DESCRIPTION
docker can be installed, but the service might be disabled --

```
+ which docker
/usr/bin/docker
+ sudo /tmp/tmp.2smJEwQi56/cephadm --image ceph/daemon-base:latest-master-devel --docker version
+ grep 'ceph version'
INFO:cephadm:Non-zero exit code 125 from /usr/bin/docker run --rm --net=host -e CONTAINER_IMAGE=ceph/daemon-base:latest-master-devel -e NODE_NAME=foobar --entrypoint ceph ceph/daemon-base:latest-master-devel --version
INFO:cephadm:ceph:stderr /usr/bin/docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.
INFO:cephadm:ceph:stderr See '/usr/bin/docker run --help'.
Traceback (most recent call last):
  File "/tmp/tmp.2smJEwQi56/cephadm", line 2812, in <module>
    r = args.func()
  File "/tmp/tmp.2smJEwQi56/cephadm", line 1555, in command_version
    out = CephContainer(args.image, 'ceph', ['--version']).run()
  File "/tmp/tmp.2smJEwQi56/cephadm", line 1548, in run
    self.run_cmd(), desc=self.entrypoint, timeout=timeout)
  File "/tmp/tmp.2smJEwQi56/cephadm", line 492, in call_throws
    raise RuntimeError('Failed command: %s' % ' '.join(command))
RuntimeError: Failed command: /usr/bin/docker run --rm --net=host -e CONTAINER_IMAGE=ceph/daemon-base:latest-master-devel -e NODE_NAME=foobar --entrypoint ceph ceph/daemon-base:latest-master-devel --version
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
