### PR TITLE
mimic: rgw: Add support bucket policy for subuser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ GTAGS
 \#*\#
 
 .idea
+
+.vscode

--- a/doc/radosgw/bucketpolicy.rst
+++ b/doc/radosgw/bucketpolicy.rst
@@ -21,7 +21,7 @@ For example, one may use s3cmd to set or delete a policy thus::
     "Version": "2012-10-17",
     "Statement": [{
       "Effect": "Allow",
-      "Principal": {"AWS": ["arn:aws:iam::usfolks:user/fred"]},
+      "Principal": {"AWS": ["arn:aws:iam::usfolks:user/fred:subuser"]},
       "Action": "s3:PutObjectAcl",
       "Resource": [
         "arn:aws:s3:::happybucket/*"

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -482,9 +482,18 @@ bool rgw::auth::LocalApplier::is_identity(const idset_t& ids) const {
 	       id.get_tenant() == user_info.user_id.tenant) {
       return true;
     } else if (id.is_user() &&
-	       (id.get_tenant() == user_info.user_id.tenant) &&
-	       (id.get_id() == user_info.user_id.id)) {
-      return true;
+	       (id.get_tenant() == user_info.user_id.tenant)) {
+      if (id.get_id() == user_info.user_id.id) {
+        return true;
+      }
+      for (auto subuser : user_info.subusers) {
+        std::string user = user_info.user_id.id;
+        user.append(":");
+        user.append(subuser.second.name);
+        if (user == id.get_id()) {
+          return true;
+        }
+      }
     }
   }
   return false;

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -486,10 +486,10 @@ bool rgw::auth::LocalApplier::is_identity(const idset_t& ids) const {
       if (id.get_id() == user_info.user_id.id) {
         return true;
       }
-      for (auto subuser : user_info.subusers) {
+      if (subuser != NO_SUBUSER) {
         std::string user = user_info.user_id.id;
         user.append(":");
-        user.append(subuser.second.name);
+        user.append(subuser);
         if (user == id.get_id()) {
           return true;
         }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -71,8 +71,6 @@ using rgw::IAM::ARN;
 using rgw::IAM::Effect;
 using rgw::IAM::Policy;
 
-using rgw::IAM::Policy;
-
 static string mp_ns = RGW_OBJ_NS_MULTIPART;
 static string shadow_ns = RGW_OBJ_NS_SHADOW;
 

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -124,6 +124,7 @@ protected:
   static string example1;
   static string example2;
   static string example3;
+  static string example7;
 public:
   PolicyTest() {
     cct = new CephContext(CEPH_ENTITY_TYPE_CLIENT);
@@ -453,6 +454,68 @@ TEST_F(PolicyTest, Eval3) {
   }
 }
 
+TEST_F(PolicyTest, Parse7) {
+  boost::optional<Policy> p;
+
+  ASSERT_NO_THROW(p = Policy(cct.get(), arbitrary_tenant,
+			     bufferlist::static_from_string(example7)));
+  ASSERT_TRUE(p);
+
+  EXPECT_EQ(p->text, example7);
+  EXPECT_EQ(p->version, Version::v2012_10_17);
+  ASSERT_FALSE(p->statements.empty());
+  EXPECT_EQ(p->statements.size(), 1U);
+  EXPECT_FALSE(p->statements[0].princ.empty());
+  EXPECT_EQ(p->statements[0].princ.size(), 1U);
+  EXPECT_TRUE(p->statements[0].noprinc.empty());
+  EXPECT_EQ(p->statements[0].effect, Effect::Allow);
+  Action_t act;
+  act[s3ListBucket] = 1;
+  EXPECT_EQ(p->statements[0].action, act);
+  EXPECT_EQ(p->statements[0].notaction, None);
+  ASSERT_FALSE(p->statements[0].resource.empty());
+  ASSERT_EQ(p->statements[0].resource.size(), 1U);
+  EXPECT_EQ(p->statements[0].resource.begin()->partition, Partition::aws);
+  EXPECT_EQ(p->statements[0].resource.begin()->service, Service::s3);
+  EXPECT_TRUE(p->statements[0].resource.begin()->region.empty());
+  EXPECT_EQ(p->statements[0].resource.begin()->account, arbitrary_tenant);
+  EXPECT_EQ(p->statements[0].resource.begin()->resource, "mybucket/*");
+  EXPECT_TRUE(p->statements[0].princ.begin()->is_user());
+  EXPECT_FALSE(p->statements[0].princ.begin()->is_wildcard());
+  EXPECT_EQ(p->statements[0].princ.begin()->get_tenant(), "");
+  EXPECT_EQ(p->statements[0].princ.begin()->get_id(), "A:subA");
+  EXPECT_TRUE(p->statements[0].notresource.empty());
+  EXPECT_TRUE(p->statements[0].conditions.empty());
+}
+
+TEST_F(PolicyTest, Eval7) {
+  auto p  = Policy(cct.get(), arbitrary_tenant,
+		   bufferlist::static_from_string(example7));
+  Environment e;
+
+  auto subacct = FakeIdentity(
+    Principal::user(std::move(""), "A:subA"));
+  auto parentacct = FakeIdentity(
+    Principal::user(std::move(""), "A"));
+  auto sub2acct = FakeIdentity(
+    Principal::user(std::move(""), "A:sub2A"));
+
+  EXPECT_EQ(p.eval(e, subacct, s3ListBucket,
+		   ARN(Partition::aws, Service::s3,
+		       "", arbitrary_tenant, "mybucket/*")),
+	    Effect::Allow);
+  
+  EXPECT_EQ(p.eval(e, parentacct, s3ListBucket,
+		   ARN(Partition::aws, Service::s3,
+		       "", arbitrary_tenant, "mybucket/*")),
+	    Effect::Pass);
+  
+  EXPECT_EQ(p.eval(e, sub2acct, s3ListBucket,
+		   ARN(Partition::aws, Service::s3,
+		       "", arbitrary_tenant, "mybucket/*")),
+	    Effect::Pass);
+}
+
 const string PolicyTest::arbitrary_tenant = "arbitrary_tenant";
 string PolicyTest::example1 = R"(
 {
@@ -515,6 +578,17 @@ string PolicyTest::example3 = R"(
 }
 )";
 
+string PolicyTest::example7 = R"(
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {"AWS": ["arn:aws:iam:::user/A:subA"]},
+    "Action": "s3:ListBucket",
+    "Resource": "arn:aws:s3:::mybucket/*"
+  }
+}
+)";
 class IPPolicyTest : public ::testing::Test {
 protected:
   intrusive_ptr<CephContext> cct;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44411

---

backport of 

* https://github.com/ceph/ceph/pull/33165
* https://github.com/ceph/ceph/pull/33398

parent tracker: https://tracker.ceph.com/issues/39605

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh

---

To Do

- [x] https://github.com/ceph/ceph/pull/33398 gets merged
- [x] cherry-pick https://github.com/ceph/ceph/pull/33398 into this PR