### PR TITLE
msg/async/dpdk: Use hash map to manage mbuf releasing

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -180,7 +180,6 @@ OPTION(ms_dpdk_hw_flow_control, OPT_BOOL)
 // Weighing of a hardware network queue relative to a software queue (0=no work, 1=     equal share)")
 OPTION(ms_dpdk_hw_queue_weight, OPT_FLOAT)
 OPTION(ms_dpdk_debug_allow_loopback, OPT_BOOL)
-OPTION(ms_dpdk_rx_buffer_count_per_core, OPT_INT)
 
 OPTION(inject_early_sigterm, OPT_BOOL)
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1243,10 +1243,6 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
-    Option("ms_dpdk_rx_buffer_count_per_core", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(8192)
-    .set_description(""),
-
     Option("inject_early_sigterm", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .set_description("send ourselves a SIGTERM early during startup"),


### PR DESCRIPTION
In rx_gc(), it is need rte_mem_virt2phy() to fill the mbuf when
releasing mbuf, we observes that rte_mem_virt2phy costs a lot time
because of syscall. Use hash map to manage the mappings of message
addr and mbuf, it isn't need rte_mem_virt2phy() when releasing mbuf.

the test result using perf_msgr_client shows below: 
before optimization:
Total op 2000 run time 99934968us, bw = 1280.83MB/s
after optimization:
Total op 2000 run time 78687214us, bw = 1626.69MB/s

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>
Signed-off-by: luo rixin <luorixin@huawei.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
