### PR TITLE
qa/workunits/rbd: use context managers to control Rados lifespan

### DIFF
--- a/qa/workunits/rbd/permissions.sh
+++ b/qa/workunits/rbd/permissions.sh
@@ -168,12 +168,11 @@ create_self_managed_snapshot() {
   cat << EOF | CEPH_ARGS="-k $KEYRING" python3
 import rados
 
-cluster = rados.Rados(conffile="", rados_id="${ID}")
-cluster.connect()
-ioctx = cluster.open_ioctx("${POOL}")
+with rados.Rados(conffile="", rados_id="${ID}") as cluster:
+  ioctx = cluster.open_ioctx("${POOL}")
 
-snap_id = ioctx.create_self_managed_snap()
-print ("Created snap id {}".format(snap_id))
+  snap_id = ioctx.create_self_managed_snap()
+  print ("Created snap id {}".format(snap_id))
 EOF
 }
 
@@ -184,19 +183,17 @@ remove_self_managed_snapshot() {
   cat << EOF | CEPH_ARGS="-k $KEYRING" python3
 import rados
 
-cluster1 = rados.Rados(conffile="", rados_id="mon_write")
-cluster1.connect()
-ioctx1 = cluster1.open_ioctx("${POOL}")
+with rados.Rados(conffile="", rados_id="mon_write") as cluster1, \
+     rados.Rados(conffile="", rados_id="${ID}") as cluster2:
+  ioctx1 = cluster1.open_ioctx("${POOL}")
 
-snap_id = ioctx1.create_self_managed_snap()
-print ("Created snap id {}".format(snap_id))
+  snap_id = ioctx1.create_self_managed_snap()
+  print ("Created snap id {}".format(snap_id))
 
-cluster2 = rados.Rados(conffile="", rados_id="${ID}")
-cluster2.connect()
-ioctx2 = cluster2.open_ioctx("${POOL}")
+  ioctx2 = cluster2.open_ioctx("${POOL}")
 
-ioctx2.remove_self_managed_snap(snap_id)
-print ("Removed snap id {}".format(snap_id))
+  ioctx2.remove_self_managed_snap(snap_id)
+  print ("Removed snap id {}".format(snap_id))
 EOF
 }
 


### PR DESCRIPTION
There is a potential race between the expected exceptions being
thrown and Python shutting down racing with librados background
threads. Ensure that librados is properly shut down prior to
exiting Python.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
