### PR TITLE
mgr/cephadm: cache device inventory; zap

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1772,6 +1772,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                     'osd', osd_id, host,
                     osd_uuid_map=osd_uuid_map)
 
+        self.cache.invalidate_host_devices(host)
         return "Created osd(s) on host '{}'".format(host)
 
     def _create_daemon(self, daemon_type, daemon_id, host,

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -163,11 +163,13 @@ class HostCache():
         # type: (str) -> None
         if host in self.last_daemon_update:
             del self.last_daemon_update[host]
+        self.mgr.event.set()
 
     def invalidate_host_devices(self, host):
         # type: (str) -> None
         if host in self.last_device_update:
             del self.last_device_update[host]
+        self.mgr.event.set()
 
     def save_host(self, host):
         # type: (str) -> None
@@ -1870,7 +1872,6 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             sd.status_desc = 'starting'
             self.cache.add_daemon(host, sd)
         self.cache.invalidate_host_daemons(host)
-        self.event.set()
         return "{} {} on host '{}'".format(
             'Reconfigured' if reconfig else 'Deployed', name, host)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1621,6 +1621,16 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                                                      inventory.Devices(dls)))
         return trivial_result(result)
 
+    def zap_device(self, host, path):
+        out, err, code = self._run_cephadm(
+            host, 'osd', 'ceph-volume',
+            ['--', 'lvm', 'zap', '--destroy', path],
+            error_ok=True)
+        self.cache.invalidate_host_devices(host)
+        if code:
+            raise OrchestratorError('Zap failed: %s' % '\n'.join(out + err))
+        return trivial_result('\n'.join(out + err))
+
     def blink_device_light(self, ident_fault, on, locs):
         @async_map_completion
         def blink(host, dev, path):

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -60,8 +60,8 @@ class TestCephadm(object):
 
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_host(self, _get_connection, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             assert wait(cephadm_module, cephadm_module.get_hosts()) == [InventoryNode('test')]
@@ -69,16 +69,16 @@ class TestCephadm(object):
         assert wait(cephadm_module, c) == []
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_service_ls(self, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.list_daemons(refresh=True)
             assert wait(cephadm_module, c) == []
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_device_ls(self, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.get_inventory()
@@ -99,8 +99,8 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_daemon_action(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         cephadm_module.service_cache_timeout = 10
         with self._with_host(cephadm_module, 'test'):
@@ -118,8 +118,8 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_mon_update(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test:0.0.0.0=a'], count=1)
@@ -135,8 +135,8 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_mgr_update(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test:0.0.0.0=a'], count=1)
@@ -149,8 +149,8 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_create_osds(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             dg = DriveGroupSpec('test', data_devices=DeviceSelection(paths=['']))
@@ -169,8 +169,8 @@ class TestCephadm(object):
             )
         ])
     ))
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_remove_osds(self, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.list_daemons(refresh=True)
@@ -183,8 +183,8 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_mds(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
@@ -196,8 +196,8 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_rgw(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
 
         with self._with_host(cephadm_module, 'test'):
@@ -211,8 +211,8 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_rgw_update(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
 
         with self._with_host(cephadm_module, 'host1'):
@@ -231,8 +231,8 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_rgw_update_fail(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
 
         with self._with_host(cephadm_module, 'host1'):
@@ -269,8 +269,8 @@ class TestCephadm(object):
             )
         ])
     ))
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_remove_daemon(self, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.list_daemons(refresh=True)
@@ -291,8 +291,8 @@ class TestCephadm(object):
             )
         ])
     ))
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_remove_service(self, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.list_daemons(refresh=True)
@@ -305,8 +305,8 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_rbd_mirror(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         # type: (mock.Mock, mock.Mock, mock.Mock, mock.Mock, CephadmOrchestrator) -> None
         with self._with_host(cephadm_module, 'test'):
@@ -320,8 +320,8 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_prometheus(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
@@ -334,8 +334,8 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_node_exporter(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         # type: (mock.Mock, mock.Mock, mock.Mock, mock.Mock, CephadmOrchestrator) -> None
         with self._with_host(cephadm_module, 'test'):
@@ -349,8 +349,8 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.DaemonCache.save_host")
-    @mock.patch("cephadm.module.DaemonCache.rm_host")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
     def test_blink_device_light(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.blink_device_light('ident', True, [('test', '', '')])

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -988,6 +988,11 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def zap_device(self, host, path):
+        # type: (str, str) -> Completion
+        """Zap/Erase a device (DESTROYS DATA)"""
+        raise NotImplementedError()
+
     def add_mon(self, spec):
         # type: (ServiceSpec) -> Completion
         """Create mon daemon(s)"""

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -292,6 +292,20 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
             out.append(table.get_string())
             return HandleCommandResult(stdout='\n'.join(out))
 
+    @_cli_write_command(
+        'orch device zap',
+        'name=host,type=CephString '
+        'name=path,type=CephString '
+        'name=force,type=CephBool,req=false',
+        'Zap (erase!) a device so it can be re-used')
+    def _zap_device(self, host, path, force=False):
+        if not force:
+            raise OrchestratorError('must pass --force to PERMANENTLY ERASE DEVICE DATA')
+        completion = self.zap_device(host, path)
+        self._orchestrator_wait([completion])
+        raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
     @_cli_read_command(
         'orch ls',
         "name=service_type,type=CephString,req=false "


### PR DESCRIPTION
- extend the daemon cache to also include device info
- remove old crufty inventory_cache
- implement 'zap', with cache invalidation where appropriate