### PR TITLE
nautilus: common/blkdev: compilation of telemetry and device backports

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -1229,3 +1229,26 @@ int block_device_run_nvme(const char *device, const char *vendor, int timeout,
 }
 
 #endif
+
+
+void get_device_metadata(
+  const std::set<std::string>& devnames,
+  std::map<std::string,std::string> *pm,
+  std::map<std::string,std::string> *errs)
+{
+  (*pm)["devices"] = stringify(devnames);
+  string &devids = (*pm)["device_ids"];
+  string &devpaths = (*pm)["device_paths"];
+  for (auto& dev : devnames) {
+    string err;
+    string id = get_device_id(dev, &err);
+    if (id.size()) {
+      if (!devids.empty()) {
+	devids += ",";
+      }
+      devids += dev + "=" + id;
+    } else {
+      (*errs)[dev] = " no unique device id for "s + dev + ": " + err;
+    }
+  }
+}

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -681,7 +681,7 @@ static int block_device_run_smartctl(const string& devname, int timeout,
     "smartctl",
     "-a",
     //"-x",
-    "--json",
+    "--json=o",
     device.c_str(),
     NULL);
 

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -542,15 +542,22 @@ std::string get_device_id(const std::string& devname,
   if (!blkdev.model(buf, sizeof(buf))) {
     model = buf;
   }
-  if (blkdev.serial(buf, sizeof(buf))) {
+  if (!blkdev.serial(buf, sizeof(buf))) {
     serial = buf;
   }
-  if (!model.size() || serial.size()) {
-    if (err) {
+  if (err) {
+    if (model.empty() && serial.empty()) {
+      *err = std::string("fallback method has no model nor serial'");
+      return {};
+    } else if (model.empty()) {
       *err = std::string("fallback method has serial '") + serial
-	+ "'but no model";
+        + "' but no model'";
+      return {};
+    } else if (serial.empty()) {
+      *err = std::string("fallback method has model '") + model
+        + "' but no serial'";
+      return {};
     }
-    return {};
   }
 
   device_id = model + "_" + serial;

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -161,8 +161,10 @@ int64_t BlkDev::get_string_property(blkdev_prop_t prop,
   } else {
     dev = devname.c_str();
   }
-  snprintf(filename, sizeof(filename),
-	   "%s/block/%s/%s", sysfsdir(), dev, propstr);
+  if (snprintf(filename, sizeof(filename), "%s/block/%s/%s", sysfsdir(), dev,
+	       propstr) >= static_cast<int>(sizeof(filename))) {
+    return -ERANGE;
+  }
 
   FILE *fp = fopen(filename, "r");
   if (fp == NULL) {

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -675,6 +675,34 @@ static int block_device_run_vendor_nvme(
   return ret;
 }
 
+std::string get_device_path(const std::string& devname,
+			    std::string *err)
+{
+  std::set<std::string> links;
+  int r = easy_readdir("/dev/disk/by-path", &links);
+  if (r < 0) {
+    *err = "unable to list contents of /dev/disk/by-path: "s +
+      cpp_strerror(r);
+    return {};
+  }
+  for (auto& i : links) {
+    char fn[PATH_MAX];
+    char target[PATH_MAX+1];
+    snprintf(fn, sizeof(fn), "/dev/disk/by-path/%s", i.c_str());
+    int r = readlink(fn, target, sizeof(target));
+    if (r < 0 || r >= (int)sizeof(target))
+      continue;
+    target[r] = 0;
+    if ((unsigned)r > devname.size() + 1 &&
+	strncmp(target + r - devname.size(), devname.c_str(), r) == 0 &&
+	target[r - devname.size() - 1] == '/') {
+      return fn;
+    }
+  }
+  *err = "no symlink to "s + devname + " in /dev/disk/by-path";
+  return {};
+}
+
 static int block_device_run_smartctl(const string& devname, int timeout,
 				     std::string *result)
 {
@@ -882,6 +910,16 @@ std::string get_device_id(const std::string& devname,
   return std::string();
 }
 
+std::string get_device_path(const std::string& devname,
+			    std::string *err)
+{
+  // FIXME: implement me
+  if (err) {
+    *err = "not implemented";
+  }
+  return std::string();
+}
+
 #elif defined(__FreeBSD__)
 
 const char *BlkDev::sysfsdir() const {
@@ -1061,6 +1099,16 @@ std::string get_device_id(const std::string& devname,
   return std::string();
 }
 
+std::string get_device_path(const std::string& devname,
+			    std::string *err)
+{
+  // FIXME: implement me for freebsd
+  if (err) {
+    *err = "not implemented for FreeBSD";
+  }
+  return std::string();
+}
+
 int block_device_run_smartctl(const char *device, int timeout,
 			      std::string *result)
 {
@@ -1210,6 +1258,16 @@ std::string get_device_id(const std::string& devname,
   return std::string();
 }
 
+std::string get_device_path(const std::string& devname,
+			  std::string *err)
+{
+  // not implemented
+  if (err) {
+    *err = "not implemented";
+  }
+  return std::string();
+}
+
 int block_device_run_smartctl(const char *device, int timeout,
 			      std::string *result)
 {
@@ -1231,6 +1289,7 @@ int block_device_run_nvme(const char *device, const char *vendor, int timeout,
 #endif
 
 
+
 void get_device_metadata(
   const std::set<std::string>& devnames,
   std::map<std::string,std::string> *pm,
@@ -1249,6 +1308,15 @@ void get_device_metadata(
       devids += dev + "=" + id;
     } else {
       (*errs)[dev] = " no unique device id for "s + dev + ": " + err;
+    }
+    string path = get_device_path(dev, &err);
+    if (path.size()) {
+      if (!devpaths.empty()) {
+	devpaths += ",";
+      }
+      devpaths += dev + "=" + path;
+    } else {
+      (*errs)[dev] + " no unique device path for "s + dev + ": " + err;
     }
   }
 }

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -28,6 +28,11 @@ extern std::string _decode_model_enc(const std::string& in);  // helper, exporte
 // get $vendor_$model_$serial style device id
 extern std::string get_device_id(const std::string& devname,
 				 std::string *err=0);
+
+// get /dev/disk/by-path/... style device id that is stable for a disk slot across reboots etc
+extern std::string get_device_path(const std::string& devname,
+				   std::string *err=0);
+
 // populate daemon metadata map with device info
 extern void get_device_metadata(
   const std::set<std::string>& devnames,

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -5,6 +5,7 @@
 #define __CEPH_COMMON_BLKDEV_H
 
 #include <set>
+#include <map>
 #include <string>
 #include "json_spirit/json_spirit_value.h"
 
@@ -24,8 +25,15 @@ extern int get_device_by_path(const char *path, char* partition, char* device, s
 
 extern std::string _decode_model_enc(const std::string& in);  // helper, exported only so we can unit test
 
+// get $vendor_$model_$serial style device id
 extern std::string get_device_id(const std::string& devname,
 				 std::string *err=0);
+// populate daemon metadata map with device info
+extern void get_device_metadata(
+  const std::set<std::string>& devnames,
+  std::map<std::string,std::string> *pm,
+  std::map<std::string,std::string> *errs);
+
 extern void get_dm_parents(const std::string& dev, std::set<std::string> *ls);
 extern int block_device_get_metrics(const std::string& devname, int timeout,
 				    json_spirit::mValue *result);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2287,21 +2287,11 @@ void Monitor::collect_metadata(Metadata *m)
   string devname = store->get_devname();
   set<string> devnames;
   get_raw_devices(devname, &devnames);
-  (*m)["devices"] = stringify(devnames);
-  string devids;
-  for (auto& devname : devnames) {
-    string err;
-    string id = get_device_id(devname, &err);
-    if (id.size()) {
-      if (!devids.empty()) {
-	devids += ",";
-      }
-      devids += devname + "=" + id;
-    } else {
-      derr << "failed to get devid for " << devname << ": " << err << dendl;
-    }
+  map<string,string> errs;
+  get_device_metadata(devnames, m, &errs);
+  for (auto& i : errs) {
+    dout(1) << __func__ << " " << i.first << ": " << i.second << dendl;
   }
-  (*m)["device_ids"] = devids;
 }
 
 void Monitor::finish_election()

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6461,23 +6461,11 @@ void OSD::_collect_metadata(map<string,string> *pm)
 
   set<string> devnames;
   store->get_devices(&devnames);
-  (*pm)["devices"] = stringify(devnames);
-  string devids;
-  for (auto& dev : devnames) {
-    string err;
-    string id = get_device_id(dev, &err);
-    if (id.size()) {
-      if (!devids.empty()) {
-	devids += ",";
-      }
-      devids += dev + "=" + id;
-    } else {
-      dout(10) << __func__ << " no unique device id for " << dev << ": "
-	       << err << dendl;
-    }
+  map<string,string> errs;
+  get_device_metadata(devnames, pm, &errs);
+  for (auto& i : errs) {
+    dout(1) << __func__ << " " << i.first << ": " << i.second << dendl;
   }
-  (*pm)["device_ids"] = devids;
-
   dout(10) << __func__ << " " << *pm << dendl;
 }
 

--- a/sudoers.d/ceph-osd-smartctl
+++ b/sudoers.d/ceph-osd-smartctl
@@ -1,4 +1,4 @@
 ## allow ceph-osd (which runs as user ceph) to collect device health metrics
 
-ceph ALL=NOPASSWD: /usr/sbin/smartctl -a --json /dev/*
+ceph ALL=NOPASSWD: /usr/sbin/smartctl -a --json=o /dev/*
 ceph ALL=NOPASSWD: /usr/sbin/nvme * smart-log-add --json /dev/*


### PR DESCRIPTION
This is a bunch of missing patches in the infrastructure of telemetry and devicehealth modules. 

These patches were originally included:
https://github.com/ceph/ceph/commit/7ac955e5ddc106a7e04fd4f580377bd104706d30
https://github.com/ceph/ceph/commit/9accb70e228eed6bdd9f82d64476f0b776cee30b
https://github.com/ceph/ceph/commit/43e666350d68a74c5dc923073c66c116020eeb0e
https://github.com/ceph/ceph/commit/cff30ce6661bec5a1e046423e6335ec49471966a
https://github.com/ceph/ceph/commit/ef882d10a09310be31f6585efbdf3f87a779a9fd

but dropped since they're in https://github.com/ceph/ceph/pull/33421.

Signed-off-by: Yaarit Hatuka <yaarit@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
