### PR TITLE
cephadm: fix error handing in `command_check_host()`

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -538,7 +538,7 @@ def call_timeout(command, timeout):
 
 ##################################
 
-def is_available(what, func, retry_max=5):
+def is_available(what, func, retry_max=10):
     # type (str, func, Optional[int]) -> func
     """
     Wait for a service to become available

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2426,17 +2426,18 @@ def command_check_host():
     # caller already checked for docker/podman
     logger.info('podman|docker (%s) is present' % container_path)
 
-    if not find_program('systemctl'):
-        raise RuntimeError('unable to location systemctl')
-    logger.info('systemctl is present')
+    commands = ['systemctl', 'lvcreate']
 
-    if not find_program('lvcreate'):
-        raise RuntimeError('LVM does not appear to be installed')
-    logger.info('LVM2 is present')
+    for command in commands:
+        try:
+            find_program(command)
+            logger.info('%s is present' % command)
+        except ValueError:
+            raise Error('%s binary does not appear to be installed' % command)
 
     # check for configured+running chronyd or ntp
     if not check_time_sync():
-        raise RuntimeError('No time synchronization is active')
+        raise Error('No time synchronization is active')
 
     logger.info('Host looks OK')
 


### PR DESCRIPTION
cephadm: fix error handling in `command_check_host()`
    
`find_program()` raises `ValueError` when the executable hasn't been
found. It means we need to catch `ValueError` exception in
`command_check_host()` and raise `Error` instead of `RuntimeError` since
only `Error` is caught at the end.
    
Typical failure:
    
```
INFO:cephadm:/usr/bin/ceph:stderr Error ENOENT: New host mon1 failed check: ['INFO:cephadm:podman|docker (/bin/podman) is present', 'INFO:cephadm:systemctl is present', 'Traceback (most recent call last):', '  File "<stdin>", line 2820, in <module>', '  File "<stdin>", line 2434, in command_check_host', '  File "<stdin>", line 796, in find_program', 'ValueError: lvcreate not found']
```
    
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
