### PR TITLE
Build the target 'common' without relying on using namespace in headers

### DIFF
--- a/src/auth/AuthClientHandler.cc
+++ b/src/auth/AuthClientHandler.cc
@@ -40,4 +40,3 @@ AuthClientHandler::create(CephContext* cct, int proto,
     return NULL;
   }
 }
-

--- a/src/auth/AuthMethodList.cc
+++ b/src/auth/AuthMethodList.cc
@@ -28,7 +28,7 @@ AuthMethodList::AuthMethodList(CephContext *cct, std::string str)
   if (sup_list.empty()) {
     lderr(cct) << "WARNING: empty auth protocol list" << dendl;
   }
-  for (list<string>::iterator iter = sup_list.begin(); iter != sup_list.end(); ++iter) {
+  for (auto iter = sup_list.begin(); iter != sup_list.end(); ++iter) {
     ldout(cct, 5) << "adding auth protocol: " << *iter << dendl;
     if (iter->compare("cephx") == 0) {
       auth_supported.push_back(CEPH_AUTH_CEPHX);
@@ -54,7 +54,7 @@ bool AuthMethodList::is_supported_auth(int auth_type)
 
 int AuthMethodList::pick(const std::set<__u32>& supported)
 {
-  for (set<__u32>::const_reverse_iterator p = supported.rbegin(); p != supported.rend(); ++p)
+  for (auto p = supported.rbegin(); p != supported.rend(); ++p)
     if (is_supported_auth(*p))
       return *p;
   return CEPH_AUTH_UNKNOWN;
@@ -62,7 +62,7 @@ int AuthMethodList::pick(const std::set<__u32>& supported)
 
 void AuthMethodList::remove_supported_auth(int auth_type)
 {
-  for (list<__u32>::iterator p = auth_supported.begin(); p != auth_supported.end(); ) {
+  for (auto p = auth_supported.begin(); p != auth_supported.end(); ) {
     if (*p == (__u32)auth_type)
       auth_supported.erase(p++);
     else 

--- a/src/auth/AuthRegistry.cc
+++ b/src/auth/AuthRegistry.cc
@@ -16,6 +16,8 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "AuthRegistry(" << this << ") "
 
+using std::string;
+
 AuthRegistry::AuthRegistry(CephContext *cct)
   : cct(cct)
 {

--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -39,6 +39,13 @@
 
 #include <unistd.h>
 
+using std::ostringstream;
+using std::string;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::Formatter;
+
 static bool getentropy_works()
 {
   char buf;
@@ -476,7 +483,7 @@ void CryptoKey::decode(bufferlist::const_iterator& bl)
   bufferptr tmp;
   bl.copy_deep(len, tmp);
   if (_set_secret(type, tmp) < 0)
-    throw buffer::malformed_input("malformed secret");
+    throw ceph::buffer::malformed_input("malformed secret");
 }
 
 int CryptoKey::set_secret(int type, const bufferptr& s, utime_t c)

--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -30,6 +30,14 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "auth: "
 
+using std::map;
+using std::ostream;
+using std::ostringstream;
+using std::string;
+
+using ceph::bufferlist;
+using ceph::Formatter;
+
 int KeyRing::from_ceph_context(CephContext *cct)
 {
   const auto& conf = cct->_conf;
@@ -53,7 +61,7 @@ int KeyRing::from_ceph_context(CephContext *cct)
       add(conf->name, ea);
       return 0;
     }
-    catch (buffer::error& e) {
+    catch (ceph::buffer::error& e) {
       lderr(cct) << "failed to decode key '" << conf->key << "'" << dendl;
       return -EINVAL;
     }
@@ -73,7 +81,7 @@ int KeyRing::from_ceph_context(CephContext *cct)
       ea.key.decode_base64(k);
       add(conf->name, ea);
     }
-    catch (buffer::error& e) {
+    catch (ceph::buffer::error& e) {
       lderr(cct) << "failed to decode key '" << k << "'" << dendl;
       return -EINVAL;
     }
@@ -96,7 +104,7 @@ int KeyRing::set_modifier(const char *type,
     string l(val);
     try {
       key.decode_base64(l);
-    } catch (const buffer::error& err) {
+    } catch (const ceph::buffer::error& err) {
       return -EINVAL;
     }
     set_key(name, key);
@@ -162,7 +170,7 @@ void KeyRing::decode_plaintext(bufferlist::const_iterator& bli)
   ConfFile cf;
 
   if (cf.parse_bufferlist(&bl, nullptr) != 0) {
-    throw buffer::malformed_input("cannot parse buffer");
+    throw ceph::buffer::malformed_input("cannot parse buffer");
   }
 
   for (auto& [name, section] : cf) {
@@ -174,7 +182,7 @@ void KeyRing::decode_plaintext(bufferlist::const_iterator& bli)
     if (!ename.from_str(name)) {
       ostringstream oss;
       oss << "bad entity name in keyring: " << name;
-      throw buffer::malformed_input(oss.str().c_str());
+      throw ceph::buffer::malformed_input(oss.str().c_str());
     }
 
     for (auto& [k, val] : section) {
@@ -187,7 +195,7 @@ void KeyRing::decode_plaintext(bufferlist::const_iterator& bli)
 	ostringstream oss;
 	oss << "error setting modifier for [" << name << "] type=" << key
 	    << " val=" << val;
-	throw buffer::malformed_input(oss.str().c_str());
+	throw ceph::buffer::malformed_input(oss.str().c_str());
       }
     }
   }
@@ -200,7 +208,7 @@ void KeyRing::decode(bufferlist::const_iterator& bl) {
     using ceph::decode;
     decode(struct_v, bl);
     decode(keys, bl);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     keys.clear();
     decode_plaintext(start_pos);
   }
@@ -223,7 +231,7 @@ int KeyRing::load(CephContext *cct, const std::string &filename)
     auto iter = bl.cbegin();
     decode(iter);
   }
-  catch (const buffer::error& err) {
+  catch (const ceph::buffer::error& err) {
     lderr(cct) << "error parsing file " << filename << ": " << err.what() << dendl;
     return -EIO;
   }

--- a/src/auth/RotatingKeyRing.cc
+++ b/src/auth/RotatingKeyRing.cc
@@ -31,7 +31,7 @@ void RotatingKeyRing::set_secrets(RotatingSecrets&& s)
 void RotatingKeyRing::dump_rotating() const
 {
   ldout(cct, 10) << "dump_rotating:" << dendl;
-  for (map<uint64_t, ExpiringCryptoKey>::const_iterator iter = secrets.secrets.begin();
+  for (auto iter = secrets.secrets.begin();
        iter != secrets.secrets.end();
        ++iter)
     ldout(cct, 10) << " id " << iter->first << " " << iter->second << dendl;
@@ -54,8 +54,7 @@ bool RotatingKeyRing::get_service_secret(uint32_t service_id_, uint64_t secret_i
     return false;
   }
 
-  map<uint64_t, ExpiringCryptoKey>::const_iterator iter =
-    secrets.secrets.find(secret_id);
+  auto iter = secrets.secrets.find(secret_id);
   if (iter == secrets.secrets.end()) {
     ldout(cct, 0) << "could not find secret_id=" << secret_id << dendl;
     dump_rotating();

--- a/src/auth/cephx/CephxAuthorizeHandler.cc
+++ b/src/auth/cephx/CephxAuthorizeHandler.cc
@@ -4,14 +4,12 @@
 
 #define dout_subsys ceph_subsys_auth
 
-
-
 bool CephxAuthorizeHandler::verify_authorizer(
   CephContext *cct,
   const KeyStore& keys,
-  const bufferlist& authorizer_data,
+  const ceph::bufferlist& authorizer_data,
   size_t connection_secret_required_len,
-  bufferlist *authorizer_reply,
+  ceph::bufferlist *authorizer_reply,
   EntityName *entity_name,
   uint64_t *global_id,
   AuthCapsInfo *caps_info,

--- a/src/auth/cephx/CephxAuthorizeHandler.h
+++ b/src/auth/cephx/CephxAuthorizeHandler.h
@@ -22,9 +22,9 @@ struct CephxAuthorizeHandler : public AuthAuthorizeHandler {
   bool verify_authorizer(
     CephContext *cct,
     const KeyStore& keys,
-    const bufferlist& authorizer_data,
+    const ceph::buffer::list& authorizer_data,
     size_t connection_secret_required_len,
-    bufferlist *authorizer_reply,
+    ceph::buffer::list *authorizer_reply,
     EntityName *entity_name,
     uint64_t *global_id,
     AuthCapsInfo *caps_info,

--- a/src/auth/cephx/CephxClientHandler.cc
+++ b/src/auth/cephx/CephxClientHandler.cc
@@ -28,6 +28,10 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "cephx client: "
 
+using std::string;
+
+using ceph::bufferlist;
+
 void CephxClientHandler::reset()
 {
   ldout(cct,10) << __func__ << dendl;
@@ -130,7 +134,7 @@ int CephxClientHandler::handle_response(
     CephXServerChallenge ch;
     try {
       decode(ch, indata);
-    } catch (buffer::error& e) {
+    } catch (ceph::buffer::error& e) {
       ldout(cct, 1) << __func__ << " failed to decode CephXServerChallenge: "
 		    << e.what() << dendl;
       return -EPERM;
@@ -147,7 +151,7 @@ int CephxClientHandler::handle_response(
   struct CephXResponseHeader header;
   try {
     decode(header, indata);
-  } catch (buffer::error& e) {
+  } catch (ceph::buffer::error& e) {
     ldout(cct, 1) << __func__ << " failed to decode CephXResponseHeader: "
 		  << e.what() << dendl;
     return -EPERM;
@@ -171,10 +175,11 @@ int CephxClientHandler::handle_response(
       ldout(cct, 10) << " want=" << want << " need=" << need << " have=" << have << dendl;
       if (!indata.end()) {
 	bufferlist cbl, extra_tickets;
+	using ceph::decode;
 	try {
 	  decode(cbl, indata);
 	  decode(extra_tickets, indata);
-	} catch (buffer::error& e) {
+	} catch (ceph::buffer::error& e) {
 	  ldout(cct, 1) << __func__ << " failed to decode tickets: "
 			<< e.what() << dendl;
 	  return -EPERM;

--- a/src/auth/cephx/CephxClientHandler.h
+++ b/src/auth/cephx/CephxClientHandler.h
@@ -50,11 +50,11 @@ public:
 
   void reset() override;
   void prepare_build_request() override;
-  int build_request(bufferlist& bl) const override;
-  int handle_response(int ret, bufferlist::const_iterator& iter,
+  int build_request(ceph::buffer::list& bl) const override;
+  int handle_response(int ret, ceph::buffer::list::const_iterator& iter,
 		      CryptoKey *session_key,
 		      std::string *connection_secret) override;
-  bool build_rotating_request(bufferlist& bl) const override;
+  bool build_rotating_request(ceph::buffer::list& bl) const override;
 
   int get_protocol() const override { return CEPH_AUTH_CEPHX; }
 

--- a/src/auth/cephx/CephxProtocol.cc
+++ b/src/auth/cephx/CephxProtocol.cc
@@ -23,7 +23,13 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "cephx: "
 
+using std::dec;
+using std::hex;
+using std::vector;
 
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
 
 void cephx_calc_client_server_challenge(CephContext *cct, CryptoKey& secret, uint64_t server_challenge, 
 		  uint64_t client_challenge, uint64_t *key, std::string &error)
@@ -92,6 +98,7 @@ bool cephx_build_service_ticket_reply(CephContext *cct,
                      bufferlist& reply)
 {
   __u8 service_ticket_reply_v = 1;
+  using ceph::encode;
   encode(service_ticket_reply_v, reply);
 
   uint32_t num = ticket_info_vec.size();
@@ -99,7 +106,7 @@ bool cephx_build_service_ticket_reply(CephContext *cct,
   ldout(cct, 10) << "build_service_ticket_reply encoding " << num
 	   << " tickets with secret " << principal_secret << dendl;
 
-  for (vector<CephXSessionAuthInfo>::iterator ticket_iter = ticket_info_vec.begin(); 
+  for (auto ticket_iter = ticket_info_vec.begin(); 
        ticket_iter != ticket_info_vec.end();
        ++ticket_iter) {
     CephXSessionAuthInfo& info = *ticket_iter;
@@ -149,6 +156,7 @@ bool CephXTicketHandler::verify_service_ticket_reply(
   CryptoKey& secret,
   bufferlist::const_iterator& indata)
 {
+  using ceph::decode;
   try {
     __u8 service_ticket_v;
     decode(service_ticket_v, indata);
@@ -198,7 +206,7 @@ bool CephXTicketHandler::verify_service_ticket_reply(
 
     have_key_flag = true;
     return true;
-  } catch (buffer::error& e) {
+  } catch (ceph::buffer::error& e) {
     ldout(cct, 1) << __func__ << " decode error: " << e.what() << dendl;
     return false;
   }
@@ -224,7 +232,7 @@ bool CephXTicketHandler::need_key() const
 
 bool CephXTicketManager::have_key(uint32_t service_id)
 {
-  map<uint32_t, CephXTicketHandler>::iterator iter = tickets_map.find(service_id);
+  auto iter = tickets_map.find(service_id);
   if (iter == tickets_map.end())
     return false;
   return iter->second.have_key();
@@ -232,7 +240,7 @@ bool CephXTicketManager::have_key(uint32_t service_id)
 
 bool CephXTicketManager::need_key(uint32_t service_id) const
 {
-  map<uint32_t, CephXTicketHandler>::const_iterator iter = tickets_map.find(service_id);
+  auto iter = tickets_map.find(service_id);
   if (iter == tickets_map.end())
     return true;
   return iter->second.need_key();
@@ -240,7 +248,7 @@ bool CephXTicketManager::need_key(uint32_t service_id) const
 
 void CephXTicketManager::set_have_need_key(uint32_t service_id, uint32_t& have, uint32_t& need)
 {
-  map<uint32_t, CephXTicketHandler>::iterator iter = tickets_map.find(service_id);
+  auto iter = tickets_map.find(service_id);
   if (iter == tickets_map.end()) {
     have &= ~service_id;
     need |= service_id;
@@ -265,7 +273,7 @@ void CephXTicketManager::set_have_need_key(uint32_t service_id, uint32_t& have, 
 
 void CephXTicketManager::invalidate_ticket(uint32_t service_id)
 {
-  map<uint32_t, CephXTicketHandler>::iterator iter = tickets_map.find(service_id);
+  auto iter = tickets_map.find(service_id);
   if (iter != tickets_map.end())
     iter->second.invalidate_ticket();
 }
@@ -282,7 +290,7 @@ bool CephXTicketManager::verify_service_ticket_reply(CryptoKey& secret,
   try {
     decode(service_ticket_reply_v, indata);
     decode(num, indata);
-  } catch (buffer::error& e) {
+  } catch (ceph::buffer::error& e) {
     ldout(cct, 10) << __func__ << " failed to decode ticket v or count: "
 		   << e.what() << dendl;
   }
@@ -292,7 +300,7 @@ bool CephXTicketManager::verify_service_ticket_reply(CryptoKey& secret,
     uint32_t type = 0;
     try {
       decode(type, indata);
-    } catch (buffer::error& e) {
+    } catch (ceph::buffer::error& e) {
       ldout(cct, 10) << __func__ << " failed to decode ticket type: " << e.what()
 		     << dendl;
     }
@@ -345,7 +353,7 @@ CephXAuthorizer *CephXTicketHandler::build_authorizer(uint64_t global_id) const
  */
 CephXAuthorizer *CephXTicketManager::build_authorizer(uint32_t service_id) const
 {
-  map<uint32_t, CephXTicketHandler>::const_iterator iter = tickets_map.find(service_id);
+  auto iter = tickets_map.find(service_id);
   if (iter == tickets_map.end()) {
     ldout(cct, 0) << "no TicketHandler for service "
 		  << ceph_entity_type_name(service_id) << dendl;
@@ -429,7 +437,7 @@ bool cephx_verify_authorizer(CephContext *cct, const KeyStore& keys,
     decode(global_id, indata);
     decode(service_id, indata);
     decode(ticket, indata);
-  } catch (buffer::end_of_buffer &e) {
+  } catch (ceph::buffer::end_of_buffer &e) {
     // Unable to decode!
     return false;
   }

--- a/src/auth/cephx/CephxProtocol.h
+++ b/src/auth/cephx/CephxProtocol.h
@@ -43,13 +43,13 @@
 struct CephXServerChallenge {
   uint64_t server_challenge;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     __u8 struct_v = 1;
     encode(struct_v, bl);
     encode(server_challenge, bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     using ceph::decode;
     __u8 struct_v;
     decode(struct_v, bl);
@@ -64,11 +64,11 @@ WRITE_CLASS_ENCODER(CephXServerChallenge)
 struct CephXRequestHeader {
   __u16 request_type;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     encode(request_type, bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     using ceph::decode;
     decode(request_type, bl);
   }
@@ -79,12 +79,12 @@ struct CephXResponseHeader {
   uint16_t request_type;
   int32_t status;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     encode(request_type, bl);
     encode(status, bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     using ceph::decode;
     decode(request_type, bl);
     decode(status, bl);
@@ -94,11 +94,11 @@ WRITE_CLASS_ENCODER(CephXResponseHeader)
 
 struct CephXTicketBlob {
   uint64_t secret_id;
-  bufferlist blob;
+  ceph::buffer::list blob;
 
   CephXTicketBlob() : secret_id(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
      using ceph::encode;
      __u8 struct_v = 1;
      encode(struct_v, bl);
@@ -106,7 +106,7 @@ struct CephXTicketBlob {
      encode(blob, bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
      using ceph::decode;
      __u8 struct_v;
      decode(struct_v, bl);
@@ -123,7 +123,7 @@ struct CephXAuthenticate {
   CephXTicketBlob old_ticket;
   uint32_t other_keys = 0;  // replaces CephXServiceTicketRequest
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     __u8 struct_v = 2;
     encode(struct_v, bl);
@@ -132,7 +132,7 @@ struct CephXAuthenticate {
     encode(old_ticket, bl);
     encode(other_keys, bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     using ceph::decode;
     __u8 struct_v;
     decode(struct_v, bl);
@@ -149,12 +149,12 @@ WRITE_CLASS_ENCODER(CephXAuthenticate)
 struct CephXChallengeBlob {
   uint64_t server_challenge, client_challenge;
   
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
      using ceph::encode;
     encode(server_challenge, bl);
     encode(client_challenge, bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     using ceph::decode;
     decode(server_challenge, bl);
     decode(client_challenge, bl);
@@ -185,25 +185,25 @@ extern bool cephx_build_service_ticket_blob(CephContext *cct,
 
 extern void cephx_build_service_ticket_request(CephContext *cct, 
 					       uint32_t keys,
-					       bufferlist& request);
+					       ceph::buffer::list& request);
 
 extern bool cephx_build_service_ticket_reply(CephContext *cct,
 					     CryptoKey& principal_secret,
-					     vector<CephXSessionAuthInfo> ticket_info,
+					     std::vector<CephXSessionAuthInfo> ticket_info,
                                              bool should_encrypt_ticket,
                                              CryptoKey& ticket_enc_key,
-					     bufferlist& reply);
+					     ceph::buffer::list& reply);
 
 struct CephXServiceTicketRequest {
   uint32_t keys;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     __u8 struct_v = 1;
     encode(struct_v, bl);
     encode(keys, bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     using ceph::decode;
     __u8 struct_v;
     decode(struct_v, bl);
@@ -220,7 +220,7 @@ WRITE_CLASS_ENCODER(CephXServiceTicketRequest)
 struct CephXAuthorizeReply {
   uint64_t nonce_plus_one;
   std::string connection_secret;
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     __u8 struct_v = 1;
     if (connection_secret.size()) {
@@ -233,7 +233,7 @@ struct CephXAuthorizeReply {
       encode(connection_secret, bl);
     }
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     using ceph::decode;
     __u8 struct_v;
     decode(struct_v, bl);
@@ -251,15 +251,15 @@ private:
   CephContext *cct;
 public:
   uint64_t nonce;
-  bufferlist base_bl;
+  ceph::buffer::list base_bl;
 
   explicit CephXAuthorizer(CephContext *cct_)
     : AuthAuthorizer(CEPH_AUTH_CEPHX), cct(cct_), nonce(0) {}
 
   bool build_authorizer();
-  bool verify_reply(bufferlist::const_iterator& reply,
+  bool verify_reply(ceph::buffer::list::const_iterator& reply,
 		    std::string *connection_secret) override;
-  bool add_challenge(CephContext *cct, const bufferlist& challenge) override;
+  bool add_challenge(CephContext *cct, const ceph::buffer::list& challenge) override;
 };
 
 
@@ -279,7 +279,7 @@ struct CephXTicketHandler {
 
   // to build our ServiceTicket
   bool verify_service_ticket_reply(CryptoKey& principal_secret,
-				 bufferlist::const_iterator& indata);
+				 ceph::buffer::list::const_iterator& indata);
   // to access the service
   CephXAuthorizer *build_authorizer(uint64_t global_id) const;
 
@@ -294,14 +294,14 @@ private:
 };
 
 struct CephXTicketManager {
-  typedef map<uint32_t, CephXTicketHandler> tickets_map_t;
+  typedef std::map<uint32_t, CephXTicketHandler> tickets_map_t;
   tickets_map_t tickets_map;
   uint64_t global_id;
 
   explicit CephXTicketManager(CephContext *cct_) : global_id(0), cct(cct_) {}
 
   bool verify_service_ticket_reply(CryptoKey& principal_secret,
-				 bufferlist::const_iterator& indata);
+				 ceph::buffer::list::const_iterator& indata);
 
   CephXTicketHandler& get_handler(uint32_t type) {
     tickets_map_t::iterator i = tickets_map.find(type);
@@ -330,14 +330,14 @@ struct CephXServiceTicket {
   CryptoKey session_key;
   utime_t validity;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     __u8 struct_v = 1;
     encode(struct_v, bl);
     encode(session_key, bl);
     encode(validity, bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     using ceph::decode;
     __u8 struct_v;
     decode(struct_v, bl);
@@ -352,14 +352,14 @@ struct CephXServiceTicketInfo {
   AuthTicket ticket;
   CryptoKey session_key;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     __u8 struct_v = 1;
     encode(struct_v, bl);
     encode(ticket, bl);
     encode(session_key, bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     using ceph::decode;
     __u8 struct_v;
     decode(struct_v, bl);
@@ -371,13 +371,13 @@ WRITE_CLASS_ENCODER(CephXServiceTicketInfo)
 
 struct CephXAuthorizeChallenge : public AuthAuthorizerChallenge {
   uint64_t server_challenge;
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     __u8 struct_v = 1;
     encode(struct_v, bl);
     encode(server_challenge, bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     using ceph::decode;
     __u8 struct_v;
     decode(struct_v, bl);
@@ -390,7 +390,7 @@ struct CephXAuthorize {
   uint64_t nonce;
   bool have_challenge = false;
   uint64_t server_challenge_plus_one = 0;
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     __u8 struct_v = 2;
     encode(struct_v, bl);
@@ -398,7 +398,7 @@ struct CephXAuthorize {
     encode(have_challenge, bl);
     encode(server_challenge_plus_one, bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     using ceph::decode;
     __u8 struct_v;
     decode(struct_v, bl);
@@ -424,12 +424,12 @@ bool cephx_decode_ticket(CephContext *cct, KeyStore *keys,
 extern bool cephx_verify_authorizer(
   CephContext *cct,
   const KeyStore& keys,
-  bufferlist::const_iterator& indata,
+  ceph::buffer::list::const_iterator& indata,
   size_t connection_secret_required_len,
   CephXServiceTicketInfo& ticket_info,
   std::unique_ptr<AuthAuthorizerChallenge> *challenge,
   std::string *connection_secret,
-  bufferlist *reply_bl);
+  ceph::buffer::list *reply_bl);
 
 
 
@@ -443,21 +443,22 @@ static constexpr uint64_t AUTH_ENC_MAGIC = 0xff009cad8826aa55ull;
 
 template <typename T>
 void decode_decrypt_enc_bl(CephContext *cct, T& t, CryptoKey key,
-			   const bufferlist& bl_enc,
+			   const ceph::buffer::list& bl_enc,
 			   std::string &error)
 {
   uint64_t magic;
-  bufferlist bl;
+  ceph::buffer::list bl;
 
   if (key.decrypt(cct, bl_enc, bl, &error) < 0)
     return;
 
   auto iter2 = bl.cbegin();
   __u8 struct_v;
+  using ceph::decode;
   decode(struct_v, iter2);
   decode(magic, iter2);
   if (magic != AUTH_ENC_MAGIC) {
-    ostringstream oss;
+    std::ostringstream oss;
     oss << "bad magic in decode_decrypt, " << magic << " != " << AUTH_ENC_MAGIC;
     error = oss.str();
     return;
@@ -468,10 +469,11 @@ void decode_decrypt_enc_bl(CephContext *cct, T& t, CryptoKey key,
 
 template <typename T>
 void encode_encrypt_enc_bl(CephContext *cct, const T& t, const CryptoKey& key,
-			   bufferlist& out, std::string &error)
+			   ceph::buffer::list& out, std::string &error)
 {
-  bufferlist bl;
+  ceph::buffer::list bl;
   __u8 struct_v = 1;
+  using ceph::encode;
   encode(struct_v, bl);
   uint64_t magic = AUTH_ENC_MAGIC;
   encode(magic, bl);
@@ -482,14 +484,15 @@ void encode_encrypt_enc_bl(CephContext *cct, const T& t, const CryptoKey& key,
 
 template <typename T>
 int decode_decrypt(CephContext *cct, T& t, const CryptoKey& key,
-		    bufferlist::const_iterator& iter, std::string &error)
+		    ceph::buffer::list::const_iterator& iter, std::string &error)
 {
-  bufferlist bl_enc;
+  ceph::buffer::list bl_enc;
+  using ceph::decode;
   try {
     decode(bl_enc, iter);
     decode_decrypt_enc_bl(cct, t, key, bl_enc, error);
   }
-  catch (buffer::error &e) {
+  catch (ceph::buffer::error &e) {
     error = "error decoding block for decryption";
   }
   if (!error.empty())
@@ -499,9 +502,10 @@ int decode_decrypt(CephContext *cct, T& t, const CryptoKey& key,
 
 template <typename T>
 int encode_encrypt(CephContext *cct, const T& t, const CryptoKey& key,
-		    bufferlist& out, std::string &error)
+		    ceph::buffer::list& out, std::string &error)
 {
-  bufferlist bl_enc;
+  using ceph::encode;
+  ceph::buffer::list bl_enc;
   encode_encrypt_enc_bl(cct, t, key, bl_enc, error);
   if (!error.empty()){
     return CEPHX_CRYPT_ERR;

--- a/src/auth/none/AuthNoneAuthorizeHandler.cc
+++ b/src/auth/none/AuthNoneAuthorizeHandler.cc
@@ -20,9 +20,9 @@
 bool AuthNoneAuthorizeHandler::verify_authorizer(
   CephContext *cct,
   const KeyStore& keys,
-  const bufferlist& authorizer_data,
+  const ceph::buffer::list& authorizer_data,
   size_t connection_secret_required_len,
-  bufferlist *authorizer_reply,
+  ceph::buffer::list *authorizer_reply,
   EntityName *entity_name,
   uint64_t *global_id,
   AuthCapsInfo *caps_info,
@@ -30,6 +30,7 @@ bool AuthNoneAuthorizeHandler::verify_authorizer(
   std::string *connection_secret,
   std::unique_ptr<AuthAuthorizerChallenge> *challenge)
 {
+  using ceph::decode;
   auto iter = authorizer_data.cbegin();
 
   try {
@@ -37,7 +38,7 @@ bool AuthNoneAuthorizeHandler::verify_authorizer(
     decode(struct_v, iter);
     decode(*entity_name, iter);
     decode(*global_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     ldout(cct, 0) << "AuthNoneAuthorizeHandle::verify_authorizer() failed to decode" << dendl;
     return false;
   }

--- a/src/auth/none/AuthNoneAuthorizeHandler.h
+++ b/src/auth/none/AuthNoneAuthorizeHandler.h
@@ -22,9 +22,9 @@ struct AuthNoneAuthorizeHandler : public AuthAuthorizeHandler {
   bool verify_authorizer(
     CephContext *cct,
     const KeyStore& keys,
-    const bufferlist& authorizer_data,
+    const ceph::buffer::list& authorizer_data,
     size_t connection_secret_required_len,
-    bufferlist *authorizer_reply,
+    ceph::buffer::list *authorizer_reply,
     EntityName *entity_name,
     uint64_t *global_id,
     AuthCapsInfo *caps_info,

--- a/src/auth/none/AuthNoneClientHandler.h
+++ b/src/auth/none/AuthNoneClientHandler.h
@@ -29,11 +29,11 @@ public:
   void reset() override { }
 
   void prepare_build_request() override {}
-  int build_request(bufferlist& bl) const override { return 0; }
-  int handle_response(int ret, bufferlist::const_iterator& iter,
+  int build_request(ceph::buffer::list& bl) const override { return 0; }
+  int handle_response(int ret, ceph::buffer::list::const_iterator& iter,
 		      CryptoKey *session_key,
 		      std::string *connection_secret) override { return 0; }
-  bool build_rotating_request(bufferlist& bl) const override { return false; }
+  bool build_rotating_request(ceph::buffer::list& bl) const override { return false; }
 
   int get_protocol() const override { return CEPH_AUTH_NONE; }
   

--- a/src/auth/none/AuthNoneProtocol.h
+++ b/src/auth/none/AuthNoneProtocol.h
@@ -22,14 +22,15 @@ struct AuthNoneAuthorizer : public AuthAuthorizer {
   AuthNoneAuthorizer() : AuthAuthorizer(CEPH_AUTH_NONE) { }
   bool build_authorizer(const EntityName &ename, uint64_t global_id) {
     __u8 struct_v = 1; // see AUTH_MODE_* in Auth.h
+    using ceph::encode;
     encode(struct_v, bl);
     encode(ename, bl);
     encode(global_id, bl);
     return 0;
   }
-  bool verify_reply(bufferlist::const_iterator& reply,
+  bool verify_reply(ceph::buffer::list::const_iterator& reply,
 		    std::string *connection_secret) override { return true; }
-  bool add_challenge(CephContext *cct, const bufferlist& ch) override {
+  bool add_challenge(CephContext *cct, const ceph::buffer::list& ch) override {
     return true;
   }
 };

--- a/src/common/CommandTable.h
+++ b/src/common/CommandTable.h
@@ -34,13 +34,13 @@ class CommandOp
 			 bool mgr=false) const
   {
     if (mgr) {
-      auto m = make_message<MMgrCommand>(fsid);
+      auto m = ceph::make_message<MMgrCommand>(fsid);
       m->cmd = cmd;
       m->set_data(inbl);
       m->set_tid(tid);
       return m;
     } else {
-      auto m = make_message<MCommand>(fsid);
+      auto m = ceph::make_message<MCommand>(fsid);
       m->cmd = cmd;
       m->set_data(inbl);
       m->set_tid(tid);

--- a/src/common/DecayCounter.cc
+++ b/src/common/DecayCounter.cc
@@ -17,7 +17,7 @@
 
 #include "include/encoding.h"
 
-void DecayCounter::encode(bufferlist& bl) const
+void DecayCounter::encode(ceph::buffer::list& bl) const
 {
   decay();
   ENCODE_START(5, 4, bl);
@@ -25,7 +25,7 @@ void DecayCounter::encode(bufferlist& bl) const
   ENCODE_FINISH(bl);
 }
 
-void DecayCounter::decode(bufferlist::const_iterator &p)
+void DecayCounter::decode(ceph::buffer::list::const_iterator &p)
 {
   DECODE_START_LEGACY_COMPAT_LEN(5, 4, 4, p);
   if (struct_v < 2) {
@@ -47,7 +47,7 @@ void DecayCounter::decode(bufferlist::const_iterator &p)
   DECODE_FINISH(p);
 }
 
-void DecayCounter::dump(Formatter *f) const
+void DecayCounter::dump(ceph::Formatter *f) const
 {
   decay();
   f->dump_float("value", val);

--- a/src/common/DecayCounter.h
+++ b/src/common/DecayCounter.h
@@ -60,9 +60,9 @@ public:
   DecayCounter() : DecayCounter(DecayRate()) {}
   explicit DecayCounter(const DecayRate &rate) : last_decay(clock::now()), rate(rate) {}
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<DecayCounter*>& ls);
 
   /**
@@ -117,10 +117,10 @@ private:
   DecayRate rate;
 };
 
-inline void encode(const DecayCounter &c, bufferlist &bl) {
+inline void encode(const DecayCounter &c, ceph::buffer::list &bl) {
   c.encode(bl);
 }
-inline void decode(DecayCounter &c, bufferlist::const_iterator &p) {
+inline void decode(DecayCounter &c, ceph::buffer::list::const_iterator &p) {
   c.decode(p);
 }
 

--- a/src/common/Graylog.cc
+++ b/src/common/Graylog.cc
@@ -7,8 +7,9 @@
 #include "log/Entry.h"
 #include "log/SubsystemMap.h"
 
-namespace ceph {
-namespace logging {
+using std::cerr;
+
+namespace ceph::logging {
 
 Graylog::Graylog(const SubsystemMap * const s, const std::string &logger)
     : m_subs(s),
@@ -166,5 +167,4 @@ void Graylog::log_log_entry(LogEntry const * const e)
   }
 }
 
-} // ceph::logging::
-} // ceph::
+} // name ceph::logging

--- a/src/common/HeartbeatMap.cc
+++ b/src/common/HeartbeatMap.cc
@@ -24,6 +24,10 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "heartbeat_map "
 
+using std::chrono::duration_cast;
+using std::chrono::seconds;
+using std::string;
+
 namespace ceph {
 
 HeartbeatMap::HeartbeatMap(CephContext *cct)
@@ -88,8 +92,8 @@ void HeartbeatMap::reset_timeout(heartbeat_handle_d *h,
 {
   ldout(m_cct, 20) << "reset_timeout '" << h->name << "' grace " << grace
 		   << " suicide " << suicide_grace << dendl;
-  auto now = chrono::duration_cast<chrono::seconds>(
-	       ceph::coarse_mono_clock::now().time_since_epoch()).count();
+  auto now = duration_cast<seconds>(coarse_mono_clock::now()
+				    .time_since_epoch()).count();
   _check(h, "reset_timeout", now);
 
   h->timeout = now + grace;
@@ -105,8 +109,8 @@ void HeartbeatMap::reset_timeout(heartbeat_handle_d *h,
 void HeartbeatMap::clear_timeout(heartbeat_handle_d *h)
 {
   ldout(m_cct, 20) << "clear_timeout '" << h->name << "'" << dendl;
-  auto now = chrono::duration_cast<std::chrono::seconds>(
-	       ceph::coarse_mono_clock::now().time_since_epoch()).count();
+  auto now = duration_cast<seconds>(coarse_mono_clock::now()
+				    .time_since_epoch()).count();
   _check(h, "clear_timeout", now);
   h->timeout = 0;
   h->suicide_timeout = 0;
@@ -132,11 +136,11 @@ bool HeartbeatMap::is_healthy()
     healthy = false;
   }
 
-  for (list<heartbeat_handle_d*>::iterator p = m_workers.begin();
+  for (auto p = m_workers.begin();
        p != m_workers.end();
        ++p) {
     heartbeat_handle_d *h = *p;
-    auto epoch = chrono::duration_cast<chrono::seconds>(now.time_since_epoch()).count();
+    auto epoch = duration_cast<seconds>(now.time_since_epoch()).count();
     if (!_check(h, "is_healthy", epoch)) {
       healthy = false;
       unhealthy++;

--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -22,6 +22,11 @@
 
 #define dout_subsys ceph_subsys_monc
 
+using std::map;
+using std::ostream;
+using std::ostringstream;
+using std::string;
+
 int parse_log_client_options(CephContext *cct,
 			     map<string,string> &log_to_monitors,
 			     map<string,string> &log_to_syslog,
@@ -351,7 +356,7 @@ bool LogClient::handle_log_ack(MLogAck *m)
 
   version_t last = m->last;
 
-  deque<LogEntry>::iterator q = log_queue.begin();
+  auto q = log_queue.begin();
   while (q != log_queue.end()) {
     const LogEntry &entry(*q);
     if (entry.seq > last)
@@ -361,4 +366,3 @@ bool LogClient::handle_log_ack(MLogAck *m)
   }
   return true;
 }
-

--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -8,6 +8,17 @@
 #include "Formatter.h"
 #include "include/stringify.h"
 
+using std::list;
+using std::map;
+using std::make_pair;
+using std::pair;
+using std::string;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::Formatter;
+
 // ----
 // LogEntryKey
 
@@ -372,4 +383,3 @@ void LogSummary::generate_test_instances(list<LogSummary*>& o)
   o.push_back(new LogSummary);
   // more!
 }
-

--- a/src/common/OutputDataSocket.cc
+++ b/src/common/OutputDataSocket.cc
@@ -255,7 +255,7 @@ bool OutputDataSocket::do_accept()
 
 void OutputDataSocket::handle_connection(int fd)
 {
-  bufferlist bl;
+  ceph::buffer::list bl;
 
   m_lock.lock();
   init_connection(bl);
@@ -294,13 +294,13 @@ void OutputDataSocket::handle_connection(int fd)
 int OutputDataSocket::dump_data(int fd)
 {
   m_lock.lock();
-  vector<buffer::list> l = std::move(data);
+  auto l = std::move(data);
   data.clear();
   data_size = 0;
   m_lock.unlock();
 
   for (auto iter = l.begin(); iter != l.end(); ++iter) {
-    bufferlist& bl = *iter;
+    ceph::buffer::list& bl = *iter;
     int ret = safe_write(fd, bl.c_str(), bl.length());
     if (ret >= 0) {
       ret = safe_write(fd, delim.c_str(), delim.length());
@@ -308,7 +308,7 @@ int OutputDataSocket::dump_data(int fd)
     if (ret < 0) {
       std::scoped_lock lock(m_lock);
       for (; iter != l.end(); ++iter) {
-        bufferlist& bl = *iter;
+        ceph::buffer::list& bl = *iter;
 	data.push_back(bl);
 	data_size += bl.length();
       }
@@ -384,7 +384,7 @@ void OutputDataSocket::shutdown()
   m_path.clear();
 }
 
-void OutputDataSocket::append_output(bufferlist& bl)
+void OutputDataSocket::append_output(ceph::buffer::list& bl)
 {
   std::lock_guard l(m_lock);
 

--- a/src/common/OutputDataSocket.h
+++ b/src/common/OutputDataSocket.h
@@ -29,10 +29,10 @@ public:
 
   bool init(const std::string &path);
   
-  void append_output(bufferlist& bl);
+  void append_output(ceph::buffer::list& bl);
 
 protected:
-  virtual void init_connection(bufferlist& bl) {}
+  virtual void init_connection(ceph::buffer::list& bl) {}
   void shutdown();
 
   std::string create_shutdown_pipe(int *pipe_rd, int *pipe_wr);
@@ -57,11 +57,11 @@ protected:
   uint64_t data_size;
   uint32_t skipped;
 
-  std::vector<buffer::list> data;
+  std::vector<ceph::buffer::list> data;
 
   ceph::mutex m_lock = ceph::make_mutex("OutputDataSocket::m_lock");
   ceph::condition_variable cond;
-  buffer::list delim;
+  ceph::buffer::list delim;
 };
 
 #endif

--- a/src/common/PluginRegistry.cc
+++ b/src/common/PluginRegistry.cc
@@ -34,6 +34,11 @@
 
 #define dout_subsys ceph_subsys_context
 
+using std::map;
+using std::string;
+
+namespace ceph {
+
 PluginRegistry::PluginRegistry(CephContext *cct) :
   cct(cct),
   loading(false),
@@ -210,6 +215,7 @@ int PluginRegistry::load(const std::string &type,
   ldout(cct, 1) << __func__ << ": " << type << " " << name
 		<< " loaded and registered" << dendl;
   return 0;
+}
 }
 
 /*

--- a/src/common/Readahead.cc
+++ b/src/common/Readahead.cc
@@ -4,6 +4,8 @@
 #include "common/Readahead.h"
 #include "common/Cond.h"
 
+using std::vector;
+
 Readahead::Readahead()
   : m_trigger_requests(10),
     m_readahead_min_bytes(0),
@@ -30,7 +32,7 @@ Readahead::extent_t Readahead::update(const vector<extent_t>& extents, uint64_t 
     m_lock.unlock();
     return extent_t(0, 0);
   }
-  pair<uint64_t, uint64_t> extent = _compute_readahead(limit);
+  std::pair<uint64_t, uint64_t> extent = _compute_readahead(limit);
   m_lock.unlock();
   return extent;
 }

--- a/src/common/SloppyCRCMap.cc
+++ b/src/common/SloppyCRCMap.cc
@@ -5,6 +5,7 @@
 #include "common/Formatter.h"
 
 using namespace std;
+using ceph::bufferlist;
 
 void SloppyCRCMap::write(uint64_t offset, uint64_t len, const bufferlist& bl,
 			 std::ostream *out)

--- a/src/common/SloppyCRCMap.h
+++ b/src/common/SloppyCRCMap.h
@@ -33,7 +33,7 @@ public:
     block_size = b;
     //zero_crc = ceph_crc32c(0xffffffff, NULL, block_size);
     if (b) {
-      bufferlist bl;
+      ceph::buffer::list bl;
       bl.append_zero(block_size);
       zero_crc = bl.crc32c(crc_iv);
     } else {
@@ -42,7 +42,7 @@ public:
   }
 
   /// update based on a write
-  void write(uint64_t offset, uint64_t len, const bufferlist& bl,
+  void write(uint64_t offset, uint64_t len, const ceph::buffer::list& bl,
 	     std::ostream *out = NULL);
 
   /// update based on a truncate
@@ -64,10 +64,10 @@ public:
    * @param err option ostream to describe errors in detail
    * @returns error count, 0 for success
    */
-  int read(uint64_t offset, uint64_t len, const bufferlist& bl, std::ostream *err);
+  int read(uint64_t offset, uint64_t len, const ceph::buffer::list& bl, std::ostream *err);
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& bl);
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<SloppyCRCMap*>& ls);
 };

--- a/src/common/Throttle.cc
+++ b/src/common/Throttle.cc
@@ -16,8 +16,13 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "throttle(" << name << " " << (void*)this << ") "
 
+using std::list;
+using std::ostream;
+using std::string;
+
 using ceph::mono_clock;
 using ceph::mono_time;
+using ceph::timespan;
 
 enum {
   l_throttle_first = 532430,

--- a/src/common/Timer.cc
+++ b/src/common/Timer.cc
@@ -20,7 +20,9 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "timer(" << this << ")."
 
+using std::pair;
 
+using ceph::operator <<;
 
 class SafeTimerThread : public Thread {
   SafeTimer *parent;

--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -17,6 +17,16 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout)
 
+using std::list;
+using std::make_pair;
+using std::ostream;
+using std::pair;
+using std::set;
+using std::string;
+using std::stringstream;
+
+using ceph::Formatter;
+
 static ostream& _prefix(std::ostream* _dout)
 {
   return *_dout << "-- op tracker -- ";

--- a/src/common/WorkQueue.cc
+++ b/src/common/WorkQueue.cc
@@ -20,8 +20,7 @@
 #undef dout_prefix
 #define dout_prefix *_dout << name << " "
 
-
-ThreadPool::ThreadPool(CephContext *cct_, string nm, string tn, int n, const char *option)
+ThreadPool::ThreadPool(CephContext *cct_, std::string nm, std::string tn, int n, const char *option)
   : cct(cct_), name(std::move(nm)), thread_name(std::move(tn)),
     lockname(name + "::lock"),
     _lock(ceph::make_mutex(lockname)),  // this should be safe due to declaration order
@@ -83,10 +82,10 @@ void ThreadPool::worker(WorkThread *wt)
 {
   std::unique_lock ul(_lock);
   ldout(cct,10) << "worker start" << dendl;
-  
+
   std::stringstream ss;
   ss << name << " thread " << (void *)pthread_self();
-  heartbeat_handle_d *hb = cct->get_heartbeat_map()->add_worker(ss.str(), pthread_self());
+  auto hb = cct->get_heartbeat_map()->add_worker(ss.str(), pthread_self());
 
   while (!_stop) {
 
@@ -197,9 +196,7 @@ void ThreadPool::stop(bool clear_after)
   _cond.notify_all();
   join_old_threads();
   _lock.unlock();
-  for (set<WorkThread*>::iterator p = _threads.begin();
-       p != _threads.end();
-       ++p) {
+  for (auto p = _threads.begin(); p != _threads.end(); ++p) {
     (*p)->join();
     delete *p;
   }
@@ -252,8 +249,8 @@ void ThreadPool::drain(WorkQueue_* wq)
   _draining--;
 }
 
-ShardedThreadPool::ShardedThreadPool(CephContext *pcct_, string nm, string tn,
-  uint32_t pnum_threads):
+ShardedThreadPool::ShardedThreadPool(CephContext *pcct_, std::string nm, std::string tn,
+				     uint32_t pnum_threads):
   cct(pcct_),
   name(std::move(nm)),
   thread_name(std::move(tn)),
@@ -271,7 +268,7 @@ void ShardedThreadPool::shardedthreadpool_worker(uint32_t thread_index)
 
   std::stringstream ss;
   ss << name << " thread " << (void *)pthread_self();
-  heartbeat_handle_d *hb = cct->get_heartbeat_map()->add_worker(ss.str(), pthread_self());
+  auto hb = cct->get_heartbeat_map()->add_worker(ss.str(), pthread_self());
 
   while (!stop_threads) {
     if (pause_threads) {
@@ -348,7 +345,7 @@ void ShardedThreadPool::stop()
   stop_threads = true;
   ceph_assert(wq != NULL);
   wq->return_waiting_threads();
-  for (vector<WorkThreadSharded*>::iterator p = threads_shardedpool.begin();
+  for (auto p = threads_shardedpool.begin();
        p != threads_shardedpool.end();
        ++p) {
     (*p)->join();

--- a/src/common/address_helper.cc
+++ b/src/common/address_helper.cc
@@ -19,8 +19,8 @@ int entity_addr_from_url(entity_addr_t *addr /* out */, const char *url)
 	std::cmatch m;
 
 	if (std::regex_match(url, m, expr)) {
-		string host(m[2].first, m[2].second);
-		string port(m[3].first, m[3].second);
+	        std::string host(m[2].first, m[2].second);
+		std::string port(m[3].first, m[3].second);
 		addrinfo hints;
 		// FIPS zeroization audit 20191115: this memset is fine.
 		memset(&hints, 0, sizeof(hints));
@@ -36,4 +36,3 @@ int entity_addr_from_url(entity_addr_t *addr /* out */, const char *url)
 
 	return 1;
 }
-

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -41,9 +41,18 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "asok(" << (void*)m_cct << ") "
 
+using namespace std::literals;
 
 using std::ostringstream;
+using std::string;
+using std::stringstream;
+
 using namespace TOPNSPC::common;
+
+using ceph::bufferlist;
+using ceph::cref_t;
+using ceph::Formatter;
+
 
 /*
  * UNIX domain sockets created by an application persist even after that
@@ -490,7 +499,7 @@ void AdminSocket::execute_command(
 		     empty);
   }
 
-  Formatter *f = Formatter::create(format, "json-pretty", "json-pretty");
+  auto f = Formatter::create(format, "json-pretty", "json-pretty");
 
   std::unique_lock l(lock);
   decltype(hooks)::iterator p;
@@ -651,7 +660,7 @@ public:
       // do what you'd expect. GCC 7 does not.
       (void)command;
       ostringstream secname;
-      secname << "cmd" << setfill('0') << std::setw(3) << cmdnum;
+      secname << "cmd" << std::setfill('0') << std::setw(3) << cmdnum;
       dump_cmd_and_help_to_json(f,
                                 CEPH_FEATURES_ALL,
 				secname.str().c_str(),

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -30,13 +30,10 @@
 #include "common/ref.h"
 #include "common/cmdparse.h"
 
-class AdminSocket;
 class MCommand;
 class MMonCommand;
 
-using namespace std::literals;
-
-inline constexpr auto CEPH_ADMIN_SOCK_VERSION = "2"sv;
+inline constexpr auto CEPH_ADMIN_SOCK_VERSION = std::string_view("2");
 
 class AdminSocketHook {
 public:
@@ -63,7 +60,7 @@ public:
   virtual int call(
     std::string_view command,
     const cmdmap_t& cmdmap,
-    Formatter *f,
+    ceph::Formatter *f,
     std::ostream& errss,
     ceph::buffer::list& out) = 0;
 
@@ -93,11 +90,11 @@ public:
   virtual void call_async(
     std::string_view command,
     const cmdmap_t& cmdmap,
-    Formatter *f,
-    const bufferlist& inbl,
-    std::function<void(int,const std::string&,bufferlist&)> on_finish) {
+    ceph::Formatter *f,
+    const ceph::buffer::list& inbl,
+    std::function<void(int,const std::string&,ceph::buffer::list&)> on_finish) {
     // by default, call the synchronous handler and then finish
-    bufferlist out;
+    ceph::buffer::list out;
     std::ostringstream errss;
     int r = call(command, cmdmap, f, errss, out);
     on_finish(r, errss.str(), out);
@@ -152,18 +149,18 @@ public:
   /// execute (async)
   void execute_command(
     const std::vector<std::string>& cmd,
-    const bufferlist& inbl,
-    std::function<void(int,const std::string&,bufferlist&)> on_fin);
+    const ceph::buffer::list& inbl,
+    std::function<void(int,const std::string&,ceph::buffer::list&)> on_fin);
 
   /// execute (blocking)
   int execute_command(
     const std::vector<std::string>& cmd,
-    const bufferlist& inbl,
+    const ceph::buffer::list& inbl,
     std::ostream& errss,
-    bufferlist *outbl);
+    ceph::buffer::list *outbl);
 
-  void queue_tell_command(cref_t<MCommand> m);
-  void queue_tell_command(cref_t<MMonCommand> m); // for compat
+  void queue_tell_command(ceph::cref_t<MCommand> m);
+  void queue_tell_command(ceph::cref_t<MMonCommand> m); // for compat
 
 private:
 
@@ -194,8 +191,8 @@ private:
   std::unique_ptr<AdminSocketHook> getdescs_hook;
 
   std::mutex tell_lock;
-  std::list<cref_t<MCommand>> tell_queue;
-  std::list<cref_t<MMonCommand>> tell_legacy_queue;
+  std::list<ceph::cref_t<MCommand>> tell_queue;
+  std::list<ceph::cref_t<MMonCommand>> tell_legacy_queue;
 
   struct hook_info {
     AdminSocketHook* hook;

--- a/src/common/assert.cc
+++ b/src/common/assert.cc
@@ -15,6 +15,8 @@
 #include "include/compat.h"
 #include "common/debug.h"
 
+using std::ostringstream;
+
 namespace ceph {
   static CephContext *g_assert_context = NULL;
 
@@ -156,7 +158,7 @@ namespace ceph {
   }
 
   [[gnu::cold]] void __ceph_abort(const char *file, int line,
-				  const char *func, const string& msg)
+				  const char *func, const std::string& msg)
   {
     ostringstream tss;
     tss << ceph_clock_now();

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -38,6 +38,7 @@
 
 #include "json_spirit/json_spirit_reader.h"
 
+
 int get_device_by_path(const char *path, char* partition, char* device,
 		       size_t max)
 {
@@ -76,6 +77,12 @@ int get_device_by_path(const char *path, char* partition, char* device,
 #define UUID_LEN 36
 
 #endif
+
+using namespace std::literals;
+
+using std::string;
+
+using ceph::bufferlist;
 
 
 BlkDev::BlkDev(int f)

--- a/src/common/bloom_filter.cc
+++ b/src/common/bloom_filter.cc
@@ -5,6 +5,10 @@
 
 MEMPOOL_DEFINE_FACTORY(unsigned char, byte, bloom_filter);
 
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::Formatter;
+
 void bloom_filter::encode(bufferlist& bl) const
 {
   ENCODE_START(2, 2, bl);

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -36,6 +36,11 @@
 #include "include/spinlock.h"
 #include "include/scope_guard.h"
 
+using std::cerr;
+using std::make_pair;
+using std::pair;
+using std::string;
+
 using namespace ceph;
 
 #define CEPH_BUFFER_ALLOC_UNIT  4096u

--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -55,9 +55,9 @@ struct strict_str_convert {
 
 void string_to_vec(std::vector<std::string>& args, std::string argstr)
 {
-  istringstream iss(argstr);
+  std::istringstream iss(argstr);
   while(iss) {
-    string sub;
+    std::string sub;
     iss >> sub;
     if (sub == "") break;
     args.push_back(sub);
@@ -79,7 +79,7 @@ split_dashdash(const std::vector<const char*>& args) {
 }
 
 static std::mutex g_str_vec_lock;
-static vector<string> g_str_vec;
+static std::vector<std::string> g_str_vec;
 
 void clear_g_str_vec()
 {
@@ -138,7 +138,7 @@ void vec_to_argv(const char *argv0, std::vector<const char*>& args,
 {
   *argv = (const char**)malloc(sizeof(char*) * (args.size() + 1));
   if (!*argv)
-    throw bad_alloc();
+    throw std::bad_alloc();
   *argc = 1;
   (*argv)[0] = argv0;
 
@@ -191,10 +191,10 @@ void ceph_arg_value_type(const char * nextargstr, bool *bool_option, bool *bool_
 }
 
 
-bool parse_ip_port_vec(const char *s, vector<entity_addrvec_t>& vec, int type)
+bool parse_ip_port_vec(const char *s, std::vector<entity_addrvec_t>& vec, int type)
 {
   // first split by [ ;], which are not valid for an addrvec
-  list<string> items;
+  std::list<std::string> items;
   get_str_list(s, " ;", items);
 
   for (auto& i : items) {
@@ -480,7 +480,7 @@ bool ceph_argparse_witharg(std::vector<const char*> &args,
   int r;
   va_list ap;
   va_start(ap, ret);
-  r = va_ceph_argparse_witharg(args, i, ret, cerr, ap);
+  r = va_ceph_argparse_witharg(args, i, ret, std::cerr, ap);
   va_end(ap);
   if (r < 0)
     _exit(1);
@@ -494,7 +494,7 @@ CephInitParameters ceph_argparse_early_args
   CephInitParameters iparams(module_type);
   std::string val;
 
-  vector<const char *> orig_args = args;
+  auto orig_args = args;
 
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (strcmp(*i, "--") == 0) {
@@ -504,7 +504,7 @@ CephInitParameters ceph_argparse_early_args
       break;
     }
     else if (ceph_argparse_flag(args, i, "--version", "-v", (char*)NULL)) {
-      cout << pretty_version_to_str() << std::endl;
+      std::cout << pretty_version_to_str() << std::endl;
       _exit(0);
     }
     else if (ceph_argparse_witharg(args, i, &val, "--conf", "-c", (char*)NULL)) {
@@ -525,20 +525,20 @@ CephInitParameters ceph_argparse_early_args
     }
     else if (ceph_argparse_witharg(args, i, &val, "--name", "-n", (char*)NULL)) {
       if (!iparams.name.from_str(val)) {
-	cerr << "error parsing '" << val << "': expected string of the form TYPE.ID, "
-	     << "valid types are: " << EntityName::get_valid_types_as_str()
-	     << std::endl;
+	std::cerr << "error parsing '" << val << "': expected string of the form TYPE.ID, "
+		  << "valid types are: " << EntityName::get_valid_types_as_str()
+		  << std::endl;
 	_exit(1);
       }
     }
     else if (ceph_argparse_flag(args, i, "--show_args", (char*)NULL)) {
-      cout << "args: ";
+      std::cout << "args: ";
       for (std::vector<const char *>::iterator ci = orig_args.begin(); ci != orig_args.end(); ++ci) {
-        if (ci != orig_args.begin())
-          cout << " ";
-        cout << *ci;
+	if (ci != orig_args.begin())
+	  std::cout << " ";
+	std::cout << *ci;
       }
-      cout << std::endl;
+      std::cout << std::endl;
     }
     else {
       // ignore
@@ -550,7 +550,7 @@ CephInitParameters ceph_argparse_early_args
 
 static void generic_usage(bool is_server)
 {
-  cout <<
+  std::cout <<
     "  --conf/-c FILE    read configuration from the given configuration file" << std::endl <<
     (is_server ?
     "  --id/-i ID        set ID portion of my name" :
@@ -563,14 +563,14 @@ static void generic_usage(bool is_server)
     << std::endl;
 
   if (is_server) {
-    cout <<
+    std::cout <<
       "  -d                run in foreground, log to stderr" << std::endl <<
       "  -f                run in foreground, log to usual location" << std::endl <<
       std::endl <<
       "  --debug_ms N      set message debug level (e.g. 1)" << std::endl;
   }
 
-  cout.flush();
+  std::cout.flush();
 }
 
 bool ceph_argparse_need_usage(const std::vector<const char*>& args)

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -46,14 +46,17 @@
 #include "common/valgrind.h"
 #include "include/spinlock.h"
 
-using ceph::bufferlist;
-using ceph::HeartbeatMap;
-
 // for CINIT_FLAGS
 #include "common/common_init.h"
 
 #include <iostream>
 #include <pthread.h>
+
+using namespace std::literals;
+
+using ceph::bufferlist;
+using ceph::HeartbeatMap;
+
 
 #if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
 namespace crimson::common {
@@ -171,7 +174,7 @@ public:
 
   // AdminSocketHook
   int call(std::string_view command, const cmdmap_t& cmdmap,
-	   Formatter *f,
+	   ceph::Formatter *f,
 	   std::ostream& errss,
 	   bufferlist& out) override {
     if (command == "dump_mempools") {
@@ -316,7 +319,7 @@ public:
     }
 
     if (changed.count("log_stderr_prefix")) {
-      log->set_log_stderr_prefix(conf.get_val<string>("log_stderr_prefix"));
+      log->set_log_stderr_prefix(conf.get_val<std::string>("log_stderr_prefix"));
     }
 
     if (changed.count("log_max_new")) {
@@ -426,7 +429,7 @@ public:
 
 bool CephContext::check_experimental_feature_enabled(const std::string& feat)
 {
-  stringstream message;
+  std::stringstream message;
   bool enabled = check_experimental_feature_enabled(feat, &message);
   lderr(this) << message.str() << dendl;
   return enabled;
@@ -562,13 +565,13 @@ int CephContext::_do_command(
 	r = -EINVAL;
       } else {
 	// val may be multiple words
-	string valstr = str_join(val, " ");
+	auto valstr = str_join(val, " ");
         r = _conf.set_val(var.c_str(), valstr.c_str());
         if (r < 0) {
           ss << "error setting '" << var << "' to '" << valstr << "': "
 	     << cpp_strerror(r);
         } else {
-	  stringstream ss;
+	  std::stringstream ss;
           _conf.apply_changes(&ss);
 	  f->dump_string("success", ss.str());
         }
@@ -620,12 +623,10 @@ int CephContext::_do_command(
       f->close_section(); // unknown
     }
     else if (command == "injectargs") {
-      vector<string> argsvec;
+      std::vector<std::string> argsvec;
       cmd_getval(cmdmap, "injected_args", argsvec);
       if (!argsvec.empty()) {
-	string args = joinify<std::string>(argsvec.begin(),
-					   argsvec.end(),
-					   " ");
+	auto args = joinify<std::string>(argsvec.begin(), argsvec.end(), " ");
 	r = _conf.injectargs(args, &ss);
       }
     }
@@ -890,13 +891,13 @@ void CephContext::_enable_perf_counter()
   _mempool_perf_names.reserve(mempool::num_pools * 2);
   _mempool_perf_descriptions.reserve(mempool::num_pools * 2);
   for (unsigned i = 0; i < mempool::num_pools; ++i) {
-    string n = mempool::get_pool_name(mempool::pool_index_t(i));
-    _mempool_perf_names.push_back(n + "_bytes");
+    std::string n = mempool::get_pool_name(mempool::pool_index_t(i));
+    _mempool_perf_names.push_back(n + "_bytes"s);
     _mempool_perf_descriptions.push_back(
-      string("mempool ") + n + " total bytes");
-    _mempool_perf_names.push_back(n + "_items");
+      "mempool "s + n + " total bytes");
+    _mempool_perf_names.push_back(n + "_items"s);
     _mempool_perf_descriptions.push_back(
-      string("mempool ") + n + " total items");
+      "mempool "s + n + " total items"s);
   }
 
   PerfCountersBuilder plb2(this, "mempool", l_mempool_first,

--- a/src/common/ceph_json.cc
+++ b/src/common/ceph_json.cc
@@ -13,11 +13,18 @@
 
 using namespace json_spirit;
 
+using std::ifstream;
+using std::pair;
+using std::ostream;
+using std::string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::Formatter;
+
 #define dout_subsys ceph_subsys_rgw
 
-
 static JSONFormattable default_formattable;
-
 
 void encode_json(const char *name, const JSONObj::data_val& v, Formatter *f)
 {
@@ -61,8 +68,7 @@ ostream& operator<<(ostream &out, const JSONObj &obj) {
 
 JSONObj::~JSONObj()
 {
-  multimap<string, JSONObj *>::iterator iter;
-  for (iter = children.begin(); iter != children.end(); ++iter) {
+  for (auto iter = children.begin(); iter != children.end(); ++iter) {
     JSONObj *obj = iter->second;
     delete obj;
   }
@@ -86,11 +92,9 @@ bool JSONObj::get_attr(string name, data_val& attr)
 JSONObjIter JSONObj::find(const string& name)
 {
   JSONObjIter iter;
-  map<string, JSONObj *>::iterator first;
-  map<string, JSONObj *>::iterator last;
-  first = children.find(name);
+  auto first = children.find(name);
   if (first != children.end()) {
-    last = children.upper_bound(name);
+    auto last = children.upper_bound(name);
     iter.set(first, last);
   }
   return iter;
@@ -106,8 +110,7 @@ JSONObjIter JSONObj::find_first()
 JSONObjIter JSONObj::find_first(const string& name)
 {
   JSONObjIter iter;
-  map<string, JSONObj *>::iterator first;
-  first = children.find(name);
+  auto first = children.find(name);
   iter.set(first, children.end());
   return iter;
 }
@@ -457,7 +460,7 @@ void decode_json_obj(bufferlist& val, JSONObj *obj)
   bl.append(s.c_str(), s.size());
   try {
     val.decode_base64(bl);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
    throw JSONDecoder::err("failed to decode base64");
   }
 }

--- a/src/common/ceph_time.cc
+++ b/src/common/ceph_time.cc
@@ -52,6 +52,8 @@ int clock_gettime(int clk_id, struct timespec *tp)
 }
 #endif
 
+using namespace std::literals;
+
 namespace ceph {
   namespace time_detail {
     void real_clock::to_ceph_timespec(const time_point& t,
@@ -155,7 +157,7 @@ namespace ceph {
     // FIXME: somebody pretty please make a version of this function
     // that isn't as lame as this one!
     uint64_t nsec = std::chrono::nanoseconds(t).count();
-    ostringstream ss;
+    std::ostringstream ss;
     if (nsec < 2000000000) {
       ss << ((float)nsec / 1000000000) << "s";
       return ss.str();
@@ -201,7 +203,7 @@ namespace ceph {
     uint64_t sec = nsec / 1000000000;
     nsec %= 1000000000;
     uint64_t yr = sec / (60 * 60 * 24 * 365);
-    ostringstream ss;
+    std::ostringstream ss;
     if (yr) {
       ss << yr << "y";
       sec -= yr * (60 * 60 * 24 * 365);
@@ -245,7 +247,7 @@ namespace ceph {
 
   std::chrono::seconds parse_timespan(const std::string& s)
   {
-    static std::map<string,int> units = {
+    static std::map<std::string,int> units = {
       { "s", 1 },
       { "sec", 1 },
       { "second", 1 },
@@ -291,13 +293,13 @@ namespace ceph {
 	++pos;
       }
       if (val_start == pos) {
-	throw invalid_argument("expected digit");
+	throw std::invalid_argument("expected digit");
       }
-      string n = s.substr(val_start, pos - val_start);
-      string err;
+      auto n = s.substr(val_start, pos - val_start);
+      std::string err;
       auto val = strict_strtoll(n.c_str(), 10, &err);
       if (err.size()) {
-	throw invalid_argument(err);
+	throw std::invalid_argument(err);
       }
 
       // skip whitespace
@@ -311,16 +313,16 @@ namespace ceph {
 	++pos;
       }
       if (unit_start != pos) {
-	string unit = s.substr(unit_start, pos - unit_start);
+	auto unit = s.substr(unit_start, pos - unit_start);
 	auto p = units.find(unit);
 	if (p == units.end()) {
-	  throw invalid_argument("unrecogized unit '"s + unit + "'");
+	  throw std::invalid_argument("unrecogized unit '"s + unit + "'");
 	}
 	val *= p->second;
       } else if (pos < s.size()) {
-	throw invalid_argument("unexpected trailing '"s + s.substr(pos) + "'");
+	throw std::invalid_argument("unexpected trailing '"s + s.substr(pos) + "'");
       }
-      r += chrono::seconds(val);
+      r += std::chrono::seconds(val);
     }
     return r;
   }

--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -19,6 +19,13 @@
 #include "common/strtol.h"
 #include "json_spirit/json_spirit.h"
 
+using std::is_same_v;
+using std::ostringstream;
+using std::string;
+using std::stringstream;
+using std::string_view;
+using std::vector;
+
 /**
  * Given a cmddesc like "foo baz name=bar,type=CephString",
  * return the prefix "foo baz".
@@ -293,15 +300,14 @@ cmdmap_from_json(const vector<string>& cmd, cmdmap_t *mapp, stringstream &ss)
 
   try {
     if (!json_spirit::read(fullcmd, v))
-      throw runtime_error("unparseable JSON " + fullcmd);
+      throw std::runtime_error("unparseable JSON " + fullcmd);
     if (v.type() != json_spirit::obj_type)
-      throw(runtime_error("not JSON object " + fullcmd));
+      throw std::runtime_error("not JSON object " + fullcmd);
 
     // allocate new mObject (map) to return
     // make sure all contents are simple types (not arrays or objects)
     json_spirit::mObject o = v.get_obj();
-    for (map<string, json_spirit::mValue>::iterator it = o.begin();
-	 it != o.end(); ++it) {
+    for (auto it = o.begin(); it != o.end(); ++it) {
 
       // ok, marshal it into our string->cmd_vartype map, or throw an
       // exception if it's not a simple datatype.  This is kind of
@@ -312,7 +318,7 @@ cmdmap_from_json(const vector<string>& cmd, cmdmap_t *mapp, stringstream &ss)
 
       case json_spirit::obj_type:
       default:
-	throw(runtime_error("JSON array/object not allowed " + fullcmd));
+	throw std::runtime_error("JSON array/object not allowed " + fullcmd);
         break;
 
       case json_spirit::array_type:
@@ -329,7 +335,7 @@ cmdmap_from_json(const vector<string>& cmd, cmdmap_t *mapp, stringstream &ss)
 	    vector<string> outv;
 	    for (const auto& sv : spvals) {
 	      if (sv.type() != json_spirit::str_type) {
-		throw(runtime_error("Can't handle arrays of multiple types"));
+		throw std::runtime_error("Can't handle arrays of multiple types");
 	      }
 	      outv.push_back(sv.get_str());
 	    }
@@ -338,7 +344,7 @@ cmdmap_from_json(const vector<string>& cmd, cmdmap_t *mapp, stringstream &ss)
 	    vector<int64_t> outv;
 	    for (const auto& sv : spvals) {
 	      if (spvals.front().type() != json_spirit::int_type) {
-		throw(runtime_error("Can't handle arrays of multiple types"));
+		throw std::runtime_error("Can't handle arrays of multiple types");
 	      }
 	      outv.push_back(sv.get_int64());
 	    }
@@ -347,14 +353,14 @@ cmdmap_from_json(const vector<string>& cmd, cmdmap_t *mapp, stringstream &ss)
 	    vector<double> outv;
 	    for (const auto& sv : spvals) {
 	      if (spvals.front().type() != json_spirit::real_type) {
-		throw(runtime_error("Can't handle arrays of multiple types"));
+		throw std::runtime_error("Can't handle arrays of multiple types");
 	      }
 	      outv.push_back(sv.get_real());
 	    }
 	    (*mapp)[it->first] = std::move(outv);
 	  } else {
-	    throw(runtime_error("Can't handle arrays of types other than "
-				"int, string, or double"));
+	    throw std::runtime_error("Can't handle arrays of types other than "
+				     "int, string, or double");
 	  }
 	}
 	break;
@@ -376,7 +382,7 @@ cmdmap_from_json(const vector<string>& cmd, cmdmap_t *mapp, stringstream &ss)
       }
     }
     return true;
-  } catch (runtime_error &e) {
+  } catch (const std::runtime_error &e) {
     ss << e.what();
     return false;
   }
@@ -502,7 +508,7 @@ bool arg_in_range(T value, const arg_desc_t& desc, std::ostream& os) {
   }
   auto min_max = get_str_list(string(range->second), "|");
   auto min = str_to_num<T>(min_max.front());
-  auto max = numeric_limits<T>::max();
+  auto max = std::numeric_limits<T>::max();
   if (min_max.size() > 1) {
     max = str_to_num<T>(min_max.back());
   }
@@ -546,9 +552,9 @@ bool validate_str_arg(std::string_view value,
 
 template<bool is_vector,
 	 typename T,
-	 typename Value = conditional_t<is_vector,
-					vector<T>,
-					T>>
+	 typename Value = std::conditional_t<is_vector,
+					     vector<T>,
+					     T>>
 bool validate_arg(CephContext* cct,
 		  const cmdmap_t& cmdmap,
 		  const arg_desc_t& desc,

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -71,7 +71,7 @@ CephContext *common_preinit(const CephInitParameters &iparams,
 #endif	// #ifndef WITH_SEASTAR
 
 void complain_about_parse_error(CephContext *cct,
-				const string& parse_error)
+				const std::string& parse_error)
 {
   if (parse_error.empty())
     return;

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -37,11 +37,22 @@
 // set set_mon_vals()
 #define dout_subsys ceph_subsys_monc
 
+using std::cerr;
+using std::cout;
 using std::map;
+using std::less;
 using std::list;
+using std::ostream;
 using std::ostringstream;
 using std::pair;
 using std::string;
+using std::string_view;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::Formatter;
 
 static const char *CEPH_CONF_FILE_DEFAULT = "$data_dir/config, /etc/ceph/$cluster.conf, $home/.ceph/$cluster.conf, $cluster.conf"
 #if defined(__FreeBSD__)

--- a/src/common/dns_resolve.cc
+++ b/src/common/dns_resolve.cc
@@ -20,6 +20,8 @@
 
 #define dout_subsys ceph_subsys_
 
+using std::map;
+using std::string;
 
 namespace ceph {
 
@@ -52,8 +54,7 @@ int ResolvHWrapper::res_search(const char *hostname, int cls,
 DNSResolver::~DNSResolver()
 {
 #ifdef HAVE_RES_NQUERY
-  list<res_state>::iterator iter;
-  for (iter = states.begin(); iter != states.end(); ++iter) {
+  for (auto iter = states.begin(); iter != states.end(); ++iter) {
     struct __res_state *s = *iter;
     delete s;
   }

--- a/src/common/fs_types.cc
+++ b/src/common/fs_types.cc
@@ -1,9 +1,11 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
 #include "include/fs_types.h"
 #include "common/Formatter.h"
 #include "include/ceph_features.h"
 
-void dump(const ceph_file_layout& l, Formatter *f)
+void dump(const ceph_file_layout& l, ceph::Formatter *f)
 {
   f->dump_unsigned("stripe_unit", l.fl_stripe_unit);
   f->dump_unsigned("stripe_count", l.fl_stripe_count);
@@ -16,7 +18,7 @@ void dump(const ceph_file_layout& l, Formatter *f)
     f->dump_unsigned("pg_pool", l.fl_pg_pool);
 }
 
-void dump(const ceph_dir_layout& l, Formatter *f)
+void dump(const ceph_dir_layout& l, ceph::Formatter *f)
 {
   f->dump_unsigned("dir_hash", l.dl_dir_hash);
   f->dump_unsigned("unused1", l.dl_unused1);
@@ -71,7 +73,7 @@ void file_layout_t::to_legacy(ceph_file_layout *fl) const
     fl->fl_pg_pool = 0;
 }
 
-void file_layout_t::encode(bufferlist& bl, uint64_t features) const
+void file_layout_t::encode(ceph::buffer::list& bl, uint64_t features) const
 {
   using ceph::encode;
   if ((features & CEPH_FEATURE_FS_FILE_LAYOUT_V2) == 0) {
@@ -91,7 +93,7 @@ void file_layout_t::encode(bufferlist& bl, uint64_t features) const
   ENCODE_FINISH(bl);
 }
 
-void file_layout_t::decode(bufferlist::const_iterator& p)
+void file_layout_t::decode(ceph::buffer::list::const_iterator& p)
 {
   using ceph::decode;
   if (*p == 0) {
@@ -109,7 +111,7 @@ void file_layout_t::decode(bufferlist::const_iterator& p)
   DECODE_FINISH(p);
 }
 
-void file_layout_t::dump(Formatter *f) const
+void file_layout_t::dump(ceph::Formatter *f) const
 {
   f->dump_unsigned("stripe_unit", stripe_unit);
   f->dump_unsigned("stripe_count", stripe_count);
@@ -118,7 +120,7 @@ void file_layout_t::dump(Formatter *f) const
   f->dump_string("pool_ns", pool_ns);
 }
 
-void file_layout_t::generate_test_instances(list<file_layout_t*>& o)
+void file_layout_t::generate_test_instances(std::list<file_layout_t*>& o)
 {
   o.push_back(new file_layout_t);
   o.push_back(new file_layout_t);
@@ -129,11 +131,10 @@ void file_layout_t::generate_test_instances(list<file_layout_t*>& o)
   o.back()->pool_ns = "myns";
 }
 
-ostream& operator<<(ostream& out, const file_layout_t &layout)
+std::ostream& operator<<(std::ostream& out, const file_layout_t &layout)
 {
-  JSONFormatter f;
+  ceph::JSONFormatter f;
   layout.dump(&f);
   f.flush(out);
   return out;
 }
-

--- a/src/common/histogram.cc
+++ b/src/common/histogram.cc
@@ -16,7 +16,7 @@
 #include "common/Formatter.h"
 
 // -- pow2_hist_t --
-void pow2_hist_t::dump(Formatter *f) const
+void pow2_hist_t::dump(ceph::Formatter *f) const
 {
   f->open_array_section("histogram");
   for (std::vector<int32_t>::const_iterator p = h.begin(); p != h.end(); ++p)
@@ -25,14 +25,14 @@ void pow2_hist_t::dump(Formatter *f) const
   f->dump_int("upper_bound", upper_bound());
 }
 
-void pow2_hist_t::encode(bufferlist& bl) const
+void pow2_hist_t::encode(ceph::buffer::list& bl) const
 {
   ENCODE_START(1, 1, bl);
   encode(h, bl);
   ENCODE_FINISH(bl);
 }
 
-void pow2_hist_t::decode(bufferlist::const_iterator& p)
+void pow2_hist_t::decode(ceph::buffer::list::const_iterator& p)
 {
   DECODE_START(1, p);
   decode(h, p);

--- a/src/common/hobject.cc
+++ b/src/common/hobject.cc
@@ -4,6 +4,14 @@
 #include "hobject.h"
 #include "common/Formatter.h"
 
+using std::list;
+using std::ostream;
+using std::set;
+using std::string;
+
+using ceph::bufferlist;
+using ceph::Formatter;
+
 static void append_escaped(const string &in, string *out)
 {
   for (string::const_iterator i = in.begin(); i != in.end(); ++i) {

--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -1,3 +1,5 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
 #include <arpa/inet.h>
 #include <ifaddrs.h>
@@ -13,6 +15,8 @@
 #include "include/ipaddr.h"
 #include "msg/msg_types.h"
 #include "common/pick_address.h"
+
+using std::string;
 
 void netmask_ipv4(const struct in_addr *addr,
 			 unsigned int prefix_len,

--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -29,16 +29,18 @@ struct lockdep_stopper_t {
     g_lockdep = 0;
   }
 };
+
+
 static pthread_mutex_t lockdep_mutex = PTHREAD_MUTEX_INITIALIZER;
 static CephContext *g_lockdep_ceph_ctx = NULL;
 static lockdep_stopper_t lockdep_stopper;
 static ceph::unordered_map<std::string, int> lock_ids;
-static map<int, std::string> lock_names;
-static map<int, int> lock_refs;
+static std::map<int, std::string> lock_names;
+static std::map<int, int> lock_refs;
 static char free_ids[MAX_LOCKS/8]; // bit set = free
-static ceph::unordered_map<pthread_t, map<int,BackTrace*> > held;
+static ceph::unordered_map<pthread_t, std::map<int,ceph::BackTrace*> > held;
 static char follows[MAX_LOCKS][MAX_LOCKS/8]; // follows[a][b] means b taken after a
-static BackTrace *follows_bt[MAX_LOCKS][MAX_LOCKS];
+static ceph::BackTrace *follows_bt[MAX_LOCKS][MAX_LOCKS];
 unsigned current_maxid;
 int last_freed_id = -1;
 static bool free_ids_inited;
@@ -93,7 +95,7 @@ void lockdep_unregister_ceph_context(CephContext *cct)
     lock_ids.clear();
     // FIPS zeroization audit 20191115: these memsets are not security related.
     memset((void*)&follows[0][0], 0, current_maxid * MAX_LOCKS/8);
-    memset((void*)&follows_bt[0][0], 0, sizeof(BackTrace*) * current_maxid * MAX_LOCKS);
+    memset((void*)&follows_bt[0][0], 0, sizeof(ceph::BackTrace*) * current_maxid * MAX_LOCKS);
   }
   pthread_mutex_unlock(&lockdep_mutex);
 }
@@ -104,11 +106,9 @@ int lockdep_dump_locks()
   if (!g_lockdep)
     goto out;
 
-  for (ceph::unordered_map<pthread_t, map<int,BackTrace*> >::iterator p = held.begin();
-       p != held.end();
-       ++p) {
+  for (auto p = held.begin(); p != held.end(); ++p) {
     lockdep_dout(0) << "--- thread " << p->first << " ---" << dendl;
-    for (map<int,BackTrace*>::iterator q = p->second.begin();
+    for (auto q = p->second.begin();
 	 q != p->second.end();
 	 ++q) {
       lockdep_dout(0) << "  * " << lock_names[q->first] << "\n";
@@ -205,7 +205,7 @@ void lockdep_unregister(int id)
   pthread_mutex_lock(&lockdep_mutex);
 
   std::string name;
-  map<int, std::string>::iterator p = lock_names.find(id);
+  auto p = lock_names.find(id);
   if (p == lock_names.end())
     name = "unknown" ;
   else
@@ -289,15 +289,13 @@ int lockdep_will_lock(const char *name, int id, bool force_backtrace,
   lockdep_dout(20) << "_will_lock " << name << " (" << id << ")" << dendl;
 
   // check dependency graph
-  map<int, BackTrace *> &m = held[p];
-  for (map<int, BackTrace *>::iterator p = m.begin();
-       p != m.end();
-       ++p) {
+  auto& m = held[p];
+  for (auto p = m.begin(); p != m.end(); ++p) {
     if (p->first == id) {
       if (!recursive) {
 	lockdep_dout(0) << "\n";
 	*_dout << "recursive lock of " << name << " (" << id << ")\n";
-	BackTrace *bt = new BackTrace(BACKTRACE_SKIP);
+	auto bt = new ceph::BackTrace(BACKTRACE_SKIP);
 	bt->print(*_dout);
 	if (p->second) {
 	  *_dout << "\npreviously locked at\n";
@@ -313,7 +311,7 @@ int lockdep_will_lock(const char *name, int id, bool force_backtrace,
 
       // did we just create a cycle?
       if (does_follow(id, p->first)) {
-        BackTrace *bt = new BackTrace(BACKTRACE_SKIP);
+        auto bt = new ceph::BackTrace(BACKTRACE_SKIP);
 	lockdep_dout(0) << "new dependency " << lock_names[p->first]
 		<< " (" << p->first << ") -> " << name << " (" << id << ")"
 		<< " creates a cycle at\n";
@@ -321,9 +319,7 @@ int lockdep_will_lock(const char *name, int id, bool force_backtrace,
 	*_dout << dendl;
 
 	lockdep_dout(0) << "btw, i am holding these locks:" << dendl;
-	for (map<int, BackTrace *>::iterator q = m.begin();
-	     q != m.end();
-	     ++q) {
+	for (auto q = m.begin(); q != m.end(); ++q) {
 	  lockdep_dout(0) << "  " << lock_names[q->first] << " (" << q->first << ")" << dendl;
 	  if (q->second) {
 	    lockdep_dout(0) << " ";
@@ -339,9 +335,9 @@ int lockdep_will_lock(const char *name, int id, bool force_backtrace,
 
 	ceph_abort();  // actually, we should just die here.
       } else {
-        BackTrace *bt = NULL;
+	ceph::BackTrace* bt = NULL;
         if (force_backtrace || lockdep_force_backtrace()) {
-          bt = new BackTrace(BACKTRACE_SKIP);
+          bt = new ceph::BackTrace(BACKTRACE_SKIP);
         }
         follows[p->first][id/8] |= 1 << (id % 8);
         follows_bt[p->first][id] = bt;
@@ -366,7 +362,7 @@ int lockdep_locked(const char *name, int id, bool force_backtrace)
 
   lockdep_dout(20) << "_locked " << name << dendl;
   if (force_backtrace || lockdep_force_backtrace())
-    held[p][id] = new BackTrace(BACKTRACE_SKIP);
+    held[p][id] = new ceph::BackTrace(BACKTRACE_SKIP);
   else
     held[p][id] = 0;
 out:

--- a/src/common/numa.cc
+++ b/src/common/numa.cc
@@ -10,6 +10,10 @@
 #include "include/stringify.h"
 #include "common/safe_io.h"
 
+using namespace std::literals;
+
+using std::set;
+
 
 // list
 #if defined(__linux__)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -18,6 +18,12 @@
 // rbd feature validation
 #include "librbd/Features.h"
 
+using std::ostream;
+using std::ostringstream;
+
+using ceph::Formatter;
+using ceph::parse_timespan;
+
 namespace {
 class printer : public boost::static_visitor<> {
   ostream& out;
@@ -198,7 +204,7 @@ int Option::parse_value(
   } else if (type == Option::TYPE_SECS) {
     try {
       *out = parse_timespan(val);
-    } catch (const invalid_argument& e) {
+    } catch (const std::invalid_argument& e) {
       *error_message = e.what();
       return -EINVAL;
     }

--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -19,6 +19,8 @@
 #include "include/common_fwd.h"
 
 using std::ostringstream;
+using std::make_pair;
+using std::pair;
 
 namespace TOPNSPC::common {
 PerfCountersCollectionImpl::PerfCountersCollectionImpl()
@@ -544,13 +546,13 @@ void PerfCountersBuilder::add_u64_counter_histogram(
 {
   add_impl(idx, name, description, nick, prio,
 	   PERFCOUNTER_U64 | PERFCOUNTER_HISTOGRAM | PERFCOUNTER_COUNTER, unit,
-           unique_ptr<PerfHistogram<>>{new PerfHistogram<>{x_axis_config, y_axis_config}});
+           std::unique_ptr<PerfHistogram<>>{new PerfHistogram<>{x_axis_config, y_axis_config}});
 }
 
 void PerfCountersBuilder::add_impl(
   int idx, const char *name,
   const char *description, const char *nick, int prio, int ty, int unit,
-  unique_ptr<PerfHistogram<>> histogram)
+  std::unique_ptr<PerfHistogram<>> histogram)
 {
   ceph_assert(idx > m_perf_counters->m_lower_bound);
   ceph_assert(idx < m_perf_counters->m_upper_bound);

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -34,6 +34,9 @@
 
 #define dout_subsys ceph_subsys_
 
+using std::string;
+using std::vector;
+
 const struct sockaddr *find_ip_in_subnet_list(
   CephContext *cct,
   const struct ifaddrs *ifa,
@@ -465,7 +468,7 @@ std::string pick_iface(CephContext *cct, const struct sockaddr_storage &network)
     return {};
   }
 
-  const unsigned int prefix_len = max(sizeof(in_addr::s_addr), sizeof(in6_addr::s6_addr)) * CHAR_BIT;
+  const unsigned int prefix_len = std::max(sizeof(in_addr::s_addr), sizeof(in6_addr::s6_addr)) * CHAR_BIT;
   const struct ifaddrs *found = find_ip_in_subnet(
     ifa,
     (const struct sockaddr *) &network, prefix_len);
@@ -481,7 +484,7 @@ std::string pick_iface(CephContext *cct, const struct sockaddr_storage &network)
 }
 
 
-bool have_local_addr(CephContext *cct, const list<entity_addr_t>& ls, entity_addr_t *match)
+bool have_local_addr(CephContext *cct, const std::list<entity_addr_t>& ls, entity_addr_t *match)
 {
   struct ifaddrs *ifa;
   int r = getifaddrs(&ifa);
@@ -518,7 +521,7 @@ int get_iface_numa_node(
     PHY_PORT,
     BOND_PORT
   } ifatype = iface_t::PHY_PORT;
-  string_view ifa{iface};
+  std::string_view ifa{iface};
   if (auto pos = ifa.find(":"); pos != ifa.npos) {
     ifa.remove_suffix(ifa.size() - pos);
   }

--- a/src/common/rabin.cc
+++ b/src/common/rabin.cc
@@ -1,9 +1,10 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <cstring>
+
 #include "include/types.h"
 #include "rabin.h"
-#include <string.h>
 
 
 uint64_t RabinChunk::gen_rabin_hash(char* chunk_data, uint64_t off, uint64_t len) {
@@ -35,8 +36,8 @@ bool RabinChunk::end_of_chunk(const uint64_t fp , int numbits) {
  *   output_chunks split by Rabin
  */
 
-int RabinChunk::do_rabin_chunks(bufferlist & inputdata, 
-				vector<pair<uint64_t, uint64_t>> & chunks, 
+int RabinChunk::do_rabin_chunks(ceph::buffer::list& inputdata,
+				std::vector<std::pair<uint64_t, uint64_t>>& chunks,
 				uint64_t min_val = 0, uint64_t max_val = 0)
 {
   char *ptr = inputdata.c_str();
@@ -56,7 +57,7 @@ int RabinChunk::do_rabin_chunks(bufferlist & inputdata,
   }
 
   if (data_size < min) {
-    chunks.push_back(make_pair(0, data_size));
+    chunks.push_back(std::make_pair(0, data_size));
     return 0;
   }
 
@@ -113,7 +114,7 @@ int RabinChunk::do_rabin_chunks(bufferlist & inputdata,
     }
 
     if (store_chunk) {
-      chunks.push_back(make_pair(c_start, c_size));
+      chunks.push_back(std::make_pair(c_start, c_size));
       c_start += c_size;
       c_offset = c_start;
       start_new_chunk = true;
@@ -127,7 +128,7 @@ int RabinChunk::do_rabin_chunks(bufferlist & inputdata,
 
   if (c_start < data_size) {
     c_size = data_size - c_start;
-    chunks.push_back(make_pair(c_start, c_size));
+    chunks.push_back(std::make_pair(c_start, c_size));
   }
 
   return 0;

--- a/src/common/rabin.h
+++ b/src/common/rabin.h
@@ -15,19 +15,27 @@
 #ifndef CEPH_COMMON_RABIN_H_
 #define CEPH_COMMON_RABIN_H_
 
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "include/buffer_fwd.h"
+
 class RabinChunk {
 public:
-  RabinChunk(uint32_t window_size, uint32_t rabin_prime, 
-	     uint64_t mod_prime, uint64_t pow, vector<uint64_t> rabin_mask, uint64_t min,
-	     uint64_t max, uint32_t num_bits):
-	      window_size(window_size), rabin_prime(rabin_prime), mod_prime(mod_prime),
-	      pow(pow), rabin_mask(rabin_mask), min(min), max(max), num_bits(num_bits) {}
+  RabinChunk(uint32_t window_size, uint32_t rabin_prime,
+	     uint64_t mod_prime, uint64_t pow, std::vector<uint64_t> rabin_mask,
+	     uint64_t min, uint64_t max, uint32_t num_bits):
+	      window_size(window_size), rabin_prime(rabin_prime),
+	      mod_prime(mod_prime), pow(pow), rabin_mask(rabin_mask), min(min),
+	      max(max), num_bits(num_bits) {}
   RabinChunk() {
     default_init_rabin_options();
   }
 
   void default_init_rabin_options() {
-    vector<uint64_t> _rabin_mask = {0,1,3,7,15,31,63,127,255,511,1023,2047,4095,8191,16383,32767,65535};
+    std::vector<uint64_t> _rabin_mask = {0,1,3,7,15,31,63,127,255,511,1023,2047,
+					 4095,8191,16383,32767,65535};
     window_size = 48;
     rabin_prime = 3;
     mod_prime = 6148914691236517051;
@@ -38,8 +46,8 @@ public:
     rabin_mask = _rabin_mask;
   }
 
-  int do_rabin_chunks(bufferlist & inputdata, 
-		      vector<pair<uint64_t, uint64_t>> & chunks, 
+  int do_rabin_chunks(ceph::buffer::list& inputdata,
+		      std::vector<std::pair<uint64_t, uint64_t>>& chunks,
 		      uint64_t min, uint64_t max);
   uint64_t gen_rabin_hash(char* chunk_data, uint64_t off, uint64_t len = 0);
   bool end_of_chunk(const uint64_t fp , int numbits);
@@ -47,10 +55,10 @@ public:
   void set_rabin_prime(uint32_t r_prime) { rabin_prime = r_prime; }
   void set_mod_prime(uint64_t m_prime) { mod_prime = m_prime; }
   void set_pow(uint64_t p) { pow = p; }
-  void set_rabin_mask(vector<uint64_t> & mask) { rabin_mask = mask; }
+  void set_rabin_mask(std::vector<uint64_t> & mask) { rabin_mask = mask; }
   void set_min_chunk(uint32_t c_min) { min = c_min; }
   void set_max_chunk(uint32_t c_max) { max = c_max; }
-  int add_rabin_mask(uint64_t mask) { 
+  int add_rabin_mask(uint64_t mask) {
     rabin_mask.push_back(mask);
     for (int i = 0; rabin_mask.size(); i++) {
       if (rabin_mask[i] == mask) {
@@ -66,8 +74,8 @@ private:
   uint32_t window_size;
   uint32_t rabin_prime;
   uint64_t mod_prime;
-  uint64_t pow; 
-  vector<uint64_t> rabin_mask;
+  uint64_t pow;
+  std::vector<uint64_t> rabin_mask;
   uint64_t min;
   uint64_t max;
   uint32_t num_bits;

--- a/src/common/scrub_types.cc
+++ b/src/common/scrub_types.cc
@@ -1,5 +1,7 @@
 #include "scrub_types.h"
 
+using std::map;
+
 using namespace librados;
 
 void object_id_wrapper::encode(bufferlist& bl) const

--- a/src/common/signal.cc
+++ b/src/common/signal.cc
@@ -12,18 +12,23 @@
  *
  */
 
-#include "common/BackTrace.h"
-#include "common/perf_counters.h"
-#include "global/pidfile.h"
-#include "common/debug.h"
-#include "common/signal.h"
-#include "common/config.h"
-
-#include <signal.h>
+#include <cstdlib>
 #include <sstream>
-#include <stdlib.h>
+
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#include <signal.h>
+
+#include "common/BackTrace.h"
+#include "common/config.h"
+#include "common/debug.h"
+#include "common/signal.h"
+#include "common/perf_counters.h"
+
+#include "global/pidfile.h"
+
+using namespace std::literals;
 
 std::string signal_mask_to_str()
 {
@@ -32,9 +37,9 @@ std::string signal_mask_to_str()
     return "(pthread_signmask failed)";
   }
 
-  ostringstream oss;
+  std::ostringstream oss;
   oss << "show_signal_mask: { ";
-  string sep("");
+  auto sep = ""s;
   for (int signum = 0; signum < NSIG; ++signum) {
     if (sigismember(&old_sigset, signum) == 1) {
       oss << sep << signum;

--- a/src/common/snap_types.cc
+++ b/src/common/snap_types.cc
@@ -1,26 +1,28 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
 #include "snap_types.h"
 #include "common/Formatter.h"
 
-void SnapRealmInfo::encode(bufferlist& bl) const
+void SnapRealmInfo::encode(ceph::buffer::list& bl) const
 {
   h.num_snaps = my_snaps.size();
   h.num_prior_parent_snaps = prior_parent_snaps.size();
   using ceph::encode;
   encode(h, bl);
-  encode_nohead(my_snaps, bl);
-  encode_nohead(prior_parent_snaps, bl);
+  ceph::encode_nohead(my_snaps, bl);
+  ceph::encode_nohead(prior_parent_snaps, bl);
 }
 
-void SnapRealmInfo::decode(bufferlist::const_iterator& bl)
+void SnapRealmInfo::decode(ceph::buffer::list::const_iterator& bl)
 {
   using ceph::decode;
   decode(h, bl);
-  decode_nohead(h.num_snaps, my_snaps, bl);
-  decode_nohead(h.num_prior_parent_snaps, prior_parent_snaps, bl);
+  ceph::decode_nohead(h.num_snaps, my_snaps, bl);
+  ceph::decode_nohead(h.num_prior_parent_snaps, prior_parent_snaps, bl);
 }
 
-void SnapRealmInfo::dump(Formatter *f) const
+void SnapRealmInfo::dump(ceph::Formatter *f) const
 {
   f->dump_unsigned("ino", ino());
   f->dump_unsigned("parent", parent());
@@ -29,17 +31,17 @@ void SnapRealmInfo::dump(Formatter *f) const
   f->dump_unsigned("created", created());
 
   f->open_array_section("snaps");
-  for (vector<snapid_t>::const_iterator p = my_snaps.begin(); p != my_snaps.end(); ++p)
+  for (auto p = my_snaps.begin(); p != my_snaps.end(); ++p)
     f->dump_unsigned("snap", *p);
   f->close_section();
 
   f->open_array_section("prior_parent_snaps");
-  for (vector<snapid_t>::const_iterator p = prior_parent_snaps.begin(); p != prior_parent_snaps.end(); ++p)
+  for (auto p = prior_parent_snaps.begin(); p != prior_parent_snaps.end(); ++p)
     f->dump_unsigned("snap", *p);
-  f->close_section();  
+  f->close_section();
 }
 
-void SnapRealmInfo::generate_test_instances(list<SnapRealmInfo*>& o)
+void SnapRealmInfo::generate_test_instances(std::list<SnapRealmInfo*>& o)
 {
   o.push_back(new SnapRealmInfo);
   o.push_back(new SnapRealmInfo(1, 10, 10, 0));
@@ -74,19 +76,19 @@ bool SnapContext::is_valid() const
   return true;
 }
 
-void SnapContext::dump(Formatter *f) const
+void SnapContext::dump(ceph::Formatter *f) const
 {
   f->dump_unsigned("seq", seq);
   f->open_array_section("snaps");
-  for (vector<snapid_t>::const_iterator p = snaps.begin(); p != snaps.end(); ++p)
+  for (auto p = snaps.cbegin(); p != snaps.cend(); ++p)
     f->dump_unsigned("snap", *p);
   f->close_section();
 }
 
-void SnapContext::generate_test_instances(list<SnapContext*>& o)
+void SnapContext::generate_test_instances(std::list<SnapContext*>& o)
 {
   o.push_back(new SnapContext);
-  vector<snapid_t> v;
+  std::vector<snapid_t> v;
   o.push_back(new SnapContext(10, v));
   v.push_back(18);
   v.push_back(3);

--- a/src/common/types.cc
+++ b/src/common/types.cc
@@ -24,7 +24,7 @@
 
 const shard_id_t shard_id_t::NO_SHARD(-1);
 
-ostream &operator<<(ostream &lhs, const shard_id_t &rhs)
+std::ostream& operator<<(std::ostream& lhs, const shard_id_t& rhs)
 {
   return lhs << (unsigned)(uint8_t)rhs.id;
 }

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -39,6 +39,13 @@
 
 #include <stdio.h>
 
+using std::list;
+using std::map;
+using std::string;
+
+using ceph::bufferlist;
+using ceph::Formatter;
+
 int get_fs_stats(ceph_data_stats_t &stats, const char *path)
 {
   if (!path)
@@ -72,7 +79,7 @@ static char* value_sanitize(char *value)
 }
 
 static bool value_set(char *buf, const char *prefix,
-			    map<string, string> *pm, const char *key)
+		      map<string, string> *pm, const char *key)
 {
   if (strncmp(buf, prefix, strlen(prefix))) {
     return false;
@@ -287,12 +294,12 @@ void dump_services(Formatter* f, const map<string, list<int> >& services, const 
   ceph_assert(f);
 
   f->open_object_section(type);
-  for (map<string, list<int> >::const_iterator host = services.begin();
+  for (auto host = services.begin();
        host != services.end(); ++host) {
     f->open_array_section(host->first.c_str());
     const list<int>& hosted = host->second;
-    for (list<int>::const_iterator s = hosted.begin();
-	 s != hosted.end(); ++s) {
+    for (auto s = hosted.cbegin();
+	 s != hosted.cend(); ++s) {
       f->dump_int(type, *s);
     }
     f->close_section();

--- a/src/include/compact_set.h
+++ b/src/include/compact_set.h
@@ -271,7 +271,7 @@ public:
     decode(n, p);
     if (n > 0) {
       alloc_internal();
-      decode_nohead(n, *set, p);
+      ceph::decode_nohead(n, *set, p);
     } else
       free_internal();
   }

--- a/src/include/frag.h
+++ b/src/include/frag.h
@@ -151,12 +151,12 @@ public:
     return false;
   }
 
-  void encode(bufferlist& bl) const {
-    encode_raw(_enc, bl);
+  void encode(ceph::buffer::list& bl) const {
+    ceph::encode_raw(_enc, bl);
   }
-  void decode(bufferlist::const_iterator& p) {
+  void decode(ceph::buffer::list::const_iterator& p) {
     __u32 v;
-    decode_raw(v, p);
+    ceph::decode_raw(v, p);
     _enc = v;
   }
   bool operator<(const frag_t& b) const
@@ -182,8 +182,8 @@ inline std::ostream& operator<<(std::ostream& out, const frag_t& hb)
   return out << '*';
 }
 
-inline void encode(const frag_t &f, bufferlist& bl) { f.encode(bl); }
-inline void decode(frag_t &f, bufferlist::const_iterator& p) { f.decode(p); }
+inline void encode(const frag_t &f, ceph::buffer::list& bl) { f.encode(bl); }
+inline void decode(frag_t &f, ceph::buffer::list::const_iterator& p) { f.decode(p); }
 
 using frag_vec_t = boost::container::small_vector<frag_t, 4>;
 
@@ -464,15 +464,15 @@ public:
   }
 
   // encoding
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     encode(_splits, bl);
   }
-  void decode(bufferlist::const_iterator& p) {
+  void decode(ceph::buffer::list::const_iterator& p) {
     using ceph::decode;
     decode(_splits, p);
   }
-  void encode_nohead(bufferlist& bl) const {
+  void encode_nohead(ceph::buffer::list& bl) const {
     using ceph::encode;
     for (compact_map<frag_t,int32_t>::const_iterator p = _splits.begin();
 	 p != _splits.end();
@@ -481,7 +481,7 @@ public:
       encode(p->second, bl);
     }
   }
-  void decode_nohead(int n, bufferlist::const_iterator& p) {
+  void decode_nohead(int n, ceph::buffer::list::const_iterator& p) {
     using ceph::decode;
     _splits.clear();
     while (n-- > 0) {
@@ -514,11 +514,9 @@ public:
     out << ")";
   }
 
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->open_array_section("splits");
-    for (compact_map<frag_t,int32_t>::const_iterator p = _splits.begin();
-         p != _splits.end();
-         ++p) {
+    for (auto p = _splits.begin(); p != _splits.end(); ++p) {
       f->open_object_section("split");
       std::ostringstream frag_str;
       frag_str << p->first;

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -574,7 +574,7 @@ struct sha_digest_t {
     for (size_t i = 0; i < S; i++) {
       ::sprintf(&str[i * 2], "%02x", static_cast<int>(v[i]));
     }
-    return string(str);
+    return std::string(str);
   }
   sha_digest_t(const unsigned char *_v) { memcpy(v, _v, SIZE); };
   sha_digest_t() {}

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -9,10 +9,8 @@
  * modify it under the terms of the GNU Lesser General Public
  * License version 2.1, as published by the Free Software 
  * Foundation.  See file COPYING.
- * 
+ *
  */
-
-
 
 #ifndef CEPH_CDENTRY_H
 #define CEPH_CDENTRY_H
@@ -249,7 +247,7 @@ public:
   // -- exporting
   // note: this assumes the dentry already exists.  
   // i.e., the name is already extracted... so we just need the other state.
-  void encode_export(bufferlist& bl) {
+  void encode_export(ceph::buffer::list& bl) {
     ENCODE_START(1, 1, bl);
     encode(first, bl);
     encode(state, bl);
@@ -272,7 +270,7 @@ public:
   void abort_export() {
     put(PIN_TEMPEXPORTING);
   }
-  void decode_import(bufferlist::const_iterator& blp, LogSegment *ls) {
+  void decode_import(ceph::buffer::list::const_iterator& blp, LogSegment *ls) {
     DECODE_START(1, blp);
     decode(first, blp);
     __u32 nstate;
@@ -299,8 +297,8 @@ public:
     return &lock;
   }
   void set_object_info(MDSCacheObjectInfo &info) override;
-  void encode_lock_state(int type, bufferlist& bl) override;
-  void decode_lock_state(int type, const bufferlist& bl) override;
+  void encode_lock_state(int type, ceph::buffer::list& bl) override;
+  void decode_lock_state(int type, const ceph::buffer::list& bl) override;
 
   // ---------------------------------------------
   // replicas (on clients)
@@ -330,9 +328,9 @@ public:
   void remove_client_lease(ClientLease *r, Locker *locker);  // returns remaining mask (if any), and kicks locker eval_gathers
   void remove_client_leases(Locker *locker);
 
-  ostream& print_db_line_prefix(ostream& out) override;
-  void print(ostream& out) override;
-  void dump(Formatter *f) const;
+  std::ostream& print_db_line_prefix(std::ostream& out) override;
+  void print(std::ostream& out) override;
+  void dump(ceph::Formatter *f) const;
 
 
   __u32 hash;
@@ -371,7 +369,7 @@ private:
   mempool::mds_co::string name;
 };
 
-ostream& operator<<(ostream& out, const CDentry& dn);
+std::ostream& operator<<(std::ostream& out, const CDentry& dn);
 
 
 #endif

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -41,7 +41,7 @@ class MDCache;
 
 struct ObjectOperation;
 
-ostream& operator<<(ostream& out, const class CDir& dir);
+std::ostream& operator<<(std::ostream& out, const class CDir& dir);
 
 class CDir : public MDSCacheObject, public Counter<CDir> {
 public:
@@ -428,9 +428,9 @@ public:
     }
   }
 
-  static void encode_dirstat(bufferlist& bl, const session_info_t& info, const DirStat& ds);
+  static void encode_dirstat(ceph::buffer::list& bl, const session_info_t& info, const DirStat& ds);
 
-  void _encode_base(bufferlist& bl) {
+  void _encode_base(ceph::buffer::list& bl) {
     ENCODE_START(1, 1, bl);
     encode(first, bl);
     encode(fnode, bl);
@@ -438,7 +438,7 @@ public:
     encode(dir_rep_by, bl);
     ENCODE_FINISH(bl);
   }
-  void _decode_base(bufferlist::const_iterator& p) {
+  void _decode_base(ceph::buffer::list::const_iterator& p) {
     DECODE_START(1, p);
     decode(first, p);
     decode(fnode, p);
@@ -497,12 +497,12 @@ public:
   void finish_waiting(uint64_t mask, int result = 0);    // ditto
 
   // -- import/export --
-  void encode_export(bufferlist& bl);
+  void encode_export(ceph::buffer::list& bl);
   void finish_export();
   void abort_export() {
     put(PIN_TEMPEXPORTING);
   }
-  void decode_import(bufferlist::const_iterator& blp, LogSegment *ls);
+  void decode_import(ceph::buffer::list::const_iterator& blp, LogSegment *ls);
   void abort_import();
 
   // -- auth pins --
@@ -528,13 +528,13 @@ public:
 
   void maybe_finish_freeze();
 
-  pair<bool,bool> is_freezing_or_frozen_tree() const {
+  std::pair<bool,bool> is_freezing_or_frozen_tree() const {
     if (freeze_tree_state) {
       if (freeze_tree_state->frozen)
-	return make_pair(false, true);
-      return make_pair(true, false);
+	return std::make_pair(false, true);
+      return std::make_pair(true, false);
     }
-    return make_pair(false, false);
+    return std::make_pair(false, false);
   }
 
   bool is_freezing() const override { return is_freezing_dir() || is_freezing_tree(); }
@@ -591,10 +591,10 @@ public:
   }
   void enable_frozen_inode();
 
-  ostream& print_db_line_prefix(ostream& out) override;
-  void print(ostream& out) override;
-  void dump(Formatter *f, int flags = DUMP_DEFAULT) const;
-  void dump_load(Formatter *f);
+  std::ostream& print_db_line_prefix(std::ostream& out) override;
+  void print(std::ostream& out) override;
+  void dump(ceph::Formatter *f, int flags = DUMP_DEFAULT) const;
+  void dump_load(ceph::Formatter *f);
 
   // context
   MDCache *cache;
@@ -635,13 +635,13 @@ protected:
 
   void _omap_fetch(MDSContext *fin, const std::set<dentry_key_t>& keys);
   void _omap_fetch_more(
-    bufferlist& hdrbl, std::map<std::string, bufferlist>& omap,
+    ceph::buffer::list& hdrbl, std::map<std::string, ceph::buffer::list>& omap,
     MDSContext *fin);
   CDentry *_load_dentry(
       std::string_view key,
       std::string_view dname,
       snapid_t last,
-      bufferlist &bl,
+      ceph::buffer::list &bl,
       int pos,
       const std::set<snapid_t> *snaps,
       bool *force_dirty);
@@ -661,13 +661,13 @@ protected:
    */
   void go_bad(bool complete);
 
-  void _omap_fetched(bufferlist& hdrbl, std::map<std::string, bufferlist>& omap,
+  void _omap_fetched(ceph::buffer::list& hdrbl, std::map<std::string, ceph::buffer::list>& omap,
 		     bool complete, int r);
 
   // -- commit --
   void _commit(version_t want, int op_prio);
   void _omap_commit(int op_prio);
-  void _encode_dentry(CDentry *dn, bufferlist& bl, const std::set<snapid_t> *snaps);
+  void _encode_dentry(CDentry *dn, ceph::buffer::list& bl, const std::set<snapid_t> *snaps);
   void _committed(int r, version_t v);
 
   version_t projected_version = 0;
@@ -730,7 +730,7 @@ protected:
   mempool::mds_co::compact_map< string_snap_t, MDSContext::vec_alloc<mempool::mds_co::pool_allocator> > waiting_on_dentry; // FIXME string_snap_t not in mempool
 
 private:
-  friend ostream& operator<<(ostream& out, const class CDir& dir);
+  friend std::ostream& operator<<(std::ostream& out, const class CDir& dir);
 
   void log_mark_dirty();
 
@@ -755,7 +755,7 @@ private:
   void purge_stale_snap_data(const std::set<snapid_t>& snaps);
 
   void prepare_new_fragment(bool replay);
-  void prepare_old_fragment(map<string_snap_t, MDSContext::vec >& dentry_waiters, bool replay);
+  void prepare_old_fragment(std::map<string_snap_t, MDSContext::vec >& dentry_waiters, bool replay);
   void steal_dentry(CDentry *dn);  // from another dir.  used by merge/split.
   void finish_old_fragment(MDSContext::vec& waiters, bool replay);
   void init_fragment_pins();

--- a/src/mds/Capability.cc
+++ b/src/mds/Capability.cc
@@ -23,7 +23,7 @@
  * Capability::Export
  */
 
-void Capability::Export::encode(bufferlist &bl) const
+void Capability::Export::encode(ceph::buffer::list &bl) const
 {
   ENCODE_START(3, 2, bl);
   encode(cap_id, bl);
@@ -38,7 +38,7 @@ void Capability::Export::encode(bufferlist &bl) const
   ENCODE_FINISH(bl);
 }
 
-void Capability::Export::decode(bufferlist::const_iterator &p)
+void Capability::Export::decode(ceph::buffer::list::const_iterator &p)
 {
   DECODE_START_LEGACY_COMPAT_LEN(3, 2, 2, p);
   decode(cap_id, p);
@@ -54,7 +54,7 @@ void Capability::Export::decode(bufferlist::const_iterator &p)
   DECODE_FINISH(p);
 }
 
-void Capability::Export::dump(Formatter *f) const
+void Capability::Export::dump(ceph::Formatter *f) const
 {
   f->dump_unsigned("cap_id", cap_id);
   f->dump_unsigned("wanted", wanted);
@@ -78,7 +78,7 @@ void Capability::Export::generate_test_instances(std::list<Capability::Export*>&
   ls.back()->last_issue_stamp = utime_t(6, 7);
 }
 
-void Capability::Import::encode(bufferlist &bl) const
+void Capability::Import::encode(ceph::buffer::list &bl) const
 {
   ENCODE_START(1, 1, bl);
   encode(cap_id, bl);
@@ -87,7 +87,7 @@ void Capability::Import::encode(bufferlist &bl) const
   ENCODE_FINISH(bl);
 }
 
-void Capability::Import::decode(bufferlist::const_iterator &bl)
+void Capability::Import::decode(ceph::buffer::list::const_iterator &bl)
 {
   DECODE_START(1, bl);
   decode(cap_id, bl);
@@ -96,7 +96,7 @@ void Capability::Import::decode(bufferlist::const_iterator &bl)
   DECODE_FINISH(bl);
 }
 
-void Capability::Import::dump(Formatter *f) const
+void Capability::Import::dump(ceph::Formatter *f) const
 {
   f->dump_unsigned("cap_id", cap_id);
   f->dump_unsigned("issue_seq", issue_seq);
@@ -107,7 +107,7 @@ void Capability::Import::dump(Formatter *f) const
  * Capability::revoke_info
  */
 
-void Capability::revoke_info::encode(bufferlist& bl) const
+void Capability::revoke_info::encode(ceph::buffer::list& bl) const
 {
   ENCODE_START(2, 2, bl)
   encode(before, bl);
@@ -116,7 +116,7 @@ void Capability::revoke_info::encode(bufferlist& bl) const
   ENCODE_FINISH(bl);
 }
 
-void Capability::revoke_info::decode(bufferlist::const_iterator& bl)
+void Capability::revoke_info::decode(ceph::buffer::list::const_iterator& bl)
 {
   DECODE_START_LEGACY_COMPAT_LEN(2, 2, 2, bl);
   decode(before, bl);
@@ -125,7 +125,7 @@ void Capability::revoke_info::decode(bufferlist::const_iterator& bl)
   DECODE_FINISH(bl);
 }
 
-void Capability::revoke_info::dump(Formatter *f) const
+void Capability::revoke_info::dump(ceph::Formatter *f) const
 {
   f->dump_unsigned("before", before);
   f->dump_unsigned("seq", seq);
@@ -227,7 +227,7 @@ void Capability::set_wanted(int w) {
   _wanted = w;
 }
 
-void Capability::encode(bufferlist& bl) const
+void Capability::encode(ceph::buffer::list& bl) const
 {
   ENCODE_START(2, 2, bl)
   encode(last_sent, bl);
@@ -239,7 +239,7 @@ void Capability::encode(bufferlist& bl) const
   ENCODE_FINISH(bl);
 }
 
-void Capability::decode(bufferlist::const_iterator &bl)
+void Capability::decode(ceph::buffer::list::const_iterator &bl)
 {
   DECODE_START_LEGACY_COMPAT_LEN(2, 2, 2, bl)
   decode(last_sent, bl);
@@ -255,7 +255,7 @@ void Capability::decode(bufferlist::const_iterator &bl)
   calc_issued();
 }
 
-void Capability::dump(Formatter *f) const
+void Capability::dump(ceph::Formatter *f) const
 {
   f->dump_unsigned("last_sent", last_sent);
   f->dump_unsigned("last_issue_stamp", last_issue_stamp);

--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -79,9 +79,9 @@ public:
 	   ceph_seq_t s, ceph_seq_t m, utime_t lis, unsigned st) :
       cap_id(id), wanted(w), issued(i), pending(p), client_follows(cf),
       seq(s), mseq(m), last_issue_stamp(lis), state(st) {}
-    void encode(bufferlist &bl) const;
-    void decode(bufferlist::const_iterator &p);
-    void dump(Formatter *f) const;
+    void encode(ceph::buffer::list &bl) const;
+    void decode(ceph::buffer::list::const_iterator &p);
+    void dump(ceph::Formatter *f) const;
     static void generate_test_instances(std::list<Export*>& ls);
 
     int64_t cap_id = 0;
@@ -97,9 +97,9 @@ public:
   struct Import {
     Import() {}
     Import(int64_t i, ceph_seq_t s, ceph_seq_t m) : cap_id(i), issue_seq(s), mseq(m) {}
-    void encode(bufferlist &bl) const;
-    void decode(bufferlist::const_iterator &p);
-    void dump(Formatter *f) const;
+    void encode(ceph::buffer::list &bl) const;
+    void decode(ceph::buffer::list::const_iterator &p);
+    void dump(ceph::Formatter *f) const;
 
     int64_t cap_id = 0;
     ceph_seq_t issue_seq = 0;
@@ -108,9 +108,9 @@ public:
   struct revoke_info {
     revoke_info() {}
     revoke_info(__u32 b, ceph_seq_t s, ceph_seq_t li) : before(b), seq(s), last_issue(li) {}
-    void encode(bufferlist& bl) const;
-    void decode(bufferlist::const_iterator& bl);
-    void dump(Formatter *f) const;
+    void encode(ceph::buffer::list& bl) const;
+    void decode(ceph::buffer::list::const_iterator& bl);
+    void dump(ceph::Formatter *f) const;
     static void generate_test_instances(std::list<revoke_info*>& ls);
 
     __u32 before = 0;
@@ -348,11 +348,11 @@ public:
   }
 
   // serializers
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<Capability*>& ls);
-  
+
   snapid_t client_follows = 0;
   version_t client_xattr_version = 0;
   version_t client_inline_version = 0;

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -26,7 +26,15 @@
 #include "global/global_context.h"
 #include "mon/health_check.h"
 
+using std::list;
+using std::pair;
+using std::ostream;
+using std::ostringstream;
+using std::string;
 using std::stringstream;
+
+using ceph::bufferlist;
+using ceph::Formatter;
 
 void Filesystem::dump(Formatter *f) const
 {

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -52,10 +52,10 @@ public:
     return std::make_shared<Filesystem>(std::forward<Args>(args)...);
   }
 
-  void encode(bufferlist& bl, uint64_t features) const;
-  void decode(bufferlist::const_iterator& p);
+  void encode(ceph::buffer::list& bl, uint64_t features) const;
+  void decode(ceph::buffer::list::const_iterator& p);
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   void print(std::ostream& out) const;
 
   /**
@@ -365,8 +365,8 @@ public:
 
   const mds_info_t* find_replacement_for(mds_role_t role) const;
 
-  void get_health(list<pair<health_status_t,std::string> >& summary,
-		  list<pair<health_status_t,std::string> > *detail) const;
+  void get_health(std::list<std::pair<health_status_t,std::string> >& summary,
+		  std::list<std::pair<health_status_t,std::string> > *detail) const;
 
   void get_health_checks(health_check_map_t *checks) const;
 
@@ -378,18 +378,18 @@ public:
    */
   void sanity() const;
 
-  void encode(bufferlist& bl, uint64_t features) const;
-  void decode(bufferlist::const_iterator& p);
-  void decode(bufferlist& bl) {
+  void encode(ceph::buffer::list& bl, uint64_t features) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void decode(ceph::buffer::list& bl) {
     auto p = bl.cbegin();
     decode(p);
   }
   void sanitize(const std::function<bool(int64_t pool)>& pool_exists);
 
-  void print(ostream& out) const;
-  void print_summary(Formatter *f, ostream *out) const;
+  void print(std::ostream& out) const;
+  void print_summary(ceph::Formatter *f, std::ostream *out) const;
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<FSMap*>& ls);
 
 protected:
@@ -412,7 +412,7 @@ protected:
 };
 WRITE_CLASS_ENCODER_FEATURES(FSMap)
 
-inline ostream& operator<<(ostream& out, const FSMap& m) {
+inline std::ostream& operator<<(std::ostream& out, const FSMap& m) {
   m.print_summary(NULL, &out);
   return out;
 }

--- a/src/mds/FSMapUser.cc
+++ b/src/mds/FSMapUser.cc
@@ -1,6 +1,6 @@
 #include "FSMapUser.h"
 
-void FSMapUser::encode(bufferlist& bl, uint64_t features) const
+void FSMapUser::encode(ceph::buffer::list& bl, uint64_t features) const
 {
   ENCODE_START(1, 1, bl);
   encode(epoch, bl);
@@ -12,7 +12,7 @@ void FSMapUser::encode(bufferlist& bl, uint64_t features) const
   ENCODE_FINISH(bl);
 }
 
-void FSMapUser::decode(bufferlist::const_iterator& p)
+void FSMapUser::decode(ceph::buffer::list::const_iterator& p)
 {
   DECODE_START(1, p);
   decode(epoch, p);
@@ -25,7 +25,7 @@ void FSMapUser::decode(bufferlist::const_iterator& p)
   DECODE_FINISH(p);
 }
 
-void FSMapUser::fs_info_t::encode(bufferlist& bl, uint64_t features) const
+void FSMapUser::fs_info_t::encode(ceph::buffer::list& bl, uint64_t features) const
 {
   ENCODE_START(1, 1, bl);
   encode(cid, bl);
@@ -33,7 +33,7 @@ void FSMapUser::fs_info_t::encode(bufferlist& bl, uint64_t features) const
   ENCODE_FINISH(bl);
 }
 
-void FSMapUser::fs_info_t::decode(bufferlist::const_iterator& p)
+void FSMapUser::fs_info_t::decode(ceph::buffer::list::const_iterator& p)
 {
   DECODE_START(1, p);
   decode(cid, p);
@@ -54,7 +54,7 @@ void FSMapUser::generate_test_instances(std::list<FSMapUser*>& ls)
 }
 
 
-void FSMapUser::print(ostream& out) const
+void FSMapUser::print(std::ostream& out) const
 {
   out << "e" << epoch << std::endl;
   out << "legacy_client_fscid: " << legacy_client_fscid << std::endl;
@@ -62,10 +62,10 @@ void FSMapUser::print(ostream& out) const
     out << " id " <<  p.second.cid << " name " << p.second.name << std::endl;
 }
 
-void FSMapUser::print_summary(Formatter *f, ostream *out)
+void FSMapUser::print_summary(ceph::Formatter *f, std::ostream *out)
 {
-  map<mds_role_t,string> by_rank;
-  map<string,int> by_state;
+  std::map<mds_role_t,std::string> by_rank;
+  std::map<std::string,int> by_state;
 
   if (f) {
     f->dump_unsigned("epoch", get_epoch());

--- a/src/mds/FSMapUser.h
+++ b/src/mds/FSMapUser.h
@@ -24,8 +24,8 @@ class FSMapUser {
 public:
   struct fs_info_t {
     fs_info_t() {}
-    void encode(bufferlist& bl, uint64_t features) const;
-    void decode(bufferlist::const_iterator &bl);
+    void encode(ceph::buffer::list& bl, uint64_t features) const;
+    void decode(ceph::buffer::list::const_iterator &bl);
     std::string name;
     fs_cluster_id_t cid = FS_CLUSTER_ID_NONE;
   };
@@ -42,11 +42,11 @@ public:
     return FS_CLUSTER_ID_NONE;
   }
 
-  void encode(bufferlist& bl, uint64_t features) const;
-  void decode(bufferlist::const_iterator& bl);
+  void encode(ceph::buffer::list& bl, uint64_t features) const;
+  void decode(ceph::buffer::list::const_iterator& bl);
 
-  void print(ostream& out) const;
-  void print_summary(Formatter *f, ostream *out);
+  void print(std::ostream& out) const;
+  void print_summary(ceph::Formatter *f, std::ostream *out);
 
   static void generate_test_instances(std::list<FSMapUser*>& ls);
 
@@ -57,7 +57,7 @@ public:
 WRITE_CLASS_ENCODER_FEATURES(FSMapUser::fs_info_t)
 WRITE_CLASS_ENCODER_FEATURES(FSMapUser)
 
-inline ostream& operator<<(ostream& out, FSMapUser& m) {
+inline std::ostream& operator<<(std::ostream& out, FSMapUser& m) {
   m.print_summary(NULL, &out);
   return out;
 }

--- a/src/mds/LocalLock.h
+++ b/src/mds/LocalLock.h
@@ -49,8 +49,8 @@ public:
   client_t get_last_wrlock_client() const {
     return last_wrlock_client;
   }
-  
-  void print(ostream& out) const override {
+
+  void print(std::ostream& out) const override {
     out << "(";
     _print(out);
     if (last_wrlock_client >= 0)

--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -111,7 +111,7 @@ struct MDSCapMatch {
   bool match(std::string_view target_path,
 	     const int caller_uid,
 	     const int caller_gid,
-	     const vector<uint64_t> *caller_gid_list) const;
+	     const std::vector<uint64_t> *caller_gid_list) const;
 
   /**
    * Check whether this path *might* be accessible (actual permission
@@ -168,7 +168,7 @@ public:
   bool allow_all() const;
   bool is_capable(std::string_view inode_path,
 		  uid_t inode_uid, gid_t inode_gid, unsigned inode_mode,
-		  uid_t uid, gid_t gid, const vector<uint64_t> *caller_gid_list,
+		  uid_t uid, gid_t gid, const std::vector<uint64_t> *caller_gid_list,
 		  unsigned mask, uid_t new_uid, gid_t new_gid,
 		  const entity_addr_t& addr) const;
   bool path_capable(std::string_view inode_path) const;

--- a/src/mds/MDSCacheObject.cc
+++ b/src/mds/MDSCacheObject.cc
@@ -28,7 +28,7 @@ void MDSCacheObject::finish_waiting(uint64_t mask, int result) {
   finish_contexts(g_ceph_context, finished, result);
 }
 
-void MDSCacheObject::dump(Formatter *f) const
+void MDSCacheObject::dump(ceph::Formatter *f) const
 {
   f->dump_bool("is_auth", is_auth());
 
@@ -74,7 +74,7 @@ void MDSCacheObject::dump(Formatter *f) const
  * Use this in subclasses when printing their specialized
  * states too.
  */
-void MDSCacheObject::dump_states(Formatter *f) const
+void MDSCacheObject::dump_states(ceph::Formatter *f) const
 {
   if (state_test(STATE_AUTH)) f->dump_string("state", "auth");
   if (state_test(STATE_DIRTY)) f->dump_string("state", "dirty");

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -27,6 +27,10 @@ class SimpleLock;
 class MDSCacheObject;
 class MDSContext;
 
+namespace ceph {
+class Formatter;
+}
+
 struct ClientLease {
   ClientLease(client_t c, MDSCacheObject *p) :
     client(c), parent(p),
@@ -191,8 +195,8 @@ class MDSCacheObject {
   }
 #endif
 
-  void dump_states(Formatter *f) const;
-  void dump(Formatter *f) const;
+  void dump_states(ceph::Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
 
   // auth pins
   enum {
@@ -263,9 +267,9 @@ class MDSCacheObject {
       seq = ++last_wait_seq;
       mask &= ~WAIT_ORDERED;
     }
-    waiting.insert(pair<uint64_t, pair<uint64_t, MDSContext*> >(
+    waiting.insert(std::pair<uint64_t, std::pair<uint64_t, MDSContext*> >(
 			    mask,
-			    pair<uint64_t, MDSContext*>(seq, c)));
+			    std::pair<uint64_t, MDSContext*>(seq, c)));
 //    pdout(10,g_conf()->debug_mds) << (mdsco_db_line_prefix(this)) 
 //			       << "add_waiter " << hex << mask << dec << " " << c
 //			       << " on " << *this
@@ -280,8 +284,8 @@ class MDSCacheObject {
   // noop unless overloaded.
   virtual SimpleLock* get_lock(int type) { ceph_abort(); return 0; }
   virtual void set_object_info(MDSCacheObjectInfo &info) { ceph_abort(); }
-  virtual void encode_lock_state(int type, bufferlist& bl) { ceph_abort(); }
-  virtual void decode_lock_state(int type, const bufferlist& bl) { ceph_abort(); }
+  virtual void encode_lock_state(int type, ceph::buffer::list& bl) { ceph_abort(); }
+  virtual void decode_lock_state(int type, const ceph::buffer::list& bl) { ceph_abort(); }
   virtual void finish_lock_waiters(int type, uint64_t mask, int r=0) { ceph_abort(); }
   virtual void add_lock_waiter(int type, uint64_t mask, MDSContext *c) { ceph_abort(); }
   virtual bool is_lock_waiting(int type, uint64_t mask) { ceph_abort(); return false; }

--- a/src/mds/MDSContext.h
+++ b/src/mds/MDSContext.h
@@ -103,7 +103,7 @@ public:
 
   void complete(int r) override;
 
-  virtual void print(ostream& out) const = 0;
+  virtual void print(std::ostream& out) const = 0;
 
   static bool check_ios_in_flight(ceph::coarse_mono_time cutoff,
 				  std::string& slow_count,
@@ -130,7 +130,7 @@ public:
   void complete(int r) final;
   void set_write_pos(uint64_t wp) { write_pos = wp; }
   virtual void pre_finish(int r) {}
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "log_event(" << write_pos << ")";
   }
 };
@@ -156,7 +156,7 @@ protected:
 public:
   MDSIOContextWrapper(MDSRank *m, Context *c) : MDSHolder(m), fin(c) {}
   void finish(int r) override;
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "io_context_wrapper(" << fin << ")";
   }
 };
@@ -200,7 +200,7 @@ public:
     }
   }
   void complete(int r) final;
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "io_wrapper(" << wrapped << ")";
   }
 };

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -12,13 +12,27 @@
  * 
  */
 
+#include <sstream>
+
 #include "common/debug.h"
 #include "mon/health_check.h"
 
 #include "MDSMap.h"
 
-#include <sstream>
+using std::dec;
+using std::hex;
+using std::list;
+using std::make_pair;
+using std::map;
+using std::multimap;
+using std::ostream;
+using std::pair;
+using std::string;
+using std::set;
 using std::stringstream;
+
+using ceph::bufferlist;
+using ceph::Formatter;
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_
@@ -440,7 +454,7 @@ void MDSMap::get_health_checks(health_check_map_t *checks) const
     health_check_t& fscheck = checks->get_or_add(
       "FS_DEGRADED", HEALTH_WARN,
       "%num% filesystem%plurals% %isorare% degraded", 1);
-    ostringstream ss;
+    std::ostringstream ss;
     ss << "fs " << fs_name << " is degraded";
     fscheck.detail.push_back(ss.str());
 

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -125,12 +125,12 @@ public:
       return addrs;
     }
 
-    void encode(bufferlist& bl, uint64_t features) const {
+    void encode(ceph::buffer::list& bl, uint64_t features) const {
       if ((features & CEPH_FEATURE_MDSENC) == 0 ) encode_unversioned(bl);
       else encode_versioned(bl, features);
     }
-    void decode(bufferlist::const_iterator& p);
-    void dump(Formatter *f) const;
+    void decode(ceph::buffer::list::const_iterator& p);
+    void dump(ceph::Formatter *f) const;
     void dump(std::ostream&) const;
 
     // The long form name for use in cluster log messages`
@@ -154,8 +154,8 @@ public:
       FROZEN = 1 << 0,
     };
   private:
-    void encode_versioned(bufferlist& bl, uint64_t features) const;
-    void encode_unversioned(bufferlist& bl) const;
+    void encode_versioned(ceph::buffer::list& bl, uint64_t features) const;
+    void encode_unversioned(ceph::buffer::list& bl) const;
   };
 
   friend class MDSMonitor;
@@ -348,8 +348,8 @@ public:
   void get_mds_set_lower_bound(std::set<mds_rank_t>& s, DaemonState first) const;
   void get_mds_set(std::set<mds_rank_t>& s, DaemonState state) const;
 
-  void get_health(list<pair<health_status_t,std::string> >& summary,
-		  list<pair<health_status_t,std::string> > *detail) const;
+  void get_health(std::list<std::pair<health_status_t,std::string> >& summary,
+		  std::list<std::pair<health_status_t,std::string> > *detail) const;
 
   void get_health_checks(health_check_map_t *checks) const;
 
@@ -525,18 +525,18 @@ public:
       return mds_info_entry->second.inc;
     return -1;
   }
-  void encode(bufferlist& bl, uint64_t features) const;
-  void decode(bufferlist::const_iterator& p);
-  void decode(const bufferlist& bl) {
+  void encode(ceph::buffer::list& bl, uint64_t features) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void decode(const ceph::buffer::list& bl) {
     auto p = bl.cbegin();
     decode(p);
   }
   void sanitize(const std::function<bool(int64_t pool)>& pool_exists);
 
-  void print(ostream& out) const;
-  void print_summary(Formatter *f, ostream *out) const;
+  void print(std::ostream& out) const;
+  void print_summary(ceph::Formatter *f, std::ostream *out) const;
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<MDSMap*>& ls);
 
   static bool state_transition_valid(DaemonState prev, DaemonState next);
@@ -580,7 +580,7 @@ protected:
   mds_rank_t max_mds = 1; /* The maximum number of active MDSes. Also, the maximum rank. */
   mds_rank_t old_max_mds = 0; /* Value to restore when MDS cluster is marked up */
   mds_rank_t standby_count_wanted = -1;
-  string balancer;    /* The name/version of the mantle balancer (i.e. the rados obj name) */
+  std::string balancer;    /* The name/version of the mantle balancer (i.e. the rados obj name) */
 
   std::set<mds_rank_t> in;              // currently defined cluster
 
@@ -600,7 +600,7 @@ protected:
 WRITE_CLASS_ENCODER_FEATURES(MDSMap::mds_info_t)
 WRITE_CLASS_ENCODER_FEATURES(MDSMap)
 
-inline ostream& operator<<(ostream &out, const MDSMap &m) {
+inline std::ostream& operator<<(std::ostream &out, const MDSMap &m) {
   m.print_summary(NULL, &out);
   return out;
 }

--- a/src/mds/ScatterLock.h
+++ b/src/mds/ScatterLock.h
@@ -142,7 +142,7 @@ public:
       state = LOCK_LOCK;
   }
 
-  void encode_state_for_rejoin(bufferlist& bl, int rep) {
+  void encode_state_for_rejoin(ceph::buffer::list& bl, int rep) {
     __s16 s = get_replica_state();
     if (is_gathering(rep)) {
       // the recovering mds may hold rejoined wrlocks
@@ -171,7 +171,7 @@ public:
     encode(s, bl);
   }
 
-  void decode_state_rejoin(bufferlist::const_iterator& p, MDSContext::vec& waiters, bool survivor) {
+  void decode_state_rejoin(ceph::buffer::list::const_iterator& p, MDSContext::vec& waiters, bool survivor) {
     SimpleLock::decode_state_rejoin(p, waiters, survivor);
     if (is_flushing()) {
       set_dirty();
@@ -190,7 +190,7 @@ public:
     return SimpleLock::remove_replica(from);
   }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "(";
     _print(out);
     if (is_dirty())

--- a/src/mds/ScrubHeader.h
+++ b/src/mds/ScrubHeader.h
@@ -16,7 +16,15 @@
 #ifndef SCRUB_HEADER_H_
 #define SCRUB_HEADER_H_
 
+#include <memory>
+#include <string>
 #include <string_view>
+
+#include "include/ceph_assert.h"
+
+namespace ceph {
+class Formatter;
+};
 
 class CInode;
 
@@ -27,7 +35,7 @@ class CInode;
 class ScrubHeader {
 public:
   ScrubHeader(std::string_view tag_, bool is_tag_internal_, bool force_,
-              bool recursive_, bool repair_, Formatter *f_)
+              bool recursive_, bool repair_, ceph::Formatter *f_)
     : tag(tag_), is_tag_internal(is_tag_internal_), force(force_),
       recursive(recursive_), repair(repair_), formatter(f_)
   {
@@ -44,7 +52,7 @@ public:
   bool is_internal_tag() const { return is_tag_internal; }
   CInode *get_origin() const { return origin; }
   std::string_view get_tag() const { return tag; }
-  Formatter &get_formatter() const { return *formatter; }
+  ceph::Formatter& get_formatter() const { return *formatter; }
 
   bool get_repaired() const { return repaired; }
   void set_repaired() { repaired = true; }
@@ -55,7 +63,7 @@ protected:
   const bool force;
   const bool recursive;
   const bool repair;
-  Formatter * const formatter;
+  ceph::Formatter* const formatter;
   CInode *origin = nullptr;
 
   bool repaired = false;  // May be set during scrub if repairs happened
@@ -65,4 +73,3 @@ typedef std::shared_ptr<ScrubHeader> ScrubHeaderRef;
 typedef std::shared_ptr<const ScrubHeader> ScrubHeaderRefConst;
 
 #endif // SCRUB_HEADER_H_
-

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -117,7 +117,7 @@ public:
     }
   }
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   void push_pv(version_t pv)
   {
     ceph_assert(projected.empty() || projected.back() != pv);
@@ -142,7 +142,7 @@ public:
 
   void set_reconnecting(bool s) { reconnecting = s; }
 
-  void decode(bufferlist::const_iterator &p);
+  void decode(ceph::buffer::list::const_iterator &p);
   template<typename T>
   void set_client_metadata(T&& meta)
   {
@@ -264,7 +264,7 @@ public:
   }
 
   double get_session_uptime() const {
-    chrono::duration<double> uptime = clock::now() - birth_time;
+    std::chrono::duration<double> uptime = clock::now() - birth_time;
     return uptime.count();
   }
 
@@ -331,7 +331,7 @@ public:
     return erased_any;
   }
   bool have_completed_request(ceph_tid_t tid, inodeno_t *pcreated) const {
-    map<ceph_tid_t,inodeno_t>::const_iterator p = info.completed_requests.find(tid);
+    auto p = info.completed_requests.find(tid);
     if (p == info.completed_requests.end())
       return false;
     if (pcreated)
@@ -383,7 +383,7 @@ public:
   }
 
   int check_access(CInode *in, unsigned mask, int caller_uid, int caller_gid,
-		   const vector<uint64_t> *gid_list, int new_uid, int new_gid);
+		   const std::vector<uint64_t> *gid_list, int new_uid, int new_gid);
 
   void set_connection(ConnectionRef con) {
     connection = std::move(con);
@@ -413,7 +413,7 @@ public:
 
   xlist<Session*>::item item_session_list;
 
-  list<ref_t<Message>> preopen_out_queue;  ///< messages for client, queued before they connect
+  std::list<ceph::ref_t<Message>> preopen_out_queue;  ///< messages for client, queued before they connect
 
   /* This is mutable to allow get_request_count to be const. elist does not
    * support const iterators yet.
@@ -477,7 +477,7 @@ private:
   // -- caps --
   uint32_t cap_gen = 0;
   version_t cap_push_seq = 0;        // cap push seq #
-  map<version_t, MDSContext::vec > waitfor_flush; // flush session messages
+  std::map<version_t, MDSContext::vec > waitfor_flush; // flush session messages
 
   // Has completed_requests been modified since the last time we
   // wrote this session out?
@@ -531,11 +531,11 @@ public:
 
   version_t get_version() const {return version;}
 
-  virtual void encode_header(bufferlist *header_bl);
-  virtual void decode_header(bufferlist &header_bl);
-  virtual void decode_values(std::map<std::string, bufferlist> &session_vals);
-  virtual void decode_legacy(bufferlist::const_iterator& blp);
-  void dump(Formatter *f) const;
+  virtual void encode_header(ceph::buffer::list *header_bl);
+  virtual void decode_header(ceph::buffer::list &header_bl);
+  virtual void decode_values(std::map<std::string, ceph::buffer::list> &session_vals);
+  virtual void decode_legacy(ceph::buffer::list::const_iterator& blp);
+  void dump(ceph::Formatter *f) const;
 
   void set_rank(mds_rank_t r)
   {
@@ -627,7 +627,7 @@ public:
   }
 
   // sessions
-  void decode_legacy(bufferlist::const_iterator& blp) override;
+  void decode_legacy(ceph::buffer::list::const_iterator& blp) override;
   bool empty() const { return session_map.empty(); }
   const auto& get_sessions() const {
     return session_map;
@@ -723,12 +723,12 @@ public:
       int header_r,
       int values_r,
       bool first,
-      bufferlist &header_bl,
-      std::map<std::string, bufferlist> &session_vals,
+      ceph::buffer::list &header_bl,
+      std::map<std::string, ceph::buffer::list> &session_vals,
       bool more_session_vals);
 
   void load_legacy();
-  void _load_legacy_finish(int r, bufferlist &bl);
+  void _load_legacy_finish(int r, ceph::buffer::list &bl);
 
   void save(MDSContext *onsave, version_t needv=0);
   void _save_finish(version_t v);
@@ -774,8 +774,8 @@ public:
    * mark these sessions as dirty.
    */
   void replay_open_sessions(version_t event_cmapv,
-			    map<client_t,entity_inst_t>& client_map,
-			    map<client_t,client_metadata_t>& client_metadata_map);
+			    std::map<client_t,entity_inst_t>& client_map,
+			    std::map<client_t,client_metadata_t>& client_metadata_map);
 
   /**
    * For these session IDs, if a session exists with this ID, and it has
@@ -790,8 +790,8 @@ public:
   void handle_conf_change(const std::set <std::string> &changed);
 
   MDSRank *mds;
-  map<int,xlist<Session*>* > by_state;
-  map<version_t, MDSContext::vec > commit_waiters;
+  std::map<int,xlist<Session*>*> by_state;
+  std::map<version_t, MDSContext::vec> commit_waiters;
 
   // -- loading, saving --
   inodeno_t ino;

--- a/src/mds/SimpleLock.cc
+++ b/src/mds/SimpleLock.cc
@@ -16,7 +16,7 @@
 #include "SimpleLock.h"
 #include "Mutation.h"
 
-void SimpleLock::dump(Formatter *f) const {
+void SimpleLock::dump(ceph::Formatter *f) const {
   ceph_assert(f != NULL);
   if (is_sync_and_unlocked()) {
     return;

--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -204,10 +204,10 @@ public:
   int get_cap_shift() const;
   int get_cap_mask() const;
 
-  void decode_locked_state(const bufferlist& bl) {
+  void decode_locked_state(const ceph::buffer::list& bl) {
     parent->decode_lock_state(type->type, bl);
   }
-  void encode_locked_state(bufferlist& bl) {
+  void encode_locked_state(ceph::buffer::list& bl) {
     parent->encode_lock_state(type->type, bl);
   }
   void finish_waiters(uint64_t mask, int r=0) {
@@ -283,10 +283,10 @@ public:
   }
 
   // gather set
-  static set<int32_t> empty_gather_set;
+  static std::set<int32_t> empty_gather_set;
 
   // int32_t: <0 is client, >=0 is MDS rank
-  const set<int32_t>& get_gather_set() const {
+  const std::set<int32_t>& get_gather_set() const {
     return have_more() ? more()->gather_set : empty_gather_set;
   }
 
@@ -465,7 +465,7 @@ public:
   }
 
   // encode/decode
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 2, bl);
     encode(state, bl);
     if (have_more())
@@ -474,28 +474,28 @@ public:
       encode(empty_gather_set, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator& p) {
+  void decode(ceph::buffer::list::const_iterator& p) {
     DECODE_START(2, p);
     decode(state, p);
-    set<__s32> g;
+    std::set<__s32> g;
     decode(g, p);
     if (!g.empty())
       more()->gather_set.swap(g);
     DECODE_FINISH(p);
   }
-  void encode_state_for_replica(bufferlist& bl) const {
+  void encode_state_for_replica(ceph::buffer::list& bl) const {
     __s16 s = get_replica_state();
     using ceph::encode;
     encode(s, bl);
   }
-  void decode_state(bufferlist::const_iterator& p, bool is_new=true) {
+  void decode_state(ceph::buffer::list::const_iterator& p, bool is_new=true) {
     using ceph::decode;
     __s16 s;
     decode(s, p);
     if (is_new)
       state = s;
   }
-  void decode_state_rejoin(bufferlist::const_iterator& p, MDSContext::vec& waiters, bool survivor) {
+  void decode_state_rejoin(ceph::buffer::list::const_iterator& p, MDSContext::vec& waiters, bool survivor) {
     __s16 s;
     using ceph::decode;
     decode(s, p);
@@ -562,7 +562,7 @@ public:
     return false;
   }
 
-  void _print(ostream& out) const {
+  void _print(std::ostream& out) const {
     out << get_lock_type_name(get_type()) << " ";
     out << get_state_name(get_state());
     if (!get_gather_set().empty())
@@ -589,9 +589,9 @@ public:
    * Write bare values (caller must be in an object section)
    * to formatter, or nothing if is_sync_and_unlocked.
    */
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
 
-  virtual void print(ostream& out) const {
+  virtual void print(std::ostream& out) const {
     out << "(";
     _print(out);
     out << ")";
@@ -629,7 +629,7 @@ private:
 	lock_caches.empty();
     }
 
-    set<__s32> gather_set;  // auth+rep.  >= 0 is mds, < 0 is client
+    std::set<__s32> gather_set;  // auth+rep.  >= 0 is mds, < 0 is client
 
     // local state
     int num_wrlock = 0, num_xlock = 0;
@@ -658,7 +658,7 @@ private:
 };
 WRITE_CLASS_ENCODER(SimpleLock)
 
-inline ostream& operator<<(ostream& out, const SimpleLock& l) 
+inline std::ostream& operator<<(std::ostream& out, const SimpleLock& l) 
 {
   l.print(out);
   return out;

--- a/src/mds/SnapRealm.h
+++ b/src/mds/SnapRealm.h
@@ -29,9 +29,7 @@ public:
   SnapRealm(MDCache *c, CInode *in);
 
   bool exists(std::string_view name) const {
-    for (map<snapid_t,SnapInfo>::const_iterator p = srnode.snaps.begin();
-	 p != srnode.snaps.end();
-	 ++p) {
+    for (auto p = srnode.snaps.begin(); p != srnode.snaps.end(); ++p) {
       if (p->second.name == name)
 	return true;
     }
@@ -53,15 +51,15 @@ public:
   }
 
   void build_snap_set() const;
-  void get_snap_info(map<snapid_t, const SnapInfo*>& infomap, snapid_t first=0, snapid_t last=CEPH_NOSNAP);
+  void get_snap_info(std::map<snapid_t, const SnapInfo*>& infomap, snapid_t first=0, snapid_t last=CEPH_NOSNAP);
 
-  const bufferlist& get_snap_trace() const;
+  const ceph::buffer::list& get_snap_trace() const;
   void build_snap_trace() const;
 
   std::string_view get_snapname(snapid_t snapid, inodeno_t atino);
   snapid_t resolve_snapname(std::string_view name, inodeno_t atino, snapid_t first=0, snapid_t last=CEPH_NOSNAP);
 
-  const set<snapid_t>& get_snaps() const;
+  const std::set<snapid_t>& get_snaps() const;
   const SnapContext& get_snap_context() const;
   void invalidate_cached_snaps() {
     cached_seq = 0;
@@ -88,8 +86,8 @@ public:
 
   snapid_t get_snap_following(snapid_t follows) {
     check_cache();
-    const set<snapid_t>& s = get_snaps();
-    set<snapid_t>::const_iterator p = s.upper_bound(follows);
+    const std::set<snapid_t>& s = get_snaps();
+    auto p = s.upper_bound(follows);
     if (p != s.end())
       return *p;
     return CEPH_NOSNAP;
@@ -97,8 +95,8 @@ public:
 
   bool has_snaps_in_range(snapid_t first, snapid_t last) {
     check_cache();
-    const set<snapid_t>& s = get_snaps();
-    set<snapid_t>::const_iterator p = s.lower_bound(first);
+    const auto& s = get_snaps();
+    auto p = s.lower_bound(first);
     return (p != s.end() && *p <= last);
   }
 
@@ -133,11 +131,11 @@ public:
   bool past_parents_dirty = false;
 
   SnapRealm *parent = nullptr;
-  set<SnapRealm*> open_children;    // active children that are currently open
-  set<SnapRealm*> open_past_children;  // past children who has pinned me
+  std::set<SnapRealm*> open_children;    // active children that are currently open
+  std::set<SnapRealm*> open_past_children;  // past children who has pinned me
 
   elist<CInode*> inodes_with_caps = 0;             // for efficient realm splits
-  map<client_t, xlist<Capability*>* > client_caps;   // to identify clients who need snap notifications
+  std::map<client_t, xlist<Capability*>* > client_caps;   // to identify clients who need snap notifications
 
 protected:
   void check_cache() const;
@@ -146,17 +144,17 @@ private:
   mutable bool open = false;                        // set to true once all past_parents are opened
   bool global;
 
-  map<inodeno_t, pair<SnapRealm*, set<snapid_t> > > open_past_parents;  // these are explicitly pinned.
+  std::map<inodeno_t, std::pair<SnapRealm*, std::set<snapid_t>>> open_past_parents;  // these are explicitly pinned.
   unsigned num_open_past_parents = 0;
 
   // cache
   mutable snapid_t cached_seq;           // max seq over self and all past+present parents.
   mutable snapid_t cached_last_created;  // max last_created over all past+present parents
   mutable snapid_t cached_last_destroyed;
-  mutable set<snapid_t> cached_snaps;
+  mutable std::set<snapid_t> cached_snaps;
   mutable SnapContext cached_snap_context;
-  mutable bufferlist cached_snap_trace;
+  mutable ceph::buffer::list cached_snap_trace;
 };
 
-ostream& operator<<(ostream& out, const SnapRealm &realm);
+std::ostream& operator<<(std::ostream& out, const SnapRealm &realm);
 #endif

--- a/src/mds/flock.cc
+++ b/src/mds/flock.cc
@@ -8,6 +8,10 @@
 
 #define dout_subsys ceph_subsys_mds
 
+using std::list;
+using std::pair;
+using std::multimap;
+
 static multimap<ceph_filelock, ceph_lock_state_t*> global_waiting_locks;
 
 static void remove_global_waiting(ceph_filelock &fl, ceph_lock_state_t *lock_state)
@@ -35,7 +39,7 @@ ceph_lock_state_t::~ceph_lock_state_t()
 
 bool ceph_lock_state_t::is_waiting(const ceph_filelock &fl) const
 {
-  multimap<uint64_t, ceph_filelock>::const_iterator p = waiting_locks.find(fl.start);
+  auto p = waiting_locks.find(fl.start);
   while (p != waiting_locks.end()) {
     if (p->second.start > fl.start)
       return false;
@@ -81,7 +85,7 @@ bool ceph_lock_state_t::is_deadlock(const ceph_filelock& fl,
     return false;
 
   // find conflict locks' owners
-  set<ceph_filelock> lock_owners;
+  std::set<ceph_filelock> lock_owners;
   for (auto p = overlapping_locks.begin();
        p != overlapping_locks.end();
        ++p) {

--- a/src/mds/inode_backtrace.cc
+++ b/src/mds/inode_backtrace.cc
@@ -7,7 +7,7 @@
 
 /* inode_backpointer_t */
 
-void inode_backpointer_t::encode(bufferlist& bl) const
+void inode_backpointer_t::encode(ceph::buffer::list& bl) const
 {
   ENCODE_START(2, 2, bl);
   encode(dirino, bl);
@@ -16,7 +16,7 @@ void inode_backpointer_t::encode(bufferlist& bl) const
   ENCODE_FINISH(bl);
 }
 
-void inode_backpointer_t::decode(bufferlist::const_iterator& bl)
+void inode_backpointer_t::decode(ceph::buffer::list::const_iterator& bl)
 {
   DECODE_START_LEGACY_COMPAT_LEN(2, 2, 2, bl);
   decode(dirino, bl);
@@ -25,7 +25,7 @@ void inode_backpointer_t::decode(bufferlist::const_iterator& bl)
   DECODE_FINISH(bl);
 }
 
-void inode_backpointer_t::decode_old(bufferlist::const_iterator& bl)
+void inode_backpointer_t::decode_old(ceph::buffer::list::const_iterator& bl)
 {
   using ceph::decode;
   decode(dirino, bl);
@@ -33,7 +33,7 @@ void inode_backpointer_t::decode_old(bufferlist::const_iterator& bl)
   decode(version, bl);
 }
 
-void inode_backpointer_t::dump(Formatter *f) const
+void inode_backpointer_t::dump(ceph::Formatter *f) const
 {
   f->dump_unsigned("dirino", dirino);
   f->dump_string("dname", dname);
@@ -54,7 +54,7 @@ void inode_backpointer_t::generate_test_instances(std::list<inode_backpointer_t*
  * inode_backtrace_t
  */
 
-void inode_backtrace_t::encode(bufferlist& bl) const
+void inode_backtrace_t::encode(ceph::buffer::list& bl) const
 {
   ENCODE_START(5, 4, bl);
   encode(ino, bl);
@@ -64,7 +64,7 @@ void inode_backtrace_t::encode(bufferlist& bl) const
   ENCODE_FINISH(bl);
 }
 
-void inode_backtrace_t::decode(bufferlist::const_iterator& bl)
+void inode_backtrace_t::decode(ceph::buffer::list::const_iterator& bl)
 {
   DECODE_START_LEGACY_COMPAT_LEN(5, 4, 4, bl);
   if (struct_v < 3)
@@ -87,11 +87,11 @@ void inode_backtrace_t::decode(bufferlist::const_iterator& bl)
   DECODE_FINISH(bl);
 }
 
-void inode_backtrace_t::dump(Formatter *f) const
+void inode_backtrace_t::dump(ceph::Formatter *f) const
 {
   f->dump_unsigned("ino", ino);
   f->open_array_section("ancestors");
-  for (vector<inode_backpointer_t>::const_iterator p = ancestors.begin(); p != ancestors.end(); ++p) {
+  for (auto p = ancestors.begin(); p != ancestors.end(); ++p) {
     f->open_object_section("backpointer");
     p->dump(f);
     f->close_section();
@@ -99,7 +99,7 @@ void inode_backtrace_t::dump(Formatter *f) const
   f->close_section();
   f->dump_int("pool", pool);
   f->open_array_section("old_pools");
-  for (set<int64_t>::iterator p = old_pools.begin(); p != old_pools.end(); ++p) {
+  for (auto p = old_pools.begin(); p != old_pools.end(); ++p) {
     f->dump_int("old_pool", *p);
   }
   f->close_section();

--- a/src/mds/inode_backtrace.h
+++ b/src/mds/inode_backtrace.h
@@ -25,14 +25,14 @@ struct inode_backpointer_t {
   inode_backpointer_t() {}
   inode_backpointer_t(inodeno_t i, std::string_view d, version_t v) : dirino(i), dname(d), version(v) {}
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator &bl);
-  void decode_old(bufferlist::const_iterator &bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator &bl);
+  void decode_old(ceph::buffer::list::const_iterator &bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<inode_backpointer_t*>& ls);
 
   inodeno_t dirino;    // containing directory ino
-  string dname;        // linking dentry name
+  std::string dname;        // linking dentry name
   version_t version = 0;   // child's version at time of backpointer creation
 };
 WRITE_CLASS_ENCODER(inode_backpointer_t)
@@ -41,7 +41,7 @@ inline bool operator==(const inode_backpointer_t& l, const inode_backpointer_t& 
 	return l.dirino == r.dirino && l.version == r.version && l.dname == r.dname;
 }
 
-inline ostream& operator<<(ostream& out, const inode_backpointer_t& ib) {
+inline std::ostream& operator<<(std::ostream& out, const inode_backpointer_t& ib) {
   return out << "<" << ib.dirino << "/" << ib.dname << " v" << ib.version << ">";
 }
 
@@ -53,9 +53,9 @@ inline ostream& operator<<(ostream& out, const inode_backpointer_t& ib) {
 struct inode_backtrace_t {
   inode_backtrace_t() {}
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator &bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator &bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<inode_backtrace_t*>& ls);
 
   /**
@@ -74,14 +74,14 @@ struct inode_backtrace_t {
                bool *equivalent, bool *divergent) const;
 
   inodeno_t ino;       // my ino
-  vector<inode_backpointer_t> ancestors;
+  std::vector<inode_backpointer_t> ancestors;
   int64_t pool = -1;
   // we use a set for old_pools to avoid duplicate entries, e.g. setlayout 0, 1, 0
-  set<int64_t> old_pools;
+  std::set<int64_t> old_pools;
 };
 WRITE_CLASS_ENCODER(inode_backtrace_t)
 
-inline ostream& operator<<(ostream& out, const inode_backtrace_t& it) {
+inline std::ostream& operator<<(std::ostream& out, const inode_backtrace_t& it) {
   return out << "(" << it.pool << ")" << it.ino << ":" << it.ancestors << "//" << it.old_pools;
 }
 

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -8,6 +8,14 @@
 
 const mds_gid_t MDS_GID_NONE = mds_gid_t(0);
 
+using std::list;
+using std::make_pair;
+using std::ostream;
+using std::set;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::Formatter;
 
 /*
  * frag_info_t
@@ -237,7 +245,7 @@ void inline_data_t::decode(bufferlist::const_iterator &p)
   uint32_t inline_len;
   decode(inline_len, p);
   if (inline_len > 0)
-    decode_nohead(inline_len, get_data(), p);
+    ceph::decode_nohead(inline_len, get_data(), p);
   else
     free_data();
 }
@@ -849,7 +857,7 @@ void cap_reconnect_t::encode_old(bufferlist& bl) const {
   encode(path, bl);
   capinfo.flock_len = flockbl.length();
   encode(capinfo, bl);
-  encode_nohead(flockbl, bl);
+  ceph::encode_nohead(flockbl, bl);
 }
 
 void cap_reconnect_t::decode(bufferlist::const_iterator& bl) {
@@ -864,7 +872,7 @@ void cap_reconnect_t::decode_old(bufferlist::const_iterator& bl) {
   using ceph::decode;
   decode(path, bl);
   decode(capinfo, bl);
-  decode_nohead(capinfo.flock_len, flockbl, bl);
+  ceph::decode_nohead(capinfo.flock_len, flockbl, bl);
 }
 
 void cap_reconnect_t::dump(Formatter *f) const

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -109,9 +109,9 @@ inline std::ostream& operator<<(std::ostream& out, const mds_role_t& role) {
 }
 
 // CAPS
-inline string gcap_string(int cap)
+inline std::string gcap_string(int cap)
 {
-  string s;
+  std::string s;
   if (cap & CEPH_CAP_GSHARED) s += "s";  
   if (cap & CEPH_CAP_GEXCL) s += "x";
   if (cap & CEPH_CAP_GCACHE) s += "c";
@@ -122,9 +122,9 @@ inline string gcap_string(int cap)
   if (cap & CEPH_CAP_GLAZYIO) s += "l";
   return s;
 }
-inline string ccap_string(int cap)
+inline std::string ccap_string(int cap)
 {
-  string s;
+  std::string s;
   if (cap & CEPH_CAP_PIN) s += "p";
 
   int a = (cap >> CEPH_CAP_SAUTH) & 3;
@@ -186,9 +186,9 @@ struct frag_info_t : public scatter_info_t {
 	nsubdirs == o.nsubdirs;
   }
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator& bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator& bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<frag_info_t*>& ls);
 
   // this frag
@@ -246,9 +246,9 @@ struct nest_info_t : public scatter_info_t {
         rsnaps == o.rsnaps;
   }
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator& bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator& bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<nest_info_t*>& ls);
 
   // this frag + children
@@ -273,12 +273,12 @@ struct vinodeno_t {
   vinodeno_t() {}
   vinodeno_t(inodeno_t i, snapid_t s) : ino(i), snapid(s) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     encode(ino, bl);
     encode(snapid, bl);
   }
-  void decode(bufferlist::const_iterator& p) {
+  void decode(ceph::buffer::list::const_iterator& p) {
     using ceph::decode;
     decode(ino, p);
     decode(snapid, p);
@@ -303,20 +303,20 @@ inline bool operator<(const vinodeno_t &l, const vinodeno_t &r) {
 
 struct quota_info_t
 {
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(max_bytes, bl);
     encode(max_files, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator& p) {
+  void decode(ceph::buffer::list::const_iterator& p) {
     DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, p);
     decode(max_bytes, p);
     decode(max_files, p);
     DECODE_FINISH(p);
   }
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<quota_info_t *>& ls);
 
   bool is_valid() const {
@@ -335,7 +335,7 @@ inline bool operator==(const quota_info_t &l, const quota_info_t &r) {
   return memcmp(&l, &r, sizeof(l)) == 0;
 }
 
-ostream& operator<<(ostream &out, const quota_info_t &n);
+std::ostream& operator<<(std::ostream &out, const quota_info_t &n);
 
 namespace std {
   template<> struct hash<vinodeno_t> {
@@ -361,16 +361,17 @@ struct client_writeable_range_t {
     uint64_t first = 0, last = 0;    // interval client can write to
   };
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator& bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator& bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<client_writeable_range_t*>& ls);
 
   byte_range_t range;
   snapid_t follows = 0;     // aka "data+metadata flushed thru"
 };
 
-inline void decode(client_writeable_range_t::byte_range_t& range, bufferlist::const_iterator& bl) {
+inline void decode(client_writeable_range_t::byte_range_t& range, ceph::buffer::list::const_iterator& bl) {
+  using ceph::decode;
   decode(range.first, bl);
   decode(range.last, bl);
 }
@@ -404,9 +405,9 @@ public:
   void free_data() {
     blp.reset();
   }
-  bufferlist& get_data() {
+  ceph::buffer::list& get_data() {
     if (!blp)
-      blp.reset(new bufferlist);
+      blp.reset(new ceph::buffer::list);
     return *blp;
   }
   size_t length() const { return blp ? blp->length() : 0; }
@@ -414,18 +415,18 @@ public:
   bool operator==(const inline_data_t& o) const {
    return length() == o.length() &&
 	  (length() == 0 ||
-	   (*const_cast<bufferlist*>(blp.get()) == *const_cast<bufferlist*>(o.blp.get())));
+	   (*const_cast<ceph::buffer::list*>(blp.get()) == *const_cast<ceph::buffer::list*>(o.blp.get())));
   }
   bool operator!=(const inline_data_t& o) const {
     return !(*this == o);
   }
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator& bl);
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator& bl);
 
   version_t version = 1;
 
 private:
-  std::unique_ptr<bufferlist> blp;
+  std::unique_ptr<ceph::buffer::list> blp;
 };
 WRITE_CLASS_ENCODER(inline_data_t)
 
@@ -524,9 +525,9 @@ struct inode_t {
     old_pools.insert(l);
   }
 
-  void encode(bufferlist &bl, uint64_t features) const;
-  void decode(bufferlist::const_iterator& bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl, uint64_t features) const;
+  void decode(ceph::buffer::list::const_iterator& bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<inode_t*>& ls);
   /**
    * Compare this inode_t with another that represent *the same inode*
@@ -606,7 +607,7 @@ private:
 
 // These methods may be moved back to mdstypes.cc when we have pmr
 template<template<typename> class Allocator>
-void inode_t<Allocator>::encode(bufferlist &bl, uint64_t features) const
+void inode_t<Allocator>::encode(ceph::buffer::list &bl, uint64_t features) const
 {
   ENCODE_START(15, 6, bl);
 
@@ -664,7 +665,7 @@ void inode_t<Allocator>::encode(bufferlist &bl, uint64_t features) const
 }
 
 template<template<typename> class Allocator>
-void inode_t<Allocator>::decode(bufferlist::const_iterator &p)
+void inode_t<Allocator>::decode(ceph::buffer::list::const_iterator &p)
 {
   DECODE_START_LEGACY_COMPAT_LEN(15, 6, 6, p);
 
@@ -703,10 +704,9 @@ void inode_t<Allocator>::decode(bufferlist::const_iterator &p)
   if (struct_v >= 3) {
     decode(client_ranges, p);
   } else {
-    map<client_t, client_writeable_range_t::byte_range_t> m;
+    std::map<client_t, client_writeable_range_t::byte_range_t> m;
     decode(m, p);
-    for (map<client_t, client_writeable_range_t::byte_range_t>::iterator
-	q = m.begin(); q != m.end(); ++q)
+    for (auto q = m.begin(); q != m.end(); ++q)
       client_ranges[q->first].range = q->second;
   }
 
@@ -761,7 +761,7 @@ void inode_t<Allocator>::decode(bufferlist::const_iterator &p)
 }
 
 template<template<typename> class Allocator>
-void inode_t<Allocator>::dump(Formatter *f) const
+void inode_t<Allocator>::dump(ceph::Formatter *f) const
 {
   f->dump_unsigned("ino", ino);
   f->dump_unsigned("rdev", rdev);
@@ -907,14 +907,14 @@ bool inode_t<Allocator>::older_is_consistent(const inode_t<Allocator> &other) co
 }
 
 template<template<typename> class Allocator>
-inline void encode(const inode_t<Allocator> &c, ::ceph::bufferlist &bl, uint64_t features)
+inline void encode(const inode_t<Allocator> &c, ::ceph::buffer::list &bl, uint64_t features)
 {
   ENCODE_DUMP_PRE();
   c.encode(bl, features);
   ENCODE_DUMP_POST(cl);
 }
 template<template<typename> class Allocator>
-inline void decode(inode_t<Allocator> &c, ::ceph::bufferlist::const_iterator &p)
+inline void decode(inode_t<Allocator> &c, ::ceph::buffer::list::const_iterator &p)
 {
   c.decode(p);
 }
@@ -923,7 +923,11 @@ template<template<typename> class Allocator>
 using alloc_string = std::basic_string<char,std::char_traits<char>,Allocator<char>>;
 
 template<template<typename> class Allocator>
-using xattr_map = compact_map<alloc_string<Allocator>, bufferptr, std::less<alloc_string<Allocator>>, Allocator<std::pair<const alloc_string<Allocator>, bufferptr>>>; // FIXME bufferptr not in mempool
+using xattr_map = compact_map<alloc_string<Allocator>,
+			      ceph::bufferptr,
+			      std::less<alloc_string<Allocator>>,
+			      Allocator<std::pair<const alloc_string<Allocator>,
+						  ceph::bufferptr>>>; // FIXME bufferptr not in mempool
 
 template<template<typename> class Allocator = std::allocator>
 struct old_inode_t {
@@ -931,15 +935,15 @@ struct old_inode_t {
   inode_t<Allocator> inode;
   xattr_map<Allocator> xattrs;
 
-  void encode(bufferlist &bl, uint64_t features) const;
-  void decode(bufferlist::const_iterator& bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl, uint64_t features) const;
+  void decode(ceph::buffer::list::const_iterator& bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<old_inode_t*>& ls);
 };
 
 // These methods may be moved back to mdstypes.cc when we have pmr
 template<template<typename> class Allocator>
-void old_inode_t<Allocator>::encode(bufferlist& bl, uint64_t features) const
+void old_inode_t<Allocator>::encode(ceph::buffer::list& bl, uint64_t features) const
 {
   ENCODE_START(2, 2, bl);
   encode(first, bl);
@@ -949,7 +953,7 @@ void old_inode_t<Allocator>::encode(bufferlist& bl, uint64_t features) const
 }
 
 template<template<typename> class Allocator>
-void old_inode_t<Allocator>::decode(bufferlist::const_iterator& bl)
+void old_inode_t<Allocator>::decode(ceph::buffer::list::const_iterator& bl)
 {
   DECODE_START_LEGACY_COMPAT_LEN(2, 2, 2, bl);
   decode(first, bl);
@@ -959,7 +963,7 @@ void old_inode_t<Allocator>::decode(bufferlist::const_iterator& bl)
 }
 
 template<template<typename> class Allocator>
-void old_inode_t<Allocator>::dump(Formatter *f) const
+void old_inode_t<Allocator>::dump(ceph::Formatter *f) const
 {
   f->dump_unsigned("first", first);
   inode.dump(f);
@@ -980,19 +984,19 @@ void old_inode_t<Allocator>::generate_test_instances(std::list<old_inode_t<Alloc
   std::list<inode_t<Allocator>*> ils;
   inode_t<Allocator>::generate_test_instances(ils);
   ls.back()->inode = *ils.back();
-  ls.back()->xattrs["user.foo"] = buffer::copy("asdf", 4);
-  ls.back()->xattrs["user.unprintable"] = buffer::copy("\000\001\002", 3);
+  ls.back()->xattrs["user.foo"] = ceph::buffer::copy("asdf", 4);
+  ls.back()->xattrs["user.unprintable"] = ceph::buffer::copy("\000\001\002", 3);
 }
 
 template<template<typename> class Allocator>
-inline void encode(const old_inode_t<Allocator> &c, ::ceph::bufferlist &bl, uint64_t features)
+inline void encode(const old_inode_t<Allocator> &c, ::ceph::buffer::list &bl, uint64_t features)
 {
   ENCODE_DUMP_PRE();
   c.encode(bl, features);
   ENCODE_DUMP_POST(cl);
 }
 template<template<typename> class Allocator>
-inline void decode(old_inode_t<Allocator> &c, ::ceph::bufferlist::const_iterator &p)
+inline void decode(old_inode_t<Allocator> &c, ::ceph::buffer::list::const_iterator &p)
 {
   c.decode(p);
 }
@@ -1001,9 +1005,9 @@ inline void decode(old_inode_t<Allocator> &c, ::ceph::bufferlist::const_iterator
  * like an inode, but for a dir frag 
  */
 struct fnode_t {
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator& bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator& bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<fnode_t*>& ls);
 
   version_t version = 0;
@@ -1023,9 +1027,9 @@ WRITE_CLASS_ENCODER(fnode_t)
 
 
 struct old_rstat_t {
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<old_rstat_t*>& ls);
 
   snapid_t first;
@@ -1045,7 +1049,7 @@ public:
   feature_bitset_t(const feature_bitset_t& other) : _vec(other._vec) {}
   feature_bitset_t(feature_bitset_t&& other) : _vec(std::move(other._vec)) {}
   feature_bitset_t(unsigned long value = 0);
-  feature_bitset_t(const vector<size_t>& array);
+  feature_bitset_t(const std::vector<size_t>& array);
   feature_bitset_t& operator=(const feature_bitset_t& other) {
     _vec = other._vec;
     return *this;
@@ -1071,12 +1075,12 @@ public:
   void clear() {
     _vec.clear();
   }
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator &p);
-  void dump(Formatter *f) const;
-  void print(ostream& out) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator &p);
+  void dump(ceph::Formatter *f) const;
+  void print(std::ostream& out) const;
 private:
-  vector<block_type> _vec;
+  std::vector<block_type> _vec;
 };
 WRITE_CLASS_ENCODER(feature_bitset_t)
 
@@ -1113,10 +1117,10 @@ struct metric_spec_t {
     metric_flags.clear();
   }
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
-  void print(ostream& out) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
+  void print(std::ostream& out) const;
 
   // set of metrics that a client is capable of forwarding
   feature_bitset_t metric_flags;
@@ -1164,9 +1168,9 @@ struct client_metadata_t {
     metric_spec.clear();
   }
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
 
   kv_map_t kv_map;
   feature_bitset_t features;
@@ -1190,9 +1194,9 @@ struct session_info_t {
     client_metadata.clear();
   }
 
-  void encode(bufferlist& bl, uint64_t features) const;
-  void decode(bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl, uint64_t features) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<session_info_t*>& ls);
 
   entity_inst_t inst;
@@ -1215,13 +1219,13 @@ struct dentry_key_t {
 
   // encode into something that can be decoded as a string.
   // name_ (head) or name_%x (!head)
-  void encode(bufferlist& bl) const {
-    string key;
+  void encode(ceph::buffer::list& bl) const {
+    std::string key;
     encode(key);
     using ceph::encode;
     encode(key, bl);
   }
-  void encode(string& key) const {
+  void encode(std::string& key) const {
     char b[20];
     if (snapid != CEPH_NOSNAP) {
       uint64_t val(snapid);
@@ -1229,18 +1233,20 @@ struct dentry_key_t {
     } else {
       snprintf(b, sizeof(b), "%s", "head");
     }
-    ostringstream oss;
+    std::ostringstream oss;
     oss << name << "_" << b;
     key = oss.str();
   }
-  static void decode_helper(bufferlist::const_iterator& bl, string& nm, snapid_t& sn) {
-    string key;
+  static void decode_helper(ceph::buffer::list::const_iterator& bl, std::string& nm,
+			    snapid_t& sn) {
+    std::string key;
+    using ceph::decode;
     decode(key, bl);
     decode_helper(key, nm, sn);
   }
-  static void decode_helper(std::string_view key, string& nm, snapid_t& sn) {
+  static void decode_helper(std::string_view key, std::string& nm, snapid_t& sn) {
     size_t i = key.find_last_of('_');
-    ceph_assert(i != string::npos);
+    ceph_assert(i != std::string::npos);
     if (key.compare(i+1, std::string_view::npos, "head") == 0) {
       // name_head
       sn = CEPH_NOSNAP;
@@ -1285,12 +1291,12 @@ struct string_snap_t {
   string_snap_t() {}
   string_snap_t(std::string_view n, snapid_t s) : name(n), snapid(s) {}
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<string_snap_t*>& ls);
 
-  string name;
+  std::string name;
   snapid_t snapid;
 };
 WRITE_CLASS_ENCODER(string_snap_t)
@@ -1312,9 +1318,9 @@ inline std::ostream& operator<<(std::ostream& out, const string_snap_t &k)
  * pending mutation state in the table.
  */
 struct mds_table_pending_t {
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<mds_table_pending_t*>& ls);
 
   uint64_t reqid = 0;
@@ -1327,12 +1333,12 @@ WRITE_CLASS_ENCODER(mds_table_pending_t)
 struct metareqid_t {
   metareqid_t() {}
   metareqid_t(entity_name_t n, ceph_tid_t t) : name(n), tid(t) {}
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     encode(name, bl);
     encode(tid, bl);
   }
-  void decode(bufferlist::const_iterator &p) {
+  void decode(ceph::buffer::list::const_iterator &p) {
     using ceph::decode;
     decode(name, p);
     decode(tid, p);
@@ -1377,7 +1383,7 @@ namespace std {
 struct cap_reconnect_t {
   cap_reconnect_t() {}
   cap_reconnect_t(uint64_t cap_id, inodeno_t pino, std::string_view p, int w, int i,
-		  inodeno_t sr, snapid_t sf, bufferlist& lb) :
+		  inodeno_t sr, snapid_t sf, ceph::buffer::list& lb) :
     path(p) {
     capinfo.cap_id = cap_id;
     capinfo.wanted = w;
@@ -1388,18 +1394,18 @@ struct cap_reconnect_t {
     snap_follows = sf;
     flockbl.claim(lb);
   }
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& bl);
-  void encode_old(bufferlist& bl) const;
-  void decode_old(bufferlist::const_iterator& bl);
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& bl);
+  void encode_old(ceph::buffer::list& bl) const;
+  void decode_old(ceph::buffer::list::const_iterator& bl);
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<cap_reconnect_t*>& ls);
 
-  string path;
+  std::string path;
   mutable ceph_mds_cap_reconnect capinfo = {};
   snapid_t snap_follows = 0;
-  bufferlist flockbl;
+  ceph::buffer::list flockbl;
 };
 WRITE_CLASS_ENCODER(cap_reconnect_t)
 
@@ -1410,12 +1416,12 @@ struct snaprealm_reconnect_t {
     realm.seq = seq;
     realm.parent = parent;
   }
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& bl);
-  void encode_old(bufferlist& bl) const;
-  void decode_old(bufferlist::const_iterator& bl);
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& bl);
+  void encode_old(ceph::buffer::list& bl) const;
+  void decode_old(ceph::buffer::list::const_iterator& bl);
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<snaprealm_reconnect_t*>& ls);
 
   mutable ceph_mds_snaprealm_reconnect realm = {};
@@ -1455,18 +1461,18 @@ struct old_cap_reconnect_t {
     return n;
   }
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     encode(path, bl);
     encode(capinfo, bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     using ceph::decode;
     decode(path, bl);
     decode(capinfo, bl);
   }
 
-  string path;
+  std::string path;
   old_ceph_mds_cap_reconnect capinfo;
 };
 WRITE_CLASS_ENCODER(old_cap_reconnect_t)
@@ -1476,12 +1482,12 @@ struct dirfrag_t {
   dirfrag_t() {}
   dirfrag_t(inodeno_t i, frag_t f) : ino(i), frag(f) { }
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     encode(ino, bl);
     encode(frag, bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     using ceph::decode;
     decode(ino, bl);
     decode(frag, bl);
@@ -1533,26 +1539,26 @@ public:
   inode_load_vec_t() : vec{DecayCounter(DecayRate()), DecayCounter(DecayRate())} {}
   inode_load_vec_t(const DecayRate &rate) : vec{DecayCounter(rate), DecayCounter(rate)} {}
 
-  DecayCounter &get(int t) { 
-    return vec[t]; 
+  DecayCounter &get(int t) {
+    return vec[t];
   }
   void zero() {
     for (auto &d : vec) {
       d.reset();
     }
   }
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<inode_load_vec_t*>& ls);
 
 private:
   std::array<DecayCounter, NUM> vec;
 };
-inline void encode(const inode_load_vec_t &c, bufferlist &bl) {
+inline void encode(const inode_load_vec_t &c, ceph::buffer::list &bl) {
   c.encode(bl);
 }
-inline void decode(inode_load_vec_t & c, bufferlist::const_iterator &p) {
+inline void decode(inode_load_vec_t & c, ceph::buffer::list::const_iterator &p) {
   c.decode(p);
 }
 
@@ -1574,22 +1580,22 @@ public:
       vec{DecayCounter(rate), DecayCounter(rate), DecayCounter(rate), DecayCounter(rate), DecayCounter(rate)}
   {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(2, 2, bl);
     for (const auto &i : vec) {
       encode(i, bl);
     }
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &p) {
+  void decode(ceph::buffer::list::const_iterator &p) {
     DECODE_START_LEGACY_COMPAT_LEN(2, 2, 2, p);
     for (auto &i : vec) {
       decode(i, p);
     }
     DECODE_FINISH(p);
   }
-  void dump(Formatter *f) const;
-  void dump(Formatter *f, const DecayRate& rate) const;
+  void dump(ceph::Formatter *f) const;
+  void dump(ceph::Formatter *f, const DecayRate& rate) const;
   static void generate_test_instances(std::list<dirfrag_load_vec_t*>& ls);
 
   const DecayCounter &get(int t) const {
@@ -1635,10 +1641,10 @@ private:
   std::array<DecayCounter, NUM> vec;
 };
 
-inline void encode(const dirfrag_load_vec_t &c, bufferlist &bl) {
+inline void encode(const dirfrag_load_vec_t &c, ceph::buffer::list &bl) {
   c.encode(bl);
 }
-inline void decode(dirfrag_load_vec_t& c, bufferlist::const_iterator &p) {
+inline void decode(dirfrag_load_vec_t& c, ceph::buffer::list::const_iterator &p) {
   c.decode(p);
 }
 
@@ -1673,15 +1679,15 @@ struct mds_load_t {
   double cpu_load_avg = 0.0;
 
   double mds_load() const;  // defiend in MDBalancer.cc
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<mds_load_t*>& ls);
 };
-inline void encode(const mds_load_t &c, bufferlist &bl) {
+inline void encode(const mds_load_t &c, ceph::buffer::list &bl) {
   c.encode(bl);
 }
-inline void decode(mds_load_t &c, bufferlist::const_iterator &p) {
+inline void decode(mds_load_t &c, ceph::buffer::list::const_iterator &p) {
   c.decode(p);
 }
 
@@ -1743,14 +1749,14 @@ typedef std::pair<mds_rank_t, mds_rank_t> mds_authority_t;
 
 class MDSCacheObjectInfo {
 public:
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<MDSCacheObjectInfo*>& ls);
 
   inodeno_t ino = 0;
   dirfrag_t dirfrag;
-  string dname;
+  std::string dname;
   snapid_t snapid;
 };
 
@@ -1774,7 +1780,7 @@ namespace qi = boost::spirit::qi;
 
 template <typename Iterator>
 struct keys_and_values
-  : qi::grammar<Iterator, std::map<string, string>()>
+  : qi::grammar<Iterator, std::map<std::string, std::string>()>
 {
     keys_and_values()
       : keys_and_values::base_type(query)
@@ -1784,9 +1790,9 @@ struct keys_and_values
       key   =  qi::char_("a-zA-Z_") >> *qi::char_("a-zA-Z_0-9");
       value = +qi::char_("a-zA-Z_0-9");
     }
-    qi::rule<Iterator, std::map<string, string>()> query;
-    qi::rule<Iterator, std::pair<string, string>()> pair;
-    qi::rule<Iterator, string()> key, value;
+  qi::rule<Iterator, std::map<std::string, std::string>()> query;
+  qi::rule<Iterator, std::pair<std::string, std::string>()> pair;
+  qi::rule<Iterator, std::string()> key, value;
 };
 
 #endif

--- a/src/mds/snap.h
+++ b/src/mds/snap.h
@@ -26,9 +26,9 @@
  * generic snap descriptor.
  */
 struct SnapInfo {
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<SnapInfo*>& ls);
 
   std::string_view get_long_name() const;
@@ -36,9 +36,9 @@ struct SnapInfo {
   snapid_t snapid;
   inodeno_t ino;
   utime_t stamp;
-  string name;
+  std::string name;
 
-  mutable string long_name; ///< cached _$ino_$name
+  mutable std::string long_name; ///< cached _$ino_$name
 };
 WRITE_CLASS_ENCODER(SnapInfo)
 
@@ -48,7 +48,7 @@ inline bool operator==(const SnapInfo &l, const SnapInfo &r)
 	 l.stamp == r.stamp && l.name == r.name;
 }
 
-ostream& operator<<(ostream& out, const SnapInfo &sn);
+std::ostream& operator<<(std::ostream& out, const SnapInfo &sn);
 
 /*
  * SnapRealm - a subtree that shares the same set of snapshots.
@@ -56,9 +56,9 @@ ostream& operator<<(ostream& out, const SnapInfo &sn);
 struct SnapRealm;
 
 struct snaplink_t {
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<snaplink_t*>& ls);
 
   inodeno_t ino;
@@ -66,7 +66,7 @@ struct snaplink_t {
 };
 WRITE_CLASS_ENCODER(snaplink_t)
 
-ostream& operator<<(ostream& out, const snaplink_t &l);
+std::ostream& operator<<(std::ostream& out, const snaplink_t &l);
 
 // carry data about a specific version of a SnapRealm
 struct sr_t {
@@ -74,9 +74,9 @@ struct sr_t {
   void clear_parent_global() { flags &= ~PARENT_GLOBAL; }
   bool is_parent_global() const { return flags & PARENT_GLOBAL; }
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<sr_t*>& ls);
 
   snapid_t seq = 0;                     // basically, a version/seq # for changes to _this_ realm.
@@ -84,9 +84,9 @@ struct sr_t {
   snapid_t last_created = 0;            // last snap created in _this_ realm.
   snapid_t last_destroyed = 0;          // seq for last removal
   snapid_t current_parent_since = 1;
-  map<snapid_t, SnapInfo> snaps;
-  map<snapid_t, snaplink_t> past_parents;  // key is "last" (or NOSNAP)
-  set<snapid_t> past_parent_snaps;
+  std::map<snapid_t, SnapInfo> snaps;
+  std::map<snapid_t, snaplink_t> past_parents;  // key is "last" (or NOSNAP)
+  std::set<snapid_t> past_parent_snaps;
 
   __u32 flags = 0;
   enum {

--- a/src/messages/MBackfillReserve.h
+++ b/src/messages/MBackfillReserve.h
@@ -110,7 +110,7 @@ public:
     return "MBackfillReserve";
   }
 
-  void inner_print(ostream& out) const override {
+  void inner_print(std::ostream& out) const override {
     switch (type) {
     case REQUEST:
       out << "REQUEST";
@@ -137,6 +137,7 @@ public:
 
   void decode_payload() override {
     auto p = payload.cbegin();
+    using ceph::decode;
     decode(pgid.pgid, p);
     decode(query_epoch, p);
     decode(type, p);

--- a/src/messages/MClientCapRelease.h
+++ b/src/messages/MClientCapRelease.h
@@ -21,14 +21,15 @@
 class MClientCapRelease : public SafeMessage {
  public:
   std::string_view get_type_name() const override { return "client_cap_release";}
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "client_cap_release(" << caps.size() << ")";
   }
-  
+
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(head, p);
-    decode_nohead(head.num, caps, p);
+    ceph::decode_nohead(head.num, caps, p);
     if (header.version >= 2) {
       decode(osd_epoch_barrier, p);
     }
@@ -37,12 +38,12 @@ class MClientCapRelease : public SafeMessage {
     using ceph::encode;
     head.num = caps.size();
     encode(head, payload);
-    encode_nohead(caps, payload);
+    ceph::encode_nohead(caps, payload);
     encode(osd_epoch_barrier, payload);
   }
 
   struct ceph_mds_cap_release head;
-  vector<ceph_mds_cap_item> caps;
+  std::vector<ceph_mds_cap_item> caps;
 
   // The message receiver must wait for this OSD epoch
   // before actioning this cap release.

--- a/src/messages/MClientLease.h
+++ b/src/messages/MClientLease.h
@@ -63,7 +63,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "client_lease"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "client_lease(a=" << ceph_lease_op_name(get_action())
 	<< " seq " << get_seq()
 	<< " mask " << get_mask();
@@ -74,8 +74,9 @@ public:
       out << "/" << dname;
     out << ")";
   }
-  
+
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(h, p);
     decode(dname, p);

--- a/src/messages/MClientQuota.h
+++ b/src/messages/MClientQuota.h
@@ -18,7 +18,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "client_quota"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "client_quota(";
     out << " [" << ino << "] ";
     out << rstat << " ";
@@ -36,6 +36,7 @@ public:
     encode(quota, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(ino, p);
     decode(rstat.rctime, p);

--- a/src/messages/MClientReclaim.h
+++ b/src/messages/MClientReclaim.h
@@ -28,7 +28,7 @@ public:
   std::string_view get_uuid() const { return uuid; }
 
   std::string_view get_type_name() const override { return "client_reclaim"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     std::ios_base::fmtflags f(o.flags());
     o << "client_reclaim(" << get_uuid() << " flags 0x" << std::hex << get_flags() << ")";
     o.flags(f);

--- a/src/messages/MClientReclaimReply.h
+++ b/src/messages/MClientReclaimReply.h
@@ -31,7 +31,7 @@ public:
   void set_addrs(const entity_addrvec_t& _addrs)  { addrs = _addrs; }
 
   std::string_view get_type_name() const override { return "client_reclaim_reply"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "client_reclaim_reply(" << result << " e " << epoch << ")";
   }
 

--- a/src/messages/MClientReconnect.h
+++ b/src/messages/MClientReconnect.h
@@ -26,8 +26,8 @@ private:
   static constexpr int COMPAT_VERSION = 4;
 
 public:
-  map<inodeno_t, cap_reconnect_t> caps; // only head inodes
-  vector<snaprealm_reconnect_t> realms;
+  std::map<inodeno_t, cap_reconnect_t> caps; // only head inodes
+  std::vector<snaprealm_reconnect_t> realms;
   bool more = false;
 
 private:
@@ -42,7 +42,7 @@ private:
   void calc_item_size() {
     using ceph::encode;
     {
-      bufferlist bl;
+      ceph::buffer::list bl;
       inodeno_t ino;
       cap_reconnect_t cr;
       encode(ino, bl);
@@ -50,7 +50,7 @@ private:
       cap_size = bl.length();
     }
     {
-      bufferlist bl;
+      ceph::buffer::list bl;
       snaprealm_reconnect_t sr;
       encode(sr, bl);
       realm_size = bl.length();
@@ -59,7 +59,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "client_reconnect"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "client_reconnect("
 	<< caps.size() << " caps " << realms.size() << " realms )";
   }
@@ -77,8 +77,8 @@ public:
   void mark_more() { more = true; }
   bool has_more() const { return more; }
 
-  void add_cap(inodeno_t ino, uint64_t cap_id, inodeno_t pathbase, const string& path,
-	       int wanted, int issued, inodeno_t sr, snapid_t sf, bufferlist& lb)
+  void add_cap(inodeno_t ino, uint64_t cap_id, inodeno_t pathbase, const std::string& path,
+	       int wanted, int issued, inodeno_t sr, snapid_t sf, ceph::buffer::list& lb)
   {
     caps[ino] = cap_reconnect_t(cap_id, pathbase, path, wanted, issued, sr, sf, lb);
     if (!cap_size)
@@ -125,7 +125,7 @@ public:
 	  p.second.encode_old(data);
 	}
       } else {
-	map<inodeno_t, old_cap_reconnect_t> ocaps;
+	std::map<inodeno_t, old_cap_reconnect_t> ocaps;
 	for (auto& p : caps) {
 	  ocaps[p.first] = p.second;
 	encode(ocaps, data);
@@ -136,6 +136,7 @@ public:
     }
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = data.cbegin();
     if (header.version >= 4) {
       decode(caps, p);
@@ -155,7 +156,7 @@ public:
 	  caps[ino].decode_old(p);
 	}
       } else {
-	map<inodeno_t, old_cap_reconnect_t> ocaps;
+	std::map<inodeno_t, old_cap_reconnect_t> ocaps;
 	decode(ocaps, p);
 	for (auto &q : ocaps)
 	  caps[q.first] = q.second;

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -54,7 +54,7 @@ struct LeaseStat {
   LeaseStat() : mask(0), duration_ms(0), seq(0) {}
   LeaseStat(__u16 msk, __u32 dur, __u32 sq) : mask{msk}, duration_ms{dur}, seq{sq} {}
 
-  void decode(bufferlist::const_iterator &bl, const uint64_t features) {
+  void decode(ceph::buffer::list::const_iterator &bl, const uint64_t features) {
     using ceph::decode;
     if (features == (uint64_t)-1) {
       DECODE_START(1, bl);
@@ -71,7 +71,7 @@ struct LeaseStat {
   }
 };
 
-inline ostream& operator<<(ostream& out, const LeaseStat& l) {
+inline std::ostream& operator<<(std::ostream& out, const LeaseStat& l) {
   return out << "lease(mask " << l.mask << " dur " << l.duration_ms << ")";
 }
 
@@ -79,14 +79,14 @@ struct DirStat {
   // mds distribution hints
   frag_t frag;
   __s32 auth;
-  set<__s32> dist;
+  std::set<__s32> dist;
   
   DirStat() : auth(CDIR_AUTH_PARENT) {}
-  DirStat(bufferlist::const_iterator& p, const uint64_t features) {
+  DirStat(ceph::buffer::list::const_iterator& p, const uint64_t features) {
     decode(p, features);
   }
 
-  void decode(bufferlist::const_iterator& p, const uint64_t features) {
+  void decode(ceph::buffer::list::const_iterator& p, const uint64_t features) {
     using ceph::decode;
     if (features == (uint64_t)-1) {
       DECODE_START(1, p);
@@ -123,13 +123,13 @@ struct InodeStat {
   nest_info_t rstat;
 
   fragtree_t dirfragtree;
-  string  symlink;   // symlink content (if symlink)
+  std::string  symlink;   // symlink content (if symlink)
 
   ceph_dir_layout dir_layout;
 
-  bufferlist xattrbl;
+  ceph::buffer::list xattrbl;
 
-  bufferlist inline_data;
+  ceph::buffer::list inline_data;
   version_t inline_version;
 
   quota_info_t quota;
@@ -138,11 +138,11 @@ struct InodeStat {
 
  public:
   InodeStat() {}
-  InodeStat(bufferlist::const_iterator& p, const uint64_t features) {
+  InodeStat(ceph::buffer::list::const_iterator& p, const uint64_t features) {
     decode(p, features);
   }
 
-  void decode(bufferlist::const_iterator &p, const uint64_t features) {
+  void decode(ceph::buffer::list::const_iterator &p, const uint64_t features) {
     using ceph::decode;
     if (features == (uint64_t)-1) {
       DECODE_START(2, p);
@@ -274,7 +274,7 @@ public:
     encode(delegated_inos, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &p) {
+  void decode(ceph::buffer::list::const_iterator &p) {
     using ceph::decode;
     DECODE_START(1, p);
     decode(created_ino, p);
@@ -288,9 +288,9 @@ class MClientReply : public SafeMessage {
 public:
   // reply data
   struct ceph_mds_reply_head head {};
-  bufferlist trace_bl;
-  bufferlist extra_bl;
-  bufferlist snapbl;
+  ceph::buffer::list trace_bl;
+  ceph::buffer::list extra_bl;
+  ceph::buffer::list snapbl;
 
   int get_op() const { return head.op; }
 
@@ -321,7 +321,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "creply"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "client_reply(???:" << get_tid();
     o << " = " << get_result();
     if (get_result() <= 0) {
@@ -338,6 +338,7 @@ public:
 
   // serialization
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(head, p);
     decode(trace_bl, p);
@@ -355,24 +356,24 @@ public:
 
 
   // dir contents
-  void set_extra_bl(bufferlist& bl) {
+  void set_extra_bl(ceph::buffer::list& bl) {
     extra_bl.claim(bl);
   }
-  bufferlist& get_extra_bl() {
+  ceph::buffer::list& get_extra_bl() {
     return extra_bl;
   }
-  const bufferlist& get_extra_bl() const {
+  const ceph::buffer::list& get_extra_bl() const {
     return extra_bl;
   }
 
   // trace
-  void set_trace(bufferlist& bl) {
+  void set_trace(ceph::buffer::list& bl) {
     trace_bl.claim(bl);
   }
-  bufferlist& get_trace_bl() {
+  ceph::buffer::list& get_trace_bl() {
     return trace_bl;
   }
-  const bufferlist& get_trace_bl() const {
+  const ceph::buffer::list& get_trace_bl() const {
     return trace_bl;
   }
 private:

--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -59,29 +59,29 @@ public:
 
   struct Release {
     mutable ceph_mds_request_release item;
-    string dname;
+    std::string dname;
 
     Release() : item(), dname() {}
-    Release(const ceph_mds_request_release& rel, string name) :
+    Release(const ceph_mds_request_release& rel, std::string name) :
       item(rel), dname(name) {}
 
-    void encode(bufferlist& bl) const {
+    void encode(ceph::buffer::list& bl) const {
       using ceph::encode;
       item.dname_len = dname.length();
       encode(item, bl);
-      encode_nohead(dname, bl);
+      ceph::encode_nohead(dname, bl);
     }
-    void decode(bufferlist::const_iterator& bl) {
+    void decode(ceph::buffer::list::const_iterator& bl) {
       using ceph::decode;
       decode(item, bl);
-      decode_nohead(item.dname_len, dname, bl);
+      ceph::decode_nohead(item.dname_len, dname, bl);
     }
   };
-  mutable vector<Release> releases; /* XXX HACK! */
+  mutable std::vector<Release> releases; /* XXX HACK! */
 
   // path arguments
   filepath path, path2;
-  vector<uint64_t> gid_list;
+  std::vector<uint64_t> gid_list;
 
   /* XXX HACK */
   mutable bool queued_for_replay = false;
@@ -169,11 +169,11 @@ public:
   int get_op() const { return head.op; }
   unsigned get_caller_uid() const { return head.caller_uid; }
   unsigned get_caller_gid() const { return head.caller_gid; }
-  const vector<uint64_t>& get_caller_gid_list() const { return gid_list; }
+  const std::vector<uint64_t>& get_caller_gid_list() const { return gid_list; }
 
-  const string& get_path() const { return path.get_path(); }
+  const std::string& get_path() const { return path.get_path(); }
   const filepath& get_filepath() const { return path; }
-  const string& get_path2() const { return path2.get_path(); }
+  const std::string& get_path2() const { return path2.get_path(); }
   const filepath& get_filepath2() const { return path2; }
 
   int get_dentry_wanted() const { return get_flags() & CEPH_MDS_FLAG_WANT_DENTRY; }
@@ -182,6 +182,7 @@ public:
   bool is_queued_for_replay() const { return queued_for_replay; }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
 
     if (header.version >= 4) {
@@ -206,7 +207,7 @@ public:
 
     decode(path, p);
     decode(path2, p);
-    decode_nohead(head.num_releases, releases, p);
+    ceph::decode_nohead(head.num_releases, releases, p);
     if (header.version >= 2)
       decode(stamp, p);
     if (header.version >= 4) // epoch 3 was for a ceph_mds_request_args change
@@ -229,15 +230,15 @@ public:
 
     encode(path, payload);
     encode(path2, payload);
-    encode_nohead(releases, payload);
+    ceph::encode_nohead(releases, payload);
     encode(stamp, payload);
     encode(gid_list, payload);
   }
 
   std::string_view get_type_name() const override { return "creq"; }
-  void print(ostream& out) const override {
-    out << "client_request(" << get_orig_source() 
-	<< ":" << get_tid() 
+  void print(std::ostream& out) const override {
+    out << "client_request(" << get_orig_source()
+	<< ":" << get_tid()
 	<< " " << ceph_mds_op_name(get_op());
     if (head.op == CEPH_MDS_OP_GETATTR)
       out << " " << ccap_string(head.args.getattr.mask);

--- a/src/messages/MClientRequestForward.h
+++ b/src/messages/MClientRequestForward.h
@@ -42,7 +42,7 @@ public:
   bool must_resend() const { return client_must_resend; }
 
   std::string_view get_type_name() const override { return "client_request_forward"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "client_request_forward(" << get_tid()
       << " to mds." << dest_mds
       << " num_fwd=" << num_fwd
@@ -58,6 +58,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(dest_mds, p);
     decode(num_fwd, p);

--- a/src/messages/MClientSession.h
+++ b/src/messages/MClientSession.h
@@ -55,7 +55,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "client_session"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "client_session(" << ceph_session_op_name(get_op());
     if (get_seq())
       out << " seq " << get_seq();
@@ -64,7 +64,8 @@ public:
     out << ")";
   }
 
-  void decode_payload() override { 
+  void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(head, p);
     if (header.version >= 2)

--- a/src/messages/MClientSnap.h
+++ b/src/messages/MClientSnap.h
@@ -20,11 +20,11 @@
 class MClientSnap : public SafeMessage {
 public:
   ceph_mds_snap_head head;
-  bufferlist bl;
+  ceph::buffer::list bl;
   
   // (for split only)
-  vector<inodeno_t> split_inos;
-  vector<inodeno_t> split_realms;
+  std::vector<inodeno_t> split_inos;
+  std::vector<inodeno_t> split_realms;
 
 protected:
   MClientSnap(int o=0) : 
@@ -36,7 +36,7 @@ protected:
 
 public:  
   std::string_view get_type_name() const override { return "client_snap"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "client_snap(" << ceph_snap_op_name(head.op);
     if (head.split)
       out << " split=" << inodeno_t(head.split);
@@ -50,16 +50,17 @@ public:
     head.num_split_realms = split_realms.size();
     head.trace_len = bl.length();
     encode(head, payload);
-    encode_nohead(split_inos, payload);
-    encode_nohead(split_realms, payload);
-    encode_nohead(bl, payload);
+    ceph::encode_nohead(split_inos, payload);
+    ceph::encode_nohead(split_realms, payload);
+    ceph::encode_nohead(bl, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(head, p);
-    decode_nohead(head.num_split_inos, split_inos, p);
-    decode_nohead(head.num_split_realms, split_realms, p);
-    decode_nohead(head.trace_len, bl, p);
+    ceph::decode_nohead(head.num_split_inos, split_inos, p);
+    ceph::decode_nohead(head.num_split_realms, split_realms, p);
+    ceph::decode_nohead(head.trace_len, bl, p);
     ceph_assert(p.end());
   }
 private:

--- a/src/messages/MDentryLink.h
+++ b/src/messages/MDentryLink.h
@@ -27,16 +27,16 @@ private:
   
   dirfrag_t subtree;
   dirfrag_t dirfrag;
-  string dn;
+  std::string dn;
   bool is_primary = false;
 
  public:
   dirfrag_t get_subtree() const { return subtree; }
   dirfrag_t get_dirfrag() const { return dirfrag; }
-  const string& get_dn() const { return dn; }
+  const std::string& get_dn() const { return dn; }
   bool get_is_primary() const { return is_primary; }
 
-  bufferlist bl;
+  ceph::buffer::list bl;
 
 protected:
   MDentryLink() :
@@ -51,11 +51,12 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "dentry_link";}
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "dentry_link(" << dirfrag << " " << dn << ")";
   }
   
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(subtree, p);
     decode(dirfrag, p);

--- a/src/messages/MDentryUnlink.h
+++ b/src/messages/MDentryUnlink.h
@@ -26,14 +26,14 @@ private:
   static const int COMPAT_VERSION = 1;
   
   dirfrag_t dirfrag;
-  string dn;
+  std::string dn;
 
  public:
   dirfrag_t get_dirfrag() const { return dirfrag; }
-  const string& get_dn() const { return dn; }
+  const std::string& get_dn() const { return dn; }
 
-  bufferlist straybl;
-  bufferlist snapbl;
+  ceph::buffer::list straybl;
+  ceph::buffer::list snapbl;
 
 protected:
   MDentryUnlink() :
@@ -46,11 +46,12 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "dentry_unlink";}
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "dentry_unlink(" << dirfrag << " " << dn << ")";
   }
   
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(dirfrag, p);
     decode(dn, p);

--- a/src/messages/MDirUpdate.h
+++ b/src/messages/MDirUpdate.h
@@ -31,11 +31,12 @@ public:
   void inc_tried_discover() const { ++tried_discover; }
 
   std::string_view get_type_name() const override { return "dir_update"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "dir_update(" << get_dirfrag() << ")";
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(from_mds, p);
     decode(dirfrag, p);

--- a/src/messages/MDiscover.h
+++ b/src/messages/MDiscover.h
@@ -68,12 +68,13 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "Dis"; }
-  void print(ostream &out) const override {
+  void print(std::ostream &out) const override {
     out << "discover(" << header.tid << " " << base_ino << "." << base_dir_frag
 	<< " " << want << ")";
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(base_ino, p);
     decode(base_dir_frag, p);

--- a/src/messages/MDiscoverReply.h
+++ b/src/messages/MDiscoverReply.h
@@ -85,7 +85,7 @@ private:
 
  public:
   __u8 starts_with = 0;
-  bufferlist trace;
+  ceph::buffer::list trace;
 
   enum { DIR, DENTRY, INODE };
 
@@ -145,10 +145,10 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "discover_reply"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "discover_reply(" << header.tid << " " << base_ino << ")";
   }
-  
+
   // builders
   bool is_empty() const {
     return trace.length() == 0 &&
@@ -159,11 +159,11 @@ public:
 
   //  void set_flag_forward() { flag_forward = true; }
   void set_flag_error_dn(std::string_view dn) { 
-    flag_error_dn = true; 
-    error_dentry = dn; 
+    flag_error_dn = true;
+    error_dentry = dn;
   }
-  void set_flag_error_dir() { 
-    flag_error_dir = true; 
+  void set_flag_error_dir() {
+    flag_error_dir = true;
   }
   void set_dir_auth_hint(int a) {
     dir_auth_hint = a;
@@ -175,6 +175,7 @@ public:
 
   // ...
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(base_ino, p);
     decode(base_dir_frag, p);

--- a/src/messages/MExportCaps.h
+++ b/src/messages/MExportCaps.h
@@ -26,9 +26,9 @@ private:
 
 public:  
   inodeno_t ino;
-  bufferlist cap_bl;
-  map<client_t,entity_inst_t> client_map;
-  map<client_t,client_metadata_t> client_metadata_map;
+  ceph::buffer::list cap_bl;
+  std::map<client_t,entity_inst_t> client_map;
+  std::map<client_t,client_metadata_t> client_metadata_map;
 
 protected:
   MExportCaps() :
@@ -37,7 +37,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "export_caps"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "export_caps(" << ino << ")";
   }
 
@@ -49,6 +49,7 @@ public:
     encode(client_metadata_map, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(ino, p);
     decode(cap_bl, p);

--- a/src/messages/MExportCapsAck.h
+++ b/src/messages/MExportCapsAck.h
@@ -25,7 +25,7 @@ class MExportCapsAck : public SafeMessage {
 
 public:  
   inodeno_t ino;
-  bufferlist cap_bl;
+  ceph::buffer::list cap_bl;
 
 protected:
   MExportCapsAck() :
@@ -36,7 +36,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "export_caps_ack"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "export_caps_ack(" << ino << ")";
   }
 
@@ -46,6 +46,7 @@ public:
     encode(cap_bl, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(ino, p);
     decode(cap_bl, p);

--- a/src/messages/MExportDir.h
+++ b/src/messages/MExportDir.h
@@ -22,9 +22,9 @@
 class MExportDir : public SafeMessage {
 public:
   dirfrag_t dirfrag;
-  bufferlist export_data;
-  vector<dirfrag_t> bounds;
-  bufferlist client_map;
+  ceph::buffer::list export_data;
+  std::vector<dirfrag_t> bounds;
+  ceph::buffer::list client_map;
 
 protected:
   MExportDir() : SafeMessage{MSG_MDS_EXPORTDIR} {}
@@ -36,7 +36,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "Ex"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "export(" << dirfrag << ")";
   }
 
@@ -52,6 +52,7 @@ public:
     encode(client_map, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(dirfrag, p);
     decode(bounds, p);

--- a/src/messages/MExportDirAck.h
+++ b/src/messages/MExportDirAck.h
@@ -21,7 +21,7 @@
 class MExportDirAck : public SafeMessage {
 public:
   dirfrag_t dirfrag;
-  bufferlist imported_caps;
+  ceph::buffer::list imported_caps;
 
   dirfrag_t get_dirfrag() const { return dirfrag; }
   
@@ -35,11 +35,12 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "ExAck"; }
-    void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "export_ack(" << dirfrag << ")";
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(dirfrag, p);
     decode(imported_caps, p);

--- a/src/messages/MExportDirCancel.h
+++ b/src/messages/MExportDirCancel.h
@@ -37,7 +37,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "ExCancel"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "export_cancel(" << dirfrag << ")";
   }
 
@@ -46,6 +46,7 @@ public:
     encode(dirfrag, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(dirfrag, p);
   }

--- a/src/messages/MExportDirDiscover.h
+++ b/src/messages/MExportDirDiscover.h
@@ -47,11 +47,12 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "ExDis"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "export_discover(" << dirfrag << " " << path << ")";
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(from, p);
     decode(dirfrag, p);

--- a/src/messages/MExportDirDiscoverAck.h
+++ b/src/messages/MExportDirDiscoverAck.h
@@ -42,7 +42,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "ExDisA"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "export_discover_ack(" << dirfrag;
     if (success) 
       o << " success)";
@@ -51,6 +51,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(dirfrag, p);
     decode(success, p);

--- a/src/messages/MExportDirFinish.h
+++ b/src/messages/MExportDirFinish.h
@@ -40,7 +40,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "ExFin"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "export_finish(" << dirfrag << (last ? " last" : "") << ")";
   }
   
@@ -50,6 +50,7 @@ public:
     encode(last, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(dirfrag, p);
     decode(last, p);

--- a/src/messages/MExportDirNotify.h
+++ b/src/messages/MExportDirNotify.h
@@ -24,21 +24,22 @@ private:
 
   dirfrag_t base;
   bool ack;
-  pair<__s32,__s32> old_auth, new_auth;
-  list<dirfrag_t> bounds;  // bounds; these dirs are _not_ included (tho the dirfragdes are)
+  std::pair<__s32,__s32> old_auth, new_auth;
+  std::list<dirfrag_t> bounds;  // bounds; these dirs are _not_ included (tho the dirfragdes are)
 
  public:
   dirfrag_t get_dirfrag() const { return base; }
-  pair<__s32,__s32> get_old_auth() const { return old_auth; }
-  pair<__s32,__s32> get_new_auth() const { return new_auth; }
+  std::pair<__s32,__s32> get_old_auth() const { return old_auth; }
+  std::pair<__s32,__s32> get_new_auth() const { return new_auth; }
   bool wants_ack() const { return ack; }
-  const list<dirfrag_t>& get_bounds() const { return bounds; }
-  list<dirfrag_t>& get_bounds() { return bounds; }
+  const std::list<dirfrag_t>& get_bounds() const { return bounds; }
+  std::list<dirfrag_t>& get_bounds() { return bounds; }
 
 protected:
   MExportDirNotify() :
     SafeMessage{MSG_MDS_EXPORTDIRNOTIFY, HEAD_VERSION, COMPAT_VERSION} {}
-  MExportDirNotify(dirfrag_t i, uint64_t tid, bool a, pair<__s32,__s32> oa, pair<__s32,__s32> na) :
+  MExportDirNotify(dirfrag_t i, uint64_t tid, bool a, std::pair<__s32,__s32> oa,
+		   std::pair<__s32,__s32> na) :
     SafeMessage{MSG_MDS_EXPORTDIRNOTIFY, HEAD_VERSION, COMPAT_VERSION},
     base(i), ack(a), old_auth(oa), new_auth(na) {
     set_tid(tid);
@@ -47,7 +48,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "ExNot"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "export_notify(" << base;
     o << " " << old_auth << " -> " << new_auth;
     if (ack) 
@@ -56,12 +57,11 @@ public:
       o << " no ack)";
   }
   
-  void copy_bounds(list<dirfrag_t>& ex) {
+  void copy_bounds(std::list<dirfrag_t>& ex) {
     this->bounds = ex;
   }
-  void copy_bounds(set<dirfrag_t>& ex) {
-    for (set<dirfrag_t>::iterator i = ex.begin();
-	 i != ex.end(); ++i)
+  void copy_bounds(std::set<dirfrag_t>& ex) {
+    for (auto i = ex.begin(); i != ex.end(); ++i)
       bounds.push_back(*i);
   }
 
@@ -74,6 +74,7 @@ public:
     encode(bounds, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(base, p);
     decode(ack, p);

--- a/src/messages/MExportDirNotifyAck.h
+++ b/src/messages/MExportDirNotifyAck.h
@@ -23,16 +23,16 @@ private:
   static const int COMPAT_VERSION = 1;
 
   dirfrag_t dirfrag;
-  pair<__s32,__s32> new_auth;
+  std::pair<__s32,__s32> new_auth;
 
  public:
   dirfrag_t get_dirfrag() const { return dirfrag; }
-  pair<__s32,__s32> get_new_auth() const { return new_auth; }
+  std::pair<__s32,__s32> get_new_auth() const { return new_auth; }
   
 protected:
   MExportDirNotifyAck() :
     SafeMessage{MSG_MDS_EXPORTDIRNOTIFYACK, HEAD_VERSION, COMPAT_VERSION} {}
-  MExportDirNotifyAck(dirfrag_t df, uint64_t tid, pair<__s32,__s32> na) :
+  MExportDirNotifyAck(dirfrag_t df, uint64_t tid, std::pair<__s32,__s32> na) :
     SafeMessage{MSG_MDS_EXPORTDIRNOTIFYACK, HEAD_VERSION, COMPAT_VERSION}, dirfrag(df), new_auth(na) {
     set_tid(tid);
   }
@@ -40,7 +40,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "ExNotA"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "export_notify_ack(" << dirfrag << ")";
   }
 

--- a/src/messages/MExportDirPrep.h
+++ b/src/messages/MExportDirPrep.h
@@ -25,18 +25,18 @@ private:
   static const int COMPAT_VERSION = 1;
 
   dirfrag_t dirfrag;
- public:
-  bufferlist basedir;
-  list<dirfrag_t> bounds;
-  list<bufferlist> traces;
+public:
+  ceph::buffer::list basedir;
+  std::list<dirfrag_t> bounds;
+  std::list<ceph::buffer::list> traces;
 private:
-  set<mds_rank_t> bystanders;
+  std::set<mds_rank_t> bystanders;
   bool b_did_assim = false;
 
 public:
   dirfrag_t get_dirfrag() const { return dirfrag; }
-  const list<dirfrag_t>& get_bounds() const { return bounds; }
-  const set<mds_rank_t> &get_bystanders() const { return bystanders; }
+  const std::list<dirfrag_t>& get_bounds() const { return bounds; }
+  const std::set<mds_rank_t> &get_bystanders() const { return bystanders; }
 
   bool did_assim() const { return b_did_assim; }
   void mark_assim() { b_did_assim = true; }
@@ -53,14 +53,14 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "ExP"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "export_prep(" << dirfrag << ")";
   }
 
   void add_bound(dirfrag_t df) {
     bounds.push_back( df );
   }
-  void add_trace(bufferlist& bl) {
+  void add_trace(ceph::buffer::list& bl) {
     traces.push_back(bl);
   }
   void add_bystander(mds_rank_t who) {

--- a/src/messages/MExportDirPrepAck.h
+++ b/src/messages/MExportDirPrepAck.h
@@ -41,7 +41,7 @@ protected:
 public:  
   bool is_success() const { return success; }
   std::string_view get_type_name() const override { return "ExPAck"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "export_prep_ack(" << dirfrag << (success ? " success)" : " fail)");
   }
 

--- a/src/messages/MFSMap.h
+++ b/src/messages/MFSMap.h
@@ -23,7 +23,7 @@
 class MFSMap : public Message {
 public:
   epoch_t epoch;
-  bufferlist encoded;
+  ceph::buffer::list encoded;
 
   version_t get_epoch() const { return epoch; }
   const FSMap& get_fsmap() const {return fsmap;}
@@ -42,12 +42,13 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "fsmap"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "fsmap(e " << epoch << ")";
   }
 
   // marshalling
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(epoch, p);
     decode(fsmap, p);

--- a/src/messages/MFSMapUser.h
+++ b/src/messages/MFSMapUser.h
@@ -40,12 +40,13 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "fsmap.user"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "fsmap.user(e " << epoch << ")";
   }
 
   // marshalling
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(epoch, p);
     decode(fsmap, p);

--- a/src/messages/MForward.h
+++ b/src/messages/MForward.h
@@ -35,8 +35,8 @@ public:
   EntityName entity_name;
   PaxosServiceMessage *msg;   // incoming or outgoing message
 
-  string msg_desc;  // for operator<< only
-  
+  std::string msg_desc;  // for operator<< only
+
   static constexpr int HEAD_VERSION = 4;
   static constexpr int COMPAT_VERSION = 4;
 
@@ -109,6 +109,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(tid, p);
     if (header.version < 4) {
@@ -138,7 +139,7 @@ public:
   }
 
   std::string_view get_type_name() const override { return "forward"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "forward(";
     if (msg) {
       o << *msg;

--- a/src/messages/MGatherCaps.h
+++ b/src/messages/MGatherCaps.h
@@ -18,7 +18,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "gather_caps"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "gather_caps(" << ino << ")";
   }
 

--- a/src/messages/MHeartbeat.h
+++ b/src/messages/MHeartbeat.h
@@ -23,15 +23,15 @@
 class MHeartbeat : public Message {
 private:
   mds_load_t load;
-  __s32        beat = 0;
-  map<mds_rank_t, float> import_map;
+  __s32 beat = 0;
+  std::map<mds_rank_t, float> import_map;
 
  public:
   const mds_load_t& get_load() const { return load; }
   int get_beat() const { return beat; }
 
-  const map<mds_rank_t, float>& get_import_map() const { return import_map; }
-  map<mds_rank_t, float>& get_import_map() { return import_map; }
+  const std::map<mds_rank_t, float>& get_import_map() const { return import_map; }
+  std::map<mds_rank_t, float>& get_import_map() { return import_map; }
 
 protected:
   MHeartbeat() : Message(MSG_MDS_HEARTBEAT), load(DecayRate()) {}
@@ -52,6 +52,7 @@ public:
     encode(import_map, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(load, p);
     decode(beat, p);

--- a/src/messages/MInodeFileCaps.h
+++ b/src/messages/MInodeFileCaps.h
@@ -40,7 +40,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "inode_file_caps";}
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "inode_file_caps(" << ino << " " << ccap_string(caps) << ")";
   }
   

--- a/src/messages/MLock.h
+++ b/src/messages/MLock.h
@@ -32,11 +32,11 @@ private:
   __u16      lock_type = 0;  // lock object type
   MDSCacheObjectInfo object_info;  
   
-  bufferlist lockdata;  // and possibly some data
+  ceph::buffer::list lockdata;  // and possibly some data
   
 public:
-  bufferlist& get_data() { return lockdata; }
-  const bufferlist& get_data() const { return lockdata; }
+  ceph::buffer::list& get_data() { return lockdata; }
+  const ceph::buffer::list& get_data() const { return lockdata; }
   int get_asker() const { return asker; }
   int get_action() const { return action; }
   metareqid_t get_reqid() const { return reqid; }
@@ -57,7 +57,7 @@ protected:
     lock_type(lock->get_type()) {
     lock->get_parent()->set_object_info(object_info);
   }
-  MLock(SimpleLock *lock, int ac, mds_rank_t as, bufferlist& bl) :
+  MLock(SimpleLock *lock, int ac, mds_rank_t as, ceph::buffer::list& bl) :
     SafeMessage{MSG_MDS_LOCK, HEAD_VERSION, COMPAT_VERSION},
     action(ac), asker(as), lock_type(lock->get_type()) {
     lock->get_parent()->set_object_info(object_info);
@@ -67,7 +67,7 @@ protected:
   
 public:
   std::string_view get_type_name() const override { return "ILock"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "lock(a=" << SimpleLock::get_lock_action_name(action)
 	<< " " << SimpleLock::get_lock_type_name(lock_type)
 	<< " " << object_info
@@ -75,7 +75,7 @@ public:
   }
   
   void set_reqid(metareqid_t ri) { reqid = ri; }
-  void set_data(const bufferlist& lockdata) {
+  void set_data(const ceph::buffer::list& lockdata) {
     this->lockdata = lockdata;
   }
   

--- a/src/messages/MLog.h
+++ b/src/messages/MLog.h
@@ -24,7 +24,7 @@ class MLog : public PaxosServiceMessage {
 public:
   uuid_d fsid;
   std::deque<LogEntry> entries;
-  
+
   MLog() : PaxosServiceMessage{MSG_LOG, 0} {}
   MLog(const uuid_d& f, std::deque<LogEntry>&& e)
     : PaxosServiceMessage{MSG_LOG, 0}, fsid(f), entries{std::move(e)} { }
@@ -34,7 +34,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "log"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "log(";
     if (entries.size())
       out << entries.size() << " entries from seq " << entries.front().seq
@@ -49,6 +49,7 @@ public:
     encode(entries, payload, features);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     paxos_decode(p);
     decode(fsid, p);

--- a/src/messages/MMDSBeacon.h
+++ b/src/messages/MMDSBeacon.h
@@ -119,7 +119,7 @@ struct MDSHealthMetric
   std::string message;
   std::map<std::string, std::string> metadata;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     ceph_assert(type != MDS_HEALTH_NULL);
     encode((uint16_t)type, bl);
@@ -129,7 +129,7 @@ struct MDSHealthMetric
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode((uint16_t&)type, bl);
     ceph_assert(type != MDS_HEALTH_NULL);
@@ -159,13 +159,13 @@ struct MDSHealth
 {
   std::vector<MDSHealthMetric> metrics;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(metrics, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(metrics, bl);
     DECODE_FINISH(bl);
@@ -187,7 +187,7 @@ private:
 
   uuid_d fsid;
   mds_gid_t global_id = MDS_GID_NONE;
-  string name;
+  std::string name;
 
   MDSMap::DaemonState state = MDSMap::STATE_NULL;
   version_t seq = 0;
@@ -196,18 +196,19 @@ private:
 
   MDSHealth health;
 
-  map<string, string> sys_info;
+  std::map<std::string, std::string> sys_info;
 
   uint64_t mds_features = 0;
 
-  string fs;
+  std::string fs;
 
 protected:
   MMDSBeacon() : PaxosServiceMessage(MSG_MDS_BEACON, 0, HEAD_VERSION, COMPAT_VERSION)
   {
     set_priority(CEPH_MSG_PRIO_HIGH);
   }
-  MMDSBeacon(const uuid_d &f, mds_gid_t g, const string& n, epoch_t les, MDSMap::DaemonState st, version_t se, uint64_t feat) :
+  MMDSBeacon(const uuid_d &f, mds_gid_t g, const std::string& n, epoch_t les,
+	     MDSMap::DaemonState st, version_t se, uint64_t feat) :
     PaxosServiceMessage(MSG_MDS_BEACON, les, HEAD_VERSION, COMPAT_VERSION),
     fsid(f), global_id(g), name(n), state(st), seq(se),
     mds_features(feat) {
@@ -218,7 +219,7 @@ protected:
 public:
   const uuid_d& get_fsid() const { return fsid; }
   mds_gid_t get_global_id() const { return global_id; }
-  const string& get_name() const { return name; }
+  const std::string& get_name() const { return name; }
   epoch_t get_last_epoch_seen() const { return version; }
   MDSMap::DaemonState get_state() const { return state; }
   version_t get_seq() const { return seq; }
@@ -231,13 +232,13 @@ public:
   MDSHealth const& get_health() const { return health; }
   void set_health(const MDSHealth &h) { health = h; }
 
-  const string& get_fs() const { return fs; }
+  const std::string& get_fs() const { return fs; }
   void set_fs(std::string_view s) { fs = s; }
 
-  const map<string, string>& get_sys_info() const { return sys_info; }
-  void set_sys_info(const map<string, string>& i) { sys_info = i; }
+  const std::map<std::string, std::string>& get_sys_info() const { return sys_info; }
+  void set_sys_info(const std::map<std::string, std::string>& i) { sys_info = i; }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "mdsbeacon(" << global_id << "/" << name
 	<< " " << ceph_mds_state_name(state);
     if (fs.size()) {

--- a/src/messages/MMDSCacheRejoin.h
+++ b/src/messages/MMDSCacheRejoin.h
@@ -50,7 +50,7 @@ public:
     inode_strong(int n, int cw, int dl, int nl, int dftl) :
       nonce(n), caps_wanted(cw),
       filelock(dl), nestlock(nl), dftlock(dftl) { }
-    void encode(bufferlist &bl) const {
+    void encode(ceph::buffer::list &bl) const {
       using ceph::encode;
       encode(nonce, bl);
       encode(caps_wanted, bl);
@@ -58,7 +58,7 @@ public:
       encode(nestlock, bl);
       encode(dftlock, bl);
     }
-    void decode(bufferlist::const_iterator &bl) {
+    void decode(ceph::buffer::list::const_iterator &bl) {
       using ceph::decode;
       decode(nonce, bl);
       decode(caps_wanted, bl);
@@ -74,12 +74,12 @@ public:
     int8_t  dir_rep = 0;
     dirfrag_strong() {}
     dirfrag_strong(int n, int dr) : nonce(n), dir_rep(dr) {}
-    void encode(bufferlist &bl) const {
+    void encode(ceph::buffer::list &bl) const {
       using ceph::encode;
       encode(nonce, bl);
       encode(dir_rep, bl);
     }
-    void decode(bufferlist::const_iterator &bl) {
+    void decode(ceph::buffer::list::const_iterator &bl) {
       using ceph::decode;
       decode(nonce, bl);
       decode(dir_rep, bl);
@@ -101,7 +101,7 @@ public:
     bool is_primary() const { return ino > 0; }
     bool is_remote() const { return remote_ino > 0; }
     bool is_null() const { return ino == 0 && remote_ino == 0; }
-    void encode(bufferlist &bl) const {
+    void encode(ceph::buffer::list &bl) const {
       using ceph::encode;
       encode(first, bl);
       encode(ino, bl);
@@ -110,7 +110,7 @@ public:
       encode(nonce, bl);
       encode(lock, bl);
     }
-    void decode(bufferlist::const_iterator &bl) {
+    void decode(ceph::buffer::list::const_iterator &bl) {
       using ceph::decode;
       decode(first, bl);
       decode(ino, bl);
@@ -127,12 +127,12 @@ public:
     inodeno_t ino;
     dn_weak() : ino(0) {}
     dn_weak(snapid_t f, inodeno_t pi) : first(f), ino(pi) {}
-    void encode(bufferlist &bl) const {
+    void encode(ceph::buffer::list &bl) const {
       using ceph::encode;
       encode(first, bl);
       encode(ino, bl);
     }
-    void decode(bufferlist::const_iterator &bl) {
+    void decode(ceph::buffer::list::const_iterator &bl) {
       using ceph::decode;
       decode(first, bl);
       decode(ino, bl);
@@ -141,14 +141,14 @@ public:
   WRITE_CLASS_ENCODER(dn_weak)
 
   struct lock_bls {
-    bufferlist file, nest, dft;
-    void encode(bufferlist& bl) const {
+    ceph::buffer::list file, nest, dft;
+    void encode(ceph::buffer::list& bl) const {
       using ceph::encode;
       encode(file, bl);
       encode(nest, bl);
       encode(dft, bl);
     }
-    void decode(bufferlist::const_iterator& bl) {
+    void decode(ceph::buffer::list::const_iterator& bl) {
       using ceph::decode;
       decode(file, bl);
       decode(nest, bl);
@@ -164,12 +164,12 @@ public:
     slave_reqid() : attempt(0) {}
     slave_reqid(const metareqid_t& r, __u32 a)
       : reqid(r), attempt(a) {}
-    void encode(bufferlist& bl) const {
+    void encode(ceph::buffer::list& bl) const {
       using ceph::encode;
       encode(reqid, bl);
       encode(attempt, bl);
     }
-    void decode(bufferlist::const_iterator& bl) {
+    void decode(ceph::buffer::list::const_iterator& bl) {
       using ceph::decode;
       decode(reqid, bl);
       decode(attempt, bl);
@@ -177,7 +177,7 @@ public:
   };
 
   std::string_view get_type_name() const override { return "cache_rejoin"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "cache_rejoin " << get_opname(op);
   }
 
@@ -189,7 +189,7 @@ public:
   void add_strong_inode(vinodeno_t i, int n, int cw, int dl, int nl, int dftl) {
     strong_inodes[i] = inode_strong(n, cw, dl, nl, dftl);
   }
-  void add_inode_locks(CInode *in, __u32 nonce, bufferlist& bl) {
+  void add_inode_locks(CInode *in, __u32 nonce, ceph::buffer::list& bl) {
     using ceph::encode;
     encode(in->inode.ino, inode_locks);
     encode(in->last, inode_locks);
@@ -200,7 +200,7 @@ public:
     using ceph::encode;
     encode(in->inode.ino, inode_base);
     encode(in->last, inode_base);
-    bufferlist bl;
+    ceph::buffer::list bl;
     in->_encode_base(bl, features);
     encode(bl, inode_base);
   }
@@ -230,7 +230,7 @@ public:
     strong_dirfrags[df] = dirfrag_strong(n, dr);
   }
   void add_dirfrag_base(CDir *dir) {
-    bufferlist& bl = dirfrag_bases[dir->dirfrag()];
+    ceph::buffer::list& bl = dirfrag_bases[dir->dirfrag()];
     dir->_encode_base(bl);
   }
 
@@ -312,33 +312,33 @@ public:
   int32_t op = 0;
 
   // weak
-  map<inodeno_t, map<string_snap_t, dn_weak> > weak;
-  set<dirfrag_t> weak_dirfrags;
-  set<vinodeno_t> weak_inodes;
-  map<inodeno_t, lock_bls> inode_scatterlocks;
+  std::map<inodeno_t, std::map<string_snap_t, dn_weak> > weak;
+  std::set<dirfrag_t> weak_dirfrags;
+  std::set<vinodeno_t> weak_inodes;
+  std::map<inodeno_t, lock_bls> inode_scatterlocks;
 
   // strong
-  map<dirfrag_t, dirfrag_strong> strong_dirfrags;
-  map<dirfrag_t, map<string_snap_t, dn_strong> > strong_dentries;
-  map<vinodeno_t, inode_strong> strong_inodes;
+  std::map<dirfrag_t, dirfrag_strong> strong_dirfrags;
+  std::map<dirfrag_t, std::map<string_snap_t, dn_strong> > strong_dentries;
+  std::map<vinodeno_t, inode_strong> strong_inodes;
 
   // open
-  map<inodeno_t,map<client_t, cap_reconnect_t> > cap_exports;
-  map<client_t, entity_inst_t> client_map;
-  map<client_t,client_metadata_t> client_metadata_map;
-  bufferlist imported_caps;
+  std::map<inodeno_t,std::map<client_t, cap_reconnect_t> > cap_exports;
+  std::map<client_t, entity_inst_t> client_map;
+  std::map<client_t,client_metadata_t> client_metadata_map;
+  ceph::buffer::list imported_caps;
 
   // full
-  bufferlist inode_base;
-  bufferlist inode_locks;
-  map<dirfrag_t, bufferlist> dirfrag_bases;
+  ceph::buffer::list inode_base;
+  ceph::buffer::list inode_locks;
+  std::map<dirfrag_t, ceph::buffer::list> dirfrag_bases;
 
-  map<vinodeno_t, list<slave_reqid> > authpinned_inodes;
-  map<vinodeno_t, slave_reqid> frozen_authpin_inodes;
-  map<vinodeno_t, map<__s32, slave_reqid> > xlocked_inodes;
-  map<vinodeno_t, map<__s32, list<slave_reqid> > > wrlocked_inodes;
-  map<dirfrag_t, map<string_snap_t, list<slave_reqid> > > authpinned_dentries;
-  map<dirfrag_t, map<string_snap_t, slave_reqid> > xlocked_dentries;
+  std::map<vinodeno_t, std::list<slave_reqid> > authpinned_inodes;
+  std::map<vinodeno_t, slave_reqid> frozen_authpin_inodes;
+  std::map<vinodeno_t, std::map<__s32, slave_reqid> > xlocked_inodes;
+  std::map<vinodeno_t, std::map<__s32, std::list<slave_reqid> > > wrlocked_inodes;
+  std::map<dirfrag_t, std::map<string_snap_t, std::list<slave_reqid> > > authpinned_dentries;
+  std::map<dirfrag_t, std::map<string_snap_t, slave_reqid> > xlocked_dentries;
 
 private:
   template<class T, typename... Args>
@@ -359,7 +359,7 @@ WRITE_CLASS_ENCODER(MMDSCacheRejoin::dn_weak)
 WRITE_CLASS_ENCODER(MMDSCacheRejoin::lock_bls)
 WRITE_CLASS_ENCODER(MMDSCacheRejoin::slave_reqid)
 
-inline ostream& operator<<(ostream& out, const MMDSCacheRejoin::slave_reqid& r) {
+inline std::ostream& operator<<(std::ostream& out, const MMDSCacheRejoin::slave_reqid& r) {
   return out << r.reqid << '.' << r.attempt;
 }
 

--- a/src/messages/MMDSFindIno.h
+++ b/src/messages/MMDSFindIno.h
@@ -32,7 +32,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "findino"; }
-  void print(ostream &out) const override {
+  void print(std::ostream &out) const override {
     out << "findino(" << tid << " " << ino << ")";
   }
 
@@ -42,6 +42,7 @@ public:
     encode(ino, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(tid, p);
     decode(ino, p);

--- a/src/messages/MMDSFindInoReply.h
+++ b/src/messages/MMDSFindInoReply.h
@@ -32,16 +32,17 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "findinoreply"; }
-  void print(ostream &out) const override {
+  void print(std::ostream &out) const override {
     out << "findinoreply(" << tid << " " << path << ")";
   }
-  
+
   void encode_payload(uint64_t features) override {
     using ceph::encode;
     encode(tid, payload);
     encode(path, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(tid, p);
     decode(path, p);

--- a/src/messages/MMDSFragmentNotify.h
+++ b/src/messages/MMDSFragmentNotify.h
@@ -34,7 +34,7 @@ private:
   bool is_ack_wanted() const { return ack_wanted; }
   void mark_ack_wanted() { ack_wanted = true; }
 
-  bufferlist basebl;
+  ceph::buffer::list basebl;
 
 protected:
   MMDSFragmentNotify() :
@@ -46,9 +46,9 @@ protected:
   }
   ~MMDSFragmentNotify() override {}
 
-public:  
+public: 
   std::string_view get_type_name() const override { return "fragment_notify"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "fragment_notify(" << base_dirfrag << " " << (int)bits << ")";
   }
 
@@ -60,6 +60,7 @@ public:
     encode(ack_wanted, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(base_dirfrag, p);
     decode(bits, p);

--- a/src/messages/MMDSFragmentNotifyAck.h
+++ b/src/messages/MMDSFragmentNotifyAck.h
@@ -26,7 +26,7 @@ private:
   dirfrag_t get_base_dirfrag() const { return base_dirfrag; }
   int get_bits() const { return bits; }
 
-  bufferlist basebl;
+  ceph::buffer::list basebl;
 
 protected:
   MMDSFragmentNotifyAck() : SafeMessage{MSG_MDS_FRAGMENTNOTIFYACK} {}
@@ -39,7 +39,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "fragment_notify_ack"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "fragment_notify_ack(" << base_dirfrag << " " << (int)bits << ")";
   }
 
@@ -49,6 +49,7 @@ public:
     encode(bits, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(base_dirfrag, p);
     decode(bits, p);

--- a/src/messages/MMDSLoadTargets.h
+++ b/src/messages/MMDSLoadTargets.h
@@ -26,18 +26,18 @@ using std::map;
 class MMDSLoadTargets : public PaxosServiceMessage {
 public:
   mds_gid_t global_id;
-  set<mds_rank_t> targets;
+  std::set<mds_rank_t> targets;
 
 protected:
   MMDSLoadTargets() : PaxosServiceMessage(MSG_MDS_OFFLOAD_TARGETS, 0) {}
-  MMDSLoadTargets(mds_gid_t g, set<mds_rank_t>& mds_targets) :
+  MMDSLoadTargets(mds_gid_t g, std::set<mds_rank_t>& mds_targets) :
     PaxosServiceMessage(MSG_MDS_OFFLOAD_TARGETS, 0),
     global_id(g), targets(mds_targets) {}
   ~MMDSLoadTargets() override {}
 
 public:
   std::string_view get_type_name() const override { return "mds_load_targets"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "mds_load_targets(" << global_id << " " << targets << ")";
   }
 

--- a/src/messages/MMDSMap.h
+++ b/src/messages/MMDSMap.h
@@ -27,10 +27,10 @@ private:
 public:
   uuid_d fsid;
   epoch_t epoch = 0;
-  bufferlist encoded;
+  ceph::buffer::list encoded;
 
   version_t get_epoch() const { return epoch; }
-  const bufferlist& get_encoded() const { return encoded; }
+  const ceph::buffer::list& get_encoded() const { return encoded; }
 
 protected:
   MMDSMap() : 
@@ -45,12 +45,13 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "mdsmap"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "mdsmap(e " << epoch << ")";
   }
 
   // marshalling
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(fsid, p);
     decode(epoch, p);

--- a/src/messages/MMDSOpenIno.h
+++ b/src/messages/MMDSOpenIno.h
@@ -22,11 +22,11 @@ class MMDSOpenIno : public SafeMessage {
   static const int COMPAT_VERSION = 1;
 public:
   inodeno_t ino;
-  vector<inode_backpointer_t> ancestors;
+  std::vector<inode_backpointer_t> ancestors;
 
 protected:
   MMDSOpenIno() : SafeMessage{MSG_MDS_OPENINO, HEAD_VERSION, COMPAT_VERSION} {}
-  MMDSOpenIno(ceph_tid_t t, inodeno_t i, vector<inode_backpointer_t>* pa) :
+  MMDSOpenIno(ceph_tid_t t, inodeno_t i, std::vector<inode_backpointer_t>* pa) :
     SafeMessage{MSG_MDS_OPENINO, HEAD_VERSION, COMPAT_VERSION}, ino(i) {
     header.tid = t;
     if (pa)
@@ -36,7 +36,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "openino"; }
-  void print(ostream &out) const override {
+  void print(std::ostream &out) const override {
     out << "openino(" << header.tid << " " << ino << " " << ancestors << ")";
   }
 
@@ -46,6 +46,7 @@ public:
     encode(ancestors, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(ino, p);
     decode(ancestors, p);

--- a/src/messages/MMDSOpenInoReply.h
+++ b/src/messages/MMDSOpenInoReply.h
@@ -22,7 +22,7 @@ public:
   static const int HEAD_VERSION = 1;
   static const int COMPAT_VERSION = 1;
   inodeno_t ino;
-  vector<inode_backpointer_t> ancestors;
+  std::vector<inode_backpointer_t> ancestors;
   mds_rank_t hint;
   int32_t error;
 
@@ -36,7 +36,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "openinoreply"; }
-  void print(ostream &out) const override {
+  void print(std::ostream &out) const override {
     out << "openinoreply(" << header.tid << " "
 	<< ino << " " << hint << " " << ancestors << ")";
   }
@@ -49,6 +49,7 @@ public:
     encode(error, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(ino, p);
     decode(ancestors, p);

--- a/src/messages/MMDSResolve.h
+++ b/src/messages/MMDSResolve.h
@@ -26,23 +26,23 @@ class MMDSResolve : public SafeMessage {
   static const int COMPAT_VERSION = 1;
 
 public:
-  map<dirfrag_t, vector<dirfrag_t> > subtrees;
-  map<dirfrag_t, vector<dirfrag_t> > ambiguous_imports;
+  std::map<dirfrag_t, std::vector<dirfrag_t>> subtrees;
+  std::map<dirfrag_t, std::vector<dirfrag_t>> ambiguous_imports;
 
   class slave_inode_cap {
   public:
     inodeno_t ino;
-    map<client_t,Capability::Export> cap_exports;
+    std::map<client_t,Capability::Export> cap_exports;
     slave_inode_cap() {}
     slave_inode_cap(inodeno_t a, map<client_t, Capability::Export> b) : ino(a), cap_exports(b) {}
-    void encode(bufferlist &bl) const 
+    void encode(ceph::buffer::list &bl) const 
     {
       ENCODE_START(1, 1, bl);
       encode(ino, bl);
       encode(cap_exports, bl);
       ENCODE_FINISH(bl);
     }
-    void decode(bufferlist::const_iterator &blp)
+    void decode(ceph::buffer::list::const_iterator &blp)
     {
       DECODE_START(1, blp);
       decode(ino, blp);
@@ -53,16 +53,16 @@ public:
   WRITE_CLASS_ENCODER(slave_inode_cap)
 
   struct slave_request {
-    bufferlist inode_caps;
+    ceph::buffer::list inode_caps;
     bool committing;
     slave_request() : committing(false) {}
-    void encode(bufferlist &bl) const {
+    void encode(ceph::buffer::list &bl) const {
       ENCODE_START(1, 1, bl);
       encode(inode_caps, bl);
       encode(committing, bl);
       ENCODE_FINISH(bl);
     }
-    void decode(bufferlist::const_iterator &blp) {
+    void decode(ceph::buffer::list::const_iterator &blp) {
       DECODE_START(1, blp);
       decode(inode_caps, blp);
       decode(committing, blp);
@@ -70,30 +70,30 @@ public:
     }
   };
 
-  map<metareqid_t, slave_request> slave_requests;
+  std::map<metareqid_t, slave_request> slave_requests;
 
   // table client information
   struct table_client {
     __u8 type;
-    set<version_t> pending_commits;
+    std::set<version_t> pending_commits;
 
     table_client() : type(0) {}
-    table_client(int _type, const set<version_t>& commits)
+    table_client(int _type, const std::set<version_t>& commits)
       : type(_type), pending_commits(commits) {}
 
-    void encode(bufferlist& bl) const {
+    void encode(ceph::buffer::list& bl) const {
       using ceph::encode;
       encode(type, bl);
       encode(pending_commits, bl);
     }
-    void decode(bufferlist::const_iterator& bl) {
+    void decode(ceph::buffer::list::const_iterator& bl) {
       using ceph::decode;
       decode(type, bl);
       decode(pending_commits, bl);
     }
   };
 
-  list<table_client> table_clients;
+  std::list<table_client> table_clients;
 
 protected:
   MMDSResolve() : SafeMessage{MSG_MDS_RESOLVE, HEAD_VERSION, COMPAT_VERSION}
@@ -103,7 +103,7 @@ protected:
 public:
   std::string_view get_type_name() const override { return "mds_resolve"; }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "mds_resolve(" << subtrees.size()
 	<< "+" << ambiguous_imports.size()
 	<< " subtrees +" << slave_requests.size() << " slave requests)";
@@ -116,7 +116,7 @@ public:
     subtrees[im].push_back(ex);
   }
 
-  void add_ambiguous_import(dirfrag_t im, const vector<dirfrag_t>& m) {
+  void add_ambiguous_import(dirfrag_t im, const std::vector<dirfrag_t>& m) {
     ambiguous_imports[im] = m;
   }
 
@@ -124,11 +124,11 @@ public:
     slave_requests[reqid].committing = committing;
   }
 
-  void add_slave_request(metareqid_t reqid, bufferlist& bl) {
+  void add_slave_request(metareqid_t reqid, ceph::buffer::list& bl) {
     slave_requests[reqid].inode_caps.claim(bl);
   }
 
-  void add_table_commits(int table, const set<version_t>& pending_commits) {
+  void add_table_commits(int table, const std::set<version_t>& pending_commits) {
     table_clients.push_back(table_client(table, pending_commits));
   }
 
@@ -152,7 +152,7 @@ private:
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
 };
 
-inline ostream& operator<<(ostream& out, const MMDSResolve::slave_request&) {
+inline std::ostream& operator<<(std::ostream& out, const MMDSResolve::slave_request&) {
     return out;
 }
 

--- a/src/messages/MMDSResolveAck.h
+++ b/src/messages/MMDSResolveAck.h
@@ -24,8 +24,8 @@ class MMDSResolveAck : public SafeMessage {
   static const int HEAD_VERSION = 1;
   static const int COMPAT_VERSION = 1;
 public:
-  map<metareqid_t, bufferlist> commit;
-  vector<metareqid_t> abort;
+  std::map<metareqid_t, ceph::buffer::list> commit;
+  std::vector<metareqid_t> abort;
 
 protected:
   MMDSResolveAck() : SafeMessage{MSG_MDS_RESOLVEACK, HEAD_VERSION, COMPAT_VERSION} {}

--- a/src/messages/MMDSSlaveRequest.h
+++ b/src/messages/MMDSSlaveRequest.h
@@ -112,21 +112,21 @@ public:
   MDSCacheObjectInfo object_info;
   
   // for authpins
-  vector<MDSCacheObjectInfo> authpins;
+  std::vector<MDSCacheObjectInfo> authpins;
 
  public:
   // for rename prep
   filepath srcdnpath;
   filepath destdnpath;
-  set<mds_rank_t> witnesses;
-  bufferlist inode_export;
+  std::set<mds_rank_t> witnesses;
+  ceph::buffer::list inode_export;
   version_t inode_export_v;
   mds_rank_t srcdn_auth;
   utime_t op_stamp;
 
-  mutable bufferlist straybl;  // stray dir + dentry
-  bufferlist srci_snapbl;
-  bufferlist desti_snapbl;
+  mutable ceph::buffer::list straybl;  // stray dir + dentry
+  ceph::buffer::list srci_snapbl;
+  ceph::buffer::list desti_snapbl;
 
 public:
   metareqid_t get_reqid() const { return reqid; }
@@ -140,8 +140,8 @@ public:
   const MDSCacheObjectInfo &get_authpin_freeze() const { return object_info; }
   MDSCacheObjectInfo &get_authpin_freeze() { return object_info; }
 
-  const vector<MDSCacheObjectInfo>& get_authpins() const { return authpins; }
-  vector<MDSCacheObjectInfo>& get_authpins() { return authpins; }
+  const std::vector<MDSCacheObjectInfo>& get_authpins() const { return authpins; }
+  std::vector<MDSCacheObjectInfo>& get_authpins() { return authpins; }
   void mark_nonblocking() { flags |= FLAG_NONBLOCKING; }
   bool is_nonblocking() const { return (flags & FLAG_NONBLOCKING); }
   void mark_error_wouldblock() { flags |= FLAG_WOULDBLOCK; }
@@ -161,8 +161,8 @@ public:
   void mark_req_blocked() { flags |= FLAG_REQBLOCKED; }
 
   void set_lock_type(int t) { lock_type = t; }
-  const bufferlist& get_lock_data() const { return inode_export; }
-  bufferlist& get_lock_data() { return inode_export; }
+  const ceph::buffer::list& get_lock_data() const { return inode_export; }
+  ceph::buffer::list& get_lock_data() { return inode_export; }
 
 protected:
   MMDSSlaveRequest() : SafeMessage{MSG_MDS_SLAVE_REQUEST, HEAD_VERSION, COMPAT_VERSION} { }
@@ -194,6 +194,7 @@ public:
     encode(desti_snapbl, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(reqid, p);
     decode(attempt, p);
@@ -215,7 +216,7 @@ public:
   }
 
   std::string_view get_type_name() const override { return "slave_request"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "slave_request(" << reqid
 	<< "." << attempt
 	<< " " << get_opname(op) 

--- a/src/messages/MMDSSnapUpdate.h
+++ b/src/messages/MMDSSnapUpdate.h
@@ -26,7 +26,7 @@ public:
   inodeno_t get_ino() const { return ino; }
   int get_snap_op() const { return snap_op; }
 
-  bufferlist snap_blob;
+  ceph::buffer::list snap_blob;
 
 protected:
   MMDSSnapUpdate() : SafeMessage{MSG_MDS_SNAPUPDATE} {}
@@ -38,7 +38,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "snap_update"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "snap_update(" << ino << " table_tid " << get_tid() << ")";
   }
 

--- a/src/messages/MMDSTableRequest.h
+++ b/src/messages/MMDSTableRequest.h
@@ -24,7 +24,7 @@ public:
   __u16 table = 0;
   __s16 op = 0;
   uint64_t reqid = 0;
-  bufferlist bl;
+  ceph::buffer::list bl;
 
 protected:
   MMDSTableRequest() : SafeMessage{MSG_MDS_TABLE_REQUEST} {}
@@ -35,9 +35,9 @@ protected:
   }
   ~MMDSTableRequest() override {}
 
-public:  
+public:
   std::string_view get_type_name() const override { return "mds_table_request"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "mds_table_request(" << get_mdstable_name(table)
       << " " << get_mdstableserver_opname(op);
     if (reqid) o << " " << reqid;
@@ -47,6 +47,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(table, p);
     decode(op, p);

--- a/src/messages/MMgrBeacon.h
+++ b/src/messages/MMgrBeacon.h
@@ -43,7 +43,7 @@ protected:
   // Information about the modules found locally on this daemon
   std::vector<MgrMap::ModuleInfo> modules;
 
-  map<string,string> metadata; ///< misc metadata about this osd
+  std::map<std::string,std::string> metadata; ///< misc metadata about this osd
 
   std::vector<entity_addrvec_t> clients;
 
@@ -58,7 +58,7 @@ public:
   MMgrBeacon(const uuid_d& fsid_, uint64_t gid_, const std::string &name_,
              entity_addrvec_t server_addrs_, bool available_,
 	     std::vector<MgrMap::ModuleInfo>&& modules_,
-	     map<string,string>&& metadata_,
+	     std::map<std::string,std::string>&& metadata_,
              std::vector<entity_addrvec_t> clients,
 	     uint64_t feat)
     : PaxosServiceMessage{MSG_MGR_BEACON, 0, HEAD_VERSION, COMPAT_VERSION},
@@ -114,7 +114,7 @@ public:
 
   std::string_view get_type_name() const override { return "mgrbeacon"; }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << get_type_name() << " mgr." << name << "(" << fsid << ","
 	<< gid << ", " << server_addrs << ", " << available
 	<< ")";
@@ -155,6 +155,7 @@ public:
     encode(clients, payload, features);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     paxos_decode(p);
     decode(server_addrs, p);  // entity_addr_t for version < 8

--- a/src/messages/MMgrDigest.h
+++ b/src/messages/MMgrDigest.h
@@ -24,15 +24,16 @@
  */
 class MMgrDigest : public Message {
 public:
-  bufferlist mon_status_json;
-  bufferlist health_json;
+  ceph::buffer::list mon_status_json;
+  ceph::buffer::list health_json;
 
   std::string_view get_type_name() const override { return "mgrdigest"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << get_type_name();
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(mon_status_json, p);
     decode(health_json, p);

--- a/src/messages/MMonElection.h
+++ b/src/messages/MMonElection.h
@@ -40,18 +40,18 @@ public:
     default: ceph_abort(); return 0;
     }
   }
-  
+
   uuid_d fsid;
   int32_t op;
   epoch_t epoch;
-  bufferlist monmap_bl;
-  set<int32_t> quorum;
+  ceph::buffer::list monmap_bl;
+  std::set<int32_t> quorum;
   uint64_t quorum_features;
   mon_feature_t mon_features;
   ceph_release_t mon_release{ceph_release_t::unknown};
-  bufferlist sharing_bl;
-  map<string,string> metadata;
-  
+  ceph::buffer::list sharing_bl;
+  std::map<std::string,std::string> metadata;
+
   MMonElection() : Message{MSG_MON_ELECTION, HEAD_VERSION, COMPAT_VERSION},
     op(0), epoch(0),
     quorum_features(0),
@@ -71,13 +71,13 @@ public:
 private:
   ~MMonElection() override {}
 
-public:  
+public:
   std::string_view get_type_name() const override { return "election"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "election(" << fsid << " " << get_opname(op)
 	<< " rel " << (int)mon_release << " e" << epoch << ")";
   }
-  
+
   void encode_payload(uint64_t features) override {
     using ceph::encode;
     if (monmap_bl.length() && (features != CEPH_FEATURES_ALL)) {
@@ -102,6 +102,7 @@ public:
     encode(mon_release, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(fsid, p);
     decode(op, p);

--- a/src/messages/MMonGetPurgedSnapsReply.h
+++ b/src/messages/MMonGetPurgedSnapsReply.h
@@ -10,7 +10,7 @@
 class MMonGetPurgedSnapsReply : public PaxosServiceMessage {
 public:
   epoch_t start, last;
-  map<epoch_t,mempool::osdmap::map<int64_t,snap_interval_set_t>> purged_snaps;
+  std::map<epoch_t,mempool::osdmap::map<int64_t,snap_interval_set_t>> purged_snaps;
 
   MMonGetPurgedSnapsReply(epoch_t s=0, epoch_t l=0)
     : PaxosServiceMessage{MSG_MON_GET_PURGED_SNAPS_REPLY, 0},

--- a/src/messages/MMonGlobalID.h
+++ b/src/messages/MMonGlobalID.h
@@ -27,11 +27,12 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "global_id"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "global_id  (" << old_max_id << ")";
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     paxos_decode(p);
     decode(old_max_id, p);

--- a/src/messages/MMonHealth.h
+++ b/src/messages/MMonHealth.h
@@ -35,7 +35,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "mon_health"; }
-  void print(ostream &o) const override {
+  void print(std::ostream &o) const override {
     o << "mon_health("
       << " e " << get_epoch()
       << " r " << get_round()
@@ -43,6 +43,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     service_decode(p);
     decode(service_type, p);

--- a/src/messages/MMonHealthChecks.h
+++ b/src/messages/MMonHealthChecks.h
@@ -27,11 +27,12 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "mon_health_checks"; }
-  void print(ostream &o) const override {
+  void print(std::ostream &o) const override {
     o << "mon_health_checks(" << health_checks.checks.size() << " checks)";
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     paxos_decode(p);
     decode(health_checks, p);

--- a/src/messages/MMonJoin.h
+++ b/src/messages/MMonJoin.h
@@ -17,20 +17,17 @@
 
 #include "messages/PaxosServiceMessage.h"
 
-#include <vector>
-using std::vector;
-
 class MMonJoin : public PaxosServiceMessage {
 public:
   static constexpr int HEAD_VERSION = 2;
   static constexpr int COMPAT_VERSION = 2;
 
   uuid_d fsid;
-  string name;
+  std::string name;
   entity_addrvec_t addrs;
 
   MMonJoin() : PaxosServiceMessage{MSG_MON_JOIN, 0, HEAD_VERSION, COMPAT_VERSION} {}
-  MMonJoin(uuid_d &f, string n, const entity_addrvec_t& av)
+  MMonJoin(uuid_d &f, std::string n, const entity_addrvec_t& av)
     : PaxosServiceMessage{MSG_MON_JOIN, 0, HEAD_VERSION, COMPAT_VERSION},
       fsid(f), name(n), addrs(av)
   { }
@@ -38,12 +35,12 @@ public:
 private:
   ~MMonJoin() override {}
 
-public:  
+public:
   std::string_view get_type_name() const override { return "mon_join"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     o << "mon_join(" << name << " " << addrs << ")";
   }
-  
+
   void encode_payload(uint64_t features) override {
     using ceph::encode;
     paxos_encode();
@@ -60,6 +57,7 @@ public:
     }
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     paxos_decode(p);
     decode(fsid, p);

--- a/src/messages/MMonMetadata.h
+++ b/src/messages/MMonMetadata.h
@@ -45,6 +45,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(data, p);
   }

--- a/src/messages/MMonMgrReport.h
+++ b/src/messages/MMonMgrReport.h
@@ -29,7 +29,7 @@ private:
 public:
   // PGMapDigest is in data payload
   health_check_map_t health_checks;
-  bufferlist service_map_bl;  // encoded ServiceMap
+  ceph::buffer::list service_map_bl;  // encoded ServiceMap
   std::map<std::string,ProgressEvent> progress_events;
 
   MMonMgrReport()
@@ -41,7 +41,7 @@ private:
 public:
   std::string_view get_type_name() const override { return "monmgrreport"; }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << get_type_name() << "(" << health_checks.checks.size() << " checks, "
 	<< progress_events.size() << " progress events)";
   }
@@ -65,12 +65,13 @@ public:
       PGMapDigest digest;
       auto p = data.cbegin();
       decode(digest, p);
-      bufferlist bl;
+      ceph::buffer::list bl;
       encode(digest, bl, features);
       set_data(bl);
     }
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     paxos_decode(p);
     decode(health_checks, p);

--- a/src/messages/MMonPaxos.h
+++ b/src/messages/MMonPaxos.h
@@ -59,11 +59,11 @@ private:
   utime_t sent_timestamp;
 
   version_t latest_version = 0;
-  bufferlist latest_value;
+  ceph::buffer::list latest_value;
 
-  map<version_t,bufferlist> values;
+  std::map<version_t,ceph::buffer::list> values;
 
-  bufferlist feature_map;
+  ceph::buffer::list feature_map;
 
   MMonPaxos() : Message{MSG_MON_PAXOS, HEAD_VERSION, COMPAT_VERSION} { }
   MMonPaxos(epoch_t e, int o, utime_t now) : 
@@ -78,10 +78,10 @@ private:
 private:
   ~MMonPaxos() override {}
 
-public:  
+public:
   std::string_view get_type_name() const override { return "paxos"; }
-  
-  void print(ostream& out) const override {
+
+  void print(std::ostream& out) const override {
     out << "paxos(" << get_opname(op) 
 	<< " lc " << last_committed
 	<< " fc " << first_committed
@@ -109,6 +109,7 @@ public:
     encode(feature_map, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(epoch, p);
     decode(op, p);

--- a/src/messages/MMonProbe.h
+++ b/src/messages/MMonProbe.h
@@ -49,9 +49,9 @@ public:
   
   uuid_d fsid;
   int32_t op = 0;
-  string name;
-  set<int32_t> quorum;
-  bufferlist monmap_bl;
+  std::string name;
+  std::set<int32_t> quorum;
+  ceph::buffer::list monmap_bl;
   version_t paxos_first_version = 0;
   version_t paxos_last_version = 0;
   bool has_ever_joined = 0;
@@ -60,7 +60,7 @@ public:
 
   MMonProbe()
     : Message{MSG_MON_PROBE, HEAD_VERSION, COMPAT_VERSION} {}
-  MMonProbe(const uuid_d& f, int o, const string& n, bool hej, ceph_release_t mr)
+  MMonProbe(const uuid_d& f, int o, const std::string& n, bool hej, ceph_release_t mr)
     : Message{MSG_MON_PROBE, HEAD_VERSION, COMPAT_VERSION},
       fsid(f),
       op(o),
@@ -73,9 +73,9 @@ public:
 private:
   ~MMonProbe() override {}
 
-public:  
+public:
   std::string_view get_type_name() const override { return "mon_probe"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "mon_probe(" << get_opname(op) << " " << fsid << " name " << name;
     if (quorum.size())
       out << " quorum " << quorum;
@@ -93,7 +93,7 @@ public:
       out << " mon_release " << mon_release;
     out << ")";
   }
-  
+
   void encode_payload(uint64_t features) override {
     using ceph::encode;
     if (monmap_bl.length() &&
@@ -118,6 +118,7 @@ public:
     encode(mon_release, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(fsid, p);
     decode(op, p);

--- a/src/messages/MMonQuorumService.h
+++ b/src/messages/MMonQuorumService.h
@@ -50,7 +50,8 @@ public:
     encode(round, payload);
   }
 
-  void service_decode(bufferlist::const_iterator &p) {
+  void service_decode(ceph::buffer::list::const_iterator &p) {
+    using ceph::decode;
     decode(epoch, p);
     decode(round, p);
   }

--- a/src/messages/MMonScrub.h
+++ b/src/messages/MMonScrub.h
@@ -39,7 +39,7 @@ public:
   version_t version = 0;
   ScrubResult result;
   int32_t num_keys;
-  pair<string,string> key;
+  std::pair<std::string,std::string> key;
 
   MMonScrub()
     : Message{MSG_MON_SCRUB, HEAD_VERSION, COMPAT_VERSION},
@@ -53,7 +53,7 @@ public:
 
   std::string_view get_type_name() const override { return "mon_scrub"; }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "mon_scrub(" << get_opname((op_type_t)op);
     out << " v " << version;
     if (op == OP_RESULT)
@@ -74,6 +74,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     uint8_t o;
     decode(o, p);

--- a/src/messages/MMonSync.h
+++ b/src/messages/MMonSync.h
@@ -56,8 +56,8 @@ public:
   uint32_t op = 0;
   uint64_t cookie = 0;
   version_t last_committed = 0;
-  pair<string,string> last_key;
-  bufferlist chunk_bl;
+  std::pair<std::string,std::string> last_key;
+  ceph::buffer::list chunk_bl;
   entity_inst_t reply_to;
 
   MMonSync()
@@ -73,7 +73,7 @@ public:
 
   std::string_view get_type_name() const override { return "mon_sync"; }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "mon_sync(" << get_opname(op);
     if (cookie)
       out << " cookie " << cookie;
@@ -98,6 +98,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(op, p);
     decode(cookie, p);

--- a/src/messages/MOSDAlive.h
+++ b/src/messages/MOSDAlive.h
@@ -37,11 +37,12 @@ public:
   void decode_payload() override {
     auto p = payload.cbegin();
     paxos_decode(p);
+    using ceph::decode;
     decode(want, p);
   }
 
   std::string_view get_type_name() const override { return "osd_alive"; }
-  void print(ostream &out) const override {
+  void print(std::ostream &out) const override {
     out << "osd_alive(want up_thru " << want << " have " << version << ")";
   }
 private:

--- a/src/messages/MOSDBeacon.h
+++ b/src/messages/MOSDBeacon.h
@@ -33,6 +33,7 @@ public:
   }
   void decode_payload() override {
     auto p = payload.cbegin();
+    using ceph::decode;
     paxos_decode(p);
     decode(pgs, p);
     decode(min_last_epoch_clean, p);
@@ -41,7 +42,7 @@ public:
     }
   }
   std::string_view get_type_name() const override { return "osd_beacon"; }
-  void print(ostream &out) const {
+  void print(std::ostream &out) const {
     out << get_type_name()
         << "(pgs " << pgs
         << " lec " << min_last_epoch_clean

--- a/src/messages/MOSDBoot.h
+++ b/src/messages/MOSDBoot.h
@@ -31,7 +31,7 @@ private:
   entity_addrvec_t hb_back_addrs, hb_front_addrs;
   entity_addrvec_t cluster_addrs;
   epoch_t boot_epoch;  // last epoch this daemon was added to the map (if any)
-  map<string,string> metadata; ///< misc metadata about this osd
+  std::map<std::string,std::string> metadata; ///< misc metadata about this osd
   uint64_t osd_features;
 
   MOSDBoot()
@@ -57,12 +57,12 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "osd_boot"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "osd_boot(osd." << sb.whoami << " booted " << boot_epoch
 	<< " features " << osd_features
 	<< " v" << version << ")";
   }
-  
+
   void encode_payload(uint64_t features) override {
     header.version = HEAD_VERSION;
     header.compat_version = COMPAT_VERSION;
@@ -90,6 +90,7 @@ public:
   }
   void decode_payload() override {
     auto p = payload.cbegin();
+    using ceph::decode;
     paxos_decode(p);
     if (header.version < 7) {
       entity_addr_t a;

--- a/src/messages/MOSDECSubOpRead.h
+++ b/src/messages/MOSDECSubOpRead.h
@@ -46,6 +46,7 @@ public:
     {}
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(pgid, p);
     decode(map_epoch, p);
@@ -69,7 +70,7 @@ public:
 
   std::string_view get_type_name() const override { return "MOSDECSubOpRead"; }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "MOSDECSubOpRead(" << pgid
 	<< " " << map_epoch << "/" << min_epoch
 	<< " " << op;

--- a/src/messages/MOSDECSubOpReadReply.h
+++ b/src/messages/MOSDECSubOpReadReply.h
@@ -46,6 +46,7 @@ public:
     {}
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(pgid, p);
     decode(map_epoch, p);
@@ -69,7 +70,7 @@ public:
 
   std::string_view get_type_name() const override { return "MOSDECSubOpReadReply"; }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "MOSDECSubOpReadReply(" << pgid
 	<< " " << map_epoch << "/" << min_epoch
 	<< " " << op;

--- a/src/messages/MOSDECSubOpWrite.h
+++ b/src/messages/MOSDECSubOpWrite.h
@@ -50,6 +50,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(pgid, p);
     decode(map_epoch, p);
@@ -73,7 +74,7 @@ public:
 
   std::string_view get_type_name() const override { return "MOSDECSubOpWrite"; }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "MOSDECSubOpWrite(" << pgid
 	<< " " << map_epoch << "/" << min_epoch
 	<< " " << op;

--- a/src/messages/MOSDECSubOpWriteReply.h
+++ b/src/messages/MOSDECSubOpWriteReply.h
@@ -46,6 +46,7 @@ public:
   {}
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(pgid, p);
     decode(map_epoch, p);
@@ -69,7 +70,7 @@ public:
 
   std::string_view get_type_name() const override { return "MOSDECSubOpWriteReply"; }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "MOSDECSubOpWriteReply(" << pgid
 	<< " " << map_epoch << "/" << min_epoch
 	<< " " << op;

--- a/src/messages/MOSDFailure.h
+++ b/src/messages/MOSDFailure.h
@@ -71,6 +71,7 @@ public:
   epoch_t get_epoch() const { return epoch; }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     paxos_decode(p);
     decode(fsid, p);
@@ -113,7 +114,7 @@ public:
   }
 
   std::string_view get_type_name() const override { return "osd_failure"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "osd_failure("
 	<< (if_osd_failed() ? "failed " : "recovered ")
 	<< (is_immediate() ? "immediate " : "timeout ")

--- a/src/messages/MOSDForceRecovery.h
+++ b/src/messages/MOSDForceRecovery.h
@@ -37,14 +37,14 @@ public:
   static constexpr int COMPAT_VERSION = 2;
 
   uuid_d fsid;
-  vector<spg_t> forced_pgs;
+  std::vector<spg_t> forced_pgs;
   uint8_t options = 0;
 
   MOSDForceRecovery() : Message{MSG_OSD_FORCE_RECOVERY, HEAD_VERSION, COMPAT_VERSION} {}
   MOSDForceRecovery(const uuid_d& f, char opts) :
     Message{MSG_OSD_FORCE_RECOVERY, HEAD_VERSION, COMPAT_VERSION},
     fsid(f), options(opts) {}
-  MOSDForceRecovery(const uuid_d& f, vector<spg_t>& pgs, char opts) :
+  MOSDForceRecovery(const uuid_d& f, std::vector<spg_t>& pgs, char opts) :
     Message{MSG_OSD_FORCE_RECOVERY, HEAD_VERSION, COMPAT_VERSION},
     fsid(f), forced_pgs(pgs), options(opts) {}
 private:
@@ -52,7 +52,7 @@ private:
 
 public:
   std::string_view get_type_name() const { return "force_recovery"; }
-  void print(ostream& out) const {
+  void print(std::ostream& out) const {
     out << "force_recovery(";
     if (forced_pgs.empty())
       out << "osd";
@@ -72,7 +72,7 @@ public:
     if (!HAVE_FEATURE(features, SERVER_MIMIC)) {
       header.version = 1;
       header.compat_version = 1;
-      vector<pg_t> pgs;
+      std::vector<pg_t> pgs;
       for (auto pgid : forced_pgs) {
 	pgs.push_back(pgid.pgid);
       }
@@ -88,9 +88,10 @@ public:
     encode(options, payload);
   }
   void decode_payload() {
+    using ceph::decode;
     auto p = payload.cbegin();
     if (header.version == 1) {
-      vector<pg_t> pgs;
+      std::vector<pg_t> pgs;
       decode(fsid, p);
       decode(pgs, p);
       decode(options, p);

--- a/src/messages/MOSDFull.h
+++ b/src/messages/MOSDFull.h
@@ -33,6 +33,7 @@ public:
     encode(state, payload);
   }
   void decode_payload() {
+    using ceph::decode;
     auto p = payload.cbegin();
     paxos_decode(p);
     decode(map_epoch, p);
@@ -40,8 +41,8 @@ public:
   }
 
   std::string_view get_type_name() const { return "osd_full"; }
-  void print(ostream &out) const {
-    set<string> states;
+  void print(std::ostream &out) const {
+    std::set<std::string> states;
     OSDMap::calc_state_set(state, states);
     out << "osd_full(e" << map_epoch << " " << states << " v" << version << ")";
   }

--- a/src/messages/MOSDMarkMeDead.h
+++ b/src/messages/MOSDMarkMeDead.h
@@ -31,6 +31,7 @@ public:
   epoch_t get_epoch() const { return epoch; }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     paxos_decode(p);
     decode(fsid, p);
@@ -49,7 +50,7 @@ public:
   }
 
   std::string_view get_type_name() const override { return "MOSDMarkMeDead"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "MOSDMarkMeDead("
 	<< "osd." << target_osd
 	<< ", epoch " << epoch

--- a/src/messages/MOSDMarkMeDown.h
+++ b/src/messages/MOSDMarkMeDown.h
@@ -45,6 +45,7 @@ public:
   epoch_t get_epoch() const { return epoch; }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     paxos_decode(p);
     if (header.version <= 2) {
@@ -88,7 +89,7 @@ public:
   }
 
   std::string_view get_type_name() const override { return "MOSDMarkMeDown"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "MOSDMarkMeDown("
 	<< "request_ack=" << request_ack
 	<< ", osd." << target_osd

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -106,7 +106,7 @@ public:
     o.swap(ops);
     bdata_encode = false;
   }
-  void set_op_returns(const vector<pg_log_op_return_item_t>& op_returns) {
+  void set_op_returns(const std::vector<pg_log_op_return_item_t>& op_returns) {
     if (op_returns.size()) {
       ceph_assert(ops.empty() || ops.size() == op_returns.size());
       ops.resize(op_returns.size());

--- a/src/messages/MOSDPGBackfill.h
+++ b/src/messages/MOSDPGBackfill.h
@@ -53,6 +53,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(op, p);
     decode(map_epoch, p);
@@ -100,7 +101,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "pg_backfill"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "pg_backfill(" << get_op_name(op)
 	<< " " << pgid
 	<< " e " << map_epoch << "/" << query_epoch

--- a/src/messages/MOSDPGBackfillRemove.h
+++ b/src/messages/MOSDPGBackfillRemove.h
@@ -28,7 +28,7 @@ public:
 
   spg_t pgid;            ///< target spg_t
   epoch_t map_epoch = 0;
-  list<pair<hobject_t,eversion_t>> ls;    ///< objects to remove
+  std::list<std::pair<hobject_t,eversion_t>> ls;    ///< objects to remove
 
   epoch_t get_map_epoch() const override {
     return map_epoch;
@@ -53,7 +53,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "backfill_remove"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "backfill_remove(" << pgid << " e" << map_epoch
 	<< " " << ls << ")";
   }
@@ -65,6 +65,7 @@ public:
     encode(ls, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(pgid, p);
     decode(map_epoch, p);

--- a/src/messages/MOSDPGCreate.h
+++ b/src/messages/MOSDPGCreate.h
@@ -29,8 +29,8 @@ public:
   static constexpr int COMPAT_VERSION = 3;
 
   version_t          epoch = 0;
-  map<pg_t,pg_create_t> mkpg;
-  map<pg_t,utime_t> ctimes;
+  std::map<pg_t,pg_create_t> mkpg;
+  std::map<pg_t,utime_t> ctimes;
 
   MOSDPGCreate()
     : MOSDPGCreate{0}
@@ -42,7 +42,7 @@ public:
 private:
   ~MOSDPGCreate() override {}
 
-public:  
+public:
   std::string_view get_type_name() const override { return "pg_create"; }
 
   void encode_payload(uint64_t features) override {
@@ -52,16 +52,15 @@ public:
     encode(ctimes, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(epoch, p);
     decode(mkpg, p);
     decode(ctimes, p);
   }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "osd_pg_create(e" << epoch;
-    for (map<pg_t,pg_create_t>::const_iterator i = mkpg.begin();
-         i != mkpg.end();
-         ++i) {
+    for (auto i = mkpg.begin(); i != mkpg.end(); ++i) {
       out << " " << i->first << ":" << i->second.created;
     }
     out << ")";

--- a/src/messages/MOSDPGCreate2.h
+++ b/src/messages/MOSDPGCreate2.h
@@ -31,7 +31,7 @@ public:
   std::string_view get_type_name() const override {
     return "pg_create2";
   }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "pg_create2(e" << epoch << " " << pgs << ")";
   }
 

--- a/src/messages/MOSDPGCreated.h
+++ b/src/messages/MOSDPGCreated.h
@@ -17,7 +17,7 @@ public:
       pgid(pgid)
   {}
   std::string_view get_type_name() const override { return "pg_created"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "osd_pg_created(" << pgid << ")";
   }
   void encode_payload(uint64_t features) override {
@@ -26,6 +26,7 @@ public:
     encode(pgid, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     paxos_decode(p);
     decode(pgid, p);

--- a/src/messages/MOSDPGInfo.h
+++ b/src/messages/MOSDPGInfo.h
@@ -50,7 +50,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "pg_info"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "pg_info(";
     for (auto i = pg_list.begin();
          i != pg_list.end();
@@ -80,6 +80,7 @@ public:
     encode(pg_list, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(epoch, p);
     if (header.version == 5) {

--- a/src/messages/MOSDPGLease.h
+++ b/src/messages/MOSDPGLease.h
@@ -45,7 +45,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "pg_lease"; }
-  void inner_print(ostream& out) const override {
+  void inner_print(std::ostream& out) const override {
     out << lease;
   }
 
@@ -56,6 +56,7 @@ public:
     encode(lease, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(epoch, p);
     decode(spgid, p);

--- a/src/messages/MOSDPGLeaseAck.h
+++ b/src/messages/MOSDPGLeaseAck.h
@@ -45,7 +45,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "pg_lease_ack"; }
-  void inner_print(ostream& out) const override {
+  void inner_print(std::ostream& out) const override {
     out << lease_ack;
   }
 
@@ -56,6 +56,7 @@ public:
     encode(lease_ack, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(epoch, p);
     decode(spgid, p);

--- a/src/messages/MOSDPGNotify.h
+++ b/src/messages/MOSDPGNotify.h
@@ -76,6 +76,7 @@ public:
 
   void decode_payload() override {
     auto p = payload.cbegin();
+    using ceph::decode;
     decode(epoch, p);
     if (header.version == 6) {
       // decode legacy vector<pair<pg_notify_t,PastIntervals>>
@@ -90,7 +91,7 @@ public:
     }
     decode(pg_list, p);
   }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "pg_notify(";
     for (auto i = pg_list.begin();
          i != pg_list.end();

--- a/src/messages/MOSDPGPull.h
+++ b/src/messages/MOSDPGPull.h
@@ -22,7 +22,7 @@ private:
   static constexpr int HEAD_VERSION = 3;
   static constexpr int COMPAT_VERSION = 2;
 
-  vector<PullOp> pulls;
+  std::vector<PullOp> pulls;
 
 public:
   pg_shard_t from;
@@ -40,10 +40,10 @@ public:
     return pgid;
   }
 
-  void take_pulls(vector<PullOp> *outpulls) {
+  void take_pulls(std::vector<PullOp> *outpulls) {
     outpulls->swap(pulls);
   }
-  void set_pulls(vector<PullOp> *inpulls) {
+  void set_pulls(std::vector<PullOp> *inpulls) {
     inpulls->swap(pulls);
   }
 
@@ -53,9 +53,7 @@ public:
 
   void compute_cost(CephContext *cct) {
     cost = 0;
-    for (vector<PullOp>::iterator i = pulls.begin();
-	 i != pulls.end();
-	 ++i) {
+    for (auto i = pulls.begin(); i != pulls.end(); ++i) {
       cost += i->cost(cct);
     }
   }
@@ -65,6 +63,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(pgid.pgid, p);
     decode(map_epoch, p);
@@ -92,7 +91,7 @@ public:
 
   std::string_view get_type_name() const override { return "MOSDPGPull"; }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "MOSDPGPull(" << pgid
 	<< " e" << map_epoch << "/" << min_epoch
 	<< " cost " << cost

--- a/src/messages/MOSDPGPush.h
+++ b/src/messages/MOSDPGPush.h
@@ -26,7 +26,7 @@ public:
   pg_shard_t from;
   spg_t pgid;
   epoch_t map_epoch = 0, min_epoch = 0;
-  vector<PushOp> pushes;
+  std::vector<PushOp> pushes;
   bool is_repair = false;
 
 private:
@@ -35,9 +35,7 @@ private:
 public:
   void compute_cost(CephContext *cct) {
     cost = 0;
-    for (vector<PushOp>::iterator i = pushes.begin();
-	 i != pushes.end();
-	 ++i) {
+    for (auto i = pushes.begin(); i != pushes.end(); ++i) {
       cost += i->cost(cct);
     }
   }
@@ -65,6 +63,7 @@ public:
   {}
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(pgid.pgid, p);
     decode(map_epoch, p);
@@ -98,7 +97,7 @@ public:
 
   std::string_view get_type_name() const override { return "MOSDPGPush"; }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "MOSDPGPush(" << pgid
 	<< " " << map_epoch << "/" << min_epoch
 	<< " " << pushes;

--- a/src/messages/MOSDPGPushReply.h
+++ b/src/messages/MOSDPGPushReply.h
@@ -26,7 +26,7 @@ public:
   pg_shard_t from;
   spg_t pgid;
   epoch_t map_epoch = 0, min_epoch = 0;
-  vector<PushReplyOp> replies;
+  std::vector<PushReplyOp> replies;
   uint64_t cost = 0;
 
   epoch_t get_map_epoch() const override {
@@ -45,9 +45,7 @@ public:
 
   void compute_cost(CephContext *cct) {
     cost = 0;
-    for (vector<PushReplyOp>::iterator i = replies.begin();
-	 i != replies.end();
-	 ++i) {
+    for (auto i = replies.begin(); i != replies.end(); ++i) {
       cost += i->cost(cct);
     }
   }
@@ -57,6 +55,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(pgid.pgid, p);
     decode(map_epoch, p);
@@ -82,7 +81,7 @@ public:
     encode(min_epoch, payload);
   }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "MOSDPGPushReply(" << pgid
 	<< " " << map_epoch << "/" << min_epoch
 	<< " " << replies;

--- a/src/messages/MOSDPGQuery.h
+++ b/src/messages/MOSDPGQuery.h
@@ -53,10 +53,9 @@ private:
 
 public:  
   std::string_view get_type_name() const override { return "pg_query"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "pg_query(";
-    for (map<spg_t,pg_query_t>::const_iterator p = pg_list.begin();
-	 p != pg_list.end(); ++p) {
+    for (auto p = pg_list.begin(); p != pg_list.end(); ++p) {
       if (p != pg_list.begin())
 	out << ",";
       out << p->first;
@@ -70,6 +69,7 @@ public:
     encode(pg_list, payload, features);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(epoch, p);
     decode(pg_list, p);

--- a/src/messages/MOSDPGReadyToMerge.h
+++ b/src/messages/MOSDPGReadyToMerge.h
@@ -35,7 +35,8 @@ public:
     encode(ready, payload);
   }
   void decode_payload() override {
-    bufferlist::const_iterator p = payload.begin();
+    using ceph::decode;
+    auto p = payload.cbegin();
     paxos_decode(p);
     decode(pgid, p);
     decode(source_version, p);
@@ -45,7 +46,7 @@ public:
     decode(ready, p);
   }
   std::string_view get_type_name() const override { return "osd_pg_ready_to_merge"; }
-  void print(ostream &out) const {
+  void print(std::ostream &out) const {
     out << get_type_name()
         << "(" << pgid
 	<< " sv " << source_version

--- a/src/messages/MOSDPGRecoveryDelete.h
+++ b/src/messages/MOSDPGRecoveryDelete.h
@@ -18,7 +18,7 @@ public:
   pg_shard_t from;
   spg_t pgid;            ///< target spg_t
   epoch_t map_epoch, min_epoch;
-  list<pair<hobject_t, eversion_t> > objects;    ///< objects to remove
+  std::list<std::pair<hobject_t, eversion_t>> objects;    ///< objects to remove
 
 private:
   uint64_t cost = 0;
@@ -62,7 +62,7 @@ private:
 
 public:
   std::string_view get_type_name() const { return "recovery_delete"; }
-  void print(ostream& out) const {
+  void print(std::ostream& out) const {
     out << "MOSDPGRecoveryDelete(" << pgid << " e" << map_epoch << ","
 	<< min_epoch << " " << objects << ")";
   }
@@ -77,6 +77,7 @@ public:
     encode(objects, payload);
   }
   void decode_payload() {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(from, p);
     decode(pgid, p);

--- a/src/messages/MOSDPGRecoveryDeleteReply.h
+++ b/src/messages/MOSDPGRecoveryDeleteReply.h
@@ -15,7 +15,7 @@ public:
   spg_t pgid;
   epoch_t map_epoch = 0;
   epoch_t min_epoch = 0;
-  list<pair<hobject_t, eversion_t> > objects;
+  std::list<std::pair<hobject_t, eversion_t> > objects;
 
   epoch_t get_map_epoch() const override {
     return map_epoch;
@@ -32,6 +32,7 @@ public:
   {}
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(pgid.pgid, p);
     decode(map_epoch, p);
@@ -51,7 +52,7 @@ public:
     encode(from, payload);
   }
 
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "MOSDPGRecoveryDeleteReply(" << pgid
         << " e" << map_epoch << "," << min_epoch << " " << objects << ")";
   }

--- a/src/messages/MOSDPGRemove.h
+++ b/src/messages/MOSDPGRemove.h
@@ -28,13 +28,13 @@ private:
   epoch_t epoch = 0;
 
  public:
-  vector<spg_t> pg_list;
+  std::vector<spg_t> pg_list;
 
   epoch_t get_epoch() const { return epoch; }
 
   MOSDPGRemove() :
     Message{MSG_OSD_PG_REMOVE, HEAD_VERSION, COMPAT_VERSION} {}
-  MOSDPGRemove(epoch_t e, vector<spg_t>& l) :
+  MOSDPGRemove(epoch_t e, std::vector<spg_t>& l) :
     Message{MSG_OSD_PG_REMOVE, HEAD_VERSION, COMPAT_VERSION} {
     this->epoch = e;
     pg_list.swap(l);
@@ -42,7 +42,7 @@ private:
 private:
   ~MOSDPGRemove() override {}
 
-public:  
+public:
   std::string_view get_type_name() const override { return "PGrm"; }
 
   void encode_payload(uint64_t features) override {
@@ -51,15 +51,14 @@ public:
     encode(pg_list, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(epoch, p);
     decode(pg_list, p);
   }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "osd pg remove(" << "epoch " << epoch << "; ";
-    for (vector<spg_t>::const_iterator i = pg_list.begin();
-         i != pg_list.end();
-         ++i) {
+    for (auto i = pg_list.begin(); i != pg_list.end(); ++i) {
       out << "pg" << *i << "; ";
     }
     out << ")";

--- a/src/messages/MOSDPGScan.h
+++ b/src/messages/MOSDPGScan.h
@@ -52,6 +52,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(op, p);
     decode(map_epoch, p);
@@ -103,7 +104,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "pg_scan"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "pg_scan(" << get_op_name(op)
 	<< " " << pgid
 	<< " " << begin << "-" << end

--- a/src/messages/MOSDPGTemp.h
+++ b/src/messages/MOSDPGTemp.h
@@ -22,7 +22,7 @@
 class MOSDPGTemp : public PaxosServiceMessage {
 public:
   epoch_t map_epoch = 0;
-  map<pg_t, vector<int32_t> > pg_temp;
+  std::map<pg_t, std::vector<int32_t> > pg_temp;
   bool forced = false;
 
   MOSDPGTemp(epoch_t e)
@@ -44,6 +44,7 @@ public:
     encode(forced, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     paxos_decode(p);
     decode(map_epoch, p);
@@ -54,7 +55,7 @@ public:
   }
 
   std::string_view get_type_name() const override { return "osd_pgtemp"; }
-  void print(ostream &out) const override {
+  void print(std::ostream &out) const override {
     out << "osd_pgtemp(e" << map_epoch << " " << pg_temp << " v" << version << ")";
   }
 private:

--- a/src/messages/MOSDPGTrim.h
+++ b/src/messages/MOSDPGTrim.h
@@ -55,7 +55,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "pg_trim"; }
-  void inner_print(ostream& out) const override {
+  void inner_print(std::ostream& out) const override {
     out << trim_to;
   }
 
@@ -67,6 +67,7 @@ public:
     encode(pgid.shard, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(epoch, p);
     decode(pgid.pgid, p);

--- a/src/messages/MOSDPGUpdateLogMissing.h
+++ b/src/messages/MOSDPGUpdateLogMissing.h
@@ -77,7 +77,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "PGUpdateLogMissing"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "pg_update_log_missing(" << pgid << " epoch " << map_epoch
 	<< "/" << min_epoch
 	<< " rep_tid " << rep_tid
@@ -99,6 +99,7 @@ public:
     encode(pg_roll_forward_to, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(map_epoch, p);
     decode(pgid, p);

--- a/src/messages/MOSDPGUpdateLogMissingReply.h
+++ b/src/messages/MOSDPGUpdateLogMissingReply.h
@@ -75,7 +75,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "PGUpdateLogMissingReply"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "pg_update_log_missing_reply(" << pgid << " epoch " << map_epoch
 	<< "/" << min_epoch
 	<< " rep_tid " << rep_tid
@@ -92,6 +92,7 @@ public:
     encode(last_complete_ondisk, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(map_epoch, p);
     decode(pgid, p);

--- a/src/messages/MOSDPing.h
+++ b/src/messages/MOSDPing.h
@@ -93,6 +93,7 @@ private:
 
 public:
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(fsid, p);
     decode(map_epoch, p);
@@ -138,17 +139,17 @@ public:
       // that at runtime we are only adding a bufferptr reference to it.
       static char zeros[16384] = {};
       while (s > sizeof(zeros)) {
-        payload.append(buffer::create_static(sizeof(zeros), zeros));
+        payload.append(ceph::buffer::create_static(sizeof(zeros), zeros));
         s -= sizeof(zeros);
       }
       if (s) {
-        payload.append(buffer::create_static(s, zeros));
+        payload.append(ceph::buffer::create_static(s, zeros));
       }
     }
   }
 
   std::string_view get_type_name() const override { return "osd_ping"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "osd_ping(" << get_op_name(op)
 	<< " e" << map_epoch
 	<< " up_from " << up_from

--- a/src/messages/MOSDRepScrub.h
+++ b/src/messages/MOSDRepScrub.h
@@ -76,7 +76,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "replica scrub"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "replica_scrub(pg: "	<< pgid
 	<< ",from:" << scrub_from
 	<< ",to:" << scrub_to
@@ -109,6 +109,7 @@ public:
     encode(high_priority, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(pgid.pgid, p);
     decode(scrub_from, p);

--- a/src/messages/MOSDRepScrubMap.h
+++ b/src/messages/MOSDRepScrubMap.h
@@ -29,7 +29,7 @@ public:
   spg_t pgid;            // primary spg_t
   epoch_t map_epoch = 0;
   pg_shard_t from;   // whose scrubmap this is
-  bufferlist scrub_map_bl;
+  ceph::buffer::list scrub_map_bl;
   bool preempted = false;
 
   epoch_t get_map_epoch() const override {
@@ -53,7 +53,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "rep_scrubmap"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "rep_scrubmap(" << pgid << " e" << map_epoch
 	<< " from shard " << from
 	<< (preempted ? " PREEMPTED":"") << ")";
@@ -67,6 +67,7 @@ public:
     encode(preempted, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(pgid, p);
     decode(map_epoch, p);

--- a/src/messages/MOSDScrub.h
+++ b/src/messages/MOSDScrub.h
@@ -28,7 +28,7 @@ public:
   static constexpr int COMPAT_VERSION = 2;
 
   uuid_d fsid;
-  vector<pg_t> scrub_pgs;
+  std::vector<pg_t> scrub_pgs;
   bool repair = false;
   bool deep = false;
 
@@ -36,7 +36,7 @@ public:
   MOSDScrub(const uuid_d& f, bool r, bool d) :
     Message{MSG_OSD_SCRUB, HEAD_VERSION, COMPAT_VERSION},
     fsid(f), repair(r), deep(d) {}
-  MOSDScrub(const uuid_d& f, vector<pg_t>& pgs, bool r, bool d) :
+  MOSDScrub(const uuid_d& f, std::vector<pg_t>& pgs, bool r, bool d) :
     Message{MSG_OSD_SCRUB, HEAD_VERSION, COMPAT_VERSION},
     fsid(f), scrub_pgs(pgs), repair(r), deep(d) {}
 private:
@@ -44,7 +44,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "scrub"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "scrub(";
     if (scrub_pgs.empty())
       out << "osd";
@@ -65,6 +65,7 @@ public:
     encode(deep, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(fsid, p);
     decode(scrub_pgs, p);

--- a/src/messages/MOSDScrub2.h
+++ b/src/messages/MOSDScrub2.h
@@ -16,12 +16,12 @@ public:
 
   uuid_d fsid;
   epoch_t epoch;
-  vector<spg_t> scrub_pgs;
+  std::vector<spg_t> scrub_pgs;
   bool repair = false;
   bool deep = false;
 
   MOSDScrub2() : Message{MSG_OSD_SCRUB2, HEAD_VERSION, COMPAT_VERSION} {}
-  MOSDScrub2(const uuid_d& f, epoch_t e, vector<spg_t>& pgs, bool r, bool d) :
+  MOSDScrub2(const uuid_d& f, epoch_t e, std::vector<spg_t>& pgs, bool r, bool d) :
     Message{MSG_OSD_SCRUB2, HEAD_VERSION, COMPAT_VERSION},
     fsid(f), epoch(e), scrub_pgs(pgs), repair(r), deep(d) {}
 private:
@@ -29,7 +29,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "scrub2"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "scrub2(" << scrub_pgs;
     if (repair)
       out << " repair";
@@ -47,6 +47,7 @@ public:
     encode(deep, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(fsid, p);
     decode(epoch, p);

--- a/src/messages/MOSDScrubReserve.h
+++ b/src/messages/MOSDScrubReserve.h
@@ -55,7 +55,7 @@ public:
     return "MOSDScrubReserve";
   }
 
-  void print(ostream& out) const {
+  void print(std::ostream& out) const {
     out << "MOSDScrubReserve(" << pgid << " ";
     switch (type) {
     case REQUEST:
@@ -76,6 +76,7 @@ public:
   }
 
   void decode_payload() {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(pgid, p);
     decode(map_epoch, p);

--- a/src/messages/MPGStatsAck.h
+++ b/src/messages/MPGStatsAck.h
@@ -19,8 +19,8 @@
 
 class MPGStatsAck : public Message {
 public:
-  map<pg_t,pair<version_t,epoch_t> > pg_stat;
-  
+  std::map<pg_t,std::pair<version_t,epoch_t> > pg_stat;
+
   MPGStatsAck() : Message{MSG_PGSTATSACK} {}
 
 private:
@@ -28,7 +28,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "pg_stats_ack"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "pg_stats_ack(" << pg_stat.size() << " pgs tid " << get_tid() << ")";
   }
 
@@ -37,6 +37,7 @@ public:
     encode(pg_stat, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(pg_stat, p);
   }

--- a/src/messages/MRecoveryReserve.h
+++ b/src/messages/MRecoveryReserve.h
@@ -87,7 +87,7 @@ public:
     return "MRecoveryReserve";
   }
 
-  void inner_print(ostream& out) const override {
+  void inner_print(std::ostream& out) const override {
     switch (type) {
     case REQUEST:
       out << "REQUEST";
@@ -107,6 +107,7 @@ public:
 
   void decode_payload() override {
     auto p = payload.cbegin();
+    using ceph::decode;
     decode(pgid.pgid, p);
     decode(query_epoch, p);
     decode(type, p);

--- a/src/messages/MRemoveSnaps.h
+++ b/src/messages/MRemoveSnaps.h
@@ -19,12 +19,12 @@
 
 class MRemoveSnaps : public PaxosServiceMessage {
 public:
-  map<int32_t, vector<snapid_t> > snaps;
-  
+  std::map<int32_t, std::vector<snapid_t>> snaps;
+
 protected:
-  MRemoveSnaps() : 
+  MRemoveSnaps() :
     PaxosServiceMessage{MSG_REMOVE_SNAPS, 0} { }
-  MRemoveSnaps(map<int, vector<snapid_t> >& s) : 
+  MRemoveSnaps(std::map<int, std::vector<snapid_t>>& s) : 
     PaxosServiceMessage{MSG_REMOVE_SNAPS, 0} {
     snaps.swap(s);
   }
@@ -32,7 +32,7 @@ protected:
 
 public:
   std::string_view get_type_name() const override { return "remove_snaps"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "remove_snaps(" << snaps << " v" << version << ")";
   }
 
@@ -42,6 +42,7 @@ public:
     encode(snaps, payload);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     paxos_decode(p);
     decode(snaps, p);

--- a/src/messages/MRoute.h
+++ b/src/messages/MRoute.h
@@ -47,6 +47,7 @@ private:
 public:
   void decode_payload() override {
     auto p = payload.cbegin();
+    using ceph::decode;
     decode(session_mon_tid, p);
     entity_inst_t dest_unused;
     decode(dest_unused, p);
@@ -69,7 +70,7 @@ public:
   }
 
   std::string_view get_type_name() const override { return "route"; }
-  void print(ostream& o) const override {
+  void print(std::ostream& o) const override {
     if (msg)
       o << "route(" << *msg;
     else

--- a/src/messages/MServiceMap.h
+++ b/src/messages/MServiceMap.h
@@ -20,7 +20,7 @@ private:
 
 public:
   std::string_view get_type_name() const override { return "service_map"; }
-  void print(ostream& out) const override {
+  void print(std::ostream& out) const override {
     out << "service_map(e" << service_map.epoch << " "
 	<< service_map.services.size() << " svc)";
   }
@@ -29,6 +29,7 @@ public:
     encode(service_map, payload, features);
   }
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(service_map, p);
   }

--- a/src/messages/MTimeCheck.h
+++ b/src/messages/MTimeCheck.h
@@ -52,7 +52,7 @@ public:
     }
     return "???";
   }
-  void print(ostream &o) const override {
+  void print(std::ostream &o) const override {
     o << "time_check( " << get_op_name()
       << " e " << epoch << " r " << round;
     if (op == OP_PONG) {
@@ -65,6 +65,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(op, p);
     decode(epoch, p);

--- a/src/messages/MTimeCheck2.h
+++ b/src/messages/MTimeCheck2.h
@@ -52,7 +52,7 @@ public:
     }
     return "???";
   }
-  void print(ostream &o) const override {
+  void print(std::ostream &o) const override {
     o << "time_check( " << get_op_name()
       << " e " << epoch << " r " << round;
     if (op == OP_PONG) {
@@ -65,6 +65,7 @@ public:
   }
 
   void decode_payload() override {
+    using ceph::decode;
     auto p = payload.cbegin();
     decode(op, p);
     decode(epoch, p);

--- a/src/mgr/MetricTypes.h
+++ b/src/mgr/MetricTypes.h
@@ -47,7 +47,7 @@ typedef boost::variant<OSDMetricPayload,
 
 class EncodeMetricPayloadVisitor : public boost::static_visitor<void> {
 public:
-  explicit EncodeMetricPayloadVisitor(bufferlist &bl) : m_bl(bl) {
+  explicit EncodeMetricPayloadVisitor(ceph::buffer::list &bl) : m_bl(bl) {
   }
 
   template <typename MetricPayload>
@@ -58,12 +58,12 @@ public:
   }
 
 private:
-  bufferlist &m_bl;
+  ceph::buffer::list &m_bl;
 };
 
 class DecodeMetricPayloadVisitor : public boost::static_visitor<void> {
 public:
-  DecodeMetricPayloadVisitor(bufferlist::const_iterator &iter) : m_iter(iter) {
+  DecodeMetricPayloadVisitor(ceph::buffer::list::const_iterator &iter) : m_iter(iter) {
   }
 
   template <typename MetricPayload>
@@ -73,7 +73,7 @@ public:
   }
 
 private:
-  bufferlist::const_iterator &m_iter;
+  ceph::buffer::list::const_iterator &m_iter;
 };
 
 struct MetricReportMessage {
@@ -83,11 +83,11 @@ struct MetricReportMessage {
     : payload(payload) {
   }
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     boost::apply_visitor(EncodeMetricPayloadVisitor(bl), payload);
   }
 
-  void decode(bufferlist::const_iterator &iter) {
+  void decode(ceph::buffer::list::const_iterator &iter) {
     using ceph::decode;
 
     uint32_t metric_report_type;
@@ -149,7 +149,7 @@ typedef boost::variant<OSDConfigPayload,
 
 class EncodeConfigPayloadVisitor : public boost::static_visitor<void> {
 public:
-  explicit EncodeConfigPayloadVisitor(bufferlist &bl) : m_bl(bl) {
+  explicit EncodeConfigPayloadVisitor(ceph::buffer::list &bl) : m_bl(bl) {
   }
 
   template <typename ConfigPayload>
@@ -160,12 +160,12 @@ public:
   }
 
 private:
-  bufferlist &m_bl;
+  ceph::buffer::list &m_bl;
 };
 
 class DecodeConfigPayloadVisitor : public boost::static_visitor<void> {
 public:
-  DecodeConfigPayloadVisitor(bufferlist::const_iterator &iter) : m_iter(iter) {
+  DecodeConfigPayloadVisitor(ceph::buffer::list::const_iterator &iter) : m_iter(iter) {
   }
 
   template <typename ConfigPayload>
@@ -175,7 +175,7 @@ public:
   }
 
 private:
-  bufferlist::const_iterator &m_iter;
+  ceph::buffer::list::const_iterator &m_iter;
 };
 
 struct MetricConfigMessage {
@@ -185,11 +185,11 @@ struct MetricConfigMessage {
     : payload(payload) {
   }
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     boost::apply_visitor(EncodeConfigPayloadVisitor(bl), payload);
   }
 
-  void decode(bufferlist::const_iterator &iter) {
+  void decode(ceph::buffer::list::const_iterator &iter) {
     using ceph::decode;
 
     uint32_t metric_config_type;

--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -33,6 +33,9 @@ using std::string;
 using std::vector;
 
 using ceph::bufferlist;
+using ceph::make_message;
+using ceph::ref_cast;
+using ceph::ref_t;
 
 #define dout_subsys ceph_subsys_mgrc
 #undef dout_prefix

--- a/src/mgr/MgrClient.h
+++ b/src/mgr/MgrClient.h
@@ -126,7 +126,7 @@ public:
   bool handle_mgr_close(ceph::ref_t<MMgrClose> m);
   bool handle_command_reply(
     uint64_t tid,
-    bufferlist& data,
+    ceph::buffer::list& data,
     const std::string& rs,
     int r);
 
@@ -151,7 +151,7 @@ public:
     ceph::buffer::list *outbl, std::string *outs,
     Context *onfinish);
   int start_tell_command(
-    const string& name,
+    const std::string& name,
     const std::vector<std::string>& cmd, const ceph::buffer::list& inbl,
     ceph::buffer::list *outbl, std::string *outs,
     Context *onfinish);

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -542,7 +542,7 @@ int MonClient::authenticate(double timeout)
   while (!active_con && authenticate_err >= 0) {
     if (timeout > 0.0) {
       auto r = auth_cond.wait_until(lock, until);
-      if (r == cv_status::timeout && !active_con) {
+      if (r == std::cv_status::timeout && !active_con) {
 	ldout(cct, 0) << "authenticate timed out after " << timeout << dendl;
 	authenticate_err = -ETIMEDOUT;
       }

--- a/src/mon/MonCommand.h
+++ b/src/mon/MonCommand.h
@@ -39,14 +39,14 @@ struct MonCommand {
   void set_flag(uint64_t flag) { flags |= flag; }
   void unset_flag(uint64_t flag) { flags &= ~flag; }
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode_bare(bl);
     encode(flags, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode_bare(bl);
     decode(flags, bl);
@@ -56,7 +56,7 @@ struct MonCommand {
   /**
    * Unversioned encoding for use within encode_array.
    */
-  void encode_bare(bufferlist &bl) const {
+  void encode_bare(ceph::buffer::list &bl) const {
     using ceph::encode;
     encode(cmdstring, bl);
     encode(helpstring, bl);
@@ -65,7 +65,7 @@ struct MonCommand {
     std::string availability = "cli,rest";  // Removed field, for backward compat
     encode(availability, bl);
   }
-  void decode_bare(bufferlist::const_iterator &bl) {
+  void decode_bare(ceph::buffer::list::const_iterator &bl) {
     using ceph::decode;
     decode(cmdstring, bl);
     decode(helpstring, bl);
@@ -103,7 +103,7 @@ struct MonCommand {
     return has_flag(MonCommand::FLAG_HIDDEN);
   }
 
-  static void encode_array(const MonCommand *cmds, int size, bufferlist &bl) {
+  static void encode_array(const MonCommand *cmds, int size, ceph::buffer::list &bl) {
     ENCODE_START(2, 1, bl);
     uint16_t s = size;
     encode(s, bl);
@@ -116,7 +116,7 @@ struct MonCommand {
     ENCODE_FINISH(bl);
   }
   static void decode_array(MonCommand **cmds, int *size,
-                           bufferlist::const_iterator &bl) {
+                           ceph::buffer::list::const_iterator &bl) {
     DECODE_START(2, bl);
     uint16_t s = 0;
     decode(s, bl);
@@ -137,7 +137,7 @@ struct MonCommand {
 
   // this uses a u16 for the count, so we need a special encoder/decoder.
   static void encode_vector(const std::vector<MonCommand>& cmds,
-			    bufferlist &bl) {
+			    ceph::buffer::list &bl) {
     ENCODE_START(2, 1, bl);
     uint16_t s = cmds.size();
     encode(s, bl);
@@ -150,7 +150,7 @@ struct MonCommand {
     ENCODE_FINISH(bl);
   }
   static void decode_vector(std::vector<MonCommand> &cmds,
-			    bufferlist::const_iterator &bl) {
+			    ceph::buffer::list::const_iterator &bl) {
     DECODE_START(2, bl);
     uint16_t s = 0;
     decode(s, bl);

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -31,6 +31,8 @@ using std::stringstream;
 using std::vector;
 
 using ceph::bufferlist;
+using ceph::fixed_u_to_string;
+
 using TOPNSPC::common::cmd_getval;
 
 MEMPOOL_DEFINE_OBJECT_FACTORY(PGMapDigest, pgmap_digest, pgmap);

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -492,12 +492,12 @@ public:
   void get_filtered_pg_stats(uint64_t state, int64_t poolid, int64_t osdid,
                              bool primary, std::set<pg_t>& pgs) const;
 
-  set<std::string> osd_parentage(const OSDMap& osdmap, int id) const;
+  std::set<std::string> osd_parentage(const OSDMap& osdmap, int id) const;
   void get_health_checks(
     CephContext *cct,
     const OSDMap& osdmap,
     health_check_map_t *checks) const;
-  void print_summary(ceph::Formatter *f, ostream *out) const;
+  void print_summary(ceph::Formatter *f, std::ostream *out) const;
 
   static void generate_test_instances(std::list<PGMap*>& o);
 };

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -110,7 +110,7 @@ struct MonSession : public RefCountedObject {
     return socket_addr;
   }
 
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->dump_stream("name") << name;
     f->dump_stream("entity_name") << entity_name;
     f->dump_object("addrs", addrs);

--- a/src/mon/health_check.h
+++ b/src/mon/health_check.h
@@ -74,7 +74,7 @@ struct health_mute_t {
   std::string code;
   utime_t ttl;
   bool sticky = false;
-  string summary;
+  std::string summary;
   int64_t count;
 
   DENC(health_mute_t, v, p) {

--- a/src/msg/DispatchQueue.cc
+++ b/src/msg/DispatchQueue.cc
@@ -20,6 +20,8 @@
 #define dout_subsys ceph_subsys_ms
 #include "common/debug.h"
 
+using ceph::cref_t;
+using ceph::ref_t;
 
 /*******************
  * DispatchQueue
@@ -213,11 +215,9 @@ void DispatchQueue::entry()
 
 void DispatchQueue::discard_queue(uint64_t id) {
   std::lock_guard l{lock};
-  list<QueueItem> removed;
+  std::list<QueueItem> removed;
   mqueue.remove_by_class(id, &removed);
-  for (list<QueueItem>::iterator i = removed.begin();
-       i != removed.end();
-       ++i) {
+  for (auto i = removed.begin(); i != removed.end(); ++i) {
     ceph_assert(!(i->is_code())); // We don't discard id 0, ever!
     const ref_t<Message>& m = i->get_message();
     remove_arrival(m);

--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -10,7 +10,7 @@
 
 #include "msg/async/AsyncMessenger.h"
 
-Messenger *Messenger::create_client_messenger(CephContext *cct, string lname)
+Messenger *Messenger::create_client_messenger(CephContext *cct, std::string lname)
 {
   std::string public_msgr_type = cct->_conf->ms_public_type.empty() ? cct->_conf.get_val<std::string>("ms_type") : cct->_conf->ms_public_type;
   auto nonce = get_random_nonce();
@@ -33,8 +33,8 @@ uint64_t Messenger::get_random_nonce()
   return ceph::util::generate_random_number<uint64_t>();
 }
 
-Messenger *Messenger::create(CephContext *cct, const string &type,
-			     entity_name_t name, string lname,
+Messenger *Messenger::create(CephContext *cct, const std::string &type,
+			     entity_name_t name, std::string lname,
 			     uint64_t nonce, uint64_t cflags)
 {
   int r = -1;

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -648,7 +648,7 @@ public:
    *
    * @param m The Message we are testing.
    */
-  bool ms_can_fast_dispatch(const cref_t<Message>& m) {
+  bool ms_can_fast_dispatch(const ceph::cref_t<Message>& m) {
     for (const auto &dispatcher : fast_dispatchers) {
       if (dispatcher->ms_can_fast_dispatch2(m))
 	return true;
@@ -662,7 +662,7 @@ public:
    * @param m The Message we are fast dispatching.
    * If none of our Dispatchers can handle it, ceph_abort().
    */
-  void ms_fast_dispatch(const ref_t<Message> &m) {
+  void ms_fast_dispatch(const ceph::ref_t<Message> &m) {
     m->set_dispatch_stamp(ceph_clock_now());
     for (const auto &dispatcher : fast_dispatchers) {
       if (dispatcher->ms_can_fast_dispatch2(m)) {
@@ -673,12 +673,12 @@ public:
     ceph_abort();
   }
   void ms_fast_dispatch(Message *m) {
-    return ms_fast_dispatch(ref_t<Message>(m, false)); /* consume ref */
+    return ms_fast_dispatch(ceph::ref_t<Message>(m, false)); /* consume ref */
   }
   /**
    *
    */
-  void ms_fast_preprocess(const ref_t<Message> &m) {
+  void ms_fast_preprocess(const ceph::ref_t<Message> &m) {
     for (const auto &dispatcher : fast_dispatchers) {
       dispatcher->ms_fast_preprocess2(m);
     }
@@ -690,7 +690,7 @@ public:
    *
    *  @param m The Message to deliver.
    */
-  void ms_deliver_dispatch(const ref_t<Message> &m) {
+  void ms_deliver_dispatch(const ceph::ref_t<Message> &m) {
     m->set_dispatch_stamp(ceph_clock_now());
     for (const auto &dispatcher : dispatchers) {
       if (dispatcher->ms_dispatch2(m))
@@ -701,7 +701,7 @@ public:
     ceph_assert(!cct->_conf->ms_die_on_unhandled_msg);
   }
   void ms_deliver_dispatch(Message *m) {
-    return ms_deliver_dispatch(ref_t<Message>(m, false)); /* consume ref */
+    return ms_deliver_dispatch(ceph::ref_t<Message>(m, false)); /* consume ref */
   }
   /**
    * Notify each Dispatcher of a new Connection. Call

--- a/src/msg/QueueStrategy.cc
+++ b/src/msg/QueueStrategy.cc
@@ -44,11 +44,11 @@ void QueueStrategy::ds_dispatch(Message *m) {
 void QueueStrategy::entry(QSThread *thrd)
 {
   for (;;) {
-    ref_t<Message> m;
+    ceph::ref_t<Message> m;
     std::unique_lock l{lock};
     for (;;) {
       if (! mqueue.empty()) {
-	m = ref_t<Message>(&mqueue.front(), false);
+	m = ceph::ref_t<Message>(&mqueue.front(), false);
 	mqueue.pop_front();
 	break;
       }
@@ -98,7 +98,7 @@ void QueueStrategy::start()
   std::lock_guard l{lock};
   threads.reserve(n_threads);
   for (int ix = 0; ix < n_threads; ++ix) {
-    string thread_name = "ms_qs_";
+    std::string thread_name = "ms_qs_";
     thread_name.append(std::to_string(ix));
     auto thrd = std::make_unique<QSThread>(this);
     thrd->create(thread_name.c_str());

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -35,7 +35,7 @@
 #define dout_subsys ceph_subsys_ms
 #undef dout_prefix
 #define dout_prefix _conn_prefix(_dout)
-ostream& AsyncConnection::_conn_prefix(std::ostream *_dout) {
+std::ostream& AsyncConnection::_conn_prefix(std::ostream *_dout) {
   return *_dout << "-- " << async_msgr->get_myaddrs() << " >> "
 		<< *peer_addrs << " conn(" << this
 		<< (msgr2 ? " msgr2=" : " legacy=")
@@ -168,8 +168,8 @@ void AsyncConnection::maybe_start_delay_thread()
   if (!delay_state) {
     async_msgr->cct->_conf.with_val<std::string>(
       "ms_inject_delay_type",
-      [this](const string& s) {
-	if (s.find(ceph_entity_type_name(peer_type)) != string::npos) {
+      [this](const std::string& s) {
+	if (s.find(ceph_entity_type_name(peer_type)) != std::string::npos) {
 	  ldout(msgr->cct, 1) << __func__ << " setting up a delay queue"
 			      << dendl;
 	  delay_state = new DelayedDelivery(async_msgr, center, dispatch_queue,
@@ -300,7 +300,7 @@ ssize_t AsyncConnection::read_bulk(char *buf, unsigned len)
   return nread;
 }
 
-ssize_t AsyncConnection::write(bufferlist &bl,
+ssize_t AsyncConnection::write(ceph::buffer::list &bl,
                                std::function<void(ssize_t)> callback,
                                bool more) {
 

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -56,7 +56,7 @@ class AsyncConnection : public Connection {
   ssize_t read_until(unsigned needed, char *p);
   ssize_t read_bulk(char *buf, unsigned len);
 
-  ssize_t write(bufferlist &bl, std::function<void(ssize_t)> callback,
+  ssize_t write(ceph::buffer::list &bl, std::function<void(ssize_t)> callback,
                 bool more=false);
   ssize_t _try_send(bool more=false);
 
@@ -114,7 +114,7 @@ private:
 public:
   void maybe_start_delay_thread();
 
-  ostream& _conn_prefix(std::ostream *_dout);
+  std::ostream& _conn_prefix(std::ostream *_dout);
 
   bool is_connected() override;
 
@@ -182,7 +182,7 @@ private:
   DispatchQueue *dispatch_queue;
 
   // lockfree, only used in own thread
-  bufferlist outgoing_bl;
+  ceph::buffer::list outgoing_bl;
   bool open_write = false;
 
   std::mutex write_lock;
@@ -197,7 +197,7 @@ private:
   uint32_t recv_max_prefetch;
   uint32_t recv_start;
   uint32_t recv_end;
-  set<uint64_t> register_time_events; // need to delete it if stop
+  std::set<uint64_t> register_time_events; // need to delete it if stop
   ceph::coarse_mono_clock::time_point last_connect_started;
   ceph::coarse_mono_clock::time_point last_active;
   ceph::mono_clock::time_point recv_start_time;

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -32,11 +32,11 @@
 #define dout_subsys ceph_subsys_ms
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)
-static ostream& _prefix(std::ostream *_dout, AsyncMessenger *m) {
+static std::ostream& _prefix(std::ostream *_dout, AsyncMessenger *m) {
   return *_dout << "-- " << m->get_myaddrs() << " ";
 }
 
-static ostream& _prefix(std::ostream *_dout, Processor *p) {
+static std::ostream& _prefix(std::ostream *_dout, Processor *p) {
   return *_dout << " Processor -- ";
 }
 
@@ -60,7 +60,7 @@ Processor::Processor(AsyncMessenger *r, Worker *w, CephContext *c)
     listen_handler(new C_processor_accept(this)) {}
 
 int Processor::bind(const entity_addrvec_t &bind_addrs,
-		    const set<int>& avoid_ports,
+		    const std::set<int>& avoid_ports,
 		    entity_addrvec_t* bound_addrs)
 {
   const auto& conf = msgr->cct->_conf;
@@ -278,7 +278,7 @@ class C_handle_reap : public EventCallback {
  */
 
 AsyncMessenger::AsyncMessenger(CephContext *cct, entity_name_t name,
-                               const std::string &type, string mname, uint64_t _nonce)
+                               const std::string &type, std::string mname, uint64_t _nonce)
   : SimplePolicyMessenger(cct, name),
     dispatch_queue(cct, this, mname),
     nonce(_nonce)
@@ -397,7 +397,7 @@ int AsyncMessenger::bindv(const entity_addrvec_t &bind_addrs)
   lock.unlock();
 
   // bind to a socket
-  set<int> avoid_ports;
+  std::set<int> avoid_ports;
   entity_addrvec_t bound_addrs;
   unsigned i = 0;
   for (auto &&p : processors) {
@@ -421,7 +421,7 @@ int AsyncMessenger::bindv(const entity_addrvec_t &bind_addrs)
   return 0;
 }
 
-int AsyncMessenger::rebind(const set<int>& avoid_ports)
+int AsyncMessenger::rebind(const std::set<int>& avoid_ports)
 {
   ldout(cct,1) << __func__ << " rebind avoid " << avoid_ports << dendl;
   ceph_assert(did_bind);
@@ -437,7 +437,7 @@ int AsyncMessenger::rebind(const set<int>& avoid_ports)
 
   entity_addrvec_t bound_addrs;
   entity_addrvec_t bind_addrs = get_myaddrs();
-  set<int> new_avoid(avoid_ports);
+  std::set<int> new_avoid(avoid_ports);
   for (auto& a : bind_addrs.v) {
     new_avoid.insert(a.get_port());
     a.set_port(0);

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -44,9 +44,9 @@ class AsyncMessenger;
  */
 class Processor {
   AsyncMessenger *msgr;
-  NetHandler net;
+  ceph::NetHandler net;
   Worker *worker;
-  vector<ServerSocket> listen_sockets;
+  std::vector<ServerSocket> listen_sockets;
   EventCallbackRef listen_handler;
 
   class C_processor_accept;
@@ -57,7 +57,7 @@ class Processor {
 
   void stop();
   int bind(const entity_addrvec_t &bind_addrs,
-	   const set<int>& avoid_ports,
+	   const std::set<int>& avoid_ports,
 	   entity_addrvec_t* bound_addrs);
   void start();
   void accept();
@@ -82,7 +82,7 @@ public:
    * be a value that will be repeated if the daemon restarts.
    */
   AsyncMessenger(CephContext *cct, entity_name_t name, const std::string &type,
-                 string mname, uint64_t _nonce);
+                 std::string mname, uint64_t _nonce);
 
   /**
    * Destroy the AsyncMessenger. Pretty simple since all the work is done
@@ -115,7 +115,7 @@ public:
   }
 
   int bind(const entity_addr_t& bind_addr) override;
-  int rebind(const set<int>& avoid_ports) override;
+  int rebind(const std::set<int>& avoid_ports) override;
   int client_bind(const entity_addr_t& bind_addr) override;
 
   int bindv(const entity_addrvec_t& bind_addrs) override;
@@ -268,10 +268,10 @@ private:
    *
    * These are not yet in the conns map.
    */
-  set<AsyncConnectionRef> accepting_conns;
+  std::set<AsyncConnectionRef> accepting_conns;
 
   /// anonymous outgoing connections
-  set<AsyncConnectionRef> anon_conns;
+  std::set<AsyncConnectionRef> anon_conns;
 
   /**
    * list of connection are closed which need to be clean up
@@ -285,7 +285,7 @@ private:
    * AsyncConnection in this set.
    */
   ceph::mutex deleted_lock = ceph::make_mutex("AsyncMessenger::deleted_lock");
-  set<AsyncConnectionRef> deleted_conns;
+  std::set<AsyncConnectionRef> deleted_conns;
 
   EventCallbackRef reap_handler;
 

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -69,7 +69,7 @@ class C_handle_notify : public EventCallback {
  *      about the poller. The name of the superclass is probably sufficient
  *      for most cases.
  */
-EventCenter::Poller::Poller(EventCenter* center, const string& name)
+EventCenter::Poller::Poller(EventCenter* center, const std::string& name)
     : owner(center), poller_name(name), slot(owner->pollers.size())
 {
   owner->pollers.push_back(this);
@@ -94,7 +94,7 @@ EventCenter::Poller::~Poller()
   slot = -1;
 }
 
-ostream& EventCenter::_event_prefix(std::ostream *_dout)
+std::ostream& EventCenter::_event_prefix(std::ostream *_dout)
 {
   return *_dout << "Event(" << this << " nevent=" << nevent
                 << " time_id=" << time_event_next_id << ").";
@@ -340,6 +340,7 @@ int EventCenter::process_time_events()
 {
   int processed = 0;
   clock_type::time_point now = clock_type::now();
+  using ceph::operator <<;
   ldout(cct, 30) << __func__ << " cur time is " << now << dendl;
 
   while (!time_events.empty()) {
@@ -388,7 +389,7 @@ int EventCenter::process_events(unsigned timeout_microseconds,  ceph::timespan *
   tv.tv_usec = timeout_microseconds % 1000000;
 
   ldout(cct, 30) << __func__ << " wait second " << tv.tv_sec << " usec " << tv.tv_usec << dendl;
-  vector<FiredFileEvent> fired_events;
+  std::vector<FiredFileEvent> fired_events;
   numevents = driver->event_wait(fired_events, &tv);
   auto working_start = ceph::mono_clock::now();
   for (int event_id = 0; event_id < numevents; event_id++) {
@@ -422,7 +423,7 @@ int EventCenter::process_events(unsigned timeout_microseconds,  ceph::timespan *
 
   if (external_num_events.load()) {
     external_lock.lock();
-    deque<EventCallbackRef> cur_process;
+    std::deque<EventCallbackRef> cur_process;
     cur_process.swap(external_events);
     external_num_events.store(0);
     external_lock.unlock();

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -76,7 +76,7 @@ class EventDriver {
   virtual int init(EventCenter *center, int nevent) = 0;
   virtual int add_event(int fd, int cur_mask, int mask) = 0;
   virtual int del_event(int fd, int cur_mask, int del_mask) = 0;
-  virtual int event_wait(vector<FiredFileEvent> &fired_events, struct timeval *tp) = 0;
+  virtual int event_wait(std::vector<FiredFileEvent> &fired_events, struct timeval *tp) = 0;
   virtual int resize_events(int newsize) = 0;
   virtual bool need_wakeup() { return true; }
 };
@@ -121,7 +121,7 @@ class EventCenter {
      */
   class Poller {
    public:
-    explicit Poller(EventCenter* center, const string& pollerName);
+    explicit Poller(EventCenter* center, const std::string& pollerName);
     virtual ~Poller();
 
     /**
@@ -142,7 +142,7 @@ class EventCenter {
     /// Human-readable string name given to the poller to make it
     /// easy to identify for debugging. For most pollers just passing
     /// in the subclass name probably makes sense.
-    string poller_name;
+    std::string poller_name;
 
     /// Index of this Poller in EventCenter::pollers.  Allows deletion
     /// without having to scan all the entries in pollers. -1 means
@@ -159,8 +159,8 @@ class EventCenter {
   pthread_t owner = 0;
   std::mutex external_lock;
   std::atomic_ulong external_num_events;
-  deque<EventCallbackRef> external_events;
-  vector<FileEvent> file_events;
+  std::deque<EventCallbackRef> external_events;
+  std::vector<FileEvent> file_events;
   EventDriver *driver;
   std::multimap<clock_type::time_point, TimeEvent> time_events;
   // Keeps track of all of the pollers currently defined.  We don't
@@ -171,7 +171,7 @@ class EventCenter {
   uint64_t time_event_next_id;
   int notify_receive_fd;
   int notify_send_fd;
-  NetHandler net;
+  ceph::NetHandler net;
   EventCallbackRef notify_handler;
   unsigned center_id;
   AssociatedCenters *global_centers = nullptr;
@@ -190,7 +190,7 @@ class EventCenter {
     notify_receive_fd(-1), notify_send_fd(-1), net(c),
     notify_handler(NULL), center_id(0) { }
   ~EventCenter();
-  ostream& _event_prefix(std::ostream *_dout);
+  std::ostream& _event_prefix(std::ostream *_dout);
 
   int init(int nevent, unsigned center_id, const std::string &type);
   void set_owner();

--- a/src/msg/async/EventEpoll.cc
+++ b/src/msg/async/EventEpoll.cc
@@ -116,7 +116,7 @@ int EpollDriver::resize_events(int newsize)
   return 0;
 }
 
-int EpollDriver::event_wait(vector<FiredFileEvent> &fired_events, struct timeval *tvp)
+int EpollDriver::event_wait(std::vector<FiredFileEvent> &fired_events, struct timeval *tvp)
 {
   int retval, numevents = 0;
 

--- a/src/msg/async/EventEpoll.h
+++ b/src/msg/async/EventEpoll.h
@@ -42,7 +42,7 @@ class EpollDriver : public EventDriver {
   int add_event(int fd, int cur_mask, int add_mask) override;
   int del_event(int fd, int cur_mask, int del_mask) override;
   int resize_events(int newsize) override;
-  int event_wait(vector<FiredFileEvent> &fired_events,
+  int event_wait(std::vector<FiredFileEvent> &fired_events,
 		 struct timeval *tp) override;
 };
 

--- a/src/msg/async/EventSelect.cc
+++ b/src/msg/async/EventSelect.cc
@@ -67,7 +67,7 @@ int SelectDriver::resize_events(int newsize)
   return 0;
 }
 
-int SelectDriver::event_wait(vector<FiredFileEvent> &fired_events, struct timeval *tvp)
+int SelectDriver::event_wait(std::vector<FiredFileEvent> &fired_events, struct timeval *tvp)
 {
   int retval, numevents = 0;
 

--- a/src/msg/async/EventSelect.h
+++ b/src/msg/async/EventSelect.h
@@ -35,7 +35,7 @@ class SelectDriver : public EventDriver {
   int add_event(int fd, int cur_mask, int add_mask) override;
   int del_event(int fd, int cur_mask, int del_mask) override;
   int resize_events(int newsize) override;
-  int event_wait(vector<FiredFileEvent> &fired_events,
+  int event_wait(std::vector<FiredFileEvent> &fired_events,
 		 struct timeval *tp) override;
 };
 

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -38,13 +38,14 @@
 #define dout_prefix *_dout << "PosixStack "
 
 class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
-  NetHandler &handler;
+  ceph::NetHandler &handler;
   int _fd;
   entity_addr_t sa;
   bool connected;
 
  public:
-  explicit PosixConnectedSocketImpl(NetHandler &h, const entity_addr_t &sa, int f, bool connected)
+  explicit PosixConnectedSocketImpl(ceph::NetHandler &h, const entity_addr_t &sa,
+				    int f, bool connected)
       : handler(h), _fd(f), sa(sa), connected(connected) {}
 
   int is_connected() override {
@@ -106,7 +107,7 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
     return (ssize_t)sent;
   }
 
-  ssize_t send(bufferlist &bl, bool more) override {
+  ssize_t send(ceph::buffer::list &bl, bool more) override {
     size_t sent_bytes = 0;
     auto pb = std::cbegin(bl.buffers());
     uint64_t left_pbrs = bl.get_num_buffers();
@@ -138,7 +139,7 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
     }
 
     if (sent_bytes) {
-      bufferlist swapped;
+      ceph::buffer::list swapped;
       if (sent_bytes < bl.length()) {
         bl.splice(sent_bytes, bl.length()-sent_bytes, &swapped);
         bl.swap(swapped);
@@ -163,11 +164,11 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
 };
 
 class PosixServerSocketImpl : public ServerSocketImpl {
-  NetHandler &handler;
+  ceph::NetHandler &handler;
   int _fd;
 
  public:
-  explicit PosixServerSocketImpl(NetHandler &h, int f,
+  explicit PosixServerSocketImpl(ceph::NetHandler &h, int f,
 				 const entity_addr_t& listen_addr, unsigned slot)
     : ServerSocketImpl(listen_addr.get_type(), slot),
       handler(h), _fd(f) {}
@@ -281,7 +282,7 @@ int PosixWorker::connect(const entity_addr_t &addr, const SocketOptions &opts, C
   return 0;
 }
 
-PosixNetworkStack::PosixNetworkStack(CephContext *c, const string &t)
+PosixNetworkStack::PosixNetworkStack(CephContext *c, const std::string &t)
     : NetworkStack(c, t)
 {
 }

--- a/src/msg/async/PosixStack.h
+++ b/src/msg/async/PosixStack.h
@@ -25,7 +25,7 @@
 #include "Stack.h"
 
 class PosixWorker : public Worker {
-  NetHandler net;
+  ceph::NetHandler net;
   void initialize() override;
  public:
   PosixWorker(CephContext *c, unsigned i)
@@ -38,10 +38,10 @@ class PosixWorker : public Worker {
 };
 
 class PosixNetworkStack : public NetworkStack {
-  vector<std::thread> threads;
+  std::vector<std::thread> threads;
 
  public:
-  explicit PosixNetworkStack(CephContext *c, const string &t);
+  explicit PosixNetworkStack(CephContext *c, const std::string &t);
 
   void spawn_worker(unsigned i, std::function<void ()> &&func) override {
     threads.resize(i+1);

--- a/src/msg/async/Protocol.h
+++ b/src/msg/async/Protocol.h
@@ -47,7 +47,7 @@ public:
 };
 
 using rx_buffer_t =
-    std::unique_ptr<buffer::ptr_node, buffer::ptr_node::disposer>;
+  std::unique_ptr<ceph::buffer::ptr_node, ceph::buffer::ptr_node::disposer>;
 
 template <class C>
 class CtRxNode : public Ct<C> {

--- a/src/msg/async/ProtocolV1.h
+++ b/src/msg/async/ProtocolV1.h
@@ -104,9 +104,9 @@ protected:
 
   enum class WriteStatus { NOWRITE, REPLACING, CANWRITE, CLOSED };
   std::atomic<WriteStatus> can_write;
-  std::list<Message *> sent;  // the first bufferlist need to inject seq
+  std::list<Message *> sent;  // the first ceph::buffer::list need to inject seq
   // priority queue for outbound msgs
-  std::map<int, std::list<std::pair<bufferlist, Message *>>> out_q;
+  std::map<int, std::list<std::pair<ceph::buffer::list, Message *>>> out_q;
   bool keepalive;
   bool write_in_progress = false;
 
@@ -120,8 +120,8 @@ protected:
   // Open state
   ceph_msg_connect connect_msg;
   ceph_msg_connect_reply connect_reply;
-  bufferlist authorizer_buf;  // auth(orizer) payload read off the wire
-  bufferlist authorizer_more;  // connect-side auth retry (we added challenge)
+  ceph::buffer::list authorizer_buf;  // auth(orizer) payload read off the wire
+  ceph::buffer::list authorizer_more;  // connect-side auth retry (we added challenge)
 
   utime_t backoff;  // backoff time
   utime_t recv_stamp;
@@ -129,9 +129,9 @@ protected:
   unsigned msg_left;
   uint64_t cur_msg_size;
   ceph_msg_header current_header;
-  bufferlist data_buf;
-  bufferlist::iterator data_blp;
-  bufferlist front, middle, data;
+  ceph::buffer::list data_buf;
+  ceph::buffer::list::iterator data_blp;
+  ceph::buffer::list front, middle, data;
 
   bool replacing;  // when replacing process happened, we will reply connect
                    // side with RETRY tag and accept side will clear replaced
@@ -147,7 +147,7 @@ protected:
   void run_continuation(CtPtr pcontinuation);
   CtPtr read(CONTINUATION_RX_TYPE<ProtocolV1> &next, int len,
              char *buffer = nullptr);
-  CtPtr write(CONTINUATION_TX_TYPE<ProtocolV1> &next,bufferlist &bl);
+  CtPtr write(CONTINUATION_TX_TYPE<ProtocolV1> &next,ceph::buffer::list &bl);
   inline CtPtr _fault() {  // helper fault method that stops continuation
     fault();
     return nullptr;
@@ -194,10 +194,10 @@ protected:
   void session_reset();
   void randomize_out_seq();
 
-  Message *_get_next_outgoing(bufferlist *bl);
+  Message *_get_next_outgoing(ceph::buffer::list *bl);
 
-  void prepare_send_message(uint64_t features, Message *m, bufferlist &bl);
-  ssize_t write_message(Message *m, bufferlist &bl, bool more);
+  void prepare_send_message(uint64_t features, Message *m, ceph::buffer::list &bl);
+  ssize_t write_message(Message *m, ceph::buffer::list &bl, bool more);
 
   void requeue_sent();
   uint64_t discard_requeued_up_to(uint64_t out_seq, uint64_t seq);
@@ -205,7 +205,7 @@ protected:
 
   void reset_recv_state();
 
-  ostream &_conn_prefix(std::ostream *_dout);
+  std::ostream& _conn_prefix(std::ostream *_dout);
 
 public:
   ProtocolV1(AsyncConnection *connection);
@@ -281,11 +281,11 @@ protected:
   CtPtr handle_connect_message_auth(char *buffer, int r);
   CtPtr handle_connect_message_2();
   CtPtr send_connect_message_reply(char tag, ceph_msg_connect_reply &reply,
-                                   bufferlist &authorizer_reply);
+                                   ceph::buffer::list &authorizer_reply);
   CtPtr handle_connect_message_reply_write(int r);
   CtPtr replace(const AsyncConnectionRef& existing, ceph_msg_connect_reply &reply,
-                bufferlist &authorizer_reply);
-  CtPtr open(ceph_msg_connect_reply &reply, bufferlist &authorizer_reply);
+                ceph::buffer::list &authorizer_reply);
+  CtPtr open(ceph_msg_connect_reply &reply, ceph::buffer::list &authorizer_reply);
   CtPtr handle_ready_connect_message_reply_write(int r);
   CtPtr wait_seq();
   CtPtr handle_seq(char *buffer, int r);

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -115,7 +115,7 @@ private:
   bool keepalive;
   bool write_in_progress = false;
 
-  ostream &_conn_prefix(std::ostream *_dout);
+  std::ostream& _conn_prefix(std::ostream *_dout);
   void run_continuation(Ct<ProtocolV2> *pcontinuation);
   void run_continuation(Ct<ProtocolV2> &continuation);
 
@@ -127,7 +127,7 @@ private:
 			F &frame);
   Ct<ProtocolV2> *write(const std::string &desc,
                         CONTINUATION_TYPE<ProtocolV2> &next,
-                        bufferlist &buffer);
+                        ceph::bufferlist &buffer);
 
   void requeue_sent();
   uint64_t discard_requeued_up_to(uint64_t out_seq, uint64_t seq);
@@ -238,7 +238,7 @@ private:
   Ct<ProtocolV2> *post_server_banner_exchange();
   Ct<ProtocolV2> *handle_auth_request(ceph::bufferlist &payload);
   Ct<ProtocolV2> *handle_auth_request_more(ceph::bufferlist &payload);
-  Ct<ProtocolV2> *_handle_auth_request(bufferlist& auth_payload, bool more);
+  Ct<ProtocolV2> *_handle_auth_request(ceph::bufferlist& auth_payload, bool more);
   Ct<ProtocolV2> *_auth_bad_method(int r);
   Ct<ProtocolV2> *handle_client_ident(ceph::bufferlist &payload);
   Ct<ProtocolV2> *handle_ident_missing_features_write(int r);

--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -63,7 +63,8 @@ std::function<void ()> NetworkStack::add_thread(unsigned worker_id)
   };
 }
 
-std::shared_ptr<NetworkStack> NetworkStack::create(CephContext *c, const string &t)
+std::shared_ptr<NetworkStack> NetworkStack::create(CephContext *c,
+						   const std::string &t)
 {
   if (t == "posix")
     return std::make_shared<PosixNetworkStack>(c, t);
@@ -82,7 +83,7 @@ std::shared_ptr<NetworkStack> NetworkStack::create(CephContext *c, const string 
   return nullptr;
 }
 
-Worker* NetworkStack::create_worker(CephContext *c, const string &type, unsigned worker_id)
+Worker* NetworkStack::create_worker(CephContext *c, const std::string &type, unsigned worker_id)
 {
   if (type == "posix")
     return new PosixWorker(c, worker_id);
@@ -101,7 +102,7 @@ Worker* NetworkStack::create_worker(CephContext *c, const string &type, unsigned
   return nullptr;
 }
 
-NetworkStack::NetworkStack(CephContext *c, const string &t): type(t), started(false), cct(c)
+NetworkStack::NetworkStack(CephContext *c, const std:: string &t): type(t), started(false), cct(c)
 {
   ceph_assert(cct->_conf->ms_async_op_threads > 0);
 

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -28,7 +28,7 @@ class ConnectedSocketImpl {
   virtual ~ConnectedSocketImpl() {}
   virtual int is_connected() = 0;
   virtual ssize_t read(char*, size_t) = 0;
-  virtual ssize_t send(bufferlist &bl, bool more) = 0;
+  virtual ssize_t send(ceph::buffer::list &bl, bool more) = 0;
   virtual void shutdown() = 0;
   virtual void close() = 0;
   virtual int fd() const = 0;
@@ -96,7 +96,7 @@ class ConnectedSocket {
   /// Gets the output stream.
   ///
   /// Gets an object that sends data to the remote endpoint.
-  ssize_t send(bufferlist &bl, bool more) {
+  ssize_t send(ceph::buffer::list &bl, bool more) {
     return _csi->send(bl, more);
   }
   /// Disables output to the socket.
@@ -302,9 +302,9 @@ class NetworkStack {
 
  protected:
   CephContext *cct;
-  vector<Worker*> workers;
+  std::vector<Worker*> workers;
 
-  explicit NetworkStack(CephContext *c, const string &t);
+  explicit NetworkStack(CephContext *c, const std::string &t);
  public:
   NetworkStack(const NetworkStack &) = delete;
   NetworkStack& operator=(const NetworkStack &) = delete;
@@ -314,10 +314,10 @@ class NetworkStack {
   }
 
   static std::shared_ptr<NetworkStack> create(
-          CephContext *c, const string &type);
+    CephContext *c, const std::string &type);
 
   static Worker* create_worker(
-          CephContext *c, const string &t, unsigned i);
+    CephContext *c, const std::string &t, unsigned i);
   // backend need to override this method if backend doesn't support shared
   // listen table.
   // For example, posix backend has in kernel global listen table. If one

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -403,14 +403,14 @@ protected:
 
 struct AuthRequestFrame : public ControlFrame<AuthRequestFrame,
                                               uint32_t, // auth method
-                                              vector<uint32_t>, // preferred modes
+                                              std::vector<uint32_t>, // preferred modes
                                               bufferlist> { // auth payload
   static const Tag tag = Tag::AUTH_REQUEST;
   using ControlFrame::Encode;
   using ControlFrame::Decode;
 
   inline uint32_t &method() { return get_val<0>(); }
-  inline vector<uint32_t> &preferred_modes() { return get_val<1>(); }
+  inline std::vector<uint32_t> &preferred_modes() { return get_val<1>(); }
   inline bufferlist &auth_payload() { return get_val<2>(); }
 
 protected:

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -579,7 +579,7 @@ int Infiniband::CompletionChannel::init()
                           << cpp_strerror(errno) << dendl;
     return -1;
   }
-  int rc = NetHandler(cct).set_nonblock(channel->fd);
+  int rc = ceph::NetHandler(cct).set_nonblock(channel->fd);
   if (rc < 0) {
     ibv_destroy_comp_channel(channel);
     return -1;
@@ -1062,7 +1062,7 @@ void Infiniband::init()
   device->binding_port(cct, port_num);
   ib_physical_port = device->active_port->get_port_num();
   pd = new ProtectionDomain(cct, device);
-  ceph_assert(NetHandler(cct).set_nonblock(device->ctxt->async_fd) == 0);
+  ceph_assert(ceph::NetHandler(cct).set_nonblock(device->ctxt->async_fd) == 0);
 
   support_srq = cct->_conf->ms_async_rdma_support_srq;
   if (support_srq) {

--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -549,7 +549,7 @@ class Infiniband {
     uint32_t     max_recv_wr;
     uint32_t     q_key;
     bool dead;
-    vector<Chunk*> recv_queue;
+    std::vector<Chunk*> recv_queue;
     ceph::mutex lock = ceph::make_mutex("queue_pair_lock");
   };
 

--- a/src/msg/async/rdma/RDMAIWARPConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAIWARPConnectedSocketImpl.cc
@@ -7,8 +7,8 @@
 #define TIMEOUT_MS 3000
 #define RETRY_COUNT 7
 
-RDMAIWARPConnectedSocketImpl::RDMAIWARPConnectedSocketImpl(CephContext *cct, shared_ptr<Infiniband>& ib,
-                                                           shared_ptr<RDMADispatcher>& rdma_dispatcher,
+RDMAIWARPConnectedSocketImpl::RDMAIWARPConnectedSocketImpl(CephContext *cct, std::shared_ptr<Infiniband>& ib,
+                                                           std::shared_ptr<RDMADispatcher>& rdma_dispatcher,
                                                            RDMAWorker *w, RDMACMInfo *info)
   : RDMAConnectedSocketImpl(cct, ib, rdma_dispatcher, w), cm_con_handler(new C_handle_cm_connection(this))
 {

--- a/src/msg/async/rdma/RDMAIWARPServerSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAIWARPServerSocketImpl.cc
@@ -8,8 +8,8 @@
 #define dout_prefix *_dout << " RDMAIWARPServerSocketImpl "
 
 RDMAIWARPServerSocketImpl::RDMAIWARPServerSocketImpl(
-  CephContext *cct, shared_ptr<Infiniband>& ib,
-  shared_ptr<RDMADispatcher>& rdma_dispatcher, RDMAWorker *w,
+  CephContext *cct, std::shared_ptr<Infiniband>& ib,
+  std::shared_ptr<RDMADispatcher>& rdma_dispatcher, RDMAWorker *w,
   entity_addr_t& a, unsigned addr_slot)
   : RDMAServerSocketImpl(cct, ib, rdma_dispatcher, w, a, addr_slot)
 {

--- a/src/msg/async/rdma/RDMAServerSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAServerSocketImpl.cc
@@ -25,8 +25,8 @@
 #define dout_prefix *_dout << " RDMAServerSocketImpl "
 
 RDMAServerSocketImpl::RDMAServerSocketImpl(
-  CephContext *cct, shared_ptr<Infiniband>& ib,
-  shared_ptr<RDMADispatcher>& rdma_dispatcher,
+  CephContext *cct, std::shared_ptr<Infiniband>& ib,
+  std::shared_ptr<RDMADispatcher>& rdma_dispatcher,
   RDMAWorker *w, entity_addr_t& a, unsigned slot)
   : ServerSocketImpl(a.get_type(), slot),
     cct(cct), net(cct), server_setup_socket(-1), ib(ib),

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -40,7 +40,7 @@ RDMADispatcher::~RDMADispatcher()
   ceph_assert(dead_queue_pairs.empty());
 }
 
-RDMADispatcher::RDMADispatcher(CephContext* c, shared_ptr<Infiniband>& ib)
+RDMADispatcher::RDMADispatcher(CephContext* c, std::shared_ptr<Infiniband>& ib)
   : cct(c), ib(ib)
 {
   PerfCountersBuilder plb(cct, "AsyncMessenger::RDMADispatcher", l_msgr_rdma_dispatcher_first, l_msgr_rdma_dispatcher_last);
@@ -772,9 +772,9 @@ void RDMAWorker::handle_pending_message()
   dispatcher->notify_pending_workers();
 }
 
-RDMAStack::RDMAStack(CephContext *cct, const string &t)
-  : NetworkStack(cct, t), ib(make_shared<Infiniband>(cct)),
-    rdma_dispatcher(make_shared<RDMADispatcher>(cct, ib))
+RDMAStack::RDMAStack(CephContext *cct, const std::string &t)
+  : NetworkStack(cct, t), ib(std::make_shared<Infiniband>(cct)),
+    rdma_dispatcher(std::make_shared<RDMADispatcher>(cct, ib))
 {
   ldout(cct, 20) << __func__ << " constructing RDMAStack..." << dendl;
 

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -40,7 +40,7 @@ class RDMADispatcher {
 
   std::thread t;
   CephContext *cct;
-  shared_ptr<Infiniband> ib;
+  std::shared_ptr<Infiniband> ib;
   Infiniband::CompletionQueue* tx_cq = nullptr;
   Infiniband::CompletionQueue* rx_cq = nullptr;
   Infiniband::CompletionChannel *tx_cc = nullptr, *rx_cc = nullptr;
@@ -81,7 +81,7 @@ class RDMADispatcher {
  public:
   PerfCounters *perf_logger;
 
-  explicit RDMADispatcher(CephContext* c, shared_ptr<Infiniband>& ib);
+  explicit RDMADispatcher(CephContext* c, std::shared_ptr<Infiniband>& ib);
   virtual ~RDMADispatcher();
   void handle_async_event();
 
@@ -120,10 +120,10 @@ class RDMAWorker : public Worker {
   typedef Infiniband::MemoryManager::Chunk Chunk;
   typedef Infiniband::MemoryManager MemoryManager;
   typedef std::vector<Chunk*>::iterator ChunkIter;
-  shared_ptr<Infiniband> ib;
+  std::shared_ptr<Infiniband> ib;
   EventCallbackRef tx_handler;
   std::list<RDMAConnectedSocketImpl*> pending_sent_conns;
-  shared_ptr<RDMADispatcher> dispatcher;
+  std::shared_ptr<RDMADispatcher> dispatcher;
   ceph::mutex lock = ceph::make_mutex("RDMAWorker::lock");
 
   class C_handle_cq_tx : public EventCallback {
@@ -150,8 +150,8 @@ class RDMAWorker : public Worker {
     pending_sent_conns.remove(o);
   }
   void handle_pending_message();
-  void set_dispatcher(shared_ptr<RDMADispatcher>& dispatcher) { this->dispatcher = dispatcher; }
-  void set_ib(shared_ptr<Infiniband> &ib) {this->ib = ib;}
+  void set_dispatcher(std::shared_ptr<RDMADispatcher>& dispatcher) { this->dispatcher = dispatcher; }
+  void set_ib(std::shared_ptr<Infiniband> &ib) {this->ib = ib;}
   void notify_worker() {
     center.dispatch_event_external(tx_handler);
   }
@@ -178,12 +178,12 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
   uint32_t local_qpn = 0;
   int connected;
   int error;
-  shared_ptr<Infiniband> ib;
-  shared_ptr<RDMADispatcher> dispatcher;
+  std::shared_ptr<Infiniband> ib;
+  std::shared_ptr<RDMADispatcher> dispatcher;
   RDMAWorker* worker;
   std::vector<Chunk*> buffers;
   int notify_fd = -1;
-  bufferlist pending_bl;
+  ceph::buffer::list pending_bl;
 
   ceph::mutex lock = ceph::make_mutex("RDMAConnectedSocketImpl::lock");
   std::vector<ibv_wc> wc;
@@ -204,8 +204,8 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
       const decltype(std::cbegin(pending_bl.buffers()))& end);
 
  public:
-  RDMAConnectedSocketImpl(CephContext *cct, shared_ptr<Infiniband>& ib,
-      shared_ptr<RDMADispatcher>& rdma_dispatcher, RDMAWorker *w);
+  RDMAConnectedSocketImpl(CephContext *cct, std::shared_ptr<Infiniband>& ib,
+			  std::shared_ptr<RDMADispatcher>& rdma_dispatcher, RDMAWorker *w);
   virtual ~RDMAConnectedSocketImpl();
 
   void pass_wc(std::vector<ibv_wc> &&v);
@@ -213,7 +213,7 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
   virtual int is_connected() override { return connected; }
 
   virtual ssize_t read(char* buf, size_t len) override;
-  virtual ssize_t send(bufferlist &bl, bool more) override;
+  virtual ssize_t send(ceph::buffer::list &bl, bool more) override;
   virtual void shutdown() override;
   virtual void close() override;
   virtual int fd() const override { return notify_fd; }
@@ -249,8 +249,9 @@ enum RDMA_CM_STATUS {
 
 class RDMAIWARPConnectedSocketImpl : public RDMAConnectedSocketImpl {
   public:
-    RDMAIWARPConnectedSocketImpl(CephContext *cct, shared_ptr<Infiniband>& ib,
-        shared_ptr<RDMADispatcher>& rdma_dispatcher, RDMAWorker *w, RDMACMInfo *info = nullptr);
+  RDMAIWARPConnectedSocketImpl(CephContext *cct, std::shared_ptr<Infiniband>& ib,
+			       std::shared_ptr<RDMADispatcher>& rdma_dispatcher,
+			       RDMAWorker *w, RDMACMInfo *info = nullptr);
     ~RDMAIWARPConnectedSocketImpl();
     virtual int try_connect(const entity_addr_t&, const SocketOptions &opt) override;
     virtual void close() override;
@@ -283,16 +284,16 @@ class RDMAIWARPConnectedSocketImpl : public RDMAConnectedSocketImpl {
 class RDMAServerSocketImpl : public ServerSocketImpl {
   protected:
     CephContext *cct;
-    NetHandler net;
+    ceph::NetHandler net;
     int server_setup_socket;
-    shared_ptr<Infiniband> ib;
-    shared_ptr<RDMADispatcher> dispatcher;
+    std::shared_ptr<Infiniband> ib;
+    std::shared_ptr<RDMADispatcher> dispatcher;
     RDMAWorker *worker;
     entity_addr_t sa;
 
  public:
-  RDMAServerSocketImpl(CephContext *cct, shared_ptr<Infiniband>& ib,
-                       shared_ptr<RDMADispatcher>& rdma_dispatcher,
+  RDMAServerSocketImpl(CephContext *cct, std::shared_ptr<Infiniband>& ib,
+                       std::shared_ptr<RDMADispatcher>& rdma_dispatcher,
 		       RDMAWorker *w, entity_addr_t& a, unsigned slot);
 
   virtual int listen(entity_addr_t &sa, const SocketOptions &opt);
@@ -304,8 +305,8 @@ class RDMAServerSocketImpl : public ServerSocketImpl {
 class RDMAIWARPServerSocketImpl : public RDMAServerSocketImpl {
   public:
     RDMAIWARPServerSocketImpl(
-      CephContext *cct, shared_ptr<Infiniband>& ib,
-      shared_ptr<RDMADispatcher>& rdma_dispatcher,
+      CephContext *cct, std::shared_ptr<Infiniband>& ib,
+      std::shared_ptr<RDMADispatcher>& rdma_dispatcher,
       RDMAWorker* w, entity_addr_t& addr, unsigned addr_slot);
     virtual int listen(entity_addr_t &sa, const SocketOptions &opt) override;
     virtual int accept(ConnectedSocket *s, const SocketOptions &opts, entity_addr_t *out, Worker *w) override;
@@ -316,15 +317,15 @@ class RDMAIWARPServerSocketImpl : public RDMAServerSocketImpl {
 };
 
 class RDMAStack : public NetworkStack {
-  vector<std::thread> threads;
+  std::vector<std::thread> threads;
   PerfCounters *perf_counter;
-  shared_ptr<Infiniband> ib;
-  shared_ptr<RDMADispatcher> rdma_dispatcher;
+  std::shared_ptr<Infiniband> ib;
+  std::shared_ptr<RDMADispatcher> rdma_dispatcher;
 
   std::atomic<bool> fork_finished = {false};
 
  public:
-  explicit RDMAStack(CephContext *cct, const string &t);
+  explicit RDMAStack(CephContext *cct, const std::string &t);
   virtual ~RDMAStack();
   virtual bool nonblock_connect_need_writable_event() const override { return false; }
 

--- a/src/msg/msg_types.cc
+++ b/src/msg/msg_types.cc
@@ -1,3 +1,5 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
 
 #include "msg_types.h"
 
@@ -8,26 +10,26 @@
 
 #include "common/Formatter.h"
 
-void entity_name_t::dump(Formatter *f) const
+void entity_name_t::dump(ceph::Formatter *f) const
 {
   f->dump_string("type", type_str());
   f->dump_unsigned("num", num());
 }
 
-void entity_addr_t::dump(Formatter *f) const
+void entity_addr_t::dump(ceph::Formatter *f) const
 {
   f->dump_string("type", get_type_name(type));
   f->dump_stream("addr") << get_sockaddr();
   f->dump_unsigned("nonce", nonce);
 }
 
-void entity_inst_t::dump(Formatter *f) const
+void entity_inst_t::dump(ceph::Formatter *f) const
 {
   f->dump_object("name", name);
   f->dump_object("addr", addr);
 }
 
-void entity_name_t::generate_test_instances(list<entity_name_t*>& o)
+void entity_name_t::generate_test_instances(std::list<entity_name_t*>& o)
 {
   o.push_back(new entity_name_t(entity_name_t::MON()));
   o.push_back(new entity_name_t(entity_name_t::MON(1)));
@@ -35,7 +37,7 @@ void entity_name_t::generate_test_instances(list<entity_name_t*>& o)
   o.push_back(new entity_name_t(entity_name_t::CLIENT(1)));
 }
 
-void entity_addr_t::generate_test_instances(list<entity_addr_t*>& o)
+void entity_addr_t::generate_test_instances(std::list<entity_addr_t*>& o)
 {
   o.push_back(new entity_addr_t());
   entity_addr_t *a = new entity_addr_t();
@@ -53,7 +55,7 @@ void entity_addr_t::generate_test_instances(list<entity_addr_t*>& o)
   o.push_back(b);
 }
 
-void entity_inst_t::generate_test_instances(list<entity_inst_t*>& o)
+void entity_inst_t::generate_test_instances(std::list<entity_inst_t*>& o)
 {
   o.push_back(new entity_inst_t());
   entity_name_t name;
@@ -175,7 +177,7 @@ bool entity_addr_t::parse(const char *s, const char **end, int default_type)
   return true;
 }
 
-ostream& operator<<(ostream& out, const entity_addr_t &addr)
+std::ostream& operator<<(std::ostream& out, const entity_addr_t &addr)
 {
   if (addr.type == entity_addr_t::TYPE_NONE) {
     return out << "-";
@@ -187,7 +189,7 @@ ostream& operator<<(ostream& out, const entity_addr_t &addr)
   return out;
 }
 
-ostream& operator<<(ostream& out, const sockaddr *psa)
+std::ostream& operator<<(std::ostream& out, const sockaddr *psa)
 {
   char buf[NI_MAXHOST] = { 0 };
 
@@ -211,7 +213,7 @@ ostream& operator<<(ostream& out, const sockaddr *psa)
   }
 }
 
-ostream& operator<<(ostream& out, const sockaddr_storage &ss)
+std::ostream& operator<<(std::ostream& out, const sockaddr_storage &ss)
 {
   return out << (const sockaddr*)&ss;
 }
@@ -274,7 +276,7 @@ bool entity_addrvec_t::parse(const char *s, const char **end)
   return !v.empty();
 }
 
-void entity_addrvec_t::encode(bufferlist& bl, uint64_t features) const
+void entity_addrvec_t::encode(ceph::buffer::list& bl, uint64_t features) const
 {
   using ceph::encode;
   if ((features & CEPH_FEATURE_MSG_ADDR2) == 0) {
@@ -286,7 +288,7 @@ void entity_addrvec_t::encode(bufferlist& bl, uint64_t features) const
   encode(v, bl, features);
 }
 
-void entity_addrvec_t::decode(bufferlist::const_iterator& bl)
+void entity_addrvec_t::decode(ceph::buffer::list::const_iterator& bl)
 {
   using ceph::decode;
   __u8 marker;
@@ -315,21 +317,20 @@ void entity_addrvec_t::decode(bufferlist::const_iterator& bl)
     return;
   }
   if (marker > 2)
-    throw buffer::malformed_input("entity_addrvec_marker > 2");
+    throw ceph::buffer::malformed_input("entity_addrvec_marker > 2");
   decode(v, bl);
 }
 
-void entity_addrvec_t::dump(Formatter *f) const
+void entity_addrvec_t::dump(ceph::Formatter *f) const
 {
   f->open_array_section("addrvec");
-  for (vector<entity_addr_t>::const_iterator p = v.begin();
-       p != v.end(); ++p) {
+  for (auto p = v.begin(); p != v.end(); ++p) {
     f->dump_object("addr", *p);
   }
   f->close_section();
 }
 
-void entity_addrvec_t::generate_test_instances(list<entity_addrvec_t*>& ls)
+void entity_addrvec_t::generate_test_instances(std::list<entity_addrvec_t*>& ls)
 {
   ls.push_back(new entity_addrvec_t());
   ls.push_back(new entity_addrvec_t());

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -523,13 +523,13 @@ struct entity_addr_t {
 #endif
       uint16_t ss_family;
       if (elen < sizeof(ss_family)) {
-	throw buffer::malformed_input("elen smaller than family len");
+	throw ceph::buffer::malformed_input("elen smaller than family len");
       }
       decode(ss_family, bl);
       u.sa.sa_family = ss_family;
       elen -= sizeof(ss_family);
       if (elen > get_sockaddr_len() - sizeof(u.sa.sa_family)) {
-	throw buffer::malformed_input("elen exceeds sockaddr len");
+	throw ceph::buffer::malformed_input("elen exceeds sockaddr len");
       }
       bl.copy(elen, u.sa.sa_data);
     }

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -14,11 +14,13 @@
 #ifndef CEPH_OBJECTSTORE_H
 #define CEPH_OBJECTSTORE_H
 
+#include "include/buffer.h"
 #include "include/common_fwd.h"
 #include "include/Context.h"
-#include "include/buffer.h"
-#include "include/types.h"
+#include "include/interval_set.h"
 #include "include/stringify.h"
+#include "include/types.h"
+
 #include "osd/osd_types.h"
 #include "common/TrackedOp.h"
 #include "common/WorkQueue.h"
@@ -514,7 +516,7 @@ public:
      uint32_t op_flags = 0) {
      int total = 0;
      for (auto p = m.begin(); p != m.end(); p++) {
-       bufferlist t;
+       ceph::buffer::list t;
        int r = read(c, oid, p.get_start(), p.get_len(), t, op_flags);
        if (r < 0)
          return r;
@@ -554,7 +556,7 @@ public:
     CollectionHandle &c,
     const ghobject_t& oid,
     const string& section_name,
-    Formatter *f) {
+    ceph::Formatter *f) {
     return -ENOTSUP;
   }
 

--- a/src/os/Transaction.h
+++ b/src/os/Transaction.h
@@ -5,8 +5,10 @@
 
 #include <map>
 
+#include "include/Context.h"
 #include "include/int_types.h"
 #include "include/buffer.h"
+
 #include "osd/osd_types.h"
 
 #define OPS_PER_PTR 32
@@ -362,7 +364,7 @@ public:
   }
   static Context *collect_all_contexts(
     Transaction& t) {
-    list<Context*> contexts;
+    std::list<Context*> contexts;
     contexts.splice(contexts.end(), t.on_applied);
     contexts.splice(contexts.end(), t.on_commit);
     contexts.splice(contexts.end(), t.on_applied_sync);

--- a/src/osd/ClassHandler.cc
+++ b/src/osd/ClassHandler.cc
@@ -25,6 +25,12 @@
 #define CLS_PREFIX "libcls_"
 #define CLS_SUFFIX ".so"
 
+using std::map;
+using std::set;
+using std::string;
+
+using ceph::bufferlist;
+
 
 int ClassHandler::open_class(const string& cname, ClassData **pcls)
 {
@@ -319,7 +325,7 @@ int ClassHandler::ClassMethod::exec(cls_method_context_t ctx, bufferlist& indata
       ret = method(ctx, indata.c_str(), indata.length(), &out, &olen);
       if (out) {
         // assume *out was allocated via cls_alloc (which calls malloc!)
-        buffer::ptr bp = buffer::claim_malloc(olen, out);
+	ceph::buffer::ptr bp = ceph::buffer::claim_malloc(olen, out);
         outdata.push_back(bp);
       }
     } else {

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1054,17 +1054,17 @@ public:
    */
   uint64_t get_up_osd_features() const;
 
-  void get_upmap_pgs(vector<pg_t> *upmap_pgs) const;
+  void get_upmap_pgs(std::vector<pg_t> *upmap_pgs) const;
   bool check_pg_upmaps(
     CephContext *cct,
-    const vector<pg_t>& to_check,
-    vector<pg_t> *to_cancel,
-    map<pg_t, mempool::osdmap::vector<pair<int,int>>> *to_remap) const;
+    const std::vector<pg_t>& to_check,
+    std::vector<pg_t> *to_cancel,
+    std::map<pg_t, mempool::osdmap::vector<std::pair<int,int>>> *to_remap) const;
   void clean_pg_upmaps(
     CephContext *cct,
     Incremental *pending_inc,
-    const vector<pg_t>& to_cancel,
-    const map<pg_t, mempool::osdmap::vector<pair<int,int>>>& to_remap) const;
+    const std::vector<pg_t>& to_cancel,
+    const std::map<pg_t, mempool::osdmap::vector<std::pair<int,int>>>& to_remap) const;
   bool clean_pg_upmaps(CephContext *cct, Incremental *pending_inc) const;
 
   int apply_incremental(const Incremental &inc);
@@ -1427,7 +1427,7 @@ public:
       pg_upmap_items.count(pg);
   }
 
-  bool check_full(const set<pg_shard_t> &missing_on) const {
+  bool check_full(const std::set<pg_shard_t> &missing_on) const {
     for (auto shard : missing_on) {
       if (get_state(shard.osd) & CEPH_OSD_FULL)
 	return true;

--- a/src/osd/OSDMapMapping.cc
+++ b/src/osd/OSDMapMapping.cc
@@ -8,6 +8,8 @@
 
 #include "common/debug.h"
 
+using std::vector;
+
 MEMPOOL_DEFINE_OBJECT_FACTORY(OSDMapMapping, osdmapmapping,
 			      osdmap_mapping);
 

--- a/src/osd/OSDMapMapping.h
+++ b/src/osd/OSDMapMapping.h
@@ -33,7 +33,7 @@ public:
     }
 
     // child must implement either form of process
-    virtual void process(const vector<pg_t>& pgs) = 0;
+    virtual void process(const std::vector<pg_t>& pgs) = 0;
     virtual void process(int64_t poolid, unsigned ps_begin, unsigned ps_end) = 0;
     virtual void complete() = 0;
 
@@ -100,9 +100,9 @@ protected:
     Job *job;
     int64_t pool;
     unsigned begin, end;
-    vector<pg_t> pgs;
+    std::vector<pg_t> pgs;
 
-    Item(Job *j, vector<pg_t> pgs) : job(j), pgs(pgs) {}
+    Item(Job *j, std::vector<pg_t> pgs) : job(j), pgs(pgs) {}
     Item(Job *j, int64_t p, unsigned b, unsigned e)
       : job(j),
 	pool(p),
@@ -158,7 +158,7 @@ public:
   void queue(
     Job *job,
     unsigned pgs_per_item,
-    const vector<pg_t>& input_pgs);
+    const std::vector<pg_t>& input_pgs);
 
   void drain() {
     wq.drain();
@@ -275,7 +275,7 @@ private:
       : Job(osdmap), mapping(m) {
       mapping->_start(*osdmap);
     }
-    void process(const vector<pg_t>& pgs) override {}
+    void process(const std::vector<pg_t>& pgs) override {}
     void process(int64_t pool, unsigned ps_begin, unsigned ps_end) override {
       mapping->_update_range(*osdmap, pool, ps_begin, ps_end);
     }

--- a/src/osd/osd_op_util.cc
+++ b/src/osd/osd_op_util.cc
@@ -6,6 +6,12 @@
 #include "osd/ClassHandler.h"
 #include "messages/MOSDOp.h"
 
+using std::ostream;
+using std::string;
+using std::vector;
+
+using ceph::bufferlist;
+
 bool OpInfo::check_rmw(int flag) const {
   ceph_assert(rmw_flags != 0);
   return rmw_flags & flag;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -51,11 +51,14 @@ using std::stringstream;
 using std::unique_ptr;
 using std::vector;
 
+using ceph::bufferlist;
 using ceph::decode;
 using ceph::decode_nohead;
 using ceph::encode;
 using ceph::encode_nohead;
 using ceph::Formatter;
+using ceph::make_timespan;
+using ceph::JSONFormatter;
 
 using namespace std::literals;
 
@@ -3715,7 +3718,7 @@ public:
   pair<epoch_t, epoch_t> get_bounds() const override {
     return make_pair(first, last + 1);
   }
-  void adjust_start_backwards(epoch_t last_epoch_clean) {
+  void adjust_start_backwards(epoch_t last_epoch_clean) override {
     first = last_epoch_clean;
   }
 
@@ -6961,7 +6964,7 @@ int PGLSPlainFilter::init(ceph::bufferlist::const_iterator &params)
   try {
     decode(xattr, params);
     decode(val, params);
-  } catch (buffer::error &e) {
+  } catch (ceph::buffer::error &e) {
     return -EINVAL;
   }
   return 0;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -12,7 +12,7 @@
  * modify it under the terms of the GNU Lesser General Public
  * License version 2.1, as published by the Free Software 
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 #ifndef CEPH_OSD_TYPES_H
@@ -2372,7 +2372,7 @@ struct osd_stat_t {
     uint32_t front_max[3];
     uint32_t front_last;
   };
-  map<int, Interfaces> hb_pingtime;  ///< map of osd id to Interfaces
+  std::map<int, Interfaces> hb_pingtime;  ///< map of osd id to Interfaces
 
   osd_stat_t() : snap_trim_queue_len(0), num_snap_trimming(0),
        num_shards_repaired(0)	{}
@@ -3686,7 +3686,7 @@ struct pg_lease_t {
   void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<pg_lease_t*>& o);
 
-  friend ostream& operator<<(ostream& out, const pg_lease_t& l) {
+  friend std::ostream& operator<<(std::ostream& out, const pg_lease_t& l) {
     return out << "pg_lease(ru " << l.readable_until
 	       << " ub " << l.readable_until_ub
 	       << " int " << l.interval << ")";
@@ -3713,7 +3713,7 @@ struct pg_lease_ack_t {
   void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<pg_lease_ack_t*>& o);
 
-  friend ostream& operator<<(ostream& out, const pg_lease_ack_t& l) {
+  friend std::ostream& operator<<(std::ostream& out, const pg_lease_ack_t& l) {
     return out << "pg_lease_ack(ruub " << l.readable_until_ub << ")";
   }
 };
@@ -3905,7 +3905,7 @@ private:
    * finally, clean_offsets becomes {[5~10], [30~10]}
    */
   void trim();
-  friend ostream& operator<<(ostream& out, const ObjectCleanRegions& ocr);
+  friend std::ostream& operator<<(std::ostream& out, const ObjectCleanRegions& ocr);
 public:
   ObjectCleanRegions() : new_object(false), clean_omap(true) {
     clean_offsets.insert(0, (uint64_t)-1);
@@ -3927,13 +3927,13 @@ public:
   bool omap_is_dirty() const;
   bool object_is_exist() const;
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &bl);
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<ObjectCleanRegions*>& o);
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &bl);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<ObjectCleanRegions*>& o);
 };
 WRITE_CLASS_ENCODER(ObjectCleanRegions)
-ostream& operator<<(ostream& out, const ObjectCleanRegions& ocr);
+std::ostream& operator<<(std::ostream& out, const ObjectCleanRegions& ocr);
 
 
 struct OSDOp {
@@ -4001,18 +4001,18 @@ std::ostream& operator<<(std::ostream& out, const OSDOp& op);
 
 struct pg_log_op_return_item_t {
   int32_t rval;
-  bufferlist bl;
-  void encode(bufferlist& p) const {
+  ceph::buffer::list bl;
+  void encode(ceph::buffer::list& p) const {
     using ceph::encode;
     encode(rval, p);
     encode(bl, p);
   }
-  void decode(bufferlist::const_iterator& p) {
+  void decode(ceph::buffer::list::const_iterator& p) {
     using ceph::decode;
     decode(rval, p);
     decode(bl, p);
   }
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->dump_int("rval", rval);
     f->dump_unsigned("bl_length", bl.length());
   }
@@ -4025,7 +4025,7 @@ struct pg_log_op_return_item_t {
 			 const pg_log_op_return_item_t& rhs) {
     return !(lhs == rhs);
   }
-  friend ostream& operator<<(ostream& out, const pg_log_op_return_item_t& i) {
+  friend std::ostream& operator<<(std::ostream& out, const pg_log_op_return_item_t& i) {
     return out << "r=" << i.rval << "+" << i.bl.length() << "b";
   }
 };
@@ -4091,7 +4091,7 @@ struct pg_log_entry_t {
   utime_t     mtime;  // this is the _user_ mtime, mind you
   int32_t return_code; // only stored for ERRORs for dup detection
 
-  vector<pg_log_op_return_item_t> op_returns;
+  std::vector<pg_log_op_return_item_t> op_returns;
 
   __s32      op;
   bool invalid_hash; // only when decoding sobject_t based entries
@@ -4185,7 +4185,7 @@ struct pg_log_dup_t {
   version_t user_version; // the user version for this entry
   int32_t return_code; // only stored for ERRORs for dup detection
 
-  vector<pg_log_op_return_item_t> op_returns;
+  std::vector<pg_log_op_return_item_t> op_returns;
 
   pg_log_dup_t()
     : user_version(0), return_code(0)
@@ -6220,11 +6220,11 @@ WRITE_CLASS_ENCODER(pool_pg_num_history_t)
 
 // prefix pgmeta_oid keys with _ so that PGLog::read_log_and_missing() can
 // easily skip them
-static const string_view infover_key = "_infover"sv;
-static const string_view info_key = "_info"sv;
-static const string_view biginfo_key = "_biginfo"sv;
-static const string_view epoch_key = "_epoch"sv;
-static const string_view fastinfo_key = "_fastinfo"sv;
+static const std::string_view infover_key = "_infover";
+static const std::string_view info_key = "_info";
+static const std::string_view biginfo_key = "_biginfo";
+static const std::string_view epoch_key = "_epoch";
+static const std::string_view fastinfo_key = "_fastinfo";
 
 static const __u8 pg_latest_struct_v = 10;
 // v10 is the new past_intervals encoding
@@ -6236,8 +6236,8 @@ static const __u8 pg_compat_struct_v = 10;
 
 int prepare_info_keymap(
   CephContext* cct,
-  map<string,bufferlist> *km,
-  string *key_to_remove,
+  std::map<std::string,ceph::buffer::list> *km,
+  std::string *key_to_remove,
   epoch_t epoch,
   pg_info_t &info,
   pg_info_t &last_written_info,
@@ -6299,10 +6299,10 @@ public:
 class PGLSPlainFilter : public PGLSFilter {
   std::string val;
 public:
-  int init(ceph::bufferlist::const_iterator &params) override;
+  int init(ceph::buffer::list::const_iterator &params) override;
   ~PGLSPlainFilter() override {}
   bool filter(const hobject_t& obj,
-              const ceph::bufferlist& xattr_data) const override;
+              const ceph::buffer::list& xattr_data) const override;
 };
 
 

--- a/src/osdc/Filer.cc
+++ b/src/osdc/Filer.cc
@@ -34,6 +34,10 @@
 #undef dout_prefix
 #define dout_prefix *_dout << objecter->messenger->get_myname() << ".filer "
 
+using std::hex;
+using std::dec;
+using std::vector;
+
 class Filer::C_Probe : public Context {
 public:
   Filer *filer;
@@ -156,9 +160,7 @@ void Filer::_probe(Probe *probe, Probe::unique_lock& pl)
 			   probe->probing_len, 0, probe->probing);
 
   std::vector<ObjectExtent> stat_extents;
-  for (vector<ObjectExtent>::iterator p = probe->probing.begin();
-       p != probe->probing.end();
-       ++p) {
+  for (auto p = probe->probing.begin(); p != probe->probing.end(); ++p) {
     ldout(cct, 10) << "_probe  probing " << p->oid << dendl;
     probe->ops.insert(p->oid);
     stat_extents.push_back(*p);
@@ -211,9 +213,7 @@ bool Filer::_probed(Probe *probe, const object_t& oid, uint64_t size,
     std::reverse(probe->probing.begin(), probe->probing.end());
   }
 
-  for (vector<ObjectExtent>::iterator p = probe->probing.begin();
-       p != probe->probing.end();
-       ++p) {
+  for (auto p = probe->probing.begin(); p != probe->probing.end(); ++p) {
     uint64_t shouldbe = p->length + p->offset;
     ldout(cct, 10) << "_probed  " << probe->ino << " object " << hex
 		   << p->oid << dec << " should be " << shouldbe
@@ -231,8 +231,7 @@ bool Filer::_probed(Probe *probe, const object_t& oid, uint64_t size,
       // aha, we found the end!
       // calc offset into buffer_extent to get distance from probe->from.
       uint64_t oleft = probe->known_size[p->oid] - p->offset;
-      for (vector<pair<uint64_t, uint64_t> >::iterator i
-	     = p->buffer_extents.begin();
+      for (auto i = p->buffer_extents.begin();
 	   i != p->buffer_extents.end();
 	   ++i) {
 	if (oleft <= (uint64_t)i->second) {

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -61,34 +61,34 @@ class ObjectCacher {
 
   // read scatter/gather
   struct OSDRead {
-    vector<ObjectExtent> extents;
+    std::vector<ObjectExtent> extents;
     snapid_t snap;
-    bufferlist *bl;
+    ceph::buffer::list *bl;
     int fadvise_flags;
-    OSDRead(snapid_t s, bufferlist *b, int f)
+    OSDRead(snapid_t s, ceph::buffer::list *b, int f)
       : snap(s), bl(b), fadvise_flags(f) {}
   };
 
-  OSDRead *prepare_read(snapid_t snap, bufferlist *b, int f) const {
+  OSDRead *prepare_read(snapid_t snap, ceph::buffer::list *b, int f) const {
     return new OSDRead(snap, b, f);
   }
 
   // write scatter/gather
   struct OSDWrite {
-    vector<ObjectExtent> extents;
+    std::vector<ObjectExtent> extents;
     SnapContext snapc;
-    bufferlist bl;
+    ceph::buffer::list bl;
     ceph::real_time mtime;
     int fadvise_flags;
     ceph_tid_t journal_tid;
-    OSDWrite(const SnapContext& sc, const bufferlist& b, ceph::real_time mt,
+    OSDWrite(const SnapContext& sc, const ceph::buffer::list& b, ceph::real_time mt,
 	     int f, ceph_tid_t _journal_tid)
       : snapc(sc), bl(b), mtime(mt), fadvise_flags(f),
 	journal_tid(_journal_tid) {}
   };
 
   OSDWrite *prepare_write(const SnapContext& sc,
-			  const bufferlist &b,
+			  const ceph::buffer::list &b,
 			  ceph::real_time mt,
 			  int f,
 			  ceph_tid_t journal_tid) const {
@@ -121,7 +121,7 @@ class ObjectCacher {
 
   public:
     Object *ob;
-    bufferlist  bl;
+    ceph::buffer::list  bl;
     ceph_tid_t last_write_tid;  // version of bh (if non-zero)
     ceph_tid_t last_read_tid;   // tid of last read op (if any)
     ceph::real_time last_write;
@@ -129,7 +129,7 @@ class ObjectCacher {
     ceph_tid_t journal_tid;
     int error; // holds return value for failed reads
 
-    map<loff_t, list<Context*> > waitfor_read;
+    std::map<loff_t, std::list<Context*> > waitfor_read;
 
     // cons
     explicit BufferHead(Object *o) :
@@ -243,14 +243,14 @@ class ObjectCacher {
     bool complete;
     bool exists;
 
-    map<loff_t, BufferHead*>     data;
+    std::map<loff_t, BufferHead*>     data;
 
     ceph_tid_t last_write_tid;  // version of bh (if non-zero)
     ceph_tid_t last_commit_tid; // last update committed.
 
     int dirty_or_tx;
 
-    map< ceph_tid_t, list<Context*> > waitfor_commit;
+    std::map< ceph_tid_t, std::list<Context*> > waitfor_commit;
     xlist<C_ReadFinish*> reads;
 
     Object(const Object&) = delete;
@@ -280,7 +280,7 @@ class ObjectCacher {
     object_t get_oid() { return oid.oid; }
     snapid_t get_snap() { return oid.snap; }
     ObjectSet *get_object_set() const { return oset; }
-    string get_namespace() { return oloc.nspace; }
+    std::string get_namespace() { return oloc.nspace; }
     uint64_t get_object_number() const { return object_no; }
 
     const object_locator_t& get_oloc() const { return oloc; }
@@ -309,8 +309,8 @@ class ObjectCacher {
      * @param offset object byte offset
      * @return iterator pointing to buffer, or data.end()
      */
-    map<loff_t,BufferHead*>::const_iterator data_lower_bound(loff_t offset) const {
-      map<loff_t,BufferHead*>::const_iterator p = data.lower_bound(offset);
+    std::map<loff_t,BufferHead*>::const_iterator data_lower_bound(loff_t offset) const {
+      auto p = data.lower_bound(offset);
       if (p != data.begin() &&
 	  (p == data.end() || p->first > offset)) {
 	--p;     // might overlap!
@@ -347,10 +347,10 @@ class ObjectCacher {
     bool is_cached(loff_t off, loff_t len) const;
     bool include_all_cached_data(loff_t off, loff_t len);
     int map_read(ObjectExtent &ex,
-                 map<loff_t, BufferHead*>& hits,
-                 map<loff_t, BufferHead*>& missing,
-                 map<loff_t, BufferHead*>& rx,
-		 map<loff_t, BufferHead*>& errors);
+                 std::map<loff_t, BufferHead*>& hits,
+                 std::map<loff_t, BufferHead*>& missing,
+                 std::map<loff_t, BufferHead*>& rx,
+		 std::map<loff_t, BufferHead*>& errors);
     BufferHead *map_write(ObjectExtent &ex, ceph_tid_t tid);
 
     void replace_journal_tid(BufferHead *bh, ceph_tid_t tid);
@@ -398,7 +398,7 @@ class ObjectCacher {
   WritebackHandler& writeback_handler;
   bool scattered_write;
 
-  string name;
+  std::string name;
   ceph::mutex& lock;
 
   uint64_t max_dirty, target_dirty, max_size, max_objects;
@@ -411,13 +411,13 @@ class ObjectCacher {
   void *flush_set_callback_arg;
 
   // indexed by pool_id
-  vector<ceph::unordered_map<sobject_t, Object*> > objects;
+  std::vector<ceph::unordered_map<sobject_t, Object*> > objects;
 
-  list<Context*> waitfor_read;
+  std::list<Context*> waitfor_read;
 
   ceph_tid_t last_read_tid;
 
-  set<BufferHead*, BufferHead::ptr_lt> dirty_or_tx_bh;
+  std::set<BufferHead*, BufferHead::ptr_lt> dirty_or_tx_bh;
   LRU   bh_lru_dirty, bh_lru_rest;
   LRU   ob_lru;
 
@@ -529,7 +529,7 @@ class ObjectCacher {
   void bh_read(BufferHead *bh, int op_flags,
                const ZTracer::Trace &parent_trace);
   void bh_write(BufferHead *bh, const ZTracer::Trace &parent_trace);
-  void bh_write_scattered(list<BufferHead*>& blist);
+  void bh_write_scattered(std::list<BufferHead*>& blist);
   void bh_write_adjacencies(BufferHead *bh, ceph::real_time cutoff,
 			    int64_t *amount, int *max_count);
 
@@ -562,10 +562,10 @@ class ObjectCacher {
  public:
   void bh_read_finish(int64_t poolid, sobject_t oid, ceph_tid_t tid,
 		      loff_t offset, uint64_t length,
-		      bufferlist &bl, int r,
+		      ceph::buffer::list &bl, int r,
 		      bool trust_enoent);
   void bh_write_commit(int64_t poolid, sobject_t oid,
-		       vector<pair<loff_t, uint64_t> >& ranges,
+		       std::vector<std::pair<loff_t, uint64_t> >& ranges,
 		       ceph_tid_t t, int r);
 
   class C_WriteCommit;
@@ -576,7 +576,7 @@ class ObjectCacher {
 
 
 
-  ObjectCacher(CephContext *cct_, string name, WritebackHandler& wb, ceph::mutex& l,
+  ObjectCacher(CephContext *cct_, std::string name, WritebackHandler& wb, ceph::mutex& l,
 	       flush_set_callback_t flush_callback,
 	       void *flush_callback_arg,
 	       uint64_t max_bytes, uint64_t max_objects,
@@ -610,7 +610,7 @@ class ObjectCacher {
 	    ZTracer::Trace *parent_trace = nullptr);
   int writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace,
 	     ZTracer::Trace *parent_trace = nullptr);
-  bool is_cached(ObjectSet *oset, vector<ObjectExtent>& extents,
+  bool is_cached(ObjectSet *oset, std::vector<ObjectExtent>& extents,
 		 snapid_t snapid);
 
 private:
@@ -620,7 +620,7 @@ private:
   void _maybe_wait_for_writeback(uint64_t len, ZTracer::Trace *trace);
   bool _flush_set_finish(C_GatherBuilder *gather, Context *onfinish);
 
-  void _discard(ObjectSet *oset, const vector<ObjectExtent>& exls,
+  void _discard(ObjectSet *oset, const std::vector<ObjectExtent>& exls,
                 C_GatherBuilder* gather);
   void _discard_finish(ObjectSet *oset, bool was_dirty, Context* on_finish);
 
@@ -630,7 +630,7 @@ public:
   bool set_is_dirty_or_committing(ObjectSet *oset);
 
   bool flush_set(ObjectSet *oset, Context *onfinish=0);
-  bool flush_set(ObjectSet *oset, vector<ObjectExtent>& ex,
+  bool flush_set(ObjectSet *oset, std::vector<ObjectExtent>& ex,
                  ZTracer::Trace *trace, Context *onfinish = 0);
   bool flush_all(Context *onfinish = 0);
 
@@ -640,8 +640,8 @@ public:
   loff_t release_set(ObjectSet *oset);
   uint64_t release_all();
 
-  void discard_set(ObjectSet *oset, const vector<ObjectExtent>& ex);
-  void discard_writeback(ObjectSet *oset, const vector<ObjectExtent>& ex,
+  void discard_set(ObjectSet *oset, const std::vector<ObjectExtent>& ex);
+  void discard_writeback(ObjectSet *oset, const std::vector<ObjectExtent>& ex,
                          Context* on_finish);
 
   /**
@@ -664,7 +664,7 @@ public:
     max_size = v;
   }
   void set_max_dirty_age(double a) {
-    max_dirty_age = make_timespan(a);
+    max_dirty_age = ceph::make_timespan(a);
   }
   void set_max_objects(int64_t v) {
     max_objects = v;
@@ -676,14 +676,14 @@ public:
   /*** async+caching (non-blocking) file interface ***/
   int file_is_cached(ObjectSet *oset, file_layout_t *layout,
 		     snapid_t snapid, loff_t offset, uint64_t len) {
-    vector<ObjectExtent> extents;
+    std::vector<ObjectExtent> extents;
     Striper::file_to_extents(cct, oset->ino, layout, offset, len,
 			     oset->truncate_size, extents);
     return is_cached(oset, extents, snapid);
   }
 
   int file_read(ObjectSet *oset, file_layout_t *layout, snapid_t snapid,
-		loff_t offset, uint64_t len, bufferlist *bl, int flags,
+		loff_t offset, uint64_t len, ceph::buffer::list *bl, int flags,
 		Context *onfinish) {
     OSDRead *rd = prepare_read(snapid, bl, flags);
     Striper::file_to_extents(cct, oset->ino, layout, offset, len,
@@ -693,7 +693,7 @@ public:
 
   int file_write(ObjectSet *oset, file_layout_t *layout,
 		 const SnapContext& snapc, loff_t offset, uint64_t len,
-		 bufferlist& bl, ceph::real_time mtime, int flags) {
+		 ceph::buffer::list& bl, ceph::real_time mtime, int flags) {
     OSDWrite *wr = prepare_write(snapc, bl, mtime, flags, 0);
     Striper::file_to_extents(cct, oset->ino, layout, offset, len,
 			     oset->truncate_size, wr->extents);
@@ -703,7 +703,7 @@ public:
   bool file_flush(ObjectSet *oset, file_layout_t *layout,
 		  const SnapContext& snapc, loff_t offset, uint64_t len,
 		  Context *onfinish) {
-    vector<ObjectExtent> extents;
+    std::vector<ObjectExtent> extents;
     Striper::file_to_extents(cct, oset->ino, layout, offset, len,
 			     oset->truncate_size, extents);
     ZTracer::Trace trace;
@@ -712,7 +712,8 @@ public:
 };
 
 
-inline ostream& operator<<(ostream &out, const ObjectCacher::BufferHead &bh)
+inline std::ostream& operator<<(std::ostream &out,
+				const ObjectCacher::BufferHead &bh)
 {
   out << "bh[ " << &bh << " "
       << bh.start() << "~" << bh.length()
@@ -732,11 +733,9 @@ inline ostream& operator<<(ostream &out, const ObjectCacher::BufferHead &bh)
   if (bh.error) out << " error=" << bh.error;
   out << "]";
   out << " waiters = {";
-  for (map<loff_t, list<Context*> >::const_iterator it
-	 = bh.waitfor_read.begin();
-       it != bh.waitfor_read.end(); ++it) {
+  for (auto it = bh.waitfor_read.begin(); it != bh.waitfor_read.end(); ++it) {
     out << " " << it->first << "->[";
-    for (list<Context*>::const_iterator lit = it->second.begin();
+    for (auto lit = it->second.begin();
 	 lit != it->second.end(); ++lit) {
 	 out << *lit << ", ";
     }
@@ -746,7 +745,8 @@ inline ostream& operator<<(ostream &out, const ObjectCacher::BufferHead &bh)
   return out;
 }
 
-inline ostream& operator<<(ostream &out, const ObjectCacher::ObjectSet &os)
+inline std::ostream& operator<<(std::ostream &out,
+				const ObjectCacher::ObjectSet &os)
 {
   return out << "objectset[" << os.ino
 	     << " ts " << os.truncate_seq << "/" << os.truncate_size
@@ -755,10 +755,11 @@ inline ostream& operator<<(ostream &out, const ObjectCacher::ObjectSet &os)
 	     << "]";
 }
 
-inline ostream& operator<<(ostream &out, const ObjectCacher::Object &ob)
+inline std::ostream& operator<<(std::ostream &out,
+				const ObjectCacher::Object &ob)
 {
   out << "object["
-      << ob.get_soid() << " oset " << ob.oset << dec
+      << ob.get_soid() << " oset " << ob.oset << std::dec
       << " wr " << ob.last_write_tid << "/" << ob.last_commit_tid;
 
   if (ob.complete)

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -4518,7 +4518,7 @@ void Objecter::_dump_ops(const OSDSession *s, Formatter *fmt)
        p != s->ops.end();
        ++p) {
     Op *op = p->second;
-    auto age = std::chrono::duration<double>(coarse_mono_clock::now() - op->stamp);
+    auto age = std::chrono::duration<double>(ceph::coarse_mono_clock::now() - op->stamp);
     fmt->open_object_section("op");
     fmt->dump_unsigned("tid", op->tid);
     op->target.dump(fmt);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1004,7 +1004,8 @@ struct ObjectOperation {
   }
 
   void omap_rm_range(std::string_view key_begin, std::string_view key_end) {
-    bufferlist bl;
+    ceph::buffer::list bl;
+    using ceph::encode;
     encode(key_begin, bl);
     encode(key_end, bl);
     add_data(CEPH_OSD_OP_OMAPRMKEYRANGE, 0, bl.length(), bl);
@@ -2108,7 +2109,7 @@ private:
     return op_budget;
   }
   int take_linger_budget(LingerOp *info);
-  friend class WatchContext; // to invoke put_up_budget_bytes
+  friend struct WatchContext; // to invoke put_up_budget_bytes
   void put_op_budget_bytes(int op_budget) {
     ceph_assert(op_budget >= 0);
     op_throttle_bytes.put(op_budget);

--- a/src/osdc/Striper.h
+++ b/src/osdc/Striper.h
@@ -122,7 +122,7 @@
 
     private:
       void add_partial_sparse_result(
-          CephContext *cct, bufferlist& bl,
+          CephContext *cct, ceph::buffer::list& bl,
           std::map<uint64_t, uint64_t>::const_iterator* it,
           const std::map<uint64_t, uint64_t>::const_iterator& end_it,
           uint64_t* bl_off, uint64_t tofs, uint64_t tlen);

--- a/src/osdc/WritebackHandler.h
+++ b/src/osdc/WritebackHandler.h
@@ -15,7 +15,7 @@ class WritebackHandler {
 
   virtual void read(const object_t& oid, uint64_t object_no,
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
-		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
+		    snapid_t snapid, ceph::buffer::list *pbl, uint64_t trunc_size,
 		    __u32 trunc_seq, int op_flags,
                     const ZTracer::Trace &parent_trace, Context *onfinish) = 0;
   /**
@@ -34,7 +34,7 @@ class WritebackHandler {
   virtual ceph_tid_t write(const object_t& oid, const object_locator_t& oloc,
 			   uint64_t off, uint64_t len,
 			   const SnapContext& snapc,
-			   const bufferlist &bl, ceph::real_time mtime,
+			   const ceph::buffer::list &bl, ceph::real_time mtime,
 			   uint64_t trunc_size, __u32 trunc_seq,
                            ceph_tid_t journal_tid,
                            const ZTracer::Trace &parent_trace,
@@ -46,7 +46,7 @@ class WritebackHandler {
 
   virtual bool can_scattered_write() { return false; }
   virtual ceph_tid_t write(const object_t& oid, const object_locator_t& oloc,
-			   vector<pair<uint64_t, bufferlist> >& io_vec,
+			   std::vector<std::pair<uint64_t, ceph::buffer::list> >& io_vec,
 			   const SnapContext& snapc, ceph::real_time mtime,
 			   uint64_t trunc_size, __u32 trunc_seq,
 			   Context *oncommit) {


### PR DESCRIPTION
With this change, the entire target 'common' builds with all top-level 'using namespace std' and 'using namespace ceph' declarations removed from header files.

This provides a foundation for subsystems to be cleaned up one at a time until we can finally get rid of them and stop running into collisions.

`using namespace std::literals` is acceptable, by the way if people want to keep that. Since nonstandard literal operators *SHOULD* always begin with an _ the problems of namespace pollution/collision don't apply.