### PR TITLE
qa: changing fio_version='3.18' and rbd_default_features = 1

### DIFF
--- a/qa/suites/krbd/rbd/conf.yaml
+++ b/qa/suites/krbd/rbd/conf.yaml
@@ -4,4 +4,4 @@ overrides:
       global:
         ms die on skipped message: false
       client:
-        rbd default features: 37
+              rbd default features: 1

--- a/qa/tasks/rbd_fio.py
+++ b/qa/tasks/rbd_fio.py
@@ -127,7 +127,7 @@ def run_fio(remote, config, rbd_test_dir):
 
     formats=[1,2]
     features=[['layering'],['striping'],['exclusive-lock','object-map']]
-    fio_version='2.21'
+    fio_version='3.18'
     if config.get('formats'):
         formats=config['formats']
     if config.get('features'):


### PR DESCRIPTION
Rhel8 does not support fio_version='2.21'.
rbd_default_featuresis changed to fix "RBD image feature set mismatch"

Signed-off-by: harishmunjulur <harishmunjulur@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
