### PR TITLE
mgr/dashboard: do not get iSCSI gateways from Orchestrator

### DIFF
--- a/src/pybind/mgr/dashboard/services/iscsi_config.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_config.py
@@ -3,15 +3,12 @@ from __future__ import absolute_import
 
 import json
 
-from orchestrator import OrchestratorError
-
 try:
     from urlparse import urlparse
 except ImportError:
     from urllib.parse import urlparse
 
 from mgr_util import merge_dicts
-from .orchestrator import OrchClient
 from .. import mgr
 
 
@@ -79,14 +76,8 @@ class IscsiGatewaysConfig(object):
     @staticmethod
     def _load_config_from_orchestrator():
         config = {'gateways': {}}  # type: dict
-        try:
-            instances = OrchClient.instance().services.list("iscsi")
-            for instance in instances:
-                config['gateways'][instance.hostname] = {
-                    'service_url': instance.service_url
-                }
-        except (RuntimeError, OrchestratorError, ImportError):
-            pass
+        # FIXME: get iSCSI gateways from orchestrator  # pylint: disable=fixme
+        # See https://tracker.ceph.com/issues/44593.
         return config
 
     @classmethod


### PR DESCRIPTION
Remove the code for now to prevent any possible error. We should add the
feature back when iSCSI daemons are ready in Orchestrator.

Fixes: https://tracker.ceph.com/issues/44514
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
