### PR TITLE
mimic: ceph-volume: fix is_ceph_device for lvm batch

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -274,7 +274,10 @@ def is_ceph_device(lv):
         logger.warning('device is not part of ceph: %s', lv)
         return False
 
-    return True
+    if lv.tags['ceph.osd_id'] == 'null':
+        return False
+    else:
+        return True
 
 
 ####################################

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -213,6 +213,24 @@ class TestGetVG(object):
         assert api.get_vg(vg_name='foo') == FooVG
 
 
+class TestVolume(object):
+
+    def test_is_ceph_device(self):
+        lv_tags = "ceph.type=data,ceph.osd_id=0"
+        osd = api.Volume(lv_name='osd/volume', lv_tags=lv_tags)
+        assert api.is_ceph_device(osd)
+
+    @pytest.mark.parametrize('dev',[
+        '/dev/sdb',
+        api.VolumeGroup(vg_name='foo'),
+        api.Volume(lv_name='vg/no_osd', lv_tags=''),
+        api.Volume(lv_name='vg/no_osd', lv_tags='ceph.osd_id=null'),
+        None,
+    ])
+    def test_is_not_ceph_device(self, dev):
+        assert not api.is_ceph_device(dev)
+
+
 class TestVolumes(object):
 
     def test_volume_get_has_no_volumes(self, volumes):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44110

---

backport of https://github.com/ceph/ceph/pull/33223
parent tracker: https://tracker.ceph.com/issues/44069

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh