### PR TITLE
nautilus: doc/mgr/telemetry: added device channel details

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -31,14 +31,19 @@ the per-channel setting has no effect.)
     - operating system (OS distribution, kernel version)
     - stack trace identifying where in the Ceph code the crash occurred
 
-* **ident** (default: on): User-provided identifying information about
+* **device** (default: on): Information about device metrics, including
+
+    - anonymized SMART metrics
+
+* **ident** (default: off): User-provided identifying information about
   the cluster
 
     - cluster description
     - contact email address
 
 The data being reported does *not* contain any sensitive
-data like pool names, object names, object contents, or hostnames.
+data like pool names, object names, object contents, hostnames, or device
+serial numbers.
 
 It contains counters and statistics on how the cluster has been
 deployed, the version of Ceph, the distribition of the hosts and other
@@ -63,6 +68,15 @@ You can look at what data is reported at any time with the command::
 
   ceph telemetry show
 
+To protect your privacy, device reports are generated separately, and data such
+as hostname and device serial number is anonymized. The device telemetry is
+sent to a different endpoint and does not associate the device data with a
+particular cluster. To see a preview of the device report use the command::
+
+  ceph telemetry show-device
+
+Please note: In order to generate the device report we use Smartmontools
+version 7.0 and up, which supports JSON output.
 If you have any concerns about privacy with regard to the information included in
 this report, please contact the Ceph developers.
 
@@ -74,14 +88,21 @@ Individual channels can be enabled or disabled with::
   ceph config set mgr mgr/telemetry/channel_ident false
   ceph config set mgr mgr/telemetry/channel_basic false
   ceph config set mgr mgr/telemetry/channel_crash false
+  ceph config set mgr mgr/telemetry/channel_device false
   ceph telemetry show
+  ceph telemetry show-device
 
 Enabling Telemetry
 ------------------
 
-To allow the *telemetry* module to start sharing data,::
+To allow the *telemetry* module to start sharing data::
 
   ceph telemetry on
+
+Please note: Telemetry data is licensed under the Community Data License
+Agreement - Sharing - Version 1.0 (https://cdla.io/sharing-1-0/). Hence,
+telemetry module can be enabled only after you add '--license sharing-1-0' to
+the 'ceph telemetry on' command.
 
 Telemetry can be disabled at any time with::
 
@@ -94,6 +115,13 @@ The module compiles and sends a new report every 24 hours by default.
 You can adjust this interval with::
 
   ceph config set mgr mgr/telemetry/interval 72    # report every three days
+
+Status
+--------
+
+The see the current configuration::
+
+  ceph telemetry status
 
 Sending telemetry through a proxy
 ---------------------------------
@@ -108,6 +136,7 @@ You can also include a *user:pass* if needed::
 
   ceph config set mgr mgr/telemetry/proxy https://ceph:telemetry@10.0.0.1:8080
 
+
 Contact and Description
 -----------------------
 
@@ -117,4 +146,3 @@ completely optional, and disabled by default.::
   ceph config set mgr mgr/telemetry/contact 'John Doe <john.doe@example.com>'
   ceph config set mgr mgr/telemetry/description 'My first Ceph cluster'
   ceph config set mgr mgr/telemetry/channel_ident true
-


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44367

---

backport of https://github.com/ceph/ceph/pull/33113
parent tracker: https://tracker.ceph.com/issues/43648

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh