### PR TITLE
mgr/cephadm: fix dump output by formatting to yaml first

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2990,7 +2990,7 @@ receivers:
         specs = list()
         for service_name, spec in self.spec_store.specs.items():
             specs.append('---')
-            specs.append(yaml.dump(spec))
+            specs.append(yaml.safe_dump(spec.to_json()))
         return trivial_result(specs)
 
     def apply_service_config(self, spec_document: str) -> orchestrator.Completion:


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

This produces an output that can be read by the orchestrator again.

``` terminal
➜  build (fix_spec_dump) ✗ ceph orch spec dump | tee ss.yaml
---
placement:
  all_hosts: true
  count: null
  hosts: []
  label: null
service_id: null
service_type: crash
---
placement:
  all_hosts: false
  count: 1
  hosts: []
  label: null
service_id: test_that
service_type: mds

➜  build (fix_spec_dump) ✗ ceph orch apply -i ss.yaml
ServiceSpecs saved
```

The output is verbose (does not exclude 'null/None' values) which aligns with the representation seen in the mon store.

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
