### PR TITLE
qa/suites/rados/cephadm/upgrade: fix initial version

### DIFF
--- a/qa/suites/rados/cephadm/upgrade/1-start.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start.yaml
@@ -1,4 +1,4 @@
 tasks:
 - cephadm:
-    image: quay.io/ceph-ci/ceph:wip-sage-testing-2020-02-14-0900
-    cephadm_branch: wip-sage-testing-2020-02-14-0900
+    image: quay.io/ceph-ci/ceph:wip-sage4-testing-2020-02-17-1727
+    cephadm_branch: wip-sage4-testing-2020-02-17-1727


### PR DESCRIPTION
Switch initial version to one with the renamed orchestrator module.

Signed-off-by: Sage Weil <sage@redhat.com>