### PR TITLE
osd/PeeringState: do not trim pg log past last_update_ondisk

### DIFF
--- a/qa/overrides/short_pg_log.yaml
+++ b/qa/overrides/short_pg_log.yaml
@@ -4,3 +4,4 @@ overrides:
       global:
         osd_min_pg_log_entries: 1
         osd_max_pg_log_entries: 2
+        osd_pg_log_trim_min: 0

--- a/qa/suites/rados/singleton/all/osd-recovery.yaml
+++ b/qa/suites/rados/singleton/all/osd-recovery.yaml
@@ -27,5 +27,6 @@ tasks:
     conf:
       osd:
         osd min pg log entries: 5
+        osd pg log trim min: 0
         osd_fast_fail_on_connection_refused: false
 - osd_recovery:

--- a/qa/suites/rados/thrash/workloads/radosbench-high-concurrency.yaml
+++ b/qa/suites/rados/thrash/workloads/radosbench-high-concurrency.yaml
@@ -1,0 +1,49 @@
+overrides:
+  ceph:
+    conf:
+      client.0:
+        debug ms: 1
+        debug objecter: 20
+        debug rados: 20
+tasks:
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90

--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -23,6 +23,7 @@ def task(ctx, config):
         time: <seconds to run>
         pool: <pool to use>
         size: write size to use
+        concurrency: max number of outstanding writes (16)
         objectsize: object size to use
         unique_pool: use a unique pool, defaults to False
         ec_pool: create an ec pool, defaults to False
@@ -83,6 +84,7 @@ def task(ctx, config):
                 pool = manager.create_pool_with_unique_name(erasure_code_profile_name=profile_name)
 
         size = config.get('size', 65536)
+        concurrency = config.get('concurrency', 16)
         osize = config.get('objectsize', 65536)
         sizeargs = ['-b', str(size)]
         if osize != 0 and osize != size:
@@ -102,6 +104,7 @@ def task(ctx, config):
                               '--no-log-to-stderr',
                               '--name', role]
                               + sizeargs +
+                              ['-t', str(concurrency)] +
                               ['-p' , pool,
                           'bench', str(60), "write", "--no-cleanup"
                           ]).format(tdir=testdir),

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -4094,9 +4094,10 @@ void PeeringState::calc_trim_to_aggressive()
   size_t target = pl->get_target_pg_log_entries();
 
   // limit pg log trimming up to the can_rollback_to value
-  eversion_t limit = std::min(
+  eversion_t limit = std::min({
     pg_log.get_head(),
-    pg_log.get_can_rollback_to());
+    pg_log.get_can_rollback_to(),
+    last_update_ondisk});
   psdout(10) << __func__ << " limit = " << limit << dendl;
 
   if (limit != eversion_t() &&

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -2273,6 +2273,10 @@ public:
     return last_update_applied;
   }
 
+  eversion_t get_last_update_ondisk() const {
+    return last_update_ondisk;
+  }
+
   bool debug_has_dirty_state() const {
     return dirty_info || dirty_big_info;
   }

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -463,6 +463,9 @@ public:
     bool transaction_applied,
     ObjectStore::Transaction &t,
     bool async = false) override {
+    if (is_primary()) {
+      ceph_assert(trim_to <= recovery_state.get_last_update_ondisk());
+    }
     if (hset_history) {
       recovery_state.update_hset(*hset_history);
     }


### PR DESCRIPTION
Trimming past last_update_ondisk would be really bad, e.g.,
a new interval change would cancel&redo a previous op, and if
we trim past last_update_ondisk, there could be potential
object inconsistencies as log merging won't necessarily be able
to find all divergent entries later (we lost track of the unfinished
op that should really be reverted).


Fixes: https://tracker.ceph.com/issues/44532
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
