### PR TITLE
build-integration-branch: don't fail on existing branch

### DIFF
--- a/src/script/build-integration-branch
+++ b/src/script/build-integration-branch
@@ -86,6 +86,7 @@ print("branch %s" % branch)
 
 # assemble
 print('--- creating branch %s' % branch)
+r = call(['git', 'branch', '-D', branch])
 r = call(['git', 'checkout', '-b', branch])
 assert not r
 for pr in prs:


### PR DESCRIPTION
This behavior is too annoying, and you can always get back to something
clobbered with 'git reflog'.

Signed-off-by: Sage Weil <sage@redhat.com>