### PR TITLE
[WIP] os/bluestore: SPDK Support improvement

### DIFF
--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -812,6 +812,7 @@ int NVMEDevice::collect_metadata(const string& prefix, map<string,string> *pm) c
 
 int NVMEDevice::flush()
 {
+  dout(10) << __func__ << dendl;
   return 0;
 }
 

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -964,8 +964,6 @@ int NVMEDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
   bufferptr p = buffer::create_small_page_aligned(len);
   char *buf = p.c_str();
 
-  ceph_assert(ioc->nvme_task_first == nullptr);
-  ceph_assert(ioc->nvme_task_last == nullptr);
   make_read_tasks(this, off, ioc, buf, len, &t, off, len);
   dout(5) << __func__ << " " << off << "~" << len << dendl;
   aio_submit(ioc);

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -412,6 +412,7 @@ void SharedDriverQueueData::_aio_handle(Task *t, IOContext *ioc)
             r = spdk_nvme_ns_cmd_writev(
                 ns, qpair, lba_off, lba_count, io_complete, t, 0,
                 data_buf_reset_sgl, data_buf_next_sge);
+            if (r == 0) current_queue_depth++;
           }
           if (r < 0) {
             derr << __func__ << " failed to do write command: " << cpp_strerror(r) << dendl;
@@ -439,6 +440,7 @@ void SharedDriverQueueData::_aio_handle(Task *t, IOContext *ioc)
             r = spdk_nvme_ns_cmd_readv(
               ns, qpair, lba_off, lba_count, io_complete, t, 0,
               data_buf_reset_sgl, data_buf_next_sge);
+            if (r == 0) current_queue_depth++;
           }
           if (r < 0) {
             derr << __func__ << " failed to read: " << cpp_strerror(r) << dendl;
@@ -459,6 +461,7 @@ void SharedDriverQueueData::_aio_handle(Task *t, IOContext *ioc)
             std::lock_guard guard(lock);
 
             r = spdk_nvme_ns_cmd_flush(ns, qpair, io_complete, t);
+            if (r == 0) current_queue_depth++;
           }
           if (r < 0) {
             derr << __func__ << " failed to flush: " << cpp_strerror(r) << dendl;
@@ -473,7 +476,6 @@ void SharedDriverQueueData::_aio_handle(Task *t, IOContext *ioc)
           break;
         }
       }
-      current_queue_depth++;
     }
     cur = ceph::coarse_real_clock::now();
     auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(cur - start);

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -46,6 +46,9 @@ class NVMEDevice : public BlockDevice {
    */
   SharedDriverData *driver;
   string name;
+  std::atomic_int queue_index = {0};
+  std::vector<SharedDriverQueueData*> queues;
+  SharedDriverQueueData* get_next_queue();
 
  public:
   std::atomic_int queue_number = {0};

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -47,8 +47,8 @@ class NVMEDevice : public BlockDevice {
   SharedDriverData *driver;
   string name;
   std::atomic_int queue_index = {0};
-  std::vector<SharedDriverQueueData*> queues;
-  SharedDriverQueueData* get_next_queue();
+  SharedDriverQueueData* queue;
+  SharedDriverQueueData* get_next_queue() { return queue;}
 
  public:
   std::atomic_int queue_number = {0};


### PR DESCRIPTION
This is still WIP....

There is several improvements in this changeset:
1. Use one single queue pair for one NVMEDevice class.
The original implementation uses TLS to store the reference to a queue pair. When the NVMEDevice close is called, only one queue pair get deleted and the queue pairs in other I/O threads are leaked. There is not an easy solution to properly clean up the queue pair whose reference is stored in TLS. 

Due to this leak, SPDK NVME support fails run on the device which only supports 6 queue pairs. Normally the queue pairs number is a hardware limitation. Some devices may support up to 31. The current logic makes it is unpredictable how many queue-paris needed and doesn't have a graceful way to deal with it. (crash as today.)

SPDK is also suggesting one single queue for one NVME device to max out the performance. (reference: https://github.com/spdk/spdk/issues/166)

2. Implement aio_read/aio_write as async and support flush
The aio_sumit will loop until the I/O is finished. This is indeed a sync read/write.

The new implementation spawns a new thread to check the completion and do the callback.
