### PR TITLE
nautilus: mgr/dashboard: 'destroyed' view in CRUSH map viewer

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.html
@@ -1,27 +1,31 @@
 <div class="row">
   <div class="col-sm-12 col-lg-12">
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">
-          <span i18n>CRUSH map viewer</span>
-        </h3>
-      </div>
-      <div class="panel-body">
-        <div class="col-sm-6 col-lg-6">
-          <tree [tree]="tree"
-                [settings]="{rootIsVisible: false}"
-                (nodeSelected)="onNodeSelected($event)">
-            <ng-template let-node>
-              <span class="label"
-                    [ngClass]="{'label-success': ['in', 'up'].includes(node.status), 'label-danger': ['down', 'out'].includes(node.status)}">{{ node.status }}</span>
-              <span>&nbsp;</span>
-              <span class="node-name" [innerHTML]="node.value"></span>
-            </ng-template>
-          </tree>
-        </div>
-        <div class="col-sm-6 col-lg-6 metadata" *ngIf="metadata">
-          <legend>{{ metadataTitle }}</legend>
-          <cd-table-key-value [data]="metadata"></cd-table-key-value>
+    <div class="card">
+      <div class="card-header"
+           i18n>CRUSH map viewer</div>
+      <div class="card-body">
+        <div class="row">
+          <div class="col-sm-6 col-lg-6">
+            <tree [tree]="tree"
+                  [settings]="{rootIsVisible: false}"
+                  (nodeSelected)="onNodeSelected($event)">
+              <ng-template let-node>
+                <span class="badge"
+                      [ngClass]="{'badge-success': ['in', 'up'].includes(node.status), 'badge-danger': ['down', 'out', 'destroyed'].includes(node.status)}">
+                  {{ node.status }}
+                </span>
+                <span>&nbsp;</span>
+                <span class="node-name"
+                      [ngClass]="{'type-osd': node.type === 'osd'}"
+                      [innerHTML]="node.value"></span>
+              </ng-template>
+            </tree>
+          </div>
+          <div class="col-sm-6 col-lg-6 metadata"
+               *ngIf="metadata">
+            <legend>{{ metadataTitle }}</legend>
+            <cd-table-key-value [data]="metadata"></cd-table-key-value>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.spec.ts
@@ -33,8 +33,8 @@ describe('CrushmapComponent', () => {
 
   it('should display right title', () => {
     fixture.detectChanges();
-    const span = debugElement.nativeElement.querySelector('span');
-    expect(span.textContent).toBe('CRUSH map viewer');
+    const card = debugElement.nativeElement.querySelector('.card-header');
+    expect(card.textContent).toBe('CRUSH map viewer');
   });
 
   describe('test tree', () => {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44327

---

backport of https://github.com/ceph/ceph/pull/33405
parent tracker: https://tracker.ceph.com/issues/44198

this backport was staged using ceph-backport.sh version 15.1.0.1009
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh