### PR TITLE
ceph.in: only shut down rados on clean exit

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -1273,11 +1273,10 @@ def main():
 if __name__ == '__main__':
     try:
         retval = main()
+        # shutdown explicitly; Rados() does not
+        if retval == 0 and cluster_handle:
+            run_in_thread(cluster_handle.shutdown)
     except KeyboardInterrupt:
         print('Interrupted')
         retval = errno.EINTR
-    finally:
-        # shutdown explicitly; Rados() does not
-        if cluster_handle:
-            run_in_thread(cluster_handle.shutdown)
     sys.exit(retval)

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2048,8 +2048,13 @@ def command_bootstrap():
         def is_dashboard_available():
             # type: () -> bool
             timeout=args.timeout if args.timeout else 30 # seconds
-            out = cli(['-h'], timeout=timeout)
-            return 'dashboard' in out
+            try:
+                out = cli(['-h'], timeout=timeout)
+                return 'dashboard' in out
+            except RuntimeError as e:
+                # sometimes -h command times out/errors out
+                logger.debug('Command errored out: %s' % e)
+                return False
         is_available('Dashboard', is_dashboard_available)
 
 


### PR DESCRIPTION
If we exit due to a timeout, then calling rados shutdown can lead to all
sorts of problems, because we may still have another thread that is
trying to call rados_connect and/or do some work, and rados_connect
and rados_shutdown don't (and can't!) really behave well when racing
against each other.

Note that shutdown here isn't that important--the process is about to
exit anyway.  It's only useful to exercise the shutdown code path more
often.

Fixes: https://tracker.ceph.com/issues/44526
Signed-off-by: Sage Weil <sage@redhat.com>