### PR TITLE
rgw: fix bug where bucket listing end marker not always set correctly

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8344,7 +8344,7 @@ int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
     // into results_trackers vector
     tracker_idx = candidates.begin()->second;
     auto& tracker = results_trackers.at(tracker_idx);
-    last_entry_visited = &tracker.dir_entry();
+
     const string& name = tracker.entry_name();
     rgw_bucket_dir_entry& dirent = tracker.dir_entry();
 
@@ -8377,10 +8377,12 @@ int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
       ldout(cct, 10) << "RGWRados::" << __func__ << ": got " <<
 	dirent.key.name << "[" << dirent.key.instance << "]" << dendl;
       m[name] = std::move(dirent);
+      last_entry_visited = &(m[name]);
       ++count;
     } else {
       ldout(cct, 10) << "RGWRados::" << __func__ << ": skipping " <<
 	dirent.key.name << "[" << dirent.key.instance << "]" << dendl;
+      last_entry_visited = &tracker.dir_entry();
     }
 
     // refresh the candidates map
@@ -8432,8 +8434,7 @@ int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
   }
 
   if (last_entry_visited != nullptr && last_entry) {
-    // since we'll not need this any more, might as well move it...
-    *last_entry = std::move(last_entry_visited->key);
+    *last_entry = last_entry_visited->key;
     ldout(cct, 20) << "RGWRados::" << __func__ <<
       ": returning, last_entry=" << *last_entry << dendl;
   } else {


### PR DESCRIPTION
Due to using std::move a second time, often RGWRados::cls_bucket_list_ordered would not set its end marker correctly. This affected the behavior of RGWRados::Bucket::List::list_objects_ordered, and might have caused it return fewer elements than it may have otherwise.

Tracker: https://tracker.ceph.com/issues/44553