### PR TITLE
mgr/orchestrator: fix `ceph orch apply -i` + yaml cleanup + Completion cleanup

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -538,12 +538,10 @@ def async_map_completion(f):
 
 def trivial_completion(f):
     # type: (Callable) -> Callable[..., orchestrator.Completion]
-    return ssh_completion(cls=orchestrator.Completion)(f)
-
-
-def trivial_result(val):
-    # type: (Any) -> AsyncCompletion
-    return AsyncCompletion(value=val, name='trivial_result')
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        return AsyncCompletion(value=f(*args, **kwargs), name=f.__name__)
+    return wrapper
 
 
 @six.add_metaclass(CLICommandMeta)
@@ -1769,6 +1767,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         # hmm!
         return 0
 
+    @trivial_completion
     def describe_service(self, service_type=None, service_name=None,
                          refresh=False):
         if refresh:
@@ -1824,8 +1823,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 size=self._get_spec_size(spec),
                 running=0,
             )
-        return trivial_result([s for n, s in sm.items()])
+        return [s for n, s in sm.items()]
 
+    @trivial_completion
     def list_daemons(self, daemon_type=None, daemon_id=None,
                      host=None, refresh=False):
         if refresh:
@@ -1845,7 +1845,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 if daemon_id and daemon_id != dd.daemon_id:
                     continue
                 result.append(dd)
-        return trivial_result(result)
+        return result
 
     def service_action(self, action, service_name):
         args = []
@@ -1911,12 +1911,14 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         self.log.info('Remove daemons %s' % [a[0] for a in args])
         return self._remove_daemons(args)
 
+    @trivial_completion
     def remove_service(self, service_name):
         self.log.info('Remove service %s' % service_name)
         self.spec_store.rm(service_name)
         self._kick_serve_loop()
-        return trivial_result(['Removed service %s' % service_name])
+        return ['Removed service %s' % service_name]
 
+    @trivial_completion
     def get_inventory(self, host_filter=None, refresh=False):
         """
         Return the storage inventory of hosts matching the given filter.
@@ -1941,8 +1943,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 continue
             result.append(orchestrator.InventoryHost(host,
                                                      inventory.Devices(dls)))
-        return trivial_result(result)
+        return result
 
+    @trivial_completion
     def zap_device(self, host, path):
         self.log.info('Zap device %s:%s' % (host, path))
         out, err, code = self._run_cephadm(
@@ -1952,7 +1955,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         self.cache.invalidate_host_devices(host)
         if code:
             raise OrchestratorError('Zap failed: %s' % '\n'.join(out + err))
-        return trivial_result('\n'.join(out + err))
+        return '\n'.join(out + err)
 
     def blink_device_light(self, ident_fault, on, locs):
         @async_map_completion
@@ -1990,14 +1993,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 r[str(o['osd'])] = o['uuid']
         return r
 
-    def apply_drivegroups(self, specs: List[DriveGroupSpec]) -> Sequence[orchestrator.Completion]:
-        completions: List[orchestrator.Completion] = list()
-        for spec in specs:
-            completions.extend(self._apply(spec))
-        return completions
+    @trivial_completion
+    def apply_drivegroups(self, specs: List[DriveGroupSpec]):
+        return [self._apply(spec) for spec in specs]
 
-    def create_osds(self, drive_group):
-        # type: (DriveGroupSpec) -> orchestrator.Completion
+    @trivial_completion
+    def create_osds(self, drive_group: DriveGroupSpec):
         self.log.debug("Processing DriveGroup {}".format(drive_group))
         # 1) use fn_filter to determine matching_hosts
         matching_hosts = drive_group.placement.pattern_matches_hosts([x for x in self.cache.get_hosts()])
@@ -2027,7 +2028,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 drive_group.service_name(), host))
             ret_msg = self._create_osd(host, cmd)
             ret.append(ret_msg)
-        return trivial_result(", ".join(ret))
+        return ", ".join(ret)
 
     def _create_osd(self, host, cmd):
 
@@ -2272,7 +2273,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         create_func = create_fns.get(daemon_type, None)
         if not create_func:
             self.log.debug('unrecognized service type %s' % daemon_type)
-            return trivial_result([])
+            return False
         config_func = config_fns.get(daemon_type, None)
 
         daemons = self.cache.get_daemons_by_service(service_name)
@@ -2480,6 +2481,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
         return create_func_map(args)
 
+    @trivial_completion
     def apply_mon(self, spec):
         return self._apply(spec)
 
@@ -2547,7 +2549,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         # type: (ServiceSpec) -> orchestrator.Completion
         return self._add_daemon('mgr', spec, self._create_mgr)
 
-    def _apply(self, spec: ServiceSpec):
+    def _apply(self, spec: ServiceSpec) -> str:
         if spec.placement.is_empty():
             # fill in default placement
             defaults = {
@@ -2572,19 +2574,21 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             spec.service_name(), spec.placement.pretty_str()))
         self.spec_store.save(spec)
         self._kick_serve_loop()
-        return trivial_result("Scheduled %s update..." % spec.service_type)
+        return "Scheduled %s update..." % spec.service_type
 
-    def apply(self, specs: List[ServiceSpec]) -> AsyncCompletion:
-        return self._apply(specs)
+    @trivial_completion
+    def apply(self, specs: List[ServiceSpec]):
+        return [self._apply(spec) for spec in specs]
 
+    @trivial_completion
     def apply_mgr(self, spec):
         return self._apply(spec)
 
-    def add_mds(self, spec):
-        # type: (ServiceSpec) -> AsyncCompletion
+    def add_mds(self, spec: ServiceSpec):
         return self._add_daemon('mds', spec, self._create_mds, self._config_mds)
 
-    def apply_mds(self, spec: ServiceSpec) -> orchestrator.Completion:
+    @trivial_completion
+    def apply_mds(self, spec: ServiceSpec):
         return self._apply(spec)
 
     def _config_mds(self, spec):
@@ -2636,6 +2640,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         })
         return self._create_daemon('rgw', rgw_id, host, keyring=keyring)
 
+    @trivial_completion
     def apply_rgw(self, spec):
         return self._apply(spec)
 
@@ -2652,6 +2657,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         return self._create_daemon('rbd-mirror', daemon_id, host,
                                    keyring=keyring)
 
+    @trivial_completion
     def apply_rbd_mirror(self, spec):
         return self._apply(spec)
 
@@ -2874,6 +2880,7 @@ receivers:
     def _create_prometheus(self, daemon_id, host):
         return self._create_daemon('prometheus', daemon_id, host)
 
+    @trivial_completion
     def apply_prometheus(self, spec):
         return self._apply(spec)
 
@@ -2882,6 +2889,7 @@ receivers:
         return self._add_daemon('node-exporter', spec,
                                 self._create_node_exporter)
 
+    @trivial_completion
     def apply_node_exporter(self, spec):
         return self._apply(spec)
 
@@ -2893,6 +2901,7 @@ receivers:
         return self._add_daemon('crash', spec,
                                 self._create_crash)
 
+    @trivial_completion
     def apply_crash(self, spec):
         return self._apply(spec)
 
@@ -2909,8 +2918,8 @@ receivers:
         # type: (ServiceSpec) -> AsyncCompletion
         return self._add_daemon('grafana', spec, self._create_grafana)
 
-    def apply_grafana(self, spec):
-        # type: (ServiceSpec) -> AsyncCompletion
+    @trivial_completion
+    def apply_grafana(self, spec: ServiceSpec):
         return self._apply(spec)
 
     def _create_grafana(self, daemon_id, host):
@@ -2921,8 +2930,8 @@ receivers:
         # type: (ServiceSpec) -> AsyncCompletion
         return self._add_daemon('alertmanager', spec, self._create_alertmanager)
 
-    def apply_alertmanager(self, spec):
-        # type: (ServiceSpec) -> AsyncCompletion
+    @trivial_completion
+    def apply_alertmanager(self, spec: ServiceSpec):
         return self._apply(spec)
 
     def _create_alertmanager(self, daemon_id, host):
@@ -2952,6 +2961,7 @@ receivers:
                        (image_name, image_id, ceph_version))
         return image_id, ceph_version
 
+    @trivial_completion
     def upgrade_check(self, image, version):
         if version:
             target_name = self.container_image_base + ':v' + version
@@ -2982,6 +2992,7 @@ receivers:
                     }
         return json.dumps(r, indent=4, sort_keys=True)
 
+    @trivial_completion
     def upgrade_status(self):
         r = orchestrator.UpgradeStatusSpec()
         if self.upgrade_state:
@@ -2991,8 +3002,9 @@ receivers:
                 r.message = 'Error: ' + self.upgrade_state.get('error')
             elif self.upgrade_state.get('paused'):
                 r.message = 'Upgrade paused'
-        return trivial_result(r)
+        return r
 
+    @trivial_completion
     def upgrade_start(self, image, version):
         if self.mode != 'root':
             raise OrchestratorError('upgrade is not supported in %s mode' % (
@@ -3019,10 +3031,8 @@ receivers:
             if self.upgrade_state.get('paused'):
                 del self.upgrade_state['paused']
                 self._save_upgrade_state()
-                return trivial_result('Resumed upgrade to %s' %
-                                      self.upgrade_state.get('target_name'))
-            return trivial_result('Upgrade to %s in progress' %
-                                  self.upgrade_state.get('target_name'))
+                return 'Resumed upgrade to %s' % self.upgrade_state.get('target_name')
+            return 'Upgrade to %s in progress' % self.upgrade_state.get('target_name')
         self.upgrade_state = {
             'target_name': target_name,
             'progress_id': str(uuid.uuid4()),
@@ -3031,34 +3041,33 @@ receivers:
         self._save_upgrade_state()
         self._clear_upgrade_health_checks()
         self.event.set()
-        return trivial_result('Initiating upgrade to %s' % (image))
+        return 'Initiating upgrade to %s' % (image)
 
+    @trivial_completion
     def upgrade_pause(self):
         if not self.upgrade_state:
             raise OrchestratorError('No upgrade in progress')
         if self.upgrade_state.get('paused'):
-            return trivial_result('Upgrade to %s already paused' %
-                                  self.upgrade_state.get('target_name'))
+            return 'Upgrade to %s already paused' % self.upgrade_state.get('target_name')
         self.upgrade_state['paused'] = True
         self._save_upgrade_state()
-        return trivial_result('Paused upgrade to %s' %
-                              self.upgrade_state.get('target_name'))
+        return 'Paused upgrade to %s' % self.upgrade_state.get('target_name')
 
+    @trivial_completion
     def upgrade_resume(self):
         if not self.upgrade_state:
             raise OrchestratorError('No upgrade in progress')
         if not self.upgrade_state.get('paused'):
-            return trivial_result('Upgrade to %s not paused' %
-                                  self.upgrade_state.get('target_name'))
+            return 'Upgrade to %s not paused' % self.upgrade_state.get('target_name')
         del self.upgrade_state['paused']
         self._save_upgrade_state()
         self.event.set()
-        return trivial_result('Resumed upgrade to %s' %
-                              self.upgrade_state.get('target_name'))
+        return 'Resumed upgrade to %s' % self.upgrade_state.get('target_name')
 
+    @trivial_completion
     def upgrade_stop(self):
         if not self.upgrade_state:
-            return trivial_result('No upgrade in progress')
+            return 'No upgrade in progress'
         target_name = self.upgrade_state.get('target_name')
         if 'progress_id' in self.upgrade_state:
             self.remote('progress', 'complete',
@@ -3067,11 +3076,12 @@ receivers:
         self._save_upgrade_state()
         self._clear_upgrade_health_checks()
         self.event.set()
-        return trivial_result('Stopped upgrade to %s' % target_name)
+        return 'Stopped upgrade to %s' % target_name
 
+    @trivial_completion
     def remove_osds(self, osd_ids: List[str],
                     replace: bool = False,
-                    force: bool = False) -> orchestrator.Completion:
+                    force: bool = False):
         """
         Takes a list of OSDs and schedules them for removal.
         The function that takes care of the actual removal is
@@ -3095,19 +3105,21 @@ receivers:
 
         # trigger the serve loop to initiate the removal
         self._kick_serve_loop()
-        return trivial_result(f"Scheduled OSD(s) for removal")
+        return "Scheduled OSD(s) for removal"
 
-    def remove_osds_status(self) -> orchestrator.Completion:
+    @trivial_completion
+    def remove_osds_status(self):
         """
         The CLI call to retrieve an osd removal report
         """
-        return trivial_result(self.rm_util.report)
+        return self.rm_util.report
 
-    def list_specs(self, service_name=None) -> orchestrator.Completion:
+    @trivial_completion
+    def list_specs(self, service_name=None):
         """
         Loads all entries from the service_spec mon_store root.
         """
-        return trivial_result(self.spec_store.find(service_name=service_name))
+        return self.spec_store.find(service_name=service_name)
 
 
 class BaseScheduler(object):

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2547,7 +2547,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         # type: (ServiceSpec) -> orchestrator.Completion
         return self._add_daemon('mgr', spec, self._create_mgr)
 
-    def _apply(self, spec):
+    def _apply(self, spec: ServiceSpec):
         if spec.placement.is_empty():
             # fill in default placement
             defaults = {
@@ -2573,6 +2573,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         self.spec_store.save(spec)
         self._kick_serve_loop()
         return trivial_result("Scheduled %s update..." % spec.service_type)
+
+    def apply(self, specs: List[ServiceSpec]) -> AsyncCompletion:
+        return self._apply(specs)
 
     def apply_mgr(self, spec):
         return self._apply(spec)
@@ -3104,30 +3107,7 @@ receivers:
         """
         Loads all entries from the service_spec mon_store root.
         """
-        specs = list()
-        for spec in self.spec_store.find(service_name=service_name):
-            specs.append('---')
-            specs.append(yaml.safe_dump(spec.to_json()))
-        return trivial_result(specs)
-
-    def apply_service_config(self, spec_document: str) -> orchestrator.Completion:
-        """
-        Parse a multi document yaml file (represented in a inbuf object)
-        and loads it with it's respective ServiceSpec to validate the
-        initial input.
-        If no errors are raised, save them.
-        """
-        content: Iterator[Any] = yaml.load_all(spec_document)
-        # Load all specs from a multi document yaml file.
-        loaded_specs: List[ServiceSpec] = list()
-        for spec in content:
-            # load ServiceSpec once to validate
-            spec_o = ServiceSpec.from_json(spec)
-            loaded_specs.append(spec_o)
-        for spec in loaded_specs:
-            self.spec_store.save(spec)
-        self._kick_serve_loop()
-        return trivial_result("ServiceSpecs saved")
+        return trivial_result(self.spec_store.find(service_name=service_name))
 
 
 class BaseScheduler(object):

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -356,7 +356,7 @@ class TestCephadm(object):
     def test_apply_node_exporter_save(self, _save_spec, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            spec = ServiceSpec('node_exporter', placement=ps)
+            spec = ServiceSpec('node-exporter', placement=ps)
             c = cephadm_module.apply_node_exporter(spec)
-            assert wait(cephadm_module, c) == 'Scheduled node_exporter update...'
+            assert wait(cephadm_module, c) == 'Scheduled node-exporter update...'
             _save_spec.assert_called_with(spec)

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -360,15 +360,3 @@ class TestCephadm(object):
             c = cephadm_module.apply_node_exporter(spec)
             _save_spec.assert_called_with(spec)
             assert wait(cephadm_module, c) == 'Scheduled node_exporter update...'
-
-    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
-    @mock.patch("cephadm.module.SpecStore.save")
-    @mock.patch("cephadm.module.yaml.load_all", return_value=[{'service_type': 'rgw', 'placement': {'count': 1}, 'spec': {'rgw_realm': 'realm1', 'rgw_zone': 'zone1'}}])
-    @mock.patch("cephadm.module.ServiceSpec")
-    def test_apply_service_config(self, _sspec, _yaml, _save_spec, cephadm_module):
-        with self._with_host(cephadm_module, 'test'):
-            c = cephadm_module.apply_service_config('dummy')
-            _save_spec.assert_called_once()
-            _sspec.from_json.assert_called_once()
-            assert wait(cephadm_module, c) == 'ServiceSpecs saved'
-

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -302,61 +302,56 @@ class TestCephadm(object):
             assert wait(cephadm_module, c) == ['Set ident light for test: on']
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
-    @mock.patch("cephadm.module.SpecStore.save")
-    def test_apply_mgr_save(self, _save_spec, cephadm_module):
+    def test_apply_mgr_save(self, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
             spec = ServiceSpec('mgr', placement=ps)
             c = cephadm_module.apply_mgr(spec)
             assert wait(cephadm_module, c) == 'Scheduled mgr update...'
-            _save_spec.assert_called_with(spec)
+            assert wait(cephadm_module, cephadm_module.list_specs()) == [spec]
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
-    @mock.patch("cephadm.module.SpecStore.save")
-    def test_apply_mds_save(self, _save_spec, cephadm_module):
+    def test_apply_mds_save(self, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
             spec = ServiceSpec('mds', 'fsname', placement=ps)
             c = cephadm_module.apply_mds(spec)
             assert wait(cephadm_module, c) == 'Scheduled mds update...'
-            _save_spec.assert_called_with(spec)
+            assert wait(cephadm_module, cephadm_module.list_specs()) == [spec]
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
-    @mock.patch("cephadm.module.SpecStore.save")
-    def test_apply_rgw_save(self, _save_spec, cephadm_module):
+    def test_apply_rgw_save(self, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
             spec = ServiceSpec('rgw', 'r.z', placement=ps)
             c = cephadm_module.apply_rgw(spec)
             assert wait(cephadm_module, c) == 'Scheduled rgw update...'
-            _save_spec.assert_called_with(spec)
+            assert wait(cephadm_module, cephadm_module.list_specs()) == [spec]
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
-    @mock.patch("cephadm.module.SpecStore.save")
-    def test_apply_rbd_mirror_save(self, _save_spec, cephadm_module):
+    def test_apply_rbd_mirror_save(self, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
             spec = ServiceSpec('rbd-mirror', placement=ps)
             c = cephadm_module.apply_rbd_mirror(spec)
             assert wait(cephadm_module, c) == 'Scheduled rbd-mirror update...'
-            _save_spec.assert_called_with(spec)
+            assert wait(cephadm_module, cephadm_module.list_specs()) == [spec]
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
-    @mock.patch("cephadm.module.SpecStore.save")
-    def test_apply_prometheus_save(self, _save_spec, cephadm_module):
+    def test_apply_prometheus_save(self, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
             spec = ServiceSpec('prometheus', placement=ps)
             c = cephadm_module.apply_prometheus(spec)
             assert wait(cephadm_module, c) == 'Scheduled prometheus update...'
-            _save_spec.assert_called_with(spec)
+            assert wait(cephadm_module, cephadm_module.list_specs()) == [spec]
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
-    @mock.patch("cephadm.module.SpecStore.save")
-    def test_apply_node_exporter_save(self, _save_spec, cephadm_module):
+    def test_apply_node_exporter_save(self, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            spec = ServiceSpec('node-exporter', placement=ps)
+            spec = ServiceSpec('node-exporter', placement=ps, service_id='my_exporter')
             c = cephadm_module.apply_node_exporter(spec)
             assert wait(cephadm_module, c) == 'Scheduled node-exporter update...'
-            _save_spec.assert_called_with(spec)
+            assert wait(cephadm_module, cephadm_module.list_specs()) == [spec]
+            assert wait(cephadm_module, cephadm_module.list_specs('node-exporter.my_exporter')) == [spec]

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -125,8 +125,8 @@ class TestCephadm(object):
             spec = ServiceSpec.from_json(json_spec)
             assert isinstance(spec, DriveGroupSpec)
             c = cephadm_module.apply_drivegroups([spec])
+            assert wait(cephadm_module, c) == ['Scheduled osd update...']
             _save_spec.assert_called_with(spec)
-            assert wait(cephadm_module, c[0]) == 'Scheduled osd update...'
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.SpecStore.save")
@@ -136,8 +136,8 @@ class TestCephadm(object):
             spec = ServiceSpec.from_json(json_spec)
             assert isinstance(spec, DriveGroupSpec)
             c = cephadm_module.apply_drivegroups([spec])
+            assert wait(cephadm_module, c) == ['Scheduled osd update...']
             _save_spec.assert_called_with(spec)
-            assert wait(cephadm_module, c[0]) == 'Scheduled osd update...'
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     def test_create_osds(self, cephadm_module):

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -308,8 +308,8 @@ class TestCephadm(object):
             ps = PlacementSpec(hosts=['test'], count=1)
             spec = ServiceSpec('mgr', placement=ps)
             c = cephadm_module.apply_mgr(spec)
-            _save_spec.assert_called_with(spec)
             assert wait(cephadm_module, c) == 'Scheduled mgr update...'
+            _save_spec.assert_called_with(spec)
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.SpecStore.save")
@@ -318,8 +318,8 @@ class TestCephadm(object):
             ps = PlacementSpec(hosts=['test'], count=1)
             spec = ServiceSpec('mds', 'fsname', placement=ps)
             c = cephadm_module.apply_mds(spec)
-            _save_spec.assert_called_with(spec)
             assert wait(cephadm_module, c) == 'Scheduled mds update...'
+            _save_spec.assert_called_with(spec)
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.SpecStore.save")
@@ -328,8 +328,8 @@ class TestCephadm(object):
             ps = PlacementSpec(hosts=['test'], count=1)
             spec = ServiceSpec('rgw', 'r.z', placement=ps)
             c = cephadm_module.apply_rgw(spec)
-            _save_spec.assert_called_with(spec)
             assert wait(cephadm_module, c) == 'Scheduled rgw update...'
+            _save_spec.assert_called_with(spec)
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.SpecStore.save")
@@ -338,8 +338,8 @@ class TestCephadm(object):
             ps = PlacementSpec(hosts=['test'], count=1)
             spec = ServiceSpec('rbd-mirror', placement=ps)
             c = cephadm_module.apply_rbd_mirror(spec)
-            _save_spec.assert_called_with(spec)
             assert wait(cephadm_module, c) == 'Scheduled rbd-mirror update...'
+            _save_spec.assert_called_with(spec)
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.SpecStore.save")
@@ -348,8 +348,8 @@ class TestCephadm(object):
             ps = PlacementSpec(hosts=['test'], count=1)
             spec = ServiceSpec('prometheus', placement=ps)
             c = cephadm_module.apply_prometheus(spec)
-            _save_spec.assert_called_with(spec)
             assert wait(cephadm_module, c) == 'Scheduled prometheus update...'
+            _save_spec.assert_called_with(spec)
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.SpecStore.save")
@@ -358,5 +358,5 @@ class TestCephadm(object):
             ps = PlacementSpec(hosts=['test'], count=1)
             spec = ServiceSpec('node_exporter', placement=ps)
             c = cephadm_module.apply_node_exporter(spec)
-            _save_spec.assert_called_with(spec)
             assert wait(cephadm_module, c) == 'Scheduled node_exporter update...'
+            _save_spec.assert_called_with(spec)

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -36,15 +36,10 @@ class OrchestratorAPI(OrchestratorClientMixin):
 def wait_api_result(method):
     @wraps(method)
     def inner(self, *args, **kwargs):
-        completions = method(self, *args, **kwargs)
-        if not isinstance(completions, list):
-            completions = [completions]
-        self.api.orchestrator_wait(completions)
-        for compl in completions:
-            raise_if_exception(compl)
-        if len(completions) == 1:
-            return completions[0].result
-        return [compl.result for compl in completions]
+        completion = method(self, *args, **kwargs)
+        self.api.orchestrator_wait([completion])
+        raise_if_exception(completion)
+        return completion.result
     return inner
 
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -913,7 +913,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def apply_drivegroups(self, specs: List[DriveGroupSpec]) -> Sequence[Completion]:
+    def apply_drivegroups(self, specs: List[DriveGroupSpec]) -> Completion:
         """ Update OSD cluster """
         raise NotImplementedError()
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -846,9 +846,28 @@ class Orchestrator(object):
 
     def apply(self, specs: List[ServiceSpec]) -> Completion:
         """
-        Saves Service Specs from a yaml|json file
+        Applies any spec
         """
-        raise NotImplementedError()
+        fns = {
+            'alertmanager': self.apply_alertmanager,
+            'crash': self.apply_crash,
+            'grafana': self.apply_grafana,
+            'mds': self.apply_mds,
+            'mgr': self.apply_mgr,
+            'mon': self.apply_mon,
+            'nfs': self.apply_nfs,
+            'node-exporter': self.apply_node_exporter,
+            'osd': self.apply_drivegroups,
+            'prometheus': self.apply_prometheus,
+            'rbd-mirror': self.apply_rbd_mirror,
+            'rgw': self.apply_rgw,
+        }
+        spec, [specs] = specs
+
+        completion = fns[spec.service_name](spec)
+        for s in specs:
+            completion.then(fns[spec.service_name](spec))
+        return completion
 
     def remove_daemons(self, names):
         # type: (List[str]) -> Completion

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -844,7 +844,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def apply_service_config(self, spec_document: str) -> Completion:
+    def apply(self, specs: List[ServiceSpec]) -> Completion:
         """
         Saves Service Specs from a yaml|json file
         """

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -703,7 +703,7 @@ Usage:
         completion = self.list_specs(service_name=service_name)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
-        specs = completion.result()
+        specs = completion.result
         return HandleCommandResult(stdout=yaml.safe_dump_all(specs))
 
     @_cli_write_command(

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -11,7 +11,7 @@ from prettytable import PrettyTable
 from mgr_util import format_bytes, to_pretty_timedelta
 
 try:
-    from typing import List, Set, Optional, Dict
+    from typing import List, Set, Optional, Dict, Iterator
 except ImportError:
     pass  # just for type checking.
 
@@ -568,15 +568,6 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command(
-        'orch apply',
-        desc='Applies a Service Specification from a file. ceph orch apply -i $file')
-    def _apply_services(self, inbuf):
-        completion = self.apply_service_config(inbuf)
-        self._orchestrator_wait([completion])
-        raise_if_exception(completion)
-        return HandleCommandResult(stdout=completion.result_str())
-
-    @_cli_write_command(
         'orch daemon add mds',
         'name=fs_name,type=CephString '
         'name=placement,type=CephString,req=false',
@@ -703,39 +694,32 @@ Usage:
         completion = self.list_specs(service_name=service_name)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
-        specs = completion.result_str()
-        return HandleCommandResult(stdout=specs)
+        specs = completion.result()
+        return HandleCommandResult(stdout=yaml.safe_dump_all(specs))
 
     @_cli_write_command(
         'orch apply',
-        'name=service_type,type=CephChoices,strings=mon|mgr|rbd-mirror|crash|alertmanager|grafana|node-exporter|prometheus '
+        'name=service_type,type=CephChoices,strings=mon|mgr|rbd-mirror|crash|alertmanager|grafana|node-exporter|prometheus,req=false '
         'name=placement,type=CephString,req=false '
         'name=unmanaged,type=CephBool,req=false',
-        'Update the size or placement for a service')
-    def _apply_misc(self, service_type, placement=None, unmanaged=False):
-        placement = PlacementSpec.from_string(placement)
-        placement.validate()
+        'Update the size or placement for a service or apply a large yaml spec')
+    def _apply_misc(self, service_type=None, placement=None, unmanaged=False, inbuf=None):
+        usage = """Usage:
+  ceph orch apply -i <yaml spec>
+  ceph orch apply <service_type> <placement> [--unmanaged]
+        """
+        if inbuf:
+            if service_type or placement or unmanaged:
+                raise OrchestratorValidationError(usage)
+            content: Iterator = yaml.load_all(inbuf)
+            specs = [ServiceSpec.from_json(s) for s in content]
+        else:
+            placement = PlacementSpec.from_string(placement)
+            placement.validate()
 
-        spec = ServiceSpec(service_type, placement=placement,
-                           unmanaged=unmanaged)
+            specs = [ServiceSpec(service_type, placement=placement, unmanaged=unmanaged)]
 
-        if service_type == 'mgr':
-            completion = self.apply_mgr(spec)
-        elif service_type == 'mon':
-            completion = self.apply_mon(spec)
-        elif service_type == 'rbd-mirror':
-            completion = self.apply_rbd_mirror(spec)
-        elif service_type == 'crash':
-            completion = self.apply_crash(spec)
-        elif service_type == 'alertmanager':
-            completion = self.apply_alertmanager(spec)
-        elif service_type == 'grafana':
-            completion = self.apply_grafana(spec)
-        elif service_type == 'node-exporter':
-            completion = self.apply_node_exporter(spec)
-        elif service_type == 'prometheus':
-            completion = self.apply_prometheus(spec)
-
+        completion = self.apply(specs)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -465,11 +465,10 @@ Usage:
                 )
             ]
 
-        completions = self.apply_drivegroups(dg_specs)
-        [self._orchestrator_wait([completion]) for completion in completions]  # type: ignore
-        [raise_if_exception(completion) for completion in completions]  # type: ignore
-        result_strings = [completion.result_str() for completion in completions]
-        return HandleCommandResult(stdout=" ".join(result_strings))
+        completion = self.apply_drivegroups(dg_specs)
+        self._orchestrator_wait([completion])
+        raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command(
         'orch daemon add osd',

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -259,7 +259,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         )
 
     def apply_drivegroups(self, specs):
-        # type: (List[DriveGroupSpec]) -> Sequence[TestCompletion]
+        # type: (List[DriveGroupSpec]) -> TestCompletion
         drive_group = specs[0]
         def run(all_hosts):
             # type: (List[orchestrator.HostSpec]) -> None
@@ -267,12 +267,12 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
             if drive_group.placement.host_pattern:
                 if not drive_group.placement.pattern_matches_hosts([h.hostname for h in all_hosts]):
                     raise orchestrator.OrchestratorValidationError('failed to match')
-        return [self.get_hosts().then(run).then(
+        return self.get_hosts().then(run).then(
             on_complete=orchestrator.ProgressReference(
                 message='apply_drivesgroups',
                 mgr=self,
             )
-        )]
+        )
 
     @deferred_write("remove_daemons")
     def remove_daemons(self, names):

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -22,9 +22,14 @@ if 'UNITTEST' in os.environ:
             self._ceph_get_version = mock.Mock()
             self._ceph_get = mock.MagicMock()
             self._ceph_get_module_option = mock.MagicMock()
+            self._ceph_get_option = mock.MagicMock()
+            self._validate_module_option = lambda _: True
+            self._configure_logging = lambda *_: None
+            self._unconfigure_logging = mock.MagicMock()
             self._ceph_log = mock.MagicMock()
             self._ceph_get_store = lambda _: ''
             self._ceph_get_store_prefix = lambda _: {}
+            self._ceph_dispatch_remote = lambda *_: None
 
 
     cm = mock.Mock()

--- a/src/pybind/mgr/tests/test_orchestrator.py
+++ b/src/pybind/mgr/tests/test_orchestrator.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from ceph.deployment.service_spec import ServiceSpec
+from test_orchestrator import TestOrchestrator as _TestOrchestrator
 from tests import mock
 
 import pytest
@@ -226,3 +228,12 @@ def test_pretty_print():
 
     assert p.result == 5
 
+def test_apply():
+    to = _TestOrchestrator('', 0, 0)
+    completion = to.apply([
+        ServiceSpec(service_type='nfs'),
+        ServiceSpec(service_type='nfs'),
+        ServiceSpec(service_type='nfs'),
+    ])
+    completion.finalize(42)
+    assert  completion.result == [None, None, None]

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -302,6 +302,8 @@ class ServiceSpec(object):
     start the services.
 
     """
+    KNOWN_SERVICE_TYPES = 'alertmanager crash grafana mds mgr mon nfs ' \
+                          'node-exporter osd prometheus rbd-mirror rgw'.split()
 
     def __init__(self,
                  service_type,     # type: str
@@ -312,7 +314,7 @@ class ServiceSpec(object):
                  ):
         self.placement = PlacementSpec() if placement is None else placement  # type: PlacementSpec
 
-        assert service_type
+        assert service_type in ServiceSpec.KNOWN_SERVICE_TYPES, service_type
         self.service_type = service_type
         self.service_id = service_id
         self.unmanaged = unmanaged


### PR DESCRIPTION
* mgr/orchestrator: `orch daemon add` accepts a yaml

    Fixes: https://tracker.ceph.com/issues/44622

* mgr/cephadm: apply_drivegroups() returns a single Completion
* mgr/cephadm: remove `trivial_result()`

    Replaced with `@trivial_completion`, otherwise
    `self._apply()` would have needed to accept a list
    of specs.


* mgr/cephadm: Fix `ceph orch apply -i`

    * We had two implementations for `ceph orcha apply`
    * Remove yaml pasing in `mgr/cephadm`



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
