### PR TITLE
nautilus: rgw:  when you abort a multipart upload request, the quota may be not updated

### DIFF
--- a/src/rgw/rgw_multi.cc
+++ b/src/rgw/rgw_multi.cc
@@ -235,6 +235,7 @@ int abort_multipart_upload(RGWRados *store, CephContext *cct,
   bool truncated;
   int marker = 0;
   int ret;
+  uint64_t parts_accounted_size = 0;
 
   do {
     ret = list_multipart_parts(store, bucket_info, cct,
@@ -271,6 +272,7 @@ int abort_multipart_upload(RGWRados *store, CephContext *cct,
           remove_objs.push_back(key);
         }
       }
+      parts_accounted_size += obj_part.accounted_size;
     }
   } while (truncated);
 
@@ -288,6 +290,9 @@ int abort_multipart_upload(RGWRados *store, CephContext *cct,
   if (!remove_objs.empty()) {
     del_op.params.remove_objs = &remove_objs;
   }
+  
+  del_op.params.abortmp = true;
+  del_op.params.parts_accounted_size = parts_accounted_size;
 
   // and also remove the metadata obj
   ret = del_op.delete_obj();

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5517,6 +5517,10 @@ int RGWRados::Object::Delete::delete_obj()
   }
   uint64_t obj_accounted_size = state->accounted_size;
 
+  if(params.abortmp) {
+    obj_accounted_size = params.parts_accounted_size;
+  }
+
   if (!real_clock::is_zero(params.expiration_time)) {
     bufferlist bl;
     real_time delete_at;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1643,8 +1643,10 @@ public:
         ceph::real_time mtime; /* for setting delete marker mtime */
         bool high_precision_time;
         rgw_zone_set *zones_trace;
+	bool abortmp;
+	uint64_t parts_accounted_size;
 
-        DeleteParams() : versioning_status(0), olh_epoch(0), bilog_flags(0), remove_objs(NULL), high_precision_time(false), zones_trace(nullptr) {}
+        DeleteParams() : versioning_status(0), olh_epoch(0), bilog_flags(0), remove_objs(NULL), high_precision_time(false), zones_trace(nullptr), abortmp(false), parts_accounted_size(0) {}
       } params;
 
       struct DeleteResult {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43878

---

backport of https://github.com/ceph/ceph/pull/29703
parent tracker: https://tracker.ceph.com/issues/41606

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh