### PR TITLE
test/cli-integration: fixed spacing issue for RBD formatted tables

### DIFF
--- a/src/test/cli-integration/rbd/formatted-output.t
+++ b/src/test/cli-integration/rbd/formatted-output.t
@@ -689,15 +689,15 @@ For now, use a more inclusive regex.
     <name>quuy</name>
   </images>
   $ rbd list -l
-  NAME      SIZE    PARENT FMT PROT LOCK 
-  foo         1 GiB          1           
-  foo@snap    1 GiB          1           
-  quux        1 MiB          1      excl 
-  bar         1 GiB          2           
-  bar@snap  512 MiB          2 yes       
-  bar@snap2   1 GiB          2           
-  baz         2 GiB          2      shr  
-  quuy        2 GiB          2           
+  NAME       SIZE     PARENT  FMT  PROT  LOCK
+  foo          1 GiB            1            
+  foo@snap     1 GiB            1            
+  quux         1 MiB            1        excl
+  bar          1 GiB            2            
+  bar@snap   512 MiB            2  yes       
+  bar@snap2    1 GiB            2            
+  baz          2 GiB            2        shr 
+  quuy         2 GiB            2            
   $ rbd list -l --format json | python3 -mjson.tool --sort-keys | sed 's/,$/, /'
   [
       {
@@ -836,11 +836,11 @@ For now, use a more inclusive regex.
     <name>deep-flatten-child</name>
   </images>
   $ rbd list rbd_other -l
-  NAME                    SIZE    PARENT       FMT PROT LOCK 
-  child                   512 MiB                2           
-  child@snap              512 MiB rbd/bar@snap   2           
-  deep-flatten-child      512 MiB                2           
-  deep-flatten-child@snap 512 MiB                2           
+  NAME                     SIZE     PARENT        FMT  PROT  LOCK
+  child                    512 MiB                  2            
+  child@snap               512 MiB  rbd/bar@snap    2            
+  deep-flatten-child       512 MiB                  2            
+  deep-flatten-child@snap  512 MiB                  2            
   $ rbd list rbd_other -l --format json | python3 -mjson.tool --sort-keys | sed 's/,$/, /'
   [
       {
@@ -1077,12 +1077,12 @@ For now, use a more inclusive regex.
     </snapshot>
   </snapshots>
   $ rbd disk-usage --pool rbd_other 2>/dev/null
-  NAME                    PROVISIONED USED  
-  child@snap                  512 MiB   0 B 
-  child                       512 MiB 4 MiB 
-  deep-flatten-child@snap     512 MiB   0 B 
-  deep-flatten-child          512 MiB   0 B 
-  <TOTAL>                       1 GiB 4 MiB 
+  NAME                     PROVISIONED  USED 
+  child@snap                   512 MiB    0 B
+  child                        512 MiB  4 MiB
+  deep-flatten-child@snap      512 MiB    0 B
+  deep-flatten-child           512 MiB    0 B
+  <TOTAL>                        1 GiB  4 MiB
   $ rbd disk-usage --pool rbd_other --format json | python3 -mjson.tool --sort-keys | sed 's/,$/, /'
   {
       "images": [


### PR DESCRIPTION
The tables now use two spaces between columns instead of one.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
