### PR TITLE
mgr/devicehealth: set default monitoring to 'on'

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -554,6 +554,7 @@ function run_mgr() {
     shift
     local data=$dir/$id
 
+    ceph config set mgr mgr/devicehealth/enable_monitoring off --force
     ceph-mgr \
         --id $id \
         $EXTRA_OPTS \

--- a/qa/suites/rados/multimon/no_pools.yaml
+++ b/qa/suites/rados/multimon/no_pools.yaml
@@ -1,3 +1,5 @@
 overrides:
   ceph:
     create_rbd_pool: false
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force

--- a/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
@@ -18,6 +18,8 @@ overrides:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
 - rgw:
   - client.0
 - exec:

--- a/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
@@ -3,6 +3,8 @@ roles:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     fs: xfs
     log-whitelist:
       - \(PG_AVAILABILITY\)

--- a/qa/suites/rados/singleton-nomsgr/all/cache-fs-trunc.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/cache-fs-trunc.yaml
@@ -7,6 +7,8 @@ roles:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)

--- a/qa/suites/rados/singleton-nomsgr/all/ceph-kvstore-tool.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/ceph-kvstore-tool.yaml
@@ -7,6 +7,8 @@ roles:
 
 overrides:
   ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
     - but it is still running
     - overall HEALTH_

--- a/qa/suites/rados/singleton-nomsgr/all/export-after-evict.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/export-after-evict.yaml
@@ -12,6 +12,8 @@ roles:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)

--- a/qa/suites/rados/singleton-nomsgr/all/full-tiering.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/full-tiering.yaml
@@ -17,6 +17,8 @@ overrides:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     conf:
       global:
         osd max object name len: 460

--- a/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
@@ -3,6 +3,8 @@ roles:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     conf:
       osd:
 # we may land on ext4

--- a/qa/suites/rados/singleton-nomsgr/all/large-omap-object-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/large-omap-object-warnings.yaml
@@ -6,6 +6,8 @@ roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 overrides:
   ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - \(OSDMAP_FLAGS\)
       - \(OSD_FULL\)

--- a/qa/suites/rados/singleton-nomsgr/all/lazy_omap_stats_output.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/lazy_omap_stats_output.yaml
@@ -11,6 +11,8 @@ overrides:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
 - exec:
     client.0:
       - ceph_test_lazy_omap_stats

--- a/qa/suites/rados/singleton-nomsgr/all/librados_hello_world.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/librados_hello_world.yaml
@@ -16,6 +16,8 @@ tasks:
         - librados-devel
         - libradospp-devel
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-nomsgr/all/msgr.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/msgr.yaml
@@ -16,6 +16,8 @@ openstack:
       size: 1 # GB
 overrides:
   ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     conf:
       client:
         debug ms: 20

--- a/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
@@ -15,6 +15,8 @@ roles:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - overall HEALTH_
       - \(PG_

--- a/qa/suites/rados/singleton-nomsgr/all/osd_stale_reads.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/osd_stale_reads.yaml
@@ -21,6 +21,8 @@ overrides:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
 - exec:
     client.0:
       - ceph_test_osd_stale_read

--- a/qa/suites/rados/singleton-nomsgr/all/pool-access.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/pool-access.yaml
@@ -7,6 +7,8 @@ roles:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-nomsgr/all/recovery-unfound-found.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/recovery-unfound-found.yaml
@@ -12,6 +12,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     fs: xfs
     conf:
       osd:

--- a/qa/suites/rados/singleton-nomsgr/all/version-number-sanity.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/version-number-sanity.yaml
@@ -7,6 +7,8 @@ overrides:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton/all/deduptool.yaml
+++ b/qa/suites/rados/singleton/all/deduptool.yaml
@@ -12,6 +12,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
     - but it is still running
     - had wrong client addr

--- a/qa/suites/rados/singleton/all/divergent_priors.yaml
+++ b/qa/suites/rados/singleton/all/divergent_priors.yaml
@@ -23,4 +23,6 @@ overrides:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
 - divergent_priors:

--- a/qa/suites/rados/singleton/all/divergent_priors2.yaml
+++ b/qa/suites/rados/singleton/all/divergent_priors2.yaml
@@ -23,4 +23,6 @@ overrides:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
 - divergent_priors2:

--- a/qa/suites/rados/singleton/all/dump-stuck.yaml
+++ b/qa/suites/rados/singleton/all/dump-stuck.yaml
@@ -10,6 +10,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - but it is still running
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/ec-lost-unfound.yaml
+++ b/qa/suites/rados/singleton/all/ec-lost-unfound.yaml
@@ -15,6 +15,8 @@ tasks:
 - install:
 - ceph:
     create_rbd_pool: false
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - objects unfound and apparently lost
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/lost-unfound-delete.yaml
+++ b/qa/suites/rados/singleton/all/lost-unfound-delete.yaml
@@ -13,6 +13,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - objects unfound and apparently lost
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/lost-unfound.yaml
+++ b/qa/suites/rados/singleton/all/lost-unfound.yaml
@@ -13,6 +13,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - objects unfound and apparently lost
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/max-pg-per-osd.from-mon.yaml
+++ b/qa/suites/rados/singleton/all/max-pg-per-osd.from-mon.yaml
@@ -10,6 +10,8 @@ openstack:
 overrides:
   ceph:
     create_rbd_pool: False
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     conf:
       mon:
         osd pool default size: 2

--- a/qa/suites/rados/singleton/all/max-pg-per-osd.from-primary.yaml
+++ b/qa/suites/rados/singleton/all/max-pg-per-osd.from-primary.yaml
@@ -12,6 +12,8 @@ openstack:
 overrides:
   ceph:
     create_rbd_pool: False
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     conf:
       mon:
         osd pool default size: 2

--- a/qa/suites/rados/singleton/all/max-pg-per-osd.from-replica.yaml
+++ b/qa/suites/rados/singleton/all/max-pg-per-osd.from-replica.yaml
@@ -12,6 +12,8 @@ openstack:
 overrides:
   ceph:
     create_rbd_pool: False
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     conf:
       mon:
         osd pool default size: 2

--- a/qa/suites/rados/singleton/all/mon-auth-caps.yaml
+++ b/qa/suites/rados/singleton/all/mon-auth-caps.yaml
@@ -8,6 +8,8 @@ roles:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
     - overall HEALTH_
     - \(AUTH_BAD_CAPS\)

--- a/qa/suites/rados/singleton/all/mon-config-key-caps.yaml
+++ b/qa/suites/rados/singleton/all/mon-config-key-caps.yaml
@@ -8,6 +8,8 @@ roles:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
     - overall HEALTH_
     - \(AUTH_BAD_CAPS\)

--- a/qa/suites/rados/singleton/all/mon-config-keys.yaml
+++ b/qa/suites/rados/singleton/all/mon-config-keys.yaml
@@ -14,6 +14,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton/all/mon-config.yaml
+++ b/qa/suites/rados/singleton/all/mon-config.yaml
@@ -14,6 +14,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton/all/mon-memory-target-compliance.yaml.disabled
+++ b/qa/suites/rados/singleton/all/mon-memory-target-compliance.yaml.disabled
@@ -42,6 +42,8 @@ tasks:
     branch: wip-sseshasa2-testing-2019-07-30-1825 # change as appropriate
 - ceph:
     create_rbd_pool: false
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton/all/osd-backfill.yaml
+++ b/qa/suites/rados/singleton/all/osd-backfill.yaml
@@ -13,6 +13,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - but it is still running
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/osd-recovery-incomplete.yaml
+++ b/qa/suites/rados/singleton/all/osd-recovery-incomplete.yaml
@@ -14,6 +14,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - but it is still running
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/osd-recovery.yaml
+++ b/qa/suites/rados/singleton/all/osd-recovery.yaml
@@ -13,6 +13,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - but it is still running
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/peer.yaml
+++ b/qa/suites/rados/singleton/all/peer.yaml
@@ -13,6 +13,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     config:
       global:
         osd pool default min size : 1

--- a/qa/suites/rados/singleton/all/pg-autoscaler.yaml
+++ b/qa/suites/rados/singleton/all/pg-autoscaler.yaml
@@ -20,6 +20,8 @@ tasks:
 - install:
 - ceph:
     create_rbd_pool: false
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton/all/pg-removal-interruption.yaml
+++ b/qa/suites/rados/singleton/all/pg-removal-interruption.yaml
@@ -12,6 +12,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - but it is still running
       - slow request

--- a/qa/suites/rados/singleton/all/radostool.yaml
+++ b/qa/suites/rados/singleton/all/radostool.yaml
@@ -12,6 +12,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
     - but it is still running
     - had wrong client addr

--- a/qa/suites/rados/singleton/all/random-eio.yaml
+++ b/qa/suites/rados/singleton/all/random-eio.yaml
@@ -15,6 +15,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
     - missing primary copy of
     - objects unfound and apparently lost

--- a/qa/suites/rados/singleton/all/rebuild-mondb.yaml
+++ b/qa/suites/rados/singleton/all/rebuild-mondb.yaml
@@ -14,6 +14,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - no reply from
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/recovery-preemption.yaml
+++ b/qa/suites/rados/singleton/all/recovery-preemption.yaml
@@ -14,6 +14,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     conf:
       osd:
         osd recovery sleep: .1

--- a/qa/suites/rados/singleton/all/resolve_stuck_peering.yaml
+++ b/qa/suites/rados/singleton/all/resolve_stuck_peering.yaml
@@ -5,6 +5,8 @@ roles:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     fs: xfs
     log-whitelist:
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/test-crash.yaml
+++ b/qa/suites/rados/singleton/all/test-crash.yaml
@@ -4,6 +4,8 @@ roles:
 tasks:
   - install:
   - ceph:
+      pre-mgr-commands:
+        - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
       log-whitelist:
         - Reduced data availability
         - OSD_.*DOWN

--- a/qa/suites/rados/singleton/all/test_envlibrados_for_rocksdb.yaml
+++ b/qa/suites/rados/singleton/all/test_envlibrados_for_rocksdb.yaml
@@ -10,6 +10,8 @@ roles:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - overall HEALTH_
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rados/singleton/all/thrash-backfill-full.yaml
+++ b/qa/suites/rados/singleton/all/thrash-backfill-full.yaml
@@ -22,6 +22,8 @@ override:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
     - but it is still running
     - missing primary copy of

--- a/qa/suites/rados/singleton/all/thrash-eio.yaml
+++ b/qa/suites/rados/singleton/all/thrash-eio.yaml
@@ -20,6 +20,8 @@ override:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
     - but it is still running
     - missing primary copy of

--- a/qa/suites/rados/singleton/all/thrash_cache_writeback_proxy_none.yaml
+++ b/qa/suites/rados/singleton/all/thrash_cache_writeback_proxy_none.yaml
@@ -15,6 +15,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     log-whitelist:
       - but it is still running
       - slow request

--- a/qa/suites/rados/singleton/all/watch-notify-same-primary.yaml
+++ b/qa/suites/rados/singleton/all/watch-notify-same-primary.yaml
@@ -14,6 +14,8 @@ openstack:
 tasks:
 - install:
 - ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     config:
       global:
         osd pool default min size : 1

--- a/qa/suites/rados/thrash-erasure-code/thrashers/minsize_recovery.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/minsize_recovery.yaml
@@ -4,6 +4,8 @@ overrides:
     - but it is still running
     - objects unfound and apparently lost
     create_rbd_pool: False
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     conf:
       osd:
         osd debug reject backfill probability: .3

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1447,6 +1447,13 @@ def run_daemon(ctx, config, type_):
                 role = cluster_name + '.' + type_
                 ctx.daemons.get_daemon(type_, id_, cluster_name).restart()
 
+    # kludge: run any pre-manager commands
+    if type_ == 'mon':
+        for cmd in config.get('pre-mgr-commands', []):
+            firstmon = teuthology.get_first_mon(ctx, config, cluster_name)
+            (remote,) = ctx.cluster.only(firstmon).remotes.keys()
+            remote.run(args=cmd.split(' '))
+
     try:
         yield
     finally:

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -29,7 +29,7 @@ class Module(MgrModule):
     MODULE_OPTIONS = [
         {
             'name': 'enable_monitoring',
-            'default': False,
+            'default': True,
             'type': 'bool',
             'desc': 'monitor device health metrics',
             'runtime': True,


### PR DESCRIPTION
When devicehealth monitoring is 'off' telemetry module cannot generate
device reports, once a user opts-in.

(needs to be backported to nautilus)

Fixes: https://tracker.ceph.com/issues/44002
Signed-off-by: Yaarit Hatuka <yaarit@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
