### PR TITLE
nautilus: mgr/devicehealth: fix telemetry stops sending device reports after 48 hours

### DIFF
--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -422,16 +422,11 @@ class Module(MgrModule):
                 ioctx.remove_omap_keys(op, tuple(erase))
             ioctx.operate_write_op(op, devid)
 
-    def show_device_metrics(self, devid, sample):
-        # verify device exists
-        r = self.get("device " + devid)
-        if not r or 'device' not in r.keys():
-            return -errno.ENOENT, '', 'device ' + devid + ' not found'
-        # fetch metrics
+    def _get_device_metrics(self, devid, sample=None, min_sample=None):
         res = {}
         ioctx = self.open_connection(create_if_missing=False)
         if not ioctx:
-            return 0, json.dumps(res, indent=4), ''
+            return {}
         with ioctx:
             with rados.ReadOpCtx() as op:
                 omap_iter, ret = ioctx.get_omap_vals(op, "", sample or '',
@@ -441,6 +436,8 @@ class Module(MgrModule):
                     ioctx.operate_read_op(op, devid)
                     for key, value in list(omap_iter):
                         if sample and key != sample:
+                            break
+                        if min_sample and key < min_sample:
                             break
                         try:
                             v = json.loads(value)
@@ -454,8 +451,16 @@ class Module(MgrModule):
                 except rados.Error as e:
                     self.log.exception("RADOS error reading omap: {0}".format(e))
                     raise
+        return res
 
-        return 0, json.dumps(res, indent=4), ''
+    def show_device_metrics(self, devid, sample):
+        # verify device exists
+        r = self.get("device " + devid)
+        if not r or 'device' not in r.keys():
+            return -errno.ENOENT, '', 'device ' + devid + ' not found'
+        # fetch metrics
+        res = self._get_device_metrics(devid, sample=sample)
+        return 0, json.dumps(res, indent=4, sort_keys=True), ''
 
     def check_health(self):
         self.log.info('Check health')

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -429,7 +429,7 @@ class Module(MgrModule):
             return {}
         with ioctx:
             with rados.ReadOpCtx() as op:
-                omap_iter, ret = ioctx.get_omap_vals(op, "", sample or '',
+                omap_iter, ret = ioctx.get_omap_vals(op, min_sample or '', sample or '',
                                                      MAX_SAMPLES)  # fixme
                 assert ret == 0
                 try:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43873

backport of https://github.com/ceph/ceph/pull/32903
parent tracker: https://tracker.ceph.com/issues/43837

replaces: https://github.com/ceph/ceph/pull/33148
had to cherry-pick also: https://github.com/ceph/ceph/pull/30724/commits/7be5c1323b3814e2634d5cd66d45cab5a77df680

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
