### PR TITLE
doc: Fix some link errors about ceph-deploy

### DIFF
--- a/doc/install/ceph-deploy/install-ceph-gateway.rst
+++ b/doc/install/ceph-deploy/install-ceph-gateway.rst
@@ -611,5 +611,5 @@ The output should be::
 
  my-new-bucket
 
-.. _Preflight:  ../../start/quick-start-preflight
-.. _HTTP Frontends: ../../radosgw/frontends
+.. _Preflight:  ../quick-start-preflight
+.. _HTTP Frontends: ../../../radosgw/frontends

--- a/doc/install/ceph-deploy/quick-ceph-deploy.rst
+++ b/doc/install/ceph-deploy/quick-ceph-deploy.rst
@@ -331,16 +331,16 @@ data migration or balancing manually.
 
 
 .. _Preflight Checklist: ../quick-start-preflight
-.. _Ceph Deploy: ../../rados/deployment
-.. _ceph-deploy install -h: ../../rados/deployment/ceph-deploy-install
-.. _ceph-deploy new -h: ../../rados/deployment/ceph-deploy-new
-.. _ceph-deploy osd: ../../rados/deployment/ceph-deploy-osd
-.. _Running Ceph with Upstart: ../../rados/operations/operating#running-ceph-with-upstart
-.. _Running Ceph with sysvinit: ../../rados/operations/operating#running-ceph-with-sysvinit
-.. _CRUSH Map: ../../rados/operations/crush-map
-.. _pool: ../../rados/operations/pools
-.. _placement group: ../../rados/operations/placement-groups
-.. _Monitoring a Cluster: ../../rados/operations/monitoring
-.. _Monitoring OSDs and PGs: ../../rados/operations/monitoring-osd-pg
-.. _Network Configuration Reference: ../../rados/configuration/network-config-ref
-.. _User Management: ../../rados/operations/user-management
+.. _Ceph Deploy: ../../../rados/deployment
+.. _ceph-deploy install -h: ../../../rados/deployment/ceph-deploy-install
+.. _ceph-deploy new -h: ../../../rados/deployment/ceph-deploy-new
+.. _ceph-deploy osd: ../../../rados/deployment/ceph-deploy-osd
+.. _Running Ceph with Upstart: ../../../rados/operations/operating#running-ceph-with-upstart
+.. _Running Ceph with sysvinit: ../../../rados/operations/operating#running-ceph-with-sysvinit
+.. _CRUSH Map: ../../../rados/operations/crush-map
+.. _pool: ../../../rados/operations/pools
+.. _placement group: ../../../rados/operations/placement-groups
+.. _Monitoring a Cluster: ../../../rados/operations/monitoring
+.. _Monitoring OSDs and PGs: ../../../rados/operations/monitoring-osd-pg
+.. _Network Configuration Reference: ../../../rados/configuration/network-config-ref
+.. _User Management: ../../../rados/operations/user-management

--- a/doc/install/ceph-deploy/quick-cephfs.rst
+++ b/doc/install/ceph-deploy/quick-cephfs.rst
@@ -201,12 +201,12 @@ See `CephFS`_ for additional information. See `Troubleshooting`_ if you
 encounter trouble.
 
 .. _Storage Cluster Quick Start: ../quick-ceph-deploy
-.. _CephFS: ../../cephfs/
-.. _Troubleshooting: ../../cephfs/troubleshooting
-.. _OS Recommendations: ../os-recommendations
-.. _Placement Group: ../../rados/operations/placement-groups
-.. _mount.ceph man page: ../../man/8/mount.ceph
-.. _Mount CephFS using Kernel Driver: ../../cephfs/mount-using-kernel-driver
-.. _ceph-fuse man page: ../../man/8/ceph-fuse
-.. _Mount CephFS using FUSE: ../../cephfs/mount-using-fuse
-.. _Erasure Code: ../../rados/operations/erasure-code
+.. _CephFS: ../../../cephfs/
+.. _Troubleshooting: ../../../cephfs/troubleshooting
+.. _OS Recommendations: ../../../start/os-recommendations
+.. _Placement Group: ../../../rados/operations/placement-groups
+.. _mount.ceph man page: ../../../man/8/mount.ceph
+.. _Mount CephFS using Kernel Driver: ../../../cephfs/mount-using-kernel-driver
+.. _ceph-fuse man page: ../../../man/8/ceph-fuse
+.. _Mount CephFS using FUSE: ../../../cephfs/mount-using-fuse
+.. _Erasure Code: ../../../rados/operations/erasure-code

--- a/doc/install/ceph-deploy/quick-rgw-old.rst
+++ b/doc/install/ceph-deploy/quick-rgw-old.rst
@@ -26,5 +26,5 @@ the steps specific to Apache are no longer needed.
 
 
 .. _Storage Cluster Quick Start: ../quick-ceph-deploy
-.. _RGW Admin Guide: ../../radosgw/admin
-.. _Configuring Ceph Object Gateway: ../../radosgw/config-fcgi
+.. _RGW Admin Guide: ../../../radosgw/admin
+.. _Configuring Ceph Object Gateway: ../../../radosgw/config-fcgi

--- a/doc/install/ceph-deploy/quick-rgw.rst
+++ b/doc/install/ceph-deploy/quick-rgw.rst
@@ -97,5 +97,5 @@ Configuring the Ceph Object Gateway Instance
 See the `Configuring Ceph Object Gateway`_ guide for additional administration
 and API details.
 
-.. _Configuring Ceph Object Gateway: ../../radosgw/config-ref
+.. _Configuring Ceph Object Gateway: ../../../radosgw/config-ref
 .. _Preflight Checklist: ../quick-start-preflight

--- a/doc/install/ceph-deploy/quick-start-preflight.rst
+++ b/doc/install/ceph-deploy/quick-start-preflight.rst
@@ -356,9 +356,9 @@ This completes the Quick Start Preflight. Proceed to the `Storage Cluster
 Quick Start`_.
 
 .. _Storage Cluster Quick Start: ../quick-ceph-deploy
-.. _OS Recommendations: ../os-recommendations
-.. _Network Configuration Reference: ../../rados/configuration/network-config-ref
-.. _Clock: ../../rados/configuration/mon-config-ref#clock
+.. _OS Recommendations: ../../../start/os-recommendations
+.. _Network Configuration Reference: ../../../rados/configuration/network-config-ref
+.. _Clock: ../../../rados/configuration/mon-config-ref#clock
 .. _NTP: http://www.ntp.org/
-.. _Infernalis release: ../../release-notes/#v9-1-0-infernalis-release-candidate
+.. _Infernalis release: ../../../release-notes/#v9-1-0-infernalis-release-candidate
 .. _EPEL wiki: https://fedoraproject.org/wiki/EPEL

--- a/doc/install/ceph-deploy/upgrading-ceph.rst
+++ b/doc/install/ceph-deploy/upgrading-ceph.rst
@@ -229,7 +229,7 @@ If you do not have the latest version, you may need to uninstall, auto remove
 dependencies and reinstall.
 
 
-.. _using your distro's package manager: ../install-storage-cluster/
-.. _Operating a Cluster: ../../rados/operations/operating
-.. _Monitoring a Cluster: ../../rados/operations/monitoring
-.. _release notes document of your release: ../../releases
+.. _using your distro's package manager: ../../install-storage-cluster/
+.. _Operating a Cluster: ../../../rados/operations/operating
+.. _Monitoring a Cluster: ../../../rados/operations/monitoring
+.. _release notes document of your release: ../../../releases

--- a/doc/install/index_manual.rst
+++ b/doc/install/index_manual.rst
@@ -68,4 +68,4 @@ sequence.
 .. toctree::
    :maxdepth: 2
 
-.. _get packages: ../install/get-packages
+.. _get packages: ../get-packages

--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -11,7 +11,7 @@ whether authentication is required, etc. Most of these values are set by
 default, so it's useful to know about them when setting up your cluster for
 production.
 
-Following the same configuration as `Installation (Quick)`_, we will set up a
+Following the same configuration as `Installation (ceph-deploy)`_, we will set up a
 cluster with ``node1`` as  the monitor node, and ``node2`` and ``node3`` for
 OSD nodes.
 
@@ -530,7 +530,7 @@ To add (or remove) additional monitors, see `Add/Remove Monitors`_.
 To add (or remove) additional Ceph OSD Daemons, see `Add/Remove OSDs`_.
 
 
-.. _Installation (Quick): ../../start
+.. _Installation (ceph-deploy): ../ceph-deploy
 .. _Add/Remove Monitors: ../../rados/operations/add-or-rm-mons
 .. _Add/Remove OSDs: ../../rados/operations/add-or-rm-osds
 .. _Network Configuration Reference: ../../rados/configuration/network-config-ref

--- a/doc/install/manual-freebsd-deployment.rst
+++ b/doc/install/manual-freebsd-deployment.rst
@@ -15,7 +15,7 @@ whether authentication is required, etc. Most of these values are set by
 default, so it's useful to know about them when setting up your cluster for
 production.
 
-Following the same configuration as `Installation (Quick)`_, we will set up a
+Following the same configuration as `Installation (ceph-deploy)`_, we will set up a
 cluster with ``node1`` as  the monitor node, and ``node2`` and ``node3`` for
 OSD nodes.
 
@@ -572,7 +572,7 @@ To add (or remove) additional monitors, see `Add/Remove Monitors`_.
 To add (or remove) additional Ceph OSD Daemons, see `Add/Remove OSDs`_.
 
 
-.. _Installation (Quick): ../../start
+.. _Installation (ceph-deploy): ../ceph-deploy
 .. _Add/Remove Monitors: ../../rados/operations/add-or-rm-mons
 .. _Add/Remove OSDs: ../../rados/operations/add-or-rm-osds
 .. _Network Configuration Reference: ../../rados/configuration/network-config-ref


### PR DESCRIPTION
Previously moved "ceph-deploy" did not change the link jump in it correctly

Signed-off-by: Sean Fang <silence.boy@live.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
