### PR TITLE
mimic: ceph-volume: avoid calling zap_lv with a LV-less VG

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -223,7 +223,13 @@ class Zap(object):
         Requirements: An LV or VG present in the device, making it an LVM member
         """
         for lv in device.lvs:
-            self.zap_lv(Device(lv.lv_path))
+            if lv.lv_name:
+                mlogger.info('Zapping lvm member {}. lv_path is {}'.format(device.abspath, lv.lv_path))
+                self.zap_lv(Device(lv.lv_path))
+            else:
+                mlogger.info('Found empty VG {}, removing'.format(lv.vg_name))
+                api.remove_vg(lv.vg_name)
+
 
 
     def zap_raw_device(self, device):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44134

---

backport of https://github.com/ceph/ceph/pull/33283
parent tracker: https://tracker.ceph.com/issues/44125

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh