### PR TITLE
cephadm: init config and keyring with None

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1371,7 +1371,10 @@ def get_parm(option):
         return js
 
 def get_config_and_keyring():
-    # type: () -> Tuple[str, str]
+    # type: () -> Tuple[Optional[str], Optional[str]]
+    config = None
+    keyring = None
+
     if 'config_json' in args and args.config_json:
         d = get_parm(args.config_json)
         config = d.get('config')
@@ -1386,11 +1389,6 @@ def get_config_and_keyring():
     elif 'keyring' in args and args.keyring:
         with open(args.keyring, 'r') as f:
             keyring = f.read()
-
-    if not config:
-        raise Error('no config provided')
-    elif not keyring:
-        raise Error('no keyring provided')
 
     return (config, keyring)
 


### PR DESCRIPTION
and we should not assume that both `config` and `keying` are specified
when calling this method. because, for instance, `create_daemon_dirs()`
does handle the case where `config` and/or `keyring` is not specified.

this is a follow-up fix of 245d6a5cec9cc0f299613b8cc0415e494a4c3ac5

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
