### PR TITLE
cls/rbd: use explicitly sized integer in mirror status summary

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -5356,7 +5356,7 @@ int image_status_get_summary(
     cls_method_context_t hctx,
     cls::rbd::MirrorPeerDirection mirror_peer_direction,
     const std::set<std::string>& tx_peer_mirror_uuids,
-    std::map<cls::rbd::MirrorImageStatusState, int> *states) {
+    std::map<cls::rbd::MirrorImageStatusState, int32_t> *states) {
   std::set<entity_inst_t> watchers;
   int r = list_watchers(hctx, &watchers);
   if (r < 0) {
@@ -6450,7 +6450,7 @@ int mirror_image_status_list(cls_method_context_t hctx, bufferlist *in,
  * @param std::vector<cls::rbd::MirrorPeer> - optional peers (backwards compatibility)
  *
  * Output:
- * @param std::map<cls::rbd::MirrorImageStatusState, int>: states counts
+ * @param std::map<cls::rbd::MirrorImageStatusState, int32_t>: states counts
  * @returns 0 on success, negative error code on failure
  */
 int mirror_image_status_get_summary(cls_method_context_t hctx, bufferlist *in,
@@ -6483,7 +6483,7 @@ int mirror_image_status_get_summary(cls_method_context_t hctx, bufferlist *in,
     }
   }
 
-  std::map<cls::rbd::MirrorImageStatusState, int> states;
+  std::map<cls::rbd::MirrorImageStatusState, int32_t> states;
   int r = mirror::image_status_get_summary(hctx, mirror_peer_direction,
                                            tx_peer_mirror_uuids, &states);
   if (r < 0) {

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -2232,7 +2232,7 @@ int mirror_image_status_list_finish(bufferlist::const_iterator *iter,
 int mirror_image_status_get_summary(
     librados::IoCtx *ioctx,
     const std::vector<cls::rbd::MirrorPeer>& mirror_peer_sites,
-    std::map<cls::rbd::MirrorImageStatusState, int> *states) {
+    std::map<cls::rbd::MirrorImageStatusState, int32_t> *states) {
   librados::ObjectReadOperation op;
   mirror_image_status_get_summary_start(&op, mirror_peer_sites);
 
@@ -2260,7 +2260,7 @@ void mirror_image_status_get_summary_start(
 
 int mirror_image_status_get_summary_finish(
     bufferlist::const_iterator *iter,
-    std::map<cls::rbd::MirrorImageStatusState, int> *states) {
+    std::map<cls::rbd::MirrorImageStatusState, int32_t> *states) {
   try {
     decode(*states, *iter);
   } catch (const buffer::error &err) {

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -470,13 +470,13 @@ int mirror_image_status_list_finish(bufferlist::const_iterator *iter,
 int mirror_image_status_get_summary(
     librados::IoCtx *ioctx,
     const std::vector<cls::rbd::MirrorPeer>& mirror_peer_sites,
-    std::map<cls::rbd::MirrorImageStatusState, int> *states);
+    std::map<cls::rbd::MirrorImageStatusState, int32_t> *states);
 void mirror_image_status_get_summary_start(
     librados::ObjectReadOperation *op,
     const std::vector<cls::rbd::MirrorPeer>& mirror_peer_sites);
 int mirror_image_status_get_summary_finish(
     bufferlist::const_iterator *iter,
-    std::map<cls::rbd::MirrorImageStatusState, int> *states);
+    std::map<cls::rbd::MirrorImageStatusState, int32_t> *states);
 int mirror_image_status_remove_down(librados::IoCtx *ioctx);
 void mirror_image_status_remove_down(librados::ObjectWriteOperation *op);
 

--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -1830,7 +1830,7 @@ int Mirror<I>::image_status_summary(librados::IoCtx& io_ctx,
     return r;
   }
 
-  std::map<cls::rbd::MirrorImageStatusState, int> states_;
+  std::map<cls::rbd::MirrorImageStatusState, int32_t> states_;
   r = cls_client::mirror_image_status_get_summary(&io_ctx, mirror_peers,
                                                   &states_);
   if (r < 0 && r != -ENOENT) {

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -1811,7 +1811,7 @@ TEST_F(TestClsRbd, mirror_image_status) {
 
   map<std::string, cls::rbd::MirrorImage> images;
   map<std::string, cls::rbd::MirrorImageStatus> statuses;
-  std::map<cls::rbd::MirrorImageStatusState, int> states;
+  std::map<cls::rbd::MirrorImageStatusState, int32_t> states;
   std::map<std::string, entity_inst_t> instances;
   cls::rbd::MirrorImageStatus read_status;
   entity_inst_t read_instance;


### PR DESCRIPTION
PR #33673 accidentally broke enum encoding but it was originally
thought that it somehow broke endianness encoding of the non-
explicitly sized `int` state counter. Switch to use the explicitly
sized int32_t instead as a cleanup measure.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
