### PR TITLE
crimson: fix crimson pg coll usage error

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -285,13 +285,13 @@ void PG::prepare_write(pg_info_t &info,
     ceph_assert(ret == 0);
   }
   pglog.write_log_and_missing(
-    t, &km, coll, pgmeta_oid,
+    t, &km, coll_ref->get_cid(), pgmeta_oid,
     peering_state.get_pool().info.require_rollback());
   if (!km.empty()) {
-    t.omap_setkeys(coll, pgmeta_oid, km);
+    t.omap_setkeys(coll_ref->get_cid(), pgmeta_oid, km);
   }
   if (!key_to_remove.empty()) {
-    t.omap_rmkey(coll, pgmeta_oid, key_to_remove);
+    t.omap_rmkey(coll_ref->get_cid(), pgmeta_oid, key_to_remove);
   }
 }
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -60,7 +60,6 @@ class PG : public boost::intrusive_ref_counter<
 
   spg_t pgid;
   pg_shard_t pg_whoami;
-  coll_t coll;
   crimson::os::CollectionRef coll_ref;
   ghobject_t pgmeta_oid;
 public:


### PR DESCRIPTION
coll in pg isn't initialized, should use coll_ref->get_cid() insead.

Signed-off-by: Chunmei Liu <chunmei.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
