### PR TITLE
nautilus: common/bl: fix the dangling last_p issue.

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -1002,6 +1002,7 @@ inline namespace v14_2_0 {
         _carriage = &always_empty_bptr;
         _buffers.clone_from(other._buffers);
         _len = other._len;
+        last_p = begin();
       }
       return *this;
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43722

---

backport of https://github.com/ceph/ceph/pull/32702
parent tracker: https://tracker.ceph.com/issues/43646

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh