### PR TITLE
qa/vstart_runner.py: make run()'s interface same as teuthology's run

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -325,9 +325,14 @@ class LocalRemote(object):
 
         return args
 
-    def run(self, args, check_status=True, wait=True,
-            stdout=None, stderr=None, cwd=None, stdin=None,
-            logger=None, label=None, env=None, timeout=None, omit_sudo=False):
+    # Wrapper to keep the interface exactly same as that of
+    # teuthology.remote.run.
+    def run(self, **kwargs):
+        return self._do_run(**kwargs)
+
+    def _do_run(self, args, check_status=True, wait=True, stdout=None,
+                stderr=None, cwd=None, stdin=None, logger=None, label=None,
+                env=None, timeout=None, omit_sudo=False):
         args = self._perform_checks_and_return_list_of_args(args, omit_sudo)
 
         # We have to use shell=True if any run.Raw was present, e.g. &&
@@ -477,7 +482,9 @@ class LocalDaemon(object):
         if self._get_pid() is not None:
             self.stop()
 
-        self.proc = self.controller.run([os.path.join(BIN_PREFIX, "./ceph-{0}".format(self.daemon_type)), "-i", self.daemon_id])
+        self.proc = self.controller.run(args=[
+            os.path.join(BIN_PREFIX, "./ceph-{0}".format(self.daemon_type)),
+            "-i", self.daemon_id])
 
     def signal(self, sig, silent=False):
         if not self.running():
@@ -526,7 +533,7 @@ class LocalKernelMount(KernelMount):
         # FIXME maybe should add a pwd arg to teuthology.orchestra so that
         # the "cd foo && bar" shenanigans isn't needed to begin with and
         # then we wouldn't have to special case this
-        return self.client_remote.run(args, wait=wait, cwd=self.mountpoint,
+        return self.client_remote.run(args=args, wait=wait, cwd=self.mountpoint,
                                       stdin=stdin, check_status=check_status,
                                       omit_sudo=omit_sudo)
 
@@ -544,7 +551,7 @@ class LocalKernelMount(KernelMount):
             args = ['sudo', '-u', user, '-s', '/bin/bash', '-c']
             args.append(cmd)
 
-        return self.client_remote.run(args, wait=wait, cwd=self.mountpoint,
+        return self.client_remote.run(args=args, wait=wait, cwd=self.mountpoint,
                                       check_status=check_status, stdin=stdin,
                                       omit_sudo=False)
 
@@ -557,7 +564,7 @@ class LocalKernelMount(KernelMount):
         if isinstance(args, list):
             args.insert(0, 'sudo')
 
-        return self.client_remote.run(args, wait=wait, cwd=self.mountpoint,
+        return self.client_remote.run(args=args, wait=wait, cwd=self.mountpoint,
                                       check_status=check_status,
                                       omit_sudo=False)
 
@@ -711,7 +718,7 @@ class LocalFuseMount(FuseMount):
         # FIXME maybe should add a pwd arg to teuthology.orchestra so that
         # the "cd foo && bar" shenanigans isn't needed to begin with and
         # then we wouldn't have to special case this
-        return self.client_remote.run(args, wait=wait, cwd=self.mountpoint,
+        return self.client_remote.run(args=args, wait=wait, cwd=self.mountpoint,
                                       stdin=stdin, check_status=check_status,
                                       omit_sudo=omit_sudo)
 
@@ -729,7 +736,7 @@ class LocalFuseMount(FuseMount):
             args = ['sudo', '-u', user, '-s', '/bin/bash', '-c']
             args.append(cmd)
 
-        return self.client_remote.run(args, wait=wait, cwd=self.mountpoint,
+        return self.client_remote.run(args=args, wait=wait, cwd=self.mountpoint,
                                       check_status=check_status, stdin=stdin,
                                       omit_sudo=False)
 
@@ -742,7 +749,7 @@ class LocalFuseMount(FuseMount):
         if isinstance(args, list):
             args.insert(0, 'sudo')
 
-        return self.client_remote.run(args, wait=wait, cwd=self.mountpoint,
+        return self.client_remote.run(args=args, wait=wait, cwd=self.mountpoint,
                                       check_status=check_status,
                                       omit_sudo=False)
 
@@ -931,7 +938,7 @@ class LocalCephManager(CephManager):
         if watch_channel is not None:
             args.append("--watch-channel")
             args.append(watch_channel)
-        proc = self.controller.run(args, wait=False, stdout=StringIO())
+        proc = self.controller.run(args=args, wait=False, stdout=StringIO())
         return proc
 
     def raw_cluster_cmd(self, *args, **kwargs):
@@ -939,7 +946,8 @@ class LocalCephManager(CephManager):
         args like ["osd", "dump"}
         return stdout string
         """
-        proc = self.controller.run([os.path.join(BIN_PREFIX, "ceph")] + list(args), **kwargs)
+        proc = self.controller.run(args=[os.path.join(BIN_PREFIX, "ceph")] + \
+                                        list(args), **kwargs)
         return proc.stdout.getvalue()
 
     def raw_cluster_cmd_result(self, *args, **kwargs):
@@ -947,7 +955,8 @@ class LocalCephManager(CephManager):
         like raw_cluster_cmd but don't check status, just return rc
         """
         kwargs['check_status'] = False
-        proc = self.controller.run([os.path.join(BIN_PREFIX, "ceph")] + list(args), **kwargs)
+        proc = self.controller.run(args=[os.path.join(BIN_PREFIX, "ceph")] + \
+                                        list(args), **kwargs)
         return proc.exitstatus
 
     def admin_socket(self, daemon_type, daemon_id, command, check_status=True, timeout=None):
@@ -1269,8 +1278,8 @@ class LocalContext(object):
 
 def teardown_cluster():
     log.info('\ntearing down the cluster...')
-    remote.run(args = [os.path.join(SRC_PREFIX, "stop.sh")], timeout=60)
-    remote.run(args = ['rm', '-rf', './dev', './out'])
+    remote.run(args=[os.path.join(SRC_PREFIX, "stop.sh")], timeout=60)
+    remote.run(args=['rm', '-rf', './dev', './out'])
 
 def clear_old_log():
     from os import stat
@@ -1367,7 +1376,7 @@ def exec_test():
 
         # usually, i get vstart.sh running completely in less than 100
         # seconds.
-        remote.run(args, env=vstart_env, timeout=(3 * 60))
+        remote.run(args=args, env=vstart_env, timeout=(3 * 60))
 
         # Wait for OSD to come up so that subsequent injectargs etc will
         # definitely succeed


### PR DESCRIPTION
Arguments accepted by method run in teuthology should be exactly same as
that of arguments accepted by vstart_runner.py's method run to prevent
test failure with teuthology due to silly argument mismatch.
Teuthology's entry method run expects **kwargs, therefore so should
vstart_runner.py's run.

Fixes: https://tracker.ceph.com/issues/44117



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>