### PR TITLE
nautilus: monitoring: fix prometheus alert for full pools

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -207,9 +207,7 @@ groups:
   - name: pools
     rules:
       - alert: pool full
-        expr: |
-          ceph_pool_stored / ceph_pool_max_avail
-          * on(pool_id) group_right ceph_pool_metadata * 100 > 90
+        expr: ceph_pool_stored / (ceph_pool_stored + ceph_pool_max_avail) * on(pool_id) group_right ceph_pool_metadata > 0.9
         labels:
           severity: critical
           type: ceph_default


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43732

---

backport of https://github.com/ceph/ceph/pull/32325
parent tracker: https://tracker.ceph.com/issues/42982

this backport was staged using ceph-backport.sh version 15.1.0.1009
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh