### PR TITLE
qa/suites/rados/cephadm: deploy all monitoring components

### DIFF
--- a/qa/suites/rados/cephadm/smoke/fixed-2.yaml
+++ b/qa/suites/rados/cephadm/smoke/fixed-2.yaml
@@ -1,6 +1,24 @@
 roles:
-- [mon.a, mon.c, mgr.y, osd.0, osd.1, osd.2, osd.3, client.0]
-- [mon.b, mgr.x, osd.4, osd.5, osd.6, osd.7, client.1, prometheus.a]
+- - mon.a
+  - mon.c
+  - mgr.y
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+  - client.0
+  - node-exporter.a
+  - alertmanager.a
+- - mon.b
+  - mgr.x
+  - osd.4
+  - osd.5
+  - osd.6
+  - osd.7
+  - client.1
+  - prometheus.a
+  - grafana.a
+  - node-exporter.b
 openstack:
 - volumes: # attached to each instance
     count: 4

--- a/qa/suites/rados/cephadm/with-work/fixed-2.yaml
+++ b/qa/suites/rados/cephadm/with-work/fixed-2.yaml
@@ -1,1 +1,1 @@
-.qa/clusters/fixed-2.yaml
+../smoke/fixed-2.yaml

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -1043,6 +1043,8 @@ def task(ctx, config):
             lambda: ceph_rgw(ctx=ctx, config=config),
             lambda: ceph_monitoring('prometheus', ctx=ctx, config=config),
             lambda: ceph_monitoring('node-exporter', ctx=ctx, config=config),
+            lambda: ceph_monitoring('alertmanager', ctx=ctx, config=config),
+            lambda: ceph_monitoring('grafana', ctx=ctx, config=config),
             lambda: ceph_clients(ctx=ctx, config=config),
             lambda: distribute_config_and_admin_keyring(ctx=ctx, config=config),
     ):


### PR DESCRIPTION
grafana, alertmanager, node-exporter, prometheus