### PR TITLE
denc: support enums wider than 8 bits

### DIFF
--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -268,17 +268,7 @@ template<typename T> int DencDumper<T>::i = 0;
 namespace _denc {
 template<typename T, typename... Us>
 inline constexpr bool is_any_of = (... || std::is_same_v<T, Us>);
-
-template<typename T, typename=void> struct underlying_type {
-  using type = T;
-};
-template<typename T>
-struct underlying_type<T, std::enable_if_t<std::is_enum_v<T>>> {
-  using type = std::underlying_type_t<T>;
-};
-template<typename T>
-using underlying_type_t = typename underlying_type<T>::type;
-}
+} // namespace _denc
 
 template<class It>
 struct is_const_iterator
@@ -307,11 +297,12 @@ get_pos_add(It& i) {
   return *reinterpret_cast<T*>(i.get_pos_add(sizeof(T)));
 }
 
+// network-order integer encoding
 template<typename T>
 struct denc_traits<
   T,
   std::enable_if_t<
-    _denc::is_any_of<_denc::underlying_type_t<T>,
+    _denc::is_any_of<T,
 		     ceph_le64, ceph_le32, ceph_le16, uint8_t
 #ifndef _CHAR_IS_SIGNED
 		       , int8_t

--- a/src/test/test_denc.cc
+++ b/src/test/test_denc.cc
@@ -180,6 +180,28 @@ TEST(denc, string)
   test_denc(c);
 }
 
+TEST(denc, enum_class)
+{
+  enum class enum_class_8 : int8_t { value };
+  test_denc(enum_class_8::value);
+  enum class enum_class_u8 : uint8_t { value };
+  test_denc(enum_class_u8::value);
+  enum class enum_class_16 : int16_t { value };
+  test_denc(enum_class_16::value);
+  enum class enum_class_u16 : uint16_t { value };
+  test_denc(enum_class_u16::value);
+  enum class enum_class_32 : int32_t { value };
+  test_denc(enum_class_32::value);
+  enum class enum_class_u32 : uint32_t { value };
+  test_denc(enum_class_u32::value);
+  enum class enum_class_64 : int64_t { value };
+  test_denc(enum_class_64::value);
+  enum class enum_class_u64 : uint64_t { value };
+  test_denc(enum_class_u64::value);
+  enum class enum_class { value };
+  test_denc(enum_class::value);
+}
+
 struct legacy_t {
   int32_t a = 1;
   void encode(bufferlist& bl) const {


### PR DESCRIPTION
the denc_traits specialization that supports enums looks like this:
```c++
struct denc_traits<
  T,
  std::enable_if_t<
    _denc::is_any_of<_denc::underlying_type_t<T>,
		     ceph_le64, ceph_le32, ceph_le16, uint8_t ...
```
however, an enum's underlying_type must be integral, so it's not possible for any of the ceph_le* types to match. for example, this:
```c++
enum class enum_class_16 : ceph_le16 {};
```
fails to compile with:
> underlying type ‘ceph_le16’ {aka ‘ceph_le\<short unsigned int\>’} of ‘enum_class_16’ must be an integral type

in order to support normal enums like this:
```c++
enum class enum_class_16 : uint16_t {};
```
we need a new denc_traits specialization that matches enums only, and maps its operations onto the traits of its underlying type. those traits themselves will convert to ceph_le\<T\> where necessary