### PR TITLE
msg/Policy: make stateless_server default to anon (again)

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -163,12 +163,11 @@ int main(int argc, const char **argv)
   common_init_finish(g_ceph_context);
   global_init_chdir(g_ceph_context);
 
-  auto nonce = ceph::util::generate_random_number<uint64_t>();
-
   std::string public_msgr_type = g_conf()->ms_public_type.empty() ? g_conf().get_val<std::string>("ms_type") : g_conf()->ms_public_type;
   Messenger *msgr = Messenger::create(g_ceph_context, public_msgr_type,
 				      entity_name_t::MDS(-1), "mds",
-				      nonce, Messenger::HAS_MANY_CONNECTIONS);
+				      Messenger::get_random_nonce(),
+				      Messenger::HAS_MANY_CONNECTIONS);
   if (!msgr)
     forker.exit(1);
   msgr->set_cluster_protocol(CEPH_MDS_PROTOCOL);

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -784,17 +784,17 @@ int main(int argc, const char **argv)
   msgr->set_cluster_protocol(CEPH_MON_PROTOCOL);
   msgr->set_default_send_priority(CEPH_MSG_PRIO_HIGH);
 
-  msgr->set_default_policy(Messenger::Policy::stateless_anon_server(0));
+  msgr->set_default_policy(Messenger::Policy::stateless_server(0));
   msgr->set_policy(entity_name_t::TYPE_MON,
                    Messenger::Policy::lossless_peer_reuse(
 		     CEPH_FEATURE_SERVER_LUMINOUS));
   msgr->set_policy(entity_name_t::TYPE_OSD,
-                   Messenger::Policy::stateless_anon_server(
+                   Messenger::Policy::stateless_server(
 		     CEPH_FEATURE_SERVER_LUMINOUS));
   msgr->set_policy(entity_name_t::TYPE_CLIENT,
-                   Messenger::Policy::stateless_anon_server(0));
+                   Messenger::Policy::stateless_server(0));
   msgr->set_policy(entity_name_t::TYPE_MDS,
-                   Messenger::Policy::stateless_anon_server(0));
+                   Messenger::Policy::stateless_server(0));
 
   // throttle client traffic
   Throttle *client_throttler = new Throttle(g_ceph_context, "mon_client_bytes",

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -778,7 +778,8 @@ int main(int argc, const char **argv)
   std::string public_msgr_type = g_conf()->ms_public_type.empty() ? g_conf().get_val<std::string>("ms_type") : g_conf()->ms_public_type;
   Messenger *msgr = Messenger::create(g_ceph_context, public_msgr_type,
 				      entity_name_t::MON(rank), "mon",
-				      0, Messenger::HAS_MANY_CONNECTIONS);
+				      0,  // zero nonce
+				      Messenger::HAS_MANY_CONNECTIONS);
   if (!msgr)
     exit(1);
   msgr->set_cluster_protocol(CEPH_MON_PROTOCOL);
@@ -829,7 +830,8 @@ int main(int argc, const char **argv)
 
   Messenger *mgr_msgr = Messenger::create(g_ceph_context, public_msgr_type,
 					  entity_name_t::MON(rank), "mon-mgrc",
-					  getpid(), 0);
+					  Messenger::get_pid_nonce(),
+					  0);
   if (!mgr_msgr) {
     derr << "unable to create mgr_msgr" << dendl;
     prefork.exit(1);

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -574,7 +574,7 @@ flushjournal_out:
     CEPH_FEATURE_PGID64 |
     CEPH_FEATURE_OSDENC;
 
-  ms_public->set_default_policy(Messenger::Policy::stateless_server(0));
+  ms_public->set_default_policy(Messenger::Policy::stateless_registered_server(0));
   ms_public->set_policy_throttlers(entity_name_t::TYPE_CLIENT,
 				   client_byte_throttler.get(),
 				   nullptr);

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -583,10 +583,6 @@ flushjournal_out:
   ms_public->set_policy(entity_name_t::TYPE_MGR,
                         Messenger::Policy::lossy_client(osd_required));
 
-  //try to poison pill any OSD connections on the wrong address
-  ms_public->set_policy(entity_name_t::TYPE_OSD,
-			Messenger::Policy::stateless_server(0));
-
   ms_cluster->set_default_policy(Messenger::Policy::stateless_server(0));
   ms_cluster->set_policy(entity_name_t::TYPE_MON, Messenger::Policy::lossy_client(0));
   ms_cluster->set_policy(entity_name_t::TYPE_OSD,

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -524,31 +524,32 @@ flushjournal_out:
 
   public_msg_type = public_msg_type.empty() ? msg_type : public_msg_type;
   cluster_msg_type = cluster_msg_type.empty() ? msg_type : cluster_msg_type;
+  uint64_t nonce = Messenger::get_pid_nonce();
   Messenger *ms_public = Messenger::create(g_ceph_context, public_msg_type,
 					   entity_name_t::OSD(whoami), "client",
-					   getpid(),
+					   nonce,
 					   Messenger::HAS_HEAVY_TRAFFIC |
 					   Messenger::HAS_MANY_CONNECTIONS);
   Messenger *ms_cluster = Messenger::create(g_ceph_context, cluster_msg_type,
 					    entity_name_t::OSD(whoami), "cluster",
-					    getpid(),
+					    nonce,
 					    Messenger::HAS_HEAVY_TRAFFIC |
 					    Messenger::HAS_MANY_CONNECTIONS);
   Messenger *ms_hb_back_client = Messenger::create(g_ceph_context, cluster_msg_type,
 					     entity_name_t::OSD(whoami), "hb_back_client",
-					     getpid(), Messenger::HEARTBEAT);
+					     nonce, Messenger::HEARTBEAT);
   Messenger *ms_hb_front_client = Messenger::create(g_ceph_context, public_msg_type,
 					     entity_name_t::OSD(whoami), "hb_front_client",
-					     getpid(), Messenger::HEARTBEAT);
+					     nonce, Messenger::HEARTBEAT);
   Messenger *ms_hb_back_server = Messenger::create(g_ceph_context, cluster_msg_type,
 						   entity_name_t::OSD(whoami), "hb_back_server",
-						   getpid(), Messenger::HEARTBEAT);
+						   nonce, Messenger::HEARTBEAT);
   Messenger *ms_hb_front_server = Messenger::create(g_ceph_context, public_msg_type,
 						    entity_name_t::OSD(whoami), "hb_front_server",
-						    getpid(), Messenger::HEARTBEAT);
+						    nonce, Messenger::HEARTBEAT);
   Messenger *ms_objecter = Messenger::create(g_ceph_context, public_msg_type,
 					     entity_name_t::OSD(whoami), "ms_objecter",
-					     getpid(), 0);
+					     nonce, 0);
   if (!ms_public || !ms_cluster || !ms_hb_front_client || !ms_hb_back_client || !ms_hb_back_server || !ms_hb_front_server || !ms_objecter)
     forker.exit(1);
   ms_cluster->set_cluster_protocol(CEPH_OSD_PROTOCOL);

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -108,7 +108,8 @@ int DaemonServer::init(uint64_t gid, entity_addrvec_t client_addrs)
   msgr = Messenger::create(g_ceph_context, public_msgr_type,
 			   entity_name_t::MGR(gid),
 			   "mgr",
-			   getpid(), 0);
+			   Messenger::get_pid_nonce(),
+			   0);
   msgr->set_default_policy(Messenger::Policy::stateless_server(0));
 
   msgr->set_auth_client(monc);

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -44,7 +44,7 @@ MgrStandby::MgrStandby(int argc, const char **argv) :
 		     cct->_conf.get_val<std::string>("ms_type"),
 		     entity_name_t::MGR(),
 		     "mgr",
-		     getpid(),
+		     Messenger::get_pid_nonce(),
 		     0)),
   objecter{g_ceph_context, client_messenger.get(), &monc, NULL, 0, 0},
   client{client_messenger.get(), &monc, &objecter},

--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -13,9 +13,24 @@
 Messenger *Messenger::create_client_messenger(CephContext *cct, string lname)
 {
   std::string public_msgr_type = cct->_conf->ms_public_type.empty() ? cct->_conf.get_val<std::string>("ms_type") : cct->_conf->ms_public_type;
-  auto nonce = ceph::util::generate_random_number<uint64_t>();
+  auto nonce = get_random_nonce();
   return Messenger::create(cct, public_msgr_type, entity_name_t::CLIENT(),
 			   std::move(lname), nonce, 0);
+}
+
+uint64_t Messenger::get_pid_nonce()
+{
+  uint64_t nonce = getpid();
+  if (nonce == 1) {
+    // we're running in a container; use a random number instead!
+    nonce = ceph::util::generate_random_number<uint64_t>();
+  }
+  return nonce;
+}
+
+uint64_t Messenger::get_random_nonce()
+{
+  return ceph::util::generate_random_number<uint64_t>();
 }
 
 Messenger *Messenger::create(CephContext *cct, const string &type,

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -153,6 +153,9 @@ public:
                            uint64_t nonce,
 			   uint64_t cflags);
 
+  static uint64_t get_random_nonce();
+  static uint64_t get_pid_nonce();
+
   /**
    * create a new messenger
    *

--- a/src/msg/Policy.h
+++ b/src/msg/Policy.h
@@ -65,10 +65,10 @@ public:
   static Policy stateful_server(uint64_t req) {
     return Policy(false, true, true, true, true, req);
   }
-  static Policy stateless_server(uint64_t req) {
+  static Policy stateless_registered_server(uint64_t req) {
     return Policy(true, true, false, false, true, req);
   }
-  static Policy stateless_anon_server(uint64_t req) {
+  static Policy stateless_server(uint64_t req) {
     return Policy(true, true, false, false, false, req);
   }
   static Policy lossless_peer(uint64_t req) {


### PR DESCRIPTION
Midway through the octopus cycle, we made stateless server more stateless
in the sense that it would not register incoming client connections.  And,
in so doing, it would not enforce that client connections came from unique
addresses, by closing an existing connection from the same addr when a new
connection was accepted.

This turned out to cause out of order OSD ops because the OSD needed that
behavior.  See https://tracker.ceph.com/issues/42328.  We fixed that by
reverting to the old behavior for all but monitor connections, where we
needed it, in 507d213cc453ed86ab38619590f710f33245c652.

This, in turn, breaks most OSD <-> OSD communication (and probably lots of
other things) with cephadm, because we make entity_addr_t unique with a
nonce that is populated by getpid()... and the containerized daemons all
have pid 1.  When we finally merged the follow-on fixes for the change
above cephadm OSDs can't ping each other.

In my view, the 'anon' connection handling is a good idea in the general
case.  So, let's adjust our fix for #42328 so that it is only the OSD
client-side interface that registers client connections and makes them
unique.