### PR TITLE
nautilus: test: Fix race with osd restart and doing a scrub

### DIFF
--- a/qa/run-standalone.sh
+++ b/qa/run-standalone.sh
@@ -93,13 +93,9 @@ if ls $(dirname $(sysctl -n $KERNCORE)) | grep -q '^core\|core$' ; then
 fi
 
 ulimit -c unlimited
-for f in $(cd $location ; find . -perm $exec_mode -type f)
+for f in $(cd $location ; find . -mindepth 2 -perm $exec_mode -type f)
 do
     f=$(echo $f | sed 's/\.\///')
-    # This is tested with misc/test-ceph-helpers.sh
-    if [[ "$f" = "ceph-helpers.sh" ]]; then
-        continue
-    fi
     if [[ "$all" = "false" ]]; then
         found=false
         for c in "${!select[@]}"

--- a/qa/standalone/erasure-code/test-erasure-eio.sh
+++ b/qa/standalone/erasure-code/test-erasure-eio.sh
@@ -173,7 +173,7 @@ function rados_put_get_data() {
         ceph osd out ${last_osd} || return 1
         ! get_osds $poolname $objname | grep '\<'${last_osd}'\>' || return 1
         ceph osd in ${last_osd} || return 1
-        run_osd $dir ${last_osd} || return 1
+        activate_osd $dir ${last_osd} || return 1
         wait_for_clean || return 1
     fi
 
@@ -373,7 +373,7 @@ function TEST_ec_object_attr_read_error() {
     inject_eio ec mdata $poolname $objname $dir 1 || return 1
 
     # Restart OSD
-    run_osd $dir ${primary_osd} || return 1
+    activate_osd $dir ${primary_osd} || return 1
 
     # Cluster should recover this object
     wait_for_clean || return 1
@@ -541,7 +541,7 @@ function TEST_ec_backfill_unfound() {
     inject_eio ec data $poolname $testobj $dir 0 || return 1
     inject_eio ec data $poolname $testobj $dir 1 || return 1
 
-    run_osd $dir ${last_osd} || return 1
+    activate_osd $dir ${last_osd} || return 1
     ceph osd in ${last_osd} || return 1
 
     sleep 15
@@ -621,7 +621,7 @@ function TEST_ec_recovery_unfound() {
     inject_eio ec data $poolname $testobj $dir 0 || return 1
     inject_eio ec data $poolname $testobj $dir 1 || return 1
 
-    run_osd $dir ${last_osd} || return 1
+    activate_osd $dir ${last_osd} || return 1
     ceph osd in ${last_osd} || return 1
 
     sleep 15

--- a/qa/standalone/osd/ec-error-rollforward.sh
+++ b/qa/standalone/osd/ec-error-rollforward.sh
@@ -37,7 +37,7 @@ function TEST_ec_error_rollforward() {
 
     rados -p ec put foo /etc/passwd
 
-    kill -STOP `cat $dir/osd.2.pid`
+    kill -STOP $(cat $dir/osd.2.pid)
 
     rados -p ec rm foo &
     pids="$!"
@@ -49,7 +49,9 @@ function TEST_ec_error_rollforward() {
     rados -p ec rm c &
     pids+=" $!"
     sleep 1
-    kill -9 `cat $dir/osd.?.pid`
+    # Use SIGKILL so stopped osd.2 will terminate
+    # and kill_daemons waits for daemons to die
+    kill_daemons $dir KILL osd
     kill $pids
     wait
 

--- a/qa/standalone/osd/ec-error-rollforward.sh
+++ b/qa/standalone/osd/ec-error-rollforward.sh
@@ -53,10 +53,10 @@ function TEST_ec_error_rollforward() {
     kill $pids
     wait
 
-    run_osd $dir 0 || return 1
-    run_osd $dir 1 || return 1
-    run_osd $dir 2 || return 1
-    run_osd $dir 3 || return 1
+    activate_osd $dir 0 || return 1
+    activate_osd $dir 1 || return 1
+    activate_osd $dir 2 || return 1
+    activate_osd $dir 3 || return 1
 
     wait_for_clean || return 1
 }

--- a/qa/standalone/osd/osd-backfill-space.sh
+++ b/qa/standalone/osd/osd-backfill-space.sh
@@ -147,7 +147,7 @@ function TEST_backfill_test_simple() {
     do
       ceph osd pool set "${poolprefix}$p" size 2
     done
-    sleep 5
+    sleep 30
 
     wait_for_not_backfilling 240 || return 1
     wait_for_not_activating 60 || return 1
@@ -226,7 +226,7 @@ function TEST_backfill_test_multi() {
     do
       ceph osd pool set "${poolprefix}$p" size 2
     done
-    sleep 5
+    sleep 30
 
     wait_for_not_backfilling 240 || return 1
     wait_for_not_activating 60 || return 1
@@ -378,7 +378,7 @@ function TEST_backfill_test_sametarget() {
 
     ceph osd pool set $pool1 size 2
     ceph osd pool set $pool2 size 2
-    sleep 5
+    sleep 30
 
     wait_for_not_backfilling 240 || return 1
     wait_for_not_activating 60 || return 1
@@ -470,10 +470,8 @@ function TEST_backfill_multi_partial() {
       osd="0"
     fi
 
-    sleep 5
-    kill $(cat $dir/osd.$fillosd.pid)
+    kill_daemon $dir/osd.$fillosd.pid TERM
     ceph osd out osd.$fillosd
-    sleep 2
 
     _objectstore_tool_nodown $dir $fillosd --op export-remove --pgid 1.0 --file $dir/fillexport.out || return 1
     activate_osd $dir $fillosd || return 1
@@ -489,8 +487,7 @@ function TEST_backfill_multi_partial() {
     ceph pg dump pgs
     # The $osd OSD is started, but we don't wait so we can kill $fillosd at the same time
     _objectstore_tool_nowait $dir $osd --op export --pgid 2.0 --file $dir/export.out
-    kill $(cat $dir/osd.$fillosd.pid)
-    sleep 5
+    kill_daemon $dir/osd.$fillosd.pid TERM
     _objectstore_tool_nodown $dir $fillosd --force --op remove --pgid 2.0
     _objectstore_tool_nodown $dir $fillosd --op import --pgid 2.0 --file $dir/export.out || return 1
     _objectstore_tool_nodown $dir $fillosd --op import --pgid 1.0 --file $dir/fillexport.out || return 1
@@ -508,12 +505,12 @@ function TEST_backfill_multi_partial() {
       done
     done
 
-    kill $(cat $dir/osd.$osd.pid)
+    kill_daemon $dir/osd.$osd.pid TERM
     ceph osd out osd.$osd
 
     activate_osd $dir $fillosd || return 1
     ceph osd in osd.$fillosd
-    sleep 15
+    sleep 30
 
     wait_for_not_backfilling 240 || return 1
     wait_for_not_activating 60 || return 1
@@ -664,7 +661,7 @@ function TEST_ec_backfill_simple() {
     fi
 
     sleep 5
-    kill $(cat $dir/osd.$fillosd.pid)
+    kill_daemon $dir/osd.$fillosd.pid TERM
     ceph osd out osd.$fillosd
     sleep 2
     ceph osd erasure-code-profile set ec-profile k=$k m=$m crush-failure-domain=osd technique=reed_sol_van plugin=jerasure || return 1
@@ -689,7 +686,7 @@ function TEST_ec_backfill_simple() {
       done
     done
 
-    kill $(cat $dir/osd.$osd.pid)
+    kill_daemon $dir/osd.$osd.pid TERM
     ceph osd out osd.$osd
 
     activate_osd $dir $fillosd || return 1
@@ -820,7 +817,7 @@ function TEST_ec_backfill_multi() {
       ceph osd pg-upmap $(expr $p + 1).0 ${nonfillosds% *} $fillosd
     done
 
-    sleep 10
+    sleep 30
 
     wait_for_not_backfilling 240 || return 1
     wait_for_not_activating 60 || return 1
@@ -958,7 +955,7 @@ function SKIP_TEST_ec_backfill_multi_partial() {
     #activate_osd $dir $lastosd || return 1
     #ceph tell osd.0 debug kick_recovery_wq 0
 
-    sleep 10
+    sleep 30
     ceph pg dump pgs
 
     wait_for_not_backfilling 240 || return 1
@@ -1033,7 +1030,7 @@ function SKIP_TEST_ec_backfill_multi_partial() {
     fi
 
     sleep 5
-    kill $(cat $dir/osd.$fillosd.pid)
+    kill_daemon $dir/osd.$fillosd.pid TERM
     ceph osd out osd.$fillosd
     sleep 2
     ceph osd erasure-code-profile set ec-profile k=3 m=2 crush-failure-domain=osd technique=reed_sol_van plugin=jerasure || return 1
@@ -1059,7 +1056,7 @@ function SKIP_TEST_ec_backfill_multi_partial() {
     done
 
     #ceph pg map 2.0 --format=json | jq '.'
-    kill $(cat $dir/osd.$osd.pid)
+    kill_daemon $dir/osd.$osd.pid TERM
     ceph osd out osd.$osd
 
     _objectstore_tool_nodown $dir $osd --op export --pgid 2.0 --file $dir/export.out
@@ -1067,7 +1064,7 @@ function SKIP_TEST_ec_backfill_multi_partial() {
 
     activate_osd $dir $fillosd || return 1
     ceph osd in osd.$fillosd
-    sleep 15
+    sleep 30
 
     wait_for_not_backfilling 240 || return 1
     wait_for_not_activating 60 || return 1

--- a/qa/standalone/osd/osd-bluefs-volume-ops.sh
+++ b/qa/standalone/osd/osd-bluefs-volume-ops.sh
@@ -140,13 +140,13 @@ function TEST_bluestore() {
 
     ceph-bluestore-tool --path $dir/3 fsck || return 1
 
-    run_osd $dir 0 || return 1
+    activate_osd $dir 0 || return 1
     osd_pid0=$(cat $dir/osd.0.pid)
-    run_osd $dir 1 || return 1
+    activate_osd $dir 1 || return 1
     osd_pid1=$(cat $dir/osd.1.pid)
-    run_osd $dir 2 || return 1
+    activate_osd $dir 2 || return 1
     osd_pid2=$(cat $dir/osd.2.pid)
-    run_osd $dir 3 || return 1
+    activate_osd $dir 3 || return 1
     osd_pid3=$(cat $dir/osd.3.pid)
 
     wait_for_clean || return 1
@@ -218,13 +218,13 @@ function TEST_bluestore() {
 
     ceph-bluestore-tool --path $dir/3 fsck || return 1
 
-    run_osd $dir 0 || return 1
+    activate_osd $dir 0 || return 1
     osd_pid0=$(cat $dir/osd.0.pid)
-    run_osd $dir 1 || return 1
+    activate_osd $dir 1 || return 1
     osd_pid1=$(cat $dir/osd.1.pid)
-    run_osd $dir 2 || return 1
+    activate_osd $dir 2 || return 1
     osd_pid2=$(cat $dir/osd.2.pid)
-    run_osd $dir 3 || return 1
+    activate_osd $dir 3 || return 1
     osd_pid3=$(cat $dir/osd.3.pid)
 
     # write some objects
@@ -324,13 +324,13 @@ function TEST_bluestore() {
 
     ceph-bluestore-tool --path $dir/3 fsck || return 1
 
-    run_osd $dir 0 || return 1
+    activate_osd $dir 0 || return 1
     osd_pid0=$(cat $dir/osd.0.pid)
-    run_osd $dir 1 || return 1
+    activate_osd $dir 1 || return 1
     osd_pid1=$(cat $dir/osd.1.pid)
-    run_osd $dir 2 || return 1
+    activate_osd $dir 2 || return 1
     osd_pid2=$(cat $dir/osd.2.pid)
-    run_osd $dir 3 || return 1
+    activate_osd $dir 3 || return 1
     osd_pid3=$(cat $dir/osd.3.pid)
 
     # write some objects

--- a/qa/standalone/osd/osd-dup.sh
+++ b/qa/standalone/osd/osd-dup.sh
@@ -61,7 +61,7 @@ function TEST_filestore_to_bluestore() {
 			  --op dup || return 1
     CEPH_ARGS=$O
 
-    run_osd $dir 0 || return 1
+    activate_osd $dir 0 || return 1
 
     while ! ceph osd stat | grep '3 up' ; do sleep 1 ; done
     ceph osd metadata 0 | grep bluestore || return 1

--- a/qa/standalone/osd/osd-recovery-stats.sh
+++ b/qa/standalone/osd/osd-recovery-stats.sh
@@ -472,7 +472,7 @@ function TEST_recovery_multi() {
 
     kill $(cat $dir/osd.${primary}.pid)
     ceph osd down osd.${primary}
-    run_osd $dir ${otherosd}
+    activate_osd $dir ${otherosd}
     sleep 3
 
     for i in $(seq $(expr $half + 1) $objects)
@@ -485,7 +485,7 @@ function TEST_recovery_multi() {
 
     ceph osd unset noout
     ceph osd out osd.$primary osd.$otherosd
-    run_osd $dir ${primary}
+    activate_osd $dir ${primary}
     sleep 3
 
     ceph osd pool set test size 4

--- a/qa/standalone/osd/osd-rep-recov-eio.sh
+++ b/qa/standalone/osd/osd-rep-recov-eio.sh
@@ -208,7 +208,7 @@ function TEST_rep_backfill_unfound() {
     inject_eio rep data $poolname $testobj $dir 0 || return 1
     inject_eio rep data $poolname $testobj $dir 1 || return 1
 
-    run_osd $dir ${last_osd} || return 1
+    activate_osd $dir ${last_osd} || return 1
     ceph osd in ${last_osd} || return 1
 
     sleep 15
@@ -285,7 +285,7 @@ function TEST_rep_recovery_unfound() {
     inject_eio rep data $poolname $testobj $dir 0 || return 1
     inject_eio rep data $poolname $testobj $dir 1 || return 1
 
-    run_osd $dir ${last_osd} || return 1
+    activate_osd $dir ${last_osd} || return 1
     ceph osd in ${last_osd} || return 1
 
     sleep 15

--- a/qa/standalone/osd/repro_long_log.sh
+++ b/qa/standalone/osd/repro_long_log.sh
@@ -105,7 +105,7 @@ function TEST_repro_long_log2()
     local PRIMARY=$(ceph pg $PGID query  | jq '.info.stats.up_primary')
     kill_daemons $dir TERM osd.$PRIMARY || return 1
     CEPH_ARGS="--osd-max-pg-log-entries=2 --no-mon-config" ceph-objectstore-tool --data-path $dir/$PRIMARY --pgid $PGID --op trim-pg-log || return 1
-    run_osd $dir $PRIMARY || return 1
+    activate_osd $dir $PRIMARY || return 1
     wait_for_clean || return 1
     test_log_size $PGID 2 || return 1
 }

--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -600,8 +600,8 @@ function TEST_repair_stats() {
       OSD=$(expr $i % 2)
       _objectstore_tool_nodown $dir $OSD obj$i remove || return 1
     done
-    run_osd $dir $primary $ceph_osd_args || return 1
-    run_osd $dir $other $ceph_osd_args || return 1
+    activate_osd $dir $primary $ceph_osd_args || return 1
+    activate_osd $dir $other $ceph_osd_args || return 1
     wait_for_clean || return 1
 
     repair $pgid
@@ -673,8 +673,8 @@ function TEST_repair_stats_ec() {
       OSD=$(expr $i % 2)
       _objectstore_tool_nodown $dir $OSD obj$i remove || return 1
     done
-    run_osd $dir $primary $ceph_osd_args || return 1
-    run_osd $dir $other $ceph_osd_args || return 1
+    activate_osd $dir $primary $ceph_osd_args || return 1
+    activate_osd $dir $other $ceph_osd_args || return 1
     wait_for_clean || return 1
 
     repair $pgid

--- a/qa/standalone/scrub/osd-scrub-snaps.sh
+++ b/qa/standalone/scrub/osd-scrub-snaps.sh
@@ -201,8 +201,10 @@ function TEST_scrub_snaps() {
 
     for osd in $(seq 0 $(expr $OSDS - 1))
     do
-      run_osd $dir $osd || return 1
+      activate_osd $dir $osd || return 1
     done
+
+    wait_for_clean || return 1
 
     local pgid="${poolid}.0"
     if ! pg_scrub "$pgid" ; then
@@ -811,8 +813,10 @@ function _scrub_snaps_multi() {
 
     for osd in $(seq 0 $(expr $OSDS - 1))
     do
-      run_osd $dir $osd || return 1
+      activate_osd $dir $osd || return 1
     done
+
+    wait_for_clean || return 1
 
     local pgid="${poolid}.0"
     if ! pg_scrub "$pgid" ; then


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43852

---

backport of https://github.com/ceph/ceph/pull/32039
parent tracker: https://tracker.ceph.com/issues/43150

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh