### PR TITLE
rgw: cls_bucket_list_(un)ordered should clear results collection

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6762,6 +6762,8 @@ next:
     uint16_t expansion_factor = 1;
     while (is_truncated) {
       RGWRados::ent_map_t result;
+      result.reserve(NUM_ENTRIES);
+
       int r = store->getRados()->cls_bucket_list_ordered(
 	bucket_info, RGW_NO_SHARD,
 	marker, empty_prefix, empty_delimiter,


### PR DESCRIPTION
Each call to cls_bucket_list_(un)ordered should have an empty collection to populate with results. Rather than rely on the caller to inure this, it's more reliable to have these functions do the clear.

Tracker: https://tracker.ceph.com/issues/44395