### PR TITLE
log: fix timestap precision of log can't set to millisecond.

### DIFF
--- a/src/log/Entry.h
+++ b/src/log/Entry.h
@@ -41,7 +41,6 @@ public:
   pthread_t m_thread;
   short m_prio, m_subsys;
 
-private:
   static log_clock& clock() {
     static log_clock clock;
     return clock;

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -62,9 +62,9 @@ Log::~Log()
 void Log::set_coarse_timestamps(bool coarse) {
   std::scoped_lock lock(m_flush_mutex);
   if (coarse)
-    clock.coarsen();
+    Entry::clock().coarsen();
   else
-    clock.refine();
+    Entry::clock().refine();
 }
 
 void Log::set_flush_on_exit()

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -33,7 +33,6 @@ class Log : private Thread
   static const std::size_t DEFAULT_MAX_RECENT = 10000;
 
   Log **m_indirect_this;
-  log_clock clock;
 
   const SubsystemMap *m_subs;
 


### PR DESCRIPTION
log: fix timestap precision of log can't set to millisecond.

The option log_coarse_timestamps can be set to Log::clock
successfully,but the Log::clock has no effect on time accuracy
because the dout_impl really use is Entry::clock.So we should
set Entry::clock by log_coarse_timestamps option instead of
Log:clock.In addition, i think the Log::clock can be removed
because i didn't see what it was for.

Fixes: https://tracker.ceph.com/issues/44409
Signed-off-by: Guan yunfei <yunfei.guan@xtaotech.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>