### PR TITLE
cephadm: fix adoption safety check

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2400,6 +2400,15 @@ def command_adopt():
                     osd_fsid = f.read().strip()
             except IOError:
                 raise Error('unable to read OSD fsid from %s' % path)
+            os_type = None
+            if os.path.exists(os.path.join(data_dir_src, 'type')):
+                with open(os.path.join(data_dir_src, 'type')) as f:
+                    os_type = f.read().strip()
+            else:
+                raise Error('"type" file missing for OSD data dir')
+            logger.info('objectstore_type is %s' % os_type)
+            if os_type == 'filestore':
+                raise Error('FileStore is not supported by cephadm')
 
         # NOTE: implicit assumption here that the units correspond to the
         # cluster we are adopting based on the /etc/{defaults,sysconfig}/ceph
@@ -2415,15 +2424,6 @@ def command_adopt():
             call_throws(['systemctl', 'disable', unit_name])
 
         # data
-        os_type = None
-        if os.path.exists(os.path.join(data_dir_src, 'type')):
-            with open(os.path.join(data_dir_src, 'type')) as f:
-                os_type = f.read().strip()
-        else:
-            raise Error('"type" file missing for OSD data dir')
-        logger.info('objectstore_type is %s' % os_type)
-        if os_type == 'filestore':
-            raise Error('FileStore is not supported by cephadm')
         logger.info('Moving data...')
         data_dir_dst = make_data_dir(fsid, daemon_type, daemon_id,
                                      uid=uid, gid=gid)


### PR DESCRIPTION
The 'type' file is only required for *osds*.

Signed-off-by: Sage Weil <sage@redhat.com>