### PR TITLE
luminous: osd/PeeringState: do not exclude up from acting_recovery_backfill

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1396,9 +1396,6 @@ void PG::calc_replicated_acting(
       usable++;
       ss << " osd." << *i << " (up) accepted " << cur_info << std::endl;
     }
-    if (want->size() >= size) {
-      break;
-    }
   }
 
   // This no longer has backfill OSDs, but they are covered above.

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1576,7 +1576,14 @@ bool PG::choose_acting(pg_shard_t &auth_log_shard_id,
     dout(10) << "choose_acting failed, not recoverable" << dendl;
     return false;
   }
-
+  while (want.size() > pool.info.size) {
+    // async recovery should have taken out as many osds as it can.
+    // if not, then always evict the last peer
+    // (will get synchronously recovered later)
+    dout(10) << __func__ << " evicting osd." << want.back()
+               << " from oversized want " << want << dendl;
+    want.pop_back();
+  }
   if (want != acting) {
     dout(10) << "choose_acting want " << want << " != acting " << acting
 	     << ", requesting pg_temp change" << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42996

---

backport of https://github.com/ceph/ceph/pull/31703
parent tracker: https://tracker.ceph.com/issues/42577

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh