### PR TITLE
librbd/cache/rwl: fix {offset, len}:len to construct block

### DIFF
--- a/src/librbd/cache/rwl/Types.cc
+++ b/src/librbd/cache/rwl/Types.cc
@@ -79,7 +79,7 @@ ExtentsSummary<ExtentsType>::ExtentsSummary(const ExtentsType &extents)
    * and last_image_byte, inclusive, but we don't guarantee here
    * that they address all of those bytes. There may be gaps. */
   first_image_byte = extents.front().first;
-  last_image_byte = first_image_byte + extents.front().second;
+  last_image_byte = first_image_byte + extents.front().second - 1;
   for (auto &extent : extents) {
     /* Ignore zero length extents */
     if (extent.second) {
@@ -87,8 +87,9 @@ ExtentsSummary<ExtentsType>::ExtentsSummary(const ExtentsType &extents)
       if (extent.first < first_image_byte) {
         first_image_byte = extent.first;
       }
-      if ((extent.first + extent.second) > last_image_byte) {
-        last_image_byte = extent.first + extent.second;
+      auto extent_tail = extent.first + extent.second - 1;
+      if (extent_tail > last_image_byte) {
+        last_image_byte = extent_tail;
       }
     }
   }


### PR DESCRIPTION
ExtentsSummary is used to get the potential accessed block
range. The tail of this block should be "offset + len - 1"

Signed-off-by: Changcheng Liu <changcheng.liu@aliyun.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
