### PR TITLE
doc/rbd: s/use use/use/

### DIFF
--- a/doc/rbd/rbd-snapshot.rst
+++ b/doc/rbd/rbd-snapshot.rst
@@ -12,7 +12,7 @@ quickly and easily. Ceph supports block device snapshots using the ``rbd``
 command and many higher level interfaces, including `QEMU`_, `libvirt`_, 
 `OpenStack`_ and `CloudStack`_.
 
-.. important:: To use use RBD snapshots, you must have a running Ceph cluster.
+.. important:: To use RBD snapshots, you must have a running Ceph cluster.
 
 .. note:: Because RBD does not know about the file system, snapshots are
 	  `crash-consistent` if they are not coordinated with the mounting


### PR DESCRIPTION
just a typo, really.

Signed-off-by: Peter Gervai <grin@grin.hu>

