### PR TITLE
mon/MonClient: send logs to mon on separate schedule than pings

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -331,6 +331,7 @@ OPTION(auth_service_ticket_ttl, OPT_DOUBLE)
 OPTION(auth_debug, OPT_BOOL)          // if true, assert when weird things happen
 OPTION(mon_client_hunt_parallel, OPT_U32)   // how many mons to try to connect to in parallel during hunt
 OPTION(mon_client_hunt_interval, OPT_DOUBLE)   // try new mon every N seconds until we connect
+OPTION(mon_client_log_interval, OPT_DOUBLE)  // send logs every N seconds
 OPTION(mon_client_ping_interval, OPT_DOUBLE)  // ping every N seconds
 OPTION(mon_client_ping_timeout, OPT_DOUBLE)   // fail if we don't hear back
 OPTION(mon_client_hunt_interval_backoff, OPT_DOUBLE) // each time we reconnect to a monitor, double our timeout

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2257,6 +2257,10 @@ std::vector<Option> get_global_options() {
     .set_default(3.0)
     .set_description(""),
 
+    Option("mon_client_log_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(1.0)
+    .set_description("How frequently we send queued cluster log messages to mon"),
+
     Option("mon_client_ping_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(10.0)
     .set_description(""),

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -924,10 +924,11 @@ void MonClient::tick()
 		      << " seconds), reconnecting" << dendl;
 	return _reopen_session();
       }
-      send_log();
     }
 
     _un_backoff();
+
+    send_log();
   }
 }
 

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -280,6 +280,9 @@ private:
   void handle_auth(MAuthReply *m);
 
   // monitor session
+  utime_t last_keepalive;
+  utime_t last_send_log;
+
   void tick();
   void schedule_tick();
 


### PR DESCRIPTION
Default to every 1s (vs every 10s!).

This fixes a subtle regression from way back in a2eb6ae3fb57b09efdd4d7baac6871ca8dd8e79f ... @tchaikov, can you take a look?