### PR TITLE
tests: remove spurious whitespace

### DIFF
--- a/qa/tasks/cephfs/test_snapshots.py
+++ b/qa/tasks/cephfs/test_snapshots.py
@@ -465,7 +465,7 @@ class TestSnapshots(CephFSTestCase):
 
     def create_dir_and_snaps(self, dir_name, snaps):
         self.mount_a.run_shell(["mkdir", dir_name])
-        
+
         for sno in range(1, snaps+1, 1):
             sname = self.get_snap_name(dir_name, sno)
             try:
@@ -489,7 +489,7 @@ class TestSnapshots(CephFSTestCase):
     def test_mds_max_snaps_per_dir_with_increased_limit(self):
         """
         Test the newly introudced option named mds_max_snaps_per_dir
-        First create 101 directories and ensure that the 101st directory 
+        First create 101 directories and ensure that the 101st directory
         creation fails. Then increase the default by one and see if the
         additional directory creation succeeds
         """


### PR DESCRIPTION
remove spurious whitespace from test_snapshot.py

Fixes: https://tracker.ceph.com/issues/44528
Signed-off-by: Milind Changire <mchangir@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>