### PR TITLE
luminous: ceph-volume: strip _dmcrypt suffix in simple scan json output

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/simple/scan.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/scan.py
@@ -98,11 +98,16 @@ class Scan(object):
             raise RuntimeError(
                 'OSD files not found, required "keyring" file is not present at: %s' % path
             )
-        for _file in os.listdir(path):
-            file_path = os.path.join(path, _file)
+        for file_ in os.listdir(path):
+            file_path = os.path.join(path, file_)
+            file_json_key = file_
+            if file_.endswith('_dmcrypt'):
+                file_json_key = file_.rstrip('_dmcrypt')
+                logger.info(('reading file {}, stripping _dmcrypt',
+                             'suffix').format(file_))
             if os.path.islink(file_path):
                 if os.path.exists(file_path):
-                    osd_metadata[_file] = self.scan_device(file_path)
+                    osd_metadata[file_json_key] = self.scan_device(file_path)
                 else:
                     msg = 'broken symlink found %s -> %s' % (file_path, os.path.realpath(file_path))
                     terminal.warning(msg)
@@ -126,9 +131,9 @@ class Scan(object):
                 if 'keyring' in file_path:
                     content = parse_keyring(content)
                 try:
-                    osd_metadata[_file] = int(content)
+                    osd_metadata[file_json_key] = int(content)
                 except ValueError:
-                    osd_metadata[_file] = content
+                    osd_metadata[file_json_key] = content
 
         # we must scan the paths again because this might be a temporary mount
         path_mounts = system.get_mounts(paths=True)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44333

---

backport of https://github.com/ceph/ceph/pull/33079
parent tracker: https://tracker.ceph.com/issues/43966

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh