### PR TITLE
common/admin_socket: Add ability to register commands with instances

### DIFF
--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -29,6 +29,7 @@ class AdminSocket;
 class CephContext;
 class MCommand;
 class MMonCommand;
+class InstancesHook;
 
 using namespace std::literals;
 
@@ -135,6 +136,12 @@ public:
 		       AdminSocketHook *hook,
 		       std::string_view help);
 
+  int register_command(std::string_view cmddesc,
+			AdminSocketHook *hook,
+			std::string_view help,
+			std::string_view instance_variable,
+			std::string_view instance_value);
+
   /*
    * unregister all commands belong to hook.
    */
@@ -162,7 +169,13 @@ public:
   void queue_tell_command(cref_t<MMonCommand> m); // for compat
 
 private:
+  int add_instance(InstancesHook* ih,
+		   std::string_view variable,
+		   std::string_view value,
+		   AdminSocketHook* hook);
 
+  int rm_instance(InstancesHook* ih,
+		  const AdminSocketHook* hook);
   void shutdown();
   void wakeup();
 


### PR DESCRIPTION
Instances for commands allows to register multiple commands under same name, but different instances.
Those instances will not spam 'help' command. Valid instances are listed if instance is not provided.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>

This allows to reduce spam in help command:
Before:
`
"bluestore allocator dump block": "dump allocator free regions",

"bluestore allocator dump bluefs-db": "dump allocator free regions",

"bluestore allocator dump bluefs-slow": "dump allocator free regions",

"bluestore allocator dump bluefs-wal": "dump allocator free regions",

"bluestore allocator fragmentation block": "give allocator fragmentation (0-no fragmentation, 1-absolute fragmentation)",

"bluestore allocator fragmentation bluefs-db": "give allocator fragmentation (0-no fragmentation, 1-absolute fragmentation)",

"bluestore allocator fragmentation bluefs-slow": "give allocator fragmentation (0-no fragmentation, 1-absolute fragmentation)",

"bluestore allocator fragmentation bluefs-wal": "give allocator fragmentation (0-no fragmentation, 1-absolute fragmentation)",

"bluestore allocator score block": "give score on allocator fragmentation (0-no fragmentation, 1-absolute fragmentation)",

"bluestore allocator score bluefs-db": "give score on allocator fragmentation (0-no fragmentation, 1-absolute fragmentation)",

"bluestore allocator score bluefs-slow": "give score on allocator fragmentation (0-no fragmentation, 1-absolute fragmentation)",

"bluestore allocator score bluefs-wal": "give score on allocator fragmentation (0-no fragmentation, 1-absolute fragmentation)"
`
After:
`
"bluestore allocator dump": "dump allocator free regions",
"bluestore allocator fragmentation": "give allocator fragmentation (0-no fragmentation, 1-absolute fragmentation)",
"bluestore allocator score": "give score on allocator fragmentation (0-no fragmentation, 1-absolute fragmentation)",
`