### PR TITLE
mgr/dashboard: fix error when enabling SSO with cert. file

### DIFF
--- a/src/pybind/mgr/dashboard/services/sso.py
+++ b/src/pybind/mgr/dashboard/services/sso.py
@@ -191,12 +191,12 @@ def handle_sso_command(cmd):
         has_sp_cert = sp_x_509_cert_path != "" and sp_private_key_path != ""
         if has_sp_cert:
             try:
-                with open(sp_x_509_cert_path, 'r') as f:
+                with open(sp_x_509_cert_path, 'r', encoding='utf-8') as f:
                     sp_x_509_cert = f.read()
             except FileNotFoundError:
                 return -errno.EINVAL, '', '`{}` not found.'.format(sp_x_509_cert_path)
             try:
-                with open(sp_private_key_path, 'r') as f:
+                with open(sp_private_key_path, 'r', encoding='utf-8') as f:
                     sp_private_key = f.read()
             except FileNotFoundError:
                 return -errno.EINVAL, '', '`{}` not found.'.format(sp_private_key_path)
@@ -207,7 +207,7 @@ def handle_sso_command(cmd):
         if os.path.isfile(idp_metadata):
             warnings.warn(
                 "Please prepend 'file://' to indicate a local SAML2 IdP file", DeprecationWarning)
-            with open(idp_metadata, 'r') as f:
+            with open(idp_metadata, 'r', encoding='utf-8') as f:
                 idp_settings = Saml2Parser.parse(f.read(), entity_id=idp_entity_id)
         elif parse.urlparse(idp_metadata)[0] in ('http', 'https', 'file'):
             idp_settings = Saml2Parser.parse_remote(
@@ -249,7 +249,7 @@ def handle_sso_command(cmd):
                 "wantMessagesSigned": has_sp_cert,
                 "wantAssertionsSigned": has_sp_cert,
                 "wantAssertionsEncrypted": has_sp_cert,
-                "wantNameIdEncrypted": has_sp_cert,
+                "wantNameIdEncrypted": False,  # Not all Identity Providers support this.
                 "metadataValidUntil": '',
                 "wantAttributeStatement": False
             }


### PR DESCRIPTION
Also:
* Disabled security setting 'wantNameIdEncrypted': not all Identity Providers support this and we are already requiring encrypted assertions (which is the default). See:
https://www.samltool.com/generic_sso_res.php
https://help.salesforce.com/articleView?id=sso_saml_assertion_examples.htm&type=5#sample_asserts_encrypted_saml
https://github.com/onelogin/python-saml/issues/59#issuecomment-90109857


Fixes: https://tracker.ceph.com/issues/44666
Signed-off-by: Alfonso Martínez <almartin@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
