### PR TITLE
mgr/pg_autoscaler: treat target ratios as weights

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -226,6 +226,15 @@
   autoscaling, see :ref:`pg-autoscaler`.  Note that existing pools in
   upgraded clusters will still be set to ``warn`` by default.
 
+* The pool parameter ``target_size_ratio``, used by the pg autoscaler,
+  has changed meaning. It is now normalized across pools, rather than
+  specifying an absolute ratio. For details, see :ref:`pg-autoscaler`.
+  If you have set target size ratios on any pools, you may want to set
+  these pools to autoscale ``warn`` mode to avoid data movement during
+  the upgrade::
+
+    ceph osd pool set <pool-name> pg_autoscale_mode warn
+
 * The ``upmap_max_iterations`` config option of mgr/balancer has been
   renamed to ``upmap_max_optimizations`` to better match its behaviour.
 

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -848,6 +848,21 @@ the pool is too large and should be reduced or set to zero with::
 
 For more information, see :ref:`specifying_pool_target_size`.
 
+POOL_HAS_TARGET_SIZE_BYTES_AND_RATIO
+____________________________________
+
+One or more pools have both ``target_size_bytes`` and
+``target_size_ratio`` set to estimate the expected size of the pool.
+Only one of these properties should be non-zero. If both are set,
+``target_size_ratio`` takes precedence and ``target_size_bytes`` is
+ignored.
+
+To reset ``target_size_bytes`` to zero::
+
+  ceph osd pool set <pool-name> target_size_bytes 0
+
+For more information, see :ref:`specifying_pool_target_size`.
+
 TOO_FEW_OSDS
 ____________
 

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -833,21 +833,6 @@ recommended amount with::
 Please refer to :ref:`choosing-number-of-placement-groups` and
 :ref:`pg-autoscaler` for more information.
 
-POOL_TARGET_SIZE_RATIO_OVERCOMMITTED
-____________________________________
-
-One or more pools have a ``target_size_ratio`` property set to
-estimate the expected size of the pool as a fraction of total storage,
-but the value(s) exceed the total available storage (either by
-themselves or in combination with other pools' actual usage).
-
-This is usually an indication that the ``target_size_ratio`` value for
-the pool is too large and should be reduced or set to zero with::
-
-  ceph osd pool set <pool-name> target_size_ratio 0
-
-For more information, see :ref:`specifying_pool_target_size`.
-
 POOL_TARGET_SIZE_BYTES_OVERCOMMITTED
 ____________________________________
 

--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -41,10 +41,10 @@ the PG count with this command::
 
 Output will be something like::
 
-   POOL    SIZE  TARGET SIZE  RATE  RAW CAPACITY   RATIO  TARGET RATIO  PG_NUM  NEW PG_NUM  AUTOSCALE
-   a     12900M                3.0        82431M  0.4695                     8         128  warn
-   c         0                 3.0        82431M  0.0000        0.2000       1          64  warn
-   b         0        953.6M   3.0        82431M  0.0347                     8              warn
+   POOL    SIZE  TARGET SIZE  RATE  RAW CAPACITY   RATIO  TARGET RATIO  EFFECTIVE RATIO PG_NUM  NEW PG_NUM  AUTOSCALE
+   a     12900M                3.0        82431M  0.4695                                     8         128  warn
+   c         0                 3.0        82431M  0.0000        0.2000           0.9884      1          64  warn
+   b         0        953.6M   3.0        82431M  0.0347                                     8              warn
 
 **SIZE** is the amount of data stored in the pool. **TARGET SIZE**, if
 present, is the amount of data the administrator has specified that
@@ -62,10 +62,20 @@ pools') data.  **RATIO** is the ratio of that total capacity that
 this pool is consuming (i.e., ratio = size * rate / raw capacity).
 
 **TARGET RATIO**, if present, is the ratio of storage that the
-administrator has specified that they expect this pool to consume.
-The system uses the larger of the actual ratio and the target ratio
-for its calculation.  If both target size bytes and ratio are specified, the
+administrator has specified that they expect this pool to consume
+relative to other pools with target ratios set.
+If both target size bytes and ratio are specified, the
 ratio takes precedence.
+
+**EFFECTIVE RATIO** is the target ratio after adjusting in two ways:
+
+1. subtracting any capacity expected to be used by pools with target size set
+2. normalizing the target ratios among pools with target ratio set so
+   they collectively target the rest of the space. For example, 4
+   pools with target_ratio 1.0 would have an effective ratio of 0.25.
+
+The system uses the larger of the actual ratio and the effective ratio
+for its calculation.
 
 **PG_NUM** is the current number of PGs for the pool (or the current
 number of PGs that the pool is working towards, if a ``pg_num``
@@ -119,9 +129,9 @@ PGs can be used from the beginning, preventing subsequent changes in
 ``pg_num`` and the overhead associated with moving data around when
 those adjustments are made.
 
-The *target size** of a pool can be specified in two ways: either in
-terms of the absolute size of the pool (i.e., bytes), or as a ratio of
-the total cluster capacity.
+The *target size* of a pool can be specified in two ways: either in
+terms of the absolute size of the pool (i.e., bytes), or as a weight
+relative to other pools with a ``target_size_ratio`` set.
 
 For example,::
 
@@ -130,16 +140,23 @@ For example,::
 will tell the system that `mypool` is expected to consume 100 TiB of
 space.  Alternatively,::
 
-  ceph osd pool set mypool target_size_ratio .9
+  ceph osd pool set mypool target_size_ratio 1.0
 
-will tell the system that `mypool` is expected to consume 90% of the
-total cluster capacity.
+will tell the system that `mypool` is expected to consume 1.0 relative
+to the other pools with ``target_size_ratio`` set. If `mypool` is the
+only pool in the cluster, this means an expected use of 100% of the
+total capacity. If there is a second pool with ``target_size_ratio``
+1.0, both pools would expect to use 50% of the cluster capacity.
 
 You can also set the target size of a pool at creation time with the optional ``--target-size-bytes <bytes>`` or ``--target-size-ratio <ratio>`` arguments to the ``ceph osd pool create`` command.
 
 Note that if impossible target size values are specified (for example,
 a capacity larger than the total cluster) then a health warning
 (``POOL_TARGET_SIZE_BYTES_OVERCOMMITTED``) will be raised.
+
+If both ``target_size_ratio`` and ``target_size_bytes`` are specified
+for a pool, only the ratio will be considered, and a health warning
+(``POOL_HAS_TARGET_SIZE_BYTES_AND_RATIO``) will be issued.
 
 Specifying bounds on a pool's PGs
 ---------------------------------

--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -138,10 +138,8 @@ total cluster capacity.
 You can also set the target size of a pool at creation time with the optional ``--target-size-bytes <bytes>`` or ``--target-size-ratio <ratio>`` arguments to the ``ceph osd pool create`` command.
 
 Note that if impossible target size values are specified (for example,
-a capacity larger than the total cluster, or ratio(s) that sum to more
-than 1.0) then a health warning
-(``POOL_TARET_SIZE_RATIO_OVERCOMMITTED`` or
-``POOL_TARGET_SIZE_BYTES_OVERCOMMITTED``) will be raised.
+a capacity larger than the total cluster) then a health warning
+(``POOL_TARGET_SIZE_BYTES_OVERCOMMITTED``) will be raised.
 
 Specifying bounds on a pool's PGs
 ---------------------------------

--- a/qa/workunits/mon/pg_autoscaler.sh
+++ b/qa/workunits/mon/pg_autoscaler.sh
@@ -68,6 +68,11 @@ ceph osd pool set a target_size_ratio 0
 ceph osd pool set b target_size_ratio 0
 wait_for 60 "ceph health detail | grep POOL_TARGET_SIZE_BYTES_OVERCOMMITTED"
 
+ceph osd pool set a target_size_bytes 1000
+ceph osd pool set b target_size_bytes 1000
+ceph osd pool set a target_size_ratio 1
+wait_for 60 "ceph health detail | grep POOL_HAS_TARGET_SIZE_BYTES_AND_RATIO"
+
 ceph osd pool rm a a --yes-i-really-really-mean-it
 ceph osd pool rm b b --yes-i-really-really-mean-it
 

--- a/qa/workunits/mon/pg_autoscaler.sh
+++ b/qa/workunits/mon/pg_autoscaler.sh
@@ -70,9 +70,9 @@ ceph osd pool set b target_size_ratio 0
 # target_size
 ceph osd pool set a target_size_bytes 1000000000000000
 ceph osd pool set b target_size_bytes 1000000000000000
-wait_for 60 "ceph health detail | grep POOL_TARGET_SIZE_BYTES_OVERCOMMITTED"
-ceph osd pool set a target_size_bytes 0
+ceph osd pool set a target_size_ratio 0
 ceph osd pool set b target_size_ratio 0
+wait_for 60 "ceph health detail | grep POOL_TARGET_SIZE_BYTES_OVERCOMMITTED"
 
 ceph osd pool rm a a --yes-i-really-really-mean-it
 ceph osd pool rm b b --yes-i-really-really-mean-it

--- a/qa/workunits/mon/pg_autoscaler.sh
+++ b/qa/workunits/mon/pg_autoscaler.sh
@@ -44,20 +44,22 @@ wait_for 120 "ceph osd pool get a pg_num | grep 4"
 wait_for 120 "ceph osd pool get b pg_num | grep 2"
 
 # target ratio
-ceph osd pool set a target_size_ratio .5
-ceph osd pool set b target_size_ratio .1
-sleep 30
-APGS=$(ceph osd dump -f json-pretty | jq '.pools[0].pg_num')
-BPGS=$(ceph osd dump -f json-pretty | jq '.pools[1].pg_num')
+ceph osd pool set a target_size_ratio 5
+ceph osd pool set b target_size_ratio 1
+sleep 10
+APGS=$(ceph osd dump -f json-pretty | jq '.pools[0].pg_num_target')
+BPGS=$(ceph osd dump -f json-pretty | jq '.pools[1].pg_num_target')
 test $APGS -gt 100
 test $BPGS -gt 10
 
 # small ratio change does not change pg_num
-ceph osd pool set a target_size_ratio .7
-ceph osd pool set b target_size_ratio .2
+ceph osd pool set a target_size_ratio 7
+ceph osd pool set b target_size_ratio 2
 sleep 10
-ceph osd pool get a pg_num | grep $APGS
-ceph osd pool get b pg_num | grep $BPGS
+APGS2=$(ceph osd dump -f json-pretty | jq '.pools[0].pg_num_target')
+BPGS2=$(ceph osd dump -f json-pretty | jq '.pools[1].pg_num_target')
+test $APGS -eq $APGS2
+test $BPGS -eq $BPGS2
 
 # too much ratio
 ceph osd pool set a target_size_ratio .9

--- a/qa/workunits/mon/pg_autoscaler.sh
+++ b/qa/workunits/mon/pg_autoscaler.sh
@@ -61,14 +61,6 @@ BPGS2=$(ceph osd dump -f json-pretty | jq '.pools[1].pg_num_target')
 test $APGS -eq $APGS2
 test $BPGS -eq $BPGS2
 
-# too much ratio
-ceph osd pool set a target_size_ratio .9
-ceph osd pool set b target_size_ratio .9
-wait_for 60 "ceph health detail | grep POOL_TARGET_SIZE_RATIO_OVERCOMMITTED"
-wait_for 60 "ceph health detail | grep 1.8"
-ceph osd pool set a target_size_ratio 0
-ceph osd pool set b target_size_ratio 0
-
 # target_size
 ceph osd pool set a target_size_bytes 1000000000000000
 ceph osd pool set b target_size_bytes 1000000000000000

--- a/src/pybind/mgr/pg_autoscaler/__init__.py
+++ b/src/pybind/mgr/pg_autoscaler/__init__.py
@@ -1,1 +1,1 @@
-from .module import PgAutoscaler
+from .module import PgAutoscaler, effective_target_ratio

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -136,6 +136,7 @@ class PgAutoscaler(MgrModule):
             table = PrettyTable(['POOL', 'SIZE', 'TARGET SIZE',
                                  'RATE', 'RAW CAPACITY',
                                  'RATIO', 'TARGET RATIO',
+                                 'EFFECTIVE RATIO',
                                  'BIAS',
                                  'PG_NUM',
 #                                 'IDEAL',
@@ -150,6 +151,7 @@ class PgAutoscaler(MgrModule):
             table.align['RAW CAPACITY'] = 'r'
             table.align['RATIO'] = 'r'
             table.align['TARGET RATIO'] = 'r'
+            table.align['EFFECTIVE RATIO'] = 'r'
             table.align['BIAS'] = 'r'
             table.align['PG_NUM'] = 'r'
 #            table.align['IDEAL'] = 'r'
@@ -168,6 +170,10 @@ class PgAutoscaler(MgrModule):
                     tr = '%.4f' % p['target_ratio']
                 else:
                     tr = ''
+                if p['effective_target_ratio'] > 0.0:
+                    etr = '%.4f' % p['effective_target_ratio']
+                else:
+                    etr = ''
                 table.add_row([
                     p['pool_name'],
                     mgr_util.format_bytes(p['logical_used'], 6),
@@ -176,6 +182,7 @@ class PgAutoscaler(MgrModule):
                     mgr_util.format_bytes(p['subtree_capacity'], 6),
                     '%.4f' % p['capacity_ratio'],
                     tr,
+                    etr,
                     p['bias'],
                     p['pg_num_target'],
 #                    p['pg_num_ideal'],
@@ -376,6 +383,7 @@ class PgAutoscaler(MgrModule):
                 'actual_capacity_ratio': actual_capacity_ratio,
                 'capacity_ratio': capacity_ratio,
                 'target_ratio': p['options'].get('target_size_ratio', 0.0),
+                'effective_target_ratio': target_ratio,
                 'pg_num_ideal': int(pool_pg_target),
                 'pg_num_final': final_pg_target,
                 'would_adjust': adjust,

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -2,14 +2,12 @@
 Automatically scale pg_num based on how much data is stored in each pool.
 """
 
-import errno
 import json
 import mgr_util
 import threading
 import uuid
 from six import itervalues, iteritems
-from collections import defaultdict
-from prettytable import PrettyTable, PLAIN_COLUMNS
+from prettytable import PrettyTable
 from mgr_module import MgrModule
 
 """

--- a/src/pybind/mgr/pg_autoscaler/tests/test_autoscaler.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_autoscaler.py
@@ -1,0 +1,34 @@
+from pg_autoscaler import effective_target_ratio
+from pytest import approx
+
+def check_simple_ratio(target_ratio, tot_ratio):
+    etr = effective_target_ratio(target_ratio, tot_ratio, 0, 0)
+    assert (target_ratio / tot_ratio) == approx(etr)
+    return etr
+
+def test_simple():
+    etr1 = check_simple_ratio(0.2, 0.9)
+    etr2 = check_simple_ratio(2, 9)
+    etr3 = check_simple_ratio(20, 90)
+    assert etr1 == approx(etr2)
+    assert etr1 == approx(etr3)
+
+    etr = check_simple_ratio(0.9, 0.9)
+    assert etr == approx(1.0)
+    etr1 = check_simple_ratio(1, 2)
+    etr2 = check_simple_ratio(0.5, 1.0)
+    assert etr1 == approx(etr2)
+
+def test_total_bytes():
+    etr = effective_target_ratio(1, 10, 5, 10)
+    assert etr == approx(0.05)
+    etr = effective_target_ratio(0.1, 1, 5, 10)
+    assert etr == approx(0.05)
+    etr = effective_target_ratio(1, 1, 5, 10)
+    assert etr == approx(0.5)
+    etr = effective_target_ratio(1, 1, 0, 10)
+    assert etr == approx(1.0)
+    etr = effective_target_ratio(0, 1, 5, 10)
+    assert etr == approx(0.0)
+    etr = effective_target_ratio(1, 1, 10, 10)
+    assert etr == approx(0.0)

--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -5,3 +5,4 @@ ipaddress; python_version < '3.3'
 kubernetes
 requests-mock
 pyyaml
+prettytable

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -5,7 +5,7 @@ skipsdist = true
 [testenv]
 setenv = UNITTEST = true
 deps = -r requirements.txt
-commands = pytest -v --cov --cov-append --cov-report=term --doctest-modules {posargs:mgr_util.py tests/ cephadm/ progress/}
+commands = pytest -v --cov --cov-append --cov-report=term --doctest-modules {posargs:mgr_util.py tests/ cephadm/ pg_autoscaler/ progress/}
 
 [testenv:mypy]
 basepython = python3


### PR DESCRIPTION
The tests quickly ran into bugs in the progress handling that crashed the module, so those are fixed too.

https://tracker.ceph.com/issues/43947

Only the first 7 commits (in --topo-order, not as shown by github) are relevant for a backport - the rest are master-specific.