### PR TITLE
cephadm: fix inspect-image

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1581,13 +1581,16 @@ def command_pull():
 def command_inspect_image():
     # type: () -> int
     out, err, ret = call_throws([
-        container_path, 'images', '--format', 'json', args.image])
-    j = json.loads(out)
-    if not j:
-        return -errno.ENOENT
+        container_path, 'inspect',
+        '--format', '{{.Id}}',
+        args.image])
+    if ret:
+        return errno.ENOENT
+    image_id = normalize_container_id(out.strip())
+    ver = CephContainer(args.image, 'ceph', ['--version']).run()
     r = {
-        'image_id': normalize_container_id(j[0].get('id')),
-        'ceph_version': CephContainer(args.image, 'ceph', ['--version']).run(),
+        'image_id': image_id,
+        'ceph_version': ver,
     }
     print(json.dumps(r, indent=4, sort_keys=True))
     return 0


### PR DESCRIPTION
This was broken by d8debba782cd4f40ed13db7f1af8ef43503ccec5
because the 'images' json output works with podman but not with
docker.  (Also, the inspect command is more explicit and cleaner.)

Signed-off-by: Sage Weil <sage@redhat.com>