### PR TITLE
common,mgr,osd: pass string_view as "name"

### DIFF
--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -117,7 +117,7 @@ void Formatter::flush(bufferlist &bl)
   bl.append(os.str());
 }
 
-void Formatter::dump_format(const char *name, const char *fmt, ...)
+void Formatter::dump_format(std::string_view name, const char *fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
@@ -125,7 +125,7 @@ void Formatter::dump_format(const char *name, const char *fmt, ...)
   va_end(ap);
 }
 
-void Formatter::dump_format_ns(const char *name, const char *ns, const char *fmt, ...)
+void Formatter::dump_format_ns(std::string_view name, const char *ns, const char *fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
@@ -134,7 +134,7 @@ void Formatter::dump_format_ns(const char *name, const char *ns, const char *fmt
 
 }
 
-void Formatter::dump_format_unquoted(const char *name, const char *fmt, ...)
+void Formatter::dump_format_unquoted(std::string_view name, const char *fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
@@ -193,7 +193,7 @@ void JSONFormatter::print_quoted_string(std::string_view s)
   m_ss << '\"' << json_stream_escaper(s) << '\"';
 }
 
-void JSONFormatter::print_name(const char *name)
+void JSONFormatter::print_name(std::string_view name)
 {
   finish_pending_string();
   if (m_stack.empty())
@@ -213,7 +213,7 @@ void JSONFormatter::print_name(const char *name)
   ++entry.size;
 }
 
-void JSONFormatter::open_section(const char *name, const char *ns, bool is_array)
+void JSONFormatter::open_section(std::string_view name, const char *ns, bool is_array)
 {
   if (handle_open_section(name, ns, is_array)) {
     return;
@@ -235,22 +235,22 @@ void JSONFormatter::open_section(const char *name, const char *ns, bool is_array
   m_stack.push_back(n);
 }
 
-void JSONFormatter::open_array_section(const char *name)
+void JSONFormatter::open_array_section(std::string_view name)
 {
   open_section(name, nullptr, true);
 }
 
-void JSONFormatter::open_array_section_in_ns(const char *name, const char *ns)
+void JSONFormatter::open_array_section_in_ns(std::string_view name, const char *ns)
 {
   open_section(name, ns, true);
 }
 
-void JSONFormatter::open_object_section(const char *name)
+void JSONFormatter::open_object_section(std::string_view name)
 {
   open_section(name, nullptr, false);
 }
 
-void JSONFormatter::open_object_section_in_ns(const char *name, const char *ns)
+void JSONFormatter::open_object_section_in_ns(std::string_view name, const char *ns)
 {
   open_section(name, ns, false);
 }
@@ -286,7 +286,7 @@ void JSONFormatter::finish_pending_string()
 }
 
 template <class T>
-void JSONFormatter::add_value(const char *name, T val)
+void JSONFormatter::add_value(std::string_view name, T val)
 {
   std::stringstream ss;
   ss.precision(std::numeric_limits<T>::max_digits10);
@@ -294,7 +294,7 @@ void JSONFormatter::add_value(const char *name, T val)
   add_value(name, ss.str(), false);
 }
 
-void JSONFormatter::add_value(const char *name, std::string_view val, bool quoted)
+void JSONFormatter::add_value(std::string_view name, std::string_view val, bool quoted)
 {
   if (handle_value(name, val, quoted)) {
     return;
@@ -307,27 +307,27 @@ void JSONFormatter::add_value(const char *name, std::string_view val, bool quote
   }
 }
 
-void JSONFormatter::dump_unsigned(const char *name, uint64_t u)
+void JSONFormatter::dump_unsigned(std::string_view name, uint64_t u)
 {
   add_value(name, u);
 }
 
-void JSONFormatter::dump_int(const char *name, int64_t s)
+void JSONFormatter::dump_int(std::string_view name, int64_t s)
 {
   add_value(name, s);
 }
 
-void JSONFormatter::dump_float(const char *name, double d)
+void JSONFormatter::dump_float(std::string_view name, double d)
 {
   add_value(name, d);
 }
 
-void JSONFormatter::dump_string(const char *name, std::string_view s)
+void JSONFormatter::dump_string(std::string_view name, std::string_view s)
 {
   add_value(name, s, true);
 }
 
-std::ostream& JSONFormatter::dump_stream(const char *name)
+std::ostream& JSONFormatter::dump_stream(std::string_view name)
 {
   finish_pending_string();
   m_pending_name = name;
@@ -335,7 +335,7 @@ std::ostream& JSONFormatter::dump_stream(const char *name)
   return m_pending_string;
 }
 
-void JSONFormatter::dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap)
+void JSONFormatter::dump_format_va(std::string_view name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
   char buf[LARGE_SIZE];
   vsnprintf(buf, LARGE_SIZE, fmt, ap);
@@ -407,32 +407,32 @@ void XMLFormatter::output_footer()
   }
 }
 
-void XMLFormatter::open_object_section(const char *name)
+void XMLFormatter::open_object_section(std::string_view name)
 {
   open_section_in_ns(name, NULL, NULL);
 }
 
-void XMLFormatter::open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs)
+void XMLFormatter::open_object_section_with_attrs(std::string_view name, const FormatterAttrs& attrs)
 {
   open_section_in_ns(name, NULL, &attrs);
 }
 
-void XMLFormatter::open_object_section_in_ns(const char *name, const char *ns)
+void XMLFormatter::open_object_section_in_ns(std::string_view name, const char *ns)
 {
   open_section_in_ns(name, ns, NULL);
 }
 
-void XMLFormatter::open_array_section(const char *name)
+void XMLFormatter::open_array_section(std::string_view name)
 {
   open_section_in_ns(name, NULL, NULL);
 }
 
-void XMLFormatter::open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs)
+void XMLFormatter::open_array_section_with_attrs(std::string_view name, const FormatterAttrs& attrs)
 {
   open_section_in_ns(name, NULL, &attrs);
 }
 
-void XMLFormatter::open_array_section_in_ns(const char *name, const char *ns)
+void XMLFormatter::open_array_section_in_ns(std::string_view name, const char *ns)
 {
   open_section_in_ns(name, ns, NULL);
 }
@@ -453,7 +453,7 @@ void XMLFormatter::close_section()
 }
 
 template <class T>
-void XMLFormatter::add_value(const char *name, T val)
+void XMLFormatter::add_value(std::string_view name, T val)
 {
   std::string e(name);
   std::transform(e.begin(), e.end(), e.begin(),
@@ -466,22 +466,22 @@ void XMLFormatter::add_value(const char *name, T val)
     m_ss << "\n";
 }
 
-void XMLFormatter::dump_unsigned(const char *name, uint64_t u)
+void XMLFormatter::dump_unsigned(std::string_view name, uint64_t u)
 {
   add_value(name, u);
 }
 
-void XMLFormatter::dump_int(const char *name, int64_t s)
+void XMLFormatter::dump_int(std::string_view name, int64_t s)
 {
   add_value(name, s);
 }
 
-void XMLFormatter::dump_float(const char *name, double d)
+void XMLFormatter::dump_float(std::string_view name, double d)
 {
   add_value(name, d);
 }
 
-void XMLFormatter::dump_string(const char *name, std::string_view s)
+void XMLFormatter::dump_string(std::string_view name, std::string_view s)
 {
   std::string e(name);
   std::transform(e.begin(), e.end(), e.begin(),
@@ -493,7 +493,7 @@ void XMLFormatter::dump_string(const char *name, std::string_view s)
     m_ss << "\n";
 }
 
-void XMLFormatter::dump_string_with_attrs(const char *name, std::string_view s, const FormatterAttrs& attrs)
+void XMLFormatter::dump_string_with_attrs(std::string_view name, std::string_view s, const FormatterAttrs& attrs)
 {
   std::string e(name);
   std::transform(e.begin(), e.end(), e.begin(),
@@ -507,7 +507,7 @@ void XMLFormatter::dump_string_with_attrs(const char *name, std::string_view s, 
     m_ss << "\n";
 }
 
-std::ostream& XMLFormatter::dump_stream(const char *name)
+std::ostream& XMLFormatter::dump_stream(std::string_view name)
 {
   print_spaces();
   m_pending_string_name = name;
@@ -515,7 +515,7 @@ std::ostream& XMLFormatter::dump_stream(const char *name)
   return m_pending_string;
 }
 
-void XMLFormatter::dump_format_va(const char* name, const char *ns, bool quoted, const char *fmt, va_list ap)
+void XMLFormatter::dump_format_va(std::string_view name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
   char buf[LARGE_SIZE];
   size_t len = vsnprintf(buf, LARGE_SIZE, fmt, ap);
@@ -557,7 +557,7 @@ void XMLFormatter::get_attrs_str(const FormatterAttrs *attrs, std::string& attrs
   attrs_str = attrs_ss.str();
 }
 
-void XMLFormatter::open_section_in_ns(const char *name, const char *ns, const FormatterAttrs *attrs)
+void XMLFormatter::open_section_in_ns(std::string_view name, const char *ns, const FormatterAttrs *attrs)
 {
   print_spaces();
   std::string attrs_str;
@@ -577,7 +577,7 @@ void XMLFormatter::open_section_in_ns(const char *name, const char *ns, const Fo
   }
   if (m_pretty)
     m_ss << "\n";
-  m_sections.push_back(name);
+  m_sections.push_back(std::string(name));
 }
 
 void XMLFormatter::finish_pending_string()
@@ -746,39 +746,39 @@ void TableFormatter::reset()
   m_section_open = 0;
 }
 
-void TableFormatter::open_object_section(const char *name)
+void TableFormatter::open_object_section(std::string_view name)
 {
   open_section_in_ns(name, NULL, NULL);
 }
 
-void TableFormatter::open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs)
+void TableFormatter::open_object_section_with_attrs(std::string_view name, const FormatterAttrs& attrs)
 {
   open_section_in_ns(name, NULL, NULL);
 }
 
-void TableFormatter::open_object_section_in_ns(const char *name, const char *ns)
+void TableFormatter::open_object_section_in_ns(std::string_view name, const char *ns)
 {
   open_section_in_ns(name, NULL, NULL);
 }
 
-void TableFormatter::open_array_section(const char *name)
+void TableFormatter::open_array_section(std::string_view name)
 {
   open_section_in_ns(name, NULL, NULL);
 }
 
-void TableFormatter::open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs)
+void TableFormatter::open_array_section_with_attrs(std::string_view name, const FormatterAttrs& attrs)
 {
   open_section_in_ns(name, NULL, NULL);
 }
 
-void TableFormatter::open_array_section_in_ns(const char *name, const char *ns)
+void TableFormatter::open_array_section_in_ns(std::string_view name, const char *ns)
 {
   open_section_in_ns(name, NULL, NULL);
 }
 
-void TableFormatter::open_section_in_ns(const char *name, const char *ns, const FormatterAttrs *attrs)
+void TableFormatter::open_section_in_ns(std::string_view name, const char *ns, const FormatterAttrs *attrs)
 {
-  m_section.push_back(name);
+  m_section.push_back(std::string(name));
   m_section_open++;
 }
 
@@ -792,7 +792,7 @@ void TableFormatter::close_section()
   }
 }
 
-size_t TableFormatter::m_vec_index(const char *name)
+size_t TableFormatter::m_vec_index(std::string_view name)
 {
   std::string key(name);
 
@@ -817,9 +817,9 @@ size_t TableFormatter::m_vec_index(const char *name)
   return i;
 }
 
-std::string TableFormatter::get_section_name(const char* name)
+std::string TableFormatter::get_section_name(std::string_view name)
 {
-  std::string t_name = name;
+  std::string t_name{name};
   for (size_t i = 0; i < m_section.size(); i++) {
     t_name.insert(0, ":");
     t_name.insert(0, m_section[i]);
@@ -837,7 +837,7 @@ std::string TableFormatter::get_section_name(const char* name)
 }
 
 template <class T>
-void TableFormatter::add_value(const char *name, T val) {
+void TableFormatter::add_value(std::string_view name, T val) {
   finish_pending_string();
   size_t i = m_vec_index(name);
   m_ss.precision(std::numeric_limits<double>::max_digits10);
@@ -848,22 +848,22 @@ void TableFormatter::add_value(const char *name, T val) {
   m_ss.str("");
 }
 
-void TableFormatter::dump_unsigned(const char *name, uint64_t u)
+void TableFormatter::dump_unsigned(std::string_view name, uint64_t u)
 {
   add_value(name, u);
 }
 
-void TableFormatter::dump_int(const char *name, int64_t s)
+void TableFormatter::dump_int(std::string_view name, int64_t s)
 {
   add_value(name, s);
 }
 
-void TableFormatter::dump_float(const char *name, double d)
+void TableFormatter::dump_float(std::string_view name, double d)
 {
   add_value(name, d);
 }
 
-void TableFormatter::dump_string(const char *name, std::string_view s)
+void TableFormatter::dump_string(std::string_view name, std::string_view s)
 {
   finish_pending_string();
   size_t i = m_vec_index(name);
@@ -874,7 +874,7 @@ void TableFormatter::dump_string(const char *name, std::string_view s)
   m_ss.str("");
 }
 
-void TableFormatter::dump_string_with_attrs(const char *name, std::string_view s, const FormatterAttrs& attrs)
+void TableFormatter::dump_string_with_attrs(std::string_view name, std::string_view s, const FormatterAttrs& attrs)
 {
   finish_pending_string();
   size_t i = m_vec_index(name);
@@ -888,7 +888,9 @@ void TableFormatter::dump_string_with_attrs(const char *name, std::string_view s
   m_ss.str("");
 }
 
-void TableFormatter::dump_format_va(const char* name, const char *ns, bool quoted, const char *fmt, va_list ap)
+void TableFormatter::dump_format_va(std::string_view name,
+				    const char *ns, bool quoted,
+				    const char *fmt, va_list ap)
 {
   finish_pending_string();
   char buf[LARGE_SIZE];
@@ -905,7 +907,7 @@ void TableFormatter::dump_format_va(const char* name, const char *ns, bool quote
   m_ss.str("");
 }
 
-std::ostream& TableFormatter::dump_stream(const char *name)
+std::ostream& TableFormatter::dump_stream(std::string_view name)
 {
   finish_pending_string();
   // we don't support this

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -27,10 +27,10 @@ namespace ceph {
       Formatter& formatter;
 
     public:
-      ObjectSection(Formatter& f, const char *name) : formatter(f) {
+      ObjectSection(Formatter& f, std::string_view name) : formatter(f) {
         formatter.open_object_section(name);
       }
-      ObjectSection(Formatter& f, const char *name, const char *ns) : formatter(f) {
+      ObjectSection(Formatter& f, std::string_view name, const char *ns) : formatter(f) {
         formatter.open_object_section_in_ns(name, ns);
       }
       ~ObjectSection() {
@@ -41,10 +41,10 @@ namespace ceph {
       Formatter& formatter;
 
     public:
-      ArraySection(Formatter& f, const char *name) : formatter(f) {
+      ArraySection(Formatter& f, std::string_view name) : formatter(f) {
         formatter.open_array_section(name);
       }
-      ArraySection(Formatter& f, const char *name, const char *ns) : formatter(f) {
+      ArraySection(Formatter& f, std::string_view name, const char *ns) : formatter(f) {
         formatter.open_array_section_in_ns(name, ns);
       }
       ~ArraySection() {
@@ -75,42 +75,42 @@ namespace ceph {
     virtual void output_header() = 0;
     virtual void output_footer() = 0;
 
-    virtual void open_array_section(const char *name) = 0;
-    virtual void open_array_section_in_ns(const char *name, const char *ns) = 0;
-    virtual void open_object_section(const char *name) = 0;
-    virtual void open_object_section_in_ns(const char *name, const char *ns) = 0;
+    virtual void open_array_section(std::string_view name) = 0;
+    virtual void open_array_section_in_ns(std::string_view name, const char *ns) = 0;
+    virtual void open_object_section(std::string_view name) = 0;
+    virtual void open_object_section_in_ns(std::string_view name, const char *ns) = 0;
     virtual void close_section() = 0;
-    virtual void dump_unsigned(const char *name, uint64_t u) = 0;
-    virtual void dump_int(const char *name, int64_t s) = 0;
-    virtual void dump_float(const char *name, double d) = 0;
-    virtual void dump_string(const char *name, std::string_view s) = 0;
-    virtual void dump_bool(const char *name, bool b)
+    virtual void dump_unsigned(std::string_view name, uint64_t u) = 0;
+    virtual void dump_int(std::string_view name, int64_t s) = 0;
+    virtual void dump_float(std::string_view name, double d) = 0;
+    virtual void dump_string(std::string_view name, std::string_view s) = 0;
+    virtual void dump_bool(std::string_view name, bool b)
     {
       dump_format_unquoted(name, "%s", (b ? "true" : "false"));
     }
     template<typename T>
-    void dump_object(const char *name, const T& foo) {
+    void dump_object(std::string_view name, const T& foo) {
       open_object_section(name);
       foo.dump(this);
       close_section();
     }
-    virtual std::ostream& dump_stream(const char *name) = 0;
-    virtual void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap) = 0;
-    virtual void dump_format(const char *name, const char *fmt, ...);
-    virtual void dump_format_ns(const char *name, const char *ns, const char *fmt, ...);
-    virtual void dump_format_unquoted(const char *name, const char *fmt, ...);
+    virtual std::ostream& dump_stream(std::string_view name) = 0;
+    virtual void dump_format_va(std::string_view name, const char *ns, bool quoted, const char *fmt, va_list ap) = 0;
+    virtual void dump_format(std::string_view name, const char *fmt, ...);
+    virtual void dump_format_ns(std::string_view name, const char *ns, const char *fmt, ...);
+    virtual void dump_format_unquoted(std::string_view name, const char *fmt, ...);
     virtual int get_len() const = 0;
     virtual void write_raw_data(const char *data) = 0;
     /* with attrs */
-    virtual void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs)
+    virtual void open_array_section_with_attrs(std::string_view name, const FormatterAttrs& attrs)
     {
       open_array_section(name);
     }
-    virtual void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs)
+    virtual void open_object_section_with_attrs(std::string_view name, const FormatterAttrs& attrs)
     {
       open_object_section(name);
     }
-    virtual void dump_string_with_attrs(const char *name, std::string_view s, const FormatterAttrs& attrs)
+    virtual void dump_string_with_attrs(std::string_view name, std::string_view s, const FormatterAttrs& attrs)
     {
       dump_string(name, s);
     }
@@ -143,26 +143,26 @@ namespace ceph {
     void flush(std::ostream& os) override;
     using Formatter::flush; // don't hide Formatter::flush(bufferlist &bl)
     void reset() override;
-    void open_array_section(const char *name) override;
-    void open_array_section_in_ns(const char *name, const char *ns) override;
-    void open_object_section(const char *name) override;
-    void open_object_section_in_ns(const char *name, const char *ns) override;
+    void open_array_section(std::string_view name) override;
+    void open_array_section_in_ns(std::string_view name, const char *ns) override;
+    void open_object_section(std::string_view name) override;
+    void open_object_section_in_ns(std::string_view name, const char *ns) override;
     void close_section() override;
-    void dump_unsigned(const char *name, uint64_t u) override;
-    void dump_int(const char *name, int64_t s) override;
-    void dump_float(const char *name, double d) override;
-    void dump_string(const char *name, std::string_view s) override;
-    std::ostream& dump_stream(const char *name) override;
-    void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap) override;
+    void dump_unsigned(std::string_view name, uint64_t u) override;
+    void dump_int(std::string_view name, int64_t s) override;
+    void dump_float(std::string_view name, double d) override;
+    void dump_string(std::string_view name, std::string_view s) override;
+    std::ostream& dump_stream(std::string_view name) override;
+    void dump_format_va(std::string_view name, const char *ns, bool quoted, const char *fmt, va_list ap) override;
     int get_len() const override;
     void write_raw_data(const char *data) override;
 
   protected:
-    virtual bool handle_value(const char *name, std::string_view s, bool quoted) {
+    virtual bool handle_value(std::string_view name, std::string_view s, bool quoted) {
       return false; /* is handling done? */
     }
 
-    virtual bool handle_open_section(const char *name, const char *ns, bool is_array) {
+    virtual bool handle_open_section(std::string_view name, const char *ns, bool is_array) {
       return false; /* is handling done? */
     }
 
@@ -179,15 +179,15 @@ namespace ceph {
     };
 
     bool m_pretty;
-    void open_section(const char *name, const char *ns, bool is_array);
+    void open_section(std::string_view name, const char *ns, bool is_array);
     void print_quoted_string(std::string_view s);
-    void print_name(const char *name);
+    void print_name(std::string_view name);
     void print_comma(json_formatter_stack_entry_d& entry);
     void finish_pending_string();
 
     template <class T>
-    void add_value(const char *name, T val);
-    void add_value(const char *name, std::string_view val, bool quoted);
+    void add_value(std::string_view name, T val);
+    void add_value(std::string_view name, std::string_view val, bool quoted);
 
     copyable_sstream m_ss;
     copyable_sstream m_pending_string;
@@ -198,7 +198,7 @@ namespace ceph {
   };
 
   template <class T>
-  void add_value(const char *name, T val);
+  void add_value(std::string_view name, T val);
 
   class XMLFormatter : public Formatter {
   public:
@@ -213,27 +213,27 @@ namespace ceph {
     void flush(std::ostream& os) override;
     using Formatter::flush; // don't hide Formatter::flush(bufferlist &bl)
     void reset() override;
-    void open_array_section(const char *name) override;
-    void open_array_section_in_ns(const char *name, const char *ns) override;
-    void open_object_section(const char *name) override;
-    void open_object_section_in_ns(const char *name, const char *ns) override;
+    void open_array_section(std::string_view name) override;
+    void open_array_section_in_ns(std::string_view name, const char *ns) override;
+    void open_object_section(std::string_view name) override;
+    void open_object_section_in_ns(std::string_view name, const char *ns) override;
     void close_section() override;
-    void dump_unsigned(const char *name, uint64_t u) override;
-    void dump_int(const char *name, int64_t s) override;
-    void dump_float(const char *name, double d) override;
-    void dump_string(const char *name, std::string_view s) override;
-    std::ostream& dump_stream(const char *name) override;
-    void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap) override;
+    void dump_unsigned(std::string_view name, uint64_t u) override;
+    void dump_int(std::string_view name, int64_t s) override;
+    void dump_float(std::string_view name, double d) override;
+    void dump_string(std::string_view name, std::string_view s) override;
+    std::ostream& dump_stream(std::string_view name) override;
+    void dump_format_va(std::string_view name, const char *ns, bool quoted, const char *fmt, va_list ap) override;
     int get_len() const override;
     void write_raw_data(const char *data) override;
 
     /* with attrs */
-    void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs) override;
-    void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs) override;
-    void dump_string_with_attrs(const char *name, std::string_view s, const FormatterAttrs& attrs) override;
+    void open_array_section_with_attrs(std::string_view name, const FormatterAttrs& attrs) override;
+    void open_object_section_with_attrs(std::string_view name, const FormatterAttrs& attrs) override;
+    void dump_string_with_attrs(std::string_view name, std::string_view s, const FormatterAttrs& attrs) override;
 
   protected:
-    void open_section_in_ns(const char *name, const char *ns, const FormatterAttrs *attrs);
+    void open_section_in_ns(std::string_view name, const char *ns, const FormatterAttrs *attrs);
     void finish_pending_string();
     void print_spaces();
     void get_attrs_str(const FormatterAttrs *attrs, std::string& attrs_str);
@@ -249,7 +249,7 @@ namespace ceph {
     bool m_line_break_enabled = false;
   private:
     template <class T>
-    void add_value(const char *name, T val);
+    void add_value(std::string_view name, T val);
   };
 
   class TableFormatter : public Formatter {
@@ -263,22 +263,22 @@ namespace ceph {
     void flush(std::ostream& os) override;
     using Formatter::flush; // don't hide Formatter::flush(bufferlist &bl)
     void reset() override;
-    void open_array_section(const char *name) override;
-    void open_array_section_in_ns(const char *name, const char *ns) override;
-    void open_object_section(const char *name) override;
-    void open_object_section_in_ns(const char *name, const char *ns) override;
+    void open_array_section(std::string_view name) override;
+    void open_array_section_in_ns(std::string_view name, const char *ns) override;
+    void open_object_section(std::string_view name) override;
+    void open_object_section_in_ns(std::string_view name, const char *ns) override;
 
-    void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs) override;
-    void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs) override;
+    void open_array_section_with_attrs(std::string_view name, const FormatterAttrs& attrs) override;
+    void open_object_section_with_attrs(std::string_view name, const FormatterAttrs& attrs) override;
 
     void close_section() override;
-    void dump_unsigned(const char *name, uint64_t u) override;
-    void dump_int(const char *name, int64_t s) override;
-    void dump_float(const char *name, double d) override;
-    void dump_string(const char *name, std::string_view s) override;
-    void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap) override;
-    void dump_string_with_attrs(const char *name, std::string_view s, const FormatterAttrs& attrs) override;
-    std::ostream& dump_stream(const char *name) override;
+    void dump_unsigned(std::string_view name, uint64_t u) override;
+    void dump_int(std::string_view name, int64_t s) override;
+    void dump_float(std::string_view name, double d) override;
+    void dump_string(std::string_view name, std::string_view s) override;
+    void dump_format_va(std::string_view name, const char *ns, bool quoted, const char *fmt, va_list ap) override;
+    void dump_string_with_attrs(std::string_view name, std::string_view s, const FormatterAttrs& attrs) override;
+    std::ostream& dump_stream(std::string_view name) override;
 
     int get_len() const override;
     void write_raw_data(const char *data) override;
@@ -286,12 +286,12 @@ namespace ceph {
 
   private:
     template <class T>
-    void add_value(const char *name, T val);
-    void open_section_in_ns(const char *name, const char *ns, const FormatterAttrs *attrs);
+    void add_value(std::string_view name, T val);
+    void open_section_in_ns(std::string_view name, const char *ns, const FormatterAttrs *attrs);
     std::vector< std::vector<std::pair<std::string, std::string> > > m_vec;
     std::stringstream m_ss;
-    size_t m_vec_index(const char* name);
-    std::string get_section_name(const char* name);
+    size_t m_vec_index(std::string_view name);
+    std::string get_section_name(std::string_view name);
     void finish_pending_string();
     std::string m_pending_name;
     bool m_keyval;

--- a/src/common/HTMLFormatter.cc
+++ b/src/common/HTMLFormatter.cc
@@ -89,7 +89,7 @@ void HTMLFormatter::output_header() {
 }
 
 template <typename T>
-void HTMLFormatter::dump_template(const char *name, T arg)
+void HTMLFormatter::dump_template(std::string_view name, T arg)
 {
   print_spaces();
   m_ss << "<li>" << name << ": " << arg << "</li>";
@@ -97,27 +97,27 @@ void HTMLFormatter::dump_template(const char *name, T arg)
     m_ss << "\n";
 }
 
-void HTMLFormatter::dump_unsigned(const char *name, uint64_t u)
+void HTMLFormatter::dump_unsigned(std::string_view name, uint64_t u)
 {
   dump_template(name, u);
 }
 
-void HTMLFormatter::dump_int(const char *name, int64_t u)
+void HTMLFormatter::dump_int(std::string_view name, int64_t u)
 {
   dump_template(name, u);
 }
 
-void HTMLFormatter::dump_float(const char *name, double d)
+void HTMLFormatter::dump_float(std::string_view name, double d)
 {
   dump_template(name, d);
 }
 
-void HTMLFormatter::dump_string(const char *name, std::string_view s)
+void HTMLFormatter::dump_string(std::string_view name, std::string_view s)
 {
   dump_template(name, xml_stream_escaper(s));
 }
 
-void HTMLFormatter::dump_string_with_attrs(const char *name, std::string_view s, const FormatterAttrs& attrs)
+void HTMLFormatter::dump_string_with_attrs(std::string_view name, std::string_view s, const FormatterAttrs& attrs)
 {
   std::string e(name);
   std::string attrs_str;
@@ -128,7 +128,7 @@ void HTMLFormatter::dump_string_with_attrs(const char *name, std::string_view s,
     m_ss << "\n";
 }
 
-std::ostream& HTMLFormatter::dump_stream(const char *name)
+std::ostream& HTMLFormatter::dump_stream(std::string_view name)
 {
   print_spaces();
   m_pending_string_name = "li";
@@ -136,7 +136,7 @@ std::ostream& HTMLFormatter::dump_stream(const char *name)
   return m_pending_string;
 }
 
-void HTMLFormatter::dump_format_va(const char* name, const char *ns, bool quoted, const char *fmt, va_list ap)
+void HTMLFormatter::dump_format_va(std::string_view name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
   char buf[LARGE_SIZE];
   size_t len = vsnprintf(buf, LARGE_SIZE, fmt, ap);

--- a/src/common/HTMLFormatter.h
+++ b/src/common/HTMLFormatter.h
@@ -15,17 +15,17 @@ namespace ceph {
     void set_status(int status, const char* status_name) override;
     void output_header() override;
 
-    void dump_unsigned(const char *name, uint64_t u) override;
-    void dump_int(const char *name, int64_t u) override;
-    void dump_float(const char *name, double d) override;
-    void dump_string(const char *name, std::string_view s) override;
-    std::ostream& dump_stream(const char *name) override;
-    void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap) override;
+    void dump_unsigned(std::string_view name, uint64_t u) override;
+    void dump_int(std::string_view name, int64_t u) override;
+    void dump_float(std::string_view name, double d) override;
+    void dump_string(std::string_view name, std::string_view s) override;
+    std::ostream& dump_stream(std::string_view name) override;
+    void dump_format_va(std::string_view name, const char *ns, bool quoted, const char *fmt, va_list ap) override;
 
     /* with attrs */
-    void dump_string_with_attrs(const char *name, std::string_view s, const FormatterAttrs& attrs) override;
+    void dump_string_with_attrs(std::string_view name, std::string_view s, const FormatterAttrs& attrs) override;
   private:
-    template <typename T> void dump_template(const char *name, T arg);
+    template <typename T> void dump_template(std::string_view name, T arg);
 
     int m_status;
     const char* m_status_name;

--- a/src/common/ceph_json.cc
+++ b/src/common/ceph_json.cc
@@ -887,21 +887,24 @@ void JSONFormattable::encode_json(const char *name, Formatter *f) const
   }
 }
 
-bool JSONFormattable::handle_value(const char *name, std::string_view s, bool quoted) {
+bool JSONFormattable::handle_value(std::string_view name, std::string_view s, bool quoted) {
   JSONFormattable *new_val;
   if (cur_enc->is_array()) {
     cur_enc->arr.push_back(JSONFormattable());
     new_val = &cur_enc->arr.back();
   } else {
     cur_enc->set_type(JSONFormattable::FMT_OBJ);
-    new_val  = &cur_enc->obj[name];
+    new_val  = &cur_enc->obj[string{name}];
   }
   new_val->set_type(JSONFormattable::FMT_VALUE);
   new_val->value.set(s, quoted);
 
   return false;
 }
-bool JSONFormattable::handle_open_section(const char *name, const char *ns, bool section_is_array) {
+
+bool JSONFormattable::handle_open_section(std::string_view name,
+                                          const char *ns,
+                                          bool section_is_array) {
   if (cur_enc->is_array()) {
     cur_enc->arr.push_back(JSONFormattable());
     cur_enc = &cur_enc->arr.back();
@@ -909,7 +912,7 @@ bool JSONFormattable::handle_open_section(const char *name, const char *ns, bool
       /* only open a new section if already nested,
        * otherwise root is the container
        */
-      cur_enc = &cur_enc->obj[name];
+    cur_enc = &cur_enc->obj[string{name}];
   }
   enc_stack.push_back(cur_enc);
 

--- a/src/common/ceph_json.h
+++ b/src/common/ceph_json.h
@@ -643,8 +643,8 @@ class JSONFormattable : public ceph::JSONFormatter {
   JSONFormattable *cur_enc;
 
 protected:
-  bool handle_value(const char *name, std::string_view s, bool quoted) override;
-  bool handle_open_section(const char *name, const char *ns, bool section_is_array) override;
+  bool handle_value(std::string_view name, std::string_view s, bool quoted) override;
+  bool handle_open_section(std::string_view name, const char *ns, bool section_is_array) override;
   bool handle_close_section() override;
 
 public:

--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -47,8 +47,7 @@ std::string cmddesc_get_prefix(const std::string_view &cmddesc)
 using arg_desc_t = std::map<std::string_view, std::string_view>;
 
 // Snarf up all the key=val,key=val pairs, put 'em in a dict.
-template<class String>
-arg_desc_t cmddesc_get_args(const String& cmddesc)
+arg_desc_t cmddesc_get_args(const string_view cmddesc)
 {
   arg_desc_t arg_desc;
   for_each_substr(cmddesc, ",", [&](auto kv) {

--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -139,7 +139,7 @@ dump_cmd_to_json(Formatter *f, uint64_t features, const string& cmd)
     // accumulate descriptor keywords in desckv
     auto desckv = cmddesc_get_args(word);
     // name the individual desc object based on the name key
-    f->open_object_section(string(desckv["name"]).c_str());
+    f->open_object_section(desckv["name"]);
 
     // Compatibility for pre-nautilus clients that don't know about CephBool
     std::string val;
@@ -160,7 +160,7 @@ dump_cmd_to_json(Formatter *f, uint64_t features, const string& cmd)
 
     // dump all the keys including name into the array
     for (auto [key, value] : desckv) {
-      f->dump_string(string(key).c_str(), string(value));
+      f->dump_string(key, value);
     }
     f->close_section(); // attribute object for individual desc
   }
@@ -173,11 +173,11 @@ dump_cmd_and_help_to_json(Formatter *jf,
 			  const string& cmdsig,
 			  const string& helptext)
 {
-      jf->open_object_section(secname.c_str());
+      jf->open_object_section(secname);
       jf->open_array_section("sig");
       dump_cmd_to_json(jf, features, cmdsig);
       jf->close_section(); // sig array
-      jf->dump_string("help", helptext.c_str());
+      jf->dump_string("help", helptext);
       jf->close_section(); // cmd
 }
 
@@ -191,13 +191,13 @@ dump_cmddesc_to_json(Formatter *jf,
 		     const string& perm,
 		     uint64_t flags)
 {
-      jf->open_object_section(secname.c_str());
+      jf->open_object_section(secname);
       jf->open_array_section("sig");
       dump_cmd_to_json(jf, features, cmdsig);
       jf->close_section(); // sig array
-      jf->dump_string("help", helptext.c_str());
-      jf->dump_string("module", module.c_str());
-      jf->dump_string("perm", perm.c_str());
+      jf->dump_string("help", helptext);
+      jf->dump_string("module", module);
+      jf->dump_string("perm", perm);
       jf->dump_int("flags", flags);
       jf->close_section(); // cmd
 }
@@ -218,28 +218,28 @@ void cmdmap_dump(const cmdmap_t &cmdmap, Formatter *f)
 
     void operator()(const std::string &operand) const
     {
-      f->dump_string(key.c_str(), operand);
+      f->dump_string(key, operand);
     }
 
     void operator()(const bool &operand) const
     {
-      f->dump_bool(key.c_str(), operand);
+      f->dump_bool(key, operand);
     }
 
     void operator()(const int64_t &operand) const
     {
-      f->dump_int(key.c_str(), operand);
+      f->dump_int(key, operand);
     }
 
     void operator()(const double &operand) const
     {
-      f->dump_float(key.c_str(), operand);
+      f->dump_float(key, operand);
     }
 
     void operator()(const std::vector<std::string> &operand) const
     {
-      f->open_array_section(key.c_str());
-      for (const auto i : operand) {
+      f->open_array_section(key);
+      for (const auto& i : operand) {
         f->dump_string("item", i);
       }
       f->close_section();
@@ -247,7 +247,7 @@ void cmdmap_dump(const cmdmap_t &cmdmap, Formatter *f)
 
     void operator()(const std::vector<int64_t> &operand) const
     {
-      f->open_array_section(key.c_str());
+      f->open_array_section(key);
       for (const auto i : operand) {
         f->dump_int("item", i);
       }
@@ -256,7 +256,7 @@ void cmdmap_dump(const cmdmap_t &cmdmap, Formatter *f)
 
     void operator()(const std::vector<double> &operand) const
     {
-      f->open_array_section(key.c_str());
+      f->open_array_section(key);
       for (const auto i : operand) {
         f->dump_float("item", i);
       }

--- a/src/mgr/PyFormatter.cc
+++ b/src/mgr/PyFormatter.cc
@@ -20,7 +20,7 @@
 #define LARGE_SIZE 1024
 
 
-void PyFormatter::open_array_section(const char *name)
+void PyFormatter::open_array_section(std::string_view name)
 {
   PyObject *list = PyList_New(0);
   dump_pyobject(name, list);
@@ -28,7 +28,7 @@ void PyFormatter::open_array_section(const char *name)
   cursor = list;
 }
 
-void PyFormatter::open_object_section(const char *name)
+void PyFormatter::open_object_section(std::string_view name)
 {
   PyObject *dict = PyDict_New();
   dump_pyobject(name, dict);
@@ -36,31 +36,31 @@ void PyFormatter::open_object_section(const char *name)
   cursor = dict;
 }
 
-void PyFormatter::dump_unsigned(const char *name, uint64_t u)
+void PyFormatter::dump_unsigned(std::string_view name, uint64_t u)
 {
   PyObject *p = PyLong_FromUnsignedLong(u);
   ceph_assert(p);
   dump_pyobject(name, p);
 }
 
-void PyFormatter::dump_int(const char *name, int64_t u)
+void PyFormatter::dump_int(std::string_view name, int64_t u)
 {
   PyObject *p = PyLong_FromLongLong(u);
   ceph_assert(p);
   dump_pyobject(name, p);
 }
 
-void PyFormatter::dump_float(const char *name, double d)
+void PyFormatter::dump_float(std::string_view name, double d)
 {
   dump_pyobject(name, PyFloat_FromDouble(d));
 }
 
-void PyFormatter::dump_string(const char *name, std::string_view s)
+void PyFormatter::dump_string(std::string_view name, std::string_view s)
 {
   dump_pyobject(name, PyUnicode_FromString(s.data()));
 }
 
-void PyFormatter::dump_bool(const char *name, bool b)
+void PyFormatter::dump_bool(std::string_view name, bool b)
 {
   if (b) {
     Py_INCREF(Py_True);
@@ -71,7 +71,7 @@ void PyFormatter::dump_bool(const char *name, bool b)
   }
 }
 
-std::ostream& PyFormatter::dump_stream(const char *name)
+std::ostream& PyFormatter::dump_stream(std::string_view name)
 {
   // Give the caller an ostream, construct a PyString,
   // and remember the association between the two.  On flush,
@@ -85,7 +85,7 @@ std::ostream& PyFormatter::dump_stream(const char *name)
   return ps->stream;
 }
 
-void PyFormatter::dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap)
+void PyFormatter::dump_format_va(std::string_view name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
   char buf[LARGE_SIZE];
   vsnprintf(buf, LARGE_SIZE, fmt, ap);
@@ -96,13 +96,13 @@ void PyFormatter::dump_format_va(const char *name, const char *ns, bool quoted, 
 /**
  * Steals reference to `p`
  */
-void PyFormatter::dump_pyobject(const char *name, PyObject *p)
+void PyFormatter::dump_pyobject(std::string_view name, PyObject *p)
 {
   if (PyList_Check(cursor)) {
     PyList_Append(cursor, p);
     Py_DECREF(p);
   } else if (PyDict_Check(cursor)) {
-    PyObject *key = PyUnicode_FromString(name);
+    PyObject *key = PyUnicode_DecodeUTF8(name.data(), name.size(), nullptr);
     PyDict_SetItem(cursor, key, p);
     Py_DECREF(key);
     Py_DECREF(p);

--- a/src/mgr/PyFormatter.h
+++ b/src/mgr/PyFormatter.h
@@ -56,9 +56,9 @@ public:
   }
 
   // Obscure, don't care.
-  void open_array_section_in_ns(const char *name, const char *ns) override
+  void open_array_section_in_ns(std::string_view name, const char *ns) override
   {ceph_abort();}
-  void open_object_section_in_ns(const char *name, const char *ns) override
+  void open_object_section_in_ns(std::string_view name, const char *ns) override
   {ceph_abort();}
 
   void reset() override
@@ -77,8 +77,8 @@ public:
   void output_footer() override {};
   void enable_line_break() override {};
 
-  void open_array_section(const char *name) override;
-  void open_object_section(const char *name) override;
+  void open_array_section(std::string_view name) override;
+  void open_object_section(std::string_view name) override;
   void close_section() override
   {
     ceph_assert(cursor != root);
@@ -86,13 +86,13 @@ public:
     cursor = stack.top();
     stack.pop();
   }
-  void dump_bool(const char *name, bool b) override;
-  void dump_unsigned(const char *name, uint64_t u) override;
-  void dump_int(const char *name, int64_t u) override;
-  void dump_float(const char *name, double d) override;
-  void dump_string(const char *name, std::string_view s) override;
-  std::ostream& dump_stream(const char *name) override;
-  void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap) override;
+  void dump_bool(std::string_view name, bool b) override;
+  void dump_unsigned(std::string_view name, uint64_t u) override;
+  void dump_int(std::string_view name, int64_t u) override;
+  void dump_float(std::string_view name, double d) override;
+  void dump_string(std::string_view name, std::string_view s) override;
+  std::ostream& dump_stream(std::string_view name) override;
+  void dump_format_va(std::string_view name, const char *ns, bool quoted, const char *fmt, va_list ap) override;
 
   void flush(std::ostream& os) override
   {
@@ -128,7 +128,7 @@ private:
   PyObject *cursor;
   std::stack<PyObject *> stack;
 
-  void dump_pyobject(const char *name, PyObject *p);
+  void dump_pyobject(std::string_view name, PyObject *p);
 
   class PendingStream {
     public:

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1198,7 +1198,7 @@ void OSDMap::Incremental::dump(Formatter *f) const
   OSDMap::dump_erasure_code_profiles(new_erasure_code_profiles, f);
   f->open_array_section("old_erasure_code_profiles");
   for (const auto &erasure_code_profile : old_erasure_code_profiles) {
-    f->dump_string("old", erasure_code_profile.c_str());
+    f->dump_string("old", erasure_code_profile);
   }
   f->close_section();
 
@@ -3390,7 +3390,7 @@ void OSDMap::dump_erasure_code_profiles(
   for (const auto &profile : profiles) {
     f->open_object_section(profile.first.c_str());
     for (const auto &profm : profile.second) {
-      f->dump_string(profm.first.c_str(), profm.second.c_str());
+      f->dump_string(profm.first.c_str(), profm.second);
     }
     f->close_section();
   }

--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -63,7 +63,7 @@ void RGWFormatter_Plain::reset()
   min_stack_level = 0;
 }
 
-void RGWFormatter_Plain::open_array_section(const char *name)
+void RGWFormatter_Plain::open_array_section(std::string_view name)
 {
   struct plain_stack_entry new_entry;
   new_entry.is_array = true;
@@ -79,14 +79,14 @@ void RGWFormatter_Plain::open_array_section(const char *name)
   stack.push_back(new_entry);
 }
 
-void RGWFormatter_Plain::open_array_section_in_ns(const char *name, const char *ns)
+void RGWFormatter_Plain::open_array_section_in_ns(std::string_view name, const char *ns)
 {
   ostringstream oss;
   oss << name << " " << ns;
   open_array_section(oss.str().c_str());
 }
 
-void RGWFormatter_Plain::open_object_section(const char *name)
+void RGWFormatter_Plain::open_object_section(std::string_view name)
 {
   struct plain_stack_entry new_entry;
   new_entry.is_array = false;
@@ -98,7 +98,7 @@ void RGWFormatter_Plain::open_object_section(const char *name)
   stack.push_back(new_entry);
 }
 
-void RGWFormatter_Plain::open_object_section_in_ns(const char *name,
+void RGWFormatter_Plain::open_object_section_in_ns(std::string_view name,
 						   const char *ns)
 {
   ostringstream oss;
@@ -111,33 +111,33 @@ void RGWFormatter_Plain::close_section()
   stack.pop_back();
 }
 
-void RGWFormatter_Plain::dump_unsigned(const char *name, uint64_t u)
+void RGWFormatter_Plain::dump_unsigned(std::string_view name, uint64_t u)
 {
   dump_value_int(name, "%" PRIu64, u);
 }
 
-void RGWFormatter_Plain::dump_int(const char *name, int64_t u)
+void RGWFormatter_Plain::dump_int(std::string_view name, int64_t u)
 {
   dump_value_int(name, "%" PRId64, u);
 }
 
-void RGWFormatter_Plain::dump_float(const char *name, double d)
+void RGWFormatter_Plain::dump_float(std::string_view name, double d)
 {
   dump_value_int(name, "%f", d);
 }
 
-void RGWFormatter_Plain::dump_string(const char *name, std::string_view s)
+void RGWFormatter_Plain::dump_string(std::string_view name, std::string_view s)
 {
   dump_format(name, "%s", s.data());
 }
 
-std::ostream& RGWFormatter_Plain::dump_stream(const char *name)
+std::ostream& RGWFormatter_Plain::dump_stream(std::string_view name)
 {
   // TODO: implement this!
   ceph_abort();
 }
 
-void RGWFormatter_Plain::dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap)
+void RGWFormatter_Plain::dump_format_va(std::string_view name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
   char buf[LARGE_SIZE];
 
@@ -248,7 +248,7 @@ done_free:
     free(p);
 }
 
-void RGWFormatter_Plain::dump_value_int(const char *name, const char *fmt, ...)
+void RGWFormatter_Plain::dump_value_int(std::string_view name, const char *fmt, ...)
 {
   char buf[LARGE_SIZE];
   va_list ap;

--- a/src/rgw/rgw_formats.h
+++ b/src/rgw/rgw_formats.h
@@ -33,23 +33,23 @@ public:
   void flush(ostream& os) override;
   void reset() override;
 
-  void open_array_section(const char *name) override;
-  void open_array_section_in_ns(const char *name, const char *ns) override;
-  void open_object_section(const char *name) override;
-  void open_object_section_in_ns(const char *name, const char *ns) override;
+  void open_array_section(std::string_view name) override;
+  void open_array_section_in_ns(std::string_view name, const char *ns) override;
+  void open_object_section(std::string_view name) override;
+  void open_object_section_in_ns(std::string_view name, const char *ns) override;
   void close_section() override;
-  void dump_unsigned(const char *name, uint64_t u) override;
-  void dump_int(const char *name, int64_t u) override;
-  void dump_float(const char *name, double d) override;
-  void dump_string(const char *name, std::string_view s) override;
-  std::ostream& dump_stream(const char *name) override;
-  void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap) override;
+  void dump_unsigned(std::string_view name, uint64_t u) override;
+  void dump_int(std::string_view name, int64_t u) override;
+  void dump_float(std::string_view name, double d) override;
+  void dump_string(std::string_view name, std::string_view s) override;
+  std::ostream& dump_stream(std::string_view name) override;
+  void dump_format_va(std::string_view name, const char *ns, bool quoted, const char *fmt, va_list ap) override;
   int get_len() const override;
   void write_raw_data(const char *data) override;
 
 private:
   void write_data(const char *fmt, ...);
-  void dump_value_int(const char *name, const char *fmt, ...);
+  void dump_value_int(std::string_view name, const char *fmt, ...);
 
   char *buf = nullptr;
   int len = 0;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
