### PR TITLE
qa: Add a tox env that can test importing files

### DIFF
--- a/qa/test_import.py
+++ b/qa/test_import.py
@@ -1,0 +1,43 @@
+# try to import all .py files from a given directory
+
+import argparse
+import glob
+import os
+import importlib
+import importlib.util
+
+
+def _module_name(path):
+    task = os.path.splitext(path)[0]
+    parts = task.split(os.path.sep)
+    package = parts[0]
+    name = ''.join('.' + c for c in parts[1:])
+    return package, name
+
+def _import_file(path):
+    package, mod_name = _module_name(path)
+    line = f'Importing {package}{mod_name} from {path}'
+    print(f'{line:<80}', end='')
+    mod_spec = importlib.util.find_spec(mod_name, package)
+    mod = mod_spec.loader.load_module()
+    if mod is None:
+        result = 'FAIL'
+    else:
+        result = 'DONE'
+    print(f'{result:>6}')
+    mod_spec.loader.exec_module(mod)
+
+def _parser():
+    parser = argparse.ArgumentParser(
+        description='Try to import a file',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('path', nargs='+', help='Glob to select files')
+    return parser
+
+
+if __name__ == '__main__':
+    parser = _parser()
+    args = parser.parse_args()
+    for g in args.path:
+        for p in glob.glob(g, recursive=True):
+            _import_file(p)

--- a/qa/tox.ini
+++ b/qa/tox.ini
@@ -18,3 +18,8 @@ commands=flake8 --select=F,E9 --exclude=venv,.tox
 basepython = python3
 deps = mypy==0.770
 commands = mypy {posargs:.}
+
+[testenv:import-tasks]
+basepython = python3
+deps = {env:TEUTHOLOGY_GIT:git+https://github.com/ceph/teuthology.git@master}#egg=teuthology[coverage,orchestra,test]
+commands = python test_import.py {posargs:tasks/**/*.py}


### PR DESCRIPTION
While switching to python3, we need to make sure that we can import
the qa/tasks (and others, but this starts with qa/tasks) on a python3
environment.
To test this, we need to install teuthology into the test
venv. Currently, teuthology is not py3 ready so this will fail.

To test the current state of the qa/tasks directory with the ongoing
work for python3 within teuthology, you can now do:

TEUTHOLOGY_GIT=git+https://github.com/kshtsk/teuthology.git@wip-py3-compat \
    tox -eimport-tasks

This is using the current branch from
https://github.com/ceph/teuthology/pull/1362 which does the work to
make teuthology python3 ready.

NOTE: This tox env is not activated by default. It's currently failing
but it provides a way to iterate over the failures and once we have
them fixed, we can activate the tox env during make-check.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
