### PR TITLE
mds : enable fragmentation of stray dir when conditions are met

### DIFF
--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -392,11 +392,13 @@ public:
   void merge(const std::vector<CDir*>& subs, MDSContext::vec& waiters, bool replay);
 
   bool should_split() const {
-    return (int)get_frag_size() > g_conf()->mds_bal_split_size;
+    return g_conf()->mds_bal_split_size > 0 &&
+           (int)get_frag_size() > g_conf()->mds_bal_split_size;
   }
   bool should_split_fast() const;
   bool should_merge() const {
-    return (int)get_frag_size() < g_conf()->mds_bal_merge_size;
+    return get_frag() != frag_t() &&
+	   (int)get_frag_size() < g_conf()->mds_bal_merge_size;
   }
 
   mds_authority_t authority() const override;

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -1154,7 +1154,7 @@ void MDBalancer::maybe_fragment(CDir *dir, bool hot)
       !dir->inode->is_stray()) { // not straydir
 
     // split
-    if (g_conf()->mds_bal_split_size > 0 && (dir->should_split() || hot)) {
+    if (dir->should_split() || hot) {
       if (split_pending.count(dir->dirfrag()) == 0) {
         queue_split(dir, false);
       } else {
@@ -1177,6 +1177,8 @@ void MDBalancer::maybe_fragment(CDir *dir, bool hot)
 
 void MDBalancer::hit_dir(CDir *dir, int type, int who, double amount)
 {
+  if (dir->inode->is_stray())
+    return;
   // hit me
   double v = dir->pop_me.get(type).hit(amount);
 

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -58,6 +58,9 @@ public:
 
   void queue_split(const CDir *dir, bool fast);
   void queue_merge(CDir *dir);
+  bool is_fragment_pending(dirfrag_t df) {
+    return split_pending.count(df) || merge_pending.count(df);
+  }
 
   /**
    * Based on size and configuration, decide whether to issue a queue_split

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -794,25 +794,6 @@ CDir *MDCache::get_stray_dir(CInode *in)
   return straydir;
 }
 
-CDentry *MDCache::get_or_create_stray_dentry(CInode *in)
-{
-  CDir *straydir = get_stray_dir(in);
-  string straydname;
-  in->name_stray_dentry(straydname);
-  CDentry *straydn = straydir->lookup(straydname);
-  if (!straydn) {
-    straydn = straydir->add_null_dentry(straydname);
-    straydn->mark_new();
-  } else {
-    ceph_assert(straydn->get_projected_linkage()->is_null());
-  }
-
-  straydn->state_set(CDentry::STATE_STRAY);
-  return straydn;
-}
-
-
-
 MDSCacheObject *MDCache::get_object(const MDSCacheObjectInfo &info)
 {
   // inode?
@@ -10813,6 +10794,7 @@ void MDCache::decode_replica_inode(CInode *&in, bufferlist::const_iterator& p, C
  
 void MDCache::encode_replica_stray(CDentry *straydn, mds_rank_t who, bufferlist& bl)
 {
+  ceph_assert(straydn->get_num_auth_pins());
   ENCODE_START(1, 1, bl);
   uint64_t features = mds->mdsmap->get_up_features();
   encode_replica_inode(get_myin(), who, bl, features);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -213,9 +213,7 @@ class MDCache {
     return cache_size() > cache_memory_limit*cache_health_threshold;
   }
 
-  void advance_stray() {
-    stray_index = (stray_index+1)%NUM_STRAY;
-  }
+  void advance_stray();
 
   /**
    * Call this when you know that a CDentry is ready to be passed
@@ -1112,6 +1110,7 @@ class MDCache {
   bool readonly = false;
 
   int stray_index = 0;
+  int stray_fragmenting_index = -1;
 
   set<CInode*> base_inodes;
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -760,7 +760,6 @@ class MDCache {
 
   void open_foreign_mdsdir(inodeno_t ino, MDSContext *c);
   CDir *get_stray_dir(CInode *in);
-  CDentry *get_or_create_stray_dentry(CInode *in);
 
   /**
    * Find the given dentry (and whether it exists or not), its ancestors,

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -554,8 +554,6 @@ void MDLog::_prepare_new_segment()
   logger->set(l_mdl_seg, segments.size());
 
   // Adjust to next stray dir
-  dout(10) << "Advancing to next stray directory on mds " << mds->get_nodeid() 
-	   << dendl;
   mds->mdcache->advance_stray();
 }
 

--- a/src/mds/StrayManager.h
+++ b/src/mds/StrayManager.h
@@ -103,7 +103,7 @@ protected:
   friend class StrayManagerContext;
 
   friend class C_StraysFetched;
-  friend class C_OpenSnapParents;
+  friend class C_RetryEnqueue;
   friend class C_PurgeStrayLogged;
   friend class C_TruncateStrayLogged;
   friend class C_IO_PurgeStrayPurged;


### PR DESCRIPTION
    when select a stray, fragment a stray that meets the criteria at the same time

Signed-off-by: Simon Gao <simon29rock@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
