### PR TITLE
nautilus: mgr/telemetry: check get_metadata return val

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -231,7 +231,11 @@ class Module(MgrModule):
             metadata[key] = defaultdict(int)
 
         for osd in osd_map['osds']:
-            for k, v in self.get_metadata('osd', str(osd['osd'])).items():
+            res = self.get_metadata('osd', str(osd['osd'])).items()
+            if res is None:
+                self.log.debug('Could not get metadata for osd.%s' % str(osd['osd']))
+                continue
+            for k, v in res:
                 if k not in keys:
                     continue
 
@@ -248,7 +252,11 @@ class Module(MgrModule):
             metadata[key] = defaultdict(int)
 
         for mon in mon_map['mons']:
-            for k, v in self.get_metadata('mon', mon['name']).items():
+            res = self.get_metadata('mon', mon['name']).items()
+            if res is None:
+                self.log.debug('Could not get metadata for mon.%s' % (mon['name']))
+                continue
+            for k, v in res:
                 if k not in keys:
                     continue
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43979

---

backport of https://github.com/ceph/ceph/pull/33051
parent tracker: https://tracker.ceph.com/issues/43642

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh