### PR TITLE
rbd/cache: Replicated Write Log core codes part 3

### DIFF
--- a/src/librbd/cache/ImageWriteback.h
+++ b/src/librbd/cache/ImageWriteback.h
@@ -16,13 +16,35 @@ struct ImageCtx;
 
 namespace cache {
 
+class ImageWritebackInterface {
+public:
+  typedef std::vector<std::pair<uint64_t,uint64_t> > Extents;
+  virtual ~ImageWritebackInterface() {
+  }
+  virtual void aio_read(Extents &&image_extents, ceph::bufferlist *bl,
+                        int fadvise_flags, Context *on_finish) = 0;
+  virtual void aio_write(Extents &&image_extents, ceph::bufferlist&& bl,
+                         int fadvise_flags, Context *on_finish) = 0;
+  virtual void aio_discard(uint64_t offset, uint64_t length,
+                           uint32_t discard_granularity_bytes, Context *on_finish) = 0;
+  virtual void aio_flush(Context *on_finish) = 0 ;
+  virtual void aio_writesame(uint64_t offset, uint64_t length,
+                             ceph::bufferlist&& bl,
+                             int fadvise_flags, Context *on_finish) = 0;
+  virtual void aio_compare_and_write(Extents &&image_extents,
+                                     ceph::bufferlist&& cmp_bl,
+                                     ceph::bufferlist&& bl,
+                                     uint64_t *mismatch_offset,
+                                     int fadvise_flags, Context *on_finish) = 0;
+};
+
 /**
  * client-side, image extent cache writeback handler
  */
 template <typename ImageCtxT = librbd::ImageCtx>
-class ImageWriteback {
+class ImageWriteback : public ImageWritebackInterface {
 public:
-  typedef std::vector<std::pair<uint64_t,uint64_t> > Extents;
+  using ImageWritebackInterface::Extents;
 
   explicit ImageWriteback(ImageCtxT &image_ctx);
 

--- a/src/librbd/cache/ReplicatedWriteLog.h
+++ b/src/librbd/cache/ReplicatedWriteLog.h
@@ -214,6 +214,8 @@ private:
   bool m_appending = false;
   bool m_dispatching_deferred_ops = false;
 
+  Contexts m_flush_complete_contexts;
+
   rwl::GenericLogOperations m_ops_to_flush; /* Write ops needing flush in local log */
   rwl::GenericLogOperations m_ops_to_append; /* Write ops needing event append in local log */
 
@@ -256,6 +258,7 @@ private:
   void wake_up();
   void process_work();
 
+  void flush_dirty_entries(Context *on_finish);
   bool can_flush_entry(const std::shared_ptr<rwl::GenericLogEntry> log_entry);
   Context *construct_flush_entry_ctx(const std::shared_ptr<rwl::GenericLogEntry> log_entry);
   void persist_last_flushed_sync_gen();
@@ -266,6 +269,7 @@ private:
   void init_flush_new_sync_point(rwl::DeferredContexts &later);
   void new_sync_point(rwl::DeferredContexts &later);
   rwl::C_FlushRequest<ReplicatedWriteLog<ImageCtxT>>* make_flush_req(Context *on_finish);
+  void flush_new_sync_point_if_needed(C_FlushRequestT *flush_req, rwl::DeferredContexts &later);
 
   void dispatch_deferred_writes(void);
   void alloc_and_dispatch_io_req(C_BlockIORequestT *write_req);
@@ -279,6 +283,7 @@ private:
   int append_op_log_entries(rwl::GenericLogOperations &ops);
   void complete_op_log_entries(rwl::GenericLogOperations &&ops, const int r);
   void schedule_complete_op_log_entries(rwl::GenericLogOperations &&ops, const int r);
+  void internal_flush(Context *on_finish);
 };
 
 } // namespace cache

--- a/src/librbd/cache/rwl/LogOperation.cc
+++ b/src/librbd/cache/rwl/LogOperation.cc
@@ -235,7 +235,7 @@ WriteLogOperationSet::WriteLogOperationSet(utime_t dispatched, PerfCounters *per
     dispatch_time(dispatched),
     perfcounter(perfcounter),
     sync_point(sync_point) {
-  on_ops_appending = sync_point->prior_log_entries_persisted->new_sub();
+  on_ops_appending = sync_point->prior_persisted_gather_new_sub();
   on_ops_persist = nullptr;
   extent_ops_persist =
     new C_Gather(m_cct,

--- a/src/librbd/cache/rwl/Request.h
+++ b/src/librbd/cache/rwl/Request.h
@@ -153,7 +153,7 @@ public:
 
   void dispatch() override;
 
-  virtual void setup_log_operations();
+  virtual void setup_log_operations(DeferredContexts &on_exit);
 
   bool append_write_request(std::shared_ptr<SyncPoint> sync_point);
 
@@ -193,6 +193,7 @@ template <typename T>
 class C_FlushRequest : public C_BlockIORequest<T> {
 public:
   using C_BlockIORequest<T>::rwl;
+  bool internal = false;
   std::shared_ptr<SyncPoint> to_append;
 
   C_FlushRequest(T &rwl, const utime_t arrived,

--- a/src/librbd/cache/rwl/SyncPoint.cc
+++ b/src/librbd/cache/rwl/SyncPoint.cc
@@ -14,8 +14,8 @@ namespace rwl {
 
 SyncPoint::SyncPoint(uint64_t sync_gen_num, CephContext *cct)
   : log_entry(std::make_shared<SyncPointLogEntry>(sync_gen_num)), m_cct(cct) {
-  prior_log_entries_persisted = new C_Gather(cct, nullptr);
-  sync_point_persist = new C_Gather(cct, nullptr);
+  m_prior_log_entries_persisted = new C_Gather(cct, nullptr);
+  m_sync_point_persist = new C_Gather(cct, nullptr);
   on_sync_point_appending.reserve(MAX_WRITES_PER_SYNC_POINT + 2);
   on_sync_point_persisted.reserve(MAX_WRITES_PER_SYNC_POINT + 2);
   ldout(m_cct, 20) << "sync point " << sync_gen_num << dendl;
@@ -32,14 +32,76 @@ std::ostream &operator<<(std::ostream &os,
   os << "log_entry=[" << *p.log_entry << "], "
      << "earlier_sync_point=" << p.earlier_sync_point << ", "
      << "later_sync_point=" << p.later_sync_point << ", "
-     << "final_op_sequence_num=" << p.final_op_sequence_num << ", "
-     << "prior_log_entries_persisted=" << p.prior_log_entries_persisted << ", "
-     << "prior_log_entries_persisted_complete=" << p.prior_log_entries_persisted_complete << ", "
-     << "append_scheduled=" << p.append_scheduled << ", "
+     << "m_final_op_sequence_num=" << p.m_final_op_sequence_num << ", "
+     << "m_prior_log_entries_persisted=" << p.m_prior_log_entries_persisted << ", "
+     << "m_prior_log_entries_persisted_complete=" << p.m_prior_log_entries_persisted_complete << ", "
+     << "m_append_scheduled=" << p.m_append_scheduled << ", "
      << "appending=" << p.appending << ", "
      << "on_sync_point_appending=" << p.on_sync_point_appending.size() << ", "
      << "on_sync_point_persisted=" << p.on_sync_point_persisted.size() << "";
   return os;
+}
+
+void SyncPoint::persist_gather_set_finisher(Context *ctx) {
+  m_append_scheduled = true;
+  /* All prior sync points that are still in this list must already be scheduled for append */
+  std::shared_ptr<SyncPoint> previous = earlier_sync_point;
+  while (previous) {
+    ceph_assert(previous->m_append_scheduled);
+    previous = previous->earlier_sync_point;
+  }
+
+  m_sync_point_persist->set_finisher(ctx);
+}
+
+void SyncPoint::persist_gather_activate() {
+  m_sync_point_persist->activate();
+}
+
+Context* SyncPoint::persist_gather_new_sub() {
+  return m_sync_point_persist->new_sub();
+}
+
+void SyncPoint::prior_persisted_gather_activate() {
+  m_prior_log_entries_persisted->activate();
+}
+
+Context* SyncPoint::prior_persisted_gather_new_sub() {
+  return m_prior_log_entries_persisted->new_sub();
+}
+
+void SyncPoint::prior_persisted_gather_set_finisher() {
+  Context *sync_point_persist_ready = persist_gather_new_sub();
+  std::shared_ptr<SyncPoint> sp = shared_from_this();
+  m_prior_log_entries_persisted->
+    set_finisher(new LambdaContext([this, sp, sync_point_persist_ready](int r) {
+      ldout(m_cct, 20) << "Prior log entries persisted for sync point =["
+                       << sp << "]" << dendl;
+      sp->m_prior_log_entries_persisted_result = r;
+      sp->m_prior_log_entries_persisted_complete = true;
+      sync_point_persist_ready->complete(r);
+    }));
+}
+
+void SyncPoint::add_in_on_persisted_ctxs(Context* ctx) {
+  on_sync_point_persisted.push_back(ctx);
+}
+
+void SyncPoint::add_in_on_appending_ctxs(Context* ctx) {
+  on_sync_point_appending.push_back(ctx);
+}
+
+void SyncPoint::setup_earlier_sync_point(std::shared_ptr<SyncPoint> sync_point,
+                                         uint64_t last_op_sequence_num) {
+    earlier_sync_point = sync_point;
+    log_entry->prior_sync_point_flushed = false;
+    earlier_sync_point->log_entry->next_sync_point_entry = log_entry;
+    earlier_sync_point->later_sync_point = shared_from_this();
+    earlier_sync_point->m_final_op_sequence_num = last_op_sequence_num;
+    if (!earlier_sync_point->appending) {
+      /* Append of new sync point deferred until old sync point is appending */
+      earlier_sync_point->add_in_on_appending_ctxs(prior_persisted_gather_new_sub());
+    }
 }
 
 } // namespace rwl

--- a/src/librbd/cache/rwl/SyncPoint.h
+++ b/src/librbd/cache/rwl/SyncPoint.h
@@ -12,27 +12,12 @@ namespace librbd {
 namespace cache {
 namespace rwl {
 
-class SyncPoint {
+class SyncPoint: public std::enable_shared_from_this<SyncPoint> {
 public:
   std::shared_ptr<SyncPointLogEntry> log_entry;
   /* Use lock for earlier/later links */
   std::shared_ptr<SyncPoint> earlier_sync_point; /* NULL if earlier has completed */
   std::shared_ptr<SyncPoint> later_sync_point;
-  uint64_t final_op_sequence_num = 0;
-  /* A sync point can't appear in the log until all the writes bearing
-   * it and all the prior sync points have been appended and
-   * persisted.
-   *
-   * Writes bearing this sync gen number and the prior sync point will be
-   * sub-ops of this Gather. This sync point will not be appended until all
-   * these complete to the point where their persist order is guaranteed. */
-  C_Gather *prior_log_entries_persisted;
-  int prior_log_entries_persisted_result = 0;
-  int prior_log_entries_persisted_complete = false;
-  /* The finisher for this will append the sync point to the log.  The finisher
-   * for m_prior_log_entries_persisted will be a sub-op of this. */
-  C_Gather *sync_point_persist;
-  bool append_scheduled = false;
   bool appending = false;
   /* Signal these when this sync point is appending to the log, and its order
    * of appearance is guaranteed. One of these is is a sub-operation of the
@@ -46,9 +31,33 @@ public:
   ~SyncPoint();
   SyncPoint(const SyncPoint&) = delete;
   SyncPoint &operator=(const SyncPoint&) = delete;
-
+  void persist_gather_activate();
+  Context* persist_gather_new_sub();
+  void persist_gather_set_finisher(Context *ctx);
+  void prior_persisted_gather_activate();
+  Context* prior_persisted_gather_new_sub();
+  void prior_persisted_gather_set_finisher();
+  void add_in_on_persisted_ctxs(Context* cxt);
+  void add_in_on_appending_ctxs(Context* cxt);
+  void setup_earlier_sync_point(std::shared_ptr<SyncPoint> sync_point,
+                                uint64_t last_op_sequence_num);
 private:
   CephContext *m_cct;
+  bool m_append_scheduled = false;
+  uint64_t m_final_op_sequence_num = 0;
+  /* A sync point can't appear in the log until all the writes bearing
+   * it and all the prior sync points have been appended and
+   * persisted.
+   *
+   * Writes bearing this sync gen number and the prior sync point will be
+   * sub-ops of this Gather. This sync point will not be appended until all
+   * these complete to the point where their persist order is guaranteed. */
+  C_Gather *m_prior_log_entries_persisted;
+  /* The finisher for this will append the sync point to the log.  The finisher
+   * for m_prior_log_entries_persisted will be a sub-op of this. */
+  C_Gather *m_sync_point_persist;
+  int m_prior_log_entries_persisted_result = 0;
+  int m_prior_log_entries_persisted_complete = false;
   friend std::ostream &operator<<(std::ostream &os,
                                   const SyncPoint &p);
 };

--- a/src/librbd/cache/rwl/Types.cc
+++ b/src/librbd/cache/rwl/Types.cc
@@ -107,6 +107,10 @@ io::Extent whole_volume_extent() {
   return io::Extent({0, std::numeric_limits<uint64_t>::max()});
 }
 
+BlockExtent block_extent(const io::Extent& image_extent) {
+  return convert_to_block_extent(image_extent.first, image_extent.second);
+}
+
 } // namespace rwl
 } // namespace cache
 } // namespace librbd

--- a/src/librbd/cache/rwl/Types.cc
+++ b/src/librbd/cache/rwl/Types.cc
@@ -103,6 +103,10 @@ std::ostream &operator<<(std::ostream &os,
   return os;
 };
 
+io::Extent whole_volume_extent() {
+  return io::Extent({0, std::numeric_limits<uint64_t>::max()});
+}
+
 } // namespace rwl
 } // namespace cache
 } // namespace librbd

--- a/src/librbd/cache/rwl/Types.h
+++ b/src/librbd/cache/rwl/Types.h
@@ -261,6 +261,8 @@ public:
 
 io::Extent whole_volume_extent();
 
+BlockExtent block_extent(const io::Extent& image_extent);
+
 } // namespace rwl
 } // namespace cache
 } // namespace librbd

--- a/src/librbd/cache/rwl/Types.h
+++ b/src/librbd/cache/rwl/Types.h
@@ -141,6 +141,9 @@ namespace librbd {
 namespace cache {
 namespace rwl {
 
+const int IN_FLIGHT_FLUSH_WRITE_LIMIT = 64;
+const int IN_FLIGHT_FLUSH_BYTES_LIMIT = (1 * 1024 * 1024);
+
 /* Limit work between sync points */
 const uint64_t MAX_WRITES_PER_SYNC_POINT = 256;
 const uint64_t MAX_BYTES_PER_SYNC_POINT = (1024 * 1024 * 8);

--- a/src/librbd/cache/rwl/Types.h
+++ b/src/librbd/cache/rwl/Types.h
@@ -143,6 +143,7 @@ namespace rwl {
 
 /* Limit work between sync points */
 const uint64_t MAX_WRITES_PER_SYNC_POINT = 256;
+const uint64_t MAX_BYTES_PER_SYNC_POINT = (1024 * 1024 * 8);
 
 const uint32_t MIN_WRITE_ALLOC_SIZE = 512;
 const uint32_t LOG_STATS_INTERVAL_SECONDS = 5;
@@ -254,6 +255,8 @@ public:
     return image_extent(block_extent());
   }
 };
+
+io::Extent whole_volume_extent();
 
 } // namespace rwl
 } // namespace cache

--- a/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc
+++ b/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc
@@ -225,5 +225,41 @@ TEST_F(TestMockCacheReplicatedWriteLog, aio_write) {
   ASSERT_EQ(0, finish_ctx3.wait());
 }
 
+TEST_F(TestMockCacheReplicatedWriteLog, flush) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockReplicatedWriteLog rwl(mock_image_ctx, get_cache_state(mock_image_ctx));
+  expect_op_work_queue(mock_image_ctx);
+  expect_metadata_set(mock_image_ctx);
+
+  MockContextRWL finish_ctx1;
+  expect_context_complete(finish_ctx1, 0);
+  rwl.init(&finish_ctx1);
+  ASSERT_EQ(0, finish_ctx1.wait());
+
+  MockContextRWL finish_ctx2;
+  expect_context_complete(finish_ctx2, 0);
+  Extents image_extents{{0, 4096}};
+  bufferlist bl;
+  bl.append(std::string(4096, '1'));
+  bufferlist bl_copy = bl;
+  int fadvise_flags = 0;
+  rwl.aio_write(std::move(image_extents), std::move(bl), fadvise_flags, &finish_ctx2);
+  ASSERT_EQ(0, finish_ctx2.wait());
+
+  MockContextRWL finish_ctx_flush;
+  expect_context_complete(finish_ctx_flush, 0);
+  rwl.flush(&finish_ctx_flush);
+  ASSERT_EQ(0, finish_ctx_flush.wait());
+
+  MockContextRWL finish_ctx3;
+  expect_context_complete(finish_ctx3, 0);
+  rwl.shut_down(&finish_ctx3);
+
+  ASSERT_EQ(0, finish_ctx3.wait());
+}
+
 } // namespace cache
 } // namespace librbd


### PR DESCRIPTION
Adds Replicated Write Log, a persistent, write back cache for Ceph RBD.
Implements: http://tracker.ceph.com/projects/ceph/wiki/Rbd_-_ordered_crash-consistent_write-back_caching_extension

Trello: https://trello.com/c/QnsQaGTn

[Obsoletes https://github.com//pull/29087]

The PR 29087 is split into smaller PRs to make review easier.
The first PR: #31279
The second PR: #31963 

This is the 3rd PR (flush cached data to OSD) which defines the following parts:

librbd: add FlushRequest to handle flush
librbd: flush sync point into cache device
librbd: flush dirty entries to osd
librbd: add internal flush
librbd: add flush test case

Signed-off-by: Scott Peterson scott.d.peterson@intel.com
Signed-off-by: Lisa Li xiaoyan.li@intel.com
Signed-off-by: Yuan Lu yuan.y.lu@intel.com
Signed-off-by: Mahati Chamarthy mahati.chamarthy@intel.com

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
