### PR TITLE
mimic: ceph-disk,ceph-detect-init: Pin testtools test requirement for old py versions

### DIFF
--- a/src/ceph-detect-init/test-requirements.txt
+++ b/src/ceph-detect-init/test-requirements.txt
@@ -3,7 +3,7 @@ discover
 fixtures>=0.3.14
 python-subunit
 testrepository>=0.0.17
-testtools>=0.9.32
+testtools>=0.9.32,<=2.3.0
 mock
 pytest
 tox

--- a/src/ceph-disk/test-requirements.txt
+++ b/src/ceph-disk/test-requirements.txt
@@ -4,7 +4,7 @@ discover
 fixtures>=0.3.14
 python-subunit
 testrepository>=0.0.17
-testtools>=0.9.32
+testtools>=0.9.32,<=2.3.0
 mock
 pytest
 tox>=2.0


### PR DESCRIPTION
When running make-check on python 3.4, the test requirements
installation fails with:

```
ERROR: testtools requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, \
  !=3.3.*, !=3.4.*' but the running Python is 3.4.6
```

This happens because there is a new testtols release on pypi from Mar
14, 2020. Pinning to an older version fixes this.

This is not needed for Master, Octopus and Nautilus  given that python
3.4 is already EOL[1] before Nautilus got released.

[1] https://www.python.org/downloads/release/python-3410/

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>


