### PR TITLE
cephadm: re-introduce the `podman logs` command

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2145,6 +2145,27 @@ def command_unit():
 
 ##################################
 
+@infer_fsid
+def command_logs():
+    # type: () -> None
+    if not args.fsid:
+        raise Error('must pass --fsid to specify cluster')
+
+    (daemon_type, daemon_id) = args.name.split('.', 1)
+    unit_name = get_unit_name(args.fsid, daemon_type, daemon_id)
+
+    cmd = [find_program('journalctl')]
+    cmd.extend(['-u', unit_name])
+    if args.command:
+        cmd.extend(args.command)
+
+    # call this directly, without our wrapper, so that we get an unmolested
+    # stdout with logger prefixing.
+    logger.debug("Running command: %s" % ' '.join(cmd))
+    subprocess.call(cmd) # type: ignore
+
+##################################
+
 def command_ls():
     # type: () -> None
     ls = list_daemons(detail=not args.no_detail,
@@ -2715,6 +2736,20 @@ def _get_parser():
         '--name', '-n',
         required=True,
         help='daemon name (type.id)')
+
+    parser_logs = subparsers.add_parser(
+        'logs', help='print journald logs for a daemon container')
+    parser_logs.set_defaults(func=command_logs)
+    parser_logs.add_argument(
+        '--fsid',
+        help='cluster FSID')
+    parser_logs.add_argument(
+        '--name', '-n',
+        required=True,
+        help='daemon name (type.id)')
+    parser_logs.add_argument(
+        'command', nargs='*',
+        help='additional journalctl args')
 
     parser_bootstrap = subparsers.add_parser(
         'bootstrap', help='bootstrap a cluster (mon + mgr daemons)')


### PR DESCRIPTION
Fetch `journald` logs via `cephadm logs`

Simplifies log retrieval without needing to know the systemd unit name:
```
# cephadm logs --name mgr.x | tail -2
INFO:cephadm:Inferring fsid 00000000-0000-0000-0000-0000deadbeef
Feb 05 11:40:55 foobar bash[32386]: debug 2020-02-05T18:40:55.513+0000 7f8bf3e00700  0 log_channel(cluster) log [DBG] : pgmap v76: 64 pgs: 64 active+clean; 16 B data, 4.5 MiB used, 5.7 GiB / 5.7 GiB avail; 85 B/s rd, 0 op/s
Feb 05 11:40:57 foobar bash[32386]: debug 2020-02-05T18:40:57.513+0000 7f8bf3e00700  0 log_channel(cluster) log [DBG] : pgmap v77: 64 pgs: 64 active+clean; 16 B data, 4.5 MiB used, 5.7 GiB / 5.7 GiB avail; 85 B/s rd, 0 op/s
```

Also, can pass arbitrary `journalctl` args to customize the output:
```
# cephadm logs --name mgr.x -- -n2 -o json-sse
INFO:cephadm:Inferring fsid 00000000-0000-0000-0000-0000deadbeef
data: {"_HOSTNAME":"foobar","_CMDLINE":"/usr/bin/podman run --rm --net=host --privileged --name ceph-00000000-0000-0000-0000-0000deadbeef-mgr.x -e CONTAINER_IMAGE=ceph/daemon-base:latest-master-devel -e NODE_NAME=foobar -v /var/run/ceph/00000000-0000-0000-0000-0000deadbeef:/var/run/ceph:z -v /var/log/ceph/00000000-0000-0000-0000-0000deadbeef:/var/log/ceph:z -v /var/lib/ceph/00000000-0000-0000-0000-0000deadbeef/crash:/var/lib/ceph/crash:z -v /var/lib/ceph/00000000-0000-0000-0000-0000deadbeef/mgr.x:/var/lib/ceph/mgr/ceph-x:z -v /var/lib/ceph/00000000-0000-0000-0000-0000deadbeef/mgr.x/config:/etc/ceph/ceph.conf:z --entrypoint /usr/bin/ceph-mgr ceph/daemon-base:latest-master-devel -n mgr.x -f --setuser ceph --setgroup ceph --default-log-to-file=false --default-log-to-stderr=true --default-log-stderr-prefix=debug","_MACHINE_ID":"1de4246ae4a94faa9d84eda7e9ace938","_STREAM_ID":"6fed216ed8ee4b879e0206145a90848b","_COMM":"podman","_SYSTEMD_SLICE":"system-ceph\\x2d00000000\\x2d0000\\x2d0000\\x2d0000\\x2d0000deadbeef.slice","_SYSTEMD_UNIT":"ceph-00000000-0000-0000-0000-0000deadbeef@mgr.x.service","_SYSTEMD_INVOCATION_ID":"8388fffea2e54bf28e7ff32beaa528e7","SYSLOG_FACILITY":"3","_EXE":"/usr/bin/podman","_TRANSPORT":"stdout","_PID":"32386","_BOOT_ID":"4257465059fe4e82834333c81b08b21a","_GID":"0","_SELINUX_CONTEXT":"unconfined\n","SYSLOG_IDENTIFIER":"bash","__MONOTONIC_TIMESTAMP":"589472364734","__CURSOR":"s=cafb4cdd178f4e9b9e0a629d87124baa;i=13973d;b=4257465059fe4e82834333c81b08b21a;m=893f4a78be;t=59dd87adf26fb;x=17bd72efaae2fd61","MESSAGE":"debug 2020-02-05T18:39:43.493+0000 7f8bf3e00700  0 log_channel(cluster) log [DBG] : pgmap v40: 64 pgs: 64 active+clean; 16 B data, 4.5 MiB used, 5.7 GiB / 5.7 GiB avail; 85 B/s rd, 0 op/s","_SYSTEMD_CGROUP":"/system.slice/system-ceph\\x2d00000000\\x2d0000\\x2d0000\\x2d0000\\x2d0000deadbeef.slice/ceph-00000000-0000-0000-0000-0000deadbeef@mgr.x.service","_CAP_EFFECTIVE":"3fffffffff","_UID":"0","PRIORITY":"6","__REALTIME_TIMESTAMP":"1580927983494907"}

data: {"_SELINUX_CONTEXT":"unconfined\n","_COMM":"podman","_UID":"0","_CMDLINE":"/usr/bin/podman run --rm --net=host --privileged --name ceph-00000000-0000-0000-0000-0000deadbeef-mgr.x -e CONTAINER_IMAGE=ceph/daemon-base:latest-master-devel -e NODE_NAME=foobar -v /var/run/ceph/00000000-0000-0000-0000-0000deadbeef:/var/run/ceph:z -v /var/log/ceph/00000000-0000-0000-0000-0000deadbeef:/var/log/ceph:z -v /var/lib/ceph/00000000-0000-0000-0000-0000deadbeef/crash:/var/lib/ceph/crash:z -v /var/lib/ceph/00000000-0000-0000-0000-0000deadbeef/mgr.x:/var/lib/ceph/mgr/ceph-x:z -v /var/lib/ceph/00000000-0000-0000-0000-0000deadbeef/mgr.x/config:/etc/ceph/ceph.conf:z --entrypoint /usr/bin/ceph-mgr ceph/daemon-base:latest-master-devel -n mgr.x -f --setuser ceph --setgroup ceph --default-log-to-file=false --default-log-to-stderr=true --default-log-stderr-prefix=debug","_STREAM_ID":"6fed216ed8ee4b879e0206145a90848b","__MONOTONIC_TIMESTAMP":"589474365506","SYSLOG_IDENTIFIER":"bash","_CAP_EFFECTIVE":"3fffffffff","MESSAGE":"debug 2020-02-05T18:39:45.489+0000 7f8bf3e00700  0 log_channel(cluster) log [DBG] : pgmap v41: 64 pgs: 64 active+clean; 16 B data, 4.5 MiB used, 5.7 GiB / 5.7 GiB avail; 85 B/s rd, 0 op/s","__REALTIME_TIMESTAMP":"1580927985495680","_GID":"0","__CURSOR":"s=cafb4cdd178f4e9b9e0a629d87124baa;i=139748;b=4257465059fe4e82834333c81b08b21a;m=893f690042;t=59dd87afdae80;x=99f9dd0928ab97f6","SYSLOG_FACILITY":"3","_PID":"32386","_SYSTEMD_INVOCATION_ID":"8388fffea2e54bf28e7ff32beaa528e7","_HOSTNAME":"foobar","_SYSTEMD_CGROUP":"/system.slice/system-ceph\\x2d00000000\\x2d0000\\x2d0000\\x2d0000\\x2d0000deadbeef.slice/ceph-00000000-0000-0000-0000-0000deadbeef@mgr.x.service","_MACHINE_ID":"1de4246ae4a94faa9d84eda7e9ace938","_TRANSPORT":"stdout","_SYSTEMD_SLICE":"system-ceph\\x2d00000000\\x2d0000\\x2d0000\\x2d0000\\x2d0000deadbeef.slice","_EXE":"/usr/bin/podman","_SYSTEMD_UNIT":"ceph-00000000-0000-0000-0000-0000deadbeef@mgr.x.service","PRIORITY":"6","_BOOT_ID":"4257465059fe4e82834333c81b08b21a"
```
Fixes: https://tracker.ceph.com/issues/43973
Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
