### PR TITLE
doc: Fix link errors

### DIFF
--- a/doc/cephfs/createfs.rst
+++ b/doc/cephfs/createfs.rst
@@ -68,8 +68,8 @@ choose which to use when mounting.
 	- `Mount CephFS`_
 	- `Mount CephFS as FUSE`_
 
-.. _Mount CephFS: ../../cephfs/kernel
-.. _Mount CephFS as FUSE: ../../cephfs/fuse
+.. _Mount CephFS: ../../cephfs/mount-using-kernel-driver
+.. _Mount CephFS as FUSE: ../../cephfs/mount-using-fuse
 
 If you have created more than one file system, and a client does not
 specify a file system when mounting, you can control which file system

--- a/doc/man/8/ceph-fuse.rst
+++ b/doc/man/8/ceph-fuse.rst
@@ -82,4 +82,4 @@ See also
 fusermount(8),
 :doc:`ceph <ceph>`\(8)
 
-.. _Mount CephFS using FUSE: ../../../cephfs/fuse/
+.. _Mount CephFS using FUSE: ../../../cephfs/mount-using-fuse/

--- a/doc/start/quick-cephfs.rst
+++ b/doc/start/quick-cephfs.rst
@@ -206,7 +206,7 @@ encounter trouble.
 .. _OS Recommendations: ../os-recommendations
 .. _Placement Group: ../../rados/operations/placement-groups
 .. _mount.ceph man page: ../../man/8/mount.ceph
-.. _Mount CephFS using Kernel Driver: ../cephfs/kernel
+.. _Mount CephFS using Kernel Driver: ../../cephfs/mount-using-kernel-driver
 .. _ceph-fuse man page: ../../man/8/ceph-fuse
-.. _Mount CephFS using FUSE: ../../cephfs/fuse
+.. _Mount CephFS using FUSE: ../../cephfs/mount-using-fuse
 .. _Erasure Code: ../../rados/operations/erasure-code


### PR DESCRIPTION
Some links about mount cephfs did not jump to the right place.

Signed-off-by: Sean Fang <silence.boy@live.cn>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
