### PR TITLE
qa/standalone/scrub/osd-scrub-test: wait longer for update

### DIFF
--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -5758,6 +5758,7 @@ function TEST_periodic_scrub_replicated() {
     # Can't upgrade with this set
     ceph osd set nodeep-scrub
     # Let map change propagate to OSDs
+    ceph tell osd.0 get_latest_osdmap
     flush_pg_stats
     sleep 5
 

--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -134,7 +134,7 @@ function TEST_interval_changes() {
     local week="$(expr $day \* 7)"
     local min_interval=$day
     local max_interval=$week
-    local WAIT_FOR_UPDATE=3
+    local WAIT_FOR_UPDATE=15
 
     TESTDATA="testdata.$$"
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43865
Signed-off-by: Sage Weil <sage@redhat.com>