### PR TITLE
run-make-check.sh: honor WITH_SEASTAR environment variable

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -54,7 +54,8 @@ function main() {
     fi
     FOR_MAKE_CHECK=1 prepare
     # Init defaults after deps are installed.
-    configure " -DWITH_PYTHON3=3 -DWITH_GTEST_PARALLEL=ON -DWITH_FIO=ON -DWITH_SEASTAR=ON -DWITH_CEPHFS_SHELL=ON -DWITH_SPDK=ON -DENABLE_GIT_VERSION=OFF $@"
+    [ $WITH_SEASTAR ] && with_seastar="-DWITH_SEASTAR=ON " || with_seastar=""
+    configure " -DWITH_PYTHON3=3 -DWITH_GTEST_PARALLEL=ON -DWITH_FIO=ON ${with_seastar}-DWITH_CEPHFS_SHELL=ON -DWITH_SPDK=ON -DENABLE_GIT_VERSION=OFF $@"
     build tests && echo "make check: successful run on $(git rev-parse HEAD)"
     run
 }

--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -88,7 +88,11 @@ function prepare() {
     fi
 
     if test -f ./install-deps.sh ; then
-	    export WITH_SEASTAR=1
+            if [ "$WITHOUT_SEASTAR" ] ; then
+                true
+            else
+	        export WITH_SEASTAR=1
+            fi
 	    $DRY_RUN source ./install-deps.sh || return 1
         trap clean_up_after_myself EXIT
     fi


### PR DESCRIPTION
Recently we started to see this when running `run-make-check.sh` with GCC7:

```
02:24:27 + cmake -DWITH_RADOSGW_AMQP_ENDPOINT=OFF -DWITH_RADOSGW_KAFKA_ENDPOINT=OFF -DWITH_PYTHON3=3 -DWITH_CCACHE=ON -DBOOST_J=8 -DWITH_PYTHON3=3 -DWITH_GTEST_PARALLEL=ON -DWITH_FIO=ON -DWITH_SEASTAR=ON -DWITH_CEPHFS_SHELL=ON -DWITH_SPDK=ON -DENABLE_GIT_VERSION=OFF -DWITH_LTTNG=false -DWITH_BABELTRACE=false ..
```

... lots of output snipped ...

```
02:32:14 /opt/j/ws/mkck/src/seastar/src/core/future.cc:67:50: error: explicit qualification in declaration of 'seastar::future<> seastar::internal::current_exception_as_future()'
02:32:14  future<> internal::current_exception_as_future() noexcept;
02:32:14                                                   ^~~~~~~~
02:32:14 cc1plus: warning: unrecognized command line option '-Wno-address-of-packed-member'
02:32:14 cc1plus: warning: unrecognized command line option '-Wno-pessimizing-move'
02:32:14 make[3]: *** [src/seastar/CMakeFiles/seastar.dir/build.make:365: src/seastar/CMakeFiles/seastar.dir/src/core/future.cc.o] Error 1
```