### PR TITLE
qa/suites/rados/verify: debug_ms = 1

### DIFF
--- a/qa/suites/rados/verify/ceph.yaml
+++ b/qa/suites/rados/verify/ceph.yaml
@@ -1,6 +1,8 @@
 overrides:
   ceph:
     conf:
+      global:
+        osd heartbeat grace: 60
       mon:
         mon min osdmap epochs: 50
         paxos service trim min: 10
@@ -10,6 +12,8 @@ overrides:
         mon osdmap full prune txsize: 2
       osd:
         debug monc: 20
+        debug ms: 1
+        debug osd: 20
 tasks:
 - install:
 - ceph:


### PR DESCRIPTION
The rados api tests are failing WatchNotify because the OSDs are so
heavily lagged.. in large part due to the high debug level of debug_ms=20
and debug_osd=25.  Reduce that.

Signed-off-by: Sage Weil <sage@redhat.com>