### PR TITLE
crimson: fix bugs that come up when osds go through down/up

### DIFF
--- a/src/crimson/os/alienstore/alien_collection.h
+++ b/src/crimson/os/alienstore/alien_collection.h
@@ -11,15 +11,16 @@
 
 namespace crimson::os {
 
-struct AlienCollection final : public FuturizedCollection {
-
-  ObjectStore::CollectionHandle collection;
-
+class AlienCollection final : public FuturizedCollection {
+public:
   AlienCollection(ObjectStore::CollectionHandle ch)
   : FuturizedCollection(ch->cid),
     collection(ch) {}
 
   ~AlienCollection() {}
-};
 
+private:
+  ObjectStore::CollectionHandle collection;
+  friend AlienStore;
+};
 }

--- a/src/crimson/os/cyanstore/cyan_object.h
+++ b/src/crimson/os/cyanstore/cyan_object.h
@@ -1,10 +1,13 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
+#pragma once
+
 #include <cstddef>
 #include <map>
 #include <string>
 #include <boost/intrusive_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
+
 #include "include/buffer.h"
 
 namespace crimson::os {

--- a/src/crimson/os/cyanstore/cyan_store.h
+++ b/src/crimson/os/cyanstore/cyan_store.h
@@ -16,6 +16,7 @@
 #include "osd/osd_types.h"
 #include "include/uuid.h"
 
+#include "crimson/os/cyanstore/cyan_object.h"
 #include "crimson/os/futurized_store.h"
 
 namespace ceph::os {
@@ -35,6 +36,34 @@ class CyanStore final : public FuturizedStore {
   uuid_d osd_fsid;
 
 public:
+  class CyanOmapIterator final : public OmapIterator {
+  public:
+    CyanOmapIterator() {}
+    CyanOmapIterator(ObjectRef obj) : obj(obj) {
+      iter = obj->omap.begin();
+    }
+    virtual seastar::future<int> seek_to_first();
+    virtual seastar::future<int> upper_bound(const std::string &after);
+    virtual seastar::future<int> lower_bound(const std::string &to);
+    virtual bool valid() const;
+    virtual seastar::future<int> next();
+    virtual std::string key() {
+      return iter->first;
+    }
+    virtual seastar::future<std::string> tail_key() {
+      return seastar::make_ready_future<std::string>((++obj->omap.end())->first);
+    }
+    virtual ceph::buffer::list value() {
+      return iter->second;
+    }
+    virtual int status() const {
+      return iter != obj->omap.end() ? 0 : -1;
+    }
+    virtual ~CyanOmapIterator() {}
+  private:
+    std::map<std::string, bufferlist>::const_iterator iter;
+    ObjectRef obj;
+  };
 
   CyanStore(const std::string& path);
   ~CyanStore() final;
@@ -45,6 +74,9 @@ public:
 
   seastar::future<> mkfs(uuid_d new_osd_fsid) final;
   seastar::future<store_statfs_t> stat() const final;
+  seastar::future<struct stat> stat(
+    CollectionRef c,
+    const ghobject_t& oid) final;
 
   read_errorator::future<ceph::bufferlist> read(
     CollectionRef c,
@@ -78,6 +110,10 @@ public:
     const std::optional<std::string> &start ///< [in] start, empty for begin
     ) final; ///< @return <done, values> values.empty() iff done
 
+  seastar::future<ceph::bufferlist> omap_get_header(
+    CollectionRef c,
+    const ghobject_t& oid) final;
+
   seastar::future<CollectionRef> create_new_collection(const coll_t& cid) final;
   seastar::future<CollectionRef> open_collection(const coll_t& cid) final;
   seastar::future<std::vector<coll_t>> list_collections() final;
@@ -90,6 +126,15 @@ public:
   seastar::future<int, std::string> read_meta(const std::string& key) final;
   uuid_d get_fsid() const final;
   unsigned get_max_attr_name_length() const final;
+
+  seastar::future<OmapIteratorRef> get_omap_iterator(
+    CollectionRef c,
+    const ghobject_t& oid);
+
+  seastar::future<std::map<uint64_t, uint64_t>> fiemap(CollectionRef c,
+						       const ghobject_t& oid,
+						       uint64_t off,
+						       uint64_t len);
 
 private:
   int _remove(const coll_t& cid, const ghobject_t& oid);

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -26,6 +26,43 @@ class FuturizedCollection;
 class FuturizedStore {
 
 public:
+  class OmapIterator {
+  public:
+    virtual seastar::future<int> seek_to_first() {
+      return seastar::make_ready_future<int>(0);
+    }
+    virtual seastar::future<int> upper_bound(const std::string &after) {
+      return seastar::make_ready_future<int>(0);
+    }
+    virtual seastar::future<int> lower_bound(const std::string &to) {
+      return seastar::make_ready_future<int>(0);
+    }
+    virtual bool valid() const {
+      return false;
+    }
+    virtual seastar::future<int> next() {
+      return seastar::make_ready_future<int>(0);
+    }
+    virtual std::string key() {
+      return {};
+    }
+    virtual seastar::future<std::string> tail_key() {
+      return seastar::make_ready_future<std::string>();
+    }
+    virtual ceph::buffer::list value() {
+      return {};
+    }
+    virtual int status() const {
+      return 0;
+    }
+    virtual ~OmapIterator() {}
+  private:
+    unsigned count = 0;
+    friend void intrusive_ptr_add_ref(FuturizedStore::OmapIterator* iter);
+    friend void intrusive_ptr_release(FuturizedStore::OmapIterator* iter);
+  };
+  using OmapIteratorRef = boost::intrusive_ptr<OmapIterator>;
+
   static std::unique_ptr<FuturizedStore> create(const std::string& type,
                                                 const std::string& data,
                                                 const ConfigValues& values);
@@ -70,6 +107,9 @@ public:
   virtual get_attrs_ertr::future<attrs_t> get_attrs(
     CollectionRef c,
     const ghobject_t& oid) = 0;
+  virtual seastar::future<struct stat> stat(
+    CollectionRef c,
+    const ghobject_t& oid) = 0;
 
   using omap_values_t = std::map<std::string, bufferlist, std::less<>>;
   using omap_keys_t = std::set<std::string>;
@@ -88,12 +128,24 @@ public:
     const std::optional<std::string> &start ///< [in] start, empty for begin
     ) = 0; ///< @return <done, values> values.empty() iff done
 
+  virtual seastar::future<bufferlist> omap_get_header(
+    CollectionRef c,
+    const ghobject_t& oid) = 0;
+
   virtual seastar::future<CollectionRef> create_new_collection(const coll_t& cid) = 0;
   virtual seastar::future<CollectionRef> open_collection(const coll_t& cid) = 0;
   virtual seastar::future<std::vector<coll_t>> list_collections() = 0;
 
   virtual seastar::future<> do_transaction(CollectionRef ch,
 					   ceph::os::Transaction&& txn) = 0;
+  virtual seastar::future<OmapIteratorRef> get_omap_iterator(
+    CollectionRef ch,
+    const ghobject_t& oid) = 0;
+  virtual seastar::future<std::map<uint64_t, uint64_t>> fiemap(
+    CollectionRef ch,
+    const ghobject_t& oid,
+    uint64_t off,
+    uint64_t len) = 0;
 
   virtual seastar::future<> write_meta(const std::string& key,
 				       const std::string& value) = 0;
@@ -101,5 +153,18 @@ public:
   virtual uuid_d get_fsid() const  = 0;
   virtual unsigned get_max_attr_name_length() const = 0;
 };
+
+inline void intrusive_ptr_add_ref(FuturizedStore::OmapIterator* iter) {
+  assert(iter);
+  iter->count++;
+}
+
+inline void intrusive_ptr_release(FuturizedStore::OmapIterator* iter) {
+  assert(iter);
+  assert(iter->count > 0);
+  if ((--iter->count) == 0) {
+    delete iter;
+  }
+}
 
 }

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -549,13 +549,15 @@ seastar::future<Ref<PG>> OSD::make_pg(cached_map_t create_map,
 
 seastar::future<Ref<PG>> OSD::load_pg(spg_t pgid)
 {
-  return PGMeta{store.get(), pgid}.get_epoch().then([this](epoch_t e) {
+  return seastar::do_with(PGMeta(store.get(), pgid), [this, pgid] (auto& pg_meta) {
+    return pg_meta.get_epoch();
+  }).then([this](epoch_t e) {
     return get_map(e);
   }).then([pgid, this] (auto&& create_map) {
     return make_pg(std::move(create_map), pgid, false);
-  }).then([this, pgid](Ref<PG> pg) {
+  }).then([this](Ref<PG> pg) {
     return pg->read_state(store.get()).then([pg] {
-      return seastar::make_ready_future<Ref<PG>>(std::move(pg));
+	return seastar::make_ready_future<Ref<PG>>(std::move(pg));
     });
   }).handle_exception([pgid](auto ep) {
     logger().info("pg {} saw exception on load {}", pgid, ep);

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -364,8 +364,9 @@ void PG::init(
 
 seastar::future<> PG::read_state(crimson::os::FuturizedStore* store)
 {
-  return PGMeta{store, pgid}.load(
-  ).then([this, store](pg_info_t pg_info, PastIntervals past_intervals) {
+  return seastar::do_with(PGMeta(store, pgid), [this, store] (auto& pg_meta) {
+    return pg_meta.load();
+  }).then([this, store](pg_info_t pg_info, PastIntervals past_intervals) {
     return peering_state.init_from_disk_state(
 	std::move(pg_info),
 	std::move(past_intervals),


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
Currently, there exists bugs when an OSD with pg stored in it go through the down/up procedure, this PR fix those.

NOTE: the commit "crimson: add necessary FuturizedStore APIs for data recovery" contains several
added interface, among which only "get_omap_iterator()" is used by now, the others are the ones that will be used when doing pglog-based recovery.

Signed-off-by: Xuehan Xu <xxhdx1985126@163.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
