### PR TITLE
mount.ceph: new mount option alias -- translate "fs=" option to "mds_namespace="

### DIFF
--- a/doc/cephfs/mount-using-kernel-driver.rst
+++ b/doc/cephfs/mount-using-kernel-driver.rst
@@ -92,9 +92,9 @@ To mount a subtree of the CephFS root, append the path to the device string::
     mount -t ceph :/subvolume/dir1/dir2 /mnt/mycephfs -o name=fs
 
 If you have more than one file system on your Ceph cluster, you can mount the
-non-default FS on your local FS as follows::
+non-default FS as follows::
 
-    mount -t ceph :/ /mnt/mycephfs2 -o name=fs,mds_namespace=mycephfs2
+    mount -t ceph :/ /mnt/mycephfs2 -o name=fs,fs=mycephfs2
 
 Unmounting CephFS
 =================

--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -61,9 +61,12 @@ Basic
     for autodiscovery of monitor addresses and auth secrets. The default is
     to use the standard search path for ceph.conf files.
 
-:command:`mds_namespace=<fs-name>`
+:command: `fs=<fs-name>`
     Specify the non-default file system to be mounted. Not passing this
     option mounts the default file system.
+
+:command: `mds_namespace=<fs-name>`
+    A synonym of "fs=" and its use is deprecated.
 
 :command:`mount_timeout`
     int (seconds), Default: 60

--- a/doc/start/quick-cephfs.rst
+++ b/doc/start/quick-cephfs.rst
@@ -164,9 +164,9 @@ by the mount.ceph helper program::
     sudo mount -t ceph {ip-address-of-MON}:{port-number-of-MON}:{path-to-be-mounted} -o name={user-name},secret={secret-key} {mount-point}
 
 If you have multiple file systems on your cluster you would need to pass
-``mds_namespace={fs-name}`` option to ``-o`` option to the ``mount`` command::
+``fs={fs-name}`` option to ``-o`` option to the ``mount`` command::
 
-    sudo mount -t ceph :/ /mnt/kcephfs2 -o name=admin,mds_namespace=mycephfs2
+    sudo mount -t ceph :/ /mnt/kcephfs2 -o name=admin,fs=mycephfs2
 
 Refer `mount.ceph man page`_ and `Mount CephFS using Kernel Driver`_ to read
 more about this.

--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -268,6 +268,13 @@ static int parse_options(const char *data, struct ceph_mount_info *cmi)
 			/* ignore */
 		} else if (strcmp(data, "nofail") == 0) {
 			/* ignore */
+		} else if (strcmp(data, "fs") == 0) {
+			if (!value || !*value) {
+				fprintf(stderr, "mount option fs requires a value.\n");
+				return -EINVAL;
+			}
+			data = "mds_namespace";
+			skip = false;
 		} else if (strcmp(data, "secretfile") == 0) {
 			int ret;
 


### PR DESCRIPTION
Use 'fs=<fs-name>' instead to make it cleaner.

Fixes: https://tracker.ceph.com/issues/44214
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
