### PR TITLE
nautilus: rgw: get barbican secret key request maybe return error code

### DIFF
--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -175,6 +175,10 @@ public:
     return http_status;
   }
 
+  void set_http_status(long _http_status) {
+    http_status = _http_status;
+  }
+
   void set_verify_ssl(bool flag) {
     verify_ssl = flag;
   }
@@ -324,7 +328,7 @@ class RGWHTTPManager {
   bool unregister_request(rgw_http_req_data *req_data);
   void _unlink_request(rgw_http_req_data *req_data);
   void unlink_request(rgw_http_req_data *req_data);
-  void finish_request(rgw_http_req_data *req_data, int r);
+  void finish_request(rgw_http_req_data *req_data, int r, long http_status = -1);
   void _finish_request(rgw_http_req_data *req_data, int r);
   void _set_req_state(set_state& ss);
   int link_request(rgw_http_req_data *req_data);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44466

---

backport of https://github.com/ceph/ceph/pull/29639
parent tracker: https://tracker.ceph.com/issues/44443

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh