### PR TITLE
nautilus: ceph-volume: silence 'ceph-bluestore-tool' failures

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -41,7 +41,7 @@ class List(object):
             # bluestore?
             out, err, ret = process.call([
                 'ceph-bluestore-tool', 'show-label',
-                '--dev', dev])
+                '--dev', dev], verbose_on_failure=False)
             if ret:
                 logger.debug('No label on %s' % dev)
                 continue


### PR DESCRIPTION
If 'ceph-bluestore-tool' fails on a device, the json output of the list
command will be messed up. Ignoring stderr of that command fixes this.

Signed-off-by: Sébastien Han <seb@redhat.com>

Fixes: https://tracker.ceph.com/issues/44226


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

Backport of https://github.com/ceph/ceph/pull/33371
Tracker https://tracker.ceph.com/issues/44222

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
