### PR TITLE
mon: --format=json does not work for config get or show

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -308,6 +308,7 @@ set(libcommon_files
   global/global_context.cc
   xxHash/xxhash.c
   log/Log.cc
+  mon/ConfigMap.cc
   mon/MonCap.cc
   mon/MonClient.cc
   mon/MonMap.cc

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1812,12 +1812,12 @@ bool DaemonServer::_handle_command(
       auto p = daemon->config.find(name);
       if (p != daemon->config.end() &&
 	  !p->second.empty()) {
-	cmdctx->odata.append(p->second.rbegin()->second + "\n");
+	monc->configmap.print_value(f.get(), cmdctx->odata, name, p->second.rbegin()->second);
       } else {
 	auto& defaults = daemon->_get_config_defaults();
 	auto q = defaults.find(name);
 	if (q != defaults.end()) {
-	  cmdctx->odata.append(q->second + "\n");
+	  monc->configmap.print_value(f.get(), cmdctx->odata, name, q->second);
 	} else {
 	  r = -ENOENT;
 	}

--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -204,6 +204,20 @@ bool ConfigMap::parse_mask(
   return true;
 }
 
+void ConfigMap::print_value(Formatter *f, bufferlist &odata,
+                 const string &name, const string &value)
+{
+  if (f) {
+    f->open_object_section("config");
+    f->dump_string("name", name);
+    f->dump_string("value", value);
+    f->close_section();
+    f->flush(odata);
+  } else {
+    odata.append(value);
+    odata.append("\n");
+  }
+}
 
 // --------------
 

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -131,6 +131,9 @@ struct ConfigMap {
     const std::string& in,
     std::string *section,
     OptionMask *mask);
+
+  void print_value(Formatter *f, bufferlist &odata,
+                   const string &name, const string &value);
 };
 
 

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -306,8 +306,7 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
       if (opt->has_flag(Option::FLAG_NO_MON_UPDATE)) {
 	// handle special options
 	if (name == "fsid") {
-	  odata.append(stringify(mon->monmap->get_fsid()));
-	  odata.append("\n");
+	  config_map.print_value(f.get(), odata, name, stringify(mon->monmap->get_fsid()));
 	  goto reply;
 	}
 	err = -EINVAL;
@@ -317,17 +316,15 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
       // get a single value
       auto p = config.find(name);
       if (p != config.end()) {
-	odata.append(p->second);
-	odata.append("\n");
+	config_map.print_value(f.get(), odata, name, p->second);
 	goto reply;
       }
       if (!entity.is_client() &&
 	  !boost::get<boost::blank>(&opt->daemon_value)) {
-	odata.append(Option::to_str(opt->daemon_value));
+	config_map.print_value(f.get(), odata, name, Option::to_str(opt->daemon_value));
       } else {
-	odata.append(Option::to_str(opt->value));
+	config_map.print_value(f.get(), odata, name, Option::to_str(opt->value));
       }
-      odata.append("\n");
     } else {
       // dump all (non-default) values for this entity
       TextTable tbl;

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -24,6 +24,7 @@
 
 #include "msg/Messenger.h"
 
+#include "ConfigMap.h"
 #include "MonMap.h"
 #include "MonSub.h"
 
@@ -247,6 +248,7 @@ class MonClient : public Dispatcher,
 public:
   MonMap monmap;
   std::map<std::string,std::string> config_mgr;
+  ConfigMap configmap;
 
 private:
   Messenger *messenger;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44089
Signed-off-by: Zheng Yin <zhengyin@cmss.chinamobile.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
