### PR TITLE
doc/bootstrap: Add zypper as package management option + minor tweaks

### DIFF
--- a/doc/bootstrap.rst
+++ b/doc/bootstrap.rst
@@ -54,7 +54,8 @@ To create a new cluster, you need to know:
 
 To bootstrap the cluster run the following command::
 
-  [node 1] $ sudo ./cephadm bootstrap --mon-ip *<mon-ip>*
+  [node 1] $ sudo ./cephadm bootstrap --mon-ip *<mon-ip>*  # or
+  [node 1] $ sudo cephadm bootstrap --mon-ip *<mon-ip>*
 
 This command does a few things:
 
@@ -73,7 +74,8 @@ Interacting with the cluster
 To interact with your cluster, start up a container that has all of 
 the Ceph packages installed::
 
-  [any node] $ sudo ./cephadm shell --config ceph.conf --keyring ceph.client.admin.keyring
+  [any node] $ sudo ./cephadm shell --config ceph.conf --keyring ceph.client.admin.keyring  # or
+  [any node] $ sudo cephadm shell --config ceph.conf --keyring ceph.client.admin.keyring
 
 The ``--config`` and ``--keyring`` arguments will bind those local
 files to the default locations in ``/etc/ceph`` inside the container

--- a/doc/bootstrap.rst
+++ b/doc/bootstrap.rst
@@ -48,11 +48,11 @@ Bootstrap a new cluster
 To create a new cluster, you need to know:
 
 * Which *IP address* to use for the cluster's first monitor.  This is
-  normally just the IP for the first cluster node.  If there are
+  normally just the IP of the first cluster node.  If there are
   multiple networks and interfaces, be sure to choose one that will be
   accessible by any hosts accessing the Ceph cluster.
 
-To bootstrap the cluster run the following command::
+To bootstrap the cluster run the following command on the first node::
 
   [node 1] $ sudo ./cephadm bootstrap --mon-ip *<mon-ip>*  # or
   [node 1] $ sudo cephadm bootstrap --mon-ip *<mon-ip>*

--- a/doc/bootstrap.rst
+++ b/doc/bootstrap.rst
@@ -89,7 +89,8 @@ administrator key in a global location::
 
    [any node] $ sudo apt install -y ceph-common   # or,
    [any node] $ sudo dnf install -y ceph-common   # or,
-   [any node] $ sudo yum install -y ceph-common
+   [any node] $ sudo yum install -y ceph-common   # or,
+   [any node] $ sudo zypper in -y ceph-common
 
    [any node] $ sudo install -m 0644 ceph.conf /etc/ceph/ceph.conf
    [any node] $ sudo install -m 0600 ceph.keyring /etc/ceph/ceph.keyring


### PR DESCRIPTION
Just some minor tweaks to the bootstrap document.

## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
