### PR TITLE
mgr/telemetry: fix and document proxy usage

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -114,6 +114,20 @@ The see the current configuration::
 
   ceph telemetry status
 
+Sending telemetry through a proxy
+---------------------------------
+
+If the cluster cannot directly connect to the configured telemetry
+endpoint (default *telemetry.ceph.com*), you can configure a HTTP/HTTPS
+proxy server with::
+
+  ceph config set mgr mgr/telemetry/proxy https://10.0.0.1:8080
+
+You can also include a *user:pass* if needed::
+
+  ceph config set mgr mgr/telemetry/proxy https://ceph:telemetry@10.0.0.1:8080
+
+
 Contact and Description
 -----------------------
 

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -681,7 +681,7 @@ class Module(MgrModule):
             proxies['http'] = self.proxy
             proxies['https'] = self.proxy
         try:
-            resp = requests.put(url=url, json=report)
+            resp = requests.put(url=url, json=report, proxies=proxies)
             resp.raise_for_status()
         except Exception as e:
             fail_reason = 'Failed to send %s to %s: %s' % (what, url, str(e))


### PR DESCRIPTION
This addresses https://tracker.ceph.com/issues/44320 - fix and document
use of proxies for mgr/telemetry.

Signed-off-by: Lars Marowsky-Bree <lmb@suse.com>
