### PR TITLE
luminous: tests: pybind/test_volume_client: print python version correctly

### DIFF
--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -19,7 +19,9 @@ class TestVolumeClient(CephFSTestCase):
     def setUp(self):
         CephFSTestCase.setUp(self)
         self.py_version = self.ctx.config.get('overrides', {}).get('python', 'python')
-        log.info("using python version: %s".format(self.py_version))
+        log.info("using python version: {python_version}".format(
+            python_version=self.py_version
+        ))
 
     def _volume_client_python(self, client, script, vol_prefix=None, ns_prefix=None):
         # Can't dedent this *and* the script we pass in, because they might have different


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/40315

---

backport of https://github.com/ceph/ceph/pull/28221
parent tracker: https://tracker.ceph.com/issues/40184

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh