### PR TITLE
mimic: ceph-volume: silence 'ceph-bluestore-tool' failures

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -43,7 +43,7 @@ class List(object):
             # bluestore?
             out, err, ret = process.call([
                 'ceph-bluestore-tool', 'show-label',
-                '--dev', dev])
+                '--dev', dev], verbose_on_failure=False)
             if ret:
                 logger.debug('No label on %s' % dev)
                 continue


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44227

---

backport of https://github.com/ceph/ceph/pull/33371
parent tracker: https://tracker.ceph.com/issues/44222

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh