### PR TITLE
os/bluestore: Adds shutdown in destructor of AvlAllocator

### DIFF
--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -212,6 +212,11 @@ AvlAllocator::AvlAllocator(CephContext* cct,
   cct(cct)
 {}
 
+AvlAllocator::~AvlAllocator()
+{
+  shutdown();
+}
+
 int64_t AvlAllocator::allocate(
   uint64_t want,
   uint64_t unit,

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -50,6 +50,7 @@ class AvlAllocator final : public Allocator {
 public:
   AvlAllocator(CephContext* cct, int64_t device_size, int64_t block_size,
 	       const std::string& name);
+  ~AvlAllocator();
   int64_t allocate(
     uint64_t want,
     uint64_t unit,

--- a/src/test/objectstore/Allocator_bench.cc
+++ b/src/test/objectstore/Allocator_bench.cc
@@ -326,6 +326,38 @@ TEST_P(AllocTest, test_alloc_bench_10_300)
   doOverwriteTest(capacity, prefill, overwrite);
 }
 
+TEST_P(AllocTest, mempoolAccounting)
+{
+  uint64_t bytes = mempool::bluestore_alloc::allocated_bytes();
+  uint64_t items = mempool::bluestore_alloc::allocated_items();
+
+  uint64_t alloc_size = 4 * 1024;
+  uint64_t capacity = 512ll * 1024 * 1024 * 1024;
+  Allocator* alloc = Allocator::create(g_ceph_context, string(GetParam()),
+				       capacity, alloc_size);
+  ASSERT_NE(alloc, nullptr);
+  alloc->init_add_free(0, capacity);
+
+  std::map<uint32_t, PExtentVector> all_allocs;
+  for (size_t i = 0; i < 10000; i++) {
+    PExtentVector tmp;
+    alloc->allocate(alloc_size, alloc_size, 0, 0, &tmp);
+    all_allocs[rand()] = tmp;
+    alloc->allocate(alloc_size, alloc_size, 0, 0, &tmp);
+    all_allocs[rand()] = tmp;
+
+    auto it = all_allocs.upper_bound(rand());
+    if (it != all_allocs.end()) {
+      alloc->release(it->second);
+      all_allocs.erase(it);
+    }
+  }
+
+  delete(alloc);
+  ASSERT_EQ(mempool::bluestore_alloc::allocated_bytes(), bytes);
+  ASSERT_EQ(mempool::bluestore_alloc::allocated_items(), items);
+}
+
 INSTANTIATE_TEST_SUITE_P(
   Allocator,
   AllocTest,


### PR DESCRIPTION
Adds shutdown. Fixes incorrect mempool accounting.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>