### PR TITLE
nautilus: common/blkdev: fix some problems with smart scraping

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -725,10 +725,11 @@ int block_device_get_metrics(const string& devname, int timeout,
   // smartctl
   if (int r = block_device_run_smartctl(devname, timeout, &s);
       r != 0) {
+    string orig = s;
     s = "{\"error\": \"smartctl failed\", \"dev\": \"/dev/";
     s += devname;
     s += "\", \"smartctl_error_code\": " + stringify(r);
-    s += "\", \"smartctl_output\": \"" + s;
+    s += "\", \"smartctl_output\": \"" + escape_quotes(orig);
     s += + "\"}";
   } else if (!json_spirit::read(s, *result)) {
     string orig = s;

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -729,7 +729,7 @@ int block_device_get_metrics(const string& devname, int timeout,
     s = "{\"error\": \"smartctl failed\", \"dev\": \"/dev/";
     s += devname;
     s += "\", \"smartctl_error_code\": " + stringify(r);
-    s += "\", \"smartctl_output\": \"" + escape_quotes(orig);
+    s += ", \"smartctl_output\": \"" + escape_quotes(orig);
     s += + "\"}";
   } else if (!json_spirit::read(s, *result)) {
     string orig = s;

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -698,8 +698,10 @@ static int block_device_run_smartctl(const string& devname, int timeout,
     *result = output.to_str();
   }
 
-  if (smartctl.join() != 0) {
-    *result = std::string("smartctl returned an error:") + smartctl.err();
+  int joinerr = smartctl.join();
+  if (joinerr) {
+    *result = std::string("smartctl returned an error (") + stringify(joinerr) +
+      "): stderr:\n") + smartctl.err() + "\nstdout:\n" + *result;
     return -EINVAL;
   }
 

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -706,6 +706,17 @@ static int block_device_run_smartctl(const string& devname, int timeout,
   return ret;
 }
 
+static std::string escape_quotes(const std::string& s)
+{
+  std::string r = s;
+  auto pos = r.find("\"");
+  while (pos != std::string::npos) {
+    r.replace(pos, 1, "\"");
+    pos = r.find("\"", pos + 1);
+  }
+  return r;
+}
+
 int block_device_get_metrics(const string& devname, int timeout,
 			     json_spirit::mValue *result)
 {
@@ -719,10 +730,12 @@ int block_device_get_metrics(const string& devname, int timeout,
     s += "\", \"smartctl_error_code\": " + stringify(r);
     s += "\", \"smartctl_output\": \"" + s;
     s += + "\"}";
-  }
-  if (!json_spirit::read(s, *result)) {
+  } else if (!json_spirit::read(s, *result)) {
+    string orig = s;
     s = "{\"error\": \"smartctl returned invalid JSON\", \"dev\": \"/dev/";
     s += devname;
+    s += "\",\"output\":\"";
+    s += escape_quotes(orig);
     s += "\"}";
   }
   if (!json_spirit::read(s, *result)) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44218

---

backport of https://github.com/ceph/ceph/pull/28848
parent tracker: https://tracker.ceph.com/issues/44210

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh