### PR TITLE
qa/suites/rados/verify/tasks/mon_recovery: whitelist SLOW_OPS

### DIFF
--- a/qa/suites/rados/verify/tasks/mon_recovery.yaml
+++ b/qa/suites/rados/verify/tasks/mon_recovery.yaml
@@ -6,5 +6,7 @@ overrides:
       - \(OSDMAP_FLAGS\)
       - \(SMALLER_PGP_NUM\)
       - \(POOL_APP_NOT_ENABLED\)
+      - \(SLOW OPS\)
+      - slow request
 tasks:
 - mon_recovery:


### PR DESCRIPTION
The mon can see slow ops when thrashing.

Signed-off-by: Sage Weil <sage@redhat.com>