### PR TITLE
mimic: osd/PeeringState.cc: skip peer_purged when discovering all missing

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -798,6 +798,11 @@ void PG::discover_all_missing(map<int, map<spg_t,pg_query_t> > &query_map)
       continue;
     }
 
+    if (peer_purged.count(peer)) {
+      dout(20) << __func__ << " skipping purged osd." << peer << dendl;
+      continue;
+    }
+
     map<pg_shard_t, pg_info_t>::const_iterator iter = peer_info.find(peer);
     if (iter != peer_info.end() &&
         (iter->second.is_empty() || iter->second.dne())) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43320

---

backport of https://github.com/ceph/ceph/pull/32195
parent tracker: https://tracker.ceph.com/issues/41317

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh