### PR TITLE
mgr/cephadm: do not refresh daemon and device inventory as often

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -545,13 +545,13 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         {
             'name': 'device_cache_timeout',
             'type': 'secs',
-            'default': 10 * 60,
+            'default': 30 * 60,
             'desc': 'seconds to cache device inventory',
         },
         {
             'name': 'daemon_cache_timeout',
             'type': 'secs',
-            'default': 60,
+            'default': 10 * 60,
             'desc': 'seconds to cache service (daemon) inventory',
         },
         {


### PR DESCRIPTION
The device inventory rarely changes.

A daemon inventory of 60s may trigger every time around the loop when
doing upgrades, which is pretty slow (esp since it's currently done
synchronously).  We're doing a good job (I think?) of queueing refreshes,
so the only reason to time this data out is to catch daemon stops that
are caused by external factors.

Signed-off-by: Sage Weil <sage@redhat.com>