### PR TITLE
test/CMakeLists: disable memstore make check test

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -537,7 +537,9 @@ if(WITH_RBD)
   endif(FREEBSD)
 endif(WITH_RBD)
 add_ceph_test(run-cli-tests ${CMAKE_CURRENT_SOURCE_DIR}/run-cli-tests)
-add_ceph_test(test_objectstore_memstore.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_objectstore_memstore.sh)
+
+# flaky, see https://tracker.ceph.com/issues/44243
+#add_ceph_test(test_objectstore_memstore.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_objectstore_memstore.sh)
 
 # flaky
 #add_ceph_test(test_pidfile.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_pidfile.sh)


### PR DESCRIPTION
This is flaky, with frequent failures like

[ RUN      ] ObjectStore/StoreTest.CompressionTest/0
2020-02-21T19:06:13.940+0000 7f5cdErrors while running CTest
Build step 'Execute shell' marked build as failure

Tracked by https://tracker.ceph.com/issues/44243

Signed-off-by: Sage Weil <sage@redhat.com>