### PR TITLE
rgw: warn on potential insecure mon connection

### DIFF
--- a/src/auth/AuthRegistry.h
+++ b/src/auth/AuthRegistry.h
@@ -60,6 +60,14 @@ public:
 		     uint32_t auth_method,
 		     const std::vector<uint32_t>& preferred_modes);
 
+  static bool is_secure_method(uint32_t method) {
+    return (method == CEPH_AUTH_CEPHX);
+  }
+
+  static bool is_secure_mode(uint32_t mode) {
+    return (mode == CEPH_CON_MODE_SECURE);
+  }
+
   AuthAuthorizeHandler *get_handler(int peer_type, int method);
 
   const char** get_tracked_conf_keys() const override;

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -673,6 +673,7 @@ bool LogMonitor::prepare_command(MonOpRequestRef op)
 
   if (prefix == "log") {
     vector<string> logtext;
+    string level_str;
     cmd_getval(cmdmap, "logtext", logtext);
     LogEntry le;
     le.rank = m->get_orig_source();
@@ -680,7 +681,8 @@ bool LogMonitor::prepare_command(MonOpRequestRef op)
     le.name = session->entity_name;
     le.stamp = m->get_recv_stamp();
     le.seq = 0;
-    le.prio = CLOG_INFO;
+    cmd_getval(cmdmap, "level", level_str, string("info"));
+    le.prio = LogEntry::str_to_level(level_str);
     le.channel = CLOG_CHANNEL_DEFAULT;
     le.msg = str_join(logtext, " ");
     pending_summary.add(le);

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -603,7 +603,7 @@ int AsioFrontend::get_config_key_val(string name,
   }
 
   auto svc = env.store->svc()->config_key;
-  int r = svc->get(name, pbl);
+  int r = svc->get(name, true, pbl);
   if (r < 0) {
     lderr(ctx()) << type << " was not found: " << name << dendl;
     return r;

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -160,6 +160,12 @@ int RGWServices_Def::init(CephContext *cct,
     return r;
   }
 
+  r = config_key_rados->start();
+  if (r < 0) {
+    ldout(cct, 0) << "ERROR: failed to start config_key service (" << cpp_strerror(-r) << dendl;
+    return r;
+  }
+
   r = zone_utils->start();
   if (r < 0) {
     ldout(cct, 0) << "ERROR: failed to start zone_utils service (" << cpp_strerror(-r) << dendl;

--- a/src/rgw/services/svc_config_key.h
+++ b/src/rgw/services/svc_config_key.h
@@ -26,6 +26,6 @@ public:
   RGWSI_ConfigKey(CephContext *cct) : RGWServiceInstance(cct) {}
   virtual ~RGWSI_ConfigKey() {}
 
-  virtual int get(const string& key, bufferlist *result) = 0;
+  virtual int get(const string& key, bool secure, bufferlist *result) = 0;
 };
 

--- a/src/rgw/services/svc_config_key_rados.cc
+++ b/src/rgw/services/svc_config_key_rados.cc
@@ -2,7 +2,28 @@
 #include "svc_rados.h"
 #include "svc_config_key_rados.h"
 
-int RGWSI_ConfigKey_RADOS::get(const string& key, bufferlist *result)
+int RGWSI_ConfigKey_RADOS::do_start()
+{
+  maybe_insecure_mon_conn = !svc.rados->check_secure_mon_conn();
+
+  return 0;
+}
+
+void RGWSI_ConfigKey_RADOS::warn_if_insecure()
+{
+  if (!maybe_insecure_mon_conn ||
+      warned_insecure.test_and_set()) {
+    return;
+  }
+
+  string s = "rgw is configured to optionally allow insecure connections to the monitors (auth_supported, ms_mon_client_mode), ssl certificates stored at the monitor configuration could leak";
+
+  svc.rados->clog_warn(s);
+
+  lderr(ctx()) << __func__ << "(): WARNING: " << s << dendl;
+}
+
+int RGWSI_ConfigKey_RADOS::get(const string& key, bool secure, bufferlist *result)
 {
   string cmd =
     "{"
@@ -12,5 +33,14 @@ int RGWSI_ConfigKey_RADOS::get(const string& key, bufferlist *result)
 
   bufferlist inbl;
   auto handle = svc.rados->handle();
-  return handle.mon_command(cmd, inbl, result, nullptr);
+  int ret = handle.mon_command(cmd, inbl, result, nullptr);
+  if (ret < 0) {
+    return ret;
+  }
+
+  if (secure) {
+    warn_if_insecure();
+  }
+
+  return 0;
 }

--- a/src/rgw/services/svc_config_key_rados.h
+++ b/src/rgw/services/svc_config_key_rados.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "rgw/rgw_service.h"
 
 #include "svc_config_key.h"
@@ -26,6 +28,13 @@ class RGWSI_RADOS;
 
 class RGWSI_ConfigKey_RADOS : public RGWSI_ConfigKey
 {
+  bool maybe_insecure_mon_conn{false};
+  std::atomic_flag warned_insecure{ATOMIC_FLAG_INIT};
+
+  int do_start() override;
+
+  void warn_if_insecure();
+
 public:
   struct Svc {
     RGWSI_RADOS *rados{nullptr};
@@ -37,7 +46,7 @@ public:
 
   RGWSI_ConfigKey_RADOS(CephContext *cct) : RGWSI_ConfigKey(cct) {}
 
-  int get(const string& key, bufferlist *result) override;
+  int get(const string& key, bool secure, bufferlist *result) override;
 };
 
 

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -9,6 +9,8 @@
 #include "rgw/rgw_tools.h"
 #include "rgw/rgw_cr_rados.h"
 
+#include "auth/AuthRegistry.h"
+
 #define dout_subsys ceph_subsys_rgw
 
 RGWSI_RADOS::RGWSI_RADOS(CephContext *cct) : RGWServiceInstance(cct)
@@ -381,5 +383,34 @@ int RGWSI_RADOS::clog_warn(const string& msg)
   bufferlist inbl;
   auto h = handle();
   return h.mon_command(cmd, inbl, nullptr, nullptr);
+}
+
+bool RGWSI_RADOS::check_secure_mon_conn() const
+{
+  AuthRegistry reg(cct);
+
+  reg.refresh_config();
+
+  std::vector<uint32_t> methods;
+  std::vector<uint32_t> modes;
+
+  reg.get_supported_methods(CEPH_ENTITY_TYPE_MON, &methods, &modes);
+  ldout(cct, 20) << __func__ << "(): auth registy supported: methods=" << methods << " modes=" << modes << dendl;
+
+  for (auto method : methods) {
+    if (!reg.is_secure_method(method)) {
+      ldout(cct, 20) << __func__ << "(): method " << method << " is insecure" << dendl;
+      return false;
+    }
+  }
+
+  for (auto mode : modes) {
+    if (!reg.is_secure_mode(mode)) {
+      ldout(cct, 20) << __func__ << "(): mode " << mode << " is insecure" << dendl;
+      return false;
+    }
+  }
+
+  return true;
 }
 

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -369,3 +369,17 @@ int RGWSI_RADOS::Pool::List::get_marker(string *marker)
   return 0;
 }
 
+int RGWSI_RADOS::clog_warn(const string& msg)
+{
+  string cmd =
+    "{"
+      "\"prefix\": \"log\", "
+      "\"level\": \"warn\", "
+      "\"logtext\": [\"" + msg + "\"]"
+    "}";
+
+  bufferlist inbl;
+  auto h = handle();
+  return h.mon_command(cmd, inbl, nullptr, nullptr);
+}
+

--- a/src/rgw/services/svc_rados.h
+++ b/src/rgw/services/svc_rados.h
@@ -73,6 +73,8 @@ public:
     return async_processor.get();
   }
 
+  int clog_warn(const string& msg);
+
   class Handle;
 
   class Pool {

--- a/src/rgw/services/svc_rados.h
+++ b/src/rgw/services/svc_rados.h
@@ -68,6 +68,7 @@ public:
   void shutdown() override;
 
   uint64_t instance_id();
+  bool check_secure_mon_conn() const;
 
   RGWAsyncRadosProcessor *get_async_processor() {
     return async_processor.get();


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

If the configured auth method or mode allows for insecure connections (even though it's connected securely), send a cluster log warning message if ssl certificate is configured via config-key. This is done to help preventing misconfiguration that can lead to leakage of ssl certificate. Also changing the default auth mode to only 'secure'.
See discussion here: https://github.com/ceph/ceph/pull/33287

Fixes: https://tracker.ceph.com/issues/44460

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
