### PR TITLE
mds: add perf counters for openfiletable

### DIFF
--- a/qa/tasks/cephfs/test_openfiletable.py
+++ b/qa/tasks/cephfs/test_openfiletable.py
@@ -1,11 +1,20 @@
 import time
+import logging
 from cephfs_test_case import CephFSTestCase
 from teuthology.exceptions import CommandFailedError
 from tasks.cephfs.cephfs_test_case import CephFSTestCase, for_teuthology
 
+log = logging.getLogger(__name__)
+
 class OpenFileTable(CephFSTestCase):
     CLIENTS_REQUIRED = 1
     MDSS_REQUIRED = 1
+
+    def _check_oft_counter(self, name, count):
+        perf_dump = self.fs.mds_asok(['perf', 'dump'])
+        if perf_dump['oft'][name] == count:
+            return True
+        return False
 
     def test_max_items_per_obj(self):
         """
@@ -39,3 +48,40 @@ class OpenFileTable(CephFSTestCase):
 
         # Now close the file
         self.mount_a.kill_background(p)
+
+    def test_perf_counters(self):
+        """
+        Opening a file should increment omap_total_updates by 1.
+        """
+
+        self.set_conf("mds", "osd_deep_scrub_large_omap_object_key_threshold", "1")
+        self.fs.mds_restart()
+        self.fs.wait_for_daemons()
+
+        perf_dump = self.fs.mds_asok(['perf', 'dump'])
+        omap_total_updates_0 = perf_dump['oft']['omap_total_updates']
+        log.info("omap_total_updates_0:{}".format(omap_total_updates_0))
+        
+        # Open the file
+        p = self.mount_a.open_background("omap_counter_test_file")
+        self.wait_until_true(lambda: self._check_oft_counter('omap_total_updates', 2), timeout=30)
+        
+        perf_dump = self.fs.mds_asok(['perf', 'dump'])
+        omap_total_updates_1 = perf_dump['oft']['omap_total_updates']
+        log.info("omap_total_updates_1:{}".format(omap_total_updates_1))
+        
+        self.assertTrue((omap_total_updates_1 - omap_total_updates_0) == 2)
+        
+        # Now close the file
+        self.mount_a.kill_background(p)
+        # Ensure that the file does not exist any more
+        self.wait_until_true(lambda: self._check_oft_counter('omap_total_removes', 1), timeout=30)
+        self.wait_until_true(lambda: self._check_oft_counter('omap_total_kv_pairs', 1), timeout=30)
+
+        perf_dump = self.fs.mds_asok(['perf', 'dump'])
+        omap_total_removes = perf_dump['oft']['omap_total_removes']
+        omap_total_kv_pairs = perf_dump['oft']['omap_total_kv_pairs']
+        log.info("omap_total_removes:{}".format(omap_total_removes))
+        log.info("omap_total_kv_pairs:{}".format(omap_total_kv_pairs))
+        self.assertTrue(omap_total_removes == 1)
+        self.assertTrue(omap_total_kv_pairs == 1)

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -23,12 +23,42 @@
 #include "common/config.h"
 #include "common/errno.h"
 
+enum {
+  l_oft_first = 1000000,
+  l_oft_omap_total_objs,
+  l_oft_omap_total_kv_pairs,
+  l_oft_omap_total_updates,
+  l_oft_omap_total_removes,
+  l_oft_last
+};
+
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mds)
 static ostream& _prefix(std::ostream *_dout, MDSRank *mds) {
   return *_dout << "mds." << mds->get_nodeid() << ".openfiles ";
+}
+
+OpenFileTable::OpenFileTable(MDSRank *m) : mds(m) {
+  PerfCountersBuilder b(mds->cct, "oft", l_oft_first, l_oft_last);
+
+  b.add_u64(l_oft_omap_total_objs, "omap_total_objs");
+  b.add_u64(l_oft_omap_total_kv_pairs, "omap_total_kv_pairs");
+  b.add_u64(l_oft_omap_total_updates, "omap_total_updates");
+  b.add_u64(l_oft_omap_total_removes, "omap_total_removes");
+  logger.reset(b.create_perf_counters());
+  mds->cct->get_perfcounters_collection()->add(logger.get());
+  logger->set(l_oft_omap_total_objs, 0);
+  logger->set(l_oft_omap_total_kv_pairs, 0);
+  logger->set(l_oft_omap_total_updates, 0);
+  logger->set(l_oft_omap_total_removes, 0);
+}
+
+OpenFileTable::~OpenFileTable() {
+  if (logger) {
+    mds->cct->get_perfcounters_collection()->remove(logger.get());
+  }
 }
 
 void OpenFileTable::get_ref(CInode *in)
@@ -536,8 +566,8 @@ void OpenFileTable::commit(MDSContext *c, uint64_t log_seq, int op_prio)
     loaded_dirfrags.clear();
   }
 
+  size_t total_items = 0;
   {
-    size_t total_items = 0;
     unsigned used_objs = 1;
     std::vector<unsigned> objs_to_write;
     bool journaled = false;
@@ -588,6 +618,9 @@ void OpenFileTable::commit(MDSContext *c, uint64_t log_seq, int op_prio)
     ceph_assert(!gather.has_subs());
   }
 
+  uint64_t total_updates = 0;
+  uint64_t total_removes = 0;
+
   for (unsigned omap_idx = 0; omap_idx < omap_updates.size(); omap_idx++) {
     auto& ctl = omap_updates[omap_idx];
     ceph_assert(ctl.to_update.empty() && ctl.to_remove.empty());
@@ -603,6 +636,7 @@ void OpenFileTable::commit(MDSContext *c, uint64_t log_seq, int op_prio)
 	ctl.write_size = 0;
 	first = false;
       }
+      total_updates++;
     }
 
     for (auto& key : ctl.journaled_remove) {
@@ -613,6 +647,7 @@ void OpenFileTable::commit(MDSContext *c, uint64_t log_seq, int op_prio)
 	ctl.write_size = 0;
 	first = false;
       }
+      total_removes++;
     }
 
     for (unsigned i = 0; i < ctl.journal_idx; ++i) {
@@ -636,6 +671,10 @@ void OpenFileTable::commit(MDSContext *c, uint64_t log_seq, int op_prio)
   } else {
     submit_ops_func();
   }
+  logger->set(l_oft_omap_total_objs, omap_num_objs);
+  logger->set(l_oft_omap_total_kv_pairs, total_items);
+  logger->inc(l_oft_omap_total_updates, total_updates);
+  logger->inc(l_oft_omap_total_removes, total_removes);
 }
 
 class C_IO_OFT_Load : public MDSIOContextBase {

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -27,7 +27,8 @@ class MDSRank;
 class OpenFileTable
 {
 public:
-  explicit OpenFileTable(MDSRank *m) : mds(m) {}
+  explicit OpenFileTable(MDSRank *m);
+  ~OpenFileTable();
 
   void add_inode(CInode *in);
   void remove_inode(CInode *in);
@@ -146,6 +147,8 @@ protected:
 
   std::map<uint64_t, vector<inodeno_t> > logseg_destroyed_inos;
   std::set<inodeno_t> destroyed_inos_set;
+
+  std::unique_ptr<PerfCounters> logger;
 };
 
 #endif


### PR DESCRIPTION
Add perf counters for:
* total omap objects
* total omap key-value pairs
* total omap updates
* total omap removes

Fixes: https://tracker.ceph.com/issues/43750
Signed-off-by: Milind Changire <mchangir@redhat.com>




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>