### PR TITLE
qa/distros: rhel and centos: whitelist cephadm logrotate selinux denial

### DIFF
--- a/qa/distros/all/centos_7.6.yaml
+++ b/qa/distros/all/centos_7.6.yaml
@@ -1,2 +1,6 @@
 os_type: centos
 os_version: "7.6"
+overrides:
+  selinux:
+    whitelist:
+      - scontext=system_u:system_r:logrotate_t:s0

--- a/qa/distros/all/centos_8.0.yaml
+++ b/qa/distros/all/centos_8.0.yaml
@@ -1,2 +1,6 @@
 os_type: centos
 os_version: "8.0"
+overrides:
+  selinux:
+    whitelist:
+      - scontext=system_u:system_r:logrotate_t:s0

--- a/qa/distros/all/centos_8.1.yaml
+++ b/qa/distros/all/centos_8.1.yaml
@@ -1,2 +1,6 @@
 os_type: centos
 os_version: "8.1"
+overrides:
+  selinux:
+    whitelist:
+      - scontext=system_u:system_r:logrotate_t:s0

--- a/qa/distros/all/rhel_7.6.yaml
+++ b/qa/distros/all/rhel_7.6.yaml
@@ -1,2 +1,6 @@
 os_type: rhel
 os_version: "7.6"
+overrides:
+  selinux:
+    whitelist:
+      - scontext=system_u:system_r:logrotate_t:s0

--- a/qa/distros/all/rhel_7.7.yaml
+++ b/qa/distros/all/rhel_7.7.yaml
@@ -1,2 +1,6 @@
 os_type: rhel
 os_version: "7.7"
+overrides:
+  selinux:
+    whitelist:
+      - scontext=system_u:system_r:logrotate_t:s0

--- a/qa/distros/all/rhel_8.0.yaml
+++ b/qa/distros/all/rhel_8.0.yaml
@@ -1,2 +1,6 @@
 os_type: rhel
 os_version: "8.0"
+overrides:
+  selinux:
+    whitelist:
+      - scontext=system_u:system_r:logrotate_t:s0

--- a/qa/distros/all/rhel_8.1.yaml
+++ b/qa/distros/all/rhel_8.1.yaml
@@ -1,2 +1,6 @@
 os_type: rhel
 os_version: "8.1"
+overrides:
+  selinux:
+    whitelist:
+      - scontext=system_u:system_r:logrotate_t:s0


### PR DESCRIPTION
This is fixed in RHEL 8.1.1 (and by extension centos/rhel 8.2+).

No fix for el 7 yet

Partially-fixes: https://tracker.ceph.com/issues/43703
Signed-off-by: Sage Weil <sage@redhat.com>