### PR TITLE
mimic: qa: krbd_exclusive_option.sh: update for recent kernel changes

### DIFF
--- a/qa/workunits/rbd/kernel.sh
+++ b/qa/workunits/rbd/kernel.sh
@@ -77,6 +77,10 @@ cp /tmp/img1 /tmp/img1.trunc
 truncate -s 41943040 /tmp/img1.trunc
 cmp /tmp/img1.trunc /tmp/img1.small
 
+# rollback expects an unlocked image
+# (acquire and) release the lock as a side effect
+rbd bench --io-type read --io-size 1 --io-threads 1 --io-total 1 testimg1
+
 # rollback and check data again
 rbd snap rollback --snap=snap1 testimg1
 cat /sys/bus/rbd/devices/$DEV_ID1/size | grep 76800000

--- a/qa/workunits/rbd/krbd_exclusive_option.sh
+++ b/qa/workunits/rbd/krbd_exclusive_option.sh
@@ -53,6 +53,15 @@ function assert_unlocked() {
         grep '"lockers":\[\]'
 }
 
+function blacklist_add() {
+    local dev_id="${1#/dev/rbd}"
+
+    local client_addr
+    client_addr="$(< $SYSFS_DIR/$dev_id/client_addr)"
+
+    ceph osd blacklist add $client_addr
+}
+
 SYSFS_DIR="/sys/bus/rbd/devices"
 IMAGE_NAME="exclusive-option-test"
 
@@ -69,11 +78,27 @@ assert_unlocked
 expect_false sudo rbd map -o exclusive $IMAGE_NAME
 assert_unlocked
 
+expect_false sudo rbd map -o lock_on_read $IMAGE_NAME
+assert_unlocked
+
 rbd feature enable $IMAGE_NAME exclusive-lock
 rbd snap create $IMAGE_NAME@snap
 
 DEV=$(sudo rbd map $IMAGE_NAME)
+assert_locked $DEV
+[[ $(blockdev --getro $DEV) -eq 0 ]]
+sudo rbd unmap $DEV
 assert_unlocked
+
+DEV=$(sudo rbd map $IMAGE_NAME@snap)
+assert_unlocked
+[[ $(blockdev --getro $DEV) -eq 1 ]]
+sudo rbd unmap $DEV
+assert_unlocked
+
+DEV=$(sudo rbd map -o ro $IMAGE_NAME)
+assert_unlocked
+[[ $(blockdev --getro $DEV) -eq 1 ]]
 sudo rbd unmap $DEV
 assert_unlocked
 
@@ -84,32 +109,74 @@ sudo rbd unmap $DEV
 assert_unlocked
 
 DEV=$(sudo rbd map -o exclusive $IMAGE_NAME@snap)
-assert_locked $DEV
+assert_unlocked
 [[ $(blockdev --getro $DEV) -eq 1 ]]
 sudo rbd unmap $DEV
 assert_unlocked
 
 DEV=$(sudo rbd map -o exclusive,ro $IMAGE_NAME)
-assert_locked $DEV
+assert_unlocked
 [[ $(blockdev --getro $DEV) -eq 1 ]]
 sudo rbd unmap $DEV
 assert_unlocked
 
 # alternate syntax
 DEV=$(sudo rbd map --exclusive --read-only $IMAGE_NAME)
-assert_locked $DEV
+assert_unlocked
 [[ $(blockdev --getro $DEV) -eq 1 ]]
 sudo rbd unmap $DEV
 assert_unlocked
 
 DEV=$(sudo rbd map $IMAGE_NAME)
-assert_unlocked
+assert_locked $DEV
+OTHER_DEV=$(sudo rbd map -o noshare $IMAGE_NAME)
+assert_locked $OTHER_DEV
 dd if=/dev/urandom of=$DEV bs=4k count=10 oflag=direct
 assert_locked $DEV
-OTHER_DEV=$(sudo rbd map -o noshare,exclusive $IMAGE_NAME)
+dd if=/dev/urandom of=$OTHER_DEV bs=4k count=10 oflag=direct
 assert_locked $OTHER_DEV
 sudo rbd unmap $DEV
 sudo rbd unmap $OTHER_DEV
+assert_unlocked
+
+DEV=$(sudo rbd map $IMAGE_NAME)
+assert_locked $DEV
+OTHER_DEV=$(sudo rbd map -o noshare,exclusive $IMAGE_NAME)
+assert_locked $OTHER_DEV
+dd if=$DEV of=/dev/null bs=4k count=10 iflag=direct
+expect_false dd if=/dev/urandom of=$DEV bs=4k count=10 oflag=direct
+assert_locked $OTHER_DEV
+sudo rbd unmap $OTHER_DEV
+assert_unlocked
+dd if=$DEV of=/dev/null bs=4k count=10 iflag=direct
+assert_unlocked
+dd if=/dev/urandom of=$DEV bs=4k count=10 oflag=direct
+assert_locked $DEV
+sudo rbd unmap $DEV
+assert_unlocked
+
+DEV=$(sudo rbd map -o lock_on_read $IMAGE_NAME)
+assert_locked $DEV
+OTHER_DEV=$(sudo rbd map -o noshare,exclusive $IMAGE_NAME)
+assert_locked $OTHER_DEV
+expect_false dd if=$DEV of=/dev/null bs=4k count=10 iflag=direct
+expect_false dd if=/dev/urandom of=$DEV bs=4k count=10 oflag=direct
+sudo udevadm settle
+assert_locked $OTHER_DEV
+sudo rbd unmap $OTHER_DEV
+assert_unlocked
+dd if=$DEV of=/dev/null bs=4k count=10 iflag=direct
+assert_locked $DEV
+dd if=/dev/urandom of=$DEV bs=4k count=10 oflag=direct
+assert_locked $DEV
+sudo rbd unmap $DEV
+assert_unlocked
+
+DEV=$(sudo rbd map -o exclusive $IMAGE_NAME)
+assert_locked $DEV
+expect_false sudo rbd map -o noshare $IMAGE_NAME
+assert_locked $DEV
+sudo rbd unmap $DEV
 assert_unlocked
 
 DEV=$(sudo rbd map -o exclusive $IMAGE_NAME)
@@ -119,44 +186,31 @@ assert_locked $DEV
 sudo rbd unmap $DEV
 assert_unlocked
 
+DEV=$(sudo rbd map $IMAGE_NAME)
+assert_locked $DEV
+rbd resize --size 1G $IMAGE_NAME
+assert_unlocked
+sudo rbd unmap $DEV
+assert_unlocked
+
 DEV=$(sudo rbd map -o exclusive $IMAGE_NAME)
 assert_locked $DEV
-OTHER_DEV=$(sudo rbd map -o noshare $IMAGE_NAME)
-dd if=/dev/urandom of=$OTHER_DEV bs=4k count=10 oflag=direct &
-PID=$!
-sleep 20
+expect_false rbd resize --size 2G $IMAGE_NAME
 assert_locked $DEV
-[[ "$(ps -o stat= $PID)" =~ ^D ]]
 sudo rbd unmap $DEV
+assert_unlocked
+
+DEV=$(sudo rbd map $IMAGE_NAME)
+assert_locked $DEV
+dd if=/dev/urandom of=$DEV bs=4k count=10 oflag=direct
+{ sleep 10; blacklist_add $DEV; } &
+PID=$!
+expect_false dd if=/dev/urandom of=$DEV bs=4k count=200000 oflag=direct
 wait $PID
+# break lock
+OTHER_DEV=$(sudo rbd map -o noshare $IMAGE_NAME)
 assert_locked $OTHER_DEV
-sudo rbd unmap $OTHER_DEV
-assert_unlocked
-
-DEV=$(sudo rbd map -o exclusive $IMAGE_NAME)
-assert_locked $DEV
-OTHER_DEV=$(sudo rbd map -o noshare,lock_timeout=60 $IMAGE_NAME)
-dd if=/dev/urandom of=$OTHER_DEV bs=4k count=10 oflag=direct &
-PID=$!
-sleep 20
-assert_locked $DEV
-[[ "$(ps -o stat= $PID)" =~ ^D ]]
-expect_false wait $PID
-assert_locked $DEV
 sudo rbd unmap $DEV
-sudo rbd unmap $OTHER_DEV
-assert_unlocked
-
-DEV=$(sudo rbd map -o exclusive $IMAGE_NAME)
-assert_locked $DEV
-sudo rbd map -o noshare,lock_on_read $IMAGE_NAME &
-SUDO_PID=$!
-sleep 20
-assert_locked $DEV
-PID="$(ps -o pid= --ppid $SUDO_PID)"
-[[ "$(ps -o stat= $PID)" =~ ^D ]]
-sudo rbd unmap $DEV
-wait $SUDO_PID
 assert_locked $OTHER_DEV
 sudo rbd unmap $OTHER_DEV
 assert_unlocked


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43242

---

backport of https://github.com/ceph/ceph/pull/32088
parent tracker: https://tracker.ceph.com/issues/43127

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh