### PR TITLE
rgw: handle "BucketAlreadyExists" error in cloud sync module

### DIFF
--- a/doc/radosgw/cloud-sync-module.rst
+++ b/doc/radosgw/cloud-sync-module.rst
@@ -37,6 +37,7 @@ Trivial Configuration:
                   "source_id": <source_id>,
                   "dest_id": <dest_id> } ... ],
       "target_path": <target_path>,
+      "allow_bucketalreadyexists": <true | false>,
     }
 
 
@@ -60,6 +61,7 @@ Non Trivial Configuration:
           "dest_id": <id>
         } ... ]
         "target_path": <path> # optional
+        "allow_bucketalreadyexists": <true | false>, # optional, default is false
       },
       "connections": [
           {
@@ -85,6 +87,7 @@ Non Trivial Configuration:
            "connection_id": <connection_id>,
            "acls_id": <mappings_id>,
            "target_path": <dest>,          # optional
+           "allow_bucketalreadyexists": <true | false>, # optional, default is false
           } ... ],
     }
 
@@ -150,6 +153,9 @@ variables:
 
 For example: ``target_path = rgwx-${zone}-${sid}/${owner}/${bucket}``
 
+* ``"allow_bucketalreadyexists`` (true | false)
+
+Some S3 servers return BucketAlreadyExists error even if its the same owner recreating the bucket. This option can be used to handle such servers.
 
 * ``acl_profiles`` (array)
 


### PR DESCRIPTION
Cloud-sync module tries to create parent bucket for every object it syncs to the remote s3 cloud server. If the bucket already exists, it expects "BucketAlreadyOwnedByYou" to be
returned by the server (which seem to be the right response as per https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html)

However there are some s3 server implementation(eg., Noobaa) which return "BucketAlreadyExists" error instead. To be able to handle such servers, included "BucketAlreadyExists" error to the list of acceptable error codes in cloud-sync module.