### PR TITLE
luminous: rgw: change the "rgw admin status" 'num_shards' output to signed int

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1082,7 +1082,7 @@ static void show_reshard_status(
     formatter->dump_string("reshard_status", to_string(entry.reshard_status));
     formatter->dump_string("new_bucket_instance_id",
 			   entry.new_bucket_instance_id);
-    formatter->dump_unsigned("num_shards", entry.num_shards);
+    formatter->dump_int("num_shards", entry.num_shards);
     formatter->close_section();
   }
   formatter->close_section();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43481

---

backport of https://github.com/ceph/ceph/pull/25538
parent tracker: https://tracker.ceph.com/issues/37645

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh