### PR TITLE
mgr/cephadm: fix placement when existing + specified don't overlap

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3036,8 +3036,11 @@ class HostAssignment(object):
         # prefer hosts that already have services
         daemons = self.get_daemons_func(self.service_name)
         hosts_with_daemons = {d.hostname for d in daemons}
+        # calc existing daemons (that aren't already in chosen)
+        chosen_hosts = [hs.hostname for hs in chosen]
         existing = [hs for hs in hosts
-                    if hs.hostname in hosts_with_daemons]
+                    if hs.hostname in hosts_with_daemons and \
+                    hs.hostname not in chosen_hosts]
         if len(chosen + existing) >= self.spec.placement.count:
             chosen = chosen + self.scheduler.place(
                 existing,

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -54,6 +54,26 @@ class NodeAssignmentTest(NamedTuple):
             ],
             ['host1', 'host3']
         ),
+        # count + partial host list + existing (deterministic)
+        NodeAssignmentTest(
+            'mon',
+            PlacementSpec(count=2, hosts=['host1']),
+            'host1 host2'.split(),
+            [
+                DaemonDescription('mon', 'a', 'host1'),
+            ],
+            ['host1', 'host2']
+        ),
+        # count + partial host list + existing (deterministic)
+        NodeAssignmentTest(
+            'mon',
+            PlacementSpec(count=2, hosts=['host1']),
+            'host1 host2'.split(),
+            [
+                DaemonDescription('mon', 'a', 'host2'),
+            ],
+            ['host1', 'host2']
+        ),
         # label only
         NodeAssignmentTest(
             'mon',


### PR DESCRIPTION
If we have a daemon on A, and our spec is (count=2, hosts=[B]), we should
always return [A,B], but we sometimes were returning [B,B].

Signed-off-by: Sage Weil <sage@redhat.com>