### PR TITLE
qa/rgw/pubsub: fix tests to sync from master

### DIFF
--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -354,7 +354,7 @@ def compare_bucket_status(target_zone, source_zone, bucket_name, log_status, syn
     return True
 
 def zone_data_checkpoint(target_zone, source_zone):
-    if not target_zone.syncs_from(source_zone):
+    if not target_zone.syncs_from(source_zone.name):
         return
 
     log_status = data_source_log_status(source_zone)
@@ -384,7 +384,7 @@ def zonegroup_data_checkpoint(zonegroup_conns):
             zone_data_checkpoint(target_conn.zone, source_conn.zone)
 
 def zone_bucket_checkpoint(target_zone, source_zone, bucket_name):
-    if not target_zone.syncs_from(source_zone):
+    if not target_zone.syncs_from(source_zone.name):
         return
 
     log_status = bucket_source_log_status(source_zone, bucket_name)


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

Fixes: https://tracker.ceph.com/issues/43768

This is the second step in fixing the above issue (first was done here: https://github.com/ceph/ceph/pull/32941).

2 tests are always failing (in teuthology and local runs), When a pubsub zone exists, the pubsub zone syncing with the master is failing:
http://qa-proxy.ceph.com/teuthology/yuvalif-2020-02-03_07:09:13-rgw:multisite-master-distro-basic-smithi/4728525/teuthology.log
