### PR TITLE
cephadm: --pid=host

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -268,7 +268,7 @@ expect_false $CEPHADM enter
 $CEPHADM enter --fsid $FSID --name mon.a -- test -d /var/lib/ceph/mon/ceph-a
 $CEPHADM enter --fsid $FSID --name mgr.x -- test -d /var/lib/ceph/mgr/ceph-x
 $CEPHADM enter --fsid $FSID --name mon.a -- pidof ceph-mon
-expect_false $CEPHADM enter --fsid $FSID --name mgr.x -- pidof ceph-mon
+#expect_false $CEPHADM enter --fsid $FSID --name mgr.x -- pidof ceph-mon
 $CEPHADM enter --fsid $FSID --name mgr.x -- pidof ceph-mgr
 # this triggers a bug in older versions of podman, including 18.04's 1.6.2
 #expect_false $CEPHADM --timeout 1 enter --fsid $FSID --name mon.a -- sleep 10

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1562,6 +1562,7 @@ class CephContainer:
             'run',
             '--rm',
             '--net=host',
+            '--pid=host',
         ] + self.container_args + priv + \
         cname + envs + \
         vols + entrypoint + \


### PR DESCRIPTION
Ceph currently has a 'nonce' portion of the entity_addr_t that should
uniquely identify the daemon on a host.  We currently use the pid.  When
daemons are run via cephadm, the pid is always 1, so these are no longer
unique, and things break.

Specifically, with ac7b21bf3fd84f52454f511da67eb7a609e15075 and related
commits, we can't handle multiple incoming connections that do not have
unique addresses.

For now, we can just work around with by using the host pid namespace.

This is a work-around for https://tracker.ceph.com/issues/44358

Signed-off-by: Sage Weil <sage@redhat.com>