### PR TITLE
mgr/cephadm: adapt osd deployment to service_apply 

### DIFF
--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -590,7 +590,7 @@ def ceph_osds(ctx, config):
             _shell(ctx, cluster_name, remote, [
                 'ceph-volume', 'lvm', 'zap', dev])
             _shell(ctx, cluster_name, remote, [
-                'ceph', 'orch', 'osd', 'create',
+                'ceph', 'orch', 'daemon', 'add', 'osd',
                 remote.shortname + ':' + short_dev
             ])
             ctx.daemons.register_daemon(

--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -253,7 +253,7 @@ $SUDO pvcreate $loop_dev && $SUDO vgcreate $OSD_VG_NAME $loop_dev
 for id in `seq 0 $((--OSD_TO_CREATE))`; do
     $SUDO lvcreate -l $((100/$OSD_TO_CREATE))%VG -n $OSD_LV_NAME.$id $OSD_VG_NAME
     $CEPHADM shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
-            ceph orch osd create \
+            ceph orch daemon add osd \
                 $(hostname):/dev/$OSD_VG_NAME/$OSD_LV_NAME.$id
 done
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1712,9 +1712,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         for n, spec in self.spec_store.specs.items():
             if n in sm:
                 continue
-            if n.startswith('osd.'):
-                self.log.debug("Not adding drivegroup specs  to the ServiceDescription map for now")
-                continue
             sm[n] = orchestrator.ServiceDescription(
                 service_name=n,
                 spec=spec,

--- a/src/pybind/mgr/orchestrator/__init__.py
+++ b/src/pybind/mgr/orchestrator/__init__.py
@@ -14,4 +14,4 @@ from ._interface import \
     DaemonDescription, \
     InventoryHost, DeviceLightLoc, \
     OutdatableData, OutdatablePersistentDict, \
-    UpgradeStatusSpec
+    UpgradeStatusSpec, OSDSpec

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -107,24 +107,6 @@ class DriveGroupValidationError(Exception):
         super(DriveGroupValidationError, self).__init__('Failed to validate Drive Group: ' + msg)
 
 
-class DriveGroupSpecs(object):
-    """ Container class to parse drivegroups """
-
-    def __init__(self, drive_group_json):
-        # type: (dict) -> None
-        self.drive_group_json = drive_group_json
-        self.drive_groups = list()  # type: List[DriveGroupSpec]
-        self.build_drive_groups()
-
-    def build_drive_groups(self):
-        for drive_group_name, drive_group_spec in self.drive_group_json.items():
-            self.drive_groups.append(DriveGroupSpec.from_json
-                                     (drive_group_spec, name=drive_group_name))
-
-    def __repr__(self):
-        return ", ".join([repr(x) for x in self.drive_groups])
-
-
 class DriveGroupSpec(object):
     """
     Describe a drive group in the same form that ceph-volume
@@ -136,7 +118,7 @@ class DriveGroupSpec(object):
         "db_slots", "wal_slots", "block_db_size", "host_pattern",
         "data_devices", "db_devices", "wal_devices", "journal_devices",
         "data_directories", "osds_per_device", "objectstore", "osd_id_claims",
-        "journal_size"
+        "journal_size", "name"
     ]
 
     def __init__(self,
@@ -214,8 +196,8 @@ class DriveGroupSpec(object):
         self.osd_id_claims = osd_id_claims
 
     @classmethod
-    def from_json(cls, json_drive_group, name=None):
-        # type: (dict, Optional[str]) -> DriveGroupSpec
+    def from_json(cls, json_drive_group):
+        # type: (dict) -> DriveGroupSpec
         """
         Initialize 'Drive group' structure
 
@@ -238,7 +220,7 @@ class DriveGroupSpec(object):
                     json_drive_group.items()}
             if not args:
                 raise DriveGroupValidationError("Didn't find Drivegroup specs")
-            return DriveGroupSpec(name=name, **args)
+            return DriveGroupSpec(**args)
         except (KeyError, TypeError) as e:
             raise DriveGroupValidationError(str(e))
 

--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -120,7 +120,7 @@ class DriveSelection(object):
                         device_filter))
                 continue
 
-            for disk in self.disks.devices:
+            for disk in self.disks:
                 logger.debug("Processing disk {}".format(disk.path))
 
                 # continue criteria
@@ -155,7 +155,7 @@ class DriveSelection(object):
 
         # This disk is already taken and must not be re-assigned.
         for taken_device in devices:
-            if taken_device in self.disks.devices:
-                self.disks.devices.remove(taken_device)
+            if taken_device in self.disks:
+                self.disks.remove(taken_device)
 
         return sorted([x for x in devices], key=lambda dev: dev.path)

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -3,23 +3,21 @@ import pytest
 from ceph.deployment import drive_selection, translate
 from ceph.deployment.inventory import Device
 from ceph.tests.utils import _mk_inventory, _mk_device
-from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupSpecs, \
-                                        DeviceSelection, DriveGroupValidationError
+from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection, \
+    DriveGroupValidationError
 
 
 def test_DriveGroup():
-    dg_json = {'testing_drivegroup':
-               {'host_pattern': 'hostname',
+    dg_json = {'host_pattern': 'hostname',
+                'name': 'testing_drivegroup',
                 'data_devices': {'paths': ['/dev/sda']}
-                }
-               }
+              }
 
-    dgs = DriveGroupSpecs(dg_json)
-    for dg in dgs.drive_groups:
-        assert dg.hosts(['hostname']) == ['hostname']
-        assert dg.name == 'testing_drivegroup'
-        assert all([isinstance(x, Device) for x in dg.data_devices.paths])
-        assert dg.data_devices.paths[0].path == '/dev/sda'
+    dg = DriveGroupSpec.from_json(dg_json)
+    assert dg.hosts(['hostname']) == ['hostname']
+    assert dg.name == 'testing_drivegroup'
+    assert all([isinstance(x, Device) for x in dg.data_devices.paths])
+    assert dg.data_devices.paths[0].path == '/dev/sda'
 
 
 def test_DriveGroup_fail():

--- a/src/python-common/ceph/tests/utils.py
+++ b/src/python-common/ceph/tests/utils.py
@@ -35,4 +35,4 @@ def _mk_inventory(devices):
         dev.path = '/dev/sd' + name
         dev.sys_api = dict(dev_.sys_api, path='/dev/sd' + name)
         devs.append(dev)
-    return Devices(devices=devs)
+    return Devices(devices=devs).devices

--- a/test_cephadm.sh
+++ b/test_cephadm.sh
@@ -92,7 +92,7 @@ pvcreate $loop_dev && vgcreate $OSD_VG_NAME $loop_dev
 for id in `seq 0 $((--OSD_TO_CREATE))`; do
     lvcreate -l $((100/$OSD_TO_CREATE))%VG -n $OSD_LV_NAME.$id $OSD_VG_NAME
     $SUDO $CEPHADM shell --fsid $fsid --config c --keyring k -- \
-            ceph orch osd create \
+            ceph orch daemon add osd \
                 $(hostname):/dev/$OSD_VG_NAME/$OSD_LV_NAME.$id
 done
 


### PR DESCRIPTION
- revamped `ceph orch apply osd -i <dg_file>` to `ceph orch apply osd -i <dg_file>`
- follows the same approach as other services
- saves drivegroup under `mgr/cephadm/spec.osd.$dg_name(default to 'default')`

- added `ceph orch daemon add osd host:dev` for non-spec based deployments


full servicespec file format:

``` yaml
# .. other content
---
service_type: osd
drivegroup:
  name: test_drivegroup
  host_pattern: '*'
  data_devices:
    all: True
---
# .. other content
```

known issues:

- When you more an OSD and also purge/zap the disk, the apply logic will re-add it to the cluster.

Possible solution:

Implement a ceph-volume native command `ceph-volume lock <disk> --reason <Custom lock>`
This way we can show the reason as to why we're not including a disk via the `REASON` field.


- `ceph orch ls` (and also ps) is not capable of mapping drives/daemons to a certain drivegroup.

This leaves the SPEC and PLACEMENT fields empty. Also if you remove OSDs, we cannot easily remove the specs from the mon store..

Possible solution:
 
If an OSD gets deployed using a spec, append the name of the drivegroup (or even the entire drivegroup spec?) to the DemonDescription. This way we can probably track and group OSDs by their respective drivegroup affinity.


TODO:

- [ ] Adapt OSD Drivegroup docs
- [ ] Add qa/.. tests for drivegroups
- [ ] Address issues

Signed-off-by: Joshua Schmid <jschmid@suse.de>
