### PR TITLE
doc: add section about new kclient recover_session=clean mount option

### DIFF
--- a/doc/releases/octopus.rst
+++ b/doc/releases/octopus.rst
@@ -134,6 +134,9 @@ Major Changes from Nautilus
   * The mgr volumes plugin has received numerous improvements to support CephFS
     via CSI, including snapshots and cloning.
   * cephfs-shell has had numerous incremental improvements and bug fixes.
+  * The Linux kernel (as of release v5.4) supports a new
+    "recover_session=clean" mount option that allows the client to
+    automatically reconnect to the MDS after being blacklisted.
 
 
 Upgrading from Mimic or Nautilus


### PR DESCRIPTION
Added this at the behest of @batrick, but I'll note that recover_session= is really not tied to any particular userland ceph release. Should we instead limit this file to covering changes that are?