### PR TITLE
doc: fix a spelling error at /doc/radosgw/dynamicresharding.rst

### DIFF
--- a/doc/radosgw/dynamicresharding.rst
+++ b/doc/radosgw/dynamicresharding.rst
@@ -21,7 +21,7 @@ reduction of the number of entries in each bucket index shard. This
 process is transparent to the user.
 
 By default dynamic bucket index resharding can only increase the
-number of bucket index sharts to 1999, although the upper-bound is a
+number of bucket index shards to 1999, although the upper-bound is a
 configuration parameter (see Configuration below). Furthermore, when
 possible, the process chooses a prime number of bucket index shards to
 help spread the number of bucket index entries across the bucket index


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

Commit : wip-doc-ceph-chenbm
Author: bangmingcheng<bangmingcheng@gmail.com>
Date: Thur, March 19 2020
doc: Fixes a spelling error at /doc/radosgw/dynamicresharding.rst
In the dynamicresharding.rst, there is a spelling error in "bucket index sharts to 1999". it should be "shards" not "sharts", so i fix it in this doc.

Signed-off-by: bangmingcheng<bangmingcheng@gmail.com>
## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
