### PR TITLE
doc/cephadm/administration: clarify log gathering

### DIFF
--- a/doc/cephadm/administration.rst
+++ b/doc/cephadm/administration.rst
@@ -202,10 +202,17 @@ To read the log file of one specific daemon, run::
 
     cephadm logs --name <name-of-daemon>
 
+Note: this only works when run on the same host where the daemon is running. To
+get logs of a daemon running on a different host, give the ``--fsid`` option::
+
+    cephadm logs --fsid <fsid> --name <name-of-daemon>
+
+Where the ``<fsid>`` corresponds to the cluster id printed by ``ceph status``.
+
 To fetch all log files of all daemons on a given host, run::
 
     for name in $(cephadm ls | jq -r '.[].name') ; do
-      cephadm logs --name "$name" > $name;
+      cephadm logs --fsid <fsid> --name "$name" > $name;
     done
 
 Collecting systemd status


### PR DESCRIPTION
This is an attempt to bring the current state of the documentation more
into line with the current state of the cephadm code.

However, when I try to grab logs from a daemon on a host other than the
one where the daemon is running, I get an empty log...

References: https://tracker.ceph.com/issues/44354
Signed-off-by: Nathan Cutler <ncutler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
