### PR TITLE
mgr/test_orchestrator: fix apply_drivegroups

### DIFF
--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -259,7 +259,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         )
 
     def apply_drivegroups(self, specs):
-        # type: (List[DriveGroupSpec]) -> TestCompletion
+        # type: (List[DriveGroupSpec]) -> List[orchestrator.Completion]
         drive_group = specs[0]
         def run(all_hosts):
             # type: (List[orchestrator.HostSpec]) -> None
@@ -267,12 +267,12 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
             if drive_group.placement.host_pattern:
                 if not drive_group.placement.pattern_matches_hosts([h.hostname for h in all_hosts]):
                     raise orchestrator.OrchestratorValidationError('failed to match')
-        return self.get_hosts().then(run).then(
+        return [self.get_hosts().then(run).then(
             on_complete=orchestrator.ProgressReference(
                 message='apply_drivesgroups',
                 mgr=self,
             )
-        )
+        )]
 
     @deferred_write("remove_daemons")
     def remove_daemons(self, names, force):


### PR DESCRIPTION
test_orchestrator/module.py: note: In member "apply_drivegroups" of class "TestOrchestrator":
test_orchestrator/module.py:261: error: Return type "TestCompletion" of "apply_drivegroups" incompatible with return type "List[Completion]" in supertype "Orchestrator"

Signed-off-by: Sage Weil <sage@redhat.com>