### PR TITLE
mgr/cephadm: adapt osd deployment to service_apply

### DIFF
--- a/qa/suites/rados/cephadm/upgrade/1-start.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start.yaml
@@ -1,4 +1,4 @@
 tasks:
 - cephadm:
-    image: quay.io/ceph-ci/ceph:wip-sage2-testing-2020-03-10-1354
-    cephadm_branch: wip-sage2-testing-2020-03-10-1354
+    image: quay.io/ceph-ci/ceph:wip-sage3-testing-2020-03-14-0747
+    cephadm_branch: wip-sage3-testing-2020-03-14-0747

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -604,7 +604,7 @@ def ceph_osds(ctx, config):
             _shell(ctx, cluster_name, remote, [
                 'ceph-volume', 'lvm', 'zap', dev])
             _shell(ctx, cluster_name, remote, [
-                'ceph', 'orch', 'osd', 'create',
+                'ceph', 'orch', 'daemon', 'add', 'osd',
                 remote.shortname + ':' + short_dev
             ])
             ctx.daemons.register_daemon(

--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -82,21 +82,17 @@ class TestOrchestratorCli(MgrTestCase):
         self._orch_cmd("daemon", "start", "mds.a")
 
     def test_osd_create(self):
-        self._orch_cmd("osd", "create", "*:device")
-        self._orch_cmd("osd", "create", "*:device,device2")
-
-        drive_groups = {
-            'test': {
-                "host_pattern": "*",
-                "data_devices": {"paths": ["/dev/sda"]}
-            }
-        }
-
-        res = self._orch_cmd_result("osd", "create", "-i", "-", stdin=json.dumps(drive_groups))
+        drive_group = """
+service_type: osd
+service_id: any.sda
+placement:
+  host_pattern: '*'
+data_devices:
+  all: True
+"""
+        res = self._orch_cmd_result("apply", "osd", "-i", "-",
+                                    stdin=drive_group)
         self.assertEqual(res, 0)
-
-        with self.assertRaises(Exception):
-           self._orch_cmd("osd", "create", "notfound:device")
 
     def test_blink_device_light(self):
         def _ls_lights(what):

--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -268,7 +268,7 @@ $SUDO pvcreate $loop_dev && $SUDO vgcreate $OSD_VG_NAME $loop_dev
 for id in `seq 0 $((--OSD_TO_CREATE))`; do
     $SUDO lvcreate -l $((100/$OSD_TO_CREATE))%VG -n $OSD_LV_NAME.$id $OSD_VG_NAME
     $CEPHADM shell --fsid $FSID --config $CONFIG --keyring $KEYRING -- \
-            ceph orch osd create \
+            ceph orch daemon add osd \
                 $(hostname):/dev/$OSD_VG_NAME/$OSD_LV_NAME.$id
 done
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1955,7 +1955,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     def create_osds(self, drive_group):
         # type: (DriveGroupSpec) -> orchestrator.Completion
-        self.log.info("Processing DriveGroup {}".format(drive_group))
+        self.log.debug("Processing DriveGroup {}".format(drive_group))
         # 1) use fn_filter to determine matching_hosts
         matching_hosts = drive_group.placement.pattern_matches_hosts([x for x in self.cache.get_hosts()])
         # 2) Map the inventory to the InventoryHost object
@@ -1978,8 +1978,10 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             cmd = translate.to_ceph_volume(drive_group, drive_selection).run()
             self.log.debug(f"translated to cmd {cmd}")
             if not cmd:
-                self.log.info("No data_devices, skipping DriveGroup: {}".format(drive_group.service_name()))
+                self.log.debug("No data_devices, skipping DriveGroup: {}".format(drive_group.service_name()))
                 continue
+            self.log.info('Applying %s on host %s...' % (
+                drive_group.service_name(), host))
             ret_msg = self._create_osd(host, cmd)
             ret.append(ret_msg)
         return trivial_result(", ".join(ret))

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -4,7 +4,7 @@ import json
 import logging
 import time
 
-from ceph.deployment.drive_group import DriveGroupSpecs, DriveGroupValidationError
+from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupValidationError
 from mgr_util import get_most_recent_rate
 
 from . import ApiController, RESTController, Endpoint, Task
@@ -249,11 +249,11 @@ class Osd(RESTController):
 
     @raise_if_no_orchestrator
     @handle_orchestrator_error('osd')
-    def _create_with_drive_groups(self, drive_groups):
+    def _create_with_drive_groups(self, drive_group):
         """Create OSDs with DriveGroups."""
         orch = OrchClient.instance()
         try:
-            orch.osds.create(DriveGroupSpecs(drive_groups).drive_groups)
+            orch.osds.create(DriveGroupSpec.from_json(drive_group))
         except (ValueError, TypeError, DriveGroupValidationError) as e:
             raise DashboardException(e, component='osd')
 
@@ -262,7 +262,7 @@ class Osd(RESTController):
     def create(self, method, data, tracking_id):  # pylint: disable=W0622
         if method == 'bare':
             return self._create_bare(data)
-        if method == 'drive_groups':
+        if method == 'drive_group':
             return self._create_with_drive_groups(data)
         raise DashboardException(
             component='osd', http_status_code=400, msg='Unknown method: {}'.format(method))

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -105,8 +105,8 @@ class ServiceManager(ResourceManager):
 
 class OsdManager(ResourceManager):
     @wait_api_result
-    def create(self, drive_groups):
-        return self.api.create_osds(drive_groups)
+    def create(self, drive_group):
+        return self.api.create_osds(drive_group)
 
     @wait_api_result
     def remove(self, osd_ids):

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -901,8 +901,8 @@ class Orchestrator(object):
         #assert action in ["start", "stop", "reload, "restart", "redeploy"]
         raise NotImplementedError()
 
-    def create_osds(self, drive_groups):
-        # type: (List[DriveGroupSpec]) -> Completion
+    def create_osds(self, drive_group):
+        # type: (DriveGroupSpec) -> Completion
         """
         Create one or more OSDs within a single Drive Group.
 
@@ -910,13 +910,11 @@ class Orchestrator(object):
         of OsdSpec: other fields are advisory/extensible for any
         finer-grained OSD feature enablement (choice of backing store,
         compression/encryption, etc).
-
-        :param drive_groups: a list of DriveGroupSpec
-        :param all_hosts: TODO, this is required because the orchestrator methods are not composable
-                Probably this parameter can be easily removed because each orchestrator can use
-                the "get_inventory" method and the "drive_group.host_pattern" attribute
-                to obtain the list of hosts where to apply the operation
         """
+        raise NotImplementedError()
+
+    def apply_drivegroups(self, specs: List[DriveGroupSpec]) -> List[Completion]:
+        """ Update OSD cluster """
         raise NotImplementedError()
 
     def remove_osds(self, osd_ids: List[str],

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -16,8 +16,8 @@ except ImportError:
     pass  # just for type checking.
 
 
-from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection, \
-    DriveGroupSpecs
+from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection
+
 from ceph.deployment.service_spec import PlacementSpec, ServiceSpec
 from mgr_module import MgrModule, HandleCommandResult
 
@@ -428,45 +428,58 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
             return HandleCommandResult(stdout=table.get_string())
 
     @_cli_write_command(
-        'orch osd create',
+        'orch apply osd',
+        desc='Create an OSD daemons using drive_groups')
+    def _apply_osd(self, inbuf=None):
+        # type: (Optional[str]) -> HandleCommandResult
+        """Apply DriveGroupSpecs to create OSDs"""
+        usage = """
+Usage:
+  ceph orch apply osd -i <json_file/yaml_file>
+"""
+        if not inbuf:
+            return HandleCommandResult(-errno.EINVAL, stderr=usage)
+        try:
+            drivegroups = yaml.load_all(inbuf)
+            dg_specs = [ServiceSpec.from_json(dg) for dg in drivegroups]
+        except ValueError as e:
+            msg = 'Failed to read JSON/YAML input: {}'.format(str(e)) + usage
+            return HandleCommandResult(-errno.EINVAL, stderr=msg)
+
+        completions = self.apply_drivegroups(dg_specs)
+        [self._orchestrator_wait([completion]) for completion in completions]  # type: ignore
+        [raise_if_exception(completion) for completion in completions]  # type: ignore
+        result_strings = [completion.result_str() for completion in completions]
+        return HandleCommandResult(stdout=" ".join(result_strings))
+
+    @_cli_write_command(
+        'orch daemon add osd',
         "name=svc_arg,type=CephString,req=false",
-        'Create an OSD service. Either --svc_arg=host:drives or -i <drive_group>')
-    def _create_osd(self, svc_arg=None, inbuf=None):
-        # type: (Optional[str], Optional[str]) -> HandleCommandResult
+        'Create an OSD service. Either --svc_arg=host:drives')
+    def _daemon_add_osd(self, svc_arg=None):
+        # type: (Optional[str]) -> HandleCommandResult
         """Create one or more OSDs"""
 
         usage = """
 Usage:
-  ceph orch osd create -i <json_file/yaml_file>
-  ceph orch osd create host:device1,device2,...
+  ceph orch daemon add osd host:device1,device2,...
 """
-
-        if inbuf:
-            try:
-                dgs = DriveGroupSpecs(yaml.load(inbuf))
-                drive_groups = dgs.drive_groups
-            except ValueError as e:
-                msg = 'Failed to read JSON input: {}'.format(str(e)) + usage
-                return HandleCommandResult(-errno.EINVAL, stderr=msg)
-
-        elif svc_arg:
-            try:
-                host_name, block_device = svc_arg.split(":")
-                block_devices = block_device.split(',')
-            except (TypeError, KeyError, ValueError):
-                msg = "Invalid host:device spec: '{}'".format(svc_arg) + usage
-                return HandleCommandResult(-errno.EINVAL, stderr=msg)
-
-            devs = DeviceSelection(paths=block_devices)
-            drive_groups = [DriveGroupSpec(placement=PlacementSpec(host_pattern=host_name), data_devices=devs)]
-        else:
+        if not svc_arg:
             return HandleCommandResult(-errno.EINVAL, stderr=usage)
+        try:
+            host_name, block_device = svc_arg.split(":")
+            block_devices = block_device.split(',')
+            devs = DeviceSelection(paths=block_devices)
+            drive_group = DriveGroupSpec(placement=PlacementSpec(host_pattern=host_name), data_devices=devs)
+        except (TypeError, KeyError, ValueError):
+            msg = "Invalid host:device spec: '{}'".format(svc_arg) + usage
+            return HandleCommandResult(-errno.EINVAL, stderr=msg)
 
-        completion = self.create_osds(drive_groups)
+        completion = self.create_osds(drive_group)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
-    
+
     @_cli_write_command(
         'orch osd rm',
         "name=svc_id,type=CephString,n=N "

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -441,22 +441,14 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             mgr=self
         )
 
-    def create_osds(self, drive_groups):
-        # type: (List[DriveGroupSpec]) -> RookCompletion
+    def create_osds(self, drive_group):
+        # type: (DriveGroupSpec) -> RookCompletion
         """ Creates OSDs from a drive group specification.
-
-        Caveat: Currently limited to a single DriveGroup.
-        The orchestrator_cli expects a single completion which
-        ideally represents a set of operations. This orchestrator
-        doesn't support this notion, yet. Hence it's only accepting
-        a single DriveGroup for now.
-        You can work around it by invoking:
 
         $: ceph orch osd create -i <dg.file>
 
-        multiple times. The drivegroup file must only contain one spec at a time.
+        The drivegroup file must only contain one spec at a time.
         """
-        drive_group = drive_groups[0]
 
         targets = []  # type: List[str]
         if drive_group.data_devices and drive_group.data_devices.paths:

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -258,6 +258,22 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
             )
         )
 
+    def apply_drivegroups(self, specs):
+        # type: (List[DriveGroupSpec]) -> TestCompletion
+        drive_group = specs[0]
+        def run(all_hosts):
+            # type: (List[orchestrator.HostSpec]) -> None
+            drive_group.validate()
+            if drive_group.placement.host_pattern:
+                if not drive_group.placement.pattern_matches_hosts([h.hostname for h in all_hosts]):
+                    raise orchestrator.OrchestratorValidationError('failed to match')
+        return self.get_hosts().then(run).then(
+            on_complete=orchestrator.ProgressReference(
+                message='apply_drivesgroups',
+                mgr=self,
+            )
+        )
+
     @deferred_write("remove_daemons")
     def remove_daemons(self, names, force):
         assert isinstance(names, list)

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -236,22 +236,14 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         return list(filter(_filter_func, daemons))
 
-    def create_osds(self, drive_groups):
-        # type: (List[DriveGroupSpec]) -> TestCompletion
+    def create_osds(self, drive_group):
+        # type: (DriveGroupSpec) -> TestCompletion
         """ Creates OSDs from a drive group specification.
-
-        Caveat: Currently limited to a single DriveGroup.
-        The orchestrator_cli expects a single completion which
-        ideally represents a set of operations. This orchestrator
-        doesn't support this notion, yet. Hence it's only accepting
-        a single DriveGroup for now.
-        You can work around it by invoking:
 
         $: ceph orch osd create -i <dg.file>
 
-        multiple times. The drivegroup file must only contain one spec at a time.
+        The drivegroup file must only contain one spec at a time.
         """
-        drive_group = drive_groups[0]
 
         def run(all_hosts):
             # type: (List[orchestrator.HostSpec]) -> None
@@ -264,9 +256,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
                 message='create_osds',
                 mgr=self,
             )
-
         )
-
 
     @deferred_write("remove_daemons")
     def remove_daemons(self, names, force):

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -87,7 +87,11 @@ class DeviceSelection(object):
         return cls(**device_spec)
 
     def to_json(self):
-        return self.__dict__.copy()
+        # type: () -> Dict[str, Any]
+        c = self.__dict__.copy()
+        if self.paths:
+            c['paths'] = [p.path for p in self.paths]
+        return c
 
     def __repr__(self):
         keys = [

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -77,12 +77,17 @@ class DeviceSelection(object):
     @classmethod
     def from_json(cls, device_spec):
         # type: (dict) -> DeviceSelection
+        if not device_spec:
+            return  # type: ignore
         for applied_filter in list(device_spec.keys()):
             if applied_filter not in cls._supported_filters:
                 raise DriveGroupValidationError(
                     "Filtering for <{}> is not supported".format(applied_filter))
 
         return cls(**device_spec)
+
+    def to_json(self):
+        return self.__dict__.copy()
 
     def __repr__(self):
         keys = [
@@ -106,28 +111,6 @@ class DriveGroupValidationError(ServiceSpecValidationError):
 
     def __init__(self, msg):
         super(DriveGroupValidationError, self).__init__('Failed to validate Drive Group: ' + msg)
-
-
-class DriveGroupSpecs(object):
-    """ Container class to parse drivegroups """
-
-    def __init__(self, drive_group_json):
-        # type: (list) -> None
-        self.drive_group_json = drive_group_json
-
-        if isinstance(self.drive_group_json, dict):
-            # from legacy representation (till Octopus)
-            self.drive_group_json = [
-                dict(service_id=name, service_type='osd', **dg)
-                for name, dg in self.drive_group_json.items()
-            ]
-        if not isinstance(self.drive_group_json, list):
-            raise ServiceSpecValidationError('Specs needs to be a list of specs')
-        dgs = list(map(DriveGroupSpec.from_json, self.drive_group_json))  # type: ignore
-        self.drive_groups = dgs  # type: List[DriveGroupSpec]
-
-    def __repr__(self):
-        return ", ".join([repr(x) for x in self.drive_groups])
 
 
 class DriveGroupSpec(ServiceSpec):
@@ -282,6 +265,19 @@ class DriveGroupSpec(ServiceSpec):
             self.service_id,
             ', '.join('{}={}'.format(key, repr(getattr(self, key))) for key in keys)
         )
+
+    def to_json(self):
+        # type: () -> Dict[str, Any]
+        c = self.__dict__.copy()
+        if self.placement:
+            c['placement'] = self.placement.to_json()
+        if self.data_devices:
+            c['data_devices'] = self.data_devices.to_json()
+        if self.db_devices:
+            c['db_devices'] = self.db_devices.to_json()
+        if self.wal_devices:
+            c['wal_devices'] = self.wal_devices.to_json()
+        return c
 
     def __eq__(self, other):
         return repr(self) == repr(other)

--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -113,7 +113,7 @@ class DriveSelection(object):
             return []
 
         devices = list()  # type: List[Device]
-        for disk in self.disks.devices:
+        for disk in self.disks:
             logger.debug("Processing disk {}".format(disk.path))
 
             if not disk.available:
@@ -147,7 +147,7 @@ class DriveSelection(object):
 
         # This disk is already taken and must not be re-assigned.
         for taken_device in devices:
-            if taken_device in self.disks.devices:
-                self.disks.devices.remove(taken_device)
+            if taken_device in self.disks:
+                self.disks.remove(taken_device)
 
         return sorted([x for x in devices], key=lambda dev: dev.path)

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -5,8 +5,8 @@ from ceph.deployment import drive_selection, translate
 from ceph.deployment.inventory import Device
 from ceph.deployment.service_spec import PlacementSpec, ServiceSpecValidationError
 from ceph.tests.utils import _mk_inventory, _mk_device
-from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupSpecs, \
-                                        DeviceSelection, DriveGroupValidationError
+from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection, \
+    DriveGroupValidationError
 
 @pytest.mark.parametrize("test_input",
 [
@@ -20,25 +20,13 @@ from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupSpecs, \
             }
         ]
     ),
-    (
-        {  # old style json
-            'testing_drivegroup':
-                {
-                    'host_pattern': 'hostname',
-                    'data_devices': {'paths': ['/dev/sda']}
-                }
-       }
-    )
-
 ])
-
 def test_DriveGroup(test_input):
-    dgs = DriveGroupSpecs(test_input)
-    for dg in dgs.drive_groups:
-        assert dg.placement.pattern_matches_hosts(['hostname']) == ['hostname']
-        assert dg.service_id == 'testing_drivegroup'
-        assert all([isinstance(x, Device) for x in dg.data_devices.paths])
-        assert dg.data_devices.paths[0].path == '/dev/sda'
+    dg = [DriveGroupSpec.from_json(inp) for inp in test_input][0]
+    assert dg.placement.pattern_matches_hosts(['hostname']) == ['hostname']
+    assert dg.service_id == 'testing_drivegroup'
+    assert all([isinstance(x, Device) for x in dg.data_devices.paths])
+    assert dg.data_devices.paths[0].path == '/dev/sda'
 
 
 def test_DriveGroup_fail():

--- a/src/python-common/ceph/tests/utils.py
+++ b/src/python-common/ceph/tests/utils.py
@@ -35,4 +35,4 @@ def _mk_inventory(devices):
         dev.path = '/dev/sd' + name
         dev.sys_api = dict(dev_.sys_api, path='/dev/sd' + name)
         devs.append(dev)
-    return Devices(devices=devs)
+    return Devices(devices=devs).devices

--- a/test_cephadm.sh
+++ b/test_cephadm.sh
@@ -92,7 +92,7 @@ pvcreate $loop_dev && vgcreate $OSD_VG_NAME $loop_dev
 for id in `seq 0 $((--OSD_TO_CREATE))`; do
     lvcreate -l $((100/$OSD_TO_CREATE))%VG -n $OSD_LV_NAME.$id $OSD_VG_NAME
     $SUDO $CEPHADM shell --fsid $fsid --config c --keyring k -- \
-            ceph orch osd create \
+            ceph orch daemon add osd \
                 $(hostname):/dev/$OSD_VG_NAME/$OSD_LV_NAME.$id
 done
 


### PR DESCRIPTION
supersedes #33381 

- revamped `ceph orch apply osd -i <dg_spec_file>` to `ceph orch apply osd -i <dg_spec_file>`
- follows the same approach as other services
- saves drivegroup under `mgr/cephadm/spec.osd.$service_id`

- added `ceph orch daemon add osd host:dev` for non-spec based deployments


full servicespec file format:

``` yaml
# .. other content
---
service_type: osd
service_id: test_drivegroup
placement:
  host_pattern: '*'
data_devices:
  all: True
---
# .. other content
```

known issues:

- When you more an OSD and also purge/zap the disk, the apply logic will re-add it to the cluster.

Possible solution:

Implement a ceph-volume native command `ceph-volume lock <disk> --reason <Custom lock>`
This way we can show the reason as to why we're not including a disk via the `REASON` field.


- `ceph orch ls` (and also ps) is not capable of mapping drives/daemons to a certain drivegroup.

This leaves the SPEC and PLACEMENT fields empty. Also if you remove OSDs, we cannot easily remove the specs from the mon store..

Possible solution:
 
If an OSD gets deployed using a spec, append the name of the drivegroup (or even the entire drivegroup spec?) to the DemonDescription. This way we can probably track and group OSDs by their respective drivegroup affinity.


TODO:

- [ ] Adapt OSD Drivegroup docs
- [ ] Add qa/.. tests for drivegroups
- [ ] Address issues

Signed-off-by: Joshua Schmid <jschmid@suse.de>
