### PR TITLE
vstart.sh: fix install of cephadm ssh keys from ~/.ssh

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -987,8 +987,8 @@ EOF
 
     if [ "$cephadm" -eq 1 ]; then
         debug echo Enabling cephadm orchestrator
-        ceph_adm config-key set mgr/ssh/ssh_identity_key -i ~/.ssh/id_rsa
-        ceph_adm config-key set mgr/ssh/ssh_identity_pub -i ~/.ssh/id_rsa.pub
+        ceph_adm config-key set mgr/cephadm/ssh_identity_key -i ~/.ssh/id_rsa
+        ceph_adm config-key set mgr/cephadm/ssh_identity_pub -i ~/.ssh/id_rsa.pub
         ceph_adm mgr module enable cephadm
         ceph_adm orch set backend cephadm
         ceph_adm orch host add $HOSTNAME


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@redhat.com>