### PR TITLE
mgr/cephadm: upgrade: handle stopped daemons

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -700,7 +700,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                     r = json.loads(''.join(out))
                     if r.get('image_id') != target_id:
                         self.log.info('Upgrade: image %s pull on %s got new image %s (not %s), restarting' % (target_name, d.hostname, r['image_id'], target_id))
-                        self.upgrade_state['image_id'] = r['image_id']
+                        self.upgrade_state['target_id'] = r['image_id']
                         self._save_upgrade_state()
                         return None
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -706,6 +706,10 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
 
                 self._update_upgrade_progress(done / len(daemons))
 
+                if d.status <= 0:
+                    if d.container_image_name == target_name:
+                        self.log.debug('daemon %s is stopped but has correct image name' % (d.name()))
+                        continue
                 if not self._wait_for_ok_to_stop(d):
                     return None
                 self.log.info('Upgrade: Redeploying %s.%s' %


### PR DESCRIPTION
A stopped daemon should have the correct target_name, and we should ensure
that the host has an up-to-date image, so that when it does start it
comes up with the new image.  If it has an old image name, we should
redeploy as per usual.

Signed-off-by: Sage Weil <sage@redhat.com>