### PR TITLE
common/ceph_time: tolerate mono time going backwards

### DIFF
--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -482,7 +482,19 @@ inline timespan abs(signedspan z) {
     timespan(-z.count());
 }
 inline timespan to_timespan(signedspan z) {
-  ceph_assert(z >= signedspan::zero());
+  if (z < signedspan::zero()) {
+    //ceph_assert(z >= signedspan::zero());
+    // There is a kernel bug that seems to be triggering this assert.  We've
+    // seen it in:
+    //   centos 8.1: 4.18.0-147.el8.x86_64
+    //   debian 10.3: 4.19.0-8-amd64
+    //   debian 10.1: 4.19.67-2+deb10u1
+    //   ubuntu 18.04
+    // see bugs:
+    //   https://tracker.ceph.com/issues/43365
+    //   https://tracker.ceph.com/issues/44078
+    z = signedspan::zero();
+  }
   return std::chrono::duration_cast<timespan>(z);
 }
 


### PR DESCRIPTION
Some kernels (and possibly some hardware?) can trigger a monotonic clock
that goes back in time.  That, in turn, can lead to a negative monotonic
time span.  This would trigger an assert.

This this problem seems to be widespread, tolerate the case and interpret
it as a 0-length interval (vs something negative).

Fixes: https://tracker.ceph.com/issues/44078
Fixes: https://tracker.ceph.com/issues/43365
Signed-off-by: Sage Weil <sage@redhat.com>