### PR TITLE
client: add client_fs mount option support

### DIFF
--- a/doc/cephfs/mount-using-fuse.rst
+++ b/doc/cephfs/mount-using-fuse.rst
@@ -55,11 +55,11 @@ root of CephFS on your local FS::
     ceph-fuse --id foo -r /path/to/dir /mnt/mycephfs
 
 If you have more than one FS on your Ceph cluster, use the option
-``--client_mds_namespace`` to mount the non-default FS::
+``--client_fs`` to mount the non-default FS::
 
-    ceph-fuse --id foo --client_mds_namespace mycephfs2 /mnt/mycephfs2
+    ceph-fuse --id foo --client_fs mycephfs2 /mnt/mycephfs2
 
-You may also add a ``client_mds_namespace`` setting to your ``ceph.conf``
+You may also add a ``client_fs`` setting to your ``ceph.conf``
 
 Unmounting CephFS
 =================

--- a/doc/start/quick-cephfs.rst
+++ b/doc/start/quick-cephfs.rst
@@ -184,9 +184,9 @@ To mount a particular directory within CephFS you can use ``-r``::
     sudo ceph-fuse -r {path-to-be-mounted} /mnt/mycephfs
 
 If you have multiple file systems on your cluster you would need to pass
-``--client_mds_namespace {fs-name}`` to the ``ceph-fuse`` command::
+``--client_fs {fs-name}`` to the ``ceph-fuse`` command::
 
-	sudo ceph-fuse /mnt/mycephfs2 --client_mds_namespace mycephfs2
+	sudo ceph-fuse /mnt/mycephfs2 --client_fs mycephfs2
 
 Refer `ceph-fuse man page`_ and `Mount CephFS using FUSE`_ to read more about
 this.

--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -68,7 +68,7 @@ class FuseMount(CephFSMount):
             fuse_cmd += ["--client_mountpoint={0}".format(mount_path)]
 
         if mount_fs_name is not None:
-            fuse_cmd += ["--client_mds_namespace={0}".format(mount_fs_name)]
+            fuse_cmd += ["--client_fs={0}".format(mount_fs_name)]
 
         fuse_cmd += [
             '--name', 'client.{id}'.format(id=self.client_id),

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -844,7 +844,7 @@ class LocalFuseMount(FuseMount):
             prefix += ["--client_mountpoint={0}".format(mount_path)]
 
         if mount_fs_name is not None:
-            prefix += ["--client_mds_namespace={0}".format(mount_fs_name)]
+            prefix += ["--client_fs={0}".format(mount_fs_name)]
 
         self.fuse_daemon = self.client_remote.run(args=
                                             prefix + [

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5825,7 +5825,10 @@ int Client::subscribe_mdsmap(const std::string &fs_name)
 
   std::string resolved_fs_name;
   if (fs_name.empty()) {
-    resolved_fs_name = cct->_conf.get_val<std::string>("client_mds_namespace");
+    resolved_fs_name = cct->_conf.get_val<std::string>("client_fs");
+    if (resolved_fs_name.empty())
+	    // Try the backwards compatibility fs name option
+	    resolved_fs_name = cct->_conf.get_val<std::string>("client_mds_namespace");
   } else {
     resolved_fs_name = fs_name;
   }

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8352,15 +8352,20 @@ std::vector<Option> get_mds_client_options() {
     .set_default(false)
     .set_description(""),
 
-    Option("client_mds_namespace", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    Option("client_fs", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_flag(Option::FLAG_STARTUP)
     .set_default("")
-
     .set_description("CephFS file system name to mount")
     .set_long_description("Use this with ceph-fuse, or with any process "
         "that uses libcephfs.  Programs using libcephfs may also pass "
         "the filesystem name into mount(), which will override this setting. "
         "If no filesystem name is given in mount() or this setting, the default "
         "filesystem will be mounted (usually the first created)."),
+
+    /* Alias for client_fs. Deprecated */
+    Option("client_mds_namespace", Option::TYPE_STR, Option::LEVEL_DEV)
+    .set_flag(Option::FLAG_STARTUP)
+    .set_default(""),
 
     Option("fake_statfs_for_testing", Option::TYPE_INT, Option::LEVEL_DEV)
     .set_default(0)

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -251,8 +251,8 @@ int ceph_init(struct ceph_mount_info *cmount);
  *
  * An error will be returned if this libcephfs instance is already
  * mounted. This function is an alternative to setting the global
- * client_mds_namespace setting.  Using this function enables multiple
- * libcephfs instances in the same process to mount different filesystems.
+ * client_fs setting.  Using this function enables multiple libcephfs
+ * instances in the same process to mount different filesystems.
  *
  * The filesystem name is *not* validated in this function.  That happens
  * during mount(), where an ENOENT error will result if a non-existent


### PR DESCRIPTION
"client_fs" is one alias for "client_mds_namespace=" and it will be
cleaner and be more user-friendly to use. "client_mds_namespace="
will be kept and backwards compatibility used.

Update the documents at the same time.

Fixes: https://tracker.ceph.com/issues/44212
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
