### PR TITLE
qa/suites/rados/multimon/tasks/mon_clock_with_skews: disable ntpd etc

### DIFF
--- a/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
@@ -2,6 +2,10 @@ tasks:
 - install:
 - exec:
     mon.b:
+    - sudo systemctl stop chronyd.service || true
+    - sudo systemctl stop systemd-timesync.service || true
+    - sudo systemctl stop ntpd.service || true
+    - sudo systemctl stop ntp.service || true
     - date -u -s @$(expr $(date -u +%s) + 2)
 - ceph:
     wait-for-healthy: false

--- a/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
@@ -15,6 +15,7 @@ tasks:
     - overall HEALTH_
     - \(MON_CLOCK_SKEW\)
     - \(MGR_DOWN\)
+    - \(MON_DOWN\)
     - \(PG_
     - \(SLOW_OPS\)
     - No standby daemons available


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43889