### PR TITLE
osd/osd_types: reset head etc. if the whole pg-log list is divergent

### DIFF
--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4363,6 +4363,13 @@ public:
     if (rollback_info_trimmed_to > newhead)
       rollback_info_trimmed_to = newhead;
 
+    if (log.empty()) {
+      // hmm, the whole log list is divergent, reset everything
+      head = tail = eversion_t();
+      can_rollback_to = eversion_t();
+      rollback_info_trimmed_to = eversion_t();
+    }
+
     return divergent;
   }
 


### PR DESCRIPTION
When merging log, it is possible that we have all local log
entries falling behind with the incoming log list (usually
the authoritative history), as a result of which we may have
to throw the whole local list out and reset head to:
	MAX(incoming-log's tail, my-log's tail)

Since by definition a log tail is the cursor pointing to the
log version that is prior to oldest, it is also possible the
oldest incoming log entry could have a version greater than
the new local head. For example::

	incoming-log: (19'4620,34'6006], oldest(33'4621)
        local-log:(19'5300,19'5379], oldest(19'5301)
	local-log-head(when rewinding is done) = MAX(19'4620, 19'5300) = 19'5300

As we start to merge incoming log entries into our local empty
list, OSDs will crash if they see any log entry to add has a newer
version than current log head (e.g., because PG-logs are strictly
ordered)::

	first-log-entry-to-merge: 33'4621
	local-log-head: 19'5300

Fix by resetting log head etc. to a sane version if the whole
thing goes divergent, which are also the default values by
definition that an empty log list should have.

Fixes: https://tracker.ceph.com/issues/44532
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
