### PR TITLE
mgr/dashboard: remove 'config-opt: read' perm. from system roles.

### DIFF
--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -406,8 +406,10 @@ class PoolTest(DashboardTestCase):
             'compression_algorithms': JList(six.string_types),
             'compression_modes': JList(six.string_types),
             'is_all_bluestore': bool,
-            "bluestore_compression_algorithm": six.string_types,
+            'bluestore_compression_algorithm': six.string_types,
             'osd_count': int,
             'crush_rules_replicated': JList(JObj({}, allow_unknown=True)),
             'crush_rules_erasure': JList(JObj({}, allow_unknown=True)),
+            'pg_autoscale_default_mode': six.string_types,
+            'pg_autoscale_modes': JList(six.string_types),
         }))

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -220,20 +220,23 @@ class Pool(RESTController):
             return all(o['osd_objectstore'] == 'bluestore'
                        for o in mgr.get('osd_metadata').values())
 
-        def compression_enum(conf_name):
+        def get_config_option_enum(conf_name):
             return [[v for v in o['enum_values'] if len(v) > 0]
                     for o in mgr.get('config_options')['options']
                     if o['name'] == conf_name][0]
 
+        mgr_config = mgr.get('config')
         result = {
             "pool_names": [p['pool_name'] for p in self._pool_list()],
             "crush_rules_replicated": rules(1),
             "crush_rules_erasure": rules(3),
             "is_all_bluestore": all_bluestore(),
             "osd_count": len(mgr.get('osd_map')['osds']),
-            "bluestore_compression_algorithm": mgr.get('config')['bluestore_compression_algorithm'],
-            "compression_algorithms": compression_enum('bluestore_compression_algorithm'),
-            "compression_modes": compression_enum('bluestore_compression_mode'),
+            "bluestore_compression_algorithm": mgr_config['bluestore_compression_algorithm'],
+            "compression_algorithms": get_config_option_enum('bluestore_compression_algorithm'),
+            "compression_modes": get_config_option_enum('bluestore_compression_mode'),
+            "pg_autoscale_default_mode": mgr_config['osd_pool_default_pg_autoscale_mode'],
+            "pg_autoscale_modes": get_config_option_enum('osd_pool_default_pg_autoscale_mode'),
         }
 
         if pool_name:

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -18,7 +18,6 @@ import {
   i18nProviders
 } from '../../../../testing/unit-test-helper';
 import { NotFoundComponent } from '../../../core/not-found/not-found.component';
-import { ConfigurationService } from '../../../shared/api/configuration.service';
 import { ErasureCodeProfileService } from '../../../shared/api/erasure-code-profile.service';
 import { PoolService } from '../../../shared/api/pool.service';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
@@ -40,7 +39,6 @@ describe('PoolFormComponent', () => {
   let component: PoolFormComponent;
   let fixture: ComponentFixture<PoolFormComponent>;
   let poolService: PoolService;
-  let configurationService: ConfigurationService;
   let form: CdFormGroup;
   let router: Router;
   let ecpService: ErasureCodeProfileService;
@@ -133,7 +131,9 @@ describe('PoolFormComponent', () => {
       compression_algorithms: ['snappy'],
       compression_modes: ['none', 'passive'],
       crush_rules_replicated: [],
-      crush_rules_erasure: []
+      crush_rules_erasure: [],
+      pg_autoscale_default_mode: 'off',
+      pg_autoscale_modes: ['off', 'warn', 'on']
     };
     const ecp1 = new ErasureCodeProfile();
     ecp1.name = 'ecp1';
@@ -164,10 +164,6 @@ describe('PoolFormComponent', () => {
 
   beforeEach(() => {
     setUpPoolComponent();
-    configurationService = TestBed.get(ConfigurationService);
-    spyOn(configurationService, 'get').and.callFake(() => [
-      { default: 'off', enum_values: ['on', 'warn', 'off'], value: [] }
-    ]);
     poolService = TestBed.get(PoolService);
     spyOn(poolService, 'getInfo').and.callFake(() => [component.info]);
     ecpService = TestBed.get(ErasureCodeProfileService);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/pool-form-info.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/pool-form-info.ts
@@ -9,4 +9,6 @@ export class PoolFormInfo {
   compression_modes: string[];
   crush_rules_replicated: CrushRule[];
   crush_rules_erasure: CrushRule[];
+  pg_autoscale_default_mode: string;
+  pg_autoscale_modes: string[];
 }

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -237,7 +237,6 @@ BLOCK_MGR_ROLE = Role('block-manager', 'Block Manager', {
 # RadosGW manager role provides all permissions for block related scopes
 RGW_MGR_ROLE = Role('rgw-manager', 'RGW Manager', {
     Scope.RGW: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
-    Scope.CONFIG_OPT: [_P.READ],
     Scope.GRAFANA: [_P.READ],
 })
 
@@ -258,14 +257,12 @@ CLUSTER_MGR_ROLE = Role('cluster-manager', 'Cluster Manager', {
 # Pool manager role provides all permissions for pool related scopes
 POOL_MGR_ROLE = Role('pool-manager', 'Pool Manager', {
     Scope.POOL: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
-    Scope.CONFIG_OPT: [_P.READ],
     Scope.GRAFANA: [_P.READ],
 })
 
-# Pool manager role provides all permissions for CephFS related scopes
+# CephFS manager role provides all permissions for CephFS related scopes
 CEPHFS_MGR_ROLE = Role('cephfs-manager', 'CephFS Manager', {
     Scope.CEPHFS: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
-    Scope.CONFIG_OPT: [_P.READ],
     Scope.GRAFANA: [_P.READ],
 })
 
@@ -273,7 +270,6 @@ GANESHA_MGR_ROLE = Role('ganesha-manager', 'NFS Ganesha Manager', {
     Scope.NFS_GANESHA: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
     Scope.CEPHFS: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
     Scope.RGW: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
-    Scope.CONFIG_OPT: [_P.READ],
     Scope.GRAFANA: [_P.READ],
 })
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44237
Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
