### PR TITLE
cephadm: fix deploy crash when no `args.fsid`

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1391,8 +1391,8 @@ def deploy_crash(fsid, uid, gid, config, keyring):
     # type: (str, int, int, str, str) -> None
     crash_dir = os.path.join(args.data_dir, fsid, 'crash')
     makedirs(crash_dir, uid, gid, DATA_DIR_MODE)
-    c = get_container(args.fsid, 'crash', get_hostname())
-    deploy_daemon(args.fsid, 'crash', get_hostname(), c, uid, gid,
+    c = get_container(fsid, 'crash', get_hostname())
+    deploy_daemon(fsid, 'crash', get_hostname(), c, uid, gid,
                   config, keyring)
 
 def get_unit_file(fsid, uid, gid):


### PR DESCRIPTION
broken by 724199dd873e2a02f67ea2e191093d8080c686a7 when the
crash agent was made to behave like all other services

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
