### PR TITLE
mgr/telegraf: Catch FileNotFoundError on sending statistics

### DIFF
--- a/src/pybind/mgr/telegraf/module.py
+++ b/src/pybind/mgr/telegraf/module.py
@@ -249,7 +249,7 @@ class Module(MgrModule):
                                 measurement['tags'], now)
                     self.log.debug(line.to_line_protocol())
                     s.send(line.to_line_protocol())
-            except (socket.error, RuntimeError, IOError, OSError):
+            except (socket.error, RuntimeError, IOError, OSError, FileNotFoundError):
                 self.log.exception('Failed to send statistics to Telegraf:')
 
     def shutdown(self):


### PR DESCRIPTION
The default Unix socket '/tmp/telegraf.sock' might not exist and
this will cause an FileNotFoundError to be raised by Python.

We should catch it and then log about it. Not issue a HEALTH_WARN
in Ceph.

Fixes: https://tracker.ceph.com/issues/43551
