### PR TITLE
mgr/orchestrator: Substitute `hostname` for `nodename`, globally

### DIFF
--- a/doc/mgr/cephadm.rst
+++ b/doc/mgr/cephadm.rst
@@ -5,7 +5,7 @@ cephadm orchestrator
 ====================
 
 The cephadm orchestrator is an orchestrator module that does not rely on a separate
-system such as Rook or Ansible, but rather manages nodes in a cluster by
+system such as Rook or Ansible, but rather manages hosts in a cluster by
 establishing an SSH connection and issuing explicit management commands.
 
 Orchestrator modules only provide services to other modules, which in turn

--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -115,8 +115,8 @@ OSD Management
 List Devices
 ^^^^^^^^^^^^
 
-Print a list of discovered devices, grouped by node and optionally
-filtered to a particular node:
+Print a list of discovered devices, grouped by host and optionally
+filtered to a particular host:
 
 ::
 
@@ -211,13 +211,13 @@ Monitor and manager management
 Creates or removes MONs or MGRs from the cluster. Orchestrator may return an
 error if it doesn't know how to do this transition.
 
-Update the number of monitor nodes::
+Update the number of monitor hosts::
 
     ceph orch apply mon <num> [host, host:network...]
 
 Each host can optionally specify a network for the monitor to listen on.
 
-Update the number of manager nodes::
+Update the number of manager hosts::
 
     ceph orch apply mgr <num> [host...]
 

--- a/doc/mgr/orchestrator_modules.rst
+++ b/doc/mgr/orchestrator_modules.rst
@@ -72,9 +72,9 @@ Stateless service
 
 Label
   arbitrary string tags that may be applied by administrators
-  to nodes.  Typically administrators use labels to indicate
-  which nodes should run which kinds of service.  Labels are
-  advisory (from human input) and do not guarantee that nodes
+  to hosts.  Typically administrators use labels to indicate
+  which hosts should run which kinds of service.  Labels are
+  advisory (from human input) and do not guarantee that hosts
   have particular physical capabilities.
 
 Drive group
@@ -83,20 +83,20 @@ Drive group
   journals/dbs for a group of HDDs).
 
 Placement
-  choice of which node is used to run a service.
+  choice of which host is used to run a service.
 
 Key Concepts
 ------------
 
 The underlying orchestrator remains the source of truth for information
 about whether a service is running, what is running where, which
-nodes are available, etc.  Orchestrator modules should avoid taking
+hosts are available, etc.  Orchestrator modules should avoid taking
 any internal copies of this information, and read it directly from
 the orchestrator backend as much as possible.
 
-Bootstrapping nodes and adding them to the underlying orchestration
+Bootstrapping hosts and adding them to the underlying orchestration
 system is outside the scope of Ceph's orchestrator interface.  Ceph
-can only work on nodes when the orchestrator is already aware of them.
+can only work on hosts when the orchestrator is already aware of them.
 
 Calls to orchestrator modules are all asynchronous, and return *completion*
 objects (see below) rather than returning values immediately.
@@ -207,7 +207,7 @@ Excluded functionality
   the Ceph cluster's services only.
 - Multipathed storage is not handled (multipathing is unnecessary for
   Ceph clusters).  Each drive is assumed to be visible only on
-  a single node.
+  a single host.
 
 Host management
 ---------------

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     pass
 
-from orchestrator import ServiceDescription, DaemonDescription, InventoryNode, \
+from orchestrator import ServiceDescription, DaemonDescription, InventoryHost, \
     ServiceSpec, PlacementSpec, RGWSpec, HostSpec, OrchestratorError
 from tests import mock
 from .fixtures import cephadm_module, wait
@@ -96,7 +96,7 @@ class TestCephadm(object):
     def test_device_ls(self, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.get_inventory()
-            assert wait(cephadm_module, c) == [InventoryNode('test')]
+            assert wait(cephadm_module, c) == [InventoryHost('test')]
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm(
         json.dumps([

--- a/src/pybind/mgr/dashboard/controllers/orchestrator.py
+++ b/src/pybind/mgr/dashboard/controllers/orchestrator.py
@@ -109,17 +109,17 @@ class OrchestratorInventory(RESTController):
     def list(self, hostname=None):
         orch = OrchClient.instance()
         hosts = [hostname] if hostname else None
-        inventory_nodes = [node.to_json() for node in orch.inventory.list(hosts)]
+        inventory_hosts = [host.to_json() for host in orch.inventory.list(hosts)]
         device_osd_map = get_device_osd_map()
-        for inventory_node in inventory_nodes:
-            node_osds = device_osd_map.get(inventory_node['name'])
-            for device in inventory_node['devices']:
-                if node_osds:
+        for inventory_host in inventory_hosts:
+            host_osds = device_osd_map.get(inventory_host['name'])
+            for device in inventory_host['devices']:
+                if host_osds:
                     dev_name = os.path.basename(device['path'])
-                    device['osd_ids'] = sorted(node_osds.get(dev_name, []))
+                    device['osd_ids'] = sorted(host_osds.get(dev_name, []))
                 else:
                     device['osd_ids'] = []
-        return inventory_nodes
+        return inventory_hosts
 
 
 @ApiController('/orchestrator/service', Scope.HOSTS)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-host.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-host.model.ts
@@ -1,6 +1,6 @@
 import { InventoryDevice } from './inventory-devices/inventory-device.model';
 
-export class InventoryNode {
+export class InventoryHost {
   name: string;
   devices: InventoryDevice[];
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.spec.ts
@@ -16,25 +16,25 @@ describe('ServicesComponent', () => {
 
   const services = [
     {
-      nodename: 'host0',
+      hostname: 'host0',
       service: '',
       service_instance: 'x',
       service_type: 'mon'
     },
     {
-      nodename: 'host0',
+      hostname: 'host0',
       service: '',
       service_instance: '0',
       service_type: 'osd'
     },
     {
-      nodename: 'host1',
+      hostname: 'host1',
       service: '',
       service_instance: 'y',
       service_type: 'mon'
     },
     {
-      nodename: 'host1',
+      hostname: 'host1',
       service: '',
       service_instance: '1',
       service_type: 'osd'
@@ -42,7 +42,7 @@ describe('ServicesComponent', () => {
   ];
 
   const getServiceList = (hostname: String) => {
-    return hostname ? services.filter((service) => service.nodename === hostname) : services;
+    return hostname ? services.filter((service) => service.hostname === hostname) : services;
   };
 
   configureTestBed({
@@ -78,7 +78,7 @@ describe('ServicesComponent', () => {
     reqHostname = 'host0';
     component.getServices(new CdTableFetchDataContext(() => {}));
     expect(component.services.length).toBe(2);
-    expect(component.services[0].nodename).toBe(reqHostname);
-    expect(component.services[1].nodename).toBe(reqHostname);
+    expect(component.services[0].hostname).toBe(reqHostname);
+    expect(component.services[1].hostname).toBe(reqHostname);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -42,7 +42,7 @@ export class ServicesComponent implements OnChanges, OnInit {
     const columns = [
       {
         name: this.i18n('Hostname'),
-        prop: 'nodename',
+        prop: 'hostname',
         flexGrow: 2
       },
       {
@@ -132,7 +132,7 @@ export class ServicesComponent implements OnChanges, OnInit {
       (data: Service[]) => {
         const services: Service[] = [];
         data.forEach((service: Service) => {
-          service.uid = `${service.nodename}-${service.service_type}-${service.service}-${service.service_instance}`;
+          service.uid = `${service.hostname}-${service.service_type}-${service.service}-${service.service_instance}`;
           services.push(service);
         });
         this.services = services;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.model.ts
@@ -1,7 +1,7 @@
 export class Service {
   uid: string;
 
-  nodename: string;
+  hostname: string;
   container_id: string;
   service: string;
   service_instance: string;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.ts
@@ -6,7 +6,7 @@ import { Observable, of as observableOf } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 
 import { InventoryDevice } from '../../ceph/cluster/inventory/inventory-devices/inventory-device.model';
-import { InventoryNode } from '../../ceph/cluster/inventory/inventory-node.model';
+import { InventoryHost } from '../../ceph/cluster/inventory/inventory-host.model';
 import { ApiModule } from './api.module';
 
 @Injectable({
@@ -29,17 +29,17 @@ export class OrchestratorService {
     });
   }
 
-  inventoryList(hostname?: string): Observable<InventoryNode[]> {
+  inventoryList(hostname?: string): Observable<InventoryHost[]> {
     const options = hostname ? { params: new HttpParams().set('hostname', hostname) } : {};
-    return this.http.get<InventoryNode[]>(`${this.url}/inventory`, options);
+    return this.http.get<InventoryHost[]>(`${this.url}/inventory`, options);
   }
 
   inventoryDeviceList(hostname?: string): Observable<InventoryDevice[]> {
     return this.inventoryList(hostname).pipe(
-      mergeMap((nodes: InventoryNode[]) => {
-        const devices = _.flatMap(nodes, (node) => {
-          return node.devices.map((device) => {
-            device.hostname = node.name;
+      mergeMap((hosts: InventoryHost[]) => {
+        const devices = _.flatMap(hosts, (host) => {
+          return host.devices.map((device) => {
+            device.hostname = host.name;
             device.uid = device.device_id ? device.device_id : `${device.hostname}-${device.path}`;
             return device;
           });

--- a/src/pybind/mgr/dashboard/services/ganesha.py
+++ b/src/pybind/mgr/dashboard/services/ganesha.py
@@ -89,7 +89,7 @@ class Ganesha(object):
                 instance.service = "_default_"
             if instance.service not in result:
                 result[instance.service] = {}
-            result[instance.service][instance.nodename] = {
+            result[instance.service][instance.hostname] = {
                 'status': instance.status,
                 'desc': instance.status_desc,
             }

--- a/src/pybind/mgr/dashboard/services/iscsi_config.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_config.py
@@ -82,7 +82,7 @@ class IscsiGatewaysConfig(object):
         try:
             instances = OrchClient.instance().services.list("iscsi")
             for instance in instances:
-                config['gateways'][instance.nodename] = {
+                config['gateways'][instance.hostname] = {
                     'service_url': instance.service_url
                 }
         except (RuntimeError, OrchestratorError, ImportError):

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -69,15 +69,15 @@ class InventoryManager(ResourceManager):
 
     @wait_api_result
     def list(self, hosts=None, refresh=False):
-        node_filter = InventoryFilter(nodes=hosts) if hosts else None
-        return self.api.get_inventory(node_filter=node_filter, refresh=refresh)
+        host_filter = InventoryFilter(hosts=hosts) if hosts else None
+        return self.api.get_inventory(host_filter=host_filter, refresh=refresh)
 
 
 class ServiceManager(ResourceManager):
 
     @wait_api_result
-    def list(self, service_type=None, service_id=None, node_name=None):
-        return self.api.list_daemons(service_type, service_id, node_name)
+    def list(self, service_type=None, service_id=None, host_name=None):
+        return self.api.list_daemons(service_type, service_id, host_name)
 
     def reload(self, service_type, service_ids):
         if not isinstance(service_ids, list):

--- a/src/pybind/mgr/dashboard/tests/test_orchestrator.py
+++ b/src/pybind/mgr/dashboard/tests/test_orchestrator.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     from unittest import mock
 
-from orchestrator import InventoryNode
+from orchestrator import InventoryHost
 
 from . import ControllerTestCase
 from .. import mgr
@@ -48,11 +48,11 @@ class OrchestratorControllerTest(ControllerTestCase):
     def _set_inventory(self, mock_instance, inventory):
         # pylint: disable=unused-argument
         def _list_inventory(hosts=None, refresh=False):
-            nodes = []
-            for node in inventory:
-                if hosts is None or node['name'] in hosts:
-                    nodes.append(InventoryNode.from_json(node))
-            return nodes
+            inv_hosts = []
+            for inv_host in inventory:
+                if hosts is None or inv_host['name'] in hosts:
+                    inv_hosts.append(InventoryHost.from_json(inv_host))
+            return inv_hosts
         mock_instance.inventory.list.side_effect = _list_inventory
 
     @mock.patch('dashboard.controllers.orchestrator.get_device_osd_map')
@@ -174,8 +174,8 @@ class TestOrchestrator(unittest.TestCase):
         mgr.get.assert_called_with('osd_metadata')
         # sort OSD IDs to make assertDictEqual work
         for devices in device_osd_map.values():
-            for node in devices.keys():
-                devices[node] = sorted(devices[node])
+            for host in devices.keys():
+                devices[host] = sorted(devices[host])
         self.assertDictEqual(device_osd_map, {
             'node0': {
                 'nvme0n1': [0, 1],

--- a/src/pybind/mgr/orchestrator/__init__.py
+++ b/src/pybind/mgr/orchestrator/__init__.py
@@ -12,6 +12,6 @@ from ._interface import \
     servicespec_validate_add, servicespec_validate_hosts_have_network_spec, \
     ServiceDescription, InventoryFilter, PlacementSpec,  HostSpec, \
     DaemonDescription, \
-    InventoryNode, DeviceLightLoc, \
+    InventoryHost, DeviceLightLoc, \
     OutdatableData, OutdatablePersistentDict, \
     UpgradeStatusSpec

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -879,12 +879,12 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def get_inventory(self, node_filter=None, refresh=False):
+    def get_inventory(self, host_filter=None, refresh=False):
         # type: (Optional[InventoryFilter], bool) -> Completion
         """
         Returns something that was created by `ceph-volume inventory`.
 
-        :return: list of InventoryNode
+        :return: list of InventoryHost
         """
         raise NotImplementedError()
 
@@ -1171,7 +1171,7 @@ class UpgradeStatusSpec(object):
 
 class PlacementSpec(object):
     """
-    For APIs that need to specify a node subset
+    For APIs that need to specify a host subset
     """
     def __init__(self, label=None, hosts=None, count=None):
         # type: (Optional[str], Optional[List], Optional[int]) -> None
@@ -1200,7 +1200,7 @@ class PlacementSpec(object):
     def validate(self):
         if self.hosts and self.label:
             # TODO: a less generic Exception
-            raise Exception('Node and label are mutually exclusive')
+            raise Exception('Host and label are mutually exclusive')
         if self.count is not None and self.count <= 0:
             raise Exception("num/count must be > 1")
 
@@ -1265,7 +1265,7 @@ class DaemonDescription(object):
     This is not about health or performance monitoring of daemons: it's
     about letting the orchestrator tell Ceph whether and where a
     daemon is scheduled in the cluster.  When an orchestrator tells
-    Ceph "it's running on node123", that's not a promise that the process
+    Ceph "it's running on host123", that's not a promise that the process
     is literally up this second, it's a description of where the orchestrator
     has decided the daemon should run.
     """
@@ -1273,7 +1273,7 @@ class DaemonDescription(object):
     def __init__(self,
                  daemon_type=None,
                  daemon_id=None,
-                 nodename=None,
+                 hostname=None,
                  container_id=None,
                  container_image_id=None,
                  container_image_name=None,
@@ -1281,8 +1281,8 @@ class DaemonDescription(object):
                  status=None,
                  status_desc=None,
                  last_refresh=None):
-        # Node is at the same granularity as InventoryNode
-        self.nodename = nodename
+        # Host is at the same granularity as InventoryHost
+        self.hostname = hostname
 
         # Not everyone runs in containers, but enough people do to
         # justify having the container_id (runtime id) and container_image
@@ -1335,7 +1335,7 @@ class DaemonDescription(object):
 
     def to_json(self):
         out = {
-            'nodename': self.nodename,
+            'hostname': self.hostname,
             'container_id': self.container_id,
             'container_image_id': self.container_image_id,
             'container_image_name': self.container_image_name,
@@ -1366,7 +1366,7 @@ class ServiceDescription(object):
     This is not about health or performance monitoring of services: it's
     about letting the orchestrator tell Ceph whether and where a
     service is scheduled in the cluster.  When an orchestrator tells
-    Ceph "it's running on node123", that's not a promise that the process
+    Ceph "it's running on host123", that's not a promise that the process
     is literally up this second, it's a description of where the orchestrator
     has decided the service should run.
     """
@@ -1593,7 +1593,7 @@ class InventoryFilter(object):
     When fetching inventory, use this filter to avoid unnecessarily
     scanning the whole estate.
 
-    Typical use: filter by node when presenting UI workflow for configuring
+    Typical use: filter by host when presenting UI workflow for configuring
                  a particular server.
                  filter by label when not all of estate is Ceph servers,
                  and we want to only learn about the Ceph servers.
@@ -1601,20 +1601,20 @@ class InventoryFilter(object):
                  in e.g. OSD servers.
 
     """
-    def __init__(self, labels=None, nodes=None):
+    def __init__(self, labels=None, hosts=None):
         # type: (Optional[List[str]], Optional[List[str]]) -> None
 
-        #: Optional: get info about nodes matching labels
+        #: Optional: get info about hosts matching labels
         self.labels = labels
 
-        #: Optional: get info about certain named nodes only
-        self.nodes = nodes
+        #: Optional: get info about certain named hosts only
+        self.hosts = hosts
 
 
-class InventoryNode(object):
+class InventoryHost(object):
     """
     When fetching inventory, all Devices are groups inside of an
-    InventoryNode.
+    InventoryHost.
     """
     def __init__(self, name, devices=None, labels=None, addr=None):
         # type: (str, Optional[inventory.Devices], Optional[List[str]], Optional[str]) -> None
@@ -1662,12 +1662,12 @@ class InventoryNode(object):
         return [cls(item[0], devs(item[1].data)) for item in hosts]
 
     def __repr__(self):
-        return "<InventoryNode>({name})".format(name=self.name)
+        return "<InventoryHost>({name})".format(name=self.name)
 
     @staticmethod
-    def get_host_names(nodes):
-        # type: (List[InventoryNode]) -> List[str]
-        return [node.name for node in nodes]
+    def get_host_names(hosts):
+        # type: (List[InventoryHost]) -> List[str]
+        return [host.name for host in hosts]
 
     def __eq__(self, other):
         return self.name == other.name and self.devices == other.devices

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -321,7 +321,7 @@ class RookCluster(object):
             # p['metadata']['creationTimestamp']
             pods_summary.append({
                 "name": d['metadata']['name'],
-                "nodename": d['spec']['node_name'],
+                "hostname": d['spec']['node_name'],
                 "labels": d['metadata']['labels'],
                 'phase': d['status']['phase']
             })

--- a/src/pybind/mgr/test_orchestrator/dummy_data.json
+++ b/src/pybind/mgr/test_orchestrator/dummy_data.json
@@ -147,7 +147,7 @@
   ],
   "daemons": [
     {
-      "nodename": "host0",
+      "hostname": "host0",
       "daemon_type": "osd",
       "daemon_id": "1"
     }

--- a/src/pybind/mgr/tests/test_orchestrator.py
+++ b/src/pybind/mgr/tests/test_orchestrator.py
@@ -8,7 +8,7 @@ import pytest
 from ceph.deployment import inventory
 from orchestrator import raise_if_exception, RGWSpec, Completion, ProgressReference, \
     servicespec_validate_add
-from orchestrator import InventoryNode, ServiceDescription, DaemonDescription
+from orchestrator import InventoryHost, ServiceDescription, DaemonDescription
 from orchestrator import OrchestratorValidationError
 from orchestrator import HostPlacementSpec
 
@@ -72,19 +72,19 @@ def test_inventory():
             }
         ]
     }
-    _test_resource(json_data, InventoryNode, {'abc': False})
+    _test_resource(json_data, InventoryHost, {'abc': False})
     for devices in json_data['devices']:
         _test_resource(devices, inventory.Device)
 
     json_data = [{}, {'name': 'host0', 'addr': '1.2.3.4'}, {'devices': []}]
     for data in json_data:
         with pytest.raises(OrchestratorValidationError):
-            InventoryNode.from_json(data)
+            InventoryHost.from_json(data)
 
 
 def test_daemon_description():
     json_data = {
-        'nodename': 'test',
+        'hostname': 'test',
         'daemon_type': 'mon',
         'daemon_id': 'a'
     }


### PR DESCRIPTION
Right now, there is a mix of `node` and `host`. Unify this to `host`

* mgr/rook is special, as Kubernetes nativaly uses "node"

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
