### PR TITLE
Doc: added space requirement to "Build Prerequisites"

### DIFF
--- a/doc/install/build-ceph.rst
+++ b/doc/install/build-ceph.rst
@@ -3,15 +3,23 @@
 ============
 
 You can get Ceph software by retrieving Ceph source code and building it yourself.
-To build Ceph, you need to set up a development environment, compile Ceph, 
-and then either install in user space or build packages and install the packages. 
+To build Ceph, you need to set up a development environment, compile Ceph,
+and then either install in user space or build packages and install the packages.
 
 Build Prerequisites
 ===================
 
 
-.. tip:: Check this section to see if there are specific prerequisites for your 
+.. tip:: Check this section to see if there are specific prerequisites for your
    Linux/Unix distribution.
+
+A debug build of Ceph may take around 40 gigabytes. If you want to build Ceph in
+a virtual machine (VM) please make sure total disk space on the VM is at least
+60 gigabytes.
+
+Please also be aware that some distributions of Linux, like CentOS, use Linux
+Volume Manager (LVM) for the default installation. LVM may reserve a large
+portion of disk space of a typical sized virtual disk for the operating system.
 
 Before you can build Ceph source code, you need to install several libraries
 and tools::


### PR DESCRIPTION
Build prerequisites section does not include how much space Ceph takes. A Ceph debug build can take 40 gigabytes by itself - double the default size of many VMs by default, including CentOS 8 for virt-manager. New contributors may be turned off or may not understand why Ceph does not build. Also, a warning on LVM taking up too much disk space.

Signed-off-by: John B. Wyatt IV <<jbwyatt4@gmail.com>>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [X ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
