### PR TITLE
mgr/cephadm: Handle empty optional spec values in add_mds

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1933,7 +1933,12 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
 
     def add_mds(self, spec):
         # type: (orchestrator.ServiceSpec) -> AsyncCompletion
-        if not spec.placement.hosts or spec.placement.count is None or len(spec.placement.hosts) < spec.placement.count:
+        spec.placement.count = spec.count 
+
+        if not spec.placement.hosts:
+            spec = NodeAssignment(spec=spec, get_hosts_func=self._get_hosts, service_type='mds').load()
+
+        if len(spec.placement.hosts) < spec.placement.count:
             raise RuntimeError("must specify at least %s hosts" % spec.placement.count)
         # ensure mds_join_fs is set for these daemons
         assert spec.name


### PR DESCRIPTION
spec.placement.count and spec.placement.hosts need to be filled for add_mds to be successful

Fixes: https://tracker.ceph.com/issues/43835

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>