### PR TITLE
rgw: add the url params "append" and "position" to the signature

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -50,7 +50,9 @@ static const auto signed_subresources = {
   "versioning",
   "versions",
   "website",
-  "object-lock"
+  "object-lock",
+  "append",
+  "position"
 };
 
 /*


### PR DESCRIPTION
When append an oject, I found out that the param "append" and "position" are not signed in rgw. If the request was hacked and the param "position" was changed, it will make the request fail always.
We need calculate key signature inclued the two params.

sorry for not signed off correctly before.

Fixes: https://tracker.ceph.com/issues/44635
Signed-off-by: wangyunqing wangyunqing@inspur.com