### PR TITLE
osd: get_full_state_name returns 'invalid' by default instead '???'

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -788,7 +788,7 @@ private:
     case BACKFILLFULL: return "backfillfull";
     case FULL: return "full";
     case FAILSAFE: return "failsafe";
-    default: return "???";
+    default: return "invalid";
     }
   }
   s_names get_full_state(string type) const {


### PR DESCRIPTION
Signed-off-by: Yanhu Cao <gmayyyha@gmail.com>