### PR TITLE
nautilus: mgr/dashboard: add popover list of Stand-by Managers & Metadata Servers (MDS) in landing page

### DIFF
--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -78,7 +78,7 @@ class HealthTest(DashboardTestCase):
                         'mdsmap': self.__mdsmap_schema
                     }),
                 ),
-                'standbys': JList(JObj({})),
+                'standbys': JList(JObj({}, allow_unknown=True)),
             }),
             'health': JObj({
                 'checks': JList(str),

--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -19,6 +19,41 @@ class HealthTest(DashboardTestCase):
         'statuses': JObj({}, allow_unknown=True, unknown_schema=int)
     })
 
+    __mdsmap_schema = JObj({
+        'session_autoclose': int,
+        'balancer': str,
+        'up': JObj({}, allow_unknown=True),
+        'last_failure_osd_epoch': int,
+        'in': JList(int),
+        'last_failure': int,
+        'max_file_size': int,
+        'explicitly_allowed_features': int,
+        'damaged': JList(int),
+        'tableserver': int,
+        'failed': JList(int),
+        'metadata_pool': int,
+        'epoch': int,
+        'stopped': JList(int),
+        'max_mds': int,
+        'compat': JObj({
+            'compat': JObj({}, allow_unknown=True),
+            'ro_compat': JObj({}, allow_unknown=True),
+            'incompat': JObj({}, allow_unknown=True)
+        }),
+        'min_compat_client': str,
+        'data_pools': JList(int),
+        'info': JObj({}, allow_unknown=True),
+        'fs_name': str,
+        'created': str,
+        'standby_count_wanted': int,
+        'enabled': bool,
+        'modified': str,
+        'session_timeout': int,
+        'flags': int,
+        'ever_allowed_features': int,
+        'root': int
+    })
+
     def test_minimal_health(self):
         data = self._get('/api/health/minimal')
         self.assertStatus(200)
@@ -40,15 +75,7 @@ class HealthTest(DashboardTestCase):
             'fs_map': JObj({
                 'filesystems': JList(
                     JObj({
-                        'mdsmap': JObj({
-                            'info': JObj(
-                                {},
-                                allow_unknown=True,
-                                unknown_schema=JObj({
-                                    'state': str
-                                })
-                            )
-                        })
+                        'mdsmap': self.__mdsmap_schema
                     }),
                 ),
                 'standbys': JList(JObj({})),
@@ -164,16 +191,7 @@ class HealthTest(DashboardTestCase):
                 'filesystems': JList(
                     JObj({
                         'id': int,
-                        'mdsmap': JObj({
-                            # TODO: Expand mdsmap schema
-                            'info': JObj(
-                                {},
-                                allow_unknown=True,
-                                unknown_schema=JObj({
-                                    'state': str
-                                }, allow_unknown=True)
-                            )
-                        }, allow_unknown=True)
+                        'mdsmap': self.__mdsmap_schema
                     }),
                 ),
                 'standbys': JList(JObj({}, allow_unknown=True)),

--- a/src/pybind/mgr/dashboard/controllers/health.py
+++ b/src/pybind/mgr/dashboard/controllers/health.py
@@ -106,7 +106,6 @@ class HealthData(object):
         fs_map = mgr.get('fs_map')
         if self._minimal:
             fs_map = self._partial_dict(fs_map, ['filesystems', 'standbys'])
-            fs_map['standbys'] = [{}] * len(fs_map['standbys'])
             fs_map['filesystems'] = [self._partial_dict(item, ['mdsmap']) for
                                      item in fs_map['filesystems']]
             for fs in fs_map['filesystems']:
@@ -114,7 +113,6 @@ class HealthData(object):
                 min_mdsmap_info = dict()
                 for k, v in mdsmap_info.items():
                     min_mdsmap_info[k] = self._partial_dict(v, ['state'])
-                fs['mdsmap'] = dict(info=min_mdsmap_info)
         return fs_map
 
     def host_count(self):
@@ -128,7 +126,6 @@ class HealthData(object):
         mgr_map = mgr.get('mgr_map')
         if self._minimal:
             mgr_map = self._partial_dict(mgr_map, ['active_name', 'standbys'])
-            mgr_map['standbys'] = [{}] * len(mgr_map['standbys'])
         return mgr_map
 
     def mon_status(self):

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
@@ -98,10 +98,11 @@
     <cd-info-card cardTitle="Metadata Servers"
                   i18n-cardTitle
                   class="col-sm-6 col-md-4 col-lg-3"
-                  *ngIf="(enabledFeature.cephfs && healthData.fs_map | mdsSummary) as transformedResult"
+                  *ngIf="((enabledFeature.cephfs && healthData.fs_map) | mdsSummary) as transformedResult"
                   [contentClass]="(transformedResult.length > 1 ? 'text-area-size-2' : '') + ' content-highlight'">
       <span *ngFor="let result of transformedResult"
-            [ngClass]="result.class">
+            [ngClass]="result.class"
+            [title]="result.titleText != null ? result.titleText : ''">
         {{ result.content }}
       </span>
     </cd-info-card>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.scss
@@ -84,6 +84,6 @@ cd-info-card {
   white-space: pre;
 }
 
-.mgr-active-name:hover {
+.popover-info:hover {
   cursor: pointer;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
@@ -33,7 +33,7 @@ describe('HealthComponent', () => {
     mgr_map: { standbys: [] },
     hosts: 0,
     rgw: 0,
-    fs_map: { filesystems: [] },
+    fs_map: { filesystems: [], standbys: [] },
     iscsi_daemons: 0,
     client_perf: {},
     scrub_status: 'Inactive',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mds-summary.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mds-summary.pipe.spec.ts
@@ -20,13 +20,13 @@ describe('MdsSummaryPipe', () => {
 
   it('transforms with 0 active and 2 standy', () => {
     const payload = {
-      standbys: [0],
+      standbys: [{ name: 'a' }],
       filesystems: [{ mdsmap: { info: [{ state: 'up:standby-replay' }] } }]
     };
     const expected = [
-      { class: '', content: '0 active' },
-      { class: 'card-text-line-break', content: '' },
-      { class: '', content: '2 standby' }
+      { class: 'popover-info', content: '0 active', titleText: '1 standbyReplay' },
+      { class: 'card-text-line-break', content: '', titleText: '' },
+      { class: 'popover-info', content: '2 standby', titleText: 'standby daemons: a' }
     ];
 
     expect(pipe.transform(payload)).toEqual(expected);
@@ -34,13 +34,13 @@ describe('MdsSummaryPipe', () => {
 
   it('transforms with 1 active and 1 standy', () => {
     const payload = {
-      standbys: [0],
-      filesystems: [{ mdsmap: { info: [{ state: 'up:active' }] } }]
+      standbys: [{ name: 'b' }],
+      filesystems: [{ mdsmap: { info: [{ state: 'up:active', name: 'a' }] } }]
     };
     const expected = [
-      { class: '', content: '1 active' },
-      { class: 'card-text-line-break', content: '' },
-      { class: '', content: '1 standby' }
+      { class: 'popover-info', content: '1 active', titleText: 'active daemon: a' },
+      { class: 'card-text-line-break', content: '', titleText: '' },
+      { class: 'popover-info', content: '1 standby', titleText: 'standby daemons: b' }
     ];
     expect(pipe.transform(payload)).toEqual(expected);
   });
@@ -50,17 +50,17 @@ describe('MdsSummaryPipe', () => {
       standbys: [0],
       filesystems: []
     };
-    const expected = [{ class: '', content: 'no filesystems' }];
+    const expected = [{ class: 'popover-info', content: 'no filesystems', titleText: '' }];
 
     expect(pipe.transform(payload)).toEqual(expected);
   });
 
   it('transforms without filesystem', () => {
-    const payload = { standbys: [0] };
+    const payload = { standbys: [{ name: 'a' }] };
     const expected = [
-      { class: '', content: '1 up' },
-      { class: 'card-text-line-break', content: '' },
-      { class: '', content: 'no filesystems' }
+      { class: 'popover-info', content: '1 up', titleText: '' },
+      { class: 'card-text-line-break', content: '', titleText: '' },
+      { class: 'popover-info', content: 'no filesystems', titleText: 'standby daemons: a' }
     ];
 
     expect(pipe.transform(payload)).toEqual(expected);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mds-summary.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mds-summary.pipe.ts
@@ -42,22 +42,39 @@ export class MdsSummaryPipe implements PipeTransform {
       contentLine1 = `${active} ${this.i18n('active')}`;
       contentLine2 = `${standbys + standbyReplay} ${this.i18n('standby')}`;
     }
-
+    const standbyHoverText = value.standbys.map((s: any): string => s.name).join(', ');
+    const standbyTitleText = !standbyHoverText
+      ? ''
+      : `${this.i18n('standby daemons')}: ${standbyHoverText}`;
+    const fsLength = value.filesystems ? value.filesystems.length : 0;
+    const infoObject = fsLength > 0 ? value.filesystems[0].mdsmap.info : {};
+    const activeHoverText = Object.values(infoObject)
+      .map((info: any): string => info.name)
+      .join(', ');
+    let activeTitleText = !activeHoverText
+      ? ''
+      : `${this.i18n('active daemon')}: ${activeHoverText}`;
+    // There is always one standbyreplay to replace active daemon, if active one is down
+    if (!active && fsLength > 0) {
+      activeTitleText = `${standbyReplay} ${this.i18n('standbyReplay')}`;
+    }
     const mgrSummary = [
       {
         content: contentLine1,
-        class: ''
+        class: 'popover-info',
+        titleText: activeTitleText
       }
     ];
-
     if (contentLine2) {
       mgrSummary.push({
         content: '',
-        class: 'card-text-line-break'
+        class: 'card-text-line-break',
+        titleText: ''
       });
       mgrSummary.push({
         content: contentLine2,
-        class: ''
+        class: 'popover-info',
+        titleText: standbyTitleText
       });
     }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mgr-summary.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mgr-summary.pipe.spec.ts
@@ -29,9 +29,9 @@ describe('MgrSummaryPipe', () => {
       standbys: []
     };
     const expected = [
-      { class: 'mgr-active-name', content: 'n/a active', titleText: '' },
+      { class: 'popover-info', content: 'n/a active', titleText: '' },
       { class: 'card-text-line-break', content: '', titleText: '' },
-      { class: '', content: '0 standby', titleText: '' }
+      { class: 'popover-info', content: '0 standby', titleText: '' }
     ];
 
     expect(pipe.transform(payload)).toEqual(expected);
@@ -39,13 +39,13 @@ describe('MgrSummaryPipe', () => {
 
   it('transforms with 1 active and 2 standbys', () => {
     const payload = {
-      active_name: 'a',
-      standbys: ['b', 'c']
+      active_name: 'x',
+      standbys: [{ name: 'y' }, { name: 'z' }]
     };
     const expected = [
-      { class: 'mgr-active-name', content: '1 active', titleText: 'active daemon: a' },
+      { class: 'popover-info', content: '1 active', titleText: 'active daemon: x' },
       { class: 'card-text-line-break', content: '', titleText: '' },
-      { class: '', content: '2 standby', titleText: '' }
+      { class: 'popover-info', content: '2 standby', titleText: 'standby daemons: y, z' }
     ];
 
     expect(pipe.transform(payload)).toEqual(expected);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mgr-summary.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mgr-summary.pipe.ts
@@ -15,18 +15,23 @@ export class MgrSummaryPipe implements PipeTransform {
     }
 
     let activeCount = this.i18n('n/a');
-    const titleText = _.isUndefined(value.active_name)
+    const activeTitleText = _.isUndefined(value.active_name)
       ? ''
       : `${this.i18n('active daemon')}: ${value.active_name}`;
-    if (titleText.length > 0) {
+    // There is always one standbyreplay to replace active daemon, if active one is down
+    if (activeTitleText.length > 0) {
       activeCount = '1';
     }
+    const standbyHoverText = value.standbys.map((s: any): string => s.name).join(', ');
+    const standbyTitleText = !standbyHoverText
+      ? ''
+      : `${this.i18n('standby daemons')}: ${standbyHoverText}`;
     const standbyCount = value.standbys.length;
     const mgrSummary = [
       {
         content: `${activeCount} ${this.i18n('active')}`,
-        class: 'mgr-active-name',
-        titleText: titleText
+        class: 'popover-info',
+        titleText: activeTitleText
       }
     ];
 
@@ -37,8 +42,8 @@ export class MgrSummaryPipe implements PipeTransform {
     });
     mgrSummary.push({
       content: `${standbyCount} ${this.i18n('standby')}`,
-      class: '',
-      titleText: ''
+      class: 'popover-info',
+      titleText: standbyTitleText
     });
 
     return mgrSummary;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44696

---

backport of https://github.com/ceph/ceph/pull/33529
parent tracker: https://tracker.ceph.com/issues/42979

this backport was staged using ceph-backport.sh version 15.1.0.1009
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh