### PR TITLE
common, include: bump the version of ceph::buffer's C++ API.

### DIFF
--- a/src/common/buffer_seastar.cc
+++ b/src/common/buffer_seastar.cc
@@ -41,7 +41,7 @@ class raw_seastar_local_ptr : public raw {
   }
 };
 
-inline namespace v14_2_0 {
+inline namespace v15_2_0 {
 
 ceph::unique_leakable_ptr<buffer::raw> create_foreign(temporary_buffer&& buf) {
   return ceph::unique_leakable_ptr<buffer::raw>(
@@ -53,7 +53,7 @@ ceph::unique_leakable_ptr<buffer::raw> create(temporary_buffer&& buf) {
     new raw_seastar_local_ptr(std::move(buf)));
 }
 
-} // inline namespace v14_2_0
+} // inline namespace v15_2_0
 
 // buffer::ptr conversions
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -99,7 +99,7 @@ struct unique_leakable_ptr : public std::unique_ptr<T, ceph::nop_delete<T>> {
 };
 
 namespace buffer CEPH_BUFFER_API {
-inline namespace v14_2_0 {
+inline namespace v15_2_0 {
 
   /*
    * exceptions
@@ -1200,7 +1200,7 @@ inline namespace v14_2_0 {
     static list static_from_string(std::string& s);
   };
 
-} // inline namespace v14_2_0
+} // inline namespace v15_2_0
 
   /*
    * efficient hash of one or more bufferlists

--- a/src/include/buffer_fwd.h
+++ b/src/include/buffer_fwd.h
@@ -3,7 +3,7 @@
 
 namespace ceph {
   namespace buffer {
-    inline namespace v14_2_0 {
+    inline namespace v15_2_0 {
       class ptr;
       class list;
     }

--- a/src/include/buffer_raw.h
+++ b/src/include/buffer_raw.h
@@ -24,7 +24,7 @@
 #include "include/spinlock.h"
 
 namespace ceph::buffer {
-inline namespace v14_2_0 {
+inline namespace v15_2_0 {
 
   class raw {
   public:
@@ -115,7 +115,7 @@ public:
     }
   };
 
-} // inline namespace v14_2_0
+} // inline namespace v15_2_0
 } // namespace ceph::buffer
 
 #endif // CEPH_BUFFER_RAW_H

--- a/src/librados/librados.map
+++ b/src/librados/librados.map
@@ -5,7 +5,7 @@ LIBRADOS_PRIVATE {
 LIBRADOS_14.2.0 {
         global:
                 extern "C++" {
-			ceph::buffer::v14_2_0::*;
+			ceph::buffer::v15_2_0::*;
 			librados::v14_2_0::*;
 
                         "typeinfo for librados::v14_2_0::ObjectOperation";


### PR DESCRIPTION
The commit doesn't change the version of `librados` API which is still `14.2.0` as I'm aware only about modifications to the `ceph::buffer` C++ API.

It's also assumed that `librados2` upgrade is atomic in both debian- and RHEL-like distros. The reason for the concern is that `ceph::buffer` belongs to `libceph-common.so` while it's reached from `librados.so`. Still, these shared objects reside in the same package: `librados2`.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
