### PR TITLE
[RFC] mgr/orch,python-common: replace {to|from}_json with {to|from}_dict

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -347,6 +347,6 @@ class TestCephadm(object):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.apply_service_config('dummy')
             _save_spec.assert_called_once()
-            _sspec.from_json.assert_called_once()
+            _sspec.from_dict.assert_called_once()
             assert wait(cephadm_module, c) == 'ServiceSpecs saved'
 

--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -122,4 +122,4 @@ class Host(RESTController):
     def daemons(self, hostname: str) -> List[dict]:
         orch = OrchClient.instance()
         daemons = orch.services.list_daemons(None, hostname)
-        return [d.to_json() for d in daemons]
+        return [d.to_dict() for d in daemons]

--- a/src/pybind/mgr/dashboard/controllers/orchestrator.py
+++ b/src/pybind/mgr/dashboard/controllers/orchestrator.py
@@ -105,7 +105,7 @@ class OrchestratorInventory(RESTController):
     def list(self, hostname=None):
         orch = OrchClient.instance()
         hosts = [hostname] if hostname else None
-        inventory_hosts = [host.to_json() for host in orch.inventory.list(hosts)]
+        inventory_hosts = [host.to_dict() for host in orch.inventory.list(hosts)]
         device_osd_map = get_device_osd_map()
         for inventory_host in inventory_hosts:
             host_osds = device_osd_map.get(inventory_host['name'])

--- a/src/pybind/mgr/dashboard/controllers/service.py
+++ b/src/pybind/mgr/dashboard/controllers/service.py
@@ -13,7 +13,7 @@ class Service(RESTController):
     @raise_if_no_orchestrator
     def list(self, service_name: Optional[str] = None) -> List[dict]:
         orch = OrchClient.instance()
-        return [service.to_json() for service in orch.services.list(service_name)]
+        return [service.to_dict() for service in orch.services.list(service_name)]
 
     @raise_if_no_orchestrator
     def get(self, service_name: str) -> List[dict]:
@@ -21,11 +21,11 @@ class Service(RESTController):
         services = orch.services.get(service_name)
         if not services:
             raise cherrypy.HTTPError(404, 'Service {} not found'.format(service_name))
-        return services[0].to_json()
+        return services[0].to_dict()
 
     @RESTController.Resource('GET')
     @raise_if_no_orchestrator
     def daemons(self, service_name: str) -> List[dict]:
         orch = OrchClient.instance()
         daemons = orch.services.list_daemons(service_name)
-        return [d.to_json() for d in daemons]
+        return [d.to_dict() for d in daemons]

--- a/src/pybind/mgr/dashboard/tests/test_orchestrator.py
+++ b/src/pybind/mgr/dashboard/tests/test_orchestrator.py
@@ -43,7 +43,7 @@ class OrchestratorControllerTest(ControllerTestCase):
             inv_hosts = []
             for inv_host in inventory:
                 if hosts is None or inv_host['name'] in hosts:
-                    inv_hosts.append(InventoryHost.from_json(inv_host))
+                    inv_hosts.append(InventoryHost.from_dict(inv_host))
             return inv_hosts
         mock_instance.inventory.list.side_effect = _list_inventory
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1127,7 +1127,7 @@ class HostSpec(object):
         #: human readable status
         self.status = status or ''  # type: str
 
-    def to_json(self):
+    def to_dict(self) -> dict:
         return {
             'hostname': self.hostname,
             'addr': self.addr,
@@ -1260,7 +1260,7 @@ class DaemonDescription(object):
         return "<DaemonDescription>({type}.{id})".format(type=self.daemon_type,
                                                          id=self.daemon_id)
 
-    def to_json(self):
+    def to_dict(self) -> dict:
         out = {
             'hostname': self.hostname,
             'container_id': self.container_id,
@@ -1280,7 +1280,7 @@ class DaemonDescription(object):
 
     @classmethod
     @handle_type_error
-    def from_json(cls, data):
+    def from_dict(cls, data) -> "DaemonDescription":
         c = data.copy()
         for k in ['last_refresh', 'created', 'started', 'last_deployed',
                   'last_configured']:
@@ -1350,7 +1350,7 @@ class ServiceDescription(object):
     def __repr__(self):
         return "<ServiceDescription>({name})".format(name=self.service_name)
 
-    def to_json(self):
+    def to_dict(self) -> dict:
         out = {
             'container_image_id': self.container_image_id,
             'container_image_name': self.container_image_name,
@@ -1359,7 +1359,7 @@ class ServiceDescription(object):
             'service_url': self.service_url,
             'size': self.size,
             'running': self.running,
-            'spec': self.spec.to_json() if self.spec is not None else None
+            'spec': self.spec.to_dict() if self.spec is not None else None
         }
         for k in ['last_refresh', 'created']:
             if getattr(self, k):
@@ -1368,7 +1368,7 @@ class ServiceDescription(object):
 
     @classmethod
     @handle_type_error
-    def from_json(cls, data):
+    def from_dict(cls, data) -> "ServiceDescription":
         c = data.copy()
         for k in ['last_refresh', 'created']:
             if k in c:
@@ -1417,21 +1417,21 @@ class InventoryHost(object):
         self.devices = devices
         self.labels = labels
 
-    def to_json(self):
+    def to_dict(self) -> dict:
         return {
             'name': self.name,
             'addr': self.addr,
-            'devices': self.devices.to_json(),
+            'devices': self.devices.to_dict(),
             'labels': self.labels,
         }
 
     @classmethod
-    def from_json(cls, data):
+    def from_dict(cls, data) -> "InventoryHost":
         try:
             _data = copy.deepcopy(data)
             name = _data.pop('name')
             addr = _data.pop('addr', None) or name
-            devices = inventory.Devices.from_json(_data.pop('devices'))
+            devices = inventory.Devices.from_dict(_data.pop('devices'))
             if _data:
                 error_msg = 'Unknown key(s) in Inventory: {}'.format(','.join(_data.keys()))
                 raise OrchestratorValidationError(error_msg)
@@ -1445,8 +1445,8 @@ class InventoryHost(object):
 
 
     @classmethod
-    def from_nested_items(cls, hosts):
-        devs = inventory.Devices.from_json
+    def from_nested_items(cls, hosts) -> List["InventoryHost"]:
+        devs = inventory.Devices.from_dict
         return [cls(item[0], devs(item[1].data)) for item in hosts]
 
     def __repr__(self):

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -209,7 +209,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         if format == 'json':
-            hosts = [host.to_json()
+            hosts = [host.to_dict()
                      for host in completion.result]
             output = json.dumps(hosts, sort_keys=True)
         else:
@@ -269,7 +269,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
         raise_if_exception(completion)
 
         if format == 'json':
-            data = [n.to_json() for n in completion.result]
+            data = [n.to_dict() for n in completion.result]
             return HandleCommandResult(stdout=json.dumps(data))
         else:
             out = []
@@ -336,7 +336,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
         if len(services) == 0:
             return HandleCommandResult(stdout="No services reported")
         elif format == 'json':
-            data = [s.to_json() for s in services]
+            data = [s.to_dict() for s in services]
             return HandleCommandResult(stdout=json.dumps(data))
         else:
             now = datetime.datetime.utcnow()
@@ -393,7 +393,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
         if len(daemons) == 0:
             return HandleCommandResult(stdout="No daemons reported")
         elif format == 'json':
-            data = [s.to_json() for s in daemons]
+            data = [s.to_dict() for s in daemons]
             return HandleCommandResult(stdout=json.dumps(data))
         else:
             now = datetime.datetime.utcnow()
@@ -584,7 +584,7 @@ Usage:
         """
         if inbuf:
             try:
-                rgw_spec = RGWSpec.from_json(json.loads(inbuf))
+                rgw_spec = RGWSpec.from_dict(json.loads(inbuf))
             except ValueError as e:
                 msg = 'Failed to read JSON input: {}'.format(str(e)) + usage
                 return HandleCommandResult(-errno.EINVAL, stderr=msg)

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -119,11 +119,11 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
             self._shutdown.wait(5)
 
     def _init_data(self, data=None):
-        self._inventory = [orchestrator.InventoryHost.from_json(inventory_host)
+        self._inventory = [orchestrator.InventoryHost.from_dict(inventory_host)
                            for inventory_host in data.get('inventory', [])]
-        self._services = [orchestrator.ServiceDescription.from_json(service)
+        self._services = [orchestrator.ServiceDescription.from_dict(service)
                            for service in data.get('services', [])]
-        self._daemons = [orchestrator.DaemonDescription.from_json(daemon)
+        self._daemons = [orchestrator.DaemonDescription.from_dict(daemon)
                           for daemon in data.get('daemons', [])]
 
     @deferred_read
@@ -154,7 +154,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         for out in c_v_out.splitlines():
             self.log.error(out)
-            devs = inventory.Devices.from_json(json.loads(out))
+            devs = inventory.Devices.from_dict(json.loads(out))
             return [orchestrator.InventoryHost('localhost', devs)]
         self.log.error('c-v failed: ' + str(c_v_out))
         raise Exception('c-v failed')

--- a/src/pybind/mgr/tests/test_orchestrator.py
+++ b/src/pybind/mgr/tests/test_orchestrator.py
@@ -12,14 +12,14 @@ from orchestrator import OrchestratorValidationError
 
 def _test_resource(data, resource_class, extra=None):
     # ensure we can deserialize and serialize
-    rsc = resource_class.from_json(data)
-    rsc.to_json()
+    rsc = resource_class.from_dict(data)
+    rsc.to_dict()
 
     if extra:
         # if there is an unexpected data provided
         data.update(extra)
         with pytest.raises(OrchestratorValidationError):
-            resource_class.from_json(data)
+            resource_class.from_dict(data)
 
 
 def test_inventory():
@@ -46,7 +46,7 @@ def test_inventory():
     json_data = [{}, {'name': 'host0', 'addr': '1.2.3.4'}, {'devices': []}]
     for data in json_data:
         with pytest.raises(OrchestratorValidationError):
-            InventoryHost.from_json(data)
+            InventoryHost.from_dict(data)
 
 
 def test_daemon_description():

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -75,7 +75,7 @@ class DeviceSelection(object):
                     repr(self)))
 
     @classmethod
-    def from_json(cls, device_spec):
+    def from_dict(cls, device_spec):
         # type: (dict) -> DeviceSelection
         for applied_filter in list(device_spec.keys()):
             if applied_filter not in cls._supported_filters:
@@ -123,7 +123,7 @@ class DriveGroupSpecs(object):
             ]
         if not isinstance(self.drive_group_json, list):
             raise ServiceSpecValidationError('Specs needs to be a list of specs')
-        dgs = list(map(DriveGroupSpec.from_json, self.drive_group_json))  # type: ignore
+        dgs = list(map(DriveGroupSpec.from_dict, self.drive_group_json))  # type: ignore
         self.drive_groups = dgs  # type: List[DriveGroupSpec]
 
     def __repr__(self):
@@ -212,12 +212,12 @@ class DriveGroupSpec(ServiceSpec):
         self.osd_id_claims = osd_id_claims
 
     @classmethod
-    def _from_json_impl(cls, json_drive_group):
+    def _from_dict_impl(cls, json_drive_group):
         # type: (dict) -> DriveGroupSpec
         """
         Initialize 'Drive group' structure
 
-        :param json_drive_group: A valid json string with a Drive Group
+        :param json_drive_group: A valid dict with a Drive Group
                specification
         """
         # legacy json (pre Octopus)
@@ -237,10 +237,10 @@ class DriveGroupSpec(ServiceSpec):
                     json_drive_group[key] = SizeMatcher.str_to_byte(json_drive_group[key])
 
         if 'placement' in json_drive_group:
-            json_drive_group['placement'] = PlacementSpec.from_json(json_drive_group['placement'])
+            json_drive_group['placement'] = PlacementSpec.from_dict(json_drive_group['placement'])
 
         try:
-            args = {k: (DeviceSelection.from_json(v) if k.endswith('_devices') else v) for k, v in
+            args = {k: (DeviceSelection.from_dict(v) if k.endswith('_devices') else v) for k, v in
                     json_drive_group.items()}
             if not args:
                 raise DriveGroupValidationError("Didn't find Drivegroup specs")

--- a/src/python-common/ceph/deployment/drive_selection/matchers.py
+++ b/src/python-common/ceph/deployment/drive_selection/matchers.py
@@ -51,7 +51,7 @@ class Matcher(object):
         # using the . notation, but some keys are nested, and hidden behind
         # a different hierarchy, which makes it harder to access programatically
         # hence, make it a dict.
-        disk = device.to_json()
+        disk = device.to_dict()
 
         def findkeys(node, key_val):
             """ Find keys in non-flat dict recursively """

--- a/src/python-common/ceph/deployment/inventory.py
+++ b/src/python-common/ceph/deployment/inventory.py
@@ -16,16 +16,16 @@ class Devices(object):
         self.devices = devices  # type: List[Device]
 
     def __eq__(self, other):
-        return self.to_json() == other.to_json()
+        return self.to_dict() == other.to_dict()
 
-    def to_json(self):
+    def to_dict(self):
         # type: () -> List[dict]
-        return [d.to_json() for d in self.devices]
+        return [d.to_dict() for d in self.devices]
 
     @classmethod
-    def from_json(cls, input):
+    def from_dict(cls, input):
         # type: (List[Dict[str, Any]]) -> Devices
-        return cls([Device.from_json(i) for i in input])
+        return cls([Device.from_dict(i) for i in input])
 
     def copy(self):
         return Devices(devices=list(self.devices))
@@ -57,14 +57,14 @@ class Device(object):
         self.lvs = lvs
         self.device_id = device_id
 
-    def to_json(self):
+    def to_dict(self):
         # type: () -> dict
         return {
             k: getattr(self, k) for k in self.report_fields
         }
 
     @classmethod
-    def from_json(cls, input):
+    def from_dict(cls, input):
         # type: (Dict[str, Any]) -> Device
         if not isinstance(input, dict):
             raise ValueError('Device: Expected dict. Got `{}...`'.format(json.dumps(input)[:10]))

--- a/src/python-common/ceph/tests/test_disk_selector.py
+++ b/src/python-common/ceph/tests/test_disk_selector.py
@@ -328,7 +328,7 @@ class TestDriveGroup(object):
                     'placement': {'host_pattern': 'data*'}
                 }
 
-            dgo = DriveGroupSpec.from_json(raw_sample)
+            dgo = DriveGroupSpec.from_dict(raw_sample)
             return dgo
 
         return make_sample_data

--- a/src/python-common/ceph/tests/test_inventory.py
+++ b/src/python-common/ceph/tests/test_inventory.py
@@ -16,6 +16,6 @@ def test_from_json(filename):
         data = json.load(f)
     if 'inventory' in data:
         data = data['inventory']
-    ds = Devices.from_json(data)
+    ds = Devices.from_dict(data)
     assert len(ds.devices) == len(data)
-    assert Devices.from_json(ds.to_json()) == ds
+    assert Devices.from_dict(ds.to_dict()) == ds

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -65,5 +65,5 @@ def test_rgwspec():
     }
     """
     example = json.loads(test_rgwspec.__doc__.strip())
-    spec = RGWSpec.from_json(example)
+    spec = RGWSpec.from_dict(example)
     assert servicespec_validate_add(spec) is None

--- a/src/python-common/ceph/tests/utils.py
+++ b/src/python-common/ceph/tests/utils.py
@@ -31,7 +31,7 @@ def _mk_device(rotational=True,
 def _mk_inventory(devices):
     devs = []
     for dev_, name in zip(devices, map(chr, range(ord('a'), ord('z')))):
-        dev = Device.from_json(dev_.to_json())
+        dev = Device.from_dict(dev_.to_dict())
         dev.path = '/dev/sd' + name
         dev.sys_api = dict(dev_.sys_api, path='/dev/sd' + name)
         devs.append(dev)


### PR DESCRIPTION
Because they are actually not returning a JSON string.

But, is this actually PR worth it????

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
