### PR TITLE
nautilus: ceph-volume: lvm: get_device_vgs() filter by provided prefix

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -1356,7 +1356,8 @@ def get_device_lvs(device, name_prefix=''):
         verbose_on_failure=False
     )
     lvs = _output_parser(stdout, LV_FIELDS)
-    return [Volume(**lv) for lv in lvs]
+    return [Volume(**lv) for lv in lvs if lv['lv_name'] and
+            lv['lv_name'].startswith(name_prefix)]
 
 
 #############################################################

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -866,7 +866,7 @@ def get_device_vgs(device, name_prefix=''):
         verbose_on_failure=False
     )
     vgs = _output_parser(stdout, VG_FIELDS)
-    return [VolumeGroup(**vg) for vg in vgs if vg['vg_name'].startswith(name_prefix)]
+    return [VolumeGroup(**vg) for vg in vgs if vg['vg_name'] and vg['vg_name'].startswith(name_prefix)]
 
 
 #################################

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -563,6 +563,8 @@ class VolumeGroup(object):
         for k, v in kw.items():
             setattr(self, k, v)
         self.name = kw['vg_name']
+        if not self.name:
+            raise ValueError('VolumeGroup must have a non-empty name')
         self.tags = parse_tags(kw.get('vg_tags', ''))
 
     def __str__(self):
@@ -908,6 +910,8 @@ class Volume(object):
             setattr(self, k, v)
         self.lv_api = kw
         self.name = kw['lv_name']
+        if not self.name:
+            raise ValueError('Volume must have a non-empty name')
         self.tags = parse_tags(kw['lv_tags'])
         self.encrypted = self.tags.get('ceph.encrypted', '0') == '1'
         self.used_by_ceph = 'ceph.osd_id' in self.tags

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -866,7 +866,7 @@ def get_device_vgs(device, name_prefix=''):
         verbose_on_failure=False
     )
     vgs = _output_parser(stdout, VG_FIELDS)
-    return [VolumeGroup(**vg) for vg in vgs]
+    return [VolumeGroup(**vg) for vg in vgs if vg['vg_name'].startswith(name_prefix)]
 
 
 #################################

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -230,6 +230,10 @@ class TestVolume(object):
     def test_is_not_ceph_device(self, dev):
         assert not api.is_ceph_device(dev)
 
+    def test_no_empty_lv_name(self):
+        with pytest.raises(ValueError):
+            api.Volume(lv_name='', lv_tags='')
+
 
 class TestVolumes(object):
 
@@ -326,6 +330,13 @@ class TestVolumes(object):
     def test_filter_requires_params(self, volumes):
         with pytest.raises(TypeError):
             volumes.filter()
+
+
+class TestVolumeGroup(object):
+
+    def test_volume_group_no_empty_name(self):
+        with pytest.raises(ValueError):
+            api.VolumeGroup(vg_name='')
 
 
 class TestVolumeGroups(object):
@@ -961,3 +972,23 @@ class TestIsLV(object):
         splitname = {'LV_NAME': 'data', 'VG_NAME': 'ceph'}
         monkeypatch.setattr(api, 'dmsetup_splitname', lambda x, **kw: splitname)
         assert api.is_lv('/dev/sda1', lvs=volumes) is True
+
+class TestGetDeviceVgs(object):
+
+    @patch('ceph_volume.process.call')
+    @patch('ceph_volume.api.lvm._output_parser')
+    def test_get_device_vgs_with_empty_pv(self, patched_output_parser, pcall):
+        patched_output_parser.return_value = [{'vg_name': ''}]
+        pcall.return_value = ('', '', '')
+        vgs = api.get_device_vgs('/dev/foo')
+        assert vgs == []
+
+class TestGetDeviceLvs(object):
+
+    @patch('ceph_volume.process.call')
+    @patch('ceph_volume.api.lvm._output_parser')
+    def test_get_device_lvs_with_empty_vg(self, patched_output_parser, pcall):
+        patched_output_parser.return_value = [{'lv_name': ''}]
+        pcall.return_value = ('', '', '')
+        vgs = api.get_device_lvs('/dev/foo')
+        assert vgs == []


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44325

---

backport of https://github.com/ceph/ceph/pull/33478
parent tracker: https://tracker.ceph.com/issues/44246

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh