### PR TITLE
python-common: Make DriveGroupSpec a sub type of ServiceSpec

### DIFF
--- a/doc/mgr/orchestrator_modules.rst
+++ b/doc/mgr/orchestrator_modules.rst
@@ -237,16 +237,24 @@ functionality to choose a location in this way. Optionally, you can
 specify a location when creating a stateless service.
 
 
+.. py:currentmodule:: ceph.deployment.service_spec
+
 .. autoclass:: PlacementSpec
    :members:
 
-   
+.. py:currentmodule:: orchestrator
+
+
 Services
 --------
 
 .. autoclass:: ServiceDescription
 
+.. py:currentmodule:: ceph.deployment.service_spec
+
 .. autoclass:: ServiceSpec
+
+.. py:currentmodule:: orchestrator
 
 .. automethod:: Orchestrator.describe_service
 
@@ -307,12 +315,20 @@ Stateless Services
 .. automethod:: Orchestrator.add_rbd_mirror
 .. automethod:: Orchestrator.apply_rbd_mirror
 
+.. py:currentmodule:: ceph.deployment.service_spec
+
 .. autoclass:: RGWSpec
+
+.. py:currentmodule:: orchestrator
 
 .. automethod:: Orchestrator.add_rgw
 .. automethod:: Orchestrator.apply_rgw
 
+.. py:currentmodule:: ceph.deployment.service_spec
+
 .. autoclass:: NFSServiceSpec
+
+.. py:currentmodule:: orchestrator
 
 .. automethod:: Orchestrator.add_nfs
 .. automethod:: Orchestrator.apply_nfs

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -30,7 +30,7 @@ import uuid
 from ceph.deployment import inventory, translate
 from ceph.deployment.drive_group import DriveGroupSpec
 from ceph.deployment.drive_selection import selector
-from ceph.deployment.service_spec import HostPlacementSpec, ServiceSpec
+from ceph.deployment.service_spec import HostPlacementSpec, ServiceSpec, PlacementSpec
 
 from mgr_module import MgrModule
 import orchestrator
@@ -2424,16 +2424,16 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         if spec.placement.is_empty():
             # fill in default placement
             defaults = {
-                'mon': orchestrator.PlacementSpec(count=5),
-                'mgr': orchestrator.PlacementSpec(count=2),
-                'mds': orchestrator.PlacementSpec(count=2),
-                'rgw': orchestrator.PlacementSpec(count=2),
-                'rbd-mirror': orchestrator.PlacementSpec(count=2),
-                'grafana': orchestrator.PlacementSpec(count=1),
-                'alertmanager': orchestrator.PlacementSpec(count=1),
-                'prometheus': orchestrator.PlacementSpec(count=1),
-                'node-exporter': orchestrator.PlacementSpec(all_hosts=True),
-                'crash': orchestrator.PlacementSpec(all_hosts=True),
+                'mon': PlacementSpec(count=5),
+                'mgr': PlacementSpec(count=2),
+                'mds': PlacementSpec(count=2),
+                'rgw': PlacementSpec(count=2),
+                'rbd-mirror': PlacementSpec(count=2),
+                'grafana': PlacementSpec(count=1),
+                'alertmanager': PlacementSpec(count=1),
+                'prometheus': PlacementSpec(count=1),
+                'node-exporter': PlacementSpec(all_hosts=True),
+                'crash': PlacementSpec(all_hosts=True),
             }
             spec.placement = defaults[spec.service_type]
         self.log.info('Saving service %s spec with placement %s' % (
@@ -3008,7 +3008,7 @@ class BaseScheduler(object):
     """
 
     def __init__(self, placement_spec):
-        # type: (orchestrator.PlacementSpec) -> None
+        # type: (PlacementSpec) -> None
         self.placement_spec = placement_spec
 
     def place(self, host_pool, count=None):
@@ -3061,7 +3061,7 @@ class HostAssignment(object):
         self.service_name = spec.service_name()
 
     def place(self):
-        # type: () -> List[orchestrator.HostPlacementSpec]
+        # type: () -> List[HostPlacementSpec]
         """
         Load hosts into the spec.placement.hosts container.
         """

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1931,7 +1931,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         for drive_group in drive_groups:
             self.log.info("Processing DriveGroup {}".format(drive_group))
             # 1) use fn_filter to determine matching_hosts
-            matching_hosts = drive_group.hosts([x.hostname for x in all_hosts])
+            matching_hosts = drive_group.placement.pattern_matches_hosts([x.hostname for x in all_hosts])
             # 2) Map the inventory to the InventoryHost object
             # FIXME: lazy-load the inventory from a InventoryHost object;
             #        this would save one call to the inventory(at least externally)
@@ -1950,7 +1950,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 drive_selection = selector.DriveSelection(drive_group, inventory_for_host.devices)
                 cmd = translate.to_ceph_volume(drive_group, drive_selection).run()
                 if not cmd:
-                    self.log.info("No data_devices, skipping DriveGroup: {}".format(drive_group.name))
+                    self.log.info("No data_devices, skipping DriveGroup: {}".format(drive_group.service_id))
                     continue
                 cmds.append((host, cmd))
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3083,6 +3083,15 @@ class HostAssignment(object):
             logger.debug('All hosts: {}'.format(candidates))
             return candidates
 
+        # respect host_pattern
+        if self.spec.placement.host_pattern:
+            candidates = [
+                HostPlacementSpec(x, '', '')
+                for x in self.spec.placement.pattern_matches_hosts(self.get_hosts_func(None))
+            ]
+            logger.debug('All hosts: {}'.format(candidates))
+            return candidates
+
         count = 0
         if self.spec.placement.hosts and \
            self.spec.placement.count and \

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -121,7 +121,7 @@ class TestCephadm(object):
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     def test_create_osds(self, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
-            dg = DriveGroupSpec('test', data_devices=DeviceSelection(paths=['']))
+            dg = DriveGroupSpec(placement=PlacementSpec(host_pattern='test'), data_devices=DeviceSelection(paths=['']))
             c = cephadm_module.create_osds([dg])
             assert wait(cephadm_module, c) == ["Created no osd(s) on host test; already created?"]
 

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -12,8 +12,9 @@ try:
 except ImportError:
     pass
 
+from ceph.deployment.service_spec import ServiceSpec, PlacementSpec, RGWSpec
 from orchestrator import ServiceDescription, DaemonDescription, InventoryHost, \
-    ServiceSpec, PlacementSpec, RGWSpec, HostSpec, OrchestratorError
+    HostSpec, OrchestratorError
 from tests import mock
 from .fixtures import cephadm_module, wait, _run_cephadm, mon_command, match_glob
 from cephadm.module import CephadmOrchestrator

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -104,6 +104,14 @@ class NodeAssignmentTest(NamedTuple):
             [],
             ['host1', 'host2', 'host3']
         ),
+        # host_pattern
+        NodeAssignmentTest(
+            'mon',
+            PlacementSpec(host_pattern='mon*'),
+            'monhost1 monhost2 datahost'.split(),
+            [],
+            ['monhost1', 'monhost2']
+        ),
     ])
 def test_node_assignment(service_type, placement, hosts, daemons, expected):
     hosts = HostAssignment(

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -1,8 +1,10 @@
 from typing import NamedTuple, List
 import pytest
 
+from ceph.deployment.service_spec import ServiceSpec, PlacementSpec, ServiceSpecValidationError
+
 from cephadm.module import HostAssignment
-from orchestrator import ServiceSpec, PlacementSpec, DaemonDescription, OrchestratorValidationError
+from orchestrator import DaemonDescription, OrchestratorValidationError
 
 
 class NodeAssignmentTest(NamedTuple):
@@ -241,5 +243,5 @@ def test_bad_placements(placement):
     try:
         s = PlacementSpec.from_string(placement.split(' '))
         assert False
-    except OrchestratorValidationError as e:
+    except ServiceSpecValidationError as e:
         pass

--- a/src/pybind/mgr/dashboard/tests/test_osd.py
+++ b/src/pybind/mgr/dashboard/tests/test_osd.py
@@ -9,6 +9,7 @@ try:
 except ImportError:
     from unittest import mock
 from ceph.deployment.drive_group import DeviceSelection, DriveGroupSpec
+from ceph.deployment.service_spec import PlacementSpec
 
 from . import ControllerTestCase
 from ..controllers.osd import Osd
@@ -301,11 +302,11 @@ class OsdTest(ControllerTestCase):
         self._task_post('/api/osd', data)
         self.assertStatus(201)
         fake_client.osds.create.assert_called_with(
-            [DriveGroupSpec(host_pattern='*',
-                            name='all_hdd',
+            [DriveGroupSpec(placement=PlacementSpec(host_pattern='*'),
+                            service_id='all_hdd',
                             data_devices=DeviceSelection(rotational=True)),
-             DriveGroupSpec(host_pattern='b',
-                            name='b_ssd',
+             DriveGroupSpec(placement=PlacementSpec(host_pattern='b'),
+                            service_id='b_ssd',
                             data_devices=DeviceSelection(rotational=False))])
 
         # Invalid DriveGroups

--- a/src/pybind/mgr/orchestrator/__init__.py
+++ b/src/pybind/mgr/orchestrator/__init__.py
@@ -8,9 +8,7 @@ from ._interface import \
     CLICommand, _cli_write_command, _cli_read_command, CLICommandMeta, \
     Orchestrator, OrchestratorClientMixin, \
     OrchestratorValidationError, OrchestratorError, NoOrchestrator, \
-    ServiceSpec, NFSServiceSpec, RGWSpec, HostPlacementSpec, \
-    servicespec_validate_add, \
-    ServiceDescription, InventoryFilter, PlacementSpec,  HostSpec, \
+    ServiceDescription, InventoryFilter, HostSpec, \
     DaemonDescription, \
     InventoryHost, DeviceLightLoc, \
     OutdatableData, OutdatablePersistentDict, \

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -15,7 +15,8 @@ import copy
 import errno
 
 from ceph.deployment import inventory
-from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec
+from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec, \
+    ServiceSpecValidationError
 from ceph.deployment.drive_group import DriveGroupSpec
 
 from mgr_module import MgrModule, PersistentStoreDict, CLICommand, HandleCommandResult
@@ -60,7 +61,7 @@ def handle_exception(prefix, cmd_args, desc, perm, func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except (OrchestratorError, ImportError) as e:
+        except (OrchestratorError, ImportError, ServiceSpecValidationError) as e:
             # Do not print Traceback for expected errors.
             return HandleCommandResult(-errno.ENOENT, stderr=str(e))
         except NotImplementedError:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -4,31 +4,23 @@ ceph-mgr orchestrator interface
 
 Please see the ceph-mgr module developer's guide for more information.
 """
-import copy
-import functools
 import logging
 import pickle
-import json
-import sys
 import time
 from collections import namedtuple
 from functools import wraps, partialmethod
 import uuid
-import string
-import random
 import datetime
 import copy
-import re
-import six
 import errno
 
 from ceph.deployment import inventory
+from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec
+from ceph.deployment.drive_group import DriveGroupSpec
 
 from mgr_module import MgrModule, PersistentStoreDict, CLICommand, HandleCommandResult
-from mgr_util import format_bytes
 
 try:
-    from ceph.deployment.drive_group import DriveGroupSpec
     from typing import TypeVar, Generic, List, Optional, Union, Tuple, Iterator, Callable, Any, \
         Type, Sequence, Dict
 except ImportError:
@@ -37,92 +29,6 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 DATEFMT = '%Y-%m-%dT%H:%M:%S.%f'
-
-class HostPlacementSpec(namedtuple('HostPlacementSpec', ['hostname', 'network', 'name'])):
-    def __str__(self):
-        res = ''
-        res += self.hostname
-        if self.network:
-            res += ':' + self.network
-        if self.name:
-            res += '=' + self.name
-        return res
-
-    @classmethod
-    def from_json(cls, data):
-        return cls(**data)
-
-    def to_json(self):
-        return {
-            'hostname': self.hostname,
-            'network': self.network,
-            'name': self.name
-        }
-
-    @classmethod
-    def parse(cls, host, require_network=True):
-        # type: (str, bool) -> HostPlacementSpec
-        """
-        Split host into host, network, and (optional) daemon name parts.  The network
-        part can be an IP, CIDR, or ceph addrvec like '[v2:1.2.3.4:3300,v1:1.2.3.4:6789]'.
-        e.g.,
-          "myhost"
-          "myhost=name"
-          "myhost:1.2.3.4"
-          "myhost:1.2.3.4=name"
-          "myhost:1.2.3.0/24"
-          "myhost:1.2.3.0/24=name"
-          "myhost:[v2:1.2.3.4:3000]=name"
-          "myhost:[v2:1.2.3.4:3000,v1:1.2.3.4:6789]=name"
-        """
-        # Matches from start to : or = or until end of string
-        host_re = r'^(.*?)(:|=|$)'
-        # Matches from : to = or until end of string
-        ip_re = r':(.*?)(=|$)'
-        # Matches from = to end of string
-        name_re = r'=(.*?)$'
-
-        # assign defaults
-        host_spec = cls('', '', '')
-
-        match_host = re.search(host_re, host)
-        if match_host:
-            host_spec = host_spec._replace(hostname=match_host.group(1))
-
-        name_match = re.search(name_re, host)
-        if name_match:
-            host_spec = host_spec._replace(name=name_match.group(1))
-
-        ip_match = re.search(ip_re, host)
-        if ip_match:
-            host_spec = host_spec._replace(network=ip_match.group(1))
-
-        if not require_network:
-            return host_spec
-
-        from ipaddress import ip_network, ip_address
-        networks = list()  # type: List[str]
-        network = host_spec.network
-        # in case we have [v2:1.2.3.4:3000,v1:1.2.3.4:6478]
-        if ',' in network:
-            networks = [x for x in network.split(',')]
-        else:
-            networks.append(network)
-        for network in networks:
-            # only if we have versioned network configs
-            if network.startswith('v') or network.startswith('[v'):
-                network = network.split(':')[1]
-            try:
-                # if subnets are defined, also verify the validity
-                if '/' in network:
-                    ip_network(six.text_type(network))
-                else:
-                    ip_address(six.text_type(network))
-            except ValueError as e:
-                # logging?
-                raise e
-
-        return host_spec
 
 
 class OrchestratorError(Exception):
@@ -1248,152 +1154,6 @@ class UpgradeStatusSpec(object):
         self.message = ""  # Freeform description
 
 
-class PlacementSpec(object):
-    """
-    For APIs that need to specify a host subset
-    """
-    def __init__(self, label=None, hosts=None, count=None, all_hosts=False):
-        # type: (Optional[str], Optional[List], Optional[int], bool) -> None
-        if all_hosts and (count or hosts or label):
-            raise OrchestratorValidationError('cannot combine all:true and count|hosts|label')
-        self.label = label
-        self.hosts = []  # type: List[HostPlacementSpec]
-        if hosts:
-            if all([isinstance(host, HostPlacementSpec) for host in hosts]):
-                self.hosts = hosts
-            else:
-                self.hosts = [HostPlacementSpec.parse(x, require_network=False) for x in hosts if x]
-
-        self.count = count  # type: Optional[int]
-        self.all_hosts = all_hosts  # type: bool
-
-    def is_empty(self):
-        return not self.all_hosts and \
-            self.label is None and \
-            not self.hosts and \
-            self.count is None
-
-    def set_hosts(self, hosts):
-        # To backpopulate the .hosts attribute when using labels or count
-        # in the orchestrator backend.
-        self.hosts = hosts
-
-    def pretty_str(self):
-        kv = []
-        if self.count:
-            kv.append('count:%d' % self.count)
-        if self.label:
-            kv.append('label:%s' % self.label)
-        if self.hosts:
-            kv.append('%s' % ','.join([str(h) for h in self.hosts]))
-        if self.all_hosts:
-            kv.append('all:true')
-        return ' '.join(kv)
-
-    def __repr__(self):
-        return "PlacementSpec(%s)" % self.pretty_str()
-
-    @classmethod
-    def from_json(cls, data):
-        hosts = data.get('hosts', [])
-        if hosts:
-            data['hosts'] = [HostPlacementSpec.from_json(host) for host in hosts]
-        _cls = cls(**data)
-        _cls.validate()
-        return _cls
-    
-    def to_json(self):
-        return {
-            'label': self.label,
-            'hosts': [host.to_json() for host in self.hosts] if self.hosts else [],
-            'count': self.count,
-            'all_hosts': self.all_hosts
-        }
-
-    def validate(self):
-        if self.hosts and self.label:
-            # TODO: a less generic Exception
-            raise OrchestratorValidationError('Host and label are mutually exclusive')
-        if self.count is not None and self.count <= 0:
-            raise OrchestratorValidationError("num/count must be > 1")
-
-    @classmethod
-    def from_string(cls, arg):
-        # type: (Optional[str]) -> PlacementSpec
-        """
-        A single integer is parsed as a count:
-        >>> PlacementSpec.from_string('3')
-        PlacementSpec(count=3)
-        A list of names is parsed as host specifications:
-        >>> PlacementSpec.from_string('host1 host2')
-        PlacementSpec(label=[HostSpec(hostname='host1', network='', name=''), HostSpec(hostname='host2', network='', name='')])
-        You can also prefix the hosts with a count as follows:
-        >>> PlacementSpec.from_string('2 host1 host2')
-        PlacementSpec(label=[HostSpec(hostname='host1', network='', name=''), HostSpec(hostname='host2', network='', name='')], count=2)
-        You can spefify labels using `label:<label>`
-        >>> PlacementSpec.from_string('label:mon')
-        PlacementSpec(label='label:mon')
-        Labels als support a count:
-        >>> PlacementSpec.from_string('3 label:mon')
-        PlacementSpec(label='label:mon', count=3)
-        >>> PlacementSpec.from_string(None)
-        PlacementSpec()
-        """
-        if arg is None:
-            strings = []
-        elif isinstance(arg, str):
-            if ' ' in arg:
-                strings = arg.split(' ')
-            elif ';' in arg:
-                strings = arg.split(';')
-            elif ',' in arg and '[' not in arg:
-                # FIXME: this isn't quite right.  we want to avoid breaking
-                # a list of mons with addrvecs... so we're basically allowing
-                # , most of the time, except when addrvecs are used.  maybe
-                # ok?
-                strings = arg.split(',')
-            else:
-                strings = [arg]
-        else:
-            raise OrchestratorValidationError('invalid placement %s' % arg)
-
-        count = None
-        if strings:
-            try:
-                count = int(strings[0])
-                strings = strings[1:]
-            except ValueError:
-                pass
-        for s in strings:
-            if s.startswith('count:'):
-                try:
-                    count = int(s[6:])
-                    strings.remove(s)
-                    break
-                except ValueError:
-                    pass
-
-        all_hosts = False
-        if '*' in strings:
-            all_hosts = True
-            strings.remove('*')
-        if 'all:true' in strings:
-            all_hosts = True
-            strings.remove('all:true')
-
-        hosts = [x for x in strings if x != '*' and 'label:' not in x]
-        labels = [x[6:] for x in strings if 'label:' in x]
-        if len(labels) > 1:
-            raise OrchestratorValidationError('more than one label provided: {}'.format(labels))
-
-        ps = PlacementSpec(count=count,
-                           hosts=hosts,
-                           label=labels[0] if labels else None,
-                           all_hosts=all_hosts)
-        ps.validate()
-        return ps
-
-
 def handle_type_error(method):
     @wraps(method)
     def inner(cls, *args, **kwargs):
@@ -1606,125 +1366,6 @@ class ServiceDescription(object):
             if k in c:
                 c[k] = datetime.datetime.strptime(c[k], DATEFMT)
         return cls(**c)
-
-
-class ServiceSpec(object):
-    """
-    Details of service creation.
-
-    Request to the orchestrator for a cluster of daemons
-    such as MDS, RGW, iscsi gateway, MONs, MGRs, Prometheus
-
-    This structure is supposed to be enough information to
-    start the services.
-
-    """
-
-    def __init__(self,
-                 service_type : str,
-                 service_id : Optional[str] = None,
-                 placement : Optional[PlacementSpec] = None,
-                 count : Optional[int] = None):
-        self.placement = PlacementSpec() if placement is None else placement  # type: PlacementSpec
-
-        assert service_type
-        self.service_type = service_type
-        self.service_id = service_id
-
-    @classmethod
-    def from_json(cls, json_spec: dict) -> "ServiceSpec":
-        """
-        Initialize 'ServiceSpec' object data from a json structure
-        :param json_spec: A valid dict with ServiceSpec
-        """
-        args: Dict[str, Dict[Any, Any]] = {}
-        service_type = json_spec.get('service_type', '')
-        assert service_type
-        if service_type == 'rgw':
-            _cls = RGWSpec  # type: ignore
-        elif service_type == 'nfs':
-            _cls = NFSServiceSpec  # type: ignore
-        else:
-            _cls = ServiceSpec  # type: ignore
-        for k, v in json_spec.items():
-            if k == 'placement':
-                v = PlacementSpec.from_json(v)
-            if k == 'spec':
-                args.update(v)
-                continue
-            args.update({k: v})
-        return _cls(**args)  # type: ignore
-
-    def service_name(self):
-        n = self.service_type
-        if self.service_id:
-            n += '.' + self.service_id
-        return n
-
-    def to_json(self):
-        # type: () -> Dict[str, Any]
-        c = self.__dict__.copy()
-        if self.placement:
-            c['placement'] = self.placement.to_json()
-        return c
-
-    def __repr__(self):
-        return "{}({!r})".format(self.__class__.__name__, self.__dict__)
-
-
-def servicespec_validate_add(self: ServiceSpec):
-    # This must not be a method of ServiceSpec, otherwise you'll hunt
-    # sub-interpreter affinity bugs.
-    if not self.service_type:
-        raise OrchestratorValidationError('Cannot add Service: type required')
-    if self.service_type in ['mds', 'rgw', 'nfs'] and not self.service_id:
-        raise OrchestratorValidationError('Cannot add Service: id required')
-
-
-
-class NFSServiceSpec(ServiceSpec):
-    def __init__(self, service_id, pool=None, namespace=None, placement=None,
-                 service_type='nfs'):
-        assert service_type == 'nfs'
-        super(NFSServiceSpec, self).__init__('nfs', service_id=service_id, placement=placement)
-
-        #: RADOS pool where NFS client recovery data is stored.
-        self.pool = pool
-
-        #: RADOS namespace where NFS client recovery data is stored in the pool.
-        self.namespace = namespace
-
-    def validate_add(self):
-        servicespec_validate_add(self)
-        
-        if not self.pool:
-            raise OrchestratorValidationError('Cannot add NFS: No Pool specified')
-
-class RGWSpec(ServiceSpec):
-    """
-    Settings to configure a (multisite) Ceph RGW
-
-    """
-    def __init__(self,
-                 rgw_realm=None,  # type: Optional[str]
-                 rgw_zone=None,  # type: Optional[str]
-                 service_id=None, # type: Optional[str]
-                 placement=None,
-                 service_type='rgw',
-                 rgw_frontend_port=None,  # type: Optional[int]
-                 ):
-        assert service_type == 'rgw'
-        if service_id:
-            (rgw_realm, rgw_zone) = service_id.split('.', 1)
-        else:
-            service_id = '%s.%s' % (rgw_realm, rgw_zone)
-        super(RGWSpec, self).__init__('rgw', service_id=service_id, placement=placement)
-
-
-        self.rgw_realm = rgw_realm
-        self.rgw_zone = rgw_zone
-        self.rgw_frontend_port = rgw_frontend_port
-
 
 
 class InventoryFilter(object):

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -18,12 +18,13 @@ except ImportError:
 
 from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection, \
     DriveGroupSpecs
+from ceph.deployment.service_spec import PlacementSpec, ServiceSpec
 from mgr_module import MgrModule, HandleCommandResult
 
 from ._interface import OrchestratorClientMixin, DeviceLightLoc, _cli_read_command, \
     raise_if_exception, _cli_write_command, TrivialReadCompletion, OrchestratorError, \
-    NoOrchestrator, ServiceSpec, PlacementSpec, OrchestratorValidationError, NFSServiceSpec, \
-    RGWSpec, InventoryFilter, InventoryHost, HostPlacementSpec, HostSpec, CLICommandMeta
+    NoOrchestrator, OrchestratorValidationError, NFSServiceSpec, \
+    RGWSpec, InventoryFilter, InventoryHost, HostSpec, CLICommandMeta
 
 def nice_delta(now, t, suffix=''):
     if t:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -458,7 +458,7 @@ Usage:
                 return HandleCommandResult(-errno.EINVAL, stderr=msg)
 
             devs = DeviceSelection(paths=block_devices)
-            drive_groups = [DriveGroupSpec(host_name, data_devices=devs)]
+            drive_groups = [DriveGroupSpec(placement=PlacementSpec(host_pattern=host_name), data_devices=devs)]
         else:
             return HandleCommandResult(-errno.EINVAL, stderr=usage)
 

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -3,6 +3,7 @@ import functools
 import os
 
 from ceph.deployment import inventory
+from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec
 
 try:
     from typing import List, Dict, Optional, Callable, Any
@@ -297,17 +298,17 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         )
 
     def add_mds(self, spec):
-        # type: (orchestrator.ServiceSpec) -> RookCompletion
+        # type: (ServiceSpec) -> RookCompletion
         return self._service_add_decorate('MDS', spec,
                                        self.rook_cluster.add_filesystem)
 
     def add_rgw(self, spec):
-        # type: (orchestrator.RGWSpec) -> RookCompletion
+        # type: (RGWSpec) -> RookCompletion
         return self._service_add_decorate('RGW', spec,
                                        self.rook_cluster.add_objectstore)
 
     def add_nfs(self, spec):
-        # type: (orchestrator.NFSServiceSpec) -> RookCompletion
+        # type: (NFSServiceSpec) -> RookCompletion
         return self._service_add_decorate("NFS", spec,
                                           self.rook_cluster.add_nfsgw)
 
@@ -334,7 +335,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             )
 
     def apply_mon(self, spec):
-        # type: (orchestrator.ServiceSpec) -> RookCompletion
+        # type: (ServiceSpec) -> RookCompletion
         if spec.placement.hosts or spec.placement.label:
             raise RuntimeError("Host list or label is not supported by rook.")
 
@@ -345,7 +346,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         )
 
     def apply_mds(self, spec):
-        # type: (orchestrator.ServiceSpec) -> RookCompletion
+        # type: (ServiceSpec) -> RookCompletion
         num = spec.placement.count
         return write_completion(
             lambda: self.rook_cluster.update_mds_count(spec.service_id, num),
@@ -354,7 +355,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         )
 
     def apply_nfs(self, spec):
-        # type: (orchestrator.NFSServiceSpec) -> RookCompletion
+        # type: (NFSServiceSpec) -> RookCompletion
         num = spec.placement.count
         return write_completion(
             lambda: self.rook_cluster.update_nfs_count(spec.service_id, num),

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -19,6 +19,7 @@ from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 from urllib3.exceptions import ProtocolError
 
 from ceph.deployment.drive_group import DriveGroupSpec
+from ceph.deployment.service_spec import ServiceSpec
 from mgr_util import merge_dicts
 
 try:
@@ -343,7 +344,7 @@ class RookCluster(object):
                 raise
 
     def add_filesystem(self, spec):
-        # type: (orchestrator.ServiceSpec) -> None
+        # type: (ServiceSpec) -> None
         # TODO use spec.placement
         # TODO warn if spec.extended has entries we don't kow how
         #      to action.

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -493,10 +493,11 @@ class RookCluster(object):
                 new_cluster.spec.storage.nodes = ccl.NodesList()
 
             current_nodes = getattr(current_cluster.spec.storage, 'nodes', ccl.NodesList())
+            matching_host = drive_group.placement.pattern_matches_hosts(all_hosts)[0]
 
-            if drive_group.hosts(all_hosts)[0] not in [n.name for n in current_nodes]:
+            if matching_host not in [n.name for n in current_nodes]:
                 pd = ccl.NodesItem(
-                    name=drive_group.hosts(all_hosts)[0],
+                    name=matching_host,
                     config=ccl.Config(
                         storeType=drive_group.objectstore
                     )
@@ -514,7 +515,7 @@ class RookCluster(object):
             else:
                 for _node in new_cluster.spec.storage.nodes:
                     current_node = _node  # type: ccl.NodesItem
-                    if current_node.name == drive_group.hosts(all_hosts)[0]:
+                    if current_node.name == matching_host:
                         if block_devices:
                             if not hasattr(current_node, 'devices'):
                                 current_node.devices = ccl.DevicesList()

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -256,6 +256,9 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         def run(all_hosts):
             # type: (List[orchestrator.HostSpec]) -> None
             drive_group.validate()
+            if drive_group.placement.host_pattern:
+                if not drive_group.placement.pattern_matches_hosts(all_hosts):
+                    raise orchestrator.OrchestratorValidationError('failed to match')
         return self.get_hosts().then(run).then(
             on_complete=orchestrator.ProgressReference(
                 message='create_osds',

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -255,7 +255,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         def run(all_hosts):
             # type: (List[orchestrator.HostSpec]) -> None
-            drive_group.validate([h.hostname for h in all_hosts])
+            drive_group.validate()
         return self.get_hosts().then(run).then(
             on_complete=orchestrator.ProgressReference(
                 message='create_osds',

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -257,7 +257,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
             # type: (List[orchestrator.HostSpec]) -> None
             drive_group.validate()
             if drive_group.placement.host_pattern:
-                if not drive_group.placement.pattern_matches_hosts(all_hosts):
+                if not drive_group.placement.pattern_matches_hosts([h.hostname for h in all_hosts]):
                     raise orchestrator.OrchestratorValidationError('failed to match')
         return self.get_hosts().then(run).then(
             on_complete=orchestrator.ProgressReference(

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -6,6 +6,9 @@ import threading
 import functools
 import itertools
 from subprocess import check_output, CalledProcessError
+
+from ceph.deployment.service_spec import NFSServiceSpec, ServiceSpec
+
 try:
     from typing import Callable, List, Tuple
 except ImportError:
@@ -286,7 +289,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
 
     @deferred_write("Adding NFS service")
     def add_nfs(self, spec):
-        # type: (orchestrator.NFSServiceSpec) -> None
+        # type: (NFSServiceSpec) -> None
         assert isinstance(spec.pool, str)
 
     @deferred_write("apply_nfs")
@@ -329,14 +332,14 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
 
     @deferred_write("apply_mgr")
     def apply_mgr(self, spec):
-        # type: (orchestrator.ServiceSpec) -> None
+        # type: (ServiceSpec) -> None
 
         assert not spec.placement.hosts or len(spec.placement.hosts) == spec.placement.count
         assert all([isinstance(h, str) for h in spec.placement.hosts])
 
     @deferred_write("apply_mon")
     def apply_mon(self, spec):
-        # type: (orchestrator.ServiceSpec) -> None
+        # type: (ServiceSpec) -> None
 
         assert not spec.placement.hosts or len(spec.placement.hosts) == spec.placement.count
         assert all([isinstance(h[0], str) for h in spec.placement.hosts])

--- a/src/pybind/mgr/tests/test_orchestrator.py
+++ b/src/pybind/mgr/tests/test_orchestrator.py
@@ -1,64 +1,13 @@
 from __future__ import absolute_import
-import json
 
 from tests import mock
 
 import pytest
 
 from ceph.deployment import inventory
-from orchestrator import raise_if_exception, RGWSpec, Completion, ProgressReference, \
-    servicespec_validate_add
-from orchestrator import InventoryHost, ServiceDescription, DaemonDescription
+from orchestrator import raise_if_exception, Completion, ProgressReference
+from orchestrator import InventoryHost, DaemonDescription
 from orchestrator import OrchestratorValidationError
-from orchestrator import HostPlacementSpec, PlacementSpec
-
-
-@pytest.mark.parametrize("test_input,expected, require_network",
-                         [("myhost", ('myhost', '', ''), False),
-                          ("myhost=sname", ('myhost', '', 'sname'), False),
-                          ("myhost:10.1.1.10", ('myhost', '10.1.1.10', ''), True),
-                          ("myhost:10.1.1.10=sname", ('myhost', '10.1.1.10', 'sname'), True),
-                          ("myhost:10.1.1.0/32", ('myhost', '10.1.1.0/32', ''), True),
-                          ("myhost:10.1.1.0/32=sname", ('myhost', '10.1.1.0/32', 'sname'), True),
-                          ("myhost:[v1:10.1.1.10:6789]", ('myhost', '[v1:10.1.1.10:6789]', ''), True),
-                          ("myhost:[v1:10.1.1.10:6789]=sname", ('myhost', '[v1:10.1.1.10:6789]', 'sname'), True),
-                          ("myhost:[v1:10.1.1.10:6789,v2:10.1.1.11:3000]", ('myhost', '[v1:10.1.1.10:6789,v2:10.1.1.11:3000]', ''), True),
-                          ("myhost:[v1:10.1.1.10:6789,v2:10.1.1.11:3000]=sname", ('myhost', '[v1:10.1.1.10:6789,v2:10.1.1.11:3000]', 'sname'), True),
-                          ])
-def test_parse_host_placement_specs(test_input, expected, require_network):
-    ret = HostPlacementSpec.parse(test_input, require_network=require_network)
-    assert ret == expected
-    assert str(ret) == test_input
-
-@pytest.mark.parametrize(
-    "test_input,expected",
-    [
-        ('', "PlacementSpec()"),
-        ("count:2", "PlacementSpec(count:2)"),
-        ("3", "PlacementSpec(count:3)"),
-        ("host1 host2", "PlacementSpec(host1,host2)"),
-        ("host1=a host2=b", "PlacementSpec(host1=a,host2=b)"),
-        ("host1:1.2.3.4=a host2:1.2.3.5=b", "PlacementSpec(host1:1.2.3.4=a,host2:1.2.3.5=b)"),
-        ('2 host1 host2', "PlacementSpec(count:2 host1,host2)"),
-        ('label:foo', "PlacementSpec(label:foo)"),
-        ('3 label:foo', "PlacementSpec(count:3 label:foo)"),
-        ('*', 'PlacementSpec(all:true)'),
-    ])
-def test_parse_placement_specs(test_input, expected):
-    ret = PlacementSpec.from_string(test_input)
-    assert str(ret) == expected
-
-@pytest.mark.parametrize("test_input",
-                         # wrong subnet
-                         [("myhost:1.1.1.1/24"),
-                          # wrong ip format
-                          ("myhost:1"),
-                          # empty string
-                          ("myhost=1"),
-                          ])
-def test_parse_host_placement_specs_raises(test_input):
-    with pytest.raises(ValueError):
-        ret = HostPlacementSpec.parse(test_input)
 
 
 def _test_resource(data, resource_class, extra=None):
@@ -114,20 +63,6 @@ def test_raise():
     c._exception = ZeroDivisionError()
     with pytest.raises(ZeroDivisionError):
         raise_if_exception(c)
-
-
-def test_rgwspec():
-    """
-    {
-        "rgw_zone": "zonename",
-        "service_type": "rgw",
-        "rgw_frontend_port": 8080,
-        "rgw_realm": "realm"
-    }
-    """
-    example = json.loads(test_rgwspec.__doc__.strip())
-    spec = RGWSpec.from_json(example)
-    assert servicespec_validate_add(spec) is None
 
 
 def test_promise():

--- a/src/pybind/mgr/volumes/fs/fs_util.py
+++ b/src/pybind/mgr/volumes/fs/fs_util.py
@@ -2,6 +2,8 @@ import os
 import errno
 import logging
 
+from ceph.deployment.service_spec import ServiceSpec, PlacementSpec
+
 import cephfs
 import orchestrator
 
@@ -34,9 +36,9 @@ def remove_filesystem(mgr, fs_name):
     return mgr.mon_command(command)
 
 def create_mds(mgr, fs_name, placement):
-    spec = orchestrator.ServiceSpec(service_type='mds',
+    spec = ServiceSpec(service_type='mds',
                                     service_id=fs_name,
-                                    placement=orchestrator.PlacementSpec.from_string(placement))
+                                    placement=PlacementSpec.from_string(placement))
     try:
         completion = mgr.apply_mds(spec)
         mgr._orchestrator_wait([completion])

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -1,5 +1,7 @@
 import fnmatch
 from ceph.deployment.inventory import Device
+from ceph.deployment.service_spec import ServiceSpecValidationError
+
 try:
     from typing import Optional, List, Dict, Any
 except ImportError:
@@ -97,7 +99,7 @@ class DeviceSelection(object):
         return repr(self) == repr(other)
 
 
-class DriveGroupValidationError(Exception):
+class DriveGroupValidationError(ServiceSpecValidationError):
     """
     Defining an exception here is a bit problematic, cause you cannot properly catch it,
     if it was raised in a different mgr module.

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -140,7 +140,9 @@ class PlacementSpec(object):
 
     def pattern_matches_hosts(self, all_hosts):
         # type: (List[str]) -> List[str]
-        return fnmatch.filter(all_hosts, self.host_pattern)  # type: ignore
+        if not self.host_pattern:
+            return []
+        return fnmatch.filter(all_hosts, self.host_pattern)
 
     def pretty_str(self):
         kv = []

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1,0 +1,356 @@
+import re
+from collections import namedtuple
+from typing import Optional, Dict, Any, List
+
+import six
+
+
+class HostPlacementSpec(namedtuple('HostPlacementSpec', ['hostname', 'network', 'name'])):
+    def __str__(self):
+        res = ''
+        res += self.hostname
+        if self.network:
+            res += ':' + self.network
+        if self.name:
+            res += '=' + self.name
+        return res
+
+    @classmethod
+    def from_json(cls, data):
+        return cls(**data)
+
+    def to_json(self):
+        return {
+            'hostname': self.hostname,
+            'network': self.network,
+            'name': self.name
+        }
+
+    @classmethod
+    def parse(cls, host, require_network=True):
+        # type: (str, bool) -> HostPlacementSpec
+        """
+        Split host into host, network, and (optional) daemon name parts.  The network
+        part can be an IP, CIDR, or ceph addrvec like '[v2:1.2.3.4:3300,v1:1.2.3.4:6789]'.
+        e.g.,
+          "myhost"
+          "myhost=name"
+          "myhost:1.2.3.4"
+          "myhost:1.2.3.4=name"
+          "myhost:1.2.3.0/24"
+          "myhost:1.2.3.0/24=name"
+          "myhost:[v2:1.2.3.4:3000]=name"
+          "myhost:[v2:1.2.3.4:3000,v1:1.2.3.4:6789]=name"
+        """
+        # Matches from start to : or = or until end of string
+        host_re = r'^(.*?)(:|=|$)'
+        # Matches from : to = or until end of string
+        ip_re = r':(.*?)(=|$)'
+        # Matches from = to end of string
+        name_re = r'=(.*?)$'
+
+        # assign defaults
+        host_spec = cls('', '', '')
+
+        match_host = re.search(host_re, host)
+        if match_host:
+            host_spec = host_spec._replace(hostname=match_host.group(1))
+
+        name_match = re.search(name_re, host)
+        if name_match:
+            host_spec = host_spec._replace(name=name_match.group(1))
+
+        ip_match = re.search(ip_re, host)
+        if ip_match:
+            host_spec = host_spec._replace(network=ip_match.group(1))
+
+        if not require_network:
+            return host_spec
+
+        from ipaddress import ip_network, ip_address
+        networks = list()  # type: List[str]
+        network = host_spec.network
+        # in case we have [v2:1.2.3.4:3000,v1:1.2.3.4:6478]
+        if ',' in network:
+            networks = [x for x in network.split(',')]
+        else:
+            networks.append(network)
+        for network in networks:
+            # only if we have versioned network configs
+            if network.startswith('v') or network.startswith('[v'):
+                network = network.split(':')[1]
+            try:
+                # if subnets are defined, also verify the validity
+                if '/' in network:
+                    ip_network(six.text_type(network))
+                else:
+                    ip_address(six.text_type(network))
+            except ValueError as e:
+                # logging?
+                raise e
+
+        return host_spec
+
+
+class PlacementSpec(object):
+    """
+    For APIs that need to specify a host subset
+    """
+
+    def __init__(self, label=None, hosts=None, count=None, all_hosts=False):
+        # type: (Optional[str], Optional[List], Optional[int], bool) -> None
+        if all_hosts and (count or hosts or label):
+            raise ValueError('cannot combine all:true and count|hosts|label')
+        self.label = label
+        self.hosts = []  # type: List[HostPlacementSpec]
+        if hosts:
+            if all([isinstance(host, HostPlacementSpec) for host in hosts]):
+                self.hosts = hosts
+            else:
+                self.hosts = [HostPlacementSpec.parse(x, require_network=False) for x in hosts if x]
+
+        self.count = count  # type: Optional[int]
+        self.all_hosts = all_hosts  # type: bool
+
+    def is_empty(self):
+        return not self.all_hosts and \
+            self.label is None and \
+            not self.hosts and \
+            self.count is None
+    
+    def set_hosts(self, hosts):
+        # To backpopulate the .hosts attribute when using labels or count
+        # in the orchestrator backend.
+        self.hosts = hosts
+
+    def pretty_str(self):
+        kv = []
+        if self.count:
+            kv.append('count:%d' % self.count)
+        if self.label:
+            kv.append('label:%s' % self.label)
+        if self.hosts:
+            kv.append('%s' % ','.join([str(h) for h in self.hosts]))
+        if self.all_hosts:
+            kv.append('all:true')
+        return ' '.join(kv)
+
+    def __repr__(self):
+        return "PlacementSpec(%s)" % self.pretty_str()
+
+    @classmethod
+    def from_json(cls, data):
+        hosts = data.get('hosts', [])
+        if hosts:
+            data['hosts'] = [HostPlacementSpec.from_json(host) for host in hosts]
+        _cls = cls(**data)
+        _cls.validate()
+        return _cls
+
+    def to_json(self):
+        return {
+            'label': self.label,
+            'hosts': [host.to_json() for host in self.hosts] if self.hosts else [],
+            'count': self.count,
+            'all_hosts': self.all_hosts
+        }
+
+    def validate(self):
+        if self.hosts and self.label:
+            # TODO: a less generic Exception
+            raise ValueError('Host and label are mutually exclusive')
+        if self.count is not None and self.count <= 0:
+            raise ValueError("num/count must be > 1")
+
+    @classmethod
+    def from_string(cls, arg):
+        # type: (Optional[str]) -> PlacementSpec
+        """
+        A single integer is parsed as a count:
+        >>> PlacementSpec.from_string('3')
+        PlacementSpec(count=3)
+        A list of names is parsed as host specifications:
+        >>> PlacementSpec.from_string('host1 host2')
+        PlacementSpec(label=[HostSpec(hostname='host1', network='', name=''), HostSpec(hostname='host2', network='', name='')])
+        You can also prefix the hosts with a count as follows:
+        >>> PlacementSpec.from_string('2 host1 host2')
+        PlacementSpec(label=[HostSpec(hostname='host1', network='', name=''), HostSpec(hostname='host2', network='', name='')], count=2)
+        You can spefify labels using `label:<label>`
+        >>> PlacementSpec.from_string('label:mon')
+        PlacementSpec(label='label:mon')
+        Labels als support a count:
+        >>> PlacementSpec.from_string('3 label:mon')
+        PlacementSpec(label='label:mon', count=3)
+        >>> PlacementSpec.from_string(None)
+        PlacementSpec()
+        """
+        if arg is None:
+            strings = []
+        elif isinstance(arg, str):
+            if ' ' in arg:
+                strings = arg.split(' ')
+            elif ';' in arg:
+                strings = arg.split(';')
+            elif ',' in arg and '[' not in arg:
+                # FIXME: this isn't quite right.  we want to avoid breaking
+                # a list of mons with addrvecs... so we're basically allowing
+                # , most of the time, except when addrvecs are used.  maybe
+                # ok?
+                strings = arg.split(',')
+            else:
+                strings = [arg]
+        else:
+            raise ValueError('invalid placement %s' % arg)
+
+        count = None
+        if strings:
+            try:
+                count = int(strings[0])
+                strings = strings[1:]
+            except ValueError:
+                pass
+        for s in strings:
+            if s.startswith('count:'):
+                try:
+                    count = int(s[6:])
+                    strings.remove(s)
+                    break
+                except ValueError:
+                    pass
+
+        all_hosts = False
+        if '*' in strings:
+            all_hosts = True
+            strings.remove('*')
+        if 'all:true' in strings:
+            all_hosts = True
+            strings.remove('all:true')
+
+        hosts = [x for x in strings if x != '*' and 'label:' not in x]
+        labels = [x[6:] for x in strings if 'label:' in x]
+        if len(labels) > 1:
+            raise ValueError('more than one label provided: {}'.format(labels))
+
+        ps = PlacementSpec(count=count,
+                           hosts=hosts,
+                           label=labels[0] if labels else None,
+                           all_hosts=all_hosts)
+        ps.validate()
+        return ps
+
+
+class ServiceSpec(object):
+    """
+    Details of service creation.
+
+    Request to the orchestrator for a cluster of daemons
+    such as MDS, RGW, iscsi gateway, MONs, MGRs, Prometheus
+
+    This structure is supposed to be enough information to
+    start the services.
+
+    """
+
+    def __init__(self,
+                 service_type,  # type: str
+                 service_id = None,  # type: Optional[str]
+                 placement: Optional[PlacementSpec] = None,
+                 count: Optional[int] = None):
+        self.placement = PlacementSpec() if placement is None else placement  # type: PlacementSpec
+
+        assert service_type
+        self.service_type = service_type
+        self.service_id = service_id
+
+    @classmethod
+    def from_json(cls, json_spec: dict) -> "ServiceSpec":
+        """
+        Initialize 'ServiceSpec' object data from a json structure
+        :param json_spec: A valid dict with ServiceSpec
+        """
+        args = {}  # type: Dict[str, Dict[Any, Any]]
+        service_type = json_spec.get('service_type', '')
+        assert service_type
+        if service_type == 'rgw':
+            _cls = RGWSpec  # type: ignore
+        elif service_type == 'nfs':
+            _cls = NFSServiceSpec  # type: ignore
+        else:
+            _cls = ServiceSpec  # type: ignore
+        for k, v in json_spec.items():
+            if k == 'placement':
+                v = PlacementSpec.from_json(v)
+            if k == 'spec':
+                args.update(v)
+                continue
+            args.update({k: v})
+        return _cls(**args)  # type: ignore
+
+    def service_name(self):
+        n = self.service_type
+        if self.service_id:
+            n += '.' + self.service_id
+        return n
+
+    def to_json(self):
+        # type: () -> Dict[str, Any]
+        c = self.__dict__.copy()
+        if self.placement:
+            c['placement'] = self.placement.to_json()
+        return c
+
+    def __repr__(self):
+        return "{}({!r})".format(self.__class__.__name__, self.__dict__)
+
+
+def servicespec_validate_add(self: ServiceSpec):
+    # This must not be a method of ServiceSpec, otherwise you'll hunt
+    # sub-interpreter affinity bugs.
+    if not self.service_type:
+        raise ValueError('Cannot add Service: type required')
+    if self.service_type in ['mds', 'rgw', 'nfs'] and not self.service_id:
+        raise ValueError('Cannot add Service: id required')
+
+
+class NFSServiceSpec(ServiceSpec):
+    def __init__(self, service_id, pool=None, namespace=None, placement=None,
+                 service_type='nfs'):
+        assert service_type == 'nfs'
+        super(NFSServiceSpec, self).__init__('nfs', service_id=service_id, placement=placement)
+
+        #: RADOS pool where NFS client recovery data is stored.
+        self.pool = pool
+
+        #: RADOS namespace where NFS client recovery data is stored in the pool.
+        self.namespace = namespace
+
+    def validate_add(self):
+        servicespec_validate_add(self)
+
+        if not self.pool:
+            raise ValueError('Cannot add NFS: No Pool specified')
+
+
+class RGWSpec(ServiceSpec):
+    """
+    Settings to configure a (multisite) Ceph RGW
+
+    """
+    def __init__(self,
+                 rgw_realm=None,  # type: Optional[str]
+                 rgw_zone=None,  # type: Optional[str]
+                 service_id=None,  # type: Optional[str]
+                 placement=None,
+                 service_type='rgw',
+                 rgw_frontend_port=None,  # type: Optional[int]
+                 ):
+        assert service_type == 'rgw'
+        if service_id:
+            (rgw_realm, rgw_zone) = service_id.split('.', 1)
+        else:
+            service_id = '%s.%s' % (rgw_realm, rgw_zone)
+        super(RGWSpec, self).__init__('rgw', service_id=service_id, placement=placement)
+
+        self.rgw_realm = rgw_realm
+        self.rgw_zone = rgw_zone
+        self.rgw_frontend_port = rgw_frontend_port

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -253,7 +253,7 @@ class ServiceSpec(object):
 
     def __init__(self,
                  service_type,  # type: str
-                 service_id = None,  # type: Optional[str]
+                 service_id=None,  # type: Optional[str]
                  placement: Optional[PlacementSpec] = None,
                  count: Optional[int] = None):
         self.placement = PlacementSpec() if placement is None else placement  # type: PlacementSpec

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -317,24 +317,28 @@ class ServiceSpec(object):
         self.service_type = service_type
         self.service_id = service_id
 
-    @staticmethod
-    def from_json(json_spec):
-        # type: (dict) -> "ServiceSpec"
+    @classmethod
+    def from_json(cls, json_spec):
+        # type: (dict) -> Any
+        # Python 3:
+        # >>> ServiceSpecs = TypeVar('Base', bound=ServiceSpec)
+        # then, the real type is: (dict) -> ServiceSpecs
         """
         Initialize 'ServiceSpec' object data from a json structure
         :param json_spec: A valid dict with ServiceSpec
         """
         from ceph.deployment.drive_group import DriveGroupSpec
 
-        if 'service_type' not in json_spec:
-            raise ServiceSpecValidationError('Spec needs a "service_type" key.')
-        service_type = json_spec.get('service_type')
-        assert service_type
+        service_type = json_spec.get('service_type', '')
         _cls = {
             'rgw': RGWSpec,
             'nfs': NFSServiceSpec,
             'osd': DriveGroupSpec
-        }.get(service_type, ServiceSpec)
+        }.get(service_type, cls)
+
+        if _cls == ServiceSpec and not service_type:
+            raise ServiceSpecValidationError('Spec needs a "service_type" key.')
+
         return _cls._from_json_impl(json_spec)  # type: ignore
 
     @classmethod

--- a/src/python-common/ceph/tests/test_disk_selector.py
+++ b/src/python-common/ceph/tests/test_disk_selector.py
@@ -5,6 +5,7 @@ from ceph.deployment.inventory import Devices, Device
 from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection
 
 from ceph.deployment import drive_selection
+from ceph.deployment.service_spec import PlacementSpec
 from ceph.tests.factories import InventoryFactory
 from ceph.tests.utils import _mk_inventory, _mk_device
 
@@ -274,7 +275,7 @@ class TestDriveGroup(object):
                              osds_per_device='',
                              disk_format='bluestore'):
             raw_sample_bluestore = {
-                'host_pattern': 'data*',
+                'placement': {'host_pattern': 'data*'},
                 'data_devices': {
                     'size': '30G:50G',
                     'model': '42-RGB',
@@ -298,7 +299,7 @@ class TestDriveGroup(object):
                 'encrypted': True,
             }
             raw_sample_filestore = {
-                'host_pattern': 'data*',
+                'placement': {'host_pattern': 'data*'},
                 'objectstore': 'filestore',
                 'data_devices': {
                     'size': '30G:50G',
@@ -319,7 +320,7 @@ class TestDriveGroup(object):
                 raw_sample = raw_sample_bluestore
 
             if empty:
-                raw_sample = {'host_pattern': 'data*'}
+                raw_sample = {'placement': {'host_pattern': 'data*'}}
 
             dgo = DriveGroupSpec.from_json(raw_sample)
             return dgo
@@ -479,13 +480,13 @@ class TestDriveSelection(object):
 
     testdata = [
         (
-            DriveGroupSpec(host_pattern='*', data_devices=DeviceSelection(all=True)),
+            DriveGroupSpec(placement=PlacementSpec(host_pattern='*'), data_devices=DeviceSelection(all=True)),
             _mk_inventory(_mk_device() * 5),
             ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd', '/dev/sde'], []
         ),
         (
             DriveGroupSpec(
-                host_pattern='*',
+                placement=PlacementSpec(host_pattern='*'),
                 data_devices=DeviceSelection(all=True, limit=3),
                 db_devices=DeviceSelection(all=True)
             ),
@@ -494,7 +495,7 @@ class TestDriveSelection(object):
         ),
         (
             DriveGroupSpec(
-                host_pattern='*',
+                placement=PlacementSpec(host_pattern='*'),
                 data_devices=DeviceSelection(rotational=True),
                 db_devices=DeviceSelection(rotational=False)
             ),
@@ -503,7 +504,7 @@ class TestDriveSelection(object):
         ),
         (
             DriveGroupSpec(
-                host_pattern='*',
+                placement=PlacementSpec(host_pattern='*'),
                 data_devices=DeviceSelection(rotational=True),
                 db_devices=DeviceSelection(rotational=False)
             ),
@@ -512,7 +513,7 @@ class TestDriveSelection(object):
         ),
         (
             DriveGroupSpec(
-                host_pattern='*',
+                placement=PlacementSpec(host_pattern='*'),
                 data_devices=DeviceSelection(rotational=True),
                 db_devices=DeviceSelection(rotational=False)
             ),

--- a/src/python-common/ceph/tests/test_disk_selector.py
+++ b/src/python-common/ceph/tests/test_disk_selector.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 import pytest
 
 from ceph.deployment.inventory import Devices, Device

--- a/src/python-common/ceph/tests/test_disk_selector.py
+++ b/src/python-common/ceph/tests/test_disk_selector.py
@@ -275,6 +275,7 @@ class TestDriveGroup(object):
                              osds_per_device='',
                              disk_format='bluestore'):
             raw_sample_bluestore = {
+                'service_type': 'osd',
                 'placement': {'host_pattern': 'data*'},
                 'data_devices': {
                     'size': '30G:50G',
@@ -299,6 +300,7 @@ class TestDriveGroup(object):
                 'encrypted': True,
             }
             raw_sample_filestore = {
+                'service_type': 'osd',
                 'placement': {'host_pattern': 'data*'},
                 'objectstore': 'filestore',
                 'data_devices': {
@@ -320,7 +322,10 @@ class TestDriveGroup(object):
                 raw_sample = raw_sample_bluestore
 
             if empty:
-                raw_sample = {'placement': {'host_pattern': 'data*'}}
+                raw_sample = {
+                    'service_type': 'osd',
+                    'placement': {'host_pattern': 'data*'}
+                }
 
             dgo = DriveGroupSpec.from_json(raw_sample)
             return dgo

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -7,18 +7,32 @@ from ceph.tests.utils import _mk_inventory, _mk_device
 from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupSpecs, \
                                         DeviceSelection, DriveGroupValidationError
 
+@pytest.mark.parametrize("test_input",
+[
+    (
+        [  # new style json
+            {
+                'service_type': 'osd',
+                'service_id': 'testing_drivegroup',
+                'placement': {'host_pattern': 'hostname'},
+                'data_devices': {'paths': ['/dev/sda']}
+            }
+        ]
+    ),
+    (
+        {  # old style json
+            'testing_drivegroup':
+                {
+                    'host_pattern': 'hostname',
+                    'data_devices': {'paths': ['/dev/sda']}
+                }
+       }
+    )
 
-def test_DriveGroup():
-    dg_json = [
-        {
-            'service_type': 'osd',
-            'service_id': 'testing_drivegroup',
-            'placement': {'host_pattern': 'hostname'},
-            'data_devices': {'paths': ['/dev/sda']}
-        }
-    ]
+])
 
-    dgs = DriveGroupSpecs(dg_json)
+def test_DriveGroup(test_input):
+    dgs = DriveGroupSpecs(test_input)
     for dg in dgs.drive_groups:
         assert dg.placement.pattern_matches_hosts(['hostname']) == ['hostname']
         assert dg.service_id == 'testing_drivegroup'

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 import pytest
 
 from ceph.deployment import drive_selection, translate

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -2,7 +2,7 @@ import pytest
 
 from ceph.deployment import drive_selection, translate
 from ceph.deployment.inventory import Device
-from ceph.deployment.service_spec import PlacementSpec
+from ceph.deployment.service_spec import PlacementSpec, ServiceSpecValidationError
 from ceph.tests.utils import _mk_inventory, _mk_device
 from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupSpecs, \
                                         DeviceSelection, DriveGroupValidationError
@@ -11,6 +11,7 @@ from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupSpecs, \
 def test_DriveGroup():
     dg_json = [
         {
+            'service_type': 'osd',
             'service_id': 'testing_drivegroup',
             'placement': {'host_pattern': 'hostname'},
             'data_devices': {'paths': ['/dev/sda']}
@@ -26,7 +27,7 @@ def test_DriveGroup():
 
 
 def test_DriveGroup_fail():
-    with pytest.raises(DriveGroupValidationError):
+    with pytest.raises(ServiceSpecValidationError):
         DriveGroupSpec.from_json({})
 
 

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 import json
 
 import pytest

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -27,15 +27,15 @@ def test_parse_host_placement_specs(test_input, expected, require_network):
     "test_input,expected",
     [
         ('', "PlacementSpec()"),
-        ("count:2", "PlacementSpec(count:2)"),
-        ("3", "PlacementSpec(count:3)"),
-        ("host1 host2", "PlacementSpec(host1,host2)"),
-        ("host1=a host2=b", "PlacementSpec(host1=a,host2=b)"),
-        ("host1:1.2.3.4=a host2:1.2.3.5=b", "PlacementSpec(host1:1.2.3.4=a,host2:1.2.3.5=b)"),
-        ('2 host1 host2', "PlacementSpec(count:2 host1,host2)"),
-        ('label:foo', "PlacementSpec(label:foo)"),
-        ('3 label:foo', "PlacementSpec(count:3 label:foo)"),
-        ('*', 'PlacementSpec(all:true)'),
+        ("count:2", "PlacementSpec(count=2)"),
+        ("3", "PlacementSpec(count=3)"),
+        ("host1 host2", "PlacementSpec(hosts=[HostPlacementSpec(hostname='host1', network='', name=''), HostPlacementSpec(hostname='host2', network='', name='')])"),
+        ("host1=a host2=b", "PlacementSpec(hosts=[HostPlacementSpec(hostname='host1', network='', name='a'), HostPlacementSpec(hostname='host2', network='', name='b')])"),
+        ("host1:1.2.3.4=a host2:1.2.3.5=b", "PlacementSpec(hosts=[HostPlacementSpec(hostname='host1', network='1.2.3.4', name='a'), HostPlacementSpec(hostname='host2', network='1.2.3.5', name='b')])"),
+        ('2 host1 host2', "PlacementSpec(count=2, hosts=[HostPlacementSpec(hostname='host1', network='', name=''), HostPlacementSpec(hostname='host2', network='', name='')])"),
+        ('label:foo', "PlacementSpec(label='foo')"),
+        ('3 label:foo', "PlacementSpec(count=3, label='foo')"),
+        ('*', 'PlacementSpec(all_hosts=True)'),
     ])
 def test_parse_placement_specs(test_input, expected):
     ret = PlacementSpec.from_string(test_input)

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -1,0 +1,68 @@
+import json
+
+import pytest
+
+from ceph.deployment.service_spec import HostPlacementSpec, PlacementSpec, RGWSpec, \
+    servicespec_validate_add
+
+
+@pytest.mark.parametrize("test_input,expected, require_network",
+                         [("myhost", ('myhost', '', ''), False),
+                          ("myhost=sname", ('myhost', '', 'sname'), False),
+                          ("myhost:10.1.1.10", ('myhost', '10.1.1.10', ''), True),
+                          ("myhost:10.1.1.10=sname", ('myhost', '10.1.1.10', 'sname'), True),
+                          ("myhost:10.1.1.0/32", ('myhost', '10.1.1.0/32', ''), True),
+                          ("myhost:10.1.1.0/32=sname", ('myhost', '10.1.1.0/32', 'sname'), True),
+                          ("myhost:[v1:10.1.1.10:6789]", ('myhost', '[v1:10.1.1.10:6789]', ''), True),
+                          ("myhost:[v1:10.1.1.10:6789]=sname", ('myhost', '[v1:10.1.1.10:6789]', 'sname'), True),
+                          ("myhost:[v1:10.1.1.10:6789,v2:10.1.1.11:3000]", ('myhost', '[v1:10.1.1.10:6789,v2:10.1.1.11:3000]', ''), True),
+                          ("myhost:[v1:10.1.1.10:6789,v2:10.1.1.11:3000]=sname", ('myhost', '[v1:10.1.1.10:6789,v2:10.1.1.11:3000]', 'sname'), True),
+                          ])
+def test_parse_host_placement_specs(test_input, expected, require_network):
+    ret = HostPlacementSpec.parse(test_input, require_network=require_network)
+    assert ret == expected
+    assert str(ret) == test_input
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ('', "PlacementSpec()"),
+        ("count:2", "PlacementSpec(count:2)"),
+        ("3", "PlacementSpec(count:3)"),
+        ("host1 host2", "PlacementSpec(host1,host2)"),
+        ("host1=a host2=b", "PlacementSpec(host1=a,host2=b)"),
+        ("host1:1.2.3.4=a host2:1.2.3.5=b", "PlacementSpec(host1:1.2.3.4=a,host2:1.2.3.5=b)"),
+        ('2 host1 host2', "PlacementSpec(count:2 host1,host2)"),
+        ('label:foo', "PlacementSpec(label:foo)"),
+        ('3 label:foo', "PlacementSpec(count:3 label:foo)"),
+        ('*', 'PlacementSpec(all:true)'),
+    ])
+def test_parse_placement_specs(test_input, expected):
+    ret = PlacementSpec.from_string(test_input)
+    assert str(ret) == expected
+
+@pytest.mark.parametrize("test_input",
+                         # wrong subnet
+                         [("myhost:1.1.1.1/24"),
+                          # wrong ip format
+                          ("myhost:1"),
+                          # empty string
+                          ("myhost=1"),
+                          ])
+def test_parse_host_placement_specs_raises(test_input):
+    with pytest.raises(ValueError):
+        ret = HostPlacementSpec.parse(test_input)
+
+
+def test_rgwspec():
+    """
+    {
+        "rgw_zone": "zonename",
+        "service_type": "rgw",
+        "rgw_frontend_port": 8080,
+        "rgw_realm": "realm"
+    }
+    """
+    example = json.loads(test_rgwspec.__doc__.strip())
+    spec = RGWSpec.from_json(example)
+    assert servicespec_validate_add(spec) is None

--- a/src/python-common/tox.ini
+++ b/src/python-common/tox.ini
@@ -5,7 +5,9 @@ skip_missing_interpreters = true
 [testenv:py3]
 deps=
     -rrequirements.txt
-commands=pytest --mypy --mypy-ignore-missing-imports {posargs}
+commands=
+    pytest --doctest-modules ceph/deployment/service_spec.py
+    pytest --mypy --mypy-ignore-missing-imports {posargs}
 
 [tool:pytest]
 norecursedirs = .* _* virtualenv


### PR DESCRIPTION
Because, they already share a lot of common attributes. 

## TODO:

- [x] Make it actually work. (e.g. PlacementSpec.host_patten fully supported, DGs with arbitrary Placements)
- [x] JSON backward compatibility

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
