### PR TITLE
mimic: osd/PeeringState.cc: don't let num_objects become negative

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2933,6 +2933,16 @@ void PG::_update_calc_stats()
   info.stats.stats.sum.num_objects_unfound = 0;
   info.stats.stats.sum.num_objects_misplaced = 0;
 
+  // We should never hit this condition, but if end up hitting it,
+  // make sure to update num_objects and set PG_STATE_INCONSISTENT.
+  if (info.stats.stats.sum.num_objects < 0) {
+    dout(0) << __func__ << " negative num_objects = "
+            << info.stats.stats.sum.num_objects << " setting it to 0 "
+            << dendl;
+    info.stats.stats.sum.num_objects = 0;
+    state_set(PG_STATE_INCONSISTENT);
+  }
+
   if ((is_remapped() || is_undersized() || !is_clean()) && (is_peered() || is_activating())) {
     dout(20) << __func__ << " actingset " << actingset << " upset "
              << upset << " acting_recovery_backfill " << acting_recovery_backfill << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43472

---

backport of https://github.com/ceph/ceph/pull/32305
parent tracker: https://tracker.ceph.com/issues/43308

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh