### PR TITLE
qa/suites/rados/thrash-old-clients: skip rbd mirror_image_status test

### DIFF
--- a/qa/suites/rados/thrash-old-clients/workloads/rbd_cls.yaml
+++ b/qa/suites/rados/thrash-old-clients/workloads/rbd_cls.yaml
@@ -4,4 +4,4 @@ meta:
 tasks:
 - exec:
     client.2:
-      - ceph_test_cls_rbd --gtest_filter=-TestClsRbd.get_features:TestClsRbd.parents:TestClsRbd.mirror
+      - ceph_test_cls_rbd --gtest_filter=-TestClsRbd.get_features:TestClsRbd.parents:TestClsRbd.mirror:TestClsRbd.mirror_image_status


### PR DESCRIPTION
Older versions of this do not always pass.  E.g., with mimic,

2020-03-07T19:45:00.319 INFO:teuthology.orchestra.run.smithi077:> sudo /home/ubuntu/cephtest/cephadm --image quay.io/ceph-ci/ceph:d8f2426160f876cd44c5a8889df7591ac5eef323 shell -c /home/ubuntu/cephtest/ceph.conf -k /home/ubuntu/cephtest/ceph.keyring --fsid c72629f6-60aa-11ea-9a35-001a4aab830c -- ceph daemon osd.11
dump_blocked_ops
2020-03-07T19:45:00.326 INFO:ceph.osd.5.smithi146.stdout:Mar 07 19:45:00 smithi146 bash[12627]: debug 2020-03-07T19:45:00.332+0000 7f702717c700 -1 received  signal: Hangup from Kernel ( Could be generated by pthread_kill(), raise(), abort(), alarm() ) UID: 0
2020-03-07T19:45:00.329 INFO:teuthology.orchestra.run.smithi077.stdout:/home/jenkins-build/build/workspace/ceph-dev-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos7/DIST/centos7/MACHINE_SIZE/huge/release/13.2.8-299-gfaa7fc4/rpm/el7/BUILD/ceph-13.2.8-299-gfaa7fc4/src/test/cls_rbd/test_cls_rbd.cc:1674:
Failure
2020-03-07T19:45:00.329 INFO:teuthology.orchestra.run.smithi077.stdout:      Expected: 3
2020-03-07T19:45:00.330 INFO:teuthology.orchestra.run.smithi077.stdout:To be equal to: states[cls::rbd::MIRROR_IMAGE_STATUS_STATE_UNKNOWN]
2020-03-07T19:45:00.330 INFO:teuthology.orchestra.run.smithi077.stdout:      Which is: 50331648

Signed-off-by: Sage Weil <sage@redhat.com>