### PR TITLE
cephadm: Don't call prepare-host from bootstrap

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1651,8 +1651,6 @@ def command_bootstrap():
                 raise Error('%s already exists; delete or pass '
                               '--allow-overwrite to overwrite' % f)
 
-    command_prepare_host()
-
     # initial vars
     fsid = args.fsid or make_fsid()
     hostname = get_hostname()


### PR DESCRIPTION
bootstrapping the cluster and installing rpms on the host are two dfferent things.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

Fixes:

```
Traceback (most recent call last):
  File "/usr/sbin/cephadm", line 3395, in <module>
    r = args.func()
  File "/usr/sbin/cephadm", line 1654, in command_bootstrap
    command_prepare_host()
  File "/usr/sbin/cephadm", line 2627, in command_prepare_host
    pkg = create_packager()
  File "/usr/sbin/cephadm", line 2948, in create_packager
    raise Error('Distro %s version %s not supported' % (distro, version))
__main__.Error: Distro opensuse-leap version 15.2 not supported
```


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
