### PR TITLE
common: fix clang compile errors from cython_modules

### DIFF
--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -19,7 +19,10 @@ def filter_unsupported_flags(flags):
     if clang:
         return [f for f in flags if not (f == '-mcet' or
                                          f.startswith('-fcf-protection') or
-                                         f == '-fstack-clash-protection')]
+                                         f == '-fstack-clash-protection' or
+                                         f == '-fno-var-tracking-assignments' or
+                                         f == '-Wno-deprecated-register' or
+                                         f == '-Wno-gnu-designator')]
     else:
         return flags
 
@@ -55,7 +58,7 @@ def get_python_flags(libs):
         include_dirs=[distutils.sysconfig.get_python_inc()],
         library_dirs=distutils.sysconfig.get_config_vars('LIBDIR', 'LIBPL'),
         libraries=libs + [lib.replace('-l', '') for lib in py_libs],
-        extra_compile_args=distutils.sysconfig.get_config_var('CFLAGS').split(),
+        extra_compile_args=filter_unsupported_flags(distutils.sysconfig.get_config_var('CFLAGS').split()),
         extra_link_args=(distutils.sysconfig.get_config_var('LDFLAGS').split() +
                          distutils.sysconfig.get_config_var('LINKFORSHARED').split()))
 

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -27,7 +27,10 @@ def filter_unsupported_flags(flags):
     if clang:
         return [f for f in flags if not (f == '-mcet' or
                                          f.startswith('-fcf-protection') or
-                                         f == '-fstack-clash-protection')]
+                                         f == '-fstack-clash-protection' or
+                                         f == '-fno-var-tracking-assignments' or
+                                         f == '-Wno-deprecated-register' or
+                                         f == '-Wno-gnu-designator')]
     else:
         return flags
 
@@ -55,7 +58,7 @@ def get_python_flags(libs):
         include_dirs=[distutils.sysconfig.get_python_inc()],
         library_dirs=distutils.sysconfig.get_config_vars('LIBDIR', 'LIBPL'),
         libraries=libs + [lib.replace('-l', '') for lib in py_libs],
-        extra_compile_args=distutils.sysconfig.get_config_var('CFLAGS').split(),
+        extra_compile_args=filter_unsupported_flags(distutils.sysconfig.get_config_var('CFLAGS').split()),
         extra_link_args=(distutils.sysconfig.get_config_var('LDFLAGS').split() +
                          distutils.sysconfig.get_config_var('LINKFORSHARED').split()))
 

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -19,7 +19,10 @@ def filter_unsupported_flags(flags):
     if clang:
         return [f for f in flags if not (f == '-mcet' or
                                          f.startswith('-fcf-protection') or
-                                         f == '-fstack-clash-protection')]
+                                         f == '-fstack-clash-protection' or
+                                         f == '-fno-var-tracking-assignments' or
+                                         f == '-Wno-deprecated-register' or
+                                         f == '-Wno-gnu-designator')]
     else:
         return flags
 
@@ -55,7 +58,7 @@ def get_python_flags(libs):
         include_dirs=[distutils.sysconfig.get_python_inc()],
         library_dirs=distutils.sysconfig.get_config_vars('LIBDIR', 'LIBPL'),
         libraries=libs + [lib.replace('-l', '') for lib in py_libs],
-        extra_compile_args=distutils.sysconfig.get_config_var('CFLAGS').split(),
+        extra_compile_args=filter_unsupported_flags(distutils.sysconfig.get_config_var('CFLAGS').split()),
         extra_link_args=(distutils.sysconfig.get_config_var('LDFLAGS').split() +
                          distutils.sysconfig.get_config_var('LINKFORSHARED').split()))
 

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -19,7 +19,10 @@ def filter_unsupported_flags(flags):
     if clang:
         return [f for f in flags if not (f == '-mcet' or
                                          f.startswith('-fcf-protection') or
-                                         f == '-fstack-clash-protection')]
+                                         f == '-fstack-clash-protection' or
+                                         f == '-fno-var-tracking-assignments' or
+                                         f == '-Wno-deprecated-register' or
+                                         f == '-Wno-gnu-designator')]
     return flags
 
 def monkey_with_compiler(compiler):
@@ -58,7 +61,7 @@ def get_python_flags(libs):
         include_dirs=[distutils.sysconfig.get_python_inc()],
         library_dirs=distutils.sysconfig.get_config_vars('LIBDIR', 'LIBPL'),
         libraries=libs + [lib.replace('-l', '') for lib in py_libs],
-        extra_compile_args=distutils.sysconfig.get_config_var('CFLAGS').split(),
+        extra_compile_args=filter_unsupported_flags(distutils.sysconfig.get_config_var('CFLAGS').split()),
         extra_link_args=(distutils.sysconfig.get_config_var('LDFLAGS').split() +
                          distutils.sysconfig.get_config_var('LINKFORSHARED').split()))
 


### PR DESCRIPTION
Fix compile errors similar to:
```
/usr/bin/clang -Wall -Wtype-limits -Wignored-qualifiers -Winit-self -Wpointer-arith -Werror=format-security -fno-strict-aliasing -fsigned-char -Wno-unknown-prag
mas -Wno-unused-function -Wno-unused-local-typedef -Wno-varargs -Wno-gnu-designator -Wno-missing-braces -Wno-parentheses -Wno-deprecated-register -fdiagnostics-
color=auto -iquote/mnt/osd--host/src-git/ceph--upstream--master/src/include -w -Dvoid0=dead_function(void) -D__Pyx_check_single_interpreter(ARG)=ARG ## 0 -Wno-u
nused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTION
S -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/usr/include/
python3.7m -I/usr/include/python3.7m -c /mnt/osd--host/src-git/ceph--upstream--master/build/src/pybind/cephfs/cephfs.c -o /mnt/osd--host/src-git/ceph--upstream-
-master/build/lib/cython_modules/temp.linux-x86_64-3.7/mnt/osd--host/src-git/ceph--upstream--master/build/src/pybind/cephfs/cephfs.o -Wno-unused-result -Wsign-c
ompare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstac
k-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv

clang-9: error: unknown argument: '-fstack-clash-protection'
error: command '/usr/bin/clang' failed with exit status 1
```
when building vstart  with clang:
```
env CC=clang CXX=clang++  ./do_cmake.sh
cd build
make vstart
```



Signed-off-by: Mark Kogan <mkogan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
