### PR TITLE
nautilus: mgr/telemetry: split entity_name only once (handle ids with dots)

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -334,7 +334,8 @@ class Module(MgrModule):
                 continue
             c = json.loads(crashinfo)
             del c['utsname_hostname']
-            (etype, eid) = c.get('entity_name', '').split('.')
+            # entity_name might have more than one '.', beware
+            (etype, eid) = c.get('entity_name', '').split('.', 1)
             m = hashlib.sha1()
             m.update(self.salt.encode('utf-8'))
             m.update(eid.encode('utf-8'))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44057

---

backport of https://github.com/ceph/ceph/pull/33094
parent tracker: https://tracker.ceph.com/issues/43313

this backport was staged using ceph-backport.sh version 15.0.0.6950
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh