### PR TITLE
rgw: correct multipart meta location when upload to non-standard storage class

### DIFF
--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -316,6 +316,7 @@ int AtomicObjectProcessor::complete(size_t accounted_size,
   obj_op.meta.user_data = user_data;
   obj_op.meta.zones_trace = zones_trace;
   obj_op.meta.modify_tail = true;
+  obj_op.meta.meta_placement_rule = bucket_info.placement_rule;
 
   r = obj_op.write_meta(actual_size, accounted_size, attrs, y);
   if (r < 0) {
@@ -439,6 +440,7 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
   obj_op.meta.delete_at = delete_at;
   obj_op.meta.zones_trace = zones_trace;
   obj_op.meta.modify_tail = true;
+  obj_op.meta.meta_placement_rule = meta_placement_rule;
 
   r = obj_op.write_meta(actual_size, accounted_size, attrs, y);
   if (r < 0)
@@ -632,6 +634,7 @@ int AppendObjectProcessor::complete(size_t accounted_size, const string &etag, c
   obj_op.meta.zones_trace = zones_trace;
   obj_op.meta.modify_tail = true;
   obj_op.meta.appendable = true;
+  obj_op.meta.meta_placement_rule = bucket_info.placement_rule;
   //Add the append part number
   bufferlist cur_part_num_bl;
   encode(cur_part_num, cur_part_num_bl);

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -164,7 +164,6 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
   void set_tail_placement(const rgw_placement_rule&& tpr) {
     tail_placement_rule = tpr;
   }
-
 };
 
 
@@ -214,6 +213,7 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
   const int part_num;
   const std::string part_num_str;
   RGWMPObj mp;
+  rgw_placement_rule meta_placement_rule;
 
   // write the first chunk and wait on aio->drain() for its completion.
   // on EEXIST, retry with random prefix
@@ -224,6 +224,7 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
   MultipartObjectProcessor(Aio *aio, rgw::sal::RGWRadosStore *store,
                            const RGWBucketInfo& bucket_info,
                            const rgw_placement_rule *ptail_placement_rule,
+                           const rgw_placement_rule& meta_placement_rule,
                            const rgw_user& owner, RGWObjectCtx& obj_ctx,
                            const rgw_obj& head_obj,
                            const std::string& upload_id, uint64_t part_num,
@@ -233,7 +234,8 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
                               owner, obj_ctx, head_obj, dpp, y),
       target_obj(head_obj), upload_id(upload_id),
       part_num(part_num), part_num_str(part_num_str),
-      mp(head_obj.key.name, upload_id) 
+      mp(head_obj.key.name, upload_id),
+      meta_placement_rule(meta_placement_rule)
   {}
 
   // prepare a multipart manifest

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -461,7 +461,7 @@ class RGWRados
   uint32_t bucket_index_max_shards;
 
   int get_obj_head_ioctx(const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::IoCtx *ioctx);
-  int get_obj_head_ref(const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_rados_ref *ref);
+  int get_obj_head_ref(const rgw_placement_rule& placement_rule, const rgw_obj& obj, rgw_rados_ref *ref);
   int get_system_obj_ref(const rgw_raw_obj& obj, rgw_rados_ref *ref);
   uint64_t max_bucket_id;
 
@@ -810,6 +810,7 @@ public:
         bool modify_tail;
         bool completeMultipart;
         bool appendable;
+        rgw_placement_rule meta_placement_rule;
 
         MetaParams() : mtime(NULL), rmattrs(NULL), data(NULL), manifest(NULL), ptag(NULL),
                  remove_objs(NULL), category(RGWObjCategory::Main), flags(0),


### PR DESCRIPTION

Fixes: https://tracker.ceph.com/issues/44511
Signed-off-by: lvshuhua <lvshuhua@cmss.chinamobile.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
