### PR TITLE
mimic: common/config: update values when they are removed via mon

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -311,6 +311,11 @@ int md_config_t::set_mon_vals(CephContext *cct,
 		      << " cleared (was " << Option::to_str(j->second) << ")"
 		      << dendl;
 	_rm_val(name, CONF_MON);
+	// if this is a debug option, it needs to propagate to teh subsys;
+	// this isn't covered by update_legacy_vals() below.  similarly,
+	// we want to trigger a config notification for these items.
+	const Option *o = find_option(name);
+	_refresh(*o);
       }
     }
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43257

---

backport of https://github.com/ceph/ceph/pull/32091
parent tracker: https://tracker.ceph.com/issues/42964

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh