### PR TITLE
mimic: ceph-volume: refactor listing.py + fixes

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -1421,6 +1421,16 @@ def get_pvs(fields=PV_FIELDS, sep='";"', filters='', tags=None):
     pvs_report = _output_parser(stdout, fields)
     return [PVolume(**pv_report) for pv_report in pvs_report]
 
+def get_first_pv(fields=PV_FIELDS, sep='";"', filters=None, tags=None):
+    """
+    Wrapper of get_pv meant to be a convenience method to avoid the phrase::
+        pvs = get_pvs()
+        if len(pvs) >= 1:
+            pv = pvs[0]
+    """
+    pvs = get_pvs(fields=fields, sep=sep, filters=filters, tags=tags)
+    return pvs[0] if len(pvs) > 0 else []
+
 def get_vgs(fields=VG_FIELDS, sep='";"', filters='', tags=None):
     """
     Return a list of VGs that are available on the system and match the
@@ -1445,6 +1455,16 @@ def get_vgs(fields=VG_FIELDS, sep='";"', filters='', tags=None):
     vgs_report =_output_parser(stdout, fields)
     return [VolumeGroup(**vg_report) for vg_report in vgs_report]
 
+def get_first_vg(fields=VG_FIELDS, sep='";"', filters=None, tags=None):
+    """
+    Wrapper of get_vg meant to be a convenience method to avoid the phrase::
+        vgs = get_vgs()
+        if len(vgs) >= 1:
+            vg = vgs[0]
+    """
+    vgs = get_vgs(fields=fields, sep=sep, filters=filters, tags=tags)
+    return vgs[0] if len(vgs) > 0 else []
+
 def get_lvs(fields=LV_FIELDS, sep='";"', filters='', tags=None):
     """
     Return a list of LVs that are available on the system and match the
@@ -1468,3 +1488,13 @@ def get_lvs(fields=LV_FIELDS, sep='";"', filters='', tags=None):
     stdout, stderr, returncode = process.call(args, verbose_on_failure=False)
     lvs_report = _output_parser(stdout, fields)
     return [Volume(**lv_report) for lv_report in lvs_report]
+
+def get_first_lv(fields=LV_FIELDS, sep='";"', filters=None, tags=None):
+    """
+    Wrapper of get_lv meant to be a convenience method to avoid the phrase::
+        lvs = get_lvs()
+        if len(lvs) >= 1:
+            lv = lvs[0]
+    """
+    lvs = get_lvs(fields=fields, sep=sep, filters=filters, tags=tags)
+    return lvs[0] if len(lvs) > 0 else []

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -267,6 +267,16 @@ def dmsetup_splitname(dev):
     return _splitname_parser(out)
 
 
+def is_ceph_device(lv):
+    try:
+        lv.tags['ceph.osd_id']
+    except (KeyError, AttributeError):
+        logger.warning('device is not part of ceph: %s', lv)
+        return False
+
+    return True
+
+
 ####################################
 #
 # Code for LVM Physical Volumes

--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -169,7 +169,7 @@ class List(object):
                 lv = api.get_first_lv(filters={'vg_name': pv.vg_name})
             # or VG.
             else:
-                vg_name = os.path.basename(device)
+                vg_name = os.path.dirname(device)
                 lv = api.get_first_lv(filters={'vg_name': vg_name})
                 arg_is_vg = True
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -180,21 +180,18 @@ class List(object):
         volume in the form of vg/lv or a device with an absolute path like
         /dev/sda1 or /dev/sda
         """
-        if lvs is None:
-            lvs = api.Volumes()
         report = {}
-        lv = api.get_lv_from_argument(device)
+        lv = api.get_first_lv(filters={'lv_path': device})
 
         # check if there was a pv created with the
         # name of device
-        pv = api.get_pv(pv_name=device)
-        if pv and not lv:
-            try:
-                lv = api.get_lv(vg_name=pv.vg_name)
-            except MultipleLVsError:
-                lvs.filter(vg_name=pv.vg_name)
-                return self.full_report(lvs=lvs)
+        if not lv:
+            pv = api.get_first_pv(filters={'pv_name': device})
+            if pv:
+                return self.full_report(lvs=api.get_lv(filters={'vg_name':
+                                                                pv.vg_name}))
 
+        # TODO: a call to full_report just might work.
         if lv:
 
             try:
@@ -207,28 +204,14 @@ class List(object):
             lv_report = lv.as_dict()
             lv_report['devices'] = self.match_devices(lv.lv_uuid)
             report[_id].append(lv_report)
-
         else:
-            # this has to be a journal/wal/db device (not a logical volume) so try
-            # to find the PARTUUID that should be stored in the OSD logical
-            # volume
-            for device_type in ['journal', 'block', 'wal', 'db']:
-                device_tag_name = 'ceph.%s_device' % device_type
-                device_tag_uuid = 'ceph.%s_uuid' % device_type
-                associated_lv = lvs.get(lv_tags={device_tag_name: device})
-                if associated_lv:
-                    _id = associated_lv.tags['ceph.osd_id']
-                    uuid = associated_lv.tags[device_tag_uuid]
-
-                    report.setdefault(_id, [])
-                    report[_id].append(
-                        {
-                            'tags': {'PARTUUID': uuid},
-                            'type': device_type,
-                            'path': device,
-                        }
-                    )
-        return report
+            # this has to be a journal/wal/db device (not a logical volume)
+            # so try to find the PARTUUID that should be stored in the OSD
+            # logical volume
+            vg_name = os.path.basename(device)
+            lvs = api.get_lvs(filters={'vg_name': vg_name})
+            if lvs:
+                return self.full_report(lvs=lvs)
 
     def full_report(self, lvs=None):
         """
@@ -236,7 +219,7 @@ class List(object):
         that have been previously prepared by Ceph
         """
         if lvs is None:
-            lvs = api.Volumes()
+            lvs = api.get_lvs()
         report = {}
 
         for lv in lvs:
@@ -258,7 +241,8 @@ class List(object):
                     # bluestore will not have a journal, filestore will not have
                     # a block/wal/db, so we must skip if not present
                     continue
-                if not api.get_lv(lv_uuid=device_uuid, lvs=lvs):
+                if not api.get_lvs(filters={'lv_uuid': device_uuid}):
+                    # if not api.get_lv(lv_uuid=device_uuid, lvs=lvs):
                     # means we have a regular device, so query blkid
                     disk_device = disk.get_device_from_partuuid(device_uuid)
                     if disk_device:

--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -18,7 +18,7 @@ osd_list_header_template = """\n
 
 osd_device_header_template = """
 
-  [{type: >4}]    {path}
+  {type: <13} {path}
 """
 
 device_metadata_item_template = """
@@ -32,18 +32,18 @@ def readable_tag(tag):
 
 def pretty_report(report):
     output = []
-    for _id, devices in report.items():
+    for _id, devices in sorted(report.items()):
         output.append(
             osd_list_header_template.format(osd_id=" osd.%s " % _id)
         )
         for device in devices:
             output.append(
                 osd_device_header_template.format(
-                    type=device['type'],
+                    type='[%s]' % device['type'],
                     path=device['path']
                 )
             )
-            for tag_name, value in device.get('tags', {}).items():
+            for tag_name, value in sorted(device.get('tags', {}).items()):
                 output.append(
                     device_metadata_item_template.format(
                         tag_name=readable_tag(tag_name),
@@ -193,7 +193,6 @@ class List(object):
 
         # TODO: a call to full_report just might work.
         if lv:
-
             try:
                 _id = lv.tags['ceph.osd_id']
             except KeyError:

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -166,12 +166,14 @@ def stub_vgs(monkeypatch, volume_groups):
     return apply
 
 
+# TODO: allow init-ing pvolumes to list we want
 @pytest.fixture
 def pvolumes(monkeypatch):
     monkeypatch.setattr('ceph_volume.process.call', lambda x, **kw: ('', '', 0))
     pvolumes = lvm_api.PVolumes()
     pvolumes._purge()
     return pvolumes
+
 @pytest.fixture
 def pvolumes_empty(monkeypatch):
     monkeypatch.setattr('ceph_volume.process.call', lambda x, **kw: ('', '', 0))

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_listing.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_listing.py
@@ -86,24 +86,6 @@ class TestList(object):
         with pytest.raises(SystemExit):
             lvm.listing.List([]).list(args)
 
-    def test_lvs_list_is_created_just_once(self, monkeypatch, is_root, volumes, factory):
-        api.volumes_obj_create_count = 0
-
-        def monkey_populate(self):
-            api.volumes_obj_create_count += 1
-            for lv_item in api.get_api_lvs():
-                self.append(api.Volume(**lv_item))
-        monkeypatch.setattr(api.Volumes, '_populate', monkey_populate)
-
-        args = factory(format='pretty', device='/dev/sda1')
-        with pytest.raises(SystemExit):
-            lvm.listing.List([]).list(args)
-
-        # XXX: Ideally, the count should be just 1. Volumes._populate() is
-        # being called thrice out of which only twice is moneky_populate.
-        assert api.volumes_obj_create_count == 2
-
-
 class TestFullReport(object):
 
     def test_no_ceph_lvs(self, volumes, monkeypatch):

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_listing.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_listing.py
@@ -26,7 +26,7 @@ class TestPrettyReport(object):
             {'type': 'data', 'path': '/dev/sda1', 'devices': ['/dev/sda']}
         ]})
         stdout, stderr = capsys.readouterr()
-        assert '[data]    /dev/sda1' in stdout
+        assert '[data]        /dev/sda1' in stdout
 
     def test_osd_id_header_is_reported(self, capsys):
         lvm.listing.pretty_report({0: [

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_listing.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_listing.py
@@ -2,6 +2,11 @@ import pytest
 from ceph_volume.devices import lvm
 from ceph_volume.api import lvm as api
 
+# TODO: add tests for following commands -
+# ceph-volume list
+# ceph-volume list <path-to-pv>
+# ceph-volume list <path-to-vg>
+# ceph-volume list <path-to-lv>
 
 class TestReadableTag(object):
 
@@ -57,13 +62,15 @@ class TestPrettyReport(object):
 
 class TestList(object):
 
-    def test_empty_full_json_zero_exit_status(self, is_root, volumes, factory, capsys):
+    def test_empty_full_json_zero_exit_status(self, is_root, volumes,
+                                              factory, capsys):
         args = factory(format='json', device=None)
         lvm.listing.List([]).list(args)
         stdout, stderr = capsys.readouterr()
         assert stdout == '{}\n'
 
-    def test_empty_device_json_zero_exit_status(self, is_root, volumes, factory, capsys):
+    def test_empty_device_json_zero_exit_status(self, is_root, volumes,
+                                                factory, capsys):
         args = factory(format='json', device='/dev/sda1')
         lvm.listing.List([]).list(args)
         stdout, stderr = capsys.readouterr()
@@ -101,31 +108,49 @@ class TestFullReport(object):
 
     def test_no_ceph_lvs(self, volumes, monkeypatch):
         # ceph lvs are detected by looking into its tags
-        osd = api.Volume(lv_name='volume1', lv_path='/dev/VolGroup/lv', lv_tags={})
+        osd = api.Volume(lv_name='volume1', lv_path='/dev/VolGroup/lv',
+                         lv_tags={})
         volumes.append(osd)
-        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_lvs', lambda **kwargs:
+                            volumes)
+
         result = lvm.listing.List([]).full_report()
         assert result == {}
 
-    def test_ceph_data_lv_reported(self, volumes, monkeypatch):
+    def test_ceph_data_lv_reported(self, pvolumes, volumes, monkeypatch):
         tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=data'
-        osd = api.Volume(
-            lv_name='volume1', lv_uuid='y', lv_path='/dev/VolGroup/lv', lv_tags=tags)
+        pv = api.PVolume(pv_name='/dev/sda1', pv_tags={}, pv_uuid="0000",
+                         vg_name='VolGroup', lv_uuid="aaaa")
+        osd = api.Volume(lv_name='volume1', lv_uuid='y', lv_tags=tags,
+                         lv_path='/dev/VolGroup/lv', vg_name='VolGroup')
+        pvolumes.append(pv)
         volumes.append(osd)
-        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_pvs', lambda **kwargs:
+                            pvolumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_lvs', lambda **kwargs:
+                            volumes)
+
         result = lvm.listing.List([]).full_report()
         assert result['0'][0]['name'] == 'volume1'
 
-    def test_ceph_journal_lv_reported(self, volumes, monkeypatch):
+    def test_ceph_journal_lv_reported(self, pvolumes, volumes, monkeypatch):
         tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=data'
         journal_tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=journal'
-        osd = api.Volume(
-            lv_name='volume1', lv_uuid='y', lv_path='/dev/VolGroup/lv', lv_tags=tags)
+        pv = api.PVolume(pv_name='/dev/sda1', pv_tags={}, pv_uuid="0000",
+                         vg_name="VolGroup", lv_uuid="aaaa")
+        osd = api.Volume(lv_name='volume1', lv_uuid='y', lv_tags=tags,
+                         lv_path='/dev/VolGroup/lv', vg_name='VolGroup')
         journal = api.Volume(
-            lv_name='journal', lv_uuid='x', lv_path='/dev/VolGroup/journal', lv_tags=journal_tags)
+            lv_name='journal', lv_uuid='x', lv_tags=journal_tags,
+            lv_path='/dev/VolGroup/journal', vg_name='VolGroup')
+        pvolumes.append(pv)
         volumes.append(osd)
         volumes.append(journal)
-        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_pvs', lambda **kwargs:
+                            pvolumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_lvs', lambda **kwargs:
+                            volumes)
+
         result = lvm.listing.List([]).full_report()
         assert result['0'][0]['name'] == 'volume1'
         assert result['0'][1]['name'] == 'journal'
@@ -133,36 +158,50 @@ class TestFullReport(object):
     def test_ceph_wal_lv_reported(self, volumes, monkeypatch):
         tags = 'ceph.osd_id=0,ceph.wal_uuid=x,ceph.type=data'
         wal_tags = 'ceph.osd_id=0,ceph.wal_uuid=x,ceph.type=wal'
-        osd = api.Volume(
-            lv_name='volume1', lv_uuid='y', lv_path='/dev/VolGroup/lv', lv_tags=tags)
-        wal = api.Volume(
-            lv_name='wal', lv_uuid='x', lv_path='/dev/VolGroup/wal', lv_tags=wal_tags)
+        osd = api.Volume(lv_name='volume1', lv_uuid='y', lv_tags=tags,
+                         lv_path='/dev/VolGroup/lv', vg_name='VolGroup')
+        wal = api.Volume(lv_name='wal', lv_uuid='x', lv_tags=wal_tags,
+                         lv_path='/dev/VolGroup/wal', vg_name='VolGroup')
         volumes.append(osd)
         volumes.append(wal)
-        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_lvs', lambda **kwargs:
+                            volumes)
+
         result = lvm.listing.List([]).full_report()
         assert result['0'][0]['name'] == 'volume1'
         assert result['0'][1]['name'] == 'wal'
 
-    def test_physical_journal_gets_reported(self, volumes, monkeypatch):
-        tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=data'
-        osd = api.Volume(
-            lv_name='volume1', lv_uuid='y', lv_path='/dev/VolGroup/lv', lv_tags=tags)
+    def test_physical_journal_gets_reported(self, pvolumes, volumes, monkeypatch):
+        tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=journal'
+        pv = api.PVolume(vg_name="VolGroup", pv_name='/dev/sda1', pv_tags={},
+                         pv_uuid="0000", lv_uuid="aaaa")
+        osd = api.Volume(lv_name='volume1', lv_uuid='y', lv_tags=tags,
+                         vg_name='VolGroup', lv_path='/dev/VolGroup/lv')
+        pvolumes.append(pv)
         volumes.append(osd)
-        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
-        monkeypatch.setattr(lvm.listing.disk, 'get_device_from_partuuid', lambda x: '/dev/sda1')
+        monkeypatch.setattr(lvm.listing.api, 'get_pvs', lambda **kwargs:
+                            pvolumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_lvs', lambda **kwargs:
+                            volumes)
+
         result = lvm.listing.List([]).full_report()
         assert result['0'][1]['path'] == '/dev/sda1'
         assert result['0'][1]['tags'] == {'PARTUUID': 'x'}
         assert result['0'][1]['type'] == 'journal'
 
-    def test_physical_wal_gets_reported(self, volumes, monkeypatch):
-        tags = 'ceph.osd_id=0,ceph.wal_uuid=x,ceph.type=data'
-        osd = api.Volume(
-            lv_name='volume1', lv_uuid='y', lv_path='/dev/VolGroup/lv', lv_tags=tags)
+    def test_physical_wal_gets_reported(self, pvolumes, volumes, monkeypatch):
+        tags = 'ceph.osd_id=0,ceph.wal_uuid=x,ceph.type=wal'
+        pv = api.PVolume(pv_name='/dev/sda1', pv_tags={}, pv_uuid="0000",
+                         vg_name="VolGroup", lv_uuid="aaaa")
+        osd = api.Volume(lv_name='volume1', lv_uuid='y', lv_tags=tags,
+                         lv_path='/dev/VolGroup/lv', vg_name="VolGroup")
+        pvolumes.append(pv)
         volumes.append(osd)
-        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
-        monkeypatch.setattr(lvm.listing.disk, 'get_device_from_partuuid', lambda x: '/dev/sda1')
+        monkeypatch.setattr(lvm.listing.api, 'get_pvs', lambda **kwargs:
+                            pvolumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_lvs', lambda **kwargs:
+                            volumes)
+
         result = lvm.listing.List([]).full_report()
         assert result['0'][1]['path'] == '/dev/sda1'
         assert result['0'][1]['tags'] == {'PARTUUID': 'x'}
@@ -173,116 +212,125 @@ class TestSingleReport(object):
 
     def test_not_a_ceph_lv(self, volumes, monkeypatch):
         # ceph lvs are detected by looking into its tags
-        lv = api.Volume(
-            lv_name='lv', vg_name='VolGroup', lv_path='/dev/VolGroup/lv', lv_tags={})
+        lv = api.Volume(lv_name='lv', lv_tags={}, lv_path='/dev/VolGroup/lv',
+                        vg_name='VolGroup')
         volumes.append(lv)
-        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_lvs', lambda **kwargs:
+                            volumes)
+
         result = lvm.listing.List([]).single_report('VolGroup/lv')
         assert result == {}
 
-    def test_report_a_ceph_lv(self, volumes, monkeypatch):
+    def test_report_a_ceph_lv(self, pvolumes, volumes, monkeypatch):
         # ceph lvs are detected by looking into its tags
         tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=data'
-        lv = api.Volume(
-            lv_name='lv', vg_name='VolGroup',
-            lv_uuid='aaaa', lv_path='/dev/VolGroup/lv', lv_tags=tags
-        )
+        lv = api.Volume(lv_name='lv', vg_name='VolGroup', lv_uuid='aaaa',
+                        lv_path='/dev/VolGroup/lv', lv_tags=tags)
         volumes.append(lv)
-        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_pvs', lambda **kwargs:
+                            pvolumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_lvs', lambda **kwargs:
+                            volumes)
+
         result = lvm.listing.List([]).single_report('VolGroup/lv')
         assert result['0'][0]['name'] == 'lv'
         assert result['0'][0]['lv_tags'] == tags
         assert result['0'][0]['path'] == '/dev/VolGroup/lv'
         assert result['0'][0]['devices'] == []
 
-    def test_report_a_ceph_journal_device(self, volumes, monkeypatch):
+    def test_report_a_ceph_journal_device(self, volumes, pvolumes, monkeypatch):
         # ceph lvs are detected by looking into its tags
-        tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=data,ceph.journal_device=/dev/sda1'
-        lv = api.Volume(
-            lv_name='lv', vg_name='VolGroup', lv_path='/dev/VolGroup/lv',
-            lv_uuid='aaa', lv_tags=tags)
+        tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=journal,' + \
+               'ceph.journal_device=/dev/sda1'
+        pv = api.PVolume(pv_name='/dev/sda1', pv_uuid="0000", pv_tags={},
+                         vg_name="VolGroup", lv_uuid="aaaa")
+        lv = api.Volume(lv_name='lv', lv_uuid='aaa', lv_tags=tags,
+                        lv_path='/dev/VolGroup/lv', vg_name='VolGroup')
+        pvolumes.append(pv)
         volumes.append(lv)
-        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_pvs', lambda **kwargs:
+                            pvolumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_lvs', lambda **kwargs:
+                            volumes)
+
         result = lvm.listing.List([]).single_report('/dev/sda1')
         assert result['0'][0]['tags'] == {'PARTUUID': 'x'}
         assert result['0'][0]['type'] == 'journal'
         assert result['0'][0]['path'] == '/dev/sda1'
 
-    def test_report_a_ceph_lv_with_devices(self, volumes, monkeypatch):
-        tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=data'
-        lv = api.Volume(
-            lv_name='lv', vg_name='VolGroup',
-            lv_uuid='aaaa', lv_path='/dev/VolGroup/lv', lv_tags=tags
-        )
+    def test_report_a_ceph_lv_with_devices(self, volumes, pvolumes, monkeypatch):
+        tags = 'ceph.osd_id=0,ceph.type=data'
+        pv1 = api.PVolume(vg_name="VolGroup", pv_name='/dev/sda1',
+                          pv_uuid='', pv_tags={}, lv_uuid="aaaa")
+        pv2 = api.PVolume(vg_name="VolGroup", pv_name='/dev/sdb1',
+                          pv_uuid='', pv_tags={}, lv_uuid="aaaa")
+        lv = api.Volume(lv_name='lv', vg_name='VolGroup',lv_uuid='aaaa',
+                        lv_path='/dev/VolGroup/lv', lv_tags=tags)
+        pvolumes.append(pv1)
+        pvolumes.append(pv2)
         volumes.append(lv)
-        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_pvs', lambda **kwargs:
+                            pvolumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_lvs', lambda **kwargs:
+                            volumes)
+
         listing = lvm.listing.List([])
         listing._pvs = [
             {'lv_uuid': 'aaaa', 'pv_name': '/dev/sda1', 'pv_tags': '', 'pv_uuid': ''},
             {'lv_uuid': 'aaaa', 'pv_name': '/dev/sdb1', 'pv_tags': '', 'pv_uuid': ''},
         ]
+
         result = listing.single_report('VolGroup/lv')
         assert result['0'][0]['name'] == 'lv'
         assert result['0'][0]['lv_tags'] == tags
         assert result['0'][0]['path'] == '/dev/VolGroup/lv'
         assert result['0'][0]['devices'] == ['/dev/sda1', '/dev/sdb1']
 
-    def test_report_a_ceph_lv_with_multiple_pvs_of_same_name(self, pvolumes, monkeypatch):
-        tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=data'
-        lv = api.Volume(
-            lv_name='lv', vg_name='VolGroup',
-            lv_uuid='aaaa', lv_path='/dev/VolGroup/lv', lv_tags=tags
-        )
+    def test_report_a_ceph_lv_with_multiple_pvs_of_same_name(self, pvolumes,
+                                                             volumes,
+                                                             monkeypatch):
+        tags = 'ceph.osd_id=0,ceph.type=data'
+        lv = api.Volume(lv_name='lv', vg_name='VolGroup', lv_uuid='aaaa',
+                        lv_path='/dev/VolGroup/lv', lv_tags=tags)
+        volumes.append(lv)
         monkeypatch.setattr(api, 'get_lv_from_argument', lambda device: None)
         monkeypatch.setattr(api, 'get_lv', lambda vg_name: lv)
-        FooPVolume = api.PVolume(vg_name="vg", pv_name='/dev/sda', pv_uuid="0000", pv_tags={}, lv_uuid="aaaa")
-        BarPVolume = api.PVolume(vg_name="vg", pv_name='/dev/sda', pv_uuid="0000", pv_tags={})
+        FooPVolume = api.PVolume(vg_name="vg", pv_name='/dev/sda',
+                                 pv_uuid="0000", pv_tags={}, lv_uuid="aaaa")
+        BarPVolume = api.PVolume(vg_name="vg", pv_name='/dev/sda',
+                                 pv_uuid="0000", pv_tags={})
         pvolumes.append(FooPVolume)
         pvolumes.append(BarPVolume)
-        monkeypatch.setattr(api, 'PVolumes', lambda: pvolumes)
         listing = lvm.listing.List([])
+        monkeypatch.setattr(lvm.listing.api, 'get_lvs', lambda **kwargs:
+                            volumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_pvs', lambda **kwargs:
+                            pvolumes)
+
         result = listing.single_report('/dev/sda')
         assert result['0'][0]['name'] == 'lv'
         assert result['0'][0]['lv_tags'] == tags
         assert result['0'][0]['path'] == '/dev/VolGroup/lv'
         assert len(result) == 1
 
-    def test_report_a_ceph_lv_with_no_matching_devices(self, volumes, monkeypatch):
-        tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=data'
-        lv = api.Volume(
-            lv_name='lv', vg_name='VolGroup',
-            lv_uuid='aaaa', lv_path='/dev/VolGroup/lv', lv_tags=tags
-        )
+    def test_report_a_ceph_lv_with_no_matching_devices(self, volumes,
+                                                       monkeypatch):
+        tags = 'ceph.osd_id=0,ceph.type=data'
+        lv = api.Volume(lv_name='lv', vg_name='VolGroup', lv_uuid='aaaa',
+                        lv_path='/dev/VolGroup/lv', lv_tags=tags)
         volumes.append(lv)
-        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(lvm.listing.api, 'get_lvs', lambda **kwargs:
+                            volumes)
+
         listing = lvm.listing.List([])
         listing._pvs = [
-            {'lv_uuid': 'ffff', 'pv_name': '/dev/sda1', 'pv_tags': '', 'pv_uuid': ''},
-            {'lv_uuid': 'ffff', 'pv_name': '/dev/sdb1', 'pv_tags': '', 'pv_uuid': ''},
-        ]
+            {'lv_uuid': 'ffff', 'pv_name': '/dev/sda1', 'pv_tags': '',
+             'pv_uuid': ''},
+            {'lv_uuid': 'ffff', 'pv_name': '/dev/sdb1', 'pv_tags': '',
+             'pv_uuid': ''}]
+
         result = listing.single_report('VolGroup/lv')
         assert result['0'][0]['name'] == 'lv'
         assert result['0'][0]['lv_tags'] == tags
         assert result['0'][0]['path'] == '/dev/VolGroup/lv'
         assert result['0'][0]['devices'] == []
-
-
-class TestListingPVs(object):
-
-    def setup(self):
-        self.default_pvs = [
-            {'lv_uuid': 'ffff', 'pv_name': '/dev/sda1', 'pv_tags': '', 'pv_uuid': ''},
-            {'lv_uuid': 'ffff', 'pv_name': '/dev/sdb1', 'pv_tags': '', 'pv_uuid': ''},
-        ]
-
-    def test_pvs_is_unset(self, monkeypatch):
-        monkeypatch.setattr(lvm.listing.api, 'get_api_pvs', lambda: self.default_pvs)
-        listing = lvm.listing.List([])
-        assert listing.pvs == self.default_pvs
-
-    def test_pvs_is_set(self, monkeypatch):
-        # keep it patched so that we can fail if this gets returned
-        monkeypatch.setattr(lvm.listing.api, 'get_api_pvs', lambda: self.default_pvs)
-        listing = lvm.listing.List([])
-        listing._pvs = []
-        assert listing.pvs == []


### PR DESCRIPTION
This backports #31700 and two regression fixes - #33112 and #33077 - introduced by the original PR

In addition, #21812 is brought in to avoid cherry-pick conflicts.

Fixes: https://tracker.ceph.com/issues/43985
Fixes: https://tracker.ceph.com/issues/44033
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
