### PR TITLE
mgr/cephadm: verify host's hostname matches cephadm host

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2491,6 +2491,13 @@ def command_check_host():
     if not check_time_sync():
         raise Error('No time synchronization is active')
 
+    if args.expect_hostname:
+        if get_hostname() != args.expect_hostname:
+            raise Error('hostname "%s" does not match expected hostname "%s"' % (
+                get_hostname(), args.expect_hostname))
+        logger.info('Hostname "%s" matches what is expected.',
+                    args.expect_hostname)
+
     logger.info('Host looks OK')
 
 
@@ -2831,6 +2838,9 @@ def _get_parser():
     parser_check_host = subparsers.add_parser(
         'check-host', help='check host configuration')
     parser_check_host.set_defaults(func=command_check_host)
+    parser_check_host.add_argument(
+        '--expect-hostname',
+        help='Check that hostname matches an expected value')
 
     return parser
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -985,7 +985,8 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         'name=host,type=CephString',
         'Check whether we can access and manage a remote host')
     def _check_host(self, host):
-        out, err, code = self._run_cephadm(host, 'client', 'check-host', [],
+        out, err, code = self._run_cephadm(host, 'client', 'check-host',
+                                           ['--expect-hostname', host],
                                            error_ok=True, no_fsid=True)
         if code:
             return 1, '', ('check-host failed:\n' + '\n'.join(err))
@@ -1120,7 +1121,8 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
 
         :param host: host name
         """
-        out, err, code = self._run_cephadm(host, 'client', 'check-host', [],
+        out, err, code = self._run_cephadm(host, 'client', 'check-host',
+                                           ['--expect-hostname', host],
                                            error_ok=True, no_fsid=True)
         if code:
             raise OrchestratorError('New host %s failed check: %s' % (host, err))


### PR DESCRIPTION
gnit:build (wip-cephadm-check-hostname) 07:25 AM $ bin/ceph cephadm check-host gnit.fuggernut.com
check-host failed:
INFO:cephadm:podman|docker (/bin/podman) is present
INFO:cephadm:systemctl is present
INFO:cephadm:lvcreate is present
INFO:cephadm:Time sync unit chronyd.service is enabled and running
ERROR: hostname "gnit" does not match expected hostname "gnit.fuggernut.com"
gnit:build (wip-cephadm-check-hostname) 07:25 AM $ bin/ceph cephadm check-host gnit
gnit ok