### PR TITLE
nautilus: global: ensure CEPH_ARGS is decoded before early arg processing

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_bootstrap.sh
+++ b/qa/workunits/rbd/rbd_mirror_bootstrap.sh
@@ -13,12 +13,12 @@ testlog "TEST: bootstrap cluster2 from cluster1"
 # create token on cluster1 and import to cluster2
 TOKEN=${TEMPDIR}/peer-token
 TOKEN_2=${TEMPDIR}/peer-token-2
-rbd --cluster ${CLUSTER1} mirror pool peer bootstrap create ${POOL} > ${TOKEN}
-rbd --cluster ${CLUSTER1} mirror pool peer bootstrap create ${PARENT_POOL} > ${TOKEN_2}
+CEPH_ARGS='' rbd --cluster ${CLUSTER1} mirror pool peer bootstrap create ${POOL} > ${TOKEN}
+CEPH_ARGS='' rbd --cluster ${CLUSTER1} mirror pool peer bootstrap create ${PARENT_POOL} > ${TOKEN_2}
 cmp ${TOKEN} ${TOKEN_2}
 
-rbd --cluster ${CLUSTER2} --pool ${POOL} mirror pool peer bootstrap import ${TOKEN} --direction rx-only
-rbd --cluster ${CLUSTER2} --pool ${PARENT_POOL} mirror pool peer bootstrap import ${TOKEN} --direction rx-tx
+CEPH_ARGS='' rbd --cluster ${CLUSTER2} --pool ${POOL} mirror pool peer bootstrap import ${TOKEN} --direction rx-only
+CEPH_ARGS='' rbd --cluster ${CLUSTER2} --pool ${PARENT_POOL} mirror pool peer bootstrap import ${TOKEN} --direction rx-tx
 
 start_mirrors ${CLUSTER1}
 start_mirrors ${CLUSTER2}

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -254,7 +254,7 @@ setup_pools()
     CEPH_ARGS='' rbd --cluster ${cluster} pool init ${POOL}
     CEPH_ARGS='' rbd --cluster ${cluster} pool init ${PARENT_POOL}
 
-    rbd --cluster ${cluster} mirror pool enable ${POOL} pool
+    CEPH_ARGS='' rbd --cluster ${cluster} mirror pool enable ${POOL} pool
     rbd --cluster ${cluster} mirror pool enable ${PARENT_POOL} image
 
     if [ -z ${RBD_MIRROR_MANUAL_PEERS} ]; then

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -191,12 +191,12 @@ create_users()
 
     CEPH_ARGS='' ceph --cluster "${cluster}" \
         auth get-or-create client.${CEPH_ID} \
-        mon 'profile rbd' osd 'profile rbd' >> \
+        mon 'profile rbd' osd 'profile rbd' mgr 'profile rbd' >> \
         ${CEPH_ROOT}/run/${cluster}/keyring
     for instance in `seq 0 ${LAST_MIRROR_INSTANCE}`; do
         CEPH_ARGS='' ceph --cluster "${cluster}" \
             auth get-or-create client.${MIRROR_USER_ID_PREFIX}${instance} \
-            mon 'profile rbd-mirror' osd 'profile rbd' >> \
+            mon 'profile rbd-mirror' osd 'profile rbd' mgr 'profile rbd' >> \
             ${CEPH_ROOT}/run/${cluster}/keyring
     done
 }

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -263,19 +263,20 @@ setup_pools()
         rbd --cluster ${cluster} mirror pool peer add ${PARENT_POOL} ${remote_cluster}
       else
         mon_map_file=${TEMPDIR}/${remote_cluster}.monmap
-        ceph --cluster ${remote_cluster} mon getmap > ${mon_map_file}
+        CEPH_ARGS='' ceph --cluster ${remote_cluster} mon getmap > ${mon_map_file}
         mon_addr=$(monmaptool --print ${mon_map_file} | grep -E 'mon\.' |
           head -n 1 | sed -E 's/^[0-9]+: ([^ ]+).+$/\1/' | sed -E 's/\/[0-9]+//g')
 
         admin_key_file=${TEMPDIR}/${remote_cluster}.client.${CEPH_ID}.key
         CEPH_ARGS='' ceph --cluster ${remote_cluster} auth get-key client.${CEPH_ID} > ${admin_key_file}
 
-        rbd --cluster ${cluster} mirror pool peer add ${POOL} client.${CEPH_ID}@${remote_cluster}-DNE \
+        CEPH_ARGS='' rbd --cluster ${cluster} mirror pool peer add ${POOL} \
+            client.${CEPH_ID}@${remote_cluster}-DNE \
             --remote-mon-host "${mon_addr}" --remote-key-file ${admin_key_file}
 
         uuid=$(rbd --cluster ${cluster} mirror pool peer add ${PARENT_POOL} client.${CEPH_ID}@${remote_cluster}-DNE)
-        rbd --cluster ${cluster} mirror pool peer set ${PARENT_POOL} ${uuid} mon-host ${mon_addr}
-        rbd --cluster ${cluster} mirror pool peer set ${PARENT_POOL} ${uuid} key-file ${admin_key_file}
+        CEPH_ARGS='' rbd --cluster ${cluster} mirror pool peer set ${PARENT_POOL} ${uuid} mon-host ${mon_addr}
+        CEPH_ARGS='' rbd --cluster ${cluster} mirror pool peer set ${PARENT_POOL} ${uuid} key-file ${admin_key_file}
 
         PEER_CLUSTER_SUFFIX=-DNE
       fi
@@ -464,9 +465,9 @@ status()
     for cluster in ${CLUSTER1} ${CLUSTER2}
     do
 	echo "${cluster} status"
-	ceph --cluster ${cluster} -s
-	ceph --cluster ${cluster} service dump
-	ceph --cluster ${cluster} service status
+	CEPH_ARGS='' ceph --cluster ${cluster} -s
+	CEPH_ARGS='' ceph --cluster ${cluster} service dump
+	CEPH_ARGS='' ceph --cluster ${cluster} service status
 	echo
 
 	for image_pool in ${POOL} ${PARENT_POOL}
@@ -476,7 +477,7 @@ status()
 	    echo
 
 	    echo "${cluster} ${image_pool} mirror pool status"
-	    rbd --cluster ${cluster} -p ${image_pool} mirror pool status --verbose
+	    CEPH_ARGS='' rbd --cluster ${cluster} -p ${image_pool} mirror pool status --verbose
 	    echo
 
 	    for image in `rbd --cluster ${cluster} -p ${image_pool} ls 2>/dev/null`
@@ -683,7 +684,7 @@ test_status_in_pool_dir()
     local service_pattern="$6"
 
     local status_log=${TEMPDIR}/${cluster}-${pool}-${image}.mirror_status
-    rbd --cluster ${cluster} -p ${pool} mirror image status ${image} |
+    CEPH_ARGS='' rbd --cluster ${cluster} -p ${pool} mirror image status ${image} |
 	tee ${status_log} >&2
     grep "state: .*${state_pattern}" ${status_log} || return 1
     grep "description: .*${description_pattern}" ${status_log} || return 1

--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -117,14 +117,14 @@ void env_to_vec(std::vector<const char*>& args, const char *name)
   auto [env_options, env_arguments] = split_dashdash(env);
 
   args.clear();
-  args.insert(args.end(), options.begin(), options.end());
   args.insert(args.end(), env_options.begin(), env_options.end());
+  args.insert(args.end(), options.begin(), options.end());
   if (arguments.empty() && env_arguments.empty()) {
     return;
   }
   args.push_back("--");
-  args.insert(args.end(), arguments.begin(), arguments.end());
   args.insert(args.end(), env_arguments.begin(), env_arguments.end());
+  args.insert(args.end(), arguments.begin(), arguments.end());
 }
 
 void argv_to_vec(int argc, const char **argv,

--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -64,23 +64,18 @@ void string_to_vec(std::vector<std::string>& args, std::string argstr)
   }
 }
 
-bool split_dashdash(const std::vector<const char*>& args,
-		    std::vector<const char*>& options,
-		    std::vector<const char*>& arguments) {
-  bool dashdash = false;
-  for (std::vector<const char*>::const_iterator i = args.begin();
-       i != args.end();
-       ++i) {
-    if (dashdash) {
-      arguments.push_back(*i);
-    } else {
-      if (strcmp(*i, "--") == 0)
-	dashdash = true;
-      else
-	options.push_back(*i);
-    }
+std::pair<std::vector<const char*>, std::vector<const char*>>
+split_dashdash(const std::vector<const char*>& args) {
+  auto dashdash = std::find_if(args.begin(), args.end(),
+			       [](const char* arg) {
+				 return strcmp(arg, "--") == 0;
+			       });
+  std::vector<const char*> options{args.begin(), dashdash};
+  if (dashdash != args.end()) {
+    ++dashdash;
   }
-  return dashdash;
+  std::vector<const char*> arguments{dashdash, args.end()};
+  return {std::move(options), std::move(arguments)};
 }
 
 static std::mutex g_str_vec_lock;
@@ -98,15 +93,7 @@ void env_to_vec(std::vector<const char*>& args, const char *name)
   if (!name)
     name = "CEPH_ARGS";
 
-  bool dashdash = false;
-  std::vector<const char*> options;
-  std::vector<const char*> arguments;
-  if (split_dashdash(args, options, arguments))
-    dashdash = true;
-
-  std::vector<const char*> env_options;
-  std::vector<const char*> env_arguments;
-  std::vector<const char*> env;
+  auto [options, arguments] = split_dashdash(args);
 
   /*
    * We can only populate str_vec once. Other threads could hold pointers into
@@ -123,17 +110,19 @@ void env_to_vec(std::vector<const char*>& args, const char *name)
   }
   g_str_vec_lock.unlock();
 
-  vector<string>::iterator i;
-  for (i = g_str_vec.begin(); i != g_str_vec.end(); ++i)
-    env.push_back(i->c_str());
-  if (split_dashdash(env, env_options, env_arguments))
-    dashdash = true;
+  std::vector<const char*> env;
+  for (const auto& s : g_str_vec) {
+    env.push_back(s.c_str());
+  }
+  auto [env_options, env_arguments] = split_dashdash(env);
 
   args.clear();
   args.insert(args.end(), options.begin(), options.end());
   args.insert(args.end(), env_options.begin(), env_options.end());
-  if (dashdash)
-    args.push_back("--");
+  if (arguments.empty() && env_arguments.empty()) {
+    return;
+  }
+  args.push_back("--");
   args.insert(args.end(), arguments.begin(), arguments.end());
   args.insert(args.end(), env_arguments.begin(), env_arguments.end());
 }

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -90,6 +90,9 @@ void global_pre_init(
   std::string conf_file_list;
   std::string cluster = "";
 
+  // ensure environment arguments are included in early processing
+  env_to_vec(args);
+
   CephInitParameters iparams = ceph_argparse_early_args(
     args, module_type,
     &cluster, &conf_file_list);

--- a/src/test/ceph_argparse.cc
+++ b/src/test/ceph_argparse.cc
@@ -385,14 +385,15 @@ TEST(CephArgParse, env_to_vec) {
     clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(3u, args.size());
-    EXPECT_EQ(string("b"), args[1]);
-    EXPECT_EQ(string("c"), args[2]);
+    EXPECT_EQ(string("b"), args[0]);
+    EXPECT_EQ(string("c"), args[1]);
+    EXPECT_EQ(string("a"), args[2]);
     setenv("WHATEVER", "d e", 0);
     clear_g_str_vec();
     env_to_vec(args, "WHATEVER");
     EXPECT_EQ(5u, args.size());
-    EXPECT_EQ(string("d"), args[3]);
-    EXPECT_EQ(string("e"), args[4]);
+    EXPECT_EQ(string("d"), args[0]);
+    EXPECT_EQ(string("e"), args[1]);
   }
   {
     std::vector<const char*> args;
@@ -404,11 +405,11 @@ TEST(CephArgParse, env_to_vec) {
     clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(5u, args.size());
-    EXPECT_EQ(string("a"), args[0]);
-    EXPECT_EQ(string("b"), args[1]);
+    EXPECT_EQ(string("b"), args[0]);
+    EXPECT_EQ(string("a"), args[1]);
     EXPECT_EQ(string("--"), args[2]);
-    EXPECT_EQ(string("c"), args[3]);
-    EXPECT_EQ(string("d"), args[4]);
+    EXPECT_EQ(string("d"), args[3]);
+    EXPECT_EQ(string("c"), args[4]);
   }
   {
     std::vector<const char*> args;
@@ -419,8 +420,8 @@ TEST(CephArgParse, env_to_vec) {
     clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(4u, args.size());
-    EXPECT_EQ(string("a"), args[0]);
-    EXPECT_EQ(string("b"), args[1]);
+    EXPECT_EQ(string("b"), args[0]);
+    EXPECT_EQ(string("a"), args[1]);
     EXPECT_EQ(string("--"), args[2]);
     EXPECT_EQ(string("c"), args[3]);
   }
@@ -435,8 +436,8 @@ TEST(CephArgParse, env_to_vec) {
     EXPECT_EQ(4u, args.size());
     EXPECT_EQ(string("b"), args[0]);
     EXPECT_EQ(string("--"), args[1]);
-    EXPECT_EQ(string("c"), args[2]);
-    EXPECT_EQ(string("d"), args[3]);
+    EXPECT_EQ(string("d"), args[2]);
+    EXPECT_EQ(string("c"), args[3]);
   }
   {
     std::vector<const char*> args;
@@ -446,8 +447,8 @@ TEST(CephArgParse, env_to_vec) {
     clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(4u, args.size());
-    EXPECT_EQ(string("b"), args[0]);
-    EXPECT_EQ(string("c"), args[1]);
+    EXPECT_EQ(string("c"), args[0]);
+    EXPECT_EQ(string("b"), args[1]);
     EXPECT_EQ(string("--"), args[2]);
     EXPECT_EQ(string("d"), args[3]);
   }
@@ -463,8 +464,8 @@ TEST(CephArgParse, env_to_vec) {
     EXPECT_EQ(4u, args.size());
     EXPECT_EQ(string("a"), args[0]);
     EXPECT_EQ(string("--"), args[1]);
-    EXPECT_EQ(string("c"), args[2]);
-    EXPECT_EQ(string("d"), args[3]);
+    EXPECT_EQ(string("d"), args[2]);
+    EXPECT_EQ(string("c"), args[3]);
   }
   {
     std::vector<const char*> args;
@@ -476,8 +477,8 @@ TEST(CephArgParse, env_to_vec) {
     clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(4u, args.size());
-    EXPECT_EQ(string("a"), args[0]);
-    EXPECT_EQ(string("d"), args[1]);
+    EXPECT_EQ(string("d"), args[0]);
+    EXPECT_EQ(string("a"), args[1]);
     EXPECT_EQ(string("--"), args[2]);
     EXPECT_EQ(string("c"), args[3]);
   }

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -591,9 +591,11 @@ void PoolReplayer<I>::print_status(Formatter *f, stringstream *ss)
   Mutex::Locker l(m_lock);
 
   f->open_object_section("pool_replayer_status");
-  f->dump_string("pool", m_local_io_ctx.get_pool_name());
   f->dump_stream("peer") << m_peer;
-  f->dump_string("instance_id", m_instance_watcher->get_instance_id());
+  if (m_local_io_ctx.is_valid()) {
+    f->dump_string("pool", m_local_io_ctx.get_pool_name());
+    f->dump_stream("instance_id") << m_instance_watcher->get_instance_id();
+  }
 
   std::string state("running");
   if (m_manual_stop) {
@@ -654,7 +656,10 @@ void PoolReplayer<I>::start()
   }
 
   m_manual_stop = false;
-  m_instance_replayer->start();
+
+  if (m_instance_replayer) {
+    m_instance_replayer->start();
+  }
 }
 
 template <typename I>
@@ -672,7 +677,10 @@ void PoolReplayer<I>::stop(bool manual)
   }
 
   m_manual_stop = true;
-  m_instance_replayer->stop();
+
+  if (m_instance_replayer) {
+    m_instance_replayer->stop();
+  }
 }
 
 template <typename I>
@@ -686,7 +694,9 @@ void PoolReplayer<I>::restart()
     return;
   }
 
-  m_instance_replayer->restart();
+  if (m_instance_replayer) {
+    m_instance_replayer->restart();
+  }
 }
 
 template <typename I>
@@ -700,7 +710,9 @@ void PoolReplayer<I>::flush()
     return;
   }
 
-  m_instance_replayer->flush();
+  if (m_instance_replayer) {
+    m_instance_replayer->flush();
+  }
 }
 
 template <typename I>


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/43997
* https://tracker.ceph.com/issues/44080

---

backport of 

- [x] https://github.com/ceph/ceph/pull/32830
- [x] https://github.com/ceph/ceph/pull/33187
- [x] https://github.com/ceph/ceph/pull/33219
- [x] https://github.com/ceph/ceph/pull/33243

parent trackers:

* https://tracker.ceph.com/issues/43795
* https://tracker.ceph.com/issues/44066

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh