### PR TITLE
objectstore: cleanups to avoid using `g_ceph_context`

### DIFF
--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -354,7 +354,7 @@ int RocksDBStore::load_rocksdb_options(bool create_if_missing, rocksdb::Options&
     }
   }
 
-  if (g_conf()->rocksdb_perf)  {
+  if (cct->_conf->rocksdb_perf)  {
     dbstats = rocksdb::CreateDBStatistics();
     opt.statistics = dbstats;
   }
@@ -393,8 +393,8 @@ int RocksDBStore::load_rocksdb_options(bool create_if_missing, rocksdb::Options&
     return -e.code().value();
   }
 
-  if (g_conf()->rocksdb_log_to_ceph_log) {
-    opt.info_log.reset(new CephRocksdbLogger(g_ceph_context));
+  if (cct->_conf->rocksdb_log_to_ceph_log) {
+    opt.info_log.reset(new CephRocksdbLogger(cct));
   }
 
   if (priv) {
@@ -406,78 +406,78 @@ int RocksDBStore::load_rocksdb_options(bool create_if_missing, rocksdb::Options&
 
   // caches
   if (!set_cache_flag) {
-    cache_size = g_conf()->rocksdb_cache_size;
+    cache_size = cct->_conf->rocksdb_cache_size;
   }
-  uint64_t row_cache_size = cache_size * g_conf()->rocksdb_cache_row_ratio;
+  uint64_t row_cache_size = cache_size * cct->_conf->rocksdb_cache_row_ratio;
   uint64_t block_cache_size = cache_size - row_cache_size;
 
-  if (g_conf()->rocksdb_cache_type == "binned_lru") {
+  if (cct->_conf->rocksdb_cache_type == "binned_lru") {
     bbt_opts.block_cache = rocksdb_cache::NewBinnedLRUCache(
       cct,
       block_cache_size,
-      g_conf()->rocksdb_cache_shard_bits);
-  } else if (g_conf()->rocksdb_cache_type == "lru") {
+      cct->_conf->rocksdb_cache_shard_bits);
+  } else if (cct->_conf->rocksdb_cache_type == "lru") {
     bbt_opts.block_cache = rocksdb::NewLRUCache(
       block_cache_size,
-      g_conf()->rocksdb_cache_shard_bits);
-  } else if (g_conf()->rocksdb_cache_type == "clock") {
+      cct->_conf->rocksdb_cache_shard_bits);
+  } else if (cct->_conf->rocksdb_cache_type == "clock") {
     bbt_opts.block_cache = rocksdb::NewClockCache(
       block_cache_size,
-      g_conf()->rocksdb_cache_shard_bits);
+      cct->_conf->rocksdb_cache_shard_bits);
     if (!bbt_opts.block_cache) {
-      derr << "rocksdb_cache_type '" << g_conf()->rocksdb_cache_type
+      derr << "rocksdb_cache_type '" << cct->_conf->rocksdb_cache_type
            << "' chosen, but RocksDB not compiled with LibTBB. "
            << dendl;
       return -EINVAL;
     }
   } else {
-    derr << "unrecognized rocksdb_cache_type '" << g_conf()->rocksdb_cache_type
+    derr << "unrecognized rocksdb_cache_type '" << cct->_conf->rocksdb_cache_type
       << "'" << dendl;
     return -EINVAL;
   }
-  bbt_opts.block_size = g_conf()->rocksdb_block_size;
+  bbt_opts.block_size = cct->_conf->rocksdb_block_size;
 
   if (row_cache_size > 0)
     opt.row_cache = rocksdb::NewLRUCache(row_cache_size,
-				     g_conf()->rocksdb_cache_shard_bits);
-  uint64_t bloom_bits = g_conf().get_val<uint64_t>("rocksdb_bloom_bits_per_key");
+				     cct->_conf->rocksdb_cache_shard_bits);
+  uint64_t bloom_bits = cct->_conf.get_val<uint64_t>("rocksdb_bloom_bits_per_key");
   if (bloom_bits > 0) {
     dout(10) << __func__ << " set bloom filter bits per key to "
 	     << bloom_bits << dendl;
     bbt_opts.filter_policy.reset(rocksdb::NewBloomFilterPolicy(bloom_bits));
   }
   using std::placeholders::_1;
-  if (g_conf().with_val<std::string>("rocksdb_index_type",
+  if (cct->_conf.with_val<std::string>("rocksdb_index_type",
 				    std::bind(std::equal_to<std::string>(), _1,
 					      "binary_search")))
     bbt_opts.index_type = rocksdb::BlockBasedTableOptions::IndexType::kBinarySearch;
-  if (g_conf().with_val<std::string>("rocksdb_index_type",
+  if (cct->_conf.with_val<std::string>("rocksdb_index_type",
 				    std::bind(std::equal_to<std::string>(), _1,
 					      "hash_search")))
     bbt_opts.index_type = rocksdb::BlockBasedTableOptions::IndexType::kHashSearch;
-  if (g_conf().with_val<std::string>("rocksdb_index_type",
+  if (cct->_conf.with_val<std::string>("rocksdb_index_type",
 				    std::bind(std::equal_to<std::string>(), _1,
 					      "two_level")))
     bbt_opts.index_type = rocksdb::BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
   if (!bbt_opts.no_block_cache) {
     bbt_opts.cache_index_and_filter_blocks =
-        g_conf().get_val<bool>("rocksdb_cache_index_and_filter_blocks");
+        cct->_conf.get_val<bool>("rocksdb_cache_index_and_filter_blocks");
     bbt_opts.cache_index_and_filter_blocks_with_high_priority =
-        g_conf().get_val<bool>("rocksdb_cache_index_and_filter_blocks_with_high_priority");
+        cct->_conf.get_val<bool>("rocksdb_cache_index_and_filter_blocks_with_high_priority");
     bbt_opts.pin_l0_filter_and_index_blocks_in_cache =
-      g_conf().get_val<bool>("rocksdb_pin_l0_filter_and_index_blocks_in_cache");
+      cct->_conf.get_val<bool>("rocksdb_pin_l0_filter_and_index_blocks_in_cache");
   }
-  bbt_opts.partition_filters = g_conf().get_val<bool>("rocksdb_partition_filters");
-  if (g_conf().get_val<Option::size_t>("rocksdb_metadata_block_size") > 0)
-    bbt_opts.metadata_block_size = g_conf().get_val<Option::size_t>("rocksdb_metadata_block_size");
+  bbt_opts.partition_filters = cct->_conf.get_val<bool>("rocksdb_partition_filters");
+  if (cct->_conf.get_val<Option::size_t>("rocksdb_metadata_block_size") > 0)
+    bbt_opts.metadata_block_size = cct->_conf.get_val<Option::size_t>("rocksdb_metadata_block_size");
 
   opt.table_factory.reset(rocksdb::NewBlockBasedTableFactory(bbt_opts));
-  dout(10) << __func__ << " block size " << g_conf()->rocksdb_block_size
+  dout(10) << __func__ << " block size " << cct->_conf->rocksdb_block_size
            << ", block_cache size " << byte_u_t(block_cache_size)
 	   << ", row_cache size " << byte_u_t(row_cache_size)
 	   << "; shards "
-	   << (1 << g_conf()->rocksdb_cache_shard_bits)
-	   << ", type " << g_conf()->rocksdb_cache_type
+	   << (1 << cct->_conf->rocksdb_cache_shard_bits)
+	   << ", type " << cct->_conf->rocksdb_cache_type
 	   << dendl;
 
   opt.merge_operator.reset(new MergeOperatorRouter(*this));
@@ -607,7 +607,7 @@ int RocksDBStore::do_open(ostream &out,
   }
   ceph_assert(default_cf != nullptr);
   
-  PerfCountersBuilder plb(g_ceph_context, "rocksdb", l_rocksdb_first, l_rocksdb_last);
+  PerfCountersBuilder plb(cct, "rocksdb", l_rocksdb_first, l_rocksdb_last);
   plb.add_u64_counter(l_rocksdb_gets, "get", "Gets");
   plb.add_u64_counter(l_rocksdb_txns, "submit_transaction", "Submit transactions");
   plb.add_u64_counter(l_rocksdb_txns_sync, "submit_transaction_sync", "Submit transactions sync");
@@ -746,13 +746,13 @@ int64_t RocksDBStore::estimate_prefix_size(const string& prefix,
 
 void RocksDBStore::get_statistics(Formatter *f)
 {
-  if (!g_conf()->rocksdb_perf)  {
+  if (!cct->_conf->rocksdb_perf)  {
     dout(20) << __func__ << " RocksDB perf is disabled, can't probe for stats"
 	     << dendl;
     return;
   }
 
-  if (g_conf()->rocksdb_collect_compaction_stats) {
+  if (cct->_conf->rocksdb_collect_compaction_stats) {
     std::string stat_str;
     bool status = db->GetProperty("rocksdb.stats", &stat_str);
     if (status) {
@@ -766,7 +766,7 @@ void RocksDBStore::get_statistics(Formatter *f)
       f->close_section();
     }
   }
-  if (g_conf()->rocksdb_collect_extended_stats) {
+  if (cct->_conf->rocksdb_collect_extended_stats) {
     if (dbstats) {
       f->open_object_section("rocksdb_extended_statistics");
       string stat_str = dbstats->ToString();
@@ -782,7 +782,7 @@ void RocksDBStore::get_statistics(Formatter *f)
     logger->dump_formatted(f,0);
     f->close_section();
   }
-  if (g_conf()->rocksdb_collect_memory_stats) {
+  if (cct->_conf->rocksdb_collect_memory_stats) {
     f->open_object_section("rocksdb_memtable_statistics");
     std::string str;
     if (!bbt_opts.no_block_cache) {
@@ -806,7 +806,7 @@ int RocksDBStore::submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Tra
 {
   // enable rocksdb breakdown
   // considering performance overhead, default is disabled
-  if (g_conf()->rocksdb_perf) {
+  if (cct->_conf->rocksdb_perf) {
     rocksdb::SetPerfLevel(rocksdb::PerfLevel::kEnableTimeExceptForMutex);
     rocksdb::get_perf_context()->Reset();
   }
@@ -827,7 +827,7 @@ int RocksDBStore::submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Tra
          << " Rocksdb transaction: " << rocks_txc.seen << dendl;
   }
 
-  if (g_conf()->rocksdb_perf) {
+  if (cct->_conf->rocksdb_perf) {
     utime_t write_memtable_time;
     utime_t write_delay_time;
     utime_t write_wal_time;

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -55,7 +55,7 @@ KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, ai
   fd_directs.resize(WRITE_LIFE_MAX, -1);
   fd_buffereds.resize(WRITE_LIFE_MAX, -1);
 
-  bool use_ioring = g_ceph_context->_conf.get_val<bool>("bluestore_ioring");
+  bool use_ioring = cct->_conf.get_val<bool>("bluestore_ioring");
   unsigned int iodepth = cct->_conf->bdev_aio_max_queue_depth;
 
   if (use_ioring && ioring_queue_t::supported()) {

--- a/src/os/filestore/FileJournal.h
+++ b/src/os/filestore/FileJournal.h
@@ -417,7 +417,7 @@ private:
     full_state(FULL_NOTFULL),
     fd(-1),
     writing_seq(0),
-    throttle(cct->_conf->filestore_caller_concurrency),
+    throttle(cct, cct->_conf->filestore_caller_concurrency),
     write_stop(true),
     aio_stop(true),
     write_thread(this),

--- a/src/os/filestore/JournalThrottle.h
+++ b/src/os/filestore/JournalThrottle.h
@@ -94,8 +94,9 @@ public:
   uint64_t get_max();
 
   JournalThrottle(
+    CephContext *cct,
     unsigned expected_concurrency ///< [in] determines size of conds
-    ) : throttle(g_ceph_context, "filestore_journal", expected_concurrency) {}
+    ) : throttle(cct, "filestore_journal", expected_concurrency) {}
 };
 
 #endif


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
