### PR TITLE
qa/tasks/qemu: fix nfs setup and teardown bug in qemu task

### DIFF
--- a/qa/tasks/qemu.py
+++ b/qa/tasks/qemu.py
@@ -285,8 +285,10 @@ def _setup_nfs_mount(remote, client, service_name, mount_dir):
     export = "{dir} *(rw,no_root_squash,no_subtree_check,insecure)".format(
         dir=export_dir
     )
+    log.info("Deleting export from /etc/exports...")
     remote.run(args=[
-        'sudo', 'sed', '-i', '/^\/export\//d', "/etc/exports",
+        'sudo', 'sed', '-i', "\|{export_dir}|d".format(export_dir=export_dir),
+        '/etc/exports'
     ])
     remote.run(args=[
         'echo', export, run.Raw("|"),
@@ -319,13 +321,10 @@ def _teardown_nfs_mount(remote, client, service_name):
     remote.run(args=[
         'sudo', 'umount', export_dir
     ])
-    log.info("Deleting exported directory...")
-    remote.run(args=[
-        'sudo', 'rm', '-r', '/export'
-    ])
     log.info("Deleting export from /etc/exports...")
     remote.run(args=[
-        'sudo', 'sed', '-i', '$ d', '/etc/exports'
+        'sudo', 'sed', '-i', "\|{export_dir}|d".format(export_dir=export_dir),
+        '/etc/exports'
     ])
     log.info("Starting NFS...")
     if remote.os.package_type == "deb":
@@ -457,6 +456,12 @@ def run_qemu(ctx, config):
                         ),
                     ],
                 )
+        log.info("Deleting exported directory...")
+        for client in config.keys():
+            (remote,) = ctx.cluster.only(client).remotes.keys()
+            remote.run(args=[
+                'sudo', 'rm', '-r', '/export'
+            ])
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
when there are multiple RBD clients in the same teuthology node, no matter what the result of test case is, always produce error at below code  : 
 
`remote.run(args=[test', '-f', '{tdir}/archive/qemu/{client}/success'.format( tdir=testdir, client=client),],)`
                   


For example, cluster.yaml is as below
- [mon.a, mon.c, mgr.x, osd.0, osd.1, osd.2, osd.3]
- [mon.b, mgr.y, osd.4, osd.5, osd.6, osd.7]
- [client.0, client.1]

will produce error "test -f /home/ubuntu/cephtest/archive/qemu/client.1/success"

The main reason is that _setup_nfs_mount and _teardown_nfs_mount just support single mount point.

Signed-off-by: Dehao Shang <dehao.shang@intel.com>
Signed-off-by: zhou yuan <yuan.zhou@intel.com>

