### PR TITLE
ceph-volume: fix lvm list

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -169,7 +169,7 @@ class List(object):
                 lv = api.get_first_lv(filters={'vg_name': pv.vg_name})
             # or VG.
             else:
-                vg_name = os.path.basename(device)
+                vg_name = os.path.dirname(device)
                 lv = api.get_first_lv(filters={'vg_name': vg_name})
                 arg_is_vg = True
 


### PR DESCRIPTION
17957d9beb42a04b8f180ccb7ba07d43179a41d3 introduced a regression in `lvm
list`.

When passing a vg/lv path for generating a single report, it fails
because the filter used in the `lvs` command isn't right. It uses the lv
name instead of the vg name because `os.path.basename(device)` is used
while it should be `os.path.dirname(device)`

Fixes: https://tracker.ceph.com/issues/43969

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>