### PR TITLE
os/bluestore: introduce hybird allocator

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4016,6 +4016,7 @@ std::vector<Option> get_global_options() {
 
     Option("bluefs_allocator", Option::TYPE_STR, Option::LEVEL_DEV)
     .set_default("bitmap")
+    .set_enum_allowed({"bitmap", "stupid", "avl", "hybrid"})
     .set_description(""),
 
     Option("bluefs_preextend_wal_files", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -4383,7 +4384,7 @@ std::vector<Option> get_global_options() {
 
     Option("bluestore_allocator", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("bitmap")
-    .set_enum_allowed({"bitmap", "stupid", "avl"})
+    .set_enum_allowed({"bitmap", "stupid", "avl", "hybrid"})
     .set_description("Allocator policy")
     .set_long_description("Allocator to use for bluestore.  Stupid should only be used for testing."),
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4638,6 +4638,10 @@ std::vector<Option> get_global_options() {
     .set_default(4)
     .set_description(""),
 
+    Option("bluestore_hybrid_alloc_mem_cap", Option::TYPE_UINT, Option::LEVEL_DEV)
+    .set_default(64_M)
+    .set_description("Maximum RAM hybrid allocator should use before enabling bitmap supplement"),
+
     Option("bluestore_volume_selection_policy", Option::TYPE_STR, Option::LEVEL_DEV)
     .set_default("rocksdb_original")
     .set_enum_allowed({ "rocksdb_original", "use_some_extra" })

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -36,6 +36,7 @@ list(APPEND crimson_alien_srcs
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/bluestore_types.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/fastbmap_allocator_impl.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/FreelistManager.cc
+  ${PROJECT_SOURCE_DIR}/src/os/bluestore/HybridAllocator.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/io_uring.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/StupidAllocator.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/BitmapAllocator.cc)

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -34,6 +34,7 @@ if(WITH_BLUESTORE)
     bluestore/StupidAllocator.cc
     bluestore/BitmapAllocator.cc
     bluestore/AvlAllocator.cc
+    bluestore/HybridAllocator.cc
     bluestore/io_uring.cc
   )
 endif(WITH_BLUESTORE)

--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -5,6 +5,7 @@
 #include "StupidAllocator.h"
 #include "BitmapAllocator.h"
 #include "AvlAllocator.h"
+#include "HybridAllocator.h"
 #include "common/debug.h"
 #include "common/admin_socket.h"
 #define dout_subsys ceph_subsys_bluestore
@@ -18,6 +19,7 @@ using ceph::Formatter;
 class Allocator::SocketHook : public AdminSocketHook {
   Allocator *alloc;
 
+  friend class Allocator;
   std::string name;
 public:
   explicit SocketHook(Allocator *alloc,
@@ -105,6 +107,9 @@ Allocator::~Allocator()
   delete asok_hook;
 }
 
+const string& Allocator::get_name() const {
+  return asok_hook->name;
+}
 
 Allocator *Allocator::create(CephContext* cct, string type,
                              int64_t size, int64_t block_size, const std::string& name)
@@ -116,6 +121,8 @@ Allocator *Allocator::create(CephContext* cct, string type,
     alloc = new BitmapAllocator(cct, size, block_size, name);
   } else if (type == "avl") {
     return new AvlAllocator(cct, size, block_size, name);
+  } else if (type == "hybrid") {
+    return new HybridAllocator(cct, size, block_size, 1024 /*FIXME*/, name);
   }
   if (alloc == nullptr) {
     lderr(cct) << "Allocator::" << __func__ << " unknown alloc type "

--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -122,7 +122,9 @@ Allocator *Allocator::create(CephContext* cct, string type,
   } else if (type == "avl") {
     return new AvlAllocator(cct, size, block_size, name);
   } else if (type == "hybrid") {
-    return new HybridAllocator(cct, size, block_size, 1024 /*FIXME*/, name);
+    return new HybridAllocator(cct, size, block_size,
+      cct->_conf.get_val<uint64_t>("bluestore_hybrid_alloc_mem_cap"),
+      name);
   }
   if (alloc == nullptr) {
     lderr(cct) << "Allocator::" << __func__ << " unknown alloc type "

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -61,6 +61,9 @@ public:
 
   static Allocator *create(CephContext* cct, std::string type, int64_t size,
 			   int64_t block_size, const std::string& name = "");
+
+  const string& get_name() const;
+
 private:
   class SocketHook;
   SocketHook* asok_hook = nullptr;

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -287,7 +287,7 @@ void AvlAllocator::_shutdown()
 AvlAllocator::AvlAllocator(CephContext* cct,
                            int64_t device_size,
                            int64_t block_size,
-                           uint64_t max_entries,
+                           uint64_t max_mem,
                            const std::string& name) :
   Allocator(name),
   num_total(device_size),
@@ -296,7 +296,7 @@ AvlAllocator::AvlAllocator(CephContext* cct,
     cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_bf_threshold")),
   range_size_alloc_free_pct(
     cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_bf_free_pct")),
-  range_count_cap(max_entries),
+  range_count_cap(max_mem / sizeof(range_seg_t)),
   cct(cct)
 {}
 

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -135,13 +135,34 @@ void AvlAllocator::_remove_from_tree(uint64_t start, uint64_t size)
   }
 }
 
+int64_t AvlAllocator::_allocate(
+  uint64_t want,
+  uint64_t unit,
+  uint64_t max_alloc_size,
+  int64_t  hint, // unused, for now!
+  PExtentVector* extents)
+{
+  uint64_t allocated = 0;
+  while (allocated < want) {
+    uint64_t offset, length;
+    int r = _allocate(std::min(max_alloc_size, want - allocated),
+      unit, &offset, &length);
+    if (r < 0) {
+      // Allocation failed.
+      break;
+    }
+    extents->emplace_back(offset, length);
+    allocated += length;
+  }
+  return allocated ? allocated : -ENOSPC;
+}
+
 int AvlAllocator::_allocate(
   uint64_t size,
   uint64_t unit,
   uint64_t *offset,
   uint64_t *length)
 {
-  std::lock_guard l(lock);
   uint64_t max_size = 0;
   if (auto p = range_size_tree.rbegin(); p != range_size_tree.rend()) {
     max_size = p->end - p->start;
@@ -190,6 +211,25 @@ int AvlAllocator::_allocate(
   *offset = start;
   *length = size;
   return 0;
+}
+
+void AvlAllocator::_release(const interval_set<uint64_t>& release_set)
+{
+  for (auto p = release_set.begin(); p != release_set.end(); ++p) {
+    const auto offset = p.get_start();
+    const auto length = p.get_len();
+    ldout(cct, 10) << __func__ << std::hex
+      << " offset 0x" << offset
+      << " length 0x" << length
+      << std::dec << dendl;
+    _add_to_tree(offset, length);
+  }
+}
+
+void AvlAllocator::_shutdown()
+{
+  range_size_tree.clear();
+  range_tree.clear_and_dispose(dispose_rs{});
 }
 
 AvlAllocator::AvlAllocator(CephContext* cct,
@@ -245,34 +285,13 @@ int64_t AvlAllocator::allocate(
       max_alloc_size >= cap) {
     max_alloc_size = cap;
   }
-
-  uint64_t allocated = 0;
-  while (allocated < want) {
-    uint64_t offset, length;
-    int r = _allocate(std::min(max_alloc_size, want - allocated),
-                      unit, &offset, &length);
-    if (r < 0) {
-      // Allocation failed.
-      break;
-    }
-    extents->emplace_back(offset, length);
-    allocated += length;
-  }
-  return allocated ? allocated : -ENOSPC;
+  std::lock_guard l(lock);
+  return _allocate(want, unit, max_alloc_size, hint, extents);
 }
 
-void AvlAllocator::release(const interval_set<uint64_t>& release_set)
-{
+void AvlAllocator::release(const interval_set<uint64_t>& release_set) {
   std::lock_guard l(lock);
-  for (auto p = release_set.begin(); p != release_set.end(); ++p) {
-    const auto offset = p.get_start();
-    const auto length = p.get_len();
-    ldout(cct, 10) << __func__ << std::hex
-                   << " offset 0x" << offset
-                   << " length 0x" << length
-                   << std::dec << dendl;
-    _add_to_tree(offset, length);
-  }
+  _release(release_set);
 }
 
 uint64_t AvlAllocator::get_free()
@@ -284,30 +303,31 @@ uint64_t AvlAllocator::get_free()
 double AvlAllocator::get_fragmentation()
 {
   std::lock_guard l(lock);
-  auto free_blocks = p2align(num_free, block_size) / block_size;
-  if (free_blocks <= 1) {
-    return .0;
-  }  
-  return (static_cast<double>(range_tree.size() - 1) / (free_blocks - 1));
+  return _get_fragmentation();
 }
 
 void AvlAllocator::dump()
 {
   std::lock_guard l(lock);
+  _dump();
+}
+
+void AvlAllocator::_dump() const
+{
   ldout(cct, 0) << __func__ << " range_tree: " << dendl;
   for (auto& rs : range_tree) {
     ldout(cct, 0) << std::hex
-                  << "0x" << rs.start << "~" << rs.end
-                  << std::dec
-                  << dendl;
+      << "0x" << rs.start << "~" << rs.end
+      << std::dec
+      << dendl;
   }
 
   ldout(cct, 0) << __func__ << " range_size_tree: " << dendl;
   for (auto& rs : range_size_tree) {
     ldout(cct, 0) << std::hex
-                  << "0x" << rs.start << "~" << rs.end
-                  << std::dec
-                  << dendl;
+      << "0x" << rs.start << "~" << rs.end
+      << std::dec
+      << dendl;
   }
 }
 
@@ -341,6 +361,5 @@ void AvlAllocator::init_rm_free(uint64_t offset, uint64_t length)
 void AvlAllocator::shutdown()
 {
   std::lock_guard l(lock);
-  range_size_tree.clear();
-  range_tree.clear_and_dispose(dispose_rs{});
+  _shutdown();
 }

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -57,7 +57,7 @@ uint64_t AvlAllocator::_block_picker(const Tree& t,
 
 void AvlAllocator::_add_to_tree(uint64_t start, uint64_t size)
 {
-  assert(size != 0);
+  ceph_assert(size != 0);
 
   uint64_t end = start + size;
 
@@ -92,19 +92,9 @@ void AvlAllocator::_add_to_tree(uint64_t start, uint64_t size)
   }
 }
 
-void AvlAllocator::_remove_from_tree(uint64_t start, uint64_t size)
+void AvlAllocator::_process_range_removal(uint64_t start, uint64_t end,
+  AvlAllocator::range_tree_t::iterator& rs)
 {
-  uint64_t end = start + size;
-
-  assert(size != 0);
-  assert(size <= num_free);
-
-  auto rs = range_tree.find(range_t{start, end}, range_tree.key_comp());
-  /* Make sure we completely overlap with someone */
-  assert(rs != range_tree.end());
-  assert(rs->start <= start);
-  assert(rs->end >= end);
-
   bool left_over = (rs->start != start);
   bool right_over = (rs->end != end);
 
@@ -132,6 +122,58 @@ void AvlAllocator::_remove_from_tree(uint64_t start, uint64_t size)
     _range_size_tree_try_insert(*rs);
   } else {
     range_tree.erase_and_dispose(rs, dispose_rs{});
+  }
+}
+
+void AvlAllocator::_remove_from_tree(uint64_t start, uint64_t size)
+{
+  uint64_t end = start + size;
+
+  ceph_assert(size != 0);
+  ceph_assert(size <= num_free);
+
+  auto rs = range_tree.find(range_t{start, end}, range_tree.key_comp());
+  /* Make sure we completely overlap with someone */
+  ceph_assert(rs != range_tree.end());
+  ceph_assert(rs->start <= start);
+  ceph_assert(rs->end >= end);
+
+  _process_range_removal(start, end, rs);
+}
+
+void AvlAllocator::_try_remove_from_tree(uint64_t start, uint64_t size,
+  std::function<void(uint64_t, uint64_t, bool)> cb)
+{
+  uint64_t end = start + size;
+
+  ceph_assert(size != 0);
+
+  auto rs = range_tree.find(range_t{ start, end },
+    range_tree.key_comp());
+
+  if (rs == range_tree.end() || rs->start >= end) {
+    cb(start, size, false);
+    return;
+  }
+
+  do {
+
+    auto next_rs = rs;
+    ++next_rs;
+
+    if (start < rs->start) {
+      cb(start, rs->start - start, false);
+      start = rs->start;
+    }
+    auto range_end = std::min(rs->end, end);
+    _process_range_removal(start, range_end, rs);
+    cb(start, range_end - start, true);
+    start = range_end;
+
+    rs = next_rs;
+  } while (rs != range_tree.end() && rs->start < end && start < end);
+  if (start < end) {
+    cb(start, end - start, false);
   }
 }
 
@@ -174,7 +216,7 @@ int AvlAllocator::_allocate(
       return -ENOSPC;
     }
     size = p2align(max_size, unit);
-    assert(size > 0);
+    ceph_assert(size > 0);
     force_range_size_alloc = true;
   }
   /*
@@ -185,7 +227,7 @@ int AvlAllocator::_allocate(
    * region.
    */
   const uint64_t align = size & -size;
-  assert(align != 0);
+  ceph_assert(align != 0);
   uint64_t *cursor = &lbas[cbits(align) - 1];
 
   const int free_pct = num_free * 100 / num_total;
@@ -223,6 +265,16 @@ void AvlAllocator::_release(const interval_set<uint64_t>& release_set)
       << " length 0x" << length
       << std::dec << dendl;
     _add_to_tree(offset, length);
+  }
+}
+
+void AvlAllocator::_release(const PExtentVector& release_set) {
+  for (auto& e : release_set) {
+    ldout(cct, 10) << __func__ << std::hex
+      << " offset 0x" << e.offset
+      << " length 0x" << e.length
+      << std::dec << dendl;
+    _add_to_tree(e.offset, e.length);
   }
 }
 
@@ -275,15 +327,15 @@ int64_t AvlAllocator::allocate(
                  << " max_alloc_size 0x" << max_alloc_size
                  << " hint 0x" << hint
                  << std::dec << dendl;
-  assert(isp2(unit));
-  assert(want % unit == 0);
+  ceph_assert(isp2(unit));
+  ceph_assert(want % unit == 0);
 
   if (max_alloc_size == 0) {
     max_alloc_size = want;
   }
   if (constexpr auto cap = std::numeric_limits<decltype(bluestore_pextent_t::length)>::max();
       max_alloc_size >= cap) {
-    max_alloc_size = cap;
+    max_alloc_size = p2align(uint64_t(cap), (uint64_t)block_size);
   }
   std::lock_guard l(lock);
   return _allocate(want, unit, max_alloc_size, hint, extents);

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -64,7 +64,7 @@ protected:
   * (when entry count >= max_entries)
   */
   AvlAllocator(CephContext* cct, int64_t device_size, int64_t block_size,
-    uint64_t max_entries,
+    uint64_t max_mem,
     const std::string& name);
 
 public:

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -77,6 +77,13 @@ public:
     int64_t  hint,
     PExtentVector *extents) override;
   void release(const interval_set<uint64_t>& release_set) override;
+  int64_t get_capacity() const {
+    return num_total;
+  }
+
+  uint64_t get_block_size() const {
+    return block_size;
+  }
   uint64_t get_free() override;
   double get_fragmentation() override;
 
@@ -231,8 +238,16 @@ protected:
     PExtentVector *extents);
 
   void _release(const interval_set<uint64_t>& release_set);
+  void _release(const PExtentVector&  release_set);
   void _shutdown();
 
   void _add_to_tree(uint64_t start, uint64_t size);
+  void _process_range_removal(uint64_t start, uint64_t end, range_tree_t::iterator& rs);
   void _remove_from_tree(uint64_t start, uint64_t size);
+  void _try_remove_from_tree(uint64_t start, uint64_t size,
+    std::function<void(uint64_t offset, uint64_t length, bool found)> cb);
+
+  uint64_t _get_free() const {
+    return num_free;
+  }
 };

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -43,10 +43,30 @@ struct range_seg_t {
       }
     }
   };
+  inline uint64_t length() const {
+    return end - start;
+  }
   boost::intrusive::avl_set_member_hook<> size_hook;
 };
 
 class AvlAllocator final : public Allocator {
+  struct dispose_rs {
+    void operator()(range_seg_t* p)
+    {
+      delete p;
+    }
+  };
+
+protected:
+  /*
+  * ctor intended for the usage from descendant class(es) which
+  * provides handlig for spilled over entries
+  * (when entry count >= max_entries)
+  */
+  AvlAllocator(CephContext* cct, int64_t device_size, int64_t block_size,
+    uint64_t max_entries,
+    const std::string& name);
+
 public:
   AvlAllocator(CephContext* cct, int64_t device_size, int64_t block_size,
 	       const std::string& name);
@@ -100,7 +120,8 @@ private:
       boost::intrusive::member_hook<
 	range_seg_t,
 	boost::intrusive::avl_set_member_hook<>,
-	&range_seg_t::size_hook>>;
+	&range_seg_t::size_hook>,
+      boost::intrusive::constant_time_size<true>>;
   range_size_tree_t range_size_tree;
 
   const int64_t num_total;   ///< device size
@@ -131,6 +152,66 @@ private:
    */
   int range_size_alloc_free_pct = 0;
 
+  /*
+  * Max amount of range entries allowed. 0 - unlimited
+  */
+  uint64_t range_count_cap = 0;
+
   CephContext* cct;
   std::mutex lock;
+
+  uint64_t _lowest_size_available() {
+    auto rs = range_size_tree.begin();
+    return rs != range_size_tree.end() ? rs->length() : 0;
+  }
+  void _range_size_tree_rm(range_seg_t& r) {
+    ceph_assert(num_free >= r.length());
+    num_free -= r.length();
+    range_size_tree.erase(r);
+
+  }
+  void _range_size_tree_try_insert(range_seg_t& r) {
+    if (_try_insert_range(r.start, r.end)) {
+      range_size_tree.insert(r);
+      num_free += r.length();
+    } else {
+      range_tree.erase_and_dispose(r, dispose_rs{});
+    }
+  }
+  bool _try_insert_range(uint64_t start,
+                         uint64_t end,
+                        range_tree_t::iterator* insert_pos = nullptr) {
+    bool res = !range_count_cap || range_size_tree.size() < range_count_cap;
+    bool remove_lowest = false;
+    if (!res) {
+      if (end - start > _lowest_size_available()) {
+        remove_lowest = true;
+        res = true;
+      }
+    }
+    if (!res) {
+      _spillover_range(start, end);
+    } else {
+      // NB:  we should do insertion before the following removal
+      // to avoid potential iterator disposal insertion might depend on.
+      if (insert_pos) {
+        auto new_rs = new range_seg_t{ start, end };
+        range_tree.insert_before(*insert_pos, *new_rs);
+        range_size_tree.insert(*new_rs);
+        num_free += new_rs->length();
+      }
+      if (remove_lowest) {
+        auto r = range_size_tree.begin();
+        _range_size_tree_rm(*r);
+        _spillover_range(r->start, r->end);
+        range_tree.erase_and_dispose(*r, dispose_rs{});
+      }
+    }
+    return res;
+  }
+  virtual void _spillover_range(uint64_t start, uint64_t end) {
+    // this should be overriden when range count cap is present,
+    // i.e. (range_count_cap > 0)
+    ceph_assert(false);
+  }
 };

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -213,6 +213,10 @@ private:
     ceph_assert(false);
   }
 protected:
+  // called when extent to be released/marked free
+  virtual void _add_to_tree(uint64_t start, uint64_t size);
+
+protected:
   CephContext* cct;
   std::mutex lock;
 
@@ -241,7 +245,6 @@ protected:
   void _release(const PExtentVector&  release_set);
   void _shutdown();
 
-  void _add_to_tree(uint64_t start, uint64_t size);
   void _process_range_removal(uint64_t start, uint64_t end, range_tree_t::iterator& rs);
   void _remove_from_tree(uint64_t start, uint64_t size);
   void _try_remove_from_tree(uint64_t start, uint64_t size,

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -49,7 +49,7 @@ struct range_seg_t {
   boost::intrusive::avl_set_member_hook<> size_hook;
 };
 
-class AvlAllocator final : public Allocator {
+class AvlAllocator : public Allocator {
   struct dispose_rs {
     void operator()(range_seg_t* p)
     {
@@ -60,7 +60,7 @@ class AvlAllocator final : public Allocator {
 protected:
   /*
   * ctor intended for the usage from descendant class(es) which
-  * provides handlig for spilled over entries
+  * provides handling for spilled over entries
   * (when entry count >= max_entries)
   */
   AvlAllocator(CephContext* cct, int64_t device_size, int64_t block_size,
@@ -75,23 +75,21 @@ public:
     uint64_t unit,
     uint64_t max_alloc_size,
     int64_t  hint,
-    PExtentVector *extents) final;
-  void release(const interval_set<uint64_t>& release_set) final;
-  uint64_t get_free() final;
-  double get_fragmentation() final;
+    PExtentVector *extents) override;
+  void release(const interval_set<uint64_t>& release_set) override;
+  uint64_t get_free() override;
+  double get_fragmentation() override;
 
-  void dump() final;
-  void dump(std::function<void(uint64_t offset, uint64_t length)> notify) final;
-  void init_add_free(uint64_t offset, uint64_t length) final;
-  void init_rm_free(uint64_t offset, uint64_t length) final;
-  void shutdown() final;
+  void dump() override;
+  void dump(std::function<void(uint64_t offset, uint64_t length)> notify) override;
+  void init_add_free(uint64_t offset, uint64_t length) override;
+  void init_rm_free(uint64_t offset, uint64_t length) override;
+  void shutdown() override;
 
 private:
   template<class Tree>
   uint64_t _block_picker(const Tree& t, uint64_t *cursor, uint64_t size,
     uint64_t align);
-  void _add_to_tree(uint64_t start, uint64_t size);
-  void _remove_from_tree(uint64_t start, uint64_t size);
   int _allocate(
     uint64_t size,
     uint64_t unit,
@@ -157,13 +155,6 @@ private:
   */
   uint64_t range_count_cap = 0;
 
-  CephContext* cct;
-  std::mutex lock;
-
-  uint64_t _lowest_size_available() {
-    auto rs = range_size_tree.begin();
-    return rs != range_size_tree.end() ? rs->length() : 0;
-  }
   void _range_size_tree_rm(range_seg_t& r) {
     ceph_assert(num_free >= r.length());
     num_free -= r.length();
@@ -214,4 +205,34 @@ private:
     // i.e. (range_count_cap > 0)
     ceph_assert(false);
   }
+protected:
+  CephContext* cct;
+  std::mutex lock;
+
+  double _get_fragmentation() const {
+    auto free_blocks = p2align(num_free, block_size) / block_size;
+    if (free_blocks <= 1) {
+      return .0;
+    }
+    return (static_cast<double>(range_tree.size() - 1) / (free_blocks - 1));
+  }
+  void _dump() const;
+
+  uint64_t _lowest_size_available() {
+    auto rs = range_size_tree.begin();
+    return rs != range_size_tree.end() ? rs->length() : 0;
+  }
+
+  int64_t _allocate(
+    uint64_t want,
+    uint64_t unit,
+    uint64_t max_alloc_size,
+    int64_t  hint,
+    PExtentVector *extents);
+
+  void _release(const interval_set<uint64_t>& release_set);
+  void _shutdown();
+
+  void _add_to_tree(uint64_t start, uint64_t size);
+  void _remove_from_tree(uint64_t start, uint64_t size);
 };

--- a/src/os/bluestore/BitmapAllocator.h
+++ b/src/os/bluestore/BitmapAllocator.h
@@ -22,7 +22,6 @@ public:
   {
   }
 
-
   int64_t allocate(
     uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
     int64_t hint, PExtentVector *extents) override;

--- a/src/os/bluestore/BitmapAllocator.h
+++ b/src/os/bluestore/BitmapAllocator.h
@@ -30,6 +30,8 @@ public:
   void release(
     const interval_set<uint64_t>& release_set) override;
 
+  using Allocator::release;
+
   uint64_t get_free() override
   {
     return get_available();

--- a/src/os/bluestore/HybridAllocator.cc
+++ b/src/os/bluestore/HybridAllocator.cc
@@ -153,16 +153,6 @@ void HybridAllocator::dump(std::function<void(uint64_t offset, uint64_t length)>
   }
 }
 
-void HybridAllocator::init_add_free(uint64_t offset, uint64_t length)
-{
-  std::lock_guard l(lock);
-  ldout(cct, 10) << __func__ << std::hex
-                 << " offset 0x" << offset
-                 << " length 0x" << length
-                 << std::dec << dendl;
-  _add_to_tree(offset, length);
-}
-
 void HybridAllocator::init_rm_free(uint64_t offset, uint64_t length)
 {
   std::lock_guard l(lock);

--- a/src/os/bluestore/HybridAllocator.cc
+++ b/src/os/bluestore/HybridAllocator.cc
@@ -1,0 +1,219 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "HybridAllocator.h"
+
+#include <limits>
+
+#include "common/config_proxy.h"
+#include "common/debug.h"
+
+#define dout_context cct
+#define dout_subsys ceph_subsys_bluestore
+#undef  dout_prefix
+#define dout_prefix *_dout << "HybridAllocator "
+
+
+int64_t HybridAllocator::allocate(
+  uint64_t want,
+  uint64_t unit,
+  uint64_t max_alloc_size,
+  int64_t  hint,
+  PExtentVector* extents)
+{
+  ldout(cct, 10) << __func__ << std::hex
+                 << " want 0x" << want
+                 << " unit 0x" << unit
+                 << " max_alloc_size 0x" << max_alloc_size
+                 << " hint 0x" << hint
+                 << std::dec << dendl;
+  ceph_assert(isp2(unit));
+  ceph_assert(want % unit == 0);
+
+  if (max_alloc_size == 0) {
+    max_alloc_size = want;
+  }
+  if (constexpr auto cap = std::numeric_limits<decltype(bluestore_pextent_t::length)>::max();
+      max_alloc_size >= cap) {
+    max_alloc_size = p2align(uint64_t(cap), (uint64_t)get_block_size());
+  }
+
+  std::lock_guard l(lock);
+
+  int64_t res;
+  PExtentVector local_extents;
+
+  // preserve original 'extents' vector state
+  auto orig_size = extents->size();
+  auto orig_pos = extents->end();
+  if (orig_size) {
+    --orig_pos;
+  }
+
+  // try bitmap first to avoid unneeded contiguous extents split if
+  // desired amount is less than shortes range in AVL
+  if (bmap_alloc && bmap_alloc->get_free() &&
+    want < _lowest_size_available()) {
+    res = bmap_alloc->allocate(want, unit, max_alloc_size, hint, extents);
+    if (res < 0) {
+      // got a failure, release already allocated and
+      // start over allocation from avl
+      if (orig_size) {
+        local_extents.insert(
+          local_extents.end(), ++orig_pos, extents->end());
+        extents->resize(orig_size);
+      } else {
+        extents->swap(local_extents);
+      }
+      bmap_alloc->release(local_extents);
+      res = 0;
+    }
+    if ((uint64_t)res < want) {
+      auto res2 = _allocate(want - res, unit, max_alloc_size, hint, extents);
+      if (res2 < 0) {
+        res = res2; // caller to do the release
+      } else {
+        res += res2;
+      }
+    }
+  } else {
+    res = _allocate(want, unit, max_alloc_size, hint, extents);
+    if (res < 0) {
+      // got a failure, release already allocated and
+      // start over allocation from bitmap
+      if (orig_size) {
+        local_extents.insert(
+          local_extents.end(), ++orig_pos, extents->end());
+        extents->resize(orig_size);
+      } else {
+        extents->swap(local_extents);
+      }
+      _release(local_extents);
+      res = 0;
+    }
+    if ((uint64_t)res < want ) {
+      auto res2 = bmap_alloc ?
+        bmap_alloc->allocate(want - res, unit, max_alloc_size, hint, extents) :
+        0;
+      if (res2 < 0 ) {
+        res = res2; // caller to do the release
+      } else {
+        res += res2;
+      }
+    }
+  }
+  return res ? res : -ENOSPC;
+}
+
+void HybridAllocator::release(const interval_set<uint64_t>& release_set) {
+  std::lock_guard l(lock);
+  // this will attempt to put free ranges into AvlAllocator first and
+  // fallback to bitmap one via _try_insert_range call
+  _release(release_set);
+}
+
+uint64_t HybridAllocator::get_free()
+{
+  std::lock_guard l(lock);
+  return (bmap_alloc ? bmap_alloc->get_free() : 0) + _get_free();
+}
+
+double HybridAllocator::get_fragmentation()
+{
+  std::lock_guard l(lock);
+  auto f = AvlAllocator::_get_fragmentation();
+  auto bmap_free = bmap_alloc ? bmap_alloc->get_free() : 0;
+  if (bmap_free) {
+    auto _free = _get_free() + bmap_free;
+    auto bf = bmap_alloc->get_fragmentation();
+
+    f = f * _get_free() / _free + bf * bmap_free / _free;
+  }
+  return f;
+}
+
+void HybridAllocator::dump()
+{
+  std::lock_guard l(lock);
+  AvlAllocator::_dump();
+  if (bmap_alloc) {
+    bmap_alloc->dump();
+  }
+  ldout(cct, 0) << __func__
+    << " avl_free: " << _get_free()
+    << " bmap_free: " << (bmap_alloc ? bmap_alloc->get_free() : 0)
+    << dendl;
+}
+
+void HybridAllocator::dump(std::function<void(uint64_t offset, uint64_t length)> notify)
+{
+  AvlAllocator::dump(notify);
+  if (bmap_alloc) {
+    bmap_alloc->dump(notify);
+  }
+}
+
+void HybridAllocator::init_add_free(uint64_t offset, uint64_t length)
+{
+  std::lock_guard l(lock);
+  ldout(cct, 10) << __func__ << std::hex
+                 << " offset 0x" << offset
+                 << " length 0x" << length
+                 << std::dec << dendl;
+  _add_to_tree(offset, length);
+}
+
+void HybridAllocator::init_rm_free(uint64_t offset, uint64_t length)
+{
+  std::lock_guard l(lock);
+  ldout(cct, 10) << __func__ << std::hex
+                 << " offset 0x" << offset
+                 << " length 0x" << length
+                 << std::dec << dendl;
+  _try_remove_from_tree(offset, length,
+    [&](uint64_t o, uint64_t l, bool found) {
+      if (!found) {
+        if (bmap_alloc) {
+          bmap_alloc->init_rm_free(o, l);
+        } else {
+          lderr(cct) << "init_rm_free lambda" << std::hex
+            << "Uexpected extent: "
+            << " 0x" << o << "~" << l
+            << std::dec << dendl;
+          ceph_assert(false);
+        }
+      }
+    });
+}
+
+void HybridAllocator::shutdown()
+{
+  std::lock_guard l(lock);
+  _shutdown();
+  if (bmap_alloc) {
+    bmap_alloc->shutdown();
+    delete bmap_alloc;
+    bmap_alloc = nullptr;
+  }
+}
+
+void HybridAllocator::_spillover_range(uint64_t start, uint64_t end) {
+  auto size = end - start;
+  dout(20) << __func__
+    << std::hex << " "
+    << start << "~" << size
+    << std::dec
+    << dendl;
+  ceph_assert(size);
+  if (!bmap_alloc) {
+    dout(1) << __func__
+      << std::hex
+      << " constructing fallback allocator"
+      << dendl;
+    bmap_alloc = new BitmapAllocator(cct,
+      get_capacity(),
+      get_block_size(),
+      get_name());
+  }
+  bmap_alloc->init_add_free(start, size);
+}

--- a/src/os/bluestore/HybridAllocator.cc
+++ b/src/os/bluestore/HybridAllocator.cc
@@ -187,7 +187,8 @@ void HybridAllocator::shutdown()
   }
 }
 
-void HybridAllocator::_spillover_range(uint64_t start, uint64_t end) {
+void HybridAllocator::_spillover_range(uint64_t start, uint64_t end)
+{
   auto size = end - start;
   dout(20) << __func__
     << std::hex << " "
@@ -206,4 +207,16 @@ void HybridAllocator::_spillover_range(uint64_t start, uint64_t end) {
       get_name());
   }
   bmap_alloc->init_add_free(start, size);
+}
+
+void HybridAllocator::_add_to_tree(uint64_t start, uint64_t size)
+{
+  if (bmap_alloc) {
+    uint64_t head = bmap_alloc->claim_free_to_left(start);
+    uint64_t tail = bmap_alloc->claim_free_to_right(start + size);
+    ceph_assert(head <= start);
+    start -= head;
+    size += head + tail;
+  }
+  AvlAllocator::_add_to_tree(start, size);
 }

--- a/src/os/bluestore/HybridAllocator.h
+++ b/src/os/bluestore/HybridAllocator.h
@@ -28,7 +28,6 @@ public:
 
   void dump() override;
   void dump(std::function<void(uint64_t offset, uint64_t length)> notify) override;
-  void init_add_free(uint64_t offset, uint64_t length) override;
   void init_rm_free(uint64_t offset, uint64_t length) override;
   void shutdown() override;
 

--- a/src/os/bluestore/HybridAllocator.h
+++ b/src/os/bluestore/HybridAllocator.h
@@ -1,0 +1,46 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <mutex>
+
+#include "AvlAllocator.h"
+#include "BitmapAllocator.h"
+
+class HybridAllocator : public AvlAllocator {
+  BitmapAllocator* bmap_alloc = nullptr;
+public:
+  HybridAllocator(CephContext* cct, int64_t device_size, int64_t _block_size,
+                  uint64_t max_entries,
+	          const std::string& name) :
+      AvlAllocator(cct, device_size, _block_size, max_entries, name) {
+  }
+  int64_t allocate(
+    uint64_t want,
+    uint64_t unit,
+    uint64_t max_alloc_size,
+    int64_t  hint,
+    PExtentVector *extents) override;
+  void release(const interval_set<uint64_t>& release_set) override;
+  uint64_t get_free() override;
+  double get_fragmentation() override;
+
+  void dump() override;
+  void dump(std::function<void(uint64_t offset, uint64_t length)> notify) override;
+  void init_add_free(uint64_t offset, uint64_t length) override;
+  void init_rm_free(uint64_t offset, uint64_t length) override;
+  void shutdown() override;
+
+protected:
+  // intended primarily for UT
+  BitmapAllocator* get_bmap() {
+    return bmap_alloc;
+  }
+  const BitmapAllocator* get_bmap() const {
+    return bmap_alloc;
+  }
+private:
+
+  void _spillover_range(uint64_t start, uint64_t end) override;
+};

--- a/src/os/bluestore/HybridAllocator.h
+++ b/src/os/bluestore/HybridAllocator.h
@@ -42,4 +42,7 @@ protected:
 private:
 
   void _spillover_range(uint64_t start, uint64_t end) override;
+
+  // called when extent to be released/marked free
+  void _add_to_tree(uint64_t start, uint64_t size) override;
 };

--- a/src/os/bluestore/HybridAllocator.h
+++ b/src/os/bluestore/HybridAllocator.h
@@ -12,9 +12,9 @@ class HybridAllocator : public AvlAllocator {
   BitmapAllocator* bmap_alloc = nullptr;
 public:
   HybridAllocator(CephContext* cct, int64_t device_size, int64_t _block_size,
-                  uint64_t max_entries,
+                  uint64_t max_mem,
 	          const std::string& name) :
-      AvlAllocator(cct, device_size, _block_size, max_entries, name) {
+      AvlAllocator(cct, device_size, _block_size, max_mem, name) {
   }
   int64_t allocate(
     uint64_t want,

--- a/src/os/bluestore/fastbmap_allocator_impl.h
+++ b/src/os/bluestore/fastbmap_allocator_impl.h
@@ -634,7 +634,6 @@ protected:
   {
     uint64_t prev_allocated = *allocated;
     uint64_t d = L1_ENTRIES_PER_SLOT;
-    ceph_assert(isp2(min_length));
     ceph_assert(min_length <= l2_granularity);
     ceph_assert(max_length == 0 || max_length >= min_length);
     ceph_assert(max_length == 0 || (max_length % min_length) == 0);

--- a/src/os/bluestore/fastbmap_allocator_impl.h
+++ b/src/os/bluestore/fastbmap_allocator_impl.h
@@ -322,6 +322,9 @@ protected:
 
   void _mark_l1_on_l0(int64_t l0_pos, int64_t l0_pos_end);
   void _mark_alloc_l0(int64_t l0_pos_start, int64_t l0_pos_end);
+  uint64_t _claim_free_to_left_l0(int64_t l0_pos_start);
+  uint64_t _claim_free_to_right_l0(int64_t l0_pos_start);
+
 
   void _mark_alloc_l1_l0(int64_t l0_pos_start, int64_t l0_pos_end)
   {
@@ -424,6 +427,34 @@ protected:
     return l0_granularity * (l0_pos_end - l0_pos_start);
   }
 
+  uint64_t claim_free_to_left_l1(uint64_t offs)
+  {
+    uint64_t l0_pos_end = offs / l0_granularity;
+    uint64_t l0_pos_start = _claim_free_to_left_l0(l0_pos_end);
+    if (l0_pos_start < l0_pos_end) {
+      _mark_l1_on_l0(
+        p2align(l0_pos_start, uint64_t(bits_per_slotset)),
+        p2roundup(l0_pos_end, uint64_t(bits_per_slotset)));
+      return l0_granularity * (l0_pos_end - l0_pos_start);
+    }
+    return 0;
+  }
+
+  uint64_t claim_free_to_right_l1(uint64_t offs)
+  {
+    uint64_t l0_pos_start = offs / l0_granularity;
+    uint64_t l0_pos_end = _claim_free_to_right_l0(l0_pos_start);
+
+    if (l0_pos_start < l0_pos_end) {
+      _mark_l1_on_l0(
+        p2align(l0_pos_start, uint64_t(bits_per_slotset)),
+        p2roundup(l0_pos_end, uint64_t(bits_per_slotset)));
+      return l0_granularity * (l0_pos_end - l0_pos_start);
+    }
+    return 0;
+  }
+
+
 public:
   uint64_t debug_get_allocated(uint64_t pos0 = 0, uint64_t pos1 = 0)
   {
@@ -522,7 +553,31 @@ public:
       std::lock_guard l(lock);
       l1.collect_stats(bins_overall);
   }
+  uint64_t claim_free_to_left(uint64_t offset) {
+    std::lock_guard l(lock);
+    auto allocated = l1.claim_free_to_left_l1(offset);
+    ceph_assert(available >= allocated);
+    available -= allocated;
 
+    uint64_t l2_pos = (offset - allocated) / l2_granularity;
+    uint64_t l2_pos_end =
+      p2roundup(int64_t(offset), int64_t(l2_granularity)) / l2_granularity;
+    _mark_l2_on_l1(l2_pos, l2_pos_end);
+    return allocated;
+  }
+
+  uint64_t claim_free_to_right(uint64_t offset) {
+    std::lock_guard l(lock);
+    auto allocated = l1.claim_free_to_right_l1(offset);
+    ceph_assert(available >= allocated);
+    available -= allocated;
+
+    uint64_t l2_pos = (offset) / l2_granularity;
+    int64_t end = offset + allocated;
+    uint64_t l2_pos_end = p2roundup(end, int64_t(l2_granularity)) / l2_granularity;
+    _mark_l2_on_l1(l2_pos, l2_pos_end);
+    return allocated;
+  }
 protected:
   ceph::mutex lock = ceph::make_mutex("AllocatorLevel02::lock");
   L1 l1;

--- a/src/test/objectstore/Allocator_bench.cc
+++ b/src/test/objectstore/Allocator_bench.cc
@@ -329,4 +329,4 @@ TEST_P(AllocTest, test_alloc_bench_10_300)
 INSTANTIATE_TEST_SUITE_P(
   Allocator,
   AllocTest,
-  ::testing::Values("stupid", "bitmap", "avl"));
+  ::testing::Values("stupid", "bitmap", "avl", "hybrid"));

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -14,7 +14,6 @@
 #include "include/Context.h"
 #include "os/bluestore/Allocator.h"
 
-#include <boost/random/uniform_int.hpp>
 typedef boost::mt11213b gen_type;
 
 class AllocTest : public ::testing::TestWithParam<const char*> {
@@ -264,11 +263,15 @@ TEST_P(AllocTest, test_alloc_fragmentation)
       EXPECT_EQ(0.0, alloc->get_fragmentation());
     }
   }
+  tmp.clear();
   EXPECT_EQ(-ENOSPC, alloc->allocate(want_size, alloc_unit, 0, 0, &tmp));
 
   if (GetParam() == string("avl")) {
     // AVL allocator uses a different allocating strategy
     GTEST_SKIP() << "skipping for AVL allocator";
+  } else if (GetParam() == string("hybrid")) {
+    // AVL allocator uses a different allocating strategy
+    GTEST_SKIP() << "skipping for Hybrid allocator";
   }
 
   for (size_t i = 0; i < allocated.size(); i += 2)
@@ -423,6 +426,7 @@ TEST_P(AllocTest, test_alloc_big2)
   EXPECT_EQ(need,
       alloc->allocate(need, mas, 0, &extents));
   need = block_size * blocks / 4; // 2GB
+  extents.clear();
   EXPECT_EQ(need,
       alloc->allocate(need, mas, 0, &extents));
   EXPECT_TRUE(extents[0].length > 0);
@@ -446,7 +450,37 @@ TEST_P(AllocTest, test_alloc_big3)
   EXPECT_TRUE(extents[0].length > 0);
 }
 
+TEST_P(AllocTest, test_alloc_contiguous)
+{
+  int64_t block_size = 0x1000;
+  int64_t capacity = block_size * 1024 * 1024;
+
+  {
+    init_alloc(capacity, block_size);
+
+    alloc->init_add_free(0, capacity);
+    PExtentVector extents;
+    uint64_t need = 4 * block_size;
+    EXPECT_EQ(need,
+      alloc->allocate(need, need,
+        0, (int64_t)0, &extents));
+    EXPECT_EQ(1u, extents.size());
+    EXPECT_EQ(extents[0].offset, 0);
+    EXPECT_EQ(extents[0].length, 4 * block_size);
+
+    extents.clear();
+    EXPECT_EQ(need,
+      alloc->allocate(need, need,
+        0, (int64_t)0, &extents));
+    EXPECT_EQ(1u, extents.size());
+    EXPECT_EQ(extents[0].offset, 4 * block_size);
+    EXPECT_EQ(extents[0].length, 4 * block_size);
+  }
+
+  alloc->shutdown();
+}
+
 INSTANTIATE_TEST_SUITE_P(
   Allocator,
   AllocTest,
-  ::testing::Values("stupid", "bitmap", "avl"));
+  ::testing::Values("stupid", "bitmap", "avl", "hybrid"));

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -112,6 +112,16 @@ if(WITH_BLUESTORE)
   set_target_properties(unittest_fastbmap_allocator PROPERTIES COMPILE_FLAGS
   "${UNITTEST_CXX_FLAGS}")
 
+  add_executable(unittest_hybrid_allocator
+    hybrid_allocator_test.cc
+    $<TARGET_OBJECTS:unit-main>
+    )
+  add_ceph_unittest(unittest_hybrid_allocator)
+  target_link_libraries(unittest_hybrid_allocator os global)
+
+  set_target_properties(unittest_hybrid_allocator PROPERTIES COMPILE_FLAGS
+  "${UNITTEST_CXX_FLAGS}")
+
   add_executable(unittest_alloc_aging EXCLUDE_FROM_ALL
     Allocator_aging_fragmentation.cc)
   target_link_libraries(unittest_alloc_aging os global GTest::Main)

--- a/src/test/objectstore/hybrid_allocator_test.cc
+++ b/src/test/objectstore/hybrid_allocator_test.cc
@@ -1,0 +1,230 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <iostream>
+#include <gtest/gtest.h>
+
+#include "os/bluestore/HybridAllocator.h"
+
+class TestHybridAllocator : public HybridAllocator {
+public:
+  TestHybridAllocator(CephContext* cct,
+                      int64_t device_size,
+                      int64_t _block_size,
+                      uint64_t max_entries,
+      const std::string& name) :
+    HybridAllocator(cct, device_size, _block_size,
+      max_entries,
+      name) {
+  }
+
+  uint64_t get_bmap_free() {
+    return get_bmap() ? get_bmap()->get_free() : 0;
+  }
+  uint64_t get_avl_free() {
+    return AvlAllocator::get_free();
+  }
+};
+
+const uint64_t _1m = 1024 * 1024;
+const uint64_t _4m = 4 * 1024 * 1024;
+
+TEST(HybridAllocator, basic)
+{
+  {
+    uint64_t block_size = 0x1000;
+    uint64_t capacity = 0x10000 * _1m; // = 64GB
+    TestHybridAllocator ha(g_ceph_context, capacity, block_size, 4, "test_hybrid_allocator");
+
+    ASSERT_EQ(0, ha.get_free());
+    ASSERT_EQ(0, ha.get_avl_free());
+    ASSERT_EQ(0, ha.get_bmap_free());
+
+    ha.init_add_free(0, _4m);
+    ASSERT_EQ(_4m, ha.get_free());
+    ASSERT_EQ(_4m, ha.get_avl_free());
+    ASSERT_EQ(0, ha.get_bmap_free());
+
+    ha.init_add_free(2 * _4m, _4m);
+    ASSERT_EQ(_4m * 2, ha.get_free());
+    ASSERT_EQ(_4m * 2, ha.get_avl_free());
+    ASSERT_EQ(0, ha.get_bmap_free());
+
+    ha.init_add_free(100 * _4m, _4m);
+    ha.init_add_free(102 * _4m, _4m);
+
+    ASSERT_EQ(_4m * 4, ha.get_free());
+    ASSERT_EQ(_4m * 4, ha.get_avl_free());
+    ASSERT_EQ(0, ha.get_bmap_free());
+
+    // next allocs will go to bitmap
+    ha.init_add_free(4 * _4m, _4m);
+    ASSERT_EQ(_4m * 5, ha.get_free());
+    ASSERT_EQ(_4m * 4, ha.get_avl_free());
+    ASSERT_EQ(_4m * 1, ha.get_bmap_free());
+
+    ha.init_add_free(6 * _4m, _4m);
+    ASSERT_EQ(_4m * 6, ha.get_free());
+    ASSERT_EQ(_4m * 4, ha.get_avl_free());
+    ASSERT_EQ(_4m * 2, ha.get_bmap_free());
+
+    // so we have 6x4M chunks, 4 chunks at AVL and 2 at bitmap
+
+    ha.init_rm_free(_1m, _1m); // take 1M from AVL
+    ASSERT_EQ(_1m * 23, ha.get_free());
+    ASSERT_EQ(_1m * 14, ha.get_avl_free());
+    ASSERT_EQ(_1m * 9, ha.get_bmap_free());
+
+    ha.init_rm_free(6 * _4m + _1m, _1m); // take 1M from bmap
+    ASSERT_EQ(_1m * 22, ha.get_free());
+    ASSERT_EQ(_1m * 14, ha.get_avl_free());
+    ASSERT_EQ(_1m * 8, ha.get_bmap_free());
+
+    // so we have at avl: 2M~2M, 8M~4M, 400M~4M , 408M~4M
+    // and at bmap: 0~1M, 16M~1M, 18M~2M, 24~4M
+
+    PExtentVector extents;
+    // allocate 4K, to be served from bitmap
+    EXPECT_EQ(block_size, ha.allocate(block_size, block_size,
+      0, (int64_t)0, &extents));
+    ASSERT_EQ(1, extents.size());
+    ASSERT_EQ(0, extents[0].offset);
+
+    ASSERT_EQ(_1m * 14, ha.get_avl_free());
+    ASSERT_EQ(_1m * 8 - block_size, ha.get_bmap_free());
+
+    interval_set<uint64_t> release_set;
+    // release 4K, to be returned to bitmap
+    release_set.insert(extents[0].offset, extents[0].length);
+    ha.release(release_set);
+
+    ASSERT_EQ(_1m * 14, ha.get_avl_free());
+    ASSERT_EQ(_1m * 8, ha.get_bmap_free());
+    extents.clear();
+    release_set.clear();
+
+    // again we have at avl: 2M~2M, 8M~4M, 400M~4M , 408M~4M
+    // and at bmap: 0~1M, 16M~1M, 18M~2M, 24~4M
+
+    // add 12M~3M which will go to avl
+    ha.init_add_free(3 * _4m, 3 * _1m);
+    ASSERT_EQ(_1m * 17, ha.get_avl_free());
+    ASSERT_EQ(_1m * 8, ha.get_bmap_free());
+
+
+    // add 15M~4K which will be appended to existing slot
+    ha.init_add_free(15 * _1m, 0x1000);
+    ASSERT_EQ(_1m * 17 + 0x1000, ha.get_avl_free());
+    ASSERT_EQ(_1m * 8, ha.get_bmap_free());
+
+
+    // again we have at avl: 2M~2M, 8M~(7M+4K), 400M~4M , 408M~4M
+    // and at bmap: 0~1M, 16M~1M, 18M~2M, 24~4M
+
+    //some removals from bmap
+    ha.init_rm_free(28 * _1m - 0x1000, 0x1000);
+    ASSERT_EQ(_1m * 17 + 0x1000, ha.get_avl_free());
+    ASSERT_EQ(_1m * 8 - 0x1000, ha.get_bmap_free());
+
+    ha.init_rm_free(24 * _1m + 0x1000, 0x1000);
+    ASSERT_EQ(_1m * 17 + 0x1000, ha.get_avl_free());
+    ASSERT_EQ(_1m * 8 - 0x2000, ha.get_bmap_free());
+
+    ha.init_rm_free(24 * _1m + 0x1000, _4m - 0x2000);
+    ASSERT_EQ(_1m * 17 + 0x1000, ha.get_avl_free());
+    ASSERT_EQ(_1m * 4, ha.get_bmap_free());
+
+    //4K removal from avl
+    ha.init_rm_free(15 * _1m, 0x1000);
+    ASSERT_EQ(_1m * 17, ha.get_avl_free());
+    ASSERT_EQ(_1m * 4, ha.get_bmap_free());
+
+    //remove highest 4Ms from avl
+    ha.init_rm_free(_1m * 400, _4m);
+    ha.init_rm_free(_1m * 408, _4m);
+    ASSERT_EQ(_1m * 9, ha.get_avl_free());
+    ASSERT_EQ(_1m * 4, ha.get_bmap_free());
+
+    // we have at avl: 2M~2M, 8M~7M
+    // and at bmap: 0~1M, 16M~1M, 18M~2M
+
+    // this will go to avl making 16M~4M span broken between both allocators
+    ha.init_add_free(17 * _1m, _1m);
+    ASSERT_EQ(_1m * 10, ha.get_avl_free());
+    ASSERT_EQ(_1m * 4, ha.get_bmap_free());
+
+    // we have at avl: 2M~2M, 8M~7M, 17M~1M
+    // and at bmap: 0~1M, 16M~1M, 18M~2M
+
+    // and now do some cutoffs from this "broken" 16M~4M span
+
+    //cut off 4K from bmap
+    ha.init_rm_free(16 * _1m, 0x1000);
+    ASSERT_EQ(_1m * 10, ha.get_avl_free());
+    ASSERT_EQ(_1m * 4 - 0x1000, ha.get_bmap_free());
+
+    //cut off 1M-4K from bmap and 4K from avl
+    ha.init_rm_free(16 * _1m + 0x1000, _1m);
+    ASSERT_EQ(_1m * 10 - 0x1000, ha.get_avl_free());
+    ASSERT_EQ(_1m * 3, ha.get_bmap_free());
+
+    //cut off 512K avl
+    ha.init_rm_free(17 * _1m + 0x1000, _1m / 2);
+    ASSERT_EQ(_1m * 10 - 0x1000 - _1m / 2, ha.get_avl_free());
+    ASSERT_EQ(_1m * 3, ha.get_bmap_free());
+
+    //cut off the rest from avl and 8K from bmap
+    ha.init_rm_free(17 * _1m + 0x1000 + _1m / 2, _1m / 2 + 0x1000);
+    ASSERT_EQ(_1m * 9, ha.get_avl_free());
+    ASSERT_EQ(_1m * 3 - 0x2000, ha.get_bmap_free());
+  }
+
+  {
+    uint64_t block_size = 0x1000;
+    uint64_t capacity = 0x10000 * _1m; // = 64GB
+    TestHybridAllocator ha(g_ceph_context, capacity, block_size,
+      4 * sizeof(range_seg_t), "test_hybrid_allocator");
+
+    ha.init_add_free(_1m, _1m);
+    ha.init_add_free(_1m * 3, _1m);
+    ha.init_add_free(_1m * 5, _1m);
+    ha.init_add_free(0x4000, 0x1000);
+
+    ASSERT_EQ(_1m * 3 + 0x1000, ha.get_free());
+    ASSERT_EQ(_1m * 3 + 0x1000, ha.get_avl_free());
+    ASSERT_EQ(0, ha.get_bmap_free());
+
+    // This will substitute chunk 0x4000~1000.
+    // Since new chunk insertion into into AvlAllocator:range_tree
+    // happens immediately before 0x4000~1000 chunk care should be taken
+    // to order operations properly and do not use already disposed iterator.
+    ha.init_add_free(0, 0x2000);
+
+    ASSERT_EQ(_1m * 3 + 0x3000, ha.get_free());
+    ASSERT_EQ(_1m * 3 + 0x2000, ha.get_avl_free());
+    ASSERT_EQ(0x1000, ha.get_bmap_free());
+  }
+}
+
+TEST(HybridAllocator, fragmentation)
+{
+  {
+    uint64_t block_size = 0x1000;
+    uint64_t capacity = 0x1000 * 0x1000; // = 16M
+    TestHybridAllocator ha(g_ceph_context, capacity, block_size,
+      4 * sizeof(range_seg_t), "test_hybrid_allocator");
+
+    ha.init_add_free(0, 0x2000);
+    ha.init_add_free(0x4000, 0x2000);
+    ha.init_add_free(0x8000, 0x2000);
+    ha.init_add_free(0xc000, 0x1000);
+
+    ASSERT_EQ(0.5, ha.get_fragmentation());
+
+    // this will got to bmap with fragmentation = 1
+    ha.init_add_free(0x10000, 0x1000);
+
+    // which results in the following total fragmentation
+    ASSERT_EQ(0.5 * 7 / 8 + 1.0 / 8, ha.get_fragmentation());
+  }
+}

--- a/src/test/objectstore/hybrid_allocator_test.cc
+++ b/src/test/objectstore/hybrid_allocator_test.cc
@@ -149,35 +149,35 @@ TEST(HybridAllocator, basic)
     // we have at avl: 2M~2M, 8M~7M
     // and at bmap: 0~1M, 16M~1M, 18M~2M
 
-    // this will go to avl making 16M~4M span broken between both allocators
+    // this will be merged with neighbors from bmap and go to avl
     ha.init_add_free(17 * _1m, _1m);
-    ASSERT_EQ(_1m * 10, ha.get_avl_free());
-    ASSERT_EQ(_1m * 4, ha.get_bmap_free());
+    ASSERT_EQ(_1m * 1, ha.get_bmap_free());
+    ASSERT_EQ(_1m * 13, ha.get_avl_free());
 
-    // we have at avl: 2M~2M, 8M~7M, 17M~1M
-    // and at bmap: 0~1M, 16M~1M, 18M~2M
+    // we have at avl: 2M~2M, 8M~7M, 16M~4M
+    // and at bmap: 0~1M
 
-    // and now do some cutoffs from this "broken" 16M~4M span
+    // and now do some cutoffs from 0~1M span
 
     //cut off 4K from bmap
-    ha.init_rm_free(16 * _1m, 0x1000);
-    ASSERT_EQ(_1m * 10, ha.get_avl_free());
-    ASSERT_EQ(_1m * 4 - 0x1000, ha.get_bmap_free());
+    ha.init_rm_free(0 * _1m, 0x1000);
+    ASSERT_EQ(_1m * 13, ha.get_avl_free());
+    ASSERT_EQ(_1m * 1 - 0x1000, ha.get_bmap_free());
 
-    //cut off 1M-4K from bmap and 4K from avl
-    ha.init_rm_free(16 * _1m + 0x1000, _1m);
-    ASSERT_EQ(_1m * 10 - 0x1000, ha.get_avl_free());
-    ASSERT_EQ(_1m * 3, ha.get_bmap_free());
+    //cut off 1M-4K from bmap
+    ha.init_rm_free(0 * _1m + 0x1000, _1m - 0x1000);
+    ASSERT_EQ(_1m * 13, ha.get_avl_free());
+    ASSERT_EQ(0, ha.get_bmap_free());
 
     //cut off 512K avl
     ha.init_rm_free(17 * _1m + 0x1000, _1m / 2);
-    ASSERT_EQ(_1m * 10 - 0x1000 - _1m / 2, ha.get_avl_free());
-    ASSERT_EQ(_1m * 3, ha.get_bmap_free());
+    ASSERT_EQ(_1m * 13 - _1m / 2, ha.get_avl_free());
+    ASSERT_EQ(0, ha.get_bmap_free());
 
-    //cut off the rest from avl and 8K from bmap
-    ha.init_rm_free(17 * _1m + 0x1000 + _1m / 2, _1m / 2 + 0x1000);
-    ASSERT_EQ(_1m * 9, ha.get_avl_free());
-    ASSERT_EQ(_1m * 3 - 0x2000, ha.get_bmap_free());
+    //cut off the rest from avl
+    ha.init_rm_free(17 * _1m + 0x1000 + _1m / 2, _1m / 2);
+    ASSERT_EQ(_1m * 12, ha.get_avl_free());
+    ASSERT_EQ(0, ha.get_bmap_free());
   }
 
   {

--- a/src/test/objectstore/hybrid_allocator_test.cc
+++ b/src/test/objectstore/hybrid_allocator_test.cc
@@ -34,7 +34,8 @@ TEST(HybridAllocator, basic)
   {
     uint64_t block_size = 0x1000;
     uint64_t capacity = 0x10000 * _1m; // = 64GB
-    TestHybridAllocator ha(g_ceph_context, capacity, block_size, 4, "test_hybrid_allocator");
+    TestHybridAllocator ha(g_ceph_context, capacity, block_size,
+      4 * sizeof(range_seg_t), "test_hybrid_allocator");
 
     ASSERT_EQ(0, ha.get_free());
     ASSERT_EQ(0, ha.get_avl_free());

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -7,6 +7,7 @@
 #include "include/stringify.h"
 #include "common/ceph_time.h"
 #include "os/bluestore/BlueStore.h"
+#include "os/bluestore/AvlAllocator.h"
 #include "common/ceph_argparse.h"
 #include "global/global_init.h"
 #include "global/global_context.h"
@@ -40,6 +41,7 @@ TEST(bluestore, sizeof) {
   P(boost::intrusive::unordered_set_base_hook<>);
   P(bufferlist);
   P(bufferptr);
+  P(range_seg_t);
   cout << "map<uint64_t,uint64_t>\t" << sizeof(map<uint64_t,uint64_t>) << std::endl;
   cout << "map<char,char>\t" << sizeof(map<char,char>) << std::endl;
 }


### PR DESCRIPTION
This is a hybrid of AVL and bitmap allocators intended to cap RAM usage for AVL allocator.
New hybrid allocator uses pure AVL allocation until mem usage is below the threshold and fallbacks to bitmap allocator if needed to track short extents there. AVL is still used as a sort of cache to track long extents up to desired RAM cap.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
