### PR TITLE
mgr/orch: dump service spec by name

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -162,11 +162,13 @@ class SpecStore():
             del self.spec_created[service_name]
             self.mgr.set_store(SPEC_STORE_PREFIX + service_name, None)
 
-    def find(self, service_name):
-        # type: (str) -> List[ServiceSpec]
+    def find(self, service_name=None):
+        # type: (Optional[str]) -> List[ServiceSpec]
         specs = []
         for sn, spec in self.specs.items():
-            if sn == service_name or sn.startswith(service_name + '.'):
+            if not service_name or \
+                    sn == service_name or \
+                    sn.startswith(service_name + '.'):
                 specs.append(spec)
         return specs
 
@@ -3042,12 +3044,12 @@ receivers:
         """
         return trivial_result(self.rm_util.report)
 
-    def list_specs(self) -> orchestrator.Completion:
+    def list_specs(self, service_name=None) -> orchestrator.Completion:
         """
         Loads all entries from the service_spec mon_store root.
         """
         specs = list()
-        for service_name, spec in self.spec_store.specs.items():
+        for spec in self.spec_store.find(service_name=service_name):
             specs.append('---')
             specs.append(yaml.safe_dump(spec.to_json()))
         return trivial_result(specs)

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -859,8 +859,8 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def list_specs(self):
-        # type: () -> Completion
+    def list_specs(self, service_name=None):
+        # type: (Optional[str]) -> Completion
         """
         Lists saved service specs
         """

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -740,9 +740,10 @@ Usage:
 
     @_cli_write_command(
         'orch spec dump',
+        'name=service_name,type=CephString,req=false',
         desc='List all Service specs')
-    def _get_service_specs(self):
-        completion = self.list_specs()
+    def _get_service_specs(self, service_name=None):
+        completion = self.list_specs(service_name=service_name)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         specs = completion.result_str()


### PR DESCRIPTION
add optional arg to allow a dump by name:
`ceph orch spec dump [svc_name]`

For example:
```
# bin/ceph orch spec dump nfs
---
namespace: nfs-ns
placement:
  all_hosts: false
  count: null
  host_pattern: null
  hosts:
  - hostname: host1
    name: ''
    network: ''
  label: null
pool: cephfs.a.data
service_id: foo
service_type: nfs
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
