### PR TITLE
mgr/restful: verify pool related API argument

### DIFF
--- a/src/pybind/mgr/restful/api/pool.py
+++ b/src/pybind/mgr/restful/api/pool.py
@@ -3,6 +3,14 @@ from pecan.rest import RestController
 
 from restful import common, context
 from restful.decorators import auth
+from restful.decorators import expose as ceph_expose
+from restful.api import types
+
+
+class PoolType(types.APIBody):
+
+    name = types.StringType(require=True)
+    pg_num = types.IntegerType(require=True)
 
 
 class PoolId(RestController):
@@ -94,25 +102,19 @@ class Pool(RestController):
         return pools
 
 
-    @expose(template='json')
+    @ceph_expose(body=PoolType)
     @auth
-    def post(self, **kwargs):
+    def post(self, pool, **kwargs):
         """
         Create a new pool
         Requires name and pg_num dict arguments
         """
         args = request.json
+        args.pop("name", None)
+        args.pop("pg_num", None)
 
-        # Check for the required arguments
-        pool_name = args.pop('name', None)
-        if pool_name is None:
-            response.status = 500
-            return {'message': 'You need to specify the pool "name" argument'}
-
-        pg_num = args.pop('pg_num', None)
-        if pg_num is None:
-            response.status = 500
-            return {'message': 'You need to specify the "pg_num" argument'}
+        pool_name = pool.name
+        pg_num = pool.pg_num
 
         # Run the pool create command first
         create_command = {

--- a/src/pybind/mgr/restful/api/types.py
+++ b/src/pybind/mgr/restful/api/types.py
@@ -1,0 +1,122 @@
+from __future__ import absolute_import
+
+import re
+import abc
+import six
+import json
+
+from pecan import request
+
+
+@six.add_metaclass(abc.ABCMeta)
+class APIBody(object):
+
+    def __init__(self):
+        self._declare = dict()
+        for attr in dir(self):
+            if attr.startswith("_"):
+                continue
+            val = getattr(self, attr)
+            if isinstance(val, APIType):
+                self._declare.setdefault(attr, val)
+
+    @classmethod
+    def from_request(cls):
+        """
+        parse the request body into a python object
+
+        :raise ValueError
+        """
+        try:
+            body = json.loads(request.body)
+        except json.decoder.JSONDecodeError:
+            raise ValueError("Bad request format")
+        self = cls()
+        for arg, declare in self._declare.items():
+            v = body.pop(arg, None)
+            try:
+                value = declare(v)
+            except ValueError as err:
+                raise ValueError("%s: %s" % (arg, err))
+            setattr(self, arg, value)
+
+        return self
+
+
+@six.add_metaclass(abc.ABCMeta)
+class APIType(object):
+
+    def __init__(self, default=None, require=False):
+        self.default = default
+        self.require = require
+
+    def __call__(self, value):
+        return self.convert(value)
+
+    def convert(self, value):
+        if not value and self.default:
+            value = self.default
+
+        if self.require and not value:
+            raise ValueError("Missing required argument")
+
+        return self._convert(value)
+
+    @abc.abstractmethod
+    def _convert(self, value):
+        """
+        validate input and return target type, subclasses are responsible
+        for implementation. if input is illegal, raise ValueError
+        :param value: any
+        :raise ValueError
+        :return: value
+        """
+        return value
+
+
+class StringType(APIType):
+
+    def __init__(self, min_length=None, max_length=None, default=None, require=False, pattern=None):
+        super(StringType, self).__init__(default, require)
+        self.min_length = min_length
+        self.max_length = max_length
+        if pattern:
+            self.pattern = re.compile(pattern)
+        else:
+            self.pattern = re.compile(".*")
+
+    def _convert(self, value):
+        if not value:
+            return ""
+
+        if self.min_length and len(value) < self.min_length:
+            raise ValueError("The value should be greater than minimum length %s" % self.min_length)
+
+        if self.max_length and len(value) > self.max_length:
+            raise ValueError("The value should be less than maximum length %s" % self.max_length)
+
+        if not self.pattern.search(value):
+            raise ValueError("The value should match the pattern: %s" % self.pattern.pattern)
+
+        return str(value)
+
+
+class IntegerType(APIType):
+
+    def __init__(self, minimum=None, maximum=None, default=None, require=False):
+        super(IntegerType, self).__init__(default, require)
+        self.minimum = minimum
+        self.maximum = maximum
+
+    def _convert(self, value):
+        if not value:
+            return 0
+
+        value = int(value)
+        if self.minimum and value < self.minimum:
+            raise ValueError("Value should be greater than minimum %s" % self.minimum)
+
+        if self.maximum and value > self.maximum:
+            raise ValueError("Value should be less than maximum %s" % self.maximum)
+
+        return value


### PR DESCRIPTION
this PR adds a restful api verification mechanism 

applies a new verification mechanism to the `POST /pool` api.

fixes: https://tracker.ceph.com/issues/44573

Signed-off-by: liushi <liu.shi@navercorp.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
