### PR TITLE
admin/build-doc: enable python module to import cephfs

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -93,7 +93,12 @@ for bind in rados rbd cephfs rgw; do
     if [ ! -e $lib_fn ]; then
        lib_fn=$vdir/lib/python*/*-packages/${bind}.so
     fi
-    nm $lib_fn | grep -E "U (lib)?${bind}" | \
+    if [ ${bind} = "cephfs" ]; then
+        func_prefix="ceph"
+    else
+        func_prefix="(lib)?${bind}"
+    fi
+    nm $lib_fn | grep -E "U ${func_prefix}" | \
         awk '{ print "void "$2"(void) {}" }' | \
         gcc -shared -o $vdir/lib/lib${bind}.so.1 -xc -
     if [ ${bind} != rados ]; then

--- a/admin/build-doc
+++ b/admin/build-doc
@@ -85,7 +85,7 @@ for bind in rados rbd cephfs rgw; do
     BUILD_DOC=1 \
         CFLAGS="-iquote$TOPDIR/src/include" \
         CPPFLAGS="-iquote$TOPDIR/src/include" \
-        LDFLAGS="-L$vdir/lib -Wl,--no-as-needed" \
+        LDFLAGS="-L$vdir/lib -Wl,--no-as-needed,-rpath=$vdir/lib" \
         $vdir/bin/pip install --upgrade $TOPDIR/src/pybind/${bind}
     # rgwfile_version(), librgw_create(), rgw_mount()
     # since py3.5, distutils adds postfix in between ${bind} and so


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
