### PR TITLE
mimic: ceph-volume: finer grained availability notion in inventory

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -293,6 +293,8 @@ def device_info(monkeypatch, patch_bluestore_label):
             monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: lv)
         else:
             monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: None)
+            monkeypatch.setattr("ceph_volume.util.device.lvm.get_device_lvs",
+                                lambda path: [lv])
         monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv", lambda vg_name, lv_uuid: lv)
         monkeypatch.setattr("ceph_volume.util.device.disk.lsblk", lambda path: lsblk)
         monkeypatch.setattr("ceph_volume.util.device.disk.blkid", lambda path: blkid)

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -80,17 +80,23 @@ class Device(object):
         # LVs can have a vg/lv path, while disks will have /dev/sda
         self.abspath = path
         self.lv_api = None
+        self.vgs = []
         self.lvs = []
         self.vg_name = None
         self.lv_name = None
-        self.pvs_api = []
         self.disk_api = {}
         self.blkid_api = {}
         self.sys_api = {}
         self._exists = None
         self._is_lvm_member = None
         self._parse()
-        self.available, self.rejected_reasons = self._check_reject_reasons()
+
+        self.available_lvm, self.rejected_reasons_lvm = self._check_lvm_reject_reasons()
+        self.available_raw, self.rejected_reasons_raw = self._check_raw_reject_reasons()
+        self.available = self.available_lvm and self.available_raw
+        self.rejected_reasons = list(set(self.rejected_reasons_lvm +
+                                         self.rejected_reasons_raw))
+
         self.device_id = self._get_device_id()
 
     def __lt__(self, other):
@@ -226,23 +232,17 @@ class Device(object):
             # here, because most likely, we need to use VGs from this PV.
             self._is_lvm_member = False
             for path in self._get_pv_paths():
-                # check if there was a pv created with the
-                # name of device
-                pvs = lvm.PVolumes().filter(pv_name=path)
-                has_vgs = [pv.vg_name for pv in pvs if pv.vg_name]
-                if has_vgs:
-                    self.vgs = list(set(has_vgs))
+                vgs = lvm.get_device_vgs(path)
+                if vgs:
+                    self.vgs.extend(vgs)
                     # a pv can only be in one vg, so this should be safe
-                    self.vg_name = has_vgs[0]
+                    # FIXME: While the above assumption holds, sda1 and sda2
+                    # can each host a PV and VG. I think the vg_name property is
+                    # actually unused (not 100% sure) and can simply be removed
+                    self.vg_name = vgs[0]
                     self._is_lvm_member = True
-                    self.pvs_api = pvs
-                    for pv in pvs:
-                        if pv.vg_name and pv.lv_uuid:
-                            lv = lvm.get_lv(vg_name=pv.vg_name, lv_uuid=pv.lv_uuid)
-                            if lv:
-                                self.lvs.append(lv)
-                else:
-                    self.vgs = []
+
+                    self.lvs.extend(lvm.get_device_lvs(path))
         return self._is_lvm_member
 
     def _get_pv_paths(self):
@@ -379,13 +379,8 @@ class Device(object):
                    if lv.tags.get("ceph.type") in ["data", "block"]]
         return any(osd_ids)
 
-    def _check_reject_reasons(self):
-        """
-        This checks a number of potential reject reasons for a drive and
-        returns a tuple (boolean, list). The first element denotes whether a
-        drive is available or not, the second element lists reasons in case a
-        drive is not available.
-        """
+
+    def _check_generic_reject_reasons(self):
         reasons = [
             ('removable', 1, 'removable'),
             ('ro', 1, 'read-only'),
@@ -400,6 +395,20 @@ class Device(object):
             rejected.append("Used by ceph-disk")
         if self.has_bluestore_label:
             rejected.append('Has BlueStore device label')
+        return rejected
+
+    def _check_lvm_reject_reasons(self):
+        rejected = self._check_generic_reject_reasons()
+        available_vgs = [vg for vg in self.vgs if vg.free >= 5368709120]
+        if self.vgs and not available_vgs:
+            rejected.append('Insufficient space (<5GB) on vgs')
+
+        return len(rejected) == 0, rejected
+
+    def _check_raw_reject_reasons(self):
+        rejected = self._check_generic_reject_reasons()
+        if len(self.vgs) > 0:
+            rejected.append('LVM detected')
 
         return len(rejected) == 0, rejected
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44036

---

backport of https://github.com/ceph/ceph/pull/32634
parent tracker: https://tracker.ceph.com/issues/43400

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh