### PR TITLE
nautilus:  mgr/dashboard: Dashboard does not allow you to set norebalance OSD flag

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.ts
@@ -76,6 +76,12 @@ export class OsdFlagsModalComponent implements OnInit {
       value: false,
       description: this.i18n('Backfilling of PGs is suspended')
     },
+    norebalance: {
+      code: 'norebalance',
+      name: this.i18n('No Rebalance'),
+      value: false,
+      description: this.i18n('OSD will choose not to backfill unless PG is also degraded')
+    },
     norecover: {
       code: 'norecover',
       name: this.i18n('No Recover'),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44574

this backport was staged using ceph-backport.sh version 15.1.0.1009
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh