### PR TITLE
msg/async: fix unnecessary 4 kB allocation in secure mode.

### DIFF
--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -232,7 +232,8 @@ private:
     ceph::crypto::onwire::rxtx_t &session_stream_handlers,
     std::index_sequence<Is...>)
   {
-    session_stream_handlers.tx->reset_tx_handler({ segments[Is].length()... });
+    session_stream_handlers.tx->reset_tx_handler({ segments[Is].length()...,
+                                                   sizeof(epilogue_secure_block_t) });
   }
 
 public:


### PR DESCRIPTION
Encryption of outgoing on-wire payload can be performed in multiple steps – each segment separately to reflect the multi-buffer structure of protocol's messages.

For the sake of performance, it is desired to encrypt these plaintext buffers into single, continuous ciphertext. At the level of `TxHandler` interface this is facilitated by `reset_tx_handler()` taking `std::initializer_list` with the sizes of plainbuffers that are going to be encrypted.
All the implementation does is calling `reserve()` on the underlying, internal `bufferlist` that is used for composing ciphertext. This provides the opportunity to avoid additional allocations in both:
  * `authenticated_encrypt_update()`,
  * `authenticated_encrypt_final()`.

However, the recent stack trace obtained from Valgrind showed that an extra allocation actually happened:

```
  <kind>SyscallParam</kind>
  <what>Syscall param sendmsg(msg.msg_iov[1]) points to uninitialised byte(s)</what>
  ...
  <auxwhat>Address 0xfc805b0 is 0 bytes inside a block of size 4,096 alloc'd</auxwhat>
  <stack>
    ...
    <frame>
      <ip>0xEE7A6D</ip>
      <obj>/usr/bin/ceph-osd</obj>
      <fn>ceph::buffer::v15_2_0::list::refill_append_space(unsigned int)</fn>
      <dir>/usr/src/debug/ceph-15.1.0-1858.gf7e5770.el8.x86_64/src/common</dir>
      <file>buffer.cc</file>
      <line>1324</line>
    </frame>
    <frame>
      <ip>0xEE7EDA</ip>
      <obj>/usr/bin/ceph-osd</obj>
      <fn>ceph::buffer::v15_2_0::list::append_hole(unsigned int)</fn>
      <dir>/usr/src/debug/ceph-15.1.0-1858.gf7e5770.el8.x86_64/src/common</dir>
      <file>buffer.cc</file>
      <line>1444</line>
    </frame>
    <frame>
      <ip>0x10CA5B0</ip>
      <obj>/usr/bin/ceph-osd</obj>
      <fn>ceph::crypto::onwire::AES128GCM_OnWireTxHandler::authenticated_encrypt_final()</fn>
      <dir>/usr/src/debug/ceph-15.1.0-1858.gf7e5770.el8.x86_64/src/msg/async</dir>
      <file>crypto_onwire.cc</file>
      <line>121</line>
    </frame>
  ...
```

The reason is that the size of `epilogue_secure_block_t` has not been accounted when turning a Message into on-wire payload. This patch rectifies that.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
