### PR TITLE
[WIP] cephadm: read everything when calling `mgr dump`

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -608,82 +608,23 @@ def call(command,  # type: List[str]
     fcntl.fcntl(process.stdout, fcntl.F_SETFL, stdout_flags | os.O_NONBLOCK)
     fcntl.fcntl(process.stderr, fcntl.F_SETFL, stderr_flags | os.O_NONBLOCK)
 
-    out = ''
-    err = ''
-    reads = None
-    stop = False
-    out_buffer = ''   # partial line (no newline yet)
-    err_buffer = ''   # partial line (no newline yet)
-    start_time = time.time()
-    end_time = None
-    if timeout:
-        end_time = start_time + timeout
-    while not stop:
-        if end_time and (time.time() >= end_time):
-            logger.info(desc + ':timeout after %s seconds' % timeout)
-            stop = True
-            process.kill()
-        if reads and process.poll() is not None:
-            # we want to stop, but first read off anything remaining
-            # on stdout/stderr
-            stop = True
-        else:
-            reads, _, _ = select.select(
-                [process.stdout.fileno(), process.stderr.fileno()],
-                [], [], timeout
-            )
-        for fd in reads:
-            try:
-                message_b = os.read(fd, 1024)
-                if isinstance(message_b, bytes):
-                    message = message_b.decode('utf-8')
-                if isinstance(message_b, str):
-                    message = message_b
-                if fd == process.stdout.fileno():
-                    out += message
-                    message = out_buffer + message
-                    lines = message.split('\n')
-                    out_buffer = lines.pop()
-                    for line in lines:
-                        if verbose:
-                            logger.info(desc + ':stdout ' + line)
-                        else:
-                            logger.debug(desc + ':stdout ' + line)
-                elif fd == process.stderr.fileno():
-                    err += message
-                    message = err_buffer + message
-                    lines = message.split('\n')
-                    err_buffer = lines.pop()
-                    for line in lines:
-                        if verbose:
-                            logger.info(desc + ':stderr ' + line)
-                        else:
-                            logger.debug(desc + ':stderr ' + line)
-                else:
-                    assert False
-            except (IOError, OSError):
-                pass
+    out_b, err_b = process.communicate(timeout=timeout)
+    out, err = out_b.decode('utf-8'), err_b.decode('utf-8')
 
     returncode = process.wait()
 
-    if out_buffer != '':
-        if verbose:
-            logger.info(desc + ':stdout ' + out_buffer)
-        else:
-            logger.debug(desc + ':stdout ' + out_buffer)
-    if err_buffer != '':
-        if verbose:
-            logger.info(desc + ':stderr ' + err_buffer)
-        else:
-            logger.debug(desc + ':stderr ' + err_buffer)
-
-    if returncode != 0 and verbose_on_failure and not verbose:
-        # dump stdout + stderr
+    if returncode != 0:
         logger.info('Non-zero exit code %d from %s' % (returncode, ' '.join(command)))
-        for line in out.splitlines():
-            logger.info(desc + ':stdout ' + line)
-        for line in err.splitlines():
-            logger.info(desc + ':stderr ' + line)
+
+    if (returncode != 0 and verbose_on_failure) or verbose:
+        logger_fn = logger.info
+    else:
+        logger_fn = logger.debug
+    # dump stdout + stderr
+    for line in out.splitlines():
+        logger_fn(desc + ':stdout ' + line)
+    for line in err.splitlines():
+        logger_fn(desc + ':stderr ' + line)
 
     return out, err, returncode
 


### PR DESCRIPTION
Fixes a bug where the output is
truncated after about 100k chars

Fixes: https://tracker.ceph.com/issues/44642

## TODO: 

- [x] `ceph-salt deploy` still hangs. 

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
