### PR TITLE
qa/workunits/cephadm/test_cephadm.sh: move osd test to ceph-volume

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -273,11 +273,33 @@ loop_dev=$($SUDO losetup -f)
 $SUDO vgremove -f $OSD_VG_NAME || true
 $SUDO losetup $loop_dev $TMPDIR/$OSD_IMAGE_NAME
 $SUDO pvcreate $loop_dev && $SUDO vgcreate $OSD_VG_NAME $loop_dev
+
+# osd boostrap keyring
+$CEPHADM shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
+      ceph auth get client.bootstrap-osd > $TMPDIR/keyring.bootstrap.osd
+
 for id in `seq 0 $((--OSD_TO_CREATE))`; do
     $SUDO lvcreate -l $((100/$OSD_TO_CREATE))%VG -n $OSD_LV_NAME.$id $OSD_VG_NAME
-    $CEPHADM shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
-            ceph orch daemon add osd \
-                $(hostname):/dev/$OSD_VG_NAME/$OSD_LV_NAME.$id
+    device_name=/dev/$OSD_VG_NAME/$OSD_LV_NAME.$id
+
+    # prepare the osd
+    $CEPHADM ceph-volume --config $CONFIG --keyring $TMPDIR/keyring.bootstrap.osd -- \
+            lvm prepare --bluestore --data $device_name --no-systemd
+    $CEPHADM ceph-volume --config $CONFIG --keyring $TMPDIR/keyring.bootstrap.osd -- \
+            lvm batch --no-auto $device_name --yes --no-systemd
+
+    # osd id and osd fsid
+    $CEPHADM ceph-volume --config $CONFIG --keyring $TMPDIR/keyring.bootstrap.osd -- \
+            lvm list --format json $device_name > $TMPDIR/osd.map
+    osd_id=$($SUDO cat $TMPDIR/osd.map | jq -cr '.. | ."ceph.osd_id"? | select(.)')
+    osd_fsid=$($SUDO cat $TMPDIR/osd.map | jq -cr '.. | ."ceph.osd_fsid"? | select(.)')
+
+    # deploy the osd
+    $CEPHADM deploy --name osd.$osd_id \
+          --fsid $FSID \
+          --keyring $TMPDIR/keyring.bootstrap.osd \
+          --config $CONFIG \
+          --osd-fsid $osd_fsid
 done
 
 # add node-exporter

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2600,19 +2600,16 @@ def command_ceph_volume():
     tmp_config = None
     tmp_keyring = None
 
-    if args.config_json:
-        # note: this will always pull from args.config_json (we
-        # require it) and never args.config or args.keyring.
-        (config, keyring) = get_config_and_keyring()
+    (config, keyring) = get_config_and_keyring()
 
-        # tmp keyring file
-        tmp_keyring = write_tmp(keyring, uid, gid)
+    # tmp keyring file
+    tmp_keyring = write_tmp(keyring, uid, gid)
 
-        # tmp config file
-        tmp_config = write_tmp(config, uid, gid)
+    # tmp config file
+    tmp_config = write_tmp(config, uid, gid)
 
-        mounts[tmp_config.name] = '/etc/ceph/ceph.conf:z'
-        mounts[tmp_keyring.name] = '/var/lib/ceph/bootstrap-osd/ceph.keyring:z'
+    mounts[tmp_config.name] = '/etc/ceph/ceph.conf:z'
+    mounts[tmp_keyring.name] = '/var/lib/ceph/bootstrap-osd/ceph.keyring:z'
 
     c = CephContainer(
         image=args.image,
@@ -3949,6 +3946,12 @@ def _get_parser():
     parser_ceph_volume.add_argument(
         '--config-json',
         help='JSON file with config and (client.bootrap-osd) key')
+    parser_ceph_volume.add_argument(
+        '--config', '-c',
+        help='ceph conf file')
+    parser_ceph_volume.add_argument(
+        '--keyring', '-k',
+        help='ceph.keyring to pass through to the container')
     parser_ceph_volume.add_argument(
         'command', nargs='+',
         help='command')


### PR DESCRIPTION
instead of running via the orchestrator

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
