### PR TITLE
nautilus: mon: fix/improve mon sync over small keys

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -283,7 +283,7 @@ OPTION(mon_scrub_inject_crc_mismatch, OPT_DOUBLE) // probability of injected crc
 OPTION(mon_scrub_inject_missing_keys, OPT_DOUBLE) // probability of injected missing keys [0.0, 1.0]
 OPTION(mon_config_key_max_entry_size, OPT_INT) // max num bytes per config-key entry
 OPTION(mon_sync_timeout, OPT_DOUBLE)
-OPTION(mon_sync_max_payload_size, OPT_U32) // max size for a sync chunk payload (say)
+OPTION(mon_sync_max_payload_size, OPT_SIZE)
 OPTION(mon_sync_max_payload_keys, OPT_INT)
 OPTION(mon_sync_debug, OPT_BOOL) // enable sync-specific debug
 OPTION(mon_inject_sync_get_chunk_delay, OPT_DOUBLE)  // inject N second delay on each get_chunk request

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -284,6 +284,7 @@ OPTION(mon_scrub_inject_missing_keys, OPT_DOUBLE) // probability of injected mis
 OPTION(mon_config_key_max_entry_size, OPT_INT) // max num bytes per config-key entry
 OPTION(mon_sync_timeout, OPT_DOUBLE)
 OPTION(mon_sync_max_payload_size, OPT_U32) // max size for a sync chunk payload (say)
+OPTION(mon_sync_max_payload_keys, OPT_INT)
 OPTION(mon_sync_debug, OPT_BOOL) // enable sync-specific debug
 OPTION(mon_inject_sync_get_chunk_delay, OPT_DOUBLE)  // inject N second delay on each get_chunk request
 OPTION(mon_osd_force_trim_to, OPT_INT)   // force mon to trim maps to this point, regardless of min_last_epoch_clean (dangerous)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1941,6 +1941,11 @@ std::vector<Option> get_global_options() {
     .add_service("mon")
     .set_description("target max message payload for mon sync"),
 
+    Option("mon_sync_max_payload_keys", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(2000)
+    .add_service("mon")
+    .set_description("target max keys in message payload for mon sync"),
+
     Option("mon_sync_debug", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .add_service("mon")

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1628,8 +1628,11 @@ void Monitor::handle_sync_get_chunk(MonOpRequestRef op)
   MMonSync *reply = new MMonSync(MMonSync::OP_CHUNK, sp.cookie);
   auto tx(std::make_shared<MonitorDBStore::Transaction>());
 
-  int left = g_conf()->mon_sync_max_payload_size;
-  while (sp.last_committed < paxos->get_version() && left > 0) {
+  int bytes_left = g_conf()->mon_sync_max_payload_size;
+  int keys_left = g_conf()->mon_sync_max_payload_keys;
+  while (sp.last_committed < paxos->get_version() &&
+	 bytes_left > 0 &&
+	 keys_left > 0) {
     bufferlist bl;
     sp.last_committed++;
 
@@ -1637,14 +1640,15 @@ void Monitor::handle_sync_get_chunk(MonOpRequestRef op)
     ceph_assert(err == 0);
 
     tx->put(paxos->get_name(), sp.last_committed, bl);
-    left -= bl.length();
+    bytes_left -= bl.length();
+    --keys_left;
     dout(20) << __func__ << " including paxos state " << sp.last_committed
 	     << dendl;
   }
   reply->last_committed = sp.last_committed;
 
-  if (sp.full && left > 0) {
-    sp.synchronizer->get_chunk_tx(tx, left);
+  if (sp.full && bytes_left > 0 && keys_left > 0) {
+    sp.synchronizer->get_chunk_tx(tx, bytes_left, keys_left);
     sp.last_key = sp.synchronizer->get_last_key();
     reply->last_key = sp.last_key;
   }

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -106,6 +106,14 @@ class MonitorDBStore
       }
     }
 
+    int approx_size() const {
+      return 6 + 1 +
+	4 + prefix.size() +
+	4 + key.size() +
+	4 + endkey.size() +
+	4 + bl.length();
+    }
+
     static void generate_test_instances(list<Op*>& ls) {
       ls.push_back(new Op);
       // we get coverage here from the Transaction instances
@@ -118,7 +126,7 @@ class MonitorDBStore
     list<Op> ops;
     uint64_t bytes, keys;
 
-    Transaction() : bytes(0), keys(0) {}
+    Transaction() : bytes(6 + 4 + 8*2), keys(0) {}
 
     enum {
       OP_PUT	= 1,
@@ -130,7 +138,7 @@ class MonitorDBStore
     void put(const string& prefix, const string& key, const bufferlist& bl) {
       ops.push_back(Op(OP_PUT, prefix, key, bl));
       ++keys;
-      bytes += prefix.length() + key.length() + bl.length();
+      bytes += ops.back().approx_size();
     }
 
     void put(const string& prefix, version_t ver, const bufferlist& bl) {
@@ -149,7 +157,7 @@ class MonitorDBStore
     void erase(const string& prefix, const string& key) {
       ops.push_back(Op(OP_ERASE, prefix, key));
       ++keys;
-      bytes += prefix.length() + key.length();
+      bytes += ops.back().approx_size();
     }
 
     void erase(const string& prefix, version_t ver) {
@@ -162,7 +170,7 @@ class MonitorDBStore
 		     const string& end) {
       ops.push_back(Op(OP_ERASE_RANGE, prefix, begin, end));
       ++keys;
-      bytes += prefix.length() + begin.length() + end.length();
+      bytes += ops.back().approx_size();
     }
 
     void compact_prefix(const string& prefix) {


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/31581

And cherry-picked the following so that https://github.com/ceph/ceph/pull/31581 would apply cleanly.

```
commit 4d60b578e60c80441971e3b8311b927313397a08
Author: Sage Weil <sage@redhat.com>
Date:   Tue Sep 24 08:30:17 2019 -0500

    mon/MonitorDBStore: use const string& for args throughout
    
    const bufferlist& too
    
    Signed-off-by: Sage Weil <sage@redhat.com>
    (cherry picked from commit d4fdd5a1e667338d6bde0ca8d66e8432ddfddfdd)

commit 9f80abdf988dbf8761a783a14ace1ff79b5262e0
Author: Sage Weil <sage@redhat.com>
Date:   Mon Sep 23 10:53:27 2019 -0500

    mon/MonitorDBStore: add erase_range() op to transaction
    
    Signed-off-by: Sage Weil <sage@redhat.com>
    (cherry picked from commit 6900420d4e510e6b9e798384f70a2cb9631964db)
```