### PR TITLE
unshare-ns-mount: add isolating netns for mount helper support

### DIFF
--- a/doc/dev/developer_guide/running-tests-locally.rst
+++ b/doc/dev/developer_guide/running-tests-locally.rst
@@ -102,6 +102,8 @@ vstart_runner.py can take the following options -
 --teardown                  tears Ceph cluster down after test(s) has finished
                             runnng
 --kclient                   use the kernel cephfs client instead of FUSE
+--brxnet=<net/mask>         specify a new net/mask for the mount clients' network
+                            namespace container (Default: 192.168.0.0/16)
 
 .. note:: If using the FUSE client, ensure that the fuse package is installed
           and enabled on the system and that ``user_allow_other`` is added

--- a/qa/cephfs/begin.yaml
+++ b/qa/cephfs/begin.yaml
@@ -13,6 +13,9 @@ tasks:
         - flex
         - libelf-dev
         - libssl-dev
+        - network-manager
+        - iproute2
+        - util-linux
         # for xfstests-dev
         - dump
         - indent
@@ -21,6 +24,9 @@ tasks:
         - flex
         - elfutils-libelf-devel
         - openssl-devel
+        - NetworkManager
+        - iproute
+        - util-linux
         # for xfstests-dev
         - libacl-devel
         - libaio-devel

--- a/qa/cephfs/unshare_ns_mount.sh
+++ b/qa/cephfs/unshare_ns_mount.sh
@@ -1,0 +1,594 @@
+#!/usr/bin/env bash
+
+# This is one helper for mounting the ceph-fuse/kernel clients by
+# unsharing the network namespace, let's call it netns container.
+# With the netns container, you can easily suspend or resume the
+# virtual network interface to simulate the client node hard
+# shutdown for some test cases.
+#
+#         netnsX                 netnsY                 netnsZ
+#     --------------         --------------         --------------
+#    | mount client |       | mount client |       | mount client |
+#    |    default   |  ...  |    default   |  ...  |    default   |
+#    |192.168.0.1/16|       |192.168.0.2/16|       |192.168.0.3/16|
+#    |    veth0     |       |     veth0    |       |     veth0    |
+#     --------------         --------------         -------------
+#           |                       |                      |
+#            \                      | brx.Y               /
+#             \          ----------------------          /
+#              \  brx.X |       ceph-brx       | brx.Z  / 
+#               \------>|       default        |<------/
+#                   |   |  192.168.255.254/16  |   |
+#                   |    ----------------------    |
+#            (suspend/resume)       |       (suspend/resume)
+#                              -----------
+#                             |  Physical |
+#                             | A.B.C.D/M |
+#                              -----------
+#
+# Defaultly it will use the 192.168.X.Y/16 private network IPs for
+# the ceph-brx and netnses as above. And you can also specify your
+# own new ip/mask for the ceph-brx, like:
+#
+#  $ unshare_ns_mount.sh --fuse /mnt/cephfs --brxip 172.19.100.100/12
+#
+# Then the each netns will get a new ip from the ranges:
+# [172.16.0.1 ~ 172.19.100.99]/12 and [172.19.100.101 ~ 172.31.255.254]/12
+
+usage() {
+    echo ""
+    echo "This will help to isolate the network namespace from OS for the mount client!"
+    echo ""
+    echo "usage: unshare_ns_mount.sh [OPTIONS [paramters]] [--brxip <ip_address/mask>]"
+    echo "OPTIONS:" 
+    echo -e "  --fuse    <ceph-fuse options>"
+    echo -e "\tThe ceph-fuse command options"
+    echo -e "\t  $ unshare_ns_mount.sh --fuse -m 192.168.0.1:6789 /mnt/cephfs -o nonempty"
+    echo ""
+    echo -e "  --kernel  <mount options>"
+    echo -e "\tThe mount command options"
+    echo -e "\t  $ unshare_ns_mount.sh --kernel -t ceph 192.168.0.1:6789:/ /mnt/cephfs -o fs=a"
+    echo ""
+    echo -e "  --suspend <mountpoint>"
+    echo -e "\tDown the veth interface in the network namespace"
+    echo -e "\t  $ unshare_ns_mount.sh --suspend /mnt/cephfs"
+    echo ""
+    echo -e "  --resume  <mountpoint>"
+    echo -e "\tUp the veth interface in the network namespace"
+    echo -e "\t  $ unshare_ns_mount.sh --resume /mnt/cephfs"
+    echo ""
+    echo -e "  --umount  <mountpoint>"
+    echo -e "\tUmount and delete the network namespace"
+    echo -e "\t  $ unshare_ns_mount.sh --umount /mnt/cephfs"
+    echo ""
+    echo -e "  --brxip   <ip_address/mask>"
+    echo -e "\tSpecify ip/mask for ceph-brx and it only makes sense for --fuse/--kernel options"
+    echo -e "\t(default: 192.168.255.254/16, netns ip: 192.168.0.1/16 ~ 192.168.255.253/16)"
+    echo -e "\t  $ unshare_ns_mount.sh --fuse -m 192.168.0.1:6789 /mnt/cephfs --brxip 172.19.255.254/12"
+    echo -e "\t  $ unshare_ns_mount.sh --kernel 192.168.0.1:6789:/ /mnt/cephfs --brxip 172.19.255.254/12"
+    echo ""
+    echo -e "  -h, --help"
+    echo -e "\tPrint help"
+    echo ""
+}
+
+CEPH_BRX=ceph-brx
+CEPH_BRX_IP_DEF=192.168.255.254
+NET_MASK_DEF=16
+BRD_DEF=192.168.255.255
+
+CEPH_BRX_IP=$CEPH_BRX_IP_DEF
+NET_MASK=$NET_MASK_DEF
+BRD=$BRD_DEF
+
+mountpoint=""
+new_netns=""
+fuse_type=false
+
+function get_mountpoint() {
+    for param in $@
+    do
+        if [ -d $param ]; then
+            # skipping "--client_mountpoint/-r root_directory"
+            # option for ceph-fuse command
+            if [ "$last" == "-r" -o "$last" == "--client_mountpoint" ]; then
+                last=$param
+                continue
+	        fi
+            if [ "0$mountpoint" != "0" ]; then
+                echo "Oops: too many mountpiont options!"
+                exit 1
+            fi
+            mountpoint=$param
+        fi
+        last=$param
+    done
+
+    if [ "0$mountpoint" == "0" ]; then
+        echo "Oops: mountpoint path is not a directory or no mountpoint specified!"
+        exit 1
+    fi
+}
+
+function get_new_netns() {
+    # prune the repeating slashes:
+    # "/mnt///cephfs///" --> "/mnt/cephfs/"
+    __mountpoint=`echo "$mountpoint" | sed 's/\/\+/\//g'`
+
+    # prune the leading slashes
+    while [ ${__mountpoint:0:1} == "/" ]
+    do
+        __mountpoint=${__mountpoint:1}
+    done
+
+    # prune the last slashes
+    while [ ${__mountpoint: -1} == "/" ]
+    do
+        __mountpoint=${__mountpoint:0:-1}
+    done
+
+    # replace '/' with '-'
+    __mountpoint=${__mountpoint//\//-}
+
+    # "mnt/cephfs" --> "ceph-fuse-mnt-cephfs"
+    if [ "$1" == "--fuse" ]; then
+        new_netns=`echo ceph-fuse-$__mountpoint`
+        fuse_type=true
+        return
+    fi
+
+    # "mnt/cephfs" --> "ceph-kernel-mnt-cephfs"
+    if [ "$1" == "--kernel" ]; then
+        new_netns=`echo ceph-kernel-$__mountpoint`
+        return
+    fi
+
+    # we are in umount/suspend/resume routines
+    for ns in `ip netns list | awk '{print $1}'`
+    do
+        if [ "$ns" == "ceph-fuse-$__mountpoint" ]; then
+            new_netns=$ns
+            fuse_type=true
+            return
+        fi
+        if [ "$ns" == "ceph-kernel-$__mountpoint" ]; then
+            new_netns=$ns
+            return
+        fi
+    done
+    
+    if [ "0$new_netns" == "0" ]; then
+        echo "Oops, netns 'ceph-{fuse/kernel}-$__mountpoint' does not exists!"
+        exit 1
+    fi
+}
+
+# the peer veth name will be "brx.$nsid" on host node
+function get_netns_brx() {
+    get_new_netns 
+
+    nsid=`ip netns list-id | grep "$new_netns" | awk '{print $2}'`
+    netns_veth=brx.$nsid
+    eval $1="$netns_veth"
+}
+
+function suspend_netns_veth() {
+    get_mountpoint $@
+
+    get_netns_brx brx
+    ip link set $brx down
+    exit 0
+}
+
+function resume_netns_veth() {
+    get_mountpoint $@
+
+    get_netns_brx brx
+    ip link set $brx up
+    exit 0
+}
+
+# help and usage
+if [ $# == 0 -o "$1" == "-h" -o "$1" == "--help" ]; then
+    usage
+    exit 0
+fi
+
+# suspend the veth from network namespace
+if [ $1 == "--suspend" ]; then
+    suspend_netns_veth $@
+    exit 0
+fi
+
+# resume the veth from network namespace
+if [ $1 == "--resume" ]; then
+    resume_netns_veth $@
+    exit 0
+fi
+
+function ceph_umount() {
+    get_mountpoint $@
+    get_new_netns
+
+    if [ $fuse_type == true ]; then
+        nsenter --net=/var/run/netns/$new_netns fusermount -u $mountpoint 2>/dev/null
+    else
+        nsenter --net=/var/run/netns/$new_netns umount $mountpoint 2>/dev/null
+    fi
+
+    # let's wait for a while to let the umount operation
+    # to finish before deleting the netns
+    while [ 1 ]
+    do
+        for pid in `ip netns pids $new_netns 2>/dev/null`
+        do
+            name=`cat /proc/$pid/comm 2>/dev/null`
+            if [ "$name" == "ceph-fuse" ]; then
+                break
+            fi
+        done
+
+        if [ "$name" == "ceph-fuse" ]; then
+            name=""
+            usleep 100000
+            continue
+        fi
+
+        break
+    done
+
+    nsid=`ip netns list-id | grep "$new_netns" | awk '{print $2}'`
+    netns_brx=brx.$nsid
+
+    # brctl delif $CEPH_BRX $netns_brx 2>/dev/null
+    nmcli connection down $netns_brx down 2>/dev/null
+    nmcli connection delete $netns_brx 2>/dev/null
+
+    ip netns delete $new_netns 2>/dev/null
+    
+    # if this is the last netns_brx, will delete
+    # the $CEPH_BRX and restore the OS configure
+    # rc=`brctl show ceph-brx 2>/dev/null | grep 'brx\.'|wc -l`
+    rc=`nmcli connection show 2>/dev/null | grep 'brx\.' | wc -l`
+    if [ $rc == 0 ]; then
+        ip link set $CEPH_BRX down 2>/dev/null
+        # brctl delbr $CEPH_BRX 2>/dev/null
+        nmcli connection delete $CEPH_BRX 2>/dev/null
+
+        # restore the ip forward
+        tmpfile=`ls /tmp/ | grep "$CEPH_BRX\."`
+        tmpfile=/tmp/$tmpfile
+        if [ ! -f $tmpfile ]; then
+            echo "Oops, the $CEPH_BRX.XXX temp file does not exist!"
+        else
+            save=`cat $tmpfile`
+            echo $save > /proc/sys/net/ipv4/ip_forward
+            rm -rf $tmpfile
+        fi
+
+        # drop the iptables NAT rules
+        host_nic=`route | grep default | awk '{print $8}'`
+        iptables -D FORWARD -o $host_nic -i $CEPH_BRX -j ACCEPT
+        iptables -D FORWARD -i $host_nic -o $CEPH_BRX -j ACCEPT
+        iptables -t nat -D POSTROUTING -s $CEPH_BRX_IP/$NET_MASK -o $host_nic -j MASQUERADE
+    fi
+}
+
+function get_brd_mask() {
+    first=`echo "$CEPH_BRX_IP" | awk -F. '{print $1}'`
+    second=`echo "$CEPH_BRX_IP" | awk -F. '{print $2}'`
+    third=`echo "$CEPH_BRX_IP" | awk -F. '{print $3}'`
+    fourth=`echo "$CEPH_BRX_IP" | awk -F. '{print $4}'`
+
+    if [ "$first" == "172" ]; then
+        second_max=31
+    else
+        second_max=255
+    fi
+    third_max=255
+    fourth_max=255
+
+    if [ $NET_MASK -lt 16 ]; then
+        let power=16-$NET_MASK
+        m=`awk 'BEGIN{printf 2^"'$power'"-1}'`
+        second=$((second&~m))
+        let second_max=$second+$m
+    elif [ $NET_MASK -lt 24 ]; then
+        let power=24-$NET_MASK
+        m=`awk 'BEGIN{printf 2^"'$power'"-1}'`
+        third=$((third&~m))
+        let third_max=$third+$m
+        second_max=$second
+    elif [ $NET_MASK -lt 32 ]; then
+        let power=32-$NET_MASK
+        m=`awk 'BEGIN{printf 2^"'$power'"-1}'`
+        fourth=$((fourth&~m))
+        let fourth_max=$fourth+$m
+        second_max=$second
+        third_max=$third
+    fi
+
+    BRD=$first.$second_max.$third_max.$fourth_max
+}
+
+# As default:
+# The netns IP will be 192.168.0.1 ~ 192.168.255.253,
+# and 192.168.255.254 is saved for $CEPH_BRX
+function get_new_ns_ip() {
+    first=`echo "$CEPH_BRX_IP" | awk -F. '{print $1}'`
+    second=`echo "$CEPH_BRX_IP" | awk -F. '{print $2}'`
+    third=`echo "$CEPH_BRX_IP" | awk -F. '{print $3}'`
+    fourth=`echo "$CEPH_BRX_IP" | awk -F. '{print $4}'`
+
+    if [ "$first" == ""172 ]; then
+        second_max=31
+    else
+        second_max=255
+    fi
+    third_max=255
+    fourth_max=254
+
+    if [ $NET_MASK -lt 16 ]; then
+        let power=16-$NET_MASK
+        m=`awk 'BEGIN{printf 2^"'$power'"-1}'`
+        second=$((second&~m))
+        let second_max=$second+$m
+        third=0
+        fourth=1
+    elif [ $NET_MASK -lt 24 ]; then
+        let power=24-$NET_MASK
+        m=`awk 'BEGIN{printf 2^"'$power'"-1}'`
+        third=$((third&~m))
+        let third_max=$third+$m
+        second_max=$second
+        fourth=1
+    elif [ $NET_MASK -lt 32 ]; then
+        let power=32-$NET_MASK
+        m=`awk 'BEGIN{printf 2^"'$power'"-1}'`
+        fourth=$((fourth&~m))
+        let fourth+=1
+        let fourth_max=$fourth+$m-1
+        second_max=$second
+        third_max=$third
+    fi
+
+    while [ $second -le $second_max -a $third -le $third_max -a $fourth -le $fourth_max ]
+    do
+        conflict=false
+
+        # check from the existing network namespaces
+        for netns in `ip netns list | awk '{print $1}'`
+        do
+            ip=`ip netns exec $netns ip addr | grep "inet " | grep "veth0"`
+            ip=`echo "$ip" | awk '{print $2}' | awk -F/ '{print $1}'`
+            if [ "0$ip" == "0" ]; then
+                continue
+            fi
+            if [ "$first.$second.$third.$fourth" == "$ip" ]; then
+                conflict=true
+
+                let fourth+=1
+                if [ $fourth -le $fourth_max ]; then
+                     break
+                fi
+		
+                fourth=0
+                let third+=1
+                if [ $third -le $third_max ]; then
+                     break
+                fi
+
+                third=0
+                let second+=1
+                if [ $second -le $second_max ]; then
+                    break
+                fi
+
+                echo "Oops: we have ran out of the ip addresses!"
+                exit 1
+            fi
+        done
+
+        # have we found one ?
+        if [ $conflict == false ]; then
+            break
+        fi
+    done
+
+    ip=$first.$second.$third.$fourth
+    max=$first.$second_max.$third_max.$fourth_max
+    if [ "$ip" == "$max" ]; then
+        echo "Oops: we have ran out of the ip addresses!"
+        exit 1
+    fi
+
+    eval $1="$ip"
+}
+
+function check_valid_private_ip() {
+    first=`echo "$1" | awk -F. '{print $1}'`
+    second=`echo "$1" | awk -F. '{print $2}'`
+
+    # private network class A 10.0.0.0 - 10.255.255.255
+    if [ "$first" == "10" -a $NET_MASK -ge 8 ]; then
+        return
+    fi
+
+    # private network class B 172.16.0.0 - 172.31.255.255
+    if [ "$first" == "172" -a $second -ge 16 -a $second -le 31 -a $NET_MASK -ge 12 ]; then
+        return
+    fi
+
+    # private network class C 192.168.0.0 - 192.168.255.255
+    if [ "$first" == "192" -a "$second" == "168" -a $NET_MASK -ge 16 ]; then
+        return
+    fi
+
+    echo "Oops: invalid private ip address '$CEPH_BRX_IP/$NET_MASK'!"
+    exit 1
+}
+
+function setup_bridge_and_nat() {
+    # check and parse the --brxip parameter
+    is_brxip=false
+    for ip in $@
+    do
+        if [ "$ip" == "--brxip" ]; then
+            is_brxip=true
+            continue
+        fi
+        if [ $is_brxip == true ]; then
+            new_brxip=$ip
+            break
+        fi
+    done
+
+    # if the $CEPH_BRX already exists, then check the new
+    # brxip, if not match fail it without doing anything.
+    rc=`ip addr | grep "inet " | grep " $CEPH_BRX"`
+    if [ "0$rc" != "0" ]; then
+        existing_brxip=`echo "$rc" | awk '{print $2}'`
+        if [ "0$new_brxip" != "0" -a "$existing_brxip" != "$new_brxip" ]; then
+            echo "Oops: conflict with the existing $CEPH_BRX ip '$existing_brxip', new '$new_brxip'!"
+            exit 1
+        fi
+
+        CEPH_BRX_IP=`echo "$existing_brxip" | awk -F/ '{print $1}'`
+        NET_MASK=`echo "$existing_brxip" | awk -F/ '{print $2}'`
+        get_brd_mask
+        return
+    fi
+
+    # if it is the first time to run the the script or there
+    # is no any network namespace exists, we need to setup
+    # the $CEPH_BRX, if no --brxip is specified will use the
+    # default $CEPH_BRX_IP/$NET_MASK
+    if [ "0$new_brxip" != "0" ]; then
+        CEPH_BRX_IP=`echo "$new_brxip" | awk -F/ '{print $1}'`
+        NET_MASK=`echo "$new_brxip" | awk -F/ '{print $2}'`
+        get_brd_mask
+        check_valid_private_ip $CEPH_BRX_IP
+    fi
+
+    # brctl addbr $CEPH_BRX
+    nmcli connection add type bridge con-name $CEPH_BRX ifname $CEPH_BRX stp no
+    # ip link set $CEPH_BRX up
+    # ip addr add $CEPH_BRX_IP/$NET_MASK brd $BRD dev $CEPH_BRX
+    nmcli connection modify $CEPH_BRX ipv4.addresses $CEPH_BRX_IP/$NET_MASK ipv4.method manual
+    nmcli connection up $CEPH_BRX
+
+    # setup the NAT
+    rm -rf /tmp/ceph-brx.*
+    tmpfile=$(mktemp /tmp/ceph-brx.XXXXXXXX)
+    save=`cat /proc/sys/net/ipv4/ip_forward`
+    echo $save > $tmpfile
+    echo 1 > /proc/sys/net/ipv4/ip_forward
+
+    host_nic=`route | grep default | awk '{print $8}'`
+    iptables -A FORWARD -o $host_nic -i $CEPH_BRX -j ACCEPT
+    iptables -A FORWARD -i $host_nic -o $CEPH_BRX -j ACCEPT
+    iptables -t nat -A POSTROUTING -s $CEPH_BRX_IP/$NET_MASK -o $host_nic -j MASQUERADE
+}
+
+function __ceph_mount() {
+    # for some options like the '-t' in mount command
+    # the nsenter command will take over it, so it is
+    # hard to pass it direct to the netns.
+    # here we will create one temp file with x mode
+    tmpfile=$(mktemp /tmp/ceph-nsenter.XXXXXXXX)
+    chmod +x $tmpfile
+    if [ "$1" == "--kernel" ]; then
+        cmd=`echo "$@" | sed 's/--kernel/mount/'`
+    else
+        cmd=`echo "$@" | sed 's/--fuse/ceph-fuse/'`
+    fi
+
+    # remove the --brxip parameter
+    cmd=`echo "$cmd" | sed 's/--brxip.*\/[0-9]* //'`
+
+    # enter $new_netns and run ceph fuse client mount,
+    # we couldn't use 'ip netns exec' here because it
+    # will unshare the mount namespace.
+    echo "$cmd" > $tmpfile
+    nsenter --net=/var/run/netns/$new_netns /bin/bash $tmpfile ; echo $? > $tmpfile
+    rc=`cat $tmpfile`
+    rm -f $tmpfile
+
+    # fall back
+    if [ $rc != 0 ]; then
+        m=$mountpoint
+        mountpoint=""
+        ceph_umount $m
+    fi
+}
+
+function get_new_nsid() {
+    # get one uniq netns id
+    uniq_id=0
+    while [ 1 ]
+    do
+        rc=`ip netns list-id | grep "nsid $uniq_id "`
+        if [ "0$rc" == "0" ]; then
+            break
+        fi
+        let uniq_id+=1
+    done
+
+    eval $1="$uniq_id"
+}
+
+function ceph_mount() {
+    get_mountpoint $@
+    setup_bridge_and_nat $@
+
+    get_new_netns $1
+    rc=`ip netns list | grep "$new_netns" | awk '{print $1}'`
+    if [ "0$rc" != "0" ]; then
+        echo "Oops: the netns "$new_netns" already exists!"
+        exit 1
+    fi
+
+    get_new_nsid new_nsid
+
+    # create a new network namespace
+    ip netns add $new_netns
+    ip netns set $new_netns $new_nsid
+
+    get_new_ns_ip ns_ip
+    if [ 0"$ns_ip" == "0" ]; then
+        echo "Oops: there is no ip address could be used any more!"
+        exit 1
+    fi
+
+    # veth interface in netns
+    ns_veth=veth0
+    netns_brx=brx.$new_nsid
+
+    # setup veth interfaces
+    ip link add $ns_veth netns $new_netns type veth peer name $netns_brx
+    ip netns exec $new_netns ip addr add $ns_ip/$NET_MASK brd $BRD dev $ns_veth
+    ip netns exec $new_netns ip link set $ns_veth up
+    ip netns exec $new_netns ip link set lo up
+    ip netns exec $new_netns ip route add default via $CEPH_BRX_IP
+
+    # bring up the bridge interface and join it to $CEPH_BRX
+    # brctl addif $CEPH_BRX $netns_brx
+    nmcli connection add type bridge-slave con-name $netns_brx ifname $netns_brx master $CEPH_BRX
+    nmcli connection up $netns_brx
+    # ip link set $netns_brx up
+
+    __ceph_mount $@
+}
+
+if [ "$1" == "--umount" ]; then
+    ceph_umount $@
+    exit 0
+fi
+
+# mount in the netns
+if [ "$1" != "--kernel" -a "$1" != "--fuse" ]; then
+    echo "Oops: invalid mount options '$1'!"
+    exit 1
+fi
+
+ceph_mount $@

--- a/qa/tasks/ceph_fuse.py
+++ b/qa/tasks/ceph_fuse.py
@@ -42,12 +42,16 @@ def task(ctx, config):
     this operation on. This lets you e.g. set up one client with
     ``ceph-fuse`` and another with ``kclient``.
 
+    ``brxnet`` should be a Private IPv4 Address range, default range is
+    [192.168.0.0/16]
+
     Example that mounts all clients::
 
         tasks:
         - ceph:
         - ceph-fuse:
         - interactive:
+        - brxnet: [192.168.0.0/16]
 
     Example that uses both ``kclient` and ``ceph-fuse``::
 
@@ -106,6 +110,8 @@ def task(ctx, config):
     mounted_by_me = {}
     skipped = {}
 
+    brxnet = config.get("brxnet", None)
+
     # Construct any new FuseMount instances
     for id_, remote in clients:
         client_config = config.get("client.%s" % id_)
@@ -120,7 +126,7 @@ def task(ctx, config):
             continue
 
         if id_ not in all_mounts:
-            fuse_mount = FuseMount(ctx, client_config, testdir, auth_id, remote)
+            fuse_mount = FuseMount(ctx, client_config, testdir, auth_id, remote, brxnet)
             all_mounts[id_] = fuse_mount
         else:
             # Catch bad configs where someone has e.g. tried to use ceph-fuse and kcephfs for the same client

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -142,8 +142,7 @@ class CephFSTestCase(CephTestCase):
 
             # Mount the requested number of clients
             for i in range(0, self.CLIENTS_REQUIRED):
-                self.mounts[i].mount()
-                self.mounts[i].wait_until_mounted()
+                self.mounts[i].mount_wait()
 
         if self.REQUIRE_RECOVERY_FILESYSTEM:
             if not self.REQUIRE_FILESYSTEM:

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -20,8 +20,6 @@ class KernelMount(CephFSMount):
     def __init__(self, ctx, test_dir, client_id, client_remote, brxnet):
         super(KernelMount, self).__init__(ctx, test_dir, client_id, client_remote, brxnet)
 
-        self.mounted = False
-
     def mount(self, mount_path=None, mount_fs_name=None, mountpoint=None, mount_options=[]):
         if mountpoint is not None:
             self.mountpoint = mountpoint
@@ -121,9 +119,6 @@ class KernelMount(CephFSMount):
             self.mounted = False
             self.cleanup_netns()
             self.cleanup()
-
-    def is_mounted(self):
-        return self.mounted
 
     def wait_until_mounted(self):
         """

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -17,19 +17,16 @@ UMOUNT_TIMEOUT = 300
 
 
 class KernelMount(CephFSMount):
-    def __init__(self, ctx, test_dir, client_id, client_remote,
-                 ipmi_user, ipmi_password, ipmi_domain):
-        super(KernelMount, self).__init__(ctx, test_dir, client_id, client_remote)
+    def __init__(self, ctx, test_dir, client_id, client_remote, brxnet):
+        super(KernelMount, self).__init__(ctx, test_dir, client_id, client_remote, brxnet)
 
         self.mounted = False
-        self.ipmi_user = ipmi_user
-        self.ipmi_password = ipmi_password
-        self.ipmi_domain = ipmi_domain
 
     def mount(self, mount_path=None, mount_fs_name=None, mountpoint=None, mount_options=[]):
         if mountpoint is not None:
             self.mountpoint = mountpoint
         self.setupfs(name=mount_fs_name)
+        self.setup_netns()
 
         log.info('Mounting kclient client.{id} at {remote} {mnt}...'.format(
             id=self.client_id, remote=self.client_remote, mnt=self.mountpoint))
@@ -55,6 +52,8 @@ class KernelMount(CephFSMount):
                 'adjust-ulimits',
                 'ceph-coverage',
                 '{tdir}/archive/coverage'.format(tdir=self.test_dir),
+                'nsenter',
+                '--net=/var/run/netns/{0}'.format(self.netns_name),
                 '/bin/mount',
                 '-t',
                 'ceph',
@@ -91,19 +90,9 @@ class KernelMount(CephFSMount):
             ], timeout=(15*60))
             raise e
 
-        rproc = self.client_remote.run(
-            args=[
-                'rmdir',
-                '--',
-                self.mountpoint,
-            ],
-            wait=False
-        )
-        run.wait([rproc], UMOUNT_TIMEOUT)
         self.mounted = False
-
-    def cleanup(self):
-        pass
+        self.cleanup_netns()
+        self.cleanup()
 
     def umount_wait(self, force=False, require_clean=False, timeout=900):
         """
@@ -118,10 +107,20 @@ class KernelMount(CephFSMount):
             if not force:
                 raise
 
-            self.kill()
-            self.kill_cleanup()
+            # force delete the netns and umount
+            self.cleanup_netns()
+            self.client_remote.run(
+                args=['sudo',
+                      'umount',
+                      '-f',
+                      '-l',
+                      self.mountpoint
+                ],
+                timeout=(15*60))
 
-        self.mounted = False
+            self.mounted = False
+            self.cleanup_netns()
+            self.cleanup()
 
     def is_mounted(self):
         return self.mounted
@@ -137,57 +136,6 @@ class KernelMount(CephFSMount):
         super(KernelMount, self).teardown()
         if self.mounted:
             self.umount()
-
-    def kill(self):
-        """
-        The Ceph kernel client doesn't have a mechanism to kill itself (doing
-        that in side the kernel would be weird anyway), so we reboot the whole node
-        to get the same effect.
-
-        We use IPMI to reboot, because we don't want the client to send any
-        releases of capabilities.
-        """
-
-        con = orchestra_remote.getRemoteConsole(self.client_remote.hostname,
-                                                self.ipmi_user,
-                                                self.ipmi_password,
-                                                self.ipmi_domain)
-        con.hard_reset(wait_for_login=False)
-
-        self.mounted = False
-
-    def kill_cleanup(self):
-        assert not self.mounted
-
-        # We need to do a sleep here because we don't know how long it will
-        # take for a hard_reset to be effected.
-        time.sleep(30)
-
-        try:
-            # Wait for node to come back up after reboot
-            misc.reconnect(None, 300, [self.client_remote])
-        except:
-            # attempt to get some useful debug output:
-            con = orchestra_remote.getRemoteConsole(self.client_remote.hostname,
-                                                    self.ipmi_user,
-                                                    self.ipmi_password,
-                                                    self.ipmi_domain)
-            con.check_status(timeout=60)
-            raise
-
-        # Remove mount directory
-        self.client_remote.run(args=['uptime'], timeout=10)
-
-        # Remove mount directory
-        self.client_remote.run(
-            args=[
-                'rmdir',
-                '--',
-                self.mountpoint,
-            ],
-            timeout=(5*60),
-            check_status=False,
-        )
 
     def _find_debug_dir(self):
         """

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -491,7 +491,7 @@ class CephFSMount(object):
         return "/etc/ceph/ceph.conf"
 
     @contextmanager
-    def mounted(self):
+    def mounted_wait(self):
         """
         A context manager, from an initially unmounted state, to mount
         this, yield, and then unmount and clean up.

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -415,6 +415,11 @@ class CephFSMount(object):
     def mount(self, mount_path=None, mount_fs_name=None, mountpoint=None, mount_options=[]):
         raise NotImplementedError()
 
+    def mount_wait(self, mount_path=None, mount_fs_name=None, mountpoint=None, mount_options=[]):
+        self.mount(mount_path=mount_path, mount_fs_name=mount_fs_name, mountpoint=mountpoint,
+                   mount_options=mount_options)
+        self.wait_until_mounted()
+
     def umount(self):
         raise NotImplementedError()
 

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -33,6 +33,7 @@ class CephFSMount(object):
         self.mountpoint_dir_name = 'mnt.{id}'.format(id=self.client_id)
         self._mountpoint = None
         self.fs = None
+        self.mounted = False
         self._netns_name = None
         self.nsid = -1
         if brxnet is None:
@@ -86,7 +87,7 @@ class CephFSMount(object):
         self._netns_name = name
 
     def is_mounted(self):
-        raise NotImplementedError()
+        return self.mounted
 
     def setupfs(self, name=None):
         if name is None and self.fs is not None:

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -8,15 +8,18 @@ import time
 from six import StringIO
 from textwrap import dedent
 import os
+import re
+from IPy import IP
 from teuthology.orchestra import run
 from teuthology.orchestra.run import CommandFailedError, ConnectionLostError
 from tasks.cephfs.filesystem import Filesystem
+import platform
 
 log = logging.getLogger(__name__)
 
 
 class CephFSMount(object):
-    def __init__(self, ctx, test_dir, client_id, client_remote):
+    def __init__(self, ctx, test_dir, client_id, client_remote, brxnet):
         """
         :param test_dir: Global teuthology test dir
         :param client_id: Client ID, the 'foo' in client.foo
@@ -30,10 +33,31 @@ class CephFSMount(object):
         self.mountpoint_dir_name = 'mnt.{id}'.format(id=self.client_id)
         self._mountpoint = None
         self.fs = None
+        self._netns_name = None
+        self.nsid = -1
+        if brxnet is None:
+            self.ceph_brx_net = '192.168.0.0/16'
+        else:
+            self.ceph_brx_net = brxnet
 
         self.test_files = ['a', 'b', 'c']
 
         self.background_procs = []
+
+        # On Centos/Redhat 8 the 'brctl' has been deprecated. But the
+        # 'nmcli' in ubuntu 18.04 is buggy to setup the network bridge
+        # and there is no workaround, will continue to use the 'brctl'
+        args = ["bash", "-c",
+                "cat /etc/os-release"]
+        p = self.client_remote.run(args=args, stderr=BytesIO(),
+                                   stdout=BytesIO(), timeout=(5*60))
+        distro = re.findall(r'NAME="Ubuntu"', p.stdout.getvalue())
+        version = re.findall(r'VERSION_ID="18.04"', p.stdout.getvalue())
+        self.use_brctl = len(distro) is not 0 and len(version) is not 0
+        
+    def _parse_netns_name(self):
+        self._netns_name = '-'.join(["ceph-ns",
+                                     re.sub(r'/+', "-", self.mountpoint)])
 
     @property
     def mountpoint(self):
@@ -47,6 +71,19 @@ class CephFSMount(object):
         if not isinstance(path, str):
             raise RuntimeError('path should be of str type.')
         self._mountpoint = path
+        self._parse_netns_name()
+
+    @property
+    def netns_name(self):
+        if self._netns_name == None:
+            self._parse_netns_name()
+        return self._netns_name
+
+    @netns_name.setter
+    def netns_name(self, name):
+        if not isinstance(path, str):
+            raise RuntimeError('path should be of str type.')
+        self._netns_name = name
 
     def is_mounted(self):
         raise NotImplementedError()
@@ -59,6 +96,320 @@ class CephFSMount(object):
         log.info('Wait for MDS to reach steady state...')
         self.fs.wait_for_daemons()
         log.info('Ready to start {}...'.format(type(self).__name__))
+
+    def _bringup_network_manager_service(self):
+        args = ["sudo", "bash", "-c",
+                "systemctl start NetworkManager"]
+        self.client_remote.run(args=args, timeout=(5*60))
+
+    def _setup_brx_and_nat(self):
+        # The ip for ceph-brx should be
+        ip = IP(self.ceph_brx_net)[-2]
+        mask = self.ceph_brx_net.split('/')[1]
+        brd = IP(self.ceph_brx_net).broadcast()
+
+        brx = self.client_remote.run(args=['ip', 'addr'], stderr=BytesIO(),
+                                     stdout=BytesIO(), timeout=(5*60))
+        brx = re.findall(r'inet .* ceph-brx', brx.stdout.getvalue())
+        if brx:
+            # If the 'ceph-brx' already exists, then check whether
+            # the new net is conflicting with it
+            _ip, _mask = brx[0].split()[1].split('/', 1)
+            if _ip != "{}".format(ip) or _mask != mask:
+                raise RuntimeError("Conflict with existing ceph-brx {0}, new {1}/{2}".format(brx[0].split()[1], ip, mask))
+            return 
+
+        log.info("Setuping the 'ceph-brx' with {0}/{1}".format(ip, mask))
+
+        # Setup the ceph-brx and always use the last valid IP
+        if self.use_brctl == True:
+            args = ["sudo", "bash", "-c", "brctl addbr ceph-brx"]
+            self.client_remote.run(args=args, timeout=(5*60))
+            args = ["sudo", "bash", "-c", "ip link set ceph-brx up"]
+            self.client_remote.run(args=args, timeout=(5*60))
+            args = ["sudo", "bash", "-c",
+                    "ip addr add {0}/{1} brd {2} dev ceph-brx".format(ip, mask, brd)]
+            self.client_remote.run(args=args, timeout=(5*60))
+        else:
+            self._bringup_network_manager_service()
+            args = ["sudo", "bash", "-c",
+                    "nmcli connection add type bridge con-name ceph-brx ifname ceph-brx stp no"]
+            self.client_remote.run(args=args, timeout=(5*60))
+            args = ["sudo", "bash", "-c",
+                    "nmcli connection modify ceph-brx ipv4.addresses {0}/{1} ipv4.method manual".format(ip, mask)]
+            self.client_remote.run(args=args, timeout=(5*60))
+            args = ["sudo", "bash", "-c", "nmcli connection up ceph-brx"]
+            self.client_remote.run(args=args, timeout=(5*60))
+        
+        # Save the ip_forward
+        self.client_remote.run(args=['touch', '/tmp/python-ceph-brx'],
+                               timeout=(5*60))
+        p = self.client_remote.run(args=['cat', '/proc/sys/net/ipv4/ip_forward'],
+                                   stderr=BytesIO(), stdout=BytesIO(),
+                                   timeout=(5*60))
+        val = p.stdout.getvalue().strip()
+        args = ["sudo", "bash", "-c",
+                "echo {} > /tmp/python-ceph-brx".format(val)]
+        self.client_remote.run(args=args, timeout=(5*60))
+        args = ["sudo", "bash", "-c",
+                "echo 1 > /proc/sys/net/ipv4/ip_forward"]
+        self.client_remote.run(args=args, timeout=(5*60))
+        
+        # Setup the NAT
+        p = self.client_remote.run(args=['route'], stderr=BytesIO(),
+                                   stdout=BytesIO(), timeout=(5*60))
+        p = re.findall(r'default .*', p.stdout.getvalue())
+        if p == False:
+            raise RuntimeError("No default gw found")
+        gw = p[0].split()[7]
+        args = ["sudo", "bash", "-c",
+                "iptables -A FORWARD -o {0} -i ceph-brx -j ACCEPT".format(gw)]
+        self.client_remote.run(args=args, timeout=(5*60))
+        args = ["sudo", "bash", "-c",
+                "iptables -A FORWARD -i {0} -o ceph-brx -j ACCEPT".format(gw)]
+        self.client_remote.run(args=args, timeout=(5*60))
+        args = ["sudo", "bash", "-c",
+                "iptables -t nat -A POSTROUTING -s {0}/{1} -o {2} -j MASQUERADE".format(ip, mask, gw)]
+        self.client_remote.run(args=args, timeout=(5*60))
+
+    def _setup_netns(self):
+        p = self.client_remote.run(args=['ip', 'netns', 'list'],
+                                   stderr=BytesIO(), stdout=BytesIO(),
+                                   timeout=(5*60))
+        p = p.stdout.getvalue().strip()
+        if re.match(self.netns_name, p) is not None:
+            raise RuntimeError("the netns '{}' already exists!".format(self.netns_name))
+
+        # Get the netns name list
+        netns_list = re.findall(r'[^()\s][-.\w]+[^():\s]', p)
+
+        # Get an uniq netns id
+        nsid = 0
+        while True:
+            p = self.client_remote.run(args=['ip', 'netns', 'list-id'],
+                                       stderr=BytesIO(), stdout=BytesIO(),
+                                       timeout=(5*60))
+            p = re.search(r"nsid {} ".format(nsid), p.stdout.getvalue())
+            if p is None:
+                break
+
+            nsid += 1
+
+        self.nsid = nsid;
+
+        # Add one new netns and set it id
+        args = ["sudo", "bash", "-c",
+                "ip netns add {0}".format(self.netns_name)]
+        self.client_remote.run(args=args, timeout=(5*60))
+        args = ["sudo", "bash", "-c",
+                "ip netns set {0} {1}".format(self.netns_name, nsid)]
+        self.client_remote.run(args=args, timeout=(5*60))
+
+        # Get one ip address for netns
+        ips = IP(self.ceph_brx_net)
+        for ip in ips:
+            found = False
+            if ip == ips[0]:
+                continue
+            if ip == ips[-2]:
+                raise RuntimeError("we have ran out of the ip addresses")
+
+            for ns in netns_list:
+                ns_name = ns.split()[0]
+                args = ["sudo", "bash", "-c",
+                        "ip netns exec {0} ip addr".format(ns_name)]
+                p = self.client_remote.run(args=args, stderr=BytesIO(),
+                                           stdout=BytesIO(), timeout=(5*60))
+                q = re.search("{0}".format(ip), p.stdout.getvalue())
+                if q is not None:
+                    found = True
+                    break
+
+            if found == False:
+                break
+
+        mask = self.ceph_brx_net.split('/')[1]
+        brd = IP(self.ceph_brx_net).broadcast()
+
+        log.info("Setuping the netns '{0}' with {1}/{2}".format(self.netns_name, ip, mask))
+
+        # Setup the veth interfaces
+        args = ["sudo", "bash", "-c",
+                "ip link add veth0 netns {0} type veth peer name brx.{1}".format(self.netns_name, nsid)]
+        self.client_remote.run(args=args, timeout=(5*60))
+        args = ["sudo", "bash", "-c",
+                "ip netns exec {0} ip addr add {1}/{2} brd {3} dev veth0".format(self.netns_name, ip, mask, brd)]
+        self.client_remote.run(args=args, timeout=(5*60))
+        args = ["sudo", "bash", "-c",
+                "ip netns exec {0} ip link set veth0 up".format(self.netns_name)]
+        self.client_remote.run(args=args, timeout=(5*60))
+        args = ["sudo", "bash", "-c",
+                "ip netns exec {0} ip link set lo up".format(self.netns_name)]
+        self.client_remote.run(args=args, timeout=(5*60))
+
+        brxip = IP(self.ceph_brx_net)[-2]
+        args = ["sudo", "bash", "-c",
+                "ip netns exec {0} ip route add default via {1}".format(self.netns_name, brxip)]
+        self.client_remote.run(args=args, timeout=(5*60))
+
+        # Bring up the brx interface and join it to 'ceph-brx'
+        if self.use_brctl == True:
+            args = ["sudo", "bash", "-c",
+                    "ip link set brx.{0} up".format(nsid)]
+            self.client_remote.run(args=args, timeout=(5*60))
+            args = ["sudo", "bash", "-c",
+                    "brctl addif ceph-brx brx.{0}".format(nsid)]
+            self.client_remote.run(args=args, timeout=(5*60))
+        else:
+            self._bringup_network_manager_service()
+            args = ["sudo", "bash", "-c",
+                    "nmcli connection add type bridge-slave con-name brx.{0} ifname brx.{0} master ceph-brx".format(nsid)]
+            self.client_remote.run(args=args, timeout=(5*60))
+            args = ["sudo", "bash", "-c",
+                    "nmcli connection up brx.{0}".format(self.nsid)]
+            self.client_remote.run(args=args, timeout=(5*60))
+
+    def _cleanup_netns(self):
+        if self.nsid == -1:
+            return
+        log.info("Removing the netns '{0}'".format(self.netns_name))
+
+        # Delete the netns and the peer veth interface
+        if self.use_brctl == True:
+            args = ["sudo", "bash", "-c",
+                    "ip link set brx.{0} down".format(self.nsid)]
+            self.client_remote.run(args=args, timeout=(5*60))
+            args = ["sudo", "bash", "-c",
+                    "brctl delif ceph-brx brx.{0}".format(self.nsid)]
+            self.client_remote.run(args=args, timeout=(5*60))
+            args = ["sudo", "bash", "-c",
+                    "ip link delete brx.{0}".format(self.nsid)]
+            self.client_remote.run(args=args, timeout=(5*60))
+        else:
+            self._bringup_network_manager_service()
+            args = ["sudo", "bash", "-c",
+                    "nmcli connection down brx.{0}".format(self.nsid)]
+            self.client_remote.run(args=args, timeout=(5*60))
+            args = ["sudo", "bash", "-c",
+                    "nmcli connection delete brx.{0}".format(self.nsid)]
+            self.client_remote.run(args=args, timeout=(5*60))
+
+        args = ["sudo", "bash", "-c",
+                "ip netns delete {0}".format(self.netns_name)]
+        self.client_remote.run(args=args, timeout=(5*60))
+
+        self.nsid = -1
+
+    def _cleanup_brx_and_nat(self):
+        brx = self.client_remote.run(args=['ip', 'addr'], stderr=BytesIO(),
+                                     stdout=BytesIO(), timeout=(5*60))
+        brx = re.findall(r'inet .* ceph-brx', brx.stdout.getvalue())
+        if not brx:
+            return
+
+        # If we are the last netns, will delete the ceph-brx
+        if self.use_brctl == True:
+            p = self.client_remote.run(args=['brctl', 'show', 'ceph-brx'],
+                                       stderr=BytesIO(), stdout=BytesIO(),
+                                       timeout=(5*60))
+        else:
+            self._bringup_network_manager_service()
+            p = self.client_remote.run(args=['nmcli', 'connection', 'show'],
+                                       stderr=BytesIO(), stdout=BytesIO(),
+                                       timeout=(5*60))
+        _list = re.findall(r'brx\.', p.stdout.getvalue().strip())
+        if len(_list) != 0:
+            return
+
+        log.info("Removing the 'ceph-brx'")
+
+        if self.use_brctl == True:
+            args = ["sudo", "bash", "-c",
+                    "ip link set ceph-brx down"]
+            self.client_remote.run(args=args, timeout=(5*60))
+            args = ["sudo", "bash", "-c",
+                    "brctl delbr ceph-brx"]
+            self.client_remote.run(args=args, timeout=(5*60))
+        else:
+            args = ["sudo", "bash", "-c",
+                    "nmcli connection down ceph-brx"]
+            self.client_remote.run(args=args, timeout=(5*60))
+            args = ["sudo", "bash", "-c",
+                    "nmcli connection delete ceph-brx"]
+            self.client_remote.run(args=args, timeout=(5*60))
+
+        # Drop the iptables NAT rules
+        ip = IP(self.ceph_brx_net)[-2]
+        mask = self.ceph_brx_net.split('/')[1]
+
+        p = self.client_remote.run(args=['route'], stderr=BytesIO(),
+                                   stdout=BytesIO(), timeout=(5*60))
+        p = re.findall(r'default .*', p.stdout.getvalue())
+        if p == False:
+            raise RuntimeError("No default gw found")
+        gw = p[0].split()[7]
+        args = ["sudo", "bash", "-c",
+                "iptables -D FORWARD -o {0} -i ceph-brx -j ACCEPT".format(gw)]
+        self.client_remote.run(args=args, timeout=(5*60))
+        args = ["sudo", "bash", "-c",
+                "iptables -D FORWARD -i {0} -o ceph-brx -j ACCEPT".format(gw)]
+        self.client_remote.run(args=args, timeout=(5*60))
+        args = ["sudo", "bash", "-c",
+                "iptables -t nat -D POSTROUTING -s {0}/{1} -o {2} -j MASQUERADE".format(ip, mask, gw)]
+        self.client_remote.run(args=args, timeout=(5*60))
+
+        # Restore the ip_forward
+        p = self.client_remote.run(args=['cat', '/tmp/python-ceph-brx'],
+                                   stderr=BytesIO(), stdout=BytesIO(),
+                                   timeout=(5*60))
+        val = p.stdout.getvalue().strip()
+        args = ["sudo", "bash", "-c",
+                "echo {} > /proc/sys/net/ipv4/ip_forward".format(val)]
+        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=['rm', '-f', '/tmp/python-ceph-brx'],
+                               timeout=(5*60))
+
+    def setup_netns(self):
+        """
+        Setup the netns for the mountpoint.
+        """
+        log.info("Setting the '{0}' netns for '{1}'".format(self._netns_name, self.mountpoint))
+        self._setup_brx_and_nat()
+        self._setup_netns()
+
+    def cleanup_netns(self):
+        """
+        Cleanup the netns for the mountpoint.
+        """
+        log.info("Cleaning the '{0}' netns for '{1}'".format(self._netns_name, self.mountpoint))
+        self._cleanup_netns()
+        self._cleanup_brx_and_nat()
+
+    def suspend_netns(self):
+        """
+        Suspend the netns veth interface.
+        """
+        if self.nsid == -1:
+            return
+
+        log.info("Suspending the '{0}' netns for '{1}'".format(self._netns_name, self.mountpoint))
+
+        args = ["sudo", "bash", "-c",
+                "ip link set brx.{0} down".format(self.nsid)]
+        self.client_remote.run(args=args, timeout=(5*60))
+
+    def resume_netns(self):
+        """
+        Resume the netns veth interface.
+        """
+        if self.nsid == -1:
+            return
+
+        log.info("Resuming the '{0}' netns for '{1}'".format(self._netns_name, self.mountpoint))
+
+        args = ["sudo", "bash", "-c",
+                "ip link set brx.{0} up".format(self.nsid)]
+        self.client_remote.run(args=args, timeout=(5*60))
 
     def mount(self, mount_path=None, mount_fs_name=None, mountpoint=None, mount_options=[]):
         raise NotImplementedError()
@@ -78,14 +429,46 @@ class CephFSMount(object):
         """
         raise NotImplementedError()
 
-    def kill_cleanup(self):
-        raise NotImplementedError()
-
     def kill(self):
-        raise NotImplementedError()
+        """
+        Suspend the netns veth interface to make the client disconnected
+        from the ceph cluster
+        """
+        log.info('Killing connection on {0}...'.format(self.client_remote.name))
+        self.suspend_netns()
+
+    def kill_cleanup(self):
+        """
+        Follow up ``kill`` to get to a clean unmounted state.
+        """
+        log.info('Cleaning up killed connection on {0}'.format(self.client_remote.name))
+        self.umount_wait(force=True)
+        self.cleanup()
 
     def cleanup(self):
-        raise NotImplementedError()
+        """
+        Remove the mount point.
+
+        Prerequisite: the client is not mounted.
+        """
+        stderr = BytesIO()
+        try:
+            self.client_remote.run(
+                args=[
+                    'rmdir',
+                    '--',
+                    self.mountpoint,
+                ],
+                cwd=self.test_dir,
+                stderr=stderr,
+                timeout=(60*5),
+                check_status=False,
+            )
+        except CommandFailedError:
+            if "No such file or directory" in stderr.getvalue():
+                pass
+            else:
+                raise
 
     def wait_until_mounted(self):
         raise NotImplementedError()

--- a/qa/tasks/cephfs/test_auto_repair.py
+++ b/qa/tasks/cephfs/test_auto_repair.py
@@ -44,8 +44,7 @@ class TestMDSAutoRepair(CephFSTestCase):
         self.fs.rados(["rmxattr", dir_objname, "parent"])
 
         # readdir (fetch dirfrag) should fix testdir1's backtrace
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
         self.mount_a.run_shell(["ls", "testdir1"])
 
         # flush journal entries to dirfrag objects

--- a/qa/tasks/cephfs/test_client_limits.py
+++ b/qa/tasks/cephfs/test_client_limits.py
@@ -122,8 +122,7 @@ class TestClientLimits(CephFSTestCase):
 
         self.set_conf('client.{0}'.format(self.mount_a.client_id), 'client inject release failure', 'true')
         self.mount_a.teardown()
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
         mount_a_client_id = self.mount_a.get_global_id()
 
         # Client A creates a file.  He will hold the write caps on the file, and later (simulated bug) fail
@@ -164,8 +163,7 @@ class TestClientLimits(CephFSTestCase):
 
         self.set_conf('client', 'client inject fixed oldest tid', 'true')
         self.mount_a.teardown()
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
 
         self.fs.mds_asok(['config', 'set', 'mds_max_completed_requests', '{0}'.format(max_requests)])
 
@@ -195,8 +193,7 @@ class TestClientLimits(CephFSTestCase):
             self.mount_a.run_shell(["mkdir", "subdir"])
             self.mount_a.umount_wait()
             self.set_conf('client', 'client mountpoint', '/subdir')
-            self.mount_a.mount()
-            self.mount_a.wait_until_mounted()
+            self.mount_a.mount_wait()
             root_ino = self.mount_a.path_to_ino(".")
             self.assertEqual(root_ino, 1);
 

--- a/qa/tasks/cephfs/test_client_recovery.py
+++ b/qa/tasks/cephfs/test_client_recovery.py
@@ -103,8 +103,7 @@ class TestClientRecovery(CephFSTestCase):
 
         self.mount_b.check_files()
 
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
 
         # Check that the admin socket interface is correctly reporting
         # two sessions
@@ -169,8 +168,7 @@ class TestClientRecovery(CephFSTestCase):
 
         # Check that the client that timed out during reconnect can
         # mount again and do I/O
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
         self.mount_a.create_destroy()
 
         self.assert_session_count(2)
@@ -212,8 +210,7 @@ class TestClientRecovery(CephFSTestCase):
         self.mount_a.kill_cleanup()
 
         # Bring the client back
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
         self.mount_a.create_destroy()
 
     def _test_stale_caps(self, write):
@@ -226,8 +223,7 @@ class TestClientRecovery(CephFSTestCase):
         else:
             self.mount_a.run_shell(["touch", "background_file"])
             self.mount_a.umount_wait()
-            self.mount_a.mount()
-            self.mount_a.wait_until_mounted()
+            self.mount_a.mount_wait()
             cap_holder = self.mount_a.open_background(write=False)
 
         self.assert_session_count(2)
@@ -438,8 +434,7 @@ class TestClientRecovery(CephFSTestCase):
             self.mount_a.kill_cleanup()
 
         # Bring the client back
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
 
     def test_dir_fsync(self):
         self._test_fsync(True);
@@ -499,8 +494,7 @@ class TestClientRecovery(CephFSTestCase):
         log.info("Reached active...")
 
         # Is the child dentry visible from mount B?
-        self.mount_b.mount()
-        self.mount_b.wait_until_mounted()
+        self.mount_b.mount_wait()
         self.mount_b.run_shell(["ls", "subdir/childfile"])
 
     def test_unmount_for_evicted_client(self):

--- a/qa/tasks/cephfs/test_client_recovery.py
+++ b/qa/tasks/cephfs/test_client_recovery.py
@@ -238,7 +238,7 @@ class TestClientRecovery(CephFSTestCase):
         self.mount_b.wait_for_visible()
 
         # Simulate client death
-        self.mount_a.kill()
+        self.mount_a.suspend_netns()
 
         # wait for it to die so it doesn't voluntarily release buffer cap
         time.sleep(5)
@@ -275,10 +275,7 @@ class TestClientRecovery(CephFSTestCase):
                 pass
         finally:
             # teardown() doesn't quite handle this case cleanly, so help it out
-            self.mount_a.kill_cleanup()
-
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+            self.mount_a.resume_netns()
 
     def test_stale_read_caps(self):
         self._test_stale_caps(False)
@@ -302,7 +299,7 @@ class TestClientRecovery(CephFSTestCase):
         self.mount_b.wait_for_visible()
 
         # Simulate client death
-        self.mount_a.kill()
+        self.mount_a.suspend_netns()
 
         # wait for it to die so it doesn't voluntarily release buffer cap
         time.sleep(5)
@@ -336,10 +333,7 @@ class TestClientRecovery(CephFSTestCase):
                 # We killed it (and possibly its node), so it raises an error
                 pass
         finally:
-            self.mount_a.kill_cleanup()
-
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+            self.mount_a.resume_netns()
 
     def test_trim_caps(self):
         # Trim capability when reconnecting MDS

--- a/qa/tasks/cephfs/test_damage.py
+++ b/qa/tasks/cephfs/test_damage.py
@@ -305,8 +305,7 @@ class TestDamage(CephFSTestCase):
                 log.info("Daemons came up after mutation '{0}', proceeding to ls".format(mutation.desc))
 
             # MDS is up, should go damaged on ls or client mount
-            self.mount_a.mount()
-            self.mount_a.wait_until_mounted()
+            self.mount_a.mount_wait()
             if mutation.ls_path == ".":
                 proc = self.mount_a.run_shell(["ls", "-R", mutation.ls_path], wait=False)
             else:
@@ -401,8 +400,7 @@ class TestDamage(CephFSTestCase):
         self.fs.mds_restart()
         self.fs.wait_for_daemons()
 
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
         dentries = self.mount_a.ls("subdir/")
 
         # The damaged guy should have disappeared
@@ -461,8 +459,7 @@ class TestDamage(CephFSTestCase):
         self.assertEqual(scrub_json["raw_stats"]["passed"], False)
 
         # Check that the file count is now correct
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
         nfiles = self.mount_a.getfattr("./subdir", "ceph.dir.files")
         self.assertEqual(nfiles, "1")
 
@@ -505,7 +502,7 @@ class TestDamage(CephFSTestCase):
         self.mds_cluster.mds_fail_restart()
         self.fs.wait_for_daemons()
 
-        self.mount_a.mount()
+        self.mount_a.mount_wait()
 
         # Case 1: un-decodeable backtrace
 

--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -381,8 +381,7 @@ class TestDataScan(CephFSTestCase):
         log.info(str(self.mds_cluster.status()))
 
         # Mount a client
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
 
         # See that the files are present and correct
         errors = workload.validate()
@@ -471,8 +470,7 @@ class TestDataScan(CephFSTestCase):
         # Start filesystem back up, observe that the file appears to be gone in an `ls`
         self.fs.mds_restart()
         self.fs.wait_for_daemons()
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
         files = self.mount_a.run_shell(["ls", "subdir/"]).stdout.getvalue().strip().split("\n")
         self.assertListEqual(sorted(files), sorted(list(set(file_names) - set([victim_dentry]))))
 
@@ -491,8 +489,7 @@ class TestDataScan(CephFSTestCase):
         # and points to the correct file data.
         self.fs.mds_restart()
         self.fs.wait_for_daemons()
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
         out = self.mount_a.run_shell(["cat", "subdir/{0}".format(victim_dentry)]).stdout.getvalue().strip()
         self.assertEqual(out, victim_dentry)
 
@@ -594,8 +591,7 @@ class TestDataScan(CephFSTestCase):
         self.fs.mds_restart()
         self.fs.wait_for_daemons()
 
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
 
         # link count was adjusted?
         file1_nlink = self.mount_a.path_to_nlink("testdir1/file1")

--- a/qa/tasks/cephfs/test_failover.py
+++ b/qa/tasks/cephfs/test_failover.py
@@ -414,8 +414,7 @@ class TestFailover(CephFSTestCase):
         self.mounts[0].umount_wait()
 
         # Control: that we can mount and unmount usually, while the cluster is healthy
-        self.mounts[0].mount()
-        self.mounts[0].wait_until_mounted()
+        self.mounts[0].mount_wait()
         self.mounts[0].umount_wait()
 
         # Stop the daemon processes
@@ -432,7 +431,7 @@ class TestFailover(CephFSTestCase):
 
         self.wait_until_true(laggy, grace * 2)
         with self.assertRaises(CommandFailedError):
-            self.mounts[0].mount()
+            self.mounts[0].mount_wait()
 
     def test_standby_count_wanted(self):
         """

--- a/qa/tasks/cephfs/test_flush.py
+++ b/qa/tasks/cephfs/test_flush.py
@@ -88,8 +88,7 @@ class TestFlush(CephFSTestCase):
         initial_purges = self.fs.mds_asok(['perf', 'dump', 'mds_cache'])['mds_cache']['strays_enqueued']
 
         # Use a client to delete a file
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
         self.mount_a.run_shell(["rm", "-rf", "mydir"])
 
         # Flush the journal so that the directory inode can be purged

--- a/qa/tasks/cephfs/test_forward_scrub.py
+++ b/qa/tasks/cephfs/test_forward_scrub.py
@@ -136,7 +136,7 @@ class TestForwardScrub(CephFSTestCase):
         # Create a new inode that's just in the log, i.e. would
         # look orphaned to backward scan if backward scan wisnae
         # respectin' tha scrub_tag xattr.
-        self.mount_a.mount()
+        self.mount_a.mount_wait()
         self.mount_a.run_shell(["mkdir", "parent/unflushed"])
         self.mount_a.run_shell(["dd", "if=/dev/urandom",
                                 "of=./parent/unflushed/jfile",
@@ -159,7 +159,7 @@ class TestForwardScrub(CephFSTestCase):
         self.fs.wait_for_daemons()
 
         # See that the orphaned file is indeed missing from a client's POV
-        self.mount_a.mount()
+        self.mount_a.mount_wait()
         damaged_state = self._get_paths_to_ino()
         self.assertNotIn("./parent/flushed/bravo", damaged_state)
         self.mount_a.umount_wait()
@@ -196,7 +196,7 @@ class TestForwardScrub(CephFSTestCase):
         # and no lost+found, and no extra inodes!
         self.fs.mds_restart()
         self.fs.wait_for_daemons()
-        self.mount_a.mount()
+        self.mount_a.mount_wait()
         self._validate_linkage(inos)
 
     def _stash_inotable(self):
@@ -222,7 +222,7 @@ class TestForwardScrub(CephFSTestCase):
 
         inotable_copy = self._stash_inotable()
 
-        self.mount_a.mount()
+        self.mount_a.mount_wait()
 
         self.mount_a.write_n_mb("file2_sixmegs", 6)
         self.mount_a.write_n_mb("file3_sixmegs", 6)

--- a/qa/tasks/cephfs/test_journal_migration.py
+++ b/qa/tasks/cephfs/test_journal_migration.py
@@ -32,7 +32,7 @@ class TestJournalMigration(CephFSTestCase):
         self.assertTrue(self.fs.get_replay(status=status) is not None)
 
         # Do some client work so that the log is populated with something.
-        with self.mount_a.mounted():
+        with self.mount_a.mounted_wait():
             self.mount_a.create_files()
             self.mount_a.check_files()  # sanity, this should always pass
 
@@ -56,7 +56,7 @@ class TestJournalMigration(CephFSTestCase):
 
         # Check that files created in the initial client workload are still visible
         # in a client mount.
-        with self.mount_a.mounted():
+        with self.mount_a.mounted_wait():
             self.mount_a.check_files()
 
         # Verify that the journal really has been rewritten.
@@ -86,7 +86,7 @@ class TestJournalMigration(CephFSTestCase):
             raise RuntimeError("Unexpectedly few journal events: {0}".format(event_count))
 
         # Do some client work to check that writing the log is still working
-        with self.mount_a.mounted():
+        with self.mount_a.mounted_wait():
             workunit(self.ctx, {
                 'clients': {
                     "client.{0}".format(self.mount_a.client_id): ["fs/misc/trivial_sync.sh"],

--- a/qa/tasks/cephfs/test_journal_repair.py
+++ b/qa/tasks/cephfs/test_journal_repair.py
@@ -92,8 +92,7 @@ class TestJournalRepair(CephFSTestCase):
         self.fs.wait_for_daemons()
 
         # List files
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
 
         # First ls -R to populate MDCache, such that hardlinks will
         # resolve properly (recover_dentries does not create backtraces,
@@ -102,8 +101,7 @@ class TestJournalRepair(CephFSTestCase):
         # FIXME: hook in forward scrub here to regenerate backtraces
         proc = self.mount_a.run_shell(['ls', '-R'])
         self.mount_a.umount_wait()  # remount to clear client cache before our second ls
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
 
         proc = self.mount_a.run_shell(['ls', '-R'])
         self.assertEqual(proc.stdout.getvalue().strip(),
@@ -278,7 +276,7 @@ class TestJournalRepair(CephFSTestCase):
         self.fs.mds_fail_restart(active_mds_names[0])
         self.wait_until_equal(lambda: self.fs.get_active_names(), [active_mds_names[0]], 30,
                               reject_fn=lambda v: len(v) > 1)
-        self.mount_a.mount()
+        self.mount_a.mount_wait()
         self.mount_a.run_shell(["ls", "-R"], wait=True)
 
     def test_table_tool(self):
@@ -434,7 +432,7 @@ class TestJournalRepair(CephFSTestCase):
         self.fs.mds_restart()
         self.fs.wait_for_daemons()
 
-        self.mount_a.mount()
+        self.mount_a.mount_wait()
 
         # trivial sync moutn a
         workunit(self.ctx, {

--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -25,8 +25,7 @@ class TestMisc(CephFSTestCase):
         # on lookup/open
         self.mount_b.umount_wait()
         self.set_conf('client', 'client debug getattr caps', 'true')
-        self.mount_b.mount()
-        self.mount_b.wait_until_mounted()
+        self.mount_b.mount_wait()
 
         # create a file and hold it open. MDS will issue CEPH_CAP_EXCL_*
         # to mount_a

--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -127,7 +127,7 @@ class TestMisc(CephFSTestCase):
         self.mount_b.wait_for_visible()
 
         # Simulate client death
-        self.mount_a.kill()
+        self.mount_a.suspend_netns()
 
         try:
             # The waiter should get stuck waiting for the capability
@@ -158,10 +158,7 @@ class TestMisc(CephFSTestCase):
                 # We killed it (and possibly its node), so it raises an error
                 pass
         finally:
-            self.mount_a.kill_cleanup()
-
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+            self.mount_a.resume_netns()
 
     def test_filtered_df(self):
         pool_name = self.fs.get_data_pool_name()
@@ -249,7 +246,7 @@ class TestCacheDrop(CephFSTestCase):
         here.
         """
         self._setup()
-        self.mount_a.kill()
+        self.mount_a.suspend_netns()
         # Note: recall is subject to the timeout. The journal flush will
         # be delayed due to the client being dead.
         result = self._run_drop_cache_cmd(timeout=5)
@@ -263,9 +260,7 @@ class TestCacheDrop(CephFSTestCase):
         # particular operation causing this is journal flush which causes the
         # MDS to wait wait for cap revoke.
         #self.assertEqual(0, result['trim_cache']['trimmed'])
-        self.mount_a.kill_cleanup()
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.resume_netns()
 
     def test_drop_cache_command_dead(self):
         """
@@ -274,7 +269,7 @@ class TestCacheDrop(CephFSTestCase):
         here.
         """
         self._setup()
-        self.mount_a.kill()
+        self.mount_a.suspend_netns()
         result = self._run_drop_cache_cmd()
         self.assertEqual(result['client_recall']['return_code'], 0)
         self.assertEqual(result['flush_journal']['return_code'], 0)
@@ -285,6 +280,4 @@ class TestCacheDrop(CephFSTestCase):
         # stale session will be autoclosed at mdsmap['session_timeout']). The
         # particular operation causing this is journal flush which causes the
         # MDS to wait wait for cap revoke.
-        self.mount_a.kill_cleanup()
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.resume_netns()

--- a/qa/tasks/cephfs/test_pool_perm.py
+++ b/qa/tasks/cephfs/test_pool_perm.py
@@ -35,8 +35,7 @@ class TestPoolPerm(CephFSTestCase):
             'allow r pool={0}'.format(self.fs.get_data_pool_name()))
 
         self.mount_a.umount_wait()
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
 
         # write should fail
         self.mount_a.run_python(remote_script.format(path=file_path, check_read=str(False)))
@@ -47,8 +46,7 @@ class TestPoolPerm(CephFSTestCase):
             'allow w pool={0}'.format(self.fs.get_data_pool_name()))
 
         self.mount_a.umount_wait()
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
 
         # read should fail
         self.mount_a.run_python(remote_script.format(path=file_path, check_read=str(True)))
@@ -77,8 +75,7 @@ class TestPoolPerm(CephFSTestCase):
             ))
 
         self.mount_a.umount_wait()
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
 
         with self.assertRaises(CommandFailedError):
             self.mount_a.setfattr("layoutfile", "ceph.file.layout.pool",
@@ -96,8 +93,7 @@ class TestPoolPerm(CephFSTestCase):
                 self.fs.get_data_pool_names()[0],
                 self.fs.get_data_pool_names()[1],
             ))
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
         self.mount_a.setfattr("layoutfile", "ceph.file.layout.pool",
                               new_pool_name)
         self.mount_a.setfattr("layoutdir", "ceph.dir.layout.pool",

--- a/qa/tasks/cephfs/test_readahead.py
+++ b/qa/tasks/cephfs/test_readahead.py
@@ -15,8 +15,7 @@ class TestReadahead(CephFSTestCase):
 
         # Unmount and remount the client to flush cache
         self.mount_a.umount_wait()
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
 
         initial_op_r = self.mount_a.admin_socket(['perf', 'dump', 'objecter'])['objecter']['op_r']
         self.mount_a.run_shell(["dd", "if=foo", "of=/dev/null", "bs=128k", "count=32"])

--- a/qa/tasks/cephfs/test_recovery_pool.py
+++ b/qa/tasks/cephfs/test_recovery_pool.py
@@ -186,10 +186,8 @@ class TestRecoveryPool(CephFSTestCase):
         log.info(str(self.mds_cluster.status()))
 
         # Mount a client
-        self.mount_a.mount()
-        self.mount_b.mount(mount_fs_name=recovery_fs)
-        self.mount_a.wait_until_mounted()
-        self.mount_b.wait_until_mounted()
+        self.mount_a.mount_wait()
+        self.mount_b.mount_wait(mount_fs_name=recovery_fs)
 
         # See that the files are present and correct
         errors = workload.validate()

--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -298,8 +298,7 @@ class TestScrubChecks(CephFSTestCase):
         self.fs.mds_fail_restart()
         self.fs.wait_for_daemons()
 
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
 
         # fragstat indicates the directory is not empty, rmdir should fail
         with self.assertRaises(CommandFailedError) as ar:

--- a/qa/tasks/cephfs/test_sessionmap.py
+++ b/qa/tasks/cephfs/test_sessionmap.py
@@ -62,8 +62,7 @@ class TestSessionMap(CephFSTestCase):
 
         status = self.fs.status()
         s = self._get_connection_count(status=status)
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
         self.assertGreater(self._get_connection_count(status=status), s)
         self.mount_a.umount_wait()
         e = self._get_connection_count(status=status)
@@ -85,8 +84,8 @@ class TestSessionMap(CephFSTestCase):
         status = self.fs.wait_for_daemons()
 
         # Bring the clients back
-        self.mount_a.mount()
-        self.mount_b.mount()
+        self.mount_a.mount_wait()
+        self.mount_b.mount_wait()
 
         # See that they've got sessions
         self.assert_session_count(2, mds_id=self.fs.get_rank(status=status)['name'])
@@ -178,8 +177,7 @@ class TestSessionMap(CephFSTestCase):
         # Configure a client that is limited to /foo/bar
         self._configure_auth(self.mount_b, "badguy", "allow rw path=/foo/bar")
         # Check he can mount that dir and do IO
-        self.mount_b.mount(mount_path="/foo/bar")
-        self.mount_b.wait_until_mounted()
+        self.mount_b.mount_wait(mount_path="/foo/bar")
         self.mount_b.create_destroy()
         self.mount_b.umount_wait()
 
@@ -225,5 +223,4 @@ class TestSessionMap(CephFSTestCase):
         self.assert_session_count(1, mds_id=self.fs.get_rank(rank=1, status=status)['name'])
 
         self.mount_a.kill_cleanup()
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()

--- a/qa/tasks/cephfs/test_snapshots.py
+++ b/qa/tasks/cephfs/test_snapshots.py
@@ -131,8 +131,7 @@ class TestSnapshots(CephFSTestCase):
                 else:
                     self.assertGreater(self._get_last_created_snap(rank=0), last_created)
 
-            self.mount_a.mount()
-            self.mount_a.wait_until_mounted()
+            self.mount_a.mount_wait()
 
         self.mount_a.run_shell(["rmdir", Raw("d1/dir/.snap/*")])
 
@@ -173,8 +172,7 @@ class TestSnapshots(CephFSTestCase):
                 else:
                     self.assertGreater(self._get_last_created_snap(rank=0), last_created)
 
-            self.mount_a.mount()
-            self.mount_a.wait_until_mounted()
+            self.mount_a.mount_wait()
 
         self.mount_a.run_shell(["rmdir", Raw("d1/dir/.snap/*")])
 
@@ -216,8 +214,7 @@ class TestSnapshots(CephFSTestCase):
         self.wait_until_true(lambda: len(self._get_pending_snap_update(rank=0)) == 0, timeout=30)
         self.assertEqual(self._get_last_created_snap(rank=0), last_created)
 
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
 
     def test_snapclient_cache(self):
         """
@@ -345,8 +342,7 @@ class TestSnapshots(CephFSTestCase):
             self.assertEqual(snaps_dump["last_created"], rank0_cache["last_created"])
             self.assertTrue(_check_snapclient_cache(snaps_dump, cache_dump=rank0_cache));
 
-            self.mount_a.mount()
-            self.mount_a.wait_until_mounted()
+            self.mount_a.mount_wait()
 
         self.mount_a.run_shell(["rmdir", Raw("d0/d2/dir/.snap/*")])
 

--- a/qa/tasks/cephfs/test_strays.py
+++ b/qa/tasks/cephfs/test_strays.py
@@ -373,7 +373,7 @@ class TestStrays(CephFSTestCase):
         self.fs.mds_asok(['flush', 'journal'])
         self.fs.mds_fail_restart()
         self.fs.wait_for_daemons()
-        self.mount_a.mount()
+        self.mount_a.mount_wait()
 
         # Unlink file_a
         self.mount_a.run_shell(["rm", "-f", "dir_1/file_a"])
@@ -628,7 +628,7 @@ class TestStrays(CephFSTestCase):
         rank_0_id = active_mds_names[0]
         rank_1_id = active_mds_names[1]
 
-        self.mount_a.mount()
+        self.mount_a.mount_wait()
 
         self.mount_a.run_shell(["rm", "-f", "dir_1/original"])
         self.mount_a.umount_wait()
@@ -772,7 +772,7 @@ class TestStrays(CephFSTestCase):
         # zero, but there's actually still a stray, so at the very
         # least the StrayManager stats code is slightly off
 
-        self.mount_a.mount()
+        self.mount_a.mount_wait()
 
         # See that the data from the snapshotted revision of the file is still present
         # and correct
@@ -873,8 +873,7 @@ class TestStrays(CephFSTestCase):
         # remount+flush (release client caps)
         self.mount_a.umount_wait()
         self.fs.mds_asok(["flush", "journal"], mds_id)
-        self.mount_a.mount()
-        self.mount_a.wait_until_mounted()
+        self.mount_a.mount_wait()
 
         # Create 50% more files than the current fragment limit
         self.mount_a.run_python(dedent("""

--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -390,13 +390,13 @@ vc.disconnect()
             m.umount_wait()
 
         # Create a dir on mount A
-        self.mount_a.mount()
+        self.mount_a.mount_wait()
         self.mount_a.run_shell(["mkdir", "parent1"])
         self.mount_a.run_shell(["mkdir", "parent2"])
         self.mount_a.run_shell(["mkdir", "parent1/mydir"])
 
         # Put some files in it from mount B
-        self.mount_b.mount()
+        self.mount_b.mount_wait()
         self.mount_b.run_shell(["touch", "parent1/mydir/afile"])
         self.mount_b.umount_wait()
 

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -1280,7 +1280,7 @@ class TestVolumes(CephFSTestCase):
         for subvolume in subvolumes:
             self._fs_cmd("subvolume", "rm", self.volname, subvolume)
 
-        self.mount_a.mount()
+        self.mount_a.mount_wait()
 
         # verify trash dir is clean
         self._wait_for_trash_empty(timeout=300)

--- a/qa/tasks/kclient.py
+++ b/qa/tasks/kclient.py
@@ -22,12 +22,16 @@ def task(ctx, config):
     this operation on. This lets you e.g. set up one client with
     ``ceph-fuse`` and another with ``kclient``.
 
+    ``brxnet`` should be a Private IPv4 Address range, default range is
+    [192.168.0.0/16]
+
     Example that mounts all clients::
 
         tasks:
         - ceph:
         - kclient:
         - interactive:
+        - brxnet: [192.168.0.0/16]
 
     Example that uses both ``kclient` and ``ceph-fuse``::
 
@@ -86,9 +90,7 @@ def task(ctx, config):
             test_dir,
             id_,
             remote,
-            ctx.teuthology_config.get('ipmi_user', None),
-            ctx.teuthology_config.get('ipmi_password', None),
-            ctx.teuthology_config.get('ipmi_domain', None)
+            ctx.teuthology_config.get('brxnet', None),
         )
 
         mounts[id_] = kernel_mount

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -43,6 +43,7 @@ import os
 import time
 import sys
 import errno
+from IPy import IP
 from unittest import suite, loader
 import unittest
 import platform
@@ -514,8 +515,8 @@ def safe_kill(pid):
 
 
 class LocalKernelMount(KernelMount):
-    def __init__(self, ctx, test_dir, client_id):
-        super(LocalKernelMount, self).__init__(ctx, test_dir, client_id, LocalRemote(), None, None, None)
+    def __init__(self, ctx, test_dir, client_id, brxnet):
+        super(LocalKernelMount, self).__init__(ctx, test_dir, client_id, LocalRemote(), brxnet)
 
     @property
     def config_path(self):
@@ -656,6 +657,7 @@ class LocalKernelMount(KernelMount):
 
     def mount(self, mount_path=None, mount_fs_name=None, mount_options=[]):
         self.setupfs(name=mount_fs_name)
+        self.setup_netns()
 
         log.info('Mounting kclient client.{id} at {remote} {mnt}...'.format(
             id=self.client_id, remote=self.client_remote, mnt=self.mountpoint))
@@ -684,6 +686,8 @@ class LocalKernelMount(KernelMount):
         self.client_remote.run(
             args=[
                 'sudo',
+                'nsenter',
+                '--net=/var/run/netns/{0}'.format(self.netns_name),
                 './bin/mount.ceph',
                 ':{mount_path}'.format(mount_path=mount_path),
                 self.mountpoint,
@@ -709,8 +713,8 @@ class LocalKernelMount(KernelMount):
                                       wait=False)
 
 class LocalFuseMount(FuseMount):
-    def __init__(self, ctx, test_dir, client_id):
-        super(LocalFuseMount, self).__init__(ctx, None, test_dir, client_id, LocalRemote())
+    def __init__(self, ctx, test_dir, client_id, brxnet):
+        super(LocalFuseMount, self).__init__(ctx, None, test_dir, client_id, LocalRemote(), brxnet)
 
     @property
     def config_path(self):
@@ -823,6 +827,7 @@ class LocalFuseMount(FuseMount):
         if mountpoint is not None:
             self.mountpoint = mountpoint
         self.setupfs(name=mount_fs_name)
+        self.setup_netns()
 
         self.client_remote.run(args=['mkdir', '-p', self.mountpoint])
 
@@ -863,7 +868,9 @@ class LocalFuseMount(FuseMount):
         prefix += mount_options;
 
         self.fuse_daemon = self.client_remote.run(args=
-                                            prefix + [
+                                            ['nsenter',
+                                             '--net=/var/run/netns/{0}'.format(self.netns_name),
+                                            ] + prefix + [
                                                 "-f",
                                                 "--name",
                                                 "client.{0}".format(self.client_id),
@@ -1201,6 +1208,7 @@ class InteractiveFailureResult(unittest.TextTestResult):
 def enumerate_methods(s):
     log.info("e: {0}".format(s))
     for t in s._tests:
+	print("t {0}, s._tests {1}".format(t, s._tests))
         if isinstance(t, suite.BaseTestSuite):
             for sub in enumerate_methods(t):
                 yield sub
@@ -1232,7 +1240,10 @@ def scan_tests(modules):
     max_required_mgr = 0
     require_memstore = False
 
+    print("module = {}".format(overall_suite))
     for suite_, case in enumerate_methods(overall_suite):
+	print("suite {0}".format(suite_))
+	print("case {0}".format(case))
         max_required_mds = max(max_required_mds,
                                getattr(case, "MDSS_REQUIRED", 0))
         max_required_clients = max(max_required_clients,
@@ -1310,6 +1321,7 @@ def exec_test():
     global opt_log_ps_output
     opt_log_ps_output = False
     use_kernel_client = False
+    opt_brxnet= None
 
     args = sys.argv[1:]
     flags = [a for a in args if a.startswith("-")]
@@ -1331,6 +1343,18 @@ def exec_test():
             clear_old_log()
         elif f == "--kclient":
             use_kernel_client = True
+        elif '--brxnet' in f:
+            if re.search(r'=[0-9./]+', f) is None:
+                log.error("--brxnet=<ip/mask> option needs one argument: '{0}'".format(f))
+                sys.exit(-1)
+            opt_brxnet=f.split('=')[1]
+            try:  
+                IP(opt_brxnet)  
+                if IP(opt_brxnet).iptype() is 'PUBLIC':
+                    raise RuntimeError('is public')
+            except Exception as  e:  
+                log.error("Invalid ip '{0}' {1}".format(opt_brxnet, e))
+                sys.exit(-1)
         else:
             log.error("Unknown option '{0}'".format(f))
             sys.exit(-1)
@@ -1415,9 +1439,9 @@ def exec_test():
             open("./keyring", "a").write(p.stdout.getvalue())
 
         if use_kernel_client:
-            mount = LocalKernelMount(ctx, test_dir, client_id)
+            mount = LocalKernelMount(ctx, test_dir, client_id, opt_brxnet)
         else:
-            mount = LocalFuseMount(ctx, test_dir, client_id)
+            mount = LocalFuseMount(ctx, test_dir, client_id, opt_brxnet)
 
         mounts.append(mount)
         if os.path.exists(mount.mountpoint):


### PR DESCRIPTION
This helper script will help to unshare the network namespace from
the os and with its own private veth interface, IP, iptable rules,etc.

It could help us to simulate some test case like client node crash. Currently this works for both kernel and fuse client.

The usage:
```
# ./unshare_ns_mount.sh 

This will help to isolate the network namespace from OS for the mount client!

usage: unshare_ns_mount.sh [OPTIONS [paramters]] [--brxip <ip_address/mask>]
OPTIONS:
  --fuse    <ceph-fuse options>
	The ceph-fuse command options
	$ unshare_ns_mount.sh --fuse -m 192.168.0.1:6789 /mnt/cephfs -o nonempty

  --kernel  <mount options>
	The mount command options
	$ unshare_ns_mount.sh --kernel -t ceph 192.168.0.1:6789:/ /mnt/cephfs -o fs=a

  --suspend <mountpoint>
	Down the veth interface in the network namespace
	$ unshare_ns_mount.sh --suspend /mnt/cephfs

  --resume  <mountpoint>
	Up the veth interface in the network namespace
	$ unshare_ns_mount.sh --resume /mnt/cephfs

  --umount  <mountpoint>
	Umount and delete the network namespace
	$ unshare_ns_mount.sh --umount /mnt/cephfs

  --brxip   <ip_address/mask>
	Specify ip/mask for ceph-brx and it only makes sense for --fuse/--kernel options
	(default: 192.168.255.254/16, netns ip: 192.168.0.1/16 ~ 192.168.255.253/16)
	$ unshare_ns_mount.sh --fuse -m 192.168.0.1:6789 /mnt/cephfs --brxip 172.19.255.254/12
	$ unshare_ns_mount.sh --kernel 192.168.0.1:6789:/ /mnt/cephfs --brxip 172.19.255.254/12

  -h, --help
	Print help


```




Fixes: https://tracker.ceph.com/issues/44044
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
