### PR TITLE
doc/cephadm: replace `osd create` with `apply osd`

### DIFF
--- a/doc/cephadm/drivegroups.rst
+++ b/doc/cephadm/drivegroups.rst
@@ -10,7 +10,7 @@ with which configuration without knowing the specifics of device names and paths
 
 Instead of doing this::
 
-  [monitor 1] # ceph orchestrator osd create *<host>*:*<path-to-device>*
+  [monitor 1] # ceph orch daemon add osd *<host>*:*<path-to-device>*
 
 for each device and each host, we can define a yaml|json file that allows us to describe
 the layout. Here's the most basic example.
@@ -32,7 +32,7 @@ There will be a more detailed section on host_pattern down below.
 
 and pass it to `osd create` like so::
 
-  [monitor 1] # ceph orchestrator osd create -i /path/to/drivegroup.yml
+  [monitor 1] # ceph orch apply osd -i /path/to/drivegroup.yml
 
 This will go out on all the matching hosts and deploy these OSDs.
 

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -289,7 +289,7 @@ There are a few ways to create new OSDs:
   based on their properties, such device type (SSD or HDD), device
   model names, size, or the hosts on which the devices exist::
 
-    # ceph orch osd create -i spec.yml
+    # ceph orch apply osd -i spec.yml
 
 
 Deploy MDSs


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44692

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
