### PR TITLE
osd/PeeringState.h: ignore MLogRec in Peering/GetInfo

### DIFF
--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1237,10 +1237,16 @@ public:
       boost::statechart::custom_reaction< QueryState >,
       boost::statechart::transition< GotInfo, GetLog >,
       boost::statechart::custom_reaction< MNotifyRec >,
-      boost::statechart::transition< IsDown, Down >
+      boost::statechart::transition< IsDown, Down >,
+      boost::statechart::custom_reaction< MLogRec >
       > reactions;
     boost::statechart::result react(const QueryState& q);
     boost::statechart::result react(const MNotifyRec& infoevt);
+    boost::statechart::result react(const MLogRec& evt) {
+      // If we end up receiving a response from a previous GetLog request when
+      // we have transitioned out of Peering/GetLog due to a map change, just ignore it.
+      return discard_event();
+    }
   };
 
   struct GotLog : boost::statechart::event< GotLog > {


### PR DESCRIPTION
It is possible to receive a response for an old GetLog request, after
we've transitioned out of Started/Primary/Peering/GetLog due to a map change.
In such cases, just ignore it rather than crashing. We'll transition to GetLog
again at later point, when required.

Fixes: https://tracker.ceph.com/issues/44022
Signed-off-by: Neha Ojha <nojha@redhat.com>