### PR TITLE
ceph_argparse: put args from env before existing ones

### DIFF
--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -117,14 +117,14 @@ void env_to_vec(std::vector<const char*>& args, const char *name)
   auto [env_options, env_arguments] = split_dashdash(env);
 
   args.clear();
-  args.insert(args.end(), options.begin(), options.end());
   args.insert(args.end(), env_options.begin(), env_options.end());
+  args.insert(args.end(), options.begin(), options.end());
   if (arguments.empty() && env_arguments.empty()) {
     return;
   }
   args.push_back("--");
-  args.insert(args.end(), arguments.begin(), arguments.end());
   args.insert(args.end(), env_arguments.begin(), env_arguments.end());
+  args.insert(args.end(), arguments.begin(), arguments.end());
 }
 
 void argv_to_vec(int argc, const char **argv,

--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -64,23 +64,18 @@ void string_to_vec(std::vector<std::string>& args, std::string argstr)
   }
 }
 
-bool split_dashdash(const std::vector<const char*>& args,
-		    std::vector<const char*>& options,
-		    std::vector<const char*>& arguments) {
-  bool dashdash = false;
-  for (std::vector<const char*>::const_iterator i = args.begin();
-       i != args.end();
-       ++i) {
-    if (dashdash) {
-      arguments.push_back(*i);
-    } else {
-      if (strcmp(*i, "--") == 0)
-	dashdash = true;
-      else
-	options.push_back(*i);
-    }
+std::pair<std::vector<const char*>, std::vector<const char*>>
+split_dashdash(const std::vector<const char*>& args) {
+  auto dashdash = std::find_if(args.begin(), args.end(),
+			       [](const char* arg) {
+				 return strcmp(arg, "--") == 0;
+			       });
+  std::vector<const char*> options{args.begin(), dashdash};
+  if (dashdash != args.end()) {
+    ++dashdash;
   }
-  return dashdash;
+  std::vector<const char*> arguments{dashdash, args.end()};
+  return {std::move(options), std::move(arguments)};
 }
 
 static std::mutex g_str_vec_lock;
@@ -98,15 +93,7 @@ void env_to_vec(std::vector<const char*>& args, const char *name)
   if (!name)
     name = "CEPH_ARGS";
 
-  bool dashdash = false;
-  std::vector<const char*> options;
-  std::vector<const char*> arguments;
-  if (split_dashdash(args, options, arguments))
-    dashdash = true;
-
-  std::vector<const char*> env_options;
-  std::vector<const char*> env_arguments;
-  std::vector<const char*> env;
+  auto [options, arguments] = split_dashdash(args);
 
   /*
    * We can only populate str_vec once. Other threads could hold pointers into
@@ -123,17 +110,19 @@ void env_to_vec(std::vector<const char*>& args, const char *name)
   }
   g_str_vec_lock.unlock();
 
-  vector<string>::iterator i;
-  for (i = g_str_vec.begin(); i != g_str_vec.end(); ++i)
-    env.push_back(i->c_str());
-  if (split_dashdash(env, env_options, env_arguments))
-    dashdash = true;
+  std::vector<const char*> env;
+  for (const auto& s : g_str_vec) {
+    env.push_back(s.c_str());
+  }
+  auto [env_options, env_arguments] = split_dashdash(env);
 
   args.clear();
   args.insert(args.end(), options.begin(), options.end());
   args.insert(args.end(), env_options.begin(), env_options.end());
-  if (dashdash)
-    args.push_back("--");
+  if (arguments.empty() && env_arguments.empty()) {
+    return;
+  }
+  args.push_back("--");
   args.insert(args.end(), arguments.begin(), arguments.end());
   args.insert(args.end(), env_arguments.begin(), env_arguments.end());
 }

--- a/src/test/ceph_argparse.cc
+++ b/src/test/ceph_argparse.cc
@@ -385,14 +385,15 @@ TEST(CephArgParse, env_to_vec) {
     clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(3u, args.size());
-    EXPECT_EQ(string("b"), args[1]);
-    EXPECT_EQ(string("c"), args[2]);
+    EXPECT_EQ(string("b"), args[0]);
+    EXPECT_EQ(string("c"), args[1]);
+    EXPECT_EQ(string("a"), args[2]);
     setenv("WHATEVER", "d e", 0);
     clear_g_str_vec();
     env_to_vec(args, "WHATEVER");
     EXPECT_EQ(5u, args.size());
-    EXPECT_EQ(string("d"), args[3]);
-    EXPECT_EQ(string("e"), args[4]);
+    EXPECT_EQ(string("d"), args[0]);
+    EXPECT_EQ(string("e"), args[1]);
   }
   {
     std::vector<const char*> args;
@@ -404,11 +405,11 @@ TEST(CephArgParse, env_to_vec) {
     clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(5u, args.size());
-    EXPECT_EQ(string("a"), args[0]);
-    EXPECT_EQ(string("b"), args[1]);
+    EXPECT_EQ(string("b"), args[0]);
+    EXPECT_EQ(string("a"), args[1]);
     EXPECT_EQ(string("--"), args[2]);
-    EXPECT_EQ(string("c"), args[3]);
-    EXPECT_EQ(string("d"), args[4]);
+    EXPECT_EQ(string("d"), args[3]);
+    EXPECT_EQ(string("c"), args[4]);
   }
   {
     std::vector<const char*> args;
@@ -419,8 +420,8 @@ TEST(CephArgParse, env_to_vec) {
     clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(4u, args.size());
-    EXPECT_EQ(string("a"), args[0]);
-    EXPECT_EQ(string("b"), args[1]);
+    EXPECT_EQ(string("b"), args[0]);
+    EXPECT_EQ(string("a"), args[1]);
     EXPECT_EQ(string("--"), args[2]);
     EXPECT_EQ(string("c"), args[3]);
   }
@@ -435,8 +436,8 @@ TEST(CephArgParse, env_to_vec) {
     EXPECT_EQ(4u, args.size());
     EXPECT_EQ(string("b"), args[0]);
     EXPECT_EQ(string("--"), args[1]);
-    EXPECT_EQ(string("c"), args[2]);
-    EXPECT_EQ(string("d"), args[3]);
+    EXPECT_EQ(string("d"), args[2]);
+    EXPECT_EQ(string("c"), args[3]);
   }
   {
     std::vector<const char*> args;
@@ -446,8 +447,8 @@ TEST(CephArgParse, env_to_vec) {
     clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(4u, args.size());
-    EXPECT_EQ(string("b"), args[0]);
-    EXPECT_EQ(string("c"), args[1]);
+    EXPECT_EQ(string("c"), args[0]);
+    EXPECT_EQ(string("b"), args[1]);
     EXPECT_EQ(string("--"), args[2]);
     EXPECT_EQ(string("d"), args[3]);
   }
@@ -463,8 +464,8 @@ TEST(CephArgParse, env_to_vec) {
     EXPECT_EQ(4u, args.size());
     EXPECT_EQ(string("a"), args[0]);
     EXPECT_EQ(string("--"), args[1]);
-    EXPECT_EQ(string("c"), args[2]);
-    EXPECT_EQ(string("d"), args[3]);
+    EXPECT_EQ(string("d"), args[2]);
+    EXPECT_EQ(string("c"), args[3]);
   }
   {
     std::vector<const char*> args;
@@ -476,8 +477,8 @@ TEST(CephArgParse, env_to_vec) {
     clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(4u, args.size());
-    EXPECT_EQ(string("a"), args[0]);
-    EXPECT_EQ(string("d"), args[1]);
+    EXPECT_EQ(string("d"), args[0]);
+    EXPECT_EQ(string("a"), args[1]);
     EXPECT_EQ(string("--"), args[2]);
     EXPECT_EQ(string("c"), args[3]);
   }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43795

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
