### PR TITLE
nautilus: doc: default upmap_max_deviation is 5

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -22,7 +22,7 @@
   ``upmap_max_deviation`` which now is an integer number of PGs of deviation
   from the target PGs per OSD.  This can be set with a command like
   ``ceph config set mgr mgr/balancer/upmap_max_deviation 2``.  The default
-  ``upmap_max_deviation`` is 1.  There are situations where crush rules
+  ``upmap_max_deviation`` is 5.  There are situations where crush rules
   would not allow a pool to ever have completely balanced PGs.  For example, if
   crush requires 1 replica on each of 3 racks, but there are fewer OSDs in 1 of
   the racks.  In those cases, the configuration value can be increased.


### PR DESCRIPTION
See https://github.com/ceph/ceph/blob/nautilus/src/pybind/mgr/balancer/module.py#L303

Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>