### PR TITLE
ceph.in: use sys._exit when we don't shut down

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -1279,4 +1279,11 @@ if __name__ == '__main__':
     except KeyboardInterrupt:
         print('Interrupted')
         retval = errno.EINTR
-    sys.exit(retval)
+
+    if retval:
+        # flush explicitly because we aren't exiting in the usual way
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(retval)
+    else:
+        sys.exit(retval)


### PR DESCRIPTION
If we experience a timeout, we don't bother shutting down rados, because
it can't currently handle one thread blocked (or running) library init
at the same time that another thread calls rados_shutdown().

However, sys.exit() runs all kinds of shutdown work that will also
interfere with the running librados threads.

Fix by using _exit instead of exit.

Fixes: https://tracker.ceph.com/issues/44566
Signed-off-by: Sage Weil <sage@redhat.com>