### PR TITLE
test/crimson: Added CPU cycles per operation as an acceptance criteria to radosbench_4k_r/w yaml

### DIFF
--- a/src/test/crimson/cbt/radosbench_4K_read.yaml
+++ b/src/test/crimson/cbt/radosbench_4K_read.yaml
@@ -20,6 +20,7 @@ tasks:
           iops_avg: '(or (greater) (near 0.05))'
           iops_stddev: '(or (less) (near 0.50))'
           latency_avg: '(or (less) (near 0.05))'
+          cpu_cycles_per_op: '(or (less) (near 0.05))'
     monitoring_profiles:
       perf:
         nodes:

--- a/src/test/crimson/cbt/radosbench_4K_write.yaml
+++ b/src/test/crimson/cbt/radosbench_4K_write.yaml
@@ -18,6 +18,7 @@ tasks:
           iops_avg: '(or (greater) (near 0.05))'
           iops_stddev: '(or (less) (near 0.05))'
           latency_avg: '(or (less) (near 0.05))'
+          cpu_cycles_per_op: '(or (less) (near 0.05))'
     monitoring_profiles:
       perf:
         nodes:


### PR DESCRIPTION
CPU cycles per operation is a new metric we will use in CBT for Crimson, this pull request is needed for the following pull request: https://github.com/ceph/cbt/pull/211
