### PR TITLE
msg/async/ProtocolV2: fix typo in register_lossy_clients fix

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -828,7 +828,8 @@ int AsyncMessenger::accept_conn(const AsyncConnectionRef& conn)
 {
   std::lock_guard l{lock};
   if (conn->policy.server &&
-      conn->policy.lossy) {
+      conn->policy.lossy &&
+      !conn->policy.register_lossy_clients) {
     anon_conns.insert(conn);
     conn->get_perf_counter()->inc(l_msgr_active_connections);
     return 0;

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -2370,7 +2370,7 @@ CtPtr ProtocolV2::handle_client_ident(ceph::bufferlist &payload)
 
   if (connection->policy.server &&
       connection->policy.lossy &&
-      connection->policy.register_lossy_clients) {
+      !connection->policy.register_lossy_clients) {
     // incoming lossy client, no need to register this connection
   } else {
     // Looks good so far, let's check if there is already an existing connection


### PR DESCRIPTION
In 507d213cc453ed86ab38619590f710f33245c652 this was typoed, reversing
the condition.

Fixes: https://tracker.ceph.com/issues/42328
Signed-off-by: Sage Weil <sage@redhat.com>