### PR TITLE
mgr/dashboard: do not show RGW API keys if only read-only privileges

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.html
@@ -14,7 +14,7 @@
                 class="bold">Full name</td>
             <td>{{ user.display_name }}</td>
           </tr>
-          <tr *ngIf="user.email.length">
+          <tr *ngIf="user.email?.length">
             <td i18n
                 class="bold">Email address</td>
             <td>{{ user.email }}</td>
@@ -125,7 +125,8 @@
     </div>
   </tab>
 
-  <tab i18n-heading
+  <tab *ngIf="keys.length"
+       i18n-heading
        heading="Keys">
     <cd-table [data]="keys"
               [columns]="keysColumns"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.spec.ts
@@ -7,6 +7,7 @@ import { TabsModule } from 'ngx-bootstrap/tabs';
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../shared/shared.module';
+import { RgwUserS3Key } from '../models/rgw-user-s3-key';
 import { RgwUserDetailsComponent } from './rgw-user-details.component';
 
 describe('RgwUserDetailsComponent', () => {
@@ -28,6 +29,33 @@ describe('RgwUserDetailsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+
+    const detailsTab = fixture.debugElement.nativeElement.querySelector('tab[heading="Details"]');
+    expect(detailsTab).toBeFalsy();
+    const keysTab = fixture.debugElement.nativeElement.querySelector('tab[heading="Keys"]');
+    expect(keysTab).toBeFalsy();
+  });
+
+  it('should show "Details" tab', () => {
+    component.selection.selected = [{ uid: 'myUsername' }];
+    fixture.detectChanges();
+
+    const detailsTab = fixture.debugElement.nativeElement.querySelector('tab[heading="Details"]');
+    expect(detailsTab).toBeTruthy();
+    const keysTab = fixture.debugElement.nativeElement.querySelector('tab[heading="Keys"]');
+    expect(keysTab).toBeFalsy();
+  });
+
+  it('should show "Keys" tab', () => {
+    const s3Key = new RgwUserS3Key();
+    component.selection.selected = [{ keys: [s3Key] }];
+    component.ngOnChanges();
+    fixture.detectChanges();
+
+    const detailsTab = fixture.debugElement.nativeElement.querySelector('tab[heading="Details"]');
+    expect(detailsTab).toBeTruthy();
+    const keysTab = fixture.debugElement.nativeElement.querySelector('tab[heading="Keys"]');
+    expect(keysTab).toBeTruthy();
   });
 
   it('should show correct "System" info', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.ts
@@ -73,22 +73,27 @@ export class RgwUserDetailsComponent implements OnChanges, OnInit {
 
       // Process the keys.
       this.keys = [];
-      this.user.keys.forEach((key: RgwUserS3Key) => {
-        this.keys.push({
-          id: this.keys.length + 1, // Create an unique identifier
-          type: 'S3',
-          username: key.user,
-          ref: key
+      if (this.user.keys) {
+        this.user.keys.forEach((key: RgwUserS3Key) => {
+          this.keys.push({
+            id: this.keys.length + 1, // Create an unique identifier
+            type: 'S3',
+            username: key.user,
+            ref: key
+          });
         });
-      });
-      this.user.swift_keys.forEach((key: RgwUserSwiftKey) => {
-        this.keys.push({
-          id: this.keys.length + 1, // Create an unique identifier
-          type: 'Swift',
-          username: key.user,
-          ref: key
+      }
+      if (this.user.swift_keys) {
+        this.user.swift_keys.forEach((key: RgwUserSwiftKey) => {
+          this.keys.push({
+            id: this.keys.length + 1, // Create an unique identifier
+            type: 'Swift',
+            username: key.user,
+            ref: key
+          });
         });
-      });
+      }
+
       this.keys = _.sortBy(this.keys, 'user');
     }
   }

--- a/src/pybind/mgr/dashboard/tests/test_rgw.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw.py
@@ -86,3 +86,33 @@ class RgwUserControllerTestCase(ControllerTestCase):
         }]
         self._get('/test/api/rgw/user')
         self.assertStatus(500)
+
+    @mock.patch('dashboard.controllers.rgw.RgwRESTController.proxy')
+    @mock.patch.object(RgwUser, '_keys_allowed')
+    def test_user_get_with_keys(self, keys_allowed, mock_proxy):
+        keys_allowed.return_value = True
+        mock_proxy.return_value = {
+            'tenant': '',
+            'user_id': 'my_user_id',
+            'keys': [],
+            'swift_keys': []
+        }
+        self._get('/test/api/rgw/user/testuser')
+        self.assertStatus(200)
+        self.assertInJsonBody('keys')
+        self.assertInJsonBody('swift_keys')
+
+    @mock.patch('dashboard.controllers.rgw.RgwRESTController.proxy')
+    @mock.patch.object(RgwUser, '_keys_allowed')
+    def test_user_get_without_keys(self, keys_allowed, mock_proxy):
+        keys_allowed.return_value = False
+        mock_proxy.return_value = {
+            'tenant': '',
+            'user_id': 'my_user_id',
+            'keys': [],
+            'swift_keys': []
+        }
+        self._get('/test/api/rgw/user/testuser')
+        self.assertStatus(200)
+        self.assertNotIn('keys', self.json_body())
+        self.assertNotIn('swift_keys', self.json_body())


### PR DESCRIPTION
Do not send RGW API keys in response and hide "Keys" tab if user has only read-only privileges.

Fixes: https://tracker.ceph.com/issues/42475
Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
