### PR TITLE
rgw: append obj: prevent tail from being GC'ed

### DIFF
--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -563,6 +563,7 @@ int AppendObjectProcessor::prepare(optional_yield y)
     }
     cur_manifest = &(*astate->manifest);
     manifest.set_prefix(cur_manifest->get_prefix());
+    astate->keep_tail = true;
   }
   manifest.set_multipart_part_rule(store->ctx()->_conf->rgw_obj_stripe_size, cur_part_num);
 


### PR DESCRIPTION
append object tail gets GC'ed otherwise as the state has a manifest similar to
atomic obj processor, but if the manifest exists and the position is correct, it
is not an overwrite and shouldn't be GC'ed

Fixes: https://tracker.ceph.com/issues/42670
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>

*edit- wrong issue ref*