### PR TITLE
fix: add S3 compliant with java signature version 4 api

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -934,7 +934,7 @@ bool AWSv4ComplMulti::is_signature_mismatched()
   }
 }
 
-size_t AWSv4ComplMulti::recv_body(char* const buf, const size_t buf_max)
+size_t AWSv4ComplMulti::recv_chunk_body(char* const buf, const size_t buf_max)
 {
   /* Buffer stores only parsed stream. Raw values reflect the stream
    * we're getting from a client. */
@@ -1016,6 +1016,33 @@ size_t AWSv4ComplMulti::recv_body(char* const buf, const size_t buf_max)
     buf_pos += received;
     stream_pos += received;
     to_extract -= received;
+  }
+
+  dout(20) << "AWSv4ComplMulti: chunk filled=" << buf_pos << dendl;
+  return buf_pos;
+}
+
+size_t AWSv4ComplMulti::recv_body(char* const buf, const size_t buf_max)
+{
+  /* Get totoal buf_max data from the parsed stream. buf_max's default is regw_max_chunk_size or zero
+   * we're getting from a client. */
+  size_t buf_pos = 0;
+  size_t buf_incomplement_size = buf_max; // bul_max is 4M, exclude the last multipart [0,4M]
+
+  if (buf_incomplement_size == 0){
+    const auto read_len = recv_chunk_body( buf+buf_pos, buf_incomplement_size);
+    buf_pos += read_len;
+    buf_incomplement_size -= read_len;
+  }else{
+    while (buf_incomplement_size > 0){
+      const auto read_len = recv_chunk_body( buf+buf_pos, buf_incomplement_size);
+      if (read_len == 0) {
+        break;
+      }
+
+      buf_pos += read_len;
+      buf_incomplement_size -= read_len;
+    }
   }
 
   dout(20) << "AWSv4ComplMulti: filled=" << buf_pos << dendl;

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -364,6 +364,7 @@ public:
 
   /* rgw::io::DecoratedRestfulClient. */
   size_t recv_body(char* buf, size_t max) override;
+  size_t recv_chunk_body(char* const buf, const size_t buf_max);
 
   /* rgw::auth::Completer. */
   void modify_request_state(const DoutPrefixProvider* dpp, req_state* s_rw) override;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44008

there is a bug about multi-part upload data by using aws java Signature Version 4 API . The upload part data will lost when you abort and resume a multipart upload request.

Signed-off-by: bangmingcheng <bangmingcheng@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
