### PR TITLE
mgr/cephadm: Fix placement for new services

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1776,6 +1776,12 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             )
             daemons.append(sd)
             num_added += 1
+
+        if (len(our_daemons) + num_added) < spec.count:
+            missing = spec.count - len(our_daemons) - num_added
+            available = [p.hostname for p in hosts_without_daemons]
+            m = f'Cannot find placement for {missing} daemons. available hosts = {available}'
+            raise orchestrator.OrchestratorError(m)
         return create_func(args)
 
 

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -1084,13 +1084,13 @@ class PlacementSpec(object):
     def __init__(self, label=None, hosts=None, count=None):
         # type: (Optional[str], Optional[List], Optional[int]) -> None
         self.label = label
+        self.hosts = []  # type: List[HostPlacementSpec]
         if hosts:
             if all([isinstance(host, HostPlacementSpec) for host in hosts]):
-                self.hosts = hosts  # type: List[HostPlacementSpec]
+                self.hosts = hosts
             else:
                 self.hosts = [parse_host_placement_specs(x, require_network=False) for x in hosts if x]
-        else:
-            self.hosts = []
+
 
         self.count = count  # type: Optional[int]
 
@@ -1144,7 +1144,7 @@ class ServiceDescription(object):
                  service_type=None, version=None, rados_config_location=None,
                  service_url=None, status=None, status_desc=None):
         # Node is at the same granularity as InventoryNode
-        self.nodename = nodename
+        self.nodename = nodename  # type: Optional[str]
 
         # Not everyone runs in containers, but enough people do to
         # justify having the container_id (runtime id) and container_image


### PR DESCRIPTION
* Bail if we cannot find a host for services.
    This would require tricky manipulation of ports etc.
* Fix placement of new daemons (mds,rgw,rbd-m)
    * Don't modify spec.count, as this is irritating to me.
    * Place daemons on unused hosts
    * Reduced code duplication

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
