### PR TITLE
cmake: exclude unittest_alloc_aging from "all"

### DIFF
--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -112,11 +112,9 @@ if(WITH_BLUESTORE)
   set_target_properties(unittest_fastbmap_allocator PROPERTIES COMPILE_FLAGS
   "${UNITTEST_CXX_FLAGS}")
 
-  add_executable(unittest_alloc_aging
-    Allocator_aging_fragmentation.cc
-    $<TARGET_OBJECTS:unit-main>
-    )
-  target_link_libraries(unittest_alloc_aging os global)
+  add_executable(unittest_alloc_aging EXCLUDE_FROM_ALL
+    Allocator_aging_fragmentation.cc)
+  target_link_libraries(unittest_alloc_aging os global GTest::Main)
 
   # unittest_bluefs
   add_executable(unittest_bluefs


### PR DESCRIPTION
link it against GTest::Main, which was remove by
96a0439faf551dfae45676072eddd5f37a157289.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
