### PR TITLE
mgr/cephadm: drop mixin parent

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -421,7 +421,7 @@ def trivial_result(val):
 
 
 @six.add_metaclass(CLICommandMeta)
-class CephadmOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
+class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     _STORE_HOST_PREFIX = "host"
 


### PR DESCRIPTION
This was added a while back to let us block on completions, but that
code has since been removed.

Signed-off-by: Sage Weil <sage@redhat.com>