### PR TITLE
crimson: misc fixes for writes to multiple-osd cluster

### DIFF
--- a/src/crimson/mgr/client.cc
+++ b/src/crimson/mgr/client.cc
@@ -40,9 +40,7 @@ seastar::future<> Client::stop()
 {
   return gate.close().then([this] {
     if (conn) {
-      return conn->close();
-    } else {
-      return seastar::now();
+      conn->mark_down();
     }
   });
 }
@@ -85,8 +83,7 @@ seastar::future<> Client::ms_handle_reset(crimson::net::ConnectionRef c)
 seastar::future<> Client::reconnect()
 {
   if (conn) {
-    // crimson::net::Protocol::close() is able to close() in background
-    (void)conn->close();
+    conn->mark_down();
     conn = {};
   }
   if (!mgrmap.get_available()) {

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -79,7 +79,7 @@ public:
                              const std::vector<uint32_t>& allowed_modes);
 
   // v1 and v2
-  seastar::future<> close();
+  void close();
   bool is_my_peer(const entity_addr_t& addr) const;
   AuthAuthorizer* get_authorizer(entity_type_t peer) const;
   KeyStore& get_keys();
@@ -427,16 +427,14 @@ int Connection::handle_auth_bad_method(uint32_t old_auth_method,
   return 0;
 }
 
-seastar::future<> Connection::close()
+void Connection::close()
 {
   reply.set_value(Ref<MAuthReply>(nullptr));
   reply = {};
   auth_done.set_value(AuthResult::canceled);
   auth_done = {};
   if (conn && !std::exchange(closed, true)) {
-    return conn->close();
-  } else {
-    return seastar::now();
+    conn->mark_down();
   }
 }
 
@@ -551,7 +549,8 @@ seastar::future<> Client::ms_handle_reset(crimson::net::ConnectionRef conn)
                             });
   if (found != pending_conns.end()) {
     logger().warn("pending conn reset by {}", conn->get_peer_addr());
-    return (*found)->close();
+    (*found)->close();
+    return seastar::now();
   } else if (active_con && active_con->is_my_peer(conn->get_peer_addr())) {
     logger().warn("active conn reset {}", conn->get_peer_addr());
     active_con.reset();
@@ -920,9 +919,7 @@ seastar::future<> Client::stop()
   return tick_gate.close().then([this] {
     timer.cancel();
     if (active_con) {
-      return active_con->close();
-    } else {
-      return seastar::now();
+      active_con->close();
     }
   });
 }
@@ -953,9 +950,8 @@ seastar::future<> Client::reopen_session(int rank)
       } else {
         return mc->authenticate_v1(monmap.get_epoch(), entity_name, want_keys)
           .handle_exception([conn](auto ep) {
-            return conn->close().then([ep=std::move(ep)](){
-	      return seastar::make_exception_future<Connection::AuthResult>(ep);
-            });
+            conn->mark_down();
+            return seastar::make_exception_future<Connection::AuthResult>(ep);
           });
       }
     }).then([peer, this](auto result) {
@@ -986,21 +982,13 @@ seastar::future<> Client::reopen_session(int rank)
       ceph_assert(!active_con && !pending_conns.empty());
       active_con = std::move(*found);
       found->reset();
-      auto ret = seastar::do_with(
-	std::move(pending_conns),
-	[](auto &pending_conns) {
-	  return seastar::parallel_for_each(
-	    pending_conns,
-	    [] (auto &conn) {
-	      if (!conn) {
-		return seastar::now();
-	      } else {
-		return conn->close();
-	      }
-	    });
-	});
+      for (auto& conn : pending_conns) {
+        if (conn) {
+          conn->close();
+        }
+      }
       pending_conns.clear();
-      return ret;
+      return seastar::now();
     }).then([]() {
       logger().debug("reopen_session mon connection attempts complete");
     }).handle_exception([](auto ep) {

--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -95,6 +95,8 @@ class Connection : public seastar::enable_shared_from_this<Connection> {
 #ifdef UNIT_TESTS_BUILT
   virtual bool is_closed() const = 0;
 
+  virtual bool is_closed_clean() const = 0;
+
   virtual bool peer_wins() const = 0;
 #endif
 

--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -107,10 +107,9 @@ class Connection : public seastar::enable_shared_from_this<Connection> {
   /// handshake
   virtual seastar::future<> keepalive() = 0;
 
-  // close the connection and cancel any any pending futures from read/send
-  // Note it's OK to discard the returned future because Messenger::shutdown()
-  // will wait for all connections closed
-  virtual seastar::future<> close() = 0;
+  // close the connection and cancel any any pending futures from read/send,
+  // without dispatching any reset event
+  virtual void mark_down() = 0;
 
   virtual void print(ostream& out) const = 0;
 

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -48,6 +48,10 @@ void Protocol::close(bool dispatch_reset,
     return;
   }
 
+  logger().info("{} closing: reset {}, replace {}", conn,
+                dispatch_reset ? "yes" : "no",
+                f_accept_new ? "yes" : "no");
+
   // unregister_conn() drops a reference, so hold another until completion
   auto cleanup = [conn_ref = conn.shared_from_this(), this] {
       logger().debug("{} closed!", conn);

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -314,13 +314,8 @@ void Protocol::write_event()
    case write_state_t::open:
      [[fallthrough]];
    case write_state_t::delay:
-    (void) seastar::with_gate(pending_dispatch, [this] {
-      return do_write_dispatch_sweep(
-      ).handle_exception([this] (std::exception_ptr eptr) {
-        logger().error("{} do_write_dispatch_sweep(): unexpected exception {}",
-                       conn, eptr);
-        ceph_abort();
-      });
+    gated_dispatch("do_write_dispatch_sweep", [this] {
+      return do_write_dispatch_sweep();
     });
     return;
    case write_state_t::drop:

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -30,7 +30,7 @@ class Protocol {
 #endif
 
   // Reentrant closing
-  void close(bool dispatch_reset);
+  void close(bool dispatch_reset, std::optional<std::function<void()>> f_accept_new=std::nullopt);
   seastar::future<> close_clean(bool dispatch_reset) {
     close(dispatch_reset);
     return close_ready.get_future();

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -24,10 +24,17 @@ class Protocol {
 
   bool is_connected() const;
 
+#ifdef UNIT_TESTS_BUILT
+  bool is_closed_clean = false;
   bool is_closed() const { return closed; }
+#endif
 
   // Reentrant closing
-  seastar::future<> close();
+  void close(bool dispatch_reset);
+  seastar::future<> close_clean(bool dispatch_reset) {
+    close(dispatch_reset);
+    return close_ready.get_future();
+  }
 
   virtual void start_connect(const entity_addr_t& peer_addr,
                              const entity_type_t& peer_type) = 0;

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -64,6 +64,7 @@ class Protocol {
 
  public:
   const proto_t proto_type;
+  SocketRef socket;
 
  protected:
   template <typename Func>
@@ -79,7 +80,6 @@ class Protocol {
   Dispatcher &dispatcher;
   SocketConnection &conn;
 
-  SocketRef socket;
   AuthConnectionMetaRef auth_meta;
 
  private:

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -34,6 +34,9 @@ class Protocol {
   void close(bool dispatch_reset, std::optional<std::function<void()>> f_accept_new=std::nullopt);
   seastar::future<> close_clean(bool dispatch_reset) {
     close(dispatch_reset);
+    // it can happen if close_clean() is called inside Dispatcher::ms_handle_reset()
+    // which will otherwise result in deadlock
+    assert(close_ready.valid());
     return close_ready.get_future();
   }
 

--- a/src/crimson/net/ProtocolV1.cc
+++ b/src/crimson/net/ProtocolV1.cc
@@ -584,7 +584,7 @@ seastar::future<stop_t> ProtocolV1::repeat_handle_connect()
                         conn, *existing,
                         static_cast<int>(existing->protocol->proto_type));
           // NOTE: this is following async messenger logic, but we may miss the reset event.
-          (void) existing->close();
+          existing->mark_down();
         } else {
           return handle_connect_with_existing(existing, std::move(authorizer_reply));
         }

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1390,7 +1390,7 @@ ProtocolV2::server_reconnect()
                     conn, *existing_conn,
                     static_cast<int>(existing_conn->protocol->proto_type));
       // NOTE: this is following async messenger logic, but we may miss the reset event.
-      (void) existing_conn->close();
+      existing_conn->mark_down();
       return send_reset(true);
     }
 

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -173,7 +173,7 @@ class ProtocolV2 final : public Protocol {
   seastar::future<> finish_auth();
 
   // ESTABLISHING
-  void execute_establishing();
+  void execute_establishing(SocketConnectionRef existing_conn, bool dispatch_reset);
 
   // ESTABLISHING/REPLACING (server)
   seastar::future<> send_server_ident();

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -124,7 +124,6 @@ class ProtocolV2 final : public Protocol {
 
  private:
   void fault(bool backoff, const char* func_name, std::exception_ptr eptr);
-  void dispatch_reset();
   void reset_session(bool full);
   seastar::future<entity_type_t, entity_addr_t> banner_exchange();
 

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -80,6 +80,14 @@ class ProtocolV2 final : public Protocol {
 
   seastar::shared_future<> execution_done = seastar::now();
 
+  template <typename Func>
+  void gated_execute(const char* what, Func&& func) {
+    gated_dispatch(what, [this, &func] {
+      execution_done = seastar::futurize_apply(std::forward<Func>(func));
+      return execution_done.get_future();
+    });
+  }
+
   class Timer {
     double last_dur_ = 0.0;
     const SocketConnection& conn;

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -125,7 +125,7 @@ class ProtocolV2 final : public Protocol {
  private:
   void fault(bool backoff, const char* func_name, std::exception_ptr eptr);
   void reset_session(bool full);
-  seastar::future<entity_type_t, entity_addr_t> banner_exchange();
+  seastar::future<entity_type_t, entity_addr_t> banner_exchange(bool is_connect);
 
   enum class next_step_t {
     ready,

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -25,31 +25,25 @@ using SocketRef = std::unique_ptr<Socket>;
 
 class Socket
 {
-  const seastar::shard_id sid;
-  seastar::connected_socket socket;
-  seastar::input_stream<char> in;
-  seastar::output_stream<char> out;
-
-#ifndef NDEBUG
-  bool closed = false;
-#endif
-
-  /// buffer state for read()
-  struct {
-    bufferlist buffer;
-    size_t remaining;
-  } r;
-
   struct construct_tag {};
 
  public:
-  Socket(seastar::connected_socket&& _socket, construct_tag)
+  // if acceptor side, peer is using a different port (ephemeral_port)
+  // if connector side, I'm using a different port (ephemeral_port)
+  enum class side_t {
+    acceptor,
+    connector
+  };
+
+  Socket(seastar::connected_socket&& _socket, side_t _side, uint16_t e_port, construct_tag)
     : sid{seastar::engine().cpu_id()},
       socket(std::move(_socket)),
       in(socket.input()),
       // the default buffer size 8192 is too small that may impact our write
       // performance. see seastar::net::connected_socket::output()
-      out(socket.output(65536)) {}
+      out(socket.output(65536)),
+      side(_side),
+      ephemeral_port(e_port) {}
 
   ~Socket() {
 #ifndef NDEBUG
@@ -63,7 +57,8 @@ class Socket
   connect(const entity_addr_t& peer_addr) {
     return seastar::connect(peer_addr.in4_addr()
     ).then([] (seastar::connected_socket socket) {
-      return std::make_unique<Socket>(std::move(socket), construct_tag{});
+      return std::make_unique<Socket>(
+        std::move(socket), side_t::connector, 0, construct_tag{});
     });
   }
 
@@ -115,16 +110,51 @@ class Socket
     socket.shutdown_output();
   }
 
+  side_t get_side() const {
+    return side;
+  }
+
+  uint16_t get_ephemeral_port() const {
+    return ephemeral_port;
+  }
+
+  // learn my ephemeral_port as connector.
+  // unfortunately, there's no way to identify which port I'm using as
+  // connector with current seastar interface.
+  void learn_ephemeral_port_as_connector(uint16_t port) {
+    assert(side == side_t::connector &&
+           (ephemeral_port == 0 || ephemeral_port == port));
+    ephemeral_port = port;
+  }
+
+ private:
+  const seastar::shard_id sid;
+  seastar::connected_socket socket;
+  seastar::input_stream<char> in;
+  seastar::output_stream<char> out;
+  side_t side;
+  uint16_t ephemeral_port;
+
+#ifndef NDEBUG
+  bool closed = false;
+#endif
+
+  /// buffer state for read()
+  struct {
+    bufferlist buffer;
+    size_t remaining;
+  } r;
+
 #ifdef UNIT_TESTS_BUILT
+ public:
+  void set_trap(bp_type_t type, bp_action_t action, socket_blocker* blocker_);
+
  private:
   bp_action_t next_trap_read = bp_action_t::CONTINUE;
   bp_action_t next_trap_write = bp_action_t::CONTINUE;
   socket_blocker* blocker = nullptr;
   seastar::future<> try_trap_pre(bp_action_t& trap);
   seastar::future<> try_trap_post(bp_action_t& trap);
-
- public:
-  void set_trap(bp_type_t type, bp_action_t action, socket_blocker* blocker_);
 
 #endif
   friend class FixedCPUServerSocket;
@@ -214,7 +244,8 @@ public:
             peer_addr.set_sockaddr(&paddr.as_posix_sockaddr());
             peer_addr.set_type(entity_addr_t::TYPE_ANY);
             SocketRef _socket = std::make_unique<Socket>(
-                std::move(socket), Socket::construct_tag{});
+                std::move(socket), Socket::side_t::acceptor,
+                peer_addr.get_port(), Socket::construct_tag{});
             std::ignore = seastar::with_gate(ss.shutdown_gate,
                 [socket = std::move(_socket), peer_addr,
                  &ss, fn_accept = std::move(fn_accept)] () mutable {

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -63,6 +63,12 @@ bool SocketConnection::is_closed() const
   return protocol->is_closed();
 }
 
+bool SocketConnection::is_closed_clean() const
+{
+  assert(seastar::engine().cpu_id() == shard_id());
+  return protocol->is_closed_clean;
+}
+
 #endif
 bool SocketConnection::peer_wins() const
 {
@@ -84,7 +90,7 @@ seastar::future<> SocketConnection::keepalive()
 seastar::future<> SocketConnection::close()
 {
   assert(seastar::engine().cpu_id() == shard_id());
-  return protocol->close();
+  return protocol->close_clean(false);
 }
 
 bool SocketConnection::update_rx_seq(seq_num_t seq)

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -138,13 +138,13 @@ seastar::shard_id SocketConnection::shard_id() const {
 
 void SocketConnection::print(ostream& out) const {
     messenger.print(out);
-    if (side == side_t::none) {
+    if (!protocol->socket) {
       out << " >> " << get_peer_name() << " " << peer_addr;
-    } else if (side == side_t::acceptor) {
+    } else if (protocol->socket->get_side() == Socket::side_t::acceptor) {
       out << " >> " << get_peer_name() << " " << peer_addr
-          << "@" << ephemeral_port;
-    } else { // side == side_t::connector
-      out << "@" << ephemeral_port
+          << "@" << protocol->socket->get_ephemeral_port();
+    } else { // protocol->socket->get_side() == Socket::side_t::connector
+      out << "@" << protocol->socket->get_ephemeral_port()
           << " >> " << get_peer_name() << " " << peer_addr;
     }
 }

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -87,10 +87,10 @@ seastar::future<> SocketConnection::keepalive()
   return protocol->keepalive();
 }
 
-seastar::future<> SocketConnection::close()
+void SocketConnection::mark_down()
 {
   assert(seastar::engine().cpu_id() == shard_id());
-  return protocol->close_clean(false);
+  protocol->close(false);
 }
 
 bool SocketConnection::update_rx_seq(seq_num_t seq)
@@ -124,6 +124,12 @@ SocketConnection::start_accept(SocketRef&& sock,
                                const entity_addr_t& _peer_addr)
 {
   protocol->start_accept(std::move(sock), _peer_addr);
+}
+
+seastar::future<>
+SocketConnection::close_clean(bool dispatch_reset)
+{
+  return protocol->close_clean(dispatch_reset);
 }
 
 seastar::shard_id SocketConnection::shard_id() const {

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -90,7 +90,7 @@ class SocketConnection : public Connection {
 
   seastar::future<> keepalive() override;
 
-  seastar::future<> close() override;
+  void mark_down() override;
 
   void print(ostream& out) const override;
 
@@ -102,6 +102,8 @@ class SocketConnection : public Connection {
   /// only call when SocketConnection first construct
   void start_accept(SocketRef&& socket,
                     const entity_addr_t& peer_addr);
+
+  seastar::future<> close_clean(bool dispatch_reset);
 
   bool is_server_side() const {
     return policy.server;

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -33,20 +33,6 @@ class SocketConnection : public Connection {
   SocketMessenger& messenger;
   std::unique_ptr<Protocol> protocol;
 
-  // if acceptor side, ephemeral_port is different from peer_addr.get_port();
-  // if connector side, ephemeral_port is different from my_addr.get_port().
-  enum class side_t {
-    none,
-    acceptor,
-    connector
-  };
-  side_t side = side_t::none;
-  uint16_t ephemeral_port = 0;
-  void set_ephemeral_port(uint16_t port, side_t _side) {
-    ephemeral_port = port;
-    side = _side;
-  }
-
   ceph::net::Policy<crimson::thread::Throttle> policy;
 
   /// the seq num of the last transmitted message

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -77,6 +77,8 @@ class SocketConnection : public Connection {
   bool is_connected() const override;
 
 #ifdef UNIT_TESTS_BUILT
+  bool is_closed_clean() const override;
+
   bool is_closed() const override;
 
   bool peer_wins() const override;

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -141,6 +141,7 @@ SocketMessenger::connect(const entity_addr_t& peer_addr, const entity_type_t& pe
   ceph_assert(peer_addr.get_port() > 0);
 
   if (auto found = lookup_conn(peer_addr); found) {
+    logger().info("{} connect to existing", *found);
     return found->shared_from_this();
   }
   SocketConnectionRef conn = seastar::make_shared<SocketConnection>(

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -163,12 +163,12 @@ seastar::future<> SocketMessenger::shutdown()
   // close all connections
   }).then([this] {
     return seastar::parallel_for_each(accepting_conns, [] (auto conn) {
-      return conn->close();
+      return conn->close_clean(false);
     });
   }).then([this] {
     ceph_assert(accepting_conns.empty());
     return seastar::parallel_for_each(connections, [] (auto conn) {
-      return conn.second->close();
+      return conn.second->close_clean(false);
     });
   }).then([this] {
     ceph_assert(connections.empty());

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -113,31 +113,19 @@ void Heartbeat::add_peer(osd_id_t peer, epoch_t epoch)
   }
 }
 
-seastar::future<Heartbeat::osds_t> Heartbeat::remove_down_peers()
+Heartbeat::osds_t Heartbeat::remove_down_peers()
 {
   osds_t osds;
   for (auto& peer : peers) {
-    osds.push_back(peer.first);
+    auto osd = peer.first;
+    auto osdmap = service.get_osdmap_service().get_map();
+    if (!osdmap->is_up(osd)) {
+      remove_peer(osd);
+    } else if (peers[osd].epoch < osdmap->get_epoch()) {
+      osds.push_back(osd);
+    }
   }
-  return seastar::map_reduce(std::move(osds),
-    [this](auto& osd) {
-      auto osdmap = service.get_osdmap_service().get_map();
-      if (!osdmap->is_up(osd)) {
-        return remove_peer(osd).then([] {
-          return seastar::make_ready_future<osd_id_t>(-1);
-        });
-      } else if (peers[osd].epoch < osdmap->get_epoch()) {
-        return seastar::make_ready_future<osd_id_t>(osd);
-      } else {
-        return seastar::make_ready_future<osd_id_t>(-1);
-      }
-    }, osds_t{},
-    [](osds_t&& extras, osd_id_t extra) {
-      if (extra >= 0) {
-        extras.push_back(extra);
-      }
-      return std::move(extras);
-    });
+  return osds;
 }
 
 void Heartbeat::add_reporter_peers(int whoami)
@@ -163,49 +151,37 @@ void Heartbeat::add_reporter_peers(int whoami)
   };
 }
 
-seastar::future<> Heartbeat::update_peers(int whoami)
+void Heartbeat::update_peers(int whoami)
 {
   const auto min_peers = static_cast<size_t>(
     local_conf().get_val<int64_t>("osd_heartbeat_min_peers"));
   add_reporter_peers(whoami);
-  return remove_down_peers().then([=](osds_t&& extra) {
-    // too many?
-    struct iteration_state {
-      osds_t::const_iterator where;
-      osds_t::const_iterator end;
-    };
-    return seastar::do_with(iteration_state{extra.begin(),extra.end()},
-      [=](iteration_state& s) {
-        return seastar::do_until(
-          [min_peers, &s, this] {
-            return peers.size() <= min_peers || s.where == s.end; },
-          [&s, this] {
-            return remove_peer(*s.where); }
-        );
-    });
-  }).then([=] {
-    // or too few?
-    auto osdmap = service.get_osdmap_service().get_map();
-    auto epoch = osdmap->get_epoch();
-    for (auto next = osdmap->get_next_up_osd_after(whoami);
-      peers.size() < min_peers && next >= 0 && next != whoami;
-      next = osdmap->get_next_up_osd_after(next)) {
-      add_peer(next, epoch);
+  auto extra = remove_down_peers();
+  // too many?
+  for (auto& osd : extra) {
+    if (peers.size() <= min_peers) {
+      break;
     }
-  });
+    remove_peer(osd);
+  }
+  // or too few?
+  auto osdmap = service.get_osdmap_service().get_map();
+  auto epoch = osdmap->get_epoch();
+  for (auto next = osdmap->get_next_up_osd_after(whoami);
+    peers.size() < min_peers && next >= 0 && next != whoami;
+    next = osdmap->get_next_up_osd_after(next)) {
+    add_peer(next, epoch);
+  }
 }
 
-seastar::future<> Heartbeat::remove_peer(osd_id_t peer)
+void Heartbeat::remove_peer(osd_id_t peer)
 {
   auto found = peers.find(peer);
   assert(found != peers.end());
   logger().info("remove_peer({})", peer);
-  return seastar::when_all_succeed(found->second.con_front->close(),
-                                   found->second.con_back->close()).then(
-    [this, peer] {
-      peers.erase(peer);
-      return seastar::now();
-    });
+  found->second.con_front->mark_down();
+  found->second.con_back->mark_down();
+  peers.erase(peer);
 }
 
 seastar::future<> Heartbeat::ms_dispatch(crimson::net::Connection* conn,
@@ -231,9 +207,9 @@ seastar::future<> Heartbeat::ms_handle_reset(crimson::net::ConnectionRef conn)
   }
   const auto peer = found->first;
   const auto epoch = found->second.epoch;
-  return remove_peer(peer).then([peer, epoch, this] {
-    add_peer(peer, epoch);
-  });
+  remove_peer(peer);
+  add_peer(peer, epoch);
+  return seastar::now();
 }
 
 seastar::future<> Heartbeat::handle_osd_ping(crimson::net::Connection* conn,

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -176,9 +176,9 @@ void Heartbeat::update_peers(int whoami)
 
 void Heartbeat::remove_peer(osd_id_t peer)
 {
+  logger().info("remove_peer({})", peer);
   auto found = peers.find(peer);
   assert(found != peers.end());
-  logger().info("remove_peer({})", peer);
   found->second.con_front->mark_down();
   found->second.con_back->mark_down();
   peers.erase(peer);

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -35,8 +35,8 @@ public:
   seastar::future<> stop();
 
   void add_peer(osd_id_t peer, epoch_t epoch);
-  seastar::future<> update_peers(int whoami);
-  seastar::future<> remove_peer(osd_id_t peer);
+  void update_peers(int whoami);
+  void remove_peer(osd_id_t peer);
 
   const entity_addrvec_t& get_front_addrs() const;
   const entity_addrvec_t& get_back_addrs() const;
@@ -62,7 +62,7 @@ private:
   using osds_t = std::vector<osd_id_t>;
   /// remove down OSDs
   /// @return peers not needed in this epoch
-  seastar::future<osds_t> remove_down_peers();
+  osds_t remove_down_peers();
   /// add enough reporters for fast failure detection
   void add_reporter_peers(int whoami);
 

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -78,7 +78,7 @@ OSD::OSD(int id, uint32_t nonce,
     shard_services{*this, *cluster_msgr, *public_msgr, *monc, *mgrc, *store},
     heartbeat{new Heartbeat{shard_services, *monc, hb_front_msgr, hb_back_msgr}},
     // do this in background
-    heartbeat_timer{[this] { (void)update_heartbeat_peers(); }},
+    heartbeat_timer{[this] { update_heartbeat_peers(); }},
     asok{seastar::make_lw_shared<crimson::admin::AdminSocket>()},
     osdmap_gate("OSD::osdmap_gate", std::make_optional(std::ref(shard_services)))
 {
@@ -1049,10 +1049,10 @@ seastar::future<> OSD::send_beacon()
   return monc->send_message(m);
 }
 
-seastar::future<> OSD::update_heartbeat_peers()
+void OSD::update_heartbeat_peers()
 {
   if (!state.is_active()) {
-    return seastar::now();
+    return;
   }
   for (auto& pg : pg_map.get_pgs()) {
     vector<int> up, acting;
@@ -1067,7 +1067,7 @@ seastar::future<> OSD::update_heartbeat_peers()
       }
     }
   }
-  return heartbeat->update_peers(whoami);
+  heartbeat->update_peers(whoami);
 }
 
 seastar::future<> OSD::handle_peering_op(

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -216,7 +216,7 @@ public:
   seastar::future<> shutdown();
 
   seastar::future<> send_beacon();
-  seastar::future<> update_heartbeat_peers();
+  void update_heartbeat_peers();
 
   friend class PGAdvanceMap;
 };

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -1122,7 +1122,8 @@ class FailoverSuite : public Dispatcher {
   seastar::future<> markdown() {
     logger().info("[Test] markdown()");
     ceph_assert(tracked_conn);
-    return tracked_conn->close();
+    tracked_conn->mark_down();
+    return seastar::now();
   }
 
   seastar::future<> wait_blocked() {
@@ -1470,7 +1471,8 @@ class FailoverSuitePeer : public Dispatcher {
   seastar::future<> markdown() {
     logger().info("[TestPeer] markdown()");
     ceph_assert(tracked_conn);
-    return tracked_conn->close();
+    tracked_conn->mark_down();
+    return seastar::now();
   }
 
   static seastar::future<std::unique_ptr<FailoverSuitePeer>>

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -1375,6 +1375,7 @@ class FailoverSuitePeer : public Dispatcher {
   }
 
   seastar::future<> ms_handle_accept(ConnectionRef conn) override {
+    logger().info("[TestPeer] got accept from Test");
     ceph_assert(!tracked_conn ||
                 tracked_conn->is_closed() ||
                 tracked_conn == conn);
@@ -1383,6 +1384,7 @@ class FailoverSuitePeer : public Dispatcher {
   }
 
   seastar::future<> ms_handle_reset(ConnectionRef conn) override {
+    logger().info("[TestPeer] got reset from Test");
     ceph_assert(tracked_conn == conn);
     tracked_conn = nullptr;
     return seastar::now();

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -932,7 +932,7 @@ class FailoverSuite : public Dispatcher {
     unsigned pending_establish = 0;
     unsigned replaced_conns = 0;
     for (auto& result : interceptor.results) {
-      if (result.conn->is_closed()) {
+      if (result.conn->is_closed_clean()) {
         if (result.state == conn_state_t::replaced) {
           ++replaced_conns;
         }


### PR DESCRIPTION
Test scenario:
* 20 crimson-OSDs with cyan store;
* create a replicated test pool with 128 PGs and min-size/size set to 3;
* rados bench 4K random write;

Fixed most of the found issues, including https://github.com/ceph/ceph/pull/33836#discussion_r390745491.

The cluster can almost work now.
Writes may still fail with larger scale tests (50 OSDs, 256 PGs), seems related to peering @tchaikov @xxhdx1985126 @athanatos :
```
INFO  2020-03-14 18:43:37,262 [shard 0] osd - osdmap_subscribe(54)
WARN  2020-03-14 18:43:37,262 [shard 0] monc - renew_subs - empty
INFO  2020-03-14 18:43:37,263 [shard 0] osd - osd.2: now active
WARN  2020-03-14 18:43:37,263 [shard 0] osd - peering_event(id=7, detail=PeeringEvent(from=31 pgid=1.7f sent=103 requested=103 evt=epoch_sent: 103 epoch_requested: 103 MQuery 1.7f from 31 query_epoch 103 query: query(info 0'0 epoch_sent 103))): pg absent, did not create
WARN  2020-03-14 18:43:37,264 [shard 0] osd - peering_event(id=4, detail=PeeringEvent(from=27 pgid=1.d6 sent=103 requested=103 evt=epoch_sent: 103 epoch_requested: 103 MQuery 1.d6 from 27 query_epoch 103 query: query(info 0'0 epoch_sent 103))): pg absent, did not create
terminate called after throwing an instance of 'std::runtime_error'
  what():  read gave enoent on #-1:a502e935:::osdmap.103:0#
Aborting on shard 0.
Backtrace:

auto crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::_future<crimson::errorated_future_marker<ceph::buffer::v15_2_0::list> >::_safe_then_handle_errors<seastar::futurize<seastar::future<ceph::buffer::v15_2_0::list> >, seastar::future<ceph::buffer::v15_2_0::list>, crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::all_same_way_t<OSDMeta::load_map(unsigned int)::{lambda()#1}> >(seastar::future<ceph::buffer::v15_2_0::list>&&, crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::all_same_way_t<OSDMeta::load_map(unsigned int)::{lambda()#1}>&&) at /root/ceph/src/crimson/common/errorator.h:377
auto crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::_future<crimson::errorated_future_marker<ceph::buffer::v15_2_0::list> >::handle_error<crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::all_same_way_t<OSDMeta::load_map(unsigned int)::{lambda()#1}> >(crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::all_same_way_t<OSDMeta::load_map(unsigned int)::{lambda()#1}>&&)::{lambda(auto:1)#1}::operator()<seastar::future<ceph::buffer::v15_2_0::list> >(seastar::future<ceph::buffer::v15_2_0::list>) at /root/ceph/src/crimson/common/errorator.h:596
seastar::future<ceph::buffer::v15_2_0::list> seastar::futurize<seastar::future<ceph::buffer::v15_2_0::list> >::apply<crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::_future<crimson::errorated_future_marker<ceph::buffer::v15_2_0::list> >::handle_error<crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::all_same_way_t<OSDMeta::load_map(unsigned int)::{lambda()#1}> >(crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::all_same_way_t<OSDMeta::load_map(unsigned int)::{lambda()#1}>&&)::{lambda(auto:1)#1}, seastar::future<ceph::buffer::v15_2_0::list> >(crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::_future<crimson::errorated_future_marker<ceph::buffer::v15_2_0::list> >::handle_error<crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::all_same_way_t<OSDMeta::load_map(unsigned int)::{lambda()#1}> >(crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::all_same_way_t<OSDMeta::load_map(unsigned int)::{lambda()#1}>&&)::{lambda(auto:1)#1}, seastar::future<ceph::buffer::v15_2_0::list>&&) at /root/ceph/src/seastar/include/seastar/core/future.hh:1655
_ZZN7seastar6futureIJN4ceph6buffer7v15_2_04listEEE24then_wrapped_maybe_eraseILb0ES5_ZN7crimson9erroratorIJNS7_19unthrowable_wrapperIRKSt10error_codeL_ZNS7_2ecILSt4errc2EEEEEENS9_ISC_L_ZNSD_ILSE_5EEEEEEEE7_futureINS7_23errorated_future_markerIJS4_EEEE12handle_errorINSH_14all_same_way_tIZN7OSDMeta8load_mapEjEUlvE_EEEEDaOT_EUlSS_E_EENS_8futurizeIT0_E4typeEOT1_ENUlOS5_E_clES10_ at /root/ceph/src/seastar/include/seastar/core/future.hh:1238
seastar::noncopyable_function<seastar::future<ceph::buffer::v15_2_0::list> (seastar::future<ceph::buffer::v15_2_0::list>&&)>::direct_vtable_for<seastar::future<ceph::buffer::v15_2_0::list>::then_wrapped_maybe_erase<false, seastar::future<ceph::buffer::v15_2_0::list>, crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::_future<crimson::errorated_future_marker<ceph::buffer::v15_2_0::list> >::handle_error<crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::all_same_way_t<OSDMeta::load_map(unsigned int)::{lambda()#1}> >(crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::all_same_way_t<OSDMeta::load_map(unsigned int)::{lambda()#1}>&&)::{lambda(auto:1)#1}>(crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::_future<crimson::errorated_future_marker<ceph::buffer::v15_2_0::list> >::handle_error<crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::all_same_way_t<OSDMeta::load_map(unsigned int)::{lambda()#1}> >(crimson::errorator<crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)2> >, crimson::unthrowable_wrapper<std::error_code const&, crimson::ec<(std::errc)5> > >::all_same_way_t<OSDMeta::load_map(unsigned int)::{lambda()#1}>&&)::{lambda(auto:1)#1}&&)::{lambda(seastar::future<ceph::buffer::v15_2_0::list>&&)#1}>::call(seastar::noncopyable_function<seastar::future<ceph::buffer::v15_2_0::list> (seastar::future<ceph::buffer::v15_2_0::list>&&)> const*, seastar::future<ceph::buffer::v15_2_0::list>&&) at /root/ceph/src/seastar/include/seastar/util/noncopyable_function.hh:101
seastar::noncopyable_function<seastar::future<ceph::buffer::v15_2_0::list> (seastar::future<ceph::buffer::v15_2_0::list>&&)>::operator()(seastar::future<ceph::buffer::v15_2_0::list>&&) const at /root/ceph/src/seastar/include/seastar/util/noncopyable_function.hh:184
seastar::future<ceph::buffer::v15_2_0::list> seastar::futurize<seastar::future<ceph::buffer::v15_2_0::list> >::apply<seastar::noncopyable_function<seastar::future<ceph::buffer::v15_2_0::list> (seastar::future<ceph::buffer::v15_2_0::list>&&)>, seastar::future<ceph::buffer::v15_2_0::list> >(seastar::noncopyable_function<seastar::future<ceph::buffer::v15_2_0::list> (seastar::future<ceph::buffer::v15_2_0::list>&&)>&&, seastar::future<ceph::buffer::v15_2_0::list>&&) at /root/ceph/src/seastar/include/seastar/core/future.hh:1655
seastar::future<ceph::buffer::v15_2_0::list>::then_wrapped_common<false, seastar::future<ceph::buffer::v15_2_0::list>, seastar::noncopyable_function<seastar::future<ceph::buffer::v15_2_0::list> (seastar::future<ceph::buffer::v15_2_0::list>&&)> >(seastar::noncopyable_function<seastar::future<ceph::buffer::v15_2_0::list> (seastar::future<ceph::buffer::v15_2_0::list>&&)>&&)::{lambda()#1}::operator()() const::{lambda(seastar::future_state<ceph::buffer::v15_2_0::list>&&)#1}::operator()(seastar::future_state<ceph::buffer::v15_2_0::list>) at /root/ceph/src/seastar/include/seastar/core/future.hh:1265
seastar::continuation<seastar::future<ceph::buffer::v15_2_0::list>::then_wrapped_common<false, seastar::future<ceph::buffer::v15_2_0::list>, seastar::noncopyable_function<seastar::future<ceph::buffer::v15_2_0::list> (seastar::future<ceph::buffer::v15_2_0::list>&&)> >(seastar::noncopyable_function<seastar::future<ceph::buffer::v15_2_0::list> (seastar::future<ceph::buffer::v15_2_0::list>&&)>&&)::{lambda()#1}::operator()() const::{lambda(seastar::future_state<ceph::buffer::v15_2_0::list>&&)#1}, ceph::buffer::v15_2_0::list>::run_and_dispose() at /root/ceph/src/seastar/include/seastar/core/future.hh:506
seastar::reactor::run_tasks(seastar::reactor::task_queue&) at /root/ceph/src/seastar/src/core/reactor.cc:2067
seastar::reactor::run_some_tasks() at /root/ceph/src/seastar/src/core/reactor.cc:2482 (discriminator 2)
seastar::reactor::run() at /root/ceph/src/seastar/src/core/reactor.cc:2642
seastar::app_template::run_deprecated(int, char**, std::function<void ()>&&) at /root/ceph/src/seastar/src/core/app-template.cc:199 (discriminator 1)
main at /root/ceph/src/crimson/osd/main.cc:148 (discriminator 1)
__libc_start_main at /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310
_start at ??:?
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
