### PR TITLE
mgr/dashboard: Improve iSCSI CHAP message

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html
@@ -24,8 +24,8 @@
 
             <span class="invalid-feedback"
                   *ngIf="discoveryForm.showError('user', formDir, 'pattern')"
-                  i18n>Usernames must have a length of 8 to 64 characters and
-              can only contain letters, '.', '@', '-', '_' or ':'.</span>
+                  i18n>User names must have a length of 8 to 64 characters and can contain
+              alphanumeric characters, '.', '@', '-', '_' or ':'.</span>
           </div>
         </div>
 
@@ -58,8 +58,8 @@
 
             <span class="invalid-feedback"
                   *ngIf="discoveryForm.showError('password', formDir, 'pattern')"
-                  i18n>Passwords must have a length of 12 to 16 characters
-              and can only contain letters, '@', '-', '_' or '/'.</span>
+                  i18n>Passwords must have a length of 12 to 16 characters and can contain
+              alphanumeric characters, '@', '-', '_' or '/'.</span>
           </div>
         </div>
 
@@ -81,8 +81,8 @@
 
             <span class="invalid-feedback"
                   *ngIf="discoveryForm.showError('mutual_user', formDir, 'pattern')"
-                  i18n>Usernames must have a length of 8 to 64 characters and
-              can only contain letters, '.', '@', '-', '_' or ':'.</span>
+                  i18n>User names must have a length of 8 to 64 characters and can contain
+              alphanumeric characters, '.', '@', '-', '_' or ':'.</span>
           </div>
         </div>
 
@@ -115,8 +115,8 @@
 
             <span class="invalid-feedback"
                   *ngIf="discoveryForm.showError('mutual_password', formDir, 'pattern')"
-                  i18n>Passwords must have a length of 12 to 16 characters and
-              can only contain letters, '@', '-', '_' or '/'.</span>
+                  i18n>Passwords must have a length of 12 to 16 characters and can contain
+              alphanumeric characters, '@', '-', '_' or '/'.</span>
           </div>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
@@ -223,8 +223,8 @@
 
               <span class="invalid-feedback"
                     *ngIf="targetForm.showError('user', formDir, 'pattern')"
-                    i18n>Usernames must have a length of 8 to 64 characters and
-                can only contain letters, '.', '@', '-', '_' or ':'.</span>
+                    i18n>User names must have a length of 8 to 64 characters and can contain
+                alphanumeric characters, '.', '@', '-', '_' or ':'.</span>
             </div>
           </div>
 
@@ -260,8 +260,8 @@
 
               <span class="invalid-feedback"
                     *ngIf="targetForm.showError('password', formDir, 'pattern')"
-                    i18n>Passwords must have a length of 12 to 16 characters
-                and can only contain letters, '@', '-', '_' or '/'.</span>
+                    i18n>Passwords must have a length of 12 to 16 characters and can contain
+                alphanumeric characters, '@', '-', '_' or '/'.</span>
             </div>
           </div>
 
@@ -284,8 +284,8 @@
 
               <span class="invalid-feedback"
                     *ngIf="targetForm.showError('mutual_user', formDir, 'pattern')"
-                    i18n>Usernames must have a length of 8 to 64 characters and
-                can only contain letters, '.', '@', '-', '_' or ':'.</span>
+                    i18n>User names must have a length of 8 to 64 characters and can contain
+                alphanumeric characters, '.', '@', '-', '_' or ':'.</span>
             </div>
           </div>
 
@@ -322,8 +322,8 @@
 
               <span class="invalid-feedback"
                     *ngIf="targetForm.showError('mutual_password', formDir, 'pattern')"
-                    i18n>Passwords must have a length of 12 to 16 characters
-                and can only contain letters, '@', '-', '_' or '/'.</span>
+                    i18n>Passwords must have a length of 12 to 16 characters and can contain
+                alphanumeric characters, '@', '-', '_' or '/'.</span>
             </div>
           </div>
 
@@ -392,8 +392,8 @@
 
                       <span class="invalid-feedback"
                             *ngIf="initiator.showError('user', formDir, 'pattern')"
-                            i18n>Usernames must have a length of 8 to 64 characters and
-                        can only contain letters, '.', '@', '-', '_' or ':'.</span>
+                            i18n>User names must have a length of 8 to 64 characters and can contain
+                        alphanumeric characters, '.', '@', '-', '_' or ':'.</span>
                     </div>
                   </div>
 
@@ -426,8 +426,8 @@
 
                       <span class="invalid-feedback"
                             *ngIf="initiator.showError('password', formDir, 'pattern')"
-                            i18n>Passwords must have a length of 12 to 16 characters
-                        and can only contain letters, '@', '-', '_' or '/'.</span>
+                            i18n>Passwords must have a length of 12 to 16 characters and can contain
+                        alphanumeric characters, '@', '-', '_' or '/'.</span>
                     </div>
                   </div>
 
@@ -450,8 +450,8 @@
 
                       <span class="invalid-feedback"
                             *ngIf="initiator.showError('mutual_user', formDir, 'pattern')"
-                            i18n>Usernames must have a length of 8 to 64 characters and
-                        can only contain letters, '.', '@', '-', '_' or ':'.</span>
+                            i18n>User names must have a length of 8 to 64 characters and can contain
+                        alphanumeric characters, '.', '@', '-', '_' or ':'.</span>
                     </div>
                   </div>
 
@@ -484,8 +484,8 @@
 
                       <span class="invalid-feedback"
                             *ngIf="initiator.showError('mutual_password', formDir, 'pattern')"
-                            i18n>Passwords must have a length of 12 to 16 characters and
-                        can only contain letters, '@', '-', '_' or '/'.</span>
+                            i18n>Passwords must have a length of 12 to 16 characters and can contain
+                        alphanumeric characters, '@', '-', '_' or '/'.</span>
                     </div>
                   </div>
                 </ng-container>


### PR DESCRIPTION
iSCSI username and password can also contain numbers.

This PR was inspired by https://github.com/SUSE/doc-ses/pull/196

Fixes: https://tracker.ceph.com/issues/44618

Signed-off-by: Ricardo Marques <rimarques@suse.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
