### PR TITLE
ceph.in: print decoded output in interactive mode

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -657,7 +657,7 @@ def new_style_command(parsed_args, cmdargs, target, sigdict, inbuf, verbose):
                     if outs:
                         print(outs, file=sys.stderr)
                     if outbuf:
-                        print(outbuf)
+                        print(outbuf.decode('utf-8'))
 
     return ret, outbuf, outs
 


### PR DESCRIPTION
Under ceph CLI interactive mode, the outbuf is not decoded as utf-8 which cause the output is not proper formatted.

Signed-off-by: Jun Su <howard0su@gmail.com>
