### PR TITLE
nautilus: ceph-volume: fix has_bluestore_label() function

### DIFF
--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -321,7 +321,7 @@ class Device(object):
     def has_bluestore_label(self):
         out, err, ret = process.call([
             'ceph-bluestore-tool', 'show-label',
-            '--dev', self.abspath])
+            '--dev', self.abspath], verbose_on_failure=False)
         if ret:
             return False
         return True

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -321,7 +321,7 @@ class Device(object):
     def has_bluestore_label(self):
         out, err, ret = process.call([
             'ceph-bluestore-tool', 'show-label',
-            '--dev', self.path])
+            '--dev', self.abspath])
         if ret:
             return False
         return True


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43984

---

backport of https://github.com/ceph/ceph/pull/33074
parent tracker: https://tracker.ceph.com/issues/43970

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh