### PR TITLE
python-common: 'all:true' -> '*'

### DIFF
--- a/doc/cephadm/monitoring.rst
+++ b/doc/cephadm/monitoring.rst
@@ -23,7 +23,7 @@ To deploy a basic monitoring stack:
 
 #. Deploy a node-exporter service on every node of the cluster.  The node-exporter provides host-level metrics like CPU and memory utilization.::
 
-     ceph orch apply node-exporter all:true
+     ceph orch apply node-exporter '*'
 
 #. Deploy alertmanager::
 

--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -317,7 +317,7 @@ Placement by pattern matching
 
 Daemons can be placed on hosts as well::
 
-    orch apply prometheus all:true
+    orch apply prometheus '*'
 
 Or in yaml::
 

--- a/src/cephadm/vstart-smoke.sh
+++ b/src/cephadm/vstart-smoke.sh
@@ -19,8 +19,7 @@ bin/ceph orch host ls
 
 bin/ceph orch rm crash
 ! bin/ceph orch ls | grep crash
-bin/ceph orch apply crash all:true
-bin/ceph orch apply crash \*
+bin/ceph orch apply crash '*'
 bin/ceph orch ls | grep crash
 
 while ! bin/ceph orch ps | grep crash ; do sleep 1 ; done
@@ -58,7 +57,7 @@ while ! bin/ceph mon dump | grep 'epoch 2' ; do sleep 1 ; done
 
 bin/ceph orch apply rbd-mirror 1
 
-bin/ceph orch apply node-exporter all:true
+bin/ceph orch apply node-exporter '*'
 bin/ceph orch apply prometheus 1
 bin/ceph orch apply alertmanager 1
 bin/ceph orch apply grafana 1

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -243,9 +243,9 @@ def test_node_assignment3(service_type, placement, hosts,
 
 @pytest.mark.parametrize("placement",
     [
-        ('1 all:true'),
-        ('all:true label:foo'),
-        ('all:true host1 host2'),
+        ('1 *'),
+        ('* label:foo'),
+        ('* host1 host2'),
     ])
 def test_bad_placements(placement):
     try:

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -289,7 +289,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
                 service_name='crash',
                 spec=ServiceSpec(
                     'crash',
-                    placement=PlacementSpec.from_string('all:true'),
+                    placement=PlacementSpec.from_string('*'),
                 ),
                 size=num_nodes,
                 container_image_name=image_name,

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -996,7 +996,7 @@ EOF
         ceph_adm mgr module enable cephadm
         ceph_adm orch set backend cephadm
         ceph_adm orch host add $HOSTNAME
-        ceph_adm orch apply crash all:true
+        ceph_adm orch apply crash '*'
     fi
 }
 


### PR DESCRIPTION
'all:true' is no longer a valid PlacementSpec.

Signed-off-by: Sage Weil <sage@redhat.com>