### PR TITLE
[doc]: update the documentation to reflect the correct command to set max_misplaced

### DIFF
--- a/doc/rados/operations/balancer.rst
+++ b/doc/rados/operations/balancer.rst
@@ -41,10 +41,10 @@ healed itself).
 
 When the cluster is healthy, the balancer will throttle its changes
 such that the percentage of PGs that are misplaced (i.e., that need to
-be moved) is below a threshold of (by default) 5%.  The
-``max_misplaced`` threshold can be adjusted with::
+be moved) is below a threshold of (by default) 5%. The
+``target_max_misplaced_ratio`` threshold can be adjusted with::
 
-  ceph config set mgr mgr/balancer/max_misplaced .07   # 7%
+  ceph config set mgr target_max_misplaced_ratio .07   # 7%
 
 
 Modes


### PR DESCRIPTION
Started rewriting the balancer plugin to work like documented, but then I realised that it worked differently then described. Found https://docs.ceph.com/docs/nautilus/rados/operations/balancer/ which documented it correctly. We should maybe run an automated check to find such regressions
