### PR TITLE
[WIP] Fix KRBD workunit pool script for RHEL8

### DIFF
--- a/qa/workunits/rbd/krbd_data_pool.sh
+++ b/qa/workunits/rbd/krbd_data_pool.sh
@@ -112,12 +112,17 @@ rbd pool init rbdnonzero
 ceph osd pool create clonesonly 24 24
 rbd pool init clonesonly
 
+
 for pool in rbd rbdnonzero; do
     rbd create --size 200 --image-format 1 $pool/img0
     rbd create --size 200 $pool/img1
+    rbd feature disable $pool/img1 object-map fast-diff deep-flatten
     rbd create --size 200 --data-pool repdata $pool/img2
+    rbd feature disable $pool/img2 object-map fast-diff deep-flatten
     rbd create --size 200 --data-pool ecdata $pool/img3
+    rbd feature disable $pool/img3 object-map fast-diff deep-flatten
 done
+
 
 IMAGE_SIZE=$(rbd info --format=json img1 | python -c 'import sys, json; print json.load(sys.stdin)["size"]')
 OBJECT_SIZE=$(rbd info --format=json img1 | python -c 'import sys, json; print json.load(sys.stdin)["object_size"]')


### PR DESCRIPTION
The Fix came from Julius who is working on running KRBD TestSuite on RHEL8, Probably a better version to handle for RHEL8 is needed.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
