### PR TITLE
mgr/orch: fix 'orch ls' table spacing

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -343,7 +343,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
             table.align['IMAGE NAME'] = 'l'
             table.align['IMAGE ID'] = 'l'
             table.left_padding_width = 0
-            table.right_padding_width = 1
+            table.right_padding_width = 2
             for s in sorted(services, key=lambda s: s.service_name):
                 if s.last_refresh:
                     age = to_pretty_timedelta(now - s.last_refresh) + ' ago'


### PR DESCRIPTION
This command crossed paths with the PR (https://github.com/ceph/ceph/pull/33138) that changed the spacing.

Signed-off-by: Sage Weil <sage@redhat.com>