### PR TITLE
rgw: Fix bug on subuser policy identity checker

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -617,10 +617,10 @@ bool rgw::auth::LocalApplier::is_identity(const idset_t& ids) const {
       if (id.get_id() == user_info.user_id.id) {
         return true;
       }
-      for (auto subuser : user_info.subusers) {
+      if (subuser != NO_SUBUSER) {
         std::string user = user_info.user_id.id;
         user.append(":");
-        user.append(subuser.second.name);
+        user.append(subuser);
         if (user == id.get_id()) {
           return true;
         }


### PR DESCRIPTION
In a mistake of this PR #33165 I have check for all subusers of `user_info` to be identified but I should check for the requested user that we have it on `subuser` field in `LocalApplier`.
Sorry for this mistake :disappointed: 

Fixes: https://tracker.ceph.com/issues/44239
Signed-off-by: Seena Fallah <seenafallah@gmail.com>