### PR TITLE
rgw: allow enforcing of maximum requested in listing when possible

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6935,8 +6935,9 @@ std::vector<Option> get_rgw_options() {
     .set_default(1000)
     .set_min_max(1, 100000)
     .add_service("rgw")
-    .set_description("Upper bound on results in listing operations, ListBucket max-keys")
+    .set_description("Upper-bound on results in listing operations, ListBucket max-keys")
     .set_long_description("This caps the maximum permitted value for listing-like operations in RGW S3. "
+			  "Swift overrides this to 10000 for bucket listing. "
 			  "Affects ListBucket(max-keys), "
 			  "ListBucketVersions(max-keys), "
 			  "ListBucketMultipartUploads(max-uploads), "

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2888,9 +2888,12 @@ int RGWListBucket::parse_max_keys()
   // Bound min value of max-keys to '0'
   // Some S3 clients explicitly send max-keys=0 to detect if the bucket is
   // empty without listing any items.
-  return parse_value_and_bound(max_keys, max, 0,
-			g_conf().get_val<uint64_t>("rgw_max_listing_results"),
-			default_max);
+  return parse_value_and_bound(max_keys, // input string
+			       max, // output int
+			       0, // lower-bound
+			       g_conf().get_val<uint64_t>("rgw_max_listing_results"), // upper-bound
+			       default_max // default value
+    );
 }
 
 void RGWListBucket::pre_exec()

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2928,6 +2928,7 @@ void RGWListBucket::execute()
   list_op.params.end_marker = end_marker;
   list_op.params.list_versions = list_versions;
   list_op.params.allow_unordered = allow_unordered;
+  list_op.params.enforce_max = enforce_max;
 
   op_ret = list_op.list_objects(max, &objs, &common_prefixes, &is_truncated, s->yield);
   if (op_ret >= 0) {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2458,17 +2458,30 @@ static inline int parse_value_and_bound(
     char *endptr;
     output = strtol(input.c_str(), &endptr, 10);
     if (endptr) {
-      if (endptr == input.c_str()) return -EINVAL;
-      while (*endptr && isspace(*endptr)) // ignore white space
+      if (endptr == input.c_str()) {
+	// if no numeric characters, invalid input
+	return -EINVAL;
+      }
+      while (*endptr && isspace(*endptr)) { // ignore white space
         endptr++;
+      }
       if (*endptr) {
+	// if after skipping white-space we're not at the null
+	// terminating character, then there are one/more illegal
+	// characters
         return -EINVAL;
       }
     }
-    if(output > upper_bound) {
-      output = upper_bound;
+
+    // if the default values is greater than the upper-bound, it
+    // becomes the upper-bound; for example, Swift's default value for
+    // bucket listing is 10,000
+    const long true_upper_bound = std::max(upper_bound, default_val);
+
+    if (output > true_upper_bound) {
+      output = true_upper_bound;
     }
-    if(output < lower_bound) {
+    if (output < lower_bound) {
       output = lower_bound;
     }
   } else {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -841,6 +841,7 @@ protected:
   int default_max;
   bool is_truncated;
   bool allow_unordered;
+  bool enforce_max; // return max if possible
 
   int shard_id;
 
@@ -849,7 +850,8 @@ protected:
 public:
   RGWListBucket() : bucket(nullptr), list_versions(false), max(0),
                     default_max(0), is_truncated(false),
-		    allow_unordered(false), shard_id(-1) {}
+		    allow_unordered(false), enforce_max(false),
+		    shard_id(-1) {}
   ~RGWListBucket() { delete bucket; }
   int verify_permission() override;
   void pre_exec() override;
@@ -865,7 +867,7 @@ public:
   RGWOpType get_type() override { return RGW_OP_LIST_BUCKET; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
   virtual bool need_container_stats() { return false; }
-};
+}; // class RGWListBucket
 
 class RGWGetBucketLogging : public RGWOp {
 public:

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1973,15 +1973,24 @@ int RGWRados::Bucket::List::list_objects_ordered(
       " INFO end of outer loop, truncated=" << truncated <<
       ", count=" << count << ", attempt=" << attempt << dendl;
 
-    if (!truncated || count >= (max + 1) / 2) {
-      // if we finished listing, or if we're returning at least half the
-      // requested entries, that's enough; S3 and swift protocols allow
-      // returning fewer than max entries
-      break;
-    } else if (attempt > 8 && count >= 1) {
-      // if we've made at least 8 attempts and we have some, but very
-      // few, results, return with what we have
-      break;
+    if (params.enforce_max) {
+      // swift protocol obligates us to return max if we can
+      if (!truncated || count == max) {
+	break;
+      }
+    } else {
+      // s3 protocol allows us to return fewer than requested, so
+      // we'll try to balance between # returned and iterations
+      if (!truncated || count >= (max + 1) / 2) {
+	// if we finished listing, or if we're returning at least half the
+	// requested entries, that's enough; S3 and swift protocols allow
+	// returning fewer than max entries
+	break;
+      } else if (attempt > 8 && count >= 1) {
+	// if we've made at least 8 attempts and we have some, but very
+	// few, results, return with what we have
+	break;
+      }
     }
 
     ldout(cct, 1) << "RGWRados::Bucket::List::" << __func__ <<
@@ -1990,6 +1999,12 @@ int RGWRados::Bucket::List::list_objects_ordered(
   } // read attempt loop
 
 done:
+
+  ldout(cct, 10) << "RGWRados::Bucket::List::" << __func__ <<
+    " INFO returning " <<
+    result->size() << " entry(ies) and " <<
+    (common_prefixes ? common_prefixes->size() : 0) <<
+    " common prefix(es)" << dendl;
 
   if (is_truncated) {
     *is_truncated = truncated;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1016,12 +1016,14 @@ public:
         RGWAccessListFilter *filter;
         bool list_versions;
 	bool allow_unordered;
+	bool enforce_max; // return max # requested if at all possible
 
         Params() :
 	  enforce_ns(true),
 	  filter(NULL),
 	  list_versions(false),
-	  allow_unordered(false)
+	  allow_unordered(false),
+	  enforce_max(false)
 	{}
       } params;
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -299,6 +299,7 @@ int RGWListBucket_ObjStore_SWIFT::get_params()
   marker = s->info.args.get("marker");
   end_marker = s->info.args.get("end_marker");
   max_keys = s->info.args.get("limit");
+  enforce_max = true;
 
   // non-standard
   s->info.args.get_bool("allow_unordered", &allow_unordered, false);


### PR DESCRIPTION
Some Swift clients assume that the number of items requested in a bucket listing will be returned if possible. This allows the underlying code to enfore that behavior, so Swift can get that behavior, but S3 does not have to.

Tracker: https://tracker.ceph.com/issues/44554