### PR TITLE
nautilus: rgw: Add support bucket policy for subuser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ GTAGS
 
 .idea
 
+.vscode
+
 # dashboard
 /src/pybind/mgr/dashboard/frontend/src/environments/environment.ts
 /src/pybind/mgr/dashboard/frontend/src/environments/environment.prod.ts

--- a/doc/radosgw/bucketpolicy.rst
+++ b/doc/radosgw/bucketpolicy.rst
@@ -21,7 +21,7 @@ For example, one may use s3cmd to set or delete a policy thus::
     "Version": "2012-10-17",
     "Statement": [{
       "Effect": "Allow",
-      "Principal": {"AWS": ["arn:aws:iam::usfolks:user/fred"]},
+      "Principal": {"AWS": ["arn:aws:iam::usfolks:user/fred:subuser"]},
       "Action": "s3:PutObjectAcl",
       "Resource": [
         "arn:aws:s3:::happybucket/*"

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -542,9 +542,18 @@ bool rgw::auth::LocalApplier::is_identity(const idset_t& ids) const {
 	       id.get_tenant() == user_info.user_id.tenant) {
       return true;
     } else if (id.is_user() &&
-	       (id.get_tenant() == user_info.user_id.tenant) &&
-	       (id.get_id() == user_info.user_id.id)) {
-      return true;
+	       (id.get_tenant() == user_info.user_id.tenant)) {
+      if (id.get_id() == user_info.user_id.id) {
+        return true;
+      }
+      for (auto subuser : user_info.subusers) {
+        std::string user = user_info.user_id.id;
+        user.append(":");
+        user.append(subuser.second.name);
+        if (user == id.get_id()) {
+          return true;
+        }
+      }
     }
   }
   return false;

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -546,10 +546,10 @@ bool rgw::auth::LocalApplier::is_identity(const idset_t& ids) const {
       if (id.get_id() == user_info.user_id.id) {
         return true;
       }
-      for (auto subuser : user_info.subusers) {
+      if (subuser != NO_SUBUSER) {
         std::string user = user_info.user_id.id;
         user.append(":");
-        user.append(subuser.second.name);
+        user.append(subuser);
         if (user == id.get_id()) {
           return true;
         }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -85,8 +85,6 @@ using rgw::ARN;
 using rgw::IAM::Effect;
 using rgw::IAM::Policy;
 
-using rgw::IAM::Policy;
-
 static string mp_ns = RGW_OBJ_NS_MULTIPART;
 static string shadow_ns = RGW_OBJ_NS_SHADOW;
 

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -146,6 +146,7 @@ protected:
   static string example4;
   static string example5;
   static string example6;
+  static string example7;
 public:
   PolicyTest() {
     cct = new CephContext(CEPH_ENTITY_TYPE_CLIENT);
@@ -656,6 +657,68 @@ TEST_F(PolicyTest, Eval6) {
 	    Effect::Allow);
 }
 
+TEST_F(PolicyTest, Parse7) {
+  boost::optional<Policy> p;
+
+  ASSERT_NO_THROW(p = Policy(cct.get(), arbitrary_tenant,
+			     bufferlist::static_from_string(example7)));
+  ASSERT_TRUE(p);
+
+  EXPECT_EQ(p->text, example7);
+  EXPECT_EQ(p->version, Version::v2012_10_17);
+  ASSERT_FALSE(p->statements.empty());
+  EXPECT_EQ(p->statements.size(), 1U);
+  EXPECT_FALSE(p->statements[0].princ.empty());
+  EXPECT_EQ(p->statements[0].princ.size(), 1U);
+  EXPECT_TRUE(p->statements[0].noprinc.empty());
+  EXPECT_EQ(p->statements[0].effect, Effect::Allow);
+  Action_t act;
+  act[s3ListBucket] = 1;
+  EXPECT_EQ(p->statements[0].action, act);
+  EXPECT_EQ(p->statements[0].notaction, None);
+  ASSERT_FALSE(p->statements[0].resource.empty());
+  ASSERT_EQ(p->statements[0].resource.size(), 1U);
+  EXPECT_EQ(p->statements[0].resource.begin()->partition, Partition::aws);
+  EXPECT_EQ(p->statements[0].resource.begin()->service, Service::s3);
+  EXPECT_TRUE(p->statements[0].resource.begin()->region.empty());
+  EXPECT_EQ(p->statements[0].resource.begin()->account, arbitrary_tenant);
+  EXPECT_EQ(p->statements[0].resource.begin()->resource, "mybucket/*");
+  EXPECT_TRUE(p->statements[0].princ.begin()->is_user());
+  EXPECT_FALSE(p->statements[0].princ.begin()->is_wildcard());
+  EXPECT_EQ(p->statements[0].princ.begin()->get_tenant(), "");
+  EXPECT_EQ(p->statements[0].princ.begin()->get_id(), "A:subA");
+  EXPECT_TRUE(p->statements[0].notresource.empty());
+  EXPECT_TRUE(p->statements[0].conditions.empty());
+}
+
+TEST_F(PolicyTest, Eval7) {
+  auto p  = Policy(cct.get(), arbitrary_tenant,
+		   bufferlist::static_from_string(example7));
+  Environment e;
+
+  auto subacct = FakeIdentity(
+    Principal::user(std::move(""), "A:subA"));
+  auto parentacct = FakeIdentity(
+    Principal::user(std::move(""), "A"));
+  auto sub2acct = FakeIdentity(
+    Principal::user(std::move(""), "A:sub2A"));
+
+  EXPECT_EQ(p.eval(e, subacct, s3ListBucket,
+		   ARN(Partition::aws, Service::s3,
+		       "", arbitrary_tenant, "mybucket/*")),
+	    Effect::Allow);
+  
+  EXPECT_EQ(p.eval(e, parentacct, s3ListBucket,
+		   ARN(Partition::aws, Service::s3,
+		       "", arbitrary_tenant, "mybucket/*")),
+	    Effect::Pass);
+  
+  EXPECT_EQ(p.eval(e, sub2acct, s3ListBucket,
+		   ARN(Partition::aws, Service::s3,
+		       "", arbitrary_tenant, "mybucket/*")),
+	    Effect::Pass);
+}
+
 const string PolicyTest::arbitrary_tenant = "arbitrary_tenant";
 string PolicyTest::example1 = R"(
 {
@@ -747,6 +810,18 @@ string PolicyTest::example6 = R"(
     "Effect": "Allow",
     "Action": "*",
     "Resource": "arn:aws:iam:::user/A"
+  }
+}
+)";
+
+string PolicyTest::example7 = R"(
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {"AWS": ["arn:aws:iam:::user/A:subA"]},
+    "Action": "s3:ListBucket",
+    "Resource": "arn:aws:s3:::mybucket/*"
   }
 }
 )";


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44146

---

backport of

* https://github.com/ceph/ceph/pull/33165
* https://github.com/ceph/ceph/pull/33398

parent tracker: https://tracker.ceph.com/issues/39605

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh

---

To Do

- [x] https://github.com/ceph/ceph/pull/33398 gets merged
- [x] cherry-pick https://github.com/ceph/ceph/pull/33398 into this PR