### PR TITLE
nautilus: tools/rados: Unmask '-o' to restore original behaviour

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -14,4 +14,9 @@
 
     ceph osd pool set <pool-name> pg_autoscale_mode warn
 
+* The behaviour of the ``-o`` argument to the rados tool has been reverted to
+  its orignal behaviour of indicating an output file. This reverts it to a more
+  consistent behaviour when compared to other tools. Specifying object size is now
+  accomplished by using an upper case O ``-O``.
+
 * The format of MDSs in `ceph fs dump` has changed.

--- a/doc/man/8/rados.rst
+++ b/doc/man/8/rados.rst
@@ -71,6 +71,10 @@ Options
    Available for stat, stat2, get, put, append, truncate, rm, ls
    and all xattr related operation
 
+.. option:: -O object_size
+
+   Set the object size for put/get ops and for write benchmarking
+
 
 Global commands
 ===============

--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -80,7 +80,7 @@ def task(ctx, config):
         if osize is 0:
             objectsize = []
         else:
-            objectsize = ['-o', str(osize)]
+            objectsize = ['-O', str(osize)]
         size = ['-b', str(config.get('size', 65536))]
         # If doing a reading run then populate data
         if runtype != "write":

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -181,7 +181,7 @@ void usage(ostream& out)
 "   --format=[--format plain|json|json-pretty]\n"
 "   -b op_size\n"
 "        set the block size for put/get ops and for write benchmarking\n"
-"   -o object_size\n"
+"   -O object_size\n"
 "        set the object size for put/get ops and for write benchmarking\n"
 "   --max-objects\n"
 "        set the max number of objects for write benchmarking\n"
@@ -3960,7 +3960,7 @@ int main(int argc, const char **argv)
       opts["max-objects"] = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--offset", (char*)NULL)) {
       opts["offset"] = val;
-    } else if (ceph_argparse_witharg(args, i, &val, "-o", (char*)NULL)) {
+    } else if (ceph_argparse_witharg(args, i, &val, "-O", (char*)NULL)) {
       opts["object-size"] = val;
     } else if (ceph_argparse_witharg(args, i, &val, "-s", "--snap", (char*)NULL)) {
       opts["snap"] = val;


### PR DESCRIPTION
https://tracker.ceph.com/issues/44360