### PR TITLE
osd/PeeringState: require SERVER_OCTOPUS to respond to RenewLease

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1201,6 +1201,16 @@ void PeeringState::proc_lease_ack(int from, const pg_lease_ack_t& a)
   }
 }
 
+void PeeringState::proc_renew_lease()
+{
+  if (!HAVE_FEATURE(upacting_features, SERVER_OCTOPUS)) {
+    return;
+  }
+  renew_lease(pl->get_mnow());
+  send_lease();
+  schedule_renew_lease();
+}
+
 void PeeringState::recalc_readable_until()
 {
   assert(is_primary());
@@ -5845,9 +5855,7 @@ boost::statechart::result PeeringState::Active::react(const AllReplicasActivated
 boost::statechart::result PeeringState::Active::react(const RenewLease& rl)
 {
   DECLARE_LOCALS;
-  ps->renew_lease(pl->get_mnow());
-  ps->send_lease();
-  ps->schedule_renew_lease();
+  ps->proc_renew_lease();
   return discard_event();
 }
 

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -2001,6 +2001,7 @@ public:
 
   void proc_lease(const pg_lease_t& l);
   void proc_lease_ack(int from, const pg_lease_ack_t& la);
+  void proc_renew_lease();
 
   pg_lease_ack_t get_lease_ack() {
     return pg_lease_ack_t(readable_until_ub_from_primary);


### PR DESCRIPTION
To avoid sending pg_lease to pre-octopus OSDs during upgrades.

Fixes: https://tracker.ceph.com/issues/44156
Signed-off-by: Neha Ojha <nojha@redhat.com>