### PR TITLE
ceph.spec.in: Require gcc >= 9 on openSUSE/SLES 15.2

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -152,7 +152,12 @@ BuildRequires:	fuse-devel
 # enough.
 BuildRequires:	devtoolset-8-gcc-c++ >= 8.3.1-3.1
 %else
+%if 0%{with seastar} && 0%{?sle_version} == 150200
+# gcc-c++ is version 7 which does not work with "-DWITH_SEASTAR=ON"
+BuildRequires:	gcc9-c++
+%else
 BuildRequires:	gcc-c++
+%endif
 %endif
 BuildRequires:	gdbm
 %if 0%{with tcmalloc}


### PR DESCRIPTION
This version is needed to build seastar. With lower
versions, (eg. gcc7), the result is:

ceph/src/seastar/src/core/future.cc:67:50: error: \
    explicit qualification in declaration of 'seastar::future<> \
    seastar::internal::current_exception_as_future()'
      future<> internal::current_exception_as_future() noexcept;
                                                       ^~~~~~~~

Note: This requires rpm >= 4.13 [1] to use the boolean dependencies.

[1] https://rpm.org/user_doc/boolean_dependencies.html

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>