### PR TITLE
nautilus: mgr/dashboard: Updated existing E2E tests to match new format 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/e2e/block/iscsi.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/block/iscsi.e2e-spec.ts
@@ -12,8 +12,13 @@ describe('Iscsi Page', () => {
     Helper.checkConsole();
   });
 
-  it('should open and show breadcrumb', () => {
-    page.navigateTo();
-    Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'Overview');
+  describe('breadcrumb test', () => {
+    beforeAll(() => {
+      page.navigateTo();
+    });
+
+    it('should open and show breadcrumb', () => {
+      Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'Overview');
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/configuration.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/configuration.e2e-spec.ts
@@ -12,8 +12,13 @@ describe('Configuration page', () => {
     Helper.checkConsole();
   });
 
-  it('should open and show breadcrumb', () => {
-    page.navigateTo();
-    Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'Configuration');
+  describe('breadcrumb test', () => {
+    beforeAll(() => {
+      page.navigateTo();
+    });
+
+    it('should open and show breadcrumb', () => {
+      Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'Configuration');
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/crush-map.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/crush-map.e2e-spec.ts
@@ -12,8 +12,13 @@ describe('CRUSH map page', () => {
     Helper.checkConsole();
   });
 
-  it('should open and show breadcrumb', () => {
-    page.navigateTo();
-    Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'CRUSH map');
+  describe('breadcrumb test', () => {
+    beforeAll(() => {
+      page.navigateTo();
+    });
+
+    it('should open and show breadcrumb', () => {
+      Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'CRUSH map');
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/hosts.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/hosts.e2e-spec.ts
@@ -12,23 +12,25 @@ describe('Hosts page', () => {
     Helper.checkConsole();
   });
 
-  it('should open and show breadcrumb', () => {
-    page.navigateTo();
-    Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'Hosts');
-  });
+  describe('breadcrumb and tab tests', () => {
+    beforeAll(() => {
+      page.navigateTo();
+    });
 
-  it('should show two tabs', () => {
-    page.navigateTo();
-    expect(Helper.getTabsCount()).toEqual(2);
-  });
+    it('should open and show breadcrumb', () => {
+      Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'Hosts');
+    });
 
-  it('should show hosts list tab at first', () => {
-    page.navigateTo();
-    expect(Helper.getTabText(0)).toEqual('Hosts List');
-  });
+    it('should show two tabs', () => {
+      expect(Helper.getTabsCount()).toEqual(2);
+    });
 
-  it('should show overall performance as a second tab', () => {
-    page.navigateTo();
-    expect(Helper.getTabText(1)).toEqual('Overall Performance');
+    it('should show hosts list tab at first', () => {
+      expect(Helper.getTabText(0)).toEqual('Hosts List');
+    });
+
+    it('should show overall performance as a second tab', () => {
+      expect(Helper.getTabText(1)).toEqual('Overall Performance');
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/logs.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/logs.e2e-spec.ts
@@ -12,23 +12,25 @@ describe('Logs page', () => {
     Helper.checkConsole();
   });
 
-  it('should open and show breadcrumb', () => {
-    page.navigateTo();
-    Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'Logs');
-  });
+  describe('breadcrumb and tab tests', () => {
+    beforeAll(() => {
+      page.navigateTo();
+    });
 
-  it('should show two tabs', () => {
-    page.navigateTo();
-    expect(Helper.getTabsCount()).toEqual(2);
-  });
+    it('should open and show breadcrumb', () => {
+      Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'Logs');
+    });
 
-  it('should show cluster logs tab at first', () => {
-    page.navigateTo();
-    expect(Helper.getTabText(0)).toEqual('Cluster Logs');
-  });
+    it('should show two tabs', () => {
+      expect(Helper.getTabsCount()).toEqual(2);
+    });
 
-  it('should show audit logs as a second tab', () => {
-    page.navigateTo();
-    expect(Helper.getTabText(1)).toEqual('Audit Logs');
+    it('should show cluster logs tab at first', () => {
+      expect(Helper.getTabText(0)).toEqual('Cluster Logs');
+    });
+
+    it('should show audit logs as a second tab', () => {
+      expect(Helper.getTabText(1)).toEqual('Audit Logs');
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/monitors.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/monitors.e2e-spec.ts
@@ -12,8 +12,13 @@ describe('Monitors page', () => {
     Helper.checkConsole();
   });
 
-  it('should open and show breadcrumb', () => {
-    page.navigateTo();
-    Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'Monitors');
+  describe('breadcrumb test', () => {
+    beforeAll(() => {
+      page.navigateTo();
+    });
+
+    it('should open and show breadcrumb', () => {
+      Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'Monitors');
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/osds.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/osds.e2e-spec.ts
@@ -12,23 +12,25 @@ describe('OSDs page', () => {
     Helper.checkConsole();
   });
 
-  it('should open and show breadcrumb', () => {
-    page.navigateTo();
-    Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'OSDs');
-  });
+  describe('breadcrumb and tab tests', () => {
+    beforeAll(() => {
+      page.navigateTo();
+    });
 
-  it('should show two tabs', () => {
-    page.navigateTo();
-    expect(Helper.getTabsCount()).toEqual(2);
-  });
+    it('should open and show breadcrumb', () => {
+      Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'OSDs');
+    });
 
-  it('should show OSDs list tab at first', () => {
-    page.navigateTo();
-    expect(Helper.getTabText(0)).toEqual('OSDs List');
-  });
+    it('should show two tabs', () => {
+      expect(Helper.getTabsCount()).toEqual(2);
+    });
 
-  it('should show overall performance as a second tab', () => {
-    page.navigateTo();
-    expect(Helper.getTabText(1)).toEqual('Overall Performance');
+    it('should show OSDs list tab at first', () => {
+      expect(Helper.getTabText(0)).toEqual('OSDs List');
+    });
+
+    it('should show overall performance as a second tab', () => {
+      expect(Helper.getTabText(1)).toEqual('Overall Performance');
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/pools/pools.e2e-spec.ts
@@ -12,23 +12,25 @@ describe('Pools page', () => {
     Helper.checkConsole();
   });
 
-  it('should open and show breadcrumb', () => {
-    page.navigateTo();
-    Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'Pools');
-  });
+  describe('breadcrumb and tab tests', () => {
+    beforeAll(() => {
+      page.navigateTo();
+    });
 
-  it('should show two tabs', () => {
-    page.navigateTo();
-    expect(Helper.getTabsCount()).toEqual(2);
-  });
+    it('should open and show breadcrumb', () => {
+      Helper.waitTextToBePresent(Helper.getBreadcrumb(), 'Pools');
+    });
 
-  it('should show pools list tab at first', () => {
-    page.navigateTo();
-    expect(Helper.getTabText(0)).toEqual('Pools List');
-  });
+    it('should show two tabs', () => {
+      expect(Helper.getTabsCount()).toEqual(2);
+    });
 
-  it('should show overall performance as a second tab', () => {
-    page.navigateTo();
-    expect(Helper.getTabText(1)).toEqual('Overall Performance');
+    it('should show pools list tab at first', () => {
+      expect(Helper.getTabText(0)).toEqual('Pools List');
+    });
+
+    it('should show overall performance as a second tab', () => {
+      expect(Helper.getTabText(1)).toEqual('Overall Performance');
+    });
   });
 });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/39230

---

backport of https://github.com/ceph/ceph/pull/27408
parent tracker: https://tracker.ceph.com/issues/38245

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh