### PR TITLE
nautilus: mgr: update "hostname" when we already have the daemon state from that entity

### DIFF
--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -108,6 +108,8 @@ void MetadataUpdate::finish(int r)
       DaemonStatePtr state;
       if (daemon_state.exists(key)) {
         state = daemon_state.get(key);
+	state->hostname = daemon_meta.at("hostname").get_str();
+
         if (key.first == "mds" || key.first == "mgr" || key.first == "mon") {
           daemon_meta.erase("name");
         } else if (key.first == "osd") {

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -449,37 +449,22 @@ void Mgr::handle_osd_map()
       names_exist.insert(stringify(osd_id));
 
       // Consider whether to update the daemon metadata (new/restarted daemon)
-      bool update_meta = false;
       const auto k = DaemonKey("osd", stringify(osd_id));
       if (daemon_state.is_updating(k)) {
         continue;
       }
 
+      bool update_meta = false;
       if (daemon_state.exists(k)) {
-        auto metadata = daemon_state.get(k);
-	std::lock_guard l(metadata->lock);
-        auto addr_iter = metadata->metadata.find("front_addr");
-        if (addr_iter != metadata->metadata.end()) {
-          const std::string &metadata_addr = addr_iter->second;
-          const auto &map_addrs = osd_map.get_addrs(osd_id);
-
-          if (metadata_addr != stringify(map_addrs)) {
-            dout(4) << "OSD[" << osd_id << "] addr change " << metadata_addr
-                    << " != " << stringify(map_addrs) << dendl;
-            update_meta = true;
-          } else {
-            dout(20) << "OSD[" << osd_id << "] addr unchanged: "
-                     << metadata_addr << dendl;
-          }
-        } else {
-          // Awkward case where daemon went into DaemonState because it
-          // sent us a report but its metadata didn't get loaded yet
+        if (osd_map.get_up_from(osd_id) == osd_map.get_epoch()) {
+          dout(4) << "Mgr::handle_osd_map: osd." << osd_id
+		  << " joined cluster at " << "e" << osd_map.get_epoch()
+		  << dendl;
           update_meta = true;
         }
       } else {
         update_meta = true;
       }
-
       if (update_meta) {
         auto c = new MetadataUpdate(daemon_state, k);
         std::ostringstream cmd;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44524

backport of #33752

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
