### PR TITLE
ceph_test_rados_api_{watch_notify,misc}: tolerate some timeouts

### DIFF
--- a/qa/suites/rados/verify/ceph.yaml
+++ b/qa/suites/rados/verify/ceph.yaml
@@ -1,8 +1,6 @@
 overrides:
   ceph:
     conf:
-      global:
-        osd heartbeat grace: 60
       mon:
         mon min osdmap epochs: 50
         paxos service trim min: 10
@@ -12,8 +10,6 @@ overrides:
         mon osdmap full prune txsize: 2
       osd:
         debug monc: 20
-        debug ms: 1
-        debug osd: 20
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/verify/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/verify/tasks/rados_api_tests.yaml
@@ -23,6 +23,8 @@ overrides:
 tasks:
 - workunit:
     timeout: 6h
+    env:
+      ALLOW_TIMEOUTS: "1"
     clients:
       client.0:
         - rados/test.sh

--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -14,6 +14,8 @@ overrides:
         mon osd crush smoke test: false
       osd:
         osd fast shutdown: false
+        debug bluestore: 1
+        debug bluefs: 1
     log-whitelist:
       - overall HEALTH_
 # valgrind is slow.. we might get PGs stuck peering etc

--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -10,7 +10,6 @@ overrides:
     conf:
       global:
         osd heartbeat grace: 40
-        debug refs: 5
       mon:
         mon osd crush smoke test: false
       osd:

--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -22,6 +22,8 @@ overrides:
       - \(PG_
 # mons sometimes are left off of initial quorum due to valgrind slowness.  ok to whitelist here because we'll still catch an actual crash due to the core
       - \(MON_DOWN\)
+      - \(SLOW_OPS\)
+      - slow request
     valgrind:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]

--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -9,7 +9,7 @@ overrides:
   ceph:
     conf:
       global:
-        osd heartbeat grace: 40
+        osd heartbeat grace: 80
       mon:
         mon osd crush smoke test: false
       osd:

--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -318,7 +318,12 @@ static void shutdown_racer_func()
   int i;
 
   for (i = 0; i < niter; ++i) {
-    ASSERT_EQ("", connect_cluster(&rad));
+    auto r = connect_cluster(&rad);
+    if (getenv("ALLOW_TIMEOUTS")) {
+      ASSERT_TRUE(r == "" || r == "rados_connect failed with error -110");
+    } else {
+      ASSERT_EQ("", r);
+    }
     rados_shutdown(rad);
   }
 }

--- a/src/test/librados/watch_notify.cc
+++ b/src/test/librados/watch_notify.cc
@@ -92,7 +92,15 @@ TEST_F(LibRadosWatchNotify, WatchNotify) {
   uint64_t handle;
   ASSERT_EQ(0,
       rados_watch(ioctx, "foo", 0, &handle, watch_notify_test_cb, NULL));
-  ASSERT_EQ(0, rados_notify(ioctx, "foo", 0, NULL, 0));
+  for (unsigned i=0; i<10; ++i) {
+    int r = rados_notify(ioctx, "foo", 0, NULL, 0);
+    if (r == 0) {
+      break;
+    }
+    if (!getenv("ALLOW_TIMEOUTS")) {
+      ASSERT_EQ(0, r);
+    }
+  }
   TestAlarm alarm;
   sem_wait(sem);
   rados_unwatch(ioctx, "foo", handle);
@@ -112,7 +120,15 @@ TEST_F(LibRadosWatchNotifyEC, WatchNotify) {
   uint64_t handle;
   ASSERT_EQ(0,
       rados_watch(ioctx, "foo", 0, &handle, watch_notify_test_cb, NULL));
-  ASSERT_EQ(0, rados_notify(ioctx, "foo", 0, NULL, 0));
+  for (unsigned i=0; i<10; ++i) {
+    int r = rados_notify(ioctx, "foo", 0, NULL, 0);
+    if (r == 0) {
+      break;
+    }
+    if (!getenv("ALLOW_TIMEOUTS")) {
+      ASSERT_EQ(0, r);
+    }
+  }
   TestAlarm alarm;
   sem_wait(sem);
   rados_unwatch(ioctx, "foo", handle);

--- a/src/test/librados/watch_notify_cxx.cc
+++ b/src/test/librados/watch_notify_cxx.cc
@@ -94,7 +94,15 @@ TEST_P(LibRadosWatchNotifyPP, WatchNotify) {
   ASSERT_EQ(0, ioctx.list_watchers("foo", &watches));
   ASSERT_EQ(1u, watches.size());
   bufferlist bl2;
-  ASSERT_EQ(0, ioctx.notify("foo", 0, bl2));
+  for (unsigned i=0; i<10; ++i) {
+    int r = ioctx.notify("foo", 0, bl2);
+    if (r == 0) {
+      break;
+    }
+    if (!getenv("ALLOW_TIMEOUTS")) {
+      ASSERT_EQ(0, r);
+    }
+  }
   TestAlarm alarm;
   sem_wait(sem);
   ioctx.unwatch("foo", handle);
@@ -115,7 +123,15 @@ TEST_F(LibRadosWatchNotifyECPP, WatchNotify) {
   ASSERT_EQ(0, ioctx.list_watchers("foo", &watches));
   ASSERT_EQ(1u, watches.size());
   bufferlist bl2;
-  ASSERT_EQ(0, ioctx.notify("foo", 0, bl2));
+  for (unsigned i=0; i<10; ++i) {
+    int r = ioctx.notify("foo", 0, bl2);
+    if (r == 0) {
+      break;
+    }
+    if (!getenv("ALLOW_TIMEOUTS")) {
+      ASSERT_EQ(0, r);
+    }
+  }
   TestAlarm alarm;
   sem_wait(sem);
   ioctx.unwatch("foo", handle);


### PR DESCRIPTION
have the valgrind teuthology test set ALLOW_TIMEOUTS=1, and adjust
some tests to tolerate timeouts when that is set.