### PR TITLE
argparse: add positional=false option

### DIFF
--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -167,6 +167,11 @@ dump_cmd_to_json(Formatter *f, uint64_t features, const string& cmd)
       }
     }
 
+    // pre-pacific clients don't know about positional
+    if (!HAVE_FEATURE(features, SERVER_PACIFIC)) {
+      desckv.erase("positional");
+    }
+
     // dump all the keys including name into the array
     for (auto [key, value] : desckv) {
       f->dump_string(key, value);

--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -138,6 +138,7 @@ dump_cmd_to_json(Formatter *f, uint64_t features, const string& cmd)
 
   stringstream ss(cmd);
   std::string word;
+  bool allow_positional = true;
 
   while (std::getline(ss, word, ' ')) {
     // if no , or =, must be a plain word to put out
@@ -170,10 +171,15 @@ dump_cmd_to_json(Formatter *f, uint64_t features, const string& cmd)
     // pre-pacific clients don't know about positional
     if (!HAVE_FEATURE(features, SERVER_PACIFIC)) {
       desckv.erase("positional");
+    } else if (!allow_positional && desckv.count("positional") == 0) {
+      desckv["positional"] = "false";
     }
 
     // dump all the keys including name into the array
     for (auto [key, value] : desckv) {
+      if (key == "n" && value == "N") {
+	allow_positional = false;
+      }
       f->dump_string(key, value);
     }
     f->close_section(); // attribute object for individual desc

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -53,6 +53,7 @@
  *    n=<n> is a repeat count for how many of this argument must be supplied.
  *          n=1 is the default.
  *          n=N is a special case that means "1 or more".
+ *    param=true forces the parameter to be non positionally and use the form `--<name>=` (defaults to false)
  *
  * A perhaps-incomplete list of types:
  *

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -53,7 +53,7 @@
  *    n=<n> is a repeat count for how many of this argument must be supplied.
  *          n=1 is the default.
  *          n=N is a special case that means "1 or more".
- *    param=true forces the parameter to be non positionally and use the form `--<name>=` (defaults to false)
+ *    positional=false prevents the parameter from parsing positionally, requiring the use the form `--<name>=` (defaults to true, except for any parameters following n=N parameters)
  *
  * A perhaps-incomplete list of types:
  *

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -954,14 +954,16 @@ def _validate_non_positional_args(args, sig, d, partial=False):
                 parser.add_argument("--{}".format(desc.name),
                                     dest="{}".format(desc.name),
                                     action="store_true")
-                parser.add_argument("--{}".format(desc.name.replace('_', '-')),
-                                    dest="{}".format(desc.name),
-                                    action="store_true")
+                if '_' in desc.name:
+                    parser.add_argument("--{}".format(desc.name.replace('_', '-')),
+                                        dest="{}".format(desc.name),
+                                        action="store_true")
             else:
                 parser.add_argument("--{}".format(desc.name),
                                     dest="{}".format(desc.name))
-                parser.add_argument("--{}".format(desc.name.replace('_', '-')),
-                                    dest="{}".format(desc.name))
+                if '_' in desc.name:
+                    parser.add_argument("--{}".format(desc.name.replace('_', '-')),
+                                        dest="{}".format(desc.name))
             descs.append(desc)
             sig.remove(desc)
 

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -513,7 +513,7 @@ class CephBool(CephArgtype):
         self.strings = strings.split('|')
 
     def valid(self, s, partial=False):
-        lower_case = s.lower()
+        lower_case = str(s).lower()
         if lower_case in ['true', '1']:
             self.val = True
         elif lower_case in ['false', '0']:

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -155,7 +155,7 @@ class CephInt(CephArgtype):
     range-limited integers, [+|-][0-9]+ or 0x[0-9a-f]+
     range: list of 1 or 2 ints, [min] or [min,max]
     """
-    def __init__(self, range=''):
+    def __init__(self, range='', **kwargs):
         if range == '':
             self.range = list()
         else:
@@ -190,7 +190,7 @@ class CephFloat(CephArgtype):
     range-limited float type
     range: list of 1 or 2 floats, [min] or [min, max]
     """
-    def __init__(self, range=''):
+    def __init__(self, range='', **kwargs):
         if range == '':
             self.range = list()
         else:
@@ -223,7 +223,7 @@ class CephString(CephArgtype):
     """
     String; pretty generic.  goodchars is a RE char class of valid chars
     """
-    def __init__(self, goodchars=''):
+    def __init__(self, goodchars='', **kwargs):
         from string import printable
         try:
             re.compile(goodchars)
@@ -400,7 +400,7 @@ class CephName(CephArgtype):
 
     Also accept '*'
     """
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.nametype = None
         self.nameid = None
 
@@ -442,7 +442,7 @@ class CephOsdName(CephArgtype):
 
     osd.<id>, or <id>, or *, where id is a base10 int
     """
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.nametype = None
         self.nameid = None
 

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -22,6 +22,7 @@ import stat
 import sys
 import threading
 import uuid
+import argparse
 
 # Flags are from MonCommand.h
 class Flag:
@@ -634,7 +635,7 @@ class CephPrefix(CephArgtype):
 class argdesc(object):
     """
     argdesc(typename, name='name', n=numallowed|N,
-            req=False, helptext=helptext, **kwargs (type-specific))
+            req=False, param=True, helptext=helptext, **kwargs (type-specific))
 
     validation rules:
     typename: type(**kwargs) will be constructed
@@ -643,6 +644,7 @@ class argdesc(object):
     name is used for parse errors and for constructing JSON output
     n is a numeric literal or 'n|N', meaning "at least one, but maybe more"
     req=False means the argument need not be present in the list
+    param=True forces --name= in the helpstr
     helptext is the associated help for the command
     anything else are arguments to pass to the type constructor.
 
@@ -651,7 +653,7 @@ class argdesc(object):
     valid() will later be called with input to validate against it,
     and will store the validated value in self.instance.val for extraction.
     """
-    def __init__(self, t, name=None, n=1, req=True, **kwargs):
+    def __init__(self, t, name=None, n=1, req=True, param=False, **kwargs):
         if isinstance(t, basestring):
             self.t = CephPrefix
             self.typeargs = {'prefix': t}
@@ -667,6 +669,8 @@ class argdesc(object):
             self.n = 1
         else:
             self.n = int(n)
+
+        self.param = param in (True, 'True', 'true')
 
         self.numseen = 0
 
@@ -725,6 +729,8 @@ class argdesc(object):
         s = chunk
         if self.N:
             s += '...'
+        if self.param and not s.startswith("--"):
+            s = "--{0}={1}".format(self.name.replace("_", "-"), s)
         if not self.req:
             s = '[' + s + ']'
         return s
@@ -932,6 +938,54 @@ def store_arg(desc, d):
         d[desc.name] = desc.instance.val
 
 
+def _validate_non_positional_args(args, sig, d, partial=False):
+    # short circuit
+    if not any(map(lambda x: x.param, sig)):
+        return args, sig, d, 0
+
+    # We know there is at least 1 param argdesc, so lets deal with them now
+    # so they're not parsed positionally
+    matchcnt = 0
+    descs = []
+    parser = argparse.ArgumentParser()
+    for desc in sig.copy():
+        if desc.param:
+            if desc.t == CephBool:
+                parser.add_argument("--{}".format(desc.name),
+                                    dest="{}".format(desc.name),
+                                    action="store_true")
+                parser.add_argument("--{}".format(desc.name.replace('_', '-')),
+                                    dest="{}".format(desc.name),
+                                    action="store_true")
+            else:
+                parser.add_argument("--{}".format(desc.name),
+                                    dest="{}".format(desc.name))
+                parser.add_argument("--{}".format(desc.name.replace('_', '-')),
+                                    dest="{}".format(desc.name))
+            descs.append(desc)
+            sig.remove(desc)
+
+    # now lets parse the args to strip out these params that should be in the
+    # form '--<desc.name>'.
+    parsed_args, args = parser.parse_known_args(args)
+    parsed_args = vars(parsed_args)
+
+    for desc in descs:
+        if parsed_args.get(desc.name):
+            try:
+                validate_one(parsed_args[desc.name], desc)
+                store_arg(desc, d)
+                matchcnt += 1
+            except ArgumentError:
+                # argument mismatch
+                if partial:
+                    return args, sig, d, matchcnt
+                raise
+        elif desc.req:
+            raise ArgumentError("Missing required long parameter "
+                                "'--{}'".format(desc.name))
+    return args, sig, d, matchcnt
+
 def validate(args, signature, flags=0, partial=False):
     """
     validate(args, signature, flags=0, partial=False)
@@ -964,6 +1018,11 @@ def validate(args, signature, flags=0, partial=False):
     # Special case: detect "injectargs" (legacy way of modifying daemon
     # configs) and permit "--" string arguments if so.
     injectargs = myargs and myargs[0] == "injectargs"
+
+    # first parse and remove the non positional args, those with param=true
+    myargs, mysig, d, tmp_matchcnt = _validate_non_positional_args(
+        myargs, mysig, d, partial)
+    matchcnt += tmp_matchcnt
 
     # Make a pass through all arguments
     for desc in mysig:


### PR DESCRIPTION
Allow argdesc to contain 'positional=false', which makes an arg *not* parsed positionally, requiring the --foo[= [value syntax.

Fixes: https://tracker.ceph.com/issues/42113

Replaces https://github.com/ceph/ceph/pull/31042
Based on top of #33135 