### PR TITLE
nautilus: mgr/dashboard: show checkboxes for booleans

### DIFF
--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -153,7 +153,8 @@ def options_schema_list():
     for option, value in inspect.getmembers(Options, filter_attr):
         if option.startswith('_'):
             continue
-        result.append({'name': option, 'default': value[0]})
+        result.append({'name': option, 'default': value[0],
+                       'type': value[1].__name__})
 
     return result
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43998

---

backport of https://github.com/ceph/ceph/pull/32836
parent tracker: https://tracker.ceph.com/issues/43769

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh