### PR TITLE
pybind/mgr: apply_drivegroups should return Sequence[Completion]

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -10,7 +10,8 @@ from mgr_util import create_self_signed_cert, verify_tls, ServerConfigException
 
 import string
 try:
-    from typing import List, Dict, Optional, Callable, Tuple, TypeVar, Type, Any, NamedTuple, Iterator, Set
+    from typing import List, Dict, Optional, Callable, Tuple, TypeVar, Type, \
+        Any, NamedTuple, Iterator, Set, Sequence
     from typing import TYPE_CHECKING
 except ImportError:
     TYPE_CHECKING = False  # just for type checking
@@ -1949,7 +1950,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 r[str(o['osd'])] = o['uuid']
         return r
 
-    def apply_drivegroups(self, specs: List[DriveGroupSpec]) -> List[orchestrator.Completion]:
+    def apply_drivegroups(self, specs: List[DriveGroupSpec]) -> Sequence[orchestrator.Completion]:
         completions: List[orchestrator.Completion] = list()
         for spec in specs:
             completions.extend(self._apply(spec))

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -913,7 +913,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def apply_drivegroups(self, specs: List[DriveGroupSpec]) -> List[Completion]:
+    def apply_drivegroups(self, specs: List[DriveGroupSpec]) -> Sequence[Completion]:
         """ Update OSD cluster """
         raise NotImplementedError()
 

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -10,7 +10,7 @@ from subprocess import check_output, CalledProcessError
 from ceph.deployment.service_spec import NFSServiceSpec, ServiceSpec
 
 try:
-    from typing import Callable, List, Tuple
+    from typing import Callable, List, Sequence, Tuple
 except ImportError:
     pass  # type checking
 
@@ -259,7 +259,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         )
 
     def apply_drivegroups(self, specs):
-        # type: (List[DriveGroupSpec]) -> TestCompletion
+        # type: (List[DriveGroupSpec]) -> Sequence[TestCompletion]
         drive_group = specs[0]
         def run(all_hosts):
             # type: (List[orchestrator.HostSpec]) -> None
@@ -267,12 +267,12 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
             if drive_group.placement.host_pattern:
                 if not drive_group.placement.pattern_matches_hosts([h.hostname for h in all_hosts]):
                     raise orchestrator.OrchestratorValidationError('failed to match')
-        return self.get_hosts().then(run).then(
+        return [self.get_hosts().then(run).then(
             on_complete=orchestrator.ProgressReference(
                 message='apply_drivesgroups',
                 mgr=self,
             )
-        )
+        )]
 
     @deferred_write("remove_daemons")
     def remove_daemons(self, names, force):


### PR DESCRIPTION
to follow the interface defined by `orchestrator.Orchestrator`. see
`orchestrator/_interface.py`.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
