### PR TITLE
mgr/dashboard: Enhance user create CLI command to force password change

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -690,7 +690,11 @@ We provide a set of CLI commands to manage user accounts:
 
 - *Create User*::
 
-  $ ceph dashboard ac-user-create [--force-password] <username> [<password>] [<rolename>] [<name>] [<email>] [--enabled] [<pwd_expiration_date>]
+  $ ceph dashboard ac-user-create [--enabled] [--force-password] [--pwd_update_required] <username> [<password>] [<rolename>] [<name>] [<email>] [<pwd_expiration_date>]
+
+  To bypass the password policy checks use the `force-password` option.
+  Use the option `pwd_update_required` so that a newly created user has
+  to change their password after the first login.
 
 - *Delete User*::
 

--- a/qa/tasks/mgr/dashboard/test_user.py
+++ b/qa/tasks/mgr/dashboard/test_user.py
@@ -539,3 +539,17 @@ class UserTest(DashboardTestCase):
             'credits': 0,
             'valuation': 'Password must not be the same as the previous one.'
         })
+
+    def test_create_user_pwd_update_required(self):
+        exit_code = self._ceph_cmd_result([
+            'dashboard', 'ac-user-create', '--force-password',
+            '--pwd_update_required', 'foo', 'bar'
+        ])
+        self.assertEqual(exit_code, 0)
+        self._get('/api/user/foo')
+        self.assertStatus(200)
+        self.assertJsonSubset({
+            'username': 'foo',
+            'pwdUpdateRequired': True
+        })
+        self.delete_user('foo')

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -708,11 +708,12 @@ def ac_user_show_cmd(_, username=None):
                  'name=email,type=CephString,req=false '
                  'name=enabled,type=CephBool,req=false '
                  'name=force_password,type=CephBool,req=false '
-                 'name=pwd_expiration_date,type=CephInt,req=false',
+                 'name=pwd_expiration_date,type=CephInt,req=false '
+                 'name=pwd_update_required,type=CephBool,req=false',
                  'Create a user')
 def ac_user_create_cmd(_, username, password=None, rolename=None, name=None,
                        email=None, enabled=True, force_password=False,
-                       pwd_expiration_date=None):
+                       pwd_expiration_date=None, pwd_update_required=False):
     try:
         role = mgr.ACCESS_CTRL_DB.get_role(rolename) if rolename else None
     except RoleDoesNotExist as ex:
@@ -725,7 +726,8 @@ def ac_user_create_cmd(_, username, password=None, rolename=None, name=None,
             pw_check = PasswordPolicy(password, username)
             pw_check.check_all()
         user = mgr.ACCESS_CTRL_DB.create_user(username, password, name, email,
-                                              enabled, pwd_expiration_date)
+                                              enabled, pwd_expiration_date,
+                                              pwd_update_required)
     except PasswordPolicyException as ex:
         return -errno.EINVAL, '', str(ex)
     except UserAlreadyExists as ex:


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44301

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
