### PR TITLE
os/bluestore: open DB in read-only when expanding DB/WAL.

### DIFF
--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -504,9 +504,6 @@ err:
     return 0;
   }
 
-  int set_cache_capacity(int64_t capacity);
-  int64_t get_cache_capacity();
-
   virtual std::shared_ptr<PriorityCache::PriCache> get_priority_cache() 
       const override {
     return std::dynamic_pointer_cast<PriorityCache::PriCache>(

--- a/src/os/bluestore/BitmapFreelistManager.cc
+++ b/src/os/bluestore/BitmapFreelistManager.cc
@@ -4,6 +4,7 @@
 #include "BitmapFreelistManager.h"
 #include "kv/KeyValueDB.h"
 #include "os/kv.h"
+#include "include/stringify.h"
 
 #include "common/debug.h"
 
@@ -73,9 +74,8 @@ int BitmapFreelistManager::create(uint64_t new_size, uint64_t granularity,
 
   _init_misc();
 
-  blocks = size / bytes_per_block;
-  if (blocks / blocks_per_key * blocks_per_key != blocks) {
-    blocks = (blocks / blocks_per_key + 1) * blocks_per_key;
+  blocks = size_2_block_count(size);
+  if (blocks * bytes_per_block > size) {
     dout(10) << __func__ << " rounding blocks up from 0x" << std::hex << size
 	     << " to 0x" << (blocks * bytes_per_block)
 	     << " (0x" << blocks << " blocks)" << std::dec << dendl;
@@ -111,28 +111,29 @@ int BitmapFreelistManager::create(uint64_t new_size, uint64_t granularity,
   return 0;
 }
 
-int BitmapFreelistManager::expand(uint64_t new_size, KeyValueDB::Transaction txn)
+int BitmapFreelistManager::_expand(uint64_t old_size, KeyValueDB* db)
 {
-  assert(new_size > size);
+  assert(old_size < size);
   ceph_assert(isp2(bytes_per_block));
 
-  uint64_t blocks0 = size / bytes_per_block;
-  if (blocks0 / blocks_per_key * blocks_per_key != blocks0) {
-    blocks0 = (blocks0 / blocks_per_key + 1) * blocks_per_key;
-    dout(10) << __func__ << " rounding blocks up from 0x" << std::hex << size
-	     << " to 0x" << (blocks0 * bytes_per_block)
+  KeyValueDB::Transaction txn;
+  txn = db->get_transaction();
+
+  auto blocks0 = size_2_block_count(old_size);
+  if (blocks0 * bytes_per_block > old_size) {
+    dout(10) << __func__ << " rounding1 blocks up from 0x" << std::hex
+             << old_size << " to 0x" << (blocks0 * bytes_per_block)
 	     << " (0x" << blocks0 << " blocks)" << std::dec << dendl;
-    // reset previous past-eof blocks to unallocated
-    _xor(size, blocks0 * bytes_per_block - size, txn);
+    // reset past-eof blocks to unallocated
+    _xor(old_size, blocks0 * bytes_per_block - old_size, txn);
   }
 
-  size = p2align(new_size, bytes_per_block);
-  blocks = size / bytes_per_block;
+  size = p2align(size, bytes_per_block);
+  blocks = size_2_block_count(size);
 
-  if (blocks / blocks_per_key * blocks_per_key != blocks) {
-    blocks = (blocks / blocks_per_key + 1) * blocks_per_key;
-    dout(10) << __func__ << " rounding blocks up from 0x" << std::hex << size
-	     << " to 0x" << (blocks * bytes_per_block)
+  if (blocks * bytes_per_block > size) {
+    dout(10) << __func__ << " rounding2 blocks up from 0x" << std::hex
+             << size << " to 0x" << (blocks * bytes_per_block)
 	     << " (0x" << blocks << " blocks)" << std::dec << dendl;
     // set past-eof blocks as allocated
     _xor(size, blocks * bytes_per_block - size, txn);
@@ -154,13 +155,29 @@ int BitmapFreelistManager::expand(uint64_t new_size, KeyValueDB::Transaction txn
     encode(size, bl);
     txn->set(meta_prefix, "size", bl);
   }
+  db->submit_transaction_sync(txn);
+
   return 0;
 }
 
-int BitmapFreelistManager::init(KeyValueDB *kvdb)
+int BitmapFreelistManager::read_size_meta_from_db(KeyValueDB* kvdb,
+  uint64_t* res)
 {
-  dout(1) << __func__ << dendl;
+  bufferlist v;
+  int r = kvdb->get(meta_prefix, "size", &v);
+  if (r < 0) {
+    derr << __func__ << " missing size meta in DB" << dendl;
+    return ENOENT;
+  } else {
+    auto p = v.cbegin();
+    decode(*res, p);
+    r = 0;
+  }
+  return r;
+}
 
+void BitmapFreelistManager::_load_from_db(KeyValueDB* kvdb)
+{
   KeyValueDB::Iterator it = kvdb->get_iterator(meta_prefix);
   it->lower_bound(string());
 
@@ -172,31 +189,44 @@ int BitmapFreelistManager::init(KeyValueDB *kvdb)
       auto p = bl.cbegin();
       decode(bytes_per_block, p);
       dout(10) << __func__ << " bytes_per_block 0x" << std::hex
-	       << bytes_per_block << std::dec << dendl;
+        << bytes_per_block << std::dec << dendl;
     } else if (k == "blocks") {
       bufferlist bl = it->value();
       auto p = bl.cbegin();
       decode(blocks, p);
       dout(10) << __func__ << " blocks 0x" << std::hex << blocks << std::dec
-	       << dendl;
+        << dendl;
     } else if (k == "size") {
       bufferlist bl = it->value();
       auto p = bl.cbegin();
       decode(size, p);
       dout(10) << __func__ << " size 0x" << std::hex << size << std::dec
-	       << dendl;
+        << dendl;
     } else if (k == "blocks_per_key") {
       bufferlist bl = it->value();
       auto p = bl.cbegin();
       decode(blocks_per_key, p);
       dout(10) << __func__ << " blocks_per_key 0x" << std::hex << blocks_per_key
-	       << std::dec << dendl;
+        << std::dec << dendl;
     } else {
       derr << __func__ << " unrecognized meta " << k << dendl;
-      return -EIO;
     }
     it->next();
   }
+}
+
+
+int BitmapFreelistManager::init(const bluestore_bdev_label_t& label,
+  KeyValueDB *kvdb,
+  bool db_in_read_only)
+{
+  dout(1) << __func__ << dendl;
+  int r = _init_from_label(label);
+  if (r != 0) {
+    dout(1) << __func__ << " fall back to legacy meta repo" << dendl;
+    _load_from_db(kvdb);
+  }
+  _sync(kvdb, db_in_read_only);
 
   dout(10) << __func__ << std::hex
 	   << " size 0x" << size
@@ -205,6 +235,73 @@ int BitmapFreelistManager::init(KeyValueDB *kvdb)
 	   << " blocks_per_key 0x" << blocks_per_key
 	   << std::dec << dendl;
   _init_misc();
+  return 0;
+}
+
+int BitmapFreelistManager::_init_from_label(const bluestore_bdev_label_t& label)
+{
+  dout(1) << __func__ << dendl;
+
+  int r = ENOENT;
+  string err;
+
+  auto it = label.meta.find("bfm_size");
+  auto end = label.meta.end();
+  if (it != end) {
+    size = strict_iecstrtoll(it->second.c_str(), &err);
+    if (!err.empty()) {
+      derr << __func__ << " Failed to parse - "
+        << it->first << ":" << it->second
+        << ", error: " << err << dendl;
+      return r;
+    }
+  } else {
+    // this is expected for legacy deployed OSDs
+    dout(0) << __func__ << " bfm_size not found in bdev meta" << dendl;
+    return r;
+  }
+
+  it = label.meta.find("bfm_blocks");
+  if (it != end) {
+    blocks = strict_iecstrtoll(it->second.c_str(), &err);
+    if (!err.empty()) {
+      derr << __func__ << " Failed to parse - "
+        << it->first << ":" << it->second
+        << ", error: " << err << dendl;
+      return r;
+    }
+  } else {
+    derr << __func__ << " bfm_blocks not found in bdev meta" << dendl;
+    return r;
+  }
+
+  it = label.meta.find("bfm_bytes_per_block");
+  if (it != end) {
+    bytes_per_block = strict_iecstrtoll(it->second.c_str(), &err);
+    if (!err.empty()) {
+      derr << __func__ << " Failed to parse - "
+        << it->first << ":" << it->second
+        << ", error: " << err << dendl;
+      return r;
+    }
+  } else {
+    derr << __func__ << " bfm_bytes_per_block not found in bdev meta" << dendl;
+    return r;
+  }
+  it = label.meta.find("bfm_blocks_per_key");
+  if (it != end) {
+    blocks_per_key = strict_iecstrtoll(it->second.c_str(), &err);
+    if (!err.empty()) {
+      derr << __func__ << " Failed to parse - "
+        << it->first << ":" << it->second
+        << ", error: " << err << dendl;
+      return r;
+    }
+  } else {
+    derr << __func__ << " bfm_blocks_per_key not found in bdev meta" << dendl;
+    return r;
+  }
+  r = 0;
   return 0;
 }
 
@@ -222,6 +319,31 @@ void BitmapFreelistManager::_init_misc()
   dout(10) << __func__ << std::hex << " bytes_per_key 0x" << bytes_per_key
 	   << ", key_mask 0x" << key_mask << std::dec
 	   << dendl;
+}
+
+void BitmapFreelistManager::sync(KeyValueDB* kvdb)
+{
+  _sync(kvdb, true);
+}
+
+void BitmapFreelistManager::_sync(KeyValueDB* kvdb, bool read_only)
+{
+  dout(10) << __func__ << " checks if size sync is needed" << dendl;
+  uint64_t size_db = 0;
+  int r = read_size_meta_from_db(kvdb, &size_db);
+  ceph_assert(r >= 0);
+  if (!read_only && size_db < size) {
+    dout(1) << __func__ << " committing new size 0x" << std::hex << size
+      << std::dec << dendl;
+    r = _expand(size_db, kvdb);
+    ceph_assert(r == 0);
+  } else if (size_db > size) {
+    // this might hapen when OSD passed the following sequence:
+    // upgrade -> downgrade -> expand -> upgrade
+    // One needs to run expand once again to syncup
+    dout(1) << __func__ << " fall back to legacy meta repo" << dendl;
+    _load_from_db(kvdb);
+  }
 }
 
 void BitmapFreelistManager::shutdown()
@@ -604,4 +726,31 @@ void BitmapFreelistManager::_xor(
       txn->merge(bitmap_prefix, k, bl);
     }
   }
+}
+
+uint64_t BitmapFreelistManager::size_2_block_count(uint64_t target_size) const
+{
+  auto target_blocks = target_size / bytes_per_block;
+  if (target_blocks / blocks_per_key * blocks_per_key != target_blocks) {
+    target_blocks = (target_blocks / blocks_per_key + 1) * blocks_per_key;
+  }
+  return target_blocks;
+}
+
+void BitmapFreelistManager::get_meta(
+  uint64_t target_size,
+  std::vector<std::pair<string, string>>* res) const
+{
+  if (target_size == 0) {
+    res->emplace_back("bfm_blocks", stringify(blocks));
+    res->emplace_back("bfm_size", stringify(size));
+  } else {
+    target_size = p2align(target_size, bytes_per_block);
+    auto target_blocks = size_2_block_count(target_size);
+
+    res->emplace_back("bfm_blocks", stringify(target_blocks));
+    res->emplace_back("bfm_size", stringify(target_size));
+  }
+  res->emplace_back("bfm_bytes_per_block", stringify(bytes_per_block));
+  res->emplace_back("bfm_blocks_per_key", stringify(blocks_per_key));
 }

--- a/src/os/bluestore/BitmapFreelistManager.h
+++ b/src/os/bluestore/BitmapFreelistManager.h
@@ -46,6 +46,17 @@ class BitmapFreelistManager : public FreelistManager {
     uint64_t offset, uint64_t length,
     KeyValueDB::Transaction txn);
 
+  int _init_from_label(const bluestore_bdev_label_t& label);
+
+  int _expand(uint64_t new_size, KeyValueDB* db);
+
+  uint64_t size_2_block_count(uint64_t target_size) const;
+
+  int read_size_meta_from_db(KeyValueDB* kvdb, uint64_t* res);
+  void _sync(KeyValueDB* kvdb, bool read_only);
+
+  void _load_from_db(KeyValueDB* kvdb);
+
 public:
   BitmapFreelistManager(CephContext* cct, std::string meta_prefix,
 			std::string bitmap_prefix);
@@ -55,11 +66,12 @@ public:
   int create(uint64_t size, uint64_t granularity,
 	     KeyValueDB::Transaction txn) override;
 
-  int expand(uint64_t new_size,
-             KeyValueDB::Transaction txn) override;
+  int init(const bluestore_bdev_label_t& l,
+    KeyValueDB *kvdb,
+    bool db_in_read_only) override;
 
-  int init(KeyValueDB *kvdb) override;
   void shutdown() override;
+  void sync(KeyValueDB* kvdb) override;
 
   void dump(KeyValueDB *kvdb) override;
 
@@ -82,7 +94,8 @@ public:
   inline uint64_t get_alloc_size() const override {
     return bytes_per_block;
   }
-
+  void get_meta(uint64_t target_size,
+    std::vector<std::pair<string, string>>*) const override;
 };
 
 #endif

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -449,12 +449,22 @@ void BlueFS::dump_block_extents(ostream& out)
     }
     auto owned = get_total(i);
     auto free = get_free(i);
+
     out << i << " : device size 0x" << std::hex << bdev[i]->get_size()
         << " : own 0x" << block_all[i]
         << " = 0x" << owned
         << " : using 0x" << owned - free
-	<< std::dec << "(" << byte_u_t(owned - free) << ")"
-        << "\n";
+	<< std::dec << "(" << byte_u_t(owned - free) << ")";
+    if (i == BDEV_SLOW) {
+      ceph_assert(slow_dev_expander);
+      int id = _get_slow_device_id();
+      ceph_assert(alloc[id]);
+      free = slow_dev_expander->available_freespace(alloc_size[id]);
+      out << std::hex
+          << " : bluestore has 0x" << free
+          << std::dec << "(" << byte_u_t(free) << ") available";
+    }
+    out << "\n";
   }
 }
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3038,9 +3038,9 @@ int BlueFS::_expand_slow_device(uint64_t need, PExtentVector& extents)
 {
   int r = -ENOSPC;
   if (slow_dev_expander) {
-    int id = _get_slow_device_id();
+    auto id = _get_slow_device_id();
     auto min_alloc_size = alloc_size[id];
-    ceph_assert(id <= (int)alloc.size() && alloc[id]);
+    ceph_assert(id <= alloc.size() && alloc[id]);
     auto min_need = round_up_to(need, min_alloc_size);
     need = std::max(need,
       slow_dev_expander->get_recommended_expansion_delta(

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -455,11 +455,10 @@ void BlueFS::dump_block_extents(ostream& out)
         << " = 0x" << owned
         << " : using 0x" << owned - free
 	<< std::dec << "(" << byte_u_t(owned - free) << ")";
-    if (i == BDEV_SLOW) {
+    if (i == _get_slow_device_id()) {
       ceph_assert(slow_dev_expander);
-      int id = _get_slow_device_id();
-      ceph_assert(alloc[id]);
-      free = slow_dev_expander->available_freespace(alloc_size[id]);
+      ceph_assert(alloc[i]);
+      free = slow_dev_expander->available_freespace(alloc_size[i]);
       out << std::hex
           << " : bluestore has 0x" << free
           << std::dec << "(" << byte_u_t(free) << ") available";

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -443,7 +443,7 @@ public:
   int mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout);
   int mount();
   int maybe_verify_layout(const bluefs_layout_t& layout) const;
-  void umount();
+  void umount(bool avoid_compact = false);
   int prepare_new_device(int id, const bluefs_layout_t& layout);
   
   int log_dump();
@@ -514,7 +514,7 @@ public:
   void compact_log();
 
   /// sync any uncommitted state to disk
-  void sync_metadata();
+  void sync_metadata(bool avoid_compact);
 
   void set_slow_device_expander(BlueFSDeviceExpander* a) {
     slow_dev_expander = a;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -341,7 +341,9 @@ private:
   FileRef _get_file(uint64_t ino);
   void _drop_link(FileRef f);
 
-  int _get_slow_device_id() { return bdev[BDEV_SLOW] ? BDEV_SLOW : BDEV_DB; }
+  unsigned _get_slow_device_id() {
+    return bdev[BDEV_SLOW] ? BDEV_SLOW : BDEV_DB;
+  }
   const char* get_device_name(unsigned id);
   int _expand_slow_device(uint64_t min_size, PExtentVector& extents);
   int _allocate(uint8_t bdev, uint64_t len,

--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -299,7 +299,7 @@ class BlueRocksDirectory : public rocksdb::Directory {
   // Fsync directory. Can be called concurrently from multiple threads.
   rocksdb::Status Fsync() override {
     // it is sufficient to flush the log.
-    fs->sync_metadata();
+    fs->sync_metadata(false);
     return rocksdb::Status::OK();
   }
 };

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5695,8 +5695,7 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
         (void)r;
       }
       env = new rocksdb::EnvMirror(b, a, false, true);
-    }
-    else {
+    } else {
       env = new BlueRocksEnv(bluefs);
 
       // simplify the dir names, too, as "seen" by rocksdb
@@ -6899,6 +6898,15 @@ int BlueStore::expand_devices(ostream& out)
       }
     }
   }
+  umount();
+  return r;
+}
+
+int BlueStore::dump_bluefs_sizes(ostream& out)
+{
+  int r = _mount(true);
+  ceph_assert(r == 0);
+  bluefs->dump_block_extents(out);
   umount();
   return r;
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5118,14 +5118,16 @@ int BlueStore::_open_alloc()
     bytes += length;
   }
   fm->enumerate_reset();
-  dout(1) << __func__ << " loaded " << byte_u_t(bytes)
-	  << " in " << num << " extents"
-	  << dendl;
 
   // also mark bluefs space as allocated
   for (auto e = bluefs_extents.begin(); e != bluefs_extents.end(); ++e) {
     alloc->init_rm_free(e.get_start(), e.get_len());
   }
+
+  dout(1) << __func__ << " loaded " << byte_u_t(bytes)
+    << " in " << num << " extents"
+    << " available " << byte_u_t(alloc->get_free())
+    << dendl;
 
   return 0;
 }
@@ -6904,10 +6906,10 @@ int BlueStore::expand_devices(ostream& out)
 
 int BlueStore::dump_bluefs_sizes(ostream& out)
 {
-  int r = _mount(true);
+  int r = cold_open();
   ceph_assert(r == 0);
   bluefs->dump_block_extents(out);
-  umount();
+  cold_close();
   return r;
 }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5481,9 +5481,9 @@ int BlueStore::_open_bluefs(bool create)
   return r;
 }
 
-void BlueStore::_close_bluefs()
+void BlueStore::_close_bluefs(bool cold_close)
 {
-  bluefs->umount();
+  bluefs->umount(cold_close);
   _minimal_close_bluefs();
 }
 
@@ -5548,7 +5548,7 @@ int BlueStore::_open_db_and_around(bool read_only)
 
     // now open in R/W mode
     if (!read_only) {
-      _close_db();
+      _close_db(true);
 
       r = _open_db(false, false, false);
       if (r < 0) {
@@ -5580,18 +5580,18 @@ int BlueStore::_open_db_and_around(bool read_only)
  out_fm:
   _close_fm();
  out_db:
-  _close_db();
+  _close_db(read_only);
   return r;
 }
 
-void BlueStore::_close_db_and_around()
+void BlueStore::_close_db_and_around(bool read_only)
 {
   if (bluefs) {
-    if (out_of_sync_fm.fetch_and(0)) {
+    if (!read_only && out_of_sync_fm.fetch_and(0)) {
       _sync_bluefs_and_fm();
     }
-    _close_db();
-    while(out_of_sync_fm.fetch_and(0)) {
+    _close_db(read_only);
+    while(!read_only && out_of_sync_fm.fetch_and(0)) {
       // if seen some allocations during close - repeat open_db, sync fm, close
       dout(0) << __func__ << " syncing FreelistManager" << dendl;
       int r = _open_db(false, false, false);
@@ -5602,7 +5602,7 @@ void BlueStore::_close_db_and_around()
 	break;
       }
       _sync_bluefs_and_fm();
-      _close_db();
+      _close_db(false);
     }
     if (!_kv_only) {
       _close_alloc();
@@ -5611,7 +5611,7 @@ void BlueStore::_close_db_and_around()
   } else {
     _close_alloc();
     _close_fm();
-    _close_db();
+    _close_db(read_only);
   }
 }
 
@@ -5779,7 +5779,7 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
   if (!db) {
     derr << __func__ << " error creating db" << dendl;
     if (bluefs) {
-      _close_bluefs();
+      _close_bluefs(read_only);
     }
     // delete env manually here since we can't depend on db to do this
     // under this case
@@ -5824,7 +5824,7 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
   }
   if (r) {
     derr << __func__ << " erroring opening db: " << err.str() << dendl;
-    _close_db();
+    _close_db(read_only);
     return -EIO;
   }
   dout(1) << __func__ << " opened " << kv_backend
@@ -5832,13 +5832,13 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
   return 0;
 }
 
-void BlueStore::_close_db()
+void BlueStore::_close_db(bool cold_close)
 {
   ceph_assert(db);
   delete db;
   db = NULL;
   if (bluefs) {
-    _close_bluefs();
+    _close_bluefs(cold_close);
   }
 }
 
@@ -6469,7 +6469,7 @@ int BlueStore::mkfs()
  out_close_fm:
   _close_fm();
  out_close_db:
-  _close_db();
+  _close_db(false);
  out_close_bdev:
   _close_bdev();
  out_close_fsid:
@@ -6518,7 +6518,7 @@ int BlueStore::_mount_for_bluefs()
 
 void BlueStore::_umount_for_bluefs()
 {
-  _close_bluefs();
+  _close_bluefs(false);
   _close_fsid();
   _close_path();
 }
@@ -7057,7 +7057,7 @@ int BlueStore::_mount(bool kv_only, bool open_db)
  out_coll:
   _flush_cache();
  out_db:
-  _close_db_and_around();
+  _close_db_and_around(false);
  out_bdev:
   _close_bdev();
  out_fsid:
@@ -7083,7 +7083,7 @@ int BlueStore::umount()
     dout(20) << __func__ << " closing" << dendl;
 
   }
-  _close_db_and_around();
+  _close_db_and_around(false);
   _close_bdev();
   _close_fsid();
   _close_path();
@@ -7135,7 +7135,7 @@ int BlueStore::cold_open()
 }
 int BlueStore::cold_close()
 {
-  _close_db_and_around();
+  _close_db_and_around(true);
   _close_bdev();
   _close_fsid();
   _close_path();
@@ -8201,7 +8201,7 @@ out_scan:
   mempool_thread.shutdown();
   _flush_cache();
 out_db:
-  _close_db_and_around();
+  _close_db_and_around(false);
 out_bdev:
   _close_bdev();
 out_fsid:
@@ -8290,8 +8290,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
         e.get_start(), e.get_len(), fm->get_alloc_size(), used_blocks,
         [&](uint64_t pos, mempool_dynamic_bitset &bs) {
           bs.set(pos);
-        }
-	);
+        });
     }
     int r = bluefs->fsck();
     if (r < 0) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6817,10 +6817,10 @@ string BlueStore::get_device_path(unsigned id)
 
 int BlueStore::expand_devices(ostream& out)
 {
-  int r = _mount(false);
+  int r = cold_open();
   ceph_assert(r == 0);
   bluefs->dump_block_extents(out);
-  out << "Expanding..." << std::endl;
+  out << "Expanding DB/WAL..." << std::endl;
   for (auto devid : { BlueFS::BDEV_WAL, BlueFS::BDEV_DB}) {
     if (devid == bluefs_layout.shared_bdev ) {
       continue;
@@ -6868,13 +6868,18 @@ int BlueStore::expand_devices(ostream& out)
   }
   uint64_t size0 = fm->get_size();
   uint64_t size = bdev->get_size();
+  cold_close();
   if (size0 < size) {
+    out << "Expanding Main..." << std::endl;
+    int r = _mount(false);
+    ceph_assert(r == 0);
+
     out << bluefs_layout.shared_bdev
 	<<" : expanding " << " from 0x" << std::hex
 	<< size0 << " to 0x" << size << std::dec << std::endl;
     KeyValueDB::Transaction txn;
     txn = db->get_transaction();
-    int r = fm->expand(size, txn);
+    r = fm->expand(size, txn);
     ceph_assert(r == 0);
     db->submit_transaction_sync(txn);
 
@@ -6899,8 +6904,8 @@ int BlueStore::expand_devices(ostream& out)
 	      << std::endl;
       }
     }
+    umount();
   }
-  umount();
   return r;
 }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2573,6 +2573,8 @@ public:
   int expand_devices(std::ostream& out);
   std::string get_device_path(unsigned id);
 
+  int dump_bluefs_sizes(ostream& out);
+
 public:
   int statfs(struct store_statfs_t *buf,
              osd_alert_list_t* alerts = nullptr) override;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2244,7 +2244,7 @@ private:
   int _minimal_open_bluefs(bool create);
   void _minimal_close_bluefs();
   int _open_bluefs(bool create);
-  void _close_bluefs();
+  void _close_bluefs(bool cold_close);
 
   // Limited (u)mount intended for BlueFS operations only
   int _mount_for_bluefs();
@@ -2257,7 +2257,7 @@ private:
   * in the proper order
   */
   int _open_db_and_around(bool read_only);
-  void _close_db_and_around();
+  void _close_db_and_around(bool read_only);
 
   // updates legacy bluefs related recs in DB to a state valid for
   // downgrades from nautilus.
@@ -2270,7 +2270,7 @@ private:
   int _open_db(bool create,
 	       bool to_repair_db=false,
 	       bool read_only = false);
-  void _close_db();
+  void _close_db(bool read_only);
   int _open_fm(KeyValueDB::Transaction t);
   void _close_fm();
   int _open_alloc();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2271,8 +2271,11 @@ private:
 	       bool to_repair_db=false,
 	       bool read_only = false);
   void _close_db(bool read_only);
-  int _open_fm(KeyValueDB::Transaction t);
+  int _open_fm(KeyValueDB::Transaction t, bool read_only);
   void _close_fm();
+  int _write_out_fm_meta(uint64_t target_size,
+    bool update_root_size = false,
+    bluestore_bdev_label_t* res_label = nullptr);
   int _open_alloc();
   void _close_alloc();
   int _open_collections();
@@ -2431,7 +2434,7 @@ private:
 
   // -- ondisk version ---
 public:
-  const int32_t latest_ondisk_format = 3;        ///< our version
+  const int32_t latest_ondisk_format = 4;        ///< our version
   const int32_t min_readable_ondisk_format = 1;  ///< what we can read
   const int32_t min_compat_ondisk_format = 3;    ///< who can read us
 

--- a/src/os/bluestore/FreelistManager.h
+++ b/src/os/bluestore/FreelistManager.h
@@ -5,10 +5,11 @@
 #define CEPH_OS_BLUESTORE_FREELISTMANAGER_H
 
 #include <string>
-#include <map>
+#include <vector>
 #include <mutex>
 #include <ostream>
 #include "kv/KeyValueDB.h"
+#include "bluestore_types.h"
 
 class FreelistManager {
 public:
@@ -26,10 +27,10 @@ public:
   virtual int create(uint64_t size, uint64_t granularity,
 		     KeyValueDB::Transaction txn) = 0;
 
-  virtual int expand(uint64_t new_size,
-		     KeyValueDB::Transaction txn) = 0;
-
-  virtual int init(KeyValueDB *kvdb) = 0;
+  virtual int init(const bluestore_bdev_label_t& l,
+    KeyValueDB *kvdb,
+    bool db_in_read_only) = 0;
+  virtual void sync(KeyValueDB* kvdb) = 0;
   virtual void shutdown() = 0;
 
   virtual void dump(KeyValueDB *kvdb) = 0;
@@ -48,6 +49,8 @@ public:
   virtual uint64_t get_alloc_units() const = 0;
   virtual uint64_t get_alloc_size() const = 0;
 
+  virtual void get_meta(uint64_t target_size,
+    std::vector<std::pair<string, string>>*) const = 0;
 };
 
 

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -561,9 +561,8 @@ int main(int argc, char **argv)
     }
   }
   else if (action == "bluefs-bdev-sizes") {
-    BlueFS *fs = open_bluefs(cct.get(), path, devs);
-    fs->dump_block_extents(cout);
-    delete fs;
+    BlueStore bluestore(cct.get(), path);
+    bluestore.dump_bluefs_sizes(cout);
   }
   else if (action == "bluefs-bdev-expand") {
     BlueStore bluestore(cct.get(), path);

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -339,7 +339,7 @@ void sync_fs(BlueFS &fs)
     while (1) {
       if (writes_done == true)
         break;
-      fs.sync_metadata();
+      fs.sync_metadata(false);
       sleep(1);
     }
 }
@@ -502,10 +502,10 @@ TEST(BlueFS, test_simple_compaction_sync) {
           string file = "file.";
 	  file.append(to_string(j));
           fs.unlink(dir, file);
-	  fs.sync_metadata();
+	  fs.sync_metadata(false);
        }
        ASSERT_EQ(0, fs.rmdir(dir));
-       fs.sync_metadata();
+       fs.sync_metadata(false);
     }
   }
   fs.compact_log();
@@ -555,10 +555,10 @@ TEST(BlueFS, test_simple_compaction_async) {
           string file = "file.";
 	  file.append(to_string(j));
           fs.unlink(dir, file);
-	  fs.sync_metadata();
+	  fs.sync_metadata(false);
        }
        ASSERT_EQ(0, fs.rmdir(dir));
-       fs.sync_metadata();
+       fs.sync_metadata(false);
     }
   }
   fs.compact_log();


### PR DESCRIPTION
 This alleviates the recovery from ENOSPC case - db wouldn't flush data due to its own recovery during the expansion. And hence it avoids "deadlock" case when expansion can't proceed as DB needs more space.

Single volume setups are still vulnerable to the "deadlock".

Signed-off-by: Igor Fedotov <ifedotov@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
