### PR TITLE
mon/MgrMonitor.cc: warn about missing mgr in a cluster with osds

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -251,14 +251,11 @@ void MgrMonitor::create_pending()
 health_status_t MgrMonitor::should_warn_about_mgr_down()
 {
   utime_t now = ceph_clock_now();
-  // we warn if
-  //   - we've ever had an active mgr, or
-  //   - we have osds AND we've exceeded the grace period
+  // we warn if we have osds AND we've exceeded the grace period
   // which means a new mon cluster and be HEALTH_OK indefinitely as long as
   // no OSDs are ever created.
-  if (ever_had_active_mgr ||
-      (mon->osdmon()->osdmap.get_num_osds() > 0 &&
-       now > mon->monmap->created + g_conf().get_val<int64_t>("mon_mgr_mkfs_grace"))) {
+  if (mon->osdmon()->osdmap.get_num_osds() > 0 &&
+       now > mon->monmap->created + g_conf().get_val<int64_t>("mon_mgr_mkfs_grace")) {
     health_status_t level = HEALTH_WARN;
     if (first_seen_inactive != utime_t() &&
 	now - first_seen_inactive > g_conf().get_val<int64_t>("mon_mgr_inactive_grace")) {


### PR DESCRIPTION
A lot of our functionality depends on the mgr now. If there is a cluster
set up with osds but no mgr, issue a warning.

Fixes: https://tracker.ceph.com/issues/38942
Signed-off-by: Neha Ojha <nojha@redhat.com>