### PR TITLE
mgr/orchestrator: "addr" is optional for constructing InventoryNode

### DIFF
--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -240,12 +240,12 @@ class TestOrchestratorCli(MgrTestCase):
         self.assertEqual(len(inventory_result), 1)
         self.assertEqual(inventory_result[0]['name'], 'host0')
 
-        out = self._orch_cmd('service', 'ls', '--format=json')
+        out = self._orch_cmd('ps', '--format=json')
         services = data['services']
         services_result = json.loads(out)
         self.assertEqual(len(services), len(services_result))
 
-        out = self._orch_cmd('service', 'ls', 'host0', '--format=json')
+        out = self._orch_cmd('ps', 'host0', '--format=json')
         services_result = json.loads(out)
         self.assertEqual(len(services_result), 1)
         self.assertEqual(services_result[0]['nodename'], 'host0')

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -1487,7 +1487,7 @@ class InventoryNode(object):
         try:
             _data = copy.deepcopy(data)
             name = _data.pop('name')
-            addr = _data.pop('addr') or name
+            addr = _data.pop('addr', None) or name
             devices = inventory.Devices.from_json(_data.pop('devices'))
             if _data:
                 error_msg = 'Unknown key(s) in Inventory: {}'.format(','.join(_data.keys()))


### PR DESCRIPTION
this addresses a regression introduced by 5276871e15

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
