### PR TITLE
mgr/cephadm: if we had no record of deps, and deps are [], do not reconfig

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2203,6 +2203,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             deps = self._calc_daemon_deps(dd.daemon_type, dd.daemon_id)
             last_deps, last_config = self.cache.get_daemon_last_config_deps(
                 dd.hostname, dd.name())
+            if last_deps is None:
+                last_deps = []
             if last_deps != deps:
                 self.log.debug('%s deps %s -> %s' % (dd.name(), last_deps,
                                                      deps))


### PR DESCRIPTION
None != []

This avoids a reconfig of every daemon on upgrade, among other things.

Signed-off-by: Sage Weil <sage@redhat.com>