### PR TITLE
mgr/dashboard: hide daemon table when orchestrator is disabled

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.html
@@ -1,6 +1,9 @@
-<cd-table [data]="daemons"
+<cd-orchestrator-doc-panel *ngIf="!hasOrchestrator"></cd-orchestrator-doc-panel>
+<cd-table *ngIf="hasOrchestrator"
+          #daemonsTable
+          [data]="daemons"
           [columns]="columns"
           columnMode="flex"
-          autoReload="0"
+          [autoReload]="60000"
           (fetchData)="getDaemons($event)">
 </cd-table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.html
@@ -6,6 +6,7 @@
             forceIdentifier="true"
             columnMode="flex"
             selectionType="single"
+            [autoReload]="60000"
             (fetchData)="getServices($event)"
             (updateSelection)="updateSelection($event)">
     <cd-service-details cdTableDetail

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -28,7 +28,6 @@ export class ServicesComponent implements OnChanges, OnInit {
   permissions: Permissions;
 
   checkingOrchestrator = true;
-  orchestratorExist = false;
   hasOrchestrator = false;
   docsUrl: string;
 
@@ -90,7 +89,7 @@ export class ServicesComponent implements OnChanges, OnInit {
   }
 
   ngOnChanges() {
-    if (this.orchestratorExist) {
+    if (this.hasOrchestrator) {
       this.services = [];
       this.table.reloadData();
     }


### PR DESCRIPTION
The refresh time of services/daemons is also increased to 1 minute since
they are not updated so frequently.

Fixes: https://tracker.ceph.com/issues/44558
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

## How to test
* Start dashboard without any orchestrator: *Cluster->Hosts* should not raise an error when clicking on any host. Also, in the Daemons tab, a blue INFO alert panel will be shown.

* Testing with cephadm
  * Deploy some services with cephadm
  * Navigate to *Cluster->Hosts->Daemons tab*.
  * Navigate to *Cluster->Services*, click any service to view its daemon.
 
* Testing with test_orchestrator
  ```
  # bin/ceph mgr module enable test_orchestrator
  # bin/ceph orch set backend test_orchestrator
  # bin/ceph test_orchestrator load_data -i <ceph_src_root>/src/pybind/mgr/test_orchestrator/dummy_data.json
  ```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
