### PR TITLE
doc/rgw: design notes for compare status api

### DIFF
--- a/src/doc/rgw/comparestatusapi.md
+++ b/src/doc/rgw/comparestatusapi.md
@@ -1,0 +1,25 @@
+# Compare status api 
+
+Compare status api is used as the new admin api to compare metadata sync status.
+
+## Design
+
+Dashboard will send a request to the Status api of target zone, and get back a list of markers
+and timestamps. Include that in its request to status api on source zone .Sync.read_sync_status in
+get_md_sync_status gets sync status marker for each shard and it gets executed in
+RGWOp_MDLog_Status.
+
+CompareStatus takes as input the list of 64 status markers and the following steps are repeated
+over the markers:
+
+1: RGWOp_MDLog_CompareStatus calls meta_log.get_info() for getting the highest log marker
+for each shard. This was a function of sync.read_master_log_shards_info() in
+get_md_sync_status in rgw_admin.cc which is sending 64 HTTP requests to the master zone,
+one for each shard.
+sync.read_master_log_shards_info() was executed by RGWOp_MDLog_ShardInfo in
+rgw_rest_log.cc.
+
+2: CompareStatus output current and latest timestamp in json format.
+[ {“Shard_id” : “..” , "current_timestamp": "...", "latest_timestamp": "..." },...] 
+
+


### PR DESCRIPTION
Design notes for the new admin api to compare metdata sync status

Signed-off-by: Albin Antony <aantony@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
