### PR TITLE
mon/OSDMonitor: add flag `--yes-i-really-mean-it` for setting pool size 1

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -316,3 +316,8 @@
   If the zonegroup is part of a realm, the change must be committed with
   'radosgw-admin period update --commit' - otherwise the change will take
   effect after radosgws are restarted.
+
+* Monitors now have config option ``mon_allow_pool_size_one``, which is disabled
+  by default. However, if enabled, user now have to pass the
+  ``--yes-i-really-mean-it`` flag to ``osd pool set size 1``, if they are really
+  sure of configuring pool size 1.

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -478,6 +478,7 @@ function run_mon() {
         --run-dir=$dir \
         --pid-file=$dir/\$name.pid \
 	--mon-allow-pool-delete \
+	--mon-allow-pool-size-one \
 	--osd-pool-default-pg-autoscale-mode off \
 	--mon-osd-backfillfull-ratio .99 \
         "$@" || return 1

--- a/qa/standalone/mon/health-mute.sh
+++ b/qa/standalone/mon/health-mute.sh
@@ -38,7 +38,7 @@ function TEST_mute() {
     ceph -s
     ceph health | grep HEALTH_OK || return 1
     # test warning on setting pool size=1
-    ceph osd pool set foo size 1
+    ceph osd pool set foo size 1 --yes-i-really-mean-it
     ceph -s
     ceph health | grep HEALTH_WARN || return 1
     ceph health detail | grep POOL_NO_REDUNDANCY || return 1

--- a/qa/standalone/osd/osd-backfill-prio.sh
+++ b/qa/standalone/osd/osd-backfill-prio.sh
@@ -129,8 +129,8 @@ function TEST_backfill_priority() {
       fi
     done
 
-    ceph osd pool set $pool2 size 1
-    ceph osd pool set $pool3 size 1
+    ceph osd pool set $pool2 size 1 --yes-i-really-mean-it
+    ceph osd pool set $pool3 size 1 --yes-i-really-mean-it
     wait_for_clean || return 1
 
     dd if=/dev/urandom of=$dir/data bs=1M count=10
@@ -405,9 +405,9 @@ function TEST_backfill_pool_priority() {
     pool1_prio=$(expr $DEGRADED_PRIO + 1 + $pool1_extra_prio)
     pool2_prio=$(expr $DEGRADED_PRIO + 1 + $pool2_extra_prio)
 
-    ceph osd pool set $pool1 size 1
+    ceph osd pool set $pool1 size 1 --yes-i-really-mean-it
     ceph osd pool set $pool1 recovery_priority $pool1_extra_prio
-    ceph osd pool set $pool2 size 1
+    ceph osd pool set $pool2 size 1 --yes-i-really-mean-it
     ceph osd pool set $pool2 recovery_priority $pool2_extra_prio
     wait_for_clean || return 1
 

--- a/qa/standalone/osd/osd-backfill-space.sh
+++ b/qa/standalone/osd/osd-backfill-space.sh
@@ -124,7 +124,7 @@ function TEST_backfill_test_simple() {
     for p in $(seq 1 $pools)
     do
       create_pool "${poolprefix}$p" 1 1
-      ceph osd pool set "${poolprefix}$p" size 1
+      ceph osd pool set "${poolprefix}$p" size 1 --yes-i-really-mean-it
     done
 
     wait_for_clean || return 1
@@ -206,7 +206,7 @@ function TEST_backfill_test_multi() {
     for p in $(seq 1 $pools)
     do
       create_pool "${poolprefix}$p" 1 1
-      ceph osd pool set "${poolprefix}$p" size 1
+      ceph osd pool set "${poolprefix}$p" size 1 --yes-i-really-mean-it
     done
 
     wait_for_clean || return 1
@@ -364,8 +364,8 @@ function TEST_backfill_test_sametarget() {
       fi
     done
 
-    ceph osd pool set $pool1 size 1
-    ceph osd pool set $pool2 size 1
+    ceph osd pool set $pool1 size 1 --yes-i-really-mean-it
+    ceph osd pool set $pool2 size 1 --yes-i-really-mean-it
 
     wait_for_clean || return 1
 
@@ -444,7 +444,7 @@ function TEST_backfill_multi_partial() {
 
     ceph osd set-require-min-compat-client luminous
     create_pool fillpool 1 1
-    ceph osd pool set fillpool size 1
+    ceph osd pool set fillpool size 1 --yes-i-really-mean-it
     for p in $(seq 1 $pools)
     do
       create_pool "${poolprefix}$p" 1 1
@@ -639,7 +639,7 @@ function TEST_ec_backfill_simple() {
 
     ceph osd set-backfillfull-ratio .85
     create_pool fillpool 1 1
-    ceph osd pool set fillpool size 1
+    ceph osd pool set fillpool size 1 --yes-i-really-mean-it
 
     # Partially fill an osd
     # We have room for 200 18K replicated objects, if we create 13K objects
@@ -770,7 +770,7 @@ function TEST_ec_backfill_multi() {
 
     ceph osd set-require-min-compat-client luminous
     create_pool fillpool 1 1
-    ceph osd pool set fillpool size 1
+    ceph osd pool set fillpool size 1 --yes-i-really-mean-it
 
     # Partially fill an osd
     # We have room for 200 18K replicated objects, if we create 9K objects
@@ -888,7 +888,7 @@ function SKIP_TEST_ec_backfill_multi_partial() {
 
     ceph osd set-require-min-compat-client luminous
     create_pool fillpool 1 1
-    ceph osd pool set fillpool size 1
+    ceph osd pool set fillpool size 1 --yes-i-really-mean-it
     # last osd
     ceph osd pg-upmap 1.0 $lastosd
 
@@ -1010,7 +1010,7 @@ function SKIP_TEST_ec_backfill_multi_partial() {
 
     ceph osd set-require-min-compat-client luminous
     create_pool fillpool 1 1
-    ceph osd pool set fillpool size 1
+    ceph osd pool set fillpool size 1 --yes-i-really-mean-it
 
     # Partially fill an osd
     # We have room for 200 48K ec objects, if we create 4k replicated objects

--- a/qa/standalone/osd/osd-backfill-stats.sh
+++ b/qa/standalone/osd/osd-backfill-stats.sh
@@ -143,7 +143,7 @@ function TEST_backfill_sizeup() {
     run_osd $dir 5 || return 1
 
     create_pool $poolname 1 1
-    ceph osd pool set $poolname size 1
+    ceph osd pool set $poolname size 1 --yes-i-really-mean-it
 
     wait_for_clean || return 1
 
@@ -189,7 +189,7 @@ function TEST_backfill_sizeup_out() {
     run_osd $dir 5 || return 1
 
     create_pool $poolname 1 1
-    ceph osd pool set $poolname size 1
+    ceph osd pool set $poolname size 1 --yes-i-really-mean-it
 
     wait_for_clean || return 1
 

--- a/qa/standalone/osd/osd-recovery-prio.sh
+++ b/qa/standalone/osd/osd-recovery-prio.sh
@@ -125,8 +125,8 @@ function TEST_recovery_priority() {
       fi
     done
 
-    ceph osd pool set $pool2 size 1
-    ceph osd pool set $pool3 size 1
+    ceph osd pool set $pool2 size 1 --yes-i-really-mean-it
+    ceph osd pool set $pool3 size 1 --yes-i-really-mean-it
     wait_for_clean || return 1
 
     dd if=/dev/urandom of=$dir/data bs=1M count=10
@@ -401,9 +401,9 @@ function TEST_recovery_pool_priority() {
     pool1_prio=$(expr $NORMAL_PRIO + $pool1_extra_prio)
     pool2_prio=$(expr $NORMAL_PRIO + $pool2_extra_prio)
 
-    ceph osd pool set $pool1 size 1
+    ceph osd pool set $pool1 size 1 --yes-i-really-mean-it
     ceph osd pool set $pool1 recovery_priority $pool1_extra_prio
-    ceph osd pool set $pool2 size 1
+    ceph osd pool set $pool2 size 1 --yes-i-really-mean-it
     ceph osd pool set $pool2 recovery_priority $pool2_extra_prio
     wait_for_clean || return 1
 

--- a/qa/standalone/osd/osd-recovery-space.sh
+++ b/qa/standalone/osd/osd-recovery-space.sh
@@ -105,7 +105,7 @@ function TEST_recovery_test_simple() {
     for p in $(seq 1 $pools)
     do
       create_pool "${poolprefix}$p" 1 1
-      ceph osd pool set "${poolprefix}$p" size 1
+      ceph osd pool set "${poolprefix}$p" size 1 --yes-i-really-mean-it
     done
 
     wait_for_clean || return 1

--- a/qa/standalone/osd/osd-recovery-stats.sh
+++ b/qa/standalone/osd/osd-recovery-stats.sh
@@ -314,7 +314,7 @@ function TEST_recovery_undersized() {
     done
 
     create_pool $poolname 1 1
-    ceph osd pool set $poolname size 1
+    ceph osd pool set $poolname size 1 --yes-i-really-mean-it
 
     wait_for_clean || return 1
 

--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -30,6 +30,7 @@
 	mon warn on too few osds = false
 	mon_warn_on_pool_pg_num_not_power_of_two = false
         mon_warn_on_pool_no_redundancy = false
+	mon_allow_pool_size_one = true
 
         osd pool default erasure code profile = "plugin=jerasure technique=reed_sol_van k=2 m=1 ruleset-failure-domain=osd crush-failure-domain=osd"
 

--- a/qa/workunits/ceph-helpers-root.sh
+++ b/qa/workunits/ceph-helpers-root.sh
@@ -108,7 +108,7 @@ function pool_read_write() {
 
     ceph osd pool delete $test_pool $test_pool --yes-i-really-really-mean-it || return 1
     ceph osd pool create $test_pool 4 || return 1
-    ceph osd pool set $test_pool size $size || return 1
+    ceph osd pool set $test_pool size $size --yes-i-really-mean-it || return 1
     ceph osd pool set $test_pool min_size $size || return 1
     ceph osd pool application enable $test_pool rados
 

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -2174,9 +2174,9 @@ function test_mon_osd_pool_set()
 
   old_size=$(ceph osd pool get $TEST_POOL_GETSET size | sed -e 's/size: //')
   (( new_size = old_size + 1 ))
-  ceph osd pool set $TEST_POOL_GETSET size $new_size
+  ceph osd pool set $TEST_POOL_GETSET size $new_size --yes-i-really-mean-it
   ceph osd pool get $TEST_POOL_GETSET size | grep "size: $new_size"
-  ceph osd pool set $TEST_POOL_GETSET size $old_size
+  ceph osd pool set $TEST_POOL_GETSET size $old_size --yes-i-really-mean-it
 
   ceph osd pool create pool_erasure 1 1 erasure
   ceph osd pool application enable pool_erasure rados

--- a/qa/workunits/mon/pool_ops.sh
+++ b/qa/workunits/mon/pool_ops.sh
@@ -19,7 +19,7 @@ ceph osd pool create foooo 123
 
 ceph osd pool create foo 123 # idempotent
 
-ceph osd pool set foo size 1
+ceph osd pool set foo size 1 --yes-i-really-mean-it
 ceph osd pool set foo size 4
 ceph osd pool set foo size 10
 expect_false ceph osd pool set foo size 0

--- a/qa/workunits/rados/test_alloc_hint.sh
+++ b/qa/workunits/rados/test_alloc_hint.sh
@@ -109,7 +109,7 @@ setup_osd_data
 
 POOL="alloc_hint-rep"
 ceph osd pool create "${POOL}" "${NUM_PG}"
-ceph osd pool set "${POOL}" size "${NUM_OSDS}"
+ceph osd pool set "${POOL}" size "${NUM_OSDS}" --yes-i-really-mean-it
 ceph osd pool application enable "${POOL}" rados
 
 OBJ="foo"

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1736,6 +1736,11 @@ std::vector<Option> get_global_options() {
     .add_see_also("osd_pool_default_size")
     .add_see_also("osd_pool_default_min_size"),
 
+    Option("mon_allow_pool_size_one", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .add_service("mon")
+    .set_description("allow configuring pool with no replicas"),
+
     Option("mon_warn_on_misplaced", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .add_service("mgr")

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7929,6 +7929,19 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
       ss << "pool size must be between 1 and 10";
       return -EINVAL;
     }
+    if (n == 1) {
+      if (!g_conf().get_val<bool>("mon_allow_pool_size_one")) {
+	ss << "configuring pool size as 1 is disabled by default.";
+	return -EPERM;
+      }
+      bool sure = false;
+      cmd_getval(cmdmap, "yes_i_really_mean_it", sure);
+      if (!sure) { ss << "WARNING: setting pool size 1 could lead to data loss "
+	"without recovery. If you are *ABSOLUTELY CERTAIN* that is what you want, "
+	  "pass the flag --yes-i-really-mean-it.";
+	return -EPERM;
+      }
+    }
     if (!osdmap.crush->check_crush_rule(p.get_crush_rule(), p.type, n, ss)) {
       return -EINVAL;
     }

--- a/src/test/test_lost.sh
+++ b/src/test/test_lost.sh
@@ -27,7 +27,7 @@ setup() {
 	for pool in `./ceph osd pool ls`; do
 	    local size=`./ceph osd pool get ${pool} size | awk '{print $2}'`
 	    if [ "${size}" -gt "${CEPH_NUM_OSD}" ]; then
-		./ceph osd pool set ${pool} size ${CEPH_NUM_OSD}
+		./ceph osd pool set ${pool} size ${CEPH_NUM_OSD} --yes-i-really-mean-it
 		changed=1
 	    fi
 	done

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1259,6 +1259,7 @@ mon_osd_reporter_subtree_level = osd
 mon_data_avail_warn = 2
 mon_data_avail_crit = 1
 mon_allow_pool_delete = true
+mon_allow_pool_size_one = true
 
 [osd]
 osd_scrub_load_threshold = 2000


### PR DESCRIPTION

Adds option `mon_allow_pool_size_one` which will be disabled by default
to ensure pools are not configured without replicas.
If the user still wants to use pool size 1, they will have to change the
value of `mon_allow_pool_size_one` to true and then have to pass flag
`--yes-i-really-really-mean-it` to cli command:

Example:
`ceph osd pool test set size 1 --yes-i-really-really-mean-it`

Fixes: https://tracker.ceph.com/issues/44025
Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
