### PR TITLE
mgr/dashboard: Using more color and size variables

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../styles/defaults.scss';
+
 // Angular2-Tree Component
 ::ng-deep tree-root {
   .tree-children {
@@ -7,8 +9,8 @@
 
 .quota-origin {
   &:hover {
-    color: #212121;
+    color: $color-mild-black;
   }
   cursor: pointer;
-  color: #2b99a8;
+  color: $color-primary;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-performance-histogram/osd-performance-histogram.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-performance-histogram/osd-performance-histogram.component.scss
@@ -1,10 +1,15 @@
+$table-components-size: 10px;
+
 table {
   tr {
     height: 10px;
+    height: $table-components-size;
   }
 
   td {
     width: 10px;
     height: 10px;
+    width: $table-components-size;
+    height: $table-components-size;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.scss
@@ -5,5 +5,5 @@
 }
 
 .running:hover i {
-  color: white;
+  color: $color-solid-white;;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/styles/defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/defaults.scss
@@ -49,6 +49,7 @@ $color-input-border: #ced4da;
 $color-input-border-hover: #adadad;
 $color-brand-teal: #2b99a8 !default;
 $color-brand-gray: #374249 !default;
+$color-mild-black:#212121 !default;
 
 $color-primary: $color-brand-teal !default;
 $color-secondary: $color-brand-gray !default;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
Fixes: https://tracker.ceph.com/issues/38891
Signed-off-by: Pranav Kulshrestha <hulkcodexl16@gmail.com>

As suggested by mentors,
We can use more `scss` variables in our `scss` files. Although, most of the components have used scss variables defined in default stylesheets. 
I have removed any size and colour hex codes that could be replaced by scss variables.
I have not used variables for mentioning the size of components, because I think defining variables for all local components will be unnecessary.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
