### PR TITLE
Revert "rgw: bucket sync only allows one olh op at a time"

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3419,30 +3419,20 @@ class RGWBucketIncSyncShardMarkerTrack : public RGWSyncShardMarkerTrack<string, 
   rgw_bucket_shard_inc_sync_marker sync_marker;
 
   map<rgw_obj_key, string> key_to_marker;
-
-  struct operation {
-    rgw_obj_key key;
-    bool is_olh;
-  };
-  map<string, operation> marker_to_op;
-  std::set<std::string> pending_olh; // object names with pending olh operations
+  map<string, rgw_obj_key> marker_to_key;
 
   RGWSyncTraceNodeRef tn;
   RGWObjVersionTracker& objv_tracker;
   ceph::real_time* stable_timestamp;
 
   void handle_finish(const string& marker) override {
-    auto iter = marker_to_op.find(marker);
-    if (iter == marker_to_op.end()) {
+    map<string, rgw_obj_key>::iterator iter = marker_to_key.find(marker);
+    if (iter == marker_to_key.end()) {
       return;
     }
-    auto& op = iter->second;
-    key_to_marker.erase(op.key);
-    reset_need_retry(op.key);
-    if (op.is_olh) {
-      pending_olh.erase(op.key.name);
-    }
-    marker_to_op.erase(iter);
+    key_to_marker.erase(iter->second);
+    reset_need_retry(iter->second);
+    marker_to_key.erase(iter);
   }
 
 public:
@@ -3477,26 +3467,17 @@ public:
    * Also, we should make sure that we don't run concurrent operations on the same key with
    * different ops.
    */
-  bool index_key_to_marker(const rgw_obj_key& key, const string& marker, bool is_olh) {
-    auto result = key_to_marker.emplace(key, marker);
-    if (!result.second) { // exists
+  bool index_key_to_marker(const rgw_obj_key& key, const string& marker) {
+    if (key_to_marker.find(key) != key_to_marker.end()) {
       set_need_retry(key);
       return false;
     }
-    marker_to_op[marker] = operation{key, is_olh};
-    if (is_olh) {
-      // prevent other olh ops from starting on this object name
-      pending_olh.insert(key.name);
-    }
+    key_to_marker[key] = marker;
+    marker_to_key[marker] = key;
     return true;
   }
 
-  bool can_do_op(const rgw_obj_key& key, bool is_olh) {
-    // serialize olh ops on the same object name
-    if (is_olh && pending_olh.count(key.name)) {
-      tn->log(20, SSTR("sync of " << key << " waiting for pending olh op"));
-      return false;
-    }
+  bool can_do_op(const rgw_obj_key& key) {
     return (key_to_marker.find(key) == key_to_marker.end());
   }
 
@@ -4062,7 +4043,7 @@ int RGWBucketShardIncrementalSyncCR::operate(const DoutPrefixProvider *dpp)
         tn->log(20, SSTR("syncing object: "
             << bucket_shard_str{bs} << "/" << key));
         updated_status = false;
-        while (!marker_tracker.can_do_op(key, has_olh_epoch(entry->op))) {
+        while (!marker_tracker.can_do_op(key)) {
           if (!updated_status) {
             set_status() << "can't do op, conflicting inflight operation";
             updated_status = true;
@@ -4085,7 +4066,7 @@ int RGWBucketShardIncrementalSyncCR::operate(const DoutPrefixProvider *dpp)
           /* get error, stop */
           break;
         }
-        if (!marker_tracker.index_key_to_marker(key, cur_id, has_olh_epoch(entry->op))) {
+        if (!marker_tracker.index_key_to_marker(key, cur_id)) {
           set_status() << "can't do op, sync already in progress for object";
           tn->log(20, SSTR("skipping sync of entry: " << cur_id << ":" << key << " sync already in progress for object"));
           marker_tracker.try_update_high_marker(cur_id, 0, entry->timestamp);


### PR DESCRIPTION
This reverts commit d120ca1734d247a1b8c78e1a8bfd7441f4fef8b4.

Fixes: https://tracker.ceph.com/issues/44550

this commit came in https://github.com/ceph/ceph/pull/22347, which tried to guarantee that sync applied versioned object updates in the same order as the source zone

later work in https://github.com/ceph/ceph/pull/31325 fixed the sorting of versioned objects across zones, so that they agree regardless of the order that any zone applies the updates

as a result of https://github.com/ceph/ceph/pull/31325, this extra restriction from https://github.com/ceph/ceph/pull/22347 is no longer required

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
