### PR TITLE
nautilus: rgw multisite: set entry to lc index of slave when syncing

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -2954,6 +2954,13 @@ public:
     if (ret < 0)
       return ret;
 
+    auto lc = bci.attrs.find(RGW_ATTR_LC);
+    if (lc != bci.attrs.end()) {
+      store->get_lc()->set_entry(bci.info.bucket);
+    } else if (old_bci.attrs.find(RGW_ATTR_LC) != old_bci.attrs.end()) {
+      store->get_lc()->rm_entry(bci.info.bucket);
+    }
+
     objv_tracker = bci.info.objv_tracker;
 
     ret = store->init_bucket_index(bci.info, bci.info.num_shards);

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1439,10 +1439,7 @@ int RGWLC::set_bucket_config(RGWBucketInfo& bucket_info,
   rgw_bucket& bucket = bucket_info.bucket;
 
 
-  ret = guard_lc_modify(store, bucket, cookie, [&](librados::IoCtx *ctx, const string& oid,
-                                                   const pair<string, int>& entry) {
-    return cls_rgw_lc_set_entry(*ctx, oid, entry);
-  });
+  ret = set_entry(bucket);
 
   return ret;
 }
@@ -1464,13 +1461,28 @@ int RGWLC::remove_bucket_config(RGWBucketInfo& bucket_info,
   }
 
 
-  ret = guard_lc_modify(store, bucket, cookie, [&](librados::IoCtx *ctx, const string& oid,
-                                                   const pair<string, int>& entry) {
-    return cls_rgw_lc_rm_entry(*ctx, oid, entry);
-  });
+  ret = rm_entry(bucket);
 
   return ret;
 }
+
+int RGWLC::set_entry(rgw_bucket& bucket)
+{
+  int ret = guard_lc_modify(store, bucket, cookie, [&](librados::IoCtx *ctx, const string& oid,
+                                                   const pair<string, int>& entry) {
+    return cls_rgw_lc_set_entry(*ctx, oid, entry);
+  });
+  return ret;
+}
+
+int RGWLC::rm_entry(rgw_bucket& bucket)
+{
+  int ret = guard_lc_modify(store, bucket, cookie, [&](librados::IoCtx *ctx, const string& oid,
+                                                    const pair<string, int>& entry) {
+     return cls_rgw_lc_rm_entry(*ctx, oid, entry);
+   });
+   return ret;
+ }
 
 namespace rgw::lc {
 

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -500,6 +500,8 @@ class RGWLC : public DoutPrefixProvider {
                         RGWLifecycleConfiguration *config);
   int remove_bucket_config(RGWBucketInfo& bucket_info,
                            const map<string, bufferlist>& bucket_attrs);
+  int set_entry(rgw_bucket& bucket);
+  int rm_entry(rgw_bucket& bucket);
 
   CephContext *get_cct() const override { return store->ctx(); }
   unsigned get_subsys() const;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44268
Signed-off-by: Ilsoo Byun <ilsoobyun@linecorp.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
