### PR TITLE
rgw: Add support wildcard subuser for bucket policy

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -617,7 +617,11 @@ bool rgw::auth::LocalApplier::is_identity(const idset_t& ids) const {
       if (id.get_id() == user_info.user_id.id) {
         return true;
       }
-      if (subuser != NO_SUBUSER) {
+      std::string wildcard_subuser = user_info.user_id.id;
+      wildcard_subuser.append(":*");
+      if (wildcard_subuser == id.get_id()) {
+        return true;
+      } else if (subuser != NO_SUBUSER) {
         std::string user = user_info.user_id.id;
         user.append(":");
         user.append(subuser);


### PR DESCRIPTION
User and all subusers of that user will be identified.
Sample bucket policy:
```
{
  "Version": "2012-10-17",
  "Statement": [{
    "Effect": "Allow",
    "Principal": {"AWS": ["arn:aws:iam::usfolks:user/fred:*"]},
    "Action": "s3:PutObjectAcl",
    "Resource": [
      "arn:aws:s3:::happybucket/*"
    ]
  }]
}
```

Fixes: https://tracker.ceph.com/issues/44452
Signed-off-by: Seena Fallah <seenafallah@gmail.com>