### PR TITLE
mimic: mon: Don't put session during feature change

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4028,7 +4028,6 @@ void Monitor::_ms_dispatch(Message *m)
         // exist only while the op is being handled.
         remove_session(s);
       }
-      s->put();
       s = nullptr;
     }
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43881

---

backport of https://github.com/ceph/ceph/pull/32365
parent tracker: https://tracker.ceph.com/issues/38345

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh