### PR TITLE
ceph-volume: skip osd creation when already done

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -239,6 +239,9 @@ class Prepare(object):
         """
         if args is not None:
             self.args = args
+        if api.is_ceph_device(self.get_lv(self.args.data)):
+            logger.info("device {} is already used".format(self.args.data))
+            raise RuntimeError("skipping {}, it is already prepared".format(self.args.data))
         try:
             self.prepare()
         except Exception:

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
@@ -1,5 +1,6 @@
 import pytest
 from ceph_volume.devices import lvm
+from mock.mock import patch, Mock
 
 
 class TestLVM(object):
@@ -102,6 +103,17 @@ class TestPrepare(object):
         expected = '--journal is required when using --filestore'
         assert expected in str(error.value)
 
+    @patch('ceph_volume.devices.lvm.prepare.api.is_ceph_device')
+    def test_safe_prepare_osd_already_created(self, m_is_ceph_device):
+        m_is_ceph_device.return_value = True
+        with pytest.raises(RuntimeError) as error:
+            prepare = lvm.prepare.Prepare(argv=[])
+            prepare.args = Mock()
+            prepare.args.data = '/dev/sdfoo'
+            prepare.get_lv = Mock()
+            prepare.safe_prepare()
+            expected = 'skipping {}, it is already prepared'.format('/dev/sdfoo')
+            assert expected in str(error.value)
 
 class TestGetJournalLV(object):
 


### PR DESCRIPTION
When rerunning `ceph-volume lvm create` on a device already prepared and
activated, ceph-volume should skip the creation.

This is a regression introduced by bb4de1a3fc238eaf9f717dc59c6bdf338ef6d657

Fixes: https://tracker.ceph.com/issues/43981

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>