### PR TITLE
qa/tasks/cephfs: umount the mountpoints when tearDown

### DIFF
--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -244,6 +244,9 @@ class FuseMount(CephFSMount):
         return self.client_remote.run(args=["ls", "-d", self.mountpoint], check_status=False, cwd=self.test_dir, timeout=(15*60)).exitstatus == 0
 
     def umount(self):
+        if not self.is_mounted():
+            return
+
         try:
             log.info('Running fusermount -u on {name}...'.format(name=self.client_remote.name))
             self.client_remote.run(

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -74,6 +74,9 @@ class KernelMount(CephFSMount):
         self.mounted = True
 
     def umount(self, force=False):
+        if not self.is_mounted():
+            return
+
         log.debug('Unmounting client client.{id}...'.format(id=self.client_id))
 
         cmd=['sudo', 'umount', self.mountpoint]

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class XFSTestsDev(CephFSTestCase):
 
     def setUp(self):
-        CephFSTestCase.setUp(self)
+        super(XFSTestsDev, self).setUp()
         self.prepare_xfstests_dev()
 
     def prepare_xfstests_dev(self):
@@ -172,3 +172,5 @@ class XFSTestsDev(CephFSTestCase):
         self.mount_a.client_remote.run(args=['sudo', 'rm', '-rf',
                                              self.repo_path],
                                        omit_sudo=False, check_status=False)
+
+        super(XFSTestsDev, self).tearDown()

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -615,33 +615,6 @@ class LocalKernelMount(KernelMount):
         log.info("I think my launching pid was {0}".format(self.fuse_daemon.subproc.pid))
         return path
 
-    def umount(self, force=False):
-        log.debug('Unmounting client client.{id}...'.format(id=self.client_id))
-
-        cmd=['sudo', 'umount', self.mountpoint]
-        if force:
-            cmd.append('-f')
-
-        try:
-            self.client_remote.run(args=cmd, timeout=(15*60), omit_sudo=False)
-        except Exception as e:
-            self.client_remote.run(args=[
-                'sudo',
-                Raw('PATH=/usr/sbin:$PATH'),
-                'lsof',
-                Raw(';'),
-                'ps', 'auxf',
-            ], timeout=(15*60), omit_sudo=False)
-            raise e
-
-        rproc = self.client_remote.run(args=[
-                'rmdir',
-                '--',
-                self.mountpoint,
-            ])
-        rproc.wait()
-        self.mounted = False
-
     def mount(self, mount_path=None, mount_fs_name=None, mount_options=[]):
         self.setupfs(name=mount_fs_name)
 
@@ -802,10 +775,6 @@ class LocalFuseMount(FuseMount):
         path = "{0}/client.{1}.{2}.asok".format(d, self.client_id, self.fuse_daemon.subproc.pid)
         log.info("I think my launching pid was {0}".format(self.fuse_daemon.subproc.pid))
         return path
-
-    def umount(self):
-        if self.is_mounted():
-            super(LocalFuseMount, self).umount()
 
     def mount(self, mount_path=None, mount_fs_name=None, mountpoint=None, mount_options=[]):
         if mountpoint is not None:


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44408

All the tempory mountpoints still kept after the test case finished.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
