### PR TITLE
mgr/orchestrator: functools.partial doesn't work for methods

### DIFF
--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -11,7 +11,7 @@ import pickle
 import sys
 import time
 from collections import namedtuple
-from functools import wraps, partial
+from functools import wraps, partialmethod
 import uuid
 import string
 import random
@@ -150,7 +150,7 @@ def handle_exception(prefix, cmd_args, desc, perm, func):
             return HandleCommandResult(-errno.ENOENT, stderr=msg)
 
     # misuse partial to copy `wrapper`
-    wrapper_copy = partial(wrapper)
+    wrapper_copy = lambda *l_args, **l_kwargs: wrapper(*l_args, **l_kwargs)
     wrapper_copy._prefix = prefix  # type: ignore
     wrapper_copy._cli_command = CLICommand(prefix, cmd_args, desc, perm)  # type: ignore
     wrapper_copy._cli_command.func = wrapper_copy  # type: ignore


### PR DESCRIPTION
Use `partialmethod` instead:

```python
def decorator_partial(f):
     return partial(f)

def decorator_lambda(f):
     return lambda *l_args, **l_kwargs: f(*l_args, **l_kwargs)

class C:
     @decorator_partial
     def f(self, arg): pass

     @decorator_lambda
     def g(self, arg): pass

C().f(1)
TypeError: f() missing 1 required positional argument: 'arg'

C().g(1)
None
```

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

Fixes: `TypeError: _set_backend() missing 1 required positional argument: 'module_name'`

``

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
