### PR TITLE
RFC: pybind/mgr/mgr_module: simplify _configure_logging + improve standby behavior

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -470,8 +470,13 @@ def _define_logging_options(cls):
 
 class MgrModuleLoggingMixin(object):
 
-    def _configure_logging(self, mgr_level, module_level, cluster_level,
-                           log_to_file, log_to_cluster):
+    def _configure_logging(self):
+        mgr_level = self.get_ceph_option("debug_mgr")
+        module_level = self.get_module_option("log_level")
+        cluster_level = self.get_module_option('log_to_cluster_level')
+        log_to_file = self.get_module_option("log_to_file")
+        log_to_cluster = self.get_module_option("log_to_cluster")
+
         self._mgr_level = None
         self._module_level = None
         self._root_logger = logging.getLogger()
@@ -609,11 +614,7 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule, MgrModuleLoggingMixin):
                 else:
                     self.MODULE_OPTION_DEFAULTS[o['name']] = str(o['default'])
 
-        mgr_level = self.get_ceph_option("debug_mgr")
-        log_level = self.get_module_option("log_level")
-        cluster_level = self.get_module_option('log_to_cluster_level')
-        self._configure_logging(mgr_level, log_level, cluster_level,
-                                False, False)
+        self._configure_logging()
 
         # for backwards compatibility
         self._logger = self.getLogger()
@@ -723,13 +724,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
                     # with default and user-supplied option values.
                     self.MODULE_OPTION_DEFAULTS[o['name']] = str(o['default'])
 
-        mgr_level = self.get_ceph_option("debug_mgr")
-        log_level = self.get_module_option("log_level")
-        cluster_level = self.get_module_option('log_to_cluster_level')
-        log_to_file = self.get_module_option("log_to_file")
-        log_to_cluster = self.get_module_option("log_to_cluster")
-        self._configure_logging(mgr_level, log_level, cluster_level,
-                                log_to_file, log_to_cluster)
+        self._configure_logging()
 
         # for backwards compatibility
         self._logger = self.getLogger()

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -451,7 +451,25 @@ class FileHandler(logging.FileHandler):
         self.setFormatter(logging.Formatter("%(asctime)s [%(threadName)s] [%(levelname)-4s] [%(name)s] %(message)s"))
 
 
+def _define_logging_options(cls):
+    cls.MODULE_OPTIONS.append(
+        Option(name='log_level', type='str', default="", runtime=True,
+               enum_allowed=['info', 'debug', 'critical', 'error',
+                             'warning', '']))
+    cls.MODULE_OPTIONS.append(
+        Option(name='log_to_file', type='bool', default=False, runtime=True))
+    if not [x for x in cls.MODULE_OPTIONS if x['name'] == 'log_to_cluster']:
+        cls.MODULE_OPTIONS.append(
+            Option(name='log_to_cluster', type='bool', default=False,
+                   runtime=True))
+    cls.MODULE_OPTIONS.append(
+        Option(name='log_to_cluster_level', type='str', default='info',
+               runtime=True,
+               enum_allowed=['info', 'debug', 'critical', 'error',
+                             'warning', '']))
+
 class MgrModuleLoggingMixin(object):
+
     def _configure_logging(self, mgr_level, module_level, cluster_level,
                            log_to_file, log_to_cluster):
         self._mgr_level = None
@@ -581,6 +599,8 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule, MgrModuleLoggingMixin):
         super(MgrStandbyModule, self).__init__(capsule)
         self.module_name = module_name
 
+        _define_logging_options(self)
+
         # see also MgrModule.__init__()
         for o in self.MODULE_OPTIONS:
             if 'default' in o:
@@ -689,6 +709,8 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         self.module_name = module_name
         super(MgrModule, self).__init__(py_modules_ptr, this_ptr)
 
+        _define_logging_options(self)
+
         for o in self.MODULE_OPTIONS:
             if 'default' in o:
                 if 'type' in o:
@@ -725,22 +747,6 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
 
     @classmethod
     def _register_commands(cls, module_name):
-        cls.MODULE_OPTIONS.append(
-            Option(name='log_level', type='str', default="", runtime=True,
-                   enum_allowed=['info', 'debug', 'critical', 'error',
-                                 'warning', '']))
-        cls.MODULE_OPTIONS.append(
-            Option(name='log_to_file', type='bool', default=False, runtime=True))
-        if not [x for x in cls.MODULE_OPTIONS if x['name'] == 'log_to_cluster']:
-            cls.MODULE_OPTIONS.append(
-                Option(name='log_to_cluster', type='bool', default=False,
-                       runtime=True))
-        cls.MODULE_OPTIONS.append(
-            Option(name='log_to_cluster_level', type='str', default='info',
-                   runtime=True,
-                   enum_allowed=['info', 'debug', 'critical', 'error',
-                                 'warning', '']))
-
         cls.COMMANDS.extend(CLICommand.dump_cmd_list())
 
     @property


### PR DESCRIPTION
This is what I want to do.  But mypy does not like putting this in the mixin...
```
1: mgr_module.py: note: In member "_configure_logging" of class "MgrModuleLoggingMixin":
1: mgr_module.py:474: error: "MgrModuleLoggingMixin" has no attribute "get_ceph_option"
1: mgr_module.py:475: error: "MgrModuleLoggingMixin" has no attribute "get_module_option"
1: mgr_module.py:476: error: "MgrModuleLoggingMixin" has no attribute "get_module_option"
1: mgr_module.py:477: error: "MgrModuleLoggingMixin" has no attribute "get_module_option"
1: mgr_module.py:478: error: "MgrModuleLoggingMixin" has no attribute "get_module_option"
1: Found 5 errors in 1 file (checked 10 source files)
```

Not sure how to best work around that?