### PR TITLE
nautilus: rgw: Fix dynamic resharding not working for empty zonegroup in period

### DIFF
--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -1059,7 +1059,7 @@ public:
 
   bool is_single_zonegroup() const
   {
-      return (period_map.zonegroups.size() == 1);
+      return (period_map.zonegroups.size() <= 1);
   }
 
   /*


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43851

---

backport of https://github.com/ceph/ceph/pull/31977
parent tracker: https://tracker.ceph.com/issues/43188

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh