### PR TITLE
mgr/orch: allow list daemons by service_name

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1878,7 +1878,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         return [s for n, s in sm.items()]
 
     @trivial_completion
-    def list_daemons(self, daemon_type=None, daemon_id=None,
+    def list_daemons(self, service_name=None, daemon_type=None, daemon_id=None,
                      host=None, refresh=False):
         if refresh:
             # ugly sync path, FIXME someday perhaps?
@@ -1892,9 +1892,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             if host and h != host:
                 continue
             for name, dd in dm.items():
-                if daemon_type and daemon_type != dd.daemon_type:
+                if daemon_type is not None and daemon_type != dd.daemon_type:
                     continue
-                if daemon_id and daemon_id != dd.daemon_id:
+                if daemon_id is not None and daemon_id != dd.daemon_id:
+                    continue
+                if service_name is not None and service_name != dd.service_name():
                     continue
                 result.append(dd)
         return result

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -837,8 +837,8 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def list_daemons(self, daemon_type=None, daemon_id=None, host=None, refresh=False):
-        # type: (Optional[str], Optional[str], Optional[str], bool) -> Completion
+    def list_daemons(self, service_name=None, daemon_type=None, daemon_id=None, host=None, refresh=False):
+        # type: (Optional[str], Optional[str], Optional[str], Optional[str], bool) -> Completion
         """
         Describe a daemon (of any kind) that is already configured in
         the orchestrator.

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -377,13 +377,15 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
     @_cli_read_command(
         'orch ps',
         "name=hostname,type=CephString,req=false "
+        "name=service_name,type=CephString,req=false "
         "name=daemon_type,type=CephString,req=false "
         "name=daemon_id,type=CephString,req=false "
         "name=format,type=CephChoices,strings=json|plain,req=false "
         "name=refresh,type=CephBool,req=false",
         'List daemons known to orchestrator')
-    def _list_daemons(self, hostname=None, daemon_type=None, daemon_id=None, format='plain', refresh=False):
-        completion = self.list_daemons(daemon_type,
+    def _list_daemons(self, hostname=None, service_name=None, daemon_type=None, daemon_id=None, format='plain', refresh=False):
+        completion = self.list_daemons(service_name,
+                                       daemon_type,
                                        daemon_id=daemon_id,
                                        host=hostname,
                                        refresh=refresh)

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -358,11 +358,11 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         return [v for k, v in spec.items()]
 
     @deferred_read
-    def list_daemons(self, daemon_type=None, daemon_id=None, host=None,
+    def list_daemons(self, service_name=None, daemon_type=None, daemon_id=None, host=None,
                      refresh=False):
         return self._list_daemons(daemon_type, daemon_id, host, refresh)
 
-    def _list_daemons(self, daemon_type=None, daemon_id=None, host=None,
+    def _list_daemons(self, service_name=None, daemon_type=None, daemon_id=None, host=None,
                       refresh=False):
         pods = self.rook_cluster.describe_pods(daemon_type, daemon_id, host)
         self.log.debug('pods %s' % pods)
@@ -390,8 +390,9 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
                 # Unknown type -- skip it
                 continue
 
+            if service_name is not None and service_name != sd.service_name():
+                continue
             sd.container_image_name = p['container_image_name']
-
             sd.created = p['created']
             sd.last_configured = p['created']
             sd.last_deployed = p['created']

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -220,7 +220,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         return list(filter(_filter_func, services))
 
     @deferred_read
-    def list_daemons(self, daemon_type=None, daemon_id=None, host=None, refresh=False):
+    def list_daemons(self, service_name=None, daemon_type=None, daemon_id=None, host=None, refresh=False):
         """
         There is no guarantee which daemons are returned by describe_service, except that
         it returns the mgr we're running in.
@@ -232,6 +232,8 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         daemons = self._daemons if self._daemons else self._get_ceph_daemons()
 
         def _filter_func(d):
+            if service_name is not None and service_name != d.service_name():
+                return False
             if daemon_type is not None and daemon_type != d.daemon_type:
                 return False
             if daemon_id is not None and daemon_id != d.daemon_id:


### PR DESCRIPTION
**RFC because although I can do the filtering in the Dashboard backend, I suggest implementing this in the Orchestrator layer, so users can also list daemons belonged to mds/rgw services.**

Services like rgw and mds are differentiated by service_name. For
example: mds.xyz vs. mds.abc. With current interface, we can't list all
daemons belonged to mds.xyz only. Add service_name as a new argument to
filter daemons by it.

Fixes: https://tracker.ceph.com/issues/44541
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
