### PR TITLE
nautilus: osd/OSD: Log slow ops/types to cluster logs

### DIFF
--- a/qa/cephfs/tasks/cfuse_workunit_suites_ffsb.yaml
+++ b/qa/cephfs/tasks/cfuse_workunit_suites_ffsb.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-whitelist:
     - SLOW_OPS
+    - slow request
     conf:
       osd:
         filestore flush min: 0

--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
@@ -10,6 +10,7 @@ overrides:
     - \(SLOW_OPS\)
     - overall HEALTH_
     - \(MON_MSGR2_NOT_ENABLED\)
+    - slow request
     conf:
       global:
         bluestore warn on legacy statfs: false

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
@@ -10,6 +10,7 @@ overrides:
     - \(SLOW_OPS\)
     - overall HEALTH_
     - \(MON_MSGR2_NOT_ENABLED\)
+    - slow request
     conf:
       global:
         bluestore warn on legacy statfs: false

--- a/qa/suites/kcephfs/cephfs/tasks/kclient_workunit_suites_ffsb.yaml
+++ b/qa/suites/kcephfs/cephfs/tasks/kclient_workunit_suites_ffsb.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-whitelist:
     - SLOW_OPS
+    - slow request
 tasks:
 - workunit:
     clients:

--- a/qa/suites/kcephfs/thrash/workloads/kclient_workunit_suites_ffsb.yaml
+++ b/qa/suites/kcephfs/thrash/workloads/kclient_workunit_suites_ffsb.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-whitelist:
     - SLOW_OPS
+    - slow request
     conf:
       osd:
         filestore flush min: 0

--- a/qa/suites/rados/monthrash/ceph.yaml
+++ b/qa/suites/rados/monthrash/ceph.yaml
@@ -15,6 +15,7 @@ overrides:
 # slow mons -> slow peering -> PG_AVAILABILITY
       - \(PG_AVAILABILITY\)
       - \(SLOW_OPS\)
+      - slow request
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/monthrash/workloads/rados_api_tests.yaml
+++ b/qa/suites/rados/monthrash/workloads/rados_api_tests.yaml
@@ -11,6 +11,7 @@ overrides:
       - \(PG_
       - \(POOL_APP_NOT_ENABLED\)
       - \(SMALLER_PGP_NUM\)
+      - slow request
     conf:
       global:
         debug objecter: 20

--- a/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
@@ -19,5 +19,6 @@ tasks:
     - \(PG_
     - \(SLOW_OPS\)
     - No standby daemons available
+    - slow request
 - mon_clock_skew_check:
     expect-skew: true

--- a/qa/suites/rados/multimon/tasks/mon_recovery.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_recovery.yaml
@@ -6,4 +6,5 @@ tasks:
       - \(MON_DOWN\)
       - \(PG_AVAILABILITY\)
       - \(SLOW_OPS\)
+      - slow request
 - mon_recovery:

--- a/qa/suites/rados/multimon/tasks/mon_recovery.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_recovery.yaml
@@ -5,4 +5,5 @@ tasks:
       - overall HEALTH_
       - \(MON_DOWN\)
       - \(PG_AVAILABILITY\)
+      - \(SLOW_OPS\)
 - mon_recovery:

--- a/qa/suites/rados/singleton/all/ec-lost-unfound.yaml
+++ b/qa/suites/rados/singleton/all/ec-lost-unfound.yaml
@@ -22,4 +22,5 @@ tasks:
       - \(PG_
       - \(OBJECT_
       - \(SLOW_OPS\)
+      - slow request
 - ec_lost_unfound:

--- a/qa/suites/rados/singleton/all/lost-unfound-delete.yaml
+++ b/qa/suites/rados/singleton/all/lost-unfound-delete.yaml
@@ -20,4 +20,5 @@ tasks:
       - \(OSD_
       - \(PG_
       - \(OBJECT_
+      - \(SLOW_OPS\)
 - rep_lost_unfound_delete:

--- a/qa/suites/rados/singleton/all/lost-unfound-delete.yaml
+++ b/qa/suites/rados/singleton/all/lost-unfound-delete.yaml
@@ -21,4 +21,5 @@ tasks:
       - \(PG_
       - \(OBJECT_
       - \(SLOW_OPS\)
+      - slow request
 - rep_lost_unfound_delete:

--- a/qa/suites/rados/singleton/all/lost-unfound.yaml
+++ b/qa/suites/rados/singleton/all/lost-unfound.yaml
@@ -20,4 +20,5 @@ tasks:
       - \(OSD_
       - \(PG_
       - \(OBJECT_
+      - \(SLOW_OPS\)
 - lost_unfound:

--- a/qa/suites/rados/singleton/all/lost-unfound.yaml
+++ b/qa/suites/rados/singleton/all/lost-unfound.yaml
@@ -21,4 +21,5 @@ tasks:
       - \(PG_
       - \(OBJECT_
       - \(SLOW_OPS\)
+      - slow request
 - lost_unfound:

--- a/qa/suites/rados/singleton/all/mon-memory-target-compliance.yaml.disabled
+++ b/qa/suites/rados/singleton/all/mon-memory-target-compliance.yaml.disabled
@@ -53,7 +53,7 @@ tasks:
       - \(SLOW_OPS\)
       - \(REQUEST_SLOW\)
       - \(TOO_FEW_PGS\)
-      - slow requests
+      - slow request
 - interactive:
 - parallel:
     - log-mon-rss

--- a/qa/suites/rados/singleton/all/osd-recovery.yaml
+++ b/qa/suites/rados/singleton/all/osd-recovery.yaml
@@ -21,6 +21,7 @@ tasks:
       - \(PG_
       - \(OBJECT_DEGRADED\)
       - \(SLOW_OPS\)
+      - slow request
     conf:
       osd:
         osd min pg log entries: 5

--- a/qa/suites/rados/singleton/all/pg-autoscaler.yaml
+++ b/qa/suites/rados/singleton/all/pg-autoscaler.yaml
@@ -31,7 +31,7 @@ tasks:
       - \(SLOW_OPS\)
       - \(REQUEST_SLOW\)
       - \(TOO_FEW_PGS\)
-      - slow requests
+      - slow request
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton/all/recovery-preemption.yaml
+++ b/qa/suites/rados/singleton/all/recovery-preemption.yaml
@@ -28,6 +28,7 @@ tasks:
       - \(PG_
       - \(SLOW_OPS\)
       - overall HEALTH
+      - slow request
 - exec:
     osd.0:
       - ceph osd pool create foo 128

--- a/qa/suites/rados/singleton/all/thrash-backfill-full.yaml
+++ b/qa/suites/rados/singleton/all/thrash-backfill-full.yaml
@@ -35,6 +35,7 @@ tasks:
     - \(OBJECT_
     - \(TOO_FEW_PGS\)
     - \(POOL_BACKFILLFULL\)
+    - slow request
 - thrashosds:
     op_delay: 30
     clean_interval: 120

--- a/qa/suites/rados/singleton/all/thrash-eio.yaml
+++ b/qa/suites/rados/singleton/all/thrash-eio.yaml
@@ -32,6 +32,7 @@ tasks:
     - \(OSD_
     - \(OBJECT_
     - \(TOO_FEW_PGS\)
+    - slow request
 - thrashosds:
     op_delay: 30
     clean_interval: 120

--- a/qa/suites/rados/verify/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/verify/tasks/rados_api_tests.yaml
@@ -11,6 +11,7 @@ overrides:
       - \(POOL_APP_NOT_ENABLED\)
       - \(PG_AVAILABILITY\)
       - \(OBJECT_MISPLACED\)
+      - slow request
     conf:
       client:
         debug ms: 1

--- a/qa/suites/rbd/basic/tasks/rbd_python_api_tests_old_format.yaml
+++ b/qa/suites/rbd/basic/tasks/rbd_python_api_tests_old_format.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-whitelist:
       - \(SLOW_OPS\)
+      - slow request
 tasks:
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/mon_thrash.yaml
+++ b/qa/suites/smoke/basic/tasks/mon_thrash.yaml
@@ -14,6 +14,7 @@ overrides:
       - \(SLOW_OPS\)
       - \(TOO_FEW_PGS\)
       - \(OSD_SLOW_PING_TIME
+      - slow request
     conf:
       global:
         ms inject delay max: 1

--- a/qa/suites/smoke/basic/tasks/rados_api_tests.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_api_tests.yaml
@@ -15,6 +15,7 @@ tasks:
       - \(TOO_FEW_PGS\)
       - reached quota
       - but it is still running
+      - slow request
     conf:
       mon:
         mon warn on pool no app: false

--- a/qa/suites/smoke/basic/tasks/rados_bench.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_bench.yaml
@@ -23,6 +23,7 @@ tasks:
       - \(SLOW_OPS\)
       - \(TOO_FEW_PGS\)
       - \(OSD_SLOW_PING_TIME
+      - slow request
 - thrashosds:
     chance_pgnum_grow: 2
     chance_pgnum_shrink: 2

--- a/qa/suites/smoke/basic/tasks/rados_cache_snaps.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_cache_snaps.yaml
@@ -12,6 +12,7 @@ tasks:
       - \(OBJECT_
       - \(SLOW_OPS\)
       - \(TOO_FEW_PGS\)
+      - slow request
 - thrashosds:
     chance_pgnum_grow: 2
     chance_pgnum_shrink: 2

--- a/qa/suites/smoke/basic/tasks/rados_ec_snaps.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_ec_snaps.yaml
@@ -13,6 +13,7 @@ tasks:
       - \(OBJECT_
       - \(SLOW_OPS\)
       - \(TOO_FEW_PGS\)
+      - slow request
 - thrashosds:
     chance_pgnum_grow: 3
     chance_pgnum_shrink: 2

--- a/qa/suites/smoke/basic/tasks/rbd_fsx.yaml
+++ b/qa/suites/smoke/basic/tasks/rbd_fsx.yaml
@@ -12,6 +12,7 @@ overrides:
       - \(SLOW_OPS\)
       - \(TOO_FEW_PGS\)
       - \(OSD_SLOW_PING_TIME
+      - slow request
     conf:
       client:
         rbd cache: true

--- a/qa/suites/upgrade/mimic-x/parallel/0-cluster/start.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/0-cluster/start.yaml
@@ -37,6 +37,7 @@ overrides:
     - \(SLOW_OPS\)
     - overall HEALTH_
     - \(MON_MSGR2_NOT_ENABLED\)
+    - slow request
     conf:
       global:
         enable experimental unrecoverable data corrupting features: "*"

--- a/qa/tasks/thrashosds-health.yaml
+++ b/qa/tasks/thrashosds-health.yaml
@@ -12,4 +12,4 @@ overrides:
       - \(SLOW_OPS\)
       - \(REQUEST_SLOW\)
       - \(TOO_FEW_PGS\)
-      - slow requests
+      - slow request

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8092,9 +8092,14 @@ vector<DaemonHealthMetric> OSD::get_health_metrics()
     TrackedOpRef oldest_op;
     auto count_slow_ops = [&](TrackedOp& op) {
       if (op.get_initiated() < too_old) {
-	lgeneric_subdout(cct,osd,20) << "slow op " << op.get_desc()
-	                             << " initiated "
-	                             << op.get_initiated() << dendl;
+        stringstream ss;
+        ss << "slow request " << op.get_desc()
+           << " initiated "
+           << op.get_initiated()
+           << " currently "
+           << op.state_string();
+        lgeneric_subdout(cct,osd,20) << ss.str() << dendl;
+        clog->warn() << ss.str();
 	slow++;
 	if (!oldest_op || op.get_initiated() < oldest_op->get_initiated()) {
 	  oldest_op = &op;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44259

---

backport of:

* https://github.com/ceph/ceph/pull/29121
* https://github.com/ceph/ceph/pull/32958
* https://github.com/ceph/ceph/pull/33328
* https://github.com/ceph/ceph/pull/33497


parent tracker: https://tracker.ceph.com/issues/43975

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh