### PR TITLE
cephadm: remove orphan daemons

### DIFF
--- a/qa/suites/rados/cephadm/upgrade/1-start.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start.yaml
@@ -1,4 +1,4 @@
 tasks:
 - cephadm:
-    image: quay.io/ceph-ci/ceph:wip-sage-testing-2020-03-07-0931
-    cephadm_branch: wip-sage-testing-2020-03-07-0931
+    image: quay.io/ceph-ci/ceph:wip-sage2-testing-2020-03-10-1354
+    cephadm_branch: wip-sage2-testing-2020-03-10-1354

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -357,6 +357,7 @@ def ceph_bootstrap(ctx, config):
             '--fsid', fsid,
             '--mon-id', first_mon,
             '--mgr-id', first_mgr,
+            '--orphan-initial-daemons',   # we will do it explicitly!
             '--config', '{}/seed.{}.conf'.format(testdir, cluster_name),
             '--output-config', '/etc/ceph/{}.conf'.format(cluster_name),
             '--output-keyring',

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1817,11 +1817,6 @@ def command_bootstrap():
         entrypoint='/usr/bin/ceph-authtool',
         args=['--gen-print-key'],
     ).run().strip()
-    crash_key = CephContainer(
-        image=args.image,
-        entrypoint='/usr/bin/ceph-authtool',
-        args=['--gen-print-key'],
-    ).run().strip()
 
     keyring = ('[mon.]\n'
                '\tkey = %s\n'
@@ -1837,11 +1832,7 @@ def command_bootstrap():
                '\tcaps mon = profile mgr\n'
                '\tcaps mds = allow *\n'
                '\tcaps osd = allow *\n'
-               '[client.crash.%s]\n'
-               '\tkey = %s\n'
-               '\tcaps mon = profile crash\n'
-               '\tcaps mgr = profile crash\n'
-               % (mon_key, admin_key, mgr_id, mgr_key, hostname, crash_key))
+               % (mon_key, admin_key, mgr_id, mgr_key))
 
     # tmp keyring file
     tmp_bootstrap_keyring = write_tmp(keyring, uid, gid)

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2027,8 +2027,10 @@ def command_bootstrap():
         logger.info('Adding host %s...' % host)
         cli(['orch', 'host', 'add', host])
 
-        logger.info('Deploy crash collectors...')
-        cli(['orch', 'apply', 'crash', 'all:true'])
+        if not args.orphan_initial_daemons:
+            for t in ['mon', 'mgr', 'crash']:
+                logger.info('Deploying %s service with default placement...' % t)
+                cli(['orch', 'apply', t])
 
     if not args.skip_dashboard:
         logger.info('Enabling the dashboard module...')
@@ -3586,6 +3588,10 @@ def _get_parser():
         '--skip-prepare-host',
         action='store_true',
         help='Do not prepare host')
+    parser_bootstrap.add_argument(
+        '--orphan-initial-daemons',
+        action='store_true',
+        help='Do not create initial mon, mgr, and crash service specs')
 
     parser_deploy = subparsers.add_parser(
         'deploy', help='deploy a daemon')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2426,6 +2426,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 'crash': orchestrator.PlacementSpec(all_hosts=True),
             }
             spec.placement = defaults[spec.service_type]
+        elif spec.service_type in ['mon', 'mgr'] and \
+             spec.placement.count is not None and \
+             spec.placement.count < 1:
+            raise OrchestratorError('cannot scale %s service below 1' % (
+                spec.service_type))
         self.log.info('Saving service %s spec with placement %s' % (
             spec.service_name(), spec.placement.pretty_str()))
         self.spec_store.save(spec)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1717,7 +1717,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                     sm[n].size = self._get_spec_size(spec)
                     sm[n].created = self.spec_store.spec_created[dd.service_name()]
                 else:
-                    sm[n].size += 1
+                    sm[n].size = 0
                 if dd.status == 1:
                     sm[n].running += 1
                 if not sm[n].last_refresh or not dd.last_refresh or dd.last_refresh < sm[n].last_refresh:  # type: ignore

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1823,18 +1823,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         return self._remove_daemons(args)
 
     def remove_service(self, service_name):
-        args = []
-        for host, dm in self.cache.daemons.items():
-            for name, d in dm.items():
-                if d.matches_service(service_name):
-                    args.append(
-                        (d.name(), d.hostname, True)
-                    )
-        self.log.info('Remove service %s (daemons %s)' % (
-            service_name, [a[0] for a in args]))
+        self.log.info('Remove service %s' % service_name)
         self.spec_store.rm(service_name)
-        if args:
-            return self._remove_daemons(args)
+        self._kick_serve_loop()
         return trivial_result(['Removed service %s' % service_name])
 
     def get_inventory(self, host_filter=None, refresh=False):

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3037,7 +3037,7 @@ class SimpleScheduler(BaseScheduler):
     def place(self, host_pool, count=None):
         # type: (List, Optional[int]) -> List[HostPlacementSpec]
         if not host_pool:
-            raise Exception('List of host candidates is empty')
+            return []
         host_pool = [x for x in host_pool]
         # shuffle for pseudo random selection
         random.shuffle(host_pool)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2204,6 +2204,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
         r = False
 
+        # sanity check
+        if daemon_type in ['mon', 'mgr'] and len(hosts) < 1:
+            self.log.debug('cannot scale mon|mgr below 1 (hosts=%s)' % hosts)
+            return False
+
         # add any?
         did_config = False
         hosts_with_daemons = {d.hostname for d in daemons}

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -226,7 +226,7 @@ class TestCephadm(object):
             wait(cephadm_module, c)
             c = cephadm_module.remove_service('rgw.myrgw')
             out = wait(cephadm_module, c)
-            assert out == ["Removed rgw.myrgw.foobar from host 'test'"]
+            assert out == ["Removed service rgw.myrgw"]
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     def test_rbd_mirror(self, cephadm_module):


### PR DESCRIPTION
- create default mon, mgr services on bootstrap
- make remove service just remove the spec
- clean up any stray/orphan daemons in the serve() loop
- fix cephadm.py qa task to not create those initial services