### PR TITLE
qa: add test for cache-tier forward mode hanging

### DIFF
--- a/qa/suites/rados/thrash/workloads/cache-forward.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-forward.yaml
@@ -1,0 +1,25 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - must scrub before tier agent can activate
+tasks:
+- exec:
+    client.0:
+      - ceph osd pool create pool 16 16
+      - ceph osd pool application enable pool rados
+      - ceph osd pool create newpool 8 8
+      - ceph osd pool application enable newpool rados
+      - ceph osd tier add newpool pool --force-nonempty
+      - ceph osd tier cache-mode pool forward --yes-i-really-mean-it
+      - ceph osd tier set-overlay newpool pool
+      - rados -p pool stat doesnotexist
+- rados:
+    clients: [client.0]
+    pools: [pool]
+    ops: 4000
+    objects: 500
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      copy_from: 50

--- a/qa/workunits/rados/test_cache_forward.sh
+++ b/qa/workunits/rados/test_cache_forward.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -ex
+
+expect_false()
+{
+	set -x
+	if "$@"; then return 1; else return 0; fi
+}
+
+# create pools, set up tier relationship
+ceph osd pool create pool 16 16
+ceph osd pool application enable pool rados
+
+# stat non-existent object doesn't hang.
+expect_false rados -p pool stat doesnotexist
+
+# create newpool and overlay
+ceph osd pool create newpool 8 8
+ceph osd pool application enable newpool rados
+ceph osd tier add newpool pool --force-nonempty
+ceph osd tier cache-mode pool forward --yes-i-really-mean-it
+ceph osd tier set-overlay newpool pool
+
+# stat non-existent object still doesn't hang.
+expect_false rados -p pool stat doesnotexist
+
+# cleanup
+ceph osd tier remove-overlay newpool
+ceph osd tier remove newpool pool
+ceph osd pool delete newpool newpool --yes-i-really-really-mean-it
+ceph osd pool delete pool pool --yes-i-really-really-mean-it
+
+echo OK


### PR DESCRIPTION
As requested in #24548 - I've been busy and not had the time to get round to it.

The shell test seemed relatively straight-forward to write, not sure about the thrash/workloads test though.  Is it needed?

Signed-off-by: Iain Buclaw <iain.buclaw@dunnhumby.com>
