### PR TITLE
cmake: Removed unittest_alloc_aging from make check

### DIFF
--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -116,7 +116,6 @@ if(WITH_BLUESTORE)
     Allocator_aging_fragmentation.cc
     $<TARGET_OBJECTS:unit-main>
     )
-  add_ceph_unittest(unittest_alloc_aging)
   target_link_libraries(unittest_alloc_aging os global)
 
   # unittest_bluefs


### PR DESCRIPTION
I added (by mistake) unittest_alloc_aging to unittest list.
This is useless because unittest_alloc_aging does not give any errors, and all its functionality is in printing results.
It is useful for allocator developers for checking long-time behaviors.