### PR TITLE
pybind: customize compiler before checking cflags

### DIFF
--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -15,14 +15,14 @@ import distutils.sysconfig
 
 def filter_unsupported_flags(compiler, flags):
     if 'clang' in compiler:
-        return filterfalse(lambda f:
-                           f in ('-mcet',
-                                 '-fstack-clash-protection',
-                                 '-fno-var-tracking-assignments',
-                                 '-Wno-deprecated-register',
-                                 '-Wno-gnu-designator') or
-                           f.startswith('-fcf-protection'),
-                           flags)
+        return list(filterfalse(lambda f:
+                                f in ('-mcet',
+                                      '-fstack-clash-protection',
+                                      '-fno-var-tracking-assignments',
+                                      '-Wno-deprecated-register',
+                                      '-Wno-gnu-designator') or
+                                f.startswith('-fcf-protection'),
+                                flags))
     else:
         return flags
 

--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -9,12 +9,13 @@ import tempfile
 import textwrap
 from distutils.ccompiler import new_compiler
 from distutils.errors import CompileError, LinkError
-from itertools import filterfalse
+from itertools import filterfalse, takewhile
 import distutils.sysconfig
 
 
 def filter_unsupported_flags(compiler, flags):
-    if 'clang' in compiler:
+    args = takewhile(lambda argv: not argv.startswith('-'), [compiler] + flags)
+    if any('clang' in arg for arg in args):
         return list(filterfalse(lambda f:
                                 f in ('-mcet',
                                       '-fstack-clash-protection',

--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -61,6 +61,7 @@ def get_python_flags(libs):
     py_libs = sum((libs.split() for libs in
                    distutils.sysconfig.get_config_vars('LIBS', 'SYSLIBS')), [])
     compiler = new_compiler()
+    distutils.sysconfig.customize_compiler(compiler)
     return dict(
         include_dirs=[distutils.sysconfig.get_python_inc()],
         library_dirs=distutils.sysconfig.get_config_vars('LIBDIR', 'LIBPL'),

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -64,6 +64,7 @@ def get_python_flags(libs):
     py_libs = sum((libs.split() for libs in
                    distutils.sysconfig.get_config_vars('LIBS', 'SYSLIBS')), [])
     compiler = new_compiler()
+    distutils.sysconfig.customize_compiler(compiler)
     return dict(
         include_dirs=[distutils.sysconfig.get_python_inc()],
         library_dirs=distutils.sysconfig.get_config_vars('LIBDIR', 'LIBPL'),

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -15,14 +15,14 @@ import textwrap
 
 def filter_unsupported_flags(compiler, flags):
     if 'clang' in compiler:
-        return filterfalse(lambda f:
-                           f in ('-mcet',
-                                 '-fstack-clash-protection',
-                                 '-fno-var-tracking-assignments',
-                                 '-Wno-deprecated-register',
-                                 '-Wno-gnu-designator') or
-                           f.startswith('-fcf-protection'),
-                           flags)
+        return list(filterfalse(lambda f:
+                                f in ('-mcet',
+                                      '-fstack-clash-protection',
+                                      '-fno-var-tracking-assignments',
+                                      '-Wno-deprecated-register',
+                                      '-Wno-gnu-designator') or
+                                f.startswith('-fcf-protection'),
+                                flags))
     else:
         return flags
 

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import distutils.sysconfig
 from distutils.errors import CompileError, LinkError
 from distutils.ccompiler import new_compiler
-from itertools import filterfalse
+from itertools import filterfalse, takewhile
 
 import os
 import pkgutil
@@ -14,7 +14,8 @@ import textwrap
 
 
 def filter_unsupported_flags(compiler, flags):
-    if 'clang' in compiler:
+    args = takewhile(lambda argv: not argv.startswith('-'), [compiler] + flags)
+    if any('clang' in arg for arg in args):
         return list(filterfalse(lambda f:
                                 f in ('-mcet',
                                       '-fstack-clash-protection',

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -15,14 +15,14 @@ import distutils.sysconfig
 
 def filter_unsupported_flags(compiler, flags):
     if 'clang' in compiler:
-        return filterfalse(lambda f:
-                           f in ('-mcet',
-                                 '-fstack-clash-protection',
-                                 '-fno-var-tracking-assignments',
-                                 '-Wno-deprecated-register',
-                                 '-Wno-gnu-designator') or
-                           f.startswith('-fcf-protection'),
-                           flags)
+        return list(filterfalse(lambda f:
+                                f in ('-mcet',
+                                      '-fstack-clash-protection',
+                                      '-fno-var-tracking-assignments',
+                                      '-Wno-deprecated-register',
+                                      '-Wno-gnu-designator') or
+                                f.startswith('-fcf-protection'),
+                                flags))
     else:
         return flags
 

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -9,12 +9,13 @@ import tempfile
 import textwrap
 from distutils.ccompiler import new_compiler
 from distutils.errors import CompileError, LinkError
-from itertools import filterfalse
+from itertools import filterfalse, takewhile
 import distutils.sysconfig
 
 
 def filter_unsupported_flags(compiler, flags):
-    if 'clang' in compiler:
+    args = takewhile(lambda argv: not argv.startswith('-'), [compiler] + flags)
+    if any('clang' in arg for arg in args):
         return list(filterfalse(lambda f:
                                 f in ('-mcet',
                                       '-fstack-clash-protection',

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -61,6 +61,7 @@ def get_python_flags(libs):
     py_libs = sum((libs.split() for libs in
                    distutils.sysconfig.get_config_vars('LIBS', 'SYSLIBS')), [])
     compiler = new_compiler()
+    distutils.sysconfig.customize_compiler(compiler)
     return dict(
         include_dirs=[distutils.sysconfig.get_python_inc()],
         library_dirs=distutils.sysconfig.get_config_vars('LIBDIR', 'LIBPL'),

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -15,14 +15,14 @@ import distutils.sysconfig
 
 def filter_unsupported_flags(compiler, flags):
     if 'clang' in compiler:
-        return filterfalse(lambda f:
-                           f in ('-mcet',
-                                 '-fstack-clash-protection',
-                                 '-fno-var-tracking-assignments',
-                                 '-Wno-deprecated-register',
-                                 '-Wno-gnu-designator') or
-                           f.startswith('-fcf-protection'),
-                           flags)
+        return list(filterfalse(lambda f:
+                                f in ('-mcet',
+                                      '-fstack-clash-protection',
+                                      '-fno-var-tracking-assignments',
+                                      '-Wno-deprecated-register',
+                                      '-Wno-gnu-designator') or
+                                f.startswith('-fcf-protection'),
+                                flags))
     else:
         return flags
 

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -10,11 +10,13 @@ import tempfile
 import textwrap
 from distutils.ccompiler import new_compiler
 from distutils.errors import CompileError, LinkError
+from itertools import filterfalse, takewhile
 import distutils.sysconfig
 
 
 def filter_unsupported_flags(compiler, flags):
-    if 'clang' in compiler:
+    args = takewhile(lambda argv: not argv.startswith('-'), [compiler] + flags)
+    if any('clang' in arg for arg in args):
         return list(filterfalse(lambda f:
                                 f in ('-mcet',
                                       '-fstack-clash-protection',

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -61,6 +61,7 @@ def get_python_flags(libs):
     py_libs = sum((libs.split() for libs in
                    distutils.sysconfig.get_config_vars('LIBS', 'SYSLIBS')), [])
     compiler = new_compiler()
+    distutils.sysconfig.customize_compiler(compiler)
     return dict(
         include_dirs=[distutils.sysconfig.get_python_inc()],
         library_dirs=distutils.sysconfig.get_config_vars('LIBDIR', 'LIBPL'),


### PR DESCRIPTION
otherwise we are always looking at the default compiler on 'unix' --
'cc'. and will fail to filter cflags not supported by clang, if we
are compiling the python bindings using clang.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
