### PR TITLE
mimic: ceph-volume: pass journal_size as Size not string

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -352,7 +352,7 @@ class MixedType(MixedStrategy):
         else:
             journal_vg = self.common_vg
 
-        journal_size = prepare.get_journal_size(lv_format=True)
+        journal_size = prepare.get_journal_size(lv_format=False)
 
         # create 1 vg per data device first, mapping them to the device path,
         # when the lv gets created later, it can create as many as needed (or


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44151

---

backport of https://github.com/ceph/ceph/pull/33320
parent tracker: https://tracker.ceph.com/issues/44148

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh