### PR TITLE
doc/mgr/orchestrator.rst: updated current implementation status

### DIFF
--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -316,7 +316,7 @@ This is an overview of the current implementation status of the orchestrators.
  ps                                  ⚪      ✔
  rbd-mirror add                      ⚪      ✔
  rgw add                             ✔      ✔
- service ls                          ✔      ⚪
+ ps                                  ✔      ✔
 =================================== ====== =========
 
 where


### PR DESCRIPTION
As the command changed from `service ls` to `ps` and also it's already implemented in cephadm I updated the docs accordingly 

Signed-off-by: Kai Wagner <kwagner@suse.com>
