### PR TITLE
nautilus: rgw: Fix upload part copy range able to get almost any string

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1649,13 +1649,14 @@ int RGWPutObj_ObjStore_S3::get_params()
 
     if (copy_source_range) {
       string range = copy_source_range;
-      pos = range.find("=");
-      if (pos == std::string::npos) {
+      pos = range.find("bytes=");
+      if (pos == std::string::npos || pos != 0) {
         ret = -EINVAL;
         ldout(s->cct, 5) << "x-amz-copy-source-range bad format" << dendl;
         return ret;
       }
-      range = range.substr(pos + 1);
+      /* 6 is the length of "bytes=" */
+      range = range.substr(pos + 6);
       pos = range.find("-");
       if (pos == std::string::npos) {
         ret = -EINVAL;
@@ -1664,8 +1665,20 @@ int RGWPutObj_ObjStore_S3::get_params()
       }
       string first = range.substr(0, pos);
       string last = range.substr(pos + 1);
+      if (first.find_first_not_of("0123456789") != std::string::npos || last.find_first_not_of("0123456789") != std::string::npos)
+      {
+        ldpp_dout(this, 5) << "x-amz-copy-source-range bad format not an integer" << dendl;
+        ret = -EINVAL;
+        return ret;
+      }
       copy_source_range_fst = strtoull(first.c_str(), NULL, 10);
       copy_source_range_lst = strtoull(last.c_str(), NULL, 10);
+      if (copy_source_range_fst > copy_source_range_lst)
+      {
+        ret = -ERANGE;
+        ldpp_dout(this, 5) << "x-amz-copy-source-range bad format first number bigger than second" << dendl;
+        return ret;
+      }
     }
 
   } /* copy_source */


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43848

---

backport of https://github.com/ceph/ceph/pull/32487
parent tracker: https://tracker.ceph.com/issues/43461

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh