### PR TITLE
orchestrator: usability fixes

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1393,7 +1393,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         found = list(zip(*args))[0] if args else []
         not_found = {osd_id for osd_id in osd_ids if 'osd.%s' % osd_id not in found}
         if not_found:
-            raise OrchestratorError('Unable to find ODS: %s' % not_found)
+            raise OrchestratorError('Unable to find OSD: %s' % not_found)
         return self._remove_daemon(args)
 
     def _create_daemon(self, daemon_type, daemon_id, host,

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -503,8 +503,8 @@ Usage:
 
     @orchestrator._cli_write_command(
         'orchestrator rgw update',
-        'name=zone_name,type=CephString '
         'name=realm_name,type=CephString '
+        'name=zone_name,type=CephString '
         'name=num,type=CephInt,req=false '
         'name=hosts,type=CephString,n=N,req=false '
         'name=label,type=CephString,req=false',


### PR DESCRIPTION
Fixes:
 - https://tracker.ceph.com/issues/44029
orchestrator cli: confusing rgw param order
 - minor typo

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
