### PR TITLE
os/bluestore: log allocation stats on a daily basis.

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1000,6 +1000,7 @@ OPTION(bluestore_cache_size_hdd, OPT_U64)
 OPTION(bluestore_cache_size_ssd, OPT_U64)
 OPTION(bluestore_cache_meta_ratio, OPT_DOUBLE)
 OPTION(bluestore_cache_kv_ratio, OPT_DOUBLE)
+OPTION(bluestore_alloc_stats_dump_interval, OPT_DOUBLE)
 OPTION(bluestore_kvbackend, OPT_STR)
 OPTION(bluestore_allocator, OPT_STR)     // stupid | bitmap
 OPTION(bluestore_freelist_blocks_per_key, OPT_INT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4355,6 +4355,10 @@ std::vector<Option> get_global_options() {
     .add_see_also("bluestore_cache_autotune")
     .set_description("The number of seconds to wait between rebalances when cache autotune is enabled."),
 
+    Option("bluestore_alloc_stats_dump_interval", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+      .set_default(3600 * 24)
+      .set_description("The period (in second) for logging allocation statistics."),
+
     Option("bluestore_kvbackend", Option::TYPE_STR, Option::LEVEL_DEV)
     .set_default("rocksdb")
     .set_flag(Option::FLAG_CREATE)

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3206,7 +3206,18 @@ private:
 			CollectionRef& d,
 			unsigned bits);
 
+  void _collect_allocation_stats(uint64_t need, uint32_t alloc_size,
+                                 size_t extents);
+  void _record_allocation_stats();
 private:
+  uint64_t probe_count = 0;
+  std::atomic<uint64_t> alloc_stats_count = {0};
+  std::atomic<uint64_t> alloc_stats_fragments = { 0 };
+  std::atomic<uint64_t> alloc_stats_size = { 0 };
+  // 
+  std::array<std::tuple<uint64_t, uint64_t, uint64_t>, 5> alloc_stats_history =
+  { std::make_tuple(0ul, 0ul, 0ul) };
+
   std::atomic<uint64_t> out_of_sync_fm = {0};
   // --------------------------------------------------------
   // BlueFSDeviceExpander implementation


### PR DESCRIPTION
The primary goal is to be able to track allocator fragmentation trend.
Which might help in troubleshooting performance changes caused by aging.

Tracks history for up to last 31 days by keeping a set of 5 historic
probes selected from power of two sequence. I.e.
Dey -1
Day -2 
Day -4
Day -8
Day -16

Output samples:
Day1:
2020-02-26T23:42:34.044+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  allocation stats probe 0: cnt: 165 frags: 238 size: 16121856
2020-02-26T23:42:34.044+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -1: 0,  0, 0
2020-02-26T23:42:34.044+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -2: 0,  0, 0
2020-02-26T23:42:34.044+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -4: 0,  0, 0
2020-02-26T23:42:34.044+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -8: 0,  0, 0
2020-02-26T23:42:34.044+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -16: 0,  0, 0

Day 2:
2020-02-26T23:42:39.060+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  allocation stats probe 1: cnt: 288 frags: 407 size: 27328512
2020-02-26T23:42:39.060+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -1: 165,  238, 16121856
2020-02-26T23:42:39.060+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -3: 0,  0, 0
2020-02-26T23:42:39.060+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -5: 0,  0, 0
2020-02-26T23:42:39.060+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -9: 0,  0, 0
2020-02-26T23:42:39.060+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -17: 0,  0, 0

Day 3:
2020-02-26T23:42:44.072+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  allocation stats probe 2: cnt: 298 frags: 430 size: 28966912
2020-02-26T23:42:44.072+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -1: 288,  407, 27328512
2020-02-26T23:42:44.072+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -2: 165,  238, 16121856
2020-02-26T23:42:44.072+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -6: 0,  0, 0
2020-02-26T23:42:44.072+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -10: 0,  0, 0
2020-02-26T23:42:44.072+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -18: 0,  0, 0

Day 4:
2020-02-26T23:42:49.084+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  allocation stats probe 3: cnt: 325 frags: 472 size: 31522816
2020-02-26T23:42:49.084+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -1: 298,  430, 28966912
2020-02-26T23:42:49.084+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -3: 165,  238, 16121856
2020-02-26T23:42:49.084+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -7: 0,  0, 0
2020-02-26T23:42:49.084+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -11: 0,  0, 0
2020-02-26T23:42:49.084+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -19: 0,  0, 0
2020-02-26T23:42:49.084+0300 7f3f9244b700  0 bluestore(./fio-bluestore) ------------

Day 5:
2020-02-26T23:42:54.104+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  allocation stats probe 4: cnt: 605 frags: 884 size: 58589184
2020-02-26T23:42:54.104+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -1: 325,  472, 31522816
2020-02-26T23:42:54.104+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -2: 298,  430, 28966912
2020-02-26T23:42:54.104+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -4: 165,  238, 16121856
2020-02-26T23:42:54.104+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -12: 0,  0, 0
2020-02-26T23:42:54.104+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -20: 0,  0, 0

...

Day 8:
2020-02-26T23:43:09.156+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  allocation stats probe 7: cnt: 637 frags: 946 size: 62521344
2020-02-26T23:43:09.156+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -1: 529,  794, 52363264
2020-02-26T23:43:09.156+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -3: 605,  884, 58589184
2020-02-26T23:43:09.156+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -7: 165,  238, 16121856
2020-02-26T23:43:09.156+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -15: 0,  0, 0
2020-02-26T23:43:09.156+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -23: 0,  0, 0
2020-02-26T23:43:09.156+0300 7f3f9244b700  0 bluestore(./fio-bluestore) ------------

Day9:
2020-02-26T23:43:14.172+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  allocation stats probe 8: cnt: 609 frags: 916 size: 60162048
2020-02-26T23:43:14.172+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -1: 637,  946, 62521344
2020-02-26T23:43:14.172+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -2: 529,  794, 52363264
2020-02-26T23:43:14.172+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -4: 605,  884, 58589184
2020-02-26T23:43:14.172+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -8: 165,  238, 16121856
2020-02-26T23:43:14.172+0300 7f3f9244b700  0 bluestore(./fio-bluestore)  probe -24: 0,  0, 0
2020-02-26T23:43:14.172+0300 7f3f9244b700  0 bluestore(./fio-bluestore) ------------

Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
