### PR TITLE
vstart.sh: enable nfs-ganesha mgmt. in dashboard.

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -589,6 +589,7 @@ prepare_conf() {
         mon osd full ratio = .99
         mon osd nearfull ratio = .99
         mon osd backfillfull ratio = .99
+        mon_max_pg_per_osd = ${MON_MAX_PG_PER_OSD:-1000}
         erasure code dir = $EC_PATH
         plugin dir = $CEPH_LIB
         filestore fd cache size = 32
@@ -1155,7 +1156,15 @@ EOF
         # Wait few seconds for grace period to be removed
         sleep 2
         prun ganesha-rados-grace -p nfs-ganesha -n ganesha
-done
+
+        if $with_mgr_dashboard; then
+            $CEPH_BIN/rados -p nfs-ganesha put "conf-$name" "$ganesha_dir/ganesha.conf"
+        fi
+    done
+
+    if $with_mgr_dashboard; then
+        ceph_adm dashboard set-ganesha-clusters-rados-pool-namespace nfs-ganesha
+    fi
 }
 
 if [ "$debug" -eq 0 ]; then


### PR DESCRIPTION
Enable nfs-ganesha mgmt. in dashboard when running both: Dashboard & GANESHA=1:
- Store nfs-ganesha daemon config file as RADOS object following convention.
- Tell Dashboard in which RADOS pool the configuration objects are stored.

Extra fix: Avoid issues with max number of PGs per OSD when creating multiple pools
by setting global mon_max_pg_per_osd = 1000 (default, configurable by env. var.).

More info:
https://docs.ceph.com/docs/master/mgr/dashboard/#nfs-ganesha-management

Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
