### PR TITLE
mgr/cephadm: upgrade: fix daemons missing image_id

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -819,9 +819,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
                 self._update_upgrade_progress(done / len(daemons))
 
-                if d.status <= 0:
+                if not d.container_image_id:
                     if d.container_image_name == target_name:
-                        self.log.debug('daemon %s is stopped but has correct image name' % (d.name()))
+                        self.log.debug('daemon %s has unknown container_image_id but has correct image name' % (d.name()))
                         continue
                 if not self._wait_for_ok_to_stop(d):
                     return


### PR DESCRIPTION
If a daemon isn't running, we don't know the image_id (hash), so we skip.
But it's also possible to have a running daemon that doesn't report an
image_id... like right after we deploy it when the container hasn't
started up yet.  Skip those too.

Signed-off-by: Sage Weil <sage@redhat.com>