### PR TITLE
nautilus: do_cmake.sh: fix application of -DWITH_RADOSGW_KAFKA_ENDPOINT=OFF

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -23,13 +23,13 @@ if [ -r /etc/os-release ]; then
           ;;
       opensuse*|suse|sles)
           PYBUILD="3"
-          WITH_RADOSGW_AMQP_ENDPOINT="OFF"
+          ARGS+=" -DWITH_RADOSGW_AMQP_ENDPOINT=OFF"
           WITH_RADOSGW_KAFKA_ENDPOINT="OFF"
           ;;
   esac
 elif [ "$(uname)" == FreeBSD ] ; then
   PYBUILD="3"
-  WITH_RADOSGW_AMQP_ENDPOINT="OFF"
+  ARGS+=" -DWITH_RADOSGW_AMQP_ENDPOINT=OFF"
   WITH_RADOSGW_KAFKA_ENDPOINT="OFF"
 else
   echo Unknown release
@@ -37,15 +37,12 @@ else
 fi
 
 if [ "$PYBUILD" = "3" ] ; then
-    ARGS="$ARGS -DWITH_PYTHON2=OFF -DWITH_PYTHON3=ON -DMGR_PYTHON_VERSION=3"
+    ARGS+=" -DWITH_PYTHON2=OFF -DWITH_PYTHON3=ON -DMGR_PYTHON_VERSION=3"
 fi
 
 if type ccache > /dev/null 2>&1 ; then
     echo "enabling ccache"
-    ARGS="$ARGS -DWITH_CCACHE=ON"
-fi
-if [ -n "$WITH_RADOSGW_AMQP_ENDPOINT" ] ; then
-    ARGS="$ARGS -DWITH_RADOSGW_AMQP_ENDPOINT=$WITH_RADOSGW_AMQP_ENDPOINT"
+    ARGS+=" -DWITH_CCACHE=ON"
 fi
 
 mkdir build

--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -24,13 +24,13 @@ if [ -r /etc/os-release ]; then
       opensuse*|suse|sles)
           PYBUILD="3"
           ARGS+=" -DWITH_RADOSGW_AMQP_ENDPOINT=OFF"
-          WITH_RADOSGW_KAFKA_ENDPOINT="OFF"
+          ARGS+=" -DWITH_RADOSGW_KAFKA_ENDPOINT=OFF"
           ;;
   esac
 elif [ "$(uname)" == FreeBSD ] ; then
   PYBUILD="3"
   ARGS+=" -DWITH_RADOSGW_AMQP_ENDPOINT=OFF"
-  WITH_RADOSGW_KAFKA_ENDPOINT="OFF"
+  ARGS+=" -DWITH_RADOSGW_KAFKA_ENDPOINT=OFF"
 else
   echo Unknown release
   exit 1


### PR DESCRIPTION
50ba25b2aa4db34319a7b95e789065540347f895 broke do_cmake.sh in nautilus
and the backport of 46b3d671b4408a766aaed379274242ad4b38afb3 (which
was included in the same PR) did not fix it enough.

This commit cannot be backported from master. It is needed to fix 
a partially broken backport.

After this commit is applied, the relevant part of do_cmake.sh in
nautilus will look exactly like it does now in master.

Fixes: 50ba25b2aa4db34319a7b95e789065540347f895
Fixes: https://tracker.ceph.com/issues/44641
Signed-off-by: Nathan Cutler <ncutler@suse.com>