### PR TITLE
test: silence warning unused variable nvme

### DIFF
--- a/src/test/test_get_blkdev_props.cc
+++ b/src/test/test_get_blkdev_props.cc
@@ -15,7 +15,6 @@ int main(int argc, char **argv)
 	int fd, ret;
 	int64_t size;
 	bool discard_support;
-	bool nvme;
 	bool rotational;
 	char dev[BUFSIZE];
 	char model[BUFSIZE];


### PR DESCRIPTION
seeing this unused variable nvme for a while