### PR TITLE
ceph.spec: Recommend (but do not require) podman

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -395,9 +395,11 @@ Base is the package that includes all the files shared amongst ceph servers
 
 %package -n cephadm
 Summary:        Utility to bootstrap Ceph clusters
-Requires:       podman
 Requires:       lvm2
 Requires:       python%{python3_pkgversion}
+%if 0%{?weak_deps}
+Recommends:     podman
+%endif
 %description -n cephadm
 Utility to bootstrap a Ceph cluster and manage Ceph daemons deployed 
 with systemd and podman.

--- a/debian/control
+++ b/debian/control
@@ -168,8 +168,8 @@ Description: debugging symbols for ceph-base
 
 Package: cephadm
 Architecture: linux-any
-Depends: docker.io,
-         lvm2,
+Recommends: podman | docker.io
+Depends: lvm2,
 	 ${python:Depends},
 Description: cephadm utility to bootstrap ceph daemons with systemd and containers
  Ceph is a massively scalable, open-source, distributed


### PR DESCRIPTION
1- Strictly speaking, docker is okay too.
2- We don't want podman (or docker) installed inside the container image,
but we do need the cephadm package.

Fixes: https://tracker.ceph.com/issues/44065
Signed-off-by: Sage Weil <sage@redhat.com>