### PR TITLE
rbd_huge_tickets added the image-feature layering

### DIFF
--- a/qa/workunits/rbd/huge-tickets.sh
+++ b/qa/workunits/rbd/huge-tickets.sh
@@ -32,7 +32,7 @@ generate_keyring foo 1000 # ~25K, kmalloc
 generate_keyring bar 20000 # ~500K, vmalloc
 generate_keyring baz 300000 # ~8M, vmalloc + sg chaining
 
-rbd create --size 1 test
+rbd create --size 1 test --image-feature layering
 
 for user in {foo,bar,baz}; do
     ceph auth import -i /tmp/keyring-$user


### PR DESCRIPTION
rbd_huge_tickets added the image-feature layering. Runs fine in the Teuthology Automation
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
