### PR TITLE
RFC DNM: Wip mds session timeouts

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7652,6 +7652,16 @@ std::vector<Option> get_mds_options() {
     .set_default(true)
     .set_description("require MDS name is unique in the cluster"),
 
+    Option("mds_min_session_timeout_soft_limit", Option::TYPE_INT, Option::LEVEL_DEV)
+    .set_default(30)
+    .set_min(0)
+    .set_description("the lowest you can set the session timeout without really meaning it"),
+
+    Option("mds_min_session_timeout_hard_limit", Option::TYPE_INT, Option::LEVEL_DEV)
+    .set_default(3)
+    .set_min(0)
+    .set_description("the lowest you can set the session timeout"),
+
     Option("mds_session_blacklist_on_timeout", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description("blacklist clients whose sessions have become stale"),

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -525,7 +525,10 @@ public:
       return mds_info_entry->second.inc;
     return -1;
   }
-  void encode(bufferlist& bl, uint64_t features) const;
+  void encode(bufferlist& bl, uint64_t features, int64_t client_id) const;
+  void encode(bufferlist& bl, uint64_t features) const {
+    encode(bl, features, -1);
+  }
   void decode(bufferlist::const_iterator& p);
   void decode(const bufferlist& bl) {
     auto p = bl.cbegin();
@@ -542,6 +545,7 @@ public:
   static bool state_transition_valid(DaemonState prev, DaemonState next);
 
   CompatSet compat;
+  std::map<client_t, __u32> custom_timeouts;
 protected:
   // base map
   epoch_t epoch = 0;
@@ -595,7 +599,6 @@ protected:
   bool inline_data_enabled = false;
 
   uint64_t cached_up_features = 0;
-
 };
 WRITE_CLASS_ENCODER_FEATURES(MDSMap::mds_info_t)
 WRITE_CLASS_ENCODER_FEATURES(MDSMap)

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3311,9 +3311,13 @@ int MDSRank::config_client(int64_t session_id, bool remove,
       session->info.client_metadata.erase(it);
     } else {
       char *end;
-      strtoul(value.c_str(), &end, 0);
+      uint64_t new_timeout = strtoul(value.c_str(), &end, 0);
       if (*end) {
 	ss << "Invalid config for timeout: " << value;
+	return -EINVAL;
+      }
+      if (new_timeout < mdsmap->get_session_timeout()) {
+	ss << "Timeouts can only be configured to be HIGHER than the global default";
 	return -EINVAL;
       }
       session->info.client_metadata[option] = value;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3316,9 +3316,9 @@ int MDSRank::config_client(int64_t session_id, bool remove,
 	ss << "Invalid config for timeout: " << value;
 	return -EINVAL;
       }
-      if (new_timeout < mdsmap->get_session_timeout()) {
-	ss << "Timeouts can only be configured to be HIGHER than the global default";
-	return -EINVAL;
+      if (new_timeout < mdsmap->get_session_timeout() ||
+	  custom_timeout_exists(session)) {
+	custom_timeout_request(session, new_timeout);
       }
       session->info.client_metadata[option] = value;
     }
@@ -3329,6 +3329,16 @@ int MDSRank::config_client(int64_t session_id, bool remove,
   }
 
   return 0;
+}
+
+bool MDSRank::custom_timeout_exists(Session *s)
+{
+  return s->has_custom_timeout();
+}
+
+void MDSRank::custom_timeout_request(Session *s, int64_t new_timeout)
+{
+  sessionmap.custom_timeout_list.push_back(&s->item_custom_timeout_list);
 }
 
 bool MDSRank::evict_client(int64_t session_id,

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -333,6 +333,8 @@ class MDSRank {
     int config_client(int64_t session_id, bool remove,
 		      const std::string& option, const std::string& value,
 		      std::ostream& ss);
+    bool custom_timeout_exists(Session *session);
+    void custom_timeout_request(Session *session, int64_t timeout);
 
     void mark_base_recursively_scrubbed(inodeno_t ino);
 

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -682,6 +682,9 @@ void SessionMap::touch_session(Session *session)
     by_state_entry = by_state.emplace(session->state,
 				      new xlist<Session*>).first;
   by_state_entry->second->push_back(&session->item_session_list);
+  if (session->item_custom_timeout_list.is_on_list()) {
+    custom_timeout_list.push_back(&session->item_custom_timeout_list);
+  }
 
   session->last_cap_renew = clock::now();
 }

--- a/src/messages/MMDSMap.h
+++ b/src/messages/MMDSMap.h
@@ -35,11 +35,17 @@ public:
 protected:
   MMDSMap() : 
     SafeMessage{CEPH_MSG_MDS_MAP, HEAD_VERSION, COMPAT_VERSION} {}
+  MMDSMap(const uuid_d &f, const MDSMap &mm, int64_t client_id) :
+    SafeMessage{CEPH_MSG_MDS_MAP, HEAD_VERSION, COMPAT_VERSION},
+    fsid(f) {
+    epoch = mm.get_epoch();
+    mm.encode(encoded, -1, client_id);  // we will reencode with fewer features as necessary
+  }
   MMDSMap(const uuid_d &f, const MDSMap &mm) :
     SafeMessage{CEPH_MSG_MDS_MAP, HEAD_VERSION, COMPAT_VERSION},
     fsid(f) {
     epoch = mm.get_epoch();
-    mm.encode(encoded, -1);  // we will reencode with fewer features as necessary
+    mm.encode(encoded, -1, -1);  // we will reencode with fewer features as necessary
   }
   ~MMDSMap() override {}
 

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -566,9 +566,21 @@ public:
        ss << var << " requires an integer value";
        return -EINVAL;
       }
-      if (n < 30) {
-       ss << var << " must be at least 30s";
-       return -ERANGE;
+      int64_t soft_limit = g_conf().get_val<int64_t>
+	("mds_min_session_timeout_soft_limit");
+      int64_t hard_limit = g_conf().get_val<int64_t>
+	("mds_min_session_timeout_hard_limit");
+      if (n < soft_limit) {
+	bool confirm = false;
+        cmd_getval(cmdmap, "yes_i_really_mean_it", confirm);
+	if (!confirm) {
+	  ss << var << " must be at least " << soft_limit;
+	  return -ERANGE;
+	}
+	if (n < hard_limit) {
+	  ss << var << " even if you mean it, must be at least " << hard_limit;
+	  return -ERANGE;
+	}
       }
       fsmap.modify_filesystem(
           fs->fscid,

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1694,7 +1694,8 @@ void MDSMonitor::check_sub(Subscription *sub)
     if (sub->next > mds_map->epoch) {
       return;
     }
-    auto msg = make_message<MMDSMap>(mon->monmap->fsid, *mds_map);
+    auto msg = make_message<MMDSMap>(mon->monmap->fsid, *mds_map,
+				     sub->session->name.num());
 
     sub->session->con->send_message(msg.detach());
     if (sub->onetime) {

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -400,6 +400,11 @@ COMMAND("fs set "
 	"name=yes_i_really_mean_it,type=CephBool,req=false "
 	"name=yes_i_really_really_mean_it,type=CephBool,req=false",
 	"set fs parameter <var> to <val>", "mds", "rw")
+COMMAND("fs set_session_timeout "
+	"name=fs_name,type=CephString "
+	"name=session,type=CephInt "
+	"name=val,type=CephInt",
+	"set a custom lower-than-usual timeout for a client ID", "mds", "rw")
 COMMAND("fs flag set name=flag_name,type=CephChoices,strings=enable_multiple "
         "name=val,type=CephString "
 	"name=yes_i_really_mean_it,type=CephBool,req=false",


### PR DESCRIPTION
This provides a few options for changing the session timeouts.

The first patch, setting hard and soft limits on the global timeouts, I think we want to put in.

The second one, supporting per-session timeouts lower than the global, is a direction we probably want to explore, though it should be improved. (We can, for instance, arrange things so we don't look at every session with a custom timeout on every tick.)

The third one we definitely don't want to put in, but until we can get a better way to tell clients to lower their session timeouts directly, hacking it into the mdsmap global session timeout is the only way I could think of to distribute the need for more frequent pings.