### PR TITLE
doc: document wsync and nowsync mount options in mount.ceph(8)

### DIFF
--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -166,6 +166,15 @@ Advanced
     int (bytes), max write size. Default: 16777216 (16*1024*1024) (writeback
     uses smaller of wsize and stripe unit)
 
+:command:`wsync`
+    Execute all namespace operations synchronously. This ensures that the
+    namespace operation will only complete after receiving a reply from
+    the MDS. This is the default.
+
+:command:`nowsync`
+    Allow the client to do namespace operations asynchronously. When this
+    option is enabled, a namespace operation may complete before the MDS
+    replies, if it has sufficient capabilities to do so.
 
 Examples
 ========
@@ -216,10 +225,15 @@ history::
 Availability
 ============
 
-**mount.ceph** is part of Ceph, a massively scalable, open-source, distributed storage system. Please
-refer to the Ceph documentation at http://ceph.com/docs for more
-information.
+**mount.ceph** is part of Ceph, a massively scalable, open-source, distributed
+storage system. Please refer to the Ceph documentation at http://ceph.com/docs
+for more information.
 
+Feature Availability
+====================
+
+The ``recover_session=`` option was added to mainline Linux kernels in v5.4.
+``wsync`` and ``nowsync`` were added in v5.7.
 
 See also
 ========


### PR DESCRIPTION
Just a mount.ceph manpage update to go along with the async dirops feature. 

Fixes: https://tracker.ceph.com/issues/44441
Signed-off-by: Jeff Layton <jlayton@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
