### PR TITLE
mgr/cephadm: leverage service specs

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2813,7 +2813,11 @@ receivers:
         specs = self.spec_store.find(service_name)
         completions = list()
         for spec in specs:
-            completions.append(func(spec))
+            try:
+                completions.append(func(spec))
+            except Exception as e:
+                self.log.warning('Failed to apply %s spec %s: %s' % (
+                    service_name, spec, e))
         if completions:
             return completions
         return [trivial_result("Nothing to do..")]

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1688,6 +1688,15 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                     sm[n].container_image_id = 'mix'
                 if sm[n].container_image_name != dd.container_image_name:
                     sm[n].container_image_name = 'mix'
+        for n, spec in self.spec_store.specs.items():
+            if n in sm:
+                continue
+            sm[n] = orchestrator.ServiceDescription(
+                service_name=n,
+                spec_presence='present',
+                size=self._get_spec_size(spec),
+                running=0,
+            )
         return trivial_result([s for n, s in sm.items()])
 
     def list_daemons(self, daemon_type=None, daemon_id=None,

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -995,19 +995,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         self.log.debug("serve starting")
         while self.run:
             self._check_hosts()
-            self._remove_osds_bg()
-            service_completions = self._apply_services()
-            for service_completion in service_completions:
-                if service_completion:
-                    while not service_completion.has_result:
-                        self.process([service_completion])
-                        self.log.debug(f'Still processing {service_completion}')
-                        if service_completion.needs_result:
-                            time.sleep(1)
-                        else:
-                            break
-                    if service_completion.exception is not None:
-                        self.log.error(str(service_completion.exception))
 
             # refresh daemons
             self.log.debug('refreshing hosts')
@@ -1036,6 +1023,21 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 self.set_health_checks(self.health_checks)
 
             self._check_for_strays()
+
+            self._remove_osds_bg()
+
+            service_completions = self._apply_services()
+            for service_completion in service_completions:
+                if service_completion:
+                    while not service_completion.has_result:
+                        self.process([service_completion])
+                        self.log.debug(f'Still processing {service_completion}')
+                        if service_completion.needs_result:
+                            time.sleep(1)
+                        else:
+                            break
+                    if service_completion.exception is not None:
+                        self.log.error(str(service_completion.exception))
 
             if self.upgrade_state and not self.upgrade_state.get('paused'):
                 upgrade_completion = self._do_upgrade()

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1710,10 +1710,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             for name in names:
                 if name in dm:
                     args.append((name, host, force))
-                    # TODO: bail out for OSDs when https://github.com/ceph/ceph/pull/32983 is merged
-                    if dm[name].daemon_type == 'osd':
-                        continue
-                    self._remove_key_from_store(dm[name].service_name())
         if not args:
             raise OrchestratorError('Unable to find daemon(s) %s' % (names))
         self.log.info('Remove daemons %s' % [a[0] for a in args])

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2057,14 +2057,14 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         self.cache.invalidate_host_daemons(host)
         return "Removed {} from host '{}'".format(name, host)
 
-    def _apply_service(self, daemon_type, spec, create_func, config_func=None):
+    def _apply_service(self, spec, create_func, config_func=None):
         """
         Schedule a service.  Deploy new daemons or remove old ones, depending
         on the target label and count specified in the placement.
         """
-        service_name = daemon_type
-        if spec.name:
-            service_name += '.' + spec.name
+        daemon_type = spec.service_type
+        service_name = spec.service_name()
+        self.log.debug('Applying service %s spec' % service_name)
         daemons = self.cache.get_daemons_by_service(service_name)
         spec = HostAssignment(
             spec=spec,
@@ -2199,7 +2199,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     def _apply_mgr(self, spec):
         # type: (orchestrator.ServiceSpec) -> AsyncCompletion
-        return self._apply_service('mgr', spec, self._create_mgr)
+        return self._apply_service(spec, self._create_mgr)
 
     def add_mds(self, spec):
         # type: (orchestrator.ServiceSpec) -> AsyncCompletion
@@ -2210,7 +2210,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     def _apply_mds(self, spec):
         # type: (orchestrator.ServiceSpec) -> AsyncCompletion
-        return self._apply_service('mds', spec, self._create_mds,
+        return self._apply_service(spec, self._create_mds,
                                    self._config_mds)
 
     def _config_mds(self, spec):
@@ -2269,7 +2269,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     def _apply_rgw(self, spec):
         # type: (orchestrator.ServiceSpec) -> AsyncCompletion
-        return self._apply_service('rgw', spec, self._create_rgw,
+        return self._apply_service(spec, self._create_rgw,
                                    self._config_rgw)
 
     def add_rbd_mirror(self, spec):
@@ -2291,7 +2291,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     def _apply_rbd_mirror(self, spec):
         # type: (orchestrator.ServiceSpec) -> AsyncCompletion
-        return self._apply_service('rbd-mirror', spec, self._create_rbd_mirror)
+        return self._apply_service(spec, self._create_rbd_mirror)
 
     def _generate_prometheus_config(self):
         # scrape mgrs
@@ -2491,7 +2491,7 @@ receivers:
 
     def _apply_prometheus(self, spec):
         # type: (orchestrator.ServiceSpec) -> AsyncCompletion
-        return self._apply_service('prometheus', spec, self._create_prometheus)
+        return self._apply_service(spec, self._create_prometheus)
 
     def apply_prometheus(self, spec):
         return self._apply(spec)
@@ -2506,7 +2506,7 @@ receivers:
 
     def _apply_node_exporter(self, spec):
         # type: (orchestrator.ServiceSpec) -> AsyncCompletion
-        return self._apply_service('node-exporter', spec,
+        return self._apply_service(spec,
                                    self._create_node_exporter)
 
     @async_map_completion
@@ -2522,7 +2522,7 @@ receivers:
         return self._apply(spec)
 
     def _apply_grafana(self, spec):
-        return self._apply_service('grafana', spec, self._create_grafana)
+        return self._apply_service(spec, self._create_grafana)
 
     @async_map_completion
     def _create_grafana(self, daemon_id, host):
@@ -2538,7 +2538,7 @@ receivers:
 
     def _apply_alertmanager(self, spec):
         # type: (orchestrator.ServiceSpec) -> AsyncCompletion
-        return self._apply_service('alertmanager', spec, self._create_alertmanager)
+        return self._apply_service(spec, self._create_alertmanager)
 
     @async_map_completion
     def _create_alertmanager(self, daemon_id, host):

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -414,7 +414,7 @@ class TestCephadm(object):
             spec = ServiceSpec(placement=ps, service_type='mgr')
             c = cephadm_module.apply_mgr(spec)
             _save_spec.assert_called_with(spec)
-            assert wait(cephadm_module, c) == 'Scheduled MGR creation..'
+            assert wait(cephadm_module, c) == 'Scheduled mgr update...'
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
@@ -429,7 +429,7 @@ class TestCephadm(object):
             spec = ServiceSpec(placement=ps, service_type='mds')
             c = cephadm_module.apply_mds(spec)
             _save_spec.assert_called_with(spec)
-            assert wait(cephadm_module, c) == 'Scheduled MDS creation..'
+            assert wait(cephadm_module, c) == 'Scheduled mds update...'
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
@@ -444,7 +444,7 @@ class TestCephadm(object):
             spec = ServiceSpec(placement=ps, service_type='rgw')
             c = cephadm_module.apply_rgw(spec)
             _save_spec.assert_called_with(spec)
-            assert wait(cephadm_module, c) == 'Scheduled RGW creation..'
+            assert wait(cephadm_module, c) == 'Scheduled rgw update...'
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
@@ -459,7 +459,7 @@ class TestCephadm(object):
             spec = ServiceSpec(placement=ps, service_type='rbd-mirror')
             c = cephadm_module.apply_rbd_mirror(spec)
             _save_spec.assert_called_with(spec)
-            assert wait(cephadm_module, c) == 'Scheduled rbd-mirror creation..'
+            assert wait(cephadm_module, c) == 'Scheduled rbd-mirror update...'
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
@@ -474,7 +474,7 @@ class TestCephadm(object):
             spec = ServiceSpec(placement=ps, service_type='prometheus')
             c = cephadm_module.apply_prometheus(spec)
             _save_spec.assert_called_with(spec)
-            assert wait(cephadm_module, c) == 'Scheduled prometheus creation..'
+            assert wait(cephadm_module, c) == 'Scheduled prometheus update...'
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
@@ -489,7 +489,7 @@ class TestCephadm(object):
             spec = ServiceSpec(placement=ps, service_type='node_exporter')
             c = cephadm_module.apply_node_exporter(spec)
             _save_spec.assert_called_with(spec)
-            assert wait(cephadm_module, c) == 'Scheduled node-exporter creation..'
+            assert wait(cephadm_module, c) == 'Scheduled node_exporter update...'
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -202,7 +202,7 @@ class TestCephadm(object):
     def test_mds(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            c = cephadm_module.add_mds(ServiceSpec('name', placement=ps, service_type='mds'))
+            c = cephadm_module.add_mds(ServiceSpec(name='name', placement=ps, service_type='mds'))
             [out] = wait(cephadm_module, c)
             match_glob(out, "Deployed mds.name.* on host 'test'")
 
@@ -286,7 +286,7 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.HostCache.save_host")
     @mock.patch("cephadm.module.HostCache.rm_host")
     @mock.patch("cephadm.module.CephadmOrchestrator._remove_key_from_store")
-    def test_remove_daemon(self, _save_host, _rm_host, _save_spec, cephadm_module):
+    def test_remove_daemon(self, rm_key, _rm_host, _save_spec, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.list_daemons(refresh=True)
             wait(cephadm_module, c)
@@ -309,7 +309,7 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.HostCache.save_host")
     @mock.patch("cephadm.module.HostCache.rm_host")
     @mock.patch("cephadm.module.CephadmOrchestrator._remove_key_from_store")
-    def test_remove_service(self, _save_host, _rm_host, _save_spec, cephadm_module):
+    def test_remove_service(self, _rm_key, _rm_host, _save_spec, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.list_daemons(refresh=True)
             wait(cephadm_module, c)
@@ -387,7 +387,7 @@ class TestCephadm(object):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
 
-            c = cephadm_module.add_alertmanager(ServiceSpec(placement=ps))
+            c = cephadm_module.add_alertmanager(ServiceSpec(placement=ps, service_type='alertmanager'))
             [out] = wait(cephadm_module, c)
             match_glob(out, "Deployed alertmanager.* on host 'test'")
 
@@ -401,3 +401,156 @@ class TestCephadm(object):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.blink_device_light('ident', True, [('test', '', '')])
             assert wait(cephadm_module, c) == ['Set ident light for test: on']
+
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
+    @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
+    @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
+    @mock.patch("cephadm.module.CephadmOrchestrator.save_spec")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
+    def test_apply_mgr_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
+        with self._with_host(cephadm_module, 'test'):
+            ps = PlacementSpec(hosts=['test'], count=1)
+            spec = ServiceSpec(placement=ps, service_type='mgr')
+            c = cephadm_module.apply_mgr(spec)
+            _save_spec.assert_called_with(spec)
+            assert wait(cephadm_module, c) == 'Scheduled MGR creation..'
+
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
+    @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
+    @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
+    @mock.patch("cephadm.module.CephadmOrchestrator.save_spec")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
+    def test_apply_mds_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
+        with self._with_host(cephadm_module, 'test'):
+            ps = PlacementSpec(hosts=['test'], count=1)
+            spec = ServiceSpec(placement=ps, service_type='mds')
+            c = cephadm_module.apply_mds(spec)
+            _save_spec.assert_called_with(spec)
+            assert wait(cephadm_module, c) == 'Scheduled MDS creation..'
+
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
+    @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
+    @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
+    @mock.patch("cephadm.module.CephadmOrchestrator.save_spec")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
+    def test_apply_rgw_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
+        with self._with_host(cephadm_module, 'test'):
+            ps = PlacementSpec(hosts=['test'], count=1)
+            spec = ServiceSpec(placement=ps, service_type='rgw')
+            c = cephadm_module.apply_rgw(spec)
+            _save_spec.assert_called_with(spec)
+            assert wait(cephadm_module, c) == 'Scheduled RGW creation..'
+
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
+    @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
+    @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
+    @mock.patch("cephadm.module.CephadmOrchestrator.save_spec")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
+    def test_apply_rbd_mirror_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
+        with self._with_host(cephadm_module, 'test'):
+            ps = PlacementSpec(hosts=['test'], count=1)
+            spec = ServiceSpec(placement=ps, service_type='rbd-mirror')
+            c = cephadm_module.apply_rbd_mirror(spec)
+            _save_spec.assert_called_with(spec)
+            assert wait(cephadm_module, c) == 'Scheduled rbd-mirror creation..'
+
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
+    @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
+    @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
+    @mock.patch("cephadm.module.CephadmOrchestrator.save_spec")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
+    def test_apply_prometheus_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
+        with self._with_host(cephadm_module, 'test'):
+            ps = PlacementSpec(hosts=['test'], count=1)
+            spec = ServiceSpec(placement=ps, service_type='prometheus')
+            c = cephadm_module.apply_prometheus(spec)
+            _save_spec.assert_called_with(spec)
+            assert wait(cephadm_module, c) == 'Scheduled prometheus creation..'
+
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
+    @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
+    @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
+    @mock.patch("cephadm.module.CephadmOrchestrator.save_spec")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
+    def test_apply_node_exporter_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
+        with self._with_host(cephadm_module, 'test'):
+            ps = PlacementSpec(hosts=['test'], count=1)
+            spec = ServiceSpec(placement=ps, service_type='node_exporter')
+            c = cephadm_module.apply_node_exporter(spec)
+            _save_spec.assert_called_with(spec)
+            assert wait(cephadm_module, c) == 'Scheduled node-exporter creation..'
+
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
+    @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
+    @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
+    @mock.patch("cephadm.module.CephadmOrchestrator.save_spec")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
+    @mock.patch("cephadm.module.yaml.load_all", return_value=[{'service_type': 'rgw', 'placement': {'count': 1}, 'spec': {'rgw_realm': 'realm1', 'rgw_zone': 'zone1'}}])
+    @mock.patch("cephadm.module.ServiceSpec")
+    def test_apply_service_config(self, _sspec, _yaml, _send_command, _get_connection, _save_spec, _save_host,
+                                  _rm_host, cephadm_module):
+        with self._with_host(cephadm_module, 'test'):
+            c = cephadm_module.apply_service_config('dummy')
+            _save_spec.assert_called_once()
+            _sspec.from_json.assert_called_once()
+            assert wait(cephadm_module, c) == 'ServiceSpecs saved'
+
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
+    @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
+    @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
+    @mock.patch("cephadm.module.CephadmOrchestrator.find_json_specs")
+    def test_trigger_deployment_todo(self, _find_json_spec, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
+        with self._with_host(cephadm_module, 'test'):
+            _find_json_spec.return_value = ['something']
+            c = cephadm_module.trigger_deployment('foo', lambda x: x)
+            _find_json_spec.assert_called_with('foo')
+            assert c == ['something']
+
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
+    @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
+    @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
+    @mock.patch("cephadm.module.CephadmOrchestrator.find_json_specs")
+    def test_trigger_deployment_no_todo(self, _find_json_spec, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
+        with self._with_host(cephadm_module, 'test'):
+            _find_json_spec.return_value = []
+            c = cephadm_module.trigger_deployment('foo', lambda x: x)
+            _find_json_spec.assert_called_with('foo')
+            assert wait(cephadm_module, c[0]) == 'Nothing to do..'
+
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
+    @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
+    @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
+    @mock.patch("cephadm.module.HostCache.save_host")
+    @mock.patch("cephadm.module.HostCache.rm_host")
+    @mock.patch("cephadm.module.CephadmOrchestrator.trigger_deployment")
+    def test_apply_services(self, _trigger_deployment, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
+        with self._with_host(cephadm_module, 'test'):
+            c = cephadm_module._apply_services()
+            _trigger_deployment.assert_any_call('mgr', cephadm_module._apply_mgr)
+            _trigger_deployment.assert_any_call('prometheus', cephadm_module._apply_prometheus)
+            _trigger_deployment.assert_any_call('node-exporter', cephadm_module._apply_node_exporter)
+            _trigger_deployment.assert_any_call('mds', cephadm_module._apply_mds)
+            _trigger_deployment.assert_any_call('rgw', cephadm_module._apply_rgw)
+            _trigger_deployment.assert_any_call('rbd-mirror', cephadm_module._apply_rbd_mirror)
+            assert isinstance(c, list)

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -137,12 +137,12 @@ class TestCephadm(object):
     def test_mon_update(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test:0.0.0.0=a'], count=1)
-            c = cephadm_module.add_mon(ServiceSpec(placement=ps, service_type='mon'))
+            c = cephadm_module.add_mon(ServiceSpec('mon', placement=ps))
             assert wait(cephadm_module, c) == ["Deployed mon.a on host 'test'"]
 
             with pytest.raises(OrchestratorError, match="is missing a network spec"):
                 ps = PlacementSpec(hosts=['test'], count=1)
-                c = cephadm_module.add_mon(ServiceSpec(placement=ps, service_type='mon'))
+                c = cephadm_module.add_mon(ServiceSpec('mon', placement=ps))
                 wait(cephadm_module, c)
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
@@ -154,7 +154,7 @@ class TestCephadm(object):
     def test_mgr_update(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test:0.0.0.0=a'], count=1)
-            c = cephadm_module._apply_service(ServiceSpec(placement=ps, service_type='mgr'))
+            c = cephadm_module._apply_service(ServiceSpec('mgr', placement=ps))
             [out] = wait(cephadm_module, c)
             match_glob(out, "Deployed mgr.* on host 'test'")
 
@@ -202,7 +202,7 @@ class TestCephadm(object):
     def test_mds(self, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            c = cephadm_module.add_mds(ServiceSpec(name='name', placement=ps, service_type='mds'))
+            c = cephadm_module.add_mds(ServiceSpec('mds', 'name', placement=ps))
             [out] = wait(cephadm_module, c)
             match_glob(out, "Deployed mds.name.* on host 'test'")
 
@@ -216,7 +216,7 @@ class TestCephadm(object):
 
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            c = cephadm_module.add_rgw(RGWSpec('realm', 'zone', placement=ps, service_type='rgw'))
+            c = cephadm_module.add_rgw(RGWSpec('realm', 'zone', placement=ps))
             [out] = wait(cephadm_module, c)
             match_glob(out, "Deployed rgw.realm.zone.* on host 'test'")
 
@@ -232,12 +232,12 @@ class TestCephadm(object):
         with self._with_host(cephadm_module, 'host1'):
             with self._with_host(cephadm_module, 'host2'):
                 ps = PlacementSpec(hosts=['host1'], count=1)
-                c = cephadm_module.add_rgw(RGWSpec('realm', 'zone1', placement=ps, service_type='rgw'))
+                c = cephadm_module.add_rgw(RGWSpec('realm', 'zone1', placement=ps))
                 [out] = wait(cephadm_module, c)
                 match_glob(out, "Deployed rgw.realm.zone1.host1.* on host 'host1'")
 
                 ps = PlacementSpec(hosts=['host1', 'host2'], count=2)
-                c = cephadm_module._apply_service(RGWSpec('realm', 'zone1', placement=ps, service_type='rgw'))
+                c = cephadm_module._apply_service(RGWSpec('realm', 'zone1', placement=ps))
                 [out] = wait(cephadm_module, c)
                 match_glob(out, "Deployed rgw.realm.zone1.host2.* on host 'host2'")
 
@@ -252,12 +252,12 @@ class TestCephadm(object):
         with self._with_host(cephadm_module, 'host1'):
             with self._with_host(cephadm_module, 'host2'):
                 ps = PlacementSpec(hosts=['host1'], count=1)
-                c = cephadm_module.add_rgw(RGWSpec('realm', 'zone1', placement=ps, service_type='rgw'))
+                c = cephadm_module.add_rgw(RGWSpec('realm', 'zone1', placement=ps))
                 [out] = wait(cephadm_module, c)
                 match_glob(out, "Deployed rgw.realm.zone1.host1.* on host 'host1'")
 
                 ps = PlacementSpec(hosts=['host2'], count=1)
-                c = cephadm_module.add_rgw(RGWSpec('realm', 'zone2', placement=ps, service_type='rgw'))
+                c = cephadm_module.add_rgw(RGWSpec('realm', 'zone2', placement=ps))
                 [out] = wait(cephadm_module, c)
                 match_glob(out, "Deployed rgw.realm.zone2.host2.* on host 'host2'")
 
@@ -267,7 +267,7 @@ class TestCephadm(object):
 
                 with pytest.raises(OrchestratorError):
                     ps = PlacementSpec(hosts=['host1', 'host2'], count=3)
-                    c = cephadm_module._apply_service(RGWSpec('realm', 'zone1', placement=ps, service_type='rgw'))
+                    c = cephadm_module._apply_service(RGWSpec('realm', 'zone1', placement=ps))
                     [out] = wait(cephadm_module, c)
 
 
@@ -326,7 +326,7 @@ class TestCephadm(object):
         # type: (mock.Mock, mock.Mock, mock.Mock, mock.Mock, CephadmOrchestrator) -> None
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            c = cephadm_module.add_rbd_mirror(ServiceSpec(name='name', placement=ps, service_type='rbd-mirror'))
+            c = cephadm_module.add_rbd_mirror(ServiceSpec('rbd-mirror', placement=ps))
             [out] = wait(cephadm_module, c)
             match_glob(out, "Deployed rbd-mirror.* on host 'test'")
 
@@ -341,7 +341,7 @@ class TestCephadm(object):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
 
-            c = cephadm_module.add_prometheus(ServiceSpec(placement=ps, service_type='prometheus'))
+            c = cephadm_module.add_prometheus(ServiceSpec('prometheus', placement=ps))
             [out] = wait(cephadm_module, c)
             match_glob(out, "Deployed prometheus.* on host 'test'")
 
@@ -356,7 +356,7 @@ class TestCephadm(object):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
 
-            c = cephadm_module.add_node_exporter(ServiceSpec(placement=ps, service_type='node-exporter'))
+            c = cephadm_module.add_node_exporter(ServiceSpec('node-exporter', placement=ps))
             [out] = wait(cephadm_module, c)
             match_glob(out, "Deployed node-exporter.* on host 'test'")
 
@@ -371,7 +371,7 @@ class TestCephadm(object):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
 
-            c = cephadm_module.add_grafana(ServiceSpec(placement=ps, service_type='grafana'))
+            c = cephadm_module.add_grafana(ServiceSpec('grafana', placement=ps))
             [out] = wait(cephadm_module, c)
             match_glob(out, "Deployed grafana.* on host 'test'")
 
@@ -386,7 +386,7 @@ class TestCephadm(object):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
 
-            c = cephadm_module.add_alertmanager(ServiceSpec(placement=ps, service_type='alertmanager'))
+            c = cephadm_module.add_alertmanager(ServiceSpec('alertmanager', placement=ps))
             [out] = wait(cephadm_module, c)
             match_glob(out, "Deployed alertmanager.* on host 'test'")
 
@@ -411,7 +411,7 @@ class TestCephadm(object):
     def test_apply_mgr_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            spec = ServiceSpec(placement=ps, service_type='mgr')
+            spec = ServiceSpec('mgr', placement=ps)
             c = cephadm_module.apply_mgr(spec)
             _save_spec.assert_called_with(spec)
             assert wait(cephadm_module, c) == 'Scheduled mgr update...'
@@ -426,7 +426,7 @@ class TestCephadm(object):
     def test_apply_mds_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            spec = ServiceSpec(placement=ps, service_type='mds')
+            spec = ServiceSpec('mds', 'fsname', placement=ps)
             c = cephadm_module.apply_mds(spec)
             _save_spec.assert_called_with(spec)
             assert wait(cephadm_module, c) == 'Scheduled mds update...'
@@ -441,7 +441,7 @@ class TestCephadm(object):
     def test_apply_rgw_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            spec = ServiceSpec(placement=ps, service_type='rgw')
+            spec = ServiceSpec('rgw', 'r.z', placement=ps)
             c = cephadm_module.apply_rgw(spec)
             _save_spec.assert_called_with(spec)
             assert wait(cephadm_module, c) == 'Scheduled rgw update...'
@@ -456,7 +456,7 @@ class TestCephadm(object):
     def test_apply_rbd_mirror_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            spec = ServiceSpec(placement=ps, service_type='rbd-mirror')
+            spec = ServiceSpec('rbd-mirror', placement=ps)
             c = cephadm_module.apply_rbd_mirror(spec)
             _save_spec.assert_called_with(spec)
             assert wait(cephadm_module, c) == 'Scheduled rbd-mirror update...'
@@ -471,7 +471,7 @@ class TestCephadm(object):
     def test_apply_prometheus_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            spec = ServiceSpec(placement=ps, service_type='prometheus')
+            spec = ServiceSpec('prometheus', placement=ps)
             c = cephadm_module.apply_prometheus(spec)
             _save_spec.assert_called_with(spec)
             assert wait(cephadm_module, c) == 'Scheduled prometheus update...'
@@ -486,7 +486,7 @@ class TestCephadm(object):
     def test_apply_node_exporter_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            spec = ServiceSpec(placement=ps, service_type='node_exporter')
+            spec = ServiceSpec('node_exporter', placement=ps)
             c = cephadm_module.apply_node_exporter(spec)
             _save_spec.assert_called_with(spec)
             assert wait(cephadm_module, c) == 'Scheduled node_exporter update...'

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -285,8 +285,7 @@ class TestCephadm(object):
     ))
     @mock.patch("cephadm.module.HostCache.save_host")
     @mock.patch("cephadm.module.HostCache.rm_host")
-    @mock.patch("cephadm.module.CephadmOrchestrator._remove_key_from_store")
-    def test_remove_daemon(self, rm_key, _rm_host, _save_spec, cephadm_module):
+    def test_remove_daemon(self, _rm_host, _save_spec, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.list_daemons(refresh=True)
             wait(cephadm_module, c)
@@ -308,8 +307,8 @@ class TestCephadm(object):
     ))
     @mock.patch("cephadm.module.HostCache.save_host")
     @mock.patch("cephadm.module.HostCache.rm_host")
-    @mock.patch("cephadm.module.CephadmOrchestrator._remove_key_from_store")
-    def test_remove_service(self, _rm_key, _rm_host, _save_spec, cephadm_module):
+    @mock.patch("cephadm.module.SpecStore.rm")
+    def test_remove_service(self, _rm_spec, _rm_host, _save_spec, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.list_daemons(refresh=True)
             wait(cephadm_module, c)
@@ -406,7 +405,7 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.CephadmOrchestrator.save_spec")
+    @mock.patch("cephadm.module.SpecStore.save")
     @mock.patch("cephadm.module.HostCache.save_host")
     @mock.patch("cephadm.module.HostCache.rm_host")
     def test_apply_mgr_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
@@ -421,7 +420,7 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.CephadmOrchestrator.save_spec")
+    @mock.patch("cephadm.module.SpecStore.save")
     @mock.patch("cephadm.module.HostCache.save_host")
     @mock.patch("cephadm.module.HostCache.rm_host")
     def test_apply_mds_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
@@ -436,7 +435,7 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.CephadmOrchestrator.save_spec")
+    @mock.patch("cephadm.module.SpecStore.save")
     @mock.patch("cephadm.module.HostCache.save_host")
     @mock.patch("cephadm.module.HostCache.rm_host")
     def test_apply_rgw_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
@@ -451,7 +450,7 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.CephadmOrchestrator.save_spec")
+    @mock.patch("cephadm.module.SpecStore.save")
     @mock.patch("cephadm.module.HostCache.save_host")
     @mock.patch("cephadm.module.HostCache.rm_host")
     def test_apply_rbd_mirror_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
@@ -466,7 +465,7 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.CephadmOrchestrator.save_spec")
+    @mock.patch("cephadm.module.SpecStore.save")
     @mock.patch("cephadm.module.HostCache.save_host")
     @mock.patch("cephadm.module.HostCache.rm_host")
     def test_apply_prometheus_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
@@ -481,7 +480,7 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.CephadmOrchestrator.save_spec")
+    @mock.patch("cephadm.module.SpecStore.save")
     @mock.patch("cephadm.module.HostCache.save_host")
     @mock.patch("cephadm.module.HostCache.rm_host")
     def test_apply_node_exporter_save(self, _send_command, _get_connection, _save_spec, _save_host, _rm_host, cephadm_module):
@@ -496,7 +495,7 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator.send_command")
     @mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command)
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
-    @mock.patch("cephadm.module.CephadmOrchestrator.save_spec")
+    @mock.patch("cephadm.module.SpecStore.save")
     @mock.patch("cephadm.module.HostCache.save_host")
     @mock.patch("cephadm.module.HostCache.rm_host")
     @mock.patch("cephadm.module.yaml.load_all", return_value=[{'service_type': 'rgw', 'placement': {'count': 1}, 'spec': {'rgw_realm': 'realm1', 'rgw_zone': 'zone1'}}])
@@ -515,12 +514,12 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
     @mock.patch("cephadm.module.HostCache.save_host")
     @mock.patch("cephadm.module.HostCache.rm_host")
-    @mock.patch("cephadm.module.CephadmOrchestrator.find_json_specs")
-    def test_trigger_deployment_todo(self, _find_json_spec, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
+    @mock.patch("cephadm.module.SpecStore.find")
+    def test_trigger_deployment_todo(self, _find, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
-            _find_json_spec.return_value = ['something']
+            _find.return_value = ['something']
             c = cephadm_module.trigger_deployment('foo', lambda x: x)
-            _find_json_spec.assert_called_with('foo')
+            _find.assert_called_with('foo')
             assert c == ['something']
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
@@ -529,12 +528,12 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
     @mock.patch("cephadm.module.HostCache.save_host")
     @mock.patch("cephadm.module.HostCache.rm_host")
-    @mock.patch("cephadm.module.CephadmOrchestrator.find_json_specs")
-    def test_trigger_deployment_no_todo(self, _find_json_spec, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
+    @mock.patch("cephadm.module.SpecStore.find")
+    def test_trigger_deployment_no_todo(self, _find, _send_command, _get_connection, _save_host, _rm_host, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
-            _find_json_spec.return_value = []
+            _find.return_value = []
             c = cephadm_module.trigger_deployment('foo', lambda x: x)
-            _find_json_spec.assert_called_with('foo')
+            _find.assert_called_with('foo')
             assert wait(cephadm_module, c[0]) == 'Nothing to do..'
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1562,7 +1562,7 @@ class PersistentStoreDict(object):
     def __init__(self, mgr, prefix):
         # type: (MgrModule, str) -> None
         self.mgr = mgr
-        self.prefix = prefix + '/'
+        self.prefix = prefix + '.'
 
     def _mk_store_key(self, key):
         return self.prefix + key

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1562,7 +1562,7 @@ class PersistentStoreDict(object):
     def __init__(self, mgr, prefix):
         # type: (MgrModule, str) -> None
         self.mgr = mgr
-        self.prefix = prefix + '.'
+        self.prefix = prefix + '/'
 
     def _mk_store_key(self, key):
         return self.prefix + key
@@ -1587,7 +1587,7 @@ class PersistentStoreDict(object):
                 self.__missing__(key)
             return json.loads(val)
         except (KeyError, AttributeError, IndexError, ValueError, TypeError):
-            logging.getLogger(__name__).exception('failed to deserialize')
+            logging.getLogger(__name__).debug('failed to deserialize item in store')
             self.mgr.set_store(key, None)
             raise
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1585,7 +1585,7 @@ class ServiceSpec(object):
 
     def to_json(self):
         return json.dumps(self, default=lambda o: o.__dict__,
-                          sort_keys=True, indent=4)
+                          sort_keys=True)
 
     def __repr__(self):
         return "{}({!r})".format(self.__class__.__name__, self.__dict__)

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1642,65 +1642,15 @@ class RGWSpec(ServiceSpec):
                  rgw_zone,  # type: str
                  placement=None,
                  service_type='rgw',
-                 name=None,  # type: Optional[str]
-                 hosts=None,  # type: Optional[List[str]]
-                 rgw_multisite=None,  # type: Optional[bool]
-                 rgw_zonemaster=None,  # type: Optional[bool]
-                 rgw_zonesecondary=None,  # type: Optional[bool]
-                 rgw_multisite_proto=None,  # type: Optional[str]
                  rgw_frontend_port=None,  # type: Optional[int]
-                 rgw_zonegroup=None,  # type: Optional[str]
-                 rgw_zone_user=None,  # type: Optional[str]
-                 system_access_key=None,  # type: Optional[str]
-                 system_secret_key=None,  # type: Optional[str]
-                 count=None  # type: Optional[int]
                  ):
-        # Regarding default values. Ansible has a `set_rgwspec_defaults` that sets
-        # default values that makes sense for Ansible. Rook has default values implemented
-        # in Rook itself. Thus we don't set any defaults here in this class.
         assert service_type == 'rgw'
         super(RGWSpec, self).__init__('rgw', service_id=rgw_realm+'.'+rgw_zone, placement=placement)
 
-        #: List of hosts where RGWs should run. Not for Rook.
-        if hosts:
-            self.placement = PlacementSpec(hosts=hosts)
-
-        #: is multisite
-        self.rgw_multisite = rgw_multisite
-        self.rgw_zonemaster = rgw_zonemaster
-        self.rgw_zonesecondary = rgw_zonesecondary
-        self.rgw_multisite_proto = rgw_multisite_proto
-        self.rgw_frontend_port = rgw_frontend_port
-
         self.rgw_realm = rgw_realm
         self.rgw_zone = rgw_zone
-        self.rgw_zonegroup = rgw_zonegroup
-        self.rgw_zone_user = rgw_zone_user
+        self.rgw_frontend_port = rgw_frontend_port
 
-        self.system_access_key = system_access_key
-        self.system_secret_key = system_secret_key
-
-    @property
-    def rgw_multisite_endpoint_addr(self):
-        """Returns the first host. Not supported for Rook."""
-        return self.placement.hosts[0]
-
-    @property
-    def rgw_multisite_endpoints_list(self):
-        return ",".join(["{}://{}:{}".format(self.rgw_multisite_proto,
-                                             host,
-                                             self.rgw_frontend_port) for host in self.placement.hosts])
-
-    def genkey(self, nchars):
-        """ Returns a random string of nchars
-
-        :nchars : Length of the returned string
-        """
-        # TODO Python 3: use Secrets module instead.
-
-        return ''.join(random.choice(string.ascii_uppercase +
-                                     string.ascii_lowercase +
-                                     string.digits) for _ in range(nchars))
 
 
 class InventoryFilter(object):

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1577,6 +1577,12 @@ class ServiceSpec(object):
             args.update({k: v})
         return _cls(**args)  # type: ignore
 
+    def service_name(self):
+        n = self.service_type
+        if self.name:
+            n += '.' + self.name
+        return n
+
     def to_json(self):
         return json.dumps(self, default=lambda o: o.__dict__,
                           sort_keys=True, indent=4)

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -740,16 +740,6 @@ Usage:
         return HandleCommandResult(stdout=specs)
 
     @_cli_write_command(
-        'orch servicespecs clear',
-        desc='Clear all Service specs')
-    def _clear_service_specs(self):
-        completion = self.clear_all_specs()
-        self._orchestrator_wait([completion])
-        raise_if_exception(completion)
-        return HandleCommandResult(stdout=completion.result_str())
-
-
-    @_cli_write_command(
         'orch apply mgr',
         "name=num,type=CephInt,req=false "
         "name=hosts,type=CephString,n=N,req=false "

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -509,7 +509,7 @@ Usage:
         placement = PlacementSpec(label=label, count=num, hosts=hosts)
         placement.validate()
 
-        spec = ServiceSpec(placement=placement, service_type='mon')
+        spec = ServiceSpec('mon', placement=placement)
 
         completion = self.add_mon(spec)
         self._orchestrator_wait([completion])
@@ -523,6 +523,7 @@ Usage:
         'Start rbd-mirror daemon(s)')
     def _daemon_add_mgr(self, num=None, hosts=None):
         spec = ServiceSpec(
+            'mgr',
             placement=PlacementSpec(hosts=hosts, count=num))
         completion = self.add_mgr(spec)
         self._orchestrator_wait([completion])
@@ -545,7 +546,7 @@ Usage:
         'Start rbd-mirror daemon(s)')
     def _rbd_mirror_add(self, num=None, hosts=None):
         spec = ServiceSpec(
-            None,
+            'rbd-mirror',
             placement=PlacementSpec(hosts=hosts, count=num))
         completion = self.add_rbd_mirror(spec)
         self._orchestrator_wait([completion])
@@ -560,7 +561,7 @@ Usage:
         'Start MDS daemon(s)')
     def _mds_add(self, fs_name, num=None, hosts=None):
         spec = ServiceSpec(
-            fs_name,
+            'mds', fs_name,
             placement=PlacementSpec(hosts=hosts, count=num))
         completion = self.add_mds(spec)
         self._orchestrator_wait([completion])
@@ -627,6 +628,7 @@ Usage:
     def _daemon_add_prometheus(self, num=None, label=None, hosts=[]):
         # type: (Optional[int], Optional[str], List[str]) -> HandleCommandResult
         spec = ServiceSpec(
+            'prometheus',
             placement=PlacementSpec(label=label, hosts=hosts, count=num),
         )
         completion = self.add_prometheus(spec)
@@ -642,6 +644,7 @@ Usage:
     def _daemon_add_node_exporter(self, num=None, label=None, hosts=[]):
         # type: (Optional[int], Optional[str], List[str]) -> HandleCommandResult
         spec = ServiceSpec(
+            'node-exporter',
             placement=PlacementSpec(label=label, hosts=hosts, count=num),
         )
         completion = self.add_node_exporter(spec)
@@ -657,6 +660,7 @@ Usage:
     def _daemon_add_grafana(self, num=None, label=None, hosts=[]):
         # type: (Optional[int], Optional[str], List[str]) -> HandleCommandResult
         spec = ServiceSpec(
+            'grafana',
             placement=PlacementSpec(label=label, hosts=hosts, count=num),
         )
         completion = self.add_grafana(spec)
@@ -672,6 +676,7 @@ Usage:
     def _daemon_add_alertmanager(self, num=None, label=None, hosts=[]):
         # type: (Optional[int], Optional[str], List[str]) -> HandleCommandResult
         spec = ServiceSpec(
+            'alertmanager',
             placement=PlacementSpec(label=label, hosts=hosts, count=num),
         )
         completion = self.add_alertmanager(spec)
@@ -750,7 +755,7 @@ Usage:
             label=label, count=num, hosts=hosts)
         placement.validate()
 
-        spec = ServiceSpec(placement=placement, service_type='mgr')
+        spec = ServiceSpec('mgr', placement=placement)
 
         completion = self.apply_mgr(spec)
         self._orchestrator_wait([completion])
@@ -770,7 +775,7 @@ Usage:
         placement = PlacementSpec(label=label, count=num, hosts=hosts)
         placement.validate()
 
-        spec = ServiceSpec(placement=placement)
+        spec = ServiceSpec('mon', placement=placement)
 
         completion = self.apply_mon(spec)
         self._orchestrator_wait([completion])
@@ -788,8 +793,7 @@ Usage:
         placement = PlacementSpec(label=label, count=num, hosts=hosts)
         placement.validate()
         spec = ServiceSpec(
-            service_type='mds',
-            name=fs_name,
+            'mds', fs_name,
             placement=placement)
         completion = self.apply_mds(spec)
         self._orchestrator_wait([completion])
@@ -804,8 +808,8 @@ Usage:
         'Update the number of rbd-mirror instances')
     def _apply_rbd_mirror(self, num, label=None, hosts=[]):
         spec = ServiceSpec(
-            placement=PlacementSpec(hosts=hosts, count=num, label=label),
-            service_type='rbd-mirror')
+            'rbd-mirror',
+            placement=PlacementSpec(hosts=hosts, count=num, label=label))
         completion = self.apply_rbd_mirror(spec)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
@@ -821,7 +825,6 @@ Usage:
         'Update the number of RGW instances for the given zone')
     def _apply_rgw(self, zone_name, realm_name, num=None, label=None, hosts=[]):
         spec = RGWSpec(
-            service_type='rgw',
             rgw_realm=realm_name,
             rgw_zone=zone_name,
             placement=PlacementSpec(hosts=hosts, label=label, count=num))
@@ -856,8 +859,8 @@ Usage:
     def _apply_prometheus(self, num=None, label=None, hosts=[]):
         # type: (Optional[int], Optional[str], List[str]) -> HandleCommandResult
         spec = ServiceSpec(
+            'prometheus',
             placement=PlacementSpec(label=label, hosts=hosts, count=num),
-            service_type='prometheus'
         )
         completion = self.apply_prometheus(spec)
         self._orchestrator_wait([completion])
@@ -872,8 +875,8 @@ Usage:
     def _apply_node_exporter(self, num=None, label=None, hosts=[]):
         # type: (Optional[int], Optional[str], List[str]) -> HandleCommandResult
         spec = ServiceSpec(
+            'node-exporter',
             placement=PlacementSpec(label=label, hosts=hosts, count=num),
-            service_type='node-exporter'
         )
         completion = self.apply_node_exporter(spec)
         self._orchestrator_wait([completion])

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -292,7 +292,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
     def _service_add_decorate(self, typename, spec, func):
         return write_completion(
             on_complete=lambda : func(spec),
-            message="Creating {} services for {}".format(typename, spec.name),
+            message="Creating {} services for {}".format(typename, spec.service_id),
             mgr=self
         )
 
@@ -348,8 +348,8 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         # type: (orchestrator.ServiceSpec) -> RookCompletion
         num = spec.count
         return write_completion(
-            lambda: self.rook_cluster.update_mds_count(spec.name, num),
-            "Updating MDS server count in {0} to {1}".format(spec.name, num),
+            lambda: self.rook_cluster.update_mds_count(spec.service_id, num),
+            "Updating MDS server count in {0} to {1}".format(spec.service_id, num),
             mgr=self
         )
 
@@ -357,8 +357,8 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         # type: (orchestrator.NFSServiceSpec) -> RookCompletion
         num = spec.count
         return write_completion(
-            lambda: self.rook_cluster.update_nfs_count(spec.name, num),
-            "Updating NFS server count in {0} to {1}".format(spec.name, num),
+            lambda: self.rook_cluster.update_nfs_count(spec.service_id, num),
+            "Updating NFS server count in {0} to {1}".format(spec.service_id, num),
             mgr=self
         )
 

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -351,7 +351,7 @@ class RookCluster(object):
         rook_fs = cfs.CephFilesystem(
             apiVersion=self.rook_env.api_name,
             metadata=dict(
-                name=spec.name,
+                name=spec.service_id,
                 namespace=self.rook_env.namespace,
             ),
             spec=cfs.Spec(
@@ -362,7 +362,7 @@ class RookCluster(object):
             )
         )
 
-        with self.ignore_409("CephFilesystem '{0}' already exists".format(spec.name)):
+        with self.ignore_409("CephFilesystem '{0}' already exists".format(spec.service_id)):
             self.rook_api_post("cephfilesystems/", body=rook_fs.to_json())
 
     def add_nfsgw(self, spec):
@@ -373,7 +373,7 @@ class RookCluster(object):
         rook_nfsgw = cnfs.CephNFS(
             apiVersion=self.rook_env.api_name,
             metadata=dict(
-                name=spec.name,
+                name=spec.service_id,
                 namespace=self.rook_env.namespace,
             ),
             spec=cnfs.Spec(
@@ -389,7 +389,7 @@ class RookCluster(object):
         if spec.namespace:
             rook_nfsgw.spec.rados.namespace = spec.namespace
 
-        with self.ignore_409("NFS cluster '{0}' already exists".format(spec.name)):
+        with self.ignore_409("NFS cluster '{0}' already exists".format(spec.service_id)):
             self.rook_api_post("cephnfses/", body=rook_nfsgw.to_json())
 
     def add_objectstore(self, spec):
@@ -397,7 +397,7 @@ class RookCluster(object):
         rook_os = cos.CephObjectStore(
             apiVersion=self.rook_env.api_name,
             metadata=dict(
-                name=spec.name,
+                name=spec.service_id,
                 namespace=self.rook_env.namespace
             ),
             spec=cos.Spec(
@@ -421,7 +421,7 @@ class RookCluster(object):
             )
         )
         
-        with self.ignore_409("CephObjectStore '{0}' already exists".format(spec.name)):
+        with self.ignore_409("CephObjectStore '{0}' already exists".format(spec.service_id)):
             self.rook_api_post("cephobjectstores/", body=rook_os.to_json())
 
     def rm_service(self, rooktype, service_id):

--- a/src/pybind/mgr/tests/test_orchestrator.py
+++ b/src/pybind/mgr/tests/test_orchestrator.py
@@ -119,10 +119,7 @@ def test_rgwspec():
         "rgw_zone": "zonename",
         "service_type": "rgw",
         "rgw_frontend_port": 8080,
-        "rgw_zonegroup": "group",
-        "rgw_zone_user": "user",
-        "rgw_realm": "realm",
-        "count": 3
+        "rgw_realm": "realm"
     }
     """
     example = json.loads(test_rgwspec.__doc__.strip())

--- a/src/pybind/mgr/tests/test_orchestrator.py
+++ b/src/pybind/mgr/tests/test_orchestrator.py
@@ -117,6 +117,7 @@ def test_rgwspec():
     """
     {
         "rgw_zone": "zonename",
+        "service_type": "rgw",
         "rgw_frontend_port": 8080,
         "rgw_zonegroup": "group",
         "rgw_zone_user": "user",


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44205

This does a couple of things:

* Change the way apply_$service() works:

`ceph orch apply $service <spec>`

will now instead of triggering the deployment mechanism transform 
the already passed ServiceSpec into a json representation
and save it in the persistent mon_store section.

`mgr/cephadm/service_spec/$service|$daemon_type/service_name`

These locations will be periodically checked in the serve() thread by
the `services_apply()` method.
This works since all the apply_$service_type functions are idempotent.

* Allow to save a config-like specification in the mon_store.

`ceph orch apply -i <service_spec_file.yaml>`

will read the specified services and save them in the mon store
section like mentioned above. The same serve() mechanism like above
also applies to deployment.

* Complain on conflicts - [Explanation here](https://github.com/ceph/ceph/pull/33553/files#diff-b2eb7e15b64fdea42d7c8afdab01bcbcR2429)

Since the focus shifted more towards a declarative/spec centric approach we also need CLI options that lets you view/clear/set these specs.

* `ceph orch apply -i <file>`
* `ceph orch spec dump`
* `ceph orch servicespecs clear` (will be removed after heavy development is done) 

todo:

- [x] Properly outpout service specs with `ceph orch servicespecs ls`
~currently this plainly outputs a tuple.. This needs to be exportable to a file
(i.e. `ceph orch servicespecs ls > specs.yml|json`)~
[0] changes
- [x] Integrate spec status in `ceph orch ls`
[1] changes
- [x] Decide how to handle OSDs and DriveGroups
[2] chnanges
- [x] Adapt lint/tests
- [x] Add tests

[0] changed to `ceph orch spec dump` which will print yaml and allows to export
with `ceph orch spec dump > /tmp/foo.yaml` and a consecutive `ceph orch apply -i /tmp/foo.yaml`

[1] Added a new column `SPEC` that prints 'present' 'absent' or 'not applicable' (for OSDs)
Not sure if that gives information or not, but it's there now.

[2] DriveGroups will not be included for now.

Signed-off-by: Joshua Schmid <jschmid@suse.de>

