### PR TITLE
[RFC] auth: treat mgr the same as mon when getting supported modes

### DIFF
--- a/src/auth/AuthRegistry.cc
+++ b/src/auth/AuthRegistry.cc
@@ -196,6 +196,7 @@ void AuthRegistry::get_supported_methods(
     if (modes) {
       switch (peer_type) {
       case CEPH_ENTITY_TYPE_MON:
+      case CEPH_ENTITY_TYPE_MGR:
 	*modes = mon_client_modes;
 	break;
       default:
@@ -204,10 +205,12 @@ void AuthRegistry::get_supported_methods(
     }
     return;
   case CEPH_ENTITY_TYPE_MON:
-    // i am mon
+  case CEPH_ENTITY_TYPE_MGR:
+    // i am mon/mgr
     switch (peer_type) {
     case CEPH_ENTITY_TYPE_MON:
-      // they are mon
+    case CEPH_ENTITY_TYPE_MGR:
+      // they are mon/mgr
       if (methods) {
 	*methods = cluster_methods;
       }

--- a/src/test/test_auth.cc
+++ b/src/test/test_auth.cc
@@ -63,8 +63,10 @@ TEST(AuthRegistry, con_modes)
   cct->_set_module_type(CEPH_ENTITY_TYPE_MON);
   reg.get_supported_modes(CEPH_ENTITY_TYPE_MON, CEPH_AUTH_CEPHX, &modes);
   ASSERT_EQ(modes, secure);
+
+  /* mgr is treated same as mon */
   reg.get_supported_modes(CEPH_ENTITY_TYPE_MGR, CEPH_AUTH_CEPHX, &modes);
-  ASSERT_EQ(modes, crc_secure);
+  ASSERT_EQ(modes, secure);
 
   // how all cluster -> mon connections secure?
   cct->_conf.set_val("ms_mon_service_mode", "secure");
@@ -116,8 +118,10 @@ TEST(AuthRegistry, con_modes)
   ASSERT_EQ(modes, crc_secure);
   reg.get_supported_modes(CEPH_ENTITY_TYPE_MDS, CEPH_AUTH_CEPHX, &modes);
   ASSERT_EQ(modes, crc_secure);
+
+  /* mgr treated the same as mon */
   reg.get_supported_modes(CEPH_ENTITY_TYPE_MGR, CEPH_AUTH_CEPHX, &modes);
-  ASSERT_EQ(modes, crc_secure);
+  ASSERT_EQ(modes, secure);
 
   // how about all internal cluster connection secure?
   cct->_conf.set_val("ms_cluster_mode", "secure");
@@ -143,8 +147,10 @@ TEST(AuthRegistry, con_modes)
   ASSERT_EQ(modes, secure);
   reg.get_supported_modes(CEPH_ENTITY_TYPE_MDS, CEPH_AUTH_CEPHX, &modes);
   ASSERT_EQ(modes, secure);
+
+  /* mgr is treated the same as mon */
   reg.get_supported_modes(CEPH_ENTITY_TYPE_CLIENT, CEPH_AUTH_CEPHX, &modes);
-  ASSERT_EQ(modes, crc_secure);
+  ASSERT_EQ(modes, secure);
 
   cct->_set_module_type(CEPH_ENTITY_TYPE_MDS);
   reg.get_supported_modes(CEPH_ENTITY_TYPE_MON, CEPH_AUTH_CEPHX, &modes);


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

Communication between mon and mgr should be treated the same as internal to the mon cluster. This PR is similar to https://github.com/ceph/ceph/pull/33226 just that it doesn't force _mon\_\*\_modes_ configurables on non-client entities (when connecting to mon/mgr).

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
