### PR TITLE
nautilus: ceph-volume: batch bluestore fix create_lvs call

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -1340,7 +1340,7 @@ def create_lvs(volume_group, parts=None, size=None, name_prefix='ceph-lv'):
         size = sizing['sizes']
         extents = sizing['extents']
         lvs.append(
-            create_lv(name_prefix, uuid.uuid4(), vg=volume_group.name, extents=extents, tags=tags)
+            create_lv(name_prefix, uuid.uuid4(), vg=volume_group, extents=extents, tags=tags)
         )
     return lvs
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43871

---

backport of https://github.com/ceph/ceph/pull/32929
parent tracker: https://tracker.ceph.com/issues/43844

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh