### PR TITLE
test/rgw: fixes for test-rgw-multisite.sh

### DIFF
--- a/src/test/rgw/test-rgw-common.sh
+++ b/src/test/rgw/test-rgw-common.sh
@@ -99,7 +99,7 @@ function init_first_zone {
 # create zonegroup, zone
   x $(rgw_admin $cid) zonegroup create --rgw-zonegroup=$zg --master --default
   x $(rgw_admin $cid) zone create --rgw-zonegroup=$zg --rgw-zone=$zone --access-key=${access_key} --secret=${secret} --endpoints=$endpoints --default
-  x $(rgw_admin $cid) user create --uid=zone.user --display-name="Zone User" --access-key=${access_key} --secret=${secret} --system
+  x $(rgw_admin $cid) user create --uid=zone.user --display-name=ZoneUser --access-key=${access_key} --secret=${secret} --system
 
   x $(rgw_admin $cid) period update --commit
 }
@@ -120,7 +120,7 @@ function init_zone_in_existing_zg {
   x $(rgw_admin $cid) realm pull --url=$url:$master_zg_zone1_port --access-key=${access_key} --secret=${secret} --default
   x $(rgw_admin $cid) zonegroup default --rgw-zonegroup=$zg
   x $(rgw_admin $cid) zone create --rgw-zonegroup=$zg --rgw-zone=$zone --access-key=${access_key} --secret=${secret} --endpoints=$endpoints
-  x $(rgw_admin $cid) period update --commit --url=$url:$master_zg_zone1_port --access-key=${access_key} --secret=${secret}
+  x $(rgw_admin $cid) period update --commit
 }
 
 function init_first_zone_in_slave_zg {
@@ -146,8 +146,7 @@ function init_first_zone_in_slave_zg {
   x $(rgw_admin $cid) zone default --rgw-zone=$zone
   x $(rgw_admin $cid) zonegroup add --rgw-zonegroup=$zg --rgw-zone=$zone
 
-  x $(rgw_admin $cid) user create --uid=zone.user --display-name="Zone User" --access-key=${access_key} --secret=${secret} --system
-  x $(rgw_admin $cid) period update --commit --url=localhost:$master_zg_zone1_port --access-key=${access_key} --secret=${secret}
+  x $(rgw_admin $cid) period update --commit
 
 }
 


### PR DESCRIPTION
this fixes two different failures from the `test/rgw/test-rgw-multisite.sh` script:

first, the `--display-name="Zone User"` isn't getting escaped properly:
> $ radosgw-admin user create --uid=zone.user --display-name=Zone User --access-key=1234567890 --secret=pencil --system
Command not found: user create User

second, the period commit fails when given an `--access-key` due to a regression from https://github.com/ceph/ceph/pull/28331:
> $ radosgw-admin period update --commit --url=http://localhost:8001 --access-key=1234567890 --secret=pencil
user.init failed: (13) Permission denied