### PR TITLE
mgr: drop reference to msg on return

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -443,6 +443,7 @@ bool DaemonServer::handle_open(MMgrOpen *m)
       dout(2) << "ignoring open from " << key << " " << con->get_peer_addr()
               << "; not ready for session (expect reconnect)" << dendl;
       con->mark_down();
+      m->put();
       return true;
     }
   }


### PR DESCRIPTION
Note caveat in: https://tracker.ceph.com/issues/44245#note-7

There may be another one of these to fix...