### PR TITLE
luminous: mgr/telemetry: critical backports and fixes

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -15,10 +15,19 @@ The *telemetry* module is enabled with::
 
   ceph mgr module enable telemetry
 
+To allow the telemetry module to start sharing data::
+
+  ceph telemetry on
+
+Please note: Telemetry data is licensed under the Community Data License Agreement - Sharing - Version 1.0 (https://cdla.io/sharing-1-0/). Hence, telemetry module can start sharing data only after you add 'sharing-1-0' to the 'ceph telemetry on' command.
+
+Telemetry can be disabled at any time with::
+
+  ceph telemetry off
 
 Interval
 --------
-The module compiles and sends a new report every 72 hours by default.
+The module compiles and sends a new report every 24 hours by default.
 
 Contact and Description
 -----------------------

--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -29,6 +29,16 @@ Interval
 --------
 The module compiles and sends a new report every 24 hours by default.
 
+Manually sending telemetry
+--------------------------
+
+To ad hoc send telemetry data::
+
+  ceph telemetry send
+
+In case telemetry sending is not automated (with 'ceph telemetry on'), you need to add
+'sharing-1-0' to 'ceph telemetry send' command.
+
 Contact and Description
 -----------------------
 A contact and description can be added to the report, this is optional.

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -543,12 +543,16 @@ class Module(MgrModule):
         elif command['prefix'] == 'telemetry on':
             if command.get('license') != LICENSE:
                 return -errno.EPERM, '', "Telemetry data is licensed under the " + LICENSE_NAME + " (" + LICENSE_URL + ").\nTo enable, add '--license " + LICENSE + "' to the 'ceph telemetry on' command."
-            self.set_config('enabled', True)
-            self.set_config('last_opt_revision', REVISION)
+            self.set_config('enabled', 'True')
+            self.set_config_option('enabled', 'True')
+            self.set_config('last_opt_revision', str(REVISION))
+            self.set_config_option('last_opt_revision', str(REVISION))
             return 0, '', ''
         elif command['prefix'] == 'telemetry off':
-            self.set_config('enabled', False)
-            self.set_config('last_opt_revision', REVISION)
+            self.set_config('enabled', 'False')
+            self.set_config_option('enabled', 'False')
+            self.set_config('last_opt_revision', '1')
+            self.set_config_option('last_opt_revision', '1')
             return 0, '', ''
         elif command['prefix'] == 'telemetry send':
             self.last_report = self.compile_report()
@@ -579,7 +583,7 @@ class Module(MgrModule):
 
     def refresh_health_checks(self):
         health_checks = {}
-        if self.enabled and self.last_opt_revision < LAST_REVISION_RE_OPT_IN:
+        if self.config['enabled'] and int(self.config['last_opt_revision']) < LAST_REVISION_RE_OPT_IN:
             health_checks['TELEMETRY_CHANGED'] = {
                 'severity': 'warning',
                 'summary': 'Telemetry requires re-opt-in',
@@ -601,7 +605,7 @@ class Module(MgrModule):
 
             self.refresh_health_checks()
 
-            if self.last_opt_revision < LAST_REVISION_RE_OPT_IN:
+            if int(self.config['last_opt_revision']) < LAST_REVISION_RE_OPT_IN:
                 self.log.debug('Not sending report until user re-opts-in')
                 self.event.wait(1800)
                 continue


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/44485
* https://tracker.ceph.com/issues/44504

---

This patch fixes several bugs in telemetry module in Luminous:

- catch exception during requests.put
  (backported: https://github.com/ceph/ceph/pull/33070)
- force --license when sending while opted-out
  (backported: https://github.com/ceph/ceph/pull/33747)
- wrong syntax of getting / setting config options, which caused 'ceph telemetry on' not to work, among other things.
- 'ceph telemetry off' now reset revision, hence when re-opting-in the license has to be re-agreed to.

Fixes: https://tracker.ceph.com/issues/44563
Signed-off-by: Yaarit Hatuka yaarit@redhat.com

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
