### PR TITLE
mimic: osd: Allow 64-char hostname to be added as the "host" in CRUSH

### DIFF
--- a/src/crush/CrushLocation.cc
+++ b/src/crush/CrushLocation.cc
@@ -103,7 +103,7 @@ int CrushLocation::init_on_startup()
 
   // start with a sane default
   char hostname[HOST_NAME_MAX + 1];
-  int r = gethostname(hostname, sizeof(hostname)-1);
+  int r = gethostname(hostname, sizeof(hostname));
   if (r < 0)
     strcpy(hostname, "unknown_host");
   // use short hostname


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43987

---

backport of https://github.com/ceph/ceph/pull/32947
parent tracker: https://tracker.ceph.com/issues/43929

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh