### PR TITLE
rbd-ggate: fix fallout from bufferlist.copy() change

### DIFF
--- a/src/tools/rbd_ggate/Driver.cc
+++ b/src/tools/rbd_ggate/Driver.cc
@@ -149,7 +149,7 @@ int Driver::send(Request *req) {
       ggate_drv_req_error(req->req) == 0) {
     ceph_assert(req->bl.length() == ggate_drv_req_length(req->req));
     // TODO: avoid copying?
-    req->bl.copy(0, ggate_drv_req_length(req->req),
+    req->bl.begin().copy(ggate_drv_req_length(req->req),
                  static_cast<char *>(ggate_drv_req_buf(req->req)));
     dout(20) << "copied resulting " << req->bl.length() << " bytes to "
              << ggate_drv_req_buf(req->req) << dendl;


### PR DESCRIPTION
fixes: #3281



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>