### PR TITLE
qa: specify random distros in multimds

### DIFF
--- a/qa/suites/fs/verify/validater/valgrind.yaml
+++ b/qa/suites/fs/verify/validater/valgrind.yaml
@@ -1,5 +1,5 @@
-# see http://tracker.ceph.com/issues/20360 and http://tracker.ceph.com/issues/18126
-os_type: centos
+# Only works on os_type: centos
+# See http://tracker.ceph.com/issues/20360 and http://tracker.ceph.com/issues/18126
 
 overrides:
   install:

--- a/qa/suites/multimds/basic/0-supported-random-distro$
+++ b/qa/suites/multimds/basic/0-supported-random-distro$
@@ -1,0 +1,1 @@
+.qa/distros/supported-random-distro$/

--- a/qa/suites/multimds/thrash/0-supported-random-distro$
+++ b/qa/suites/multimds/thrash/0-supported-random-distro$
@@ -1,0 +1,1 @@
+.qa/distros/supported-random-distro$/

--- a/qa/suites/multimds/verify/centos_latest.yaml
+++ b/qa/suites/multimds/verify/centos_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/centos_latest.yaml


### PR DESCRIPTION
Note: the name is important so that kclient mount can override the
distro setting.

Fixes: https://tracker.ceph.com/issues/43968
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
