### PR TITLE
remove cephadm-adoption-corpus as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "cephadm-adoption-corpus"]
-	path = cephadm-adoption-corpus
-	url = https://github.com/ceph/cephadm-adoption-corpus.git
 [submodule "ceph-object-corpus"]
 	path = ceph-object-corpus
 	url = https://github.com/ceph/ceph-object-corpus.git


### PR DESCRIPTION
The test_adoption.sh just clones from master--no need to make this a
submodule.

Signed-off-by: Sage Weil <sage@redhat.com>