### PR TITLE
mgr/orch: try harder when pickle fails to marshal an exception

### DIFF
--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -95,8 +95,8 @@ class TestOrchestratorCli(MgrTestCase):
         res = self._orch_cmd_result("osd", "create", "-i", "-", stdin=json.dumps(drive_groups))
         self.assertEqual(res, 0)
 
-        #with self.assertRaises(Exception):
-        #    self._orch_cmd("osd", "create", "notfound:device")
+        with self.assertRaises(Exception):
+           self._orch_cmd("osd", "create", "notfound:device")
 
     def test_blink_device_light(self):
         def _ls_lights(what):

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -247,9 +247,14 @@ class _Promise(object):
         self._exception_ = e
         try:
             self._serialized_exception_ = pickle.dumps(e) if e is not None else None
-        except Exception:
-            logger.exception("failed to pickle {}".format(e))
-            # We can't properly raise anything here. Just hope for the best.
+        except pickle.PicklingError:
+            logger.error(f"failed to pickle {e}")
+            if isinstance(e, Exception):
+                e = Exception(*e.args)
+            else:
+                e = Exception(str(e))
+            # degenerate to a plain Exception
+            self._serialized_exception_ = pickle.dumps(e)
 
     @property
     def _serialized_exception(self):


### PR DESCRIPTION
pickle cannot marshal instances of class not defined in the top level of
a module. for instance, `DriveGroupValidationError` is defined in a
submodule of `ceph` python module, that's why we cannot capture it.

this prevent the `ceph` command line from getting a proper error when
the command fails if the command is implemented using cross python
module call(s).

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
