### PR TITLE
client: consider inode's last read/write when calculating wanted caps

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3629,8 +3629,12 @@ void Client::check_caps(Inode *in, unsigned flags)
     }
 
     /* want more caps from mds? */
-    if (wanted & ~(cap.wanted | cap.issued))
-      goto ack;
+    if (wanted & ~cap.wanted) {
+      if (wanted & ~(cap.wanted | cap.issued))
+	goto ack;
+      if (!in->cap_is_valid(cap))
+	goto ack;
+    }
 
     if (!revoking && unmounting && (cap_used == 0))
       goto ack;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -293,6 +293,9 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
 
   lru.lru_set_midpoint(cct->_conf->client_cache_mid);
 
+  caps_wanted_delay_min = cct->_conf.get_val<uint64_t>( "client_caps_wanted_delay_min");
+  caps_wanted_delay_max = cct->_conf.get_val<uint64_t>( "client_caps_wanted_delay_max");
+
   // file handles
   free_fd_set.insert(10, 1<<30);
 
@@ -2217,6 +2220,8 @@ void Client::send_request(MetaRequest *request, MetaSession *session,
   auto r = build_client_request(request);
   if (request->dentry()) {
     r->set_dentry_wanted();
+    if (Inode *dir = request->inode())
+      dir->touch_open_ref(CEPH_FILE_MODE_RD);
   }
   if (request->got_unsafe) {
     r->set_replayed_op();
@@ -2242,8 +2247,7 @@ void Client::send_request(MetaRequest *request, MetaSession *session,
   }
   request->mds = mds;
 
-  Inode *in = request->inode();
-  if (in) {
+  if (Inode *in = request->inode()) {
     auto it = in->caps.find(mds);
     if (it != in->caps.end()) {
       request->sent_on_mseq = it->second.mseq;
@@ -2820,9 +2824,10 @@ void Client::send_reconnect(MetaSession *session)
       }
 
       Cap &cap = it->second;
+      cap.wanted = in->caps_wanted();
       ldout(cct, 10) << " caps on " << p->first
 	       << " " << ccap_string(cap.issued)
-	       << " wants " << ccap_string(in->caps_wanted())
+	       << " wants " << ccap_string(cap.wanted)
 	       << dendl;
       filepath path;
       in->make_long_path(path);
@@ -2848,7 +2853,7 @@ void Client::send_reconnect(MetaSession *session)
       m->add_cap(p->first.ino, 
 		 cap.cap_id,
 		 path.get_ino(), path.get_path(),   // ino
-		 in->caps_wanted(), // wanted
+		 cap.wanted, // wanted
 		 cap.issued,     // issued
 		 in->snaprealm->ino,
 		 snap_follows,
@@ -3238,13 +3243,20 @@ int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
   if (r < 0)
     return r;
 
+  if (((need & CEPH_CAP_FILE_RD) && !in->is_opened_for_read()) ||
+      ((need & CEPH_CAP_FILE_WR) && !in->is_opened_for_write())) {
+    ldout(cct, 10) << "get_caps " << *in << " need " << ccap_string(need) << " EBADF " << dendl;
+    return -EBADF;
+  }
+
   while (1) {
-    int file_wanted = in->caps_file_wanted();
-    if ((file_wanted & need) != need) {
-      ldout(cct, 10) << "get_caps " << *in << " need " << ccap_string(need)
-		     << " file_wanted " << ccap_string(file_wanted) << ", EBADF "
-		     << dendl;
-      return -EBADF;
+    if (need & (CEPH_CAP_FILE_RD | CEPH_CAP_FILE_WR)) {
+      int fmode = 0;
+      if (need & CEPH_CAP_FILE_RD)
+       fmode |= CEPH_FILE_MODE_RD;
+      if (need & CEPH_CAP_FILE_WR)
+       fmode |= CEPH_FILE_MODE_WR;
+      in->touch_open_ref(fmode);
     }
 
     if ((fh->mode & CEPH_FILE_MODE_WR) && fh->gen != fd_gen)
@@ -3323,10 +3335,12 @@ int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
       continue;
     }
 
+    in->inc_cap_waiter(need);
     if (waitfor_caps)
       wait_on_list(in->waitfor_caps);
     else if (waitfor_commit)
       wait_on_list(in->waitfor_commit);
+    in->dec_cap_waiter(need);
   }
 }
 
@@ -3343,7 +3357,7 @@ void Client::cap_delay_requeue(Inode *in)
 {
   ldout(cct, 10) << __func__ << " on " << *in << dendl;
   in->hold_caps_until = ceph_clock_now();
-  in->hold_caps_until += cct->_conf->client_caps_release_delay;
+  in->hold_caps_until += caps_wanted_delay_max;
   delayed_list.push_back(&in->delay_cap_item);
 }
 
@@ -3519,7 +3533,7 @@ static int adjust_caps_used_for_lazyio(int used, int issued, int implemented)
  */
 void Client::check_caps(Inode *in, unsigned flags)
 {
-  unsigned wanted = in->caps_wanted();
+  unsigned file_wanted = in->caps_file_wanted();
   unsigned used = get_caps_used(in);
   unsigned cap_used;
 
@@ -3530,6 +3544,7 @@ void Client::check_caps(Inode *in, unsigned flags)
   int orig_used = used;
   used = adjust_caps_used_for_lazyio(used, issued, implemented);
 
+  unsigned wanted = file_wanted;
   int retain = wanted | used | CEPH_CAP_PIN;
   if (!unmounting && in->nlink > 0) {
     if (wanted) {
@@ -3551,6 +3566,9 @@ void Client::check_caps(Inode *in, unsigned flags)
 	retain |= CEPH_CAP_ANY_RD;
     }
   }
+  // match in->caps_wanted()
+  if (used & CEPH_CAP_FILE_BUFFER)
+    wanted |= CEPH_CAP_FILE_EXCL;
 
   ldout(cct, 10) << __func__ << " on " << *in
 	   << " wanted " << ccap_string(wanted)
@@ -3654,6 +3672,11 @@ void Client::check_caps(Inode *in, unsigned flags)
     send_cap(in, session, &cap, msg_flags, cap_used, wanted, retain,
 	     flushing, flush_tid);
   }
+
+  if ((file_wanted & ~CEPH_CAP_PIN) &&
+      !(used & (CEPH_CAP_FILE_RD | CEPH_CAP_ANY_FILE_WR)) &&
+      !in->delay_cap_item.is_on_list())
+    cap_delay_requeue(in);
 }
 
 
@@ -4405,7 +4428,7 @@ void Client::force_session_readonly(MetaSession *s)
   s->readonly = true;
   for (xlist<Cap*>::iterator p = s->caps.begin(); !p.end(); ++p) {
     auto &in = (*p)->inode;
-    if (in.caps_wanted() & CEPH_CAP_FILE_WR)
+    if (in.caps_file_wanted() & CEPH_CAP_FILE_WR)
       signal_cond_list(in.waitfor_caps);
   }
 }
@@ -4465,15 +4488,20 @@ void Client::flush_caps_sync()
 {
   ldout(cct, 10) << __func__ << dendl;
   xlist<Inode*>::iterator p = delayed_list.begin();
+  size_t n = delayed_list.size();
   while (!p.end()) {
     unsigned flags = CHECK_CAPS_NODELAY;
     Inode *in = *p;
 
     ++p;
+    --n;
     delayed_list.pop_front();
-    if (p.end() && dirty_list.empty())
+    if (!n && dirty_list.empty())
       flags |= CHECK_CAPS_SYNCHRONOUS;
     check_caps(in, flags);
+    // check_caps() may requeue current inode
+    if (!n)
+      break;
   }
 
   // other caps, too
@@ -4541,13 +4569,12 @@ void Client::kick_flushing_caps(Inode *in, MetaSession *session)
     }
   }
 
-  int wanted = in->caps_wanted();
   int used = get_caps_used(in) | in->caps_dirty();
   auto it = in->cap_snaps.begin();
   for (auto& p : in->flushing_cap_tids) {
     if (p.second) {
       int msg_flags = p.first < last_snap_flush ? MClientCaps::FLAG_PENDING_CAPSNAP : 0;
-      send_cap(in, session, cap, msg_flags, used, wanted, (cap->issued | cap->implemented),
+      send_cap(in, session, cap, msg_flags, used, cap->wanted, (cap->issued | cap->implemented),
 	       p.second, p.first);
     } else {
       ceph_assert(it != in->cap_snaps.end());
@@ -5259,7 +5286,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
 {
   mds_rank_t mds = session->mds_num;
   int used = get_caps_used(in);
-  int wanted = in->caps_wanted();
+  int wanted = in->caps_file_wanted();
 
   const unsigned new_caps = m->get_caps();
   const bool was_stale = session->cap_gen > cap->gen;
@@ -6507,6 +6534,7 @@ int Client::_lookup(Inode *dir, const string& dname, int mask, InodeRef *target,
   goto done;
 
  hit_dn:
+  dir->touch_open_ref(CEPH_FILE_MODE_RD);
   if (dn->inode) {
     *target = dn->inode;
   } else {
@@ -8210,8 +8238,9 @@ int Client::readdir_r_cb(dir_result_t *d, add_dirent_cb_t cb, void *p,
     return -ENOTCONN;
 
   dir_result_t *dirp = static_cast<dir_result_t*>(d);
+  InodeRef& diri = dirp->inode;
 
-  ldout(cct, 10) << __func__ << " " << *dirp->inode << " offset " << hex << dirp->offset
+  ldout(cct, 10) << __func__ << " " << *diri << " offset " << hex << dirp->offset
 		 << dec << " at_end=" << dirp->at_end()
 		 << " hash_order=" << dirp->hash_order() << dendl;
 
@@ -8220,7 +8249,6 @@ int Client::readdir_r_cb(dir_result_t *d, add_dirent_cb_t cb, void *p,
   memset(&de, 0, sizeof(de));
   memset(&stx, 0, sizeof(stx));
 
-  InodeRef& diri = dirp->inode;
 
   if (dirp->at_end())
     return 0;
@@ -8290,13 +8318,18 @@ int Client::readdir_r_cb(dir_result_t *d, add_dirent_cb_t cb, void *p,
 
   // can we read from our cache?
   ldout(cct, 10) << "offset " << hex << dirp->offset << dec
-	   << " snapid " << dirp->inode->snapid << " (complete && ordered) "
-	   << dirp->inode->is_complete_and_ordered()
-	   << " issued " << ccap_string(dirp->inode->caps_issued())
+	   << " snapid " << diri->snapid << " (complete && ordered) "
+	   << diri->is_complete_and_ordered()
+	   << " issued " << ccap_string(diri->caps_issued())
 	   << dendl;
-  if (dirp->inode->snapid != CEPH_SNAPDIR &&
-      dirp->inode->is_complete_and_ordered() &&
-      dirp->inode->caps_issued_mask(CEPH_CAP_FILE_SHARED, true)) {
+
+
+  // request Fx cap. if have Fx, we don't need to release Fs cap for later create/unlink.
+  diri->touch_open_ref(CEPH_FILE_MODE_WR);
+
+  if (diri->snapid != CEPH_SNAPDIR &&
+      diri->is_complete_and_ordered() &&
+      diri->caps_issued_mask(CEPH_CAP_FILE_SHARED, true)) {
     int err = _readdir_cache_cb(dirp, cb, p, caps, getref);
     if (err != -EAGAIN)
       return err;
@@ -14708,6 +14741,13 @@ void Client::handle_conf_change(const ConfigProxy& conf,
     acl_type = NO_ACL;
     if (cct->_conf->client_acl_type == "posix_acl")
       acl_type = POSIX_ACL;
+  }
+
+  if (changed.count("client_caps_wanted_delay_min")) {
+    caps_wanted_delay_min = cct->_conf.get_val<uint64_t>( "client_caps_wanted_delay_min");
+  }
+  if (changed.count("client_caps_wanted_delay_max")) {
+    caps_wanted_delay_max = cct->_conf.get_val<uint64_t>( "client_caps_wanted_delay_max");
   }
 }
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3229,7 +3229,7 @@ void Client::put_cap_ref(Inode *in, int cap)
       ++put_nref;
     }
     if (drop)
-      check_caps(in, 0);
+      check_caps(in);
     if (put_nref)
       put_inode(in, put_nref);
   }
@@ -3281,7 +3281,7 @@ int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
 	 }
 	 if (in->wanted_max_size > in->max_size &&
 	     in->wanted_max_size > in->requested_max_size)
-	   check_caps(in, 0);
+	   check_caps(in);
       }
 
       if (endoff >= 0 && endoff > (loff_t)in->max_size) {
@@ -3638,12 +3638,6 @@ void Client::check_caps(Inode *in, unsigned flags)
     if ((cap.issued & ~retain) == 0 && // and we don't have anything we wouldn't like
 	!in->dirty_caps)               // and we have no dirty caps
       continue;
-
-    if (!(flags & CHECK_CAPS_NODELAY)) {
-      ldout(cct, 10) << "delaying cap release" << dendl;
-      cap_delay_requeue(in);
-      continue;
-    }
 
   ack:
     if (&cap == in->auth_cap) {
@@ -4131,7 +4125,7 @@ void Client::add_update_cap(Inode *in, MetaSession *mds_session, uint64_t cap_id
       if (&p.second == &cap)
 	continue;
       if (p.second.implemented & ~p.second.issued & issued) {
-	check_caps(in, CHECK_CAPS_NODELAY);
+	check_caps(in) ;
 	break;
       }
     }
@@ -4490,7 +4484,7 @@ void Client::flush_caps_sync()
   xlist<Inode*>::iterator p = delayed_list.begin();
   size_t n = delayed_list.size();
   while (!p.end()) {
-    unsigned flags = CHECK_CAPS_NODELAY;
+    unsigned flags = 0;
     Inode *in = *p;
 
     ++p;
@@ -4507,7 +4501,7 @@ void Client::flush_caps_sync()
   // other caps, too
   p = dirty_list.begin();
   while (!p.end()) {
-    unsigned flags = CHECK_CAPS_NODELAY;
+    unsigned flags = 0;
     Inode *in = *p;
 
     ++p;
@@ -5427,7 +5421,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
   }
 
   if (check)
-    check_caps(in, 0);
+    check_caps(in);
 
   // wake up waiters
   if (new_caps)
@@ -6366,7 +6360,7 @@ void Client::tick()
     if (in->hold_caps_until > now)
       break;
     delayed_list.pop_front();
-    check_caps(in, CHECK_CAPS_NODELAY);
+    check_caps(in);
   }
 
   trim_cache(true);
@@ -8864,7 +8858,7 @@ int Client::_release_fh(Fh *f)
   if (in->snapid == CEPH_NOSNAP) {
     if (in->put_open_ref(f->mode)) {
       _flush(in, new C_Client_FlushComplete(this, in));
-      check_caps(in, 0);
+      check_caps(in);
     }
   } else {
     ceph_assert(in->snap_cap_refs > 0);
@@ -8916,7 +8910,7 @@ int Client::_open(Inode *in, int flags, mode_t mode, Fh **fhp,
 
   if ((flags & O_TRUNC) == 0 && in->caps_issued_mask(want)) {
     // update wanted?
-    check_caps(in, CHECK_CAPS_NODELAY);
+    check_caps(in);
   } else {
 
     MetaRequest *req = new MetaRequest(CEPH_MDS_OP_OPEN);
@@ -8982,7 +8976,7 @@ int Client::_renew_caps(Inode *in)
   int wanted = in->caps_file_wanted();
   if (in->is_any_caps() &&
       ((wanted & CEPH_CAP_ANY_WR) == 0 || in->auth_cap)) {
-    check_caps(in, CHECK_CAPS_NODELAY);
+    check_caps(in);
     return 0;
   }
 
@@ -9376,7 +9370,7 @@ done:
       in->inline_data.clear();
       in->inline_version = CEPH_INLINE_NONE;
       in->mark_caps_dirty(CEPH_CAP_FILE_WR);
-      check_caps(in, 0);
+      check_caps(in);
     } else
       r = ret;
   }
@@ -9830,11 +9824,9 @@ success:
     in->size = totalwritten + offset;
     in->mark_caps_dirty(CEPH_CAP_FILE_WR);
 
-    if (is_quota_bytes_approaching(in, f->actor_perms)) {
-      check_caps(in, CHECK_CAPS_NODELAY);
-    } else if (is_max_size_approaching(in)) {
-      check_caps(in, 0);
-    }
+    if (is_max_size_approaching(in) ||
+	is_quota_bytes_approaching(in, f->actor_perms))
+      check_caps(in);
 
     ldout(cct, 7) << "wrote to " << totalwritten+offset << ", extending file size" << dendl;
   } else {
@@ -9857,7 +9849,7 @@ done:
       in->inline_data.clear();
       in->inline_version = CEPH_INLINE_NONE;
       in->mark_caps_dirty(CEPH_CAP_FILE_WR);
-      check_caps(in, 0);
+      check_caps(in);
     } else
       r = uninline_ret;
   }
@@ -9964,7 +9956,7 @@ int Client::_fsync(Inode *in, bool syncdataonly)
   }
   
   if (!syncdataonly && in->dirty_caps) {
-    check_caps(in, CHECK_CAPS_NODELAY|CHECK_CAPS_SYNCHRONOUS);
+    check_caps(in, CHECK_CAPS_SYNCHRONOUS);
     if (in->flushing_caps)
       flush_tid = last_flush_tid;
   } else ldout(cct, 10) << "no metadata needs to commit" << dendl;
@@ -10683,12 +10675,12 @@ int Client::_lazyio(Fh *fh, int enable)
     fh->mode |= CEPH_FILE_MODE_LAZY;
     in->get_open_ref(fh->mode);
     in->put_open_ref(orig_mode);
-    check_caps(in, CHECK_CAPS_NODELAY);
+    check_caps(in);
   } else {
     fh->mode &= ~CEPH_FILE_MODE_LAZY;
     in->get_open_ref(fh->mode);
     in->put_open_ref(orig_mode);
-    check_caps(in, 0);
+    check_caps(in);
   }
 
   return 0;
@@ -13734,11 +13726,9 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
       in->change_attr++;
       in->mark_caps_dirty(CEPH_CAP_FILE_WR);
 
-      if (is_quota_bytes_approaching(in, fh->actor_perms)) {
-        check_caps(in, CHECK_CAPS_NODELAY);
-      } else if (is_max_size_approaching(in)) {
-	check_caps(in, 0);
-      }
+      if (is_max_size_approaching(in) ||
+	  is_quota_bytes_approaching(in, fh->actor_perms))
+	check_caps(in);
     }
   }
 
@@ -13751,7 +13741,7 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
       in->inline_data.clear();
       in->inline_version = CEPH_INLINE_NONE;
       in->mark_caps_dirty(CEPH_CAP_FILE_WR);
-      check_caps(in, 0);
+      check_caps(in);
     } else
       r = ret;
   }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3315,16 +3315,12 @@ int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
 	in->auth_cap->session->readonly)
       return -EROFS;
 
-    if (in->flags & I_CAP_DROPPED) {
-      int mds_wanted = in->caps_mds_wanted();
-      if ((mds_wanted & need) != need) {
-	int ret = _renew_caps(in);
-	if (ret < 0)
-	  return ret;
-	continue;
-      }
-      if (!(file_wanted & ~mds_wanted))
-	in->flags &= ~I_CAP_DROPPED;
+    int mds_wanted = in->caps_mds_wanted();
+    if ((mds_wanted & need) != need) {
+      int ret = _renew_caps(in);
+      if (ret < 0)
+	return ret;
+      continue;
     }
 
     if (waitfor_caps)
@@ -3866,9 +3862,6 @@ void Client::wake_up_session_caps(MetaSession *s, bool reconnect)
       if (cap->gen < s->cap_gen) {
 	// mds did not re-issue stale cap.
 	cap->issued = cap->implemented = CEPH_CAP_PIN;
-	// make sure mds knows what we want.
-	if (in.caps_file_wanted() & ~cap->wanted)
-	  in.flags |= I_CAP_DROPPED;
       }
     }
     signal_cond_list(in.waitfor_caps);
@@ -4183,8 +4176,6 @@ void Client::remove_session_caps(MetaSession *s, int err)
 	in->flags |= I_ERROR_FILELOCK;
     }
     auto caps = cap->implemented;
-    if (cap->wanted | cap->issued)
-      in->flags |= I_CAP_DROPPED;
     remove_cap(cap, false);
     in->cap_snaps.clear();
     if (dirty_caps) {
@@ -5049,9 +5040,6 @@ void Client::handle_cap_export(MetaSession *session, Inode *in, const MConstRef<
 		         &cap == in->auth_cap ? CEPH_CAP_FLAG_AUTH : 0,
 		         cap.latest_perms);
         }
-      } else {
-	if (cap.wanted | cap.issued)
-	  in->flags |= I_CAP_DROPPED;
       }
 
       remove_cap(&cap, false);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -746,13 +746,12 @@ public:
 
 protected:
   /* Flags for check_caps() */
-  static const unsigned CHECK_CAPS_NODELAY = 0x1;
-  static const unsigned CHECK_CAPS_SYNCHRONOUS = 0x2;
+  static const unsigned CHECK_CAPS_SYNCHRONOUS = 0x1;
 
 
   bool is_initialized() const { return initialized; }
 
-  void check_caps(Inode *in, unsigned flags);
+  void check_caps(Inode *in, unsigned flags=0);
 
   void set_cap_epoch_barrier(epoch_t e);
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -468,6 +468,9 @@ public:
   int get_caps_issued(int fd);
   int get_caps_issued(const char *path, const UserPerm& perms);
 
+  auto get_caps_wanted_delay_min() const { return caps_wanted_delay_min; }
+  auto get_caps_wanted_delay_max() const { return caps_wanted_delay_max; }
+
   snapid_t ll_get_snapid(Inode *in);
   vinodeno_t ll_get_vino(Inode *in) {
     std::lock_guard lock(client_lock);
@@ -1208,8 +1211,6 @@ private:
   int user_id, group_id;
   int acl_type = NO_ACL;
 
-  epoch_t cap_epoch_barrier = 0;
-
   // mds sessions
   map<mds_rank_t, MetaSession> mds_sessions;  // mds -> push seq
   std::set<mds_rank_t> mds_ranks_closing;  // mds ranks currently tearing down sessions
@@ -1262,6 +1263,12 @@ private:
   // dirty_list keeps all the dirty inodes before flushing.
   xlist<Inode*> delayed_list, dirty_list;
   int num_flushing_caps = 0;
+
+  epoch_t cap_epoch_barrier = 0;
+
+  unsigned caps_wanted_delay_min;
+  unsigned caps_wanted_delay_max;
+
   ceph::unordered_map<inodeno_t,SnapRealm*> snap_realms;
   std::map<std::string, std::string> metadata;
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1042,7 +1042,7 @@ private:
 
   // internal interface
   //   call these with client_lock held!
-  int _do_lookup(Inode *dir, const string& name, int mask, InodeRef *target,
+  int _do_lookup(Inode *dir, Dentry *dn, int mask, InodeRef *target,
 		 const UserPerm& perms);
 
   int _lookup(Inode *dir, const string& dname, int mask, InodeRef *target,

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -327,7 +327,10 @@ int Inode::caps_mds_wanted()
 {
   int want = 0;
   for (const auto &pair : caps) {
-    want |= pair.second.wanted;
+    if (auth_cap == &pair.second)
+      want |= pair.second.wanted;
+    else
+      want |= pair.second.wanted & ~CEPH_CAP_ANY_WR;
   }
   return want;
 }

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -113,8 +113,7 @@ struct CapSnap {
 #define I_DIR_ORDERED		(1 << 1)
 #define I_SNAPDIR_OPEN		(1 << 2)
 #define I_KICK_FLUSH		(1 << 3)
-#define I_CAP_DROPPED		(1 << 4)
-#define I_ERROR_FILELOCK	(1 << 5)
+#define I_ERROR_FILELOCK	(1 << 4)
 
 struct Inode {
   Client *client;

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -354,7 +354,6 @@ OPTION(client_mount_uid, OPT_INT)
 OPTION(client_mount_gid, OPT_INT)
 OPTION(client_notify_timeout, OPT_INT) // in seconds
 OPTION(osd_client_watch_timeout, OPT_INT) // in seconds
-OPTION(client_caps_release_delay, OPT_INT) // in seconds
 OPTION(client_quota_df, OPT_BOOL) // use quota for df on subdir mounts
 OPTION(client_oc, OPT_BOOL)
 OPTION(client_oc_size, OPT_INT)    // MB * n

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8466,9 +8466,15 @@ std::vector<Option> get_mds_client_options() {
     .set_default(30)
     .set_description(""),
 
-    Option("client_caps_release_delay", Option::TYPE_INT, Option::LEVEL_DEV)
+    Option("client_caps_wanted_delay_min", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(5)
-    .set_description(""),
+    .set_min_max(1, 30)
+    .set_description("delay to clear wanted caps that are not used by any open file"),
+
+    Option("client_caps_wanted_delay_max", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(60)
+    .set_min(30)
+    .set_description("delay to clear wanted caps that are only used by idle open file"),
 
     Option("client_quota_df", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -730,7 +730,7 @@ struct ceph_filelock {
 #define CEPH_FILE_MODE_WR         2
 #define CEPH_FILE_MODE_RDWR       3  /* RD | WR */
 #define CEPH_FILE_MODE_LAZY       4  /* lazy io */
-#define CEPH_FILE_MODE_NUM        8  /* bc these are bit fields.. mostly */
+#define CEPH_FILE_MODE_BITS       4
 
 int ceph_flags_to_mode(int flags);
 


### PR DESCRIPTION
Add last_rd and last_wr to struct Inode. These fields are used to track
the last time the client acquired read/write caps for the inode.

If there is no read/write on an inode for 'caps_wanted_delay_max'
seconds, __ceph_caps_file_wanted() does not request caps for read/write
even there are open files.

For dir operations. __ceph_caps_file_wanted() calculates dir's wanted
caps according to last dir read/modification. If there is recent dir
read dir inode wants CEPH_CAP_ANY_SHARED caps. If there is recent dir
modification, also wants CEPH_CAP_FILE_EXCL.

Readdir is a special case. Dir inode wants CEPH_CAP_FILE_EXCL after
readdir, as with that, modifications do not need to release
CEPH_CAP_FILE_SHARED or invalidate all dentry leases issued by readdir.

Fixes: https://tracker.ceph.com/issues/43748
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
