### PR TITLE
cephadm: add prepare-host

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -7,9 +7,9 @@ FSID='00000000-0000-0000-0000-0000deadbeef'
 FSID_LEGACY='00000000-0000-0000-0000-ffffdeadbeef'
 
 # images that are used
-IMAGE_MASTER=${IMAGE_MASTER:-'ceph/daemon-base:latest-master-devel'}
-IMAGE_NAUTILUS=${IMAGE_NAUTILUS:-'ceph/daemon-base:latest-nautilus'}
-IMAGE_MIMIC=${IMAGE_MIMIC:-'ceph/daemon-base:latest-mimic'}
+IMAGE_MASTER=${IMAGE_MASTER:-'docker.io/ceph/daemon-base:latest-master-devel'}
+IMAGE_NAUTILUS=${IMAGE_NAUTILUS:-'docker.io/ceph/daemon-base:latest-nautilus'}
+IMAGE_MIMIC=${IMAGE_MIMIC:-'docker.io/ceph/daemon-base:latest-mimic'}
 
 CORPUS_GIT_SUBMOD="cephadm-adoption-corpus"
 TMPDIR=$(mktemp -d)

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -57,7 +57,6 @@ except ImportError:
     pass
 import uuid
 
-from distutils.spawn import find_executable
 from functools import wraps
 from glob import glob
 from threading import Thread
@@ -808,6 +807,42 @@ def move_files(src, dst, uid=None, gid=None):
             shutil.move(src_file, dst_file)
             logger.debug('chown %s:%s \'%s\'' % (uid, gid, dst_file))
             os.chown(dst_file, uid, gid)
+
+## copied from distutils ##
+def find_executable(executable, path=None):
+    """Tries to find 'executable' in the directories listed in 'path'.
+    A string listing directories separated by 'os.pathsep'; defaults to
+    os.environ['PATH'].  Returns the complete filename or None if not found.
+    """
+    _, ext = os.path.splitext(executable)
+    if (sys.platform == 'win32') and (ext != '.exe'):
+        executable = executable + '.exe'
+
+    if os.path.isfile(executable):
+        return executable
+
+    if path is None:
+        path = os.environ.get('PATH', None)
+        if path is None:
+            try:
+                path = os.confstr("CS_PATH")
+            except (AttributeError, ValueError):
+                # os.confstr() or CS_PATH is not available
+                path = os.defpath
+        # bpo-35755: Don't use os.defpath if the PATH environment variable is
+        # set to an empty string
+
+    # PATH='' doesn't match, whereas PATH=':' looks in the current directory
+    if not path:
+        return None
+
+    paths = path.split(os.pathsep)
+    for p in paths:
+        f = os.path.join(p, executable)
+        if os.path.isfile(f):
+            # the file exists, we have a shot at spawn working
+            return f
+    return None
 
 def find_program(filename):
     # type: (str) -> str

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1616,6 +1616,8 @@ def command_bootstrap():
                 raise Error('%s already exists; delete or pass '
                               '--allow-overwrite to overwrite' % f)
 
+    command_prepare_host()
+
     # initial vars
     fsid = args.fsid or make_fsid()
     hostname = get_hostname()
@@ -2575,7 +2577,7 @@ def command_check_host():
     if not check_time_sync():
         raise Error('No time synchronization is active')
 
-    if args.expect_hostname:
+    if 'expect_hostname' in args and args.expect_hostname:
         if get_hostname() != args.expect_hostname:
             raise Error('hostname "%s" does not match expected hostname "%s"' % (
                 get_hostname(), args.expect_hostname))
@@ -2600,7 +2602,7 @@ def command_prepare_host():
     if not check_time_sync():
         pkg.install(['chrony'])
 
-    if args.expect_hostname and args.expect_hostname != get_hostname():
+    if 'expect_hostname' in args and args.expect_hostname and args.expect_hostname != get_hostname():
         logger.warning('Adjusting hostname from %s -> %s...' % (get_hostname(), args.expect_hostname))
         call_throws(['hostname', args.expect_hostname])
         with open('/etc/hostname', 'w') as f:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2584,6 +2584,30 @@ def command_check_host():
 
     logger.info('Host looks OK')
 
+##################################
+
+def command_prepare_host():
+    pkg = create_packager()
+    logger.info('Verifying podman|docker is present...')
+    if not container_path:
+        pkg.install_podman()
+
+    logger.info('Verifying lvm2 is present...')
+    if not find_executable('lvcreate'):
+        pkg.install(['lvm2'])
+
+    logger.info('Verifying time synchronization is in place...')
+    if not check_time_sync():
+        pkg.install(['chrony'])
+
+    if args.expect_hostname and args.expect_hostname != get_hostname():
+        logger.warning('Adjusting hostname from %s -> %s...' % (get_hostname(), args.expect_hostname))
+        call_throws(['hostname', args.expect_hostname])
+        with open('/etc/hostname', 'w') as f:
+            f.write(args.expect_hostname + '\n')
+
+    logger.info('Repeating the final host check...')
+    return command_check_host()
 
 ##################################
 
@@ -2727,6 +2751,24 @@ class Apt(Packager):
             logging.info('Removing repo at %s...' % self.repo_path())
             os.unlink(self.repo_path())
 
+    def install(self, ls):
+        logging.info('Installing packages %s...' % ls)
+        call_throws(['apt', 'install', '-y'] + ls)
+
+    def install_podman(self):
+        if self.distro == 'ubuntu':
+            logging.info('Setting up repo for pdoman...')
+            self.install(['software-properties-common'])
+            call_throws(['add-apt-repository', '-y', 'ppa:projectatomic/ppa'])
+            call_throws(['apt', 'update'])
+
+        logging.info('Attempting podman install...')
+        try:
+            self.install(['podman'])
+        except Error as e:
+            logging.info('Podman did not work.  Falling back to docker...')
+            self.install(['docker.io'])
+
 class YumDnf(Packager):
     DISTRO_NAMES = {
         'centos': ('centos', 'el'),
@@ -2849,6 +2891,14 @@ class YumDnf(Packager):
         if self.distro_code == 'el8':
             logger.info('Disabling supplementary copr repo ktdreyer/ceph-el8...')
             call_throws(['dnf', 'copr', 'disable', '-y', 'ktdreyer/ceph-el8'])
+
+    def install(self, ls):
+        logger.info('Installing packages %s...' % ls)
+        call_throws([self.tool, 'install', '-y'] + ls)
+
+    def install_podman(self):
+        self.install(['podman'])
+
 
 def create_packager(stable=None, branch=None, commit=None):
     distro, version, codename = get_distro()
@@ -3216,6 +3266,13 @@ def _get_parser():
         '--expect-hostname',
         help='Check that hostname matches an expected value')
 
+    parser_prepare_host = subparsers.add_parser(
+        'prepare-host', help='prepare a host for cephadm use')
+    parser_prepare_host.set_defaults(func=command_prepare_host)
+    parser_prepare_host.add_argument(
+        '--expect-hostname',
+        help='Set hostname')
+
     parser_add_repo = subparsers.add_parser(
         'add-repo', help='configure package repository')
     parser_add_repo.set_defaults(func=command_add_repo)
@@ -3290,7 +3347,7 @@ if __name__ == "__main__":
                 break
             except Exception as e:
                 logger.debug('Could not locate %s: %s' % (i, e))
-        if not container_path:
+        if not container_path and args.func != command_prepare_host:
             sys.stderr.write('Unable to locate any of %s\n' % CONTAINER_PREFERENCE)
             sys.exit(1)
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-DEFAULT_IMAGE='ceph/daemon-base:latest-master-devel'  # FIXME when octopus is ready!!!
+DEFAULT_IMAGE='docker.io/ceph/daemon-base:latest-master-devel'  # FIXME when octopus is ready!!!
 DATA_DIR='/var/lib/ceph'
 LOG_DIR='/var/log/ceph'
 LOCK_DIR='/run/cephadm'

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -438,7 +438,7 @@ std::vector<Option> get_global_options() {
     Option("container_image", Option::TYPE_STR, Option::LEVEL_BASIC)
     .set_description("container image (used by cephadm orchestrator)")
     .set_flag(Option::FLAG_STARTUP)
-    .set_default("ceph/daemon-base:latest-master-devel"),
+    .set_default("docker.io/ceph/daemon-base:latest-master-devel"),
 
     Option("no_config_file", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1154,6 +1154,27 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                     self.event.set()
         return 0, '%s (%s) ok' % (host, addr), err
 
+    @orchestrator._cli_read_command(
+        'cephadm prepare-host',
+        'name=host,type=CephString '
+        'name=addr,type=CephString,req=false',
+        'Prepare a remote host for use with cephadm')
+    def _prepare_host(self, host, addr=None):
+        out, err, code = self._run_cephadm(host, 'client', 'prepare-host',
+                                           ['--expect-hostname', host],
+                                           addr=addr,
+                                           error_ok=True, no_fsid=True)
+        if code:
+            return 1, '', ('prepare-host failed:\n' + '\n'.join(err))
+        # if we have an outstanding health alert for this host, give the
+        # serve thread a kick
+        if 'CEPHADM_HOST_CHECK_FAILED' in self.health_checks:
+            for item in self.health_checks['CEPHADM_HOST_CHECK_FAILED']['detail']:
+                if item.startswith('host %s ' % host):
+                    self.log.debug('kicking serve thread')
+                    self.event.set()
+        return 0, '%s (%s) ok' % (host, addr), err
+
     def _get_connection(self, host):
         """
         Setup a connection for running commands on remote host.

--- a/test_cephadm.sh
+++ b/test_cephadm.sh
@@ -3,7 +3,7 @@
 SCRIPT_NAME=$(basename ${BASH_SOURCE[0]})
 
 fsid='00000000-0000-0000-0000-0000deadbeef'
-image='ceph/daemon-base:latest-master-devel'
+image='docker.io/ceph/daemon-base:latest-master-devel'
 [ -z "$ip" ] && ip=127.0.0.1
 
 OSD_IMAGE_NAME="${SCRIPT_NAME%.*}_osd.img"


### PR DESCRIPTION
This doesn't address the first point in https://tracker.ceph.com/issues/44119:

```
root@ubuntu1804:~# sudo ./cephadm bootstrap --mon-ip 127.0.0.1
Traceback (most recent call last):
  File "./cephadm", line 59, in <module>
    from distutils.spawn import find_executable
ModuleNotFoundError: No module named 'distutils.spawn'
```

I'm not quite sure how to do that elegantly.  try and catch ImportError, but raise another error for any command other than prepare_host?