### PR TITLE
luminous: rgw: remove VLA from JSONFormatter::print_quoted_string() #33257

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -420,7 +420,7 @@ set(libcommon_files
   common/bloom_filter.cc
   common/Readahead.cc
   common/cmdparse.cc
-  common/escape.c
+  common/escape.cc
   common/url_escape.cc
   common/io_priority.cc
   common/Clock.cc

--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -189,10 +189,7 @@ void JSONFormatter::print_comma(json_formatter_stack_entry_d& entry)
 
 void JSONFormatter::print_quoted_string(boost::string_view s)
 {
-  int len = escape_json_attr_len(s.data(), s.size());
-  char escaped[len];
-  escape_json_attr(s.data(), s.size(), escaped);
-  m_ss << '\"' << escaped << '\"';
+  m_ss << '\"' << json_stream_escaper(s.data()) << '\"';
 }
 
 void JSONFormatter::print_name(const char *name)
@@ -476,7 +473,7 @@ void XMLFormatter::dump_string(const char *name, boost::string_view s)
       [this](char c) { return this->to_lower_underscore(c); });
 
   print_spaces();
-  m_ss << "<" << e << ">" << escape_xml_str(s.data()) << "</" << e << ">";
+  m_ss << "<" << e << ">" << xml_stream_escaper(s.data()) << "</" << e << ">";
   if (m_pretty)
     m_ss << "\n";
 }
@@ -490,7 +487,7 @@ void XMLFormatter::dump_string_with_attrs(const char *name, boost::string_view s
   std::string attrs_str;
   get_attrs_str(&attrs, attrs_str);
   print_spaces();
-  m_ss << "<" << e << attrs_str << ">" << escape_xml_str(s.data()) << "</" << e << ">";
+  m_ss << "<" << e << attrs_str << ">" << xml_stream_escaper(s.data()) << "</" << e << ">";
   if (m_pretty)
     m_ss << "\n";
 }
@@ -515,7 +512,7 @@ void XMLFormatter::dump_format_va(const char* name, const char *ns, bool quoted,
   if (ns) {
     m_ss << "<" << e << " xmlns=\"" << ns << "\">" << buf << "</" << e << ">";
   } else {
-    m_ss << "<" << e << ">" << escape_xml_str(buf) << "</" << e << ">";
+    m_ss << "<" << e << ">" << xml_stream_escaper(buf) << "</" << e << ">";
   }
 
   if (m_pretty)
@@ -571,7 +568,7 @@ void XMLFormatter::open_section_in_ns(const char *name, const char *ns, const Fo
 void XMLFormatter::finish_pending_string()
 {
   if (!m_pending_string_name.empty()) {
-    m_ss << escape_xml_str(m_pending_string.str().c_str())
+    m_ss << xml_stream_escaper(m_pending_string.str())
       << "</" << m_pending_string_name << ">";
     m_pending_string_name.clear();
     m_pending_string.str(std::string());
@@ -588,14 +585,6 @@ void XMLFormatter::print_spaces()
     std::string spaces(m_sections.size(), ' ');
     m_ss << spaces;
   }
-}
-
-std::string XMLFormatter::escape_xml_str(boost::string_view str)
-{
-  size_t len = escape_xml_attr_len(str.data());
-  std::vector<char> escaped(len, '\0');
-  escape_xml_attr(str.data(), &escaped[0]);
-  return std::string(&escaped[0]);
 }
 
 char XMLFormatter::to_lower_underscore(char c) const

--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -189,7 +189,7 @@ void JSONFormatter::print_comma(json_formatter_stack_entry_d& entry)
 
 void JSONFormatter::print_quoted_string(boost::string_view s)
 {
-  m_ss << '\"' << json_stream_escaper(s.data()) << '\"';
+  m_ss << '\"' << json_stream_escaper(s) << '\"';
 }
 
 void JSONFormatter::print_name(const char *name)
@@ -473,7 +473,7 @@ void XMLFormatter::dump_string(const char *name, boost::string_view s)
       [this](char c) { return this->to_lower_underscore(c); });
 
   print_spaces();
-  m_ss << "<" << e << ">" << xml_stream_escaper(s.data()) << "</" << e << ">";
+  m_ss << "<" << e << ">" << xml_stream_escaper(s) << "</" << e << ">";
   if (m_pretty)
     m_ss << "\n";
 }
@@ -487,7 +487,7 @@ void XMLFormatter::dump_string_with_attrs(const char *name, boost::string_view s
   std::string attrs_str;
   get_attrs_str(&attrs, attrs_str);
   print_spaces();
-  m_ss << "<" << e << attrs_str << ">" << xml_stream_escaper(s.data()) << "</" << e << ">";
+  m_ss << "<" << e << attrs_str << ">" << xml_stream_escaper(s) << "</" << e << ">";
   if (m_pretty)
     m_ss << "\n";
 }
@@ -503,7 +503,7 @@ std::ostream& XMLFormatter::dump_stream(const char *name)
 void XMLFormatter::dump_format_va(const char* name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
   char buf[LARGE_SIZE];
-  vsnprintf(buf, LARGE_SIZE, fmt, ap);
+  size_t len = vsnprintf(buf, LARGE_SIZE, fmt, ap);
   std::string e(name);
   std::transform(e.begin(), e.end(), e.begin(),
       [this](char c) { return this->to_lower_underscore(c); });
@@ -512,7 +512,7 @@ void XMLFormatter::dump_format_va(const char* name, const char *ns, bool quoted,
   if (ns) {
     m_ss << "<" << e << " xmlns=\"" << ns << "\">" << buf << "</" << e << ">";
   } else {
-    m_ss << "<" << e << ">" << xml_stream_escaper(buf) << "</" << e << ">";
+    m_ss << "<" << e << ">" << xml_stream_escaper(boost::string_view(buf, len)) << "</" << e << ">";
   }
 
   if (m_pretty)

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -171,7 +171,6 @@ namespace ceph {
     void open_section_in_ns(const char *name, const char *ns, const FormatterAttrs *attrs);
     void finish_pending_string();
     void print_spaces();
-    static std::string escape_xml_str(boost::string_view str);
     void get_attrs_str(const FormatterAttrs *attrs, std::string& attrs_str);
     char to_lower_underscore(char c) const;
 

--- a/src/common/HTMLFormatter.cc
+++ b/src/common/HTMLFormatter.cc
@@ -24,6 +24,8 @@
 #include <string>
 #include <string.h>     // for strdup
 
+#include "common/escape.h"
+
 // -----------------------
 namespace ceph {
 
@@ -109,7 +111,7 @@ void HTMLFormatter::dump_float(const char *name, double d)
 
 void HTMLFormatter::dump_string(const char *name, boost::string_view s)
 {
-  dump_template(name, escape_xml_str(s.data()));
+  dump_template(name, xml_stream_escaper(s.data()));
 }
 
 void HTMLFormatter::dump_string_with_attrs(const char *name, boost::string_view s, const FormatterAttrs& attrs)
@@ -118,7 +120,7 @@ void HTMLFormatter::dump_string_with_attrs(const char *name, boost::string_view 
   std::string attrs_str;
   get_attrs_str(&attrs, attrs_str);
   print_spaces();
-  m_ss << "<li>" << e << ": " << escape_xml_str(s.data()) << attrs_str << "</li>";
+  m_ss << "<li>" << e << ": " << xml_stream_escaper(s.data()) << attrs_str << "</li>";
   if (m_pretty)
     m_ss << "\n";
 }
@@ -139,9 +141,9 @@ void HTMLFormatter::dump_format_va(const char* name, const char *ns, bool quoted
   std::string e(name);
   print_spaces();
   if (ns) {
-    m_ss << "<li xmlns=\"" << ns << "\">" << e << ": " << escape_xml_str(buf) << "</li>";
+    m_ss << "<li xmlns=\"" << ns << "\">" << e << ": " << xml_stream_escaper(buf) << "</li>";
   } else {
-    m_ss << "<li>" << e << ": " << escape_xml_str(buf) << "</li>";
+    m_ss << "<li>" << e << ": " << xml_stream_escaper(buf) << "</li>";
   }
 
   if (m_pretty)

--- a/src/common/HTMLFormatter.cc
+++ b/src/common/HTMLFormatter.cc
@@ -111,7 +111,7 @@ void HTMLFormatter::dump_float(const char *name, double d)
 
 void HTMLFormatter::dump_string(const char *name, boost::string_view s)
 {
-  dump_template(name, xml_stream_escaper(s.data()));
+  dump_template(name, xml_stream_escaper(s));
 }
 
 void HTMLFormatter::dump_string_with_attrs(const char *name, boost::string_view s, const FormatterAttrs& attrs)
@@ -120,7 +120,7 @@ void HTMLFormatter::dump_string_with_attrs(const char *name, boost::string_view 
   std::string attrs_str;
   get_attrs_str(&attrs, attrs_str);
   print_spaces();
-  m_ss << "<li>" << e << ": " << xml_stream_escaper(s.data()) << attrs_str << "</li>";
+  m_ss << "<li>" << e << ": " << xml_stream_escaper(s) << attrs_str << "</li>";
   if (m_pretty)
     m_ss << "\n";
 }
@@ -136,14 +136,16 @@ std::ostream& HTMLFormatter::dump_stream(const char *name)
 void HTMLFormatter::dump_format_va(const char* name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
   char buf[LARGE_SIZE];
-  vsnprintf(buf, LARGE_SIZE, fmt, ap);
+  size_t len = vsnprintf(buf, LARGE_SIZE, fmt, ap);
 
   std::string e(name);
   print_spaces();
   if (ns) {
-    m_ss << "<li xmlns=\"" << ns << "\">" << e << ": " << xml_stream_escaper(buf) << "</li>";
+    m_ss << "<li xmlns=\"" << ns << "\">" << e << ": "
+	 << xml_stream_escaper(boost::string_view(buf, len)) << "</li>";
   } else {
-    m_ss << "<li>" << e << ": " << xml_stream_escaper(buf) << "</li>";
+    m_ss << "<li>" << e << ": "
+	 << xml_stream_escaper(boost::string_view(buf, len)) << "</li>";
   }
 
   if (m_pretty)

--- a/src/common/escape.h
+++ b/src/common/escape.h
@@ -15,11 +15,8 @@
 #ifndef CEPH_RGW_ESCAPE_H
 #define CEPH_RGW_ESCAPE_H
 
-#include <stdlib.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <ostream>
+#include <boost/utility/string_view.hpp>
 
 /* Returns the length of a buffer that would be needed to escape 'buf'
  * as an XML attrribute
@@ -47,8 +44,21 @@ void escape_json_attr(const char *buf, size_t src_len, char *out);
  * require this, Amazon does it in their XML responses.
  */
 
-#ifdef __cplusplus
-}
-#endif
+// stream output operators that write escaped text without making a copy
+// usage:
+//   std::string xml_input = ...;
+//   std::cout << xml_stream_escaper(xml_input) << std::endl;
+
+struct xml_stream_escaper {
+  boost::string_view str;
+  xml_stream_escaper(boost::string_view str) : str(str) {}
+};
+std::ostream& operator<<(std::ostream& out, const xml_stream_escaper& e);
+
+struct json_stream_escaper {
+  boost::string_view str;
+  json_stream_escaper(boost::string_view str) : str(str) {}
+};
+std::ostream& operator<<(std::ostream& out, const json_stream_escaper& e);
 
 #endif

--- a/src/common/escape.h
+++ b/src/common/escape.h
@@ -51,13 +51,13 @@ void escape_json_attr(const char *buf, size_t src_len, char *out);
 
 struct xml_stream_escaper {
   boost::string_view str;
-  xml_stream_escaper(boost::string_view str) : str(str) {}
+  xml_stream_escaper(boost::string_view str) : str(str.data(), str.size()) {}
 };
 std::ostream& operator<<(std::ostream& out, const xml_stream_escaper& e);
 
 struct json_stream_escaper {
   boost::string_view str;
-  json_stream_escaper(boost::string_view str) : str(str) {}
+  json_stream_escaper(boost::string_view str) : str(str.data(), str.size()) {}
 };
 std::ostream& operator<<(std::ostream& out, const json_stream_escaper& e);
 

--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -287,7 +287,10 @@ void RGWFormatter_Plain::dump_value_int(const char *name, const char *fmt, ...)
 class HTMLHelper : public XMLFormatter {
 public:
   static std::string escape(const std::string& unescaped_str) {
-    return escape_xml_str(unescaped_str.c_str());
+    int len = escape_xml_attr_len(unescaped_str.c_str());
+    std::string escaped(len, 0);
+    escape_xml_attr(unescaped_str.c_str(), &escaped[0]);
+    return escaped;
   }
 };
 
@@ -298,7 +301,7 @@ void RGWSwiftWebsiteListingFormatter::generate_header(
   ss << R"(<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 )"
      << R"(Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">)";
 
-  ss << "<html><head><title>Listing of " << HTMLHelper::escape(dir_path)
+  ss << "<html><head><title>Listing of " << xml_stream_escaper(dir_path)
      << "</title>";
 
   if (! css_path.empty()) {
@@ -315,7 +318,7 @@ void RGWSwiftWebsiteListingFormatter::generate_header(
 
   ss << "</head><body>";
 
-  ss << R"(<h1 id="title">Listing of )" << HTMLHelper::escape(dir_path) << "</h1>"
+  ss << R"(<h1 id="title">Listing of )" << xml_stream_escaper(dir_path) << "</h1>"
      << R"(<table id="listing">)"
      << R"(<tr id="heading">)"
      << R"(<th class="colname">Name</th>)"

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2188,7 +2188,7 @@ void RGWCopyObj_ObjStore_S3::send_response()
 
   if (op_ret == 0) {
     dump_time(s, "LastModified", &mtime);
-    std::string etag_str = etag.to_str();
+    std::string etag_str = etag.c_str();
     if (! etag_str.empty()) {
       s->formatter->dump_string("ETag", std::move(etag_str));
     }

--- a/src/test/escape.cc
+++ b/src/test/escape.cc
@@ -37,21 +37,16 @@ TEST(EscapeXml, EntityRefs1) {
 }
 
 TEST(EscapeXml, ControlChars) {
-  uint8_t cc1[] = { 0x01, 0x02, 0x03, 0x0 };
-  ASSERT_EQ(escape_xml_attrs((char*)cc1), "&#x01;&#x02;&#x03;");
+  ASSERT_EQ(escape_xml_attrs("\x01\x02\x03"), "&#x01;&#x02;&#x03;");
 
-  uint8_t cc2[] = { 0x61, 0x62, 0x63, 0x7f, 0x0 };
-  ASSERT_EQ(escape_xml_attrs((char*)cc2), "abc&#x7f;");
+  ASSERT_EQ(escape_xml_attrs("abc\x7f"), "abc&#x7f;");
 }
 
 TEST(EscapeXml, Utf8) {
-  uint8_t cc1[] = { 0xe6, 0xb1, 0x89, 0xe5, 0xad, 0x97, 0x0a, 0x0 };
-  ASSERT_EQ(escape_xml_attrs((const char*)cc1), (const char*)cc1);
+  const char *cc1 = "\xe6\xb1\x89\xe5\xad\x97\n";
+  ASSERT_EQ(escape_xml_attrs(cc1), cc1);
 
-  uint8_t cc2[] = { 0x3c, 0xe6, 0xb1, 0x89, 0xe5, 0xad, 0x97, 0x3e, 0x0a, 0x0 };
-  uint8_t cc2_out[] = { 0x26, 0x6c, 0x74, 0x3b, 0xe6, 0xb1, 0x89, 0xe5,
-			0xad, 0x97, 0x26, 0x67, 0x74, 0x3b, 0x0a, 0x0 };
-  ASSERT_EQ(escape_xml_attrs((const char*)cc2), (const char*)cc2_out);
+  ASSERT_EQ(escape_xml_attrs("<\xe6\xb1\x89\xe5\xad\x97>\n"), "&lt;\xe6\xb1\x89\xe5\xad\x97&gt;\n");
 }
 
 static std::string escape_json_attrs(const char *str)
@@ -80,14 +75,11 @@ TEST(EscapeJson, Escapes1) {
 }
 
 TEST(EscapeJson, ControlChars) {
-  uint8_t cc1[] = { 0x01, 0x02, 0x03, 0x0 };
-  ASSERT_EQ(escape_json_attrs((char*)cc1), "\\u0001\\u0002\\u0003");
+  ASSERT_EQ(escape_json_attrs("\x01\x02\x03"), "\\u0001\\u0002\\u0003");
 
-  uint8_t cc2[] = { 0x61, 0x62, 0x63, 0x7f, 0x0 };
-  ASSERT_EQ(escape_json_attrs((char*)cc2), "abc\\u007f");
+  ASSERT_EQ(escape_json_attrs("abc\x7f"), "abc\\u007f");
 }
 
 TEST(EscapeJson, Utf8) {
-  uint8_t cc1[] = { 0xe6, 0xb1, 0x89, 0xe5, 0xad, 0x97, 0x0a, 0x0 };
-  ASSERT_EQ(escape_xml_attrs((const char*)cc1), (const char*)cc1);
+  EXPECT_EQ(escape_xml_attrs("\xe6\xb1\x89\xe5\xad\x97\n"), "\xe6\xb1\x89\xe5\xad\x97\n");
 }

--- a/src/test/escape.cc
+++ b/src/test/escape.cc
@@ -81,5 +81,5 @@ TEST(EscapeJson, ControlChars) {
 }
 
 TEST(EscapeJson, Utf8) {
-  EXPECT_EQ(escape_xml_attrs("\xe6\xb1\x89\xe5\xad\x97\n"), "\xe6\xb1\x89\xe5\xad\x97\n");
+  EXPECT_EQ(escape_json_attrs("\xe6\xb1\x89\xe5\xad\x97\n"), "\xe6\xb1\x89\xe5\xad\x97\\n");
 }

--- a/src/test/escape.cc
+++ b/src/test/escape.cc
@@ -66,18 +66,21 @@ TEST(EscapeXml, Utf8) {
   ASSERT_EQ(escape_xml_stream("<\xe6\xb1\x89\xe5\xad\x97>\n"), "&lt;\xe6\xb1\x89\xe5\xad\x97&gt;\n");
 }
 
-static std::string escape_json_attrs(const char *str)
+static std::string escape_json_attrs(const char *str, size_t src_len = 0)
 {
-  int src_len = strlen(str);
+  if (!src_len)
+    src_len = strlen(str);
   int len = escape_json_attr_len(str, src_len);
   char out[len];
   escape_json_attr(str, src_len, out);
   return out;
 }
-static std::string escape_json_stream(const char *str)
+static std::string escape_json_stream(const char *str, size_t src_len = 0)
 {
+  if (!src_len)
+    src_len = strlen(str);
   std::stringstream ss;
-  ss << json_stream_escaper(str);
+  ss << json_stream_escaper(boost::string_view(str, src_len));
   return ss.str();
 }
 
@@ -110,6 +113,10 @@ TEST(EscapeJson, Escapes1) {
 TEST(EscapeJson, ControlChars) {
   ASSERT_EQ(escape_json_attrs("\x01\x02\x03"), "\\u0001\\u0002\\u0003");
   ASSERT_EQ(escape_json_stream("\x01\x02\x03"), "\\u0001\\u0002\\u0003");
+  ASSERT_EQ(escape_json_stream("\x00\x02\x03", 3), "\\u0000\\u0002\\u0003");
+
+  // json can't print binary data!
+  ASSERT_EQ(escape_json_stream("\x00\x7f\xff", 3), "\\u0000\\u007f\xff");
 
   ASSERT_EQ(escape_json_attrs("abc\x7f"), "abc\\u007f");
   ASSERT_EQ(escape_json_stream("abc\x7f"), "abc\\u007f");

--- a/src/test/escape.cc
+++ b/src/test/escape.cc
@@ -22,31 +22,48 @@ static std::string escape_xml_attrs(const char *str)
   escape_xml_attr(str, out);
   return out;
 }
+static std::string escape_xml_stream(const char *str)
+{
+  std::stringstream ss;
+  ss << xml_stream_escaper(str);
+  return ss.str();
+}
 
 TEST(EscapeXml, PassThrough) {
   ASSERT_EQ(escape_xml_attrs("simplicity itself"), "simplicity itself");
+  ASSERT_EQ(escape_xml_stream("simplicity itself"), "simplicity itself");
   ASSERT_EQ(escape_xml_attrs(""), "");
+  ASSERT_EQ(escape_xml_stream(""), "");
   ASSERT_EQ(escape_xml_attrs("simple examples please!"), "simple examples please!");
+  ASSERT_EQ(escape_xml_stream("simple examples please!"), "simple examples please!");
 }
 
 TEST(EscapeXml, EntityRefs1) {
   ASSERT_EQ(escape_xml_attrs("The \"scare quotes\""), "The &quot;scare quotes&quot;");
+  ASSERT_EQ(escape_xml_stream("The \"scare quotes\""), "The &quot;scare quotes&quot;");
   ASSERT_EQ(escape_xml_attrs("I <3 XML"), "I &lt;3 XML");
+  ASSERT_EQ(escape_xml_stream("I <3 XML"), "I &lt;3 XML");
   ASSERT_EQ(escape_xml_attrs("Some 'single' \"quotes\" here"),
+	    "Some &apos;single&apos; &quot;quotes&quot; here");
+  ASSERT_EQ(escape_xml_stream("Some 'single' \"quotes\" here"),
 	    "Some &apos;single&apos; &quot;quotes&quot; here");
 }
 
 TEST(EscapeXml, ControlChars) {
   ASSERT_EQ(escape_xml_attrs("\x01\x02\x03"), "&#x01;&#x02;&#x03;");
+  ASSERT_EQ(escape_xml_stream("\x01\x02\x03"), "&#x01;&#x02;&#x03;");
 
   ASSERT_EQ(escape_xml_attrs("abc\x7f"), "abc&#x7f;");
+  ASSERT_EQ(escape_xml_stream("abc\x7f"), "abc&#x7f;");
 }
 
 TEST(EscapeXml, Utf8) {
   const char *cc1 = "\xe6\xb1\x89\xe5\xad\x97\n";
   ASSERT_EQ(escape_xml_attrs(cc1), cc1);
+  ASSERT_EQ(escape_xml_stream(cc1), cc1);
 
   ASSERT_EQ(escape_xml_attrs("<\xe6\xb1\x89\xe5\xad\x97>\n"), "&lt;\xe6\xb1\x89\xe5\xad\x97&gt;\n");
+  ASSERT_EQ(escape_xml_stream("<\xe6\xb1\x89\xe5\xad\x97>\n"), "&lt;\xe6\xb1\x89\xe5\xad\x97&gt;\n");
 }
 
 static std::string escape_json_attrs(const char *str)
@@ -57,29 +74,48 @@ static std::string escape_json_attrs(const char *str)
   escape_json_attr(str, src_len, out);
   return out;
 }
+static std::string escape_json_stream(const char *str)
+{
+  std::stringstream ss;
+  ss << json_stream_escaper(str);
+  return ss.str();
+}
 
 TEST(EscapeJson, PassThrough) {
   ASSERT_EQ(escape_json_attrs("simplicity itself"), "simplicity itself");
+  ASSERT_EQ(escape_json_stream("simplicity itself"), "simplicity itself");
   ASSERT_EQ(escape_json_attrs(""), "");
+  ASSERT_EQ(escape_json_stream(""), "");
   ASSERT_EQ(escape_json_attrs("simple examples please!"), "simple examples please!");
+  ASSERT_EQ(escape_json_stream("simple examples please!"), "simple examples please!");
 }
 
 TEST(EscapeJson, Escapes1) {
   ASSERT_EQ(escape_json_attrs("The \"scare quotes\""),
 			     "The \\\"scare quotes\\\"");
+  ASSERT_EQ(escape_json_stream("The \"scare quotes\""),
+			      "The \\\"scare quotes\\\"");
   ASSERT_EQ(escape_json_attrs("I <3 JSON"), "I <3 JSON");
+  ASSERT_EQ(escape_json_stream("I <3 JSON"), "I <3 JSON");
   ASSERT_EQ(escape_json_attrs("Some 'single' \"quotes\" here"),
       "Some 'single' \\\"quotes\\\" here");
+  ASSERT_EQ(escape_json_stream("Some 'single' \"quotes\" here"),
+      "Some 'single' \\\"quotes\\\" here");
   ASSERT_EQ(escape_json_attrs("tabs\tand\tnewlines\n, oh my"),
+      "tabs\\tand\\tnewlines\\n, oh my");
+  ASSERT_EQ(escape_json_stream("tabs\tand\tnewlines\n, oh my"),
       "tabs\\tand\\tnewlines\\n, oh my");
 }
 
 TEST(EscapeJson, ControlChars) {
   ASSERT_EQ(escape_json_attrs("\x01\x02\x03"), "\\u0001\\u0002\\u0003");
+  ASSERT_EQ(escape_json_stream("\x01\x02\x03"), "\\u0001\\u0002\\u0003");
 
   ASSERT_EQ(escape_json_attrs("abc\x7f"), "abc\\u007f");
+  ASSERT_EQ(escape_json_stream("abc\x7f"), "abc\\u007f");
 }
 
 TEST(EscapeJson, Utf8) {
   EXPECT_EQ(escape_json_attrs("\xe6\xb1\x89\xe5\xad\x97\n"), "\xe6\xb1\x89\xe5\xad\x97\\n");
+  EXPECT_EQ(escape_json_stream("\xe6\xb1\x89\xe5\xad\x97\n"), "\xe6\xb1\x89\xe5\xad\x97\\n");
 }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43562

Signed-off-by: Mark Kogan mkogan@redhat.com

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
