### PR TITLE
librbd: don't set objectmap invalid when load objectmap timed out

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7364,6 +7364,10 @@ static std::vector<Option> get_rbd_options() {
     .set_default(true)
     .set_description("validate new image names for RBD compatibility"),
 
+    Option("rbd_invalidate_object_map_on_timeout", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(true)
+    .set_description("true if object map should be invalidated when load or update timeout"),
+
     Option("rbd_auto_exclusive_lock_until_manual_request", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description("automatically acquire/release exclusive lock until it is explicitly requested"),

--- a/src/librbd/object_map/InvalidateRequest.h
+++ b/src/librbd/object_map/InvalidateRequest.h
@@ -31,10 +31,6 @@ public:
 
 protected:
   bool should_complete(int r) override;
-  int filter_return_code(int r) const override{
-    // never propagate an error back to the caller
-    return 0;
-  }
 
 private:
   uint64_t m_snap_id;

--- a/src/librbd/object_map/RefreshRequest.cc
+++ b/src/librbd/object_map/RefreshRequest.cc
@@ -133,6 +133,11 @@ Context *RefreshRequest<I>::handle_load(int *ret_val) {
     return nullptr;
   } else if (*ret_val < 0) {
     lderr(cct) << "failed to load object map: " << oid << dendl;
+    if (*ret_val == -ETIMEDOUT &&
+        !cct->_conf.get_val<bool>("rbd_invalidate_object_map_on_timeout")) {
+      return m_on_finish;
+    }
+
     send_invalidate();
     return nullptr;
   }

--- a/src/librbd/object_map/Request.cc
+++ b/src/librbd/object_map/Request.cc
@@ -22,7 +22,11 @@ bool Request::should_complete(int r) {
   switch (m_state)
   {
   case STATE_REQUEST:
-    if (r < 0) {
+    if (r == -ETIMEDOUT &&
+        !cct->_conf.get_val<bool>("rbd_invalidate_object_map_on_timeout")) {
+      m_state = STATE_TIMEOUT;
+      return true;
+    } else if (r < 0) {
       lderr(cct) << "failed to update object map: " << cpp_strerror(r)
 		 << dendl;
       return invalidate();

--- a/src/librbd/object_map/Request.cc
+++ b/src/librbd/object_map/Request.cc
@@ -55,7 +55,7 @@ bool Request::invalidate() {
   bool flags_set;
   int r = m_image_ctx.test_flags(m_snap_id, RBD_FLAG_OBJECT_MAP_INVALID,
                                  &flags_set);
-  if (r == 0 && flags_set) {
+  if (r < 0 || flags_set) {
     return true;
   }
 

--- a/src/librbd/object_map/Request.h
+++ b/src/librbd/object_map/Request.h
@@ -41,6 +41,9 @@ protected:
 
 private:
   /**
+   *              STATE_TIMEOUT --------\
+   *                   ^                |
+   *                   |                v
    * <start> ---> STATE_REQUEST ---> <finish>
    *                   |                ^
    *                   v                |
@@ -48,6 +51,7 @@ private:
    */
   enum State {
     STATE_REQUEST,
+    STATE_TIMEOUT,
     STATE_INVALIDATE
   };
 

--- a/src/test/librbd/object_map/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/object_map/test_mock_SnapshotCreateRequest.cc
@@ -134,7 +134,7 @@ TEST_F(TestMockObjectMapSnapshotCreateRequest, ReadMapError) {
     std::shared_lock image_locker{ictx->image_lock};
     request->send();
   }
-  ASSERT_EQ(0, cond_ctx.wait());
+  ASSERT_EQ(-ENOENT, cond_ctx.wait());
 
   expect_unlock_exclusive_lock(*ictx);
 }
@@ -162,7 +162,7 @@ TEST_F(TestMockObjectMapSnapshotCreateRequest, WriteMapError) {
     std::shared_lock image_locker{ictx->image_lock};
     request->send();
   }
-  ASSERT_EQ(0, cond_ctx.wait());
+  ASSERT_EQ(-ENOENT, cond_ctx.wait());
 
   expect_unlock_exclusive_lock(*ictx);
 }
@@ -191,7 +191,7 @@ TEST_F(TestMockObjectMapSnapshotCreateRequest, AddSnapshotError) {
     std::shared_lock image_locker{ictx->image_lock};
     request->send();
   }
-  ASSERT_EQ(0, cond_ctx.wait());
+  ASSERT_EQ(-ENOENT, cond_ctx.wait());
 
   expect_unlock_exclusive_lock(*ictx);
 }


### PR DESCRIPTION
return negative error code and don't set objectmap invalid when load objectmap timed out.

Signed-off-by: songweibin <song.weibin@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
