### PR TITLE
qa/tasks/vstart_runner: fix unicode decode error

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -176,7 +176,7 @@ class LocalRemoteProcess(object):
                 return
 
         out, err = self.subproc.communicate()
-        out, err = out.decode(), err.decode()
+        out, err = out.decode('utf-8'), err.decode('utf-8')
         self.stdout.write(out)
         self.stderr.write(err)
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "../qa/tasks/vstart_runner.py", line 1544, in <module>
    exec_test()
  File "../qa/tasks/vstart_runner.py", line 1405, in exec_test
    if mount.is_mounted():
  File "/data/ceph/qa/tasks/cephfs/fuse_mount.py", line 191, in is_mounted
    proc.wait()
  File "../qa/tasks/vstart_runner.py", line 179, in wait
    out, err = out.decode(), err.decode()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 46: ordinal not in range(128)

Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
