### PR TITLE
RGW:Multisite: Verify if the synced object is identical to source

### DIFF
--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -11,5 +11,6 @@ overrides:
         rgw curl low speed time: 300
         rgw md log max shards: 4
         rgw data log num shards: 4
+        rgw sync obj etag verify: true
   rgw:
     compression type: random

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1434,6 +1434,7 @@ OPTION(rgw_curl_low_speed_limit, OPT_INT) // low speed limit for certain curl ca
 OPTION(rgw_curl_low_speed_time, OPT_INT) // low speed time for certain curl calls
 OPTION(rgw_copy_obj_progress, OPT_BOOL) // should dump progress during long copy operations?
 OPTION(rgw_copy_obj_progress_every_bytes, OPT_INT) // min bytes between copy progress output
+OPTION(rgw_copy_verify_object, OPT_BOOL) // verify if the copied object is identical to source
 OPTION(rgw_obj_tombstone_cache_size, OPT_INT) // how many objects in tombstone cache, which is used in multi-zone sync to keep
                                                     // track of removed objects' mtime
 

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1434,7 +1434,7 @@ OPTION(rgw_curl_low_speed_limit, OPT_INT) // low speed limit for certain curl ca
 OPTION(rgw_curl_low_speed_time, OPT_INT) // low speed time for certain curl calls
 OPTION(rgw_copy_obj_progress, OPT_BOOL) // should dump progress during long copy operations?
 OPTION(rgw_copy_obj_progress_every_bytes, OPT_INT) // min bytes between copy progress output
-OPTION(rgw_sync_obj_integrity, OPT_BOOL) // verify if the copied object from remote is identical to source
+OPTION(rgw_sync_obj_etag_verify, OPT_BOOL) // verify if the copied object from remote is identical to source
 OPTION(rgw_obj_tombstone_cache_size, OPT_INT) // how many objects in tombstone cache, which is used in multi-zone sync to keep
                                                     // track of removed objects' mtime
 

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1434,7 +1434,7 @@ OPTION(rgw_curl_low_speed_limit, OPT_INT) // low speed limit for certain curl ca
 OPTION(rgw_curl_low_speed_time, OPT_INT) // low speed time for certain curl calls
 OPTION(rgw_copy_obj_progress, OPT_BOOL) // should dump progress during long copy operations?
 OPTION(rgw_copy_obj_progress_every_bytes, OPT_INT) // min bytes between copy progress output
-OPTION(rgw_copy_verify_object, OPT_BOOL) // verify if the copied object is identical to source
+OPTION(rgw_sync_obj_integrity, OPT_BOOL) // verify if the copied object from remote is identical to source
 OPTION(rgw_obj_tombstone_cache_size, OPT_INT) // how many objects in tombstone cache, which is used in multi-zone sync to keep
                                                     // track of removed objects' mtime
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6287,6 +6287,13 @@ std::vector<Option> get_rgw_options() {
     .set_default(1_M)
     .set_description("Send copy-object progress info after these many bytes"),
 
+    Option("rgw_copy_verify_object", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Verify if the object copied is identical to its source")
+    .set_long_description(
+        "If true, this option computes the MD5 checksum of the data which is written at the"
+	"destination and checks if it is identical to the ETAG stored in the source."),
+
     Option("rgw_obj_tombstone_cache_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(1000)
     .set_description("Max number of entries to keep in tombstone cache")

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6287,12 +6287,14 @@ std::vector<Option> get_rgw_options() {
     .set_default(1_M)
     .set_description("Send copy-object progress info after these many bytes"),
 
-    Option("rgw_copy_verify_object", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    Option("rgw_sync_obj_integrity", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
-    .set_description("Verify if the object copied is identical to its source")
+    .set_description("Verify if the object copied from remote is identical to its source")
     .set_long_description(
-        "If true, this option computes the MD5 checksum of the data which is written at the"
-	"destination and checks if it is identical to the ETAG stored in the source."),
+        "If true, this option computes the MD5 checksum of the data which is written at the "
+	"destination and checks if it is identical to the ETAG stored in the source. "
+        "It ensures integrity of the objects fetched from a remote server over HTTP including "
+        "multisite sync."),
 
     Option("rgw_obj_tombstone_cache_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(1000)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6287,7 +6287,7 @@ std::vector<Option> get_rgw_options() {
     .set_default(1_M)
     .set_description("Send copy-object progress info after these many bytes"),
 
-    Option("rgw_sync_obj_integrity", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    Option("rgw_sync_obj_etag_verify", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .set_description("Verify if the object copied from remote is identical to its source")
     .set_long_description(

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -61,6 +61,7 @@ set(librgw_common_srcs
   rgw_cache.cc
   rgw_common.cc
   rgw_compression.cc
+  rgw_etag_verifier.cc
   rgw_cors.cc
   rgw_cors_s3.cc
   rgw_dencoder.cc

--- a/src/rgw/rgw_etag_verifier.cc
+++ b/src/rgw/rgw_etag_verifier.cc
@@ -1,0 +1,111 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#include "rgw_etag_verifier.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+int RGWPutObj_ETagVerifier_Atomic::process(bufferlist&& in, uint64_t logical_offset)
+{
+  bufferlist out;
+  if (in.length() > 0)
+    hash.Update((const unsigned char *)in.c_str(), in.length());
+
+  return Pipe::process(std::move(in), logical_offset);
+}
+
+void RGWPutObj_ETagVerifier_Atomic::calculate_etag()
+{
+  unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
+  char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
+
+  /* Return early if ETag has already been calculated */
+  if (!calculated_etag.empty())
+    return;
+
+  hash.Final(m);
+  buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
+  ldout(cct, 20) << "Single part object: " << " etag:" << calculated_etag
+          << dendl;
+  calculated_etag = calc_md5;
+}
+
+void RGWPutObj_ETagVerifier_MPU::process_end_of_MPU_part(bufferlist in)
+{
+  unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
+  char calc_md5_part[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
+  std::string calculated_etag_part;
+
+  hash.Final(m);
+  mpu_etag_hash.Update((const unsigned char *)m, sizeof(m));
+  hash.Restart();
+
+  /* Debugging begin */
+  buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5_part);
+  calculated_etag_part = calc_md5_part;
+  ldout(cct, 20) << "Part etag: " << calculated_etag_part << dendl;
+  /* Debugging end */
+
+  cur_part_index++;
+  next_part_index++;
+}
+
+int RGWPutObj_ETagVerifier_MPU::process(bufferlist&& in, uint64_t logical_offset)
+{
+  uint64_t bl_end = in.length() + logical_offset;
+
+  /* Handle the last MPU part */
+  if (next_part_index == part_ofs.size()) {
+    hash.Update((const unsigned char *)in.c_str(), in.length());
+    goto done;
+  }
+
+  /* Incoming bufferlist spans two MPU parts. Calculate separate ETags */
+  if (bl_end > part_ofs[next_part_index]) {
+
+    uint64_t part_one_len = part_ofs[next_part_index] - logical_offset;
+    hash.Update((const unsigned char *)in.c_str(), part_one_len);
+    process_end_of_MPU_part(in);
+
+    hash.Update((const unsigned char *)in.c_str() + part_one_len,
+      bl_end - part_ofs[cur_part_index]);
+    /*
+     * If we've moved to the last part of the MPU, avoid usage of
+     * parts_ofs[next_part_index] as it will lead to our-of-range access.
+     */
+    if (next_part_index == part_ofs.size())
+      goto done;
+  } else {
+    hash.Update((const unsigned char *)in.c_str(), in.length());
+  }
+
+  /* Update the MPU Etag if the current part has ended */
+  if (logical_offset + in.length() + 1 == part_ofs[next_part_index])
+    process_end_of_MPU_part(in);
+
+done:
+  return Pipe::process(std::move(in), logical_offset);
+}
+
+void RGWPutObj_ETagVerifier_MPU::calculate_etag()
+{
+  unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE], mpu_m[CEPH_CRYPTO_MD5_DIGESTSIZE];
+  char final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 16];
+
+  /* Return early if ETag has already been calculated */
+  if (!calculated_etag.empty())
+    return;
+
+  hash.Final(m);
+  mpu_etag_hash.Update((const unsigned char *)m, sizeof(m));
+
+  /* Refer RGWCompleteMultipart::execute() for ETag calculation for MPU object */
+  mpu_etag_hash.Final(mpu_m);
+  buf_to_hex(mpu_m, CEPH_CRYPTO_MD5_DIGESTSIZE, final_etag_str);
+  snprintf(&final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2],
+           sizeof(final_etag_str) - CEPH_CRYPTO_MD5_DIGESTSIZE * 2,
+           "-%lld", (long long)(part_ofs.size()));
+
+  ldout(cct, 20) << "MPU calculated ETag:" << calculated_etag << dendl;
+  calculated_etag = final_etag_str;
+}

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -18,6 +18,12 @@
 #include "rgw_putobj.h"
 #include "rgw_op.h"
 
+enum SourceObjType {
+  OBJ_TYPE_UNINIT, /* Object type is not initialised yet */
+  OBJ_TYPE_ATOMIC,
+  OBJ_TYPE_MPU, /* Object at source was created through MPU */
+};
+
 class RGWPutObj_ETagVerifier : public rgw::putobj::Pipe
 {
 protected:

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -1,0 +1,68 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * RGW Etag Verifier is an RGW filter which enables the objects copied using
+ * multisite sync to be verified using their ETag from source i.e. the MD5
+ * checksum of the object is computed at the destination and is verified to be
+ * identical to the ETag stored in the object HEAD at source cluster.
+ * 
+ * For MPU objects, a different filter named RGWMultipartEtagFilter is applied
+ * which re-computes ETag using RGWObjManifest. This computes the ETag using the
+ * same algorithm used at the source cluster i.e. MD5 sum of the individual ETag
+ * on the MPU parts.
+ */
+#ifndef CEPH_RGW_ETAG_VERIFIER_H
+#define CEPH_RGW_ETAG_VERIFIER_H
+
+#include "rgw_putobj.h"
+#include "rgw_op.h"
+
+class RGWPutObj_ETagVerifier : public rgw::putobj::Pipe
+{
+protected:
+  CephContext* cct;
+  MD5 hash;
+  string calculated_etag;
+
+public:
+  RGWPutObj_ETagVerifier(CephContext* cct_, rgw::putobj::DataProcessor *next)
+    : Pipe(next), cct(cct_) {}
+
+  virtual void calculate_etag() = 0;
+  string get_calculated_etag() { return calculated_etag;}
+  virtual void append_part_ofs(uint64_t ofs) = 0;
+
+}; /* RGWPutObj_ETagVerifier */
+
+class RGWPutObj_ETagVerifier_Atomic : public RGWPutObj_ETagVerifier
+{
+public:
+  RGWPutObj_ETagVerifier_Atomic(CephContext* cct_, rgw::putobj::DataProcessor *next)
+    : RGWPutObj_ETagVerifier(cct_, next) {}
+
+  int process(bufferlist&& data, uint64_t logical_offset) override;
+  void calculate_etag() override;
+  void append_part_ofs(uint64_t ofs) override {}
+
+}; /* RGWPutObj_ETagVerifier_Atomic */
+
+class RGWPutObj_ETagVerifier_MPU : public RGWPutObj_ETagVerifier
+{
+  std::vector<uint64_t> part_ofs;
+  int cur_part_index{0}, next_part_index{1};
+  MD5 mpu_etag_hash;
+ 
+  void process_end_of_MPU_part(bufferlist in);
+
+public:
+  RGWPutObj_ETagVerifier_MPU(CephContext* cct_, rgw::putobj::DataProcessor *next)
+    : RGWPutObj_ETagVerifier(cct_, next) {}
+
+  int process(bufferlist&& data, uint64_t logical_offset) override;
+  void calculate_etag() override;
+  void append_part_ofs(uint64_t ofs) override { part_ofs.emplace_back(ofs); }
+
+}; /* RGWPutObj_ETagVerifier_MPU */
+
+#endif /* CEPH_RGW_ETAG_VERIFIER_H */

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -31,7 +31,6 @@ public:
 
   virtual void calculate_etag() = 0;
   string get_calculated_etag() { return calculated_etag;}
-  virtual void append_part_ofs(uint64_t ofs) = 0;
 
 }; /* RGWPutObj_ETagVerifier */
 
@@ -43,7 +42,6 @@ public:
 
   int process(bufferlist&& data, uint64_t logical_offset) override;
   void calculate_etag() override;
-  void append_part_ofs(uint64_t ofs) override {}
 
 }; /* RGWPutObj_ETagVerifier_Atomic */
 
@@ -53,7 +51,7 @@ class RGWPutObj_ETagVerifier_MPU : public RGWPutObj_ETagVerifier
   int cur_part_index{0}, next_part_index{1};
   MD5 mpu_etag_hash;
  
-  void process_end_of_MPU_part(bufferlist in);
+  void process_end_of_MPU_part();
 
 public:
   RGWPutObj_ETagVerifier_MPU(CephContext* cct_, rgw::putobj::DataProcessor *next)
@@ -61,7 +59,7 @@ public:
 
   int process(bufferlist&& data, uint64_t logical_offset) override;
   void calculate_etag() override;
-  void append_part_ofs(uint64_t ofs) override { part_ofs.emplace_back(ofs); }
+  void append_part_ofs(uint64_t ofs) { part_ofs.emplace_back(ofs); }
 
 }; /* RGWPutObj_ETagVerifier_MPU */
 

--- a/src/rgw/rgw_obj_manifest.h
+++ b/src/rgw/rgw_obj_manifest.h
@@ -466,6 +466,10 @@ public:
       return location;
     }
 
+    int get_cur_part_id() const {
+      return cur_part_id;
+    }
+
     /* start of current stripe */
     uint64_t get_stripe_ofs() {
       if (manifest->explicit_objs) {

--- a/src/rgw/rgw_obj_manifest.h
+++ b/src/rgw/rgw_obj_manifest.h
@@ -466,8 +466,9 @@ public:
       return location;
     }
 
-    int get_cur_part_id() const {
-      return cur_part_id;
+    /* where current part starts */
+    uint64_t get_part_ofs() const {
+      return part_ofs;
     }
 
     /* start of current stripe */

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3254,7 +3254,7 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   rgw::putobj::ObjectProcessor *processor;
   void (*progress_cb)(off_t, void *);
   void *progress_data;
-  bufferlist extra_data_bl, full_obj;
+  bufferlist extra_data_bl, full_obj, manifest_bl;
   uint64_t extra_data_left{0};
   bool need_to_process_attrs{true};
   uint64_t data_len{0};
@@ -3291,7 +3291,8 @@ public:
       JSONDecoder::decode_json("attrs", src_attrs, &jp);
 
       src_attrs.erase(RGW_ATTR_COMPRESSION);
-      src_attrs.erase(RGW_ATTR_MANIFEST); // not interested in original object layout
+      /* We need the manifest to recompute the ETag for verification */
+      manifest_bl = src_attrs[RGW_ATTR_MANIFEST];
 
       // filter out olh attributes
       auto iter = src_attrs.lower_bound(RGW_ATTR_OLH_PREFIX);
@@ -3389,15 +3390,84 @@ public:
   }
 
   string get_calculated_etag() {
-    MD5 hash;
-    unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
+    MD5 hash, mpu_etag_hash;
+    unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE], mpu_m[CEPH_CRYPTO_MD5_DIGESTSIZE];
     char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
+    char calc_md5_part[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
+    char final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 16];
+    RGWObjManifest manifest;
+    std::string calculated_etag_part;
+    int prev_part_id = 1, cur_part_id = 1;
 
-    hash.Update((const unsigned char *)full_obj.c_str(), data_len);
+    auto miter = manifest_bl.cbegin();
+    try {
+      decode(manifest, miter);
+    } catch (buffer::error& err) {
+      ldout(cct, 0) << "ERROR: couldn't decode manifest" << dendl;
+      return std::string();
+    }
+    RGWObjManifest::obj_iterator mi;
+
+    RGWObjManifestRule rule;
+    bool found = manifest.get_rule(0, &rule);
+    if (!found) {
+      lderr(cct) << "ERROR: manifest->get_rule() could not find rule" << dendl;
+      return std::string();
+    }
+
+    /*
+     * Check if the object was created using multipart upload. This check is
+     * required as MPU objects' ETag != MD5sum.
+     */
+    if (rule.part_size == 0) {
+      hash.Update((const unsigned char *)full_obj.c_str(), data_len);
+      hash.Final(m);
+      buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
+      calculated_etag = calc_md5;
+      ldout(cct, 20) << "Single part object: " << manifest.get_obj().get_oid() <<
+	      " size:" << manifest.get_obj_size() << " etag:" <<
+	      calculated_etag << dendl;
+      return calculated_etag;
+    }
+
+    for (mi = manifest.obj_begin(); mi != manifest.obj_end(); ++mi) {
+      bufferlist obj_stripe;
+
+      cur_part_id = mi.get_cur_part_id();
+      if (cur_part_id != prev_part_id) {
+        hash.Final(m);
+        mpu_etag_hash.Update((const unsigned char *)m, sizeof(m));
+	hash.Restart();
+        buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5_part);
+        calculated_etag_part = calc_md5_part;
+        ldout(cct, 20) << "Part " << prev_part_id << " etag: " <<
+	       calculated_etag_part << dendl;
+	prev_part_id = cur_part_id;
+      }
+      full_obj.splice(0, mi.get_stripe_size(), &obj_stripe);
+      hash.Update((const unsigned char *)obj_stripe.c_str(), mi.get_stripe_size());
+    }
+
     hash.Final(m);
-    buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
-    calculated_etag = calc_md5;
+    mpu_etag_hash.Update((const unsigned char *)m, sizeof(m));
+
+    buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5_part);
+    calculated_etag_part = calc_md5_part;
+    ldout(cct, 20) << "Part " << prev_part_id << " etag: " << calculated_etag_part << dendl;
+
+    /* Refer RGWCompleteMultipart::execute() for ETag calculation for MPU object */
+    mpu_etag_hash.Final(mpu_m);
+    buf_to_hex(mpu_m, CEPH_CRYPTO_MD5_DIGESTSIZE, final_etag_str);
+    snprintf(&final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2],
+	     sizeof(final_etag_str) - CEPH_CRYPTO_MD5_DIGESTSIZE * 2,
+             "-%lld", (long long)(mi.get_cur_part_id() - 1));
+    calculated_etag = final_etag_str;
+
+    ldout(cct, 20) << "MPU calculated ETag:"<< calculated_etag << " Object:" <<
+	   manifest.get_obj().get_oid() <<
+	   " size:" << manifest.get_obj_size() << dendl;
     return calculated_etag;
+
   }
 };
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3294,10 +3294,14 @@ public:
 
       src_attrs.erase(RGW_ATTR_COMPRESSION);
       /* We need the manifest to recompute the ETag for verification */
-      manifest_bl = src_attrs[RGW_ATTR_MANIFEST];
+      auto iter = src_attrs.find(RGW_ATTR_MANIFEST);
+      if (iter != src_attrs.end()) {
+        manifest_bl = std::move(iter->second);
+        src_attrs.erase(iter);
+      }
 
       // filter out olh attributes
-      auto iter = src_attrs.lower_bound(RGW_ATTR_OLH_PREFIX);
+      iter = src_attrs.lower_bound(RGW_ATTR_OLH_PREFIX);
       while (iter != src_attrs.end()) {
         if (!boost::algorithm::starts_with(iter->first, RGW_ATTR_OLH_PREFIX)) {
           break;
@@ -3323,11 +3327,11 @@ public:
     }
 
     /*
-     * Presently we don't support ETag based verification if compression or
-     * encryption is requested. We can enable simultaneous support once we have
-     * a mechanism to know the sequence in which the filters must be applied.
+     * Presently we don't support ETag based verification if encryption is
+     * requested. We can enable simultaneous support once we have a mechanism
+     * to know the sequence in which the filters must be applied.
      */
-    if (cct->_conf->rgw_copy_verify_object && !plugin &&
+    if (cct->_conf->rgw_sync_obj_integrity &&
         src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
 
       RGWObjManifest manifest;
@@ -3354,8 +3358,6 @@ public:
       } else {
         is_mpu_obj = true;
         etag_verifier_mpu = boost::in_place(cct, filter);
-
-        RGWObjManifest::obj_iterator mi;
         uint64_t cur_part_ofs = UINT64_MAX;
 
         /*
@@ -3363,7 +3365,7 @@ public:
          * MPU part. These part ETags then become the input for the MPU object
          * Etag.
          */
-        for (mi = manifest.obj_begin(); mi != manifest.obj_end(); ++mi) {
+        for (auto mi = manifest.obj_begin(); mi != manifest.obj_end(); ++mi) {
           if (cur_part_ofs == mi.get_part_ofs())
             continue;
           cur_part_ofs = mi.get_part_ofs();
@@ -3442,6 +3444,9 @@ public:
   }
 
   string get_calculated_etag() {
+    if (!cct->_conf->rgw_sync_obj_integrity)
+      return "";
+
     if (is_mpu_obj) {
       etag_verifier_mpu->calculate_etag();
       return etag_verifier_mpu->get_calculated_etag();
@@ -4003,6 +4008,21 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     set_mtime_weight.init(set_mtime, svc.zone->get_zone_short_id(), pg_ver);
   }
 
+  if (cct->_conf->rgw_sync_obj_integrity) {
+    string trimmed_etag = etag;
+
+    /* Remove the leading and trailing double quotes from etag */
+    trimmed_etag.erase(std::remove(trimmed_etag.begin(), trimmed_etag.end(),'\"'),
+      trimmed_etag.end());
+
+    if (cb.get_calculated_etag().compare(trimmed_etag)) {
+      ret = -EIO;
+      ldout(cct, 0) << "ERROR: source and destination objects don't match. Expected etag:"
+        << trimmed_etag << " Computed etag:" << cb.get_calculated_etag() << dendl;
+      goto set_err_state;
+    }
+  }
+
 #define MAX_COMPLETE_RETRY 100
   for (i = 0; i < MAX_COMPLETE_RETRY; i++) {
     bool canceled = false;
@@ -4012,21 +4032,6 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     if (ret < 0) {
       goto set_err_state;
     }
-
-    if (cct->_conf->rgw_copy_verify_object) {
-      string trimmed_etag = etag;
-
-      /* Remove the leading and trailing double quotes from etag */
-      trimmed_etag.erase(std::remove(trimmed_etag.begin(), trimmed_etag.end(),'\"'),
-        trimmed_etag.end());
-
-      if (cb.get_calculated_etag().compare(trimmed_etag)) {
-        ret = -EIO;
-        ldout(cct, 0) << "ERROR: source and destination objects don't match. Expected etag:"
-          << trimmed_etag << " Computed etag:" << cb.get_calculated_etag() << dendl;
-        goto set_err_state;
-     }
-   }
 
     if (copy_if_newer && canceled) {
       ldout(cct, 20) << "raced with another write of obj: " << dest_obj << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3456,6 +3456,10 @@ public:
       return "";
     }
   }
+
+  SourceObjType get_obj_type() {
+    return obj_type;
+  }
 };
 
 /*
@@ -4009,7 +4013,8 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     set_mtime_weight.init(set_mtime, svc.zone->get_zone_short_id(), pg_ver);
   }
 
-  if (cct->_conf->rgw_sync_obj_etag_verify) {
+  /* Perform ETag verification is we have computed the object's MD5 sum at our end */
+  if (cb.get_obj_type() != OBJ_TYPE_UNINIT) {
     string trimmed_etag = etag;
 
     /* Remove the leading and trailing double quotes from etag */

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3259,7 +3259,8 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   void *progress_data;
   bufferlist extra_data_bl, manifest_bl;
   uint64_t extra_data_left{0};
-  bool need_to_process_attrs{true}, is_mpu_obj{false};
+  bool need_to_process_attrs{true};
+  SourceObjType obj_type{OBJ_TYPE_UNINIT};
   uint64_t data_len{0};
   map<string, bufferlist> src_attrs;
   uint64_t ofs{0};
@@ -3353,10 +3354,11 @@ public:
 
       if (rule.part_size == 0) {
         /* Atomic object */
+        obj_type = OBJ_TYPE_ATOMIC;
         etag_verifier_atomic = boost::in_place(cct, filter);
         filter = &*etag_verifier_atomic;
       } else {
-        is_mpu_obj = true;
+        obj_type = OBJ_TYPE_MPU;
         etag_verifier_mpu = boost::in_place(cct, filter);
         uint64_t cur_part_ofs = UINT64_MAX;
 
@@ -3444,15 +3446,14 @@ public:
   }
 
   string get_calculated_etag() {
-    if (!cct->_conf->rgw_sync_obj_etag_verify)
-      return "";
-
-    if (is_mpu_obj) {
+    if (obj_type == OBJ_TYPE_ATOMIC) {
+      etag_verifier_atomic->calculate_etag();
+      return etag_verifier_atomic->get_calculated_etag();
+    } else if (obj_type == OBJ_TYPE_MPU) {
       etag_verifier_mpu->calculate_etag();
       return etag_verifier_mpu->get_calculated_etag();
     } else {
-      etag_verifier_atomic->calculate_etag();
-      return etag_verifier_atomic->get_calculated_etag();
+      return "";
     }
   }
 };

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3331,7 +3331,7 @@ public:
      * requested. We can enable simultaneous support once we have a mechanism
      * to know the sequence in which the filters must be applied.
      */
-    if (cct->_conf->rgw_sync_obj_integrity &&
+    if (cct->_conf->rgw_sync_obj_etag_verify &&
         src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
 
       RGWObjManifest manifest;
@@ -3444,7 +3444,7 @@ public:
   }
 
   string get_calculated_etag() {
-    if (!cct->_conf->rgw_sync_obj_integrity)
+    if (!cct->_conf->rgw_sync_obj_etag_verify)
       return "";
 
     if (is_mpu_obj) {
@@ -4008,7 +4008,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     set_mtime_weight.init(set_mtime, svc.zone->get_zone_short_id(), pg_ver);
   }
 
-  if (cct->_conf->rgw_sync_obj_integrity) {
+  if (cct->_conf->rgw_sync_obj_etag_verify) {
     string trimmed_etag = etag;
 
     /* Remove the leading and trailing double quotes from etag */

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -43,6 +43,7 @@
 #include "rgw_tools.h"
 #include "rgw_coroutine.h"
 #include "rgw_compression.h"
+#include "rgw_etag_verifier.h"
 #include "rgw_worker.h"
 
 #undef fork // fails to compile RGWPeriod::fork() below
@@ -3249,20 +3250,21 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   rgw_obj obj;
   rgw::putobj::DataProcessor *filter;
   boost::optional<RGWPutObj_Compress>& compressor;
+  boost::optional<RGWPutObj_ETagVerifier_Atomic> etag_verifier_atomic;
+  boost::optional<RGWPutObj_ETagVerifier_MPU> etag_verifier_mpu;
   boost::optional<rgw::putobj::ChunkProcessor> buffering;
   CompressorRef& plugin;
   rgw::putobj::ObjectProcessor *processor;
   void (*progress_cb)(off_t, void *);
   void *progress_data;
-  bufferlist extra_data_bl, full_obj, manifest_bl;
+  bufferlist extra_data_bl, manifest_bl;
   uint64_t extra_data_left{0};
-  bool need_to_process_attrs{true};
+  bool need_to_process_attrs{true}, is_mpu_obj{false};
   uint64_t data_len{0};
   map<string, bufferlist> src_attrs;
   uint64_t ofs{0};
   uint64_t lofs{0}; /* logical ofs */
   std::function<int(map<string, bufferlist>&)> attrs_handler;
-  string calculated_etag;
 public:
   RGWRadosPutObj(CephContext* cct,
                  CompressorRef& plugin,
@@ -3320,6 +3322,58 @@ public:
       filter = &*buffering;
     }
 
+    /*
+     * Presently we don't support ETag based verification if compression or
+     * encryption is requested. We can enable simultaneous support once we have
+     * a mechanism to know the sequence in which the filters must be applied.
+     */
+    if (cct->_conf->rgw_copy_verify_object && !plugin &&
+        src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
+
+      RGWObjManifest manifest;
+
+      auto miter = manifest_bl.cbegin();
+      try {
+        decode(manifest, miter);
+      } catch (buffer::error& err) {
+        ldout(cct, 0) << "ERROR: couldn't decode manifest" << dendl;
+        return -EIO;
+      }
+
+      RGWObjManifestRule rule;
+      bool found = manifest.get_rule(0, &rule);
+      if (!found) {
+        lderr(cct) << "ERROR: manifest->get_rule() could not find rule" << dendl;
+        return -EIO;
+      }
+
+      if (rule.part_size == 0) {
+        /* Atomic object */
+        etag_verifier_atomic = boost::in_place(cct, filter);
+        filter = &*etag_verifier_atomic;
+      } else {
+        is_mpu_obj = true;
+        etag_verifier_mpu = boost::in_place(cct, filter);
+
+        RGWObjManifest::obj_iterator mi;
+        uint64_t cur_part_ofs = UINT64_MAX;
+
+        /*
+         * We must store the offset of each part to calculate the ETAGs for each
+         * MPU part. These part ETags then become the input for the MPU object
+         * Etag.
+         */
+        for (mi = manifest.obj_begin(); mi != manifest.obj_end(); ++mi) {
+          if (cur_part_ofs == mi.get_part_ofs())
+            continue;
+          cur_part_ofs = mi.get_part_ofs();
+          ldout(cct, 20) << "MPU Part offset:" << cur_part_ofs << dendl;
+          etag_verifier_mpu->append_part_ofs(cur_part_ofs);
+        }
+        filter = &*etag_verifier_mpu;
+      }
+    }
+
     need_to_process_attrs = false;
 
     return 0;
@@ -3366,8 +3420,6 @@ public:
 
     const uint64_t lofs = data_len;
     data_len += size;
-    if (cct->_conf->rgw_copy_verify_object)
-      full_obj.append(bl);
 
     return filter->process(std::move(bl), lofs);
   }
@@ -3390,84 +3442,13 @@ public:
   }
 
   string get_calculated_etag() {
-    MD5 hash, mpu_etag_hash;
-    unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE], mpu_m[CEPH_CRYPTO_MD5_DIGESTSIZE];
-    char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
-    char calc_md5_part[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
-    char final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 16];
-    RGWObjManifest manifest;
-    std::string calculated_etag_part;
-    int prev_part_id = 1, cur_part_id = 1;
-
-    auto miter = manifest_bl.cbegin();
-    try {
-      decode(manifest, miter);
-    } catch (buffer::error& err) {
-      ldout(cct, 0) << "ERROR: couldn't decode manifest" << dendl;
-      return std::string();
+    if (is_mpu_obj) {
+      etag_verifier_mpu->calculate_etag();
+      return etag_verifier_mpu->get_calculated_etag();
+    } else {
+      etag_verifier_atomic->calculate_etag();
+      return etag_verifier_atomic->get_calculated_etag();
     }
-    RGWObjManifest::obj_iterator mi;
-
-    RGWObjManifestRule rule;
-    bool found = manifest.get_rule(0, &rule);
-    if (!found) {
-      lderr(cct) << "ERROR: manifest->get_rule() could not find rule" << dendl;
-      return std::string();
-    }
-
-    /*
-     * Check if the object was created using multipart upload. This check is
-     * required as MPU objects' ETag != MD5sum.
-     */
-    if (rule.part_size == 0) {
-      hash.Update((const unsigned char *)full_obj.c_str(), data_len);
-      hash.Final(m);
-      buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
-      calculated_etag = calc_md5;
-      ldout(cct, 20) << "Single part object: " << manifest.get_obj().get_oid() <<
-	      " size:" << manifest.get_obj_size() << " etag:" <<
-	      calculated_etag << dendl;
-      return calculated_etag;
-    }
-
-    for (mi = manifest.obj_begin(); mi != manifest.obj_end(); ++mi) {
-      bufferlist obj_stripe;
-
-      cur_part_id = mi.get_cur_part_id();
-      if (cur_part_id != prev_part_id) {
-        hash.Final(m);
-        mpu_etag_hash.Update((const unsigned char *)m, sizeof(m));
-	hash.Restart();
-        buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5_part);
-        calculated_etag_part = calc_md5_part;
-        ldout(cct, 20) << "Part " << prev_part_id << " etag: " <<
-	       calculated_etag_part << dendl;
-	prev_part_id = cur_part_id;
-      }
-      full_obj.splice(0, mi.get_stripe_size(), &obj_stripe);
-      hash.Update((const unsigned char *)obj_stripe.c_str(), mi.get_stripe_size());
-    }
-
-    hash.Final(m);
-    mpu_etag_hash.Update((const unsigned char *)m, sizeof(m));
-
-    buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5_part);
-    calculated_etag_part = calc_md5_part;
-    ldout(cct, 20) << "Part " << prev_part_id << " etag: " << calculated_etag_part << dendl;
-
-    /* Refer RGWCompleteMultipart::execute() for ETag calculation for MPU object */
-    mpu_etag_hash.Final(mpu_m);
-    buf_to_hex(mpu_m, CEPH_CRYPTO_MD5_DIGESTSIZE, final_etag_str);
-    snprintf(&final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2],
-	     sizeof(final_etag_str) - CEPH_CRYPTO_MD5_DIGESTSIZE * 2,
-             "-%lld", (long long)(mi.get_cur_part_id() - 1));
-    calculated_etag = final_etag_str;
-
-    ldout(cct, 20) << "MPU calculated ETag:"<< calculated_etag << " Object:" <<
-	   manifest.get_obj().get_oid() <<
-	   " size:" << manifest.get_obj_size() << dendl;
-    return calculated_etag;
-
   }
 };
 
@@ -4033,10 +4014,16 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     }
 
     if (cct->_conf->rgw_copy_verify_object) {
-      if (cb.get_calculated_etag().compare(etag)) {
+      string trimmed_etag = etag;
+
+      /* Remove the leading and trailing double quotes from etag */
+      trimmed_etag.erase(std::remove(trimmed_etag.begin(), trimmed_etag.end(),'\"'),
+        trimmed_etag.end());
+
+      if (cb.get_calculated_etag().compare(trimmed_etag)) {
         ret = -EIO;
         ldout(cct, 0) << "ERROR: source and destination objects don't match. Expected etag:"
-          << etag << " Computed etag:" << cb.get_calculated_etag() << dendl;
+          << trimmed_etag << " Computed etag:" << cb.get_calculated_etag() << dendl;
         goto set_err_state;
      }
    }


### PR DESCRIPTION
Introduce an option 'rgw_copy_verify_object' which allows the object
copied from remote cluster through multisite sync is identical to the
source object. This is done by generating the MD5 checksum of the data
being copied and compared to the ETAG stored as part of the object's
attribute.

Signed-off-by: Prasad Krishnan <prasad.krishnan@flipkart.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
