### PR TITLE
doc: change case from `apis` to `APIs`

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -306,7 +306,7 @@
 
 * RGW S3: Support has been added for BlockPublicAccess set of APIs at a bucket
   level, currently blocking/ignoring public acls & policies are supported.
-  User/Account level apis are planned to be added in the future
+  User/Account level APIs are planned to be added in the future
 
 * RGW: The default number of bucket index shards for new buckets was raised
   from 1 to 11 to increase the amount of write throughput for small buckets

--- a/doc/radosgw/elastic-sync-module.rst
+++ b/doc/radosgw/elastic-sync-module.rst
@@ -96,7 +96,7 @@ As of Luminous RGW in the metadata master zone can now service end user
 requests. This allows for not exposing the elasticsearch endpoint in public and
 also solves the authentication and authorization problem since RGW itself can
 authenticate the end user requests. For this purpose RGW introduces a new query
-in the bucket apis that can service elasticsearch requests. All these requests
+in the bucket APIs that can service elasticsearch requests. All these requests
 must be sent to the metadata master zone.
 
 Syntax


### PR DESCRIPTION
use APIs instead of apis to be consistent throughout.

fixes: https://tracker.ceph.com/issues/44374
Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
