### PR TITLE
Sharding of rocksdb database using column families

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4417,8 +4417,12 @@ std::vector<Option> get_global_options() {
     .set_description("Enable use of rocksdb column families for bluestore metadata"),
 
     Option("bluestore_rocksdb_cfs", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("M= P= L=")
-    .set_description("List of whitespace-separate key/value pairs where key is CF name and value is CF options"),
+    .set_default("m(5,0-8) O(7,0-13) L")
+    .set_description("Definition of column families and their sharding")
+    .set_long_description("Space separated list of elements: column_def [ '=' rocksdb_options ]. "
+			  "column_def := column_name [ '(' shard_count [ ',' hash_begin '-' [ hash_end ] ] ')' ]. "
+			  "Example: 'I=write_buffer_size=1048576 O(6) m(7,10-)'. "
+			  "Interval [hash_begin..hash_end) defines characters to use for hash calculation."),
 
     Option("bluestore_fsck_on_mount", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4413,11 +4413,11 @@ std::vector<Option> get_global_options() {
     .set_description("Rocksdb options"),
 
     Option("bluestore_rocksdb_cf", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
+    .set_default(true)
     .set_description("Enable use of rocksdb column families for bluestore metadata"),
 
     Option("bluestore_rocksdb_cfs", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("m(5) O(7,0-13) L")
+    .set_default("m(3) O(3,0-13) L")
     .set_description("Definition of column families and their sharding")
     .set_long_description("Space separated list of elements: column_def [ '=' rocksdb_options ]. "
 			  "column_def := column_name [ '(' shard_count [ ',' hash_begin '-' [ hash_end ] ] ')' ]. "

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4417,12 +4417,14 @@ std::vector<Option> get_global_options() {
     .set_description("Enable use of rocksdb column families for bluestore metadata"),
 
     Option("bluestore_rocksdb_cfs", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("m(5,0-8) O(7,0-13) L")
+    .set_default("m(5) O(7,0-13) L")
     .set_description("Definition of column families and their sharding")
     .set_long_description("Space separated list of elements: column_def [ '=' rocksdb_options ]. "
 			  "column_def := column_name [ '(' shard_count [ ',' hash_begin '-' [ hash_end ] ] ')' ]. "
 			  "Example: 'I=write_buffer_size=1048576 O(6) m(7,10-)'. "
-			  "Interval [hash_begin..hash_end) defines characters to use for hash calculation."),
+			  "Interval [hash_begin..hash_end) defines characters to use for hash calculation. "
+			  "Recommended hash ranges: O(0-13) P(0-8) m(0-16). "
+			  "Sharding of S,T,C,M,B prefixes is inadvised"),
 
     Option("bluestore_fsck_on_mount", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -21,18 +21,6 @@
  */
 class KeyValueDB {
 public:
-  /*
-   *  See RocksDB's definition of a column family(CF) and how to use it.
-   *  The interfaces of KeyValueDB is extended, when a column family is created.
-   *  Prefix will be the name of column family to use.
-   */
-  struct ColumnFamily {
-    std::string name;      //< name of this individual column family
-    std::string option;    //< configure option string for this CF
-    ColumnFamily(const std::string &name, const std::string &option)
-      : name(name), option(option) {}
-  };
-
   class TransactionImpl {
   public:
     /// Set Keys
@@ -155,12 +143,11 @@ public:
   /// test whether we can successfully initialize; may have side effects (e.g., create)
   static int test_init(const std::string& type, const std::string& dir);
   virtual int init(std::string option_str="") = 0;
-  virtual int open(std::ostream &out, const std::vector<ColumnFamily>& cfs = {}) = 0;
+  virtual int open(std::ostream &out, const std::string& cfs="") = 0;
   // std::vector cfs contains column families to be created when db is created.
-  virtual int create_and_open(std::ostream &out,
-			      const std::vector<ColumnFamily>& cfs = {}) = 0;
+  virtual int create_and_open(std::ostream &out, const std::string& cfs="") = 0;
 
-  virtual int open_read_only(std::ostream &out, const std::vector<ColumnFamily>& cfs = {}) {
+  virtual int open_read_only(std::ostream &out, const std::string& cfs="") {
     return -ENOTSUP;
   }
 
@@ -333,14 +320,6 @@ public:
       get_wholespace_iterator());
   }
 
-  void add_column_family(const std::string& cf_name, void *handle) {
-    cf_handles.insert(std::make_pair(cf_name, handle));
-  }
-
-  bool is_column_family(const std::string& prefix) {
-    return cf_handles.count(prefix);
-  }
-
   virtual uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) = 0;
   virtual int get_statfs(struct store_statfs_t *buf) {
     return -EOPNOTSUPP;
@@ -438,8 +417,6 @@ protected:
   std::vector<std::pair<std::string,
 			std::shared_ptr<MergeOperator> > > merge_ops;
 
-  /// column families in use, name->handle
-  std::unordered_map<std::string, void *> cf_handles;
 };
 
 #endif

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -66,14 +66,14 @@ int LevelDBStore::init(string option_str)
   return 0;
 }
 
-int LevelDBStore::open(ostream &out, const vector<ColumnFamily>& cfs)  {
+int LevelDBStore::open(ostream &out, const std::string& cfs)  {
   if (!cfs.empty()) {
     ceph_abort_msg("Not implemented");
   }
   return do_open(out, false);
 }
 
-int LevelDBStore::create_and_open(ostream &out, const vector<ColumnFamily>& cfs) {
+int LevelDBStore::create_and_open(ostream &out, const std::string& cfs) {
   if (!cfs.empty()) {
     ceph_abort_msg("Not implemented");
   }

--- a/src/kv/LevelDBStore.h
+++ b/src/kv/LevelDBStore.h
@@ -177,9 +177,9 @@ public:
   int init(std::string option_str="") override;
 
   /// Opens underlying db
-  int open(std::ostream &out, const std::vector<ColumnFamily>& = {}) override;
+  int open(std::ostream &out, const std::string& cfs="") override;
   /// Creates underlying db if missing and opens it
-  int create_and_open(std::ostream &out, const std::vector<ColumnFamily>& = {}) override;
+  int create_and_open(std::ostream &out, const std::string& cfs="") override;
 
   void close() override;
 

--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -187,14 +187,14 @@ int MemDB::do_open(ostream &out, bool create)
   return _init(create);
 }
 
-int MemDB::open(ostream &out, const vector<ColumnFamily>& cfs) {
+int MemDB::open(ostream &out, const std::string& cfs) {
   if (!cfs.empty()) {
     ceph_abort_msg("Not implemented");
   }
   return do_open(out, false);
 }
 
-int MemDB::create_and_open(ostream &out, const vector<ColumnFamily>& cfs) {
+int MemDB::create_and_open(ostream &out, const std::string& cfs) {
   if (!cfs.empty()) {
     ceph_abort_msg("Not implemented");
   }

--- a/src/kv/MemDB.h
+++ b/src/kv/MemDB.h
@@ -132,8 +132,8 @@ public:
   int _init(bool format);
 
   int do_open(std::ostream &out, bool create);
-  int open(std::ostream &out, const std::vector<ColumnFamily>&) override;
-  int create_and_open(std::ostream &out, const std::vector<ColumnFamily>&) override;
+  int open(std::ostream &out, const std::string& cfs="") override;
+  int create_and_open(std::ostream &out, const std::string& cfs="") override;
   using KeyValueDB::create_and_open;
 
   KeyValueDB::Transaction get_transaction() override {

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -524,9 +524,9 @@ bool RocksDBStore::is_column_family(const std::string& prefix) {
 
 rocksdb::ColumnFamilyHandle *RocksDBStore::get_cf_handle(const std::string& prefix, const std::string& key) {
   auto iter = cf_handles.find(prefix);
-  if (iter == cf_handles.end())
+  if (iter == cf_handles.end()) {
     return nullptr;
-  else {
+  } else {
     if (iter->second.handles.size() == 1) {
       return iter->second.handles[0];
     } else {
@@ -540,9 +540,9 @@ rocksdb::ColumnFamilyHandle *RocksDBStore::get_cf_handle(const std::string& pref
 
 rocksdb::ColumnFamilyHandle *RocksDBStore::get_cf_handle(const std::string& prefix, const char* key, size_t keylen) {
   auto iter = cf_handles.find(prefix);
-  if (iter == cf_handles.end())
+  if (iter == cf_handles.end()) {
     return nullptr;
-  else {
+  } else {
     if (iter->second.handles.size() == 1) {
       return iter->second.handles[0];
     } else {

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -760,7 +760,13 @@ int RocksDBStore::verify_sharding(const rocksdb::Options& opt,
   //check if sharding_def matches stored_sharding_def
   std::vector<ColumnFamily> sharding_def;
   std::vector<ColumnFamily> stored_sharding_def;
-  parse_sharding_def(sharding_text, sharding_def);
+  if (!sharding_text.empty()) {
+    parse_sharding_def(sharding_text, sharding_def);
+  } else {
+    //if sharding requested is empty, assume that it agrees with stored
+    //this is necessary for ceph-bluestore-tool fsck
+    parse_sharding_def(stored_sharding_text, sharding_def);
+  }
   parse_sharding_def(stored_sharding_text, stored_sharding_def);
 
   std::sort(sharding_def.begin(), sharding_def.end(),

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1954,7 +1954,7 @@ private:
 	if (b->Valid()) {
 	  return false;
 	} else {
-	  return static_cast<void*>(a) < static_cast<void*>(b);
+	  return false;
 	}
       }
     }
@@ -1998,9 +1998,19 @@ public:
 	return -1;
       }
     }
-    for (size_t i = 0; i < iters.size(); i++) {
-      if (keyless(iters[0], iters[i])) {
-	swap(iters[0], iters[i]);
+    for (size_t i = 1; i < iters.size(); i++) {
+      if (iters[0]->Valid()) {
+	if (iters[i]->Valid()) {
+	  if (keyless(iters[0], iters[i])) {
+	    swap(iters[0], iters[i]);
+	  }
+	} else {
+	  //iters[i] empty
+	}
+      } else {
+	if (iters[i]->Valid()) {
+	  swap(iters[0], iters[i]);
+	}
       }
       //it might happen that cf was empty
       if (iters[i]->Valid()) {
@@ -2089,7 +2099,7 @@ public:
 	iters[0]->Prev();
 	ceph_assert(!iters[0]->Valid());
       }
-      return -1;
+      return 0;
     }
     //2,3
     rocksdb::Iterator* highest = prev_done[0];

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1906,12 +1906,6 @@ string RocksDBStore::past_prefix(const string &prefix)
   return limit;
 }
 
-RocksDBStore::WholeSpaceIterator RocksDBStore::get_wholespace_iterator()
-{
-  return std::make_shared<RocksDBWholeSpaceIteratorImpl>(
-    db->NewIterator(rocksdb::ReadOptions(), default_cf));
-}
-
 class CFIteratorImpl : public KeyValueDB::IteratorImpl {
 protected:
   string prefix;
@@ -1974,6 +1968,451 @@ public:
   }
   int status() override {
     return dbiter->status().ok() ? 0 : -1;
+  }
+};
+
+
+//merge column iterators and rest iterator
+class WholeMergeIteratorImpl : public KeyValueDB::WholeSpaceIteratorImpl {
+private:
+  RocksDBStore* db;
+  KeyValueDB::WholeSpaceIterator main;
+  std::map<std::string, KeyValueDB::Iterator> shards;
+  std::map<std::string, KeyValueDB::Iterator>::iterator current_shard;
+  enum {on_main, on_shard} smaller;
+
+public:
+  WholeMergeIteratorImpl(RocksDBStore* db)
+    : db(db)
+    , main(db->get_default_cf_iterator())
+  {
+    for (auto& e : db->cf_handles) {
+      shards.emplace(e.first, db->get_iterator(e.first));
+    }
+  }
+
+  // returns true if value in main is smaller then in shards
+  // invalid is larger then actual value
+  bool is_main_smaller() {
+    if (main->valid()) {
+      if (current_shard != shards.end()) {
+	auto main_rk = main->raw_key();
+	ceph_assert(current_shard->second->valid());
+	auto shards_rk = current_shard->second->raw_key();
+	if (main_rk.first < shards_rk.first)
+	  return true;
+	if (main_rk.first > shards_rk.first)
+	  return false;
+	return main_rk.second < shards_rk.second;
+      } else {
+	return true;
+      }
+    } else {
+      if (current_shard != shards.end()) {
+	return false;
+      } else {
+	//this means that neither is valid
+	//we select main to be smaller, so valid() will signal properly
+	return true;
+      }
+    }
+  }
+
+  int seek_to_first() override {
+    int r0 = main->seek_to_first();
+    int r1 = 0;
+    // find first shard that has some data
+    current_shard = shards.begin();
+    while (current_shard != shards.end()) {
+      r1 = current_shard->second->seek_to_first();
+      if (r1 != 0 || current_shard->second->valid()) {
+	//this is the first shard that will yield some keys
+	break;
+      }
+      ++current_shard;
+    }
+    smaller = is_main_smaller() ? on_main : on_shard;
+    return r0 == 0 && r1 == 0 ? 0 : -1;
+  }
+
+  int seek_to_first(const std::string &prefix) override {
+    int r0 = main->seek_to_first(prefix);
+    int r1 = 0;
+    // find first shard that has some data
+    current_shard = shards.lower_bound(prefix);
+    while (current_shard != shards.end()) {
+      r1 = current_shard->second->seek_to_first();
+      if (r1 != 0 || current_shard->second->valid()) {
+	//this is the first shard that will yield some keys
+	break;
+      }
+      ++current_shard;
+    }
+    smaller = is_main_smaller() ? on_main : on_shard;
+    return r0 == 0 && r1 == 0 ? 0 : -1;
+  };
+
+  int seek_to_last() override {
+    int r0 = main->seek_to_last();
+    int r1 = 0;
+    r1 = shards_seek_to_last();
+    //if we have 2 candidates, we need to select
+    if (main->valid()) {
+      if (shards_valid()) {
+	if (is_main_smaller()) {
+	  smaller = on_shard;
+	  main->next();
+	} else {
+	  smaller = on_main;
+	  shards_next();
+	}
+      } else {
+	smaller = on_main;
+      }
+    } else {
+      if (shards_valid()) {
+	smaller = on_shard;
+      } else {
+	smaller = on_main;
+      }
+    }
+    return r0 == 0 && r1 == 0 ? 0 : -1;
+  }
+
+  int seek_to_last(const std::string &prefix) override {
+    int r0 = main->seek_to_last(prefix);
+    int r1 = 0;
+    // find last shard that has some data
+    bool found = false;
+    current_shard = shards.lower_bound(prefix);
+    while (current_shard != shards.begin()) {
+      r1 = current_shard->second->seek_to_last();
+      if (r1 != 0)
+	break;
+      if (current_shard->second->valid()) {
+	found = true;
+	break;
+      }
+    }
+    //if we have 2 candidates, we need to select
+    if (main->valid() && found) {
+      if (is_main_smaller()) {
+	main->next();
+      } else {
+	shards_next();
+      }
+    }
+    if (!found) {
+      //set shards state that properly represents eof
+      current_shard = shards.end();
+    }
+    smaller = is_main_smaller() ? on_main : on_shard;
+    return r0 == 0 && r1 == 0 ? 0 : -1;
+  }
+
+  int upper_bound(const std::string &prefix, const std::string &after) override {
+    int r0 = main->upper_bound(prefix, after);
+    int r1 = 0;
+    if (r0 != 0)
+      return r0;
+    current_shard = shards.lower_bound(prefix);
+    if (current_shard != shards.end()) {
+      bool located = false;
+      if (current_shard->first == prefix) {
+	r1 = current_shard->second->upper_bound(after);
+	if (r1 != 0)
+	  return r1;
+        if (current_shard->second->valid()) {
+	  located = true;
+	}
+      }
+      if (!located) {
+	while (current_shard != shards.end()) {
+	  r1 = current_shard->second->seek_to_first();
+	  if (r1 != 0)
+	    return r1;
+	  if (current_shard->second->valid())
+	    break;
+	  ++current_shard;
+	}
+      }
+    }
+    smaller = is_main_smaller() ? on_main : on_shard;
+    return 0;
+  }
+
+  int lower_bound(const std::string &prefix, const std::string &to) override {
+    int r0 = main->lower_bound(prefix, to);
+    int r1 = 0;
+    if (r0 != 0)
+      return r0;
+    current_shard = shards.lower_bound(prefix);
+    if (current_shard != shards.end()) {
+      bool located = false;
+      if (current_shard->first == prefix) {
+	r1 = current_shard->second->lower_bound(to);
+	if (r1 != 0)
+	  return r1;
+	if (current_shard->second->valid()) {
+	  located = true;
+	}
+      }
+      if (!located) {
+	while (current_shard != shards.end()) {
+	  r1 = current_shard->second->seek_to_first();
+	  if (r1 != 0)
+	    return r1;
+	  if (current_shard->second->valid())
+	    break;
+	  ++current_shard;
+	}
+      }
+    }
+    smaller = is_main_smaller() ? on_main : on_shard;
+    return 0;
+  }
+
+  bool valid() override {
+    if (smaller == on_main) {
+      return main->valid();
+    } else {
+      if (current_shard == shards.end())
+	return false;
+      return current_shard->second->valid();
+    }
+  };
+
+  int next() override {
+    int r;
+    if (smaller == on_main) {
+      r = main->next();
+    } else {
+      r = shards_next();
+    }
+    if (r != 0)
+      return r;
+    smaller = is_main_smaller() ? on_main : on_shard;
+    return 0;
+  }
+
+  int prev() override {
+    int r;
+    bool main_was_valid = false;
+    if (main->valid()) {
+      main_was_valid = true;
+      r = main->prev();
+    } else {
+      r = main->seek_to_last();
+    }
+    if (r != 0)
+      return r;
+
+    bool shards_was_valid = false;
+    if (shards_valid()) {
+      shards_was_valid = true;
+      r = shards_prev();
+    } else {
+      r = shards_seek_to_last();
+    }
+    if (r != 0)
+      return r;
+
+    if (!main->valid() && !shards_valid()) {
+      //end, no previous. set marker so valid() can work
+      smaller = on_main;
+      return 0;
+    }
+
+    //if 1 is valid, select it
+    //if 2 are valid select larger and advance the other
+    if (main->valid()) {
+      if (shards_valid()) {
+	if (is_main_smaller()) {
+	  smaller = on_shard;
+	  if (main_was_valid) {
+	    if (main->valid()) {
+	      r = main->next();
+	    } else {
+	      r = main->seek_to_first();
+	    }
+	  } else {
+	    //if we have resurrected main, kill it
+	    if (main->valid()) {
+	      main->next();
+	    }
+	  }
+	} else {
+	  smaller = on_main;
+	  if (shards_was_valid) {
+	    if (shards_valid()) {
+	      r = shards_next();
+	    } else {
+	      r = shards_seek_to_first();
+	    }
+	  } else {
+	    //if we have resurected shards, kill it
+	    if (shards_valid()) {
+	      shards_next();
+	    }
+	  }
+	}
+      } else {
+	smaller = on_main;
+	r = shards_seek_to_first();
+      }
+    } else {
+      smaller = on_shard;
+      r = main->seek_to_first();
+    }
+    return r;
+  }
+
+  std::string key() override
+  {
+    if (smaller == on_main) {
+      return main->key();
+    } else {
+      return current_shard->second->key();
+    }
+  }
+
+  std::pair<std::string,std::string> raw_key() override
+  {
+    if (smaller == on_main) {
+      return main->raw_key();
+    } else {
+      return { current_shard->first, current_shard->second->key() };
+    }
+  }
+
+  bool raw_key_is_prefixed(const std::string &prefix) override
+  {
+    if (smaller == on_main) {
+      return main->raw_key_is_prefixed(prefix);
+    } else {
+      return current_shard->first == prefix;
+    }
+  }
+
+  ceph::buffer::list value() override
+  {
+    if (smaller == on_main) {
+      return main->value();
+    } else {
+      return current_shard->second->value();
+    }
+  }
+
+  int status() override
+  {
+    //because we already had to inspect key, it must be ok
+    return 0;
+  }
+
+  size_t key_size() override
+  {
+    if (smaller == on_main) {
+      return main->key_size();
+    } else {
+      return current_shard->second->key().size();
+    }
+  }
+  size_t value_size() override
+  {
+    if (smaller == on_main) {
+      return main->value_size();
+    } else {
+      return current_shard->second->value().length();
+    }
+  }
+
+  int shards_valid() {
+    if (current_shard == shards.end())
+      return false;
+    return current_shard->second->valid();
+  }
+
+  int shards_next() {
+    if (current_shard == shards.end()) {
+      //illegal to next() on !valid()
+      return -1;
+    }
+    int r = 0;
+    r = current_shard->second->next();
+    if (r != 0)
+      return r;
+    if (current_shard->second->valid())
+      return 0;
+    //current shard exhaused, search for key
+    ++current_shard;
+    while (current_shard != shards.end()) {
+      r = current_shard->second->seek_to_first();
+      if (r != 0)
+	return r;
+      if (current_shard->second->valid())
+	break;
+      ++current_shard;
+    }
+    //either we found key or not, but it is success
+    return 0;
+  }
+
+  int shards_prev() {
+    if (current_shard == shards.end()) {
+      //illegal to prev() on !valid()
+      return -1;
+    }
+    int r = current_shard->second->prev();
+    while (r == 0) {
+      if (current_shard->second->valid()) {
+	break;
+      }
+      if (current_shard == shards.begin()) {
+	//we have reached pre-first element
+	//this makes it !valid(), but guarantees next() moves to first element
+	break;
+      }
+      --current_shard;
+      r = current_shard->second->seek_to_last();
+    }
+    return r;
+  }
+
+  int shards_seek_to_last() {
+    int r = 0;
+    current_shard = shards.end();
+    if (current_shard == shards.begin()) {
+      //no shards at all
+      return 0;
+    }
+    while (current_shard != shards.begin()) {
+      --current_shard;
+      r = current_shard->second->seek_to_last();
+      if (r != 0)
+	return r;
+      if (current_shard->second->valid()) {
+	return 0;
+      }
+    }
+    //no keys at all
+    current_shard = shards.end();
+    return r;
+  }
+
+  int shards_seek_to_first() {
+    int r = 0;
+    current_shard = shards.begin();
+    while (current_shard != shards.end()) {
+      r = current_shard->second->seek_to_first();
+      if (r != 0)
+	break;
+      if (current_shard->second->valid()) {
+	//this is the first shard that will yield some keys
+	break;
+      }
+      ++current_shard;
+    }
+    return r;
   }
 };
 
@@ -2208,4 +2647,20 @@ KeyValueDB::Iterator RocksDBStore::get_iterator(const std::string& prefix)
 rocksdb::Iterator* RocksDBStore::new_shard_iterator(rocksdb::ColumnFamilyHandle* cf)
 {
   return db->NewIterator(rocksdb::ReadOptions(), cf);
+}
+
+RocksDBStore::WholeSpaceIterator RocksDBStore::get_wholespace_iterator()
+{
+  if (cf_handles.size() == 0) {
+    return std::make_shared<RocksDBWholeSpaceIteratorImpl>(
+      db->NewIterator(rocksdb::ReadOptions(), default_cf));
+  } else {
+    return std::make_shared<WholeMergeIteratorImpl>(this);
+  }
+}
+
+RocksDBStore::WholeSpaceIterator RocksDBStore::get_default_cf_iterator()
+{
+  return std::make_shared<RocksDBWholeSpaceIteratorImpl>(
+    db->NewIterator(rocksdb::ReadOptions(), default_cf));
 }

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -16,6 +16,7 @@
 #include "rocksdb/iostats_context.h"
 #include "rocksdb/statistics.h"
 #include "rocksdb/table.h"
+#include "rocksdb/db.h"
 #include "kv/rocksdb_cache/BinnedLRUCache.h"
 #include <errno.h>
 #include "common/errno.h"
@@ -141,6 +142,15 @@ private:
 				      std::vector<std::string>& columns);
   int create_shards(const rocksdb::Options& opt,
 		    const vector<ColumnFamily>& sharding_def);
+  int apply_sharding(const rocksdb::Options& opt,
+		     const std::string& sharding_text);
+  int verify_sharding(const rocksdb::Options& opt,
+		      const std::string& sharding_text,
+		      std::vector<rocksdb::ColumnFamilyDescriptor>& existing_cfs,
+		      std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> >& existing_cfs_shard,
+		      std::vector<rocksdb::ColumnFamilyDescriptor>& missing_cfs,
+		      std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> >& missing_cfs_shard);
+
   // manage async compactions
   ceph::mutex compact_queue_lock =
     ceph::make_mutex("RocksDBStore::compact_thread_lock");

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -77,23 +77,70 @@ class RocksDBStore : public KeyValueDB {
   void *priv;
   rocksdb::DB *db;
   rocksdb::Env *env;
+  const rocksdb::Comparator* comparator;
   std::shared_ptr<rocksdb::Statistics> dbstats;
   rocksdb::BlockBasedTableOptions bbt_opts;
   std::string options_str;
 
   uint64_t cache_size = 0;
   bool set_cache_flag = false;
+  friend class ShardMergeIteratorImpl;
+  /*
+   *  See RocksDB's definition of a column family(CF) and how to use it.
+   *  The interfaces of KeyValueDB is extended, when a column family is created.
+   *  Prefix will be the name of column family to use.
+   */
+public:
+  struct ColumnFamily {
+    string name;      //< name of this individual column family
+    size_t shard_cnt; //< count of shards
+    string options;   //< configure option string for this CF
+    uint32_t hash_l;  //< first character to take for hash calc.
+    uint32_t hash_h;  //< last character to take for hash calc.
+    ColumnFamily(const string &name, size_t shard_cnt, const string &options,
+		 uint32_t hash_l, uint32_t hash_h)
+      : name(name), shard_cnt(shard_cnt), options(options), hash_l(hash_l), hash_h(hash_h) {}
+  };
+private:
+  friend std::ostream& operator<<(std::ostream& out, const ColumnFamily& cf);
 
   bool must_close_default_cf = false;
   rocksdb::ColumnFamilyHandle *default_cf = nullptr;
+
+  /// column families in use, name->handles
+  struct prefix_shards {
+    uint32_t hash_l;  //< first character to take for hash calc.
+    uint32_t hash_h;  //< last character to take for hash calc.
+    std::vector<rocksdb::ColumnFamilyHandle *> handles;
+  };
+  std::unordered_map<std::string, prefix_shards> cf_handles;
+
+  void add_column_family(const std::string& cf_name, uint32_t hash_l, uint32_t hash_h,
+			 size_t shard_idx, rocksdb::ColumnFamilyHandle *handle);
+  bool is_column_family(const std::string& prefix);
+  rocksdb::ColumnFamilyHandle *get_cf_handle(const std::string& prefix, const std::string& key);
+  rocksdb::ColumnFamilyHandle *get_cf_handle(const std::string& prefix, const char* key, size_t keylen);
 
   int submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Transaction t);
   int install_cf_mergeop(const std::string &cf_name, rocksdb::ColumnFamilyOptions *cf_opt);
   int create_db_dir();
   int do_open(std::ostream &out, bool create_if_missing, bool open_readonly,
-	      const std::vector<ColumnFamily>* cfs = nullptr);
+	      const std::string& cfs="");
   int load_rocksdb_options(bool create_if_missing, rocksdb::Options& opt);
+public:
+  static bool parse_sharding_def(const std::string_view text_def,
+				std::vector<ColumnFamily>& sharding_def,
+				char const* *error_position = nullptr,
+				std::string *error_msg = nullptr);
+  const rocksdb::Comparator* get_comparator() const {
+    return comparator;
+  }
 
+private:
+  static void sharding_def_to_columns(const std::vector<ColumnFamily>& sharding_def,
+				      std::vector<std::string>& columns);
+  int create_shards(const rocksdb::Options& opt,
+		    const vector<ColumnFamily>& sharding_def);
   // manage async compactions
   ceph::mutex compact_queue_lock =
     ceph::make_mutex("RocksDBStore::compact_thread_lock");
@@ -162,6 +209,7 @@ public:
     priv(p),
     db(NULL),
     env(static_cast<rocksdb::Env*>(p)),
+    comparator(nullptr),
     dbstats(NULL),
     compact_queue_stop(false),
     compact_thread(this),
@@ -174,26 +222,19 @@ public:
 
   static bool check_omap_dir(std::string &omap_dir);
   /// Opens underlying db
-  int open(std::ostream &out, const std::vector<ColumnFamily>& cfs = {}) override {
-    return do_open(out, false, false, &cfs);
+  int open(std::ostream &out, const std::string& cfs="") override {
+    return do_open(out, false, false, cfs);
   }
   /// Creates underlying db if missing and opens it
   int create_and_open(std::ostream &out,
-		      const std::vector<ColumnFamily>& cfs = {}) override;
+		      const std::string& cfs="") override;
 
-  int open_read_only(std::ostream &out, const std::vector<ColumnFamily>& cfs = {}) override {
-    return do_open(out, false, true, &cfs);
+  int open_read_only(std::ostream &out, const std::string& cfs="") override {
+    return do_open(out, false, true, cfs);
   }
 
   void close() override;
 
-  rocksdb::ColumnFamilyHandle *get_cf_handle(const std::string& cf_name) {
-    auto iter = cf_handles.find(cf_name);
-    if (iter == cf_handles.end())
-      return nullptr;
-    else
-      return static_cast<rocksdb::ColumnFamilyHandle*>(iter->second);
-  }
   int repair(std::ostream &out) override;
   void split_stats(const std::string &s, char delim, std::vector<std::string> &elems);
   void get_statistics(ceph::Formatter *f) override;
@@ -399,7 +440,10 @@ public:
   };
 
   Iterator get_iterator(const std::string& prefix) override;
-
+private:
+  /// this iterator spans single cf
+  rocksdb::Iterator* new_shard_iterator(rocksdb::ColumnFamilyHandle* cf);
+public:
   /// Utility
   static std::string combine_strings(const std::string &prefix, const std::string &value) {
     std::string out = prefix;

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -86,6 +86,7 @@ class RocksDBStore : public KeyValueDB {
   uint64_t cache_size = 0;
   bool set_cache_flag = false;
   friend class ShardMergeIteratorImpl;
+  friend class WholeMergeIteratorImpl;
   /*
    *  See RocksDB's definition of a column family(CF) and how to use it.
    *  The interfaces of KeyValueDB is extended, when a column family is created.
@@ -565,8 +566,8 @@ err:
   }
 
   WholeSpaceIterator get_wholespace_iterator() override;
+private:
+  WholeSpaceIterator get_default_cf_iterator();
 };
-
-
 
 #endif

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5694,7 +5694,7 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
   std::shared_ptr<Int64ArrayMergeOperator> merge_op(new Int64ArrayMergeOperator);
 
   string kv_backend;
-  std::vector<KeyValueDB::ColumnFamily> cfs;
+  std::string sharding_def;
 
   if (create) {
     kv_backend = cct->_conf->bluestore_kvbackend;
@@ -5838,15 +5838,8 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
 
   if (kv_backend == "rocksdb") {
     options = cct->_conf->bluestore_rocksdb_options;
-
-    map<string,string> cf_map;
-    cct->_conf.with_val<string>("bluestore_rocksdb_cfs",
-                                 get_str_map,
-                                 &cf_map,
-                                 " \t");
-    for (auto& i : cf_map) {
-      dout(10) << "column family " << i.first << ": " << i.second << dendl;
-      cfs.push_back(KeyValueDB::ColumnFamily(i.first, i.second));
+    if (cct->_conf.get_val<bool>("bluestore_rocksdb_cf")) {
+      sharding_def = cct->_conf.get_val<std::string>("bluestore_rocksdb_cfs");
     }
   }
 
@@ -5854,17 +5847,13 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
   if (to_repair_db)
     return 0;
   if (create) {
-    if (cct->_conf.get_val<bool>("bluestore_rocksdb_cf")) {
-      r = db->create_and_open(err, cfs);
-    } else {
-      r = db->create_and_open(err);
-    }
+    r = db->create_and_open(err, sharding_def);
   } else {
     // we pass in cf list here, but it is only used if the db already has
     // column families created.
     r = read_only ?
-      db->open_read_only(err, cfs) :
-      db->open(err, cfs);
+      db->open_read_only(err, sharding_def) :
+      db->open(err, sharding_def);
   }
   if (r) {
     derr << __func__ << " erroring opening db: " << err.str() << dendl;

--- a/src/test/ObjectMap/KeyValueDBMemory.h
+++ b/src/test/ObjectMap/KeyValueDBMemory.h
@@ -21,10 +21,10 @@ public:
   int init(string _opt) override {
     return 0;
   }
-  int open(std::ostream &out, const vector<ColumnFamily>& cfs = {}) override {
+  int open(std::ostream &out, const std::string& cfs="") override {
     return 0;
   }
-  int create_and_open(ostream &out, const vector<ColumnFamily>& cfs = {}) override {
+  int create_and_open(ostream &out, const std::string& cfs="") override {
     return 0;
   }
 

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -18,6 +18,7 @@
 #include <time.h>
 #include <sys/mount.h>
 #include "kv/KeyValueDB.h"
+#include "kv/RocksDBStore.h"
 #include "include/Context.h"
 #include "common/ceph_argparse.h"
 #include "global/global_init.h"
@@ -315,9 +316,7 @@ TEST_P(KVTest, RocksDBColumnFamilyTest) {
   if(string(GetParam()) != "rocksdb")
     return;
 
-  std::vector<KeyValueDB::ColumnFamily> cfs;
-  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
-  cfs.push_back(KeyValueDB::ColumnFamily("cf2", ""));
+  std::string cfs("cf1 cf2");
   ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
   cout << "creating two column families and opening them" << std::endl;
   ASSERT_EQ(0, db->create_and_open(cout, cfs));
@@ -371,8 +370,7 @@ TEST_P(KVTest, RocksDBIteratorTest) {
   if(string(GetParam()) != "rocksdb")
     return;
 
-  std::vector<KeyValueDB::ColumnFamily> cfs;
-  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
+  std::string cfs("cf1");
   ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
   cout << "creating one column family and opening it" << std::endl;
   ASSERT_EQ(0, db->create_and_open(cout, cfs));
@@ -416,6 +414,48 @@ TEST_P(KVTest, RocksDBIteratorTest) {
   fini();
 }
 
+TEST_P(KVTest, RocksDBShardingIteratorTest) {
+  if(string(GetParam()) != "rocksdb")
+    return;
+
+  std::string cfs("A(6)");
+  ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
+  cout << "creating one column family and opening it" << std::endl;
+  ASSERT_EQ(0, db->create_and_open(cout, cfs));
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    for (int v = 100; v <= 999; v++) {
+      std::string str = to_string(v);
+      bufferlist val;
+      val.append(str);
+      t->set("A", str, val);
+    }
+    ASSERT_EQ(0, db->submit_transaction_sync(t));
+  }
+  {
+    KeyValueDB::Iterator it = db->get_iterator("A");
+    int pos = 0;
+    ASSERT_EQ(it->lower_bound(to_string(pos)), 0);
+    for (pos = 100; pos <= 999; pos++) {
+      ASSERT_EQ(it->valid(), true);
+      ASSERT_EQ(it->key(), to_string(pos));
+      ASSERT_EQ(it->value().to_str(), to_string(pos));
+      it->next();
+    }
+    ASSERT_EQ(it->valid(), false);
+    pos = 999;
+    ASSERT_EQ(it->lower_bound(to_string(pos)), 0);
+    for (pos = 999; pos >= 100; pos--) {
+      ASSERT_EQ(it->valid(), true);
+      ASSERT_EQ(it->key(), to_string(pos));
+      ASSERT_EQ(it->value().to_str(), to_string(pos));
+      it->prev();
+    }
+    ASSERT_EQ(it->valid(), false);
+  }
+  fini();
+}
+
 TEST_P(KVTest, RocksDBCFMerge) {
   if(string(GetParam()) != "rocksdb")
     return;
@@ -424,8 +464,7 @@ TEST_P(KVTest, RocksDBCFMerge) {
   int r = db->set_merge_operator("cf1",p);
   if (r < 0)
     return; // No merge operators for this database type
-  std::vector<KeyValueDB::ColumnFamily> cfs;
-  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
+  std::string cfs("cf1");
   ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
   cout << "creating one column family and opening it" << std::endl;
   ASSERT_EQ(0, db->create_and_open(cout, cfs));
@@ -470,8 +509,7 @@ TEST_P(KVTest, RocksDB_estimate_size) {
   if(string(GetParam()) != "rocksdb")
     GTEST_SKIP();
 
-  std::vector<KeyValueDB::ColumnFamily> cfs;
-  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
+  std::string cfs("cf1");
   ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
   cout << "creating one column family and opening it" << std::endl;
   ASSERT_EQ(0, db->create_and_open(cout));
@@ -503,8 +541,7 @@ TEST_P(KVTest, RocksDB_estimate_size_column_family) {
   if(string(GetParam()) != "rocksdb")
     GTEST_SKIP();
 
-  std::vector<KeyValueDB::ColumnFamily> cfs;
-  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
+  std::string cfs("cf1");
   ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
   cout << "creating one column family and opening it" << std::endl;
   ASSERT_EQ(0, db->create_and_open(cout, cfs));
@@ -531,6 +568,65 @@ TEST_P(KVTest, RocksDB_estimate_size_column_family) {
 
   fini();
 }
+
+TEST_P(KVTest, RocksDB_parse_sharding_def) {
+  if(string(GetParam()) != "rocksdb")
+    GTEST_SKIP();
+
+  bool result;
+  std::vector<RocksDBStore::ColumnFamily> sharding_def;
+  char const* error_position = nullptr;
+  std::string error_msg;
+
+  std::string_view text_def = "A(10,0-30) B(6)=option1,option2=aaaa C";
+  result = RocksDBStore::parse_sharding_def(text_def,
+					    sharding_def,
+					    &error_position,
+					    &error_msg);
+
+  ASSERT_EQ(result, true);
+  ASSERT_EQ(error_position, nullptr);
+  ASSERT_EQ(error_msg, "");
+  std::cout << text_def << std::endl;
+  if (error_position) std::cout << std::string(error_position - text_def.begin(), ' ') << "^" << error_msg << std::endl;
+
+  ASSERT_EQ(sharding_def.size(), 3);
+  ASSERT_EQ(sharding_def[0].name, "A");
+  ASSERT_EQ(sharding_def[0].shard_cnt, 10);
+  ASSERT_EQ(sharding_def[0].hash_l, 0);
+  ASSERT_EQ(sharding_def[0].hash_h, 30);
+
+  ASSERT_EQ(sharding_def[1].name, "B");
+  ASSERT_EQ(sharding_def[1].shard_cnt, 6);
+  ASSERT_EQ(sharding_def[1].options, "option1,option2=aaaa");
+  ASSERT_EQ(sharding_def[2].name, "C");
+  ASSERT_EQ(sharding_def[2].shard_cnt, 1);
+
+
+  text_def = "A(10 B(6)=option C";
+  result = RocksDBStore::parse_sharding_def(text_def,
+					    sharding_def,
+					    &error_position,
+					    &error_msg);
+  std::cout << text_def << std::endl;
+  if (error_position)
+    std::cout << std::string(error_position - text_def.begin(), ' ') << "^" << error_msg << std::endl;
+  ASSERT_EQ(result, false);
+  ASSERT_NE(error_position, nullptr);
+  ASSERT_NE(error_msg, "");
+
+  text_def = "A(10,1) B(6)=option C";
+  result = RocksDBStore::parse_sharding_def(text_def,
+					    sharding_def,
+					    &error_position,
+					    &error_msg);
+  std::cout << text_def << std::endl;
+  std::cout << std::string(error_position - text_def.begin(), ' ') << "^" << error_msg << std::endl;
+  ASSERT_EQ(result, false);
+  ASSERT_NE(error_position, nullptr);
+  ASSERT_NE(error_msg, "");
+}
+
 
 INSTANTIATE_TEST_SUITE_P(
   KeyValueDB,

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -665,10 +665,340 @@ TEST_P(KVTest, RocksDB_parse_sharding_def) {
 }
 
 
+
+class RocksDBShardingTest : public ::testing::TestWithParam<const char*> {
+public:
+  boost::scoped_ptr<KeyValueDB> db;
+
+  RocksDBShardingTest() : db(0) {}
+
+  string _bl_to_str(bufferlist val) {
+    string str(val.c_str(), val.length());
+    return str;
+  }
+
+  void rm_r(string path) {
+    string cmd = string("rm -r ") + path;
+    if (verbose)
+      cout << "==> " << cmd << std::endl;
+    int r = ::system(cmd.c_str());
+    if (r) {
+      cerr << "failed with exit code " << r
+	   << ", continuing anyway" << std::endl;
+    }
+  }
+
+  void SetUp() override {
+    verbose = getenv("VERBOSE") && strcmp(getenv("VERBOSE"), "1") == 0;
+
+    int r = ::mkdir("kv_test_temp_dir", 0777);
+    if (r < 0 && errno != EEXIST) {
+      r = -errno;
+      cerr << __func__ << ": unable to create kv_test_temp_dir: "
+	   << cpp_strerror(r) << std::endl;
+      return;
+    }
+    db.reset(KeyValueDB::create(g_ceph_context, "rocksdb",
+				"kv_test_temp_dir"));
+    ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
+    if (verbose)
+      cout << "Creating database with sharding: " << GetParam() << std::endl;
+    ASSERT_EQ(0, db->create_and_open(cout, GetParam()));
+  }
+  void TearDown() override {
+    db.reset(nullptr);
+    rm_r("kv_test_temp_dir");
+  }
+
+  /*
+    A - main 0/1/20
+    B - shard 1/3 x 0/1/20
+    C - main 0/1/20
+    D - shard 1/3 x 0/1/20
+    E - main 0/1/20
+  */
+  bool verbose;
+  std::vector<std::string> sharding_defs = {
+    "Betelgeuse D",
+    "Betelgeuse(3) D",
+    "Betelgeuse D(3)",
+    "Betelgeuse(3) D(3)"};
+  std::vector<std::string> prefixes = {"Ad", "Betelgeuse", "C", "D", "Evade"};
+  std::vector<std::string> randoms = {"0", "1", "2", "3", "4", "5",
+				      "found", "brain", "fully", "pen", "worth", "race",
+				      "stand", "nodded", "whenever", "surrounded", "industrial", "skin",
+				      "this", "direction", "family", "beginning", "whenever", "held",
+				      "metal", "year", "like", "valuable", "softly", "whistle",
+				      "perfectly", "broken", "idea", "also", "coffee", "branch",
+				      "tongue", "immediately", "bent", "partly", "burn", "include",
+				      "certain", "burst", "final", "smoke", "positive", "perfectly"
+  };
+  int R = randoms.size();
+
+  typedef int test_id[6];
+  void zero(test_id& x) {
+    k = 0;
+    v = 0;
+    for (auto& i:x)
+      i = 0;
+  }
+  bool end(const test_id& x) {
+    return x[5] != 0;
+  }
+  void next(test_id& x) {
+    x[0]++;
+    for (int i = 0; i < 5; i++) {
+      if (x[i] == 3) {
+	x[i] = 0;
+	++x[i + 1];
+      }
+    }
+  }
+
+  std::map<std::string, std::string> data;
+  int k = 0;
+  int v = 0;
+
+  void generate_data(const test_id& x) {
+    data.clear();
+    for (int i = 0; i < 5; i++) {
+      if (verbose)
+	std::cout << x[i] << "-";
+      switch (x[i]) {
+      case 0:
+	break;
+      case 1:
+	data[RocksDBStore::combine_strings(prefixes[i], randoms[k++ % R])] = randoms[v++ % R];
+	break;
+      case 2:
+	std::string base = randoms[k++ % R];
+	for (int j = 0; j < 10; j++) {
+	  data[RocksDBStore::combine_strings(prefixes[i], base + "." + randoms[k++ % R])] = randoms[v++ % R];
+	}
+	break;
+      }
+    }
+  }
+
+  void data_to_db() {
+    KeyValueDB::Transaction t = db->get_transaction();
+    for (auto &d : data) {
+      bufferlist v1;
+      v1.append(d.second);
+      string prefix;
+      string key;
+      RocksDBStore::split_key(d.first, &prefix, &key);
+      t->set(prefix, key, v1);
+      if (verbose)
+	std::cout << "SET " << prefix << " " << key << std::endl;
+    }
+    ASSERT_EQ(db->submit_transaction_sync(t), 0);
+  }
+
+  void clear_db() {
+    KeyValueDB::Transaction t = db->get_transaction();
+    for (auto &d : data) {
+      string prefix;
+      string key;
+      RocksDBStore::split_key(d.first, &prefix, &key);
+      t->rmkey(prefix, key);
+    }
+    ASSERT_EQ(db->submit_transaction_sync(t), 0);
+    //paranoid, check if db empty
+    KeyValueDB::WholeSpaceIterator it = db->get_wholespace_iterator();
+    ASSERT_EQ(it->seek_to_first(), 0);
+    ASSERT_EQ(it->valid(), false);
+  }
+};
+
+TEST_P(RocksDBShardingTest, wholespace_next) {
+  test_id X;
+  zero(X);
+  do {
+    generate_data(X);
+    data_to_db();
+
+    KeyValueDB::WholeSpaceIterator it = db->get_wholespace_iterator();
+    //move forward
+    auto dit = data.begin();
+    int r = it->seek_to_first();
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(it->valid(), (dit != data.end()));
+
+    while (dit != data.end()) {
+      ASSERT_EQ(it->valid(), true);
+      string prefix;
+      string key;
+      RocksDBStore::split_key(dit->first, &prefix, &key);
+      auto raw_key = it->raw_key();
+      ASSERT_EQ(raw_key.first, prefix);
+      ASSERT_EQ(raw_key.second, key);
+      ASSERT_EQ(it->value().to_str(), dit->second);
+      if (verbose)
+	std::cout << "next " << prefix << " " << key << std::endl;
+      ASSERT_EQ(it->next(), 0);
+      ++dit;
+    }
+    ASSERT_EQ(it->valid(), false);
+
+    clear_db();
+    next(X);
+  } while (!end(X));
+}
+
+TEST_P(RocksDBShardingTest, wholespace_prev) {
+  test_id X;
+  zero(X);
+  do {
+    generate_data(X);
+    data_to_db();
+
+    KeyValueDB::WholeSpaceIterator it = db->get_wholespace_iterator();
+    auto dit = data.rbegin();
+    int r = it->seek_to_last();
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(it->valid(), (dit != data.rend()));
+
+    while (dit != data.rend()) {
+      ASSERT_EQ(it->valid(), true);
+      string prefix;
+      string key;
+      RocksDBStore::split_key(dit->first, &prefix, &key);
+      auto raw_key = it->raw_key();
+      ASSERT_EQ(raw_key.first, prefix);
+      ASSERT_EQ(raw_key.second, key);
+      ASSERT_EQ(it->value().to_str(), dit->second);
+      if (verbose)
+	std::cout << "prev " << prefix << " " << key << std::endl;
+      ASSERT_EQ(it->prev(), 0);
+      ++dit;
+    }
+    ASSERT_EQ(it->valid(), false);
+
+    clear_db();
+    next(X);
+  } while (!end(X));
+}
+
+TEST_P(RocksDBShardingTest, wholespace_lower_bound) {
+  test_id X;
+  zero(X);
+  do {
+    generate_data(X);
+    data_to_db();
+
+    KeyValueDB::WholeSpaceIterator it = db->get_wholespace_iterator();
+    auto dit = data.begin();
+    int r = it->seek_to_first();
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(it->valid(), (dit != data.end()));
+
+    while (dit != data.end()) {
+      ASSERT_EQ(it->valid(), true);
+      string prefix;
+      string key;
+      RocksDBStore::split_key(dit->first, &prefix, &key);
+      KeyValueDB::WholeSpaceIterator it1 = db->get_wholespace_iterator();
+      ASSERT_EQ(it1->lower_bound(prefix, key), 0);
+      ASSERT_EQ(it1->valid(), true);
+      auto raw_key = it1->raw_key();
+      ASSERT_EQ(raw_key.first, prefix);
+      ASSERT_EQ(raw_key.second, key);
+      if (verbose)
+	std::cout << "lower_bound " << prefix << " " << key << std::endl;
+      ASSERT_EQ(it->next(), 0);
+      ++dit;
+    }
+    ASSERT_EQ(it->valid(), false);
+
+    clear_db();
+    next(X);
+  } while (!end(X));
+}
+
+TEST_P(RocksDBShardingTest, wholespace_upper_bound) {
+  test_id X;
+  zero(X);
+  do {
+    generate_data(X);
+    data_to_db();
+
+    KeyValueDB::WholeSpaceIterator it = db->get_wholespace_iterator();
+    auto dit = data.begin();
+    int r = it->seek_to_first();
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(it->valid(), (dit != data.end()));
+
+    while (dit != data.end()) {
+      ASSERT_EQ(it->valid(), true);
+      string prefix;
+      string key;
+      string key_minus_1;
+      RocksDBStore::split_key(dit->first, &prefix, &key);
+      //decrement key minimally
+      key_minus_1 = key.substr(0, key.length() - 1) + std::string(1, key[key.length() - 1] - 1);
+      KeyValueDB::WholeSpaceIterator it1 = db->get_wholespace_iterator();
+      ASSERT_EQ(it1->upper_bound(prefix, key_minus_1), 0);
+      ASSERT_EQ(it1->valid(), true);
+      auto raw_key = it1->raw_key();
+      ASSERT_EQ(raw_key.first, prefix);
+      ASSERT_EQ(raw_key.second, key);
+      if (verbose)
+	std::cout << "upper_bound " << prefix << " " << key_minus_1 << std::endl;
+      ASSERT_EQ(it->next(), 0);
+      ++dit;
+    }
+    ASSERT_EQ(it->valid(), false);
+
+    clear_db();
+    next(X);
+  } while (!end(X));
+}
+
+TEST_P(RocksDBShardingTest, wholespace_lookup_limits) {
+  test_id X;
+  zero(X);
+  do {
+    generate_data(X);
+    data_to_db();
+
+    //lookup before first
+    if (data.size() > 0) {
+      auto dit = data.begin();
+      string prefix;
+      string key;
+      RocksDBStore::split_key(dit->first, &prefix, &key);
+      KeyValueDB::WholeSpaceIterator it1 = db->get_wholespace_iterator();
+      ASSERT_EQ(it1->lower_bound(" ", " "), 0);
+      ASSERT_EQ(it1->valid(), true);
+      auto raw_key = it1->raw_key();
+      ASSERT_EQ(raw_key.first, prefix);
+      ASSERT_EQ(raw_key.second, key);
+    }
+    //lookup after last
+    KeyValueDB::WholeSpaceIterator it1 = db->get_wholespace_iterator();
+    ASSERT_EQ(it1->lower_bound("~", "~"), 0);
+    ASSERT_EQ(it1->valid(), false);
+
+    clear_db();
+    next(X);
+  } while (!end(X));
+}
+
+
+
 INSTANTIATE_TEST_SUITE_P(
   KeyValueDB,
   KVTest,
   ::testing::Values("leveldb", "rocksdb", "memdb"));
+
+INSTANTIATE_TEST_SUITE_P(
+  KeyValueDB,
+  RocksDBShardingTest,
+  ::testing::Values("Betelgeuse D",
+		    "Betelgeuse(3) D",
+		    "Betelgeuse D(3)",
+		    "Betelgeuse(3) D(3)"));
 
 int main(int argc, char **argv) {
   vector<const char*> args;


### PR DESCRIPTION
This solution allows to split large datasets into smaller parts.
When applied it reduces need for temporary space during compaction and reduces write amplification.
Split is applied on k-v prefixes. One db prefix will reside in multiple column families.
Set, get are transparently split to proper columns.
Iterator operations are transparently merged, so order is preserved.