### PR TITLE
nautilus: mon/ConfigMonitor: only propose if leader

### DIFF
--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -678,7 +678,7 @@ update:
 
 void ConfigMonitor::tick()
 {
-  if (!is_active()) {
+  if (!is_active() || !mon->is_leader()) {
     return;
   }
   dout(10) << __func__ << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43916

---

backport of https://github.com/ceph/ceph/pull/32975
parent tracker: https://tracker.ceph.com/issues/43892

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh