### PR TITLE
nautilus: mgr/telemetry: add 'last_upload' to status

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -747,6 +747,7 @@ class Module(MgrModule):
             r = {}
             for opt in self.MODULE_OPTIONS:
                 r[opt['name']] = getattr(self, opt['name'])
+            r['last_upload'] = time.ctime(self.last_upload) if self.last_upload else self.last_upload
             return 0, json.dumps(r, indent=4), ''
         elif command['prefix'] == 'telemetry on':
             if command.get('license') != LICENSE:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44199

---

backport of https://github.com/ceph/ceph/pull/33125
parent tracker: https://tracker.ceph.com/issues/44040

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh