### PR TITLE
build: Add WITH_BOOST_VALGRIND option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -656,6 +656,9 @@ if(WITH_GRAFANA)
   add_subdirectory(monitoring/grafana/dashboards)
 endif()
 
+CMAKE_DEPENDENT_OPTION(WITH_BOOST_VALGRIND "Boost support for valgrind" OFF
+  "NOT WITH_SYSTEM_BOOST" OFF)
+
 include(CTags)
 option(CTAG_EXCLUDES "Exclude files/directories when running ctag.")
 add_tags(ctags

--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -131,6 +131,9 @@ function(do_build_boost version)
     list(APPEND b2 architecture=arm)
     list(APPEND b2 binary-format=elf)
   endif()
+  if(WITH_BOOST_VALGRIND)
+    list(APPEND b2 valgrind=on)
+  endif()
   set(build_command
     ${b2} headers stage
     #"--buildid=ceph" # changes lib names--can omit for static
@@ -224,6 +227,10 @@ macro(build_boost version)
       INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
       IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
       IMPORTED_LOCATION "${Boost_${upper_c}_LIBRARY}")
+    if(c MATCHES "coroutine|context")
+      set_target_properties(Boost::${c} PROPERTIES
+	INTERFACE_COMPILE_DEFINITIONS "BOOST_USE_VALGRIND")
+    endif()
     list(APPEND Boost_LIBRARIES ${Boost_${upper_c}_LIBRARY})
   endforeach()
   foreach(c ${Boost_BUILD_COMPONENTS})


### PR DESCRIPTION
To build Boost.Context (and other libraries) with support to allow
them to be valground usefully, and to include the define to link
against them.