### PR TITLE
mimic: osd/PeeringState: transit async_recovery_targets back into acting before backfilling

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7774,8 +7774,15 @@ PG::RecoveryState::Recovering::react(const RequestBackfill &evt)
   pg->state_clear(PG_STATE_FORCED_RECOVERY);
   release_reservations();
   pg->osd->local_reserver.cancel_reservation(pg->info.pgid);
-  // XXX: Is this needed?
   pg->publish_stats_to_osd();
+  // transit any async_recovery_targets back into acting
+  // so pg won't have to stay undersized for long
+  // as backfill might take a long time to complete..
+  if (!pg->async_recovery_targets.empty()) {
+    pg_shard_t auth_log_shard;
+    bool history_les_bound = false;
+    pg->choose_acting(auth_log_shard, true, &history_les_bound);
+  }
   return transit<WaitLocalBackfillReserved>();
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43470

---

backport of https://github.com/ceph/ceph/pull/32202
parent tracker: https://tracker.ceph.com/issues/43311

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh