### PR TITLE
qa: rbd_workunit_suites_fsx: install build dependencies

### DIFF
--- a/qa/suites/krbd/rbd/tasks/rbd_workunit_suites_fsx.yaml
+++ b/qa/suites/krbd/rbd/tasks/rbd_workunit_suites_fsx.yaml
@@ -1,5 +1,16 @@
 tasks:
 - install:
+    extra_system_packages:
+      deb:
+      - libaio-dev
+      - libtool-bin
+      - uuid-dev
+      - xfslibs-dev
+      rpm:
+      - libaio-devel
+      - libtool
+      - libuuid-devel
+      - xfsprogs-devel
 - ceph:
 - rbd:
     all:


### PR DESCRIPTION
xfstests.git repo at git.ceph.com got updated and we are checking
out a newer version since commit 92c19067de23 ("qa: update xfstests
version").  It requires libtool and additional build dependencies.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>