### PR TITLE
nautilus: rgw: fix rgw crash when duration is invalid in sts request

### DIFF
--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -187,7 +187,12 @@ int RGWSTSGetSessionToken::get_params()
   tokenCode = s->info.args.get("TokenCode");
 
   if (! duration.empty()) {
-    uint64_t duration_in_secs = stoull(duration);
+    string err;
+    uint64_t duration_in_secs = strict_strtoll(duration.c_str(), 10, &err);
+    if (!err.empty()) {
+      return -EINVAL;
+    }
+
     if (duration_in_secs < STS::GetSessionTokenRequest::getMinDuration() ||
             duration_in_secs > s->cct->_conf->rgw_sts_max_session_duration)
       return -EINVAL;

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -170,12 +170,16 @@ AssumeRoleRequestBase::AssumeRoleRequestBase( const string& duration,
   if (duration.empty()) {
     this->duration = DEFAULT_DURATION_IN_SECS;
   } else {
-    this->duration = std::stoull(duration);
+    this->duration = strict_strtoll(duration.c_str(), 10, &this->err_msg);
   }
 }
 
 int AssumeRoleRequestBase::validate_input() const
 {
+  if (!err_msg.empty()) {
+    return -EINVAL;
+  }
+
   if (duration < MIN_DURATION_IN_SECS ||
           duration > MAX_DURATION_IN_SECS) {
     return -EINVAL;

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -22,6 +22,7 @@ protected:
   static constexpr uint64_t MAX_ROLE_SESSION_SIZE = 64;
   uint64_t MAX_DURATION_IN_SECS;
   uint64_t duration;
+  string err_msg;
   string iamPolicy;
   string roleArn;
   string roleSessionName;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44038

---

backport of https://github.com/ceph/ceph/pull/32119
parent tracker: https://tracker.ceph.com/issues/43207

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh