### PR TITLE
cephadm: use appropriate default image for non-ceph components

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2527,7 +2527,6 @@ def _get_parser():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         '--image',
-        default=os.environ.get('CEPHADM_IMAGE', DEFAULT_IMAGE),
         help='container image. Can also be set via the "CEPHADM_IMAGE" '
         'env var')
     parser.add_argument(
@@ -2834,6 +2833,19 @@ def _get_parser():
 
     return parser
 
+def _parse_args(av):
+    parser = _get_parser()
+    args = parser.parse_args(av)
+
+    if not args.image:
+        if 'name' in args:
+            type_ = args.name.split('.', 1)[0]
+            if type_ in Monitoring.components:
+                args.image = Monitoring.components[type_]['image']
+        if not args.image:
+            args.image = os.environ.get('CEPHADM_IMAGE', DEFAULT_IMAGE)
+
+    return args
 
 if __name__ == "__main__":
     # allow argv to be injected
@@ -2841,8 +2853,7 @@ if __name__ == "__main__":
         av = injected_argv # type: ignore
     except NameError:
         av = sys.argv[1:]
-    parser = _get_parser()
-    args = parser.parse_args(av)
+    args = _parse_args(av)
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -18,22 +18,19 @@ class TestCephAdm(object):
         assert not cd.is_fsid('no-uuid')
 
     def test__get_parser_image(self):
-        p = cd._get_parser()
-        args = p.parse_args(['--image', 'foo', 'version'])
+        args = cd._parse_args(['--image', 'foo', 'version'])
         assert args.image == 'foo'
 
     @mock.patch.dict(os.environ,{'CEPHADM_IMAGE':'bar'})
     def test__get_parser_image_with_envvar(self):
-        p = cd._get_parser()
-        args = p.parse_args(['version'])
+        args = cd._parse_args(['version'])
         assert args.image == 'bar'
 
     def test_CustomValidation(self):
-        p = cd._get_parser()
-        assert p.parse_args(['deploy', '--name', 'mon.a', '--fsid', 'fsid'])
+        assert cd._parse_args(['deploy', '--name', 'mon.a', '--fsid', 'fsid'])
 
         with pytest.raises(SystemExit):
-            p.parse_args(['deploy', '--name', 'wrong', '--fsid', 'fsid'])
+            cd._parse_args(['deploy', '--name', 'wrong', '--fsid', 'fsid'])
 
     @pytest.mark.parametrize("test_input, expected", [
         ("podman version 1.6.2", (1,6,2)),


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@redhat.com>