### PR TITLE
qa/tasks/mgr/dashboard/test_orchestrator: support addr attribute in inventory

### DIFF
--- a/qa/tasks/mgr/dashboard/test_orchestrator.py
+++ b/qa/tasks/mgr/dashboard/test_orchestrator.py
@@ -9,6 +9,7 @@ test_data = {
     'inventory': [
         {
             'name': 'test-host0',
+            'addr': '1.2.3.4',
             'devices': [
                 {
                     'path': '/dev/sda',
@@ -17,6 +18,7 @@ test_data = {
         },
         {
             'name': 'test-host1',
+            'addr': '1.2.3.5',
             'devices': [
                 {
                     'path': '/dev/sdb',


### PR DESCRIPTION
The missing attribute `addr` causes error when loading dummy data.

Fixes: https://tracker.ceph.com/issues/44054
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
