### PR TITLE
nautilus: rgw: clear ent_list for each loop of bucket list

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4981,12 +4981,12 @@ int RGWRados::transition_obj(RGWObjectCtx& obj_ctx,
 
 int RGWRados::check_bucket_empty(RGWBucketInfo& bucket_info)
 {
-  std::vector<rgw_bucket_dir_entry> ent_list;
   rgw_obj_index_key marker;
   string prefix;
   bool is_truncated;
 
   do {
+    std::vector<rgw_bucket_dir_entry> ent_list;
     constexpr uint NUM_ENTRIES = 1000u;
     int r = cls_bucket_list_unordered(bucket_info,
 				      RGW_NO_SHARD,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44472

---

backport of https://github.com/ceph/ceph/pull/33693
parent tracker: https://tracker.ceph.com/issues/44394

this backport was staged using ceph-backport.sh version 15.1.0.1009
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh