### PR TITLE
osd/PrimaryLogPG: use legacy timestamp rendering for hit_set objects

### DIFF
--- a/qa/suites/upgrade/nautilus-x-singleton/1-install/nautilus.yaml
+++ b/qa/suites/upgrade/nautilus-x-singleton/1-install/nautilus.yaml
@@ -15,3 +15,14 @@ tasks:
 - print: "**** done install nautilus"
 - ceph:
 - print: "**** done ceph"
+
+# create a hit set test pool that will generate hit sets prior to octopus
+- exec:
+    mon.a:
+      - sudo ceph osd pool create test-hit-set-base 32
+      - sudo ceph osd pool create test-hit-set-cache 32
+      - sudo ceph osd tier add test-hit-set-base test-hit-set-cache
+      - sudo ceph osd pool set test-hit-set-cache hit_set_type bloom
+      - sudo ceph osd pool set test-hit-set-cache hit_set_count 32
+      - sudo ceph osd pool set test-hit-set-cache hit_set_period 15
+      - rados -p test-hit-set-cache bench 30 write -b 1

--- a/qa/suites/upgrade/nautilus-x-singleton/6-finish-upgrade.yaml
+++ b/qa/suites/upgrade/nautilus-x-singleton/6-finish-upgrade.yaml
@@ -28,3 +28,10 @@ tasks:
       - ceph mon enable-msgr2
 - install.upgrade:
     client.0:
+
+# reduce canary pool hit set count from 32 -> 4 and do some io so that
+# we are sure they will be trimmed post-upgrade.
+- exec:
+    mon.a:
+      - sudo ceph osd pool set test-hit-set-cache hit_set_count 4
+      - rados -p test-hit-set-cache bench 5 write -b 1

--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -239,7 +239,7 @@ public:
   }
 
   // output
-  std::ostream& gmtime(std::ostream& out) const {
+  std::ostream& gmtime(std::ostream& out, bool legacy_form=false) const {
     out.setf(std::ios::right);
     char oldfill = out.fill();
     out.fill('0');
@@ -254,9 +254,13 @@ public:
       gmtime_r(&tt, &bdt);
       out << std::setw(4) << (bdt.tm_year+1900)  // 2007 -> '07'
 	  << '-' << std::setw(2) << (bdt.tm_mon+1)
-	  << '-' << std::setw(2) << bdt.tm_mday
-	  << 'T'
-	  << std::setw(2) << bdt.tm_hour
+	  << '-' << std::setw(2) << bdt.tm_mday;
+      if (legacy_form) {
+	out << ' ';
+      } else {
+	out << 'T';
+      }
+      out << std::setw(2) << bdt.tm_hour
 	  << ':' << std::setw(2) << bdt.tm_min
 	  << ':' << std::setw(2) << bdt.tm_sec;
       out << "." << std::setw(6) << usec();
@@ -322,7 +326,7 @@ public:
     return out;
   }
 
-  std::ostream& localtime(std::ostream& out) const {
+  std::ostream& localtime(std::ostream& out, bool legacy_form=false) const {
     out.setf(std::ios::right);
     char oldfill = out.fill();
     out.fill('0');
@@ -337,15 +341,21 @@ public:
       localtime_r(&tt, &bdt);
       out << std::setw(4) << (bdt.tm_year+1900)  // 2007 -> '07'
 	  << '-' << std::setw(2) << (bdt.tm_mon+1)
-	  << '-' << std::setw(2) << bdt.tm_mday
-	  << 'T'
-	  << std::setw(2) << bdt.tm_hour
+	  << '-' << std::setw(2) << bdt.tm_mday;
+      if (legacy_form) {
+	out << ' ';
+      } else {
+	out << 'T';
+      }
+      out << std::setw(2) << bdt.tm_hour
 	  << ':' << std::setw(2) << bdt.tm_min
 	  << ':' << std::setw(2) << bdt.tm_sec;
       out << "." << std::setw(6) << usec();
-      char buf[32] = { 0 };
-      strftime(buf, sizeof(buf), "%z", &bdt);
-      out << buf;
+      if (!legacy_form) {
+	char buf[32] = { 0 };
+	strftime(buf, sizeof(buf), "%z", &bdt);
+	out << buf;
+      }
     }
     out.fill(oldfill);
     out.unsetf(std::ios::right);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -13538,11 +13538,11 @@ hobject_t PrimaryLogPG::get_hit_set_archive_object(utime_t start,
   ostringstream ss;
   ss << "hit_set_" << info.pgid.pgid << "_archive_";
   if (using_gmt) {
-    start.gmtime(ss) << "_";
-    end.gmtime(ss);
+    start.gmtime(ss, true /* legacy pre-octopus form */) << "_";
+    end.gmtime(ss, true /* legacy pre-octopus form */);
   } else {
-    start.localtime(ss) << "_";
-    end.localtime(ss);
+    start.localtime(ss, true /* legacy pre-octopus form */) << "_";
+    end.localtime(ss, true /* legacy pre-octopus form */);
   }
   hobject_t hoid(sobject_t(ss.str(), CEPH_NOSNAP), "",
 		 info.pgid.ps(), info.pgid.pool(),


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44024