### PR TITLE
qa/suites/rados/ceph: drop opensuse for now

### DIFF
--- a/qa/suites/rados/cephadm/smoke/distro/opensuse_15.2.yaml
+++ b/qa/suites/rados/cephadm/smoke/distro/opensuse_15.2.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/opensuse_15.2.yaml


### PR DESCRIPTION
Until https://tracker.ceph.com/issues/44501 is resolved and the builders
are able to keep up.

Signed-off-by: Sage Weil <sage@redhat.com>