### PR TITLE
qa/cephfs: update xfstests-dev deps for RHEL 8

### DIFF
--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -109,7 +109,7 @@ class XFSTestsDev(CephFSTestCase):
             xfsprogs-devel btrfs-progs-devel python2 sqlite""".split()
             deps_old_distros = ['xfsprogs-qa-devel']
 
-            if distro == 'centos' and version > 7:
+            if distro != 'fedora' and version > 7:
                     deps.remove('btrfs-progs-devel')
 
             args = ['sudo', 'yum', 'install', '-y'] + deps + deps_old_distros

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -96,10 +96,11 @@ class XFSTestsDev(CephFSTestCase):
         distro, version = get_system_type(self.mount_a.client_remote,
                                           distro=True, version=True)
         distro = distro.lower()
-        version = int(version.split('.')[0]) # only keep major release number
+        major_ver_num = int(version.split('.')[0]) # only keep major release
+                                                   # number
 
-        distro = get_system_type(self.mount_a.client_remote,
-                                 distro=True).lower()
+        # we keep fedora here so that right deps are installed when this test
+        # is run locally by a dev.
         if distro in ('redhatenterpriseserver', 'redhatenterprise', 'fedora',
                       'centos'):
             deps = """acl attr automake bc dbench dump e2fsprogs fio \
@@ -109,7 +110,7 @@ class XFSTestsDev(CephFSTestCase):
             xfsprogs-devel btrfs-progs-devel python2 sqlite""".split()
             deps_old_distros = ['xfsprogs-qa-devel']
 
-            if distro != 'fedora' and version > 7:
+            if distro != 'fedora' and major_ver_num > 7:
                     deps.remove('btrfs-progs-devel')
 
             args = ['sudo', 'yum', 'install', '-y'] + deps + deps_old_distros
@@ -119,7 +120,7 @@ class XFSTestsDev(CephFSTestCase):
             libacl1-dev libaio-dev xfsprogs libgdbm-dev gawk fio dbench \
             uuid-runtime python sqlite3""".split()
 
-            if version >= 19:
+            if major_ver_num >= 19:
                 deps[deps.index('python')] ='python2'
             args = ['sudo', 'apt-get', 'install', '-y'] + deps
         else:


### PR DESCRIPTION
Also, this PR makes a minor change to xfstests_dev.py.

Fixes: https://tracker.ceph.com/issues/43964


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>