### PR TITLE
qa/workunits/cephadm/test_cephadm: --skip-monitoring-stack

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -191,7 +191,8 @@ $CEPHADM bootstrap \
       --output-config $CONFIG \
       --output-keyring $KEYRING \
       --allow-overwrite \
-      --skip-mon-network
+      --skip-mon-network \
+      --skip-monitoring-stack
 test -e $CONFIG
 test -e $KEYRING
 rm -f $ORIG_CONFIG


### PR DESCRIPTION
We're deploying these things manually later, and they use fixed ports.

Signed-off-by: Sage Weil <sage@redhat.com>