### PR TITLE
mimic: osd/PeeringState.h: ignore MLogRec in Peering/GetInfo

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2633,10 +2633,16 @@ protected:
 	boost::statechart::custom_reaction< QueryState >,
 	boost::statechart::transition< GotInfo, GetLog >,
 	boost::statechart::custom_reaction< MNotifyRec >,
-	boost::statechart::transition< IsDown, Down >
+	boost::statechart::transition< IsDown, Down >,
+	boost::statechart::custom_reaction< MLogRec >
 	> reactions;
       boost::statechart::result react(const QueryState& q);
       boost::statechart::result react(const MNotifyRec& infoevt);
+      boost::statechart::result react(const MLogRec& evt) {
+        // If we end up receiving a response from a previous GetLog request when
+        // we have transitioned out of Peering/GetLog due to a map change, just ignore it.
+        return discard_event();
+      }
     };
 
     struct GotLog : boost::statechart::event< GotLog > {


### PR DESCRIPTION
It is possible to receive a response for an old GetLog request, after
we've transitioned out of Started/Primary/Peering/GetLog due to a map change.
Such cases are already handled in Nautilus and beyond, due to
168e20ab8b8da3a5aed41b73f9627d10971be67b, old_peering_evt() will detect
such old responses by comparing last_peering_set with reply_epoch and
query_epoch. In Mimic, query_epoch is not reliable and we may incorrectly
start processing the MLogRec and crash the osd.

Fixes: https://tracker.ceph.com/issues/44022
Signed-off-by: Neha Ojha <nojha@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
