### PR TITLE
nautilus: monitoring: fix RGW grafana chart 'Average GET/PUT Latencies'

### DIFF
--- a/monitoring/grafana/dashboards/radosgw-overview.json
+++ b/monitoring/grafana/dashboards/radosgw-overview.json
@@ -83,14 +83,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(ceph_rgw_get_initial_lat_sum[30s]) / rate(ceph_rgw_get_initial_lat_count[30s]))",
+          "expr": "rate(ceph_rgw_get_initial_lat_sum[30s]) / rate(ceph_rgw_get_initial_lat_count[30s])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "GET AVG",
           "refId": "A"
         },
         {
-          "expr": "avg(rate(ceph_rgw_put_initial_lat_sum[30s]) / rate(ceph_rgw_put_initial_lat_count[30s]))",
+          "expr": "rate(ceph_rgw_put_initial_lat_sum[30s]) / rate(ceph_rgw_put_initial_lat_count[30s])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "PUT AVG",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44549

---

backport of https://github.com/ceph/ceph/pull/33839
parent tracker: https://tracker.ceph.com/issues/44538

this backport was staged using ceph-backport.sh version 15.1.0.1009
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh