### PR TITLE
cephadm: make default image configurable

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 DEFAULT_IMAGE='docker.io/ceph/daemon-base:latest-master-devel'  # FIXME when octopus is ready!!!
+CONFIG_FILE='/etc/ceph/cephadm.cfg'
 DATA_DIR='/var/lib/ceph'
 LOG_DIR='/var/log/ceph'
 LOCK_DIR='/run/cephadm'
@@ -2145,7 +2146,7 @@ def command_deploy():
             daemon_ports = Monitoring.port_map[daemon_type]  # type: List[int]
             if any([port_in_use(port) for port in daemon_ports]):
                 raise Error("TCP Port(s) '{}' required for {} is already in use".format(",".join(map(str, daemon_ports)), daemon_type))
-            elif args.image == DEFAULT_IMAGE:
+            elif args.image == cephadm_config.default_image:
                 raise Error("--image parameter must be supplied for {}".format(daemon_type))
 
         # make sure provided config-json is sufficient
@@ -3656,11 +3657,26 @@ def _parse_args(av):
             if type_ in Monitoring.components:
                 args.image = Monitoring.components[type_]['image']
         if not args.image:
-            args.image = os.environ.get('CEPHADM_IMAGE', DEFAULT_IMAGE)
+            args.image = os.environ.get('CEPHADM_IMAGE', cephadm_config.default_image)
 
     return args
 
+class CephadmConfig(object):
+    default_image = DEFAULT_IMAGE
+
+    def __init__(self):
+        try:
+            cp = read_config(CONFIG_FILE)
+        except FileNotFoundError:
+            return
+        if cp.has_section("config"):
+            for k, v in cp.items("config"):
+                if hasattr(self, k):
+                    self.__setattr__(k, v)
+
 if __name__ == "__main__":
+    cephadm_config = CephadmConfig()
+
     # allow argv to be injected
     try:
         av = injected_argv # type: ignore


### PR DESCRIPTION
Problem
----
After using `ceph-salt` to deploy a new cluster based on a non-default container image (`image-X`), if I try to run `cephadm shell` then cephadm will automatically pull the default `docker.io/ceph/daemon-base:latest-master-devel` image instead of using `image-X`.

Solution
----
With this PR it's now possible to configure the `default_image` on `/etc/ceph/cephadm.cfg`, so `ceph-salt` or any other tool, will be able to set the default image during the provisioning.
Note that `CEPHADM_IMAGE` env variable will override the `default_image`.

Fixes: https://tracker.ceph.com/issues/43937

Signed-off-by: Ricardo Marques <rimarques@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
