### PR TITLE
nautilus: rgw: set correct storage class for append

### DIFF
--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -557,6 +557,11 @@ int AppendObjectProcessor::prepare()
       size_t pos = s.find("-");
       cur_etag = s.substr(0, pos);
     }
+
+    iter = astate->attrset.find(RGW_ATTR_STORAGE_CLASS);
+    if (iter != astate->attrset.end()) {
+      tail_placement_rule.storage_class = iter->second.to_str();
+    }
     cur_manifest = &astate->manifest;
     manifest.set_prefix(cur_manifest->get_prefix());
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44145

---

backport of https://github.com/ceph/ceph/pull/31088
parent tracker: https://tracker.ceph.com/issues/42444

this backport was staged using ceph-backport.sh version 15.1.0.437
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh