### PR TITLE
mgr/orch,cephadm: add timestamps to daemons and services

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1324,6 +1324,17 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
         deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
                             osd_fsid=osd_fsid)
 
+    if not os.path.exists(data_dir + '/unit.created'):
+        with open(data_dir + '/unit.created', 'w') as f:
+            os.fchmod(f.fileno(), 0o600)
+            os.fchown(f.fileno(), uid, gid)
+            f.write('mtime is time the daemon deployment was created\n')
+
+    with open(data_dir + '/unit.configured', 'w') as f:
+        f.write('mtime is time we were last configured\n')
+        os.fchmod(f.fileno(), 0o600)
+        os.fchown(f.fileno(), uid, gid)
+
     update_firewalld(daemon_type)
 
     if reconfig and daemon_type not in Ceph.daemons:
@@ -2442,8 +2453,14 @@ def list_daemons(detail=True, legacy_dir=None):
                         i['container_image_id'] = image_id
                         i['version'] = version
                         i['started'] = start_stamp
+                        i['created'] = get_file_timestamp(
+                            os.path.join(data_dir, fsid, j, 'unit.created')
+                        )
                         i['deployed'] = get_file_timestamp(
                             os.path.join(data_dir, fsid, j, 'unit.image'))
+                        i['configured'] = get_file_timestamp(
+                            os.path.join(data_dir, fsid, j, 'unit.configured'))
+
                     ls.append(i)
 
     # /var/lib/rook

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -35,6 +35,7 @@ You can invoke cephadm in two ways:
 """
 
 import argparse
+import datetime
 import fcntl
 import json
 import logging
@@ -79,6 +80,8 @@ else:
 
 container_path = ''
 cached_stdin = None
+
+DATEFMT = '%Y-%m-%dT%H:%M:%S.%f'
 
 class Error(Exception):
     pass
@@ -608,6 +611,53 @@ def pathify(p):
         return os.path.join(os.getcwd(), p)
     return p
 
+def get_file_timestamp(fn):
+    try:
+        mt = os.path.getmtime(fn)
+        return datetime.datetime.fromtimestamp(
+            mt, tz=datetime.timezone.utc
+        ).strftime(DATEFMT)
+    except Exception as e:
+        return None
+
+def try_convert_datetime(s):
+    # This is super irritating because
+    #  1) podman and docker use different formats
+    #  2) python's strptime can't parse either one
+    #
+    # I've seen:
+    #  docker 18.09.7:  2020-03-03T09:21:43.636153304Z
+    #  podman 1.7.0:    2020-03-03T15:52:30.136257504-06:00
+    #                   2020-03-03 15:52:30.136257504 -0600 CST
+    # (In the podman case, there is a different string format for
+    # 'inspect' and 'inspect --format {{.Created}}'!!)
+
+    # In *all* cases, the 9 digit second precision is too much for
+    # python's strptime.  Shorten it to 6 digits.
+    p = re.compile(r'(\.\d\d\d\d\d\d)\d\d\d')
+    s = p.sub(r'\1', s)
+
+    # replace trailling Z with -0000, since (on python 3.6.8) it won't parse
+    if s and s[-1] == 'Z':
+        s = s[:-1] + '-0000'
+
+    # cut off the redundnat 'CST' part that strptime can't parse, if
+    # present.
+    v = s.split(' ')
+    s = ' '.join(v[0:3])
+
+    # try parsing with several format strings
+    fmts = [
+        '%Y-%m-%dT%H:%M:%S.%f%z',
+        '%Y-%m-%d %H:%M:%S.%f %z',
+    ]
+    for f in fmts:
+        try:
+            # return timestamp normalized to UTC, rendered as DATEFMT.
+            return datetime.datetime.strptime(s, f).astimezone(tz=datetime.timezone.utc).strftime(DATEFMT)
+        except ValueError:
+            pass
+    return None
 
 def get_podman_version():
     # type: () -> Tuple[int, ...]
@@ -2346,6 +2396,7 @@ def list_daemons(detail=True, legacy_dir=None):
                         image_name = None
                         image_id = None
                         version = None
+                        start_stamp = None
 
                         if 'podman' in container_path and get_podman_version() < (1, 6, 2):
                             image_field = '.ImageID'
@@ -2355,14 +2406,16 @@ def list_daemons(detail=True, legacy_dir=None):
                         out, err, code = call(
                             [
                                 container_path, 'inspect',
-                                '--format', '{{.Id}},{{.Config.Image}},{{%s}},{{index .Config.Labels "io.ceph.version"}}' % image_field,
+                                '--format', '{{.Id}},{{.Config.Image}},{{%s}},{{.Created}},{{index .Config.Labels "io.ceph.version"}}' % image_field,
                                 'ceph-%s-%s' % (fsid, j)
                             ],
                             verbose_on_failure=False)
                         if not code:
-                            (container_id, image_name, image_id, version) = out.strip().split(',')
+                            (container_id, image_name, image_id, start,
+                             version) = out.strip().split(',')
                             image_id = normalize_container_id(image_id)
                             daemon_type = name.split('.', 1)[0]
+                            start_stamp = try_convert_datetime(start)
                             if daemon_type in Ceph.daemons:
                                 if not version or '.' not in version:
                                     version = seen_versions.get(image_id, None)
@@ -2388,6 +2441,9 @@ def list_daemons(detail=True, legacy_dir=None):
                         i['container_image_name'] = image_name
                         i['container_image_id'] = image_id
                         i['version'] = version
+                        i['started'] = start_stamp
+                        i['deployed'] = get_file_timestamp(
+                            os.path.join(data_dir, fsid, j, 'unit.image'))
                     ls.append(i)
 
     # /var/lib/rook

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1600,6 +1600,10 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 continue
             sd = orchestrator.DaemonDescription()
             sd.last_refresh = datetime.datetime.utcnow()
+            for k in ['created', 'started', 'last_configured', 'last_deployed']:
+                v = d.get(k, None)
+                if v:
+                    setattr(sd, k, datetime.datetime.strptime(d[k], DATEFMT))
             sd.daemon_type = d['name'].split('.')[0]
             sd.daemon_id = '.'.join(d['name'].split('.')[1:])
             sd.hostname = host

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -131,14 +131,18 @@ class SpecStore():
         # type: (CephadmOrchestrator) -> None
         self.mgr = mgr
         self.specs = {} # type: Dict[str, orchestrator.ServiceSpec]
+        self.spec_created = {} # type: Dict[str, datetime.datetime]
 
     def load(self):
         # type: () -> None
         for k, v in six.iteritems(self.mgr.get_store_prefix(SPEC_STORE_PREFIX)):
             service_name = k[len(SPEC_STORE_PREFIX):]
             try:
-                spec = ServiceSpec.from_json(json.loads(v))
+                v = json.loads(v)
+                spec = ServiceSpec.from_json(v['spec'])
+                created = datetime.datetime.strptime(v['created'], DATEFMT)
                 self.specs[service_name] = spec
+                self.spec_created[service_name] = created
                 self.mgr.log.debug('SpecStore: loaded spec for %s' % (
                     service_name))
             except Exception as e:
@@ -149,13 +153,20 @@ class SpecStore():
     def save(self, spec):
         # type: (orchestrator.ServiceSpec) -> None
         self.specs[spec.service_name()] = spec
-        self.mgr.set_store(SPEC_STORE_PREFIX + spec.service_name(),
-                           spec.to_json())
+        self.spec_created[spec.service_name()] = datetime.datetime.utcnow()
+        self.mgr.set_store(
+            SPEC_STORE_PREFIX + spec.service_name(),
+            json.dumps({
+                'spec': spec.to_json(),
+                'created': self.spec_created[spec.service_name()].strftime(DATEFMT),
+            }, sort_keys=True),
+        )
 
     def rm(self, service_name):
         # type: (str) -> None
         if service_name in self.specs:
             del self.specs[service_name]
+            del self.spec_created[service_name]
             self.mgr.set_store(SPEC_STORE_PREFIX + service_name, None)
 
     def find(self, service_name):
@@ -1687,6 +1698,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                     )
                 if spec:
                     sm[n].size = self._get_spec_size(spec)
+                    sm[n].created = self.spec_store.spec_created[dd.service_name()]
                 else:
                     sm[n].size += 1
                 if dd.status == 1:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1488,6 +1488,7 @@ class ServiceDescription(object):
                  rados_config_location=None,
                  service_url=None,
                  last_refresh=None,
+                 created=None,
                  size=0,
                  running=0,
                  spec=None):
@@ -1517,6 +1518,7 @@ class ServiceDescription(object):
 
         # datetime when this info was last refreshed
         self.last_refresh = last_refresh   # type: Optional[datetime.datetime]
+        self.created = created   # type: Optional[datetime.datetime]
 
         self.spec = spec
 
@@ -1538,18 +1540,19 @@ class ServiceDescription(object):
             'size': self.size,
             'running': self.running,
         }
-        if self.last_refresh:
-            out['last_refresh'] = self.last_refresh.strftime(DATEFMT)
+        for k in ['last_refresh', 'created']:
+            if getattr(self, k):
+                out[k] = getattr(self, k).strftime(DATEFMT)
         return {k: v for (k, v) in out.items() if v is not None}
 
     @classmethod
     @handle_type_error
     def from_json(cls, data):
-        if 'last_refresh' in data:
-            data['last_refresh'] = datetime.datetime.strptime(
-                data['last_refresh'],
-                DATEFMT)
-        return cls(**data)
+        c = data.copy()
+        for k in ['last_refresh', 'created']:
+            if k in c:
+                c[k] = datetime.datetime.strptime(c[k], DATEFMT)
+        return cls(**c)
 
 
 class ServiceSpec(object):

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1609,8 +1609,11 @@ class ServiceSpec(object):
         return n
 
     def to_json(self):
-        return json.dumps(self, default=lambda o: o.__dict__,
-                          sort_keys=True)
+        # type: () -> Dict[str, Any]
+        c = self.__dict__.copy()
+        if self.placement:
+            c['placement'] = self.placement.__dict__
+        return c
 
     def __repr__(self):
         return "{}({!r})".format(self.__class__.__name__, self.__dict__)

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1376,7 +1376,11 @@ class DaemonDescription(object):
                  version=None,
                  status=None,
                  status_desc=None,
-                 last_refresh=None):
+                 last_refresh=None,
+                 created=None,
+                 started=None,
+                 last_configured=None,
+                 last_deployed=None):
         # Host is at the same granularity as InventoryHost
         self.hostname = hostname
 
@@ -1407,6 +1411,11 @@ class DaemonDescription(object):
 
         # datetime when this info was last refreshed
         self.last_refresh = last_refresh  # type: Optional[datetime.datetime]
+
+        self.created = created    # type: Optional[datetime.datetime]
+        self.started = started    # type: Optional[datetime.datetime]
+        self.last_configured = last_configured # type: Optional[datetime.datetime]
+        self.last_deployed = last_deployed    # type: Optional[datetime.datetime]
 
     def name(self):
         return '%s.%s' % (self.daemon_type, self.daemon_id)
@@ -1443,18 +1452,21 @@ class DaemonDescription(object):
             'status': self.status,
             'status_desc': self.status_desc,
         }
-        if self.last_refresh:
-            out['last_refresh'] = self.last_refresh.strftime(DATEFMT)
+        for k in ['last_refresh', 'created', 'started', 'last_deployed',
+                  'last_configured']:
+            if getattr(self, k):
+                out[k] = getattr(self, k).strftime(DATEFMT)
         return {k: v for (k, v) in out.items() if v is not None}
 
     @classmethod
     @handle_type_error
     def from_json(cls, data):
-        if 'last_refresh' in data:
-            data['last_refresh'] = datetime.datetime.strptime(
-                data['last_refresh'],
-                DATEFMT)
-        return cls(**data)
+        c = data.copy()
+        for k in ['last_refresh', 'created', 'started', 'last_deployed',
+                  'last_configured']:
+            if k in c:
+                c[k] = datetime.datetime.strptime(c[k], DATEFMT)
+        return cls(**c)
 
 class ServiceDescription(object):
     """

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -25,6 +25,11 @@ from ._interface import OrchestratorClientMixin, DeviceLightLoc, _cli_read_comma
     NoOrchestrator, ServiceSpec, PlacementSpec, OrchestratorValidationError, NFSServiceSpec, \
     RGWSpec, InventoryFilter, InventoryHost, HostPlacementSpec, HostSpec, CLICommandMeta
 
+def nice_delta(now, t, suffix=''):
+    if t:
+        return to_pretty_timedelta(now - t) + suffix
+    else:
+        return '-'
 
 @six.add_metaclass(CLICommandMeta)
 class OrchestratorCli(OrchestratorClientMixin, MgrModule):
@@ -351,16 +356,11 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
             table.left_padding_width = 0
             table.right_padding_width = 2
             for s in sorted(services, key=lambda s: s.service_name):
-                def nice_delta(t, suffix=''):
-                    if t:
-                        return to_pretty_timedelta(now - t) + suffix
-                    else:
-                        return '-'
                 table.add_row((
                     s.service_name,
                     '%d/%d' % (s.running, s.size),
-                    nice_delta(s.last_refresh, ' age'),
-                    nice_delta(s.created),
+                    nice_delta(now, s.last_refresh, ' age'),
+                    nice_delta(now, s.created),
                     'present' if s.spec else '-',
                     s.spec.placement.pretty_str() if s.spec else '-',
                     ukn(s.container_image_name),
@@ -415,17 +415,12 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
                 if s.status == 1 and s.started:
                     status += ' (%s)' % to_pretty_timedelta(now - s.started)
 
-                def nice_delta(t, suffix=''):
-                    if t:
-                        return to_pretty_timedelta(now - t) + suffix
-                    else:
-                        return '-'
                 table.add_row((
                     s.name(),
                     ukn(s.hostname),
                     status,
-                    nice_delta(s.last_refresh, ' ago'),
-                    nice_delta(s.created),
+                    nice_delta(now, s.last_refresh, ' ago'),
+                    nice_delta(now, s.created),
                     ukn(s.version),
                     ukn(s.container_image_name),
                     ukn(s.container_image_id)[0:12],

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -406,6 +406,8 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
                     1: 'running',
                     None: '<unknown>'
                 }[s.status]
+                if s.status == 1 and s.started:
+                    status += ' (%s)' % to_pretty_timedelta(now - s.started)
 
                 def nice_delta(t, suffix=''):
                     if t:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -393,7 +393,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
         else:
             now = datetime.datetime.utcnow()
             table = PrettyTable(
-                ['NAME', 'HOST', 'STATUS', 'REFRESHED',
+                ['NAME', 'HOST', 'STATUS', 'REFRESHED', 'AGE',
                  'VERSION', 'IMAGE NAME', 'IMAGE ID', 'CONTAINER ID'],
                 border=False)
             table.align = 'l'
@@ -407,15 +407,17 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
                     None: '<unknown>'
                 }[s.status]
 
-                if s.last_refresh:
-                    age = to_pretty_timedelta(now - s.last_refresh) + ' ago'
-                else:
-                    age = '-'
+                def nice_delta(t, suffix=''):
+                    if t:
+                        return to_pretty_timedelta(now - t) + suffix
+                    else:
+                        return '-'
                 table.add_row((
                     s.name(),
                     ukn(s.hostname),
                     status,
-                    age,
+                    nice_delta(s.last_refresh, ' ago'),
+                    nice_delta(s.created),
                     ukn(s.version),
                     ukn(s.container_image_name),
                     ukn(s.container_image_id)[0:12],


### PR DESCRIPTION
End result is:
```
gnit:build (cephadm-btime) 11:49 AM $ bin/ceph orch ls
NAME     RUNNING  REFRESHED  AGE  SPEC     PLACEMENT  IMAGE NAME                                      IMAGE ID      
crash        1/1  97s age    28m  present  all=true   docker.io/ceph/daemon-base:latest-master-devel  7a8f71d9429a  
mds.foo      1/1  97s age    24m  present  count=1    docker.io/ceph/daemon-base:latest-master-devel  7a8f71d9429a  
gnit:build (cephadm-btime) 11:49 AM $ bin/ceph orch ps
NAME                 HOST  STATUS         REFRESHED  AGE  VERSION               IMAGE NAME                                      IMAGE ID      CONTAINER ID  
crash.gnit           gnit  running (28m)  99s ago    28m  15.1.0-1433-gf2f7381  docker.io/ceph/daemon-base:latest-master-devel  7a8f71d9429a  fa9286078673  
mds.foo.gnit.dgtpua  gnit  running (28m)  99s ago    28m  15.1.0-1433-gf2f7381  docker.io/ceph/daemon-base:latest-master-devel  7a8f71d9429a  0b42bd574d69  
```