### PR TITLE
mgr,python-common: drop modules for python2 in requirements.txt

### DIFF
--- a/src/pybind/mgr/dashboard/requirements-test.txt
+++ b/src/pybind/mgr/dashboard/requirements-test.txt
@@ -1,4 +1,3 @@
-mock; python_version <= '3.3'
 pytest<4
 pytest-cov
 pytest-instafail

--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -1,6 +1,4 @@
 pytest-cov==2.7.1
-mock; python_version <= '3.3'
-ipaddress; python_version < '3.3'
 -e../../python-common
 kubernetes
 requests-mock

--- a/src/python-common/requirements.txt
+++ b/src/python-common/requirements.txt
@@ -1,6 +1,4 @@
 six
-pytest >=2.1.3,<5; python_version < '3.5'
-mock; python_version < '3.3'
 mypy; python_version >= '3'
 pytest-mypy; python_version >= '3'
 pytest >= 2.1.3; python_version >= '3'


### PR DESCRIPTION
we don't support python2 anymore, so no need to install them for
python2 anymore.

also, this helps to silence the messages from pip like

```
Ignoring pytest: markers 'python_version < "3.5"' don't match your environment
Ignoring mock: markers 'python_version < "3.3"' don't match your environment
```

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
