### PR TITLE
client: fix blacklist removal failed

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2500,7 +2500,9 @@ void Client::handle_osd_map(const MConstRef<MOSDMap>& m)
     // some PGs were inaccessible.
     objecter->op_cancel_writes(-EBLACKLISTED);
 
-  } else if (blacklisted) {
+  } 
+
+  if (blacklisted) {
     // Handle case where we were blacklisted but no longer are
     blacklisted = objecter->with_osdmap([myaddrs](const OSDMap &o){
         return o.is_blacklisted(myaddrs);});


### PR DESCRIPTION
when network is up until over mon_osd_blacklist_default_expire,
the ceph-fuse will receive two epoch OSDMap，one include blacklist，
the other one is blacklist recovery,but blacklist_events include recovered blacklist,
then the client is added to the blacklist in error.
the solution is that used the  objecter->with_osdmap to determine whether there is a blacklist,
the objecter->with_osdmap has the correct blacklist.

Fixes:https://tracker.ceph.com/issues/37617
Signed-off-by: gengjichao <chaofuwa2008@126.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
