### PR TITLE
mgr/dashboard: fix stray requests/error in Grafana unit test

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_grafana.py
+++ b/src/pybind/mgr/dashboard/tests/test_grafana.py
@@ -6,6 +6,8 @@ try:
 except ImportError:
     from unittest.mock import patch
 
+from requests import RequestException
+
 from . import ControllerTestCase, KVStoreMockMixin
 from ..controllers.grafana import Grafana
 from ..grafana import GrafanaRestClient
@@ -41,23 +43,32 @@ class GrafanaTest(ControllerTestCase, KVStoreMockMixin):
         self.assertStatus(200)
         self.assertJsonBody({'instance': 'http://localhost:3000'})
 
-    def test_validation(self):
+    @patch('dashboard.controllers.grafana.GrafanaRestClient.url_validation')
+    def test_validation_endpoint_returns(self, url_validation):
+        """
+        The point of this test is to see that `validation` is an active endpoint that returns a 200
+        status code.
+        """
+        url_validation.return_value = b'404'
         self.server_settings()
         self._get('/api/grafana/validation/foo')
-        self.assertStatus(500)
+        self.assertStatus(200)
+        self.assertBody(b'"404"')
 
     def test_dashboards_unavailable_no_url(self):
-        self.server_settings(url=None)
+        self.server_settings(url="")
         self._post('/api/grafana/dashboards')
         self.assertStatus(500)
 
-    def test_dashboards_unavailable_no_user(self):
-        self.server_settings(user=None)
+    @patch('dashboard.controllers.grafana.GrafanaRestClient.push_dashboard')
+    def test_dashboards_unavailable_no_user(self, pd):
+        pd.side_effect = RequestException
+        self.server_settings(user="")
         self._post('/api/grafana/dashboards')
         self.assertStatus(500)
 
     def test_dashboards_unavailable_no_password(self):
-        self.server_settings(password=None)
+        self.server_settings(password="")
         self._post('/api/grafana/dashboards')
         self.assertStatus(500)
 


### PR DESCRIPTION
Fixes a Grafana unit test error when a Grafana instance is running or any other web service occupies the configured port (3000) by preventing requests beind made to external nonexistent services.

Fixes: https://tracker.ceph.com/issues/44317

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
