### PR TITLE
crimson: solve the problem that crimson-osd's created pgs stuck in "unknown" state

### DIFF
--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library(crimson-common STATIC
   ${PROJECT_SOURCE_DIR}/src/common/Thread.cc
   ${PROJECT_SOURCE_DIR}/src/common/PluginRegistry.cc
   ${PROJECT_SOURCE_DIR}/src/common/RefCountedObj.cc
+  ${PROJECT_SOURCE_DIR}/src/common/util.cc
   ${PROJECT_SOURCE_DIR}/src/crush/builder.c
   ${PROJECT_SOURCE_DIR}/src/crush/mapper.c
   ${PROJECT_SOURCE_DIR}/src/crush/crush.c

--- a/src/crimson/mgr/client.h
+++ b/src/crimson/mgr/client.h
@@ -45,15 +45,15 @@ private:
   seastar::future<> handle_mgr_conf(crimson::net::Connection* conn,
 				    Ref<MMgrConfigure> m);
   seastar::future<> reconnect();
-  void report();
+  void tick();
 
 private:
   MgrMap mgrmap;
   crimson::net::Messenger& msgr;
   WithStats& with_stats;
   crimson::net::ConnectionRef conn;
-  std::chrono::seconds report_period{0};
-  seastar::timer<seastar::lowres_clock> report_timer;
+  std::chrono::seconds tick_period{0};
+  seastar::timer<seastar::lowres_clock> tick_timer;
   seastar::gate gate;
 };
 

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -8,6 +8,7 @@
 #include <boost/smart_ptr/make_local_shared.hpp>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <sys/utsname.h>
 #include "common/pick_address.h"
 
 #include "messages/MOSDAlive.h"
@@ -40,6 +41,7 @@
 #include "crimson/osd/osd_operations/peering_event.h"
 #include "crimson/osd/osd_operations/pg_advance_map.h"
 #include "crimson/osd/osd_operations/replicated_request.h"
+#include "include/util.h"
 
 namespace {
   seastar::logger& logger() {
@@ -343,6 +345,7 @@ seastar::future<> OSD::_send_boot()
                                   heartbeat->get_front_addrs(),
                                   cluster_msgr->get_myaddrs(),
                                   CEPH_FEATURES_ALL);
+  collect_sys_info(&m->metadata, NULL);
   return monc->send_message(m);
 }
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""

"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
crimson: solve the problem that crimson-osd's created pgs stuck in "unknown" state

As of now, there are times when pgs stuck in unknown state after successful creation.

This is due to the following issues:
1. crimson-osd may experience deadlock when closing connection with mgr
2. crimson-osd doesn't enclose metadata in the MOSDBoot message which makes mgr ignore its request "mgropen"

This PR fixes the above two issues

Signed-off-by: Xuehan Xu <xxhdx1985126@163.com>
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
