### PR TITLE
doc: adjust for mon_status changes in octopus

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -37,8 +37,6 @@ Synopsis
 
 | **ceph** **mon** [ *add* \| *dump* \| *getmap* \| *remove* \| *stat* ] ...
 
-| **ceph** **mon_status**
-
 | **ceph** **osd** [ *blacklist* \| *blocked-by* \| *create* \| *new* \| *deep-scrub* \| *df* \| *down* \| *dump* \| *erasure-code-profile* \| *find* \| *getcrushmap* \| *getmap* \| *getmaxosd* \| *in* \| *ls* \| *lspools* \| *map* \| *metadata* \| *ok-to-stop* \| *out* \| *pause* \| *perf* \| *pg-temp* \| *force-create-pg* \| *primary-affinity* \| *primary-temp* \| *repair* \| *reweight* \| *reweight-by-pg* \| *rm* \| *destroy* \| *purge* \| *safe-to-destroy* \| *scrub* \| *set* \| *setcrushmap* \| *setmaxosd*  \| *stat* \| *tree* \| *unpause* \| *unset* ] ...
 
 | **ceph** **osd** **crush** [ *add* \| *add-bucket* \| *create-or-move* \| *dump* \| *get-tunable* \| *link* \| *move* \| *remove* \| *rename-bucket* \| *reweight* \| *reweight-all* \| *reweight-subtree* \| *rm* \| *rule* \| *set* \| *set-tunable* \| *show-tunables* \| *tunables* \| *unlink* ] ...
@@ -550,15 +548,6 @@ Subcommand ``stat`` summarizes monitor status.
 Usage::
 
 	ceph mon stat
-
-mon_status
-----------
-
-Reports status of monitors.
-
-Usage::
-
-	ceph mon_status
 
 mgr
 ---

--- a/doc/rados/operations/control.rst
+++ b/doc/rados/operations/control.rst
@@ -33,12 +33,15 @@ and major events. ::
 Execute the following to show the monitor quorum, including which monitors are
 participating and which one is the leader. ::
 
+	ceph mon stat
 	ceph quorum_status
 
 Execute the following to query the status of a single monitor, including whether
 or not it is in the quorum. ::
 
-	ceph [-m monhost] mon_status
+	ceph tell mon.[id] mon_status
+
+where the value of ``[id]`` can be determined, e.g., from ``ceph -s``.
 
 
 Authentication Subsystem
@@ -396,13 +399,12 @@ This is also available more directly::
 
 The above will block until a quorum is reached.
 
-For a status of just the monitor you connect to (use ``-m HOST:PORT``
-to select)::
+For a status of just a single monitor::
 
-	ceph mon_status -f json-pretty
+	ceph tell mon.[name] mon_status
 	
-	
-.. code-block:: javascript
+where the value of ``[name]`` can be taken from ``ceph quorum_status``. Sample
+output::
 	
 	{
 	    "name": "b",

--- a/doc/rados/operations/monitoring.rst
+++ b/doc/rados/operations/monitoring.rst
@@ -19,7 +19,7 @@ with no arguments.  For example::
 	ceph> health
 	ceph> status
 	ceph> quorum_status
-	ceph> mon_status
+	ceph> mon stat
 
 Non-default paths
 -----------------

--- a/doc/rados/troubleshooting/troubleshooting-mon.rst
+++ b/doc/rados/troubleshooting/troubleshooting-mon.rst
@@ -47,12 +47,11 @@ Initial Troubleshooting
 
   If you haven't gone through all the steps so far, please go back and do.
 
-  For those running on Emperor 0.72-rc1 and forward, you will be able to
-  contact each monitor individually asking them for their status, regardless
-  of a quorum being formed. This can be achieved using ``ceph ping mon.ID``,
-  ID being the monitor's identifier. You should perform this for each monitor
-  in the cluster. In section `Understanding mon_status`_ we will explain how
-  to interpret the output of this command.
+  You can contact each monitor individually asking them for their status,
+  regardless of a quorum being formed. This can be achieved using
+  ``ceph tell mon.ID mon_status``, ID being the monitor's identifier. You should
+  perform this for each monitor in the cluster. In section `Understanding
+  mon_status`_ we will explain how to interpret the output of this command.
 
   For the rest of you who don't tread on the bleeding edge, you will need to
   ssh into the server and use the monitor's admin socket. Please jump to
@@ -79,31 +78,32 @@ still persists, it is likely that the monitor was improperly shutdown.
 Regardless, if the monitor is not running, you will not be able to use the
 admin socket, with ``ceph`` likely returning ``Error 111: Connection Refused``.
 
-Accessing the admin socket is as simple as telling the ``ceph`` tool to use
-the ``asok`` file.  In pre-Dumpling Ceph, this can be achieved by::
+Accessing the admin socket is as simple as running ``ceph tell`` on the daemon
+you are interested in. For example::
 
-  ceph --admin-daemon /var/run/ceph/ceph-mon.<id>.asok <command>
+  ceph tell mon.<id> mon_status
 
-while in Dumpling and beyond you can use the alternate (and recommended)
-format::
+Under the hood, this passes the command ``help`` to the running MON daemon
+``<id>`` via its "admin socket", which is a file ending in ``.asok``
+somewhere under ``/var/run/ceph``. Once you know the full path to the file,
+you can even do this yourself::
 
-  ceph daemon mon.<id> <command>
+  ceph --admin-daemon <full_path_to_asok_file> <command>
 
 Using ``help`` as the command to the ``ceph`` tool will show you the
 supported commands available through the admin socket. Please take a look
-at ``config get``, ``config show``, ``mon_status`` and ``quorum_status``,
+at ``config get``, ``config show``, ``mon stat`` and ``quorum_status``,
 as those can be enlightening when troubleshooting a monitor.
 
 
 Understanding mon_status
 =========================
 
-``mon_status`` can be obtained through the ``ceph`` tool when you have
-a formed quorum, or via the admin socket if you don't. This command will
-output a multitude of information about the monitor, including the same
-output you would get with ``quorum_status``.
+``mon_status`` can always be obtained via the admin socket. This command will
+output a multitude of information about the monitor, including the same output
+you would get with ``quorum_status``.
 
-Take the following example of ``mon_status``::
+Take the following example output of ``ceph tell mon.c mon_status``::
 
   
   { "name": "c",


### PR DESCRIPTION
In octopus, we no longer have `ceph mon_status`, but we do have
`ceph tell mon.<id> mon_status`, so reflect this in the docs.

Signed-off-by: Nathan Cutler <ncutler@suse.com>