### PR TITLE
cephfs.pyx: False, not empty string, must mean reading no conf

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -481,8 +481,13 @@ cdef class LibCephFS(object):
         Create a mount handle for interacting with Ceph.  All libcephfs
         functions operate on a mount info handle.
         
-        :param conf dict opt: settings overriding the default ones and conffile
-        :param conffile str opt: the path to ceph.conf to override the default settings
+        :param conf dict opt: settings overriding the default ones and
+                              conffile
+        :param conffile str opt: the path to ceph.conf to override the
+                                 default settings; passing None implies read
+                                 conf file in one of the standard locations
+                                 and passing False implies read NO conf file
+                                 (not even the one in standard locations).
         :auth_id str opt: the id used to authenticate the client entity
         """
         if conf is not None and not isinstance(conf, dict):
@@ -500,12 +505,12 @@ cdef class LibCephFS(object):
             raise Error("libcephfs_initialize failed with error code: %d" % ret)
 
         self.state = "configuring"
-        if conffile is not None:
-            # read the default conf file when '' is given
-            if conffile == '':
-                conffile = None
-            self.conf_read_file(conffile)
-        if conf is not None:
+        # skip reading default conf
+        if conffile is False:
+            pass
+        else:
+            self.conf_read_file(None if conffile == '' else conffile)
+        if conf:
             for key, value in conf.iteritems():
                 self.conf_set(key, value)
 


### PR DESCRIPTION
Currently, passing empty string to conffile argument of LibCephFS.create()
method implies skipping reading the configuration file, even the one
located in one of the standard paths. Change this behaviour to be
triggered by the value False instead of the empty string. And, let this
be the behaviour when either conffile and conf is set to False.

Fixes: https://tracker.ceph.com/issues/44415



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>