### PR TITLE
qa/*/osd-markdown.sh: propagate map to osd before testing its reaction

### DIFF
--- a/qa/standalone/osd/osd-markdown.sh
+++ b/qa/standalone/osd/osd-markdown.sh
@@ -42,6 +42,7 @@ function markdown_N_impl() {
   for i in `seq 1 $markdown_times`
   do
     # check the OSD is UP
+    ceph tell osd.0 get_latest_osdmap || return 1
     ceph osd tree
     ceph osd tree | grep osd.0 |grep up || return 1
     # mark the OSD down.
@@ -98,6 +99,7 @@ function TEST_markdown_boot() {
     markdown_N_impl $count $period $sleeptime
     #down N times, osd.0 should be up
     sleep 15  # give osd plenty of time to notice and come back up
+    ceph tell osd.0 get_latest_osdmap || return 1
     ceph osd tree | grep up | grep osd.0 || return 1
 }
 
@@ -121,6 +123,7 @@ function TEST_markdown_boot_exceed_time() {
 
     markdown_N_impl $(($count+1)) $period $sleeptime
     sleep 15  # give osd plenty of time to notice and come back up
+    ceph tell osd.0 get_latest_osdmap || return 1
     ceph osd tree | grep up | grep osd.0 || return 1
 }
 


### PR DESCRIPTION
Mon might fail to share the newest map with any of up osds, e.g.,
due to an injected broken pipe. Since we don't have any client
activities during the osd-markdown tests, osds might be unaware of
the map changes made through CLI. Make sure osds have pulled the
newest map down before we can test its reaction correctly.

Fixes: https://tracker.ceph.com/issues/44662
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
