### PR TITLE
qa/tasks: py3 compat (tasks exercised by rados suites)

### DIFF
--- a/qa/tasks/admin_socket.py
+++ b/qa/tasks/admin_socket.py
@@ -1,13 +1,13 @@
 """
 Admin Socket task -- used in rados, powercycle, and smoke testing
 """
-from cStringIO import StringIO
 
 import json
 import logging
 import os
 import time
 
+from teuthology.exceptions import CommandFailedError
 from teuthology.orchestra import run
 from teuthology import misc as teuthology
 from teuthology.parallel import parallel
@@ -84,31 +84,26 @@ def _socket_command(ctx, remote, socket_path, command, args):
 
     :returns: output of command in json format
     """
-    json_fp = StringIO()
     testdir = teuthology.get_testdir(ctx)
     max_tries = 120
     while True:
-        proc = remote.run(
-            args=[
+        try:
+            out = remote.sh([
                 'sudo',
                 'adjust-ulimits',
                 'ceph-coverage',
                 '{tdir}/archive/coverage'.format(tdir=testdir),
                 'ceph',
                 '--admin-daemon', socket_path,
-                ] + command.split(' ') + args,
-            stdout=json_fp,
-            check_status=False,
-            )
-        if proc.exitstatus == 0:
-            break
-        assert max_tries > 0
-        max_tries -= 1
-        log.info('ceph cli returned an error, command not registered yet?')
-        log.info('sleeping and retrying ...')
-        time.sleep(1)
-    out = json_fp.getvalue()
-    json_fp.close()
+                ] + command.split(' ') + args)
+        except CommandFailedError:
+            assert max_tries > 0
+            max_tries -= 1
+            log.info('ceph cli returned an error, command not registered yet?')
+            log.info('sleeping and retrying ...')
+            time.sleep(1)
+            continue
+        break
     log.debug('admin socket command %s returned %s', command, out)
     return json.loads(out)
 

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -605,7 +605,7 @@ def cluster(ctx, config):
             log.info('fs option selected, checking for scratch devs')
             log.info('found devs: %s' % (str(devs),))
             devs_id_map = teuthology.get_wwn_id_map(remote, devs)
-            iddevs = devs_id_map.values()
+            iddevs = list(devs_id_map.values())
             roles_to_devs = assign_devs(
                 teuthology.cluster_roles_of_type(roles_for_host, 'osd', cluster_name), iddevs
             )

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -19,14 +19,14 @@ import six
 import socket
 
 from paramiko import SSHException
-from ceph_manager import CephManager, write_conf
+from tasks.ceph_manager import CephManager, write_conf
 from tarfile import ReadError
 from tasks.cephfs.filesystem import Filesystem
 from teuthology import misc as teuthology
 from teuthology import contextutil
 from teuthology import exceptions
 from teuthology.orchestra import run
-import ceph_client as cclient
+import tasks.ceph_client as cclient
 from teuthology.orchestra.daemon import DaemonGroup
 from tasks.daemonwatchdog import DaemonWatchdog
 

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -3,7 +3,7 @@ Ceph cluster task.
 
 Handle the setup, starting, and clean-up of a Ceph cluster.
 """
-from cStringIO import StringIO
+from io import BytesIO
 
 import argparse
 import configobj
@@ -15,6 +15,7 @@ import json
 import time
 import gevent
 import re
+import six
 import socket
 
 from paramiko import SSHException
@@ -189,24 +190,26 @@ def ceph_log(ctx, config):
 
     def write_rotate_conf(ctx, daemons):
         testdir = teuthology.get_testdir(ctx)
+        remote_logrotate_conf = '%s/logrotate.ceph-test.conf' % testdir
         rotate_conf_path = os.path.join(os.path.dirname(__file__), 'logrotate.conf')
         with open(rotate_conf_path, 'rb') as f:
             conf = ""
             for daemon, size in daemons.items():
-                log.info('writing logrotate stanza for {daemon}'.format(daemon=daemon))
-                conf += f.read().format(daemon_type=daemon, max_size=size)
+                log.info('writing logrotate stanza for {}'.format(daemon))
+                conf += six.ensure_str(f.read()).format(daemon_type=daemon,
+                                                   max_size=size)
                 f.seek(0, 0)
 
             for remote in ctx.cluster.remotes.keys():
                 teuthology.write_file(remote=remote,
-                                      path='{tdir}/logrotate.ceph-test.conf'.format(tdir=testdir),
-                                      data=StringIO(conf)
+                                      path=remote_logrotate_conf,
+                                      data=BytesIO(conf.encode())
                                       )
                 remote.run(
                     args=[
                         'sudo',
                         'mv',
-                        '{tdir}/logrotate.ceph-test.conf'.format(tdir=testdir),
+                        remote_logrotate_conf,
                         '/etc/logrotate.d/ceph-test.conf',
                         run.Raw('&&'),
                         'sudo',
@@ -311,27 +314,20 @@ def valgrind_post(ctx, config):
         for remote in ctx.cluster.remotes.keys():
             # look at valgrind logs for each node
             proc = remote.run(
-                args=[
-                    'sudo',
-                    'zgrep',
-                    '<kind>',
-                    run.Raw('/var/log/ceph/valgrind/*'),
-                    '/dev/null',  # include a second file so that we always get a filename prefix on the output
-                    run.Raw('|'),
-                    'sort',
-                    run.Raw('|'),
-                    'uniq',
-                ],
+                args='sudo zgrep <kind> /var/log/ceph/valgrind/* '
+                     # include a second file so that we always get
+                     # a filename prefix on the output
+                     '/dev/null | sort | uniq',
                 wait=False,
                 check_status=False,
-                stdout=StringIO(),
+                stdout=BytesIO(),
             )
             lookup_procs.append((proc, remote))
 
         valgrind_exception = None
         for (proc, remote) in lookup_procs:
             proc.wait()
-            out = proc.stdout.getvalue()
+            out = six.ensure_str(proc.stdout.getvalue())
             for line in out.split('\n'):
                 if line == '':
                     continue
@@ -537,11 +533,7 @@ def create_simple_monmap(ctx, remote, conf, mons,
         path
     ])
 
-    r = remote.run(
-        args=args,
-        stdout=StringIO()
-    )
-    monmap_output = r.stdout.getvalue()
+    monmap_output = remote.sh(args)
     fsid = re.search("generated fsid (.+)$",
                      monmap_output, re.MULTILINE).group(1)
     return fsid
@@ -907,13 +899,7 @@ def cluster(ctx, config):
                 mkfs = ['mkfs.%s' % fs] + mkfs_options
                 log.info('%s on %s on %s' % (mkfs, dev, remote))
                 if package is not None:
-                    remote.run(
-                        args=[
-                            'sudo',
-                            'apt-get', 'install', '-y', package
-                        ],
-                        stdout=StringIO(),
-                    )
+                    remote.sh('sudo apt-get install -y %s' % package)
 
                 try:
                     remote.run(args=['yes', run.Raw('|')] + ['sudo'] + mkfs + [dev])
@@ -1001,7 +987,7 @@ def cluster(ctx, config):
                          'probably installing hammer: %s', e)
 
     log.info('Reading keys from all nodes...')
-    keys_fp = StringIO()
+    keys_fp = BytesIO()
     keys = []
     for remote, roles_for_host in ctx.cluster.remotes.items():
         for type_ in ['mgr',  'mds', 'osd']:
@@ -1038,7 +1024,7 @@ def cluster(ctx, config):
         ],
         stdin=run.PIPE,
         wait=False,
-        stdout=StringIO(),
+        stdout=BytesIO(),
     )
     keys_fp.seek(0)
     teuthology.feed_many_stdins_and_close(keys_fp, writes)
@@ -1140,14 +1126,8 @@ def cluster(ctx, config):
             args.extend([
                 run.Raw('|'), 'head', '-n', '1',
             ])
-            r = mon0_remote.run(
-                stdout=StringIO(),
-                args=args,
-            )
-            stdout = r.stdout.getvalue()
-            if stdout != '':
-                return stdout
-            return None
+            stdout = mon0_remote.sh(args)
+            return stdout or None
 
         if first_in_ceph_log('\[ERR\]|\[WRN\]|\[SEC\]',
                              config['log_whitelist']) is not None:
@@ -1364,11 +1344,11 @@ def run_daemon(ctx, config, type_):
             if type_ == 'osd':
                 datadir='/var/lib/ceph/osd/{cluster}-{id}'.format(
                     cluster=cluster_name, id=id_)
-                osd_uuid = teuthology.get_file(
+                osd_uuid = six.ensure_str(teuthology.get_file(
                     remote=remote,
                     path=datadir + '/fsid',
                     sudo=True,
-                ).strip()
+                )).strip()
                 osd_uuids[id_] = osd_uuid
     for osd_id in range(len(osd_uuids)):
         id_ = str(osd_id)
@@ -1513,16 +1493,9 @@ def wait_for_mon_quorum(ctx, config):
     with contextutil.safe_while(sleep=10, tries=60,
                                 action='wait for monitor quorum') as proceed:
         while proceed():
-            r = remote.run(
-                args=[
-                    'sudo',
-                    'ceph',
-                    'quorum_status',
-                ],
-                stdout=StringIO(),
-                logger=log.getChild('quorum_status'),
-            )
-            j = json.loads(r.stdout.getvalue())
+            quorum_status = remote.sh('sudo ceph quorum_status',
+                                      logger=log.getChild('quorum_status'))
+            j = json.loads(quorum_status)
             q = j.get('quorum_names', [])
             log.debug('Quorum: %s', q)
             if sorted(q) == sorted(mons):

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -17,8 +17,8 @@ import os
 from io import BytesIO
 from teuthology import misc as teuthology
 from tasks.scrub import Scrubber
-from util.rados import cmd_erasure_code_profile
-from util import get_remote
+from tasks.util.rados import cmd_erasure_code_profile
+from tasks.util import get_remote
 from teuthology.contextutil import safe_while
 from teuthology.orchestra.remote import Remote
 from teuthology.orchestra import run

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -302,7 +302,7 @@ class OSDThrasher(Thrasher):
                                         "exp list-pgs failure with status {ret}".
                                         format(ret=proc.exitstatus))
 
-            pgs = proc.stdout.getvalue().split('\n')[:-1]
+            pgs = six.ensure_str(proc.stdout.getvalue()).split('\n')[:-1]
             if len(pgs) == 0:
                 self.log("No PGs found for osd.{osd}".format(osd=exp_osd))
                 return

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1,7 +1,6 @@
 """
 ceph manager -- Thrasher and CephManager objects
 """
-from cStringIO import StringIO
 from functools import wraps
 import contextlib
 import random
@@ -14,6 +13,8 @@ import logging
 import threading
 import traceback
 import os
+
+from io import BytesIO
 from teuthology import misc as teuthology
 from tasks.scrub import Scrubber
 from util.rados import cmd_erasure_code_profile
@@ -57,7 +58,7 @@ def shell(ctx, cluster_name, remote, args, name=None, **kwargs):
     )
 
 def write_conf(ctx, conf_path=DEFAULT_CONF_PATH, cluster='ceph'):
-    conf_fp = StringIO()
+    conf_fp = BytesIO()
     ctx.ceph[cluster].conf.write(conf_fp)
     conf_fp.seek(0)
     writes = ctx.cluster.run(
@@ -212,8 +213,8 @@ class OSDThrasher(Thrasher):
         allremotes = list(set(allremotes))
         for remote in allremotes:
             proc = remote.run(args=['type', cmd], wait=True,
-                              check_status=False, stdout=StringIO(),
-                              stderr=StringIO())
+                              check_status=False, stdout=BytesIO(),
+                              stderr=BytesIO())
             if proc.exitstatus != 0:
                 return False;
         return True;
@@ -225,13 +226,13 @@ class OSDThrasher(Thrasher):
                 args=['ceph-objectstore-tool'] + cmd,
                 name=osd,
                 wait=True, check_status=False,
-                stdout=StringIO(),
-                stderr=StringIO())
+                stdout=BytesIO(),
+                stderr=BytesIO())
         else:
             return remote.run(
                 args=['sudo', 'adjust-ulimits', 'ceph-objectstore-tool'] + cmd,
-                wait=True, check_status=False, stdout=StringIO(),
-                stderr=StringIO())
+                wait=True, check_status=False, stdout=BytesIO(),
+                stderr=BytesIO())
 
     def kill_osd(self, osd=None, mark_down=False, mark_out=False):
         """
@@ -275,8 +276,8 @@ class OSDThrasher(Thrasher):
                 with safe_while(sleep=15, tries=40, action="type ceph-objectstore-tool") as proceed:
                     while proceed():
                         proc = exp_remote.run(args=['type', 'ceph-objectstore-tool'],
-                                              wait=True, check_status=False, stdout=StringIO(),
-                                              stderr=StringIO())
+                                              wait=True, check_status=False, stdout=BytesIO(),
+                                              stderr=BytesIO())
                         if proc.exitstatus == 0:
                             break
                         log.debug("ceph-objectstore-tool binary not present, trying again")
@@ -366,7 +367,7 @@ class OSDThrasher(Thrasher):
                     raise Exception("ceph-objectstore-tool: "
                                     "imp list-pgs failure with status {ret}".
                                     format(ret=proc.exitstatus))
-                pgs = proc.stdout.getvalue().split('\n')[:-1]
+                pgs = six.ensure_str(proc.stdout.getvalue()).split('\n')[:-1]
                 if pg not in pgs:
                     self.log("Moving pg {pg} from osd.{fosd} to osd.{tosd}".
                              format(pg=pg, fosd=exp_osd, tosd=imp_osd))
@@ -441,8 +442,7 @@ class OSDThrasher(Thrasher):
                                '--journal-path', JPATH.format(id=imp_osd),
                            ])
                            + " --op apply-layout-settings --pool " + pool).format(id=osd)
-                    proc = imp_remote.run(args=cmd, wait=True, check_status=False, stderr=StringIO())
-                    output = proc.stderr.getvalue()
+                    output = imp_remote.sh(cmd, wait=True, check_status=False)
                     if 'Couldn\'t find pool' in output:
                         continue
                     if proc.exitstatus:
@@ -1266,7 +1266,7 @@ class ObjectStoreTool:
 
     def run(self, options, args, stdin=None, stdout=None):
         if stdout is None:
-            stdout = StringIO()
+            stdout = BytesIO()
         self.manager.kill_osd(self.osd)
         cmd = self.build_cmd(options, args, stdin)
         self.manager.log(cmd)
@@ -1274,11 +1274,12 @@ class ObjectStoreTool:
             proc = self.remote.run(args=['bash', '-e', '-x', '-c', cmd],
                                    check_status=False,
                                    stdout=stdout,
-                                   stderr=StringIO())
+                                   stderr=BytesIO())
             proc.wait()
             if proc.exitstatus != 0:
                 self.manager.log("failed with " + str(proc.exitstatus))
-                error = proc.stdout.getvalue() + " " + proc.stderr.getvalue()
+                error = six.ensure_str(proc.stdout.getvalue())  + " " + \
+                        six.ensure_str(proc.stderr.getvalue())
                 raise Exception(error)
         finally:
             if self.do_revive:
@@ -1337,7 +1338,7 @@ class CephManager:
         if self.cephadm:
             proc = shell(self.ctx, self.cluster, self.controller,
                          args=['ceph'] + list(args),
-                         stdout=StringIO())
+                         stdout=BytesIO())
         else:
             testdir = teuthology.get_testdir(self.ctx)
             ceph_args = [
@@ -1355,9 +1356,9 @@ class CephManager:
             ceph_args.extend(args)
             proc = self.controller.run(
                 args=ceph_args,
-                stdout=StringIO(),
+                stdout=BytesIO(),
             )
-        return proc.stdout.getvalue()
+        return six.ensure_str(proc.stdout.getvalue())
 
     def raw_cluster_cmd_result(self, *args, **kwargs):
         """
@@ -1388,7 +1389,7 @@ class CephManager:
 
     def run_ceph_w(self, watch_channel=None):
         """
-        Execute "ceph -w" in the background with stdout connected to a StringIO,
+        Execute "ceph -w" in the background with stdout connected to a BytesIO,
         and return the RemoteProcess.
 
         :param watch_channel: Specifies the channel to be watched. This can be
@@ -1405,7 +1406,7 @@ class CephManager:
         if watch_channel is not None:
             args.append("--watch-channel")
             args.append(watch_channel)
-        return self.controller.run(args=args, wait=False, stdout=StringIO(), stdin=run.PIPE)
+        return self.controller.run(args=args, wait=False, stdout=BytesIO(), stdin=run.PIPE)
 
     def get_mon_socks(self):
         """
@@ -1588,7 +1589,7 @@ class CephManager:
 
     def osd_admin_socket(self, osd_id, command, check_status=True, timeout=0, stdout=None):
         if stdout is None:
-            stdout = StringIO()
+            stdout = BytesIO()
         return self.admin_socket('osd', osd_id, command, check_status, timeout, stdout)
 
     def find_remote(self, service_type, service_id):
@@ -1612,7 +1613,7 @@ class CephManager:
                         to the admin socket
         """
         if stdout is None:
-            stdout = StringIO()
+            stdout = BytesIO()
 
         remote = self.find_remote(service_type, service_id)
 
@@ -1741,7 +1742,7 @@ class CephManager:
         five seconds and try again.
         """
         if stdout is None:
-            stdout = StringIO()
+            stdout = BytesIO()
         tries = 0
         while True:
             proc = self.admin_socket(service_type, service_id,

--- a/qa/tasks/ceph_objectstore_tool.py
+++ b/qa/tasks/ceph_objectstore_tool.py
@@ -1,18 +1,23 @@
 """
 ceph_objectstore_tool - Simple test of ceph-objectstore-tool utility
 """
-from cStringIO import StringIO
+from io import BytesIO
+
 import contextlib
 import logging
 import ceph_manager
 from teuthology import misc as teuthology
 import time
 import os
+import six
 import string
 from teuthology.orchestra import run
 import sys
 import tempfile
 import json
+
+from teuthology.exceptions import CommandFailedError
+
 from util.rados import (rados, create_replicated_pool, create_ec_pool)
 # from util.rados import (rados, create_ec_pool,
 #                               create_replicated_pool,
@@ -289,14 +294,9 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
             log.info("process osd.{id} on {remote}".
                      format(id=osdid, remote=remote))
             cmd = (prefix + "--op list").format(id=osdid)
-            proc = remote.run(args=cmd.split(), check_status=False,
-                              stdout=StringIO())
-            if proc.exitstatus != 0:
-                log.error("Bad exit status {ret} from --op list request".
-                          format(ret=proc.exitstatus))
-                ERRORS += 1
-            else:
-                for pgline in proc.stdout.getvalue().splitlines():
+            try:
+                lines = remote.sh(cmd, check_status=False).splitlines()
+                for pgline in lines:
                     if not pgline:
                         continue
                     (pg, obj) = json.loads(pgline)
@@ -306,6 +306,10 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
                         objsinpg.setdefault(pg, []).append(name)
                         db[name].setdefault("pg2json",
                                             {})[pg] = json.dumps(obj)
+            except CommandFailedError as e:
+                log.error("Bad exit status {ret} from --op list request".
+                          format(ret=e.exitstatus))
+                ERRORS += 1
 
     log.info(db)
     log.info(pgswithobjects)
@@ -376,20 +380,18 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
                                    format(id=osdid, pg=pg).split())
                             cmd.append(run.Raw("'{json}'".format(json=JSON)))
                             cmd += "get-bytes -".split()
-                            proc = remote.run(args=cmd, check_status=False,
-                                              stdout=StringIO())
-                            proc.wait()
-                            if proc.exitstatus != 0:
-                                log.error("get-bytes after "
-                                          "set-bytes ret={ret}".
-                                          format(ret=proc.exitstatus))
-                                ERRORS += 1
-                            else:
-                                if data != proc.stdout.getvalue():
+                            try:
+                                output = remote.sh(cmd, wait=True)
+                                if data != output:
                                     log.error("Data inconsistent after "
                                               "set-bytes, got:")
-                                    log.error(proc.stdout.getvalue())
+                                    log.error(output)
                                     ERRORS += 1
+                            except CommandFailedError as e:
+                                log.error("get-bytes after "
+                                          "set-bytes ret={ret}".
+                                          format(ret=e.exitstatus))
+                                ERRORS += 1
 
                             cmd = ((prefix + "--pgid {pg}").
                                    format(id=osdid, pg=pg).split())
@@ -425,15 +427,13 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
                                format(id=osdid, pg=pg).split())
                         cmd.append(run.Raw("'{json}'".format(json=JSON)))
                         cmd += ["list-attrs"]
-                        proc = remote.run(args=cmd, check_status=False,
-                                          stdout=StringIO(), stderr=StringIO())
-                        proc.wait()
-                        if proc.exitstatus != 0:
+                        try:
+                            keys = remote.sh(cmd, wait=True, stderr=BytesIO()).split()
+                        except CommandFailedError as e:
                             log.error("Bad exit status {ret}".
-                                      format(ret=proc.exitstatus))
+                                      format(ret=e.exitstatus))
                             ERRORS += 1
                             continue
-                        keys = proc.stdout.getvalue().split()
                         values = dict(db[basename]["xattr"])
 
                         for key in keys:
@@ -453,15 +453,13 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
                             cmd.append(run.Raw("'{json}'".format(json=JSON)))
                             cmd += ("get-attr {key}".
                                     format(key="_" + key).split())
-                            proc = remote.run(args=cmd, check_status=False,
-                                              stdout=StringIO())
-                            proc.wait()
-                            if proc.exitstatus != 0:
+                            try:
+                                val = remote.sh(cmd, wait=True)
+                            except CommandFailedError as e:
                                 log.error("get-attr failed with {ret}".
-                                          format(ret=proc.exitstatus))
+                                          format(ret=e.exitstatus))
                                 ERRORS += 1
                                 continue
-                            val = proc.stdout.getvalue()
                             if exp != val:
                                 log.error("For key {key} got value {got} "
                                           "instead of {expected}".
@@ -483,14 +481,16 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
                             proc = remote.run(args=['bash', '-e', '-x',
                                                     '-c', cmd],
                                               check_status=False,
-                                              stdout=StringIO(),
-                                              stderr=StringIO())
+                                              stdout=BytesIO(),
+                                              stderr=BytesIO())
                             proc.wait()
                             if proc.exitstatus != 0:
                                 log.error("failed with " +
                                           str(proc.exitstatus))
-                                log.error(proc.stdout.getvalue() + " " +
-                                          proc.stderr.getvalue())
+                                log.error(" ".join([
+                                    six.ensure_str(proc.stdout.getvalue()),
+                                    six.ensure_str(proc.stderr.getvalue()),
+                                    ]))
                                 ERRORS += 1
 
                         if len(values) != 0:
@@ -509,15 +509,13 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
             for pg in pgs[osdid]:
                 cmd = ((prefix + "--op info --pgid {pg}").
                        format(id=osdid, pg=pg).split())
-                proc = remote.run(args=cmd, check_status=False,
-                                  stdout=StringIO())
-                proc.wait()
-                if proc.exitstatus != 0:
+                try:
+                    info = remote.sh(cmd, wait=True)
+                except CommandFailedError as e:
                     log.error("Failure of --op info command with {ret}".
-                              format(proc.exitstatus))
+                              format(e.exitstatus))
                     ERRORS += 1
                     continue
-                info = proc.stdout.getvalue()
                 if not str(pg) in info:
                     log.error("Bad data from info: {info}".format(info=info))
                     ERRORS += 1
@@ -534,17 +532,16 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
             for pg in pgs[osdid]:
                 cmd = ((prefix + "--op log --pgid {pg}").
                        format(id=osdid, pg=pg).split())
-                proc = remote.run(args=cmd, check_status=False,
-                                  stdout=StringIO())
-                proc.wait()
-                if proc.exitstatus != 0:
+                try:
+                    output = remote.sh(cmd, wait=True)
+                except CommandFailedError as e:
                     log.error("Getting log failed for pg {pg} "
                               "from osd.{id} with {ret}".
-                              format(pg=pg, id=osdid, ret=proc.exitstatus))
+                              format(pg=pg, id=osdid, ret=e.exitstatus))
                     ERRORS += 1
                     continue
                 HASOBJ = pg in pgswithobjects
-                MODOBJ = "modify" in proc.stdout.getvalue()
+                MODOBJ = "modify" in output
                 if HASOBJ != MODOBJ:
                     log.error("Bad log for pg {pg} from osd.{id}".
                               format(pg=pg, id=osdid))
@@ -569,13 +566,12 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
 
                 cmd = ((prefix + "--op export --pgid {pg} --file {file}").
                        format(id=osdid, pg=pg, file=fpath))
-                proc = remote.run(args=cmd, check_status=False,
-                                  stdout=StringIO())
-                proc.wait()
-                if proc.exitstatus != 0:
+                try:
+                    remote.sh(cmd, wait=True)
+                except CommandFailedError as e:
                     log.error("Exporting failed for pg {pg} "
                               "on osd.{id} with {ret}".
-                              format(pg=pg, id=osdid, ret=proc.exitstatus))
+                              format(pg=pg, id=osdid, ret=e.exitstatus))
                     EXP_ERRORS += 1
 
     ERRORS += EXP_ERRORS
@@ -593,13 +589,12 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
             for pg in pgs[osdid]:
                 cmd = ((prefix + "--force --op remove --pgid {pg}").
                        format(pg=pg, id=osdid))
-                proc = remote.run(args=cmd, check_status=False,
-                                  stdout=StringIO())
-                proc.wait()
-                if proc.exitstatus != 0:
+                try:
+                    remote.sh(cmd, wait=True)
+                except CommandFailedError as e:
                     log.error("Removing failed for pg {pg} "
                               "on osd.{id} with {ret}".
-                              format(pg=pg, id=osdid, ret=proc.exitstatus))
+                              format(pg=pg, id=osdid, ret=e.exitstatus))
                     RM_ERRORS += 1
 
     ERRORS += RM_ERRORS
@@ -622,12 +617,11 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
 
                     cmd = ((prefix + "--op import --file {file}").
                            format(id=osdid, file=fpath))
-                    proc = remote.run(args=cmd, check_status=False,
-                                      stdout=StringIO())
-                    proc.wait()
-                    if proc.exitstatus != 0:
+                    try:
+                        remote.sh(cmd, wait=True)
+                    except CommandFailedError as e:
                         log.error("Import failed from {file} with {ret}".
-                                  format(file=fpath, ret=proc.exitstatus))
+                                  format(file=fpath, ret=e.exitstatus))
                         IMP_ERRORS += 1
     else:
         log.warning("SKIPPING IMPORT TESTS DUE TO PREVIOUS FAILURES")

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -1,7 +1,7 @@
 """
 Ceph cluster task, deployed via cephadm orchestrator
 """
-from cStringIO import StringIO
+from io import BytesIO
 
 import argparse
 import configobj
@@ -189,7 +189,7 @@ def ceph_log(ctx, config):
                 run.Raw('|'), 'head', '-n', '1',
             ])
             r = ctx.ceph[cluster_name].bootstrap_remote.run(
-                stdout=StringIO(),
+                stdout=BytesIO(),
                 args=args,
             )
             stdout = r.stdout.getvalue()
@@ -313,7 +313,7 @@ def ceph_bootstrap(ctx, config):
     try:
         # write seed config
         log.info('Writing seed config...')
-        conf_fp = StringIO()
+        conf_fp = BytesIO()
         seed_config = build_initial_config(ctx, config)
         seed_config.write(conf_fp)
         teuthology.write_file(
@@ -423,7 +423,7 @@ def ceph_bootstrap(ctx, config):
             ])
             r = _shell(ctx, cluster_name, remote,
                        ['ceph', 'orch', 'host', 'ls', '--format=json'],
-                       stdout=StringIO())
+                       stdout=BytesIO())
             hosts = [node['hostname'] for node in json.loads(r.stdout.getvalue())]
             assert remote.shortname in hosts
 
@@ -490,7 +490,7 @@ def ceph_mons(ctx, config):
                             args=[
                                 'ceph', 'mon', 'dump', '-f', 'json',
                             ],
-                            stdout=StringIO(),
+                            stdout=BytesIO(),
                         )
                         j = json.loads(r.stdout.getvalue())
                         if len(j['mons']) == num_mons:
@@ -748,7 +748,7 @@ def ceph_clients(ctx, config):
                     'mds', 'allow *',
                     'mgr', 'allow *',
                 ],
-                stdout=StringIO(),
+                stdout=BytesIO(),
             )
             keyring = r.stdout.getvalue()
             teuthology.sudo_write_file(

--- a/qa/tasks/daemonwatchdog.py
+++ b/qa/tasks/daemonwatchdog.py
@@ -99,7 +99,7 @@ class DaemonWatchdog(Greenlet):
                     bark = True
 
             # If a daemon is no longer failed, remove it from tracking:
-            for name in daemon_failure_time.keys():
+            for name in list(daemon_failure_time.keys()):
                 if name not in [d.role + '.' + d.id_ for d in daemon_failures]:
                     self.log("daemon {name} has been restored".format(name=name))
                     del daemon_failure_time[name]

--- a/qa/tasks/manypools.py
+++ b/qa/tasks/manypools.py
@@ -68,6 +68,6 @@ def task(ctx, config):
             log.info('waiting for pool and object creates')
             poolprocs[remote] = proc
 
-        run.wait(poolprocs.itervalues())
+        run.wait(poolprocs.values())
 
     log.info('created all {n} pools and wrote 16 objects to each'.format(n=poolnum))

--- a/qa/tasks/mgr/test_crash.py
+++ b/qa/tasks/mgr/test_crash.py
@@ -46,13 +46,13 @@ class TestCrash(MgrTestCase):
         self.oldest_crashid = crash_id
 
     def tearDown(self):
-        for crash in self.crashes.itervalues():
+        for crash in self.crashes.values():
             self.mgr_cluster.mon_manager.raw_cluster_cmd_result(
                 'crash', 'rm', crash['crash_id']
             )
 
     def test_info(self):
-        for crash in self.crashes.itervalues():
+        for crash in self.crashes.values():
             log.warning('test_info: crash %s' % crash)
             retstr = self.mgr_cluster.mon_manager.raw_cluster_cmd(
                 'crash', 'ls'
@@ -70,7 +70,7 @@ class TestCrash(MgrTestCase):
         retstr = self.mgr_cluster.mon_manager.raw_cluster_cmd(
             'crash', 'ls',
         )
-        for crash in self.crashes.itervalues():
+        for crash in self.crashes.values():
             self.assertIn(crash['crash_id'], retstr)
 
     def test_rm(self):

--- a/qa/tasks/mon_thrash.py
+++ b/qa/tasks/mon_thrash.py
@@ -3,13 +3,13 @@ Monitor thrash
 """
 import logging
 import contextlib
-import ceph_manager
 import random
 import time
 import gevent
 import json
 import math
 from teuthology import misc as teuthology
+from tasks import ceph_manager
 from tasks.cephfs.filesystem import MDSCluster
 from tasks.thrasher import Thrasher
 

--- a/qa/tasks/netem.py
+++ b/qa/tasks/netem.py
@@ -6,7 +6,6 @@ Reference:https://wiki.linuxfoundation.org/networking/netem.
 
 import logging
 import contextlib
-from cStringIO import StringIO
 from paramiko import SSHException
 import socket
 import time
@@ -59,8 +58,8 @@ def static_delay(remote, host, interface, delay):
 
     ip = socket.gethostbyname(host.hostname)
 
-    r = remote.run(args=show_tc(interface), stdout=StringIO())
-    if r.stdout.getvalue().strip().find('refcnt') == -1:
+    tc = remote.sh(show_tc(interface))
+    if tc.strip().find('refcnt') == -1:
         # call set_priority() func to create priority queue
         # if not already created(indicated by -1)
         log.info('Create priority queue')
@@ -94,8 +93,8 @@ def variable_delay(remote, host, interface, delay_range=[]):
     delay1 = delay_range[0]
     delay2 = delay_range[1]
 
-    r = remote.run(args=show_tc(interface), stdout=StringIO())
-    if r.stdout.getvalue().strip().find('refcnt') == -1:
+    tc = remote.sh(show_tc(interface))
+    if tc.strip().find('refcnt') == -1:
         # call set_priority() func to create priority queue
         # if not already created(indicated by -1)
         remote.run(args=set_priority(interface))
@@ -121,8 +120,8 @@ def delete_dev(remote, interface):
     """ Delete the qdisc if present"""
 
     log.info('Delete tc')
-    r = remote.run(args=show_tc(interface), stdout=StringIO())
-    if r.stdout.getvalue().strip().find('refcnt') != -1:
+    tc = remote.sh(show_tc(interface))
+    if tc.strip().find('refcnt') != -1:
         remote.run(args=del_tc(interface))
 
 
@@ -144,8 +143,8 @@ class Toggle:
 
         _, _, set_ip = cmd_prefix(self.interface)
 
-        r = self.remote.run(args=show_tc(self.interface), stdout=StringIO())
-        if r.stdout.getvalue().strip().find('refcnt') == -1:
+        tc = self.remote.sh(show_tc(self.interface))
+        if tc.strip().find('refcnt') == -1:
             self.remote.run(args=set_priority(self.interface))
             # packet drop to specific ip
             log.info('Drop all packets to %s' % self.host)

--- a/qa/tasks/omapbench.py
+++ b/qa/tasks/omapbench.py
@@ -82,4 +82,4 @@ def task(ctx, config):
         yield
     finally:
         log.info('joining omapbench')
-        run.wait(omapbench.itervalues())
+        run.wait(omapbench.values())

--- a/qa/tasks/osd_failsafe_enospc.py
+++ b/qa/tasks/osd_failsafe_enospc.py
@@ -1,8 +1,9 @@
 """
 Handle osdfailsafe configuration settings (nearfull ratio and full ratio)
 """
-from cStringIO import StringIO
+from io import BytesIO
 import logging
+import six
 import time
 
 from teuthology.orchestra import run
@@ -64,7 +65,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=StringIO(),
+             stdout=BytesIO(),
              wait=False,
         )
 
@@ -74,7 +75,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = proc.stdout.getvalue().split('\n')
+    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
 
     count = len(filter(lambda line: '[WRN] OSD near full' in line, lines))
     assert count == 2, 'Incorrect number of warning messages expected 2 got %d' % count
@@ -92,7 +93,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=StringIO(),
+             stdout=BytesIO(),
              wait=False,
         )
 
@@ -102,7 +103,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = proc.stdout.getvalue().split('\n')
+    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
 
     count = len(filter(lambda line: '[ERR] OSD full dropping all updates' in line, lines))
     assert count == 2, 'Incorrect number of error messages expected 2 got %d' % count
@@ -134,7 +135,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=StringIO(),
+             stdout=BytesIO(),
              wait=False,
         )
 
@@ -142,7 +143,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = proc.stdout.getvalue().split('\n')
+    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
 
     count = len(filter(lambda line: '[WRN] OSD near full' in line, lines))
     assert count == 1 or count == 2, 'Incorrect number of warning messages expected 1 or 2 got %d' % count
@@ -163,7 +164,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=StringIO(),
+             stdout=BytesIO(),
              wait=False,
         )
 
@@ -173,7 +174,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = proc.stdout.getvalue().split('\n')
+    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
 
     count = len(filter(lambda line: '[WRN] OSD near full' in line, lines))
     assert count == 0, 'Incorrect number of warning messages expected 0 got %d' % count
@@ -194,7 +195,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=StringIO(),
+             stdout=BytesIO(),
              wait=False,
         )
 
@@ -202,7 +203,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = proc.stdout.getvalue().split('\n')
+    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
 
     count = len(filter(lambda line: '[WRN] OSD near full' in line, lines))
     assert count == 0, 'Incorrect number of warning messages expected 0 got %d' % count

--- a/qa/tasks/osd_max_pg_per_osd.py
+++ b/qa/tasks/osd_max_pg_per_osd.py
@@ -6,12 +6,12 @@ log = logging.getLogger(__name__)
 
 
 def pg_num_in_all_states(pgs, *states):
-    return sum(1 for state in pgs.itervalues()
+    return sum(1 for state in pgs.values()
                if all(s in state for s in states))
 
 
 def pg_num_in_any_state(pgs, *states):
-    return sum(1 for state in pgs.itervalues()
+    return sum(1 for state in pgs.values()
                if any(s in state for s in states))
 
 

--- a/qa/tasks/rados.py
+++ b/qa/tasks/rados.py
@@ -263,7 +263,7 @@ def task(ctx, config):
                     wait=False
                     )
                 tests[id_] = proc
-            run.wait(tests.itervalues())
+            run.wait(tests.values())
 
             for pool in created_pools:
                 manager.wait_snap_trimming_complete(pool);

--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -135,7 +135,7 @@ def task(ctx, config):
     finally:
         timeout = config.get('time', 360) * 30 + 300
         log.info('joining radosbench (timing out after %ss)', timeout)
-        run.wait(radosbench.itervalues(), timeout=timeout)
+        run.wait(radosbench.values(), timeout=timeout)
 
         if pool != 'data' and create_pool:
             manager.remove_pool(pool)

--- a/qa/tasks/radosbenchsweep.py
+++ b/qa/tasks/radosbenchsweep.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 import re
 
-from cStringIO import StringIO
+from io import BytesIO
 from itertools import product
 
 from teuthology.orchestra import run
@@ -189,7 +189,7 @@ def run_radosbench(ctx, config, f, num_osds, size, replica, rep):
             ],
             logger=log.getChild('radosbench.{id}'.format(id=id_)),
             stdin=run.PIPE,
-            stdout=StringIO(),
+            stdout=BytesIO(),
             wait=False
         )
 

--- a/qa/tasks/scrub.py
+++ b/qa/tasks/scrub.py
@@ -7,7 +7,7 @@ import logging
 import random
 import time
 
-import ceph_manager
+import tasks.ceph_manager
 from teuthology import misc as teuthology
 
 log = logging.getLogger(__name__)

--- a/qa/tasks/systemd.py
+++ b/qa/tasks/systemd.py
@@ -6,12 +6,15 @@ import logging
 import re
 import time
 
-from cStringIO import StringIO
 from teuthology.orchestra import run
 from teuthology.misc import reconnect, get_first_mon, wait_until_healthy
 
 log = logging.getLogger(__name__)
 
+def _remote_service_status(remote, service):
+    status = remote.sh('sudo systemctl status %s' % service,
+                       check_status=False)
+    return status
 
 @contextlib.contextmanager
 def task(ctx, config):
@@ -26,11 +29,10 @@ def task(ctx, config):
     for remote, roles in ctx.cluster.remotes.items():
         remote.run(args=['sudo', 'ps', '-eaf', run.Raw('|'),
                          'grep', 'ceph'])
-        r = remote.run(args=['sudo', 'systemctl', 'list-units', run.Raw('|'),
-                             'grep', 'ceph'], stdout=StringIO(),
-                       check_status=False)
-        log.info(r.stdout.getvalue())
-        if r.stdout.getvalue().find('failed'):
+        units = remote.sh('sudo systemctl list-units | grep ceph',
+                          check_status=False)
+        log.info(units)
+        if units.find('failed'):
             log.info("Ceph services in failed state")
 
         # test overall service stop and start using ceph.target
@@ -38,29 +40,25 @@ def task(ctx, config):
         # and not actual process testing using 'ps'
         log.info("Stopping all Ceph services")
         remote.run(args=['sudo', 'systemctl', 'stop', 'ceph.target'])
-        r = remote.run(args=['sudo', 'systemctl', 'status', 'ceph.target'],
-                       stdout=StringIO(), check_status=False)
-        log.info(r.stdout.getvalue())
+        status = _remote_service_status(remote, 'ceph.target')
+        log.info(status)
         log.info("Checking process status")
-        r = remote.run(args=['sudo', 'ps', '-eaf', run.Raw('|'),
-                             'grep', 'ceph'], stdout=StringIO())
-        if r.stdout.getvalue().find('Active: inactive'):
+        ps_eaf = remote.sh('sudo ps -eaf | grep ceph')
+        if ps_eaf.find('Active: inactive'):
             log.info("Successfully stopped all ceph services")
         else:
             log.info("Failed to stop ceph services")
 
         log.info("Starting all Ceph services")
         remote.run(args=['sudo', 'systemctl', 'start', 'ceph.target'])
-        r = remote.run(args=['sudo', 'systemctl', 'status', 'ceph.target'],
-                       stdout=StringIO())
-        log.info(r.stdout.getvalue())
-        if r.stdout.getvalue().find('Active: active'):
+        status = _remote_service_status(remote, 'ceph.target')
+        log.info(status)
+        if status.find('Active: active'):
             log.info("Successfully started all Ceph services")
         else:
             log.info("info", "Failed to start Ceph services")
-        r = remote.run(args=['sudo', 'ps', '-eaf', run.Raw('|'),
-                             'grep', 'ceph'], stdout=StringIO())
-        log.info(r.stdout.getvalue())
+        ps_eaf = remote.sh('sudo ps -eaf | grep ceph')
+        log.info(ps_eaf)
         time.sleep(4)
 
         # test individual services start stop
@@ -79,23 +77,20 @@ def task(ctx, config):
             remote.run(args=['sudo', 'systemctl', 'stop',
                              osd_service])
             time.sleep(4)  # immediate check will result in deactivating state
-            r = remote.run(args=['sudo', 'systemctl', 'status', osd_service],
-                           stdout=StringIO(), check_status=False)
-            log.info(r.stdout.getvalue())
-            if r.stdout.getvalue().find('Active: inactive'):
+            status = _remote_service_status(remote, osd_service)
+            log.info(status)
+            if status.find('Active: inactive'):
                 log.info("Successfully stopped single osd ceph service")
             else:
                 log.info("Failed to stop ceph osd services")
-            remote.run(args=['sudo', 'systemctl', 'start',
-                             osd_service])
+            remote.sh(['sudo', 'systemctl', 'start', osd_service])
             time.sleep(4)
         if mon_role_name in roles:
             remote.run(args=['sudo', 'systemctl', 'status', mon_name])
             remote.run(args=['sudo', 'systemctl', 'stop', mon_name])
             time.sleep(4)  # immediate check will result in deactivating state
-            r = remote.run(args=['sudo', 'systemctl', 'status', mon_name],
-                           stdout=StringIO(), check_status=False)
-            if r.stdout.getvalue().find('Active: inactive'):
+            status = _remote_service_status(remote, mon_name)
+            if status.find('Active: inactive'):
                 log.info("Successfully stopped single mon ceph service")
             else:
                 log.info("Failed to stop ceph mon service")
@@ -105,9 +100,8 @@ def task(ctx, config):
             remote.run(args=['sudo', 'systemctl', 'status', mgr_name])
             remote.run(args=['sudo', 'systemctl', 'stop', mgr_name])
             time.sleep(4)  # immediate check will result in deactivating state
-            r = remote.run(args=['sudo', 'systemctl', 'status', mgr_name],
-                           stdout=StringIO(), check_status=False)
-            if r.stdout.getvalue().find('Active: inactive'):
+            status = _remote_service_status(remote, mgr_name)
+            if status.find('Active: inactive'):
                 log.info("Successfully stopped single ceph mgr service")
             else:
                 log.info("Failed to stop ceph mgr service")
@@ -117,9 +111,8 @@ def task(ctx, config):
             remote.run(args=['sudo', 'systemctl', 'status', mds_name])
             remote.run(args=['sudo', 'systemctl', 'stop', mds_name])
             time.sleep(4)  # immediate check will result in deactivating state
-            r = remote.run(args=['sudo', 'systemctl', 'status', mds_name],
-                           stdout=StringIO(), check_status=False)
-            if r.stdout.getvalue().find('Active: inactive'):
+            status = _remote_service_status(remote, mds_name)
+            if status.find('Active: inactive'):
                 log.info("Successfully stopped single ceph mds service")
             else:
                 log.info("Failed to stop ceph mds service")

--- a/qa/tasks/thrashosds.py
+++ b/qa/tasks/thrashosds.py
@@ -3,7 +3,7 @@ Thrash -- Simulate random osd failures.
 """
 import contextlib
 import logging
-import ceph_manager
+from tasks import ceph_manager
 from teuthology import misc as teuthology
 
 

--- a/qa/tasks/watch_notify_same_primary.py
+++ b/qa/tasks/watch_notify_same_primary.py
@@ -2,7 +2,7 @@
 """
 watch_notify_same_primary task
 """
-from cStringIO import StringIO
+from io import BytesIO
 import contextlib
 import logging
 
@@ -68,8 +68,8 @@ def task(ctx, config):
                 "watch",
                 obj(n)],
             stdin=run.PIPE,
-            stdout=StringIO(),
-            stderr=StringIO(),
+            stdout=BytesIO(),
+            stderr=BytesIO(),
             wait=False)
         return proc
 
@@ -81,14 +81,8 @@ def task(ctx, config):
     for i in range(num):
         with safe_while() as proceed:
             while proceed():
-                proc = remote.run(
-                    args = [
-                        "rados",
-                        "-p", pool,
-                        "listwatchers",
-                        obj(i)],
-                    stdout=StringIO())
-                lines = proc.stdout.getvalue()
+                lines = remote.sh(
+                    ["rados", "-p", pool, "listwatchers", obj(i)])
                 num_watchers = lines.count('watcher=')
                 log.info('i see %d watchers for %s', num_watchers, obj(i))
                 if num_watchers >= 1:

--- a/qa/tasks/watch_notify_stress.py
+++ b/qa/tasks/watch_notify_stress.py
@@ -66,5 +66,5 @@ def task(ctx, config):
         yield
     finally:
         log.info('joining watch_notify_stress')
-        for i in testwatch.itervalues():
+        for i in testwatch.values():
             i.join()

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -8,8 +8,8 @@ import re
 
 import six
 
-from util import get_remote_for_role
-from util.workunit import get_refspec_after_overrides
+from tasks.util import get_remote_for_role
+from tasks.util.workunit import get_refspec_after_overrides
 
 from teuthology import misc
 from teuthology.config import config as teuth_config

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -364,7 +364,7 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
     )
 
     workunits_file = '{tdir}/workunits.list.{role}'.format(tdir=testdir, role=role)
-    workunits = sorted(misc.get_file(remote, workunits_file).split('\0'))
+    workunits = sorted(six.ensure_str(misc.get_file(remote, workunits_file)).split('\0'))
     assert workunits
 
     try:


### PR DESCRIPTION
this change is part of the ongoing effort of fixing https://tracker.ceph.com/issues/42871 . and it's a subset of #32262.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
