### PR TITLE
qa/workunits/cephadm/test_cephadm.sh: dump logs on exit

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -11,7 +11,12 @@ IMAGE_NAUTILUS=${IMAGE_NAUTILUS:-'docker.io/ceph/daemon-base:latest-nautilus'}
 IMAGE_MIMIC=${IMAGE_MIMIC:-'docker.io/ceph/daemon-base:latest-mimic'}
 
 TMPDIR=$(mktemp -d)
-trap "rm -rf $TMPDIR" EXIT
+
+function cleanup()
+{
+    rm -rf $TMPDIR
+}
+trap cleanup EXIT
 
 OSD_IMAGE_NAME="${SCRIPT_NAME%.*}_osd.img"
 OSD_IMAGE_SIZE='6G'

--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -14,6 +14,7 @@ TMPDIR=$(mktemp -d)
 
 function cleanup()
 {
+    dump_all_logs
     rm -rf $TMPDIR
 }
 trap cleanup EXIT
@@ -109,6 +110,32 @@ function is_available()
 
     echo "$name is available"
     true
+}
+
+function dump_log()
+{
+    local name="$1"
+    local num_lines="$2"
+
+    if [ -z $num_lines ]; then
+        num_lines=100
+    fi
+
+    echo '-------------------------'
+    echo 'dump daemon log:' $name
+    echo '-------------------------'
+
+    $CEPHADM logs --name $name -- --no-pager -n $num_lines
+}
+
+function dump_all_logs()
+{
+    names=$($CEPHADM ls | jq -r '.[].name')
+
+    echo 'dumping logs for daemons: ' $names
+    for name in $names; do
+        dump_log $name
+    done
 }
 
 ## prepare + check host


### PR DESCRIPTION
dumps the last few lines from each of the surviving daemon logs

```
+ echo 'dumping logs for daemons: ' mon.a mgr.x crash.host1 mon.b mgr.y osd.0 osd.1 node-exporter.a prometheus.a grafana.a
dumping logs for daemons:  mon.a mgr.x crash.host1 mon.b mgr.y osd.0 osd.1 node-exporter.a prometheus.a grafana.a
+ for name in $names
+ dump_log mon.a
+ local name=mon.a
+ local num_lines=
+ '[' -z ']'
+ num_lines=100
+ echo -------------------------
-------------------------
+ echo 'dump daemon log:' mon.a
dump daemon log: mon.a
+ echo -------------------------
-------------------------
+ sudo /tmp/tmp.NilxSX3XxM/cephadm --image docker.io/ceph/daemon-base:latest-master-devel logs --name mon.a -- --no-pager -n 100
INFO:cephadm:Inferring fsid 00000000-0000-0000-0000-0000deadbeef
-- Logs begin at Sat 2020-02-22 15:37:57 MST, end at Fri 2020-02-28 15:38:11 MST. --
Feb 28 15:37:20 host1 bash[10462]: debug 2020-02-28T22:37:20.312+0000 7f967a7e4700  0 log_channel(audit) log [INF] : from='mgr.14129 127.0.0.1:0/1' entity='mgr.x' cmd=[{"prefix":"config-key set","key":"mgr/cephadm/host.host1","val":"{\"daemons\": {\"mon.a\": {\"hosFeb 28 15:37:20 host1 bash[10462]: debug 2020-02-28T22:37:20.588+0000 7f9678fe1700  0 log_channel(audit) log [INF] : from='mgr.14129 127.0.0.1:0/1' entity='mgr.x' cmd='[{"prefix":"config-key set","key":"mgr/cephadm/host.host1","val":"{\"daemons\": {\"mon.a\": {\"hoFeb 28 15:37:20 host1 bash[10462]: debug 2020-02-28T22:37:20.592+0000 7f967a7e4700  0 mon.a@0(leader) e1 handle_command mon_command({"prefix": "config get", "who": "osd", "key": "container_image"} v 0) v1
Feb 28 15:37:20 host1 bash[10462]: debug 2020-02-28T22:37:20.592+0000 7f967a7e4700  0 log_channel(audit) log [DBG] : from='mgr.14129 127.0.0.1:0/1' entity='mgr.x' cmd=[{"prefix": "config get", "who": "osd", "key": "container_image"}]: dispatch
Feb 28 15:37:21 host1 bash[10462]: cluster 2020-02-28T22:37:10.968476+0000 mgr.x (mgr.14129) 172 : cluster [DBG] pgmap v177: 1 pgs: 1 undersized+peered; 0 B data, 112 KiB used, 2.0 GiB / 3.0 GiB avail
Feb 28 15:37:21 host1 bash[10462]: cluster 2020-02-28T22:37:12.969009+0000 mgr.x (mgr.14129) 173 : cluster [DBG] pgmap v178: 1 pgs: 1 undersized+peered; 0 B data, 112 KiB used, 2.0 GiB / 3.0 GiB avail
Feb 28 15:37:21 host1 bash[10462]: cluster 2020-02-28T22:37:14.969498+0000 mgr.x (mgr.14129) 174 : cluster [DBG] pgmap v179: 1 pgs: 1 undersized+peered; 0 B data, 112 KiB used, 2.0 GiB / 3.0 GiB avail
Feb 28 15:37:21 host1 bash[10462]: cluster 2020-02-28T22:37:16.969983+0000 mgr.x (mgr.14129) 175 : cluster [DBG] pgmap v180: 1 pgs: 1 undersized+peered; 0 B data, 112 KiB used, 2.0 GiB / 3.0 GiB avail
Feb 28 15:37:21 host1 bash[10462]: cluster 2020-02-28T22:37:18.970535+0000 mgr.x (mgr.14129) 176 : cluster [DBG] pgmap v181: 1 pgs: 1 undersized+peered; 0 B data, 112 KiB used, 2.0 GiB / 3.0 GiB avail
Feb 28 15:37:21 host1 bash[10462]: audit 2020-02-28T22:37:20.315072+0000 mon.a (mon.0) 173 : audit [INF] from='mgr.14129 127.0.0.1:0/1' entity='mgr.x' cmd=[{"prefix":"config-key set","key":"mgr/cephadm/host.host1","val":"{\"daemons\": {\"mon.a\": {\"hostname\": \"mFeb 28 15:37:21 host1 bash[10462]: audit 2020-02-28T22:37:20.592188+0000 mon.a (mon.0) 174 : audit [INF] from='mgr.14129 127.0.0.1:0/1' entity='mgr.x' cmd='[{"prefix":"config-key set","key":"mgr/cephadm/host.host1","val":"{\"daemons\": {\"mon.a\": {\"hostname\": \"Feb 28 15:37:21 host1 bash[10462]: audit 2020-02-28T22:37:20.593716+0000 mon.a (mon.0) 175 : audit [DBG] from='mgr.14129 127.0.0.1:0/1' entity='mgr.x' cmd=[{"prefix": "config get", "who": "osd", "key": "container_image"}]: dispatch
Feb 28 15:37:23 host1 bash[10462]: debug 2020-02-28T22:37:23.312+0000 7f967cfe9700  1 mon.a@0(leader).osd e12 _set_new_cache_sizes cache_size:1020054731 inc_alloc: 373293056 full_alloc: 373293056 kv_alloc: 272629760
Feb 28 15:37:26 host1 bash[10462]: debug 2020-02-28T22:37:26.528+0000 7f967a7e4700  0 mon.a@0(leader) e1 handle_command mon_command({"prefix": "osd crush set-device-class", "class": "ssd", "ids": ["1"]} v 0) v1 
Feb 28 15:37:26 host1 bash[10462]: debug 2020-02-28T22:37:26.528+0000 7f967a7e4700  0 log_channel(audit) log [INF] : from='osd.1 [v2:127.0.0.1:6810/1,v1:127.0.0.1:6811/1]' entity='osd.1' cmd=[{"prefix": "osd crush set-device-class", "class": "ssd", "ids": ["1"]}]: disFeb 28 15:37:26 host1 bash[10462]: debug 2020-02-28T22:37:26.580+0000 7f967cfe9700  1 mon.a@0(leader).osd e12 do_prune osdmap full prune enabled
Feb 28 15:37:27 host1 bash[10462]: debug 2020-02-28T22:37:27.028+0000 7f9678fe1700  1 mon.a@0(leader).osd e13 e13: 2 total, 1 up, 1 in 
Feb 28 15:37:27 host1 bash[10462]: audit 2020-02-28T22:37:26.532933+0000 mon.a (mon.0) 176 : audit [INF] from='osd.1 [v2:127.0.0.1:6810/1,v1:127.0.0.1:6811/1]' entity='osd.1' cmd=[{"prefix": "osd crush set-device-class", "class": "ssd", "ids": ["1"]}]: dispatch
Feb 28 15:37:27 host1 bash[10462]: debug 2020-02-28T22:37:27.180+0000 7f9678fe1700  0 log_channel(audit) log [INF] : from='osd.1 [v2:127.0.0.1:6810/1,v1:127.0.0.1:6811/1]' entity='osd.1' cmd='[{"prefix": "osd crush set-device-class", "class": "ssd", "ids": ["1"]}]': f
Feb 28 15:37:27 host1 bash[10462]: debug 2020-02-28T22:37:27.180+0000 7f9678fe1700  0 log_channel(cluster) log [DBG] : osdmap e13: 2 total, 1 up, 1 in 
Feb 28 15:37:27 host1 bash[10462]: debug 2020-02-28T22:37:27.184+0000 7f967a7e4700  0 mon.a@0(leader) e1 handle_command mon_command({"prefix": "osd metadata", "id": 1} v 0) v1 
Feb 28 15:37:27 host1 bash[10462]: debug 2020-02-28T22:37:27.184+0000 7f967a7e4700  0 log_channel(audit) log [DBG] : from='mgr.14129 127.0.0.1:0/1' entity='mgr.x' cmd=[{"prefix": "osd metadata", "id": 1}]: dispatch
Feb 28 15:37:27 host1 bash[10462]: debug 2020-02-28T22:37:27.184+0000 7f967a7e4700  0 mon.a@0(leader) e1 handle_command mon_command({"prefix": "osd crush create-or-move", "id": 1, "weight":0.0029, "args": ["host=host1", "root=default"]} v 0) v1 
Feb 28 15:37:27 host1 bash[10462]: debug 2020-02-28T22:37:27.184+0000 7f967a7e4700  0 log_channel(audit) log [INF] : from='osd.1 [v2:127.0.0.1:6810/1,v1:127.0.0.1:6811/1]' entity='osd.1' cmd=[{"prefix": "osd crush create-or-move", "id": 1, "weight":0.0029, "args": ["hFeb 28 15:37:27 host1 bash[10462]: debug 2020-02-28T22:37:27.184+0000 7f967a7e4700  0 mon.a@0(leader).osd e13 create-or-move crush item name 'osd.1' initial_weight 0.0029 at location {host=host1,root=default}
Feb 28 15:37:28 host1 bash[10462]: debug 2020-02-28T22:37:28.028+0000 7f967cfe9700  1 mon.a@0(leader).osd e13 do_prune osdmap full prune enabled
```

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
