### PR TITLE
update default container images

### DIFF
--- a/doc/cephadm/index.rst
+++ b/doc/cephadm/index.rst
@@ -40,7 +40,7 @@ The ``cephadm`` utility is used to bootstrap a new Ceph Cluster.
 
 Use curl to fetch the standalone script::
 
-  [monitor 1] # curl --silent --remote-name --location https://github.com/ceph/ceph/raw/master/src/cephadm/cephadm
+  [monitor 1] # curl --silent --remote-name --location https://github.com/ceph/ceph/raw/octopus/src/cephadm/cephadm
   [monitor 1] # chmod +x cephadm
   
 You can also get the utility by installing a package provided by

--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 FSID='00000000-0000-0000-0000-0000deadbeef'
 
 # images that are used
-IMAGE_MASTER=${IMAGE_MASTER:-'docker.io/ceph/daemon-base:latest-master-devel'}
+IMAGE_MASTER=${IMAGE_MASTER:-'quay.io/ceph-ci/ceph:octopus'} # octopus for octopus branch
 IMAGE_NAUTILUS=${IMAGE_NAUTILUS:-'docker.io/ceph/daemon-base:latest-nautilus'}
 IMAGE_MIMIC=${IMAGE_MIMIC:-'docker.io/ceph/daemon-base:latest-mimic'}
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-DEFAULT_IMAGE='docker.io/ceph/daemon-base:latest-master-devel'  # FIXME when octopus is ready!!!
+DEFAULT_IMAGE='docker.io/ceph/ceph:v15.2'
 DATA_DIR='/var/lib/ceph'
 LOG_DIR='/var/log/ceph'
 LOCK_DIR='/run/cephadm'

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
-DEFAULT_IMAGE='docker.io/ceph/ceph:v15.2'
+#DEFAULT_IMAGE='docker.io/ceph/ceph:v15.2'
+DEFAULT_IMAGE='quay.io/ceph-ci/ceph:octopus'
 DATA_DIR='/var/lib/ceph'
 LOG_DIR='/var/log/ceph'
 LOCK_DIR='/run/cephadm'

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -439,7 +439,8 @@ std::vector<Option> get_global_options() {
     Option("container_image", Option::TYPE_STR, Option::LEVEL_BASIC)
     .set_description("container image (used by cephadm orchestrator)")
     .set_flag(Option::FLAG_STARTUP)
-    .set_default("docker.io/ceph/ceph:v15.2"),
+    .set_default("quay.io/ceph-ci/ceph:octopus"),
+    //.set_default("docker.io/ceph/ceph:v15.2"),
 
     Option("no_config_file", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -439,7 +439,7 @@ std::vector<Option> get_global_options() {
     Option("container_image", Option::TYPE_STR, Option::LEVEL_BASIC)
     .set_description("container image (used by cephadm orchestrator)")
     .set_flag(Option::FLAG_STARTUP)
-    .set_default("docker.io/ceph/daemon-base:latest-master-devel"),
+    .set_default("docker.io/ceph/ceph:v15.2"),
 
     Option("no_config_file", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)

--- a/test_cephadm.sh
+++ b/test_cephadm.sh
@@ -3,7 +3,7 @@
 SCRIPT_NAME=$(basename ${BASH_SOURCE[0]})
 
 fsid='00000000-0000-0000-0000-0000deadbeef'
-image='docker.io/ceph/daemon-base:latest-master-devel'
+image='quay.io/ceph-ci/ceph:octopus'
 [ -z "$ip" ] && ip=127.0.0.1
 
 OSD_IMAGE_NAME="${SCRIPT_NAME%.*}_osd.img"


### PR DESCRIPTION
- For tests, use bleeding-edge octopus branch
- For production defaults, use ceph/ceph:v15.2 tag
- For bootstrap, grab cephadm script from latest octopus branch

- [x] DO NOT MERGE until the 'octopus' tag is showing up on quay at https://quay.io/repository/ceph-ci/ceph?tab=tags