### PR TITLE
qa/rgw: exercise DeleteRange in test_bucket_index_log_trim

### DIFF
--- a/qa/suites/rgw/multisite/omap_limits.yaml
+++ b/qa/suites/rgw/multisite/omap_limits.yaml
@@ -1,6 +1,9 @@
 overrides:
   ceph:
     conf:
+      osd:
+        # remove the threshold so that test_bucket_index_log_trim() will test DeleteRange
+        rocksdb delete range threshold: 0
       # instead of expanding the matrix, run each osd with a different omap limit
       osd.0:
         osd_max_omap_entries_per_request: 10


### PR DESCRIPTION
test_bucket_index_log_trim doesn't create enough keys to exceed the default threshold, so set it to 0