### PR TITLE
librbd: fix broken group snapshot handling

### DIFF
--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -39,9 +39,15 @@ template <typename I>
 snap_t get_group_snap_id(I* ictx,
                          const cls::rbd::SnapshotNamespace& in_snap_namespace) {
   ceph_assert(ceph_mutex_is_locked(ictx->image_lock));
-  auto it = ictx->snap_ids.lower_bound({in_snap_namespace, ""});
-  if (it != ictx->snap_ids.end() && it->first.first == in_snap_namespace) {
-    return it->second;
+  auto it = ictx->snap_ids.lower_bound({cls::rbd::GroupSnapshotNamespace{},
+                                        ""});
+  for (; it != ictx->snap_ids.end(); ++it) {
+    if (it->first.first == in_snap_namespace) {
+      return it->second;
+    } else if (boost::get<cls::rbd::GroupSnapshotNamespace>(&it->first.first) ==
+                 nullptr) {
+      break;
+    }
   }
   return CEPH_NOSNAP;
 }


### PR DESCRIPTION
After commit ecf71d301f, only the snapshot namespace type and snapshot
name are considered for snapshot ordering. This breaks the expectations
in the group API when searching for a newly created snapshot.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
