### PR TITLE
mgr/dashboard: Temporary fix for Chrome 80

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/main.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/main.ts
@@ -11,3 +11,26 @@ if (environment.production) {
 platformBrowserDynamic()
   .bootstrapModule(AppModule)
   .catch((err) => console.log(err));
+
+/*
+ * Temporary fix for Chrome 80 bug regarding reduce method
+ * source: https://bugs.chromium.org/p/chromium/issues/detail?id=1049982#c7
+ */
+(function() {
+  function getChromeVersion() {
+    const raw = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+    return raw ? parseInt(raw[2], 10) : false;
+  }
+
+  const chromeVersion = getChromeVersion();
+  if (chromeVersion && chromeVersion >= 80) {
+    const arrayReduce = Array.prototype.reduce;
+    let callback;
+    Object.defineProperty(Array.prototype, 'reduce', {
+      value: function(cb: any, ...args: any[]) {
+        callback = cb;
+        return arrayReduce.call(this, callback, ...args);
+      }
+    });
+  }
+})();


### PR DESCRIPTION
There is a bug in Chrome 80 that breaks the reduce method.
This solution seems to fix the problem:
https://bugs.chromium.org/p/chromium/issues/detail?id=1049982#c7

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
