### PR TITLE
cephadm: streamline bootstrap a bit

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3874,15 +3874,15 @@ def _get_parser():
         help='cluster FSID')
     parser_bootstrap.add_argument(
         '--output-keyring',
-        default='ceph.client.admin.keyring',
+        default='/etc/ceph/ceph.client.admin.keyring',
         help='location to write keyring file with new cluster admin and mon keys')
     parser_bootstrap.add_argument(
         '--output-config',
-        default='ceph.conf',
+        default='/etc/ceph/ceph.conf',
         help='location to write conf file to connect to new cluster')
     parser_bootstrap.add_argument(
         '--output-pub-ssh-key',
-        default='ceph.pub',
+        default='/etc/ceph/ceph.pub',
         help='location to write the cluster\'s public SSH key')
     parser_bootstrap.add_argument(
         '--skip-ssh',

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1973,6 +1973,14 @@ def command_inspect_image():
 def command_bootstrap():
     # type: () -> int
 
+    if not args.output_config:
+        args.output_config = os.path.join(args.output_dir, 'ceph.conf')
+    if not args.output_keyring:
+        args.output_keyring = os.path.join(args.output_dir,
+                                           'ceph.client.admin.keyring')
+    if not args.output_pub_ssh_key:
+        args.output_pub_ssh_key = os.path.join(args.output_dir, 'ceph.pub')
+
     # verify output files
     for f in [args.output_config, args.output_keyring, args.output_pub_ssh_key]:
         if not args.allow_overwrite:
@@ -3873,16 +3881,17 @@ def _get_parser():
         '--fsid',
         help='cluster FSID')
     parser_bootstrap.add_argument(
+        '--output-dir',
+        default='/etc/ceph',
+        help='directory to write config, keyring, and pub key files')
+    parser_bootstrap.add_argument(
         '--output-keyring',
-        default='/etc/ceph/ceph.client.admin.keyring',
         help='location to write keyring file with new cluster admin and mon keys')
     parser_bootstrap.add_argument(
         '--output-config',
-        default='/etc/ceph/ceph.conf',
         help='location to write conf file to connect to new cluster')
     parser_bootstrap.add_argument(
         '--output-pub-ssh-key',
-        default='/etc/ceph/ceph.pub',
         help='location to write the cluster\'s public SSH key')
     parser_bootstrap.add_argument(
         '--skip-ssh',

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4081,11 +4081,13 @@ if __name__ == "__main__":
             sys.stderr.write('Unable to locate any of %s\n' % CONTAINER_PREFERENCE)
             sys.exit(1)
 
-    inferred_image = _infer_image()
-
     if 'func' not in args:
         sys.stderr.write('No command specified; pass -h or --help for usage\n')
         sys.exit(1)
+
+    if args.func != command_bootstrap:
+        inferred_image = _infer_image()
+
     try:
         r = args.func()
     except Error as e:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1974,11 +1974,14 @@ def command_bootstrap():
     # type: () -> int
 
     # verify output files
-    if not args.allow_overwrite:
-        for f in [args.output_config, args.output_keyring, args.output_pub_ssh_key]:
+    for f in [args.output_config, args.output_keyring, args.output_pub_ssh_key]:
+        if not args.allow_overwrite:
             if os.path.exists(f):
                 raise Error('%s already exists; delete or pass '
                               '--allow-overwrite to overwrite' % f)
+        dirname = os.path.dirname(f)
+        if dirname and not os.path.exists(dirname):
+            raise Error('%s directory %s does not exist' % (f, dirname))
 
     if not args.skip_prepare_host:
         command_prepare_host()


### PR DESCRIPTION
- do not infer image
- put output files in /etc/ceph by default
- allow location of output files to be controlled via a single --output-dir arg