### PR TITLE
nautilus: mgr/devicehealth: fix telemetry stops sending device reports after 48…

### DIFF
--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -434,7 +434,7 @@ class Module(MgrModule):
             return 0, json.dumps(res, indent=4), ''
         with ioctx:
             with rados.ReadOpCtx() as op:
-                omap_iter, ret = ioctx.get_omap_vals(op, "", sample or '',
+                omap_iter, ret = ioctx.get_omap_vals(op, min_sample or '', sample or '',
                                                      MAX_SAMPLES)  # fixme
                 assert ret == 0
                 try:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43873

---

backport of https://github.com/ceph/ceph/pull/32903
parent tracker: https://tracker.ceph.com/issues/43837

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh