### PR TITLE
common/options.cc: make rocksdb_delete_range_threshold very high

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3648,7 +3648,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("rocksdb_delete_range_threshold", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(1024)
+    .set_default(1048576)
     .set_description("The number of keys required to invoke DeleteRange when deleting muliple keys."),
 
     Option("rocksdb_bloom_bits_per_key", Option::TYPE_UINT, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
In b493e96bc181e03d1ab5dfe556a866d6ffb16cec, we added a minimum
key limit before invoking DeleteRange. Existing results show
cpu and latency issues when DeleteRange is invoked for all objects.
Until we have more conclusive results to prove its usefulness, increase
this limit to a very high number to avoid users from hitting it.

Signed-off-by: Neha Ojha <nojha@redhat.com>

Notes from CDM discussion: https://pad.ceph.com/p/octopus-rados-defaults