### PR TITLE
rgw: clean up attempt loop in ordered listing

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1781,14 +1781,9 @@ int RGWRados::Bucket::List::list_objects_ordered(
   }
 
   rgw_obj_index_key prev_marker;
-  uint16_t attempt = 0;
-  while (true) {
+  for (uint16_t attempt = 1; /* empty */; ++attempt) {
     ldout(cct, 20) << "RGWRados::Bucket::List::" << __func__ <<
-      " beginning attempt=" << ++attempt << dendl;
-
-    // this loop is generally expected only to have a single
-    // iteration; the standard exit is at the bottom of the loop, but
-    // there's an error condition emergency exit as well
+      " starting attempt " << attempt << dendl;
 
     if (attempt > 1 && !(prev_marker < cur_marker)) {
       // we've failed to make forward progress
@@ -1983,11 +1978,7 @@ int RGWRados::Bucket::List::list_objects_ordered(
       // few, results, return with what we have
       break;
     }
-
-    ldout(cct, 1) << "RGWRados::Bucket::List::" << __func__ <<
-      " INFO ordered bucket listing requires read #" << (1 + attempt) <<
-      dendl;
-  } // read attempt loop
+  } // for (uint16_t attempt...
 
 done:
 


### PR DESCRIPTION
Convert a while loop into a for loop to better indicate how the "attempt" lcv is managed.

This is a clean-up, so no backports are necessary. No tracker is necessary.