### PR TITLE
mgr/dashboard: Crush rule modal

### DIFF
--- a/qa/tasks/mgr/dashboard/test_crush_rule.py
+++ b/qa/tasks/mgr/dashboard/test_crush_rule.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import six
+
+from .helper import DashboardTestCase, JObj, JList
+
+
+class CrushRuleTest(DashboardTestCase):
+
+    AUTH_ROLES = ['pool-manager']
+
+    rule_schema = JObj(sub_elems={
+        'max_size': int,
+        'min_size': int,
+        'rule_id': int,
+        'rule_name': six.string_types,
+        'ruleset': int,
+        'steps': JList(JObj({}, allow_unknown=True))
+    }, allow_unknown=True)
+
+    def create_and_delete_rule(self, data):
+        name = data['name']
+        # Creates rule
+        self._post('/api/crush_rule', data)
+        self.assertStatus(201)
+        # Makes sure rule exists
+        rule = self._get('/api/crush_rule/{}'.format(name))
+        self.assertStatus(200)
+        self.assertSchemaBody(self.rule_schema)
+        self.assertEqual(rule['rule_name'], name)
+        # Deletes rule
+        self._delete('/api/crush_rule/{}'.format(name))
+        self.assertStatus(204)
+
+    @DashboardTestCase.RunAs('test', 'test', ['rgw-manager'])
+    def test_read_access_permissions(self):
+        self._get('/api/crush_rule')
+        self.assertStatus(403)
+
+    @DashboardTestCase.RunAs('test', 'test', ['read-only'])
+    def test_write_access_permissions(self):
+        self._get('/api/crush_rule')
+        self.assertStatus(200)
+        data = {'name': 'some_rule', 'root': 'default', 'failure_domain': 'osd'}
+        self._post('/api/crush_rule', data)
+        self.assertStatus(403)
+        self._delete('/api/crush_rule/default')
+        self.assertStatus(403)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(CrushRuleTest, cls).tearDownClass()
+        cls._ceph_cmd(['osd', 'crush', 'rule', 'rm', 'some_rule'])
+        cls._ceph_cmd(['osd', 'crush', 'rule', 'rm', 'another_rule'])
+
+    def test_list(self):
+        self._get('/api/crush_rule')
+        self.assertStatus(200)
+        self.assertSchemaBody(JList(self.rule_schema))
+
+    def test_create(self):
+        self.create_and_delete_rule({
+            'name': 'some_rule',
+            'root': 'default',
+            'failure_domain': 'osd'
+        })
+
+    @DashboardTestCase.RunAs('test', 'test', ['pool-manager', 'cluster-manager'])
+    def test_create_with_ssd(self):
+        data = self._get('/api/osd/0')
+        self.assertStatus(200)
+        device_class = data['osd_metadata']['default_device_class']
+        self.create_and_delete_rule({
+            'name': 'another_rule',
+            'root': 'default',
+            'failure_domain': 'osd',
+            'device_class': device_class
+        })
+
+    def test_crush_rule_info(self):
+        self._get('/ui-api/crush_rule/info')
+        self.assertStatus(200)
+        self.assertSchemaBody(JObj({
+            'names': JList(six.string_types),
+            'nodes': JList(JObj({}, allow_unknown=True))
+        }))
+

--- a/qa/tasks/mgr/dashboard/test_erasure_code_profile.py
+++ b/qa/tasks/mgr/dashboard/test_erasure_code_profile.py
@@ -99,7 +99,7 @@ class ECPTest(DashboardTestCase):
         self.assertStatus(204)
 
     def test_ecp_info(self):
-        self._get('/api/erasure_code_profile/_info')
+        self._get('/ui-api/erasure_code_profile/info')
         self.assertSchemaBody(JObj({
             'names': JList(six.string_types),
             'failure_domains': JList(six.string_types),

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -400,7 +400,7 @@ class PoolTest(DashboardTestCase):
         })
 
     def test_pool_info(self):
-        self._get("/api/pool/_info")
+        self._get("/ui-api/pool/info")
         self.assertSchemaBody(JObj({
             'pool_names': JList(six.string_types),
             'compression_algorithms': JList(six.string_types),
@@ -412,4 +412,6 @@ class PoolTest(DashboardTestCase):
             'crush_rules_erasure': JList(JObj({}, allow_unknown=True)),
             'pg_autoscale_default_mode': six.string_types,
             'pg_autoscale_modes': JList(six.string_types),
+            'erasure_code_profiles': JList(JObj({}, allow_unknown=True)),
+            'used_rules': JObj({}, allow_unknown=True),
         }))

--- a/src/pybind/mgr/dashboard/controllers/crush_rule.py
+++ b/src/pybind/mgr/dashboard/controllers/crush_rule.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from cherrypy import NotFound
+
+from . import ApiController, RESTController, Endpoint, ReadPermission, UiApiController
+from ..security import Scope
+from ..services.ceph_service import CephService
+from .. import mgr
+
+
+@ApiController('/crush_rule', Scope.POOL)
+class CrushRule(RESTController):
+    def list(self):
+        return mgr.get('osd_map_crush')['rules']
+
+    def get(self, name):
+        rules = mgr.get('osd_map_crush')['rules']
+        for r in rules:
+            if r['rule_name'] == name:
+                return r
+        raise NotFound('No such crush rule')
+
+    def create(self, name, root, failure_domain, device_class=None):
+        rule = {
+            'name': name,
+            'root': root,
+            'type': failure_domain,
+            'class': device_class
+        }
+        CephService.send_command('mon', 'osd crush rule create-replicated', **rule)
+
+    def delete(self, name):
+        CephService.send_command('mon', 'osd crush rule rm', name=name)
+
+
+@UiApiController('/crush_rule', Scope.POOL)
+class CrushRuleUi(CrushRule):
+    @Endpoint()
+    @ReadPermission
+    def info(self):
+        '''Used for crush rule creation modal'''
+        return {
+            'names': [r['rule_name'] for r in mgr.get('osd_map_crush')['rules']],
+            'nodes': mgr.get('osd_map_tree')['nodes']
+        }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.html
@@ -1,0 +1,124 @@
+<cd-modal [modalRef]="bsModalRef">
+  <ng-container i18n="form title|Example: Create Pool@@formTitle"
+                class="modal-title">{{ action | titlecase }} {{ resource | upperFirst }}</ng-container>
+
+  <ng-container class="modal-content">
+    <form #frm="ngForm"
+          [formGroup]="form"
+          novalidate>
+      <div class="modal-body">
+        <div class="form-group row">
+          <label for="name"
+                 class="col-form-label col-sm-3">
+            <ng-container i18n>Name</ng-container>
+            <span class="required"></span>
+          </label>
+          <div class="col-sm-9">
+            <input type="text"
+                   id="name"
+                   name="name"
+                   class="form-control"
+                   placeholder="Name..."
+                   formControlName="name"
+                   autofocus>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('name', frm, 'required')"
+                  i18n>This field is required!</span>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('name', frm, 'pattern')"
+                  i18n>The name can only consist of alphanumeric characters, dashes and underscores.</span>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('name', frm, 'uniqueName')"
+                  i18n>The chosen erasure code profile name is already in use.</span>
+          </div>
+        </div>
+
+        <!-- Root -->
+        <div class="form-group row">
+          <label for="root"
+                 class="col-form-label col-sm-3">
+            <ng-container i18n>Root</ng-container>
+            <cd-helper [html]="tooltips.root">
+            </cd-helper>
+            <span class="required"></span>
+          </label>
+          <div class="col-sm-9">
+            <select class="form-control custom-select"
+                    id="root"
+                    name="root"
+                    formControlName="root">
+              <option *ngIf="!buckets"
+                      ngValue=""
+                      i18n>Loading...</option>
+              <option *ngFor="let bucket of buckets"
+                      [ngValue]="bucket">
+                {{ bucket.name }}
+              </option>
+            </select>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('root', frm, 'required')"
+                  i18n>This field is required!</span>
+          </div>
+        </div>
+
+        <!-- Failure Domain Type -->
+        <div class="form-group row">
+          <label for="failure_domain"
+                 class="col-form-label col-sm-3">
+            <ng-container i18n>Failure domain type</ng-container>
+            <cd-helper [html]="tooltips.failure_domain">
+            </cd-helper>
+            <span class="required"></span>
+          </label>
+          <div class="col-sm-9">
+            <select class="form-control custom-select"
+                    id="failure_domain"
+                    name="failure_domain"
+                    formControlName="failure_domain">
+              <option *ngIf="!failureDomains"
+                      ngValue=""
+                      i18n>Loading...</option>
+              <option *ngFor="let domain of failureDomainKeys()"
+                      [ngValue]="domain">
+                {{ domain }} ( {{failureDomains[domain].length}} )
+              </option>
+            </select>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('failure_domain', frm, 'required')"
+                  i18n>This field is required!</span>
+          </div>
+        </div>
+
+        <!-- Class -->
+        <div class="form-group row">
+          <label for="device_class"
+                 class="col-form-label col-sm-3">
+            <ng-container i18n>Device class</ng-container>
+            <cd-helper [html]="tooltips.device_class">
+            </cd-helper>
+          </label>
+          <div class="col-sm-9">
+            <select class="form-control custom-select"
+                    id="device_class"
+                    name="device_class"
+                    formControlName="device_class">
+              <option ngValue=""
+                      i18n>Let Ceph decide</option>
+              <option *ngFor="let deviceClass of devices"
+                      [ngValue]="deviceClass">
+                {{ deviceClass }}
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div class="modal-footer">
+        <cd-submit-button (submitAction)="onSubmit()"
+                          i18n="form action button|Example: Create Pool@@formActionButton"
+                          [form]="frm">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
+        <cd-back-button [back]="bsModalRef.hide"></cd-back-button>
+      </div>
+    </form>
+  </ng-container>
+</cd-modal>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.spec.ts
@@ -1,0 +1,265 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
+import { BsModalRef } from 'ngx-bootstrap/modal';
+import { ToastrModule } from 'ngx-toastr';
+import { of } from 'rxjs';
+
+import {
+  configureTestBed,
+  FixtureHelper,
+  FormHelper,
+  i18nProviders
+} from '../../../../testing/unit-test-helper';
+import { CrushRuleService } from '../../../shared/api/crush-rule.service';
+import { CrushNode } from '../../../shared/models/crush-node';
+import { CrushRuleConfig } from '../../../shared/models/crush-rule';
+import { TaskWrapperService } from '../../../shared/services/task-wrapper.service';
+import { PoolModule } from '../pool.module';
+import { CrushRuleFormModalComponent } from './crush-rule-form-modal.component';
+
+describe('CrushRuleFormComponent', () => {
+  let component: CrushRuleFormModalComponent;
+  let crushRuleService: CrushRuleService;
+  let fixture: ComponentFixture<CrushRuleFormModalComponent>;
+  let formHelper: FormHelper;
+  let fixtureHelper: FixtureHelper;
+  let data: { names: string[]; nodes: CrushNode[] };
+
+  // Object contains mock functions
+  const mock = {
+    node: (
+      name: string,
+      id: number,
+      type: string,
+      type_id: number,
+      children?: number[],
+      device_class?: string
+    ): CrushNode => {
+      return { name, type, type_id, id, children, device_class };
+    },
+    rule: (
+      name: string,
+      root: string,
+      failure_domain: string,
+      device_class?: string
+    ): CrushRuleConfig => ({
+      name,
+      root,
+      failure_domain,
+      device_class
+    })
+  };
+
+  // Object contains functions to get something
+  const get = {
+    nodeByName: (name: string): CrushNode => data.nodes.find((node) => node.name === name),
+    nodesByNames: (names: string[]): CrushNode[] => names.map(get.nodeByName)
+  };
+
+  // Expects that are used frequently
+  const assert = {
+    failureDomains: (nodes: CrushNode[], types: string[]) => {
+      const expectation = {};
+      types.forEach((type) => (expectation[type] = nodes.filter((node) => node.type === type)));
+      const keys = component.failureDomainKeys();
+      expect(keys).toEqual(types);
+      keys.forEach((key) => {
+        expect(component.failureDomains[key].length).toBe(expectation[key].length);
+      });
+    },
+    formFieldValues: (root: CrushNode, failureDomain: string, device: string) => {
+      expect(component.form.value).toEqual({
+        name: '',
+        root,
+        failure_domain: failureDomain,
+        device_class: device
+      });
+    },
+    valuesOnRootChange: (
+      rootName: string,
+      expectedFailureDomain: string,
+      expectedDevice: string
+    ) => {
+      const node = get.nodeByName(rootName);
+      formHelper.setValue('root', node);
+      assert.formFieldValues(node, expectedFailureDomain, expectedDevice);
+    },
+    creation: (rule: CrushRuleConfig) => {
+      formHelper.setValue('name', rule.name);
+      fixture.detectChanges();
+      component.onSubmit();
+      expect(crushRuleService.create).toHaveBeenCalledWith(rule);
+    }
+  };
+
+  configureTestBed({
+    imports: [
+      HttpClientTestingModule,
+      RouterTestingModule,
+      ToastrModule.forRoot(),
+      PoolModule,
+      NgBootstrapFormValidationModule.forRoot()
+    ],
+    providers: [CrushRuleService, BsModalRef, i18nProviders]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CrushRuleFormModalComponent);
+    fixtureHelper = new FixtureHelper(fixture);
+    component = fixture.componentInstance;
+    formHelper = new FormHelper(component.form);
+    crushRuleService = TestBed.get(CrushRuleService);
+    data = {
+      names: ['rule1', 'rule2'],
+      /**
+       * Create the following test crush map:
+       * > default
+       * --> ssd-host
+       * ----> 3x osd with ssd
+       * --> mix-host
+       * ----> hdd-rack
+       * ------> 2x osd-rack with hdd
+       * ----> ssd-rack
+       * ------> 2x osd-rack with ssd
+       */
+      nodes: [
+        // Root node
+        mock.node('default', -1, 'root', 11, [-2, -3]),
+        // SSD host
+        mock.node('ssd-host', -2, 'host', 1, [1, 0, 2]),
+        mock.node('osd.0', 0, 'osd', 0, undefined, 'ssd'),
+        mock.node('osd.1', 1, 'osd', 0, undefined, 'ssd'),
+        mock.node('osd.2', 2, 'osd', 0, undefined, 'ssd'),
+        // SSD and HDD mixed devices host
+        mock.node('mix-host', -3, 'host', 1, [-4, -5]),
+        // HDD rack
+        mock.node('hdd-rack', -4, 'rack', 3, [3, 4]),
+        mock.node('osd2.0', 3, 'osd-rack', 0, undefined, 'hdd'),
+        mock.node('osd2.1', 4, 'osd-rack', 0, undefined, 'hdd'),
+        // SSD rack
+        mock.node('ssd-rack', -5, 'rack', 3, [5, 6]),
+        mock.node('osd2.0', 5, 'osd-rack', 0, undefined, 'ssd'),
+        mock.node('osd2.1', 6, 'osd-rack', 0, undefined, 'ssd')
+      ]
+    };
+    spyOn(crushRuleService, 'getInfo').and.callFake(() => of(data));
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('calls listing to get rules on ngInit', () => {
+    expect(crushRuleService.getInfo).toHaveBeenCalled();
+    expect(component.names.length).toBe(2);
+    expect(component['nodes'].length).toBe(12);
+  });
+
+  describe('lists', () => {
+    afterEach(() => {
+      // The available buckets should not change
+      expect(component.buckets).toEqual(
+        get.nodesByNames(['default', 'hdd-rack', 'mix-host', 'ssd-host', 'ssd-rack'])
+      );
+    });
+
+    it('has the following lists after init', () => {
+      assert.failureDomains(data.nodes, ['host', 'osd', 'osd-rack', 'rack']); // Not root as root only exist once
+      expect(component.devices).toEqual(['hdd', 'ssd']);
+    });
+
+    it('has the following lists after selection of ssd-host', () => {
+      formHelper.setValue('root', get.nodeByName('ssd-host'));
+      assert.failureDomains(get.nodesByNames(['osd.0', 'osd.1', 'osd.2']), ['osd']); // Not host as it only exist once
+      expect(component.devices).toEqual(['ssd']);
+    });
+
+    it('has the following lists after selection of mix-host', () => {
+      formHelper.setValue('root', get.nodeByName('mix-host'));
+      expect(component.devices).toEqual(['hdd', 'ssd']);
+      assert.failureDomains(
+        get.nodesByNames(['hdd-rack', 'ssd-rack', 'osd2.0', 'osd2.1', 'osd2.0', 'osd2.1']),
+        ['osd-rack', 'rack']
+      );
+    });
+  });
+
+  describe('selection', () => {
+    it('selects the first root after init automatically', () => {
+      assert.formFieldValues(get.nodeByName('default'), 'osd-rack', '');
+    });
+
+    it('should select all values automatically by selecting "ssd-host" as root', () => {
+      assert.valuesOnRootChange('ssd-host', 'osd', 'ssd');
+    });
+
+    it('selects automatically the most common failure domain', () => {
+      // Select mix-host as mix-host has multiple failure domains (osd-rack and rack)
+      assert.valuesOnRootChange('mix-host', 'osd-rack', '');
+    });
+
+    it('should override automatic selections', () => {
+      assert.formFieldValues(get.nodeByName('default'), 'osd-rack', '');
+      assert.valuesOnRootChange('ssd-host', 'osd', 'ssd');
+      assert.valuesOnRootChange('mix-host', 'osd-rack', '');
+    });
+
+    it('should not override manual selections if possible', () => {
+      formHelper.setValue('failure_domain', 'rack', true);
+      formHelper.setValue('device_class', 'ssd', true);
+      assert.valuesOnRootChange('mix-host', 'rack', 'ssd');
+    });
+
+    it('should preselect device by domain selection', () => {
+      formHelper.setValue('failure_domain', 'osd', true);
+      assert.formFieldValues(get.nodeByName('default'), 'osd', 'ssd');
+    });
+  });
+
+  describe('form validation', () => {
+    it(`isn't valid if name is not set`, () => {
+      expect(component.form.invalid).toBeTruthy();
+      formHelper.setValue('name', 'someProfileName');
+      expect(component.form.valid).toBeTruthy();
+    });
+
+    it('sets name invalid', () => {
+      component.names = ['awesomeProfileName'];
+      formHelper.expectErrorChange('name', 'awesomeProfileName', 'uniqueName');
+      formHelper.expectErrorChange('name', 'some invalid text', 'pattern');
+      formHelper.expectErrorChange('name', null, 'required');
+    });
+
+    it(`should show all default form controls`, () => {
+      // name
+      // root (preselected(first root))
+      // failure_domain (preselected=type that is most common)
+      // device_class (preselected=any if multiple or some type if only one device type)
+      fixtureHelper.expectIdElementsVisible(
+        ['name', 'root', 'failure_domain', 'device_class'],
+        true
+      );
+    });
+  });
+
+  describe('submission', () => {
+    beforeEach(() => {
+      const taskWrapper = TestBed.get(TaskWrapperService);
+      spyOn(taskWrapper, 'wrapTaskAroundCall').and.callThrough();
+      spyOn(crushRuleService, 'create').and.stub();
+    });
+
+    it('creates a rule with only required fields', () => {
+      assert.creation(mock.rule('default-rule', 'default', 'osd-rack'));
+    });
+
+    it('creates a rule with all fields', () => {
+      assert.valuesOnRootChange('ssd-host', 'osd', 'ssd');
+      assert.creation(mock.rule('ssd-host-rule', 'ssd-host', 'osd', 'ssd'));
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.ts
@@ -1,0 +1,199 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Validators } from '@angular/forms';
+
+import { I18n } from '@ngx-translate/i18n-polyfill';
+import * as _ from 'lodash';
+import { BsModalRef } from 'ngx-bootstrap/modal';
+
+import { CrushRuleService } from '../../../shared/api/crush-rule.service';
+import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
+import { CdFormBuilder } from '../../../shared/forms/cd-form-builder';
+import { CdFormGroup } from '../../../shared/forms/cd-form-group';
+import { CdValidators } from '../../../shared/forms/cd-validators';
+import { CrushNode } from '../../../shared/models/crush-node';
+import { FinishedTask } from '../../../shared/models/finished-task';
+import { TaskWrapperService } from '../../../shared/services/task-wrapper.service';
+
+@Component({
+  selector: 'cd-crush-rule-form-modal',
+  templateUrl: './crush-rule-form-modal.component.html',
+  styleUrls: ['./crush-rule-form-modal.component.scss']
+})
+export class CrushRuleFormModalComponent implements OnInit {
+  @Output()
+  submitAction = new EventEmitter();
+
+  buckets: CrushNode[] = [];
+  failureDomains: { [type: string]: CrushNode[] } = {};
+  devices: string[] = [];
+  tooltips = this.crushRuleService.formTooltips;
+
+  form: CdFormGroup;
+  names: string[];
+  action: string;
+  resource: string;
+
+  private nodes: CrushNode[] = [];
+  private easyNodes: { [id: number]: CrushNode } = {};
+
+  constructor(
+    private formBuilder: CdFormBuilder,
+    public bsModalRef: BsModalRef,
+    private taskWrapper: TaskWrapperService,
+    private crushRuleService: CrushRuleService,
+    private i18n: I18n,
+    public actionLabels: ActionLabelsI18n
+  ) {
+    this.action = this.actionLabels.CREATE;
+    this.resource = this.i18n('Crush Rule');
+    this.createForm();
+  }
+
+  createForm() {
+    this.form = this.formBuilder.group({
+      // name: string
+      name: [
+        '',
+        [
+          Validators.required,
+          Validators.pattern('[A-Za-z0-9_-]+'),
+          CdValidators.custom(
+            'uniqueName',
+            (value: any) => this.names && this.names.indexOf(value) !== -1
+          )
+        ]
+      ],
+      // root: CrushNode
+      root: null, // Replaced with first root
+      // failure_domain: string
+      failure_domain: '', // Replaced with most common type
+      // device_class: string
+      device_class: '' // Replaced with device type if only one exists beneath domain
+    });
+  }
+
+  ngOnInit() {
+    this.crushRuleService
+      .getInfo()
+      .subscribe(({ names, nodes }: { names: string[]; nodes: CrushNode[] }) => {
+        this.nodes = nodes;
+        nodes.forEach((node) => {
+          this.easyNodes[node.id] = node;
+        });
+        this.buckets = _.sortBy(nodes.filter((n) => n.children), 'name');
+        this.names = names;
+        this.preSelectRoot();
+      });
+    this.form.get('root').valueChanges.subscribe((root: CrushNode) => this.updateRoot(root));
+    this.form
+      .get('failure_domain')
+      .valueChanges.subscribe((domain: string) => this.updateDevices(domain));
+  }
+
+  private preSelectRoot() {
+    const rootNode = this.nodes.find((node) => node.type === 'root');
+    this.form.silentSet('root', rootNode);
+    this.updateRoot(rootNode);
+  }
+
+  private updateRoot(rootNode: CrushNode) {
+    const nodes = this.getSubNodes(rootNode);
+    const domains = {};
+    nodes.forEach((node) => {
+      if (!domains[node.type]) {
+        domains[node.type] = [];
+      }
+      domains[node.type].push(node);
+    });
+    Object.keys(domains).forEach((type) => {
+      if (domains[type].length <= 1) {
+        delete domains[type];
+      }
+    });
+    this.failureDomains = domains;
+    this.updateFailureDomain();
+  }
+
+  private getSubNodes(node: CrushNode): CrushNode[] {
+    let subNodes = [node]; // Includes parent node
+    if (!node.children) {
+      return subNodes;
+    }
+    node.children.forEach((id) => {
+      const childNode = this.easyNodes[id];
+      subNodes = subNodes.concat(this.getSubNodes(childNode));
+    });
+    return subNodes;
+  }
+
+  private updateFailureDomain() {
+    let failureDomain = this.getIncludedCustomValue(
+      'failure_domain',
+      Object.keys(this.failureDomains)
+    );
+    if (failureDomain === '') {
+      failureDomain = this.setMostCommonDomain();
+    }
+    this.updateDevices(failureDomain);
+  }
+
+  private getIncludedCustomValue(controlName: string, includedIn: string[]) {
+    const control = this.form.get(controlName);
+    return control.dirty && includedIn.includes(control.value) ? control.value : '';
+  }
+
+  private setMostCommonDomain(): string {
+    let winner = { n: 0, type: '' };
+    Object.keys(this.failureDomains).forEach((type) => {
+      const n = this.failureDomains[type].length;
+      if (winner.n < n) {
+        winner = { n, type };
+      }
+    });
+    this.form.silentSet('failure_domain', winner.type);
+    return winner.type;
+  }
+
+  updateDevices(failureDomain: string) {
+    const subNodes = _.flatten(
+      this.failureDomains[failureDomain].map((node) => this.getSubNodes(node))
+    );
+    this.devices = _.uniq(subNodes.filter((n) => n.device_class).map((n) => n.device_class)).sort();
+    const device =
+      this.devices.length === 1
+        ? this.devices[0]
+        : this.getIncludedCustomValue('device_class', this.devices);
+    this.form.get('device_class').setValue(device);
+  }
+
+  failureDomainKeys(): string[] {
+    return Object.keys(this.failureDomains).sort();
+  }
+
+  onSubmit() {
+    if (this.form.invalid) {
+      this.form.setErrors({ cdSubmitButton: true });
+      return;
+    }
+    const rule = _.cloneDeep(this.form.value);
+    rule.root = rule.root.name;
+    if (rule.device_class === '') {
+      delete rule.device_class;
+    }
+    this.taskWrapper
+      .wrapTaskAroundCall({
+        task: new FinishedTask('crushRule/create', rule),
+        call: this.crushRuleService.create(rule)
+      })
+      .subscribe(
+        undefined,
+        () => {
+          this.form.setErrors({ cdSubmitButton: true });
+        },
+        () => {
+          this.bsModalRef.hide();
+          this.submitAction.emit(rule);
+        }
+      );
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -297,12 +297,30 @@
                       <i [ngClass]="[icons.questionCircle]"
                          aria-hidden="true"></i>
                     </button>
+                    <button class="btn btn-light"
+                            type="button"
+                            *ngIf="isReplicated && !editing"
+                            (click)="addCrushRule()">
+                      <i [ngClass]="[icons.add]"
+                         aria-hidden="true"></i>
+                    </button>
+                    <button class="btn btn-light"
+                            *ngIf="isReplicated && !editing"
+                            type="button"
+                            tooltip="This rule can't be deleted as it is in use."
+                            i18n-tooltip
+                            triggers=""
+                            #crushDeletionBtn="bs-tooltip"
+                            (click)="deleteCrushRule()">
+                      <i [ngClass]="[icons.trash]"
+                         aria-hidden="true"></i>
+                    </button>
                   </span>
                 </div>
                 <span class="form-text text-muted"
                       id="crush-info-block"
                       *ngIf="data.crushInfo && form.getValue('crushRule')">
-                  <tabset>
+                  <tabset #crushInfoTabs>
                     <tab i18n-heading
                          heading="Crush rule"
                          class="crush-rule-info">
@@ -320,8 +338,23 @@
                         </li>
                       </ol>
                     </tab>
+                    <tab i18n-heading
+                         heading="Used by pools"
+                         class="used-by-pools">
+                      <ng-template #ruleIsNotUsed>
+                        <span i18n>Rule is not in use.</span>
+                      </ng-template>
+                      <ul *ngIf="crushUsage; else ruleIsNotUsed">
+                        <li *ngFor="let pool of crushUsage">
+                          {{ pool }}
+                        </li>
+                      </ul>
+                    </tab>
                   </tabset>
                 </span>
+                <span class="invalid-feedback"
+                      *ngIf="form.showError('crushRule', formDir, 'required')"
+                      i18n>This field is required!</span>
                 <span class="invalid-feedback"
                       *ngIf="form.showError('crushRule', formDir, 'tooFewOsds')"
                       i18n>The rule can't be used in the current cluster as it has

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -228,15 +228,15 @@
                   </button>
                   <button class="btn btn-light"
                           type="button"
-                          [disabled]="editing"
+                          *ngIf="!editing"
                           (click)="addErasureCodeProfile()">
                     <i [ngClass]="[icons.add]"
                        aria-hidden="true"></i>
                   </button>
                   <button class="btn btn-light"
                           type="button"
-                          (click)="deleteErasureCodeProfile()"
-                          [disabled]="editing || ecProfiles.length < 1">
+                          *ngIf="!editing"
+                          (click)="deleteErasureCodeProfile()">
                     <i [ngClass]="[icons.trash]"
                        aria-hidden="true"></i>
                   </button>
@@ -254,7 +254,18 @@
           </div>
 
           <!-- Crush ruleset selection -->
-          <div class="form-group row">
+          <div class="form-group row"
+               *ngIf="isErasure && !editing">
+            <label class="cd-col-form-label"
+                   for="crushRule"
+                   i18n>Crush ruleset</label>
+            <div class="cd-col-form-input">
+              <span class="form-text text-muted"
+                    i18n>A new crush ruleset will be implicitly created.</span>
+            </div>
+          </div>
+          <div class="form-group row"
+               *ngIf="isReplicated || editing">
             <label class="cd-col-form-label"
                    for="crushRule"
                    i18n>Crush ruleset</label>
@@ -262,8 +273,6 @@
               <ng-template #noRules>
                 <span class="form-text text-muted">
                   <span i18n>There are no rules.</span>&nbsp;
-                  <span *ngIf="form.getValue('poolType') === 'erasure'"
-                        i18n>A new crush ruleset will be implicitly created.</span>
                 </span>
               </ng-template>
               <div *ngIf="current.rules.length > 0; else noRules">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -65,7 +65,7 @@
           </div>
         </div>
 
-        <div *ngIf="form.getValue('poolType')">
+        <div *ngIf="isReplicated || isErasure">
           <!-- PG Autoscale Mode -->
           <div class="form-group row">
             <label i18n
@@ -123,7 +123,7 @@
 
           <!-- Replica Size -->
           <div class="form-group row"
-               *ngIf="form.getValue('poolType') === 'replicated'">
+               *ngIf="isReplicated">
             <label class="cd-col-form-label required"
                    for="size"
                    i18n>Replicated size</label>
@@ -151,7 +151,7 @@
 
           <!-- Flags -->
           <div class="form-group row"
-               *ngIf="info.is_all_bluestore && form.getValue('poolType') === 'erasure'">
+               *ngIf="info.is_all_bluestore && isErasure">
             <label i18n
                    class="cd-col-form-label">Flags</label>
             <div class="cd-col-form-input">
@@ -187,13 +187,13 @@
         </div>
 
         <!-- CRUSH -->
-        <div *ngIf="form.getValue('poolType')">
+        <div *ngIf="isErasure || isReplicated">
 
           <legend i18n>CRUSH</legend>
 
           <!-- Erasure Profile select -->
           <div class="form-group row"
-               *ngIf="form.getValue('poolType') === 'erasure'">
+               *ngIf="isErasure">
             <label i18n
                    class="cd-col-form-label"
                    for="erasureProfile">Erasure code profile</label>
@@ -498,7 +498,7 @@
         </div>
 
         <!-- Pool configuration -->
-        <div [hidden]="form.get('poolType').value !== 'replicated' || data.applications.selected.indexOf('rbd') === -1">
+        <div [hidden]="isErasure || data.applications.selected.indexOf('rbd') === -1">
           <cd-rbd-configuration-form [form]="form"
                                      [initializeData]="initializeConfigData"
                                      (changes)="currentConfigurationValues = $event()">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -500,9 +500,13 @@ describe('PoolFormComponent', () => {
       });
 
       it('disables rule field if only one rule exists which is used in the disabled field', () => {
-        formHelper.setValue('poolType', 'erasure');
+        infoReturn.crush_rules_replicated = [
+          createCrushRule({ id: 0, min: 2, max: 4, name: 'rep1', type: 'replicated' })
+        ];
+        setUpPoolComponent();
+        formHelper.setValue('poolType', 'replicated');
         const control = form.get('crushRule');
-        expect(control.value).toEqual(component.info.crush_rules_erasure[0]);
+        expect(control.value).toEqual(component.info.crush_rules_replicated[0]);
         expect(control.disabled).toBe(true);
       });
 
@@ -513,15 +517,14 @@ describe('PoolFormComponent', () => {
         expect(control.disabled).toBe(false);
       });
 
-      it('changing between both types will not leave crushRule in a bad state', () => {
-        formHelper.setValue('poolType', 'erasure');
+      it('changing between both pool types will not forget the crush rule selection', () => {
         formHelper.setValue('poolType', 'replicated');
         const control = form.get('crushRule');
-        expect(control.value).toEqual(null);
-        expect(control.disabled).toBe(false);
+        const currentRule = component.info.crush_rules_replicated[0];
+        control.setValue(currentRule);
         formHelper.setValue('poolType', 'erasure');
-        expect(control.value).toEqual(component.info.crush_rules_erasure[0]);
-        expect(control.disabled).toBe(true);
+        formHelper.setValue('poolType', 'replicated');
+        expect(control.value).toEqual(currentRule);
       });
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -534,16 +534,16 @@ describe('PoolFormComponent', () => {
       });
     };
 
-    it('returns nothing if osd count is 0', () => {
+    it('returns 0 if osd count is 0', () => {
       component.info.osd_count = 0;
-      expect(component.getMinSize()).toBe(undefined);
-      expect(component.getMaxSize()).toBe(undefined);
+      expect(component.getMinSize()).toBe(0);
+      expect(component.getMaxSize()).toBe(0);
     });
 
-    it('returns nothing if info is not there', () => {
+    it('returns 0 if info is not there', () => {
       delete component.info;
-      expect(component.getMinSize()).toBe(undefined);
-      expect(component.getMaxSize()).toBe(undefined);
+      expect(component.getMinSize()).toBe(0);
+      expect(component.getMaxSize()).toBe(0);
     });
 
     it('returns minimum and maximum of rule', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -574,7 +574,11 @@ export class PoolFormComponent implements OnInit {
             formControlName: 'erasureProfile',
             attr: 'name'
           },
-      { externalFieldName: 'rule_name', formControlName: 'crushRule', attr: 'rule_name' },
+      {
+        externalFieldName: 'rule_name',
+        formControlName: 'crushRule',
+        replaceFn: (value: CrushRule) => (this.isReplicated ? value && value.rule_name : undefined)
+      },
       {
         externalFieldName: 'quota_max_bytes',
         formControlName: 'max_bytes',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -346,12 +346,14 @@ export class PoolFormComponent implements OnInit {
       return;
     }
     const control = this.form.get('crushRule');
-    if (rules.length === 1) {
-      control.setValue(rules[0]);
-      control.disable();
-    } else {
-      control.setValue(null);
-      control.enable();
+    if (this.isReplicated && !control.value) {
+      if (rules.length === 1) {
+        control.setValue(rules[0]);
+        control.disable();
+      } else {
+        control.setValue(null);
+        control.enable();
+      }
     }
     this.replicatedRuleChange();
     this.pgCalc();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -54,6 +54,8 @@ export class PoolFormComponent implements OnInit {
   info: PoolFormInfo;
   routeParamsSubscribe: any;
   editing = false;
+  isReplicated = false;
+  isErasure = false;
   data = new PoolFormData(this.i18n);
   externalPgChange = false;
   private modalSubscription: Subscription;
@@ -219,7 +221,7 @@ export class PoolFormComponent implements OnInit {
       initialData: pool.configuration,
       sourceType: RbdConfigurationSourceField.pool
     });
-
+    this.rulesChange(pool.type);
     const dataMap = {
       name: pool.pool_name,
       poolType: pool.type,
@@ -249,7 +251,6 @@ export class PoolFormComponent implements OnInit {
     this.data.pgs = this.form.getValue('pgNum');
     this.setAvailableApps(this.data.applications.default.concat(pool.application_metadata));
     this.data.applications.selected = pool.application_metadata;
-    this.rulesChange();
   }
 
   private setAvailableApps(apps: string[] = this.data.applications.default) {
@@ -293,15 +294,10 @@ export class PoolFormComponent implements OnInit {
 
   private listenToChangesDuringAdd() {
     this.form.get('poolType').valueChanges.subscribe((poolType) => {
-      this.form.get('size').updateValueAndValidity();
-      this.rulesChange();
-      if (poolType === 'replicated') {
-        this.replicatedRuleChange();
-      }
-      this.pgCalc();
+      this.rulesChange(poolType);
     });
     this.form.get('crushRule').valueChanges.subscribe(() => {
-      if (this.form.getValue('poolType') === 'replicated') {
+      if (this.isReplicated) {
         this.replicatedRuleChange();
       }
       this.pgCalc();
@@ -325,13 +321,23 @@ export class PoolFormComponent implements OnInit {
     });
   }
 
-  private rulesChange() {
-    const poolType = this.form.getValue('poolType');
+  private rulesChange(poolType: string) {
+    if (poolType === 'replicated') {
+      this.setTypeBooleans(true, false);
+    } else if (poolType === 'erasure') {
+      this.setTypeBooleans(false, true);
+    } else {
+      this.setTypeBooleans(false, false);
+    }
     if (!poolType || !this.info) {
       this.current.rules = [];
       return;
     }
     const rules = this.info['crush_rules_' + poolType] || [];
+    this.current.rules = rules;
+    if (this.editing) {
+      return;
+    }
     const control = this.form.get('crushRule');
     if (rules.length === 1) {
       control.setValue(rules[0]);
@@ -343,8 +349,13 @@ export class PoolFormComponent implements OnInit {
     this.current.rules = rules;
   }
 
+  private setTypeBooleans(replicated: boolean, erasure: boolean) {
+    this.isReplicated = replicated;
+    this.isErasure = erasure;
+  }
+
   private replicatedRuleChange() {
-    if (this.form.getValue('poolType') !== 'replicated') {
+    if (!this.isReplicated) {
       return;
     }
     const control = this.form.get('size');
@@ -392,8 +403,7 @@ export class PoolFormComponent implements OnInit {
       return;
     }
     const pgMax = this.info.osd_count * 100;
-    const pgs =
-      poolType === 'replicated' ? this.replicatedPgCalc(pgMax) : this.erasurePgCalc(pgMax);
+    const pgs = this.isReplicated ? this.replicatedPgCalc(pgMax) : this.erasurePgCalc(pgMax);
     if (!pgs) {
       return;
     }
@@ -446,20 +456,16 @@ export class PoolFormComponent implements OnInit {
           )
         ]);
     } else {
-      CdValidators.validateIf(
-        this.form.get('size'),
-        () => this.form.get('poolType').value === 'replicated',
-        [
-          CdValidators.custom(
-            'min',
-            (value: number) => this.form.getValue('size') && value < this.getMinSize()
-          ),
-          CdValidators.custom(
-            'max',
-            (value: number) => this.form.getValue('size') && this.getMaxSize() < value
-          )
-        ]
-      );
+      CdValidators.validateIf(this.form.get('size'), () => this.isReplicated, [
+        CdValidators.custom(
+          'min',
+          (value: number) => this.form.getValue('size') && value < this.getMinSize()
+        ),
+        CdValidators.custom(
+          'max',
+          (value: number) => this.form.getValue('size') && this.getMaxSize() < value
+        )
+      ]);
       this.form
         .get('name')
         .setValidators([
@@ -561,7 +567,7 @@ export class PoolFormComponent implements OnInit {
         replaceFn: (value: number) => (this.form.getValue('pgAutoscaleMode') === 'on' ? 1 : value),
         editable: true
       },
-      this.form.getValue('poolType') === 'replicated'
+      this.isReplicated
         ? { externalFieldName: 'size', formControlName: 'size' }
         : {
             externalFieldName: 'erasure_code_profile',
@@ -588,7 +594,7 @@ export class PoolFormComponent implements OnInit {
       this.assignFormField(pool, {
         externalFieldName: 'flags',
         formControlName: 'ecOverwrites',
-        replaceFn: () => ['ec_overwrites']
+        replaceFn: () => (this.isErasure ? ['ec_overwrites'] : undefined)
       });
 
       if (this.form.getValue('mode') !== 'none') {
@@ -650,10 +656,7 @@ export class PoolFormComponent implements OnInit {
 
     // Only collect configuration data for replicated pools, as QoS cannot be configured on EC
     // pools. EC data pools inherit their settings from the corresponding replicated metadata pool.
-    if (
-      this.form.get('poolType').value === 'replicated' &&
-      !_.isEmpty(this.currentConfigurationValues)
-    ) {
+    if (this.isReplicated && !_.isEmpty(this.currentConfigurationValues)) {
       pool['configuration'] = this.currentConfigurationValues;
     }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -1,11 +1,11 @@
-import { Component, EventEmitter, OnInit } from '@angular/core';
+import { Component, EventEmitter, OnInit, ViewChild } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
 import * as _ from 'lodash';
 import { BsModalService } from 'ngx-bootstrap/modal';
-import { forkJoin, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 
 import { ErasureCodeProfileService } from '../../../shared/api/erasure-code-profile.service';
 import { PoolService } from '../../../shared/api/pool.service';
@@ -58,7 +58,6 @@ export class PoolFormComponent implements OnInit {
   isErasure = false;
   data = new PoolFormData(this.i18n);
   externalPgChange = false;
-  private modalSubscription: Subscription;
   current: Record<string, any> = {
     rules: []
   };
@@ -71,6 +70,8 @@ export class PoolFormComponent implements OnInit {
   resource: string;
   icons = Icons;
   pgAutoscaleModes: string[];
+
+  private modalSubscription: Subscription;
 
   constructor(
     private dimlessBinaryPipe: DimlessBinaryPipe,
@@ -142,6 +143,11 @@ export class PoolFormComponent implements OnInit {
             CdValidators.custom(
               'tooFewOsds',
               (rule: any) => this.info && rule && this.info.osd_count < rule.min_size
+            ),
+            CdValidators.custom(
+              'required',
+              (rule: CrushRule) =>
+                this.isReplicated && this.info.crush_rules_replicated.length > 0 && !rule
             )
           ]
         }),
@@ -165,39 +171,41 @@ export class PoolFormComponent implements OnInit {
   }
 
   ngOnInit() {
-    forkJoin(this.poolService.getInfo(), this.ecpService.list()).subscribe(
-      (data: [PoolFormInfo, ErasureCodeProfile[]]) => {
-        this.pgAutoscaleModes = data[0].pg_autoscale_modes;
-        this.form.silentSet('pgAutoscaleMode', data[0].pg_autoscale_default_mode);
-        this.initInfo(data[0]);
-        this.initEcp(data[1]);
-        if (this.editing) {
-          this.initEditMode();
-        } else {
-          this.setAvailableApps();
-        }
-        this.listenToChanges();
-        this.setComplexValidators();
+    this.poolService.getInfo().subscribe((info: PoolFormInfo) => {
+      this.initInfo(info);
+      if (this.editing) {
+        this.initEditMode();
+      } else {
+        this.setAvailableApps();
       }
-    );
+      this.listenToChanges();
+      this.setComplexValidators();
+    });
   }
 
   private initInfo(info: PoolFormInfo) {
+    this.pgAutoscaleModes = info.pg_autoscale_modes;
+    this.form.silentSet('pgAutoscaleMode', info.pg_autoscale_default_mode);
     this.form.silentSet('algorithm', info.bluestore_compression_algorithm);
     this.info = info;
+    this.initEcp(info.erasure_code_profiles);
   }
 
   private initEcp(ecProfiles: ErasureCodeProfile[]) {
-    const control = this.form.get('erasureProfile');
-    if (ecProfiles.length <= 1) {
-      control.disable();
+    this.setListControlStatus('erasureProfile', ecProfiles);
+    this.ecProfiles = ecProfiles;
+  }
+
+  private setListControlStatus(controlName: string, arr: any[]) {
+    const control = this.form.get(controlName);
+    if (arr.length === 1) {
+      control.setValue(arr[0]);
     }
-    if (ecProfiles.length === 1) {
-      control.setValue(ecProfiles[0]);
-    } else if (ecProfiles.length > 1 && control.disabled) {
+    if (arr.length <= 1) {
+      control.disable();
+    } else if (control.disabled) {
       control.enable();
     }
-    this.ecProfiles = ecProfiles;
   }
 
   private initEditMode() {
@@ -222,12 +230,11 @@ export class PoolFormComponent implements OnInit {
       sourceType: RbdConfigurationSourceField.pool
     });
     this.rulesChange(pool.type);
+    const rules = this.info.crush_rules_replicated.concat(this.info.crush_rules_erasure);
     const dataMap = {
       name: pool.pool_name,
       poolType: pool.type,
-      crushRule: this.info['crush_rules_' + pool.type].find(
-        (rule: CrushRule) => rule.rule_name === pool.crush_rule
-      ),
+      crushRule: rules.find((rule: CrushRule) => rule.rule_name === pool.crush_rule),
       size: pool.size,
       erasureProfile: this.ecProfiles.find((ecp) => ecp.name === pool.erasure_code_profile),
       pgAutoscaleMode: pool.pg_autoscale_mode,
@@ -241,7 +248,6 @@ export class PoolFormComponent implements OnInit {
       max_bytes: this.dimlessBinaryPipe.transform(pool.quota_max_bytes),
       max_objects: pool.quota_max_objects
     };
-
     Object.keys(dataMap).forEach((controlName: string) => {
       const value = dataMap[controlName];
       if (!_.isUndefined(value) && value !== '') {
@@ -297,15 +303,16 @@ export class PoolFormComponent implements OnInit {
       this.rulesChange(poolType);
     });
     this.form.get('crushRule').valueChanges.subscribe(() => {
-      if (this.isReplicated) {
-        this.replicatedRuleChange();
-      }
+      // The crush rule can only be changed if type 'replicated' is set.
+      this.replicatedRuleChange();
       this.pgCalc();
     });
     this.form.get('size').valueChanges.subscribe(() => {
+      // The size can only be changed if type 'replicated' is set.
       this.pgCalc();
     });
     this.form.get('erasureProfile').valueChanges.subscribe(() => {
+      // The ec profile can only be changed if type 'erasure' is set.
       this.pgCalc();
     });
     this.form.get('mode').valueChanges.subscribe(() => {
@@ -346,7 +353,8 @@ export class PoolFormComponent implements OnInit {
       control.setValue(null);
       control.enable();
     }
-    this.current.rules = rules;
+    this.replicatedRuleChange();
+    this.pgCalc();
   }
 
   private setTypeBooleans(replicated: boolean, erasure: boolean) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -382,7 +382,7 @@ export class PoolFormComponent implements OnInit {
 
   getMinSize(): number {
     if (!this.info || this.info.osd_count < 1) {
-      return undefined;
+      return 0;
     }
     const rule = this.form.getValue('crushRule');
     if (rule) {
@@ -393,7 +393,7 @@ export class PoolFormComponent implements OnInit {
 
   getMaxSize(): number {
     if (!this.info || this.info.osd_count < 1) {
-      return undefined;
+      return 0;
     }
     const osds: number = this.info.osd_count;
     if (this.form.getValue('crushRule')) {
@@ -426,21 +426,13 @@ export class PoolFormComponent implements OnInit {
   private replicatedPgCalc(pgs: number): number {
     const sizeControl = this.form.get('size');
     const size = sizeControl.value;
-    if (sizeControl.valid && size > 0) {
-      return pgs / size;
-    }
-
-    return undefined;
+    return sizeControl.valid && size > 0 ? pgs / size : 0;
   }
 
   private erasurePgCalc(pgs: number): number {
     const ecpControl = this.form.get('erasureProfile');
     const ecp = ecpControl.value;
-    if ((ecpControl.valid || ecpControl.disabled) && ecp) {
-      return pgs / (ecp.k + ecp.m);
-    }
-
-    return undefined;
+    return (ecpControl.valid || ecpControl.disabled) && ecp ? pgs / (ecp.k + ecp.m) : 0;
   }
 
   private alignPgs(pgs = this.form.getValue('pgNum')) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
@@ -13,6 +13,7 @@ import { ActionLabels, URLVerbs } from '../../shared/constants/app.constants';
 import { SharedModule } from '../../shared/shared.module';
 import { BlockModule } from '../block/block.module';
 import { CephSharedModule } from '../shared/ceph-shared.module';
+import { CrushRuleFormModalComponent } from './crush-rule-form-modal/crush-rule-form-modal.component';
 import { ErasureCodeProfileFormComponent } from './erasure-code-profile-form/erasure-code-profile-form.component';
 import { PoolDetailsComponent } from './pool-details/pool-details.component';
 import { PoolFormComponent } from './pool-form/pool-form.component';
@@ -37,9 +38,10 @@ import { PoolListComponent } from './pool-list/pool-list.component';
     PoolListComponent,
     PoolFormComponent,
     ErasureCodeProfileFormComponent,
+    CrushRuleFormModalComponent,
     PoolDetailsComponent
   ],
-  entryComponents: [ErasureCodeProfileFormComponent]
+  entryComponents: [CrushRuleFormModalComponent, ErasureCodeProfileFormComponent]
 })
 export class PoolModule {}
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/crush-rule.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/crush-rule.service.spec.ts
@@ -1,0 +1,47 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { configureTestBed, i18nProviders } from '../../../testing/unit-test-helper';
+import { CrushRuleService } from './crush-rule.service';
+
+describe('CrushRuleService', () => {
+  let service: CrushRuleService;
+  let httpTesting: HttpTestingController;
+  const apiPath = 'api/crush_rule';
+
+  configureTestBed({
+    imports: [HttpClientTestingModule],
+    providers: [CrushRuleService, i18nProviders]
+  });
+
+  beforeEach(() => {
+    service = TestBed.get(CrushRuleService);
+    httpTesting = TestBed.get(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should call create', () => {
+    service.create({ root: 'default', name: 'someRule', failure_domain: 'osd' }).subscribe();
+    const req = httpTesting.expectOne(apiPath);
+    expect(req.request.method).toBe('POST');
+  });
+
+  it('should call delete', () => {
+    service.delete('test').subscribe();
+    const req = httpTesting.expectOne(`${apiPath}/test`);
+    expect(req.request.method).toBe('DELETE');
+  });
+
+  it('should call getInfo', () => {
+    service.getInfo().subscribe();
+    const req = httpTesting.expectOne(`ui-${apiPath}/info`);
+    expect(req.request.method).toBe('GET');
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/crush-rule.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/crush-rule.service.ts
@@ -1,0 +1,35 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+import { I18n } from '@ngx-translate/i18n-polyfill';
+
+import { CrushRuleConfig } from '../models/crush-rule';
+import { ApiModule } from './api.module';
+
+@Injectable({
+  providedIn: ApiModule
+})
+export class CrushRuleService {
+  apiPath = 'api/crush_rule';
+
+  formTooltips = {
+    // Copied from /doc/rados/operations/crush-map.rst
+    root: this.i18n(`The name of the node under which data should be placed.`),
+    failure_domain: this.i18n(`The type of CRUSH nodes across which we should separate replicas.`),
+    device_class: this.i18n(`The device class data should be placed on.`)
+  };
+
+  constructor(private http: HttpClient, private i18n: I18n) {}
+
+  create(rule: CrushRuleConfig) {
+    return this.http.post(this.apiPath, rule, { observe: 'response' });
+  }
+
+  delete(name: string) {
+    return this.http.delete(`${this.apiPath}/${name}`, { observe: 'response' });
+  }
+
+  getInfo() {
+    return this.http.get(`ui-${this.apiPath}/info`);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/erasure-code-profile.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/erasure-code-profile.service.spec.ts
@@ -41,27 +41,15 @@ describe('ErasureCodeProfileService', () => {
     expect(req.request.method).toBe('POST');
   });
 
-  it('should call update', () => {
-    service.update(testProfile).subscribe();
-    const req = httpTesting.expectOne(`${apiPath}/test`);
-    expect(req.request.method).toBe('PUT');
-  });
-
   it('should call delete', () => {
     service.delete('test').subscribe();
     const req = httpTesting.expectOne(`${apiPath}/test`);
     expect(req.request.method).toBe('DELETE');
   });
 
-  it('should call get', () => {
-    service.get('test').subscribe();
-    const req = httpTesting.expectOne(`${apiPath}/test`);
-    expect(req.request.method).toBe('GET');
-  });
-
   it('should call getInfo', () => {
     service.getInfo().subscribe();
-    const req = httpTesting.expectOne(`${apiPath}/_info`);
+    const req = httpTesting.expectOne(`ui-${apiPath}/info`);
     expect(req.request.method).toBe('GET');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/erasure-code-profile.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/erasure-code-profile.service.ts
@@ -14,7 +14,7 @@ export class ErasureCodeProfileService {
   apiPath = 'api/erasure_code_profile';
 
   formTooltips = {
-    // Copied from /srv/cephmgr/ceph-dev/doc/rados/operations/erasure-code.*.rst
+    // Copied from /doc/rados/operations/erasure-code.*.rst
     k: this.i18n(`Each object is split in data-chunks parts, each stored on a different OSD.`),
 
     m: this.i18n(`Compute coding chunks for each object and store them on different OSDs.
@@ -89,19 +89,11 @@ export class ErasureCodeProfileService {
     return this.http.post(this.apiPath, ecp, { observe: 'response' });
   }
 
-  update(ecp: ErasureCodeProfile) {
-    return this.http.put(`${this.apiPath}/${ecp.name}`, ecp, { observe: 'response' });
-  }
-
   delete(name: string) {
     return this.http.delete(`${this.apiPath}/${name}`, { observe: 'response' });
   }
 
-  get(name: string) {
-    return this.http.get(`${this.apiPath}/${name}`);
-  }
-
   getInfo() {
-    return this.http.get(`${this.apiPath}/_info`);
+    return this.http.get(`ui-${this.apiPath}/info`);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.spec.ts
@@ -37,7 +37,7 @@ describe('PoolService', () => {
 
   it('should call getInfo', () => {
     service.getInfo().subscribe();
-    const req = httpTesting.expectOne(`${apiPath}/_info`);
+    const req = httpTesting.expectOne(`ui-${apiPath}/info`);
     expect(req.request.method).toBe('GET');
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.ts
@@ -59,8 +59,8 @@ export class PoolService {
     );
   }
 
-  getInfo(pool_name?: string) {
-    return this.http.get(`${this.apiPath}/_info` + (pool_name ? `?pool_name=${pool_name}` : ''));
+  getInfo() {
+    return this.http.get(`ui-${this.apiPath}/info`);
   }
 
   list(attrs: string[] = []) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/crush-node.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/crush-node.ts
@@ -1,0 +1,17 @@
+export class CrushNode {
+  id: number;
+  name: string;
+  type: string;
+  type_id: number;
+  // For nodes with leafs (Buckets)
+  children?: number[]; // Holds node id's of children
+  // For non root nodes
+  pool_weights?: object;
+  // For leafs (Devices)
+  device_class?: string;
+  crush_weight?: number;
+  exists?: number;
+  primary_affinity?: number;
+  reweight?: number;
+  status?: string;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/crush-rule.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/crush-rule.ts
@@ -8,3 +8,10 @@ export class CrushRule {
   ruleset: number;
   steps: CrushStep[];
 }
+
+export class CrushRuleConfig {
+  root: string; // The name of the node under which data should be placed.
+  name: string;
+  failure_domain: string; // The type of CRUSH nodes across which we should separate replicas.
+  device_class?: string; // The device class data should be placed on.
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/pool-form-info.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/pool-form-info.ts
@@ -1,4 +1,5 @@
 import { CrushRule } from './crush-rule';
+import { ErasureCodeProfile } from './erasure-code-profile';
 
 export class PoolFormInfo {
   pool_names: string[];
@@ -11,4 +12,6 @@ export class PoolFormInfo {
   crush_rules_erasure: CrushRule[];
   pg_autoscale_default_mode: string;
   pg_autoscale_modes: string[];
+  erasure_code_profiles: ErasureCodeProfile[];
+  used_rules: { [rule_name: string]: string[] };
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.spec.ts
@@ -126,6 +126,27 @@ describe('TaskManagerMessageService', () => {
       });
     });
 
+    describe('crush rule tasks', () => {
+      beforeEach(() => {
+        const metadata = {
+          name: 'someRuleName'
+        };
+        defaultMsg = `crush rule '${metadata.name}'`;
+        finishedTask.metadata = metadata;
+      });
+
+      it('tests crushRule/create messages', () => {
+        finishedTask.name = 'crushRule/create';
+        testCreate(defaultMsg);
+        testErrorCode(17, `Name is already used by ${defaultMsg}.`);
+      });
+
+      it('tests crushRule/delete messages', () => {
+        finishedTask.name = 'crushRule/delete';
+        testDelete(defaultMsg);
+      });
+    });
+
     describe('rbd tasks', () => {
       let metadata: Record<string, any>;
       let childMsg: string;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
@@ -201,6 +201,19 @@ export class TaskMessageService {
     'ecp/delete': this.newTaskMessage(this.commonOperations.delete, (metadata) =>
       this.ecp(metadata)
     ),
+    // Crush rule tasks
+    'crushRule/create': this.newTaskMessage(
+      this.commonOperations.create,
+      (metadata) => this.crushRule(metadata),
+      (metadata) => ({
+        '17': this.i18n('Name is already used by {{name}}.', {
+          name: this.crushRule(metadata)
+        })
+      })
+    ),
+    'crushRule/delete': this.newTaskMessage(this.commonOperations.delete, (metadata) =>
+      this.crushRule(metadata)
+    ),
     // RBD tasks
     'rbd/create': this.newTaskMessage(
       this.commonOperations.create,
@@ -427,6 +440,10 @@ export class TaskMessageService {
 
   ecp(metadata: any) {
     return this.i18n(`erasure code profile '{{name}}'`, { name: metadata.name });
+  }
+
+  crushRule(metadata: any) {
+    return this.i18n(`crush rule '{{name}}'`, { name: metadata.name });
   }
 
   iscsiTarget(metadata: any) {

--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -119,6 +119,24 @@ class CephService(object):
         return pools_w_stats
 
     @classmethod
+    def get_erasure_code_profiles(cls):
+        def _serialize_ecp(name, ecp):
+            def serialize_numbers(key):
+                value = ecp.get(key)
+                if value is not None:
+                    ecp[key] = int(value)
+
+            ecp['name'] = name
+            serialize_numbers('k')
+            serialize_numbers('m')
+            return ecp
+
+        ret = []
+        for name, ecp in mgr.get('osd_map').get('erasure_code_profiles', {}).items():
+            ret.append(_serialize_ecp(name, ecp))
+        return ret
+
+    @classmethod
     def get_pool_name_from_id(cls, pool_id):
         pool_list = cls.get_pool_list()
         for pool in pool_list:

--- a/src/pybind/mgr/dashboard/tests/test_erasure_code_profile.py
+++ b/src/pybind/mgr/dashboard/tests/test_erasure_code_profile.py
@@ -29,8 +29,3 @@ class ErasureCodeProfileTest(ControllerTestCase):
         self._get('/api/erasure_code_profile')
         self.assertStatus(200)
         self.assertJsonBody([{'k': 2, 'm': 1, 'name': 'test'}])
-
-    def test_get(self):
-        self._get('/api/erasure_code_profile/test')
-        self.assertStatus(200)
-        self.assertJsonBody({'k': 2, 'm': 1, 'name': 'test'})


### PR DESCRIPTION
Now a crush rule can be created and deleted through the pool form,
similar to the ECP profile.

The creation form is somewhat more intelligent as it checks the crush
map to help create a usable rule, with only a few clicks
through preselections.

Signed-off-by: Stephan Müller <smueller@suse.com>

---

To get to the above, the pool form needed some refactoring, see each commit for more details, I will just sum up what was done here:

* Changed used info endpoints to use API-UI instead of API
* Included all needed information in the pool form info endpoint therefor removed the other now obsolete calls. Through this change I found out that the mock wasn't updated which resulted in incomplete unit tests, which I than had to fix.
* I've hidden the erasure code profile actions in edit mode as actions for ECP nor crush rules make sense during edit, as they have to be disabled.
* Used explicit returns in pool form (wasn't needed but it distracted me)
* Preserved the crush rule selection on pool type change with multiple crush rules in use.
* The crush rule attribute will only be send to the API on pool creation if a replicated pool is created.
---
![crush-rule](https://user-images.githubusercontent.com/16167865/76095573-cc0f3980-5fc4-11ea-9f6b-2ab6ac5c01d6.gif)
---

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug



<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
