### PR TITLE
nautilus: doc: reset PendingReleaseNotes following 14.2.8 release

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,49 +1,6 @@
-14.2.8
+14.2.9
 ------
 
-* The following OSD memory config options related to bluestore cache autotuning can now
-  be configured during runtime:
-
-    - osd_memory_base (default: 768 MB)
-    - osd_memory_cache_min (default: 128 MB)
-    - osd_memory_expected_fragmentation (default: 0.15)
-    - osd_memory_target (default: 4 GB)
-
-  The above options can be set with::
-
-    ceph config set global <option> <value>
-
-* The MGR now accepts 'profile rbd' and 'profile rbd-read-only' user caps.
-  These caps can be used to provide users access to MGR-based RBD functionality
-  such as 'rbd perf image iostat' an 'rbd perf image iotop'.
-
-* The configuration value ``osd_calc_pg_upmaps_max_stddev`` used for upmap
-  balancing has been removed. Instead use the mgr balancer config
-  ``upmap_max_deviation`` which now is an integer number of PGs of deviation
-  from the target PGs per OSD.  This can be set with a command like
-  ``ceph config set mgr mgr/balancer/upmap_max_deviation 2``.  The default
-  ``upmap_max_deviation`` is 1.  There are situations where crush rules
-  would not allow a pool to ever have completely balanced PGs.  For example, if
-  crush requires 1 replica on each of 3 racks, but there are fewer OSDs in 1 of
-  the racks.  In those cases, the configuration value can be increased.
-
-* RGW: a mismatch between the bucket notification documentation and the actual
-  message format was fixed. This means that any endpoints receiving bucket 
-  notification, will now receive the same notifications inside an JSON array
-  named 'Records'. Note that this does not affect pulling bucket notification
-  from a subscription in a 'pubsub' zone, as these are already wrapped inside
-  that array.
-
-* Ceph will now issue a health warning if a RADOS pool as a ``pg_num``
-  value that is not a power of two.  This can be fixed by adjusting
-  the pool to a nearby power of two::
-
-    ceph osd pool set <pool-name> pg_num <new-pg-num>
-
-  Alternatively, the warning can be silenced with::
-
-    ceph config set global mon_warn_on_pool_pg_num_not_power_of_two false
-
-* Bucket notifications now support Kafka endpoints. This require librdkafka of version 0.9.2 and up.
-  Note that Ubuntu 16.04.6 LTS (Xenial Xerus) has an older version of librdkafka, and would
-￼ require an update to the library.
+* Bucket notifications now support Kafka endpoints. This requires librdkafka of
+  version 0.9.2 and up. Note that Ubuntu 16.04.6 LTS (Xenial Xerus) has an older
+  version of librdkafka, and would require an update to the library.


### PR DESCRIPTION
This commit cannot be cherry-picked from master because
PendingReleaseNotes is maintained separately for each stable release.

Signed-off-by: Nathan Cutler <ncutler@suse.com>
