### PR TITLE
mgr/volumes: add `mypy` support

### DIFF
--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -22,4 +22,5 @@ commands = mypy --config-file=../../mypy.ini \
            progress/module.py \
            rook/module.py \
            osd_support/module.py \
-           test_orchestrator/module.py
+           test_orchestrator/module.py \
+           volumes/__init__.py

--- a/src/pybind/mgr/volumes/fs/async_cloner.py
+++ b/src/pybind/mgr/volumes/fs/async_cloner.py
@@ -36,7 +36,6 @@ def get_next_clone_entry(volume_client, volname, running_jobs):
     except VolumeException as ve:
         log.error("error fetching clone entry for volume '{0}' ({1})".format(volname, ve))
         return ve.errno, None
-    return ret
 
 @contextmanager
 def open_at_volume(volume_client, volname, groupname, subvolname, need_complete=False, expected_types=[]):

--- a/src/pybind/mgr/volumes/fs/async_cloner.py
+++ b/src/pybind/mgr/volumes/fs/async_cloner.py
@@ -68,7 +68,7 @@ def handle_clone_pending(volume_client, volname, index, groupname, subvolname, s
     try:
         next_state = OpSm.get_next_state("clone", "pending", 0)
     except OpSmException as oe:
-        raise VolumeException(oe.error, oe.error_str)
+        raise VolumeException(oe.errno, oe.error_str)
     return (next_state, False)
 
 def sync_attrs(fs_handle, target_path, source_statx):
@@ -159,7 +159,7 @@ def handle_clone_in_progress(volume_client, volname, index, groupname, subvolnam
         # jump to failed state
         next_state = OpSm.get_next_state("clone", "in-progress", -1)
     except OpSmException as oe:
-        raise VolumeException(oe.error, oe.error_str)
+        raise VolumeException(oe.errno, oe.error_str)
     return (next_state, False)
 
 def handle_clone_failed(volume_client, volname, index, groupname, subvolname, should_cancel):

--- a/src/pybind/mgr/volumes/fs/async_cloner.py
+++ b/src/pybind/mgr/volumes/fs/async_cloner.py
@@ -34,7 +34,7 @@ def get_next_clone_entry(volume_client, volname, running_jobs):
                     return 0, None
                 raise ve
     except VolumeException as ve:
-        log.error("error fetching clone entry for volume '{0}' ({1})".format(volname), ve)
+        log.error("error fetching clone entry for volume '{0}' ({1})".format(volname, ve))
         return ve.errno, None
     return ret
 

--- a/src/pybind/mgr/volumes/fs/async_job.py
+++ b/src/pybind/mgr/volumes/fs/async_job.py
@@ -94,7 +94,7 @@ class AsyncJobs(object):
     def __init__(self, volume_client, name_pfx, nr_concurrent_jobs):
         self.vc = volume_client
         # queue of volumes for starting async jobs
-        self.q = deque()
+        self.q = deque() # type: deque
         # volume => job tracking
         self.jobs = {}
         # lock, cv for kickstarting jobs

--- a/src/pybind/mgr/volumes/fs/async_job.py
+++ b/src/pybind/mgr/volumes/fs/async_job.py
@@ -25,6 +25,7 @@ class JobThread(threading.Thread):
     def run(self):
         retries = 0
         thread_id = threading.currentThread()
+        assert isinstance(thread_id, JobThread)
         thread_name = thread_id.getName()
 
         while retries < JobThread.MAX_RETRIES_ON_EXCEPTION:

--- a/src/pybind/mgr/volumes/fs/async_job.py
+++ b/src/pybind/mgr/volumes/fs/async_job.py
@@ -67,7 +67,7 @@ class JobThread(threading.Thread):
         self.cancel_event.set()
 
     def should_cancel(self):
-        return self.cancel_event.isSet()
+        return self.cancel_event.is_set()
 
     def reset_cancel(self):
         self.cancel_event.clear()

--- a/src/pybind/mgr/volumes/fs/fs_util.py
+++ b/src/pybind/mgr/volumes/fs/fs_util.py
@@ -127,6 +127,6 @@ def get_ancestor_xattr(fs, path, attr):
         return fs.getxattr(path, attr).decode('utf-8')
     except cephfs.NoData as e:
         if path == "/":
-            raise VolumeException(-e.args[0]. e.args[1])
+            raise VolumeException(-e.args[0], e.args[1])
         else:
             return get_ancestor_xattr(fs, os.path.split(path)[0], attr)

--- a/src/pybind/mgr/volumes/fs/operations/clone_index.py
+++ b/src/pybind/mgr/volumes/fs/operations/clone_index.py
@@ -35,7 +35,7 @@ class CloneIndex(Index):
         except (VolumeException, cephfs.Error) as e:
             if isinstance(e, cephfs.Error):
                 e = IndexException(-e.args[0], e.args[1])
-            elif isinstance(VolumeException, e):
+            elif isinstance(e, VolumeException):
                 e = IndexException(e.errno, e.error_str)
             raise e
 

--- a/src/pybind/mgr/volumes/fs/operations/group.py
+++ b/src/pybind/mgr/volumes/fs/operations/group.py
@@ -132,7 +132,7 @@ def create_group(fs, vol_spec, groupname, pool, mode, uid, gid):
             log.debug("cleaning up subvolume group path: {0}".format(path))
             fs.rmdir(path)
         except cephfs.Error as ce:
-            log.debug("failed to clean up subvolume group {0} with path: {0} ({1})".format(groupname, path, ce))
+            log.debug("failed to clean up subvolume group {0} with path: {1} ({2})".format(groupname, path, ce))
         if isinstance(e, cephfs.Error):
             e = VolumeException(-e.args[0], e.args[1])
         raise e

--- a/src/pybind/mgr/volumes/fs/operations/group.py
+++ b/src/pybind/mgr/volumes/fs/operations/group.py
@@ -37,13 +37,13 @@ class Group(GroupTemplate):
     def uid(self):
         return self.user_id
 
-    @property
-    def gid(self):
-        return self.group_id
-
     @uid.setter
     def uid(self, val):
         self.user_id = val
+
+    @property
+    def gid(self):
+        return self.group_id
 
     @gid.setter
     def gid(self, val):

--- a/src/pybind/mgr/volumes/fs/operations/index.py
+++ b/src/pybind/mgr/volumes/fs/operations/index.py
@@ -1,6 +1,7 @@
 import errno
 import os
 
+from ..exception import VolumeException
 from .template import GroupTemplate
 
 class Index(GroupTemplate):

--- a/src/pybind/mgr/volumes/fs/operations/index.py
+++ b/src/pybind/mgr/volumes/fs/operations/index.py
@@ -1,3 +1,4 @@
+import errno
 import os
 
 from .template import GroupTemplate

--- a/src/pybind/mgr/volumes/fs/operations/lock.py
+++ b/src/pybind/mgr/volumes/fs/operations/lock.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from threading import Lock
+from typing import Dict
 
 # singleton design pattern taken from http://www.aleax.it/5ep.html
 
@@ -21,7 +22,7 @@ class GlobalLock(object):
     _shared_state = {
         'lock' : Lock(),
         'init' : False
-    }
+    } # type: Dict
 
     def __init__(self):
         with self._shared_state['lock']:

--- a/src/pybind/mgr/volumes/fs/operations/op_sm.py
+++ b/src/pybind/mgr/volumes/fs/operations/op_sm.py
@@ -1,5 +1,7 @@
 import errno
 
+from typing import Dict
+
 from ..exception import OpSmException
 
 class OpSm(object):
@@ -16,12 +18,12 @@ class OpSm(object):
         INIT_STATE_KEY : 'pending',
         'pending'           : ('in-progress', FAILED_STATE),
         'in-progress'       : (FINAL_STATE, FAILED_STATE),
-    }
+    } # type: Dict
 
     STATE_MACHINES_TYPES = {
         "subvolume" : OP_SM_SUBVOLUME,
         "clone"     : OP_SM_CLONE,
-    }
+    } # type: Dict
 
     @staticmethod
     def is_final_state(state):

--- a/src/pybind/mgr/volumes/fs/operations/op_sm.py
+++ b/src/pybind/mgr/volumes/fs/operations/op_sm.py
@@ -1,3 +1,5 @@
+import errno
+
 from ..exception import OpSmException
 
 class OpSm(object):

--- a/src/pybind/mgr/volumes/fs/operations/template.py
+++ b/src/pybind/mgr/volumes/fs/operations/template.py
@@ -1,3 +1,5 @@
+import errno
+
 from ..exception import VolumeException
 
 class GroupTemplate(object):

--- a/src/pybind/mgr/volumes/fs/operations/versions/__init__.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/__init__.py
@@ -32,7 +32,7 @@ class SubvolumeLoader(object):
                 self.max_version = cls.version()
                 self.versions[cls.version()] = cls
         if self.max_version == SubvolumeLoader.INVALID_VERSION:
-            raise VolumeException("no subvolume version available")
+            raise VolumeException(-errno.EINVAL, "no subvolume version available")
         log.info("max subvolume version is v{0}".format(self.max_version))
 
     def _get_subvolume_version(self, version):

--- a/src/pybind/mgr/volumes/fs/operations/versions/__init__.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/__init__.py
@@ -6,7 +6,7 @@ import cephfs
 
 from .subvolume_base import SubvolumeBase
 from ..op_sm import OpSm
-from ...exception import VolumeException, MetadataMgrException
+from ...exception import MetadataMgrException, OpSmException, VolumeException
 
 log = logging.getLogger(__name__)
 

--- a/src/pybind/mgr/volumes/fs/operations/versions/__init__.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/__init__.py
@@ -67,7 +67,6 @@ class SubvolumeLoader(object):
         except MetadataMgrException as me:
             if me.errno == -errno.ENOENT and upgrade:
                 self.upgrade_legacy_subvolume(fs, subvolume)
-                subvolume = None
                 return self.get_subvolume_object(fs, vol_spec, group, subvolname, upgrade=False)
             else:
                 # log the actual error and generalize error string returned to user

--- a/src/pybind/mgr/volumes/fs/operations/versions/metadata_manager.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/metadata_manager.py
@@ -1,10 +1,11 @@
 import os
 import errno
 import logging
+import sys
 
-try:
+if sys.version_info >= (3, 2):
     import configparser
-except ImportError:
+else:
     import ConfigParser as configparser
 
 try:

--- a/src/pybind/mgr/volumes/fs/operations/versions/metadata_manager.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/metadata_manager.py
@@ -32,7 +32,10 @@ class MetadataManager(object):
         self.fs = fs
         self.mode = mode
         self.config_path = config_path
-        self.config = configparser.ConfigParser()
+        if sys.version_info >= (3, 2):
+            self.config = configparser.ConfigParser()
+        else:
+            self.config = configparser.SafeConfigParser()
 
     def refresh(self):
         fd = None

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
@@ -34,21 +34,21 @@ class SubvolumeBase(object):
     def uid(self):
         return self.user_id
 
-    @property
-    def gid(self):
-        return self.group_id
-
-    @property
-    def mode(self):
-        return self.cmode
-
     @uid.setter
     def uid(self, val):
         self.user_id = val
 
+    @property
+    def gid(self):
+        return self.group_id
+
     @gid.setter
     def gid(self, val):
         self.group_id = val
+
+    @property
+    def mode(self):
+        return self.cmode
 
     @mode.setter
     def mode(self, val):

--- a/src/pybind/mgr/volumes/fs/operations/volume.py
+++ b/src/pybind/mgr/volumes/fs/operations/volume.py
@@ -213,15 +213,15 @@ def create_volume(mgr, volname, placement):
     r, outb, outs = create_pool(mgr, data_pool)
     if r != 0:
         #cleanup
-        remove_pool(metadata_pool)
+        remove_pool(mgr, metadata_pool)
         return r, outb, outs
     # create filesystem
     r, outb, outs = create_filesystem(mgr, volname, metadata_pool, data_pool)
     if r != 0:
         log.error("Filesystem creation error: {0} {1} {2}".format(r, outb, outs))
         #cleanup
-        remove_pool(data_pool)
-        remove_pool(metadata_pool)
+        remove_pool(mgr, data_pool)
+        remove_pool(mgr, metadata_pool)
         return r, outb, outs
     # create mds
     return create_mds(mgr, volname, placement)

--- a/src/pybind/mgr/volumes/fs/operations/volume.py
+++ b/src/pybind/mgr/volumes/fs/operations/volume.py
@@ -89,6 +89,7 @@ class ConnectionPool(object):
 
         def disconnect(self):
             try:
+                assert self.fs
                 assert self.ops_in_progress == 0
                 log.info("disconnecting from cephfs '{0}'".format(self.fs_name))
                 addrs = self.fs.get_addrs()
@@ -100,6 +101,7 @@ class ConnectionPool(object):
                 raise
 
         def abort(self):
+            assert self.fs
             assert self.ops_in_progress == 0
             log.info("aborting connection from cephfs '{0}'".format(self.fs_name))
             self.fs.abort_conn()

--- a/src/pybind/mgr/volumes/fs/operations/volume.py
+++ b/src/pybind/mgr/volumes/fs/operations/volume.py
@@ -1,15 +1,15 @@
 import time
 import errno
 import logging
+import sys
+
 from contextlib import contextmanager
 from threading import Lock, Condition
 
-try:
-    # py2
-    from threading import _Timer as Timer
-except ImportError:
-    #py3
+if sys.version_info >= (3, 3):
     from threading import Timer
+else:
+    from threading import _Timer as Timer
 
 import cephfs
 import orchestrator

--- a/src/pybind/mgr/volumes/fs/operations/volume.py
+++ b/src/pybind/mgr/volumes/fs/operations/volume.py
@@ -5,6 +5,7 @@ import sys
 
 from contextlib import contextmanager
 from threading import Lock, Condition
+from typing import no_type_check
 
 if sys.version_info >= (3, 3):
     from threading import Timer
@@ -109,6 +110,7 @@ class ConnectionPool(object):
         """
         recurring timer variant of Timer
         """
+        @no_type_check
         def run(self):
             try:
                 while not self.finished.is_set():

--- a/src/pybind/mgr/volumes/fs/purge_queue.py
+++ b/src/pybind/mgr/volumes/fs/purge_queue.py
@@ -25,7 +25,6 @@ def get_trash_entry_for_volume(volume_client, volname, running_jobs):
     except VolumeException as ve:
         log.error("error fetching trash entry for volume '{0}' ({1})".format(volname, ve))
         return ve.errno, None
-    return ret
 
 # helper for starting a purge operation on a trash entry
 def purge_trash_entry_for_volume(volume_client, volname, purge_dir, should_cancel):

--- a/src/pybind/mgr/volumes/fs/purge_queue.py
+++ b/src/pybind/mgr/volumes/fs/purge_queue.py
@@ -23,7 +23,7 @@ def get_trash_entry_for_volume(volume_client, volname, running_jobs):
                     return 0, None
                 raise ve
     except VolumeException as ve:
-        log.error("error fetching trash entry for volume '{0}' ({1})".format(volname), ve)
+        log.error("error fetching trash entry for volume '{0}' ({1})".format(volname, ve))
         return ve.errno, None
     return ret
 

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -56,7 +56,7 @@ class VolumeClient(object):
             self.purge_queue.queue_job(fs['mdsmap']['fs_name'])
 
     def is_stopping(self):
-        return self.stopping.isSet()
+        return self.stopping.is_set()
 
     def shutdown(self):
         log.info("shutting down")
@@ -103,7 +103,7 @@ class VolumeClient(object):
         return delete_volume(self.mgr, volname)
 
     def list_fs_volumes(self):
-        if self.stopping.isSet():
+        if self.stopping.is_set():
             return -errno.ESHUTDOWN, "", "shutdown in progress"
         volumes = list_volumes(self.mgr)
         return 0, json.dumps(volumes, indent=4, sort_keys=True), ""


### PR DESCRIPTION
Adds `mypy` checks to the `mgr/volumes` modules.

Fixes: https://tracker.ceph.com/issues/44393
Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
