### PR TITLE
librados: allow passing flags to operate sync APIs

### DIFF
--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1131,7 +1131,9 @@ inline namespace v14_2_0 {
 
     // compound object operations
     int operate(const std::string& oid, ObjectWriteOperation *op);
+    int operate(const std::string& oid, ObjectWriteOperation *op, int flags);
     int operate(const std::string& oid, ObjectReadOperation *op, bufferlist *pbl);
+    int operate(const std::string& oid, ObjectReadOperation *op, bufferlist *pbl, int flags);
     int aio_operate(const std::string& oid, AioCompletion *c, ObjectWriteOperation *op);
     int aio_operate(const std::string& oid, AioCompletion *c, ObjectWriteOperation *op, int flags);
     /**

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -1513,12 +1513,28 @@ int librados::IoCtx::operate(const std::string& oid, librados::ObjectWriteOperat
   return io_ctx_impl->operate(obj, &o->impl->o, (ceph::real_time *)o->impl->prt);
 }
 
+int librados::IoCtx::operate(const std::string& oid, librados::ObjectWriteOperation *o, int flags)
+{
+  object_t obj(oid);
+  if (unlikely(!o->impl))
+    return -EINVAL;
+  return io_ctx_impl->operate(obj, &o->impl->o, (ceph::real_time *)o->impl->prt, translate_flags(flags));
+}
+
 int librados::IoCtx::operate(const std::string& oid, librados::ObjectReadOperation *o, bufferlist *pbl)
 {
   object_t obj(oid);
   if (unlikely(!o->impl))
     return -EINVAL;
   return io_ctx_impl->operate_read(obj, &o->impl->o, pbl);
+}
+
+int librados::IoCtx::operate(const std::string& oid, librados::ObjectReadOperation *o, bufferlist *pbl, int flags)
+{
+  object_t obj(oid);
+  if (unlikely(!o->impl))
+    return -EINVAL;
+  return io_ctx_impl->operate_read(obj, &o->impl->o, pbl, translate_flags(flags));
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,

--- a/src/test/cls_hello/test_cls_hello.cc
+++ b/src/test/cls_hello/test_cls_hello.cc
@@ -132,19 +132,35 @@ TEST(ClsHello, WriteReturnData) {
   ASSERT_EQ(-ENOENT, ioctx.getxattr("myobject2", "foo", out));
 
   // this *will* return data due to the RETURNVEC flag
-  in.clear();
-  out.clear();
-  int rval;
-  ObjectWriteOperation o;
-  o.exec("hello", "write_return_data", in, &out, &rval);
-  librados::AioCompletion *completion = cluster.aio_create_completion();
-  ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &o,
+  // using a-sync call
+  {
+    in.clear();
+    out.clear();
+    int rval;
+    ObjectWriteOperation o;
+    o.exec("hello", "write_return_data", in, &out, &rval);
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &o,
 				 librados::OPERATION_RETURNVEC));
-  completion->wait_for_complete();
-  ASSERT_EQ(42, completion->get_return_value());
-  ASSERT_EQ(42, rval);
-  out.hexdump(std::cout);
-  ASSERT_EQ("you might see this", std::string(out.c_str(), out.length()));
+    completion->wait_for_complete();
+    ASSERT_EQ(42, completion->get_return_value());
+    ASSERT_EQ(42, rval);
+    out.hexdump(std::cout);
+    ASSERT_EQ("you might see this", std::string(out.c_str(), out.length()));
+  }
+  // using sync call
+  {
+    in.clear();
+    out.clear();
+    int rval;
+    ObjectWriteOperation o;
+    o.exec("hello", "write_return_data", in, &out, &rval);
+    ASSERT_EQ(42, ioctx.operate("foo", &o,
+				 librados::OPERATION_RETURNVEC));
+    ASSERT_EQ(42, rval);
+    out.hexdump(std::cout);
+    ASSERT_EQ("you might see this", std::string(out.c_str(), out.length()));
+  }
 
   // this will overflow because the return data is too big
   {


### PR DESCRIPTION
this would allow returning values from sync write operations
by passing the RETURNVEC flag to the sync versions of the APIs

Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

tested via the modified cls_hello test