### PR TITLE
mimic: mon/OSDMonitor: fix format error ceph osd stat --format json

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4381,11 +4381,15 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   if (prefix == "osd stat") {
-    osdmap.print_summary(f.get(), ds, "", true);
-    if (f)
+    if (f) {
+      f->open_object_section("osdmap");
+      osdmap.print_summary(f.get(), ds, "", true);
+      f->close_section();
       f->flush(rdata);
-    else
+    } else {
+      osdmap.print_summary(nullptr, ds, "", true);
       rdata.append(ds);
+    }
   }
   else if (prefix == "osd dump" ||
 	   prefix == "osd tree" ||


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42852

---

backport of https://github.com/ceph/ceph/pull/31399
parent tracker: https://tracker.ceph.com/issues/42501

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh