### PR TITLE
nautilus: rgw: MultipartObjectProcessor supports stripe size > chunk size

### DIFF
--- a/qa/suites/rgw/verify/striping$/stripe-equals-chunk.yaml
+++ b/qa/suites/rgw/verify/striping$/stripe-equals-chunk.yaml
@@ -1,0 +1,7 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        # use default values where chunk-size=stripe-size
+        #rgw max chunk size: 4194304
+        #rgw obj stripe size: 4194304

--- a/qa/suites/rgw/verify/striping$/stripe-greater-than-chunk.yaml
+++ b/qa/suites/rgw/verify/striping$/stripe-greater-than-chunk.yaml
@@ -1,0 +1,7 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rgw max chunk size: 4194304
+        # stripe size greater than (and not a multiple of) chunk size
+        rgw obj stripe size: 6291456

--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -391,12 +391,10 @@ int MultipartObjectProcessor::prepare_head()
     return r;
   }
   stripe_size = manifest_gen.cur_stripe_max_size();
-
-  uint64_t max_head_size = std::min(chunk_size, stripe_size);
-  set_head_chunk_size(max_head_size);
+  set_head_chunk_size(stripe_size);
 
   chunk = ChunkProcessor(&writer, chunk_size);
-  stripe = StripeProcessor(&chunk, this, max_head_size);
+  stripe = StripeProcessor(&chunk, this, stripe_size);
   return 0;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43999

---

backport of https://github.com/ceph/ceph/pull/32996
parent tracker: https://tracker.ceph.com/issues/42669

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh