### PR TITLE
global: ensure command-line arguments override CEPH_ARGS arguments

### DIFF
--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -91,7 +91,11 @@ void global_pre_init(
   std::string cluster = "";
 
   // ensure environment arguments are included in early processing
+  // but CLI arguments take precedent
+  std::vector<const char*> cli_args;
+  std::swap(cli_args, args);
   env_to_vec(args);
+  args.insert(args.end(), cli_args.begin(), cli_args.end());
 
   CephInitParameters iparams = ceph_argparse_early_args(
     args, module_type,


### PR DESCRIPTION
For example, if you have "CEPH_ARGS='--id XYZ'", passing "--id ABC" to
a Ceph CLI tool should result in the ABC id being utilized.

Fixes: https://tracker.ceph.com/issues/43795`
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
