### PR TITLE
python: fixate mypy requirement to mypy==0.770

### DIFF
--- a/qa/tox.ini
+++ b/qa/tox.ini
@@ -16,5 +16,5 @@ commands=flake8 --select=F,E9 --exclude=venv,.tox
 
 [testenv:mypy]
 basepython = python3
-deps = mypy
+deps = mypy==0.770
 commands = mypy {posargs:.}

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -11,7 +11,7 @@ commands = pytest -v --cov --cov-append --cov-report=term --doctest-modules {pos
 basepython = python3
 deps =
     -r requirements.txt
-    mypy
+    mypy==0.770
 commands = mypy --config-file=../../mypy.ini \
            cephadm/module.py \
            mgr_module.py \

--- a/src/python-common/requirements.txt
+++ b/src/python-common/requirements.txt
@@ -1,6 +1,6 @@
 six
 pytest >=2.1.3,<5; python_version < '3.5'
 mock; python_version < '3.3'
-mypy; python_version >= '3'
+mypy==0.770; python_version >= '3'
 pytest-mypy; python_version >= '3'
 pytest >= 2.1.3; python_version >= '3'


### PR DESCRIPTION
I don't like suprises when upstream publishes a new mypy version.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
