### PR TITLE
cephadm: fix name argument parsing during image check for non-ceph components

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2849,7 +2849,7 @@ def _parse_args(av):
     args = parser.parse_args(av)
 
     if not args.image:
-        if 'name' in args:
+        if 'name' in args and args.name:
             type_ = args.name.split('.', 1)[0]
             if type_ in Monitoring.components:
                 args.image = Monitoring.components[type_]['image']


### PR DESCRIPTION
bug in parsing introduced in 97def7c
args.name may exist but will be none if flag is not used
check the value in addition to checking if it exists

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>