### PR TITLE
qa/suites/rados/singleton-bluestore/cephtool: whitelist MON_DOWN

### DIFF
--- a/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
+++ b/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
@@ -38,6 +38,9 @@ tasks:
     - \(POOL_APP_NOT_ENABLED\)
     - \(AUTH_BAD_CAPS\)
     - \(FS_INLINE_DATA_DEPRECATED\)
+    - \(MON_DOWN\)
+    - \(SLOW_OPS\)
+    - slow request
 - workunit:
     clients:
       all:


### PR DESCRIPTION
cephtool/test.sh now (#32336) includes a test that disallows mon from the quorum
for a short period.

Signed-off-by: Sage Weil <sage@redhat.com>