### PR TITLE
cmake: use specified python for running node-gyp

### DIFF
--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -37,6 +37,7 @@ else()
     COMMENT "dashboard nodeenv is being installed"
   )
   add_custom_target(mgr-dashboard-nodeenv
+    COMMAND . ${mgr-dashboard-nodeenv-dir}/bin/activate && npm config set python ${MGR_PYTHON_EXECUTABLE} && deactivate
     DEPENDS ${mgr-dashboard-nodeenv-dir}/bin/npm
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )


### PR DESCRIPTION
to make sure node-gyp is able to find a compatible python3

see also
https://github.com/nodejs/node-gyp#configuring-python-dependency

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
