### PR TITLE
nautilus: mon/PGMap: fix summary display of >32bit pg states

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -19,6 +19,19 @@
 
 #define dout_context g_ceph_context
 
+using std::list;
+using std::make_pair;
+using std::map;
+using std::pair;
+using std::ostream;
+using std::ostringstream;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::vector;
+
+using ceph::bufferlist;
+
 MEMPOOL_DEFINE_OBJECT_FACTORY(PGMapDigest, pgmap_digest, pgmap);
 MEMPOOL_DEFINE_OBJECT_FACTORY(PGMap, pgmap, pgmap);
 MEMPOOL_DEFINE_OBJECT_FACTORY(PGMap::Incremental, pgmap_inc, pgmap);
@@ -108,7 +121,7 @@ void PGMapDigest::decode(bufferlist::const_iterator& p)
   DECODE_FINISH(p);
 }
 
-void PGMapDigest::dump(Formatter *f) const
+void PGMapDigest::dump(ceph::Formatter *f) const
 {
   f->dump_unsigned("num_pg", num_pg);
   f->dump_unsigned("num_pg_active", num_pg_active);
@@ -195,13 +208,13 @@ inline std::string percentify(const float& a) {
   return ss.str();
 }
 
-void PGMapDigest::print_summary(Formatter *f, ostream *out) const
+void PGMapDigest::print_summary(ceph::Formatter *f, ostream *out) const
 {
   if (f)
     f->open_array_section("pgs_by_state");
 
   // list is descending numeric order (by count)
-  multimap<int,int> state_by_count;  // count -> state
+  std::multimap<int,int> state_by_count;  // count -> state
   for (auto p = num_pg_by_state.begin();
        p != num_pg_by_state.end();
        ++p) {
@@ -286,18 +299,14 @@ void PGMapDigest::print_summary(Formatter *f, ostream *out) const
 
   if (!f) {
     unsigned max_width = 1;
-    for (multimap<int,int>::reverse_iterator p = state_by_count.rbegin();
-         p != state_by_count.rend();
-         ++p)
+    for (auto p = state_by_count.rbegin(); p != state_by_count.rend(); ++p)
     {
       std::stringstream ss;
       ss << p->first;
       max_width = std::max<size_t>(ss.str().size(), max_width);
     }
 
-    for (multimap<int,int>::reverse_iterator p = state_by_count.rbegin();
-         p != state_by_count.rend();
-         ++p)
+    for (auto p = state_by_count.rbegin(); p != state_by_count.rend(); ++p)
     {
       if (pad) {
         *out << "             ";
@@ -331,7 +340,7 @@ void PGMapDigest::print_summary(Formatter *f, ostream *out) const
     *out << "    cache:    " << ss_cache_io.str() << "\n";
 }
 
-void PGMapDigest::print_oneline_summary(Formatter *f, ostream *out) const
+void PGMapDigest::print_oneline_summary(ceph::Formatter *f, ostream *out) const
 {
   std::stringstream ss;
 
@@ -441,7 +450,7 @@ void PGMapDigest::get_recovery_stats(
   }
 }
 
-void PGMapDigest::recovery_summary(Formatter *f, list<string> *psl,
+void PGMapDigest::recovery_summary(ceph::Formatter *f, list<string> *psl,
                              const pool_stat_t& pool_sum) const
 {
   if (pool_sum.stats.sum.num_objects_degraded && pool_sum.stats.sum.num_object_copies > 0) {
@@ -494,7 +503,7 @@ void PGMapDigest::recovery_summary(Formatter *f, list<string> *psl,
   }
 }
 
-void PGMapDigest::recovery_rate_summary(Formatter *f, ostream *out,
+void PGMapDigest::recovery_rate_summary(ceph::Formatter *f, ostream *out,
                                   const pool_stat_t& delta_sum,
                                   utime_t delta_stamp) const
 {
@@ -525,17 +534,17 @@ void PGMapDigest::recovery_rate_summary(Formatter *f, ostream *out,
   }
 }
 
-void PGMapDigest::overall_recovery_rate_summary(Formatter *f, ostream *out) const
+void PGMapDigest::overall_recovery_rate_summary(ceph::Formatter *f, ostream *out) const
 {
   recovery_rate_summary(f, out, pg_sum_delta, stamp_delta);
 }
 
-void PGMapDigest::overall_recovery_summary(Formatter *f, list<string> *psl) const
+void PGMapDigest::overall_recovery_summary(ceph::Formatter *f, list<string> *psl) const
 {
   recovery_summary(f, psl, pg_sum);
 }
 
-void PGMapDigest::pool_recovery_rate_summary(Formatter *f, ostream *out,
+void PGMapDigest::pool_recovery_rate_summary(ceph::Formatter *f, ostream *out,
                                        uint64_t poolid) const
 {
   auto p = per_pool_sum_delta.find(poolid);
@@ -547,7 +556,7 @@ void PGMapDigest::pool_recovery_rate_summary(Formatter *f, ostream *out,
   recovery_rate_summary(f, out, p->second.first, ts->second);
 }
 
-void PGMapDigest::pool_recovery_summary(Formatter *f, list<string> *psl,
+void PGMapDigest::pool_recovery_summary(ceph::Formatter *f, list<string> *psl,
                                   uint64_t poolid) const
 {
   auto p = pg_pool_sum.find(poolid);
@@ -557,7 +566,7 @@ void PGMapDigest::pool_recovery_summary(Formatter *f, list<string> *psl,
   recovery_summary(f, psl, p->second);
 }
 
-void PGMapDigest::client_io_rate_summary(Formatter *f, ostream *out,
+void PGMapDigest::client_io_rate_summary(ceph::Formatter *f, ostream *out,
                                    const pool_stat_t& delta_sum,
                                    utime_t delta_stamp) const
 {
@@ -592,12 +601,12 @@ void PGMapDigest::client_io_rate_summary(Formatter *f, ostream *out,
   }
 }
 
-void PGMapDigest::overall_client_io_rate_summary(Formatter *f, ostream *out) const
+void PGMapDigest::overall_client_io_rate_summary(ceph::Formatter *f, ostream *out) const
 {
   client_io_rate_summary(f, out, pg_sum_delta, stamp_delta);
 }
 
-void PGMapDigest::pool_client_io_rate_summary(Formatter *f, ostream *out,
+void PGMapDigest::pool_client_io_rate_summary(ceph::Formatter *f, ostream *out,
                                         uint64_t poolid) const
 {
   auto p = per_pool_sum_delta.find(poolid);
@@ -609,7 +618,7 @@ void PGMapDigest::pool_client_io_rate_summary(Formatter *f, ostream *out,
   client_io_rate_summary(f, out, p->second.first, ts->second);
 }
 
-void PGMapDigest::cache_io_rate_summary(Formatter *f, ostream *out,
+void PGMapDigest::cache_io_rate_summary(ceph::Formatter *f, ostream *out,
                                   const pool_stat_t& delta_sum,
                                   utime_t delta_stamp) const
 {
@@ -689,12 +698,12 @@ void PGMapDigest::cache_io_rate_summary(Formatter *f, ostream *out,
   }
 }
 
-void PGMapDigest::overall_cache_io_rate_summary(Formatter *f, ostream *out) const
+void PGMapDigest::overall_cache_io_rate_summary(ceph::Formatter *f, ostream *out) const
 {
   cache_io_rate_summary(f, out, pg_sum_delta, stamp_delta);
 }
 
-void PGMapDigest::pool_cache_io_rate_summary(Formatter *f, ostream *out,
+void PGMapDigest::pool_cache_io_rate_summary(ceph::Formatter *f, ostream *out,
                                        uint64_t poolid) const
 {
   auto p = per_pool_sum_delta.find(poolid);
@@ -740,7 +749,7 @@ ceph_statfs PGMapDigest::get_statfs(OSDMap &osdmap,
 void PGMapDigest::dump_pool_stats_full(
   const OSDMap &osd_map,
   stringstream *ss,
-  Formatter *f,
+  ceph::Formatter *f,
   bool verbose) const
 {
   TextTable tbl;
@@ -820,7 +829,7 @@ void PGMapDigest::dump_pool_stats_full(
 }
 
 void PGMapDigest::dump_cluster_stats(stringstream *ss,
-				     Formatter *f,
+				     ceph::Formatter *f,
 				     bool verbose) const
 {
   if (f) {
@@ -880,7 +889,7 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
 }
 
 void PGMapDigest::dump_object_stat_sum(
-  TextTable &tbl, Formatter *f,
+  TextTable &tbl, ceph::Formatter *f,
   const pool_stat_t &pool_stat, uint64_t avail,
   float raw_used_rate, bool verbose, bool per_pool,
   const pg_pool_t *pool)
@@ -1029,7 +1038,7 @@ void PGMap::get_rules_avail(const OSDMap& osdmap,
 // ---------------------
 // PGMap
 
-void PGMap::Incremental::dump(Formatter *f) const
+void PGMap::Incremental::dump(ceph::Formatter *f) const
 {
   f->dump_unsigned("version", version);
   f->dump_stream("stamp") << stamp;
@@ -1486,7 +1495,7 @@ void PGMap::decode(bufferlist::const_iterator &bl)
   calc_stats();
 }
 
-void PGMap::dump(Formatter *f) const
+void PGMap::dump(ceph::Formatter *f) const
 {
   dump_basic(f);
   dump_pg_stats(f, false);
@@ -1494,7 +1503,7 @@ void PGMap::dump(Formatter *f) const
   dump_osd_stats(f);
 }
 
-void PGMap::dump_basic(Formatter *f) const
+void PGMap::dump_basic(ceph::Formatter *f) const
 {
   f->dump_unsigned("version", version);
   f->dump_stream("stamp") << stamp;
@@ -1512,7 +1521,7 @@ void PGMap::dump_basic(Formatter *f) const
   dump_delta(f);
 }
 
-void PGMap::dump_delta(Formatter *f) const
+void PGMap::dump_delta(ceph::Formatter *f) const
 {
   f->open_object_section("pg_stats_delta");
   pg_sum_delta.dump(f);
@@ -1520,7 +1529,7 @@ void PGMap::dump_delta(Formatter *f) const
   f->close_section();
 }
 
-void PGMap::dump_pg_stats(Formatter *f, bool brief) const
+void PGMap::dump_pg_stats(ceph::Formatter *f, bool brief) const
 {
   f->open_array_section("pg_stats");
   for (auto i = pg_stat.begin();
@@ -1537,7 +1546,7 @@ void PGMap::dump_pg_stats(Formatter *f, bool brief) const
   f->close_section();
 }
 
-void PGMap::dump_pool_stats(Formatter *f) const
+void PGMap::dump_pool_stats(ceph::Formatter *f) const
 {
   f->open_array_section("pool_stats");
   for (auto p = pg_pool_sum.begin();
@@ -1554,7 +1563,7 @@ void PGMap::dump_pool_stats(Formatter *f) const
   f->close_section();
 }
 
-void PGMap::dump_osd_stats(Formatter *f, bool with_net) const
+void PGMap::dump_osd_stats(ceph::Formatter *f, bool with_net) const
 {
   f->open_array_section("osd_stats");
   for (auto q = osd_stat.begin();
@@ -1924,7 +1933,7 @@ bool PGMap::get_stuck_counts(const utime_t cutoff, map<string, int>& note) const
   return inactive || unclean || undersized || degraded || stale;
 }
 
-void PGMap::dump_stuck(Formatter *f, int types, utime_t cutoff) const
+void PGMap::dump_stuck(ceph::Formatter *f, int types, utime_t cutoff) const
 {
   mempool::pgmap::unordered_map<pg_t, pg_stat_t> stuck_pg_stats;
   get_stuck_stats(types, cutoff, stuck_pg_stats);
@@ -1950,7 +1959,7 @@ void PGMap::dump_stuck_plain(ostream& ss, int types, utime_t cutoff) const
 
 int PGMap::dump_stuck_pg_stats(
   stringstream &ds,
-  Formatter *f,
+  ceph::Formatter *f,
   int threshold,
   vector<string>& args) const
 {
@@ -1986,7 +1995,7 @@ int PGMap::dump_stuck_pg_stats(
   return 0;
 }
 
-void PGMap::dump_osd_perf_stats(Formatter *f) const
+void PGMap::dump_osd_perf_stats(ceph::Formatter *f) const
 {
   f->open_array_section("osd_perf_infos");
   for (auto i = osd_stat.begin();
@@ -2020,7 +2029,7 @@ void PGMap::print_osd_perf_stats(std::ostream *ss) const
   (*ss) << tab;
 }
 
-void PGMap::dump_osd_blocked_by_stats(Formatter *f) const
+void PGMap::dump_osd_blocked_by_stats(ceph::Formatter *f) const
 {
   f->open_array_section("osd_blocked_by_infos");
   for (auto i = blocked_by_sum.begin();
@@ -2195,7 +2204,7 @@ void PGMap::get_filtered_pg_stats(uint64_t state, int64_t poolid, int64_t osdid,
   }
 }
 
-void PGMap::dump_filtered_pg_stats(Formatter *f, set<pg_t>& pgs) const
+void PGMap::dump_filtered_pg_stats(ceph::Formatter *f, set<pg_t>& pgs) const
 {
   f->open_array_section("pg_stats");
   for (auto i = pgs.begin(); i != pgs.end(); ++i) {
@@ -2264,7 +2273,7 @@ void PGMap::dump_filtered_pg_stats(ostream& ss, set<pg_t>& pgs) const
 }
 
 void PGMap::dump_pool_stats_and_io_rate(int64_t poolid, const OSDMap &osd_map,
-                                        Formatter *f,
+                                        ceph::Formatter *f,
                                         stringstream *rs) const {
   string pool_name = osd_map.get_pool_name(poolid);
   if (f) {
@@ -3330,7 +3339,7 @@ int process_pg_map_command(
   const cmdmap_t& orig_cmdmap,
   const PGMap& pg_map,
   const OSDMap& osdmap,
-  Formatter *f,
+  ceph::Formatter *f,
   stringstream *ss,
   bufferlist *odata)
 {
@@ -3788,7 +3797,7 @@ int reweight::by_utilization(
     mempool::osdmap::map<int32_t, uint32_t>* new_weights,
     std::stringstream *ss,
     std::string *out_str,
-    Formatter *f)
+    ceph::Formatter *f)
 {
   if (oload <= 100) {
     *ss << "You must give a percentage higher than 100. "

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -214,7 +214,7 @@ void PGMapDigest::print_summary(ceph::Formatter *f, ostream *out) const
     f->open_array_section("pgs_by_state");
 
   // list is descending numeric order (by count)
-  std::multimap<int,int> state_by_count;  // count -> state
+  std::multimap<int,uint64_t> state_by_count;  // count -> state
   for (auto p = num_pg_by_state.begin();
        p != num_pg_by_state.end();
        ++p) {

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -63,7 +63,7 @@ void PGMapDigest::encode(bufferlist& bl, uint64_t features) const
     uint32_t n = num_pg_by_state.size();
     encode(n, bl);
     for (auto p : num_pg_by_state) {
-      encode((uint32_t)p.first, bl);
+      encode((int32_t)p.first, bl);
       encode(p.second, bl);
     }
   }

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -48,19 +48,19 @@ public:
   mempool::pgmap::map<int64_t,int64_t> num_pg_by_pool;
   pool_stat_t pg_sum;
   osd_stat_t osd_sum;
-  mempool::pgmap::map<string,osd_stat_t> osd_sum_by_class;
+  mempool::pgmap::map<std::string,osd_stat_t> osd_sum_by_class;
   mempool::pgmap::unordered_map<uint64_t,int32_t> num_pg_by_state;
   struct pg_count {
     int32_t acting = 0;
     int32_t up_not_acting = 0;
     int32_t primary = 0;
-    void encode(bufferlist& bl) const {
+    void encode(ceph::buffer::list& bl) const {
       using ceph::encode;
       encode(acting, bl);
       encode(up_not_acting, bl);
       encode(primary, bl);
     }
-    void decode(bufferlist::const_iterator& p) {
+    void decode(ceph::buffer::list::const_iterator& p) {
       using ceph::decode;
       decode(acting, p);
       decode(up_not_acting, p);
@@ -80,7 +80,7 @@ public:
    * keep track of last deltas for each pool, calculated using
    * @p pg_pool_sum as baseline.
    */
-  mempool::pgmap::unordered_map<int64_t, mempool::pgmap::list< pair<pool_stat_t, utime_t> > > per_pool_sum_deltas;
+  mempool::pgmap::unordered_map<int64_t, mempool::pgmap::list<std::pair<pool_stat_t, utime_t> > > per_pool_sum_deltas;
   /**
    * keep track of per-pool timestamp deltas, according to last update on
    * each pool.
@@ -92,7 +92,7 @@ public:
    * of the pair is the timestamp referring to the last update (i.e., the first
    * member of the pair) for a given pool.
    */
-  mempool::pgmap::unordered_map<int64_t, pair<pool_stat_t,utime_t> > per_pool_sum_delta;
+  mempool::pgmap::unordered_map<int64_t, std::pair<pool_stat_t,utime_t> > per_pool_sum_delta;
 
   pool_stat_t pg_sum_delta;
   utime_t stamp_delta;
@@ -103,57 +103,57 @@ public:
     double *inactive_ratio,
     double *unknown_pgs_ratio) const;
 
-  void print_summary(Formatter *f, ostream *out) const;
-  void print_oneline_summary(Formatter *f, ostream *out) const;
+  void print_summary(ceph::Formatter *f, std::ostream *out) const;
+  void print_oneline_summary(ceph::Formatter *f, std::ostream *out) const;
 
-  void recovery_summary(Formatter *f, list<string> *psl,
+  void recovery_summary(ceph::Formatter *f, std::list<std::string> *psl,
                         const pool_stat_t& pool_sum) const;
-  void overall_recovery_summary(Formatter *f, list<string> *psl) const;
-  void pool_recovery_summary(Formatter *f, list<string> *psl,
+  void overall_recovery_summary(ceph::Formatter *f, std::list<std::string> *psl) const;
+  void pool_recovery_summary(ceph::Formatter *f, std::list<std::string> *psl,
                              uint64_t poolid) const;
-  void recovery_rate_summary(Formatter *f, ostream *out,
+  void recovery_rate_summary(ceph::Formatter *f, std::ostream *out,
                              const pool_stat_t& delta_sum,
                              utime_t delta_stamp) const;
-  void overall_recovery_rate_summary(Formatter *f, ostream *out) const;
-  void pool_recovery_rate_summary(Formatter *f, ostream *out,
+  void overall_recovery_rate_summary(ceph::Formatter *f, std::ostream *out) const;
+  void pool_recovery_rate_summary(ceph::Formatter *f, std::ostream *out,
                                   uint64_t poolid) const;
   /**
    * Obtain a formatted/plain output for client I/O, source from stats for a
    * given @p delta_sum pool over a given @p delta_stamp period of time.
    */
-  void client_io_rate_summary(Formatter *f, ostream *out,
+  void client_io_rate_summary(ceph::Formatter *f, std::ostream *out,
                               const pool_stat_t& delta_sum,
                               utime_t delta_stamp) const;
   /**
    * Obtain a formatted/plain output for the overall client I/O, which is
    * calculated resorting to @p pg_sum_delta and @p stamp_delta.
    */
-  void overall_client_io_rate_summary(Formatter *f, ostream *out) const;
+  void overall_client_io_rate_summary(ceph::Formatter *f, std::ostream *out) const;
   /**
    * Obtain a formatted/plain output for client I/O over a given pool
    * with id @p pool_id.  We will then obtain pool-specific data
    * from @p per_pool_sum_delta.
    */
-  void pool_client_io_rate_summary(Formatter *f, ostream *out,
+  void pool_client_io_rate_summary(ceph::Formatter *f, std::ostream *out,
                                    uint64_t poolid) const;
   /**
    * Obtain a formatted/plain output for cache tier IO, source from stats for a
    * given @p delta_sum pool over a given @p delta_stamp period of time.
    */
-  void cache_io_rate_summary(Formatter *f, ostream *out,
+  void cache_io_rate_summary(ceph::Formatter *f, std::ostream *out,
                              const pool_stat_t& delta_sum,
                              utime_t delta_stamp) const;
   /**
    * Obtain a formatted/plain output for the overall cache tier IO, which is
    * calculated resorting to @p pg_sum_delta and @p stamp_delta.
    */
-  void overall_cache_io_rate_summary(Formatter *f, ostream *out) const;
+  void overall_cache_io_rate_summary(ceph::Formatter *f, std::ostream *out) const;
   /**
    * Obtain a formatted/plain output for cache tier IO over a given pool
    * with id @p pool_id.  We will then obtain pool-specific data
    * from @p per_pool_sum_delta.
    */
-  void pool_cache_io_rate_summary(Formatter *f, ostream *out,
+  void pool_cache_io_rate_summary(ceph::Formatter *f, std::ostream *out,
                                   uint64_t poolid) const;
 
   /**
@@ -166,13 +166,13 @@ public:
   /**
    * Dump pool usage and io ops/bytes, used by "ceph df" command
    */
-  virtual void dump_pool_stats_full(const OSDMap &osd_map, stringstream *ss,
-				    Formatter *f, bool verbose) const;
-  void dump_cluster_stats(stringstream *ss, Formatter *f, bool verbose) const;
-  static void dump_object_stat_sum(TextTable &tbl, Formatter *f,
-			    const pool_stat_t &pool_stat,
-			    uint64_t avail,
-			    float raw_used_rate,
+  virtual void dump_pool_stats_full(const OSDMap &osd_map, std::stringstream *ss,
+				    ceph::Formatter *f, bool verbose) const;
+  void dump_cluster_stats(std::stringstream *ss, ceph::Formatter *f, bool verbose) const;
+  static void dump_object_stat_sum(TextTable &tbl, ceph::Formatter *f,
+				   const pool_stat_t &pool_stat,
+				   uint64_t avail,
+				   float raw_used_rate,
 				   bool verbose, bool per_pool,
 				   const pg_pool_t *pool);
 
@@ -217,10 +217,10 @@ public:
     return 0;
   }
 
-  void encode(bufferlist& bl, uint64_t features) const;
-  void decode(bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<PGMapDigest*>& ls);
+  void encode(ceph::buffer::list& bl, uint64_t features) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<PGMapDigest*>& ls);
 };
 WRITE_CLASS_ENCODER(PGMapDigest::pg_count);
 WRITE_CLASS_ENCODER_FEATURES(PGMapDigest);
@@ -289,17 +289,17 @@ public:
       osd_stat_rm.insert(osd);
       osd_stat_updates.erase(osd);
     }
-    void dump(Formatter *f) const;
-    static void generate_test_instances(list<Incremental*>& o);
+    void dump(ceph::Formatter *f) const;
+    static void generate_test_instances(std::list<Incremental*>& o);
 
     Incremental() : version(0), osdmap_epoch(0), pg_scan(0) {}
   };
 
 
   // aggregate stats (soft state), generated by calc_stats()
-  mempool::pgmap::unordered_map<int,set<pg_t> > pg_by_osd;
+  mempool::pgmap::unordered_map<int,std::set<pg_t> > pg_by_osd;
   mempool::pgmap::unordered_map<int,int> blocked_by_sum;
-  mempool::pgmap::list< pair<pool_stat_t, utime_t> > pg_sum_deltas;
+  mempool::pgmap::list<std::pair<pool_stat_t, utime_t> > pg_sum_deltas;
   mempool::pgmap::unordered_map<int64_t,mempool::pgmap::unordered_map<uint64_t,int32_t>> num_pg_by_pool_state;
 
   utime_t stamp;
@@ -336,7 +336,7 @@ public:
     const pool_stat_t& current_pool_sum,
     pool_stat_t *result_pool_delta,
     utime_t *result_ts_delta,
-    mempool::pgmap::list<pair<pool_stat_t,utime_t> > *delta_avg_list);
+    mempool::pgmap::list<std::pair<pool_stat_t,utime_t> > *delta_avg_list);
 
   void update_one_pool_delta(CephContext *cct,
                              const utime_t ts,
@@ -346,7 +346,7 @@ public:
  public:
 
   mempool::pgmap::set<pg_t> creating_pgs;
-  mempool::pgmap::map<int,map<epoch_t,set<pg_t> > > creating_pgs_by_osd_epoch;
+  mempool::pgmap::map<int,std::map<epoch_t,std::set<pg_t> > > creating_pgs_by_osd_epoch;
 
   // Bits that use to be enum StuckPG
   static const int STUCK_INACTIVE = (1<<0);
@@ -392,7 +392,7 @@ public:
     return pool_stat_t();
   }
 
-  osd_stat_t get_osd_sum(const set<int>& osds) const {
+  osd_stat_t get_osd_sum(const std::set<int>& osds) const {
     if (osds.empty()) // all
       return osd_sum;
     osd_stat_t sum;
@@ -424,25 +424,25 @@ public:
   void stat_osd_add(int osd, const osd_stat_t &s);
   void stat_osd_sub(int osd, const osd_stat_t &s);
   
-  void encode(bufferlist &bl, uint64_t features=-1) const;
-  void decode(bufferlist::const_iterator &bl);
+  void encode(ceph::buffer::list &bl, uint64_t features=-1) const;
+  void decode(ceph::buffer::list::const_iterator &bl);
 
   /// encode subset of our data to a PGMapDigest
   void encode_digest(const OSDMap& osdmap,
-		     bufferlist& bl, uint64_t features);
+		     ceph::buffer::list& bl, uint64_t features);
 
   int64_t get_rule_avail(const OSDMap& osdmap, int ruleno) const;
   void get_rules_avail(const OSDMap& osdmap,
 		       std::map<int,int64_t> *avail_map) const;
-  void dump(Formatter *f) const; 
-  void dump_basic(Formatter *f) const;
-  void dump_pg_stats(Formatter *f, bool brief) const;
-  void dump_pool_stats(Formatter *f) const;
-  void dump_osd_stats(Formatter *f, bool with_net = false) const;
-  void dump_delta(Formatter *f) const;
-  void dump_filtered_pg_stats(Formatter *f, set<pg_t>& pgs) const;
-  void dump_pool_stats_full(const OSDMap &osd_map, stringstream *ss,
-			    Formatter *f, bool verbose) const override {
+  void dump(ceph::Formatter *f) const; 
+  void dump_basic(ceph::Formatter *f) const;
+  void dump_pg_stats(ceph::Formatter *f, bool brief) const;
+  void dump_pool_stats(ceph::Formatter *f) const;
+  void dump_osd_stats(ceph::Formatter *f, bool with_net = false) const;
+  void dump_delta(ceph::Formatter *f) const;
+  void dump_filtered_pg_stats(ceph::Formatter *f, std::set<pg_t>& pgs) const;
+  void dump_pool_stats_full(const OSDMap &osd_map, std::stringstream *ss,
+			    ceph::Formatter *f, bool verbose) const override {
     get_rules_avail(osd_map, &avail_space_by_rule);
     PGMapDigest::dump_pool_stats_full(osd_map, ss, f, verbose);
   }
@@ -451,63 +451,63 @@ public:
   * Dump client io rate, recovery io rate, cache io rate and recovery information.
   * this function is used by "ceph osd pool stats" command
   */
-  void dump_pool_stats_and_io_rate(int64_t poolid, const OSDMap &osd_map, Formatter *f,
-                              stringstream *ss) const;
+  void dump_pool_stats_and_io_rate(int64_t poolid, const OSDMap &osd_map, ceph::Formatter *f,
+				   std::stringstream *ss) const;
 
   void dump_pg_stats_plain(
-    ostream& ss,
+    std::ostream& ss,
     const mempool::pgmap::unordered_map<pg_t, pg_stat_t>& pg_stats,
     bool brief) const;
   void get_stuck_stats(
     int types, const utime_t cutoff,
     mempool::pgmap::unordered_map<pg_t, pg_stat_t>& stuck_pgs) const;
-  bool get_stuck_counts(const utime_t cutoff, map<string, int>& note) const;
-  void dump_stuck(Formatter *f, int types, utime_t cutoff) const;
-  void dump_stuck_plain(ostream& ss, int types, utime_t cutoff) const;
-  int dump_stuck_pg_stats(stringstream &ds,
-			   Formatter *f,
-			   int threshold,
-			   vector<string>& args) const;
-  void dump(ostream& ss) const;
-  void dump_basic(ostream& ss) const;
-  void dump_pg_stats(ostream& ss, bool brief) const;
-  void dump_pg_sum_stats(ostream& ss, bool header) const;
-  void dump_pool_stats(ostream& ss, bool header) const;
-  void dump_osd_stats(ostream& ss) const;
-  void dump_osd_sum_stats(ostream& ss) const;
-  void dump_filtered_pg_stats(ostream& ss, set<pg_t>& pgs) const;
+  bool get_stuck_counts(const utime_t cutoff, std::map<std::string, int>& note) const;
+  void dump_stuck(ceph::Formatter *f, int types, utime_t cutoff) const;
+  void dump_stuck_plain(std::ostream& ss, int types, utime_t cutoff) const;
+  int dump_stuck_pg_stats(std::stringstream &ds,
+			  ceph::Formatter *f,
+			  int threshold,
+			  std::vector<std::string>& args) const;
+  void dump(std::ostream& ss) const;
+  void dump_basic(std::ostream& ss) const;
+  void dump_pg_stats(std::ostream& ss, bool brief) const;
+  void dump_pg_sum_stats(std::ostream& ss, bool header) const;
+  void dump_pool_stats(std::ostream& ss, bool header) const;
+  void dump_osd_stats(std::ostream& ss) const;
+  void dump_osd_sum_stats(std::ostream& ss) const;
+  void dump_filtered_pg_stats(std::ostream& ss, std::set<pg_t>& pgs) const;
 
-  void dump_osd_perf_stats(Formatter *f) const;
+  void dump_osd_perf_stats(ceph::Formatter *f) const;
   void print_osd_perf_stats(std::ostream *ss) const;
 
-  void dump_osd_blocked_by_stats(Formatter *f) const;
+  void dump_osd_blocked_by_stats(ceph::Formatter *f) const;
   void print_osd_blocked_by_stats(std::ostream *ss) const;
 
   void get_filtered_pg_stats(uint64_t state, int64_t poolid, int64_t osdid,
-                             bool primary, set<pg_t>& pgs) const;
+                             bool primary, std::set<pg_t>& pgs) const;
 
   void get_health_checks(
     CephContext *cct,
     const OSDMap& osdmap,
     health_check_map_t *checks) const;
 
-  static void generate_test_instances(list<PGMap*>& o);
+  static void generate_test_instances(std::list<PGMap*>& o);
 };
 WRITE_CLASS_ENCODER_FEATURES(PGMap)
 
-inline ostream& operator<<(ostream& out, const PGMapDigest& m) {
+inline std::ostream& operator<<(std::ostream& out, const PGMapDigest& m) {
   m.print_oneline_summary(NULL, &out);
   return out;
 }
 
 int process_pg_map_command(
-  const string& prefix,
+  const std::string& prefix,
   const cmdmap_t& cmdmap,
   const PGMap& pg_map,
   const OSDMap& osdmap,
-  Formatter *f,
-  stringstream *ss,
-  bufferlist *odata);
+  ceph::Formatter *f,
+  std::stringstream *ss,
+  ceph::buffer::list *odata);
 
 class PGMapUpdater
 {
@@ -523,7 +523,7 @@ public:
       const OSDMap &osd_map,
       const PGMap &pg_map,
       bool check_all,
-      const set<int>& need_check_down_pg_osds,
+      const std::set<int>& need_check_down_pg_osds,
       PGMap::Incremental *pending_inc);
 };
 
@@ -538,12 +538,12 @@ namespace reweight {
 		     int oload,
 		     double max_changef,
 		     int max_osds,
-		     bool by_pg, const set<int64_t> *pools,
+		     bool by_pg, const std::set<int64_t> *pools,
 		     bool no_increasing,
 		     mempool::osdmap::map<int32_t, uint32_t>* new_weights,
 		     std::stringstream *ss,
 		     std::string *out_str,
-		     Formatter *f);
+		     ceph::Formatter *f);
 }
 
 #endif


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44081

---

backport of https://github.com/ceph/ceph/pull/33137
parent tracker: https://tracker.ceph.com/issues/44052

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh