### PR TITLE
mon/PGMap: fix summary display of >32bit pg states

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -214,7 +214,7 @@ void PGMapDigest::print_summary(ceph::Formatter *f, ostream *out) const
     f->open_array_section("pgs_by_state");
 
   // list is descending numeric order (by count)
-  std::multimap<int,int> state_by_count;  // count -> state
+  std::multimap<int,uint64_t> state_by_count;  // count -> state
   for (auto p = num_pg_by_state.begin();
        p != num_pg_by_state.end();
        ++p) {

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -63,7 +63,7 @@ void PGMapDigest::encode(bufferlist& bl, uint64_t features) const
     uint32_t n = num_pg_by_state.size();
     encode(n, bl);
     for (auto p : num_pg_by_state) {
-      encode((uint32_t)p.first, bl);
+      encode((int32_t)p.first, bl);
       encode(p.second, bl);
     }
   }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44052
