### PR TITLE
osdmaptool: add features

### DIFF
--- a/doc/man/8/osdmaptool.rst
+++ b/doc/man/8/osdmaptool.rst
@@ -17,8 +17,8 @@ Synopsis
 | **osdmaptool** *mapfilename* [--export-crush *crushmap*]
 | **osdmaptool** *mapfilename* [--upmap *file*] [--upmap-max *max-optimizations*]
   [--upmap-deviation *max-deviation*] [--upmap-pool *poolname*]
-  [--upmap-save *file*] [--upmap-save *newosdmap*] [--upmap-active]
-| **osdmaptool** *mapfilename* [--upmap-cleanup] [--upmap-save *newosdmap*]
+  [--save] [--upmap-active]
+| **osdmaptool** *mapfilename* [--upmap-cleanup] [--upmap *file*]
 
 
 Description
@@ -123,6 +123,14 @@ Options
 
    mark an osd as out (but do not persist)
 
+.. option:: --mark-up <osdid>
+
+   mark an osd as up (but do not persist)
+
+.. option:: --mark-in <osdid>
+
+   mark an osd as in (but do not persist)
+
 .. option:: --tree
 
    Displays a hierarchical tree of the map.
@@ -163,14 +171,17 @@ Options
 
    restrict upmap balancing to 1 pool or the option can be repeated for multiple pools
 
-.. option:: --upmap-save
-
-   write modified OSDMap with upmap changes
-
 .. option:: --upmap-active
 
    Act like an active balancer, keep applying changes until balanced
 
+.. option:: --adjust-crush-weight <osdid:weight>[,<osdid:weight>,<...>]
+
+   Change CRUSH weight of <osdid>
+
+.. option:: --save
+
+   write modified osdmap with upmap or crush-adjust changes
 
 Example
 =======

--- a/src/test/cli/osdmaptool/crush.t
+++ b/src/test/cli/osdmaptool/crush.t
@@ -8,3 +8,10 @@
   osdmaptool: osdmap file 'myosdmap'
   osdmaptool: imported 497 byte crush map from oc
   osdmaptool: writing epoch 3 to myosdmap
+  $ osdmaptool --adjust-crush-weight 0:5 myosdmap
+  osdmaptool: osdmap file 'myosdmap'
+  Adjusted osd.0 CRUSH weight to 5
+  $ osdmaptool --adjust-crush-weight 0:5 myosdmap --save
+  osdmaptool: osdmap file 'myosdmap'
+  Adjusted osd.0 CRUSH weight to 5
+  osdmaptool: writing epoch 5 to myosdmap

--- a/src/test/cli/osdmaptool/help.t
+++ b/src/test/cli/osdmaptool/help.t
@@ -14,6 +14,8 @@
      --test-map-pgs-dump-all [--pool <poolid>] [--range-first <first> --range-last <last>] map all pgs to osds
      --mark-up-in            mark osds up and in (but do not persist)
      --mark-out <osdid>      mark an osd as out (but do not persist)
+     --mark-up <osdid>       mark an osd as up (but do not persist)
+     --mark-in <osdid>       mark an osd as in (but do not persist)
      --with-default-pool     include default pool when creating map
      --clear-temp            clear pg_temp and primary_temp
      --clean-temps           clean pg_temps
@@ -28,9 +30,10 @@
      --upmap-deviation <max-deviation>
                              max deviation from target [default: 5]
      --upmap-pool <poolname> restrict upmap balancing to 1 or more pools
-     --upmap-save            write modified OSDMap with upmap changes
      --upmap-active          Act like an active balancer, keep applying changes until balanced
      --dump <format>         displays the map in plain text when <format> is 'plain', 'json' if specified format is not supported
      --tree                  displays a tree of the map
      --test-crush [--range-first <first> --range-last <last>] map pgs to acting osds
+     --adjust-crush-weight <osdid:weight>[,<osdid:weight>,<...>] change <osdid> CRUSH <weight> (but do not persist)
+     --save                  write modified osdmap with upmap or crush-adjust changes
   [1]

--- a/src/test/cli/osdmaptool/upmap.t
+++ b/src/test/cli/osdmaptool/upmap.t
@@ -1,7 +1,7 @@
   $ osdmaptool --create-from-conf om -c $TESTDIR/ceph.conf.withracks --with-default-pool
   osdmaptool: osdmap file 'om'
   osdmaptool: writing epoch 1 to om
-  $ osdmaptool --osd_calc_pg_upmaps_aggressively=false om --mark-up-in --upmap-max 11 --upmap c
+  $ osdmaptool --osd_calc_pg_upmaps_aggressively=false om --mark-up-in --upmap-max 11 --upmap c --save
   osdmaptool: osdmap file 'om'
   marking all OSDs up and in
   writing upmap command output to: c
@@ -9,6 +9,7 @@
   upmap, max-count 11, max deviation 5
   pools rbd 
   prepared 11/11 changes
+  osdmaptool: writing epoch 3 to om
   $ cat c
   ceph osd pg-upmap-items 1.7 142 147
   ceph osd pg-upmap-items 1.8 219 223
@@ -20,4 +21,17 @@
   ceph osd pg-upmap-items 1.51 201 202
   ceph osd pg-upmap-items 1.62 219 223
   ceph osd pg-upmap-items 1.6f 219 223
+  $ osdmaptool --print om | grep pg_upmap_items
+  osdmaptool: osdmap file 'om'
+  pg_upmap_items 1.7 [142,147]
+  pg_upmap_items 1.8 [219,223]
+  pg_upmap_items 1.17 [201,202,171,173]
+  pg_upmap_items 1.1a [201,202]
+  pg_upmap_items 1.1c [201,202]
+  pg_upmap_items 1.20 [201,202]
+  pg_upmap_items 1.24 [232,233]
+  pg_upmap_items 1.51 [201,202]
+  pg_upmap_items 1.62 [219,223]
+  pg_upmap_items 1.6f [219,223]
   $ rm -f om c
+

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -42,6 +42,8 @@ void usage()
   cout << "   --test-map-pgs-dump-all [--pool <poolid>] [--range-first <first> --range-last <last>] map all pgs to osds" << std::endl;
   cout << "   --mark-up-in            mark osds up and in (but do not persist)" << std::endl;
   cout << "   --mark-out <osdid>      mark an osd as out (but do not persist)" << std::endl;
+  cout << "   --mark-up <osdid>       mark an osd as up (but do not persist)" << std::endl;
+  cout << "   --mark-in <osdid>       mark an osd as in (but do not persist)" << std::endl;
   cout << "   --with-default-pool     include default pool when creating map" << std::endl;
   cout << "   --clear-temp            clear pg_temp and primary_temp" << std::endl;
   cout << "   --clean-temps           clean pg_temps" << std::endl;
@@ -136,6 +138,8 @@ int main(int argc, const char **argv)
   int pool = -1;
   bool mark_up_in = false;
   int marked_out = -1;
+  int marked_up = -1;
+  int marked_in = -1;
   bool clear_temp = false;
   bool clean_temps = false;
   bool test_map_pgs = false;
@@ -201,6 +205,10 @@ int main(int argc, const char **argv)
       mark_up_in = true;
     } else if (ceph_argparse_witharg(args, i, &val, "--mark-out", (char*)NULL)) {
       marked_out = std::stoi(val);
+    } else if (ceph_argparse_witharg(args, i, &val, "--mark-up", (char*)NULL)) {
+      marked_up  = std::stod(val);
+    } else if (ceph_argparse_witharg(args, i, &val, "--mark-in", (char*)NULL)) {
+      marked_in  = std::stod(val);
     } else if (ceph_argparse_flag(args, i, "--clear-temp", (char*)NULL)) {
       clear_temp = true;
     } else if (ceph_argparse_flag(args, i, "--clean-temps", (char*)NULL)) {
@@ -357,6 +365,19 @@ int main(int argc, const char **argv)
     osdmap.set_state(id, osdmap.get_state(id) | CEPH_OSD_UP);
     osdmap.set_weight(id, CEPH_OSD_OUT);
   }
+
+  if (marked_up >=0 && marked_up < osdmap.get_max_osd()) {
+    cout << "marking OSD@" << marked_up << " as up" << std::endl;
+    int id = marked_up;
+    osdmap.set_state(id, osdmap.get_state(id) | CEPH_OSD_UP);
+  }
+
+  if (marked_in >=0 && marked_in < osdmap.get_max_osd()) {
+    cout << "marking OSD@" << marked_up << " as up" << std::endl;
+    int id = marked_up;
+    osdmap.set_weight(id, CEPH_OSD_IN);
+  }
+
 
   if (clear_temp) {
     cout << "clearing pg/primary temp" << std::endl;

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -345,6 +345,9 @@ int main(int argc, const char **argv)
     for (int i=0; i<n; i++) {
       osdmap.set_state(i, osdmap.get_state(i) | CEPH_OSD_UP);
       osdmap.set_weight(i, CEPH_OSD_IN);
+      if (osdmap.crush->get_item_weight(i) == 0 ) {
+        osdmap.crush->adjust_item_weightf(g_ceph_context, i, 1.0);
+      }
     }
   }
 


### PR DESCRIPTION
Few improvements to `osdmaptool`:
 1. Do not overwrite crush weight with `--mark-up-in` if a CRUSH weight already exists
 2. Add `--mark-up <osd>` and `--mark-in <osd>` to mark up/in different OSDs in the osdmap
 3. Add the ability to change OSDs CRUSH weights (and save the new map)

Context:
2 and 3 are really handy in some of our oldest clusters. Where we have a combination of: small objects, large HDD (8TB), filestore + bluestore with default min_alloc_size.
Because of the mix of filestore/bluestore with 64k min alloc we end up with OSDs having the same amount of PGs but very different usage (e.g. 50% for filestore, 80%+ for bluestore). Because of the small objects and large HDD backfill is really slow thus it is important to be able to predict how many PG will move and where they'll end up before running any crush reweigh operation. 

With the following patches we are able to:
1. run `--test-map-pgs-dump` with current osdmap
2. run `--test-map-pgs-dump` with either `--mark-up`, `--mark-in` or `--adjust-crush-weight`
3. Diff the two to understand PG movement and eventually adjust our reweigh commands

