### PR TITLE
cephadm: implement 'install' command

### DIFF
--- a/qa/workunits/cephadm/test_repos.sh
+++ b/qa/workunits/cephadm/test_repos.sh
@@ -10,10 +10,13 @@ CEPHADM=${CEPHADM_SRC_DIR}/cephadm
 function test_install_uninstall() {
     ( sudo apt update && \
 	  sudo apt -y install cephadm && \
+	  sudo $CEPHADM install && \
 	  sudo apt -y remove cephadm ) || \
 	( sudo yum -y install cephadm && \
+	      sudo $CEPHADM install && \
 	      sudo yum -y remove cephadm ) || \
 	( sudo dnf -y install cephadm && \
+	      sudo $CEPHADM install && \
 	      sudo dnf -y remove cephadm )
 }
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3621,7 +3621,8 @@ def command_rm_repo():
     pkg.rm_repo()
 
 def command_install():
-    pass
+    pkg = create_packager()
+    pkg.install(args.packages)
 
 ##################################
 
@@ -4019,6 +4020,10 @@ def _get_parser():
     parser_install = subparsers.add_parser(
         'install', help='install ceph package(s)')
     parser_install.set_defaults(func=command_install)
+    parser_install.add_argument(
+        'packages', nargs='*',
+        default=['cephadm'],
+        help='packages')
 
     return parser
 


### PR DESCRIPTION
This was present, but a no-op.

Install cephadm and ceph-common so that you get all of the needed CLI commands to make the
installation procedure easy.