### PR TITLE
python-common: add py.typed (PEP 561)

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -24,7 +24,7 @@ import shutil
 import subprocess
 
 from ceph.deployment import inventory, translate
-from ceph.deployment.drive_group import DriveGroupSpecs
+from ceph.deployment.drive_group import DriveGroupSpec
 from ceph.deployment.drive_selection import selector
 
 from mgr_module import MgrModule
@@ -1514,11 +1514,12 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         return self.get_inventory().then(call_create)
 
     def create_osds(self, drive_groups):
+        # type: (List[DriveGroupSpec]) -> AsyncCompletion
         return self.get_hosts().then(lambda hosts: self.call_inventory(hosts, drive_groups))
 
     def _prepare_deployment(self,
                             all_hosts,  # type: List[orchestrator.InventoryNode]
-                            drive_groups,  # type: List[DriveGroupSpecs]
+                            drive_groups,  # type: List[DriveGroupSpec]
                             inventory_list  # type: List[orchestrator.InventoryNode]
                             ):
         # type: (...) -> orchestrator.Completion

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -890,7 +890,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def create_osds(self, drive_groups):
-        # type: (DriveGroupSpec) -> Completion
+        # type: (List[DriveGroupSpec]) -> Completion
         """
         Create one or more OSDs within a single Drive Group.
 

--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -1,7 +1,7 @@
 pytest-cov==2.7.1
 mock; python_version <= '3.3'
 ipaddress; python_version < '3.3'
-../../python-common
+-e../../python-common
 kubernetes
 requests-mock
 pyyaml

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -387,8 +387,8 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         drive_group = drive_groups[0]
 
         targets = []  # type: List[str]
-        if drive_group.data_devices:
-            targets += drive_group.data_devices.paths
+        if drive_group.data_devices and drive_group.data_devices.paths:
+            targets += [d.path for d in drive_group.data_devices.paths]
         if drive_group.data_directories:
             targets += drive_group.data_directories
 
@@ -409,7 +409,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
             return orchestrator.Completion.with_progress(
                 message="Creating OSD on {0}:{1}".format(
-                        drive_group.hosts(drive_group.host_pattern),
+                        drive_group.hosts(all_hosts),
                         targets),
                 mgr=self,
                 on_complete=lambda _:self.rook_cluster.add_osds(drive_group, all_hosts),

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -494,7 +494,7 @@ class RookCluster(object):
         Rook currently (0.8) can only do single-drive OSDs, so we
         treat all drive groups as just a list of individual OSDs.
         """
-        block_devices = drive_group.data_devices.paths if drive_group.data_devices else None
+        block_devices = drive_group.data_devices.paths if drive_group.data_devices else []
         directories = drive_group.data_directories
 
         assert drive_group.objectstore in ("bluestore", "filestore")
@@ -525,7 +525,7 @@ class RookCluster(object):
 
         if drive_group.hosts(all_hosts)[0] not in [n['name'] for n in current_nodes]:
             pd = { "name": drive_group.hosts(all_hosts)[0],
-                   "config": { "storeType": drive_group.objectstore }}
+                   "config": { "storeType": drive_group.objectstore }}  # type: dict
 
             if block_devices:
                 pd["devices"] = [{'name': d.path} for d in block_devices]

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -113,7 +113,7 @@ class DriveGroupSpecs(object):
     def __init__(self, drive_group_json):
         # type: (dict) -> None
         self.drive_group_json = drive_group_json
-        self.drive_groups = list()  # type: list
+        self.drive_groups = list()  # type: List[DriveGroupSpec]
         self.build_drive_groups()
 
     def build_drive_groups(self):

--- a/src/python-common/ceph/deployment/inventory.py
+++ b/src/python-common/ceph/deployment/inventory.py
@@ -51,9 +51,9 @@ class Device(object):
                  device_id=None,  # type: Optional[str]
                  ):
         self.path = path
-        self.sys_api = sys_api
+        self.sys_api = sys_api if sys_api is not None else {}  # type: Dict[str, Any]
         self.available = available
-        self.rejected_reasons = rejected_reasons
+        self.rejected_reasons = rejected_reasons if rejected_reasons is not None else []
         self.lvs = lvs
         self.device_id = device_id
 

--- a/src/python-common/ceph/py.typed
+++ b/src/python-common/ceph/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  This  package uses inline types.


### PR DESCRIPTION
Bugs found:

* Fixed documentation of how `mgr/Orchestrator.create_osds` is called
* mgr/Rook.create_osds: Added missing `.path` when querying paths.
* mgr/Rook.create_osds: Fixed progress message
* mgr/RookCluster.create_osds: Empty list instead of `None`
* python-common: use empty objects instead of `None`

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
