### PR TITLE
mimic: rgw: url encode common prefixes for List Objects response 

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -699,7 +699,6 @@ void RGWListBucket_ObjStore_S3::send_versioned_response()
   s->formatter->dump_string("IsTruncated", (max && is_truncated ? "true"
 					    : "false"));
 
-  bool encode_key = false;
   if (strcasecmp(encoding_type.c_str(), "url") == 0) {
     s->formatter->dump_string("EncodingType", "url");
     encode_key = true;
@@ -800,7 +799,6 @@ void RGWListBucket_ObjStore_S3::send_response()
   s->formatter->dump_string("IsTruncated", (max && is_truncated ? "true"
 					    : "false"));
 
-  bool encode_key = false;
   if (strcasecmp(encoding_type.c_str(), "url") == 0) {
     s->formatter->dump_string("EncodingType", "url");
     encode_key = true;

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -107,6 +107,7 @@ public:
 
 class RGWListBucket_ObjStore_S3 : public RGWListBucket_ObjStore {
   bool objs_container;
+  bool encode_key {false};
 public:
   RGWListBucket_ObjStore_S3() : objs_container(false) {
     default_max = 1000;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43160

---

backport of https://github.com/ceph/ceph/pull/30970
parent tracker: https://tracker.ceph.com/issues/41870

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh