### PR TITLE
qa/tasks/mgr/test_orchestrator_cli: s/CommandFailedError/DriveGroupVa…

### DIFF
--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -3,7 +3,7 @@ import json
 import logging
 from time import sleep
 
-from teuthology.exceptions import CommandFailedError
+from ceph.deployment.drive_group import DriveGroupValidationError
 
 from mgr_test_case import MgrTestCase
 
@@ -95,8 +95,8 @@ class TestOrchestratorCli(MgrTestCase):
         res = self._orch_cmd_result("osd", "create", "-i", "-", stdin=json.dumps(drive_groups))
         self.assertEqual(res, 0)
 
-        #with self.assertRaises(Exception):
-        #    self._orch_cmd("osd", "create", "notfound:device")
+        with self.assertRaises(DriveGroupValidationError):
+            self._orch_cmd("osd", "create", "notfound:device")
 
     def test_blink_device_light(self):
         def _ls_lights(what):


### PR DESCRIPTION
…lidationError/

`DriveGroupValidationError` is raised by `DriveGroupSpec.validate()`
when an implementation of `Orchestrator.create_osds()` validates the
given driver group with the hosts it manages before creating OSDs
from given driver group spec.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
