### PR TITLE
mon/OSDMonitor: accept 'autoscale_mode' argument to 'osd pool create'

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -1036,7 +1036,7 @@ Subcommand ``create`` creates pool.
 Usage::
 
 	ceph osd pool create <poolname> {<int[0-]>} {<int[0-]>} {replicated|erasure}
-	{<erasure_code_profile>} {<rule>} {<int>}
+	{<erasure_code_profile>} {<rule>} {<int>} {--autoscale-mode=<on,off,warn>}
 
 Subcommand ``delete`` deletes pool.
 

--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -61,7 +61,7 @@ To create a pool, execute::
 	ceph osd pool create {pool-name} [{pg-num} [{pgp-num}]] [replicated] \
              [crush-rule-name] [expected-num-objects]
 	ceph osd pool create {pool-name} [{pg-num} [{pgp-num}]]   erasure \
-             [erasure-code-profile] [crush-rule-name] [expected_num_objects]
+             [erasure-code-profile] [crush-rule-name] [expected_num_objects] [--autoscale-mode=<on,off,warn>]
 
 Where:
 
@@ -131,15 +131,15 @@ Where:
 :Type: String
 :Required: No.
 
-When you create a pool, set the number of placement groups to a reasonable value
-(e.g., ``100``). Consider the total number of placement groups per OSD too.
-Placement groups are computationally expensive, so performance will degrade when
-you have many pools with many placement groups (e.g., 50 pools with 100
-placement groups each). The point of diminishing returns depends upon the power
-of the OSD host.
+``--autoscale-mode=<on,off,warn>``
 
-See `Placement Groups`_ for details on calculating an appropriate number of
-placement groups for your pool.
+:Description: Autoscale mode
+
+:Type: String
+:Required: No.
+:Default:  The default behavior is controlled by the ``osd pool default pg autoscale mode`` option.
+
+If you set the autoscale mode to ``on`` or ``warn``, you can let the system autotune or recommend changes to the number of placement groups in your pool based on actual usage.  If you leave it off, then you should refer to `Placement Groups`_ for more information.
 
 .. _Placement Groups: ../placement-groups
 

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1945,6 +1945,16 @@ function test_mon_osd_pool()
   ceph osd crush rule rm foo
   ceph osd erasure-code-profile rm foo
 
+  # autoscale mode
+  ceph osd pool create modeon --autoscale-mode=on
+  ceph osd dump | grep modeon | grep 'autoscale_mode on'
+  ceph osd pool create modewarn --autoscale-mode=warn
+  ceph osd dump | grep modewarn | grep 'autoscale_mode warn'
+  ceph osd pool create modeoff --autoscale-mode=off
+  ceph osd dump | grep modeoff | grep 'autoscale_mode off'
+  ceph osd pool delete modeon modeon --yes-i-really-really-mean-it
+  ceph osd pool delete modewarn modewarn --yes-i-really-really-mean-it
+  ceph osd pool delete modeoff modeoff --yes-i-really-really-mean-it
 }
 
 function test_mon_osd_pool_quota()

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -999,6 +999,7 @@ COMMAND("osd pool create "
         "name=expected_num_objects,type=CephInt,range=0,req=false "
         "name=size,type=CephInt,range=0,req=false "
 	"name=pg_num_min,type=CephInt,range=0,req=false "
+	"name=autoscale_mode,type=CephChoices,strings=on|off|warn,req=false "
 	"name=target_size_bytes,type=CephInt,range=0,req=false "
 	"name=target_size_ratio,type=CephFloat,range=0|1,req=false",\
 	"create pool", "osd", "rw")

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -531,6 +531,7 @@ private:
                        const unsigned pool_type,
                        const uint64_t expected_num_objects,
                        FastReadType fast_read,
+		       const string& pg_autoscale_mode,
 		       ostream *ss);
   int prepare_new_pool(MonOpRequestRef op);
 


### PR DESCRIPTION
Allow the autoscale mode to be set atomically with pool creation.

Fixes: https://tracker.ceph.com/issues/42638
Signed-off-by: Sage Weil <sage@redhat.com>