### PR TITLE
mgr/rbd_support: don't scan pools that don't have schedules

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -964,6 +964,12 @@ test_trash_purge_schedule() {
     expect_fail rbd trash purge schedule ls -p rbd2
     rbd trash purge schedule ls -p rbd2 -R | grep 'every 2d starting at 00:17'
     rbd trash purge schedule ls -p rbd2/ns1 -R | grep 'every 2d starting at 00:17'
+    test "$(rbd trash purge schedule ls -R -p rbd2/ns1 --format xml |
+        $XMLSTARLET sel -t -v '//schedules/schedule/pool')" = "-"
+    test "$(rbd trash purge schedule ls -R -p rbd2/ns1 --format xml |
+        $XMLSTARLET sel -t -v '//schedules/schedule/namespace')" = "-"
+    test "$(rbd trash purge schedule ls -R -p rbd2/ns1 --format xml |
+        $XMLSTARLET sel -t -v '//schedules/schedule/items/item/start_time')" = "00:17:00"
 
     for i in `seq 12`; do
         rbd trash purge schedule status --format xml |

--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -965,6 +965,12 @@ test_trash_purge_schedule() {
     rbd trash purge schedule ls -p rbd2 -R | grep 'every 2d starting at 00:17'
     rbd trash purge schedule ls -p rbd2/ns1 -R | grep 'every 2d starting at 00:17'
 
+    for i in `seq 12`; do
+        rbd trash purge schedule status --format xml |
+            $XMLSTARLET sel -t -v '//scheduled/item/pool' | grep 'rbd2' && break
+        sleep 10
+    done
+    rbd trash purge schedule status
     rbd trash purge schedule status --format xml |
         $XMLSTARLET sel -t -v '//scheduled/item/pool' | grep 'rbd2'
 

--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -52,9 +52,34 @@ class LevelSpec:
             return False
         return True
 
+    def intersects(self, level_spec):
+        if self.pool_id is None or level_spec.pool_id is None:
+            return True
+        if self.pool_id != level_spec.pool_id:
+            return False
+        if self.namespace is None or level_spec.namespace is None:
+            return True
+        if self.namespace != level_spec.namespace:
+            return False
+        if self.image_id is None or level_spec.image_id is None:
+            return True
+        if self.image_id != level_spec.image_id:
+            return False
+        return True
+
     @classmethod
     def make_global(cls):
         return LevelSpec("", "", None, None, None)
+
+    @classmethod
+    def from_pool_spec(cls, pool_id, pool_name, namespace=None):
+        if namespace is None:
+            id = "{}".format(pool_id)
+            name = "{}/".format(pool_name)
+        else:
+            id = "{}/{}".format(pool_id, namespace)
+            name = "{}/{}/".format(pool_name, namespace)
+        return LevelSpec(name, id, str(pool_id), namespace, None)
 
     @classmethod
     def from_name(cls, handler, name, namespace_validator=None,
@@ -444,6 +469,12 @@ class Schedules:
                 return self.schedules[level_spec_id]
             del levels[-1]
         return None
+
+    def intersects(self, level_spec):
+        for ls in self.level_specs.values():
+            if ls.intersects(level_spec):
+                return True
+        return False
 
     def to_list(self, level_spec):
         if level_spec.id in self.schedules:

--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -497,7 +497,7 @@ class Schedules:
         result = {}
         for level_spec_id, schedule in self.schedules.items():
             ls = self.level_specs[level_spec_id]
-            if ls == parent or ls.is_child_of(parent):
+            if ls == parent or ls == level_spec or ls.is_child_of(level_spec):
                 result[level_spec_id] = {
                     'name' : schedule.name,
                     'schedule' : schedule.to_list(),


### PR DESCRIPTION
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
