### PR TITLE
mgr/telemetry: catch exception during requests.put

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -666,23 +666,14 @@ class Module(MgrModule):
             self.log.info('Send using HTTP(S) proxy: %s', self.proxy)
             proxies['http'] = self.proxy
             proxies['https'] = self.proxy
-        fail_reason = None
         try:
             resp = requests.put(url=url, json=report)
-            if not resp.ok:
-                fail_reason = 'Failed to send %s to %s: %d %s %s' % (
-                    what,
-                    url,
-                    resp.status_code,
-                    resp.reason,
-                    resp.text
-                )
+            resp.raise_for_status()
         except Exception as e:
-            fail_reason = 'Failed to send %s to %s: %s' % (
-                what, url, str(e)))
-        if fail_reason:
+            fail_reason = 'Failed to send %s to %s: %s' % (what, url, str(e))
             self.log.error(fail_reason)
-        return fail_reason
+            return fail_reason
+        return None
 
     def send(self, report, endpoint=None):
         if not endpoint:

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -673,16 +673,23 @@ class Module(MgrModule):
         for e in endpoint:
             if e == 'ceph':
                 self.log.info('Sending ceph report to: %s', self.url)
-                resp = requests.put(url=self.url, json=report, proxies=proxies)
-                if not resp.ok:
-                    self.log.error("Report send failed: %d %s %s" %
-                                   (resp.status_code, resp.reason, resp.text))
-                    failed.append('Failed to send report to %s: %d %s %s' % (
-                        self.url,
-                        resp.status_code,
-                        resp.reason,
-                        resp.text
-                    ))
+                fail_reason = None
+                try:
+                    resp = requests.put(url=self.url, json=report,
+                                        proxies=proxies)
+                    if not resp.ok:
+                        fail_reason = 'Failed to send report to %s: %d %s %s' % (
+                            self.url,
+                            resp.status_code,
+                            resp.reason,
+                            resp.text
+                        )
+                except Exception as e:
+                    fail_reason = 'Failed to send report to %s: %s' % (
+                        self.url, str(e))
+                if fail_reason:
+                    self.log.error(fail_reason)
+                    failed.append(fail_reason)
                 else:
                     now = int(time.time())
                     self.last_upload = now


### PR DESCRIPTION
Sometimes requests.put throws an exception.  When that happens, generate
an appropriate error but don't crash the module.

Fixes: https://tracker.ceph.com/issues/43963
Signed-off-by: Sage Weil <sage@redhat.com>