### PR TITLE
mgr/rook: Fix error creating OSD's

### DIFF
--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -528,7 +528,7 @@ class RookCluster(object):
                    "config": { "storeType": drive_group.objectstore }}
 
             if block_devices:
-                pd["devices"] = [{'name': d} for d in block_devices]
+                pd["devices"] = [{'name': d.path} for d in block_devices]
             if directories:
                 pd["directories"] = [{'path': p} for p in directories]
 
@@ -551,16 +551,16 @@ class RookCluster(object):
                 patch.append({
                     "op": "add",
                     "path": "/spec/storage/nodes/{0}/devices/-".format(node_idx),
-                    "value": {'name': n}  # type: ignore
+                    "value": {'name': n.path}  # type: ignore
                 })
-
-            new_dirs = list(set(directories) - set(current_node['directories']))
-            for p in new_dirs:
-                patch.append({
-                    "op": "add",
-                    "path": "/spec/storage/nodes/{0}/directories/-".format(node_idx),
-                    "value": {'path': p}  # type: ignore
-                })
+            if directories:
+                new_dirs = list(set(directories) - set(current_node['directories']))
+                for p in new_dirs:
+                    patch.append({
+                        "op": "add",
+                        "path": "/spec/storage/nodes/{0}/directories/-".format(node_idx),
+                        "value": {'path': p}  # type: ignore
+                    })
 
         if len(patch) == 0:
             return "No change"


### PR DESCRIPTION
Changes in orchestrator layer make this not work.

The name of the device was initially only one string, and this has been replaced by a "device" object, besides that, the new object hasn't got the attribute name. So no other solution in this moment,  that to use the device.path property to replace the old "name" string property.
 
In Rook, in order to create an OSD , the name of the device must be provided. This name is the one that appears in the command:
`lsblk --all --noheadings --list --output KNAME`

So the right command to create an OSD using the rook orchestrator must be:
`ceph orchestrator osd create hostname:vdb`
instead of:
`ceph orchestrator osd create hostname:/dev/vdb`
(which is what is stated in the documentation).
See [orchestrator cli doc ( create OSD)](https://docs.ceph.com/docs/master/mgr/orchestrator_cli/)

In this first review of the OSD management in the Rook Orchestrator I have seen more points of friction, so although this fix allows the user to create again OSD's using the Rook Orchestrator, I expect more changes to be done around the OSD's management in the Rook Orchestrator.

Fixes: https://tracker.ceph.com/issues/43972

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>


## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
