### PR TITLE
nautilus: rgw: tune sharded bucket listing

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -31,3 +31,8 @@
   The warning can be silenced with::
 
     ceph config set global mon_warn_on_pool_no_redundancy false
+
+* RGW: bucket listing performance on sharded bucket indexes has been
+  notably improved by heuristically -- and significantly, in many
+  cases -- reducing the number of entries requested from each bucket
+  index shard.

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6255,12 +6255,12 @@ next:
     formatter->open_array_section("objects");
 
     constexpr uint32_t NUM_ENTRIES = 1000;
-    uint16_t attempt = 1;
+    uint16_t expansion_factor = 1;
     while (is_truncated) {
       map<string, rgw_bucket_dir_entry> result;
       int r =
 	store->cls_bucket_list_ordered(bucket_info, RGW_NO_SHARD, marker,
-				       prefix, NUM_ENTRIES, true, attempt,
+				       prefix, NUM_ENTRIES, true, expansion_factor,
 				       result, &is_truncated, &marker,
 				       bucket_object_check_filter);
       if (r < 0 && r != -ENOENT) {
@@ -6270,9 +6270,10 @@ next:
       }
 
       if (result.size() < NUM_ENTRIES / 8) {
-	++attempt;
-      } else if (result.size() > NUM_ENTRIES * 7 / 8 && attempt > 1) {
-	--attempt;
+	++expansion_factor;
+      } else if (result.size() > NUM_ENTRIES * 7 / 8 &&
+		 expansion_factor > 1) {
+	--expansion_factor;
       }
 
       map<string, rgw_bucket_dir_entry>::iterator iter;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6253,20 +6253,27 @@ next:
     formatter->open_object_section("result");
     formatter->dump_string("bucket", bucket_name);
     formatter->open_array_section("objects");
+
+    constexpr uint32_t NUM_ENTRIES = 1000;
+    uint16_t attempt = 1;
     while (is_truncated) {
       map<string, rgw_bucket_dir_entry> result;
       int r =
 	store->cls_bucket_list_ordered(bucket_info, RGW_NO_SHARD, marker,
-				       prefix, 1000, true,
+				       prefix, NUM_ENTRIES, true, attempt,
 				       result, &is_truncated, &marker,
 				       bucket_object_check_filter);
-
       if (r < 0 && r != -ENOENT) {
         cerr << "ERROR: failed operation r=" << r << std::endl;
+      } else if (r == -ENOENT) {
+        break;
       }
 
-      if (r == -ENOENT)
-        break;
+      if (result.size() < NUM_ENTRIES / 8) {
+	++attempt;
+      } else if (result.size() > NUM_ENTRIES * 7 / 8 && attempt > 1) {
+	--attempt;
+      }
 
       map<string, rgw_bucket_dir_entry>::iterator iter;
       for (iter = result.begin(); iter != result.end(); ++iter) {

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -20,6 +20,7 @@
 #include "common/ceph_time.h"
 #include "rgw_formats.h"
 
+
 // define as static when RGWBucket implementation completes
 extern void rgw_get_buckets_obj(const rgw_user& user_id, string& buckets_obj_id);
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2489,8 +2489,10 @@ int RGWRados::Bucket::List::list_objects_ordered(
     for (auto eiter = ent_map.begin(); eiter != ent_map.end(); ++eiter) {
       rgw_bucket_dir_entry& entry = eiter->second;
       rgw_obj_index_key index_key = entry.key;
-
       rgw_obj_key obj(index_key);
+
+      ldout(cct, 20) << "RGWRados::Bucket::List::" << __func__ <<
+	" considering entry " << entry.key << dendl;
 
       /* note that parse_raw_oid() here will not set the correct
        * object's instance, as rgw_obj_index_key encodes that
@@ -2504,12 +2506,12 @@ int RGWRados::Bucket::List::list_objects_ordered(
         continue;
       }
 
-      bool check_ns = (obj.ns == params.ns);
+      bool matched_ns = (obj.ns == params.ns);
       if (!params.list_versions && !entry.is_visible()) {
         continue;
       }
 
-      if (params.enforce_ns && !check_ns) {
+      if (params.enforce_ns && !matched_ns) {
         if (!params.ns.empty()) {
           /* we've iterated past the namespace we're searching -- done now */
           truncated = false;
@@ -9200,19 +9202,24 @@ int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
 				      const string& prefix,
 				      const uint32_t num_entries,
 				      const bool list_versions,
-				      const uint16_t attempt,
+				      const uint16_t expansion_factor,
 				      map<string, rgw_bucket_dir_entry>& m,
 				      bool *is_truncated,
 				      rgw_obj_index_key *last_entry,
 				      bool (*force_check_filter)(const string& name))
 {
+  /* expansion_factor allows the number of entries to read to grow
+   * exponentially; this is used when earlier reads are producing too
+   * few results, perhaps due to filtering or to a series of
+   * namespaced entries */
+
   ldout(cct, 10) << "RGWRados::" << __func__ << ": " << bucket_info.bucket <<
     " start_after=\"" << start_after.name <<
     "[" << start_after.instance <<
     "]\", prefix=\"" << prefix <<
     "\" num_entries=" << num_entries <<
     ", list_versions=" << list_versions <<
-    ", attempt=" << attempt << dendl;
+    ", expansion_factor=" << expansion_factor << dendl;
 
   librados::IoCtx index_ctx;
   // key   - oid (for different shards if there is any)
@@ -9226,14 +9233,14 @@ int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
 
   const uint32_t shard_count = oids.size();
   uint32_t num_entries_per_shard;
-  if (attempt == 0) {
+  if (expansion_factor == 0) {
     num_entries_per_shard =
       calc_ordered_bucket_list_per_shard(num_entries, shard_count);
-  } else if (attempt <= 11) {
+  } else if (expansion_factor <= 11) {
     // we'll max out the exponential multiplication factor at 1024 (2<<10)
     num_entries_per_shard =
       std::min(num_entries,
-	       (uint32_t(1 << (attempt - 1)) *
+	       (uint32_t(1 << (expansion_factor - 1)) *
 		calc_ordered_bucket_list_per_shard(num_entries, shard_count)));
   } else {
     num_entries_per_shard = num_entries;
@@ -9253,7 +9260,7 @@ int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
     return r;
   }
 
-  // Create a list of iterators that are used to iterate each shard
+  // create a list of iterators that are used to iterate each shard
   vector<map<string, struct rgw_bucket_dir_entry>::iterator> vcurrents;
   vector<map<string, struct rgw_bucket_dir_entry>::iterator> vends;
   vector<string> vnames;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2205,10 +2205,13 @@ public:
                            ceph::real_time& removed_mtime, list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr);
   int cls_obj_complete_cancel(BucketShard& bs, string& tag, rgw_obj& obj, uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr);
   int cls_obj_set_bucket_tag_timeout(RGWBucketInfo& bucket_info, uint64_t timeout);
-  int cls_bucket_list_ordered(RGWBucketInfo& bucket_info, int shard_id,
-			      const rgw_obj_index_key& start,
+  int cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
+			      const int shard_id,
+			      const rgw_obj_index_key& start_after,
 			      const string& prefix,
-			      uint32_t num_entries, bool list_versions,
+			      const uint32_t num_entries,
+			      const bool list_versions,
+			      const uint16_t attempt, // 0 means ignore
 			      map<string, rgw_bucket_dir_entry>& m,
 			      bool *is_truncated,
 			      rgw_obj_index_key *last_entry,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2211,7 +2211,7 @@ public:
 			      const string& prefix,
 			      const uint32_t num_entries,
 			      const bool list_versions,
-			      const uint16_t attempt, // 0 means ignore
+			      const uint16_t exp_factor, // 0 means ignore
 			      map<string, rgw_bucket_dir_entry>& m,
 			      bool *is_truncated,
 			      rgw_obj_index_key *last_entry,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2465,6 +2465,12 @@ public:
                    bool *is_truncated, RGWAccessListFilter *filter);
 
   uint64_t next_bucket_id();
+
+  /**
+   * This is broken out to facilitate unit testing.
+   */
+  static uint32_t calc_ordered_bucket_list_per_shard(uint32_t num_entries,
+						     uint32_t num_shards);
 };
 
 class RGWStoreManager {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44143

Nautilus backport of https://github.com/ceph/ceph/pull/30853 and associated bugfix https://github.com/ceph/ceph/pull/32636.

Currently, if someone requests the 1000 next entries from a bucket, each bucket index shard will receive a request for the 1000 next entries. When there are hundreds, thousands, or tens of thousands of bucket index shards, this results in a huge amplification of the request, even though only 1000 entries will be returned.

These changes reduce the per-bucket index shard requests. These also allow re-requests in edge cases where all of one shard's returned entries are consumed. Finally these changes improve the determination of whether the resulting list is truncated.

ALSO

A change to advance the marker in RGWRados::cls_bucket_list_ordered to the last entry visited rather than the final entry in list to push progress as far as possible.

Since non-vis entries tend to cluster on the same shard, such as during incomplete multipart uploads, this can severely limit the number of entries returned by a call to RGWRados::cls_bucket_list_ordered since once that shard has provided all its members, we must stop. This interacts with a recent optimization to reduce the number of entries requested from each shard. To address this the number of attempts is sent as a parameter, so the number of entries requested from each shard can grow with each attempt.

Previously RGWRados::Bucket::List::list_objects_ordered was capped at 2 attempts, but now we keep attempting to insure we make forward progress and return entries when some exist. If we fail to make forward progress, we log the error condition and stop looping.