### PR TITLE
src/common: add cephfs-shell section to cephfs-shell.conf

### DIFF
--- a/doc/cephfs/cephfs-shell.rst
+++ b/doc/cephfs/cephfs-shell.rst
@@ -3,16 +3,22 @@
 CephFS Shell
 =============
 
-The File System (FS) shell includes various shell-like commands that directly interact with the :term:`Ceph File System`.
+CephFS Shell provides shell-like commands that directly interact with the
+:term:`Ceph File System`.
+
+Behaviour of CephFS Shell can be tweaked using cephfs-shell.conf. CephFS Shell
+looks for it by default at the path provided in environment variable
+`CEPHFS_SHELL_CONF` and then in user's home directory
+(`~/.cephfs-shell.conf`).
 
 Usage :
 
     cephfs-shell [-options] -- [command, command,...]
 
 Options :
-    -c, --config FILE     Set Configuration file.
-    -b, --batch FILE      Process a batch file.
-    -t, --test FILE       Test against transcript(s) in FILE
+    -c, --config FILE     Path to cephfs-shell.conf
+    -b, --batch FILE      Path to batch file.
+    -t, --test FILE       Path to transcript(s) in FILE for testing
 
 
 .. note::

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8491,57 +8491,6 @@ std::vector<Option> get_mds_client_options() {
 }
 
 
-std::vector<Option> get_cephfs_shell_options() {
-  return std::vector<Option>({
-    Option("allow_ansi", Option::TYPE_STR, Option::LEVEL_BASIC)
-    .set_default("Terminal")
-    .set_description("Allow ANSI escape sequences in output. Values: "
-		     "Terminal, Always, Never"),
-
-    Option("colors", Option::TYPE_STR, Option::LEVEL_BASIC)
-    .set_default("Terminal")
-    .set_description("Colouring CephFS shell input and output. Values: "
-		     "Terminal, Always, Never"),
-
-    Option("continuation_prompt", Option::TYPE_STR, Option::LEVEL_BASIC)
-    .set_default(">")
-    .set_description("Prompt string when a command continue to second line"),
-
-    Option("debug_shell", Option::TYPE_BOOL, Option::LEVEL_BASIC)
-    .set_default(false)
-    .set_description("Allow tracebacks on error for CephFS Shell"),
-
-    Option("echo", Option::TYPE_BOOL, Option::LEVEL_BASIC)
-    .set_default(false)
-    .set_description("Print command issued on prompt before execution"),
-
-    Option("editor", Option::TYPE_STR, Option::LEVEL_BASIC)
-    .set_default("vim")
-    .set_description("Default text editor for shell"),
-
-    Option("feedback_to_output", Option::TYPE_BOOL, Option::LEVEL_BASIC)
-    .set_default(false)
-    .set_description("include '|' and '>' in result"),
-
-    Option("max_completion_items", Option::TYPE_INT, Option::LEVEL_BASIC)
-    .set_default(50)
-    .set_description("Maximum number of items to be displayed by tab "
-		     "completion"),
-
-    Option("prompt", Option::TYPE_STR, Option::LEVEL_BASIC)
-    .set_default("\x1b[01;33mCephFS:~\x1b[96m/\x1b[0m\x1b[01;33m>>>\x1b[00m ")
-    .set_description("Whether non-essential feedback should be printed."),
-
-    Option("quiet", Option::TYPE_BOOL, Option::LEVEL_BASIC)
-    .set_default(false)
-    .set_description("Whether non-essential feedback should be printed."),
-
-    Option("timing", Option::TYPE_BOOL, Option::LEVEL_BASIC)
-    .set_default(false)
-    .set_description("Whether execution time should be reported"),
-  });
-}
-
 static std::vector<Option> build_options()
 {
   std::vector<Option> result = get_global_options();
@@ -8559,7 +8508,6 @@ static std::vector<Option> build_options()
   ingest(get_immutable_object_cache_options(), "immutable-objet-cache");
   ingest(get_mds_options(), "mds");
   ingest(get_mds_client_options(), "mds_client");
-  ingest(get_cephfs_shell_options(), "cephfs-shell");
 
   return result;
 }

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1483,13 +1483,13 @@ class CephFSShell(Cmd):
 #
 #####################################################
 
-def setup_cephfs(config_file):
+def setup_cephfs():
     """
     Mounting a cephfs
     """
     global cephfs
     try:
-        cephfs = libcephfs.LibCephFS(conffile=config_file)
+        cephfs = libcephfs.LibCephFS(conffile='')
         cephfs.mount()
     except libcephfs.ObjectNotFound:
         print('couldn\'t find ceph configuration not found')
@@ -1499,7 +1499,10 @@ def setup_cephfs(config_file):
         sys.exit(1)
 
 
-def get_bool_vals_for_boolopts(val):
+def str_to_bool(val):
+    """
+    Return corresponding bool values for strings like 'true' or 'false'.
+    """
     if not isinstance(val, str):
         return val
 
@@ -1512,40 +1515,60 @@ def get_bool_vals_for_boolopts(val):
         return val
 
 
-def read_ceph_conf(shell, config_file):
-    try:
-        shell.debug = get_bool_vals_for_boolopts(cephfs.
-                                                 conf_get('debug_shell'))
-        shell.allow_ansi = get_bool_vals_for_boolopts(cephfs.
-                                                      conf_get('allow_ansi'))
-        shell.echo = get_bool_vals_for_boolopts(cephfs.conf_get('echo'))
-        shell.continuation_prompt = get_bool_vals_for_boolopts(cephfs.
-                                                               conf_get('continuation_prompt'))
-        shell.colors = get_bool_vals_for_boolopts(cephfs.conf_get('colors'))
-        shell.editor = get_bool_vals_for_boolopts(cephfs.conf_get('editor'))
-        shell.feedback_to_output = get_bool_vals_for_boolopts(cephfs.
-                                                              conf_get('feedback_to_output'))
-        shell.max_completion_items = get_bool_vals_for_boolopts(cephfs.
-                                                                conf_get('max_completion_items'))
-        shell.prompt = get_bool_vals_for_boolopts(cephfs.conf_get('prompt'))
-        shell.quiet = get_bool_vals_for_boolopts(cephfs.conf_get('quiet'))
-        shell.timing = get_bool_vals_for_boolopts(cephfs.conf_get('timing'))
-    except OSError as e:
-        perror(e)
-        shell.exit_code = e.errno
-    except libcephfs.Error as e:
-        perror(e)
-        shell.exit_code = e.get_error_code()
+def read_shell_conf(shell, shell_conf_file):
+    import configparser
+
+    sec = 'cephfs-shell'
+    opts = []
+    if LooseVersion(cmd2_version) >= LooseVersion("0.10.0"):
+        for attr in shell.settables.keys():
+            opts.append(attr)
+    else:
+        if LooseVersion(cmd2_version) <= LooseVersion("0.9.13"):
+            # hardcoding options for 0.7.9 because -
+            # 1. we use cmd2 v0.7.9 with teuthology and
+            # 2. there's no way distinguish between a shell setting and shell
+            #    object attribute until v0.10.0
+            opts = ['abbrev', 'autorun_on_edit', 'colors',
+                    'continuation_prompt', 'debug', 'echo', 'editor',
+                    'feedback_to_output', 'locals_in_py', 'prompt', 'quiet',
+                    'timing']
+        elif LooseVersion(cmd2_version) >= LooseVersion("0.9.23"):
+            opts.append('allow_style')
+        # no equivalent option was defined by cmd2.
+        else:
+            pass
+
+    # default and only section in our conf file.
+    cp = configparser.ConfigParser(default_section=sec, strict=False)
+    cp.read(shell_conf_file)
+    for opt in opts:
+        if cp.has_option(sec, opt):
+            setattr(shell, opt, str_to_bool(cp.get(sec, opt)))
+
+
+def get_shell_conffile_path(arg_conf=''):
+    conf_filename = 'cephfs-shell.conf'
+    env_var = 'CEPHFS_SHELL_CONF'
+
+    arg_conf = '' if not arg_conf else arg_conf
+    home_dir_conf = os.path.expanduser('~/.' + conf_filename)
+    env_conf = os.environ[env_var] if env_var in os.environ else ''
+
+    # here's the priority by which conf gets read.
+    for path in (arg_conf, env_conf, home_dir_conf):
+        if os.path.isfile(path):
+            return path
+    else:
+        return ''
 
 
 if __name__ == '__main__':
-    config_file = ''
-
     exe = sys.argv[0]
 
     main_parser = argparse.ArgumentParser(description='')
     main_parser.add_argument('-c', '--config', action='store',
-                             help='Configuration file_path', type=str)
+                             help='Path to cephfs-shell.conf', type=str)
     main_parser.add_argument(
         '-b', '--batch', action='store', help='Batch File path.', type=str)
     main_parser.add_argument('-t', '--test', action='store',
@@ -1554,8 +1577,7 @@ if __name__ == '__main__':
     main_parser.add_argument('commands', nargs='*',
                              help='comma delimited commands', default=[])
     args = main_parser.parse_args()
-    if args.config:
-        config_file = args.config
+
     if args.batch:
         if LooseVersion(cmd2_version) <= LooseVersion("0.9.13"):
             args.commands = ['load ' + args.batch, ',quit']
@@ -1568,10 +1590,12 @@ if __name__ == '__main__':
     sys.argv.append(exe)
     sys.argv.extend([i.strip() for i in ' '.join(args.commands).split(',')])
 
-    setup_cephfs(config_file)
+    setup_cephfs()
     shell = CephFSShell()
+    # TODO: perhaps, we should add an option to pass ceph.conf?
+    read_shell_conf(shell, get_shell_conffile_path(args.config))
     shell.exit_code = 0
-    read_ceph_conf(shell, config_file)
+
     shell.exit_code = shell.cmdloop()
 
     sys.exit(shell.exit_code)

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -672,13 +672,6 @@ EOF
 
 $extra_conf
 EOF
-wconf <<EOF
-[cephfs-shell]
-        debug shell = true
-
-$extra_conf
-EOF
-
 	do_rgw_conf
 	wconf << EOF
 [mds]


### PR DESCRIPTION
This commit adds the ability to set cephfs-shell's config options
via ceph.conf as well as via ceph config subcommand.

Fixes: https://tracker.ceph.com/issues/44127



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>