### PR TITLE
cephadm: Infer ceph image

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -766,17 +766,13 @@ def get_last_local_ceph_image():
     :return: The most recent local ceph image (already pulled)
     """
     out, _, _ = call_throws(
-        [container_path, 'images', '--format', '{{ .ID }} {{.Repository}} {{.Tag}}'])
+        [container_path, 'images',
+         '--filter', 'label=ceph=True',
+         '--format', '{{.Repository}} {{.Tag}}'])
     out_lines = out.splitlines()
-    for out_line in out_lines:
-        id, repository, tag = out_line.split()
-        out, _, _ = call_throws([container_path, 'inspect', str(id)])
-        images_details = json.loads(out)
-        for image_details in images_details:
-            image_labels = image_details['Labels']
-            git_repo = image_labels.get('GIT_REPO', "")
-            if git_repo.endswith("/ceph-container.git"):
-                return '{}:{}'.format(repository, tag)
+    if len(out_lines) > 0:
+        repository, tag = out_lines[0].split()
+        return '{}:{}'.format(repository, tag)
     return None
 
 def write_tmp(s, uid, gid):

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -772,7 +772,9 @@ def get_last_local_ceph_image():
     out_lines = out.splitlines()
     if len(out_lines) > 0:
         repository, tag = out_lines[0].split()
-        return '{}:{}'.format(repository, tag)
+        r = '{}:{}'.format(repository, tag)
+        logger.info('Using recent ceph image %s' % r)
+        return r
     return None
 
 def write_tmp(s, uid, gid):

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -761,6 +761,24 @@ def infer_fsid(func):
 
     return _infer_fsid
 
+def get_last_local_ceph_image():
+    """
+    :return: The most recent local ceph image (already pulled)
+    """
+    out, _, _ = call_throws(
+        [container_path, 'images', '--format', '{{ .ID }} {{.Repository}} {{.Tag}}'])
+    out_lines = out.splitlines()
+    for out_line in out_lines:
+        id, repository, tag = out_line.split()
+        out, _, _ = call_throws([container_path, 'inspect', str(id)])
+        images_details = json.loads(out)
+        for image_details in images_details:
+            image_labels = image_details['Labels']
+            git_repo = image_labels.get('GIT_REPO', "")
+            if git_repo.endswith("/ceph-container.git"):
+                return '{}:{}'.format(repository, tag)
+    return None
+
 def write_tmp(s, uid, gid):
     tmp_f = tempfile.NamedTemporaryFile(mode='w',
                                         prefix='ceph-tmp')
@@ -2153,7 +2171,7 @@ def command_deploy():
             daemon_ports = Monitoring.port_map[daemon_type]  # type: List[int]
             if any([port_in_use(port) for port in daemon_ports]):
                 raise Error("TCP Port(s) '{}' required for {} is already in use".format(",".join(map(str, daemon_ports)), daemon_type))
-            elif args.image == DEFAULT_IMAGE:
+            elif args.image == DEFAULT_IMAGE or args.image == inferred_image:
                 raise Error("--image parameter must be supplied for {}".format(daemon_type))
 
         # make sure provided config-json is sufficient
@@ -3699,9 +3717,18 @@ def _parse_args(av):
             if type_ in Monitoring.components:
                 args.image = Monitoring.components[type_]['image']
         if not args.image:
-            args.image = os.environ.get('CEPHADM_IMAGE', DEFAULT_IMAGE)
+            args.image = os.environ.get('CEPHADM_IMAGE')
 
     return args
+
+def _infer_image():
+    inferred = None
+    if not args.image:
+        inferred = get_last_local_ceph_image()
+        args.image = inferred
+    if not args.image:
+        args.image = DEFAULT_IMAGE
+    return inferred
 
 if __name__ == "__main__":
     # allow argv to be injected
@@ -3735,6 +3762,8 @@ if __name__ == "__main__":
         if not container_path and args.func != command_prepare_host:
             sys.stderr.write('Unable to locate any of %s\n' % CONTAINER_PREFERENCE)
             sys.exit(1)
+
+    inferred_image = _infer_image()
 
     if 'func' not in args:
         sys.stderr.write('No command specified; pass -h or --help for usage\n')


### PR DESCRIPTION
**Related to https://github.com/ceph/ceph-container/pull/1604**
---

If `image` is not explicitly specified, `cephadm` will use the most recent _"ceph image"[1]_ available in the host (locally).

If no _"ceph image"[1]_ was previously pulled, then `cephadm` will use the default image.

~~[1] `ceph image` is an image with `GIT_REPO=*/ceph-container.git` Label~~
[1] `ceph image` is an image with `ceph=True` Label

Fixes: https://tracker.ceph.com/issues/44440

Signed-off-by: Ricardo Marques <rimarques@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
