### PR TITLE
mgr/rook: debug: properly set verify_ssl=False

### DIFF
--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -1,7 +1,63 @@
 [mypy]
 strict_optional = True
 no_implicit_optional = True
-ignore_missing_imports = True
 warn_incomplete_stub = True
 check_untyped_defs = True
 show_error_context = True
+
+[mypy-rados]
+# his would require a rados.pyi file
+ignore_missing_imports = True
+
+[mypy-rbd]
+# his would require a rbd.pyi file
+ignore_missing_imports = True
+
+[mypy-cephfs]
+# his would require a cephfs.pyi file
+ignore_missing_imports = True
+
+
+# Make cephadm and rook happy
+[mypy-OpenSSL]
+ignore_missing_imports = True
+
+[mypy-prettytable]
+ignore_missing_imports = True
+
+[mypy-jsonpatch]
+ignore_missing_imports = True
+
+[mypy-urllib3.*]
+ignore_missing_imports = True
+
+[mypy-execnet.*]
+ignore_missing_imports = True
+
+[mypy-remoto.*]
+ignore_missing_imports = True
+
+# Make dashboard happy:
+[mypy-coverage]
+ignore_missing_imports = True
+
+[mypy-urlparse]
+ignore_missing_imports = True
+
+[mypy-cherrypy.*]
+ignore_missing_imports = True
+
+[mypy-cheroot.*]
+ignore_missing_imports = True
+
+[mypy-bcrypt]
+ignore_missing_imports = True
+
+[mypy-onelogin.*]
+ignore_missing_imports = True
+
+# Make volumes happy:
+[mypy-StringIO]
+ignore_missing_imports = True
+
+

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -22,12 +22,12 @@ try:
     from kubernetes.client.models.v1_container_image import V1ContainerImage
     def names(self, names):
         self._names = names
-    V1ContainerImage.names = V1ContainerImage.names.setter(names)
+    V1ContainerImage.names = V1ContainerImage.names.setter(names)  # type: ignore
 
 except ImportError:
     kubernetes_imported = False
-    client = None
-    config = None
+    client = None  # type: ignore
+    config = None  # type: ignore
 
 from mgr_module import MgrModule
 import orchestrator
@@ -176,8 +176,9 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             cluster_name = "rook-ceph"
 
             # So that I can do port forwarding from my workstation - jcsp
-            from kubernetes.client import configuration
+            configuration = client.Configuration()
             configuration.verify_ssl = False
+            client.Configuration.set_default(configuration)
 
         self._k8s_CoreV1_api = client.CoreV1Api()
         self._k8s_BatchV1_api = client.BatchV1Api()

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -19,14 +19,17 @@ deps =
     cython
     -r requirements.txt
     mypy==0.770
-commands = mypy --config-file=../../mypy.ini \
-           cephadm/module.py \
-           mgr_module.py \
-           dashboard/module.py \
-           mgr_util.py \
-           orchestrator/__init__.py \
-           progress/module.py \
-           rook/module.py \
-           osd_support/module.py \
-           test_orchestrator/module.py \
-           volumes/__init__.py
+# https://github.com/python/mypy/issues/8421
+whitelist_externals = touch
+commands = touch {envsitepackagesdir}/kubernetes/py.typed
+           mypy --config-file=../../mypy.ini \
+             -m cephadm \
+             -m mgr_module \
+             -m dashboard \
+             -m mgr_util \
+             -m orchestrator \
+             -m progress \
+             -m rook \
+             -m osd_support \
+             -m test_orchestrator \
+             -m volumes


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

previously, this code to set `verify_ssl=False` did nothing at all. 
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
