### PR TITLE
mgr/cephadm: a few fixes around daemon and device caches

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -128,10 +128,14 @@ class HostCache():
                 self.mgr.set_store(k, None)
             try:
                 j = json.loads(v)
-                # we do ignore the persisted last_*_update to trigger a new
-                # scrape on mgr restart
+                if 'last_device_update' in j:
+                    self.last_device_update[host] = datetime.datetime.strptime(
+                        j['last_device_update'], DATEFMT)
+                else:
+                    self.device_refresh_queue.append(host)
+                # for services, we ignore the persisted last_*_update
+                # and always trigger a new scrape on mgr restart.
                 self.daemon_refresh_queue.append(host)
-                self.device_refresh_queue.append(host)
                 self.daemons[host] = {}
                 self.devices[host] = []
                 for name, d in j.get('daemons', {}).items():

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -180,6 +180,8 @@ class HostCache():
         }
         if host in self.last_daemon_update:
             j['last_daemon_update'] = self.last_daemon_update[host].strftime(DATEFMT) # type: ignore
+        if host in self.last_device_update:
+            j['last_device_update'] = self.last_device_update[host].strftime(DATEFMT) # type: ignore
         for name, dd in self.daemons[host].items():
             j['daemons'][name] = dd.to_json()  # type: ignore
         for d in self.devices[host]:


### PR DESCRIPTION
- invalidation is less racy
- device last_update persistence works
- don't refresh devices on every mgr restart