### PR TITLE
cephadm: allow skipping prepare_host in bootstrap step

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1663,7 +1663,10 @@ def command_bootstrap():
                 raise Error('%s already exists; delete or pass '
                               '--allow-overwrite to overwrite' % f)
 
-    command_prepare_host()
+    if not args.skip_prepare_host:
+        command_prepare_host()
+    else:
+        logger.info('Skip prepare_host')
 
     # initial vars
     fsid = args.fsid or make_fsid()
@@ -3402,6 +3405,10 @@ def _get_parser():
         '--allow-fqdn-hostname',
         action='store_true',
         help='allow hostname that is fully-qualified (contains ".")')
+    parser_bootstrap.add_argument(
+        '--skip-prepare-host',
+        action='store_true',
+        help='Do not prepare host')
 
     parser_deploy = subparsers.add_parser(
         'deploy', help='deploy a daemon')


### PR DESCRIPTION
There are situations that required packages are managed outside of
cephadm script, allowing skipping prepare_host in these situations.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
