### PR TITLE
ceph_test_cls_hello: set RETURNVEC on the expected EINVAL request

### DIFF
--- a/src/test/cls_hello/test_cls_hello.cc
+++ b/src/test/cls_hello/test_cls_hello.cc
@@ -123,12 +123,27 @@ TEST(ClsHello, WriteReturnData) {
   ASSERT_EQ(0, ioctx.exec("myobject", "hello", "write_return_data", in, out));
   ASSERT_EQ(std::string(), std::string(out.c_str(), out.length()));
 
-  // this will return return an error due to unexpected input
+  // this will return an error due to unexpected input.
+  // note that we set the RETURNVEC flag here so that we *reliably* get the
+  // "too much input data!" return data string.  do it lots of times so we are
+  // more likely to resend a request and hit the dup op handling path.
   char buf[4096];
   memset(buf, 1, sizeof(buf));
-  in.append(buf, sizeof(buf));
-  ASSERT_EQ(-EINVAL, ioctx.exec("myobject2", "hello", "write_return_data", in, out));
-  ASSERT_EQ(std::string("too much input data!"), std::string(out.c_str(), out.length()));
+  for (unsigned i=0; i<1000; ++i) {
+    std::cout << i << std::endl;
+    in.clear();
+    in.append(buf, sizeof(buf));
+    int rval;
+    ObjectWriteOperation o;
+    o.exec("hello", "write_return_data", in, &out, &rval);
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &o,
+				   librados::OPERATION_RETURNVEC));
+    completion->wait_for_complete();
+    ASSERT_EQ(-EINVAL, completion->get_return_value());
+    ASSERT_EQ(-EINVAL, rval);
+    ASSERT_EQ(std::string("too much input data!"), std::string(out.c_str(), out.length()));
+  }
   ASSERT_EQ(-ENOENT, ioctx.getxattr("myobject2", "foo", out));
 
   // this *will* return data due to the RETURNVEC flag


### PR DESCRIPTION
We are sending a request that returns an error *and* a data payload.  In order
to reliably get the payload, we need to set the RETURNVEC flag so that it is
recorded in the pg log.  Otherwise, we might get unlucky and resend the request
and end up in the dup handler and get the error code but no payload.

Fixes: https://tracker.ceph.com/issues/44385
Signed-off-by: Sage Weil <sage@redhat.com>