### PR TITLE
mimic: osdc/Objecter: only pause if respects_full()

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2666,7 +2666,7 @@ bool Objecter::target_should_be_paused(op_target_t *t)
   const pg_pool_t *pi = osdmap->get_pg_pool(t->base_oloc.pool);
   bool pauserd = osdmap->test_flag(CEPH_OSDMAP_PAUSERD);
   bool pausewr = osdmap->test_flag(CEPH_OSDMAP_PAUSEWR) ||
-    _osdmap_full_flag() || _osdmap_pool_full(*pi);
+    (t->respects_full() && (_osdmap_full_flag() || _osdmap_pool_full(*pi)));
 
   return (t->flags & CEPH_OSD_FLAG_READ && pauserd) ||
     (t->flags & CEPH_OSD_FLAG_WRITE && pausewr) ||

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2695,11 +2695,6 @@ bool Objecter::_osdmap_has_pool_full() const
   return false;
 }
 
-bool Objecter::_osdmap_pool_full(const pg_pool_t &p) const
-{
-  return p.has_flag(pg_pool_t::FLAG_FULL) && honor_osdmap_full;
-}
-
 /**
  * Wrapper around osdmap->test_flag for special handling of the FULL flag.
  */

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1082,7 +1082,7 @@ void Objecter::_scan_requests(
 			 op->session ? op->session->con.get() : nullptr);
     switch (r) {
     case RECALC_OP_TARGET_NO_ACTION:
-      if (!skipped_map && !(force_resend_writes && op->respects_full()))
+      if (!skipped_map && !(force_resend_writes && op->target.respects_full()))
 	break;
       // -- fall-thru --
     case RECALC_OP_TARGET_NEED_RESEND:
@@ -2451,7 +2451,7 @@ void Objecter::_op_submit(Op *op, shunique_lock& sul, ceph_tid_t *ptid)
 		   << dendl;
     op->target.paused = true;
     _maybe_request_map();
-  } else if (op->respects_full() &&
+  } else if (op->target.respects_full() &&
 	     (_osdmap_full_flag() ||
 	      _osdmap_pool_full(op->target.base_oloc.pool))) {
     ldout(cct, 0) << " FULL, paused modify " << op << " tid "

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2433,30 +2433,9 @@ void Objecter::_op_submit(Op *op, shunique_lock& sul, ceph_tid_t *ptid)
   }
 
   bool need_send = false;
-
-  if (osdmap->get_epoch() < epoch_barrier) {
-    ldout(cct, 10) << " barrier, paused " << op << " tid " << op->tid
+  if (op->target.paused) {
+    ldout(cct, 10) << " tid " << op->tid << " op " << op << " is paused"
 		   << dendl;
-    op->target.paused = true;
-    _maybe_request_map();
-  } else if ((op->target.flags & CEPH_OSD_FLAG_WRITE) &&
-             osdmap->test_flag(CEPH_OSDMAP_PAUSEWR)) {
-    ldout(cct, 10) << " paused modify " << op << " tid " << op->tid
-		   << dendl;
-    op->target.paused = true;
-    _maybe_request_map();
-  } else if ((op->target.flags & CEPH_OSD_FLAG_READ) &&
-	     osdmap->test_flag(CEPH_OSDMAP_PAUSERD)) {
-    ldout(cct, 10) << " paused read " << op << " tid " << op->tid
-		   << dendl;
-    op->target.paused = true;
-    _maybe_request_map();
-  } else if (op->target.respects_full() &&
-	     (_osdmap_full_flag() ||
-	      _osdmap_pool_full(op->target.base_oloc.pool))) {
-    ldout(cct, 0) << " FULL, paused modify " << op << " tid "
-		  << op->tid << dendl;
-    op->target.paused = true;
     _maybe_request_map();
   } else if (!s->is_homeless()) {
     need_send = true;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1336,7 +1336,13 @@ public:
       return r == 0 || (r > 0 && h < end);
     }
 
-    void dump(Formatter *f) const;
+    bool respects_full() const {
+      return
+	(flags & (CEPH_OSD_FLAG_WRITE | CEPH_OSD_FLAG_RWORDERED)) &&
+	!(flags & (CEPH_OSD_FLAG_FULL_TRY | CEPH_OSD_FLAG_FULL_FORCE));
+    }
+
+    void dump(ceph::Formatter *f) const;
   };
 
   struct Op : public RefCountedObject {
@@ -1433,12 +1439,6 @@ public:
 
     bool operator<(const Op& other) const {
       return tid < other.tid;
-    }
-
-    bool respects_full() const {
-      return
-	(target.flags & (CEPH_OSD_FLAG_WRITE | CEPH_OSD_FLAG_RWORDERED)) &&
-	!(target.flags & (CEPH_OSD_FLAG_FULL_TRY | CEPH_OSD_FLAG_FULL_FORCE));
     }
 
   private:

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1867,6 +1867,7 @@ public:
   bool osdmap_full_flag() const;
   bool osdmap_pool_full(const int64_t pool_id) const;
 
+
  private:
 
   /**
@@ -1876,8 +1877,10 @@ public:
    *         the global full flag is set, else false
    */
   bool _osdmap_pool_full(const int64_t pool_id) const;
-  bool _osdmap_pool_full(const pg_pool_t &p) const;
-  void update_pool_full_map(map<int64_t, bool>& pool_full_map);
+  bool _osdmap_pool_full(const pg_pool_t &p) const {
+    return p.has_flag(pg_pool_t::FLAG_FULL) && honor_pool_full;
+  }
+  void update_pool_full_map(std::map<int64_t, bool>& pool_full_map);
 
   map<uint64_t, LingerOp*> linger_ops;
   // we use this just to confirm a cookie is valid before dereferencing the ptr


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43991

---

backport of https://github.com/ceph/ceph/pull/33020
parent tracker: https://tracker.ceph.com/issues/43813

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh