### PR TITLE
mgr/cephadm: make osd create on an existing LV idempotent

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -120,7 +120,7 @@ class TestCephadm(object):
         with self._with_host(cephadm_module, 'test'):
             dg = DriveGroupSpec('test', data_devices=DeviceSelection(paths=['']))
             c = cephadm_module.create_osds([dg])
-            assert wait(cephadm_module, c) == ["Created osd(s) on host 'test'"]
+            assert wait(cephadm_module, c) == ["Created no osd(s) on host test; already created?"]
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm(
         json.dumps([


### PR DESCRIPTION
If we try to prepare an LV that was already prepared, ceph-volume will
return an error message and code.  We want our osd create command to be
idempotent, though, so recognize the error string and continue.

This is an ugly hack, but quicker than changing ceph-volume behavior, and
it is sufficient to stop all of the teuthology failures.

Works-around: https://tracker.ceph.com/issues/44313
Signed-off-by: Sage Weil <sage@redhat.com>