### PR TITLE
common/admin_socket: Added printing of error message.

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -371,6 +371,7 @@ void AdminSocket::do_accept()
   if (rval < 0) {
     ostringstream ss;
     ss << "ERROR: " << cpp_strerror(rval) << "\n";
+    ss << err.str() << "\n";
     bufferlist o;
     o.append(ss.str());
     o.claim_append(out);


### PR DESCRIPTION
Admin socket handlers can construct string error message. This has been totally omitted.
Content of 'err' is now printed if error code != 0.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>

Before:
$ ./bin/ceph daemon osd.1 pg 1.1 query
ERROR: (11) Resource temporarily unavailable
After:
$ ./bin/ceph daemon osd.1 pg 1.1 query
ERROR: (11) Resource temporarily unavailable
not primary for pgid 1.1