### PR TITLE
nautilus: ceph-volume: don't remove vg twice when zapping filestore

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -227,8 +227,10 @@ class Zap(object):
                 mlogger.info('Zapping lvm member {}. lv_path is {}'.format(device.abspath, lv.lv_path))
                 self.zap_lv(Device(lv.lv_path))
             else:
-                mlogger.info('Found empty VG {}, removing'.format(lv.vg_name))
-                api.remove_vg(lv.vg_name)
+                vg = api.get_first_vg(filters={'vg_name': lv.vg_name})
+                if vg:
+                    mlogger.info('Found empty VG {}, removing'.format(vg.vg_name))
+                    api.remove_vg(vg.vg_name)
 
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44153

---

backport of https://github.com/ceph/ceph/pull/33332
parent tracker: https://tracker.ceph.com/issues/44149

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh