### PR TITLE
cephadm: leave backup when removing stateful daemons

### DIFF
--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -129,7 +129,7 @@ data_devices:
         self._orch_cmd('daemon', 'add', "nfs", "service_name", "pool")
 
     def test_osd_rm(self):
-        self._orch_cmd('daemon', "rm", "osd.0")
+        self._orch_cmd('daemon', "rm", "osd.0", '--force')
 
     def test_mds_rm(self):
         self._orch_cmd("daemon", "rm", "mds.fsname")

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3063,18 +3063,6 @@ def command_rm_daemon():
          verbose_on_failure=False)
     call(['systemctl', 'disable', unit_name],
          verbose_on_failure=False)
-    if daemon_type == 'osd':
-        CephContainer(
-            image=args.image,
-            entrypoint='/usr/sbin/ceph-volume',
-            args=[
-                'lvm', 'zap', '--osd-id',
-                str(daemon_id)
-                # not sure if --destroy is useful here
-            ],
-            container_args=['--privileged'],
-            volume_mounts=get_container_mounts(args.fsid, daemon_type, daemon_id)
-        ).run()
     data_dir = get_data_dir(args.fsid, daemon_type, daemon_id)
     call_throws(['rm', '-rf', data_dir])
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3064,7 +3064,18 @@ def command_rm_daemon():
     call(['systemctl', 'disable', unit_name],
          verbose_on_failure=False)
     data_dir = get_data_dir(args.fsid, daemon_type, daemon_id)
-    call_throws(['rm', '-rf', data_dir])
+    if daemon_type in ['mon', 'osd', 'prometheus'] and \
+       not args.force_delete_data:
+        # rename it out of the way -- do not delete
+        backup_dir = os.path.join(args.data_dir, args.fsid, 'removed')
+        if not os.path.exists(backup_dir):
+            makedirs(backup_dir, 0, 0, DATA_DIR_MODE)
+        dirname = '%s.%s_%s' % (daemon_type, daemon_id,
+                                datetime.datetime.utcnow().strftime(DATEFMT))
+        os.rename(data_dir,
+                  os.path.join(backup_dir, dirname))
+    else:
+        call_throws(['rm', '-rf', data_dir])
 
 ##################################
 
@@ -3730,6 +3741,10 @@ def _get_parser():
         '--force',
         action='store_true',
         help='proceed, even though this may destroy valuable data')
+    parser_rm_daemon.add_argument(
+        '--force-delete-data',
+        action='store_true',
+        help='delete valuable daemon data instead of making a backup')
 
     parser_rm_cluster = subparsers.add_parser(
         'rm-cluster', help='remove all daemons for a cluster')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1858,13 +1858,13 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             ','.join(['%s.%s' % (a[0], a[1]) for a in args])))
         return self._daemon_actions(args)
 
-    def remove_daemons(self, names, force):
-        # type: (List[str], bool) -> orchestrator.Completion
+    def remove_daemons(self, names):
+        # type: (List[str]) -> orchestrator.Completion
         args = []
         for host, dm in self.cache.daemons.items():
             for name in names:
                 if name in dm:
-                    args.append((name, host, force))
+                    args.append((name, host))
         if not args:
             raise OrchestratorError('Unable to find daemon(s) %s' % (names))
         self.log.info('Remove daemons %s' % [a[0] for a in args])
@@ -2167,20 +2167,16 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             'Reconfigured' if reconfig else 'Deployed', name, host)
 
     @async_map_completion
-    def _remove_daemons(self, name, host, force=False):
-        return self._remove_daemon(name, host, force)
+    def _remove_daemons(self, name, host):
+        return self._remove_daemon(name, host)
 
-    def _remove_daemon(self, name, host, force=False):
+    def _remove_daemon(self, name, host):
         """
         Remove a daemon
         """
         (daemon_type, daemon_id) = name.split('.', 1)
         if daemon_type == 'mon':
             self._check_safe_to_destroy_mon(daemon_id)
-
-            # fail early, before we update the monmap
-            if not force:
-                raise OrchestratorError('Must pass --force to remove a monitor and DELETE potentially PRECIOUS CLUSTER DATA')
 
             # remove mon from quorum before we destroy the daemon
             self.log.info('Removing monitor %s from monmap...' % name)
@@ -2192,9 +2188,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 raise OrchestratorError('failed to remove mon %s from monmap' % (
                     name))
 
-        args = ['--name', name]
-        if force:
-            args.extend(['--force'])
+        args = ['--name', name, '--force']
         self.log.info('Removing daemon %s from %s' % (name, host))
         out, err, code = self._run_cephadm(
             host, name, 'rm-daemon', args)
@@ -2284,7 +2278,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             if d.hostname not in target_hosts:
                 # NOTE: we are passing the 'force' flag here, which means
                 # we can delete a mon instances data.
-                self._remove_daemon(d.name(), d.hostname, True)
+                self._remove_daemon(d.name(), d.hostname)
                 r = True
 
         return r
@@ -2320,7 +2314,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 # (mon and mgr specs should always exist; osds aren't matched
                 # to a service spec)
                 self.log.info('Removing orphan daemon %s...' % dd.name())
-                self._remove_daemon(dd.name(), dd.hostname, True)
+                self._remove_daemon(dd.name(), dd.hostname)
 
             # dependencies?
             if dd.daemon_type == 'grafana':

--- a/src/pybind/mgr/cephadm/osd.py
+++ b/src/pybind/mgr/cephadm/osd.py
@@ -97,7 +97,7 @@ class RemoveUtil(object):
                     # also remove it from the remove_osd list and set a health_check warning?
                     raise orchestrator.OrchestratorError(f"Could not purge OSD <{osd.osd_id}>")
 
-            self.mgr._remove_daemon(osd.fullname, osd.nodename, True)
+            self.mgr._remove_daemon(osd.fullname, osd.nodename)
             logger.info(f"Successfully removed OSD <{osd.osd_id}> on {osd.nodename}")
             logger.debug(f"Removing {osd.osd_id} from the queue.")
             self.to_remove_osds.remove(osd)

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -165,7 +165,7 @@ class TestCephadm(object):
             c = cephadm_module.list_daemons(refresh=True)
             wait(cephadm_module, c)
 
-            c = cephadm_module.remove_daemons(['osd.0'], False)
+            c = cephadm_module.remove_daemons(['osd.0'])
             out = wait(cephadm_module, c)
             assert out == ["Removed osd.0 from host 'test'"]
 
@@ -226,7 +226,7 @@ class TestCephadm(object):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.list_daemons(refresh=True)
             wait(cephadm_module, c)
-            c = cephadm_module.remove_daemons(['rgw.myrgw.myhost.myid'], False)
+            c = cephadm_module.remove_daemons(['rgw.myrgw.myhost.myid'])
             out = wait(cephadm_module, c)
             assert out == ["Removed rgw.myrgw.myhost.myid from host 'test'"]
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -850,8 +850,8 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def remove_daemons(self, names, force):
-        # type: (List[str], bool) -> Completion
+    def remove_daemons(self, names):
+        # type: (List[str]) -> Completion
         """
         Remove specific daemon(s).
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -733,7 +733,10 @@ Usage:
         for name in names:
             if '.' not in name:
                 raise OrchestratorError('%s is not a valid daemon name' % name)
-        completion = self.remove_daemons(names, force)
+            (daemon_type) = name.split('.')[0]
+            if not force and daemon_type in ['osd', 'mon', 'prometheus']:
+                raise OrchestratorError('must pass --force to REMOVE daemon with potentially PRECIOUS DATA for %s' % name)
+        completion = self.remove_daemons(names)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -434,7 +434,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             mgr=self
         )
 
-    def remove_daemons(self, names, force):
+    def remove_daemons(self, names):
         return write_completion(
             lambda: self.rook_cluster.remove_pods(names),
             "Removing daemons {}".format(','.join(names)),

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -275,7 +275,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         )
 
     @deferred_write("remove_daemons")
-    def remove_daemons(self, names, force):
+    def remove_daemons(self, names):
         assert isinstance(names, list)
 
     @deferred_write("remove_service")


### PR DESCRIPTION
Leave a copy of "deleted" daemons in /var/lib/ceph/$fsid/removed.  So if you, say, remove a monitor, there is always a leftover copy there, just in case.