### PR TITLE
nautilus: mgr/dashboard: Disable cache for static files

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/home.py
+++ b/src/pybind/mgr/dashboard/controllers/home.py
@@ -110,6 +110,8 @@ class HomeController(BaseController):
             cherrypy.response.headers['Vary'] = "{}, Accept-Language"
         else:
             cherrypy.response.headers['Vary'] = "Accept-Language"
+
+        cherrypy.response.headers['Cache-control'] = "no-cache"
         return serve_file(full_path)
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43258

---

backport of https://github.com/ceph/ceph/pull/31018
parent tracker: https://tracker.ceph.com/issues/42376

this backport was staged using ceph-backport.sh version 15.1.0.1009
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh