### PR TITLE
ceph-volume: strip _dmcrypt suffix in simple scan json output

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/simple/scan.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/scan.py
@@ -98,11 +98,16 @@ class Scan(object):
             raise RuntimeError(
                 'OSD files not found, required "keyring" file is not present at: %s' % path
             )
-        for _file in os.listdir(path):
-            file_path = os.path.join(path, _file)
+        for file_ in os.listdir(path):
+            file_path = os.path.join(path, file_)
+            file_json_key = file_
+            if file_.endswith('_dmcrypt'):
+                file_json_key = file_.rstrip('_dmcrypt')
+                logger.info(('reading file {}, stripping _dmcrypt',
+                             'suffix').format(file_))
             if os.path.islink(file_path):
                 if os.path.exists(file_path):
-                    osd_metadata[_file] = self.scan_device(file_path)
+                    osd_metadata[file_json_key] = self.scan_device(file_path)
                 else:
                     msg = 'broken symlink found %s -> %s' % (file_path, os.path.realpath(file_path))
                     terminal.warning(msg)
@@ -126,9 +131,9 @@ class Scan(object):
                 if 'keyring' in file_path:
                     content = parse_keyring(content)
                 try:
-                    osd_metadata[_file] = int(content)
+                    osd_metadata[file_json_key] = int(content)
                 except ValueError:
-                    osd_metadata[_file] = content
+                    osd_metadata[file_json_key] = content
 
         # we must scan the paths again because this might be a temporary mount
         path_mounts = system.get_mounts(paths=True)


### PR DESCRIPTION
LUKS encrypted OSDs name their block* files with a _dmcrypt suffix.
activate fails on json files like this. Stripping this suffix in scan
fixes this.

Fixes: https://tracker.ceph.com/issues/43966

Signed-off-by: Jan Fajerski <jfajerski@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
