### PR TITLE
mds: remove dead get_commands code

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -634,13 +634,6 @@ void MDSDaemon::handle_command(const cref_t<MCommand> &m)
   m->get_connection()->send_message2(reply);
 }
 
-const std::vector<MDSDaemon::MDSCommand>& MDSDaemon::get_commands()
-{
-  static const std::vector<MDSCommand> commands = {
-  };
-  return commands;
-};
-
 void MDSDaemon::handle_mds_map(const cref_t<MMDSMap> &m)
 {
   version_t epoch = m->get_epoch();

--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -139,17 +139,8 @@ class MDSDaemon : public Dispatcher {
   // tick and other timer fun
   Context *tick_event = nullptr;
   class MDSSocketHook *asok_hook = nullptr;
+
  private:
-  struct MDSCommand {
-    MDSCommand(std::string_view signature, std::string_view help)
-        : cmdstring(signature), helpstring(help)
-    {}
-
-    std::string cmdstring;
-    std::string helpstring;
-    std::string module = "mds";
-  };
-
   bool ms_dispatch2(const ref_t<Message> &m) override;
   int ms_handle_authentication(Connection *con) override;
   void ms_handle_accept(Connection *con) override;
@@ -157,8 +148,6 @@ class MDSDaemon : public Dispatcher {
   bool ms_handle_reset(Connection *con) override;
   void ms_handle_remote_reset(Connection *con) override;
   bool ms_handle_refused(Connection *con) override;
-
-  static const std::vector<MDSCommand>& get_commands();
 
   bool parse_caps(const AuthCapsInfo&, MDSAuthCaps&);
 


### PR DESCRIPTION
Left over from #31255, d8c0bde04b88cb3ad96855bd0948ae10072c9da7.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
