### PR TITLE
cephadm: merge `--config-and-keyring` and `--config-json` args

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -31,7 +31,7 @@ You can invoke cephadm in two ways:
 
        injected_argv = ['ls']
 
-   For reading stdin from the '--config-and-json -' argument,
+   For reading stdin from the '--config-json -' argument,
 
        injected_stdin = '...'
 """
@@ -1124,14 +1124,14 @@ def get_parm(option):
 
 def get_config_and_keyring():
     # type: () -> Tuple[str, str]
-    if args.config_and_keyring:
-        if args.config_and_keyring == '-':
+    if 'config_json' in args and args.config_json:
+        if args.config_json == '-':
             try:
                 j = injected_stdin # type: ignore
             except NameError:
                 j = sys.stdin.read()
         else:
-            with open(args.config_and_keyring, 'r') as f:
+            with open(args.config_json, 'r') as f:
                 j = f.read()
         d = json.loads(j)
         config = d.get('config')
@@ -2296,8 +2296,8 @@ def command_ceph_volume():
     tmp_config = None
     tmp_keyring = None
 
-    if args.config_and_keyring:
-        # note: this will always pull from args.config_and_keyring (we
+    if args.config_json:
+        # note: this will always pull from args.config_json (we
         # require it) and never args.config or args.keyring.
         (config, keyring) = get_config_and_keyring()
 
@@ -3481,7 +3481,7 @@ def _get_parser():
         '--fsid',
         help='cluster FSID')
     parser_ceph_volume.add_argument(
-        '--config-and-keyring',
+        '--config-json',
         help='JSON file with config and (client.bootrap-osd) key')
     parser_ceph_volume.add_argument(
         'command', nargs='+',
@@ -3630,9 +3630,6 @@ def _get_parser():
     parser_deploy.add_argument(
         '--key',
         help='key for new daemon')
-    parser_deploy.add_argument(
-        '--config-and-keyring',
-        help='JSON file with config and keyrings for the daemon and crash agent')
     parser_deploy.add_argument(
         '--osd-fsid',
         help='OSD uuid, if creating an OSD container')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1128,14 +1128,16 @@ def get_config_and_keyring():
         d = get_parm(args.config_json)
         config = d.get('config')
         keyring = d.get('keyring')
-    else:
-        if args.key:
-            keyring = '[%s]\n\tkey = %s\n' % (args.name, args.key)
-        elif args.keyring:
-            with open(args.keyring, 'r') as f:
-                keyring = f.read()
+
+    if 'config' in args and args.config:
         with open(args.config, 'r') as f:
             config = f.read()
+
+    if 'key' in args and args.key:
+        keyring = '[%s]\n\tkey = %s\n' % (args.name, args.key)
+    elif 'keyring' in args and args.keyring:
+        with open(args.keyring, 'r') as f:
+            keyring = f.read()
 
     if not config:
         raise Error('no config provided')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1125,15 +1125,7 @@ def get_parm(option):
 def get_config_and_keyring():
     # type: () -> Tuple[str, str]
     if 'config_json' in args and args.config_json:
-        if args.config_json == '-':
-            try:
-                j = injected_stdin # type: ignore
-            except NameError:
-                j = sys.stdin.read()
-        else:
-            with open(args.config_json, 'r') as f:
-                j = f.read()
-        d = json.loads(j)
+        d = get_parm(args.config_json)
         config = d.get('config')
         keyring = d.get('keyring')
     else:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1134,10 +1134,14 @@ def get_config_and_keyring():
         elif args.keyring:
             with open(args.keyring, 'r') as f:
                 keyring = f.read()
-        else:
-            raise Error('no keyring provided')
         with open(args.config, 'r') as f:
             config = f.read()
+
+    if not config:
+        raise Error('no config provided')
+    elif not keyring:
+        raise Error('no keyring provided')
+
     return (config, keyring)
 
 def get_container_mounts(fsid, daemon_type, daemon_id,

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1987,7 +1987,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         before_osd_uuid_map = self.get_osd_uuid_map(only_up=True)
 
         split_cmd = cmd.split(' ')
-        _cmd = ['--config-and-keyring', '-', '--']
+        _cmd = ['--config-json', '-', '--']
         _cmd.extend(split_cmd)
         out, err, code = self._run_cephadm(
             host, 'osd', 'ceph-volume',
@@ -2102,7 +2102,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 'config': config,
                 'keyring': keyring,
             }
-            extra_args.extend(['--config-and-keyring', '-'])
+            extra_args.extend(['--config-json', '-'])
 
             # osd deployments needs an --osd-uuid arg
             if daemon_type == 'osd':

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2085,7 +2085,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 if daemon_type == 'mon':
                     ename = 'mon.'
                 else:
-                    ename = '%s.%s' % (daemon_type, daemon_id)
+                    ename = name_to_config_section(daemon_type + '.' + daemon_id)
                 ret, keyring, err = self.mon_command({
                     'prefix': 'auth get',
                     'entity': ename,


### PR DESCRIPTION
Both args can be passed via `cephadm deploy` and both read JSON from stdin.

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
