### PR TITLE
mgr/orch: associate addresses with hosts

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1184,7 +1184,15 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         TODO:
           - InventoryNode probably needs to be able to report labels
         """
-        return [orchestrator.InventoryNode(host_name) for host_name in self.inventory_cache]
+        r = []
+        for hostname, info in self.inventory.items():
+            self.log.debug('host %s info %s' % (hostname, info))
+            r.append(orchestrator.InventoryNode(
+                hostname,
+                addr=info.get('addr', hostname),
+                labels=info.get('labels', []),
+            ))
+        return r
 
     @async_completion
     def add_host_label(self, host, label):

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1049,6 +1049,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         return executable_path
 
     def _run_cephadm(self, host, entity, command, args,
+                     addr=None,
                      stdin=None,
                      no_fsid=False,
                      error_ok=False,
@@ -1056,7 +1057,9 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         """
         Run cephadm on the remote host with the given command + args
         """
-        conn, connr = self._get_connection(host)
+        if not addr and host in self.inventory:
+            addr = self.inventory[host].get('addr', host)
+        conn, connr = self._get_connection(addr)
 
         try:
             if not image:
@@ -1135,8 +1138,9 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         :param host: host name
         """
         assert_valid_host(spec.hostname)
-        out, err, code = self._run_cephadm(spec.addr, 'client', 'check-host',
+        out, err, code = self._run_cephadm(spec.hostname, 'client', 'check-host',
                                            ['--expect-hostname', spec.hostname],
+                                           addr=spec.addr,
                                            error_ok=True, no_fsid=True)
         if code:
             raise OrchestratorError('New host %s (%s) failed check: %s' % (

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1173,6 +1173,16 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         self.event.set()  # refresh stray health check
         return "Removed host '{}'".format(host)
 
+    @async_completion
+    def update_host_addr(self, host, addr):
+        if host not in self.inventory:
+            raise OrchestratorError('host %s not registered' % host)
+        self.inventory[host]['addr'] = addr
+        self._save_inventory()
+        self._reset_con(host)
+        self.event.set()  # refresh stray health check
+        return "Updated host '{}' addr to '{}'".format(host, addr)
+
     @trivial_completion
     def get_hosts(self):
         """

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -30,7 +30,7 @@ from ceph.deployment.drive_selection import selector
 from mgr_module import MgrModule
 import mgr_util
 import orchestrator
-from orchestrator import OrchestratorError, HostSpec, OrchestratorValidationError
+from orchestrator import OrchestratorError, HostPlacementSpec, OrchestratorValidationError
 
 from . import remotes
 
@@ -2168,7 +2168,7 @@ class BaseScheduler(object):
 
     * requires a placement_spec
 
-    `place(host_pool)` needs to return a List[HostSpec, ..]
+    `place(host_pool)` needs to return a List[HostPlacementSpec, ..]
     """
 
     def __init__(self, placement_spec):
@@ -2176,7 +2176,7 @@ class BaseScheduler(object):
         self.placement_spec = placement_spec
 
     def place(self, host_pool, count=None):
-        # type: (List, Optional[int]) -> List[HostSpec]
+        # type: (List, Optional[int]) -> List[HostPlacementSpec]
         raise NotImplementedError
 
 
@@ -2190,10 +2190,10 @@ class SimpleScheduler(BaseScheduler):
         super(SimpleScheduler, self).__init__(placement_spec)
 
     def place(self, host_pool, count=None):
-        # type: (List, Optional[int]) -> List[HostSpec]
+        # type: (List, Optional[int]) -> List[HostPlacementSpec]
         if not host_pool:
             raise Exception('List of host candidates is empty')
-        host_pool = [HostSpec(x, '', '') for x in host_pool]
+        host_pool = [HostPlacementSpec(x, '', '') for x in host_pool]
         # shuffle for pseudo random selection
         random.shuffle(host_pool)
         return host_pool[:count]
@@ -2241,7 +2241,7 @@ class NodeAssignment(object):
         # NOTE: This currently queries for all hosts without label restriction
         if self.spec.placement.label:
             logger.info("Found labels. Assinging nodes that match the label")
-            candidates = [HostSpec(x[0], '', '') for x in self.get_hosts_func()]  # TODO: query for labels
+            candidates = [HostPlacementSpec(x[0], '', '') for x in self.get_hosts_func()]  # TODO: query for labels
             logger.info('Assigning nodes to spec: {}'.format(candidates))
             self.spec.placement.set_hosts(candidates)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -994,11 +994,13 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
 
     @orchestrator._cli_read_command(
         'cephadm check-host',
-        'name=host,type=CephString',
+        'name=host,type=CephString '
+        'name=addr,type=CephString,req=false',
         'Check whether we can access and manage a remote host')
-    def _check_host(self, host):
+    def _check_host(self, host, addr=None):
         out, err, code = self._run_cephadm(host, 'client', 'check-host',
                                            ['--expect-hostname', host],
+                                           addr=addr,
                                            error_ok=True, no_fsid=True)
         if code:
             return 1, '', ('check-host failed:\n' + '\n'.join(err))
@@ -1009,7 +1011,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                 if item.startswith('host %s ' % host):
                     self.log.debug('kicking serve thread')
                     self.event.set()
-        return 0, '%s ok' % host, err
+        return 0, '%s (%s) ok' % (host, addr), err
 
     def _get_connection(self, host):
         """

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -10,7 +10,7 @@ except ImportError:
     pass
 
 from orchestrator import ServiceDescription, InventoryNode, \
-    StatelessServiceSpec, PlacementSpec, RGWSpec, StatefulServiceSpec
+    StatelessServiceSpec, PlacementSpec, RGWSpec, StatefulServiceSpec, HostSpec
 from tests import mock
 from .fixtures import cephadm_module, wait
 
@@ -37,7 +37,7 @@ class TestCephadm(object):
 
     @contextmanager
     def _with_host(self, m, name):
-        wait(m, m.add_host(name))
+        wait(m, m.add_host(HostSpec(hostname=name)))
         yield
         wait(m, m.remove_host(name))
 

--- a/src/pybind/mgr/dashboard/tests/test_orchestrator.py
+++ b/src/pybind/mgr/dashboard/tests/test_orchestrator.py
@@ -71,6 +71,7 @@ class OrchestratorControllerTest(ControllerTestCase):
         inventory = [
             {
                 'name': 'host-0',
+                'addr': '1.2.3.4',
                 'devices': [
                     {'path': 'nvme0n1'},
                     {'path': '/dev/sdb'},
@@ -79,6 +80,7 @@ class OrchestratorControllerTest(ControllerTestCase):
             },
             {
                 'name': 'host-1',
+                'addr': '1.2.3.5',
                 'devices': [
                     {'path': '/dev/sda'},
                     {'path': 'sdb'},
@@ -97,11 +99,13 @@ class OrchestratorControllerTest(ControllerTestCase):
         self.assertEqual(len(resp), 2)
         host0 = resp[0]
         self.assertEqual(host0['name'], 'host-0')
+        self.assertEqual(host0['addr'], '1.2.3.4')
         self.assertEqual(host0['devices'][0]['osd_ids'], [1, 2])
         self.assertEqual(host0['devices'][1]['osd_ids'], [1])
         self.assertEqual(host0['devices'][2]['osd_ids'], [2])
         host1 = resp[1]
         self.assertEqual(host1['name'], 'host-1')
+        self.assertEqual(host1['addr'], '1.2.3.5')
         self.assertEqual(host1['devices'][0]['osd_ids'], [])
         self.assertEqual(host1['devices'][1]['osd_ids'], [3])
 

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -1360,8 +1360,8 @@ class InventoryNode(object):
     When fetching inventory, all Devices are groups inside of an
     InventoryNode.
     """
-    def __init__(self, name, devices=None, labels=None):
-        # type: (str, Optional[inventory.Devices], Optional[List[str]]) -> None
+    def __init__(self, name, devices=None, labels=None, addr=None):
+        # type: (str, Optional[inventory.Devices], Optional[List[str]], Optional[str]) -> None
         if devices is None:
             devices = inventory.Devices([])
         if labels is None:
@@ -1369,12 +1369,14 @@ class InventoryNode(object):
         assert isinstance(devices, inventory.Devices)
 
         self.name = name  # unique within cluster.  For example a hostname.
+        self.addr = addr or name
         self.devices = devices
         self.labels = labels
 
     def to_json(self):
         return {
             'name': self.name,
+            'addr': self.addr,
             'devices': self.devices.to_json(),
             'labels': self.labels,
         }
@@ -1384,12 +1386,13 @@ class InventoryNode(object):
         try:
             _data = copy.deepcopy(data)
             name = _data.pop('name')
+            addr = _data.pop('addr') or name
             devices = inventory.Devices.from_json(_data.pop('devices'))
             if _data:
                 error_msg = 'Unknown key(s) in Inventory: {}'.format(','.join(_data.keys()))
                 raise OrchestratorValidationError(error_msg)
             labels = _data.get('labels', list())
-            return cls(name, devices, labels)
+            return cls(name, devices, labels, addr)
         except KeyError as e:
             error_msg = '{} is required for {}'.format(e, cls.__name__)
             raise OrchestratorValidationError(error_msg)

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -784,6 +784,16 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def update_host_addr(self, host, addr):
+        # type: (str, str) -> Completion
+        """
+        Update a host's address
+
+        :param host: hostname
+        :param addr: address (dns name or IP)
+        """
+        raise NotImplementedError()
+
     def get_hosts(self):
         # type: () -> Completion
         """

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -766,8 +766,8 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def add_host(self, host):
-        # type: (str) -> Completion
+    def add_host(self, HostSpec):
+        # type: (HostSpec) -> Completion
         """
         Add a host to the orchestrator inventory.
 
@@ -1028,6 +1028,12 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+class HostSpec(object):
+    def __init__(self, hostname, addr=None, labels=None):
+        # type: (str, Optional[str], Optional[List[str]]) -> None
+        self.hostname = hostname       # the hostname on the host
+        self.addr = addr or hostname   # DNS name or IP address to reach it
+        self.labels = labels or []     # initial label(s), if any
 
 class UpgradeStatusSpec(object):
     # Orchestrator's report on what's going on with any ongoing upgrade

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -35,7 +35,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-class HostSpec(namedtuple('HostSpec', ['hostname', 'network', 'name'])):
+class HostPlacementSpec(namedtuple('HostPlacementSpec', ['hostname', 'network', 'name'])):
     def __str__(self):
         res = ''
         res += self.hostname
@@ -46,7 +46,8 @@ class HostSpec(namedtuple('HostSpec', ['hostname', 'network', 'name'])):
         return res
 
 
-def parse_host_specs(host, require_network=True):
+def parse_host_placement_specs(host, require_network=True):
+    # type: (str, Optional[bool]) -> HostPlacementSpec
     """
     Split host into host, network, and (optional) daemon name parts.  The network
     part can be an IP, CIDR, or ceph addrvec like '[v2:1.2.3.4:3300,v1:1.2.3.4:6789]'.
@@ -68,7 +69,7 @@ def parse_host_specs(host, require_network=True):
     name_re = r'=(.*?)$'
 
     # assign defaults
-    host_spec = HostSpec('', '', '')
+    host_spec = HostPlacementSpec('', '', '')
 
     match_host = re.search(host_re, host)
     if match_host:
@@ -1045,10 +1046,10 @@ class PlacementSpec(object):
         # type: (Optional[str], Optional[List], Optional[int]) -> None
         self.label = label
         if hosts:
-            if all([isinstance(host, HostSpec) for host in hosts]):
-                self.hosts = hosts  # type: List[HostSpec]
+            if all([isinstance(host, HostPlacementSpec) for host in hosts]):
+                self.hosts = hosts  # type: List[HostPlacementSpec]
             else:
-                self.hosts = [parse_host_specs(x, require_network=False) for x in hosts if x]
+                self.hosts = [parse_host_placement_specs(x, require_network=False) for x in hosts if x]
         else:
             self.hosts = []
 

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -157,10 +157,13 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @orchestrator._cli_write_command(
         'orchestrator host add',
-        "name=host,type=CephString,req=true",
+        'name=host,type=CephString,req=true '
+        'name=addr,type=CephString,req=false '
+        'name=labels,type=CephString,n=N,req=false',
         'Add a host')
-    def _add_host(self, host):
-        completion = self.add_host(host)
+    def _add_host(self, host, addr=None, labels=None):
+        s = orchestrator.HostSpec(hostname=host, addr=addr, labels=labels)
+        completion = self.add_host(s)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -192,13 +192,13 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
             output = json.dumps(hosts, sort_keys=True)
         else:
             table = PrettyTable(
-                ['HOST', 'LABELS'],
+                ['HOST', 'ADDR', 'LABELS'],
                 border=False)
             table.align = 'l'
             table.left_padding_width = 0
             table.right_padding_width = 1
             for node in completion.result:
-                table.add_row((node.name, ' '.join(node.labels)))
+                table.add_row((node.name, node.addr, ' '.join(node.labels)))
             output = table.get_string()
         return HandleCommandResult(stdout=output)
 

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -178,6 +178,17 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
         orchestrator.raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
+    @orchestrator._cli_write_command(
+        'orchestrator host set-addr',
+        'name=host,type=CephString '
+        'name=addr,type=CephString',
+        'Update a host address')
+    def _update_set_addr(self, host, addr):
+        completion = self.update_host_addr(host, addr)
+        self._orchestrator_wait([completion])
+        orchestrator.raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
     @orchestrator._cli_read_command(
         'orchestrator host ls',
         'name=format,type=CephChoices,strings=json|plain,req=false',

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -263,7 +263,9 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         return [orchestrator.InventoryNode('localhost', inventory.Devices([]))]
 
     @deferred_write("add_host")
-    def add_host(self, host):
+    def add_host(self, spec):
+        # type: (orchestrator.HostSpec) -> None
+        host = spec.hostname
         if host == 'raise_no_support':
             raise orchestrator.OrchestratorValidationError("MON count must be either 1, 3 or 5")
         if host == 'raise_bug':

--- a/src/pybind/mgr/tests/test_orchestrator.py
+++ b/src/pybind/mgr/tests/test_orchestrator.py
@@ -9,7 +9,7 @@ from ceph.deployment import inventory
 from orchestrator import raise_if_exception, RGWSpec, Completion, ProgressReference
 from orchestrator import InventoryNode, ServiceDescription
 from orchestrator import OrchestratorValidationError
-from orchestrator import parse_host_specs
+from orchestrator import parse_host_placement_specs
 
 
 @pytest.mark.parametrize("test_input,expected, require_network",
@@ -24,8 +24,8 @@ from orchestrator import parse_host_specs
                           ("myhost:[v1:10.1.1.10:6789,v2:10.1.1.11:3000]", ('myhost', '[v1:10.1.1.10:6789,v2:10.1.1.11:3000]', ''), True),
                           ("myhost:[v1:10.1.1.10:6789,v2:10.1.1.11:3000]=sname", ('myhost', '[v1:10.1.1.10:6789,v2:10.1.1.11:3000]', 'sname'), True),
                           ])
-def test_parse_host_specs(test_input, expected, require_network):
-    ret = parse_host_specs(test_input, require_network=require_network)
+def test_parse_host_placement_specs(test_input, expected, require_network):
+    ret = parse_host_placement_specs(test_input, require_network=require_network)
     assert ret == expected
     assert str(ret) == test_input
 
@@ -37,9 +37,9 @@ def test_parse_host_specs(test_input, expected, require_network):
                           # empty string
                           ("myhost=1"),
                           ])
-def test_parse_host_specs_raises(test_input):
+def test_parse_host_placement_specs_raises(test_input):
     with pytest.raises(ValueError):
-        ret = parse_host_specs(test_input)
+        ret = parse_host_placement_specs(test_input)
 
 
 def _test_resource(data, resource_class, extra=None):

--- a/src/pybind/mgr/tests/test_orchestrator.py
+++ b/src/pybind/mgr/tests/test_orchestrator.py
@@ -57,6 +57,7 @@ def _test_resource(data, resource_class, extra=None):
 def test_inventory():
     json_data = {
         'name': 'host0',
+        'addr': '1.2.3.4',
         'devices': [
             {
                 'sys_api': {
@@ -74,7 +75,7 @@ def test_inventory():
     for devices in json_data['devices']:
         _test_resource(devices, inventory.Device)
 
-    json_data = [{}, {'name': 'host0'}, {'devices': []}]
+    json_data = [{}, {'name': 'host0', 'addr': '1.2.3.4'}, {'devices': []}]
     for data in json_data:
         with pytest.raises(OrchestratorValidationError):
             InventoryNode.from_json(data)


### PR DESCRIPTION
This allows cephadm to work when there is no DNS, and/or when the host identifiers/hostnames don't allow all nodes to reach each other.

```
gnit:build (wip-cephadm-addrs) 08:35 AM $ bin/ceph orchestrator host ls
HOST ADDR       LABELS  
gnit 10.3.64.23 foo bar 
```