### PR TITLE
ceph-volume: fix has_bluestore_label() function

### DIFF
--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -321,7 +321,7 @@ class Device(object):
     def has_bluestore_label(self):
         out, err, ret = process.call([
             'ceph-bluestore-tool', 'show-label',
-            '--dev', self.abspath])
+            '--dev', self.abspath], verbose_on_failure=False)
         if ret:
             return False
         return True

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -321,7 +321,7 @@ class Device(object):
     def has_bluestore_label(self):
         out, err, ret = process.call([
             'ceph-bluestore-tool', 'show-label',
-            '--dev', self.path])
+            '--dev', self.abspath])
         if ret:
             return False
         return True


### PR DESCRIPTION
When using vg/lv, this function throws an error like following:

```
 stderr: unable to read label for test_group/data-lv2: (2) No such file or directory
 stderr: 2020-02-04T21:03:32.153+0000 7fe091af4200 -1 bluestore(test_group/data-lv2) _read_bdev_label failed to open test_group/data-lv2: (2) No such file or directory
```

using `self.abspath` fixes this error.

Fixes: https://tracker.ceph.com/issues/43970

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>