### PR TITLE
luminous: rgw: maybe coredump when reload operator happened

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4641,6 +4641,9 @@ int RGWRados::init_complete()
   data_notifier = new RGWDataNotifier(this);
   data_notifier->start();
 
+  binfo_cache = new RGWChainedCacheImpl<bucket_info_entry>;
+  binfo_cache->init(this);
+
   lc = new RGWLC();
   lc->initialize(cct, this);
 
@@ -4657,9 +4660,6 @@ int RGWRados::init_complete()
       << get_max_bucket_shards() << dendl;
   }
   ldout(cct, 20) << __func__ << " bucket index max shards: " << bucket_index_max_shards << dendl;
-
-  binfo_cache = new RGWChainedCacheImpl<bucket_info_entry>;
-  binfo_cache->init(this);
 
   bool need_tombstone_cache = !zone_data_notify_to_map.empty(); /* have zones syncing from us */
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43875

---

backport of https://github.com/ceph/ceph/pull/29733
parent tracker: https://tracker.ceph.com/issues/42119

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh