### PR TITLE
cephadm: add `--retry` arg

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1798,8 +1798,12 @@ def command_bootstrap():
         },
     )
 
+    # wait for the service to become available
     def is_mon_available():
-        out, err, ret = call(c.run_cmd(), desc=c.entrypoint, timeout=30)
+        timeout=args.timeout if args.timeout else 30 # seconds
+        out, err, ret = call(c.run_cmd(),
+                             desc=c.entrypoint,
+                             timeout=timeout)
         return ret == 0
     is_available('mon', is_mon_available)()
 
@@ -1851,9 +1855,11 @@ def command_bootstrap():
         f.write(config)
     logger.info('Wrote config to %s' % args.output_config)
 
+    # wait for the service to become available
     logger.info('Waiting for mgr to start...')
     def is_mgr_available():
-        out = cli(['status', '-f', 'json-pretty'], timeout=30)
+        timeout=args.timeout if args.timeout else 30 # seconds
+        out = cli(['status', '-f', 'json-pretty'], timeout=timeout)
         j = json.loads(out)
         return j.get('mgrmap', {}).get('available', False)
     is_available('mgr', is_mgr_available)()
@@ -1899,9 +1905,11 @@ def command_bootstrap():
         logger.info('Enabling the dashboard module...')
         cli(['mgr', 'module', 'enable', 'dashboard'])
 
+        # wait for the service to become available
         logger.info('Waiting for the dashboard to start...')
         def is_dashboard_available():
-            out = cli(['-h'], timeout=30)
+            timeout=args.timeout if args.timeout else 30 # seconds
+            out = cli(['-h'], timeout=timeout)
             return 'dashboard' in out
         is_available('Dashboard', is_dashboard_available)()
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -11,6 +11,7 @@ DATA_DIR_MODE=0o700
 CONTAINER_PREFERENCE = ['podman', 'docker']  # prefer podman to docker
 CUSTOM_PS1=r'[ceph: \u@\h \W]\$ '
 DEFAULT_TIMEOUT=None # in seconds
+DEFAULT_RETRY=10
 
 """
 You can invoke cephadm in two ways:
@@ -540,30 +541,31 @@ def call_timeout(command, timeout):
 
 ##################################
 
-def is_available(what, func, retry_max=10):
+def is_available(what, func):
     # type (str, func, Optional[int]) -> func
     """
     Wait for a service to become available
 
     :param what: the name of the service
     :param func: the callable object that determines availability
-    :param retry_max: max number of retry invocations of func
+    :param retry: max number of retry invocations of func
     """
+    retry = args.retry
     @wraps(func)
     def func_wrapper(*args, **kwargs):
         logger.info('Waiting for %s...' % (what))
-        retry_num = 1
+        num = 1
         while True:
             if func(*args, **kwargs):
                 break
-            elif retry_num > retry_max:
+            elif num > retry:
                 raise Error('%s not available after %s tries'
-                        % (what, retry_max))
+                        % (what, retry))
 
             logger.info('%s not available, waiting (%s/%s)...'
-                    % (what, retry_num, retry_max))
+                    % (what, num, retry))
 
-            retry_num += 1
+            num += 1
             time.sleep(1)
     return func_wrapper
 
@@ -1795,6 +1797,7 @@ def command_bootstrap():
             tmp_config.name: '/etc/ceph/ceph.conf:z',
         },
     )
+
     def is_mon_available():
         out, err, ret = call(c.run_cmd(), desc=c.entrypoint, timeout=30)
         return ret == 0
@@ -2857,6 +2860,11 @@ def _get_parser():
         type=int,
         default=DEFAULT_TIMEOUT,
         help='timeout in seconds')
+    parser.add_argument(
+        '--retry',
+        type=int,
+        default=DEFAULT_RETRY,
+        help='max number of retries')
 
     subparsers = parser.add_subparsers(help='sub-command')
 


### PR DESCRIPTION
On resource constrained hardware (e.g. ARM), some services need longer than 10 retries to become available.

Adds the ability to extend both the retry and/or timeout.

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
