### PR TITLE
mon: check if auth_mon if readable before auth_request

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -6189,7 +6189,9 @@ int Monitor::handle_auth_request(
     if (con->get_priv()) {
       return -EACCES; // wtf
     }
-
+    if (!authmon()->is_readable()) {
+      return -EAGAIN;
+    }
     // handler?
     unique_ptr<AuthServiceHandler> auth_handler{get_auth_service_handler(
       auth_method, g_ceph_context, &key_server)};


### PR DESCRIPTION
when performing mon thrash test, there is chance that a monitor is still
recovering when it tries to authorize a request and set the cap for the
connecting client, but if the key_server containes stale info and it's
not yet updated by the latest paxos being replayed, we might authorize the
client using the stale key ring and cap information.

in this change, check if the auth_server is readable before referencing
the key_server updated by it, return -EBUSY instead.

Fixes: https://tracker.ceph.com/issues/38082
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
