### PR TITLE
librbd: defer event socket completion until after callback issued

### DIFF
--- a/src/librbd/io/AioCompletion.cc
+++ b/src/librbd/io/AioCompletion.cc
@@ -104,12 +104,10 @@ void AioCompletion::complete() {
       complete_external_callback();
     } else {
       complete_cb(rbd_comp, complete_arg);
+      complete_event_socket();
     }
-  }
-
-  if (ictx != nullptr && event_notify && ictx->event_socket.is_valid()) {
-    ictx->event_socket_completions.push(this);
-    ictx->event_socket.notify();
+  } else {
+    complete_event_socket();
   }
   state = AIO_STATE_COMPLETE;
 
@@ -261,6 +259,7 @@ void AioCompletion::complete_external_callback() {
     AioCompletion* aio_comp;
     while (ictx->external_callback_completions.pop(aio_comp)) {
       aio_comp->complete_cb(aio_comp->rbd_comp, aio_comp->complete_arg);
+      aio_comp->complete_event_socket();
     }
 
     ictx->external_callback_in_progress.store(false);
@@ -269,6 +268,13 @@ void AioCompletion::complete_external_callback() {
       // pop and resetting the in-progress state
       break;
     }
+  }
+}
+
+void AioCompletion::complete_event_socket() {
+  if (ictx != nullptr && event_notify && ictx->event_socket.is_valid()) {
+    ictx->event_socket_completions.push(this);
+    ictx->event_socket.notify();
   }
 }
 

--- a/src/librbd/io/AioCompletion.h
+++ b/src/librbd/io/AioCompletion.h
@@ -178,6 +178,7 @@ struct AioCompletion {
 private:
   void queue_complete();
   void complete_external_callback();
+  void complete_event_socket();
 
 };
 


### PR DESCRIPTION
A change post-Nautilus fixed an issue where multiple threads could
concurrently invoke callbacks to librbd clients. However, it also
introduced the potential that a callback hasn't yet fired by the
time the event socket is completed. This resulted in a crash of
fio under high-throughput testing since it expected both a callback
and the event socket completion, in that order.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
