### PR TITLE
doc: Fixes a spelling error at /doc/radosgw/dynamicresharding.rst

### DIFF
--- a/doc/radosgw/dynamicresharding.rst
+++ b/doc/radosgw/dynamicresharding.rst
@@ -21,7 +21,7 @@ reduction of the number of entries in each bucket index shard. This
 process is transparent to the user.
 
 By default dynamic bucket index resharding can only increase the
-number of bucket index sharts to 1999, although the upper-bound is a
+number of bucket index shards to 1999, although the upper-bound is a
 configuration parameter (see Configuration below). Furthermore, when
 possible, the process chooses a prime number of bucket index shards to
 help spread the number of bucket index entries across the bucket index

--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -1029,19 +1029,15 @@ size_t AWSv4ComplMulti::recv_body(char* const buf, const size_t buf_max)
   size_t buf_pos = 0; 
   size_t buf_incomplement_size = buf_max; //bul_max is 4M, exclude the last muiltpart
 
-  size_t len  = 0;
   while (buf_incomplement_size > 0){
-          const auto read_len = recv_chunk_body( buf+buf_pos, buf_max);
-          cout << "AWSv4ComplMulti: recv_chunk_body len=" << read_len << std::endl;
+    const auto read_len = recv_chunk_body( buf+buf_pos, buf_max);
 
-         if (read_len == 0)
-         {
-            break;
-         }
+    if (read_len == 0) {
+      break;
+    }
 
-          len =  read_len;
-          buf_pos += len;
-          buf_incomplement_size -= len;
+    buf_pos += read_len;
+    buf_incomplement_size -= read_len;
   }
 
   dout(20) << "AWSv4ComplMulti: filled=" << buf_pos << dendl;

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -364,6 +364,7 @@ public:
 
   /* rgw::io::DecoratedRestfulClient. */
   size_t recv_body(char* buf, size_t max) override;
+  size_t recv_chunk_body(char* const buf, const size_t buf_max);
 
   /* rgw::auth::Completer. */
   void modify_request_state(const DoutPrefixProvider* dpp, req_state* s_rw) override;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: bangmingcheng <bangmingcheng@gmail.com>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
Commit : wip-doc-ceph-chenbm
Author: bangmingcheng <bangmingcheng@gmail.com>
Date:   Thur,  March 19 2020
doc: Fixes a spelling error at /doc/radosgw/dynamicresharding.rst
    In the dynamicresharding.rst, there is a spelling error in  "bucket index sharts to 1999".  it  should be "shards" not "sharts", so  i fix it in this doc.

Signed-off-by: bangmingcheng <bangmingcheng@gmail.com>
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
