### PR TITLE
rgw/kafka: disable kafka when not found

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -149,6 +149,17 @@ set(librgw_common_srcs
   rgw_url.cc)
 
 if(WITH_RADOSGW_AMQP_ENDPOINT)
+  find_package(RabbitMQ REQUIRED)
+endif()
+if(WITH_RADOSGW_KAFKA_ENDPOINT)
+  find_package(RDKafka 1.9.2)
+  if(NOT RDKafka_FOUND)
+    set(WITH_RADOSGW_KAFKA_ENDPOINT OFF CACHE BOOL "Rados Gateway's pubsub support for Kafka push endpoint" FORCE)
+    message(STATUS "Disabling Kafka endpoint support")
+  endif()
+endif()
+
+if(WITH_RADOSGW_AMQP_ENDPOINT)
   list(APPEND librgw_common_srcs rgw_amqp.cc)
 endif()
 if(WITH_RADOSGW_KAFKA_ENDPOINT)
@@ -218,13 +229,6 @@ add_dependencies(rgw_a civetweb_h)
 target_compile_definitions(rgw_a PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 target_include_directories(rgw_a PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src")
 target_include_directories(rgw_a SYSTEM PUBLIC "../rapidjson/include")
-
-if(WITH_RADOSGW_AMQP_ENDPOINT)
-  find_package(RabbitMQ REQUIRED)
-endif()
-if(WITH_RADOSGW_KAFKA_ENDPOINT)
-  find_package(RDKafka 0.9.2 REQUIRED)
-endif()
 
 target_link_libraries(rgw_a
   PRIVATE


### PR DESCRIPTION
also covers the case where installed kafka is of incorrect version
(e.g. this is happening in ubuntu-xenial)

Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

fix was tested on ubuntu-xenial build (from a nautilus branch, but same fix):
https://shaman.ceph.com/builds/ceph/nautilus-backport-kafka/962f6094208edd286a26220bf192f16320296102/default/188059/