### PR TITLE
rgw: implement S3Control set of AccountPublicAccessBlock apis 

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -145,6 +145,7 @@ set(librgw_common_srcs
   rgw_rest_sts.cc
   rgw_perf_counters.cc
   rgw_rest_iam.cc
+  rgw_rest_s3control.cc
   rgw_object_lock.cc
   rgw_kms.cc
   rgw_url.cc)

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1,4 +1,5 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
 /*
@@ -543,6 +544,10 @@ enum RGWOpType {
   RGW_OP_PUT_BUCKET_PUBLIC_ACCESS_BLOCK,
   RGW_OP_GET_BUCKET_PUBLIC_ACCESS_BLOCK,
   RGW_OP_DELETE_BUCKET_PUBLIC_ACCESS_BLOCK,
+  RGW_OP_PUT_ACCOUNT_PUBLIC_ACCESS_BLOCK,
+  RGW_OP_GET_ACCOUNT_PUBLIC_ACCESS_BLOCK,
+  RGW_OP_DELETE_ACCOUNT_PUBLIC_ACCESS_BLOCK,
+
 };
 
 class RGWAccessControlPolicy;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1707,6 +1707,7 @@ struct req_state : DoutPrefixProvider {
   rgw::IAM::Environment env;
   boost::optional<rgw::IAM::Policy> iam_policy;
   boost::optional<PublicAccessBlockConfiguration> bucket_access_conf;
+  boost::optional<PublicAccessBlockConfiguration> account_access_conf;
   vector<rgw::IAM::Policy> iam_user_policies;
 
   /* Is the request made by an user marked as a system one?
@@ -2134,6 +2135,7 @@ struct perm_state_base {
   int perm_mask;
   bool defer_to_bucket_acls;
   boost::optional<PublicAccessBlockConfiguration> bucket_access_conf;
+  boost::optional<PublicAccessBlockConfiguration> account_access_conf;
 
   perm_state_base(CephContext *_cct,
                   const rgw::IAM::Environment& _env,

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -29,6 +29,7 @@
 #include "rgw_rest_config.h"
 #include "rgw_rest_realm.h"
 #include "rgw_rest_sts.h"
+#include "rgw_rest_s3control.h"
 #include "rgw_swift_auth.h"
 #include "rgw_log.h"
 #include "rgw_tools.h"
@@ -382,12 +383,17 @@ int radosgw_Main(int argc, const char **argv)
   const bool sts_enabled = apis_map.count("sts") > 0;
   const bool iam_enabled = apis_map.count("iam") > 0;
   const bool pubsub_enabled = apis_map.count("pubsub") > 0;
+  const bool s3control_enabled = apis_map.count("s3control") > 0;
   // Swift API entrypoint could placed in the root instead of S3
   const bool swift_at_root = g_conf()->rgw_swift_url_prefix == "/";
   if (apis_map.count("s3") > 0 || s3website_enabled) {
     if (! swift_at_root) {
       rest.register_default_mgr(set_logging(rest_filter(store->getRados(), RGW_REST_S3,
                                                         new RGWRESTMgr_S3(s3website_enabled, sts_enabled, iam_enabled, pubsub_enabled))));
+      if (s3control_enabled) {
+      	rest.register_resource("v20180820", new RGWRESTMgr_S3Control);
+      }
+
     } else {
       derr << "Cannot have the S3 or S3 Website enabled together with "
            << "Swift API placed in the root of hierarchy" << dendl;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -58,6 +58,7 @@
 #include "rgw_rest_sts.h"
 #include "rgw_rest_iam.h"
 #include "rgw_sts.h"
+#include "rgw_rest_s3control.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
@@ -5281,6 +5282,10 @@ AWSGeneralAbstractor::get_auth_data_v4(const req_state* const s,
         case RGW_OP_PUT_BUCKET_PUBLIC_ACCESS_BLOCK:
         case RGW_OP_GET_BUCKET_PUBLIC_ACCESS_BLOCK:
         case RGW_OP_DELETE_BUCKET_PUBLIC_ACCESS_BLOCK:
+        case RGW_OP_PUT_ACCOUNT_PUBLIC_ACCESS_BLOCK:
+        case RGW_OP_GET_ACCOUNT_PUBLIC_ACCESS_BLOCK:
+        case RGW_OP_DELETE_ACCOUNT_PUBLIC_ACCESS_BLOCK:
+
           break;
         default:
           dout(10) << "ERROR: AWS4 completion for this operation NOT IMPLEMENTED" << dendl;

--- a/src/rgw/rgw_rest_s3control.cc
+++ b/src/rgw/rgw_rest_s3control.cc
@@ -102,7 +102,7 @@ void RGWPutAccountPublicAccessBlock::execute()
                                 &attrs);
     return;
   } else {
-    ldpp_dout(this, 5) << __func__ << "ERROR: empty account name" << dendl;
+    ldpp_dout(this, 5) << __func__ << "ERROR: Invalid account name" << dendl;
     op_ret = -EINVAL;
     return;
   }

--- a/src/rgw/rgw_rest_s3control.cc
+++ b/src/rgw/rgw_rest_s3control.cc
@@ -19,7 +19,7 @@ RGWOp* RGWHandler_S3AccountPublicAccessBlock::op_get()
   return new RGWGetAccountPublicAccessBlock;
 }
 
-int RGWPutAccountPublicAccessBlock::check_caps(RGWUserCaps& caps)
+int RGWPutAccountPublicAccessBlock::check_caps(const RGWUserCaps& caps)
 {
   return caps.check_cap("user-policy", RGW_CAP_WRITE);
 }
@@ -35,7 +35,7 @@ int RGWPutAccountPublicAccessBlock::verify_permission()
     return -EACCES;
   }
 
-  if(int ret = check_caps(s->user->caps); ret == 0) {
+  if(int ret = check_caps(s->user->get_caps()); ret == 0) {
     return ret;
   }
   // TODO implement x-amz-account-id stuff here
@@ -89,7 +89,7 @@ void RGWPutAccountPublicAccessBlock::execute()
 
   map<string, bufferlist> attrs;
   attrs.emplace(RGW_ATTR_PUBLIC_ACCESS, std::move(bl));
-  if (const auto account_name = s->user->user_id.tenant;
+  if (const auto account_name = s->user->get_tenant();
       ! account_name.empty()) {
     auto svc = store->getRados()->pctl->svc;
     auto obj_ctx = svc->sysobj->init_obj_ctx();
@@ -117,7 +117,7 @@ void RGWPutAccountPublicAccessBlock::send_response()
   end_header(s);
 }
 
-int RGWGetAccountPublicAccessBlock::check_caps(RGWUserCaps& caps)
+int RGWGetAccountPublicAccessBlock::check_caps(const RGWUserCaps& caps)
 {
   return caps.check_cap("user-policy", RGW_CAP_READ);
 }
@@ -138,7 +138,7 @@ int RGWGetAccountPublicAccessBlock::get_params()
       return -EINVAL;
     }
 
-    if (account_name != s->user->user_id.tenant) {
+    if (account_name != s->user->get_tenant()) {
       ldpp_dout(this, 5) << __func__ << "ERROR: Account ID doesn't match the tenant" << dendl;
       return -EINVAL;
     }
@@ -154,7 +154,7 @@ int RGWGetAccountPublicAccessBlock::verify_permission()
     return -EACCES;
   }
 
-  if(int ret = check_caps(s->user->caps); ret == 0) {
+  if(int ret = check_caps(s->user->get_caps()); ret == 0) {
     return ret;
   }
   // TODO implement x-amz-account-id stuff here
@@ -171,7 +171,7 @@ void RGWGetAccountPublicAccessBlock::execute()
 
   auto svc = store->getRados()->pctl->svc;
   auto obj_ctx = svc->sysobj->init_obj_ctx();
-  const auto& account_name = s->user->user_id.tenant;
+  const auto& account_name = s->user->get_tenant();
 
   map<string, bufferlist> attrs;
   bufferlist bl;
@@ -229,7 +229,7 @@ int RGWDeleteAccountPublicAccessBlock::get_params()
       return -EINVAL;
     }
 
-    if (account_name != s->user->user_id.tenant) {
+    if (account_name != s->user->get_tenant()) {
       ldpp_dout(this, 5) << __func__ << "ERROR: Account ID doesn't match the tenant" << dendl;
       return -EINVAL;
     }
@@ -238,7 +238,7 @@ int RGWDeleteAccountPublicAccessBlock::get_params()
 
   return 0;
 }
-int RGWDeleteAccountPublicAccessBlock::check_caps(RGWUserCaps& caps)
+int RGWDeleteAccountPublicAccessBlock::check_caps(const RGWUserCaps& caps)
 {
   return caps.check_cap("user-policy", RGW_CAP_WRITE);
 }
@@ -249,7 +249,7 @@ int RGWDeleteAccountPublicAccessBlock::verify_permission()
     return -EACCES;
   }
 
-  if(int ret = check_caps(s->user->caps); ret == 0) {
+  if(int ret = check_caps(s->user->get_caps()); ret == 0) {
     return ret;
   }
   // TODO implement x-amz-account-id stuff here
@@ -267,7 +267,7 @@ void RGWDeleteAccountPublicAccessBlock::execute()
 
   auto svc = store->getRados()->pctl->svc;
   auto obj_ctx = svc->sysobj->init_obj_ctx();
-  const auto& account_name = s->user->user_id.tenant;
+  const auto& account_name = s->user->get_tenant();
 
   map<string, bufferlist> attrs;
   bufferlist bl;

--- a/src/rgw/rgw_rest_s3control.cc
+++ b/src/rgw/rgw_rest_s3control.cc
@@ -1,0 +1,88 @@
+#include "rgw_rest_s3control.h"
+#include "rgw_common.h"
+#include "rgw_op.h"
+#include "services/svc_zone.h"
+
+RGWOp* RGWHandler_S3AccountPublicAccessBlock::op_put()
+{
+  return new RGWPutAccountPublicAccessBlock;
+}
+
+int RGWPutAccountPublicAccessBlock::check_caps(RGWUserCaps& caps)
+{
+  return caps.check_cap("user-policy", RGW_CAP_WRITE);
+}
+RGWOpType RGWPutAccountPublicAccessBlock::get_type()
+{
+  return RGW_OP_PUT_ACCOUNT_PUBLIC_ACCESS_BLOCK;
+}
+
+int RGWPutAccountPublicAccessBlock::verify_permission()
+{
+  if (s->auth.identity->is_anonymous()) {
+    return -EACCES;
+  }
+
+  if(int ret = check_caps(s->user->caps); ret == 0) {
+    return ret;
+  }
+  // TODO implement x-amz-account-id stuff here
+  return 0;
+}
+
+int RGWPutAccountPublicAccessBlock::get_params()
+{
+  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  std::tie(op_ret, data) = rgw_rest_read_all_input(s, max_size, false);
+  return op_ret;
+}
+
+void RGWPutAccountPublicAccessBlock::execute()
+{
+  RGWXMLDecoder::XMLParser parser;
+  if (!parser.init()) {
+    ldpp_dout(this, 0) << "ERROR: failed to initialize parser" << dendl;
+    op_ret = -EINVAL;
+    return;
+  }
+
+  op_ret = get_params();
+  if (op_ret < 0)
+    return;
+
+  if (!parser.parse(data.c_str(), data.length(), 1)) {
+    ldpp_dout(this, 0) << "ERROR: malformed XML" << dendl;
+    op_ret = -ERR_MALFORMED_XML;
+    return;
+  }
+
+  try {
+    RGWXMLDecoder::decode_xml("PublicAccessBlockConfiguration", access_conf, &parser, true);
+  } catch (RGWXMLDecoder::err &err) {
+    ldpp_dout(this, 5) << "unexpected xml:" << err << dendl;
+    op_ret = -ERR_MALFORMED_XML;
+    return;
+  }
+
+  if (!store->svc()->zone->is_meta_master()) {
+    op_ret = forward_request_to_master(s, NULL, store, data, nullptr);
+    if (op_ret < 0) {
+      ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
+      return;
+    }
+  }
+
+  bufferlist bl;
+  access_conf.encode(bl);
+
+  // TODO implement write!
+}
+
+void RGWPutAccountPublicAccessBlock::send_response()
+{
+  if (op_ret) {
+    set_req_state_err(s, op_ret);
+  }
+  dump_errno(s);
+  end_header(s);
+}

--- a/src/rgw/rgw_rest_s3control.h
+++ b/src/rgw/rgw_rest_s3control.h
@@ -69,7 +69,7 @@ protected:
   bufferlist data;
   PublicAccessBlockConfiguration access_conf;
 public:
-  int check_caps(RGWUserCaps& caps) override;
+  int check_caps(const RGWUserCaps& caps) override;
   int verify_permission() override;
   const char* name() const override { return "put_account_public_access_block";}
   int get_params();
@@ -81,7 +81,7 @@ public:
 class RGWGetAccountPublicAccessBlock : public RGWRESTOp {
   PublicAccessBlockConfiguration access_conf;
 public:
-  int check_caps(RGWUserCaps& caps) override;
+  int check_caps(const RGWUserCaps& caps) override;
   int verify_permission() override;
   const char* name() const override { return "get_account_public_access_block";}
   int get_params();
@@ -93,7 +93,7 @@ public:
 
 class RGWDeleteAccountPublicAccessBlock : public RGWRESTOp {
 public:
-  int check_caps(RGWUserCaps& caps) override;
+  int check_caps(const RGWUserCaps& caps) override;
   int verify_permission() override;
   const char* name() const override { return "get_account_public_access_block";}
   int get_params();

--- a/src/rgw/rgw_rest_s3control.h
+++ b/src/rgw/rgw_rest_s3control.h
@@ -21,6 +21,7 @@
 class RGWHandler_S3AccountPublicAccessBlock : public RGWHandler_REST_S3 {
 protected:
   RGWOp *op_put() override;
+  RGWOp *op_get() override;
 public:
   using RGWHandler_REST_S3::RGWHandler_REST_S3;
   ~RGWHandler_S3AccountPublicAccessBlock() override = default;
@@ -71,6 +72,18 @@ public:
   int check_caps(RGWUserCaps& caps) override;
   int verify_permission() override;
   const char* name() const override { return "put_account_public_access_block";}
+  int get_params();
+  RGWOpType get_type() override;
+  void execute() override;
+  void send_response() override;
+};
+
+class RGWGetAccountPublicAccessBlock : public RGWRESTOp {
+  PublicAccessBlockConfiguration access_conf;
+public:
+  int check_caps(RGWUserCaps& caps) override;
+  int verify_permission() override;
+  const char* name() const override { return "get_account_public_access_block";}
   int get_params();
   RGWOpType get_type() override;
   void execute() override;

--- a/src/rgw/rgw_rest_s3control.h
+++ b/src/rgw/rgw_rest_s3control.h
@@ -89,3 +89,15 @@ public:
   void execute() override;
   void send_response() override;
 };
+
+
+class RGWDeleteAccountPublicAccessBlock : public RGWRESTOp {
+public:
+  int check_caps(RGWUserCaps& caps) override;
+  int verify_permission() override;
+  const char* name() const override { return "get_account_public_access_block";}
+  int get_params();
+  RGWOpType get_type() override;
+  void execute() override;
+  void send_response() override;
+};

--- a/src/rgw/rgw_rest_s3control.h
+++ b/src/rgw/rgw_rest_s3control.h
@@ -1,0 +1,78 @@
+
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+#include "rgw_rest.h"
+#include "rgw_rest_s3.h"
+
+class RGWHandler_S3AccountPublicAccessBlock : public RGWHandler_REST_S3 {
+protected:
+  RGWOp *op_put() override;
+public:
+  using RGWHandler_REST_S3::RGWHandler_REST_S3;
+  ~RGWHandler_S3AccountPublicAccessBlock() override = default;
+};
+
+class RGWRESTMgr_S3AccountPublicAccessBlock : public RGWRESTMgr {
+public:
+  RGWRESTMgr_S3AccountPublicAccessBlock() = default;
+  ~RGWRESTMgr_S3AccountPublicAccessBlock() override = default;
+
+  RGWHandler_REST* get_handler(struct req_state* const s,
+                               const rgw::auth::StrategyRegistry& auth_registry,
+                               const std::string&) override {
+    if (RGWHandler_REST_S3::init_from_header(s, RGW_FORMAT_XML, true) < 0) {
+      return nullptr;
+    }
+
+    return new RGWHandler_S3AccountPublicAccessBlock(auth_registry);
+  }
+};
+
+class RGWHandler_S3Control: public RGWHandler_REST_S3 {
+public:
+  using RGWHandler_REST_S3::RGWHandler_REST_S3;
+  ~RGWHandler_S3Control() override = default;
+};
+
+class RGWRESTMgr_S3Control : public RGWRESTMgr {
+public:
+  ~RGWRESTMgr_S3Control() override = default;
+  RGWRESTMgr_S3Control() {
+    register_resource("configuration/publicAccessBlock",
+                      new RGWRESTMgr_S3AccountPublicAccessBlock());
+  }
+
+  RGWHandler_REST* get_handler(struct req_state*,
+			       const rgw::auth::StrategyRegistry& auth_registry,
+			       const std::string&) override {
+    return new RGWHandler_S3Control(auth_registry);
+  }
+};
+
+class RGWPutAccountPublicAccessBlock : public RGWRESTOp {
+protected:
+  bufferlist data;
+  PublicAccessBlockConfiguration access_conf;
+public:
+  int check_caps(RGWUserCaps& caps) override;
+  int verify_permission() override;
+  const char* name() const override { return "put_account_public_access_block";}
+  int get_params();
+  RGWOpType get_type() override;
+  void execute() override;
+  void send_response() override;
+};


### PR DESCRIPTION
the GET/PUT/DELETE set of apis on accounts to manage public access block configuration
https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutPublicAccessBlock.html

Current implementation still reuses the account = tenant mapping, and creates a special tenant object, that stores the attribute, which only works for tenantedusers, the main question at this point is what to do in case of non tenanted users:
1. Make this a user attribute, that applies for every non-tenanted user, but user-policy permissions still apply.
2. Drop the user policy perm settings, and make every user capable of managing their own account/bucket publicity 

TODO:
[ ]  CreateBucket restrictions
[ ]  Cross Account access restrictions 
[ ] S3 Tests for GET/PUT/Delete PublicAccountAccessConfiguration
[ ] S3 Tests for CreateBucket/GET/PUT objects with Account configuration controls
 