### PR TITLE
mgr/volume: adapt arg passing to ServiceSpec

### DIFF
--- a/src/pybind/mgr/volumes/fs/fs_util.py
+++ b/src/pybind/mgr/volumes/fs/fs_util.py
@@ -34,7 +34,9 @@ def remove_filesystem(mgr, fs_name):
     return mgr.mon_command(command)
 
 def create_mds(mgr, fs_name, placement):
-    spec = orchestrator.ServiceSpec(fs_name, orchestrator.PlacementSpec.from_strings(placement.split()))
+    spec = orchestrator.ServiceSpec(service_type='mds',
+                                    service_id=fs_name,
+                                    placement=orchestrator.PlacementSpec.from_strings(placement.split()))
     try:
         completion = mgr.apply_mds(spec)
         mgr._orchestrator_wait([completion])


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

change introduced in bfb9b4e8c416543a0f08174437100c9a658848cb

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
