### PR TITLE
mount.ceph: fix incorrect options parsing

### DIFF
--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -218,7 +218,7 @@ static int parse_options(const char *data, struct ceph_mount_info *cmi)
 		if(*data == 0)
 			break;
 		next_keyword = strchr(data,',');
-	
+
 		/* temporarily null terminate end of keyword=value pair */
 		if(next_keyword)
 			*next_keyword++ = 0;
@@ -229,46 +229,46 @@ static int parse_options(const char *data, struct ceph_mount_info *cmi)
 			value++;
 		}
 
-		if (strncmp(data, "ro", 2) == 0) {
+		if (strcmp(data, "ro") == 0) {
 			cmi->cmi_flags |= MS_RDONLY;
-		} else if (strncmp(data, "rw", 2) == 0) {
+		} else if (strcmp(data, "rw") == 0) {
 			cmi->cmi_flags &= ~MS_RDONLY;
-		} else if (strncmp(data, "nosuid", 6) == 0) {
+		} else if (strcmp(data, "nosuid") == 0) {
 			cmi->cmi_flags |= MS_NOSUID;
-		} else if (strncmp(data, "suid", 4) == 0) {
+		} else if (strcmp(data, "suid") == 0) {
 			cmi->cmi_flags &= ~MS_NOSUID;
-		} else if (strncmp(data, "dev", 3) == 0) {
+		} else if (strcmp(data, "dev") == 0) {
 			cmi->cmi_flags &= ~MS_NODEV;
-		} else if (strncmp(data, "nodev", 5) == 0) {
+		} else if (strcmp(data, "nodev") == 0) {
 			cmi->cmi_flags |= MS_NODEV;
-		} else if (strncmp(data, "noexec", 6) == 0) {
+		} else if (strcmp(data, "noexec") == 0) {
 			cmi->cmi_flags |= MS_NOEXEC;
-		} else if (strncmp(data, "exec", 4) == 0) {
+		} else if (strcmp(data, "exec") == 0) {
 			cmi->cmi_flags &= ~MS_NOEXEC;
-                } else if (strncmp(data, "sync", 4) == 0) {
+                } else if (strcmp(data, "sync") == 0) {
                         cmi->cmi_flags |= MS_SYNCHRONOUS;
-                } else if (strncmp(data, "remount", 7) == 0) {
+                } else if (strcmp(data, "remount") == 0) {
                         cmi->cmi_flags |= MS_REMOUNT;
-                } else if (strncmp(data, "mandlock", 8) == 0) {
+                } else if (strcmp(data, "mandlock") == 0) {
                         cmi->cmi_flags |= MS_MANDLOCK;
-		} else if ((strncmp(data, "nobrl", 5) == 0) || 
-			   (strncmp(data, "nolock", 6) == 0)) {
+		} else if ((strcmp(data, "nobrl") == 0) ||
+			   (strcmp(data, "nolock") == 0)) {
 			cmi->cmi_flags &= ~MS_MANDLOCK;
-		} else if (strncmp(data, "noatime", 7) == 0) {
+		} else if (strcmp(data, "noatime") == 0) {
 			cmi->cmi_flags |= MS_NOATIME;
-		} else if (strncmp(data, "nodiratime", 10) == 0) {
+		} else if (strcmp(data, "nodiratime") == 0) {
 			cmi->cmi_flags |= MS_NODIRATIME;
-		} else if (strncmp(data, "relatime", 8) == 0) {
+		} else if (strcmp(data, "relatime") == 0) {
 			cmi->cmi_flags |= MS_RELATIME;
-		} else if (strncmp(data, "strictatime", 11) == 0) {
+		} else if (strcmp(data, "strictatime") == 0) {
 			cmi->cmi_flags |= MS_STRICTATIME;
-		} else if (strncmp(data, "noauto", 6) == 0) {
+		} else if (strcmp(data, "noauto") == 0) {
 			/* ignore */
-		} else if (strncmp(data, "_netdev", 7) == 0) {
+		} else if (strcmp(data, "_netdev") == 0) {
 			/* ignore */
-		} else if (strncmp(data, "nofail", 6) == 0) {
+		} else if (strcmp(data, "nofail") == 0) {
 			/* ignore */
-		} else if (strncmp(data, "secretfile", 10) == 0) {
+		} else if (strcmp(data, "secretfile") == 0) {
 			int ret;
 
 			if (!value || !*value) {
@@ -280,7 +280,7 @@ static int parse_options(const char *data, struct ceph_mount_info *cmi)
 				fprintf(stderr, "error reading secret file: %d\n", ret);
 				return ret;
 			}
-		} else if (strncmp(data, "secret", 6) == 0) {
+		} else if (strcmp(data, "secret") == 0) {
 			size_t len;
 
 			if (!value || !*value) {
@@ -291,7 +291,7 @@ static int parse_options(const char *data, struct ceph_mount_info *cmi)
 			len = strnlen(value, sizeof(cmi->cmi_secret)) + 1;
 			if (len <= sizeof(cmi->cmi_secret))
 				memcpy(cmi->cmi_secret, value, len);
-		} else if (strncmp(data, "conf", 4) == 0) {
+		} else if (strcmp(data, "conf") == 0) {
 			if (!value || !*value) {
 				fprintf(stderr, "mount option conf requires a value.\n");
 				return -EINVAL;
@@ -300,7 +300,7 @@ static int parse_options(const char *data, struct ceph_mount_info *cmi)
 			cmi->cmi_conf = strdup(value);
 			if (!cmi->cmi_conf)
 				return -ENOMEM;
-		} else if (strncmp(data, "name", 4) == 0) {
+		} else if (strcmp(data, "name") == 0) {
 			if (!value || !*value) {
 				fprintf(stderr, "mount option name requires a value.\n");
 				return -EINVAL;
@@ -326,7 +326,6 @@ static int parse_options(const char *data, struct ceph_mount_info *cmi)
 			} else {
 				pos = safe_cat(&cmi->cmi_opts, &cmi->cmi_opts_len, pos, data);
 			}
-			
 		}
 		data = next_keyword;
 	} while (data);


### PR DESCRIPTION
The strncmp will only compare the first N bytes, this will be a
problem in some case, for example:
```
$ mount.ceph :/ /mnt/cephfs -o remount,room_size=10
```
We assume the "room_size" is a new option, we will never receive
any "room_size=10" data in kernel space, because it will be parsed
as "ro". And another example is if we move the "secret" option up
and before the "secretfile", the "secretfile" will never be correctly
parsed.

Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
