### PR TITLE
mds: relevel debug message levels for balancer/migrator

### DIFF
--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -924,11 +924,3 @@ void snaprealm_reconnect_t::generate_test_instances(std::list<snaprealm_reconnec
   ls.back()->realm.seq = 2;
   ls.back()->realm.parent = 1;
 }
-
-
-ostream& operator<<(ostream &out, const mds_role_t &role)
-{
-  out << role.fscid << ":" << role.rank;
-  return out;
-}
-

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -104,7 +104,9 @@ public:
   fs_cluster_id_t fscid = FS_CLUSTER_ID_NONE;
   mds_rank_t rank = MDS_RANK_NONE;
 };
-std::ostream& operator<<(std::ostream &out, const mds_role_t &role);
+inline std::ostream& operator<<(std::ostream& out, const mds_role_t& role) {
+  return out << role.fscid << ":" << role.rank;
+}
 
 // CAPS
 inline string gcap_string(int cap)


### PR DESCRIPTION
Some of these messages are too verbose or inconsistent with other
messages.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
