### PR TITLE
mgr/cephadm: consolidate/refactor all add_ and apply_ methods

### DIFF
--- a/doc/bootstrap.rst
+++ b/doc/bootstrap.rst
@@ -118,12 +118,12 @@ either as a simple IP address or as a CIDR network name.
 
 To deploy additional monitors,::
 
-  [monitor 1] # ceph orch apply mon *<new-num-monitors>* *<host1:network1> [<host1:network2>...]*
+  [monitor 1] # ceph orch daemon add mon *<host1:network1> [<host1:network2>...]*
 
 For example, to deploy a second monitor on ``newhost`` using an IP
 address in network ``10.1.2.0/24``,::
 
-  [monitor 1] # ceph orch apply mon 2 newhost:10.1.2.0/24
+  [monitor 1] # ceph orch daemon add mon newhost:10.1.2.0/24
 
 Deploying OSDs
 ==============

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -468,8 +468,7 @@ def ceph_mons(ctx, config):
                 log.info('Adding %s on %s' % (mon, remote.shortname))
                 num_mons += 1
                 _shell(ctx, cluster_name, remote, [
-                    'ceph', 'orch', 'apply', 'mon',
-                    str(num_mons),
+                    'ceph', 'orch', 'daemon', 'add', 'mon',
                     remote.shortname + ':' + ctx.ceph[cluster_name].mons[mon] + '=' + id_,
                 ])
                 ctx.daemons.register_daemon(

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -997,7 +997,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                 name += '.' + ''.join(random.choice(string.ascii_lowercase)
                                       for _ in range(6))
             if len([d for d in existing if d.daemon_id == name]):
-                self.log('name %s exists, trying again', name)
+                self.log.warning('name %s exists, trying again', name)
                 continue
             return name
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -982,7 +982,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         ]
         if forcename:
             if len([d for d in existing if d.daemon_id == forcename]):
-                raise RuntimeError('specified name %s already in use', forcename)
+                raise orchestrator.OrchestratorValidationError('name %s already in use', forcename)
             return forcename
 
         if '.' in host:
@@ -997,6 +997,8 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                 name += '.' + ''.join(random.choice(string.ascii_lowercase)
                                       for _ in range(6))
             if len([d for d in existing if d.daemon_id == name]):
+                if not suffix:
+                    raise orchestrator.OrchestratorValidationError('name %s already in use', name)
                 self.log.warning('name %s exists, trying again', name)
                 continue
             return name

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1350,9 +1350,13 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             self.log.exception(ex)
             raise
 
-    def _get_hosts(self):
-        # type: () -> List[str]
-        return [a for a in self.inventory.keys()]
+    def _get_hosts(self, label=None):
+        # type: (Optional[str]) -> List[str]
+        r = []
+        for h, hostspec in self.inventory.items():
+            if not label or label in hostspec.get('labels', []):
+                r.append(h)
+        return r
 
     @async_completion
     def add_host(self, spec):
@@ -2534,7 +2538,7 @@ class HostAssignment(object):
     def __init__(self,
                  spec=None,  # type: Optional[orchestrator.ServiceSpec]
                  scheduler=None,  # type: Optional[BaseScheduler]
-                 get_hosts_func=None,  # type: Optional[Callable[[],List[str]]]
+                 get_hosts_func=None,  # type: Optional[Callable[[Optional[str]],List[str]]]
                  service_type=None,  # type: Optional[str]
                  ):
         assert spec and get_hosts_func and service_type
@@ -2557,13 +2561,13 @@ class HostAssignment(object):
         """
         Assign hosts based on their label
         """
-        # Querying for labeled hosts doesn't work currently.
-        # Leaving this open for the next iteration
-        # NOTE: This currently queries for all hosts without label restriction
         if self.spec.placement.label:
-            logger.info("Found labels. Assigning hosts that match the label")
-            candidates = [HostPlacementSpec(x, '', '') for x in self.get_hosts_func()]  # TODO: query for labels
-            logger.info('Assigning hosts to spec: {}'.format(candidates))
+            logger.info("Matching label '%s'" % self.spec.placement.label)
+            candidates = [
+                HostPlacementSpec(x, '', '')
+                for x in self.get_hosts_func(self.spec.placement.label)
+            ]
+            logger.info('Assigning hostss to spec: {}'.format(candidates))
             self.spec.placement.set_hosts(candidates)
 
     def assign_hosts(self):
@@ -2576,7 +2580,7 @@ class HostAssignment(object):
         if not self.spec.placement.label and not self.spec.placement.hosts and self.spec.placement.count:
             logger.info("Found num spec. Looking for labeled hosts.")
             # TODO: actually query for labels (self.daemon_type)
-            candidates = self.scheduler.place([x for x in self.get_hosts_func()],
+            candidates = self.scheduler.place([x for x in self.get_hosts_func(None)],
                                               count=self.spec.placement.count)
             # Not enough hosts to deploy on
             if len(candidates) != self.spec.placement.count:
@@ -2588,7 +2592,7 @@ class HostAssignment(object):
                 self.spec.placement.set_hosts(candidates)
                 return None
 
-            candidates = self.scheduler.place([x for x in self.get_hosts_func()], count=self.spec.placement.count)
+            candidates = self.scheduler.place([x for x in self.get_hosts_func(None)], count=self.spec.placement.count)
             # Not enough hosts to deploy on
             if len(candidates) != self.spec.placement.count:
                 raise OrchestratorValidationError("Cannot place {} daemons on {} hosts.".

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2576,7 +2576,7 @@ class HostAssignment(object):
         if not self.spec.placement.label and not self.spec.placement.hosts and self.spec.placement.count:
             logger.info("Found num spec. Looking for labeled hosts.")
             # TODO: actually query for labels (self.daemon_type)
-            candidates = self.scheduler.place([x[0] for x in self.get_hosts_func()],
+            candidates = self.scheduler.place([x for x in self.get_hosts_func()],
                                               count=self.spec.placement.count)
             # Not enough hosts to deploy on
             if len(candidates) != self.spec.placement.count:
@@ -2588,7 +2588,7 @@ class HostAssignment(object):
                 self.spec.placement.set_hosts(candidates)
                 return None
 
-            candidates = self.scheduler.place([x[0] for x in self.get_hosts_func()], count=self.spec.placement.count)
+            candidates = self.scheduler.place([x for x in self.get_hosts_func()], count=self.spec.placement.count)
             # Not enough hosts to deploy on
             if len(candidates) != self.spec.placement.count:
                 raise OrchestratorValidationError("Cannot place {} daemons on {} hosts.".

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -213,15 +213,6 @@ class HostCache():
                 r.append(dd)
         return r
 
-    def get_daemons_by_type(self, daemon_type):
-        # type: (str) -> List[orchestrator.DaemonDescription]
-        result = []   # type: List[orchestrator.DaemonDescription]
-        for host, dm in self.daemons.items():
-            for name, d in dm.items():
-                if name.startswith(daemon_type + '.'):
-                    result.append(d)
-        return result
-
     def get_daemons_by_service(self, service_name):
         # type: (str) -> List[orchestrator.DaemonDescription]
         result = []   # type: List[orchestrator.DaemonDescription]
@@ -2172,7 +2163,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                 port = t.split(':')[1]
             # get standbys too.  assume that they are all on the same port
             # as the active.
-            for dd in self.cache.get_daemons_by_type('mgr'):
+            for dd in self.cache.get_daemons_by_service('mgr'):
                 if dd.daemon_id == self.get_mgr_id():
                     continue
                 hi = self.inventory.get(dd.hostname, None)
@@ -2182,7 +2173,7 @@ class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
 
         # scrape node exporters
         node_configs = ''
-        for dd in self.cache.get_daemons_by_type('node-exporter'):
+        for dd in self.cache.get_daemons_by_service('node-exporter'):
             hi = self.inventory.get(dd.hostname, None)
             if hi:
                 addr = hi.get('addr', dd.hostname)

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -137,12 +137,12 @@ class TestCephadm(object):
     def test_mon_update(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test:0.0.0.0=a'], count=1)
-            c = cephadm_module.apply_mon(ServiceSpec(placement=ps))
+            c = cephadm_module.add_mon(ServiceSpec(placement=ps))
             assert wait(cephadm_module, c) == ["Deployed mon.a on host 'test'"]
 
             with pytest.raises(OrchestratorError, match="is missing a network spec"):
                 ps = PlacementSpec(hosts=['test'], count=1)
-                c = cephadm_module.apply_mon(ServiceSpec(placement=ps))
+                c = cephadm_module.add_mon(ServiceSpec(placement=ps))
                 wait(cephadm_module, c)
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -266,8 +266,8 @@ class TestCephadm(object):
                 assert len(r) == 2
 
                 with pytest.raises(OrchestratorError):
-                    ps = PlacementSpec(hosts=['host1', 'host2'], count=2)
-                    c = cephadm_module.add_rgw(RGWSpec('realm', 'zone1', placement=ps))
+                    ps = PlacementSpec(hosts=['host1', 'host2'], count=3)
+                    c = cephadm_module.apply_rgw(RGWSpec('realm', 'zone1', placement=ps))
                     [out] = wait(cephadm_module, c)
 
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1192,6 +1192,18 @@ class PlacementSpec(object):
         # in the orchestrator backend.
         self.hosts = hosts
 
+    def __repr__(self):
+        kv = []
+        if self.count:
+            kv.append('count=%d' % self.count)
+        if self.label:
+            kv.append('label=%s' % self.label)
+        if self.hosts:
+            kv.append('hosts=%s' % self.hosts)
+        if self.all_hosts:
+            kv.append('all=true')
+        return "PlacementSpec(%s)" % (' '.join(kv))
+
     @classmethod
     def from_dict(cls, data):
         _cls = cls(**data)

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1246,7 +1246,7 @@ class PlacementSpec(object):
             strings.remove('all:true')
 
         hosts = [x for x in strings if x != '*' and 'label:' not in x]
-        labels = [x for x in strings if 'label:' in x]
+        labels = [x[6:] for x in strings if 'label:' in x]
         if len(labels) > 1:
             raise OrchestratorValidationError('more than one label provided: {}'.format(labels))
 

--- a/src/pybind/mgr/tests/test_orchestrator.py
+++ b/src/pybind/mgr/tests/test_orchestrator.py
@@ -10,7 +10,7 @@ from orchestrator import raise_if_exception, RGWSpec, Completion, ProgressRefere
     servicespec_validate_add
 from orchestrator import InventoryHost, ServiceDescription, DaemonDescription
 from orchestrator import OrchestratorValidationError
-from orchestrator import HostPlacementSpec
+from orchestrator import HostPlacementSpec, PlacementSpec
 
 
 @pytest.mark.parametrize("test_input,expected, require_network",
@@ -29,6 +29,21 @@ def test_parse_host_placement_specs(test_input, expected, require_network):
     ret = HostPlacementSpec.parse(test_input, require_network=require_network)
     assert ret == expected
     assert str(ret) == test_input
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ('', "PlacementSpec()"),
+        ("3", "PlacementSpec(count=3)"),
+        ("host1 host2", "PlacementSpec(hosts=[HostPlacementSpec(hostname='host1', network='', name=''), HostPlacementSpec(hostname='host2', network='', name='')])"),
+        ('2 host1 host2', "PlacementSpec(count=2 hosts=[HostPlacementSpec(hostname='host1', network='', name=''), HostPlacementSpec(hostname='host2', network='', name='')])"),
+        ('label:foo', "PlacementSpec(label=foo)"),
+        ('3 label:foo', "PlacementSpec(count=3 label=foo)"),
+        ('*', 'PlacementSpec(all=true)'),
+    ])
+def test_parse_placement_specs(test_input, expected):
+    ret = PlacementSpec.from_strings(test_input.split())
+    assert str(ret) == expected
 
 @pytest.mark.parametrize("test_input",
                          # wrong subnet


### PR DESCRIPTION
Refactor the code so that all of the add and apply methods go through the same two generic methods, sharing as much code as possible.

Removed apply_mon entirely (doesn't do anything that dameon add mon doesn't).

There is only one remaining caller for NodeAssignment, which will make it easier to improve the scheduling.