### PR TITLE
mimic: rgw: fix bad user stats on versioned bucket after reshard

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -13908,7 +13908,8 @@ int RGWRados::cls_user_get_header_async(const string& user_id, RGWGetUserHeader_
   return 0;
 }
 
-int RGWRados::cls_user_sync_bucket_stats(rgw_raw_obj& user_obj, const RGWBucketInfo& bucket_info)
+int RGWRados::cls_user_sync_bucket_stats(rgw_raw_obj& user_obj,
+					 const RGWBucketInfo& bucket_info)
 {
   vector<rgw_bucket_dir_header> headers;
   int r = cls_bucket_head(bucket_info, RGW_NO_SHARD, headers);
@@ -13923,10 +13924,13 @@ int RGWRados::cls_user_sync_bucket_stats(rgw_raw_obj& user_obj, const RGWBucketI
 
   for (const auto& hiter : headers) {
     for (const auto& iter : hiter.stats) {
-      const struct rgw_bucket_category_stats& header_stats = iter.second;
-      entry.size += header_stats.total_size;
-      entry.size_rounded += header_stats.total_size_rounded;
-      entry.count += header_stats.num_entries;
+      if (uint8_t(RGW_OBJ_CATEGORY_MAIN) == iter.first ||
+	  uint8_t(RGW_OBJ_CATEGORY_MULTIMETA) == iter.first) {
+	const struct rgw_bucket_category_stats& header_stats = iter.second;
+	entry.size += header_stats.total_size;
+	entry.size_rounded += header_stats.total_size_rounded;
+	entry.count += header_stats.num_entries;
+      }
     }
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43206

---

backport of https://github.com/ceph/ceph/pull/25414
parent tracker: https://tracker.ceph.com/issues/37528

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh