### PR TITLE
.gitignore: Add .mypy_cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ GTAGS
 /src/pybind/mgr/dashboard/frontend/src/environments/environment.ts
 /src/pybind/mgr/dashboard/frontend/src/environments/environment.prod.ts
 /src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
+
+# mypy cache
+.mypy_cache/
+


### PR DESCRIPTION
Ignore the mypy cache directory.

Signed-off-by: Kristoffer Grönlund <kgronlund@suse.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
