### PR TITLE
cephadm: switch grafana image to the ceph repo

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -133,7 +133,7 @@ class Monitoring(object):
             ],
         },
         "grafana": {
-            "image": "pcuzner/ceph-grafana-el8:latest",
+            "image": "ceph/ceph-grafana:latest",
             "cpus": "2",
             "memory": "4GB",
             "args": [],


### PR DESCRIPTION
Pull the pre-built grafana image from the ceph org on
docker.io

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>