### PR TITLE
nautilus: rgw: make max_connections configurable in beast

### DIFF
--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -73,6 +73,15 @@ Options
 :Type: Integer (0 or 1)
 :Default: 0
 
+``max_connection_backlog``
+
+:Description: Optional value to define the maximum size for the queue of
+              connections waiting to be accepted. If not configured, the value
+              from ``boost::asio::socket_base::max_connections`` will be used.
+
+:Type: Integer
+:Default: None
+
 
 Civetweb
 ========


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44129

---

backport of https://github.com/ceph/ceph/pull/33053
parent tracker: https://tracker.ceph.com/issues/43952

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh