### PR TITLE
os/bluestore/BlueFS: explicit check for too-granular allocations

### DIFF
--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -320,6 +320,7 @@ private:
   vector<Allocator*> alloc;                   ///< allocators for bdevs
   vector<uint64_t> alloc_size;                ///< alloc size for each device
   vector<interval_set<uint64_t>> pending_release; ///< extents to release
+  vector<interval_set<uint64_t>> block_unused_too_granular;
 
   BlockDevice::aio_callback_t discard_cb[3]; //discard callbacks for each dev
 
@@ -416,7 +417,7 @@ private:
     __u8 id, uint64_t offset, uint64_t length,
     const char *op);
   int _adjust_granularity(
-    __u8 id, uint64_t *offset, uint64_t *length, const char *op);
+    __u8 id, uint64_t *offset, uint64_t *length, bool alloc);
   int _replay(bool noop, bool to_stdout = false); ///< replay journal
 
   FileWriter *_create_writer(FileRef f);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -412,6 +412,9 @@ private:
     size_t dev_count,
     boost::dynamic_bitset<uint64_t>* owned_blocks,
     boost::dynamic_bitset<uint64_t>* used_blocks);
+  int _verify_alloc_granularity(
+    __u8 id, uint64_t offset, uint64_t length,
+    const char *op);
   int _adjust_granularity(
     __u8 id, uint64_t *offset, uint64_t *length, const char *op);
   int _replay(bool noop, bool to_stdout = false); ///< replay journal

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -412,6 +412,8 @@ private:
     size_t dev_count,
     boost::dynamic_bitset<uint64_t>* owned_blocks,
     boost::dynamic_bitset<uint64_t>* used_blocks);
+  int _adjust_granularity(
+    __u8 id, uint64_t *offset, uint64_t *length, const char *op);
   int _replay(bool noop, bool to_stdout = false); ///< replay journal
 
   FileWriter *_create_writer(FileRef f);


### PR DESCRIPTION
Be helpful and suggest what config option to adjust.

It is not easy to restart the replay process with a finer granularity,
since replay is adjusting in-memory state as it goes.

Fixes: https://tracker.ceph.com/issues/43904 (sort of)
Signed-off-by: Sage Weil <sage@redhat.com>