### PR TITLE
mimic: rgw: get barbican secret key request maybe return error code

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -58,8 +58,13 @@ struct rgw_http_req_data : public RefCountedObject {
 
   void set_state(int bitmask);
 
-  void finish(int r) {
+  void finish(int r, long http_status = -1) {
     Mutex::Locker l(lock);
+    if (http_status != -1) {
+      if (client) {
+        client->set_http_status(http_status);
+      }
+    }
     ret = r;
     if (curl_handle)
       do_curl_easy_cleanup(curl_handle);
@@ -86,7 +91,7 @@ struct rgw_http_req_data : public RefCountedObject {
     Mutex::Locker l(lock);
     return ret;
   }
-
+  
   RGWHTTPManager *get_manager() {
     Mutex::Locker l(lock);
     return mgr;
@@ -829,9 +834,9 @@ void RGWHTTPManager::_complete_request(rgw_http_req_data *req_data)
   req_data->put();
 }
 
-void RGWHTTPManager::finish_request(rgw_http_req_data *req_data, int ret)
+void RGWHTTPManager::finish_request(rgw_http_req_data *req_data, int ret, long http_status)
 {
-  req_data->finish(ret);
+  req_data->finish(ret, http_status);
   complete_request(req_data);
 }
 
@@ -1147,7 +1152,7 @@ void *RGWHTTPManager::reqs_thread_entry()
           status = -EAGAIN;
         }
         int id = req_data->id;
-	finish_request(req_data, status);
+	finish_request(req_data, status, http_status);
         switch (result) {
           case CURLE_OK:
             break;

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -174,6 +174,10 @@ public:
     return http_status;
   }
 
+  void set_http_status(long _http_status) {
+    http_status = _http_status;
+  }
+
   void set_verify_ssl(bool flag) {
     verify_ssl = flag;
   }
@@ -323,7 +327,7 @@ class RGWHTTPManager {
   bool unregister_request(rgw_http_req_data *req_data);
   void _unlink_request(rgw_http_req_data *req_data);
   void unlink_request(rgw_http_req_data *req_data);
-  void finish_request(rgw_http_req_data *req_data, int r);
+  void finish_request(rgw_http_req_data *req_data, int r, long http_status = -1);
   void _finish_request(rgw_http_req_data *req_data, int r);
   void _set_req_state(set_state& ss);
   int link_request(rgw_http_req_data *req_data);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44465

---

backport of https://github.com/ceph/ceph/pull/29639
parent tracker: https://tracker.ceph.com/issues/44443

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh