### PR TITLE
mgr/cephadm: remove item from cache when removing

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1601,7 +1601,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             ] + extra_args,
             stdin=j)
         self.log.debug('create_daemon code %s out %s' % (code, out))
-        if not code:
+        if not code and host in self.service_cache:
             # prime cached service state with what we (should have)
             # just created
             sd = {
@@ -1632,6 +1632,12 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             host, name, 'rm-daemon',
             ['--name', name])
         self.log.debug('_remove_daemon code %s out %s' % (code, out))
+        if not code and host in self.service_cache:
+            # remove item from cache
+            data = self.service_cache[host].data
+            if data:
+                data = [d for d in data if d['name'] != name]
+                self.service_cache[host] = orchestrator.OutdatableData(data)
         self.service_cache.invalidate(host)
         return "Removed {} from host '{}'".format(name, host)
 


### PR DESCRIPTION
This makes the daemon disappear immediately from 'service ls', and also
avoids a temporary health warning about a stray service.

Signed-off-by: Sage Weil <sage@redhat.com>