### PR TITLE
Make ceph-mon compile without top-level using namespace in headers

### DIFF
--- a/src/auth/cephx/CephxKeyServer.cc
+++ b/src/auth/cephx/CephxKeyServer.cc
@@ -21,11 +21,18 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "cephx keyserverdata: "
 
+using std::ostringstream;
+using std::string;
+using std::stringstream;
+
+using ceph::bufferptr;
+using ceph::bufferlist;
+using ceph::Formatter;
+
 bool KeyServerData::get_service_secret(CephContext *cct, uint32_t service_id,
 			    ExpiringCryptoKey& secret, uint64_t& secret_id) const
 {
-  map<uint32_t, RotatingSecrets>::const_iterator iter =
-	rotating_secrets.find(service_id);
+  auto iter = rotating_secrets.find(service_id);
   if (iter == rotating_secrets.end()) { 
     ldout(cct, 10) << "get_service_secret service " << ceph_entity_type_name(service_id) << " not found " << dendl;
     return false;
@@ -34,8 +41,7 @@ bool KeyServerData::get_service_secret(CephContext *cct, uint32_t service_id,
   const RotatingSecrets& secrets = iter->second;
 
   // second to oldest, unless it's expired
-  map<uint64_t, ExpiringCryptoKey>::const_iterator riter =
-	secrets.secrets.begin();
+  auto riter = secrets.secrets.begin();
   if (secrets.secrets.size() > 1)
     ++riter;
 
@@ -64,23 +70,20 @@ bool KeyServerData::get_service_secret(CephContext *cct, uint32_t service_id,
 bool KeyServerData::get_service_secret(CephContext *cct, uint32_t service_id,
 				uint64_t secret_id, CryptoKey& secret) const
 {
-  map<uint32_t, RotatingSecrets>::const_iterator iter =
-      rotating_secrets.find(service_id);
+  auto iter = rotating_secrets.find(service_id);
   if (iter == rotating_secrets.end())
     return false;
 
   const RotatingSecrets& secrets = iter->second;
-  map<uint64_t, ExpiringCryptoKey>::const_iterator riter = 
-      secrets.secrets.find(secret_id);
+  auto riter = secrets.secrets.find(secret_id);
 
   if (riter == secrets.secrets.end()) {
     ldout(cct, 10) << "get_service_secret service " << ceph_entity_type_name(service_id)
 	     << " secret " << secret_id << " not found" << dendl;
     ldout(cct, 30) << " I have:" << dendl;
-    for (map<uint64_t, ExpiringCryptoKey>::const_iterator iter =
-	     secrets.secrets.begin();
-        iter != secrets.secrets.end();
-        ++iter)
+    for (auto iter = secrets.secrets.begin();
+	 iter != secrets.secrets.end();
+	 ++iter)
       ldout(cct, 30) << " id " << iter->first << " " << iter->second << dendl;
     return false;
   }
@@ -90,7 +93,7 @@ bool KeyServerData::get_service_secret(CephContext *cct, uint32_t service_id,
   return true;
 }
 bool KeyServerData::get_auth(const EntityName& name, EntityAuth& auth) const {
-  map<EntityName, EntityAuth>::const_iterator iter = secrets.find(name);
+  auto iter = secrets.find(name);
   if (iter != secrets.end()) {
     auth = iter->second;
     return true;
@@ -99,7 +102,7 @@ bool KeyServerData::get_auth(const EntityName& name, EntityAuth& auth) const {
 }
 
 bool KeyServerData::get_secret(const EntityName& name, CryptoKey& secret) const {
-  map<EntityName, EntityAuth>::const_iterator iter = secrets.find(name);
+  auto iter = secrets.find(name);
   if (iter != secrets.end()) {
     secret = iter->second.key;
     return true;
@@ -113,10 +116,10 @@ bool KeyServerData::get_caps(CephContext *cct, const EntityName& name,
   caps_info.allow_all = false;
 
   ldout(cct, 10) << "get_caps: name=" << name.to_str() << dendl;
-  map<EntityName, EntityAuth>::const_iterator iter = secrets.find(name);
+  auto iter = secrets.find(name);
   if (iter != secrets.end()) {
     ldout(cct, 10) << "get_secret: num of caps=" << iter->second.caps.size() << dendl;
-    map<string, bufferlist>::const_iterator capsiter = iter->second.caps.find(type);
+    auto capsiter = iter->second.caps.find(type);
     if (capsiter != iter->second.caps.end()) {
       caps_info.caps = capsiter->second;
     }
@@ -172,11 +175,11 @@ bool KeyServer::_check_rotating_secrets()
 void KeyServer::_dump_rotating_secrets()
 {
   ldout(cct, 30) << "_dump_rotating_secrets" << dendl;
-  for (map<uint32_t, RotatingSecrets>::iterator iter = data.rotating_secrets.begin();
+  for (auto iter = data.rotating_secrets.begin();
        iter != data.rotating_secrets.end();
        ++iter) {
     RotatingSecrets& key = iter->second;
-    for (map<uint64_t, ExpiringCryptoKey>::iterator mapiter = key.secrets.begin();
+    for (auto mapiter = key.secrets.begin();
 	 mapiter != key.secrets.end();
 	 ++mapiter)
       ldout(cct, 30) << "service " << ceph_entity_type_name(iter->first)
@@ -289,7 +292,7 @@ bool KeyServer::contains(const EntityName& name) const
 int KeyServer::encode_secrets(Formatter *f, stringstream *ds) const
 {
   std::scoped_lock l{lock};
-  map<EntityName, EntityAuth>::const_iterator mapiter = data.secrets_begin();
+  auto mapiter = data.secrets_begin();
 
   if (mapiter == data.secrets_end())
     return -ENOENT;
@@ -310,8 +313,7 @@ int KeyServer::encode_secrets(Formatter *f, stringstream *ds) const
       f->open_object_section("caps");
     }
 
-    map<string, bufferlist>::const_iterator capsiter =
-        mapiter->second.caps.begin();
+    auto capsiter = mapiter->second.caps.begin();
     for (; capsiter != mapiter->second.caps.end(); ++capsiter) {
       // FIXME: need a const_iterator for bufferlist, but it doesn't exist yet.
       bufferlist *bl = const_cast<bufferlist*>(&capsiter->second);
@@ -374,14 +376,13 @@ bool KeyServer::get_rotating_encrypted(const EntityName& name,
 {
   std::scoped_lock l{lock};
 
-  map<EntityName, EntityAuth>::const_iterator mapiter = data.find_name(name);
+  auto mapiter = data.find_name(name);
   if (mapiter == data.secrets_end())
     return false;
 
   const CryptoKey& specific_key = mapiter->second.key;
 
-  map<uint32_t, RotatingSecrets>::const_iterator rotate_iter =
-    data.rotating_secrets.find(name.get_type());
+  auto rotate_iter = data.rotating_secrets.find(name.get_type());
   if (rotate_iter == data.rotating_secrets.end())
     return false;
 

--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -17,7 +17,6 @@
 
 #include "auth/KeyRing.h"
 #include "CephxProtocol.h"
-#include "CephxKeyServer.h"
 #include "common/ceph_mutex.h"
 #include "include/common_fwd.h"
 
@@ -25,19 +24,19 @@ struct KeyServerData {
   version_t version;
 
   /* for each entity */
-  map<EntityName, EntityAuth> secrets;
+  std::map<EntityName, EntityAuth> secrets;
   KeyRing *extra_secrets;
 
   /* for each service type */
   version_t rotating_ver;
-  map<uint32_t, RotatingSecrets> rotating_secrets;
+  std::map<uint32_t, RotatingSecrets> rotating_secrets;
 
   explicit KeyServerData(KeyRing *extra)
     : version(0),
       extra_secrets(extra),
       rotating_ver(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
      __u8 struct_v = 1;
     using ceph::encode;
     encode(struct_v, bl);
@@ -46,7 +45,7 @@ struct KeyServerData {
     encode(secrets, bl);
     encode(rotating_secrets, bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     using ceph::decode;
     __u8 struct_v;
     decode(struct_v, bl);
@@ -56,14 +55,14 @@ struct KeyServerData {
     decode(rotating_secrets, bl);
   }
 
-  void encode_rotating(bufferlist& bl) const {
+  void encode_rotating(ceph::buffer::list& bl) const {
     using ceph::encode;
      __u8 struct_v = 1;
     encode(struct_v, bl);
     encode(rotating_ver, bl);
     encode(rotating_secrets, bl);
   }
-  void decode_rotating(bufferlist& rotating_bl) {
+  void decode_rotating(ceph::buffer::list& rotating_bl) {
     using ceph::decode;
     auto iter = rotating_bl.cbegin();
     __u8 struct_v;
@@ -88,7 +87,7 @@ struct KeyServerData {
   }
 
   void remove_secret(const EntityName& name) {
-    map<EntityName, EntityAuth>::iterator iter = secrets.find(name);
+    auto iter = secrets.find(name);
     if (iter == secrets.end())
       return;
     secrets.erase(iter);
@@ -105,17 +104,17 @@ struct KeyServerData {
   bool get_caps(CephContext *cct, const EntityName& name,
 		const std::string& type, AuthCapsInfo& caps) const;
 
-  map<EntityName, EntityAuth>::iterator secrets_begin()
+  std::map<EntityName, EntityAuth>::iterator secrets_begin()
   { return secrets.begin(); }
-  map<EntityName, EntityAuth>::const_iterator secrets_begin() const 
+  std::map<EntityName, EntityAuth>::const_iterator secrets_begin() const 
   { return secrets.begin(); }
-  map<EntityName, EntityAuth>::iterator secrets_end()
+  std::map<EntityName, EntityAuth>::iterator secrets_end()
   { return secrets.end(); }
-  map<EntityName, EntityAuth>::const_iterator secrets_end() const
+  std::map<EntityName, EntityAuth>::const_iterator secrets_end() const
   { return secrets.end(); }
-  map<EntityName, EntityAuth>::iterator find_name(const EntityName& name)
+  std::map<EntityName, EntityAuth>::iterator find_name(const EntityName& name)
   { return secrets.find(name); }
-  map<EntityName, EntityAuth>::const_iterator find_name(const EntityName& name) const
+  std::map<EntityName, EntityAuth>::const_iterator find_name(const EntityName& name) const
   { return secrets.find(name); }
 
 
@@ -129,11 +128,11 @@ struct KeyServerData {
 
   struct Incremental {
     IncrementalOp op;
-    bufferlist rotating_bl;  // if SET_ROTATING.  otherwise,
+    ceph::buffer::list rotating_bl;  // if SET_ROTATING.  otherwise,
     EntityName name;
     EntityAuth auth;
-    
-    void encode(bufferlist& bl) const {
+
+    void encode(ceph::buffer::list& bl) const {
       using ceph::encode;
       __u8 struct_v = 1;
       encode(struct_v, bl);
@@ -146,7 +145,7 @@ struct KeyServerData {
 	encode(auth, bl);
       }
     }
-    void decode(bufferlist::const_iterator& bl) {
+    void decode(ceph::buffer::list::const_iterator& bl) {
       using ceph::decode;
       __u8 struct_v;
       decode(struct_v, bl);
@@ -211,7 +210,7 @@ public:
 
   bool get_secret(const EntityName& name, CryptoKey& secret) const override;
   bool get_auth(const EntityName& name, EntityAuth& auth) const;
-  bool get_caps(const EntityName& name, const string& type, AuthCapsInfo& caps) const;
+  bool get_caps(const EntityName& name, const std::string& type, AuthCapsInfo& caps) const;
   bool get_active_rotating_secret(const EntityName& name, CryptoKey& secret) const;
   int start_server();
   void rotate_timeout(double timeout);
@@ -233,25 +232,25 @@ public:
 
   bool generate_secret(EntityName& name, CryptoKey& secret);
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     using ceph::encode;
     encode(data, bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     std::scoped_lock l{lock};
     using ceph::decode;
     decode(data, bl);
   }
   bool contains(const EntityName& name) const;
-  int encode_secrets(Formatter *f, stringstream *ds) const;
-  void encode_formatted(string label, Formatter *f, bufferlist &bl);
-  void encode_plaintext(bufferlist &bl);
-  int list_secrets(stringstream& ds) const {
+  int encode_secrets(ceph::Formatter *f, std::stringstream *ds) const;
+  void encode_formatted(std::string label, ceph::Formatter *f, ceph::buffer::list &bl);
+  void encode_plaintext(ceph::buffer::list &bl);
+  int list_secrets(std::stringstream& ds) const {
     return encode_secrets(NULL, &ds);
   }
   version_t get_ver() const {
     std::scoped_lock l{lock};
-    return data.version;    
+    return data.version;
   }
 
   void clear_secrets() {
@@ -279,7 +278,7 @@ public:
   }
 
   bool has_secrets() {
-    map<EntityName, EntityAuth>::const_iterator b = data.secrets_begin();
+    auto b = data.secrets_begin();
     return (b != data.secrets_end());
   }
   int get_num_secrets() {
@@ -293,24 +292,22 @@ public:
   }
   void export_keyring(KeyRing& keyring) {
     std::scoped_lock l{lock};
-    for (map<EntityName, EntityAuth>::iterator p = data.secrets.begin();
-	 p != data.secrets.end();
-	 ++p) {
+    for (auto p = data.secrets.begin(); p != data.secrets.end(); ++p) {
       keyring.add(p->first, p->second);
     }
   }
 
-  bool updated_rotating(bufferlist& rotating_bl, version_t& rotating_ver);
+  bool updated_rotating(ceph::buffer::list& rotating_bl, version_t& rotating_ver);
 
-  bool get_rotating_encrypted(const EntityName& name, bufferlist& enc_bl) const;
+  bool get_rotating_encrypted(const EntityName& name, ceph::buffer::list& enc_bl) const;
 
   ceph::mutex& get_lock() const { return lock; }
   bool get_service_caps(const EntityName& name, uint32_t service_id,
 			AuthCapsInfo& caps) const;
 
-  map<EntityName, EntityAuth>::iterator secrets_begin()
+  std::map<EntityName, EntityAuth>::iterator secrets_begin()
   { return data.secrets_begin(); }
-  map<EntityName, EntityAuth>::iterator secrets_end()
+  std::map<EntityName, EntityAuth>::iterator secrets_end()
   { return data.secrets_end(); }
 };
 WRITE_CLASS_ENCODER(KeyServer)

--- a/src/auth/cephx/CephxServiceHandler.cc
+++ b/src/auth/cephx/CephxServiceHandler.cc
@@ -27,6 +27,14 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "cephx server " << entity_name << ": "
 
+using std::dec;
+using std::hex;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+
 int CephxServiceHandler::start_session(
   const EntityName& name,
   size_t connection_secret_required_length,
@@ -63,7 +71,7 @@ int CephxServiceHandler::handle_request(
   struct CephXRequestHeader cephx_header;
   try {
     decode(cephx_header, indata);
-  } catch (buffer::error& e) {
+  } catch (ceph::buffer::error& e) {
     ldout(cct, 0) << __func__ << " failed to decode CephXRequestHeader: "
 		  << e.what() << dendl;
     return -EPERM;
@@ -78,7 +86,7 @@ int CephxServiceHandler::handle_request(
       CephXAuthenticate req;
       try {
 	decode(req, indata);
-      } catch (buffer::error& e) {
+      } catch (ceph::buffer::error& e) {
 	ldout(cct, 0) << __func__ << " failed to decode CephXAuthenticate: "
 		      << e.what() << dendl;
 	ret = -EPERM;
@@ -249,7 +257,7 @@ int CephxServiceHandler::handle_request(
       CephXServiceTicketRequest ticket_req;
       try {
 	decode(ticket_req, indata);
-      } catch (buffer::error& e) {
+      } catch (ceph::buffer::error& e) {
 	ldout(cct, 0) << __func__
 		      << " failed to decode CephXServiceTicketRequest: "
 		      << e.what() << dendl;

--- a/src/auth/cephx/CephxServiceHandler.h
+++ b/src/auth/cephx/CephxServiceHandler.h
@@ -31,20 +31,20 @@ public:
   
   int start_session(const EntityName& name,
 		    size_t connection_secret_required_length,
-		    bufferlist *result_bl,
+		    ceph::buffer::list *result_bl,
 		    AuthCapsInfo *caps,
 		    CryptoKey *session_key,
 		    std::string *connection_secret) override;
   int handle_request(
-    bufferlist::const_iterator& indata,
+    ceph::buffer::list::const_iterator& indata,
     size_t connection_secret_required_length,
-    bufferlist *result_bl,
+    ceph::buffer::list *result_bl,
     uint64_t *global_id,
     AuthCapsInfo *caps,
     CryptoKey *session_key,
     std::string *connection_secret) override;
 
-  void build_cephx_response_header(int request_type, int status, bufferlist& bl);
+  void build_cephx_response_header(int request_type, int status, ceph::buffer::list& bl);
 };
 
 #endif

--- a/src/auth/none/AuthNoneServiceHandler.h
+++ b/src/auth/none/AuthNoneServiceHandler.h
@@ -27,7 +27,7 @@ public:
   
   int start_session(const EntityName& name,
 		    size_t connection_secret_required_length,
-		    bufferlist *result_bl,
+		    ceph::buffer::list *result_bl,
 		    AuthCapsInfo *caps,
 		    CryptoKey *session_key,
 		    std::string *connection_secret) override {
@@ -35,9 +35,9 @@ public:
     caps->allow_all = true;
     return 1;
   }
-  int handle_request(bufferlist::const_iterator& indata,
+  int handle_request(ceph::buffer::list::const_iterator& indata,
 		     size_t connection_secret_required_length,
-		     bufferlist *result_bl,
+		     ceph::buffer::list *result_bl,
 		     uint64_t *global_id,
 		     AuthCapsInfo *caps,
 		     CryptoKey *session_key,
@@ -45,7 +45,7 @@ public:
     return 0;
   }
   void build_cephx_response_header(int request_type, int status,
-				   bufferlist& bl) {
+				   ceph::buffer::list& bl) {
   }
 };
 

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -47,7 +47,21 @@
 
 #define dout_subsys ceph_subsys_mon
 
+using std::cerr;
+using std::cout;
+using std::list;
+using std::map;
+using std::ostringstream;
+using std::string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::JSONFormatter;
+
 Monitor *mon = NULL;
+
 
 void handle_mon_signal(int signum)
 {
@@ -396,7 +410,7 @@ int main(int argc, const char **argv)
 
 	// always mark seed/mkfs monmap as epoch 0
 	monmap.set_epoch(0);
-      } catch (const buffer::error& e) {
+      } catch (const ceph::buffer::error& e) {
 	derr << argv[0] << ": error decoding monmap " << monmap_fn << ": " << e.what() << dendl;
 	exit(1);
       }
@@ -692,7 +706,7 @@ int main(int argc, const char **argv)
     if (err >= 0) {
       try {
         monmap.decode(mapbl);
-      } catch (const buffer::error& e) {
+      } catch (const ceph::buffer::error& e) {
         derr << "can't decode monmap: " << e.what() << dendl;
       }
     } else {

--- a/src/common/Checksummer.h
+++ b/src/common/Checksummer.h
@@ -4,8 +4,11 @@
 #ifndef CEPH_OS_BLUESTORE_CHECKSUMMER
 #define CEPH_OS_BLUESTORE_CHECKSUMMER
 
-#include "xxHash/xxhash.h"
+#include "include/buffer.h"
 #include "include/byteorder.h"
+#include "include/ceph_assert.h"
+
+#include "xxHash/xxhash.h"
 
 class Checksummer {
 public:
@@ -83,7 +86,7 @@ public:
       state_t state,
       init_value_t init_value,
       size_t len,
-      bufferlist::const_iterator& p
+      ceph::buffer::list::const_iterator& p
       ) {
       return p.crc32c(len, init_value);
     }
@@ -104,7 +107,7 @@ public:
       state_t state,
       init_value_t init_value,
       size_t len,
-      bufferlist::const_iterator& p
+      ceph::buffer::list::const_iterator& p
       ) {
       return p.crc32c(len, init_value) & 0xffff;
     }
@@ -125,7 +128,7 @@ public:
       state_t state,
       init_value_t init_value,
       size_t len,
-      bufferlist::const_iterator& p
+      ceph::buffer::list::const_iterator& p
       ) {
       return p.crc32c(len, init_value) & 0xff;
     }
@@ -147,7 +150,7 @@ public:
       state_t state,
       init_value_t init_value,
       size_t len,
-      bufferlist::const_iterator& p
+      ceph::buffer::list::const_iterator& p
       ) {
       XXH32_reset(state, init_value);
       while (len > 0) {
@@ -176,7 +179,7 @@ public:
       state_t state,
       init_value_t init_value,
       size_t len,
-      bufferlist::const_iterator& p
+      ceph::buffer::list::const_iterator& p
       ) {
       XXH64_reset(state, init_value);
       while (len > 0) {
@@ -194,8 +197,8 @@ public:
     size_t csum_block_size,
     size_t offset,
     size_t length,
-    const bufferlist &bl,
-    bufferptr* csum_data
+    const ceph::buffer::list &bl,
+    ceph::buffer::ptr* csum_data
     ) {
     return calculate<Alg>(-1, csum_block_size, offset, length, bl, csum_data);
   }
@@ -206,11 +209,11 @@ public:
       size_t csum_block_size,
       size_t offset,
       size_t length,
-      const bufferlist &bl,
-      bufferptr* csum_data) {
+      const ceph::buffer::list &bl,
+      ceph::buffer::ptr* csum_data) {
     ceph_assert(length % csum_block_size == 0);
     size_t blocks = length / csum_block_size;
-    bufferlist::const_iterator p = bl.begin();
+    ceph::buffer::list::const_iterator p = bl.begin();
     ceph_assert(bl.length() >= length);
 
     typename Alg::state_t state;
@@ -235,12 +238,12 @@ public:
     size_t csum_block_size,
     size_t offset,
     size_t length,
-    const bufferlist &bl,
-    const bufferptr& csum_data,
+    const ceph::buffer::list &bl,
+    const ceph::buffer::ptr& csum_data,
     uint64_t *bad_csum=0
     ) {
     ceph_assert(length % csum_block_size == 0);
-    bufferlist::const_iterator p = bl.begin();
+    ceph::buffer::list::const_iterator p = bl.begin();
     ceph_assert(bl.length() >= length);
 
     typename Alg::state_t state;

--- a/src/common/shared_cache.hpp
+++ b/src/common/shared_cache.hpp
@@ -23,11 +23,9 @@
 #include <memory>
 #endif
 #include "common/ceph_mutex.h"
+#include "common/ceph_context.h"
 #include "common/dout.h"
 #include "include/unordered_map.h"
-
-// re-include our assert to clobber the system one; fix dout:
-#include "include/ceph_assert.h"
 
 template <class K, class V>
 class SharedLRU {
@@ -164,7 +162,7 @@ public:
     VPtr val; // release any ref we have after we drop the lock
     {
       std::lock_guard l{lock};
-      typename map<K, pair<WeakVPtr, V*>, C>::iterator i = weak_refs.find(key);
+      auto i = weak_refs.find(key);
       if (i != weak_refs.end()) {
 	val = i->second.first.lock();
       }
@@ -176,7 +174,7 @@ public:
   void clear_range(
     const K& from,
     const K& to) {
-    list<VPtr> vals; // release any refs we have after we drop the lock
+    std::list<VPtr> vals; // release any refs we have after we drop the lock
     {
       std::lock_guard l{lock};
       auto from_iter = weak_refs.lower_bound(from);
@@ -193,7 +191,7 @@ public:
     VPtr val; // release any ref we have after we drop the lock
     {
       std::lock_guard l{lock};
-      typename map<K, pair<WeakVPtr, V*>, C>::iterator i = weak_refs.find(key);
+      auto i = weak_refs.find(key);
       if (i != weak_refs.end()) {
 	val = i->second.first.lock();
         weak_refs.erase(i);
@@ -203,7 +201,7 @@ public:
   }
 
   void set_size(size_t new_size) {
-    list<VPtr> to_release;
+    std::list<VPtr> to_release;
     {
       std::lock_guard l{lock};
       max_size = new_size;
@@ -219,7 +217,7 @@ public:
 
   VPtr lower_bound(const K& key) {
     VPtr val;
-    list<VPtr> to_release;
+    std::list<VPtr> to_release;
     {
       std::unique_lock l{lock};
       ++waiting;
@@ -298,7 +296,7 @@ public:
   }
   VPtr lookup_or_create(const K &key) {
     VPtr val;
-    list<VPtr> to_release;
+    std::list<VPtr> to_release;
     {
       std::unique_lock l{lock};
       cond.wait(l, [this, &key, &val] {
@@ -346,9 +344,9 @@ public:
    */
   VPtr add(const K& key, V *value, bool *existed = NULL) {
     VPtr val;
-    list<VPtr> to_release;
+    std::list<VPtr> to_release;
     {
-      typename map<K, pair<WeakVPtr, V*>, C>::iterator actual;
+      typename std::map<K, std::pair<WeakVPtr, V*>, C>::iterator actual;
       std::unique_lock l{lock};
       cond.wait(l, [this, &key, &actual, &val] {
 	  actual = weak_refs.lower_bound(key);

--- a/src/compressor/lz4/CompressionPluginLZ4.cc
+++ b/src/compressor/lz4/CompressionPluginLZ4.cc
@@ -30,7 +30,7 @@ int __ceph_plugin_init(CephContext *cct,
                        const std::string& type,
                        const std::string& name)
 {
-  PluginRegistry *instance = cct->get_plugin_registry();
+  auto instance = cct->get_plugin_registry();
 
   return instance->add(type, name, new CompressionPluginLZ4(cct));
 }

--- a/src/compressor/lz4/CompressionPluginLZ4.h
+++ b/src/compressor/lz4/CompressionPluginLZ4.h
@@ -21,7 +21,7 @@
 #include "LZ4Compressor.h"
 // -----------------------------------------------------------------------------
 
-class CompressionPluginLZ4 : public CompressionPlugin {
+class CompressionPluginLZ4 : public ceph::CompressionPlugin {
 
 public:
 

--- a/src/compressor/lz4/LZ4Compressor.h
+++ b/src/compressor/lz4/LZ4Compressor.h
@@ -35,7 +35,7 @@ class LZ4Compressor : public Compressor {
 #endif
   }
 
-  int compress(const bufferlist &src, bufferlist &dst) override {
+  int compress(const ceph::buffer::list &src, ceph::buffer::list &dst) override {
     // older versions of liblz4 introduce bit errors when compressing
     // fragmented buffers.  this was fixed in lz4 commit
     // af127334670a5e7b710bbd6adb71aa7c3ef0cd72, which first
@@ -43,7 +43,7 @@ class LZ4Compressor : public Compressor {
     //
     // workaround: rebuild if not contiguous.
     if (!src.is_contiguous()) {
-      bufferlist new_src = src;
+      ceph::buffer::list new_src = src;
       new_src.rebuild();
       return compress(new_src, dst);
     }
@@ -52,10 +52,12 @@ class LZ4Compressor : public Compressor {
     if (qat_enabled)
       return qat_accel.compress(src, dst);
 #endif
-    bufferptr outptr = buffer::create_small_page_aligned(
+    ceph::buffer::ptr outptr = ceph::buffer::create_small_page_aligned(
       LZ4_compressBound(src.length()));
     LZ4_stream_t lz4_stream;
     LZ4_resetStream(&lz4_stream);
+
+    using ceph::encode;
 
     auto p = src.begin();
     size_t left = src.length();
@@ -81,7 +83,7 @@ class LZ4Compressor : public Compressor {
     return 0;
   }
 
-  int decompress(const bufferlist &src, bufferlist &dst) override {
+  int decompress(const ceph::buffer::list &src, ceph::buffer::list &dst) override {
 #ifdef HAVE_QATZIP
     if (qat_enabled)
       return qat_accel.decompress(src, dst);
@@ -90,13 +92,14 @@ class LZ4Compressor : public Compressor {
     return decompress(i, src.length(), dst);
   }
 
-  int decompress(bufferlist::const_iterator &p,
+  int decompress(ceph::buffer::list::const_iterator &p,
 		 size_t compressed_len,
-		 bufferlist &dst) override {
+		 ceph::buffer::list &dst) override {
 #ifdef HAVE_QATZIP
     if (qat_enabled)
       return qat_accel.decompress(p, compressed_len, dst);
 #endif
+    using ceph::decode;
     uint32_t count;
     std::vector<std::pair<uint32_t, uint32_t> > compressed_pairs;
     decode(count, p);
@@ -109,13 +112,13 @@ class LZ4Compressor : public Compressor {
     }
     compressed_len -= (sizeof(uint32_t) + sizeof(uint32_t) * count * 2);
 
-    bufferptr dstptr(total_origin);
+    ceph::buffer::ptr dstptr(total_origin);
     LZ4_streamDecode_t lz4_stream_decode;
     LZ4_setStreamDecode(&lz4_stream_decode, nullptr, 0);
 
-    bufferptr cur_ptr = p.get_current_ptr();
-    bufferptr *ptr = &cur_ptr;
-    Tub<bufferptr> data_holder;
+    ceph::buffer::ptr cur_ptr = p.get_current_ptr();
+    ceph::buffer::ptr *ptr = &cur_ptr;
+    Tub<ceph::buffer::ptr> data_holder;
     if (compressed_len != cur_ptr.length()) {
       data_holder.construct(compressed_len);
       p.copy_deep(compressed_len, *data_holder);

--- a/src/compressor/snappy/CompressionPluginSnappy.cc
+++ b/src/compressor/snappy/CompressionPluginSnappy.cc
@@ -32,7 +32,7 @@ int __ceph_plugin_init(CephContext *cct,
                        const std::string& type,
                        const std::string& name)
 {
-  PluginRegistry *instance = cct->get_plugin_registry();
+  auto instance = cct->get_plugin_registry();
 
   return instance->add(type, name, new CompressionPluginSnappy(cct));
 }

--- a/src/compressor/snappy/CompressionPluginSnappy.h
+++ b/src/compressor/snappy/CompressionPluginSnappy.h
@@ -20,7 +20,7 @@
 #include "SnappyCompressor.h"
 // -----------------------------------------------------------------------------
 
-class CompressionPluginSnappy : public CompressionPlugin {
+class CompressionPluginSnappy : public ceph::CompressionPlugin {
 
 public:
 

--- a/src/compressor/snappy/SnappyCompressor.h
+++ b/src/compressor/snappy/SnappyCompressor.h
@@ -22,11 +22,11 @@
 #include "include/buffer.h"
 
 class CEPH_BUFFER_API BufferlistSource : public snappy::Source {
-  bufferlist::const_iterator pb;
+  ceph::bufferlist::const_iterator pb;
   size_t remaining;
 
  public:
-  explicit BufferlistSource(bufferlist::const_iterator _pb, size_t _input_len)
+  explicit BufferlistSource(ceph::bufferlist::const_iterator _pb, size_t _input_len)
     : pb(_pb),
       remaining(_input_len) {
     remaining = std::min(remaining, (size_t)pb.get_remaining());
@@ -50,7 +50,7 @@ class CEPH_BUFFER_API BufferlistSource : public snappy::Source {
     remaining -= n;
   }
 
-  bufferlist::const_iterator get_pos() const {
+  ceph::bufferlist::const_iterator get_pos() const {
     return pb;
   }
 };
@@ -66,13 +66,13 @@ class SnappyCompressor : public Compressor {
 #endif
   }
 
-  int compress(const bufferlist &src, bufferlist &dst) override {
+  int compress(const ceph::bufferlist &src, ceph::bufferlist &dst) override {
 #ifdef HAVE_QATZIP
     if (qat_enabled)
       return qat_accel.compress(src, dst);
 #endif
-    BufferlistSource source(const_cast<bufferlist&>(src).begin(), src.length());
-    bufferptr ptr = buffer::create_small_page_aligned(
+    BufferlistSource source(const_cast<ceph::bufferlist&>(src).begin(), src.length());
+    ceph::bufferptr ptr = ceph::buffer::create_small_page_aligned(
       snappy::MaxCompressedLength(src.length()));
     snappy::UncheckedByteArraySink sink(ptr.c_str());
     snappy::Compress(&source, &sink);
@@ -80,7 +80,7 @@ class SnappyCompressor : public Compressor {
     return 0;
   }
 
-  int decompress(const bufferlist &src, bufferlist &dst) override {
+  int decompress(const ceph::bufferlist &src, ceph::bufferlist &dst) override {
 #ifdef HAVE_QATZIP
     if (qat_enabled)
       return qat_accel.decompress(src, dst);
@@ -89,9 +89,9 @@ class SnappyCompressor : public Compressor {
     return decompress(i, src.length(), dst);
   }
 
-  int decompress(bufferlist::const_iterator &p,
+  int decompress(ceph::bufferlist::const_iterator &p,
 		 size_t compressed_len,
-		 bufferlist &dst) override {
+		 ceph::bufferlist &dst) override {
 #ifdef HAVE_QATZIP
     if (qat_enabled)
       return qat_accel.decompress(p, compressed_len, dst);
@@ -102,7 +102,7 @@ class SnappyCompressor : public Compressor {
       return -1;
     }
     BufferlistSource source_2(p, compressed_len);
-    bufferptr ptr(res_len);
+    ceph::bufferptr ptr(res_len);
     if (snappy::RawUncompress(&source_2, ptr.c_str())) {
       p = source_2.get_pos();
       dst.append(ptr);

--- a/src/compressor/zlib/CompressionPluginZlib.cc
+++ b/src/compressor/zlib/CompressionPluginZlib.cc
@@ -32,7 +32,7 @@ int __ceph_plugin_init(CephContext *cct,
                        const std::string& type,
                        const std::string& name)
 {
-  PluginRegistry *instance = cct->get_plugin_registry();
+  auto instance = cct->get_plugin_registry();
 
   return instance->add(type, name, new CompressionPluginZlib(cct));
 }

--- a/src/compressor/zlib/CompressionPluginZlib.h
+++ b/src/compressor/zlib/CompressionPluginZlib.h
@@ -19,12 +19,13 @@
 #include "arch/probe.h"
 #include "arch/intel.h"
 #include "arch/arm.h"
+#include "common/ceph_context.h"
 #include "compressor/CompressionPlugin.h"
 #include "ZlibCompressor.h"
 
 // -----------------------------------------------------------------------------
 
-class CompressionPluginZlib : public CompressionPlugin {
+class CompressionPluginZlib : public ceph::CompressionPlugin {
 public:
   bool has_isal = false;
 

--- a/src/compressor/zlib/ZlibCompressor.cc
+++ b/src/compressor/zlib/ZlibCompressor.cc
@@ -30,6 +30,11 @@
 
 // -----------------------------------------------------------------------------
 
+using std::ostream;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
+
 static ostream&
 _prefix(std::ostream* _dout)
 {
@@ -78,7 +83,7 @@ int ZlibCompressor::zlib_compress(const bufferlist &in, bufferlist &out)
 
     strm.next_in = c_in;
     do {
-      bufferptr ptr = buffer::create_page_aligned(MAX_LEN);
+      bufferptr ptr = ceph::buffer::create_page_aligned(MAX_LEN);
       strm.next_out = (unsigned char*)ptr.c_str() + begin;
       strm.avail_out = MAX_LEN - begin;
       if (begin) {
@@ -134,7 +139,7 @@ int ZlibCompressor::isal_compress(const bufferlist &in, bufferlist &out)
     strm.next_in = c_in;
 
     do {
-      bufferptr ptr = buffer::create_page_aligned(MAX_LEN);
+      bufferptr ptr = ceph::buffer::create_page_aligned(MAX_LEN);
       strm.next_out = (unsigned char*)ptr.c_str() + begin;
       strm.avail_out = MAX_LEN - begin;
       if (begin) {
@@ -216,7 +221,7 @@ int ZlibCompressor::decompress(bufferlist::const_iterator &p, size_t compressed_
 
     do {
       strm.avail_out = MAX_LEN;
-      bufferptr ptr = buffer::create_page_aligned(MAX_LEN);
+      bufferptr ptr = ceph::buffer::create_page_aligned(MAX_LEN);
       strm.next_out = (unsigned char*)ptr.c_str();
       ret = inflate(&strm, Z_NO_FLUSH);
       if (ret != Z_OK && ret != Z_STREAM_END && ret != Z_BUF_ERROR) {

--- a/src/compressor/zlib/ZlibCompressor.h
+++ b/src/compressor/zlib/ZlibCompressor.h
@@ -34,12 +34,12 @@ public:
 #endif
   }
 
-  int compress(const bufferlist &in, bufferlist &out) override;
-  int decompress(const bufferlist &in, bufferlist &out) override;
-  int decompress(bufferlist::const_iterator &p, size_t compressed_len, bufferlist &out) override;
+  int compress(const ceph::buffer::list &in, ceph::buffer::list &out) override;
+  int decompress(const ceph::buffer::list &in, ceph::buffer::list &out) override;
+  int decompress(ceph::buffer::list::const_iterator &p, size_t compressed_len, ceph::buffer::list &out) override;
 private:
-  int zlib_compress(const bufferlist &in, bufferlist &out);
-  int isal_compress(const bufferlist &in, bufferlist &out);
+  int zlib_compress(const ceph::buffer::list &in, ceph::buffer::list &out);
+  int isal_compress(const ceph::buffer::list &in, ceph::buffer::list &out);
  };
 
 

--- a/src/compressor/zstd/CompressionPluginZstd.cc
+++ b/src/compressor/zstd/CompressionPluginZstd.cc
@@ -30,7 +30,7 @@ int __ceph_plugin_init(CephContext *cct,
                        const std::string& type,
                        const std::string& name)
 {
-  PluginRegistry *instance = cct->get_plugin_registry();
+  auto instance = cct->get_plugin_registry();
 
   return instance->add(type, name, new CompressionPluginZstd(cct));
 }

--- a/src/compressor/zstd/CompressionPluginZstd.h
+++ b/src/compressor/zstd/CompressionPluginZstd.h
@@ -21,7 +21,7 @@
 #include "ZstdCompressor.h"
 // -----------------------------------------------------------------------------
 
-class CompressionPluginZstd : public CompressionPlugin {
+class CompressionPluginZstd : public ceph::CompressionPlugin {
 
 public:
 

--- a/src/compressor/zstd/ZstdCompressor.h
+++ b/src/compressor/zstd/ZstdCompressor.h
@@ -28,14 +28,14 @@ class ZstdCompressor : public Compressor {
  public:
   ZstdCompressor() : Compressor(COMP_ALG_ZSTD, "zstd") {}
 
-  int compress(const bufferlist &src, bufferlist &dst) override {
+  int compress(const ceph::buffer::list &src, ceph::buffer::list &dst) override {
     ZSTD_CStream *s = ZSTD_createCStream();
     ZSTD_initCStream_srcSize(s, COMPRESSION_LEVEL, src.length());
     auto p = src.begin();
     size_t left = src.length();
 
     size_t const out_max = ZSTD_compressBound(left);
-    bufferptr outptr = buffer::create_small_page_aligned(out_max);
+    ceph::buffer::ptr outptr = ceph::buffer::create_small_page_aligned(out_max);
     ZSTD_outBuffer_s outbuf;
     outbuf.dst = outptr.c_str();
     outbuf.size = outptr.length();
@@ -58,27 +58,27 @@ class ZstdCompressor : public Compressor {
     ZSTD_freeCStream(s);
 
     // prefix with decompressed length
-    encode((uint32_t)src.length(), dst);
+    ceph::encode((uint32_t)src.length(), dst);
     dst.append(outptr, 0, outbuf.pos);
     return 0;
   }
 
-  int decompress(const bufferlist &src, bufferlist &dst) override {
+  int decompress(const ceph::buffer::list &src, ceph::buffer::list &dst) override {
     auto i = std::cbegin(src);
     return decompress(i, src.length(), dst);
   }
 
-  int decompress(bufferlist::const_iterator &p,
+  int decompress(ceph::buffer::list::const_iterator &p,
 		 size_t compressed_len,
-		 bufferlist &dst) override {
+		 ceph::buffer::list &dst) override {
     if (compressed_len < 4) {
       return -1;
     }
     compressed_len -= 4;
     uint32_t dst_len;
-    decode(dst_len, p);
+    ceph::decode(dst_len, p);
 
-    bufferptr dstptr(dst_len);
+    ceph::buffer::ptr dstptr(dst_len);
     ZSTD_outBuffer_s outbuf;
     outbuf.dst = dstptr.c_str();
     outbuf.size = dstptr.length();

--- a/src/crypto/crypto_plugin.h
+++ b/src/crypto/crypto_plugin.h
@@ -22,7 +22,7 @@
 #include "crypto/crypto_accel.h"
 // -----------------------------------------------------------------------------
 
-class CryptoPlugin : public Plugin {
+class CryptoPlugin : public ceph::Plugin {
 
 public:
   CryptoAccelRef cryptoaccel;

--- a/src/crypto/isa-l/isal_crypto_plugin.cc
+++ b/src/crypto/isa-l/isal_crypto_plugin.cc
@@ -28,7 +28,7 @@ int __ceph_plugin_init(CephContext *cct,
                        const std::string& type,
                        const std::string& name)
 {
-  PluginRegistry *instance = cct->get_plugin_registry();
+  auto instance = cct->get_plugin_registry();
 
   return instance->add(type, name, new ISALCryptoPlugin(cct));
 }

--- a/src/crypto/isa-l/isal_crypto_plugin.h
+++ b/src/crypto/isa-l/isal_crypto_plugin.h
@@ -31,7 +31,7 @@ public:
   ~ISALCryptoPlugin()
   {}
   virtual int factory(CryptoAccelRef *cs,
-                      ostream *ss)
+                      std::ostream *ss)
   {
     if (cryptoaccel == nullptr)
     {

--- a/src/crypto/openssl/openssl_crypto_accel.cc
+++ b/src/crypto/openssl/openssl_crypto_accel.cc
@@ -23,7 +23,7 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout)
 
-static ostream&
+static std::ostream&
 _prefix(std::ostream* _dout)
 {
   return *_dout << "OpensslCryptoAccel: ";

--- a/src/crypto/openssl/openssl_crypto_plugin.cc
+++ b/src/crypto/openssl/openssl_crypto_plugin.cc
@@ -26,7 +26,7 @@ int __ceph_plugin_init(CephContext *cct,
                        const std::string& type,
                        const std::string& name)
 {
-  PluginRegistry *instance = cct->get_plugin_registry();
+  auto instance = cct->get_plugin_registry();
 
   return instance->add(type, name, new OpenSSLCryptoPlugin(cct));
 }

--- a/src/crypto/openssl/openssl_crypto_plugin.h
+++ b/src/crypto/openssl/openssl_crypto_plugin.h
@@ -25,7 +25,7 @@ class OpenSSLCryptoPlugin : public CryptoPlugin {
 public:
   explicit OpenSSLCryptoPlugin(CephContext* cct) : CryptoPlugin(cct)
   {}
-  int factory(CryptoAccelRef *cs, ostream *ss) override {
+  int factory(CryptoAccelRef *cs, std::ostream *ss) override {
     if (cryptoaccel == nullptr)
       cryptoaccel = CryptoAccelRef(new OpenSSLCryptoAccel);
 

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -38,6 +38,10 @@
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_
+
+using std::cerr;
+using std::string;
+
 static void global_init_set_globals(CephContext *cct)
 {
   g_ceph_context = cct;
@@ -197,13 +201,13 @@ global_init(const std::map<std::string,std::string> *defaults,
   if (g_conf()->fatal_signal_handlers) {
     install_standard_sighandlers();
   }
-  register_assert_context(g_ceph_context);
+  ceph::register_assert_context(g_ceph_context);
 
   if (g_conf()->log_flush_on_exit)
     g_ceph_context->_log->set_flush_on_exit();
 
   // drop privileges?
-  ostringstream priv_ss;
+  std::ostringstream priv_ss;
  
   // consider --setuser root a no-op, even if we're not root
   if (getuid() != 0) {
@@ -570,11 +574,9 @@ int global_init_preload_erasure_code(const CephContext *cct)
   string plugins = conf->osd_erasure_code_plugins;
 
   // validate that this is a not a legacy plugin
-  list<string> plugins_list;
+  std::list<string> plugins_list;
   get_str_list(plugins, plugins_list);
-  for (list<string>::iterator i = plugins_list.begin();
-       i != plugins_list.end();
-       ++i) {
+  for (auto i = plugins_list.begin(); i != plugins_list.end(); ++i) {
 	string plugin_name = *i;
 	string replacement = "";
 
@@ -598,8 +600,8 @@ int global_init_preload_erasure_code(const CephContext *cct)
 	}
   }
 
-  stringstream ss;
-  int r = ErasureCodePluginRegistry::instance().preload(
+  std::stringstream ss;
+  int r = ceph::ErasureCodePluginRegistry::instance().preload(
     plugins,
     conf.get_val<std::string>("erasure_code_dir"),
     &ss);

--- a/src/global/pidfile.cc
+++ b/src/global/pidfile.cc
@@ -29,6 +29,8 @@
 
 #include "include/compat.h"
 
+using std::string;
+
 //
 // derr can be used for functions exclusively called from pidfile_write
 //

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -40,6 +40,12 @@ extern char *sys_siglist[];
 
 #define dout_context g_ceph_context
 
+using std::ostringstream;
+using std::string;
+
+using ceph::BackTrace;
+using ceph::JSONFormatter;
+
 void install_sighandler(int signum, signal_handler_t handler, int flags)
 {
   int ret;

--- a/src/kv/KeyValueDB.cc
+++ b/src/kv/KeyValueDB.cc
@@ -10,6 +10,9 @@
 #include "RocksDBStore.h"
 #endif
 
+using std::map;
+using std::string;
+
 KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
 			       const string& dir,
 			       map<string,string> options,

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -14,8 +14,6 @@
 #include "common/perf_counters.h"
 #include "common/PriorityCache.h"
 
-using std::string;
-using std::vector;
 /**
  * Defines virtual interface to be implemented by key value store
  *
@@ -29,9 +27,9 @@ public:
    *  Prefix will be the name of column family to use.
    */
   struct ColumnFamily {
-    string name;      //< name of this individual column family
-    string option;    //< configure option string for this CF
-    ColumnFamily(const string &name, const string &option)
+    std::string name;      //< name of this individual column family
+    std::string option;    //< configure option string for this CF
+    ColumnFamily(const std::string &name, const std::string &option)
       : name(name), option(option) {}
   };
 
@@ -56,7 +54,7 @@ public:
       uint32_t num;
       decode(num, p);
       while (num--) {
-	string key;
+	std::string key;
 	ceph::buffer::list value;
 	decode(key, p);
 	decode(value, p);
@@ -75,7 +73,7 @@ public:
       const char *k,
       size_t keylen,
       const ceph::buffer::list& bl) {
-      set(prefix, string(k, keylen), bl);
+      set(prefix, std::string(k, keylen), bl);
     }
 
     /// Removes Keys (via encoded ceph::buffer::list)
@@ -88,7 +86,7 @@ public:
       uint32_t num;
       decode(num, p);
       while (num--) {
-	string key;
+	std::string key;
 	decode(key, p);
 	rmkey(prefix, key);
       }
@@ -113,7 +111,7 @@ public:
       const char *k,	      ///< [in] Key to remove
       size_t keylen
       ) {
-      rmkey(prefix, string(k, keylen));
+      rmkey(prefix, std::string(k, keylen));
     }
 
     /// Remove Single Key which exists and was not overwritten.
@@ -132,9 +130,9 @@ public:
       ) = 0;
 
     virtual void rm_range_keys(
-      const string &prefix,    ///< [in] Prefix by which to remove keys
-      const string &start,     ///< [in] The start bound of remove keys
-      const string &end        ///< [in] The start bound of remove keys
+      const std::string &prefix,    ///< [in] Prefix by which to remove keys
+      const std::string &start,     ///< [in] The start bound of remove keys
+      const std::string &end        ///< [in] The start bound of remove keys
       ) = 0;
 
     /// Merge value into key
@@ -156,7 +154,7 @@ public:
 
   /// test whether we can successfully initialize; may have side effects (e.g., create)
   static int test_init(const std::string& type, const std::string& dir);
-  virtual int init(string option_str="") = 0;
+  virtual int init(std::string option_str="") = 0;
   virtual int open(std::ostream &out, const std::vector<ColumnFamily>& cfs = {}) = 0;
   // std::vector cfs contains column families to be created when db is created.
   virtual int create_and_open(std::ostream &out,
@@ -198,10 +196,10 @@ public:
     }
     return r;
   }
-  virtual int get(const string &prefix,
+  virtual int get(const std::string &prefix,
 		  const char *key, size_t keylen,
 		  ceph::buffer::list *value) {
-    return get(prefix, string(key, keylen), value);
+    return get(prefix, std::string(key, keylen), value);
   }
 
   // This superclass is used both by kv iterators *and* by the ObjectMap
@@ -367,8 +365,8 @@ public:
   virtual ~KeyValueDB() {}
 
   /// estimate space utilization for a prefix (in bytes)
-  virtual int64_t estimate_prefix_size(const string& prefix,
-				       const string& key_prefix) {
+  virtual int64_t estimate_prefix_size(const std::string& prefix,
+				       const std::string& key_prefix) {
     return 0;
   }
 

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -7,8 +7,6 @@
 #include <string>
 #include <cerrno>
 
-using std::string;
-
 #include "common/debug.h"
 #include "common/perf_counters.h"
 
@@ -19,6 +17,15 @@ using std::string;
 #define dout_subsys ceph_subsys_leveldb
 #undef dout_prefix
 #define dout_prefix *_dout << "leveldb: "
+
+using std::list;
+using std::string;
+using std::ostream;
+using std::pair;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
 
 class CephLevelDBLogger : public leveldb::Logger {
   CephContext *cct;

--- a/src/kv/LevelDBStore.h
+++ b/src/kv/LevelDBStore.h
@@ -57,7 +57,7 @@ class LevelDBStore : public KeyValueDB {
   CephContext *cct;
   PerfCounters *logger;
   CephLevelDBLogger *ceph_logger;
-  string path;
+  std::string path;
   boost::scoped_ptr<leveldb::Cache> db_cache;
 #ifdef HAVE_LEVELDB_FILTER_POLICY
   boost::scoped_ptr<const leveldb::FilterPolicy> filterpolicy;
@@ -65,13 +65,13 @@ class LevelDBStore : public KeyValueDB {
   boost::scoped_ptr<leveldb::DB> db;
 
   int load_leveldb_options(bool create_if_missing, leveldb::Options &opts);
-  int do_open(ostream &out, bool create_if_missing);
+  int do_open(std::ostream &out, bool create_if_missing);
 
   // manage async compactions
   ceph::mutex compact_queue_lock =
     ceph::make_mutex("LevelDBStore::compact_thread_lock");
   ceph::condition_variable compact_queue_cond;
-  list< pair<string,string> > compact_queue;
+  std::list<std::pair<std::string, std::string>> compact_queue;
   bool compact_queue_stop;
   class CompactThread : public Thread {
     LevelDBStore *db;
@@ -86,34 +86,34 @@ class LevelDBStore : public KeyValueDB {
 
   void compact_thread_entry();
 
-  void compact_range(const string& start, const string& end) {
+  void compact_range(const std::string& start, const std::string& end) {
     leveldb::Slice cstart(start);
     leveldb::Slice cend(end);
     db->CompactRange(&cstart, &cend);
   }
-  void compact_range_async(const string& start, const string& end);
+  void compact_range_async(const std::string& start, const std::string& end);
 
 public:
   /// compact the underlying leveldb store
   void compact() override;
 
   void compact_async() override {
-    compact_range_async(string(), string());
+    compact_range_async({}, {});
   }
 
   /// compact db for all keys with a given prefix
-  void compact_prefix(const string& prefix) override {
+  void compact_prefix(const std::string& prefix) override {
     compact_range(prefix, past_prefix(prefix));
   }
-  void compact_prefix_async(const string& prefix) override {
+  void compact_prefix_async(const std::string& prefix) override {
     compact_range_async(prefix, past_prefix(prefix));
   }
-  void compact_range(const string& prefix,
-		     const string& start, const string& end) override {
+  void compact_range(const std::string& prefix,
+		     const std::string& start, const std::string& end) override {
     compact_range(combine_strings(prefix, start), combine_strings(prefix, end));
   }
-  void compact_range_async(const string& prefix,
-			   const string& start, const string& end) override {
+  void compact_range_async(const std::string& prefix,
+			   const std::string& start, const std::string& end) override {
     compact_range_async(combine_strings(prefix, start),
 			combine_strings(prefix, end));
   }
@@ -142,7 +142,7 @@ public:
     bool error_if_exists;
     bool paranoid_checks;
 
-    string log_file;
+    std::string log_file;
 
     options_t() :
       write_buffer_size(0), //< 0 means default
@@ -157,7 +157,7 @@ public:
     {}
   } options;
 
-  LevelDBStore(CephContext *c, const string &path) :
+  LevelDBStore(CephContext *c, const std::string &path) :
     cct(c),
     logger(NULL),
     ceph_logger(NULL),
@@ -173,13 +173,13 @@ public:
 
   ~LevelDBStore() override;
 
-  static int _test_init(const string& dir);
-  int init(string option_str="") override;
+  static int _test_init(const std::string& dir);
+  int init(std::string option_str="") override;
 
   /// Opens underlying db
-  int open(ostream &out, const std::vector<ColumnFamily>& = {}) override;
+  int open(std::ostream &out, const std::vector<ColumnFamily>& = {}) override;
   /// Creates underlying db if missing and opens it
-  int create_and_open(ostream &out, const std::vector<ColumnFamily>& = {}) override;
+  int create_and_open(std::ostream &out, const std::vector<ColumnFamily>& = {}) override;
 
   void close() override;
 
@@ -195,20 +195,20 @@ public:
     LevelDBStore *db;
     explicit LevelDBTransactionImpl(LevelDBStore *db) : db(db) {}
     void set(
-      const string &prefix,
-      const string &k,
-      const bufferlist &bl) override;
+      const std::string &prefix,
+      const std::string &k,
+      const ceph::buffer::list &bl) override;
     using KeyValueDB::TransactionImpl::set;
     void rmkey(
-      const string &prefix,
-      const string &k) override;
+      const std::string &prefix,
+      const std::string &k) override;
     void rmkeys_by_prefix(
-      const string &prefix
+      const std::string &prefix
       ) override;
     virtual void rm_range_keys(
-        const string &prefix,
-        const string &start,
-        const string &end) override;
+      const std::string &prefix,
+      const std::string &start,
+      const std::string &end) override;
 
     using KeyValueDB::TransactionImpl::rmkey;
   };
@@ -220,14 +220,14 @@ public:
   int submit_transaction(KeyValueDB::Transaction t) override;
   int submit_transaction_sync(KeyValueDB::Transaction t) override;
   int get(
-    const string &prefix,
-    const std::set<string> &key,
-    std::map<string, bufferlist> *out
+    const std::string &prefix,
+    const std::set<std::string> &key,
+    std::map<std::string, ceph::buffer::list> *out
     ) override;
 
-  int get(const string &prefix, 
-    const string &key,   
-    bufferlist *value) override;
+  int get(const std::string &prefix, 
+	  const std::string &key,   
+	  ceph::buffer::list *value) override;
 
   using KeyValueDB::get;
 
@@ -244,7 +244,7 @@ public:
       dbiter->SeekToFirst();
       return dbiter->status().ok() ? 0 : -1;
     }
-    int seek_to_first(const string &prefix) override {
+    int seek_to_first(const std::string &prefix) override {
       leveldb::Slice slice_prefix(prefix);
       dbiter->Seek(slice_prefix);
       return dbiter->status().ok() ? 0 : -1;
@@ -253,8 +253,8 @@ public:
       dbiter->SeekToLast();
       return dbiter->status().ok() ? 0 : -1;
     }
-    int seek_to_last(const string &prefix) override {
-      string limit = past_prefix(prefix);
+    int seek_to_last(const std::string &prefix) override {
+      std::string limit = past_prefix(prefix);
       leveldb::Slice slice_limit(limit);
       dbiter->Seek(slice_limit);
 
@@ -265,17 +265,17 @@ public:
       }
       return dbiter->status().ok() ? 0 : -1;
     }
-    int upper_bound(const string &prefix, const string &after) override {
+    int upper_bound(const std::string &prefix, const std::string &after) override {
       lower_bound(prefix, after);
       if (valid()) {
-	pair<string,string> key = raw_key();
+	std::pair<std::string,std::string> key = raw_key();
 	if (key.first == prefix && key.second == after)
 	  next();
       }
       return dbiter->status().ok() ? 0 : -1;
     }
-    int lower_bound(const string &prefix, const string &to) override {
-      string bound = combine_strings(prefix, to);
+    int lower_bound(const std::string &prefix, const std::string &to) override {
+      std::string bound = combine_strings(prefix, to);
       leveldb::Slice slice_bound(bound);
       dbiter->Seek(slice_bound);
       return dbiter->status().ok() ? 0 : -1;
@@ -293,17 +293,17 @@ public:
 	dbiter->Prev();
       return dbiter->status().ok() ? 0 : -1;
     }
-    string key() override {
-      string out_key;
+    std::string key() override {
+      std::string out_key;
       split_key(dbiter->key(), 0, &out_key);
       return out_key;
     }
-    pair<string,string> raw_key() override {
-      string prefix, key;
+    std::pair<std::string,std::string> raw_key() override {
+      std::string prefix, key;
       split_key(dbiter->key(), &prefix, &key);
-      return make_pair(prefix, key);
+      return std::make_pair(prefix, key);
     }
-    bool raw_key_is_prefixed(const string &prefix) override {
+    bool raw_key_is_prefixed(const std::string &prefix) override {
       leveldb::Slice key = dbiter->key();
       if ((key.size() > prefix.length()) && (key[prefix.length()] == '\0')) {
         return memcmp(key.data(), prefix.c_str(), prefix.length()) == 0;
@@ -311,13 +311,13 @@ public:
         return false;
       }
     }
-    bufferlist value() override {
+    ceph::buffer::list value() override {
       return to_bufferlist(dbiter->value());
     }
 
-    bufferptr value_as_ptr() override {
+    ceph::bufferptr value_as_ptr() override {
       leveldb::Slice data = dbiter->value();
-      return bufferptr(data.data(), data.size());
+      return ceph::bufferptr(data.data(), data.size());
     }
 
     int status() override {
@@ -326,16 +326,16 @@ public:
   };
 
   /// Utility
-  static string combine_strings(const string &prefix, const string &value);
-  static int split_key(leveldb::Slice in, string *prefix, string *key);
-  static bufferlist to_bufferlist(leveldb::Slice in);
-  static string past_prefix(const string &prefix) {
-    string limit = prefix;
+  static std::string combine_strings(const std::string &prefix, const std::string &value);
+  static int split_key(leveldb::Slice in, std::string *prefix, std::string *key);
+  static ceph::buffer::list to_bufferlist(leveldb::Slice in);
+  static std::string past_prefix(const std::string &prefix) {
+    std::string limit = prefix;
     limit.push_back(1);
     return limit;
   }
 
-  uint64_t get_estimated_size(map<string,uint64_t> &extra) override {
+  uint64_t get_estimated_size(std::map<std::string,std::uint64_t> &extra) override {
     DIR *store_dir = opendir(path.c_str());
     if (!store_dir) {
       lderr(cct) << __func__ << " something happened opening the store: "
@@ -350,12 +350,12 @@ public:
 
     struct dirent *entry = NULL;
     while ((entry = readdir(store_dir)) != NULL) {
-      string n(entry->d_name);
+      std::string n(entry->d_name);
 
       if (n == "." || n == "..")
         continue;
 
-      string fpath = path + '/' + n;
+      std::string fpath = path + '/' + n;
       struct stat s;
       int err = stat(fpath.c_str(), &s);
       if (err < 0)
@@ -374,12 +374,12 @@ public:
       }
 
       size_t pos = n.find_last_of('.');
-      if (pos == string::npos) {
+      if (pos == std::string::npos) {
         misc_size += s.st_size;
         continue;
       }
 
-      string ext = n.substr(pos+1);
+      std::string ext = n.substr(pos+1);
       if (ext == "sst") {
         sst_size += s.st_size;
       } else if (ext == "log") {

--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -37,6 +37,16 @@
 #define dwarn dout(0)
 #define dinfo dout(0)
 
+using std::cerr;
+using std::ostream;
+using std::string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::decode;
+using ceph::encode;
+
 static void split_key(const string& raw_key, string *prefix, string *key)
 {
   size_t pos = raw_key.find(KEY_DELIM, 0);
@@ -121,8 +131,8 @@ int MemDB::_load()
     string key;
     bufferptr datap;
 
-    bytes_done += ::decode_file(fd, key);
-    bytes_done += ::decode_file(fd, datap);
+    bytes_done += ceph::decode_file(fd, key);
+    bytes_done += ceph::decode_file(fd, datap);
 
     dout(10) << __func__ << " Key:"<< key << dendl;
     m_map[key] = datap;
@@ -516,11 +526,11 @@ string MemDB::MDBWholeSpaceIteratorImpl::key()
   return key;
 }
 
-pair<string,string> MemDB::MDBWholeSpaceIteratorImpl::raw_key()
+std::pair<string,string> MemDB::MDBWholeSpaceIteratorImpl::raw_key()
 {
   string prefix, key;
   split_key(m_key_value.first, &prefix, &key);
-  return make_pair(prefix, key);
+  return { prefix, key };
 }
 
 bool MemDB::MDBWholeSpaceIteratorImpl::raw_key_is_prefixed(

--- a/src/kv/MemDB.h
+++ b/src/kv/MemDB.h
@@ -21,7 +21,6 @@
 #include "KeyValueDB.h"
 #include "osd/osd_types.h"
 
-using std::string;
 #define KEY_DELIM '\0' 
 
 
@@ -36,12 +35,12 @@ enum {
 
 class MemDB : public KeyValueDB
 {
-  typedef std::pair<std::pair<std::string, std::string>, bufferlist> ms_op_t;
+  typedef std::pair<std::pair<std::string, std::string>, ceph::bufferlist> ms_op_t;
   std::mutex m_lock;
   uint64_t m_total_bytes;
   uint64_t m_allocated_bytes;
 
-  typedef std::map<std::string, bufferptr> mdb_map_t;
+  typedef std::map<std::string, ceph::bufferptr> mdb_map_t;
   typedef mdb_map_t::iterator mdb_iter_t;
   bool m_using_btree;
 
@@ -50,22 +49,22 @@ class MemDB : public KeyValueDB
   CephContext *m_cct;
   PerfCounters *logger;
   void* m_priv;
-  string m_options;
-  string m_db_path;
+  std::string m_options;
+  std::string m_db_path;
 
   int transaction_rollback(KeyValueDB::Transaction t);
-  int _open(ostream &out);
+  int _open(std::ostream &out);
   void close() override;
-  bool _get(const string &prefix, const string &k, bufferlist *out);
-  bool _get_locked(const string &prefix, const string &k, bufferlist *out);
+  bool _get(const std::string &prefix, const std::string &k, ceph::bufferlist *out);
+  bool _get_locked(const std::string &prefix, const std::string &k, ceph::bufferlist *out);
   std::string _get_data_fn();
-  void _encode(mdb_iter_t iter, bufferlist &bl);
+  void _encode(mdb_iter_t iter, ceph::bufferlist &bl);
   void _save();
   int _load();
   uint64_t iterator_seq_no;
 
 public:
-  MemDB(CephContext *c, const string &path, void *p) :
+  MemDB(CephContext *c, const std::string &path, void *p) :
     m_total_bytes(0), m_allocated_bytes(0), m_using_btree(false),
     m_cct(c), logger(NULL), m_priv(p), m_db_path(path), iterator_seq_no(1)
   {
@@ -79,7 +78,7 @@ public:
   std::shared_ptr<MergeOperator> _find_merge_op(const std::string &prefix);
 
   static
-  int _test_init(const string& dir) { return 0; };
+  int _test_init(const std::string& dir) { return 0; };
 
   class MDBTransactionImpl : public KeyValueDB::TransactionImpl {
     public:
@@ -89,23 +88,24 @@ public:
       std::vector<std::pair<op_type, ms_op_t>> ops;
       MemDB *m_db;
 
-      bool key_is_prefixed(const string &prefix, const string& full_key);
+    bool key_is_prefixed(const std::string &prefix, const std::string& full_key);
     public:
       const std::vector<std::pair<op_type, ms_op_t>>&
         get_ops() { return ops; };
 
     void set(const std::string &prefix, const std::string &key,
-      const bufferlist &val) override;
+	     const ceph::bufferlist &val) override;
     using KeyValueDB::TransactionImpl::set;
     void rmkey(const std::string &prefix, const std::string &k) override;
     using KeyValueDB::TransactionImpl::rmkey;
     void rmkeys_by_prefix(const std::string &prefix) override;
     void rm_range_keys(
-        const string &prefix,
-        const string &start,
-        const string &end) override;
+      const std::string &prefix,
+      const std::string &start,
+      const std::string &end) override;
 
-    void merge(const std::string &prefix, const std::string &key, const bufferlist  &value) override;
+    void merge(const std::string &prefix, const std::string &key,
+	       const ceph::bufferlist  &value) override;
     void clear() {
       ops.clear();
     }
@@ -121,19 +121,19 @@ private:
   /*
    * Transaction states.
    */
-  int _merge(const std::string &k, bufferptr &bl);
+  int _merge(const std::string &k, ceph::bufferptr &bl);
   int _merge(ms_op_t &op);
   int _setkey(ms_op_t &op);
   int _rmkey(ms_op_t &op);
 
 public:
 
-  int init(string option_str="") override { m_options = option_str; return 0; }
+  int init(std::string option_str="") override { m_options = option_str; return 0; }
   int _init(bool format);
 
-  int do_open(ostream &out, bool create);
-  int open(ostream &out, const std::vector<ColumnFamily>&) override;
-  int create_and_open(ostream &out, const std::vector<ColumnFamily>&) override;
+  int do_open(std::ostream &out, bool create);
+  int open(std::ostream &out, const std::vector<ColumnFamily>&) override;
+  int create_and_open(std::ostream &out, const std::vector<ColumnFamily>&) override;
   using KeyValueDB::create_and_open;
 
   KeyValueDB::Transaction get_transaction() override {
@@ -144,17 +144,17 @@ public:
   int submit_transaction_sync(Transaction) override;
 
   int get(const std::string &prefix, const std::set<std::string> &key,
-    std::map<std::string, bufferlist> *out) override;
+	  std::map<std::string, ceph::bufferlist> *out) override;
 
   int get(const std::string &prefix, const std::string &key,
-          bufferlist *out) override;
+          ceph::bufferlist *out) override;
 
   using KeyValueDB::get;
 
   class MDBWholeSpaceIteratorImpl : public KeyValueDB::WholeSpaceIteratorImpl {
 
       mdb_iter_t m_iter;
-      std::pair<string, bufferlist> m_key_value;
+      std::pair<std::string, ceph::bufferlist> m_key_value;
       mdb_map_t *m_map_p;
       std::mutex *m_map_lock_p;
       uint64_t *global_seq_no;
@@ -194,7 +194,7 @@ public:
     std::string key() override;
     std::pair<std::string,std::string> raw_key() override;
     bool raw_key_is_prefixed(const std::string &prefix) override;
-    bufferlist value() override;
+    ceph::bufferlist value() override;
     ~MDBWholeSpaceIteratorImpl() override;
   };
 

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -19,7 +19,6 @@
 #include "rocksdb/utilities/convenience.h"
 #include "rocksdb/merge_operator.h"
 
-using std::string;
 #include "common/perf_counters.h"
 #include "common/PriorityCache.h"
 #include "include/common_fwd.h"
@@ -35,6 +34,20 @@ using std::string;
 #define dout_subsys ceph_subsys_rocksdb
 #undef dout_prefix
 #define dout_prefix *_dout << "rocksdb: "
+
+using std::function;
+using std::list;
+using std::map;
+using std::ostream;
+using std::pair;
+using std::set;
+using std::string;
+using std::unique_ptr;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::Formatter;
 
 static bufferlist to_bufferlist(rocksdb::Slice in) {
   bufferlist bl;
@@ -1235,7 +1248,7 @@ void RocksDBStore::compact_thread_entry()
   dout(10) << __func__ << " enter" << dendl;
   while (!compact_queue_stop) {
     if (!compact_queue.empty()) {
-      pair<string,string> range = compact_queue.front();
+      auto range = compact_queue.front();
       compact_queue.pop_front();
       logger->set(l_rocksdb_compact_queue_len, compact_queue.size());
       l.unlock();

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -72,14 +72,14 @@ extern rocksdb::Logger *create_rocksdb_ceph_logger();
 class RocksDBStore : public KeyValueDB {
   CephContext *cct;
   PerfCounters *logger;
-  string path;
-  map<string,string> kv_options;
+  std::string path;
+  std::map<std::string,std::string> kv_options;
   void *priv;
   rocksdb::DB *db;
   rocksdb::Env *env;
   std::shared_ptr<rocksdb::Statistics> dbstats;
   rocksdb::BlockBasedTableOptions bbt_opts;
-  string options_str;
+  std::string options_str;
 
   uint64_t cache_size = 0;
   bool set_cache_flag = false;
@@ -88,17 +88,17 @@ class RocksDBStore : public KeyValueDB {
   rocksdb::ColumnFamilyHandle *default_cf = nullptr;
 
   int submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Transaction t);
-  int install_cf_mergeop(const string &cf_name, rocksdb::ColumnFamilyOptions *cf_opt);
+  int install_cf_mergeop(const std::string &cf_name, rocksdb::ColumnFamilyOptions *cf_opt);
   int create_db_dir();
-  int do_open(ostream &out, bool create_if_missing, bool open_readonly,
-	      const vector<ColumnFamily>* cfs = nullptr);
+  int do_open(std::ostream &out, bool create_if_missing, bool open_readonly,
+	      const std::vector<ColumnFamily>* cfs = nullptr);
   int load_rocksdb_options(bool create_if_missing, rocksdb::Options& opt);
 
   // manage async compactions
   ceph::mutex compact_queue_lock =
     ceph::make_mutex("RocksDBStore::compact_thread_lock");
   ceph::condition_variable compact_queue_cond;
-  list< pair<string,string> > compact_queue;
+  std::list<std::pair<std::string,std::string>> compact_queue;
   bool compact_queue_stop;
   class CompactThread : public Thread {
     RocksDBStore *db;
@@ -113,9 +113,10 @@ class RocksDBStore : public KeyValueDB {
 
   void compact_thread_entry();
 
-  void compact_range(const string& start, const string& end);
-  void compact_range_async(const string& start, const string& end);
-  int tryInterpret(const string& key, const string& val, rocksdb::Options& opt);
+  void compact_range(const std::string& start, const std::string& end);
+  void compact_range_async(const std::string& start, const std::string& end);
+  int tryInterpret(const std::string& key, const std::string& val,
+		   rocksdb::Options& opt);
 
 public:
   /// compact the underlying rocksdb store
@@ -125,33 +126,35 @@ public:
   void compact() override;
 
   void compact_async() override {
-    compact_range_async(string(), string());
+    compact_range_async({}, {});
   }
 
-  int ParseOptionsFromString(const string& opt_str, rocksdb::Options& opt);
+  int ParseOptionsFromString(const std::string& opt_str, rocksdb::Options& opt);
   static int ParseOptionsFromStringStatic(
     CephContext* cct,
-    const string& opt_str,
+    const std::string& opt_str,
     rocksdb::Options &opt,
-    function<int(const string&, const string&, rocksdb::Options&)> interp);
-  static int _test_init(const string& dir);
-  int init(string options_str) override;
+    std::function<int(const std::string&, const std::string&, rocksdb::Options&)> interp);
+  static int _test_init(const std::string& dir);
+  int init(std::string options_str) override;
   /// compact rocksdb for all keys with a given prefix
-  void compact_prefix(const string& prefix) override {
+  void compact_prefix(const std::string& prefix) override {
     compact_range(prefix, past_prefix(prefix));
   }
-  void compact_prefix_async(const string& prefix) override {
+  void compact_prefix_async(const std::string& prefix) override {
     compact_range_async(prefix, past_prefix(prefix));
   }
 
-  void compact_range(const string& prefix, const string& start, const string& end) override {
+  void compact_range(const std::string& prefix, const std::string& start,
+		     const std::string& end) override {
     compact_range(combine_strings(prefix, start), combine_strings(prefix, end));
   }
-  void compact_range_async(const string& prefix, const string& start, const string& end) override {
+  void compact_range_async(const std::string& prefix, const std::string& start,
+			   const std::string& end) override {
     compact_range_async(combine_strings(prefix, start), combine_strings(prefix, end));
   }
 
-  RocksDBStore(CephContext *c, const string &path, map<string,string> opt, void *p) :
+  RocksDBStore(CephContext *c, const std::string &path, std::map<std::string,std::string> opt, void *p) :
     cct(c),
     logger(NULL),
     path(path),
@@ -169,16 +172,16 @@ public:
 
   ~RocksDBStore() override;
 
-  static bool check_omap_dir(string &omap_dir);
+  static bool check_omap_dir(std::string &omap_dir);
   /// Opens underlying db
-  int open(ostream &out, const vector<ColumnFamily>& cfs = {}) override {
+  int open(std::ostream &out, const std::vector<ColumnFamily>& cfs = {}) override {
     return do_open(out, false, false, &cfs);
   }
   /// Creates underlying db if missing and opens it
-  int create_and_open(ostream &out,
-		      const vector<ColumnFamily>& cfs = {}) override;
+  int create_and_open(std::ostream &out,
+		      const std::vector<ColumnFamily>& cfs = {}) override;
 
-  int open_read_only(ostream &out, const vector<ColumnFamily>& cfs = {}) override {
+  int open_read_only(std::ostream &out, const std::vector<ColumnFamily>& cfs = {}) override {
     return do_open(out, false, true, &cfs);
   }
 
@@ -193,7 +196,7 @@ public:
   }
   int repair(std::ostream &out) override;
   void split_stats(const std::string &s, char delim, std::vector<std::string> &elems);
-  void get_statistics(Formatter *f) override;
+  void get_statistics(ceph::Formatter *f) override;
 
   PerfCounters *get_perf_counters() override
   {
@@ -204,15 +207,15 @@ public:
     const std::string &property,
     uint64_t *out) final;
 
-  int64_t estimate_prefix_size(const string& prefix,
-			       const string& key_prefix) override;
+  int64_t estimate_prefix_size(const std::string& prefix,
+			       const std::string& key_prefix) override;
 
   struct  RocksWBHandler: public rocksdb::WriteBatch::Handler {
     std::string seen ;
     int num_seen = 0;
-    static string pretty_binary_string(const string& in) {
+    static std::string pretty_binary_string(const std::string& in) {
       char buf[10];
-      string out;
+      std::string out;
       out.reserve(in.length() * 3);
       enum { NONE, HEX, STRING } mode = NONE;
       unsigned from = 0, i;
@@ -260,8 +263,8 @@ public:
     }
     void Put(const rocksdb::Slice& key,
                     const rocksdb::Slice& value) override {
-      string prefix ((key.ToString()).substr(0,1));
-      string key_to_decode ((key.ToString()).substr(2,string::npos));
+      std::string prefix ((key.ToString()).substr(0,1));
+      std::string key_to_decode ((key.ToString()).substr(2, std::string::npos));
       uint64_t size = (value.ToString()).size();
       seen += "\nPut( Prefix = " + prefix + " key = " 
             + pretty_binary_string(key_to_decode) 
@@ -269,15 +272,15 @@ public:
       num_seen++;
     }
     void SingleDelete(const rocksdb::Slice& key) override {
-      string prefix ((key.ToString()).substr(0,1));
-      string key_to_decode ((key.ToString()).substr(2,string::npos));
+      std::string prefix ((key.ToString()).substr(0,1));
+      std::string key_to_decode ((key.ToString()).substr(2, std::string::npos));
       seen += "\nSingleDelete(Prefix = "+ prefix + " Key = " 
             + pretty_binary_string(key_to_decode) + ")";
       num_seen++;
     }
     void Delete(const rocksdb::Slice& key) override {
-      string prefix ((key.ToString()).substr(0,1));
-      string key_to_decode ((key.ToString()).substr(2,string::npos));
+      std::string prefix ((key.ToString()).substr(0,1));
+      std::string key_to_decode ((key.ToString()).substr(2, std::string::npos));
       seen += "\nDelete( Prefix = " + prefix + " key = " 
             + pretty_binary_string(key_to_decode) + ")";
 
@@ -285,8 +288,8 @@ public:
     }
     void Merge(const rocksdb::Slice& key,
                       const rocksdb::Slice& value) override {
-      string prefix ((key.ToString()).substr(0,1));
-      string key_to_decode ((key.ToString()).substr(2,string::npos));
+      std::string prefix ((key.ToString()).substr(0,1));
+      std::string key_to_decode ((key.ToString()).substr(2, std::string::npos));
       uint64_t size = (value.ToString()).size();
       seen += "\nMerge( Prefix = " + prefix + " key = " 
             + pretty_binary_string(key_to_decode) + " Value size = " 
@@ -308,39 +311,39 @@ public:
     void put_bat(
       rocksdb::WriteBatch& bat,
       rocksdb::ColumnFamilyHandle *cf,
-      const string &k,
-      const bufferlist &to_set_bl);
+      const std::string &k,
+      const ceph::bufferlist &to_set_bl);
   public:
     void set(
-      const string &prefix,
-      const string &k,
-      const bufferlist &bl) override;
+      const std::string &prefix,
+      const std::string &k,
+      const ceph::bufferlist &bl) override;
     void set(
-      const string &prefix,
+      const std::string &prefix,
       const char *k,
       size_t keylen,
-      const bufferlist &bl) override;
+      const ceph::bufferlist &bl) override;
     void rmkey(
-      const string &prefix,
-      const string &k) override;
+      const std::string &prefix,
+      const std::string &k) override;
     void rmkey(
-      const string &prefix,
+      const std::string &prefix,
       const char *k,
       size_t keylen) override;
     void rm_single_key(
-      const string &prefix,
-      const string &k) override;
+      const std::string &prefix,
+      const std::string &k) override;
     void rmkeys_by_prefix(
-      const string &prefix
+      const std::string &prefix
       ) override;
     void rm_range_keys(
-      const string &prefix,
-      const string &start,
-      const string &end) override;
+      const std::string &prefix,
+      const std::string &start,
+      const std::string &end) override;
     void merge(
-      const string& prefix,
-      const string& k,
-      const bufferlist &bl) override;
+      const std::string& prefix,
+      const std::string& k,
+      const ceph::bufferlist &bl) override;
   };
 
   KeyValueDB::Transaction get_transaction() override {
@@ -350,20 +353,20 @@ public:
   int submit_transaction(KeyValueDB::Transaction t) override;
   int submit_transaction_sync(KeyValueDB::Transaction t) override;
   int get(
-    const string &prefix,
-    const std::set<string> &key,
-    std::map<string, bufferlist> *out
+    const std::string &prefix,
+    const std::set<std::string> &key,
+    std::map<std::string, ceph::bufferlist> *out
     ) override;
   int get(
-    const string &prefix,
-    const string &key,
-    bufferlist *out
+    const std::string &prefix,
+    const std::string &key,
+    ceph::bufferlist *out
     ) override;
   int get(
-    const string &prefix,
+    const std::string &prefix,
     const char *key,
     size_t keylen,
-    bufferlist *out) override;
+    ceph::bufferlist *out) override;
 
 
   class RocksDBWholeSpaceIteratorImpl :
@@ -377,19 +380,19 @@ public:
     ~RocksDBWholeSpaceIteratorImpl() override;
 
     int seek_to_first() override;
-    int seek_to_first(const string &prefix) override;
+    int seek_to_first(const std::string &prefix) override;
     int seek_to_last() override;
-    int seek_to_last(const string &prefix) override;
-    int upper_bound(const string &prefix, const string &after) override;
-    int lower_bound(const string &prefix, const string &to) override;
+    int seek_to_last(const std::string &prefix) override;
+    int upper_bound(const std::string &prefix, const std::string &after) override;
+    int lower_bound(const std::string &prefix, const std::string &to) override;
     bool valid() override;
     int next() override;
     int prev() override;
-    string key() override;
-    pair<string,string> raw_key() override;
-    bool raw_key_is_prefixed(const string &prefix) override;
-    bufferlist value() override;
-    bufferptr value_as_ptr() override;
+    std::string key() override;
+    std::pair<std::string,std::string> raw_key() override;
+    bool raw_key_is_prefixed(const std::string &prefix) override;
+    ceph::bufferlist value() override;
+    ceph::bufferptr value_as_ptr() override;
     int status() override;
     size_t key_size() override;
     size_t value_size() override;
@@ -398,24 +401,24 @@ public:
   Iterator get_iterator(const std::string& prefix) override;
 
   /// Utility
-  static string combine_strings(const string &prefix, const string &value) {
-    string out = prefix;
+  static std::string combine_strings(const std::string &prefix, const std::string &value) {
+    std::string out = prefix;
     out.push_back(0);
     out.append(value);
     return out;
   }
-  static void combine_strings(const string &prefix,
+  static void combine_strings(const std::string &prefix,
 			      const char *key, size_t keylen,
-			      string *out) {
+			      std::string *out) {
     out->reserve(prefix.size() + 1 + keylen);
     *out = prefix;
     out->push_back(0);
     out->append(key, keylen);
   }
 
-  static int split_key(rocksdb::Slice in, string *prefix, string *key);
+  static int split_key(rocksdb::Slice in, std::string *prefix, std::string *key);
 
-  static string past_prefix(const string &prefix);
+  static std::string past_prefix(const std::string &prefix);
 
   class MergeOperatorRouter;
   class MergeOperatorLinker;
@@ -423,9 +426,9 @@ public:
   int set_merge_operator(
     const std::string& prefix,
     std::shared_ptr<KeyValueDB::MergeOperator> mop) override;
-  string assoc_name; ///< Name of associative operator
+  std::string assoc_name; ///< Name of associative operator
 
-  uint64_t get_estimated_size(map<string,uint64_t> &extra) override {
+  uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) override {
     DIR *store_dir = opendir(path.c_str());
     if (!store_dir) {
       lderr(cct) << __func__ << " something happened opening the store: "
@@ -440,12 +443,12 @@ public:
 
     struct dirent *entry = NULL;
     while ((entry = readdir(store_dir)) != NULL) {
-      string n(entry->d_name);
+      std::string n(entry->d_name);
 
       if (n == "." || n == "..")
         continue;
 
-      string fpath = path + '/' + n;
+      std::string fpath = path + '/' + n;
       struct stat s;
       int err = stat(fpath.c_str(), &s);
       if (err < 0)
@@ -464,12 +467,12 @@ public:
       }
 
       size_t pos = n.find_last_of('.');
-      if (pos == string::npos) {
+      if (pos == std::string::npos) {
         misc_size += s.st_size;
         continue;
       }
 
-      string ext = n.substr(pos+1);
+      std::string ext = n.substr(pos+1);
       if (ext == "sst") {
         sst_size += s.st_size;
       } else if (ext == "log") {
@@ -506,7 +509,7 @@ err:
 
   virtual std::shared_ptr<PriorityCache::PriCache> get_priority_cache() 
       const override {
-    return dynamic_pointer_cast<PriorityCache::PriCache>(
+    return std::dynamic_pointer_cast<PriorityCache::PriCache>(
         bbt_opts.block_cache);
   }
 

--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -32,6 +32,7 @@
 
 using std::ostream;
 using std::string;
+using std::vector;
 namespace qi = boost::spirit::qi;
 namespace ascii = boost::spirit::ascii;
 namespace phoenix = boost::phoenix;

--- a/src/messages/MTimeCheck2.h
+++ b/src/messages/MTimeCheck2.h
@@ -30,8 +30,8 @@ public:
   version_t round = 0;
 
   utime_t timestamp;
-  map<int, double> skews;
-  map<int, double> latencies;
+  std::map<int, double> skews;
+  std::map<int, double> latencies;
 
   MTimeCheck2() : Message{MSG_TIMECHECK2, HEAD_VERSION, COMPAT_VERSION} { }
   MTimeCheck2(int op) :

--- a/src/mgr/MgrCap.cc
+++ b/src/mgr/MgrCap.cc
@@ -44,7 +44,7 @@ static std::string maybe_quote_string(const std::string& str) {
 
 #define dout_subsys ceph_subsys_mgr
 
-ostream& operator<<(ostream& out, const mgr_rwxa_t& p) {
+std::ostream& operator<<(std::ostream& out, const mgr_rwxa_t& p) {
   if (p == MGR_CAP_ANY)
     return out << "*";
 
@@ -57,7 +57,7 @@ ostream& operator<<(ostream& out, const mgr_rwxa_t& p) {
   return out;
 }
 
-ostream& operator<<(ostream& out, const MgrCapGrantConstraint& c) {
+std::ostream& operator<<(std::ostream& out, const MgrCapGrantConstraint& c) {
   switch (c.match_type) {
   case MgrCapGrantConstraint::MATCH_TYPE_EQUAL:
     out << "=";
@@ -75,7 +75,7 @@ ostream& operator<<(ostream& out, const MgrCapGrantConstraint& c) {
   return out;
 }
 
-ostream& operator<<(ostream& out, const MgrCapGrant& m) {
+std::ostream& operator<<(std::ostream& out, const MgrCapGrant& m) {
   if (!m.profile.empty()) {
     out << "profile " << maybe_quote_string(m.profile);
   } else {
@@ -280,7 +280,7 @@ mgr_rwxa_t MgrCapGrant::get_allowed(
   return allow;
 }
 
-ostream& operator<<(ostream&out, const MgrCap& m) {
+std::ostream& operator<<(std::ostream&out, const MgrCap& m) {
   bool first = true;
   for (auto& grant : m.grants) {
     if (!first) {
@@ -365,14 +365,14 @@ bool MgrCap::is_capable(
   return false;
 }
 
-void MgrCap::encode(bufferlist& bl) const {
+void MgrCap::encode(ceph::buffer::list& bl) const {
   // remain backwards compatible w/ MgrCap
   ENCODE_START(4, 4, bl);
   encode(text, bl);
   ENCODE_FINISH(bl);
 }
 
-void MgrCap::decode(bufferlist::const_iterator& bl) {
+void MgrCap::decode(ceph::buffer::list::const_iterator& bl) {
   // remain backwards compatible w/ MgrCap
   std::string s;
   DECODE_START(4, bl);
@@ -381,11 +381,11 @@ void MgrCap::decode(bufferlist::const_iterator& bl) {
   parse(s, NULL);
 }
 
-void MgrCap::dump(Formatter *f) const {
+void MgrCap::dump(ceph::Formatter *f) const {
   f->dump_string("text", text);
 }
 
-void MgrCap::generate_test_instances(list<MgrCap*>& ls) {
+void MgrCap::generate_test_instances(std::list<MgrCap*>& ls) {
   ls.push_back(new MgrCap);
   ls.push_back(new MgrCap);
   ls.back()->parse("allow *");
@@ -462,7 +462,7 @@ struct MgrCapParser : qi::grammar<Iterator, MgrCap()> {
                              >> qi::attr(std::string())
                              >> qi::attr(std::string())
                              >> qi::attr(std::string())
-                             >> qi::attr(map<std::string, MgrCapGrantConstraint>())
+                             >> qi::attr(std::map<std::string, MgrCapGrantConstraint>())
                              >> spaces >> rwxa
                              >> -(spaces >> lit("network") >> spaces >> network_str);
 
@@ -537,7 +537,7 @@ struct MgrCapParser : qi::grammar<Iterator, MgrCap()> {
   qi::rule<Iterator, MgrCap()> mgrcap;
 };
 
-bool MgrCap::parse(const std::string& str, ostream *err) {
+bool MgrCap::parse(const std::string& str, std::ostream *err) {
   auto iter = str.begin();
   auto end = str.end();
 

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -41,6 +41,34 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon, get_last_committed())
 using namespace TOPNSPC::common;
+
+using std::cerr;
+using std::cout;
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::setfill;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+using std::unique_ptr;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::make_message;
+using ceph::mono_clock;
+using ceph::mono_time;
+using ceph::timespan_str;
 static ostream& _prefix(std::ostream *_dout, Monitor *mon, version_t v) {
   return *_dout << "mon." << mon->name << "@" << mon->rank
 		<< "(" << mon->get_state_name()
@@ -599,7 +627,7 @@ bool AuthMonitor::prep_auth(MonOpRequestRef op, bool paxos_writable)
       decode(supported, indata);
       decode(entity_name, indata);
       decode(s->con->peer_global_id, indata);
-    } catch (const buffer::error &e) {
+    } catch (const ceph::buffer::error &e) {
       dout(10) << "failed to decode initial auth message" << dendl;
       ret = -EINVAL;
       goto reply;
@@ -738,7 +766,7 @@ bool AuthMonitor::prep_auth(MonOpRequestRef op, bool paxos_writable)
       }
       ret = 0;
     }
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     ret = -EINVAL;
     dout(0) << "caught error when trying to handle auth request, probably malformed request" << dendl;
   }
@@ -1091,7 +1119,7 @@ int _create_auth(
     return -EINVAL;
   try {
     auth.key.decode_base64(key);
-  } catch (buffer::error& e) {
+  } catch (ceph::buffer::error& e) {
     return -EINVAL;
   }
   auth.caps = caps;
@@ -1346,7 +1374,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
     KeyRing keyring;
     try {
       decode(keyring, iter);
-    } catch (const buffer::error &ex) {
+    } catch (const ceph::buffer::error &ex) {
       ss << "error decoding keyring" << " " << ex.what();
       err = -EINVAL;
       goto done;
@@ -1381,7 +1409,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       auto iter = bl.cbegin();
       try {
         decode(new_keyring, iter);
-      } catch (const buffer::error &ex) {
+      } catch (const ceph::buffer::error &ex) {
         ss << "error decoding keyring";
         err = -EINVAL;
         goto done;
@@ -1762,7 +1790,7 @@ bool AuthMonitor::_upgrade_format_to_dumpling()
       auto it = p->second.caps["mon"].cbegin();
       decode(mon_caps, it);
     }
-    catch (const buffer::error&) {
+    catch (const ceph::buffer::error&) {
       dout(10) << __func__ << " unable to parse mon cap for "
 	       << p->first << dendl;
       continue;

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -24,7 +24,7 @@
 #include "mon/PaxosService.h"
 #include "mon/MonitorDBStore.h"
 
-struct MAuth;
+class MAuth;
 class KeyRing;
 class Monitor;
 
@@ -40,11 +40,11 @@ public:
     IncType inc_type;
     uint64_t max_global_id;
     uint32_t auth_type;
-    bufferlist auth_data;
+    ceph::buffer::list auth_data;
 
     Incremental() : inc_type(GLOBAL_ID), max_global_id(0), auth_type(0) {}
 
-    void encode(bufferlist& bl, uint64_t features=-1) const {
+    void encode(ceph::buffer::list& bl, uint64_t features=-1) const {
       using ceph::encode;
       ENCODE_START(2, 2, bl);
       __u32 _type = (__u32)inc_type;
@@ -57,7 +57,7 @@ public:
       }
       ENCODE_FINISH(bl);
     }
-    void decode(bufferlist::const_iterator& bl) {
+    void decode(ceph::buffer::list::const_iterator& bl) {
       DECODE_START_LEGACY_COMPAT_LEN(2, 2, 2, bl);
       __u32 _type;
       decode(_type, bl);
@@ -71,13 +71,13 @@ public:
       }
       DECODE_FINISH(bl);
     }
-    void dump(Formatter *f) const {
+    void dump(ceph::Formatter *f) const {
       f->dump_int("type", inc_type);
       f->dump_int("max_global_id", max_global_id);
       f->dump_int("auth_type", auth_type);
       f->dump_int("auth_data_len", auth_data.length());
     }
-    static void generate_test_instances(list<Incremental*>& ls) {
+    static void generate_test_instances(std::list<Incremental*>& ls) {
       ls.push_back(new Incremental);
       ls.push_back(new Incremental);
       ls.back()->inc_type = GLOBAL_ID;
@@ -96,7 +96,7 @@ public:
 
 
 private:
-  vector<Incremental> pending_auth;
+  std::vector<Incremental> pending_auth;
   version_t last_rotating_ver;
   uint64_t max_global_id;
   uint64_t last_allocated_id;
@@ -121,19 +121,20 @@ private:
   }
 
   /* validate mon/osd/mds caps; fail on unrecognized service/type */
-  bool valid_caps(const string& type, const string& caps, ostream *out);
-  bool valid_caps(const string& type, const bufferlist& bl, ostream *out) {
+  bool valid_caps(const std::string& type, const std::string& caps, std::ostream *out);
+  bool valid_caps(const std::string& type, const ceph::buffer::list& bl, std::ostream *out) {
     auto p = bl.begin();
-    string v;
+    std::string v;
     try {
+      using ceph::decode;
       decode(v, p);
-    } catch (buffer::error& e) {
+    } catch (ceph::buffer::error& e) {
       *out << "corrupt capability encoding";
       return false;
     }
     return valid_caps(type, v, out);
   }
-  bool valid_caps(const vector<string>& caps, ostream *out);
+  bool valid_caps(const std::vector<std::string>& caps, std::ostream *out);
 
   void on_active() override;
   bool should_propose(double& delay) override;
@@ -170,20 +171,20 @@ private:
   int exists_and_matches_entity(
       const auth_entity_t& entity,
       bool has_secret,
-      stringstream& ss);
+      std::stringstream& ss);
   int exists_and_matches_entity(
       const EntityName& name,
       const EntityAuth& auth,
-      const map<string,bufferlist>& caps,
+      const std::map<std::string,ceph::buffer::list>& caps,
       bool has_secret,
-      stringstream& ss);
+      std::stringstream& ss);
   int remove_entity(const EntityName &entity);
   int add_entity(
       const EntityName& name,
       const EntityAuth& auth);
 
  public:
-  AuthMonitor(Monitor *mn, Paxos *p, const string& service_name)
+  AuthMonitor(Monitor *mn, Paxos *p, const std::string& service_name)
     : PaxosService(mn, p, service_name),
       last_rotating_ver(0),
       max_global_id(0),
@@ -199,7 +200,7 @@ private:
       const uuid_d& uuid,
       EntityName& cephx_entity,
       EntityName& lockbox_entity,
-      stringstream& ss);
+      std::stringstream& ss);
   int do_osd_destroy(
       const EntityName& cephx_entity,
       const EntityName& lockbox_entity);
@@ -211,15 +212,15 @@ private:
   int validate_osd_new(
       int32_t id,
       const uuid_d& uuid,
-      const string& cephx_secret,
-      const string& lockbox_secret,
+      const std::string& cephx_secret,
+      const std::string& lockbox_secret,
       auth_entity_t& cephx_entity,
       auth_entity_t& lockbox_entity,
-      stringstream& ss);
+      std::stringstream& ss);
 
-  void dump_info(Formatter *f);
+  void dump_info(ceph::Formatter *f);
 
-  bool is_valid_cephx_key(const string& k) {
+  bool is_valid_cephx_key(const std::string& k) {
     if (k.empty())
       return false;
 
@@ -227,7 +228,7 @@ private:
     try {
       ea.key.decode_base64(k);
       return true;
-    } catch (buffer::error& e) { /* fallthrough */ }
+    } catch (ceph::buffer::error& e) { /* fallthrough */ }
     return false;
   }
 };

--- a/src/mon/ConfigKeyService.cc
+++ b/src/mon/ConfigKeyService.cc
@@ -28,6 +28,36 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon, this)
 using namespace TOPNSPC::common;
+
+using namespace std::literals;
+using std::cerr;
+using std::cout;
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::setfill;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+using std::unique_ptr;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::mono_clock;
+using ceph::mono_time;
+using ceph::parse_timespan;
+using ceph::timespan_str;
+
 static ostream& _prefix(std::ostream *_dout, const Monitor *mon,
                         const ConfigKeyService *service) {
   return *_dout << "mon." << mon->name << "@" << mon->rank

--- a/src/mon/ConfigKeyService.h
+++ b/src/mon/ConfigKeyService.h
@@ -24,19 +24,19 @@ class ConfigKeyService : public QuorumService
 {
   Paxos *paxos;
 
-  int store_get(const string &key, bufferlist &bl);
-  void store_put(const string &key, bufferlist &bl, Context *cb = NULL);
-  void store_delete(MonitorDBStore::TransactionRef t, const string &key);
-  void store_delete(const string &key, Context *cb = NULL);
+  int store_get(const std::string &key, ceph::buffer::list &bl);
+  void store_put(const std::string &key, ceph::buffer::list &bl, Context *cb = NULL);
+  void store_delete(MonitorDBStore::TransactionRef t, const std::string &key);
+  void store_delete(const std::string &key, Context *cb = NULL);
   void store_delete_prefix(
       MonitorDBStore::TransactionRef t,
-      const string &prefix);
-  void store_list(stringstream &ss);
-  void store_dump(stringstream &ss, const string& prefix);
-  bool store_exists(const string &key);
-  bool store_has_prefix(const string &prefix);
+      const std::string &prefix);
+  void store_list(std::stringstream &ss);
+  void store_dump(std::stringstream &ss, const std::string& prefix);
+  bool store_exists(const std::string &key);
+  bool store_has_prefix(const std::string &prefix);
 
-  static const string STORE_PREFIX;
+  static const std::string STORE_PREFIX;
 
 protected:
   void service_shutdown() override { }
@@ -65,18 +65,18 @@ public:
   void do_osd_destroy(int32_t id, uuid_d& uuid);
   int validate_osd_new(
       const uuid_d& uuid,
-      const string& dmcrypt_key,
-      stringstream& ss);
-  void do_osd_new(const uuid_d& uuid, const string& dmcrypt_key);
+      const std::string& dmcrypt_key,
+      std::stringstream& ss);
+  void do_osd_new(const uuid_d& uuid, const std::string& dmcrypt_key);
 
   int get_type() override {
     return QuorumService::SERVICE_CONFIG_KEY;
   }
 
-  string get_name() const override {
+  std::string get_name() const override {
     return "config_key";
   }
-  void get_store_prefixes(set<string>& s) const;
+  void get_store_prefixes(std::set<std::string>& s) const;
   /**
    * @} // ConfigKeyService_Inherited_h
    */

--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -7,6 +7,35 @@
 #include "crush/CrushWrapper.h"
 #include "common/entity_name.h"
 
+using namespace std::literals;
+
+using std::cerr;
+using std::cout;
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::setfill;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+using std::unique_ptr;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::mono_clock;
+using ceph::mono_time;
+using ceph::timespan_str;
+
 int MaskedOption::get_precision(const CrushWrapper *crush)
 {
   // 0 = most precise

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -54,14 +54,14 @@ struct OptionMask {
     }
     return r;
   }
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
 };
 
 struct MaskedOption {
-  string raw_value;               ///< raw, unparsed, unvalidated value
+  std::string raw_value;               ///< raw, unparsed, unvalidated value
   const Option *opt;              ///< the option
   OptionMask mask;
-  unique_ptr<const Option> unknown_opt; ///< if fabricated for an unknown option
+  std::unique_ptr<const Option> unknown_opt; ///< if fabricated for an unknown option
 
   MaskedOption(const Option *o, bool fab=false) : opt(o) {
     if (fab) {
@@ -80,9 +80,9 @@ struct MaskedOption {
   /// return a precision metric (smaller is more precise)
   int get_precision(const CrushWrapper *crush);
 
-  friend ostream& operator<<(ostream& out, const MaskedOption& o);
+  friend std::ostream& operator<<(std::ostream& out, const MaskedOption& o);
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
 };
 
 struct Section {
@@ -91,7 +91,7 @@ struct Section {
   void clear() {
     options.clear();
   }
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   std::string get_minimal_conf() const;
 };
 
@@ -119,13 +119,13 @@ struct ConfigMap {
     by_type.clear();
     by_id.clear();
   }
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   std::map<std::string,std::string,std::less<>> generate_entity_map(
     const EntityName& name,
-    const map<std::string,std::string>& crush_location,
+    const std::map<std::string,std::string>& crush_location,
     const CrushWrapper *crush,
     const std::string& device_class,
-    std::map<std::string,pair<std::string,const MaskedOption*>> *src=0);
+    std::map<std::string,std::pair<std::string,const MaskedOption*>> *src=0);
 
   static bool parse_mask(
     const std::string& in,
@@ -137,11 +137,11 @@ struct ConfigMap {
 struct ConfigChangeSet {
   version_t version;
   utime_t stamp;
-  string name;
+  std::string name;
 
   // key -> (old value, new value)
-  map<string,pair<boost::optional<string>,boost::optional<string>>> diff;
+  std::map<std::string,std::pair<boost::optional<std::string>,boost::optional<std::string>>> diff;
 
-  void dump(Formatter *f) const;
-  void print(ostream& out) const;
+  void dump(ceph::Formatter *f) const;
+  void print(std::ostream& out) const;
 };

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -19,6 +19,35 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon, this)
 using namespace TOPNSPC::common;
+
+using namespace std::literals;
+
+using std::cerr;
+using std::cout;
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::setfill;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+using std::unique_ptr;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::mono_clock;
+using ceph::mono_time;
+using ceph::timespan_str;
 static ostream& _prefix(std::ostream *_dout, const Monitor *mon,
                         const ConfigMonitor *hmon) {
   return *_dout << "mon." << mon->name << "@" << mon->rank
@@ -837,7 +866,7 @@ void ConfigMonitor::load_changeset(version_t v, ConfigChangeSet *ch)
 	decode(ch->stamp, p);
 	decode(ch->name, p);
       }
-      catch (buffer::error& e) {
+      catch (ceph::buffer::error& e) {
 	derr << __func__ << " failure decoding changeset " << v << dendl;
       }
     } else {

--- a/src/mon/ConfigMonitor.h
+++ b/src/mon/ConfigMonitor.h
@@ -14,14 +14,14 @@ class ConfigMonitor : public PaxosService
 {
   version_t version = 0;
   ConfigMap config_map;
-  map<string,boost::optional<bufferlist>> pending;
-  string pending_description;
-  map<string,boost::optional<bufferlist>> pending_cleanup;
+  std::map<std::string,boost::optional<ceph::buffer::list>> pending;
+  std::string pending_description;
+  std::map<std::string,boost::optional<ceph::buffer::list>> pending_cleanup;
 
-  map<string,bufferlist> current;
+  std::map<std::string,ceph::buffer::list> current;
 
 public:
-  ConfigMonitor(Monitor *m, Paxos *p, const string& service_name);
+  ConfigMonitor(Monitor *m, Paxos *p, const std::string& service_name);
 
   void init() override;
 

--- a/src/mon/CreatingPGs.h
+++ b/src/mon/CreatingPGs.h
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <set>
+#include <vector>
 
 #include "include/encoding.h"
 #include "include/utime.h"
@@ -20,14 +21,14 @@ struct creating_pgs_t {
 
     // NOTE: pre-octopus instances of this class will have a
     // zeroed-out history
-    vector<int> up;
+    std::vector<int> up;
     int up_primary = -1;
-    vector<int> acting;
+    std::vector<int> acting;
     int acting_primary = -1;
     pg_history_t history;
     PastIntervals past_intervals;
 
-    void encode(bufferlist& bl, uint64_t features) const {
+    void encode(ceph::buffer::list& bl, uint64_t features) const {
       using ceph::encode;
       if (!HAVE_FEATURE(features, SERVER_OCTOPUS)) {
 	// was pair<epoch_t,utime_t> prior to octopus
@@ -46,12 +47,12 @@ struct creating_pgs_t {
       encode(past_intervals, bl);
       ENCODE_FINISH(bl);
     }
-    void decode_legacy(bufferlist::const_iterator& p) {
+    void decode_legacy(ceph::buffer::list::const_iterator& p) {
       using ceph::decode;
       decode(create_epoch, p);
       decode(create_stamp, p);
     }
-    void decode(bufferlist::const_iterator& p) {
+    void decode(ceph::buffer::list::const_iterator& p) {
       using ceph::decode;
       DECODE_START(1, p);
       decode(create_epoch, p);
@@ -64,7 +65,7 @@ struct creating_pgs_t {
       decode(past_intervals, p);
       DECODE_FINISH(p);
     }
-    void dump(Formatter *f) const {
+    void dump(ceph::Formatter *f) const {
       f->dump_unsigned("create_epoch", create_epoch);
       f->dump_stream("create_stamp") << create_stamp;
       f->open_array_section("up");
@@ -103,14 +104,14 @@ struct creating_pgs_t {
     bool done() const {
       return start >= end;
     }
-    void encode(bufferlist& bl) const {
+    void encode(ceph::buffer::list& bl) const {
       using ceph::encode;
       encode(created, bl);
       encode(modified, bl);
       encode(start, bl);
       encode(end, bl);
     }
-    void decode(bufferlist::const_iterator& p) {
+    void decode(ceph::buffer::list::const_iterator& p) {
       using ceph::decode;
       decode(created, p);
       decode(modified, p);
@@ -120,7 +121,7 @@ struct creating_pgs_t {
   };
 
   /// queue of pgs we still need to create (poolid -> <created, set of ps>)
-  map<int64_t,pool_create_info> queue;
+  std::map<int64_t,pool_create_info> queue;
 
   /// pools that exist in the osdmap for which at least one pg has been created
   std::set<int64_t> created_pools;
@@ -154,7 +155,7 @@ struct creating_pgs_t {
     queue.erase(removed_pool);
     return total - pgs.size();
   }
-  void encode(bufferlist& bl, uint64_t features) const {
+  void encode(ceph::buffer::list& bl, uint64_t features) const {
     unsigned v = 3;
     if (!HAVE_FEATURE(features, SERVER_OCTOPUS)) {
       v = 2;
@@ -166,7 +167,7 @@ struct creating_pgs_t {
     encode(queue, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(3, bl);
     decode(last_scan_epoch, bl);
     if (struct_v >= 3) {
@@ -214,7 +215,7 @@ struct creating_pgs_t {
     }
     f->close_section();
   }
-  static void generate_test_instances(list<creating_pgs_t*>& o) {
+  static void generate_test_instances(std::list<creating_pgs_t*>& o) {
     auto c = new creating_pgs_t;
     c->last_scan_epoch = 17;
     c->pgs.emplace(pg_t{42, 2}, pg_create_info(31, utime_t{891, 113}));

--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -20,6 +20,32 @@
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, epoch, elector)
+using std::cerr;
+using std::cout;
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::setfill;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+using std::unique_ptr;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::mono_clock;
+using ceph::mono_time;
+using ceph::timespan_str;
 static ostream& _prefix(std::ostream *_dout, epoch_t epoch, ElectionOwner* elector) {
   return *_dout << "paxos." << elector->get_my_rank()
 		<< ").electionLogic(" <<  epoch << ") ";

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -25,6 +25,32 @@
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon, get_epoch())
+using std::cerr;
+using std::cout;
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::setfill;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+using std::unique_ptr;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::mono_clock;
+using ceph::mono_time;
+using ceph::timespan_str;
 static ostream& _prefix(std::ostream *_dout, Monitor *mon, epoch_t epoch) {
   return *_dout << "mon." << mon->name << "@" << mon->rank
 		<< "(" << mon->get_state_name()

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -53,7 +53,7 @@ class Elector : public ElectionOwner {
     uint64_t cluster_features = 0;
     mon_feature_t mon_features;
     ceph_release_t mon_release{0};
-    map<string,string> metadata;
+    std::map<std::string,std::string> metadata;
   };
 
   /**
@@ -100,7 +100,7 @@ class Elector : public ElectionOwner {
    * Map containing info of all those that acked our proposal to become the Leader.
    * Note each peer's info.
    */
-  map<int, elector_info_t> peer_info;
+  std::map<int, elector_info_t> peer_info;
   /**
    * @}
    */

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -21,6 +21,31 @@
 
 using TOPNSPC::common::cmd_getval;
 
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::ErasureCodeInterfaceRef;
+using ceph::ErasureCodeProfile;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::make_message;
+using ceph::mono_clock;
+using ceph::mono_time;
+
 static const string EXPERIMENTAL_WARNING("Warning! This feature is experimental."
 "It may cause problems up to and including data loss."
 "Consult the documentation at ceph.com, and if unsure, do not proceed."

--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -32,6 +32,35 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon, this)
 using namespace TOPNSPC::common;
+
+using namespace std::literals;
+using std::cerr;
+using std::cout;
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::setfill;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+using std::unique_ptr;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::mono_clock;
+using ceph::mono_time;
+using ceph::parse_timespan;
+using ceph::timespan_str;
 static ostream& _prefix(std::ostream *_dout, const Monitor *mon,
                         const HealthMonitor *hmon) {
   return *_dout << "mon." << mon->name << "@" << mon->rank

--- a/src/mon/HealthMonitor.h
+++ b/src/mon/HealthMonitor.h
@@ -19,14 +19,14 @@
 class HealthMonitor : public PaxosService
 {
   version_t version = 0;
-  map<int,health_check_map_t> quorum_checks;  // for each quorum member
+  std::map<int,health_check_map_t> quorum_checks;  // for each quorum member
   health_check_map_t leader_checks;           // leader only
-  map<string,health_mute_t> mutes;
+  std::map<std::string,health_mute_t> mutes;
 
-  map<string,health_mute_t> pending_mutes;
+  std::map<std::string,health_mute_t> pending_mutes;
 
 public:
-  HealthMonitor(Monitor *m, Paxos *p, const string& service_name);
+  HealthMonitor(Monitor *m, Paxos *p, const std::string& service_name);
 
   /**
    * @defgroup HealthMonitor_Inherited_h Inherited abstract methods
@@ -59,7 +59,7 @@ public:
   void gather_all_health_checks(health_check_map_t *all);
   health_status_t get_health_status(
     bool want_detail,
-    Formatter *f,
+    ceph::Formatter *f,
     std::string *plain,
     const char *sep1 = " ",
     const char *sep2 = "; ");

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -36,6 +36,34 @@
 
 using namespace TOPNSPC::common;
 
+using std::cerr;
+using std::cout;
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::setfill;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+using std::unique_ptr;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::make_message;
+using ceph::mono_clock;
+using ceph::mono_time;
+using ceph::timespan_str;
+
 string LogMonitor::log_channel_info::get_log_file(const string &channel)
 {
   dout(25) << __func__ << " for channel '"
@@ -324,8 +352,7 @@ void LogMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   dout(10) << __func__ << " v" << version << dendl;
   __u8 v = 1;
   encode(v, bl);
-  multimap<utime_t,LogEntry>::iterator p;
-  for (p = pending_log.begin(); p != pending_log.end(); ++p)
+  for (auto p = pending_log.begin(); p != pending_log.end(); ++p)
     p->second.encode(bl, mon->get_quorum_con_features());
 
   put_version(t, version, bl);
@@ -418,7 +445,7 @@ bool LogMonitor::preprocess_log(MonOpRequestRef op)
     goto done;
   }
   
-  for (deque<LogEntry>::iterator p = m->entries.begin();
+  for (auto p = m->entries.begin();
        p != m->entries.end();
        ++p) {
     if (!pending_summary.contains(p->key()))
@@ -460,7 +487,7 @@ bool LogMonitor::prepare_log(MonOpRequestRef op)
     return false;
   }
 
-  for (deque<LogEntry>::iterator p = m->entries.begin();
+  for (auto p = m->entries.begin();
        p != m->entries.end();
        ++p) {
     dout(10) << " logging " << *p << dendl;

--- a/src/mon/LogMonitor.h
+++ b/src/mon/LogMonitor.h
@@ -27,7 +27,7 @@
 
 class MLog;
 
-static const string LOG_META_CHANNEL = "$channel";
+static const std::string LOG_META_CHANNEL = "$channel";
 
 namespace ceph {
 namespace logging {
@@ -38,24 +38,24 @@ namespace logging {
 class LogMonitor : public PaxosService,
                    public md_config_obs_t {
 private:
-  multimap<utime_t,LogEntry> pending_log;
+  std::multimap<utime_t,LogEntry> pending_log;
   LogSummary pending_summary, summary;
 
   struct log_channel_info {
 
-    map<string,string> log_to_syslog;
-    map<string,string> syslog_level;
-    map<string,string> syslog_facility;
-    map<string,string> log_file;
-    map<string,string> expanded_log_file;
-    map<string,string> log_file_level;
-    map<string,string> log_to_graylog;
-    map<string,string> log_to_graylog_host;
-    map<string,string> log_to_graylog_port;
+    std::map<std::string,std::string> log_to_syslog;
+    std::map<std::string,std::string> syslog_level;
+    std::map<std::string,std::string> syslog_facility;
+    std::map<std::string,std::string> log_file;
+    std::map<std::string,std::string> expanded_log_file;
+    std::map<std::string,std::string> log_file_level;
+    std::map<std::string,std::string> log_to_graylog;
+    std::map<std::string,std::string> log_to_graylog_host;
+    std::map<std::string,std::string> log_to_graylog_port;
 
-    map<string, shared_ptr<ceph::logging::Graylog>> graylogs;
+    std::map<std::string, std::shared_ptr<ceph::logging::Graylog>> graylogs;
     uuid_d fsid;
-    string host;
+    std::string host;
 
     void clear() {
       log_to_syslog.clear();
@@ -81,35 +81,35 @@ private:
       expand_channel_meta(syslog_facility);
       expand_channel_meta(log_file_level);
     }
-    void expand_channel_meta(map<string,string> &m);
-    string expand_channel_meta(const string &input,
-                               const string &change_to);
+    void expand_channel_meta(std::map<std::string,std::string> &m);
+    std::string expand_channel_meta(const std::string &input,
+				    const std::string &change_to);
 
-    bool do_log_to_syslog(const string &channel);
+    bool do_log_to_syslog(const std::string &channel);
 
-    string get_facility(const string &channel) {
+    std::string get_facility(const std::string &channel) {
       return get_str_map_key(syslog_facility, channel,
                              &CLOG_CONFIG_DEFAULT_KEY);
     }
 
-    string get_level(const string &channel) {
+    std::string get_level(const std::string &channel) {
       return get_str_map_key(syslog_level, channel,
                              &CLOG_CONFIG_DEFAULT_KEY);
     }
 
-    string get_log_file(const string &channel);
+    std::string get_log_file(const std::string &channel);
 
-    string get_log_file_level(const string &channel) {
+    std::string get_log_file_level(const std::string &channel) {
       return get_str_map_key(log_file_level, channel,
                              &CLOG_CONFIG_DEFAULT_KEY);
     }
 
-    bool do_log_to_graylog(const string &channel) {
+    bool do_log_to_graylog(const std::string &channel) {
       return (get_str_map_key(log_to_graylog, channel,
 			      &CLOG_CONFIG_DEFAULT_KEY) == "true");
     }
 
-    shared_ptr<ceph::logging::Graylog> get_graylog(const string &channel);
+    std::shared_ptr<ceph::logging::Graylog> get_graylog(const std::string &channel);
   } channels;
 
   void update_log_channels();
@@ -143,7 +143,7 @@ private:
   void _create_sub_incremental(MLog *mlog, int level, version_t sv);
 
  public:
-  LogMonitor(Monitor *mn, Paxos *p, const string& service_name) 
+  LogMonitor(Monitor *mn, Paxos *p, const std::string& service_name) 
     : PaxosService(mn, p, service_name) { }
 
   void init() override {
@@ -163,7 +163,7 @@ private:
    * @param n name
    * @return id, or -1 if unrecognized
    */
-  int sub_name_to_id(const string& n);
+  int sub_name_to_id(const std::string& n);
 
   void on_shutdown() override {
     g_conf().remove_observer(this);

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -39,11 +39,36 @@
 #include "mds/mdstypes.h"
 #include "Session.h"
 
+using namespace TOPNSPC::common;
+
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::ErasureCodeInterfaceRef;
+using ceph::ErasureCodeProfile;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::make_message;
+using ceph::mono_clock;
+using ceph::mono_time;
+
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon, get_fsmap())
-using namespace TOPNSPC::common;
-
 static ostream& _prefix(std::ostream *_dout, Monitor *mon, const FSMap& fsmap) {
   return *_dout << "mon." << mon->name << "@" << mon->rank
 		<< "(" << mon->get_state_name()
@@ -1996,7 +2021,7 @@ bool MDSMonitor::check_health(FSMap& fsmap, bool* propose_osdmap)
   for (const auto& p : last_beacon) {
     latest_beacon = std::max(p.second.stamp, latest_beacon);
   }
-  auto since = chrono::duration<double>(now-latest_beacon);
+  auto since = std::chrono::duration<double>(now-latest_beacon);
   const bool may_replace = since.count() <
       std::max(g_conf()->mds_beacon_interval, g_conf()->mds_beacon_grace * 0.5);
 
@@ -2004,7 +2029,7 @@ bool MDSMonitor::check_health(FSMap& fsmap, bool* propose_osdmap)
   std::vector<mds_gid_t> to_remove;
   for (auto it = last_beacon.begin(); it != last_beacon.end(); ) {
     auto& [gid, beacon_info] = *it;
-    auto since_last = chrono::duration<double>(now-beacon_info.stamp);
+    auto since_last = std::chrono::duration<double>(now-beacon_info.stamp);
 
     if (!fsmap.gid_exists(gid)) {
       // gid no longer exists, remove from tracked beacons

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -32,14 +32,14 @@ class FileSystemCommandHandler;
 
 class MDSMonitor : public PaxosService, public PaxosFSMap, protected CommandHandler {
  public:
-  MDSMonitor(Monitor *mn, Paxos *p, string service_name);
+  MDSMonitor(Monitor *mn, Paxos *p, std::string service_name);
 
   // service methods
   void create_initial() override;
-  void get_store_prefixes(std::set<string>& s) const override;
+  void get_store_prefixes(std::set<std::string>& s) const override;
   void update_from_paxos(bool *need_bootstrap) override;
   void init() override;
-  void create_pending() override; 
+  void create_pending() override;
   void encode_pending(MonitorDBStore::TransactionRef t) override;
   // we don't require full versions; don't encode any.
   void encode_full(MonitorDBStore::TransactionRef t) override { }
@@ -62,8 +62,8 @@ class MDSMonitor : public PaxosService, public PaxosFSMap, protected CommandHand
   void check_subs();
   void check_sub(Subscription *sub);
 
-  void dump_info(Formatter *f);
-  int print_nodes(Formatter *f);
+  void dump_info(ceph::Formatter *f);
+  int print_nodes(ceph::Formatter *f);
 
   /**
    * Return true if a blacklist was done (i.e. OSD propose needed)
@@ -104,12 +104,12 @@ class MDSMonitor : public PaxosService, public PaxosFSMap, protected CommandHand
 
   // beacons
   struct beacon_info_t {
-    mono_time stamp = mono_clock::zero();
+    ceph::mono_time stamp = ceph::mono_clock::zero();
     uint64_t seq = 0;
     beacon_info_t() {}
-    beacon_info_t(mono_time stamp, uint64_t seq) : stamp(stamp), seq(seq) {}
+    beacon_info_t(ceph::mono_time stamp, uint64_t seq) : stamp(stamp), seq(seq) {}
   };
-  map<mds_gid_t, beacon_info_t> last_beacon;
+  std::map<mds_gid_t, beacon_info_t> last_beacon;
 
   std::list<std::shared_ptr<FileSystemCommandHandler> > handlers;
 
@@ -119,29 +119,29 @@ class MDSMonitor : public PaxosService, public PaxosFSMap, protected CommandHand
   bool check_health(FSMap &fsmap, bool* osd_propose);
   void tick() override;     // check state, take actions
 
-  int dump_metadata(const FSMap &fsmap, const std::string &who, Formatter *f,
-      ostream& err);
+  int dump_metadata(const FSMap &fsmap, const std::string &who, ceph::Formatter *f,
+		    std::ostream& err);
 
   void update_metadata(mds_gid_t gid, const Metadata& metadata);
   void remove_from_metadata(const FSMap &fsmap, MonitorDBStore::TransactionRef t);
-  int load_metadata(map<mds_gid_t, Metadata>& m);
-  void count_metadata(const std::string& field, Formatter *f);
+  int load_metadata(std::map<mds_gid_t, Metadata>& m);
+  void count_metadata(const std::string& field, ceph::Formatter *f);
 public:
-  void count_metadata(const std::string& field, map<string,int> *out);
+  void count_metadata(const std::string& field, std::map<std::string,int> *out);
 protected:
 
   // MDS daemon GID to latest health state from that GID
   std::map<uint64_t, MDSHealth> pending_daemon_health;
   std::set<uint64_t> pending_daemon_health_rm;
 
-  map<mds_gid_t, Metadata> pending_metadata;
+  std::map<mds_gid_t, Metadata> pending_metadata;
 
   mds_gid_t gid_from_arg(const FSMap &fsmap, const std::string &arg, std::ostream& err);
 
   // When did the mon last call into our tick() method?  Used for detecting
   // when the mon was not updating us for some period (e.g. during slow
   // election) to reset last_beacon timeouts
-  mono_time last_tick = mono_clock::zero();
+  ceph::mono_time last_tick = ceph::mono_clock::zero();
 };
 
 #endif

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -32,6 +32,32 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon, map)
 using namespace TOPNSPC::common;
+
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::ErasureCodeInterfaceRef;
+using ceph::ErasureCodeProfile;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::make_message;
+using ceph::mono_clock;
+using ceph::mono_time;
+
 static ostream& _prefix(std::ostream *_dout, Monitor *mon,
 			const MgrMap& mgrmap) {
   return *_dout << "mon." << mon->name << "@" << mon->rank
@@ -1208,7 +1234,7 @@ int MgrMonitor::load_metadata(const string& name, std::map<string, string>& m,
     auto p = bl.cbegin();
     decode(m, p);
   }
-  catch (buffer::error& e) {
+  catch (ceph::buffer::error& e) {
     if (err)
       *err << "mgr." << name << " metadata is corrupt";
     return -EIO;

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -28,8 +28,8 @@ class MgrMonitor: public PaxosService
   MgrMap pending_map;
   bool ever_had_active_mgr = false;
 
-  std::map<std::string, bufferlist> pending_metadata;
-  std::set<std::string>             pending_metadata_rm;
+  std::map<std::string, ceph::buffer::list> pending_metadata;
+  std::set<std::string> pending_metadata_rm;
 
   std::map<std::string,Option> mgr_module_options;
   std::list<std::string> misc_option_strings;
@@ -71,7 +71,7 @@ class MgrMonitor: public PaxosService
   std::vector<MonCommand> pending_command_descs;
 
 public:
-  MgrMonitor(Monitor *mn, Paxos *p, const string& service_name)
+  MgrMonitor(Monitor *mn, Paxos *p, const std::string& service_name)
     : PaxosService(mn, p, service_name)
   {}
   ~MgrMonitor() override {}
@@ -84,7 +84,7 @@ public:
   const std::map<std::string,Option>& get_mgr_module_options() {
     return mgr_module_options;
   }
-  const Option *find_module_option(const string& name);
+  const Option *find_module_option(const std::string& name);
 
   bool in_use() const { return map.epoch > 0; }
 
@@ -93,7 +93,7 @@ public:
   void prime_mgr_client();
 
   void create_initial() override;
-  void get_store_prefixes(std::set<string>& s) const override;
+  void get_store_prefixes(std::set<std::string>& s) const override;
   void update_from_paxos(bool *need_bootstrap) override;
   void post_paxos_update() override;
   void create_pending() override;
@@ -119,16 +119,16 @@ public:
 
   void tick() override;
 
-  void print_summary(Formatter *f, std::ostream *ss) const;
+  void print_summary(ceph::Formatter *f, std::ostream *ss) const;
 
   const std::vector<MonCommand> &get_command_descs() const;
 
-  int load_metadata(const string& name, std::map<string, string>& m,
-		    ostream *err) const;
-  int dump_metadata(const string& name, Formatter *f, ostream *err);
-  void print_nodes(Formatter *f) const;
-  void count_metadata(const string& field, Formatter *f);
-  void count_metadata(const string& field, std::map<string,int> *out);
+  int load_metadata(const std::string& name, std::map<std::string, std::string>& m,
+		    std::ostream *err) const;
+  int dump_metadata(const std::string& name, ceph::Formatter *f, std::ostream *err);
+  void print_nodes(ceph::Formatter *f) const;
+  void count_metadata(const std::string& field, ceph::Formatter *f);
+  void count_metadata(const std::string& field, std::map<std::string,int> *out);
 
   // When did the mon last call into our tick() method?  Used for detecting
   // when the mon was not updating us for some period (e.g. during slow

--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -16,6 +16,32 @@
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon)
+
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::ErasureCodeInterfaceRef;
+using ceph::ErasureCodeProfile;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::make_message;
+using ceph::mono_clock;
+using ceph::mono_time;
+
 static ostream& _prefix(std::ostream *_dout, Monitor *mon) {
   return *_dout << "mon." << mon->name << "@" << mon->rank
 		<< "(" << mon->get_state_name()
@@ -60,7 +86,7 @@ void MgrStatMonitor::update_from_paxos(bool *need_bootstrap)
 	       << " " << progress_events.size() << " progress events"
 	       << dendl;
     }
-    catch (buffer::error& e) {
+    catch (ceph::buffer::error& e) {
       derr << "failed to decode mgrstat state; luminous dev version? "
 	   << e.what() << dendl;
     }

--- a/src/mon/MgrStatMonitor.h
+++ b/src/mon/MgrStatMonitor.h
@@ -19,10 +19,10 @@ class MgrStatMonitor : public PaxosService {
   PGMapDigest pending_digest;
   health_check_map_t pending_health_checks;
   std::map<std::string,ProgressEvent> pending_progress_events;
-  bufferlist pending_service_map_bl;
+  ceph::buffer::list pending_service_map_bl;
 
 public:
-  MgrStatMonitor(Monitor *mn, Paxos *p, const string& service_name);
+  MgrStatMonitor(Monitor *mn, Paxos *p, const std::string& service_name);
   ~MgrStatMonitor() override;
 
   void init() override {}
@@ -88,19 +88,19 @@ public:
     return digest.get_statfs(osdmap, data_pool);
   }
 
-  void print_summary(Formatter *f, ostream *out) const {
+  void print_summary(ceph::Formatter *f, std::ostream *out) const {
     digest.print_summary(f, out);
   }
-  void dump_info(Formatter *f) const {
+  void dump_info(ceph::Formatter *f) const {
     digest.dump(f);
     f->dump_object("servicemap", get_service_map());
   }
-  void dump_cluster_stats(stringstream *ss,
-		     Formatter *f,
-		     bool verbose) const {
+  void dump_cluster_stats(std::stringstream *ss,
+			  ceph::Formatter *f,
+			  bool verbose) const {
     digest.dump_cluster_stats(ss, f, verbose);
   }
-  void dump_pool_stats(const OSDMap& osdm, stringstream *ss, Formatter *f,
+  void dump_pool_stats(const OSDMap& osdm, std::stringstream *ss, ceph::Formatter *f,
 		       bool verbose) const {
     digest.dump_pool_stats_full(osdm, ss, f, verbose);
   }

--- a/src/mon/MonOpRequest.h
+++ b/src/mon/MonOpRequest.h
@@ -38,28 +38,28 @@ struct MonOpRequest : public TrackedOp {
     forwarded_to_leader = true;
   }
 
-  void mark_svc_event(const string &service, const string &event) {
-    string s = service;
+  void mark_svc_event(const std::string &service, const std::string &event) {
+    std::string s = service;
     s.append(":").append(event);
     mark_event(s);
   }
 
-  void mark_logmon_event(const string &event) {
+  void mark_logmon_event(const std::string &event) {
     mark_svc_event("logm", event);
   }
-  void mark_osdmon_event(const string &event) {
+  void mark_osdmon_event(const std::string &event) {
     mark_svc_event("osdmap", event);
   }
-  void mark_pgmon_event(const string &event) {
+  void mark_pgmon_event(const std::string &event) {
     mark_svc_event("pgmap", event);
   }
-  void mark_mdsmon_event(const string &event) {
+  void mark_mdsmon_event(const std::string &event) {
     mark_svc_event("mdsmap", event);
   }
-  void mark_authmon_event(const string &event) {
+  void mark_authmon_event(const std::string &event) {
     mark_svc_event("auth", event);
   }
-  void mark_paxos_event(const string &event) {
+  void mark_paxos_event(const std::string &event) {
     mark_svc_event("paxos", event);
   }
 
@@ -101,7 +101,7 @@ private:
     }
   }
 
-  void _dump(Formatter *f) const override {
+  void _dump(ceph::Formatter *f) const override {
     {
       f->open_array_section("events");
       std::lock_guard l(lock);
@@ -119,7 +119,7 @@ private:
   }
 
 protected:
-  void _dump_op_descriptor_unlocked(ostream& stream) const override {
+  void _dump_op_descriptor_unlocked(std::ostream& stream) const override {
     get_req()->print(stream);
   }
 
@@ -215,7 +215,7 @@ struct C_MonOp : public Context
     _finish(r);
   }
 
-  void mark_op_event(const string &event) {
+  void mark_op_event(const std::string &event) {
     if (op)
       op->mark_event(event);
   }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -101,6 +101,37 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)
 using namespace TOPNSPC::common;
+
+using std::cout;
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::setfill;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+using std::unique_ptr;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::ErasureCodeInterfaceRef;
+using ceph::ErasureCodeProfile;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::make_message;
+using ceph::mono_clock;
+using ceph::mono_time;
+using ceph::timespan_str;
+
+
 static ostream& _prefix(std::ostream *_dout, const Monitor *mon) {
   return *_dout << "mon." << mon->name << "@" << mon->rank
 		<< "(" << mon->get_state_name() << ") e" << mon->monmap->get_epoch() << " ";
@@ -934,7 +965,7 @@ void Monitor::refresh_from_paxos(bool *need_bootstrap)
       auto p = bl.cbegin();
       decode(fingerprint, p);
     }
-    catch (buffer::error& e) {
+    catch (ceph::buffer::error& e) {
       dout(10) << __func__ << " failed to decode cluster_fingerprint" << dendl;
     }
   } else {
@@ -5851,7 +5882,7 @@ int Monitor::mkfs(bufferlist& osdmapbl)
       OSDMap om;
       om.decode(osdmapbl);
     }
-    catch (buffer::error& e) {
+    catch (ceph::buffer::error& e) {
       derr << "error decoding provided osdmap: " << e.what() << dendl;
       return -EINVAL;
     }
@@ -5875,7 +5906,7 @@ int Monitor::mkfs(bufferlist& osdmapbl)
 	  auto i = bl.cbegin();
 	  keyring.decode_plaintext(i);
 	}
-	catch (const buffer::error& e) {
+	catch (const ceph::buffer::error& e) {
 	  derr << "error decoding keyring " << keyring_plaintext
 	       << ": " << e.what() << dendl;
 	  return -EINVAL;
@@ -6212,7 +6243,7 @@ int Monitor::handle_auth_request(
       assert(mode >= AUTH_MODE_MON && mode <= AUTH_MODE_MON_MAX);
       decode(entity_name, p);
       decode(con->peer_global_id, p);
-    } catch (buffer::error& e) {
+    } catch (ceph::buffer::error& e) {
       dout(1) << __func__ << " failed to decode, " << e.what() << dendl;
       return -EACCES;
     }
@@ -6353,7 +6384,7 @@ int Monitor::ms_handle_authentication(Connection *con)
     string str;
     try {
       decode(str, p);
-    } catch (const buffer::error &err) {
+    } catch (const ceph::buffer::error &err) {
       derr << __func__ << " corrupt cap data for " << con->get_peer_entity_name()
 	   << " in auth db" << dendl;
       str.clear();

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -7,16 +7,16 @@
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
-/* 
- * This is the top level monitor. It runs on each machine in the Monitor   
- * Cluster. The election of a leader for the paxos algorithm only happens 
- * once per machine via the elector. There is a separate paxos instance (state) 
- * kept for each of the system components: Object Store Device (OSD) Monitor, 
+/*
+ * This is the top level monitor. It runs on each machine in the Monitor
+ * Cluster. The election of a leader for the paxos algorithm only happens
+ * once per machine via the elector. There is a separate paxos instance (state)
+ * kept for each of the system components: Object Store Device (OSD) Monitor,
  * Placement Group (PG) Monitor, Metadata Server (MDS) Monitor, and Client Monitor.
  */
 
@@ -113,7 +113,7 @@ public:
   const char **orig_argv = nullptr;
 
   // me
-  string name;
+  std::string name;
   int rank;
   Messenger *messenger;
   ConnectionRef con_self;
@@ -138,7 +138,7 @@ public:
   MonMap *monmap;
   uuid_d fingerprint;
 
-  set<entity_addrvec_t> extra_probe_peers;
+  std::set<entity_addrvec_t> extra_probe_peers;
 
   LogClient log_client;
   LogChannelRef clog;
@@ -151,12 +151,12 @@ public:
 
   CompatSet features;
 
-  vector<MonCommand> leader_mon_commands; // quorum leader's commands
-  vector<MonCommand> local_mon_commands;  // commands i support
-  bufferlist local_mon_commands_bl;       // encoded version of above
+  std::vector<MonCommand> leader_mon_commands; // quorum leader's commands
+  std::vector<MonCommand> local_mon_commands;  // commands i support
+  ceph::buffer::list local_mon_commands_bl;       // encoded version of above
 
-  vector<MonCommand> prenautilus_local_mon_commands;
-  bufferlist prenautilus_local_mon_commands_bl;
+  std::vector<MonCommand> prenautilus_local_mon_commands;
+  ceph::buffer::list prenautilus_local_mon_commands_bl;
 
   Messenger *mgr_messenger;
   MgrClient mgr_client;
@@ -169,8 +169,8 @@ private:
   // -- local storage --
 public:
   MonitorDBStore *store;
-  static const string MONITOR_NAME;
-  static const string MONITOR_STORE_PREFIX;
+  static const std::string MONITOR_NAME;
+  static const std::string MONITOR_STORE_PREFIX;
 
   // -- monitor state --
 private:
@@ -225,14 +225,14 @@ private:
   uint64_t required_features;
   
   int leader;            // current leader (to best of knowledge)
-  set<int> quorum;       // current active set of monitors (if !starting)
-  mono_clock::time_point quorum_since;  // when quorum formed
+  std::set<int> quorum;       // current active set of monitors (if !starting)
+  ceph::mono_clock::time_point quorum_since;  // when quorum formed
   utime_t leader_since;  // when this monitor became the leader, if it is the leader
   utime_t exited_quorum; // time detected as not in quorum; 0 if in
 
   // map of counts of connected clients, by type and features, for
   // each quorum mon
-  map<int,FeatureMap> quorum_feature_map;
+  std::map<int,FeatureMap> quorum_feature_map;
 
   /**
    * Intersection of quorum member's connection feature bits.
@@ -245,14 +245,14 @@ private:
 
   ceph_release_t quorum_min_mon_release{ceph_release_t::unknown};
 
-  set<string> outside_quorum;
+  std::set<std::string> outside_quorum;
 
   /**
    * @defgroup Monitor_h_scrub
    * @{
    */
   version_t scrub_version;            ///< paxos version we are scrubbing
-  map<int,ScrubResult> scrub_result;  ///< results so far
+  std::map<int,ScrubResult> scrub_result;  ///< results so far
 
   /**
    * trigger a cross-mon scrub
@@ -263,7 +263,7 @@ private:
   int scrub();
   void handle_scrub(MonOpRequestRef op);
   bool _scrub(ScrubResult *r,
-              pair<string,string> *start,
+              std::pair<std::string,std::string> *start,
               int *num_keys);
   void scrub_check_results();
   void scrub_timeout();
@@ -279,7 +279,7 @@ private:
   void scrub_cancel_timeout();
 
   struct ScrubState {
-    pair<string,string> last_key; ///< last scrubbed key
+    std::pair<std::string,std::string> last_key; ///< last scrubbed key
     bool finished;
 
     ScrubState() : finished(false) { }
@@ -299,7 +299,7 @@ private:
     uint64_t cookie;       ///< unique cookie for this sync attempt
     utime_t timeout;       ///< when we give up and expire this attempt
     version_t last_committed; ///< last paxos version on peer
-    pair<string,string> last_key; ///< last key sent to (or on) peer
+    std::pair<std::string,std::string> last_key; ///< last key sent to (or on) peer
     bool full;             ///< full scan?
     MonitorDBStore::Synchronizer synchronizer;   ///< iterator
 
@@ -311,7 +311,7 @@ private:
     }
   };
 
-  map<uint64_t, SyncProvider> sync_providers;  ///< cookie -> SyncProvider for those syncing from us
+  std::map<std::uint64_t, SyncProvider> sync_providers;  ///< cookie -> SyncProvider for those syncing from us
   uint64_t sync_provider_count;   ///< counter for issued cookies to keep them unique
 
   /**
@@ -361,7 +361,7 @@ private:
    *
    * @returns a set of strings referring to the prefixes being synchronized
    */
-  set<string> get_sync_targets_names();
+  std::set<std::string> get_sync_targets_names();
 
   /**
    * Reset the monitor's sync-related data structures for syncing *from* a peer
@@ -381,7 +381,7 @@ private:
   /**
    * Get the latest monmap for backup purposes during sync
    */
-  void sync_obtain_latest_monmap(bufferlist &bl);
+  void sync_obtain_latest_monmap(ceph::buffer::list &bl);
 
   /**
    * Start sync process
@@ -397,7 +397,7 @@ public:
   /**
    * force a sync on next mon restart
    */
-  void sync_force(Formatter *f);
+  void sync_force(ceph::Formatter *f);
 
 private:
   /**
@@ -458,8 +458,8 @@ private:
    * @} // Synchronization
    */
 
-  list<Context*> waitfor_quorum;
-  list<Context*> maybe_wait_for_quorum;
+  std::list<Context*> waitfor_quorum;
+  std::list<Context*> maybe_wait_for_quorum;
 
   /**
    * @defgroup Monitor_h_TimeCheck Monitor Clock Drift Early Warning System
@@ -485,9 +485,9 @@ private:
    *  - Once all the quorum members have pong'ed, the leader will share the
    *    clock skew and latency maps with all the monitors in the quorum.
    */
-  map<int, utime_t> timecheck_waiting;
-  map<int, double> timecheck_skews;
-  map<int, double> timecheck_latencies;
+  std::map<int, utime_t> timecheck_waiting;
+  std::map<int, double> timecheck_skews;
+  std::map<int, double> timecheck_latencies;
   // odd value means we are mid-round; even value means the round has
   // finished.
   version_t timecheck_round;
@@ -518,7 +518,7 @@ private:
   void timecheck_check_skews();
   void timecheck_report();
   void timecheck();
-  health_status_t timecheck_status(ostringstream &ss,
+  health_status_t timecheck_status(std::ostringstream &ss,
                                    const double skew_bound,
                                    const double latency);
   void handle_timecheck_leader(MonOpRequestRef op);
@@ -554,13 +554,13 @@ private:
 public:
   epoch_t get_epoch();
   int get_leader() const { return leader; }
-  string get_leader_name() {
-    return quorum.empty() ? string() : monmap->get_name(*quorum.begin());
+  std::string get_leader_name() {
+    return quorum.empty() ? std::string() : monmap->get_name(*quorum.begin());
   }
-  const set<int>& get_quorum() const { return quorum; }
-  list<string> get_quorum_names() {
-    list<string> q;
-    for (set<int>::iterator p = quorum.begin(); p != quorum.end(); ++p)
+  const std::set<int>& get_quorum() const { return quorum; }
+  std::list<std::string> get_quorum_names() {
+    std::list<std::string> q;
+    for (auto p = quorum.begin(); p != quorum.end(); ++p)
       q.push_back(monmap->get_name(*p));
     return q;
   }
@@ -593,12 +593,12 @@ public:
   void start_election();
   void win_standalone_election();
   // end election (called by Elector)
-  void win_election(epoch_t epoch, const set<int>& q,
+  void win_election(epoch_t epoch, const std::set<int>& q,
 		    uint64_t features,
                     const mon_feature_t& mon_features,
 		    ceph_release_t min_mon_release,
-		    const map<int,Metadata>& metadata);
-  void lose_election(epoch_t epoch, set<int>& q, int l,
+		    const std::map<int,Metadata>& metadata);
+  void lose_election(epoch_t epoch, std::set<int>& q, int l,
 		     uint64_t features,
                      const mon_feature_t& mon_features,
 		     ceph_release_t min_mon_release);
@@ -610,7 +610,7 @@ public:
   /**
    * Vector holding the Services serviced by this Monitor.
    */
-  vector<std::unique_ptr<PaxosService>> paxos_service;
+  std::vector<std::unique_ptr<PaxosService>> paxos_service;
 
   class MDSMonitor *mdsmon() {
     return (class MDSMonitor *)paxos_service[PAXOS_MDSMAP].get();
@@ -675,17 +675,17 @@ public:
   void handle_mon_get_map(MonOpRequestRef op);
 
   static void _generate_command_map(cmdmap_t& cmdmap,
-                                    map<string,string> &param_str_map);
+                                    std::map<std::string,std::string> &param_str_map);
   static const MonCommand *_get_moncommand(
-    const string &cmd_prefix,
-    const vector<MonCommand>& cmds);
-  bool _allowed_command(MonSession *s, const string& module,
-			const string& prefix,
+    const std::string &cmd_prefix,
+    const std::vector<MonCommand>& cmds);
+  bool _allowed_command(MonSession *s, const std::string& module,
+			const std::string& prefix,
                         const cmdmap_t& cmdmap,
-                        const map<string,string>& param_str_map,
+                        const std::map<std::string,std::string>& param_str_map,
                         const MonCommand *this_cmd);
-  void get_mon_status(Formatter *f);
-  void _quorum_status(Formatter *f, ostream& ss);
+  void get_mon_status(ceph::Formatter *f);
+  void _quorum_status(ceph::Formatter *f, std::ostream& ss);
   bool _add_bootstrap_peer_hint(std::string_view cmd, const cmdmap_t& cmdmap,
 				std::ostream& ss);
   void handle_tell_command(MonOpRequestRef op);
@@ -693,19 +693,19 @@ public:
   void handle_route(MonOpRequestRef op);
 
   void handle_mon_metadata(MonOpRequestRef op);
-  int get_mon_metadata(int mon, Formatter *f, ostream& err);
-  int print_nodes(Formatter *f, ostream& err);
+  int get_mon_metadata(int mon, ceph::Formatter *f, std::ostream& err);
+  int print_nodes(ceph::Formatter *f, std::ostream& err);
 
   // Accumulate metadata across calls to update_mon_metadata
-  map<int, Metadata> mon_metadata;
-  map<int, Metadata> pending_metadata;
+  std::map<int, Metadata> mon_metadata;
+  std::map<int, Metadata> pending_metadata;
 
   /**
    *
    */
   struct health_cache_t {
     health_status_t overall;
-    string summary;
+    std::string summary;
 
     void reset() {
       // health_status_t doesn't really have a NONE value and we're not
@@ -754,12 +754,12 @@ protected:
 
 public:
 
-  void get_cluster_status(stringstream &ss, Formatter *f);
+  void get_cluster_status(std::stringstream &ss, ceph::Formatter *f);
 
-  void reply_command(MonOpRequestRef op, int rc, const string &rs, version_t version);
-  void reply_command(MonOpRequestRef op, int rc, const string &rs, bufferlist& rdata, version_t version);
+  void reply_command(MonOpRequestRef op, int rc, const std::string &rs, version_t version);
+  void reply_command(MonOpRequestRef op, int rc, const std::string &rs, ceph::buffer::list& rdata, version_t version);
 
-  void reply_tell_command(MonOpRequestRef op, int rc, const string &rs);
+  void reply_tell_command(MonOpRequestRef op, int rc, const std::string &rs);
 
 
 
@@ -784,7 +784,7 @@ public:
   // request routing
   struct RoutedRequest {
     uint64_t tid;
-    bufferlist request_bl;
+    ceph::buffer::list request_bl;
     MonSession *session;
     ConnectionRef con;
     uint64_t con_features;
@@ -797,8 +797,8 @@ public:
     }
   };
   uint64_t routed_request_tid;
-  map<uint64_t, RoutedRequest*> routed_requests;
-  
+  std::map<uint64_t, RoutedRequest*> routed_requests;
+
   void forward_request_leader(MonOpRequestRef op);
   void handle_forward(MonOpRequestRef op);
   void send_reply(MonOpRequestRef op, Message *reply);
@@ -814,18 +814,18 @@ public:
   struct C_Command : public C_MonOp {
     Monitor *mon;
     int rc;
-    string rs;
-    bufferlist rdata;
+    std::string rs;
+    ceph::buffer::list rdata;
     version_t version;
-    C_Command(Monitor *_mm, MonOpRequestRef _op, int r, string s, version_t v) :
+    C_Command(Monitor *_mm, MonOpRequestRef _op, int r, std::string s, version_t v) :
       C_MonOp(_op), mon(_mm), rc(r), rs(s), version(v){}
-    C_Command(Monitor *_mm, MonOpRequestRef _op, int r, string s, bufferlist rd, version_t v) :
+    C_Command(Monitor *_mm, MonOpRequestRef _op, int r, std::string s, ceph::buffer::list rd, version_t v) :
       C_MonOp(_op), mon(_mm), rc(r), rs(s), rdata(rd), version(v){}
 
     void _finish(int r) override {
       auto m = op->get_req<MMonCommand>();
       if (r >= 0) {
-        ostringstream ss;
+	std::ostringstream ss;
         if (!op->get_req()->get_connection()) {
           ss << "connection dropped for command ";
         } else {
@@ -895,19 +895,19 @@ private:
     Connection *con,
     AuthConnectionMeta *auth_meta,
     uint32_t *method,
-    vector<uint32_t> *preferred_modes,
-    bufferlist *out) override;
+    std::vector<uint32_t> *preferred_modes,
+    ceph::buffer::list *out) override;
   int handle_auth_reply_more(
     Connection *con,
     AuthConnectionMeta *auth_meta,
-   const bufferlist& bl,
-    bufferlist *reply) override;
+   const ceph::buffer::list& bl,
+    ceph::buffer::list *reply) override;
   int handle_auth_done(
     Connection *con,
     AuthConnectionMeta *auth_meta,
     uint64_t global_id,
     uint32_t con_mode,
-    const bufferlist& bl,
+    const ceph::buffer::list& bl,
     CryptoKey *session_key,
     std::string *connection_secret) override;
   int handle_auth_bad_method(
@@ -924,18 +924,18 @@ private:
     AuthConnectionMeta *auth_meta,
     bool more,
     uint32_t auth_method,
-    const bufferlist& bl,
-    bufferlist *reply) override;
+    const ceph::buffer::list& bl,
+    ceph::buffer::list *reply) override;
   // /AuthServer
 
-  int write_default_keyring(bufferlist& bl);
+  int write_default_keyring(ceph::buffer::list& bl);
   void extract_save_mon_key(KeyRing& keyring);
 
   void collect_metadata(Metadata *m);
   void update_mon_metadata(int from, Metadata&& m);
   int load_metadata();
-  void count_metadata(const string& field, Formatter *f);
-  void count_metadata(const string& field, map<string,int> *out);
+  void count_metadata(const std::string& field, ceph::Formatter *f);
+  void count_metadata(const std::string& field, std::map<std::string,int> *out);
 
   // features
   static CompatSet get_initial_supported_features();
@@ -949,7 +949,7 @@ private:
   OpTracker op_tracker;
 
  public:
-  Monitor(CephContext *cct_, string nm, MonitorDBStore *s,
+  Monitor(CephContext *cct_, std::string nm, MonitorDBStore *s,
 	  Messenger *m, Messenger *mgr_m, MonMap *map);
   ~Monitor() override;
 
@@ -971,7 +971,7 @@ private:
 
   void handle_signal(int sig);
 
-  int mkfs(bufferlist& osdmapbl);
+  int mkfs(ceph::buffer::list& osdmapbl);
 
   /**
    * check cluster_fsid file
@@ -989,7 +989,7 @@ private:
   int write_fsid(MonitorDBStore::TransactionRef t);
 
   int do_admin_command(std::string_view command, const cmdmap_t& cmdmap,
-		       Formatter *f,
+		       ceph::Formatter *f,
 		       std::ostream& err,
 		       std::ostream& out);
 
@@ -1000,9 +1000,9 @@ private:
 
 public:
   static void format_command_descriptions(const std::vector<MonCommand> &commands,
-					  Formatter *f,
+					  ceph::Formatter *f,
 					  uint64_t features,
-					  bufferlist *rdata);
+					  ceph::buffer::list *rdata);
 
   const std::vector<MonCommand> &get_local_commands(mon_feature_t f) {
     if (f.contains_all(ceph::features::mon::FEATURE_NAUTILUS)) {
@@ -1011,7 +1011,7 @@ public:
       return prenautilus_local_mon_commands;
     }
   }
-  const bufferlist& get_local_commands_bl(mon_feature_t f) {
+  const ceph::buffer::list& get_local_commands_bl(mon_feature_t f) {
     if (f.contains_all(ceph::features::mon::FEATURE_NAUTILUS)) {
       return local_mon_commands_bl;
     } else {

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -36,12 +36,12 @@
 
 class MonitorDBStore
 {
-  string path;
+  std::string path;
   boost::scoped_ptr<KeyValueDB> db;
   bool do_dump;
   int dump_fd_binary;
   std::ofstream dump_fd_json;
-  JSONFormatter dump_fmt;
+  ceph::JSONFormatter dump_fmt;
   
 
   Finisher io_work;
@@ -50,7 +50,7 @@ class MonitorDBStore
 
  public:
 
-  string get_devname() {
+  std::string get_devname() {
     char devname[4096] = {0}, partition[4096];
     get_device_by_path(path.c_str(), partition, devname,
 		       sizeof(devname));
@@ -63,20 +63,20 @@ class MonitorDBStore
 
   struct Op {
     uint8_t type;
-    string prefix;
-    string key, endkey;
-    bufferlist bl;
+    std::string prefix;
+    std::string key, endkey;
+    ceph::buffer::list bl;
 
     Op()
       : type(0) { }
-    Op(int t, const string& p, const string& k)
+    Op(int t, const std::string& p, const std::string& k)
       : type(t), prefix(p), key(k) { }
-    Op(int t, const string& p, const string& k, const bufferlist& b)
+    Op(int t, const std::string& p, const std::string& k, const ceph::buffer::list& b)
       : type(t), prefix(p), key(k), bl(b) { }
-    Op(int t, const string& p, const string& start, const string& end)
+    Op(int t, const std::string& p, const std::string& start, const std::string& end)
       : type(t), prefix(p), key(start), endkey(end) { }
 
-    void encode(bufferlist& encode_bl) const {
+    void encode(ceph::buffer::list& encode_bl) const {
       ENCODE_START(2, 1, encode_bl);
       encode(type, encode_bl);
       encode(prefix, encode_bl);
@@ -86,7 +86,7 @@ class MonitorDBStore
       ENCODE_FINISH(encode_bl);
     }
 
-    void decode(bufferlist::const_iterator& decode_bl) {
+    void decode(ceph::buffer::list::const_iterator& decode_bl) {
       DECODE_START(2, decode_bl);
       decode(type, decode_bl);
       decode(prefix, decode_bl);
@@ -97,7 +97,7 @@ class MonitorDBStore
       DECODE_FINISH(decode_bl);
     }
 
-    void dump(Formatter *f) const {
+    void dump(ceph::Formatter *f) const {
       f->dump_int("type", type);
       f->dump_string("prefix", prefix);
       f->dump_string("key", key);
@@ -114,7 +114,7 @@ class MonitorDBStore
 	4 + bl.length();
     }
 
-    static void generate_test_instances(list<Op*>& ls) {
+    static void generate_test_instances(std::list<Op*>& ls) {
       ls.push_back(new Op);
       // we get coverage here from the Transaction instances
     }
@@ -123,7 +123,7 @@ class MonitorDBStore
   struct Transaction;
   typedef std::shared_ptr<Transaction> TransactionRef;
   struct Transaction {
-    list<Op> ops;
+    std::list<Op> ops;
     uint64_t bytes, keys;
 
     Transaction() : bytes(6 + 4 + 8*2), keys(0) {}
@@ -135,54 +135,54 @@ class MonitorDBStore
       OP_ERASE_RANGE = 4,
     };
 
-    void put(const string& prefix, const string& key, const bufferlist& bl) {
+    void put(const std::string& prefix, const std::string& key, const ceph::buffer::list& bl) {
       ops.push_back(Op(OP_PUT, prefix, key, bl));
       ++keys;
       bytes += ops.back().approx_size();
     }
 
-    void put(const string& prefix, version_t ver, const bufferlist& bl) {
-      ostringstream os;
+    void put(const std::string& prefix, version_t ver, const ceph::buffer::list& bl) {
+      std::ostringstream os;
       os << ver;
       put(prefix, os.str(), bl);
     }
 
-    void put(const string& prefix, const string& key, version_t ver) {
+    void put(const std::string& prefix, const std::string& key, version_t ver) {
       using ceph::encode;
-      bufferlist bl;
+      ceph::buffer::list bl;
       encode(ver, bl);
       put(prefix, key, bl);
     }
 
-    void erase(const string& prefix, const string& key) {
+    void erase(const std::string& prefix, const std::string& key) {
       ops.push_back(Op(OP_ERASE, prefix, key));
       ++keys;
       bytes += ops.back().approx_size();
     }
 
-    void erase(const string& prefix, version_t ver) {
-      ostringstream os;
+    void erase(const std::string& prefix, version_t ver) {
+      std::ostringstream os;
       os << ver;
       erase(prefix, os.str());
     }
 
-    void erase_range(const string& prefix, const string& begin,
-		     const string& end) {
+    void erase_range(const std::string& prefix, const std::string& begin,
+		     const std::string& end) {
       ops.push_back(Op(OP_ERASE_RANGE, prefix, begin, end));
       ++keys;
       bytes += ops.back().approx_size();
     }
 
-    void compact_prefix(const string& prefix) {
-      ops.push_back(Op(OP_COMPACT, prefix, string()));
+    void compact_prefix(const std::string& prefix) {
+      ops.push_back(Op(OP_COMPACT, prefix, {}));
     }
 
-    void compact_range(const string& prefix, const string& start,
-		       const string& end) {
+    void compact_range(const std::string& prefix, const std::string& start,
+		       const std::string& end) {
       ops.push_back(Op(OP_COMPACT, prefix, start, end));
     }
 
-    void encode(bufferlist& bl) const {
+    void encode(ceph::buffer::list& bl) const {
       ENCODE_START(2, 1, bl);
       encode(ops, bl);
       encode(bytes, bl);
@@ -190,7 +190,7 @@ class MonitorDBStore
       ENCODE_FINISH(bl);
     }
 
-    void decode(bufferlist::const_iterator& bl) {
+    void decode(ceph::buffer::list::const_iterator& bl) {
       DECODE_START(2, bl);
       decode(ops, bl);
       if (struct_v >= 2) {
@@ -200,10 +200,10 @@ class MonitorDBStore
       DECODE_FINISH(bl);
     }
 
-    static void generate_test_instances(list<Transaction*>& ls) {
+    static void generate_test_instances(std::list<Transaction*>& ls) {
       ls.push_back(new Transaction);
       ls.push_back(new Transaction);
-      bufferlist bl;
+      ceph::buffer::list bl;
       bl.append("value");
       ls.back()->put("prefix", "key", bl);
       ls.back()->erase("prefix2", "key2");
@@ -218,7 +218,7 @@ class MonitorDBStore
       bytes += other->bytes;
     }
 
-    void append_from_encoded(bufferlist& bl) {
+    void append_from_encoded(ceph::buffer::list& bl) {
       auto other(std::make_shared<Transaction>());
       auto it = bl.cbegin();
       other->decode(it);
@@ -242,9 +242,8 @@ class MonitorDBStore
     void dump(ceph::Formatter *f, bool dump_val=false) const {
       f->open_object_section("transaction");
       f->open_array_section("ops");
-      list<Op>::const_iterator it;
       int op_num = 0;
-      for (it = ops.begin(); it != ops.end(); ++it) {
+      for (auto it = ops.begin(); it != ops.end(); ++it) {
 	const Op& op = *it;
 	f->open_object_section("op");
 	f->dump_int("op_num", op_num++);
@@ -256,7 +255,7 @@ class MonitorDBStore
 	    f->dump_string("key", op.key);
 	    f->dump_unsigned("length", op.bl.length());
 	    if (dump_val) {
-	      ostringstream os;
+	      std::ostringstream os;
 	      op.bl.hexdump(os);
 	      f->dump_string("bl", os.str());
 	    }
@@ -306,7 +305,7 @@ class MonitorDBStore
 
     if (do_dump) {
       if (!g_conf()->mon_debug_dump_json) {
-        bufferlist bl;
+        ceph::buffer::list bl;
         t->encode(bl);
         bl.write_fd(dump_fd_binary);
       } else {
@@ -316,10 +315,8 @@ class MonitorDBStore
       }
     }
 
-    list<pair<string, pair<string,string> > > compact;
-    for (list<Op>::const_iterator it = t->ops.begin();
-	 it != t->ops.end();
-	 ++it) {
+    std::list<std::pair<std::string, std::pair<std::string,std::string>>> compact;
+    for (auto it = t->ops.begin(); it != t->ops.end(); ++it) {
       const Op& op = *it;
       switch (op.type) {
       case Transaction::OP_PUT:
@@ -343,8 +340,8 @@ class MonitorDBStore
     int r = db->submit_transaction_sync(dbt);
     if (r >= 0) {
       while (!compact.empty()) {
-	if (compact.front().second.first == string() &&
-	    compact.front().second.second == string())
+	if (compact.front().second.first == std::string() &&
+	    compact.front().second.second == std::string())
 	  db->compact_prefix_async(compact.front().first);
 	else
 	  db->compact_range_async(compact.front().first, compact.front().second.first, compact.front().second.second);
@@ -409,8 +406,8 @@ class MonitorDBStore
   class StoreIteratorImpl {
   protected:
     bool done;
-    pair<string,string> last_key;
-    bufferlist crc_bl;
+    std::pair<std::string,std::string> last_key;
+    ceph::buffer::list crc_bl;
 
     StoreIteratorImpl() : done(false) { }
     virtual ~StoreIteratorImpl() { }
@@ -423,7 +420,7 @@ class MonitorDBStore
 	return crc_bl.crc32c(0);
       return 0;
     }
-    pair<string,string> get_last_key() {
+    std::pair<std::string,std::string> get_last_key() {
       return last_key;
     }
     virtual bool has_next_chunk() {
@@ -431,17 +428,17 @@ class MonitorDBStore
     }
     virtual void get_chunk_tx(TransactionRef tx, uint64_t max_bytes,
 			      uint64_t max_keys) = 0;
-    virtual pair<string,string> get_next_key() = 0;
+    virtual std::pair<std::string,std::string> get_next_key() = 0;
   };
   typedef std::shared_ptr<StoreIteratorImpl> Synchronizer;
 
   class WholeStoreIteratorImpl : public StoreIteratorImpl {
     KeyValueDB::WholeSpaceIterator iter;
-    set<string> sync_prefixes;
+    std::set<std::string> sync_prefixes;
 
   public:
     WholeStoreIteratorImpl(KeyValueDB::WholeSpaceIterator iter,
-			   set<string> &prefixes)
+			   std::set<std::string> &prefixes)
       : StoreIteratorImpl(),
 	iter(iter),
 	sync_prefixes(prefixes)
@@ -460,14 +457,15 @@ class MonitorDBStore
      */
     void get_chunk_tx(TransactionRef tx, uint64_t max_bytes,
 		      uint64_t max_keys) override {
+      using ceph::encode;
       ceph_assert(done == false);
       ceph_assert(iter->valid() == true);
 
       while (iter->valid()) {
-	string prefix(iter->raw_key().first);
-	string key(iter->raw_key().second);
+	std::string prefix(iter->raw_key().first);
+	std::string key(iter->raw_key().second);
 	if (sync_prefixes.count(prefix)) {
-	  bufferlist value = iter->value();
+	  ceph::buffer::list value = iter->value();
 	  if (tx->empty() ||
 	      (tx->get_bytes() + value.length() + key.size() +
 	       prefix.size() < max_bytes &&
@@ -494,17 +492,17 @@ class MonitorDBStore
       done = true;
     }
 
-    pair<string,string> get_next_key() override {
+    std::pair<std::string,std::string> get_next_key() override {
       ceph_assert(iter->valid());
 
       for (; iter->valid(); iter->next()) {
-        pair<string,string> r = iter->raw_key();
+	std::pair<std::string,std::string> r = iter->raw_key();
         if (sync_prefixes.count(r.first) > 0) {
           iter->next();
           return r;
         }
       }
-      return pair<string,string>();
+      return std::pair<std::string,std::string>();
     }
 
     bool _is_valid() override {
@@ -512,8 +510,8 @@ class MonitorDBStore
     }
   };
 
-  Synchronizer get_synchronizer(pair<string,string> &key,
-				set<string> &prefixes) {
+  Synchronizer get_synchronizer(std::pair<std::string,std::string> &key,
+				std::set<std::string> &prefixes) {
     KeyValueDB::WholeSpaceIterator iter;
     iter = db->get_wholespace_iterator();
 
@@ -527,7 +525,7 @@ class MonitorDBStore
     );
   }
 
-  KeyValueDB::Iterator get_iterator(const string &prefix) {
+  KeyValueDB::Iterator get_iterator(const std::string &prefix) {
     ceph_assert(!prefix.empty());
     KeyValueDB::Iterator iter = db->get_iterator(prefix);
     iter->seek_to_first();
@@ -541,19 +539,20 @@ class MonitorDBStore
     return iter;
   }
 
-  int get(const string& prefix, const string& key, bufferlist& bl) {
+  int get(const std::string& prefix, const std::string& key, ceph::buffer::list& bl) {
     ceph_assert(bl.length() == 0);
     return db->get(prefix, key, &bl);
   }
 
-  int get(const string& prefix, const version_t ver, bufferlist& bl) {
-    ostringstream os;
+  int get(const std::string& prefix, const version_t ver, ceph::buffer::list& bl) {
+    std::ostringstream os;
     os << ver;
     return get(prefix, os.str(), bl);
   }
 
-  version_t get(const string& prefix, const string& key) {
-    bufferlist bl;
+  version_t get(const std::string& prefix, const std::string& key) {
+    using ceph::decode;
+    ceph::buffer::list bl;
     int err = get(prefix, key, bl);
     if (err < 0) {
       if (err == -ENOENT) // if key doesn't exist, assume its value is 0
@@ -573,7 +572,7 @@ class MonitorDBStore
     return ver;
   }
 
-  bool exists(const string& prefix, const string& key) {
+  bool exists(const std::string& prefix, const std::string& key) {
     KeyValueDB::Iterator it = db->get_iterator(prefix);
     int err = it->lower_bound(key);
     if (err < 0)
@@ -582,46 +581,44 @@ class MonitorDBStore
     return (it->valid() && it->key() == key);
   }
 
-  bool exists(const string& prefix, version_t ver) {
-    ostringstream os;
+  bool exists(const std::string& prefix, version_t ver) {
+    std::ostringstream os;
     os << ver;
     return exists(prefix, os.str());
   }
 
-  string combine_strings(const string& prefix, const string& value) {
-    string out = prefix;
+  std::string combine_strings(const std::string& prefix, const std::string& value) {
+    std::string out = prefix;
     out.push_back('_');
     out.append(value);
     return out;
   }
 
-  string combine_strings(const string& prefix, const version_t ver) {
-    ostringstream os;
+  std::string combine_strings(const std::string& prefix, const version_t ver) {
+    std::ostringstream os;
     os << ver;
     return combine_strings(prefix, os.str());
   }
 
-  void clear(set<string>& prefixes) {
-    set<string>::iterator iter;
+  void clear(std::set<std::string>& prefixes) {
     KeyValueDB::Transaction dbt = db->get_transaction();
 
-    for (iter = prefixes.begin(); iter != prefixes.end(); ++iter) {
+    for (auto iter = prefixes.begin(); iter != prefixes.end(); ++iter) {
       dbt->rmkeys_by_prefix((*iter));
     }
     int r = db->submit_transaction_sync(dbt);
     ceph_assert(r >= 0);
   }
 
-  void _open(const string& kv_type) {
-    string::const_reverse_iterator rit;
+  void _open(const std::string& kv_type) {
     int pos = 0;
-    for (rit = path.rbegin(); rit != path.rend(); ++rit, ++pos) {
+    for (auto rit = path.rbegin(); rit != path.rend(); ++rit, ++pos) {
       if (*rit != '/')
 	break;
     }
-    ostringstream os;
+    std::ostringstream os;
     os << path.substr(0, path.size() - pos) << "/store.db";
-    string full_path = os.str();
+    std::string full_path = os.str();
 
     KeyValueDB *db_ptr = KeyValueDB::create(g_ceph_context,
 					    kv_type,
@@ -659,8 +656,8 @@ class MonitorDBStore
 
   }
 
-  int open(ostream &out) {
-    string kv_type;
+  int open(std::ostream &out) {
+    std::string kv_type;
     int r = read_meta("kv_backend", &kv_type);
     if (r < 0 || kv_type.empty()) {
       // assume old monitors that did not mark the type were leveldb.
@@ -688,9 +685,9 @@ class MonitorDBStore
     return 0;
   }
 
-  int create_and_open(ostream &out) {
+  int create_and_open(std::ostream &out) {
     // record the type before open
-    string kv_type;
+    std::string kv_type;
     int r = read_meta("kv_backend", &kv_type);
     if (r < 0) {
       kv_type = g_conf()->mon_keyvaluedb;
@@ -722,11 +719,11 @@ class MonitorDBStore
     db->compact_async();
   }
 
-  void compact_prefix(const string& prefix) {
+  void compact_prefix(const std::string& prefix) {
     db->compact_prefix(prefix);
   }
 
-  uint64_t get_estimated_size(map<string, uint64_t> &extras) {
+  uint64_t get_estimated_size(std::map<std::string, uint64_t> &extras) {
     return db->get_estimated_size(extras);
   }
 
@@ -746,7 +743,7 @@ class MonitorDBStore
    */
   int write_meta(const std::string& key,
 		 const std::string& value) const {
-    string v = value;
+    std::string v = value;
     v += "\n";
     int r = safe_write_file(path.c_str(), key.c_str(),
 			    v.c_str(), v.length(),
@@ -778,11 +775,11 @@ class MonitorDBStore
     while (r && isspace(buf[r-1])) {
       --r;
     }
-    *value = string(buf, r);
+    *value = std::string(buf, r);
     return 0;
   }
 
-  explicit MonitorDBStore(const string& path)
+  explicit MonitorDBStore(const std::string& path)
     : path(path),
       db(0),
       do_dump(false),

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -30,6 +30,33 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon)
 using namespace TOPNSPC::common;
+
+using std::cout;
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::setfill;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+using std::unique_ptr;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::make_message;
+using ceph::mono_clock;
+using ceph::mono_time;
+using ceph::timespan_str;
 static ostream& _prefix(std::ostream *_dout, Monitor *mon) {
   return *_dout << "mon." << mon->name << "@" << mon->rank
 		<< "(" << mon->get_state_name()

--- a/src/mon/MonmapMonitor.h
+++ b/src/mon/MonmapMonitor.h
@@ -31,7 +31,7 @@
 
 class MonmapMonitor : public PaxosService {
  public:
-  MonmapMonitor(Monitor *mn, Paxos *p, const string& service_name)
+  MonmapMonitor(Monitor *mn, Paxos *p, const std::string& service_name)
     : PaxosService(mn, p, service_name)
   {
   }
@@ -51,7 +51,7 @@ class MonmapMonitor : public PaxosService {
   void apply_mon_features(const mon_feature_t& features,
 			  ceph_release_t min_mon_release);
 
-  void dump_info(Formatter *f);
+  void dump_info(ceph::Formatter *f);
 
   bool preprocess_query(MonOpRequestRef op) override;
   bool prepare_update(MonOpRequestRef op) override;
@@ -62,7 +62,7 @@ class MonmapMonitor : public PaxosService {
   bool preprocess_command(MonOpRequestRef op);
   bool prepare_command(MonOpRequestRef op);
 
-  int get_monmap(bufferlist &bl);
+  int get_monmap(ceph::buffer::list &bl);
 
   /*
    * Since monitors are pretty
@@ -76,7 +76,7 @@ class MonmapMonitor : public PaxosService {
 
 private:
   void check_subs();
-  bufferlist monmap_bl;
+  ceph::buffer::list monmap_bl;
 };
 
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -91,6 +91,29 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 
+using std::dec;
+using std::hex;
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::to_string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::ErasureCodeInterfaceRef;
+using ceph::ErasureCodePluginRegistry;
+using ceph::ErasureCodeProfile;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+using ceph::make_message;
+
 #define dout_subsys ceph_subsys_mon
 static const string OSD_PG_CREATING_PREFIX("osd_pg_creating");
 static const string OSD_METADATA_PREFIX("osd_metadata");
@@ -281,7 +304,7 @@ bool is_unmanaged_snap_op_permitted(CephContext* cct,
     auto p = caps_info.caps.cbegin();
     try {
       decode(caps_str, p);
-    } catch (const buffer::error &err) {
+    } catch (const ceph::buffer::error &err) {
       derr << "corrupt OSD cap data for " << entity_name << " in auth db"
            << dendl;
       return false;
@@ -1345,7 +1368,7 @@ void OSDMonitor::maybe_prime_pg_temp()
       osds.insert(p->first);
     }
   }
-  for (map<int32_t,uint32_t>::iterator p = pending_inc.new_weight.begin();
+  for (auto p = pending_inc.new_weight.begin();
        !all && p != pending_inc.new_weight.end();
        ++p) {
     if (p->second < osdmap.get_weight(p->first)) {
@@ -2019,7 +2042,7 @@ int OSDMonitor::load_metadata(int osd, map<string, string>& m, ostream *err)
     auto p = bl.cbegin();
     decode(m, p);
   }
-  catch (buffer::error& e) {
+  catch (ceph::buffer::error& e) {
     if (err)
       *err << "osd." << osd << " metadata is corrupt";
     return -EIO;
@@ -4176,7 +4199,7 @@ bool OSDMonitor::preprocess_get_purged_snaps(MonOpRequestRef op)
       auto &v = r[epoch];
       try {
 	ceph::decode(v, p);
-      } catch (buffer::error& e) {
+      } catch (ceph::buffer::error& e) {
 	derr << __func__ << " unable to parse value for key '" << it->key()
 	     << "': \n";
 	bl.hexdump(*_dout);
@@ -7265,7 +7288,7 @@ int OSDMonitor::get_erasure_code(const string &erasure_code_profile,
     return -EINVAL;
   }
   check_legacy_ec_plugin(plugin->second, erasure_code_profile);
-  ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
+  auto& instance = ErasureCodePluginRegistry::instance();
   return instance.factory(plugin->second,
 			  g_conf().get_val<std::string>("erasure_code_dir"),
 			  profile, erasure_code, ss);
@@ -11941,7 +11964,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     }
     if (osdmap.exists(id)) {
       pending_inc.new_primary_affinity[id] = ww;
-      ss << "set osd." << id << " primary-affinity to " << w << " (" << ios::hex << ww << ios::dec << ")";
+      ss << "set osd." << id << " primary-affinity to " << w << " (" << std::ios::hex << ww << std::ios::dec << ")";
       getline(ss, rs);
       wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, rs,
                                                 get_last_committed() + 1));

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -36,16 +36,15 @@
 #include "CreatingPGs.h"
 #include "PaxosService.h"
 
-class Monitor;
-class PGMap;
-class MonSession;
-class MOSDMap;
-
 #include "erasure-code/ErasureCodeInterface.h"
 #include "mon/MonOpRequest.h"
 #include <boost/functional/hash.hpp>
-// re-include our assert to clobber the system one; fix dout:
-#include "include/ceph_assert.h"
+
+class Monitor;
+class PGMap;
+struct MonSession;
+class MOSDMap;
+
 
 /// information about a particular peer's failure reports for one osd
 struct failure_reporter_t {
@@ -59,7 +58,7 @@ struct failure_reporter_t {
 
 /// information about all failure reports for one osd
 struct failure_info_t {
-  map<int, failure_reporter_t> reporters;  ///< reporter -> failed_since etc
+  std::map<int, failure_reporter_t> reporters;  ///< reporter -> failed_since etc
   utime_t max_failed_since;                ///< most recent failed_since
 
   failure_info_t() {}
@@ -67,9 +66,7 @@ struct failure_info_t {
   utime_t get_failed_since() {
     if (max_failed_since == utime_t() && !reporters.empty()) {
       // the old max must have canceled; recalculate.
-      for (map<int, failure_reporter_t>::iterator p = reporters.begin();
-	   p != reporters.end();
-	   ++p)
+      for (auto p = reporters.begin(); p != reporters.end(); ++p)
 	if (p->second.failed_since > max_failed_since)
 	  max_failed_since = p->second.failed_since;
     }
@@ -80,11 +77,11 @@ struct failure_info_t {
   // if any, so we can discard it.
   MonOpRequestRef add_report(int who, utime_t failed_since,
 			     MonOpRequestRef op) {
-    map<int, failure_reporter_t>::iterator p = reporters.find(who);
+    auto p = reporters.find(who);
     if (p == reporters.end()) {
       if (max_failed_since != utime_t() && max_failed_since < failed_since)
 	max_failed_since = failed_since;
-      p = reporters.insert(map<int, failure_reporter_t>::value_type(who, failure_reporter_t(failed_since))).first;
+      p = reporters.insert(std::map<int, failure_reporter_t>::value_type(who, failure_reporter_t(failed_since))).first;
     }
 
     MonOpRequestRef ret = p->second.op;
@@ -92,10 +89,8 @@ struct failure_info_t {
     return ret;
   }
 
-  void take_report_messages(list<MonOpRequestRef>& ls) {
-    for (map<int, failure_reporter_t>::iterator p = reporters.begin();
-	 p != reporters.end();
-	 ++p) {
+  void take_report_messages(std::list<MonOpRequestRef>& ls) {
+    for (auto p = reporters.begin(); p != reporters.end(); ++p) {
       if (p->second.op) {
 	ls.push_back(p->second.op);
         p->second.op.reset();
@@ -104,7 +99,7 @@ struct failure_info_t {
   }
 
   MonOpRequestRef cancel_report(int who) {
-    map<int, failure_reporter_t>::iterator p = reporters.find(who);
+    auto p = reporters.find(who);
     if (p == reporters.end())
       return MonOpRequestRef();
     MonOpRequestRef ret = p->second.op;
@@ -117,7 +112,7 @@ struct failure_info_t {
 
 class LastEpochClean {
   struct Lec {
-    vector<epoch_t> epoch_by_pg;
+    std::vector<epoch_t> epoch_by_pg;
     ps_t next_missing = 0;
     epoch_t floor = std::numeric_limits<epoch_t>::max();
     void report(ps_t pg, epoch_t last_epoch_clean);
@@ -133,13 +128,13 @@ public:
 struct osdmap_manifest_t {
   // all the maps we have pinned -- i.e., won't be removed unless
   // they are inside a trim interval.
-  set<version_t> pinned;
+  std::set<version_t> pinned;
 
   osdmap_manifest_t() {}
 
   version_t get_last_pinned() const
   {
-    set<version_t>::const_reverse_iterator it = pinned.crbegin();
+    auto it = pinned.crbegin();
     if (it == pinned.crend()) {
       return 0;
     }
@@ -148,7 +143,7 @@ struct osdmap_manifest_t {
 
   version_t get_first_pinned() const
   {
-    set<version_t>::const_iterator it = pinned.cbegin();
+    auto it = pinned.cbegin();
     if (it == pinned.cend()) {
       return 0;
     }
@@ -166,7 +161,7 @@ struct osdmap_manifest_t {
   }
 
   version_t get_lower_closest_pinned(version_t v) const {
-    set<version_t>::const_iterator p = pinned.lower_bound(v);
+    auto p = pinned.lower_bound(v);
     if (p == pinned.cend()) {
       return 0;
     } else if (*p > v) {
@@ -178,26 +173,26 @@ struct osdmap_manifest_t {
     return *p;
   }
 
-  void encode(bufferlist& bl) const
+  void encode(ceph::buffer::list& bl) const
   {
     ENCODE_START(1, 1, bl);
     encode(pinned, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl)
+  void decode(ceph::buffer::list::const_iterator& bl)
   {
     DECODE_START(1, bl);
     decode(pinned, bl);
     DECODE_FINISH(bl);
   }
 
-  void decode(bufferlist& bl) {
+  void decode(ceph::buffer::list& bl) {
     auto p = bl.cbegin();
     decode(p);
   }
 
-  void dump(Formatter *f) {
+  void dump(ceph::Formatter *f) {
     f->dump_unsigned("first_pinned", get_first_pinned());
     f->dump_unsigned("last_pinned", get_last_pinned());
     f->open_array_section("pinned_maps");
@@ -222,21 +217,21 @@ public:
     const std::set<std::string> &changed) override;
   // [leader]
   OSDMap::Incremental pending_inc;
-  map<int, bufferlist> pending_metadata;
-  set<int>             pending_metadata_rm;
-  map<int, failure_info_t> failure_info;
-  map<int,utime_t>    down_pending_out;  // osd down -> out
+  std::map<int, ceph::buffer::list> pending_metadata;
+  std::set<int>             pending_metadata_rm;
+  std::map<int, failure_info_t> failure_info;
+  std::map<int,utime_t>    down_pending_out;  // osd down -> out
   bool priority_convert = false;
-  map<int64_t,set<snapid_t>> pending_pseudo_purged_snaps;
+  std::map<int64_t,std::set<snapid_t>> pending_pseudo_purged_snaps;
   std::shared_ptr<PriorityCache::PriCache> rocksdb_binned_kv_cache = nullptr;
   std::shared_ptr<PriorityCache::Manager> pcm = nullptr;
   ceph::mutex balancer_lock = ceph::make_mutex("OSDMonitor::balancer_lock");
 
-  map<int,double> osd_weight;
+  std::map<int,double> osd_weight;
 
   using osdmap_key_t = std::pair<version_t, uint64_t>;
   using osdmap_cache_t = SimpleLRU<osdmap_key_t,
-                                   bufferlist,
+                                   ceph::buffer::list,
                                    std::less<osdmap_key_t>,
                                    boost::hash<osdmap_key_t>>;
   osdmap_cache_t inc_osd_cache;
@@ -274,9 +269,9 @@ public:
         osdmap(om),
         pending_inc(pi) {}
 
-    void process(const vector<pg_t>& to_check) override {
-      vector<pg_t> to_cancel;
-      map<pg_t, mempool::osdmap::vector<pair<int,int>>> to_remap;
+    void process(const std::vector<pg_t>& to_check) override {
+      std::vector<pg_t> to_cancel;
+      std::map<pg_t, mempool::osdmap::vector<std::pair<int,int>>> to_remap;
       osdmap.check_pg_upmaps(cct, to_check, &to_cancel, &to_remap);
       // don't bother taking lock if nothing changes
       if (!to_cancel.empty() || !to_remap.empty()) {
@@ -292,7 +287,7 @@ public:
   // svc
 public:
   void create_initial() override;
-  void get_store_prefixes(std::set<string>& s) const override;
+  void get_store_prefixes(std::set<std::string>& s) const override;
 
 private:
   void update_from_paxos(bool *need_bootstrap) override;
@@ -359,7 +354,7 @@ private:
   void encode_trim_extra(MonitorDBStore::TransactionRef tx, version_t first) override;
 
   void update_msgr_features();
-  int check_cluster_features(uint64_t features, stringstream &ss);
+  int check_cluster_features(uint64_t features, std::stringstream &ss);
   /**
    * check if the cluster supports the features required by the
    * given crush map. Outputs the daemons which don't support it
@@ -368,7 +363,7 @@ private:
    * @returns true if the map is passable, false otherwise
    */
   bool validate_crush_against_features(const CrushWrapper *newcrush,
-                                      stringstream &ss);
+				       std::stringstream &ss);
   void check_osdmap_subs();
   void share_map_with_random_osd();
 
@@ -384,7 +379,7 @@ private:
 	osdmon->prime_pg_temp(*osdmap, pgid);
       }
     }
-    void process(const vector<pg_t>& pgs) override {}
+    void process(const std::vector<pg_t>& pgs) override {}
     void complete() override {}
   };
   void maybe_prime_pg_temp();
@@ -392,7 +387,7 @@ private:
 
   ParallelPGMapper mapper;                        ///< for background pg work
   OSDMapMapping mapping;                          ///< pg <-> osd mappings
-  unique_ptr<ParallelPGMapper::Job> mapping_job;  ///< background mapping job
+  std::unique_ptr<ParallelPGMapper::Job> mapping_job;  ///< background mapping job
   void start_mapping();
 
   void update_logger();
@@ -421,7 +416,7 @@ public:
 			MonOpRequestRef req = MonOpRequestRef());
 
 private:
-  void print_utilization(ostream &out, Formatter *f, bool tree) const;
+  void print_utilization(std::ostream &out, ceph::Formatter *f, bool tree) const;
 
   bool check_source(MonOpRequestRef op, uuid_d fsid);
  
@@ -434,7 +429,7 @@ private:
   bool prepare_failure(MonOpRequestRef op);
   bool prepare_mark_me_down(MonOpRequestRef op);
   void process_failures();
-  void take_all_failures(list<MonOpRequestRef>& ls);
+  void take_all_failures(std::list<MonOpRequestRef>& ls);
 
   bool preprocess_mark_me_dead(MonOpRequestRef op);
   bool prepare_mark_me_dead(MonOpRequestRef op);
@@ -460,17 +455,17 @@ private:
   bool preprocess_pg_ready_to_merge(MonOpRequestRef op);
   bool prepare_pg_ready_to_merge(MonOpRequestRef op);
 
-  int _check_remove_pool(int64_t pool_id, const pg_pool_t &pool, ostream *ss);
+  int _check_remove_pool(int64_t pool_id, const pg_pool_t &pool, std::ostream *ss);
   bool _check_become_tier(
       int64_t tier_pool_id, const pg_pool_t *tier_pool,
       int64_t base_pool_id, const pg_pool_t *base_pool,
-      int *err, ostream *ss) const;
+      int *err, std::ostream *ss) const;
   bool _check_remove_tier(
       int64_t base_pool_id, const pg_pool_t *base_pool, const pg_pool_t *tier_pool,
-      int *err, ostream *ss) const;
+      int *err, std::ostream *ss) const;
 
-  int _prepare_remove_pool(int64_t pool, ostream *ss, bool no_fake);
-  int _prepare_rename_pool(int64_t pool, string newname);
+  int _prepare_remove_pool(int64_t pool, std::ostream *ss, bool no_fake);
+  int _prepare_rename_pool(int64_t pool, std::string newname);
 
   bool enforce_pool_op_caps(MonOpRequestRef op);
   bool preprocess_pool_op (MonOpRequestRef op);
@@ -478,61 +473,61 @@ private:
   bool prepare_pool_op (MonOpRequestRef op);
   bool prepare_pool_op_create (MonOpRequestRef op);
   bool prepare_pool_op_delete(MonOpRequestRef op);
-  int crush_rename_bucket(const string& srcname,
-			  const string& dstname,
-			  ostream *ss);
-  void check_legacy_ec_plugin(const string& plugin, 
-			      const string& profile) const;
-  int normalize_profile(const string& profilename, 
-			ErasureCodeProfile &profile,
+  int crush_rename_bucket(const std::string& srcname,
+			  const std::string& dstname,
+			  std::ostream *ss);
+  void check_legacy_ec_plugin(const std::string& plugin, 
+			      const std::string& profile) const;
+  int normalize_profile(const std::string& profilename, 
+			ceph::ErasureCodeProfile &profile,
 			bool force,
-			ostream *ss);
-  int crush_rule_create_erasure(const string &name,
-				const string &profile,
+			std::ostream *ss);
+  int crush_rule_create_erasure(const std::string &name,
+				const std::string &profile,
 				int *rule,
-				ostream *ss);
-  int get_crush_rule(const string &rule_name,
-			int *crush_rule,
-			ostream *ss);
-  int get_erasure_code(const string &erasure_code_profile,
-		       ErasureCodeInterfaceRef *erasure_code,
-		       ostream *ss) const;
+				std::ostream *ss);
+  int get_crush_rule(const std::string &rule_name,
+		     int *crush_rule,
+		     std::ostream *ss);
+  int get_erasure_code(const std::string &erasure_code_profile,
+		       ceph::ErasureCodeInterfaceRef *erasure_code,
+		       std::ostream *ss) const;
   int prepare_pool_crush_rule(const unsigned pool_type,
-				 const string &erasure_code_profile,
-				 const string &rule_name,
-				 int *crush_rule,
-				 ostream *ss);
+			      const std::string &erasure_code_profile,
+			      const std::string &rule_name,
+			      int *crush_rule,
+			      std::ostream *ss);
   bool erasure_code_profile_in_use(
     const mempool::osdmap::map<int64_t, pg_pool_t> &pools,
-    const string &profile,
-    ostream *ss);
-  int parse_erasure_code_profile(const vector<string> &erasure_code_profile,
-				 map<string,string> *erasure_code_profile_map,
-				 ostream *ss);
+    const std::string &profile,
+    std::ostream *ss);
+  int parse_erasure_code_profile(const std::vector<std::string> &erasure_code_profile,
+				 std::map<std::string,std::string> *erasure_code_profile_map,
+				 std::ostream *ss);
   int prepare_pool_size(const unsigned pool_type,
-			const string &erasure_code_profile,
+			const std::string &erasure_code_profile,
                         uint8_t repl_size,
 			unsigned *size, unsigned *min_size,
-			ostream *ss);
+			std::ostream *ss);
   int prepare_pool_stripe_width(const unsigned pool_type,
-				const string &erasure_code_profile,
+				const std::string &erasure_code_profile,
 				unsigned *stripe_width,
-				ostream *ss);
-  int check_pg_num(int64_t pool, int pg_num, int size, ostream* ss);
-  int prepare_new_pool(string& name,
+				std::ostream *ss);
+  int check_pg_num(int64_t pool, int pg_num, int size, std::ostream* ss);
+  int prepare_new_pool(std::string& name,
 		       int crush_rule,
-		       const string &crush_rule_name,
+		       const std::string &crush_rule_name,
                        unsigned pg_num, unsigned pgp_num,
 		       unsigned pg_num_min,
                        uint64_t repl_size,
 		       const uint64_t target_size_bytes,
 		       const float target_size_ratio,
-		       const string &erasure_code_profile,
+		       const std::string &erasure_code_profile,
                        const unsigned pool_type,
                        const uint64_t expected_num_objects,
                        FastReadType fast_read,
-		       const string& pg_autoscale_mode,
-		       ostream *ss);
+		       const std::string& pg_autoscale_mode,
+		       std::ostream *ss);
   int prepare_new_pool(MonOpRequestRef op);
 
   void set_pool_flags(int64_t pool_id, uint64_t flags);
@@ -542,10 +537,10 @@ private:
   bool _is_removed_snap(int64_t pool_id, snapid_t snapid);
   bool _is_pending_removed_snap(int64_t pool_id, snapid_t snapid);
 
-  string make_purged_snap_epoch_key(epoch_t epoch);
-  string make_purged_snap_key(int64_t pool, snapid_t snap);
-  string make_purged_snap_key_value(int64_t pool, snapid_t snap, snapid_t num,
-				    epoch_t epoch, bufferlist *v);
+  std::string make_purged_snap_epoch_key(epoch_t epoch);
+  std::string make_purged_snap_key(int64_t pool, snapid_t snap);
+  std::string make_purged_snap_key_value(int64_t pool, snapid_t snap, snapid_t num,
+				    epoch_t epoch, ceph::buffer::list *v);
 
   bool try_prune_purged_snaps();
   int lookup_purged_snap(int64_t pool, snapid_t snap,
@@ -561,7 +556,7 @@ private:
   bool prepare_unset_flag(MonOpRequestRef op, int flag);
 
   void _pool_op_reply(MonOpRequestRef op,
-                      int ret, epoch_t epoch, bufferlist *blp=NULL);
+                      int ret, epoch_t epoch, ceph::buffer::list *blp=NULL);
 
   struct C_Booted : public C_MonOp {
     OSDMonitor *cmon;
@@ -600,8 +595,8 @@ private:
     OSDMonitor *osdmon;
     int replyCode;
     int epoch;
-    bufferlist reply_data;
-    C_PoolOp(OSDMonitor * osd, MonOpRequestRef op_, int rc, int e, bufferlist *rd=NULL) :
+    ceph::buffer::list reply_data;
+    C_PoolOp(OSDMonitor * osd, MonOpRequestRef op_, int rc, int e, ceph::buffer::list *rd=NULL) :
       C_MonOp(op_), osdmon(osd), replyCode(rc), epoch(e) {
       if (rd)
 	reply_data = *rd;
@@ -623,23 +618,24 @@ private:
 
   bool preprocess_get_purged_snaps(MonOpRequestRef op);
 
-  int load_metadata(int osd, map<string, string>& m, ostream *err);
-  void count_metadata(const string& field, Formatter *f);
+  int load_metadata(int osd, std::map<std::string, std::string>& m,
+		    std::ostream *err);
+  void count_metadata(const std::string& field, ceph::Formatter *f);
 
-  void reencode_incremental_map(bufferlist& bl, uint64_t features);
-  void reencode_full_map(bufferlist& bl, uint64_t features);
+  void reencode_incremental_map(ceph::buffer::list& bl, uint64_t features);
+  void reencode_full_map(ceph::buffer::list& bl, uint64_t features);
 public:
-  void count_metadata(const string& field, map<string,int> *out);
+  void count_metadata(const std::string& field, std::map<std::string,int> *out);
 protected:
   int get_osd_objectstore_type(int osd, std::string *type);
   bool is_pool_currently_all_bluestore(int64_t pool_id, const pg_pool_t &pool,
-				       ostream *err);
+				       std::ostream *err);
 
   // when we last received PG stats from each osd
-  map<int,utime_t> last_osd_report;
+  std::map<int,utime_t> last_osd_report;
   // TODO: use last_osd_report to store the osd report epochs, once we don't
   //       need to upgrade from pre-luminous releases.
-  map<int,epoch_t> osd_epochs;
+  std::map<int,epoch_t> osd_epochs;
   LastEpochClean last_epoch_clean;
   bool preprocess_beacon(MonOpRequestRef op);
   bool prepare_beacon(MonOpRequestRef op);
@@ -660,7 +656,7 @@ protected:
     const mempool::osdmap::set<int64_t>& removed_pools,
     utime_t modified,
     creating_pgs_t* creating_pgs) const;
-  pair<int32_t, pg_t> get_parent_pg(pg_t pgid) const;
+  std::pair<int32_t, pg_t> get_parent_pg(pg_t pgid) const;
   void update_creating_pgs();
   void check_pg_creates_subs();
   epoch_t send_pg_creates(int osd, Connection *con, epoch_t next) const;
@@ -668,7 +664,7 @@ protected:
   int32_t _allocate_osd_id(int32_t* existing_id);
 
 public:
-  OSDMonitor(CephContext *cct, Monitor *mn, Paxos *p, const string& service_name);
+  OSDMonitor(CephContext *cct, Monitor *mn, Paxos *p, const std::string& service_name);
 
   void tick() override;  // check state, take actions
 
@@ -681,17 +677,17 @@ public:
       const uuid_d& uuid,
       const bool check_osd_exists,
       int32_t* existing_id,
-      stringstream& ss);
+      std::stringstream& ss);
   int prepare_command_osd_create(
       const int32_t id,
       const uuid_d& uuid,
       int32_t* existing_id,
-      stringstream& ss);
+      std::stringstream& ss);
   void do_osd_create(const int32_t id, const uuid_d& uuid,
-		     const string& device_class,
+		     const std::string& device_class,
 		     int32_t* new_id);
-  int prepare_command_osd_purge(int32_t id, stringstream& ss);
-  int prepare_command_osd_destroy(int32_t id, stringstream& ss);
+  int prepare_command_osd_purge(int32_t id, std::stringstream& ss);
+  int prepare_command_osd_destroy(int32_t id, std::stringstream& ss);
   int _prepare_command_osd_crush_remove(
       CrushWrapper &newcrush,
       int32_t id,
@@ -709,25 +705,25 @@ public:
   int prepare_command_osd_new(
       MonOpRequestRef op,
       const cmdmap_t& cmdmap,
-      const map<string,string>& secrets,
-      stringstream &ss,
-      Formatter *f);
+      const std::map<std::string,std::string>& secrets,
+      std::stringstream &ss,
+      ceph::Formatter *f);
 
   int prepare_command_pool_set(const cmdmap_t& cmdmap,
-                               stringstream& ss);
+                               std::stringstream& ss);
 
-  int prepare_command_pool_application(const string &prefix,
+  int prepare_command_pool_application(const std::string &prefix,
                                        const cmdmap_t& cmdmap,
-                                       stringstream& ss);
-  int preprocess_command_pool_application(const string &prefix,
+                                       std::stringstream& ss);
+  int preprocess_command_pool_application(const std::string &prefix,
                                           const cmdmap_t& cmdmap,
-                                          stringstream& ss,
+                                          std::stringstream& ss,
                                           bool *modified);
-  int _command_pool_application(const string &prefix,
-                                       const cmdmap_t& cmdmap,
-                                       stringstream& ss,
-                                       bool *modified,
-                                       bool preparing);
+  int _command_pool_application(const std::string &prefix,
+				const cmdmap_t& cmdmap,
+				std::stringstream& ss,
+				bool *modified,
+				bool preparing);
 
   bool handle_osd_timeouts(const utime_t &now,
 			   std::map<int,utime_t> &last_osd_report);
@@ -738,20 +734,20 @@ public:
     send_incremental(op, start);
   }
 
-  int get_version(version_t ver, bufferlist& bl) override;
-  int get_version(version_t ver, uint64_t feature, bufferlist& bl);
+  int get_version(version_t ver, ceph::buffer::list& bl) override;
+  int get_version(version_t ver, uint64_t feature, ceph::buffer::list& bl);
 
-  int get_version_full(version_t ver, uint64_t feature, bufferlist& bl);
-  int get_version_full(version_t ver, bufferlist& bl) override;
+  int get_version_full(version_t ver, uint64_t feature, ceph::buffer::list& bl);
+  int get_version_full(version_t ver, ceph::buffer::list& bl) override;
   int get_inc(version_t ver, OSDMap::Incremental& inc);
-  int get_full_from_pinned_map(version_t ver, bufferlist& bl);
+  int get_full_from_pinned_map(version_t ver, ceph::buffer::list& bl);
 
   epoch_t blacklist(const entity_addrvec_t& av, utime_t until);
   epoch_t blacklist(entity_addr_t a, utime_t until);
 
-  void dump_info(Formatter *f);
-  int dump_osd_metadata(int osd, Formatter *f, ostream *err);
-  void print_nodes(Formatter *f);
+  void dump_info(ceph::Formatter *f);
+  int dump_osd_metadata(int osd, ceph::Formatter *f, std::ostream *err);
+  void print_nodes(ceph::Formatter *f);
 
   void check_osdmap_sub(Subscription *sub);
   void check_pg_creates_sub(Subscription *sub);

--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -55,18 +55,18 @@ e 12v
  *
  * Each version's value (value_1, value_2, ..., value_n) is a blob of data,
  * incomprehensible to the Paxos. These values are proposed to the Paxos on
- * propose_new_value() and each one is a transaction encoded in a bufferlist.
+ * propose_new_value() and each one is a transaction encoded in a ceph::buffer::list.
  *
  * The Paxos will write the value to disk, associating it with its version,
  * but will take a step further: the value shall be decoded, and the operations
  * on that transaction shall be applied during the same transaction that will
- * write the value's encoded bufferlist to disk. This behavior ensures that
+ * write the value's encoded ceph::buffer::list to disk. This behavior ensures that
  * whatever is being proposed will only be available on the store when it is
  * applied by Paxos, which will then be aware of such new values, guaranteeing
  * the store state is always consistent without requiring shady workarounds.
  *
  * So, let's say that FooMonitor proposes the following transaction, neatly
- * encoded on a bufferlist of course:
+ * encoded on a ceph::buffer::list of course:
  *
  *  Tx_Foo
  *    put(foo, last_committed, 3)
@@ -75,16 +75,16 @@ e 12v
  *    erase(foo, 1)
  *    put(foo, first_committed, 3)
  *
- * And knowing that the Paxos is proposed Tx_Foo as a bufferlist, once it is
+ * And knowing that the Paxos is proposed Tx_Foo as a ceph::buffer::list, once it is
  * ready to commit, and assuming we are now committing version 5 of the Paxos,
  * we will do something along the lines of:
  *
  *  Tx proposed_tx;
- *  proposed_tx.decode(Tx_foo_bufferlist);
+ *  proposed_tx.decode(Tx_foo_ceph::buffer::list);
  *
  *  Tx our_tx;
  *  our_tx.put(paxos, last_committed, 5);
- *  our_tx.put(paxos, 5, Tx_foo_bufferlist);
+ *  our_tx.put(paxos, 5, Tx_foo_ceph::buffer::list);
  *  our_tx.append(proposed_tx);
  *
  *  store_apply(our_tx);
@@ -98,7 +98,7 @@ e 12v
  *		    2 -> value_2
  *		    3 -> value_3
  *		    4 -> value_4
- *		    5 -> Tx_foo_bufferlist
+ *		    5 -> Tx_foo_ceph::buffer::list
  *  foo:
  *    first_committed -> 3
  *     last_committed -> 3
@@ -187,12 +187,12 @@ class Paxos {
   void init_logger();
 
   // my state machine info
-  const string paxos_name;
+  const std::string paxos_name;
 
   friend class Monitor;
   friend class PaxosService;
 
-  list<std::string> extra_state_dirs;
+  std::list<std::string> extra_state_dirs;
 
   // LEADER+PEON
 
@@ -243,7 +243,7 @@ public:
    * @param s State value.
    * @return The state's name.
    */
-  static const string get_statename(int s) {
+  static const std::string get_statename(int s) {
     switch (s) {
     case STATE_RECOVERING:
       return "recovering";
@@ -377,7 +377,7 @@ private:
    * When the Leader starts the collect phase, each Peon will reply with its
    * first committed version, which will then be kept in this map.
    */
-  map<int,version_t> peer_first_committed;
+  std::map<int,version_t> peer_first_committed;
   /**
    * Map holding the last committed version by each quorum member.
    *
@@ -385,7 +385,7 @@ private:
    * When the Leader starts the collect phase, each Peon will reply with its
    * last committed version, which will then be kept in this map.
    */
-  map<int,version_t> peer_last_committed;
+  std::map<int,version_t> peer_last_committed;
   /**
    * @}
    */
@@ -406,7 +406,7 @@ private:
   /**
    * List of callbacks waiting for our state to change into STATE_ACTIVE.
    */
-  list<Context*> waiting_for_active;
+  std::list<Context*> waiting_for_active;
   /**
    * List of callbacks waiting for the chance to read a version from us.
    *
@@ -422,7 +422,7 @@ private:
    * with the latest proposal, or if we don't really care about the remaining
    * uncommitted values --, or if we're on a quorum of one.
    */
-  list<Context*> waiting_for_readable;
+  std::list<Context*> waiting_for_readable;
   /**
    * @}
    */
@@ -477,7 +477,7 @@ private:
    * on the Leader, or learnt by the Leader from a Peon during the collect
    * phase.
    */
-  bufferlist uncommitted_value;
+  ceph::buffer::list uncommitted_value;
   /**
    * Used to specify when an on-going collect phase times out.
    */
@@ -499,7 +499,7 @@ private:
    * members, guaranteeing that we trigger new elections if some don't ack in
    * the expected timeframe.
    */
-  set<int>   acked_lease;
+  std::set<int>   acked_lease;
   /**
    * Callback responsible for extending the lease periodically.
    */
@@ -535,10 +535,10 @@ private:
   /**
    * New Value being proposed to the Peons.
    *
-   * This bufferlist holds the value the Leader is proposing to the Peons, and
+   * This ceph::buffer::list holds the value the Leader is proposing to the Peons, and
    * that will be committed if the Peons do accept the proposal.
    */
-  bufferlist new_value;
+  ceph::buffer::list new_value;
   /**
    * Set of participants (Leader & Peons) that accepted the new proposed value.
    *
@@ -547,7 +547,7 @@ private:
    * participants has accepted the proposal), and when to extend the lease
    * (when all the quorum members have accepted the proposal).
    */
-  set<int>   accepted;
+  std::set<int>   accepted;
   /**
    * Callback to trigger a new election if the proposal is not accepted by the
    * full quorum within a given timeframe.
@@ -571,7 +571,7 @@ private:
    * @remarks It is not possible to write if we are not the Leader, or we are
    *	      not on the active state, or if the lease has expired.
    */
-  list<Context*> waiting_for_writeable;
+  std::list<Context*> waiting_for_writeable;
 
   /**
    * Pending proposal transaction
@@ -588,7 +588,7 @@ private:
    * These are waiting for updates in the pending proposal/transaction
    * to be committed.
    */
-  list<Context*> pending_finishers;
+  std::list<Context*> pending_finishers;
 
   /**
    * Finishers for committing transaction
@@ -596,7 +596,7 @@ private:
    * When the pending_proposal is submitted, pending_finishers move to
    * this list.  When it commits, these finishers are notified.
    */
-  list<Context*> committing_finishers;
+  std::list<Context*> committing_finishers;
   /**
    * This function re-triggers pending_ and committing_finishers
    * safely, so as to maintain existing system invariants. In particular
@@ -664,12 +664,12 @@ public:
   class C_Proposal : public Context {
     Context *proposer_context;
   public:
-    bufferlist bl;
+    ceph::buffer::list bl;
     // for debug purposes. Will go away. Soon.
     bool proposed;
     utime_t proposal_time;
 
-    C_Proposal(Context *c, bufferlist& proposal_bl) :
+    C_Proposal(Context *c, ceph::buffer::list& proposal_bl) :
 	proposer_context(c),
 	bl(proposal_bl),
 	proposed(false),
@@ -805,7 +805,7 @@ private:
    *
    * @param value The value being proposed to the quorum
    */
-  void begin(bufferlist& value);
+  void begin(ceph::buffer::list& value);
   /**
    * Accept or decline (by ignoring) a proposal from the Leader.
    *
@@ -1045,7 +1045,7 @@ public:
    * @param name A name for the paxos service. It serves as the naming space
    * of the underlying persistent storage for this service.
    */
-  Paxos(Monitor *m, const string &name) 
+  Paxos(Monitor *m, const std::string &name) 
 		 : mon(m),
 		   logger(NULL),
 		   paxos_name(name),
@@ -1065,7 +1065,7 @@ public:
 		   clock_drift_warned(0),
 		   trimming(false) { }
 
-  const string get_name() const {
+  const std::string get_name() const {
     return paxos_name;
   }
 
@@ -1079,7 +1079,7 @@ public:
   /**
    * dump state info to a formatter
    */
-  void dump_info(Formatter *f);
+  void dump_info(ceph::Formatter *f);
 
   /**
    * This function runs basic consistency checks. Importantly, if
@@ -1131,8 +1131,8 @@ public:
    *
    * Basically, we received a set of version. Or just one. It doesn't matter.
    * What matters is that we have to stash it in the store. So, we will simply
-   * write every single bufferlist into their own versions on our side (i.e.,
-   * onto paxos-related keys), and then we will decode those same bufferlists
+   * write every single ceph::buffer::list into their own versions on our side (i.e.,
+   * onto paxos-related keys), and then we will decode those same ceph::buffer::lists
    * we just wrote and apply the transactions they hold. We will also update
    * our first and last committed values to point to the new values, if need
    * be. All this is done tightly wrapped in a transaction to ensure we
@@ -1145,18 +1145,18 @@ public:
   void _sanity_check_store();
 
   /**
-   * Helper function to decode a bufferlist into a transaction and append it
+   * Helper function to decode a ceph::buffer::list into a transaction and append it
    * to another transaction.
    *
    * This function is used during the Leader's commit and during the
-   * Paxos::store_state in order to apply the bufferlist's transaction onto
+   * Paxos::store_state in order to apply the ceph::buffer::list's transaction onto
    * the store.
    *
    * @param t The transaction to which we will append the operations
-   * @param bl A bufferlist containing an encoded transaction
+   * @param bl A ceph::buffer::list containing an encoded transaction
    */
   static void decode_append_transaction(MonitorDBStore::TransactionRef t,
-					bufferlist& bl) {
+					ceph::buffer::list& bl) {
     auto vt(std::make_shared<MonitorDBStore::Transaction>());
     auto it = bl.cbegin();
     vt->decode(it);
@@ -1168,7 +1168,7 @@ public:
    *	   its objective is to allow a third-party to have a "private"
    *	   state dir. -JL
    */
-  void add_extra_state_dir(string s) {
+  void add_extra_state_dir(std::string s) {
     extra_state_dirs.push_back(s);
   }
 
@@ -1260,7 +1260,7 @@ public:
    * @param[out] bl The version's value
    * @return 'true' if we successfully read the value; 'false' otherwise
    */
-  bool read(version_t v, bufferlist &bl);
+  bool read(version_t v, ceph::buffer::list &bl);
   /**
    * Read the latest committed version
    *
@@ -1268,7 +1268,7 @@ public:
    * @return the latest committed version if we successfully read the value;
    *	     or 0 (zero) otherwise.
    */
-  version_t read_current(bufferlist &bl);
+  version_t read_current(ceph::buffer::list &bl);
   /**
    * Add onreadable to the list of callbacks waiting for us to become readable.
    *
@@ -1362,20 +1362,19 @@ public:
   MonitorDBStore *get_store();
 };
 
-inline ostream& operator<<(ostream& out, Paxos::C_Proposal& p)
+inline std::ostream& operator<<(std::ostream& out, Paxos::C_Proposal& p)
 {
-  string proposed = (p.proposed ? "proposed" : "unproposed");
+  std::string proposed = (p.proposed ? "proposed" : "unproposed");
   out << " " << proposed
       << " queued " << (ceph_clock_now() - p.proposal_time)
       << " tx dump:\n";
   auto t(std::make_shared<MonitorDBStore::Transaction>());
   auto p_it = p.bl.cbegin();
   t->decode(p_it);
-  JSONFormatter f(true);
+  ceph::JSONFormatter f(true);
   t->dump(&f);
   f.flush(out);
   return out;
 }
 
 #endif
-

--- a/src/mon/PaxosFSMap.h
+++ b/src/mon/PaxosFSMap.h
@@ -39,7 +39,7 @@ protected:
     return pending_fsmap;
   }
 
-  void decode(bufferlist &bl) {
+  void decode(ceph::buffer::list &bl) {
     fsmap.decode(bl);
     pending_fsmap = FSMap(); /* nuke it to catch invalid access */
   }

--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -19,6 +19,11 @@
 #include "include/ceph_assert.h"
 #include "mon/MonOpRequest.h"
 
+using std::ostream;
+using std::string;
+
+using ceph::bufferlist;
+
 #define dout_subsys ceph_subsys_paxos
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon, paxos, service_name, get_first_committed(), get_last_committed())
@@ -436,6 +441,7 @@ void PaxosService::load_health()
   mon->store->get("health", service_name, bl);
   if (bl.length()) {
     auto p = bl.cbegin();
+    using ceph::decode;
     decode(health_checks, p);
   }
 }

--- a/src/mon/QuorumService.h
+++ b/src/mon/QuorumService.h
@@ -118,7 +118,7 @@ public:
   virtual void init() { }
 
   virtual int get_type() = 0;
-  virtual string get_name() const = 0;
+  virtual std::string get_name() const = 0;
 
 };
 

--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -27,6 +27,15 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "fuse "
 
+using std::list;
+using std::map;
+using std::set;
+using std::string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
+
 // some fuse-y bits of state
 struct fs_info {
   struct fuse_args args;

--- a/src/os/FuseStore.h
+++ b/src/os/FuseStore.h
@@ -23,14 +23,14 @@ public:
 
   struct OpenFile {
     std::string path;
-    bufferlist bl;
+    ceph::buffer::list bl;
     bool dirty = false;
     int ref = 0;
   };
   std::map<std::string,OpenFile*> open_files;
 
   int open_file(std::string p, struct fuse_file_info *fi,
-		std::function<int(bufferlist *bl)> f);
+		std::function<int(ceph::buffer::list *bl)> f);
 
   class FuseThread : public Thread {
     FuseStore *fs;

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -28,6 +28,8 @@
 #include "kstore/KStore.h"
 #endif
 
+using std::string;
+
 ObjectStore *ObjectStore::create(CephContext *cct,
 				 const string& type,
 				 const string& data,

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -344,7 +344,7 @@ public:
   virtual int pool_statfs(uint64_t pool_id, struct store_statfs_t *buf,
 			  bool *per_pool_omap) = 0;
 
-  virtual void collect_metadata(std::map<std::string,string> *pm) { }
+  virtual void collect_metadata(std::map<std::string,std::string> *pm) { }
 
   /**
    * write_meta - write a simple configuration key out-of-band
@@ -555,7 +555,7 @@ public:
   virtual int dump_onode(
     CollectionHandle &c,
     const ghobject_t& oid,
-    const string& section_name,
+    const std::string& section_name,
     ceph::Formatter *f) {
     return -ENOTSUP;
   }

--- a/src/os/Transaction.cc
+++ b/src/os/Transaction.cc
@@ -4,6 +4,16 @@
 #include "os/Transaction.h"
 #include "common/Formatter.h"
 
+using std::list;
+using std::map;
+using std::ostream;
+using std::set;
+using std::string;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+
 void decode_str_str_map_to_bl(bufferlist::const_iterator& p,
 			      bufferlist *out)
 {

--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -9,6 +9,12 @@
 #include "common/admin_socket.h"
 #define dout_subsys ceph_subsys_bluestore
 
+using std::string;
+using std::to_string;
+
+using ceph::bufferlist;
+using ceph::Formatter;
+
 class Allocator::SocketHook : public AdminSocketHook {
   Allocator *alloc;
 

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -59,7 +59,7 @@ public:
   virtual double get_fragmentation_score();
   virtual void shutdown() = 0;
 
-  static Allocator *create(CephContext* cct, string type, int64_t size,
+  static Allocator *create(CephContext* cct, std::string type, int64_t size,
 			   int64_t block_size, const std::string& name = "");
 private:
   class SocketHook;

--- a/src/os/bluestore/BitmapFreelistManager.cc
+++ b/src/os/bluestore/BitmapFreelistManager.cc
@@ -12,6 +12,13 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "freelist "
 
+using std::string;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::decode;
+using ceph::encode;
+
 void make_offset_key(uint64_t offset, std::string *key)
 {
   key->reserve(10);

--- a/src/os/bluestore/BitmapFreelistManager.h
+++ b/src/os/bluestore/BitmapFreelistManager.h
@@ -27,11 +27,11 @@ class BitmapFreelistManager : public FreelistManager {
   uint64_t block_mask;  ///< mask to convert byte offset to block offset
   uint64_t key_mask;    ///< mask to convert offset to key offset
 
-  bufferlist all_set_bl;
+  ceph::buffer::list all_set_bl;
 
   KeyValueDB::Iterator enumerate_p;
   uint64_t enumerate_offset; ///< logical offset; position
-  bufferlist enumerate_bl;   ///< current key at enumerate_offset
+  ceph::buffer::list enumerate_bl;   ///< current key at enumerate_offset
   int enumerate_bl_pos;      ///< bit position in enumerate_bl
 
   uint64_t _get_offset(uint64_t key_off, int bit) {
@@ -47,10 +47,10 @@ class BitmapFreelistManager : public FreelistManager {
     KeyValueDB::Transaction txn);
 
 public:
-  BitmapFreelistManager(CephContext* cct, string meta_prefix,
-			string bitmap_prefix);
+  BitmapFreelistManager(CephContext* cct, std::string meta_prefix,
+			std::string bitmap_prefix);
 
-  static void setup_merge_operator(KeyValueDB *db, string prefix);
+  static void setup_merge_operator(KeyValueDB *db, std::string prefix);
 
   int create(uint64_t size, uint64_t granularity,
 	     KeyValueDB::Transaction txn) override;

--- a/src/os/bluestore/BlockDevice.cc
+++ b/src/os/bluestore/BlockDevice.cc
@@ -42,6 +42,8 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "bdev "
 
+using std::string;
+
 void IOContext::aio_wait()
 {
   std::unique_lock l(lock);

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -192,7 +192,7 @@ public:
   virtual int read(
     uint64_t off,
     uint64_t len,
-    bufferlist *pbl,
+    ceph::buffer::list *pbl,
     IOContext *ioc,
     bool buffered) = 0;
   virtual int read_random(
@@ -202,18 +202,18 @@ public:
     bool buffered) = 0;
   virtual int write(
     uint64_t off,
-    bufferlist& bl,
+    ceph::buffer::list& bl,
     bool buffered,
     int write_hint = WRITE_LIFE_NOT_SET) = 0;
 
   virtual int aio_read(
     uint64_t off,
     uint64_t len,
-    bufferlist *pbl,
+    ceph::buffer::list *pbl,
     IOContext *ioc) = 0;
   virtual int aio_write(
     uint64_t off,
-    bufferlist& bl,
+    ceph::buffer::list& bl,
     IOContext *ioc,
     bool buffered,
     int write_hint = WRITE_LIFE_NOT_SET) = 0;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -18,6 +18,24 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "bluefs "
 using TOPNSPC::common::cmd_getval;
+
+using std::byte;
+using std::list;
+using std::make_pair;
+using std::map;
+using std::ostream;
+using std::pair;
+using std::set;
+using std::string;
+using std::to_string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::Formatter;
+
+
 MEMPOOL_DEFINE_OBJECT_FACTORY(BlueFS::File, bluefs_file, bluefs);
 MEMPOOL_DEFINE_OBJECT_FACTORY(BlueFS::Dir, bluefs_dir, bluefs);
 MEMPOOL_DEFINE_OBJECT_FACTORY(BlueFS::FileWriter, bluefs_file_writer, bluefs);
@@ -1058,7 +1076,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
       auto p = bl.cbegin();
       decode(t, p);
     }
-    catch (buffer::error& e) {
+    catch (ceph::buffer::error& e) {
       derr << __func__ << " 0x" << std::hex << pos << std::dec
            << ": stop: failed to decode: " << e.what()
            << dendl;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -35,6 +35,7 @@
 #include "include/cpp-btree/btree_set.h"
 
 #include "include/ceph_assert.h"
+#include "include/interval_set.h"
 #include "include/unordered_map.h"
 #include "include/mempool.h"
 #include "include/hash.h"
@@ -164,9 +165,9 @@ public:
 	cct->_conf.get_val<double>("bluestore_max_defer_interval");
   }
 
-  class TransContext;
+  struct TransContext;
 
-  typedef map<uint64_t, bufferlist> ready_regions_t;
+  typedef std::map<uint64_t, ceph::buffer::list> ready_regions_t;
 
 
   struct BufferSpace;
@@ -212,7 +213,7 @@ public:
     uint32_t flags;             ///< FLAG_*
     uint64_t seq;
     uint32_t offset, length;
-    bufferlist data;
+    ceph::buffer::list data;
 
     boost::intrusive::list_member_hook<> lru_item;
     boost::intrusive::list_member_hook<> state_item;
@@ -220,7 +221,7 @@ public:
     Buffer(BufferSpace *space, unsigned s, uint64_t q, uint32_t o, uint32_t l,
 	   unsigned f = 0)
       : space(space), state(s), flags(f), seq(q), offset(o), length(l) {}
-    Buffer(BufferSpace *space, unsigned s, uint64_t q, uint32_t o, bufferlist& b,
+    Buffer(BufferSpace *space, unsigned s, uint64_t q, uint32_t o, ceph::buffer::list& b,
 	   unsigned f = 0)
       : space(space), state(s), flags(f), seq(q), offset(o),
 	length(b.length()), data(b) {}
@@ -242,7 +243,7 @@ public:
     void truncate(uint32_t newlen) {
       ceph_assert(newlen < length);
       if (data.length()) {
-	bufferlist t;
+	ceph::buffer::list t;
 	t.substr_of(data, 0, newlen);
 	data.claim(t);
       }
@@ -256,7 +257,7 @@ public:
       }
     }
 
-    void dump(Formatter *f) const {
+    void dump(ceph::Formatter *f) const {
       f->dump_string("state", get_state_name(state));
       f->dump_unsigned("seq", seq);
       f->dump_unsigned("offset", offset);
@@ -321,7 +322,7 @@ public:
       _rm_buffer(cache, buffer_map.find(b->offset));
     }
     void _rm_buffer(BufferCacheShard* cache,
-		    map<uint32_t, std::unique_ptr<Buffer>>::iterator p) {
+		    std::map<uint32_t, std::unique_ptr<Buffer>>::iterator p) {
       ceph_assert(p != buffer_map.end());
       cache->_audit("_rm_buffer start");
       if (p->second->is_writing()) {
@@ -333,7 +334,7 @@ public:
       cache->_audit("_rm_buffer end");
     }
 
-    map<uint32_t,std::unique_ptr<Buffer>>::iterator _data_lower_bound(
+    std::map<uint32_t,std::unique_ptr<Buffer>>::iterator _data_lower_bound(
       uint32_t offset) {
       auto i = buffer_map.lower_bound(offset);
       if (i != buffer_map.begin()) {
@@ -356,7 +357,7 @@ public:
     }
     int _discard(BufferCacheShard* cache, uint32_t offset, uint32_t length);
 
-    void write(BufferCacheShard* cache, uint64_t seq, uint32_t offset, bufferlist& bl,
+    void write(BufferCacheShard* cache, uint64_t seq, uint32_t offset, ceph::buffer::list& bl,
 	       unsigned flags) {
       std::lock_guard l(cache->lock);
       Buffer *b = new Buffer(this, Buffer::STATE_WRITING, seq, offset, bl,
@@ -366,7 +367,7 @@ public:
       cache->_trim();
     }
     void _finish_write(BufferCacheShard* cache, uint64_t seq);
-    void did_read(BufferCacheShard* cache, uint32_t offset, bufferlist& bl) {
+    void did_read(BufferCacheShard* cache, uint32_t offset, ceph::buffer::list& bl) {
       std::lock_guard l(cache->lock);
       Buffer *b = new Buffer(this, Buffer::STATE_CLEAN, 0, offset, bl);
       b->cache_private = _discard(cache, offset, bl.length());
@@ -385,7 +386,7 @@ public:
 
     void split(BufferCacheShard* cache, size_t pos, BufferSpace &r);
 
-    void dump(BufferCacheShard* cache, Formatter *f) const {
+    void dump(BufferCacheShard* cache, ceph::Formatter *f) const {
       std::lock_guard l(cache->lock);
       f->open_array_section("buffers");
       for (auto& i : buffer_map) {
@@ -429,8 +430,8 @@ public:
     friend void intrusive_ptr_add_ref(SharedBlob *b) { b->get(); }
     friend void intrusive_ptr_release(SharedBlob *b) { b->put(); }
 
-    void dump(Formatter* f) const;
-    friend ostream& operator<<(ostream& out, const SharedBlob& sb);
+    void dump(ceph::Formatter* f) const;
+    friend std::ostream& operator<<(std::ostream& out, const SharedBlob& sb);
 
     void get() {
       ++nref;
@@ -525,7 +526,7 @@ public:
   private:
     mutable bluestore_blob_t blob;  ///< decoded blob metadata
 #ifdef CACHE_BLOB_BL
-    mutable bufferlist blob_bl;     ///< cached encoded blob, blob is dirty if empty
+    mutable ceph::buffer::list blob_bl;     ///< cached encoded blob, blob is dirty if empty
 #endif
     /// refs from this shard.  ephemeral if id<0, persisted if spanning.
     bluestore_blob_use_tracker_t used_in_blob;
@@ -535,8 +536,8 @@ public:
     friend void intrusive_ptr_add_ref(Blob *b) { b->get(); }
     friend void intrusive_ptr_release(Blob *b) { b->put(); }
 
-    void dump(Formatter* f) const;
-    friend ostream& operator<<(ostream& out, const Blob &b);
+    void dump(ceph::Formatter* f) const;
+    friend std::ostream& operator<<(std::ostream& out, const Blob &b);
 
     const bluestore_blob_use_tracker_t& get_blob_use_tracker() const {
       return used_in_blob;
@@ -627,7 +628,7 @@ public:
       }
     }
     void encode(
-      bufferlist::contiguous_appender& p,
+      ceph::buffer::list::contiguous_appender& p,
       bool include_ref_map) const {
       _encode();
       p.append(blob_bl);
@@ -637,7 +638,7 @@ public:
     }
     void decode(
       Collection */*coll*/,
-      bufferptr::const_iterator& p,
+      ceph::buffer::ptr::const_iterator& p,
       bool include_ref_map) {
       const char *start = p.get_pos();
       denc(blob, p);
@@ -663,7 +664,7 @@ public:
       }
     }
     void encode(
-      bufferlist::contiguous_appender& p,
+      ceph::buffer::list::contiguous_appender& p,
       uint64_t struct_v,
       uint64_t sbid,
       bool include_ref_map) const {
@@ -677,7 +678,7 @@ public:
     }
     void decode(
       Collection *coll,
-      bufferptr::const_iterator& p,
+      ceph::buffer::ptr::const_iterator& p,
       uint64_t struct_v,
       uint64_t* sbid,
       bool include_ref_map);
@@ -713,7 +714,7 @@ public:
       }
     }
 
-    void dump(Formatter* f) const;
+    void dump(ceph::Formatter* f) const;
 
     void assign_blob(const BlobRef& b) {
       ceph_assert(!blob);
@@ -753,7 +754,7 @@ public:
   typedef boost::intrusive::set<Extent> extent_map_t;
 
 
-  friend ostream& operator<<(ostream& out, const Extent& e);
+  friend std::ostream& operator<<(std::ostream& out, const Extent& e);
 
   struct OldExtent {
     boost::intrusive::list_member_hook<> old_extent_item;
@@ -794,7 +795,7 @@ public:
     };
     mempool::bluestore_cache_other::vector<Shard> shards;    ///< shards
 
-    bufferlist inline_bl;    ///< cached encoded map, if unsharded; empty=>dirty
+    ceph::buffer::list inline_bl;    ///< cached encoded map, if unsharded; empty=>dirty
 
     uint32_t needs_reshard_begin = 0;
     uint32_t needs_reshard_end = 0;
@@ -833,15 +834,15 @@ public:
       clear_needs_reshard();
     }
 
-    void dump(Formatter* f) const;
+    void dump(ceph::Formatter* f) const;
 
-    bool encode_some(uint32_t offset, uint32_t length, bufferlist& bl,
+    bool encode_some(uint32_t offset, uint32_t length, ceph::buffer::list& bl,
 		     unsigned *pn);
-    unsigned decode_some(bufferlist& bl);
+    unsigned decode_some(ceph::buffer::list& bl);
 
     void bound_encode_spanning_blobs(size_t& p);
-    void encode_spanning_blobs(bufferlist::contiguous_appender& p);
-    void decode_spanning_blobs(bufferptr::const_iterator& p);
+    void encode_spanning_blobs(ceph::buffer::list::contiguous_appender& p);
+    void decode_spanning_blobs(ceph::buffer::ptr::const_iterator& p);
 
     BlobRef get_spanning_blob(int id) {
       auto p = spanning_blob_map.find(id);
@@ -955,7 +956,7 @@ public:
   The root cause for old_extents use is the need to handle blob ref counts
   properly. Old extents still hold blob refs and hence we need to traverse
   the collection to determine if blob to be released.
-  Protrusive extents are extents that fit into the blob set in action
+  Protrusive extents are extents that fit into the blob std::set in action
   (ones that are below the logical range from above) but not removed totally
   due to the current write. 
   E.g. for
@@ -1012,7 +1013,7 @@ public:
       }
     };
     CephContext* cct;
-    map<Blob*, BlobInfo> affected_blobs; ///< compressed blobs and their ref_map
+    std::map<Blob*, BlobInfo> affected_blobs; ///< compressed blobs and their ref_map
                                          ///< copies that are affected by the
                                          ///< specific write
 
@@ -1027,7 +1028,7 @@ public:
                                                 ///< (except the case where
                                                 ///< uncompressed extent follows
                                                 ///< compressed one - see below).
-    BlobInfo* blob_info_counted = nullptr; ///< set if previous allocation unit
+    BlobInfo* blob_info_counted = nullptr; ///< std::set if previous allocation unit
                                            ///< caused expected_allocations
 					   ///< counter increment at this blob.
                                            ///< if uncompressed extent follows 
@@ -1091,7 +1092,7 @@ public:
 	extent_map(this) {
     }
     Onode(Collection* c, const ghobject_t& o,
-      const string& k)
+      const std::string& k)
       : s(nullptr),
       nref(0),
       c(c),
@@ -1114,10 +1115,10 @@ public:
     static Onode* decode(
       CollectionRef c,
       const ghobject_t& oid,
-      const string& key,
-      const bufferlist& v);
+      const std::string& key,
+      const ceph::buffer::list& v);
 
-    void dump(Formatter* f) const;
+    void dump(ceph::Formatter* f) const;
 
     void flush();
     void get() {
@@ -1135,12 +1136,12 @@ public:
       }
     }
 
-    const string& get_omap_prefix();
-    void get_omap_header(string *out);
-    void get_omap_key(const string& key, string *out);
-    void rewrite_omap_key(const string& old, string *out);
-    void get_omap_tail(string *out);
-    void decode_omap_key(const string& key, string *user_key);
+    const std::string& get_omap_prefix();
+    void get_omap_header(std::string *out);
+    void get_omap_key(const std::string& key, std::string *out);
+    void rewrite_omap_key(const std::string& old, std::string *out);
+    void get_omap_tail(std::string *out);
+    void decode_omap_key(const std::string& key, std::string *user_key);
   };
   typedef boost::intrusive_ptr<Onode> OnodeRef;
 
@@ -1198,10 +1199,10 @@ public:
   struct OnodeCacheShard : public CacheShard {
     std::atomic<uint64_t> num_pinned = {0};
 
-    std::array<std::pair<ghobject_t, mono_clock::time_point>, 64> dumped_onodes;
+    std::array<std::pair<ghobject_t, ceph::mono_clock::time_point>, 64> dumped_onodes;
   public:
     OnodeCacheShard(CephContext* cct) : CacheShard(cct) {}
-    static OnodeCacheShard *create(CephContext* cct, string type,
+    static OnodeCacheShard *create(CephContext* cct, std::string type,
                                    PerfCounters *logger);
     virtual void _add(OnodeRef& o, int level) = 0;
     virtual void _rm(OnodeRef& o) = 0;
@@ -1233,7 +1234,7 @@ public:
 
   public:
     BufferCacheShard(CephContext* cct) : CacheShard(cct) {}
-    static BufferCacheShard *create(CephContext* cct, string type, 
+    static BufferCacheShard *create(CephContext* cct, std::string type, 
                                     PerfCounters *logger);
     virtual void _add(Buffer *b, int level, Buffer *near) = 0;
     virtual void _rm(Buffer *b) = 0;
@@ -1277,7 +1278,7 @@ public:
     /// forward lookups
     mempool::bluestore_cache_other::unordered_map<ghobject_t,OnodeRef> onode_map;
 
-    friend class Collection; // for split_cache()
+    friend struct Collection; // for split_cache()
 
   public:
     OnodeSpace(OnodeCacheShard *c) : cache(c) {}
@@ -1337,7 +1338,7 @@ public:
     //
     // i.e.,
     //  open = SharedBlob is instantiated
-    //  shared = blob_t shared flag is set; SharedBlob is hashed.
+    //  shared = blob_t shared flag is std::set; SharedBlob is hashed.
     //  loaded = SharedBlob::shared_blob_t is loaded from kv store
     void open_shared_blob(uint64_t sbid, BlobRef b);
     void load_shared_blob(SharedBlobRef sb);
@@ -1378,20 +1379,20 @@ public:
     CollectionRef c;
     OnodeRef o;
     KeyValueDB::Iterator it;
-    string head, tail;
+    std::string head, tail;
 
-    string _stringify() const;
+    std::string _stringify() const;
 
   public:
     OmapIteratorImpl(CollectionRef c, OnodeRef o, KeyValueDB::Iterator it);
     int seek_to_first() override;
-    int upper_bound(const string &after) override;
-    int lower_bound(const string &to) override;
+    int upper_bound(const std::string &after) override;
+    int lower_bound(const std::string &to) override;
     bool valid() override;
     int next() override;
-    string key() override;
-    bufferlist value() override;
-    std::string tail_key() {
+    std::string key() override;
+    ceph::buffer::list value() override;
+    std::string tail_key() override {
       return tail;
     }
 
@@ -1475,14 +1476,14 @@ public:
 	values[STATFS_COMPRESSED_ORIGINAL] == 0 &&
 	values[STATFS_COMPRESSED_ALLOCATED] == 0;
     }
-    void decode(bufferlist::const_iterator& it) {
+    void decode(ceph::buffer::list::const_iterator& it) {
       using ceph::decode;
       for (size_t i = 0; i < STATFS_LAST; i++) {
 	decode(values[i], it);
       }
     }
 
-    void encode(bufferlist& bl) {
+    void encode(ceph::buffer::list& bl) {
       using ceph::encode;
       for (size_t i = 0; i < STATFS_LAST; i++) {
 	encode(values[i], bl);
@@ -1550,14 +1551,14 @@ public:
 
     uint64_t bytes = 0, ios = 0, cost = 0;
 
-    set<OnodeRef> onodes;     ///< these need to be updated/written
-    set<OnodeRef> modified_objects;  ///< objects we modified (and need a ref)
-    set<SharedBlobRef> shared_blobs;  ///< these need to be updated/written
-    set<SharedBlobRef> shared_blobs_written; ///< update these on io completion
+    std::set<OnodeRef> onodes;     ///< these need to be updated/written
+    std::set<OnodeRef> modified_objects;  ///< objects we modified (and need a ref)
+    std::set<SharedBlobRef> shared_blobs;  ///< these need to be updated/written
+    std::set<SharedBlobRef> shared_blobs_written; ///< update these on io completion
 
     KeyValueDB::Transaction t; ///< then we will commit this
-    list<Context*> oncommits;  ///< more commit completions
-    list<CollectionRef> removed_collections; ///< colls we removed
+    std::list<Context*> oncommits;  ///< more commit completions
+    std::list<CollectionRef> removed_collections; ///< colls we removed
 
     boost::intrusive::list_member_hook<> deferred_queue_item;
     bluestore_deferred_transaction_t *deferred_txn = nullptr; ///< if any
@@ -1565,13 +1566,13 @@ public:
     interval_set<uint64_t> allocated, released;
     volatile_statfs statfs_delta;	   ///< overall store statistics delta
     uint64_t osd_pool_id = META_POOL_ID;    ///< osd pool id we're operating on
-    
+
     IOContext ioc;
     bool had_ios = false;  ///< true if we submitted IOs before our kv txn
 
     uint64_t seq = 0;
-    mono_clock::time_point start;
-    mono_clock::time_point last_stamp;
+    ceph::mono_clock::time_point start;
+    ceph::mono_clock::time_point last_stamp;
 
     uint64_t last_nid = 0;     ///< if non-zero, highest new nid we allocated
     uint64_t last_blobid = 0;  ///< if non-zero, highest new blobid we allocated
@@ -1581,11 +1582,11 @@ public:
 #endif
 
     explicit TransContext(CephContext* cct, Collection *c, OpSequencer *o,
-			  list<Context*> *on_commits)
+			  std::list<Context*> *on_commits)
       : ch(c),
 	osr(o),
 	ioc(cct, this),
-	start(mono_clock::now()) {
+	start(ceph::mono_clock::now()) {
       last_stamp = start;
       if (on_commits) {
 	oncommits.swap(*on_commits);
@@ -1622,7 +1623,7 @@ public:
 
   class BlueStoreThrottle {
 #if defined(WITH_LTTNG)
-    const std::chrono::time_point<mono_clock> time_base = mono_clock::now();
+    const std::chrono::time_point<ceph::mono_clock> time_base = ceph::mono_clock::now();
 
     // Time of last chosen io (microseconds)
     std::atomic<uint64_t> previous_emitted_tp_time_mono_mcs = {0};
@@ -1648,7 +1649,7 @@ public:
       } else {
 	ios_started_since_last_traced++;
 	auto now_mcs = ceph::to_microseconds<uint64_t>(
-	  mono_clock::now() - time_base);
+	  ceph::mono_clock::now() - time_base);
 	uint64_t previous_mcs = previous_emitted_tp_time_mono_mcs;
 	uint64_t period_mcs = now_mcs - previous_mcs;
 	if (period_mcs > min_period_mcs) {
@@ -1670,12 +1671,12 @@ public:
     void emit_initial_tracepoint(
       KeyValueDB &db,
       TransContext &txc,
-      mono_clock::time_point);
+      ceph::mono_clock::time_point);
 #else
     void emit_initial_tracepoint(
       KeyValueDB &db,
       TransContext &txc,
-      mono_clock::time_point) {}
+      ceph::mono_clock::time_point) {}
 #endif
 
     Throttle throttle_bytes;           ///< submit to commit
@@ -1697,16 +1698,16 @@ public:
     void complete(TransContext &txc) {}
 #endif
 
-    mono_clock::duration log_state_latency(
+    ceph::mono_clock::duration log_state_latency(
       TransContext &txc, PerfCounters *logger, int state);
     bool try_start_transaction(
       KeyValueDB &db,
       TransContext &txc,
-      mono_clock::time_point);
+      ceph::mono_clock::time_point);
     void finish_start_transaction(
       KeyValueDB &db,
       TransContext &txc,
-      mono_clock::time_point);
+      ceph::mono_clock::time_point);
     void release_kv_throttle(uint64_t cost) {
       throttle_bytes.put(cost);
     }
@@ -1738,14 +1739,14 @@ public:
   struct DeferredBatch final : public AioContext {
     OpSequencer *osr;
     struct deferred_io {
-      bufferlist bl;    ///< data
+      ceph::buffer::list bl;    ///< data
       uint64_t seq;     ///< deferred transaction seq
     };
-    map<uint64_t,deferred_io> iomap; ///< map of ios in this batch
+    std::map<uint64_t,deferred_io> iomap; ///< map of ios in this batch
     deferred_queue_t txcs;           ///< txcs in this batch
     IOContext ioc;                   ///< our aios
     /// bytes of pending io for each deferred seq (may be 0)
-    map<uint64_t,int> seq_bytes;
+    std::map<uint64_t,int> seq_bytes;
 
     void _discard(CephContext *cct, uint64_t offset, uint64_t length);
     void _audit(CephContext *cct);
@@ -1756,7 +1757,7 @@ public:
     /// prepare a write
     void prepare_write(CephContext *cct,
 		       uint64_t seq, uint64_t offset, uint64_t length,
-		       bufferlist::const_iterator& p);
+		       ceph::buffer::list::const_iterator& p);
 
     void aio_finish(BlueStore *store) override {
       store->_deferred_aio_finish(osr);
@@ -1791,7 +1792,7 @@ public:
 
     std::atomic_int kv_submitted_waiters = {0};
 
-    std::atomic_bool zombie = {false};    ///< in zombie_osr set (collection going away)
+    std::atomic_bool zombie = {false};    ///< in zombie_osr std::set (collection going away)
 
     const uint32_t sequencer_id;
 
@@ -1830,7 +1831,7 @@ public:
     void flush() {
       std::unique_lock l(qlock);
       while (true) {
-	// set flag before the check because the condition
+	// std::set flag before the check because the condition
 	// may become true outside qlock, and we need to make
 	// sure those threads see waiters and signal qcond.
 	++kv_submitted_waiters;
@@ -1847,7 +1848,7 @@ public:
       std::unique_lock l(qlock);
       assert (q.size() >= 1);
       while (true) {
-	// set flag before the check because the condition
+	// std::set flag before the check because the condition
 	// may become true outside qlock, and we need to make
 	// sure those threads see waiters and signal qcond.
 	++kv_submitted_waiters;
@@ -1923,18 +1924,18 @@ public:
     struct key_dist {
       uint64_t count;
       uint32_t max_len;
-      map<int, struct value_dist> val_map; ///< slab id to count, max length of value and key
+      std::map<int, struct value_dist> val_map; ///< slab id to count, max length of value and key
     };
 
-    map<string, map<int, struct key_dist> > key_hist;
-    map<int, uint64_t> value_hist;
+    std::map<std::string, std::map<int, struct key_dist> > key_hist;
+    std::map<int, uint64_t> value_hist;
     int get_key_slab(size_t sz);
-    string get_key_slab_to_range(int slab);
+    std::string get_key_slab_to_range(int slab);
     int get_value_slab(size_t sz);
-    string get_value_slab_to_range(int slab);
-    void update_hist_entry(map<string, map<int, struct key_dist> > &key_hist,
-			  const string &prefix, size_t key_size, size_t value_size);
-    void dump(Formatter *f);
+    std::string get_value_slab_to_range(int slab);
+    void update_hist_entry(std::map<std::string, std::map<int, struct key_dist> > &key_hist,
+			  const std::string &prefix, size_t key_size, size_t value_size);
+    void dump(ceph::Formatter *f);
   };
 
   // --------------------------------------------------------
@@ -1942,7 +1943,7 @@ public:
 private:
   BlueFS *bluefs = nullptr;
   bluefs_layout_t bluefs_layout;
-  mono_time bluefs_last_balance;
+  ceph::mono_time bluefs_last_balance;
   utime_t next_dump_on_bluefs_alloc_failure;
 
   KeyValueDB *db = nullptr;
@@ -1958,15 +1959,15 @@ private:
   ceph::shared_mutex coll_lock = ceph::make_shared_mutex("BlueStore::coll_lock");  ///< rwlock to protect coll_map
   mempool::bluestore_cache_other::unordered_map<coll_t, CollectionRef> coll_map;
   bool collections_had_errors = false;
-  map<coll_t,CollectionRef> new_coll_map;
+  std::map<coll_t,CollectionRef> new_coll_map;
 
-  vector<OnodeCacheShard*> onode_cache_shards;
-  vector<BufferCacheShard*> buffer_cache_shards;
+  std::vector<OnodeCacheShard*> onode_cache_shards;
+  std::vector<BufferCacheShard*> buffer_cache_shards;
 
   /// protect zombie_osr_set
   ceph::mutex zombie_osr_lock = ceph::make_mutex("BlueStore::zombie_osr_lock");
   uint32_t next_sequencer_id = 0;
-  std::map<coll_t,OpSequencerRef> zombie_osr_set; ///< set of OpSequencers for deleted collections
+  std::map<coll_t,OpSequencerRef> zombie_osr_set; ///< std::set of OpSequencers for deleted collections
 
   std::atomic<uint64_t> nid_last = {0};
   std::atomic<uint64_t> nid_max = {0};
@@ -1980,7 +1981,7 @@ private:
   std::atomic<uint64_t> deferred_seq = {0};
   deferred_osr_queue_t deferred_queue; ///< osr's with deferred io pending
   int deferred_queue_size = 0;         ///< num txc's queued across all osrs
-  atomic_int deferred_aggressive = {0}; ///< aggressive wakeup of kv thread
+  std::atomic_int deferred_aggressive = {0}; ///< aggressive wakeup of kv thread
   Finisher  finisher;
   utime_t  deferred_last_submitted = utime_t();
 
@@ -1992,27 +1993,27 @@ private:
   bool kv_stop = false;
   bool kv_finalize_started = false;
   bool kv_finalize_stop = false;
-  deque<TransContext*> kv_queue;             ///< ready, already submitted
-  deque<TransContext*> kv_queue_unsubmitted; ///< ready, need submit by kv thread
-  deque<TransContext*> kv_committing;        ///< currently syncing
-  deque<DeferredBatch*> deferred_done_queue;   ///< deferred ios done
+  std::deque<TransContext*> kv_queue;             ///< ready, already submitted
+  std::deque<TransContext*> kv_queue_unsubmitted; ///< ready, need submit by kv thread
+  std::deque<TransContext*> kv_committing;        ///< currently syncing
+  std::deque<DeferredBatch*> deferred_done_queue;   ///< deferred ios done
   bool kv_sync_in_progress = false;
 
   KVFinalizeThread kv_finalize_thread;
   ceph::mutex kv_finalize_lock = ceph::make_mutex("BlueStore::kv_finalize_lock");
   ceph::condition_variable kv_finalize_cond;
-  deque<TransContext*> kv_committing_to_finalize;   ///< pending finalization
-  deque<DeferredBatch*> deferred_stable_to_finalize; ///< pending finalization
+  std::deque<TransContext*> kv_committing_to_finalize;   ///< pending finalization
+  std::deque<DeferredBatch*> deferred_stable_to_finalize; ///< pending finalization
   bool kv_finalize_in_progress = false;
 
   PerfCounters *logger = nullptr;
 
-  list<CollectionRef> removed_collections;
+  std::list<CollectionRef> removed_collections;
 
   ceph::shared_mutex debug_read_error_lock =
     ceph::make_shared_mutex("BlueStore::debug_read_error_lock");
-  set<ghobject_t> debug_data_error_objects;
-  set<ghobject_t> debug_mdata_error_objects;
+  std::set<ghobject_t> debug_data_error_objects;
+  std::set<ghobject_t> debug_mdata_error_objects;
 
   std::atomic<int> csum_type = {Checksummer::CSUM_CRC32C};
 
@@ -2067,7 +2068,7 @@ private:
   double max_defer_interval = 0; ///< Time to wait between last deferred submit
   std::atomic<uint32_t> config_changed = {0}; ///< Counter to determine if there is a configuration change.
 
-  typedef map<uint64_t, volatile_statfs> osd_pools_map;
+  typedef std::map<uint64_t, volatile_statfs> osd_pools_map;
 
   ceph::mutex vstatfs_lock = ceph::make_mutex("BlueStore::vstatfs_lock");
   volatile_statfs vstatfs;
@@ -2144,7 +2145,7 @@ private:
       virtual void set_cache_ratio(double ratio) {
         cache_ratio = ratio;
       }
-      virtual string get_cache_name() const = 0;
+      virtual std::string get_cache_name() const = 0;
     };
 
     struct MetaCache : public MempoolCache {
@@ -2155,7 +2156,7 @@ private:
             mempool::bluestore_cache_onode::allocated_bytes();
       }
 
-      virtual string get_cache_name() const {
+      virtual std::string get_cache_name() const {
         return "BlueStore Meta Cache";
       }
 
@@ -2181,7 +2182,7 @@ private:
         }
         return bytes; 
       }
-      virtual string get_cache_name() const {
+      virtual std::string get_cache_name() const {
         return "BlueStore Data Cache";
       }
     };
@@ -2278,7 +2279,7 @@ private:
   void _fsck_collections(int64_t* errors);
   void _close_collections();
 
-  int _setup_block_symlink_or_file(string name, string path, uint64_t size,
+  int _setup_block_symlink_or_file(std::string name, std::string path, uint64_t size,
 				   bool create);
 
 public:
@@ -2288,11 +2289,11 @@ public:
   }
 
   static int _write_bdev_label(CephContext* cct,
-			       string path, bluestore_bdev_label_t label);
-  static int _read_bdev_label(CephContext* cct, string path,
+			       std::string path, bluestore_bdev_label_t label);
+  static int _read_bdev_label(CephContext* cct, std::string path,
 			      bluestore_bdev_label_t *label);
 private:
-  int _check_or_set_bdev_label(string path, uint64_t size, string desc,
+  int _check_or_set_bdev_label(std::string path, uint64_t size, std::string desc,
 			       bool create);
 
   int _open_super_meta();
@@ -2321,7 +2322,7 @@ private:
   friend void _dump_transaction(CephContext *cct, Transaction *t);
 
   TransContext *_txc_create(Collection *c, OpSequencer *osr,
-			    list<Context*> *on_commits);
+			    std::list<Context*> *on_commits);
   void _txc_update_store_statfs(TransContext *txc);
   void _txc_add_transaction(TransContext *txc, Transaction *t);
   void _txc_calc_cost(TransContext *txc);
@@ -2401,7 +2402,7 @@ private:
     TransContext *txc,
     BlobRef b,
     uint64_t offset,
-    bufferlist& bl,
+    ceph::buffer::list& bl,
     unsigned flags) {
     b->shared_blob->bc.write(b->shared_blob->get_cache(), txc->seq, offset, bl,
 			     flags);
@@ -2410,7 +2411,7 @@ private:
 
   int _collection_list(
     Collection *c, const ghobject_t& start, const ghobject_t& end,
-    int max, vector<ghobject_t> *ls, ghobject_t *next);
+    int max, std::vector<ghobject_t> *ls, ghobject_t *next);
 
   template <typename T, typename F>
   T select_option(const std::string& opt_name, T val1, F f) {
@@ -2424,7 +2425,7 @@ private:
 
   void _apply_padding(uint64_t head_pad,
 		      uint64_t tail_pad,
-		      bufferlist& padded);
+		      ceph::buffer::list& padded);
 
   void _record_onode(OnodeRef &o, KeyValueDB::Transaction &txn);
 
@@ -2443,11 +2444,11 @@ private:
 
   // --- public interface ---
 public:
-  BlueStore(CephContext *cct, const string& path);
-  BlueStore(CephContext *cct, const string& path, uint64_t min_alloc_size); // Ctor for UT only
+  BlueStore(CephContext *cct, const std::string& path);
+  BlueStore(CephContext *cct, const std::string& path, uint64_t min_alloc_size); // Ctor for UT only
   ~BlueStore() override;
 
-  string get_type() override {
+  std::string get_type() override {
     return "bluestore";
   }
 
@@ -2459,14 +2460,14 @@ public:
     return min_alloc_size;
   }
 
-  int get_devices(set<string> *ls) override;
+  int get_devices(std::set<std::string> *ls) override;
 
   bool is_rotational() override;
   bool is_journal_rotational() override;
 
-  string get_default_device_class() override {
-    string device_class;
-    map<string, string> metadata;
+  std::string get_default_device_class() override {
+    std::string device_class;
+    std::map<std::string, std::string> metadata;
     collect_metadata(&metadata);
     auto it = metadata.find("bluestore_bdev_type");
     if (it != metadata.end()) {
@@ -2477,10 +2478,10 @@ public:
 
   int get_numa_node(
     int *numa_node,
-    set<int> *nodes,
-    set<string> *failed) override;
+    std::set<int> *nodes,
+    std::set<std::string> *failed) override;
 
-  static int get_block_device_fsid(CephContext* cct, const string& path,
+  static int get_block_device_fsid(CephContext* cct, const std::string& path,
 				   uuid_d *fsid);
 
   bool test_mount_in_use() override;
@@ -2518,7 +2519,7 @@ public:
   }
 
   void set_cache_shards(unsigned num) override;
-  void dump_cache_stats(Formatter *f) override {
+  void dump_cache_stats(ceph::Formatter *f) override {
     int onode_count = 0, buffers_bytes = 0;
     for (auto i: onode_cache_shards) {
       onode_count += i->_get_num();
@@ -2529,7 +2530,7 @@ public:
     f->dump_int("bluestore_onode", onode_count);
     f->dump_int("bluestore_buffers", buffers_bytes);
   }
-  void dump_cache_stats(ostream& ss) override {
+  void dump_cache_stats(std::ostream& ss) override {
     int onode_count = 0, buffers_bytes = 0;
     for (auto i: onode_cache_shards) {
       onode_count += i->_get_num();
@@ -2553,24 +2554,24 @@ public:
     return 0;
   }
 
-  void get_db_statistics(Formatter *f) override;
-  void generate_db_histogram(Formatter *f) override;
+  void get_db_statistics(ceph::Formatter *f) override;
+  void generate_db_histogram(ceph::Formatter *f) override;
   void _flush_cache();
-  int flush_cache(ostream *os = NULL) override;
-  void dump_perf_counters(Formatter *f) override {
+  int flush_cache(std::ostream *os = NULL) override;
+  void dump_perf_counters(ceph::Formatter *f) override {
     f->open_object_section("perf_counters");
     logger->dump_formatted(f, false);
     f->close_section();
   }
 
-  int add_new_bluefs_device(int id, const string& path);
-  int migrate_to_existing_bluefs_device(const set<int>& devs_source,
+  int add_new_bluefs_device(int id, const std::string& path);
+  int migrate_to_existing_bluefs_device(const std::set<int>& devs_source,
     int id);
-  int migrate_to_new_bluefs_device(const set<int>& devs_source,
+  int migrate_to_new_bluefs_device(const std::set<int>& devs_source,
     int id,
-    const string& path);
-  int expand_devices(ostream& out);
-  string get_device_path(unsigned id);
+    const std::string& path);
+  int expand_devices(std::ostream& out);
+  std::string get_device_path(unsigned id);
 
 public:
   int statfs(struct store_statfs_t *buf,
@@ -2578,7 +2579,7 @@ public:
   int pool_statfs(uint64_t pool_id, struct store_statfs_t *buf,
 		  bool *per_pool_omap) override;
 
-  void collect_metadata(map<string,string> *pm) override;
+  void collect_metadata(std::map<std::string,std::string> *pm) override;
 
   bool exists(CollectionHandle &c, const ghobject_t& oid) override;
   int set_collection_opts(
@@ -2594,7 +2595,7 @@ public:
     const ghobject_t& oid,
     uint64_t offset,
     size_t len,
-    bufferlist& bl,
+    ceph::buffer::list& bl,
     uint32_t op_flags = 0) override;
 
 private:
@@ -2620,7 +2621,7 @@ private:
       length(from.length),
       front(from.front){}
 
-    friend ostream& operator<<(ostream& out, const region_t& r) {
+    friend std::ostream& operator<<(std::ostream& out, const region_t& r) {
       return out << "0x" << std::hex << r.logical_offset << ":"
         << r.blob_xoffset << "~" << r.length << std::dec;
     }
@@ -2630,12 +2631,12 @@ private:
   struct read_req_t {
     uint64_t r_off = 0;
     uint64_t r_len = 0;
-    bufferlist bl;
+    ceph::buffer::list bl;
     std::list<region_t> regs; // original read regions
 
     read_req_t(uint64_t off, uint64_t len) : r_off(off), r_len(len) {}
 
-    friend ostream& operator<<(ostream& out, const read_req_t& r) {
+    friend std::ostream& operator<<(std::ostream& out, const read_req_t& r) {
       out << "{<0x" << std::hex << r.r_off << ", 0x" << r.r_len << "> : [";
       for (const auto& reg : r.regs)
         out << reg;
@@ -2643,8 +2644,8 @@ private:
     }
   };
 
-  typedef list<read_req_t> regions2read_t;
-  typedef map<BlueStore::BlobRef, regions2read_t> blobs2read_t;
+  typedef std::list<read_req_t> regions2read_t;
+  typedef std::map<BlueStore::BlobRef, regions2read_t> blobs2read_t;
 
   void _read_cache(
     OnodeRef o,
@@ -2657,7 +2658,7 @@ private:
 
   int _prepare_read_ioc(
     blobs2read_t& blobs2read,
-    vector<bufferlist>* compressed_blob_bls,
+    std::vector<ceph::buffer::list>* compressed_blob_bls,
     IOContext* ioc);
 
   int _generate_read_result_bl(
@@ -2665,18 +2666,18 @@ private:
     uint64_t offset,
     size_t length,
     ready_regions_t& ready_regions,
-    vector<bufferlist>& compressed_blob_bls,
+    std::vector<ceph::buffer::list>& compressed_blob_bls,
     blobs2read_t& blobs2read,
     bool buffered,
     bool* csum_error,
-    bufferlist& bl);
+    ceph::buffer::list& bl);
 
   int _do_read(
     Collection *c,
     OnodeRef o,
     uint64_t offset,
     size_t len,
-    bufferlist& bl,
+    ceph::buffer::list& bl,
     uint32_t op_flags = 0,
     uint64_t retry_count = 0);
 
@@ -2684,35 +2685,35 @@ private:
     Collection *c,
     OnodeRef o,
     const interval_set<uint64_t>& m,
-    bufferlist& bl,
+    ceph::buffer::list& bl,
     uint32_t op_flags = 0,
     uint64_t retry_count = 0);
 
   int _fiemap(CollectionHandle &c_, const ghobject_t& oid,
- 	     uint64_t offset, size_t len, interval_set<uint64_t>& destset);
+	      uint64_t offset, size_t len, interval_set<uint64_t>& destset);
 public:
   int fiemap(CollectionHandle &c, const ghobject_t& oid,
-	     uint64_t offset, size_t len, bufferlist& bl) override;
+	     uint64_t offset, size_t len, ceph::buffer::list& bl) override;
   int fiemap(CollectionHandle &c, const ghobject_t& oid,
-	     uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap) override;
+	     uint64_t offset, size_t len, std::map<uint64_t, uint64_t>& destmap) override;
 
   int readv(
     CollectionHandle &c_,
     const ghobject_t& oid,
     interval_set<uint64_t>& m,
-    bufferlist& bl,
+    ceph::buffer::list& bl,
     uint32_t op_flags) override;
 
   int dump_onode(CollectionHandle &c, const ghobject_t& oid,
-    const string& section_name, Formatter *f) override;
+    const std::string& section_name, ceph::Formatter *f) override;
 
   int getattr(CollectionHandle &c, const ghobject_t& oid, const char *name,
-	      bufferptr& value) override;
+	      ceph::buffer::ptr& value) override;
 
   int getattrs(CollectionHandle &c, const ghobject_t& oid,
-	       map<string,bufferptr>& aset) override;
+	       std::map<std::string,ceph::buffer::ptr>& aset) override;
 
-  int list_collections(vector<coll_t>& ls) override;
+  int list_collections(std::vector<coll_t>& ls) override;
 
   CollectionHandle open_collection(const coll_t &c) override;
   CollectionHandle create_new_collection(const coll_t& cid) override;
@@ -2727,24 +2728,24 @@ public:
 		      const ghobject_t& start,
 		      const ghobject_t& end,
 		      int max,
-		      vector<ghobject_t> *ls, ghobject_t *next) override;
+		      std::vector<ghobject_t> *ls, ghobject_t *next) override;
 
   int omap_get(
     CollectionHandle &c,     ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
-    bufferlist *header,      ///< [out] omap header
-    map<string, bufferlist> *out /// < [out] Key to value map
+    ceph::buffer::list *header,      ///< [out] omap header
+    std::map<std::string, ceph::buffer::list> *out /// < [out] Key to value map
     ) override;
   int _omap_get(
     Collection *c,     ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
-    bufferlist *header,      ///< [out] omap header
-    map<string, bufferlist> *out /// < [out] Key to value map
+    ceph::buffer::list *header,      ///< [out] omap header
+    std::map<std::string, ceph::buffer::list> *out /// < [out] Key to value map
     );
   int _onode_omap_get(
     const OnodeRef &o,           ///< [in] Object containing omap
-    bufferlist *header,          ///< [out] omap header
-    map<string, bufferlist> *out /// < [out] Key to value map
+    ceph::buffer::list *header,          ///< [out] omap header
+    std::map<std::string, ceph::buffer::list> *out /// < [out] Key to value map
   );
 
 
@@ -2752,7 +2753,7 @@ public:
   int omap_get_header(
     CollectionHandle &c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
-    bufferlist *header,      ///< [out] omap header
+    ceph::buffer::list *header,      ///< [out] omap header
     bool allow_eio = false ///< [in] don't assert on eio
     ) override;
 
@@ -2760,23 +2761,23 @@ public:
   int omap_get_keys(
     CollectionHandle &c,              ///< [in] Collection containing oid
     const ghobject_t &oid, ///< [in] Object containing omap
-    set<string> *keys      ///< [out] Keys defined on oid
+    std::set<std::string> *keys      ///< [out] Keys defined on oid
     ) override;
 
   /// Get key values
   int omap_get_values(
     CollectionHandle &c,         ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
-    const set<string> &keys,     ///< [in] Keys to get
-    map<string, bufferlist> *out ///< [out] Returned keys and values
+    const std::set<std::string> &keys,     ///< [in] Keys to get
+    std::map<std::string, ceph::buffer::list> *out ///< [out] Returned keys and values
     ) override;
 
 #ifdef WITH_SEASTAR
   int omap_get_values(
     CollectionHandle &c,         ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
-    const std::optional<string> &start_after,     ///< [in] Keys to get
-    map<string, bufferlist> *out ///< [out] Returned keys and values
+    const std::optional<std::string> &start_after,     ///< [in] Keys to get
+    std::map<std::string, ceph::buffer::list> *out ///< [out] Returned keys and values
     ) override;
 #endif
 
@@ -2784,8 +2785,8 @@ public:
   int omap_check_keys(
     CollectionHandle &c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
-    const set<string> &keys, ///< [in] Keys to check
-    set<string> *out         ///< [out] Subset of keys defined on oid
+    const std::set<std::string> &keys, ///< [in] Keys to check
+    std::set<std::string> *out         ///< [out] Subset of keys defined on oid
     ) override;
 
   ObjectMap::ObjectMapIterator get_omap_iterator(
@@ -2831,7 +2832,7 @@ public:
 
   int queue_transactions(
     CollectionHandle& ch,
-    vector<Transaction>& tls,
+    std::vector<Transaction>& tls,
     TrackedOpRef op = TrackedOpRef(),
     ThreadPool::TPHandle *handle = NULL) override;
 
@@ -2846,11 +2847,11 @@ public:
   }
 
   /// methods to inject various errors fsck can repair
-  void inject_broken_shared_blob_key(const string& key,
-			 const bufferlist& bl);
+  void inject_broken_shared_blob_key(const std::string& key,
+			 const ceph::buffer::list& bl);
   void inject_leaked(uint64_t len);
   void inject_false_free(coll_t cid, ghobject_t oid);
-  void inject_statfs(const string& key, const store_statfs_t& new_statfs);
+  void inject_statfs(const std::string& key, const store_statfs_t& new_statfs);
   void inject_global_statfs(const store_statfs_t& new_statfs);
   void inject_misreference(coll_t cid1, ghobject_t oid1,
 			   coll_t cid2, ghobject_t oid2,
@@ -2888,7 +2889,7 @@ public:
     int idx,
     const ceph::timespan& lat,
     double lat_threshold,
-    std::function<string (const ceph::timespan& lat)> fn) const;
+    std::function<std::string (const ceph::timespan& lat)> fn) const;
 
 private:
   bool _debug_data_eio(const ghobject_t& o) {
@@ -2914,12 +2915,12 @@ private:
   }
 private:
   ceph::mutex qlock = ceph::make_mutex("BlueStore::Alerts::qlock");
-  string failed_cmode;
-  set<string> failed_compressors;
-  string spillover_alert;
-  string legacy_statfs_alert;
-  string no_per_pool_omap_alert;
-  string disk_size_mismatch_alert;
+  std::string failed_cmode;
+  std::set<std::string> failed_compressors;
+  std::string spillover_alert;
+  std::string legacy_statfs_alert;
+  std::string no_per_pool_omap_alert;
+  std::string disk_size_mismatch_alert;
 
   void _log_alerts(osd_alert_list_t& alerts);
   bool _set_compression_alert(bool cmode, const char* s) {
@@ -2937,7 +2938,7 @@ private:
     failed_cmode.clear();
   }
 
-  void _set_spillover_alert(const string& s) {
+  void _set_spillover_alert(const std::string& s) {
     std::lock_guard l(qlock);
     spillover_alert = s;
   }
@@ -2948,7 +2949,7 @@ private:
 
   void _check_legacy_statfs_alert();
   void _check_no_per_pool_omap_alert();
-  void _set_disk_size_mismatch_alert(const string& s) {
+  void _set_disk_size_mismatch_alert(const std::string& s) {
     std::lock_guard l(qlock);
     disk_size_mismatch_alert = s;
   }
@@ -2961,9 +2962,9 @@ private:
     OnodeRef& o,
     const bluestore_blob_t* blob,
     uint64_t blob_xoffset,
-    const bufferlist& bl,
+    const ceph::buffer::list& bl,
     uint64_t logical_offset) const;
-  int _decompress(bufferlist& source, bufferlist* result);
+  int _decompress(ceph::buffer::list& source, ceph::buffer::list* result);
 
 
   // --------------------------------------------------------
@@ -2983,7 +2984,7 @@ private:
       BlobRef b;
       uint64_t blob_length;
       uint64_t b_off;
-      bufferlist bl;
+      ceph::buffer::list bl;
       uint64_t b_off0; ///< original offset in a blob prior to padding
       uint64_t length0; ///< original data length prior to padding
 
@@ -2991,7 +2992,7 @@ private:
       bool new_blob; ///< whether new blob was created
 
       bool compressed = false;
-      bufferlist compressed_bl;
+      ceph::buffer::list compressed_bl;
       size_t compressed_len = 0;
 
       write_item(
@@ -2999,7 +3000,7 @@ private:
         BlobRef b,
         uint64_t blob_len,
         uint64_t o,
-        bufferlist& bl,
+        ceph::buffer::list& bl,
         uint64_t o0,
         uint64_t l0,
         bool _mark_unused,
@@ -3015,7 +3016,7 @@ private:
          mark_unused(_mark_unused),
 	 new_blob(_new_blob) {}
     };
-    vector<write_item> writes;                 ///< blobs we're writing
+    std::vector<write_item> writes;                 ///< blobs we're writing
 
     /// partial clone of the context
     void fork(const WriteContext& other) {
@@ -3029,7 +3030,7 @@ private:
       BlobRef b,
       uint64_t blob_len,
       uint64_t o,
-      bufferlist& bl,
+      ceph::buffer::list& bl,
       uint64_t o0,
       uint64_t len0,
       bool _mark_unused,
@@ -3057,14 +3058,14 @@ private:
     CollectionRef &c,
     OnodeRef o,
     uint64_t offset, uint64_t length,
-    bufferlist::iterator& blp,
+    ceph::buffer::list::iterator& blp,
     WriteContext *wctx);
   void _do_write_big(
     TransContext *txc,
     CollectionRef &c,
     OnodeRef o,
     uint64_t offset, uint64_t length,
-    bufferlist::iterator& blp,
+    ceph::buffer::list::iterator& blp,
     WriteContext *wctx);
   int _do_alloc_write(
     TransContext *txc,
@@ -3076,15 +3077,15 @@ private:
     CollectionRef& c,
     OnodeRef o,
     WriteContext *wctx,
-    set<SharedBlob*> *maybe_unshared_blobs=0);
+    std::set<SharedBlob*> *maybe_unshared_blobs=0);
 
   int _write(TransContext *txc,
 	     CollectionRef& c,
 	     OnodeRef& o,
 	     uint64_t offset, size_t len,
-	     bufferlist& bl,
+	     ceph::buffer::list& bl,
 	     uint32_t fadvise_flags);
-  void _pad_zeros(bufferlist *bl, uint64_t *offset,
+  void _pad_zeros(ceph::buffer::list *bl, uint64_t *offset,
 		  uint64_t chunk_size);
 
   void _choose_write_options(CollectionRef& c,
@@ -3103,14 +3104,14 @@ private:
 		CollectionRef &c,
 		OnodeRef o,
 		uint64_t offset, uint64_t length,
-		bufferlist& bl,
+		ceph::buffer::list& bl,
 		uint32_t fadvise_flags);
   void _do_write_data(TransContext *txc,
                       CollectionRef& c,
                       OnodeRef o,
                       uint64_t offset,
                       uint64_t length,
-                      bufferlist& bl,
+                      ceph::buffer::list& bl,
                       WriteContext *wctx);
 
   int _touch(TransContext *txc,
@@ -3128,7 +3129,7 @@ private:
 		   CollectionRef& c,
 		   OnodeRef o,
 		   uint64_t offset,
-		   set<SharedBlob*> *maybe_unshared_blobs=0);
+		   std::set<SharedBlob*> *maybe_unshared_blobs=0);
   int _truncate(TransContext *txc,
 		CollectionRef& c,
 		OnodeRef& o,
@@ -3142,16 +3143,16 @@ private:
   int _setattr(TransContext *txc,
 	       CollectionRef& c,
 	       OnodeRef& o,
-	       const string& name,
-	       bufferptr& val);
+	       const std::string& name,
+	       ceph::buffer::ptr& val);
   int _setattrs(TransContext *txc,
 		CollectionRef& c,
 		OnodeRef& o,
-		const map<string,bufferptr>& aset);
+		const std::map<std::string,ceph::buffer::ptr>& aset);
   int _rmattr(TransContext *txc,
 	      CollectionRef& c,
 	      OnodeRef& o,
-	      const string& name);
+	      const std::string& name);
   int _rmattrs(TransContext *txc,
 	       CollectionRef& c,
 	       OnodeRef& o);
@@ -3162,19 +3163,19 @@ private:
   int _omap_setkeys(TransContext *txc,
 		    CollectionRef& c,
 		    OnodeRef& o,
-		    bufferlist& bl);
+		    ceph::buffer::list& bl);
   int _omap_setheader(TransContext *txc,
 		      CollectionRef& c,
 		      OnodeRef& o,
-		      bufferlist& header);
+		      ceph::buffer::list& header);
   int _omap_rmkeys(TransContext *txc,
 		   CollectionRef& c,
 		   OnodeRef& o,
-		   bufferlist& bl);
+		   ceph::buffer::list& bl);
   int _omap_rmkey_range(TransContext *txc,
 			CollectionRef& c,
 			OnodeRef& o,
-			const string& first, const string& last);
+			const std::string& first, const std::string& last);
   int _set_alloc_hint(
     TransContext *txc,
     CollectionRef& c,
@@ -3248,7 +3249,7 @@ public:
   struct sb_info_t {
     coll_t cid;
     int64_t pool_id = INT64_MIN;
-    list<ghobject_t> oids;
+    std::list<ghobject_t> oids;
     BlueStore::SharedBlobRef sb;
     bluestore_extent_ref_map_t ref_map;
     bool compressed = false;
@@ -3315,10 +3316,10 @@ public:
     int64_t pool_id,
     CollectionRef c,
     const ghobject_t& oid,
-    const string& key,
-    const bufferlist& value,
-    mempool::bluestore_fsck::list<string>* expecting_shards,
-    map<BlobRef, bluestore_blob_t::unused_t>* referenced,
+    const std::string& key,
+    const ceph::buffer::list& value,
+    mempool::bluestore_fsck::list<std::string>* expecting_shards,
+    std::map<BlobRef, bluestore_blob_t::unused_t>* referenced,
     const BlueStore::FSCK_ObjectCtx& ctx);
 
 private:
@@ -3330,7 +3331,7 @@ private:
     FSCK_ObjectCtx& ctx);
 };
 
-inline ostream& operator<<(ostream& out, const BlueStore::volatile_statfs& s) {
+inline std::ostream& operator<<(std::ostream& out, const BlueStore::volatile_statfs& s) {
   return out 
     << " allocated:"
       << s.values[BlueStore::volatile_statfs::STATFS_ALLOCATED]
@@ -3488,11 +3489,11 @@ public:
   };
 public:
   void fix_per_pool_omap(KeyValueDB *db);
-  bool remove_key(KeyValueDB *db, const string& prefix, const string& key);
+  bool remove_key(KeyValueDB *db, const std::string& prefix, const std::string& key);
   bool fix_shared_blob(KeyValueDB *db,
 		         uint64_t sbid,
-		       const bufferlist* bl);
-  bool fix_statfs(KeyValueDB *db, const string& key,
+		       const ceph::buffer::list* bl);
+  bool fix_statfs(KeyValueDB *db, const std::string& key,
     const store_statfs_t& new_statfs);
 
   bool fix_leaked(KeyValueDB *db,
@@ -3650,7 +3651,7 @@ public:
     ceph_assert(dev == BlueFS::BDEV_WAL); // others aren't used atm
     return  reinterpret_cast<void*>(LEVEL_WAL);
   }
-  void* get_hint_by_dir(const string& dirname) const override;
+  void* get_hint_by_dir(const std::string& dirname) const override;
 
   void add_usage(void* hint, const bluefs_fnode_t& fnode) override {
     if (hint == nullptr)
@@ -3729,7 +3730,7 @@ public:
     const std::string& base,
     BlueFSVolumeSelector::paths& res) const override;
 
-  void dump(ostream& sout) override;
+  void dump(std::ostream& sout) override;
 };
 
 #endif

--- a/src/os/bluestore/FreelistManager.cc
+++ b/src/os/bluestore/FreelistManager.cc
@@ -6,8 +6,8 @@
 
 FreelistManager *FreelistManager::create(
   CephContext* cct,
-  string type,
-  string prefix)
+  std::string type,
+  std::string prefix)
 {
   // a bit of a hack... we hard-code the prefixes here.  we need to
   // put the freelistmanagers in different prefixes because the merge

--- a/src/os/bluestore/FreelistManager.h
+++ b/src/os/bluestore/FreelistManager.h
@@ -18,8 +18,8 @@ public:
 
   static FreelistManager *create(
     CephContext* cct,
-    string type,
-    string prefix);
+    std::string type,
+    std::string prefix);
 
   static void setup_merge_operators(KeyValueDB *db);
 

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -40,6 +40,17 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "bdev(" << this << " " << path << ") "
 
+using std::list;
+using std::map;
+using std::string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::make_timespan;
+using ceph::mono_clock;
+using ceph::operator <<;
+
 KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, aio_callback_t d_cb, void *d_cbpriv)
   : BlockDevice(cct, cb, cbpriv),
     aio(false), dio(false),
@@ -894,7 +905,7 @@ int KernelDevice::aio_write(
       ioc->pending_aios.push_back(aio_t(ioc, choose_fd(false, write_hint)));
       ++ioc->num_pending;
       auto& aio = ioc->pending_aios.back();
-      bufferptr p = buffer::create_small_page_aligned(len);
+      bufferptr p = ceph::buffer::create_small_page_aligned(len);
       aio.bl.append(std::move(p));
       aio.bl.prepare_iov(&aio.iov);
       aio.preadv(off, len);
@@ -978,7 +989,7 @@ int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
 
   auto start1 = mono_clock::now();
 
-  auto p = buffer::ptr_node::create(buffer::create_small_page_aligned(len));
+  auto p = ceph::buffer::ptr_node::create(ceph::buffer::create_small_page_aligned(len));
   int r = ::pread(buffered ? fd_buffereds[WRITE_LIFE_NOT_SET] : fd_directs[WRITE_LIFE_NOT_SET],
 		  p->c_str(), len, off);
   auto age = cct->_conf->bdev_debug_aio_log_age;
@@ -1028,7 +1039,7 @@ int KernelDevice::aio_read(
     ioc->pending_aios.push_back(aio_t(ioc, fd_directs[WRITE_LIFE_NOT_SET]));
     ++ioc->num_pending;
     aio_t& aio = ioc->pending_aios.back();
-    bufferptr p = buffer::create_small_page_aligned(len);
+    bufferptr p = ceph::buffer::create_small_page_aligned(len);
     aio.bl.append(std::move(p));
     aio.bl.prepare_iov(&aio.iov);
     aio.preadv(off, len);
@@ -1049,7 +1060,7 @@ int KernelDevice::direct_read_unaligned(uint64_t off, uint64_t len, char *buf)
 {
   uint64_t aligned_off = p2align(off, block_size);
   uint64_t aligned_len = p2roundup(off+len, block_size) - aligned_off;
-  bufferptr p = buffer::create_small_page_aligned(aligned_len);
+  bufferptr p = ceph::buffer::create_small_page_aligned(aligned_len);
   int r = 0;
 
   auto start1 = mono_clock::now();
@@ -1138,7 +1149,7 @@ int KernelDevice::read_random(uint64_t off, uint64_t len, char *buf,
     if (r < 0) {
       r = -errno;
       derr << __func__ << " direct_aligned_read" << " 0x" << std::hex
-        << off << "~" << left << std::dec << " error: " << cpp_strerror(r)
+	   << off << "~" << std::left << std::dec << " error: " << cpp_strerror(r)
         << dendl;
       goto out;
     }

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -35,7 +35,7 @@ class KernelDevice : public BlockDevice {
   bool aio, dio;
 
   int vdo_fd = -1;      ///< fd for vdo sysfs directory
-  string vdo_name;
+  std::string vdo_name;
 
   std::string devname;  ///< kernel dev name (/sys/block/$devname), if any
 
@@ -91,7 +91,7 @@ class KernelDevice : public BlockDevice {
   void _aio_log_start(IOContext *ioc, uint64_t offset, uint64_t length);
   void _aio_log_finish(IOContext *ioc, uint64_t offset, uint64_t length);
 
-  int _sync_write(uint64_t off, bufferlist& bl, bool buffered, int write_hint);
+  int _sync_write(uint64_t off, ceph::buffer::list& bl, bool buffered, int write_hint);
 
   int _lock();
 
@@ -114,7 +114,7 @@ public:
   void aio_submit(IOContext *ioc) override;
   void discard_drain() override;
 
-  int collect_metadata(const std::string& prefix, map<std::string,std::string> *pm) const override;
+  int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const override;
   int get_devname(std::string *s) const override {
     if (devname.empty()) {
       return -ENOENT;
@@ -126,15 +126,15 @@ public:
 
   bool get_thin_utilization(uint64_t *total, uint64_t *avail) const override;
 
-  int read(uint64_t off, uint64_t len, bufferlist *pbl,
+  int read(uint64_t off, uint64_t len, ceph::buffer::list *pbl,
 	   IOContext *ioc,
 	   bool buffered) override;
-  int aio_read(uint64_t off, uint64_t len, bufferlist *pbl,
+  int aio_read(uint64_t off, uint64_t len, ceph::buffer::list *pbl,
 	       IOContext *ioc) override;
   int read_random(uint64_t off, uint64_t len, char *buf, bool buffered) override;
 
-  int write(uint64_t off, bufferlist& bl, bool buffered, int write_hint = WRITE_LIFE_NOT_SET) override;
-  int aio_write(uint64_t off, bufferlist& bl,
+  int write(uint64_t off, ceph::buffer::list& bl, bool buffered, int write_hint = WRITE_LIFE_NOT_SET) override;
+  int aio_write(uint64_t off, ceph::buffer::list& bl,
 		IOContext *ioc,
 		bool buffered,
 		int write_hint = WRITE_LIFE_NOT_SET) override;

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -21,7 +21,7 @@ class StupidAllocator : public Allocator {
   int64_t block_size;
 
   typedef mempool::bluestore_alloc::pool_allocator<
-    pair<const uint64_t,uint64_t>> allocator_t;
+    std::pair<const uint64_t,uint64_t>> allocator_t;
   typedef btree::btree_map<uint64_t,uint64_t,std::less<uint64_t>,allocator_t> interval_set_map_t;
   typedef interval_set<uint64_t,interval_set_map_t> interval_set_t;
   std::vector<interval_set_t> free;  ///< leading-edge copy

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -7,6 +7,12 @@
 #include "include/uuid.h"
 #include "include/stringify.h"
 
+using std::list;
+using std::ostream;
+
+using ceph::bufferlist;
+using ceph::Formatter;
+
 // bluefs_extent_t
 void bluefs_extent_t::dump(Formatter *f) const
 {
@@ -204,7 +210,7 @@ void bluefs_transaction_t::decode(bufferlist::const_iterator& p)
   DECODE_FINISH(p);
   uint32_t actual = op_bl.crc32c(-1);
   if (actual != crc)
-    throw buffer::malformed_input("bad crc " + stringify(actual)
+    throw ceph::buffer::malformed_input("bad crc " + stringify(actual)
 				  + " expected " + stringify(crc));
 }
 

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -28,12 +28,12 @@ public:
     DENC_FINISH(p);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluefs_extent_t*>&);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluefs_extent_t*>&);
 };
 WRITE_CLASS_DENC(bluefs_extent_t)
 
-ostream& operator<<(ostream& out, const bluefs_extent_t& e);
+std::ostream& operator<<(std::ostream& out, const bluefs_extent_t& e);
 
 struct bluefs_fnode_t {
   uint64_t ino;
@@ -67,11 +67,11 @@ struct bluefs_fnode_t {
   void bound_encode(size_t& p) const {
     _denc_friend(*this, p);
   }
-  void encode(bufferlist::contiguous_appender& p) const {
+  void encode(ceph::buffer::list::contiguous_appender& p) const {
     DENC_DUMP_PRE(bluefs_fnode_t);
     _denc_friend(*this, p);
   }
-  void decode(buffer::ptr::const_iterator& p) {
+  void decode(ceph::buffer::ptr::const_iterator& p) {
     _denc_friend(*this, p);
     recalc_allocated();
   }
@@ -124,13 +124,13 @@ struct bluefs_fnode_t {
   mempool::bluefs::vector<bluefs_extent_t>::iterator seek(
     uint64_t off, uint64_t *x_off);
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluefs_fnode_t*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluefs_fnode_t*>& ls);
 
 };
 WRITE_CLASS_DENC(bluefs_fnode_t)
 
-ostream& operator<<(ostream& out, const bluefs_fnode_t& file);
+std::ostream& operator<<(std::ostream& out, const bluefs_fnode_t& file);
 
 struct bluefs_layout_t {
   unsigned shared_bdev = 0;         ///< which bluefs bdev we are sharing
@@ -147,9 +147,9 @@ struct bluefs_layout_t {
            dedicated_wal == other.dedicated_wal;
   }
 
-  void encode(ceph::bufferlist& bl) const;
-  void decode(ceph::bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(bluefs_layout_t)
 
@@ -171,14 +171,14 @@ struct bluefs_super_t {
     return ~((uint64_t)block_size - 1);
   }
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluefs_super_t*>& ls);
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluefs_super_t*>& ls);
 };
 WRITE_CLASS_ENCODER(bluefs_super_t)
 
-ostream& operator<<(ostream&, const bluefs_super_t& s);
+std::ostream& operator<<(std::ostream&, const bluefs_super_t& s);
 
 
 struct bluefs_transaction_t {
@@ -199,7 +199,7 @@ struct bluefs_transaction_t {
 
   uuid_d uuid;          ///< fs uuid
   uint64_t seq;         ///< sequence number
-  bufferlist op_bl;     ///< encoded transaction ops
+  ceph::buffer::list op_bl;     ///< encoded transaction ops
 
   bluefs_transaction_t() : seq(0) {}
 
@@ -228,24 +228,24 @@ struct bluefs_transaction_t {
     encode(offset, op_bl);
     encode(length, op_bl);
   }
-  void op_dir_create(const string& dir) {
+  void op_dir_create(const std::string& dir) {
     using ceph::encode;
     encode((__u8)OP_DIR_CREATE, op_bl);
     encode(dir, op_bl);
   }
-  void op_dir_remove(const string& dir) {
+  void op_dir_remove(const std::string& dir) {
     using ceph::encode;
     encode((__u8)OP_DIR_REMOVE, op_bl);
     encode(dir, op_bl);
   }
-  void op_dir_link(const string& dir, const string& file, uint64_t ino) {
+  void op_dir_link(const std::string& dir, const std::string& file, uint64_t ino) {
     using ceph::encode;
     encode((__u8)OP_DIR_LINK, op_bl);
     encode(dir, op_bl);
     encode(file, op_bl);
     encode(ino, op_bl);
   }
-  void op_dir_unlink(const string& dir, const string& file) {
+  void op_dir_unlink(const std::string& dir, const std::string& file) {
     using ceph::encode;
     encode((__u8)OP_DIR_UNLINK, op_bl);
     encode(dir, op_bl);
@@ -276,13 +276,13 @@ struct bluefs_transaction_t {
     op_bl.claim_append(from.op_bl);
   }
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluefs_transaction_t*>& ls);
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluefs_transaction_t*>& ls);
 };
 WRITE_CLASS_ENCODER(bluefs_transaction_t)
 
-ostream& operator<<(ostream& out, const bluefs_transaction_t& t);
+std::ostream& operator<<(std::ostream& out, const bluefs_transaction_t& t);
 
 #endif

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -17,6 +17,16 @@
 #include "common/Checksummer.h"
 #include "include/stringify.h"
 
+using std::list;
+using std::map;
+using std::make_pair;
+using std::ostream;
+using std::string;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::Formatter;
+
 // bluestore_bdev_label_t
 
 void bluestore_bdev_label_t::encode(bufferlist& bl) const
@@ -677,7 +687,7 @@ void bluestore_blob_t::generate_test_instances(list<bluestore_blob_t*>& ls)
   ls.back()->allocated_test(bluestore_pextent_t(111, 222));
   ls.push_back(new bluestore_blob_t);
   ls.back()->init_csum(Checksummer::CSUM_XXHASH32, 16, 65536);
-  ls.back()->csum_data = buffer::claim_malloc(4, strdup("abcd"));
+  ls.back()->csum_data = ceph::buffer::claim_malloc(4, strdup("abcd"));
   ls.back()->add_unused(0, 3);
   ls.back()->add_unused(8, 8);
   ls.back()->allocated_test(bluestore_pextent_t(0x40100000, 0x10000));

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -18,6 +18,7 @@
 #include <ostream>
 #include <bitset>
 #include <type_traits>
+#include "include/mempool.h"
 #include "include/types.h"
 #include "include/interval_set.h"
 #include "include/utime.h"
@@ -35,18 +36,18 @@ struct bluestore_bdev_label_t {
   uuid_d osd_uuid;     ///< osd uuid
   uint64_t size = 0;   ///< device size
   utime_t btime;       ///< birth time
-  string description;  ///< device description
+  std::string description;  ///< device description
 
-  map<string,string> meta; ///< {read,write}_meta() content from ObjectStore
+  std::map<std::string,std::string> meta; ///< {read,write}_meta() content from ObjectStore
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluestore_bdev_label_t*>& o);
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluestore_bdev_label_t*>& o);
 };
 WRITE_CLASS_ENCODER(bluestore_bdev_label_t)
 
-ostream& operator<<(ostream& out, const bluestore_bdev_label_t& l);
+std::ostream& operator<<(std::ostream& out, const bluestore_bdev_label_t& l);
 
 /// collection metadata
 struct bluestore_cnode_t {
@@ -59,12 +60,12 @@ struct bluestore_cnode_t {
     denc(v.bits, p);
     DENC_FINISH(p);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluestore_cnode_t*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluestore_cnode_t*>& o);
 };
 WRITE_CLASS_DENC(bluestore_cnode_t)
 
-ostream& operator<<(ostream& out, const bluestore_cnode_t& l);
+std::ostream& operator<<(std::ostream& out, const bluestore_cnode_t& l);
 
 template <typename OFFS_TYPE, typename LEN_TYPE>
 struct bluestore_interval_t
@@ -103,12 +104,12 @@ struct bluestore_pextent_t : public bluestore_interval_t<uint64_t, uint32_t>
     denc_varint_lowz(v.length, p);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluestore_pextent_t*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluestore_pextent_t*>& ls);
 };
 WRITE_CLASS_DENC(bluestore_pextent_t)
 
-ostream& operator<<(ostream& out, const bluestore_pextent_t& o);
+std::ostream& operator<<(std::ostream& out, const bluestore_pextent_t& o);
 
 typedef mempool::bluestore_cache_other::vector<bluestore_pextent_t> PExtentVector;
 
@@ -128,13 +129,13 @@ struct denc_traits<PExtentVector> {
     }
   }
   static void encode(const PExtentVector& v,
-		     bufferlist::contiguous_appender& p) {
+		     ceph::buffer::list::contiguous_appender& p) {
     denc_varint(v.size(), p);
     for (auto& i : v) {
       denc(i, p);
     }
   }
-  static void decode(PExtentVector& v, bufferptr::const_iterator& p) {
+  static void decode(PExtentVector& v, ceph::buffer::ptr::const_iterator& p) {
     unsigned num;
     denc_varint(num, p);
     v.clear();
@@ -145,7 +146,7 @@ struct denc_traits<PExtentVector> {
   }
 };
 
-/// extent_map: a map of reference counted extents
+/// extent_map: a std::map of reference counted extents
 struct bluestore_extent_ref_map_t {
   struct record_t {
     uint32_t length;
@@ -186,7 +187,7 @@ struct bluestore_extent_ref_map_t {
       p += elem_size * ref_map.size();
     }
   }
-  void encode(bufferlist::contiguous_appender& p) const {
+  void encode(ceph::buffer::list::contiguous_appender& p) const {
     const uint32_t n = ref_map.size();
     denc_varint(n, p);
     if (n) {
@@ -201,7 +202,7 @@ struct bluestore_extent_ref_map_t {
       }
     }
   }
-  void decode(bufferptr::const_iterator& p) {
+  void decode(ceph::buffer::ptr::const_iterator& p) {
     uint32_t n;
     denc_varint(n, p);
     if (n) {
@@ -217,13 +218,13 @@ struct bluestore_extent_ref_map_t {
     }
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluestore_extent_ref_map_t*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluestore_extent_ref_map_t*>& o);
 };
 WRITE_CLASS_DENC(bluestore_extent_ref_map_t)
 
 
-ostream& operator<<(ostream& out, const bluestore_extent_ref_map_t& rm);
+std::ostream& operator<<(std::ostream& out, const bluestore_extent_ref_map_t& rm);
 static inline bool operator==(const bluestore_extent_ref_map_t::record_t& l,
 			      const bluestore_extent_ref_map_t::record_t& r) {
   return l.length == r.length && l.refs == r.refs;
@@ -385,7 +386,7 @@ struct bluestore_blob_use_tracker_t {
       }
     }
   }
-  void encode(bufferlist::contiguous_appender& p) const {
+  void encode(ceph::buffer::list::contiguous_appender& p) const {
     denc_varint(au_size, p);
     if (au_size) {
       denc_varint(num_au, p);
@@ -400,7 +401,7 @@ struct bluestore_blob_use_tracker_t {
       }
     }
   }
-  void decode(bufferptr::const_iterator& p) {
+  void decode(ceph::buffer::ptr::const_iterator& p) {
     clear();
     denc_varint(au_size, p);
     if (au_size) {
@@ -416,13 +417,13 @@ struct bluestore_blob_use_tracker_t {
     }
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluestore_blob_use_tracker_t*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluestore_blob_use_tracker_t*>& o);
 private:
   void allocate();
 };
 WRITE_CLASS_DENC(bluestore_blob_use_tracker_t)
-ostream& operator<<(ostream& out, const bluestore_blob_use_tracker_t& rm);
+std::ostream& operator<<(std::ostream& out, const bluestore_blob_use_tracker_t& rm);
 
 /// blob: a piece of data on disk
 struct bluestore_blob_t {
@@ -436,10 +437,10 @@ public:
     LEGACY_FLAG_MUTABLE = 1,  ///< [legacy] blob can be overwritten or split
     FLAG_COMPRESSED = 2,      ///< blob is compressed
     FLAG_CSUM = 4,            ///< blob has checksums
-    FLAG_HAS_UNUSED = 8,      ///< blob has unused map
+    FLAG_HAS_UNUSED = 8,      ///< blob has unused std::map
     FLAG_SHARED = 16,         ///< blob is shared; see external SharedBlob
   };
-  static string get_flags_string(unsigned flags);
+  static std::string get_flags_string(unsigned flags);
 
   uint32_t flags = 0;                 ///< FLAG_*
 
@@ -449,7 +450,7 @@ public:
   uint8_t csum_type = Checksummer::CSUM_NONE;      ///< CSUM_*
   uint8_t csum_chunk_order = 0;       ///< csum block size is 1<<block_order bytes
 
-  bufferptr csum_data;                ///< opaque vector of csum data
+  ceph::buffer::ptr csum_data;                ///< opaque std::vector of csum data
 
   bluestore_blob_t(uint32_t f = 0) : flags(f) {}
 
@@ -474,7 +475,7 @@ public:
     p += sizeof(unused_t);
   }
 
-  void encode(bufferlist::contiguous_appender& p, uint64_t struct_v) const {
+  void encode(ceph::buffer::list::contiguous_appender& p, uint64_t struct_v) const {
     ceph_assert(struct_v == 1 || struct_v == 2);
     denc(extents, p);
     denc_varint(flags, p);
@@ -494,7 +495,7 @@ public:
     }
   }
 
-  void decode(bufferptr::const_iterator& p, uint64_t struct_v) {
+  void decode(ceph::buffer::ptr::const_iterator& p, uint64_t struct_v) {
     ceph_assert(struct_v == 1 || struct_v == 2);
     denc(extents, p);
     denc_varint(flags, p);
@@ -527,8 +528,8 @@ public:
     return !has_csum() || blob_offset % get_csum_chunk_size() == 0;
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluestore_blob_t*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluestore_blob_t*>& ls);
 
   bool has_flag(unsigned f) const {
     return flags & f;
@@ -539,7 +540,7 @@ public:
   void clear_flag(unsigned f) {
     flags &= ~f;
   }
-  string get_flags_string() const {
+  std::string get_flags_string() const {
     return get_flags_string(flags);
   }
 
@@ -705,9 +706,9 @@ public:
   }
   template<class F>
   void map_bl(uint64_t x_off,
-	      bufferlist& bl,
+	      ceph::buffer::list& bl,
 	      F&& f) const {
-    static_assert(std::is_invocable_v<F, uint64_t, bufferlist&>);
+    static_assert(std::is_invocable_v<F, uint64_t, ceph::buffer::list&>);
 
     auto p = extents.begin();
     ceph_assert(p != extents.end());
@@ -716,12 +717,12 @@ public:
       ++p;
       ceph_assert(p != extents.end());
     }
-    bufferlist::iterator it = bl.begin();
+    ceph::buffer::list::iterator it = bl.begin();
     uint64_t x_len = bl.length();
     while (x_len > 0) {
       ceph_assert(p != extents.end());
       uint64_t l = std::min(p->length - x_off, x_len);
-      bufferlist t;
+      ceph::buffer::list t;
       it.copy(l, t);
       f(p->offset + x_off, t);
       x_off = 0;
@@ -780,18 +781,18 @@ public:
     flags |= FLAG_CSUM;
     csum_type = type;
     csum_chunk_order = order;
-    csum_data = buffer::create(get_csum_value_size() * len / get_csum_chunk_size());
+    csum_data = ceph::buffer::create(get_csum_value_size() * len / get_csum_chunk_size());
     csum_data.zero();
     csum_data.reassign_to_mempool(mempool::mempool_bluestore_cache_other);
   }
 
   /// calculate csum for the buffer at the given b_off
-  void calc_csum(uint64_t b_off, const bufferlist& bl);
+  void calc_csum(uint64_t b_off, const ceph::buffer::list& bl);
 
   /// verify csum: return -EOPNOTSUPP for unsupported checksum type;
   /// return -1 and valid(nonnegative) b_bad_off for checksum error;
   /// return 0 if all is well.
-  int verify_csum(uint64_t b_off, const bufferlist& bl, int* b_bad_off,
+  int verify_csum(uint64_t b_off, const ceph::buffer::list& bl, int* b_bad_off,
 		  uint64_t *bad_csum) const;
 
   bool can_prune_tail() const {
@@ -805,9 +806,9 @@ public:
     logical_length -= p.length;
     extents.pop_back();
     if (has_csum()) {
-      bufferptr t;
+      ceph::buffer::ptr t;
       t.swap(csum_data);
-      csum_data = bufferptr(t.c_str(),
+      csum_data = ceph::buffer::ptr(t.c_str(),
 			    get_logical_length() / get_csum_chunk_size() *
 			    get_csum_value_size());
     }
@@ -822,9 +823,9 @@ public:
         new_len - logical_length));
     logical_length = new_len;
     if (has_csum()) {
-      bufferptr t;
+      ceph::buffer::ptr t;
       t.swap(csum_data);
-      csum_data = buffer::create(
+      csum_data = ceph::buffer::create(
 	get_csum_value_size() * logical_length / get_csum_chunk_size());
       csum_data.copy_in(0, t.length(), t.c_str());
       csum_data.zero(t.length(), csum_data.length() - t.length());
@@ -858,7 +859,7 @@ public:
 };
 WRITE_CLASS_DENC_FEATURED(bluestore_blob_t)
 
-ostream& operator<<(ostream& out, const bluestore_blob_t& o);
+std::ostream& operator<<(std::ostream& out, const bluestore_blob_t& o);
 
 
 /// shared blob state
@@ -878,8 +879,8 @@ struct bluestore_shared_blob_t {
   }
 
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluestore_shared_blob_t*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluestore_shared_blob_t*>& ls);
 
   bool empty() const {
     return ref_map.empty();
@@ -887,13 +888,13 @@ struct bluestore_shared_blob_t {
 };
 WRITE_CLASS_DENC(bluestore_shared_blob_t)
 
-ostream& operator<<(ostream& out, const bluestore_shared_blob_t& o);
+std::ostream& operator<<(std::ostream& out, const bluestore_shared_blob_t& o);
 
 /// onode: per-object metadata
 struct bluestore_onode_t {
   uint64_t nid = 0;                    ///< numeric id (locally unique)
   uint64_t size = 0;                   ///< object size
-  map<mempool::bluestore_cache_other::string, bufferptr> attrs;        ///< attrs
+  std::map<mempool::bluestore_cache_other::string, ceph::buffer::ptr> attrs;        ///< attrs
 
   struct shard_info {
     uint32_t offset = 0;  ///< logical offset for start of shard
@@ -902,9 +903,9 @@ struct bluestore_onode_t {
       denc_varint(v.offset, p);
       denc_varint(v.bytes, p);
     }
-    void dump(Formatter *f) const;
+    void dump(ceph::Formatter *f) const;
   };
-  vector<shard_info> extent_map_shards; ///< extent map shards (if any)
+  std::vector<shard_info> extent_map_shards; ///< extent std::map shards (if any)
 
   uint32_t expected_object_size = 0;
   uint32_t expected_write_size = 0;
@@ -918,8 +919,8 @@ struct bluestore_onode_t {
     FLAG_PERPOOL_OMAP = 4, ///< omap data is in per-pool prefix; per-pool keys
   };
 
-  string get_flags_string() const {
-    string s;
+  std::string get_flags_string() const {
+    std::string s;
     if (flags & FLAG_OMAP) {
       s = "omap";
     }
@@ -977,13 +978,13 @@ struct bluestore_onode_t {
     denc_varint(v.alloc_hint_flags, p);
     DENC_FINISH(p);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluestore_onode_t*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluestore_onode_t*>& o);
 };
 WRITE_CLASS_DENC(bluestore_onode_t::shard_info)
 WRITE_CLASS_DENC(bluestore_onode_t)
 
-ostream& operator<<(ostream& out, const bluestore_onode_t::shard_info& si);
+std::ostream& operator<<(std::ostream& out, const bluestore_onode_t::shard_info& si);
 
 /// writeahead-logged op
 struct bluestore_deferred_op_t {
@@ -993,7 +994,7 @@ struct bluestore_deferred_op_t {
   __u8 op = 0;
 
   PExtentVector extents;
-  bufferlist data;
+  ceph::buffer::list data;
 
   DENC(bluestore_deferred_op_t, v, p) {
     DENC_START(1, 1, p);
@@ -1002,8 +1003,8 @@ struct bluestore_deferred_op_t {
     denc(v.data, p);
     DENC_FINISH(p);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluestore_deferred_op_t*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluestore_deferred_op_t*>& o);
 };
 WRITE_CLASS_DENC(bluestore_deferred_op_t)
 
@@ -1011,7 +1012,7 @@ WRITE_CLASS_DENC(bluestore_deferred_op_t)
 /// writeahead-logged transaction
 struct bluestore_deferred_transaction_t {
   uint64_t seq = 0;
-  list<bluestore_deferred_op_t> ops;
+  std::list<bluestore_deferred_op_t> ops;
   interval_set<uint64_t> released;  ///< allocations to release after tx
 
   bluestore_deferred_transaction_t() : seq(0) {}
@@ -1023,8 +1024,8 @@ struct bluestore_deferred_transaction_t {
     denc(v.released, p);
     DENC_FINISH(p);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluestore_deferred_transaction_t*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluestore_deferred_transaction_t*>& o);
 };
 WRITE_CLASS_DENC(bluestore_deferred_transaction_t)
 
@@ -1042,8 +1043,8 @@ struct bluestore_compression_header_t {
     denc(v.length, p);
     DENC_FINISH(p);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<bluestore_compression_header_t*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<bluestore_compression_header_t*>& o);
 };
 WRITE_CLASS_DENC(bluestore_compression_header_t)
 

--- a/src/os/bluestore/ceph_aio.h
+++ b/src/os/bluestore/ceph_aio.h
@@ -34,7 +34,7 @@ struct aio_t {
   boost::container::small_vector<iovec,4> iov;
   uint64_t offset, length;
   long rval;
-  bufferlist bl;  ///< write payload (so that it remains stable for duration)
+  ceph::buffer::list bl;  ///< write payload (so that it remains stable for duration)
 
   boost::intrusive::list_member_hook<> queue_item;
 
@@ -94,7 +94,7 @@ typedef boost::intrusive::list<
     &aio_t::queue_item> > aio_list_t;
 
 struct io_queue_t {
-  typedef list<aio_t>::iterator aio_iter;
+  typedef std::list<aio_t>::iterator aio_iter;
 
   virtual ~io_queue_t() {};
 

--- a/src/os/filestore/BtrfsFileStoreBackend.cc
+++ b/src/os/filestore/BtrfsFileStoreBackend.cc
@@ -48,6 +48,10 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "btrfsfilestorebackend(" << get_basedir_path() << ") "
 
+using std::cerr;
+using std::list;
+using std::string;
+
 #define ALIGN_DOWN(x, by) ((x) - ((x) % (by)))
 #define ALIGNED(x, by) (!((x) % (by)))
 #define ALIGN_UP(x, by) (ALIGNED((x), (by)) ? (x) : (ALIGN_DOWN((x), (by)) + (by)))

--- a/src/os/filestore/BtrfsFileStoreBackend.h
+++ b/src/os/filestore/BtrfsFileStoreBackend.h
@@ -37,11 +37,11 @@ public:
   int detect_features() override;
   bool can_checkpoint() override;
   int create_current() override;
-  int list_checkpoints(list<string>& ls) override;
-  int create_checkpoint(const string& name, uint64_t *cid) override;
+  int list_checkpoints(std::list<std::string>& ls) override;
+  int create_checkpoint(const std::string& name, uint64_t *cid) override;
   int sync_checkpoint(uint64_t cid) override;
-  int rollback_to(const string& name) override;
-  int destroy_checkpoint(const string& name) override;
+  int rollback_to(const std::string& name) override;
+  int destroy_checkpoint(const std::string& name) override;
   int syncfs() override;
   int clone_range(int from, int to, uint64_t srcoff, uint64_t len, uint64_t dstoff) override;
 };

--- a/src/os/filestore/CollectionIndex.h
+++ b/src/os/filestore/CollectionIndex.h
@@ -43,7 +43,7 @@ protected:
   class Path {
   public:
     /// Returned path
-    string full_path;
+    std::string full_path;
     /// Ref to parent Index
     CollectionIndex* parent_ref;
     /// coll_t for parent Index
@@ -51,13 +51,13 @@ protected:
 
     /// Normal Constructor
     Path(
-      string path,                              ///< [in] Path to return.
+      std::string path,                              ///< [in] Path to return.
       CollectionIndex* ref)
       : full_path(path), parent_ref(ref), parent_coll(parent_ref->coll()) {}
 
     /// Debugging Constructor
     Path(
-      string path,                              ///< [in] Path to return.
+      std::string path,                              ///< [in] Path to return.
       const coll_t& coll)                              ///< [in] collection
       : full_path(path), parent_coll(coll) {}
 
@@ -79,7 +79,7 @@ protected:
   /// Type of returned paths
   typedef std::shared_ptr<Path> IndexedPath;
 
-  static IndexedPath get_testing_path(string path, coll_t collection) {
+  static IndexedPath get_testing_path(std::string path, coll_t collection) {
     return std::make_shared<Path>(path, collection);
   }
 
@@ -174,7 +174,7 @@ protected:
     const ghobject_t &start, ///< [in] object at which to start
     const ghobject_t &end,    ///< [in] list only objects < end
     int max_count,          ///< [in] return at most max_count objects
-    vector<ghobject_t> *ls,  ///< [out] Listed objects
+    std::vector<ghobject_t> *ls,  ///< [out] Listed objects
     ghobject_t *next         ///< [out] Next object to list
     ) = 0;
 

--- a/src/os/filestore/DBObjectMap.cc
+++ b/src/os/filestore/DBObjectMap.cc
@@ -23,6 +23,16 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "filestore "
 
+using std::map;
+using std::ostream;
+using std::ostringstream;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::vector;
+
+using ceph::bufferlist;
+
 const string DBObjectMap::USER_PREFIX = "_USER_";
 const string DBObjectMap::XATTR_PREFIX = "_AXATTR_";
 const string DBObjectMap::SYS_PREFIX = "_SYS_";

--- a/src/os/filestore/DBObjectMap.h
+++ b/src/os/filestore/DBObjectMap.h
@@ -47,11 +47,11 @@
  * store three mappings: the key mapping, the complete mapping, and the parent.
  * The complete mapping (COMPLETE_PREFIX space) is key->key.  Each x->y entry in
  * this mapping indicates that the key mapping contains all entries on [x,y).
- * Note, max string is represented by "", so ""->"" indicates that the parent
+ * Note, max std::string is represented by "", so ""->"" indicates that the parent
  * is unnecessary (@see rm_keys).  When looking up a key not contained in the
- * the complete set, we have to check the parent if we don't find it in the
- * key set.  During rm_keys, we copy keys from the parent and update the
- * complete set to reflect the change @see rm_keys.
+ * the complete std::set, we have to check the parent if we don't find it in the
+ * key std::set.  During rm_keys, we copy keys from the parent and update the
+ * complete std::set to reflect the change @see rm_keys.
  */
 class DBObjectMap : public ObjectMap {
 public:
@@ -59,17 +59,17 @@ public:
   KeyValueDB *get_db() override { return db.get(); }
 
   /**
-   * Serializes access to next_seq as well as the in_use set
+   * Serializes access to next_seq as well as the in_use std::set
    */
   ceph::mutex header_lock = ceph::make_mutex("DBOBjectMap");
   ceph::condition_variable header_cond;
   ceph::condition_variable map_header_cond;
 
   /**
-   * Set of headers currently in use
+   * Std::Set of headers currently in use
    */
-  set<uint64_t> in_use;
-  set<ghobject_t> map_header_in_use;
+  std::set<uint64_t> in_use;
+  std::set<ghobject_t> map_header_in_use;
 
   /**
    * Takes the map_header_in_use entry in constructor, releases in
@@ -122,19 +122,19 @@ public:
 
   int set_keys(
     const ghobject_t &oid,
-    const map<string, bufferlist> &set,
+    const std::map<std::string, ceph::buffer::list> &set,
     const SequencerPosition *spos=0
     ) override;
 
   int set_header(
     const ghobject_t &oid,
-    const bufferlist &bl,
+    const ceph::buffer::list &bl,
     const SequencerPosition *spos=0
     ) override;
 
   int get_header(
     const ghobject_t &oid,
-    bufferlist *bl
+    ceph::buffer::list *bl
     ) override;
 
   int clear(
@@ -149,53 +149,53 @@ public:
 
   int rm_keys(
     const ghobject_t &oid,
-    const set<string> &to_clear,
+    const std::set<std::string> &to_clear,
     const SequencerPosition *spos=0
     ) override;
 
   int get(
     const ghobject_t &oid,
-    bufferlist *header,
-    map<string, bufferlist> *out
+    ceph::buffer::list *header,
+    std::map<std::string, ceph::buffer::list> *out
     ) override;
 
   int get_keys(
     const ghobject_t &oid,
-    set<string> *keys
+    std::set<std::string> *keys
     ) override;
 
   int get_values(
     const ghobject_t &oid,
-    const set<string> &keys,
-    map<string, bufferlist> *out
+    const std::set<std::string> &keys,
+    std::map<std::string, ceph::buffer::list> *out
     ) override;
 
   int check_keys(
     const ghobject_t &oid,
-    const set<string> &keys,
-    set<string> *out
+    const std::set<std::string> &keys,
+    std::set<std::string> *out
     ) override;
 
   int get_xattrs(
     const ghobject_t &oid,
-    const set<string> &to_get,
-    map<string, bufferlist> *out
+    const std::set<std::string> &to_get,
+    std::map<std::string, ceph::buffer::list> *out
     ) override;
 
   int get_all_xattrs(
     const ghobject_t &oid,
-    set<string> *out
+    std::set<std::string> *out
     ) override;
 
   int set_xattrs(
     const ghobject_t &oid,
-    const map<string, bufferlist> &to_set,
+    const std::map<std::string, ceph::buffer::list> &to_set,
     const SequencerPosition *spos=0
     ) override;
 
   int remove_xattrs(
     const ghobject_t &oid,
-    const set<string> &to_remove,
+    const std::set<std::string> &to_remove,
     const SequencerPosition *spos=0
     ) override;
 
@@ -209,13 +209,13 @@ public:
     const ghobject_t &from,
     const ghobject_t &to,
     const SequencerPosition *spos=0
-    );
+    ) override;
 
   int legacy_clone(
     const ghobject_t &oid,
     const ghobject_t &target,
     const SequencerPosition *spos=0
-    );
+    ) override;
 
   /// Read initial state from backing store
   int get_state();
@@ -239,28 +239,28 @@ public:
   }
 
   /// Util, get all objects, there must be no other concurrent access
-  int list_objects(vector<ghobject_t> *objs ///< [out] objects
+  int list_objects(std::vector<ghobject_t> *objs ///< [out] objects
     );
 
   struct _Header;
   // Util, get all object headers, there must be no other concurrent access
-  int list_object_headers(vector<_Header> *out ///< [out] headers
+  int list_object_headers(std::vector<_Header> *out ///< [out] headers
     );
 
   ObjectMapIterator get_iterator(const ghobject_t &oid) override;
 
-  static const string USER_PREFIX;
-  static const string XATTR_PREFIX;
-  static const string SYS_PREFIX;
-  static const string COMPLETE_PREFIX;
-  static const string HEADER_KEY;
-  static const string USER_HEADER_KEY;
-  static const string GLOBAL_STATE_KEY;
-  static const string HOBJECT_TO_SEQ;
+  static const std::string USER_PREFIX;
+  static const std::string XATTR_PREFIX;
+  static const std::string SYS_PREFIX;
+  static const std::string COMPLETE_PREFIX;
+  static const std::string HEADER_KEY;
+  static const std::string USER_HEADER_KEY;
+  static const std::string GLOBAL_STATE_KEY;
+  static const std::string HOBJECT_TO_SEQ;
 
   /// Legacy
-  static const string LEAF_PREFIX;
-  static const string REVERSE_LEAF_PREFIX;
+  static const std::string LEAF_PREFIX;
+  static const std::string REVERSE_LEAF_PREFIX;
 
   /// persistent state for store @see generate_header
   struct State {
@@ -272,7 +272,7 @@ public:
     State() : v(0), seq(1), legacy(false) {}
     explicit State(uint64_t seq) : v(0), seq(seq), legacy(false) {}
 
-    void encode(bufferlist &bl) const {
+    void encode(ceph::buffer::list &bl) const {
       ENCODE_START(3, 1, bl);
       encode(v, bl);
       encode(seq, bl);
@@ -280,7 +280,7 @@ public:
       ENCODE_FINISH(bl);
     }
 
-    void decode(bufferlist::const_iterator &bl) {
+    void decode(ceph::buffer::list::const_iterator &bl) {
       DECODE_START(3, bl);
       if (struct_v >= 2)
 	decode(v, bl);
@@ -294,13 +294,13 @@ public:
       DECODE_FINISH(bl);
     }
 
-    void dump(Formatter *f) const {
+    void dump(ceph::Formatter *f) const {
       f->dump_unsigned("v", v);
       f->dump_unsigned("seq", seq);
       f->dump_bool("legacy", legacy);
     }
 
-    static void generate_test_instances(list<State*> &o) {
+    static void generate_test_instances(std::list<State*> &o) {
       o.push_back(new State(0));
       o.push_back(new State(20));
     }
@@ -315,7 +315,7 @@ public:
 
     SequencerPosition spos;
 
-    void encode(bufferlist &bl) const {
+    void encode(ceph::buffer::list &bl) const {
       coll_t unused;
       ENCODE_START(2, 1, bl);
       encode(seq, bl);
@@ -327,7 +327,7 @@ public:
       ENCODE_FINISH(bl);
     }
 
-    void decode(bufferlist::const_iterator &bl) {
+    void decode(ceph::buffer::list::const_iterator &bl) {
       coll_t unused;
       DECODE_START(2, bl);
       decode(seq, bl);
@@ -340,14 +340,14 @@ public:
       DECODE_FINISH(bl);
     }
 
-    void dump(Formatter *f) const {
+    void dump(ceph::Formatter *f) const {
       f->dump_unsigned("seq", seq);
       f->dump_unsigned("parent", parent);
       f->dump_unsigned("num_children", num_children);
       f->dump_stream("oid") << oid;
     }
 
-    static void generate_test_instances(list<_Header*> &o) {
+    static void generate_test_instances(std::list<_Header*> &o) {
       o.push_back(new _Header);
       o.push_back(new _Header);
       o.back()->parent = 20;
@@ -361,25 +361,25 @@ public:
     _Header() : seq(0), parent(0), num_children(1) {}
   };
 
-  /// String munging (public for testing)
-  static string ghobject_key(const ghobject_t &oid);
-  static string ghobject_key_v0(coll_t c, const ghobject_t &oid);
+  /// Std::String munging (public for testing)
+  static std::string ghobject_key(const ghobject_t &oid);
+  static std::string ghobject_key_v0(coll_t c, const ghobject_t &oid);
   static int is_buggy_ghobject_key_v1(CephContext* cct,
-				      const string &in);
+				      const std::string &in);
 private:
   /// Implicit lock on Header->seq
   typedef std::shared_ptr<_Header> Header;
   ceph::mutex cache_lock = ceph::make_mutex("DBObjectMap::CacheLock");
   SimpleLRU<ghobject_t, _Header> caches;
 
-  string map_header_key(const ghobject_t &oid);
-  string header_key(uint64_t seq);
-  string complete_prefix(Header header);
-  string user_prefix(Header header);
-  string sys_prefix(Header header);
-  string xattr_prefix(Header header);
-  string sys_parent_prefix(_Header header);
-  string sys_parent_prefix(Header header) {
+  std::string map_header_key(const ghobject_t &oid);
+  std::string header_key(uint64_t seq);
+  std::string complete_prefix(Header header);
+  std::string user_prefix(Header header);
+  std::string sys_prefix(Header header);
+  std::string xattr_prefix(Header header);
+  std::string sys_parent_prefix(_Header header);
+  std::string sys_parent_prefix(Header header) {
     return sys_parent_prefix(*header);
   }
 
@@ -387,12 +387,12 @@ private:
   public:
     int seek_to_first() override { return 0; }
     int seek_to_last() { return 0; }
-    int upper_bound(const string &after) override { return 0; }
-    int lower_bound(const string &to) override { return 0; }
+    int upper_bound(const std::string &after) override { return 0; }
+    int lower_bound(const std::string &to) override { return 0; }
     bool valid() override { return false; }
     int next() override { ceph_abort(); return 0; }
-    string key() override { ceph_abort(); return ""; }
-    bufferlist value() override { ceph_abort(); return bufferlist(); }
+    std::string key() override { ceph_abort(); return ""; }
+    ceph::buffer::list value() override { ceph_abort(); return ceph::buffer::list(); }
     int status() override { return 0; }
   };
 
@@ -425,12 +425,12 @@ private:
       map(map), hlock(map), header(header), r(0), ready(false), invalid(true) {}
     int seek_to_first() override;
     int seek_to_last();
-    int upper_bound(const string &after) override;
-    int lower_bound(const string &to) override;
+    int upper_bound(const std::string &after) override;
+    int lower_bound(const std::string &to) override;
     bool valid() override;
     int next() override;
-    string key() override;
-    bufferlist value() override;
+    std::string key() override;
+    ceph::buffer::list value() override;
     int status() override;
 
     bool on_parent() {
@@ -441,16 +441,16 @@ private:
     int next_parent();
     
     /// first parent() >= to
-    int lower_bound_parent(const string &to);
+    int lower_bound_parent(const std::string &to);
 
     /**
      * Tests whether to_test is in complete region
      *
      * postcondition: complete_iter will be max s.t. complete_iter->value > to_test
      */
-    int in_complete_region(const string &to_test, ///< [in] key to test
-			   string *begin,         ///< [out] beginning of region
-			   string *end            ///< [out] end of region
+    int in_complete_region(const std::string &to_test, ///< [in] key to test
+			   std::string *begin,         ///< [out] beginning of region
+			   std::string *end            ///< [out] end of region
       ); ///< @returns true if to_test is in the complete region, else false
 
   private:
@@ -469,7 +469,7 @@ private:
   /// Removes node corresponding to header
   void clear_header(Header header, KeyValueDB::Transaction t);
 
-  /// Set node containing input to new contents
+  /// Std::Set node containing input to new contents
   void set_header(Header input, KeyValueDB::Transaction t);
 
   /// Remove leaf node corresponding to oid in c
@@ -479,13 +479,13 @@ private:
     Header header,
     KeyValueDB::Transaction t);
 
-  /// Set leaf node for c and oid to the value of header
+  /// Std::Set leaf node for c and oid to the value of header
   void set_map_header(
     const MapHeaderLock &l,
     const ghobject_t &oid, _Header header,
     KeyValueDB::Transaction t);
 
-  /// Set leaf node for c and oid to the value of header
+  /// Std::Set leaf node for c and oid to the value of header
   bool check_spos(const ghobject_t &oid,
 		  Header header,
 		  const SequencerPosition *spos);
@@ -523,13 +523,13 @@ private:
 
 
   /// Helpers
-  int _get_header(Header header, bufferlist *bl);
+  int _get_header(Header header, ceph::buffer::list *bl);
 
   /// Scan keys in header into out_keys and out_values (if nonnull)
   int scan(Header header,
-	   const set<string> &in_keys,
-	   set<string> *out_keys,
-	   map<string, bufferlist> *out_values);
+	   const std::set<std::string> &in_keys,
+	   std::set<std::string> *out_keys,
+	   std::map<std::string, ceph::buffer::list> *out_values);
 
   /// Remove header and all related prefixes
   int _clear(Header header,
@@ -537,11 +537,11 @@ private:
 
   /* Scan complete region bumping *begin to the beginning of any
    * containing region and adding all complete region keys between
-   * the updated begin and end to the complete_keys_to_remove set */
+   * the updated begin and end to the complete_keys_to_remove std::set */
   int merge_new_complete(DBObjectMapIterator &iter,
-			 string *begin,
-			 const string &end,
-			 set<string> *complete_keys_to_remove);
+			 std::string *begin,
+			 const std::string &end,
+			 std::set<std::string> *complete_keys_to_remove);
 
   /// Writes out State (mainly next_seq)
   int write_state(KeyValueDB::Transaction _t =
@@ -552,7 +552,7 @@ private:
 		     KeyValueDB::Transaction t);
 
   /// Sets header @see set_header
-  void _set_header(Header header, const bufferlist &bl,
+  void _set_header(Header header, const ceph::buffer::list &bl,
 		   KeyValueDB::Transaction t);
 
   /**
@@ -579,6 +579,6 @@ private:
 WRITE_CLASS_ENCODER(DBObjectMap::_Header)
 WRITE_CLASS_ENCODER(DBObjectMap::State)
 
-ostream& operator<<(ostream& out, const DBObjectMap::_Header& h);
+std::ostream& operator<<(std::ostream& out, const DBObjectMap::_Header& h);
 
 #endif

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -46,6 +46,21 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "journal "
 
+using std::list;
+using std::map;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::Formatter;
+using ceph::JSONFormatter;
+
 const static int64_t ONE_MEG(1 << 20);
 const static int CEPH_DIRECTIO_ALIGNMENT(4096);
 
@@ -281,7 +296,7 @@ int FileJournal::create()
   void *buf = 0;
   int64_t needed_space;
   int ret;
-  buffer::ptr bp;
+  ceph::buffer::ptr bp;
   dout(2) << "create " << fn << " fsid " << fsid << dendl;
 
   ret = _open(true, true);
@@ -673,7 +688,7 @@ int FileJournal::read_header(header_t *hdr) const
   dout(10) << "read_header" << dendl;
   bufferlist bl;
 
-  buffer::ptr bp = buffer::create_small_page_aligned(block_size);
+  ceph::buffer::ptr bp = ceph::buffer::create_small_page_aligned(block_size);
   char* bpdata = bp.c_str();
   int r = ::pread(fd, bpdata, bp.length(), 0);
 
@@ -697,7 +712,7 @@ int FileJournal::read_header(header_t *hdr) const
     auto p = bl.cbegin();
     decode(*hdr, p);
   }
-  catch (buffer::error& e) {
+  catch (ceph::buffer::error& e) {
     derr << "read_header error decoding journal header" << dendl;
     return -EINVAL;
   }
@@ -728,7 +743,7 @@ bufferptr FileJournal::prepare_header()
     header.committed_up_to = journaled_seq;
   }
   encode(header, bl);
-  bufferptr bp = buffer::create_small_page_aligned(get_top());
+  bufferptr bp = ceph::buffer::create_small_page_aligned(get_top());
   // don't use bp.zero() here, because it also invalidates
   // crc cache (which is not yet populated anyway)
   char* data = bp.c_str();
@@ -1019,7 +1034,7 @@ void FileJournal::do_write(bufferlist& bl)
   if (bl.length() == 0 && !must_write_header)
     return;
 
-  buffer::ptr hbp;
+  ceph::buffer::ptr hbp;
   if (cct->_conf->journal_write_header_frequency &&
       (((++journaled_since_start) %
 	cct->_conf->journal_write_header_frequency) == 0)) {
@@ -1292,7 +1307,7 @@ void FileJournal::do_aio_write(bufferlist& bl)
   if (bl.length() == 0 && !must_write_header)
     return;
 
-  buffer::ptr hbp;
+  ceph::buffer::ptr hbp;
   if (must_write_header) {
     must_write_header = false;
     hbp = prepare_header();
@@ -1576,12 +1591,12 @@ int FileJournal::prepare_entry(vector<ObjectStore::Transaction>& tls, bufferlist
   // header
   ebl.append((const char*)&h, sizeof(h));
   if (h.pre_pad) {
-    ebl.push_back(buffer::create_static(h.pre_pad, zero_buf));
+    ebl.push_back(ceph::buffer::create_static(h.pre_pad, zero_buf));
   }
   // payload
   ebl.claim_append(bl);
   if (h.post_pad) {
-    ebl.push_back(buffer::create_static(h.post_pad, zero_buf));
+    ebl.push_back(ceph::buffer::create_static(h.post_pad, zero_buf));
   }
   // footer
   ebl.append((const char*)&h, sizeof(h));
@@ -1905,7 +1920,7 @@ void FileJournal::wrap_read_bl(
     int64_t actual = ::lseek64(fd, pos, SEEK_SET);
     ceph_assert(actual == pos);
 
-    bufferptr bp = buffer::create(len);
+    bufferptr bp = ceph::buffer::create(len);
     int r = safe_read_exact(fd, bp.c_str(), len);
     if (r) {
       derr << "FileJournal::wrap_read_bl: safe_read_exact " << pos << "~" << len << " returned "

--- a/src/os/filestore/FileJournal.h
+++ b/src/os/filestore/FileJournal.h
@@ -58,11 +58,11 @@ public:
   };
   struct write_item {
     uint64_t seq;
-    bufferlist bl;
+    ceph::buffer::list bl;
     uint32_t orig_len;
     TrackedOpRef tracked_op;
     ZTracer::Trace trace;
-    write_item(uint64_t s, bufferlist& b, int ol, TrackedOpRef opref) :
+    write_item(uint64_t s, ceph::buffer::list& b, int ol, TrackedOpRef opref) :
       seq(s), orig_len(ol), tracked_op(opref) {
       bl.claim(b);
     }
@@ -76,25 +76,25 @@ public:
 
   ceph::mutex writeq_lock = ceph::make_mutex("FileJournal::writeq_lock");
   ceph::condition_variable writeq_cond;
-  list<write_item> writeq;
+  std::list<write_item> writeq;
   bool writeq_empty();
   write_item &peek_write();
   void pop_write();
-  void batch_pop_write(list<write_item> &items);
-  void batch_unpop_write(list<write_item> &items);
+  void batch_pop_write(std::list<write_item> &items);
+  void batch_unpop_write(std::list<write_item> &items);
 
   ceph::mutex completions_lock =
     ceph::make_mutex("FileJournal::completions_lock");
-  list<completion_item> completions;
+  std::list<completion_item> completions;
   bool completions_empty() {
     std::lock_guard l{completions_lock};
     return completions.empty();
   }
-  void batch_pop_completions(list<completion_item> &items) {
+  void batch_pop_completions(std::list<completion_item> &items) {
     std::lock_guard l{completions_lock};
     completions.swap(items);
   }
-  void batch_unpop_completions(list<completion_item> &items) {
+  void batch_unpop_completions(std::list<completion_item> &items) {
     std::lock_guard l{completions_lock};
     completions.splice(completions.begin(), items);
   }
@@ -109,9 +109,9 @@ public:
     completions.pop_front();
   }
 
-  int prepare_entry(vector<ObjectStore::Transaction>& tls, bufferlist* tbl) override;
+  int prepare_entry(std::vector<ObjectStore::Transaction>& tls, ceph::buffer::list* tbl) override;
 
-  void submit_entry(uint64_t seq, bufferlist& bl, uint32_t orig_len,
+  void submit_entry(uint64_t seq, ceph::buffer::list& bl, uint32_t orig_len,
 		    Context *oncommit,
 		    TrackedOpRef osd_op = TrackedOpRef()) override;
   /// End protected by finisher_lock
@@ -161,11 +161,11 @@ public:
       return *(uint64_t*)fsid.bytes();
     }
 
-    void encode(bufferlist& bl) const {
+    void encode(ceph::buffer::list& bl) const {
       using ceph::encode;
       __u32 v = 4;
       encode(v, bl);
-      bufferlist em;
+      ceph::buffer::list em;
       {
 	encode(flags, em);
 	encode(fsid, em);
@@ -178,7 +178,7 @@ public:
       }
       encode(em, bl);
     }
-    void decode(bufferlist::const_iterator& bl) {
+    void decode(ceph::buffer::list::const_iterator& bl) {
       using ceph::decode;
       __u32 v;
       decode(v, bl);
@@ -198,7 +198,7 @@ public:
 	start_seq = 0;
 	return;
       }
-      bufferlist em;
+      ceph::buffer::list em;
       decode(em, bl);
       auto t = em.cbegin();
       decode(flags, t);
@@ -241,7 +241,7 @@ public:
   bool journalq_empty() { return journalq.empty(); }
 
 private:
-  string fn;
+  std::string fn;
 
   char *zero_buf;
   off64_t max_size;
@@ -257,13 +257,13 @@ private:
   /// Protected by aio_lock
   struct aio_info {
     struct iocb iocb {};
-    bufferlist bl;
+    ceph::buffer::list bl;
     struct iovec *iov;
     bool done;
     uint64_t off, len;    ///< these are for debug only
     uint64_t seq;         ///< seq number to complete on aio completion, if non-zero
 
-    aio_info(bufferlist& b, uint64_t o, uint64_t s)
+    aio_info(ceph::buffer::list& b, uint64_t o, uint64_t s)
       : iov(NULL), done(false), off(o), len(b.length()), seq(s) {
       bl.claim(b);
     }
@@ -275,7 +275,7 @@ private:
   ceph::condition_variable aio_cond;
   ceph::condition_variable write_finish_cond;
   io_context_t aio_ctx = 0;
-  list<aio_info> aio_queue;
+  std::list<aio_info> aio_queue;
   int aio_num = 0, aio_bytes = 0;
   uint64_t aio_write_queue_ops = 0;
   uint64_t aio_write_queue_bytes = 0;
@@ -285,7 +285,7 @@ private:
   uint64_t last_committed_seq;
   uint64_t journaled_since_start;
 
-  string devname;
+  std::string devname;
 
   /*
    * full states cycle at the beginnging of each commit epoch, when commit_start()
@@ -304,7 +304,7 @@ private:
   int fd;
 
   // in journal
-  deque<pair<uint64_t, off64_t> > journalq;  // track seq offsets, so we can trim later.
+  std::deque<std::pair<uint64_t, off64_t> > journalq;  // track seq offsets, so we can trim later.
   uint64_t writing_seq;
 
 
@@ -317,7 +317,7 @@ private:
     for (const char **i = get_tracked_conf_keys();
 	 *i;
 	 ++i) {
-      if (changed.count(string(*i))) {
+      if (changed.count(std::string(*i))) {
 	set_throttle_params();
 	return;
       }
@@ -338,10 +338,10 @@ private:
   int _open_block_device();
   void _close(int fd) const;
   int _open_file(int64_t oldsize, blksize_t blksize, bool create);
-  int _dump(ostream& out, bool simple);
+  int _dump(std::ostream& out, bool simple);
   void print_header(const header_t &hdr) const;
   int read_header(header_t *hdr) const;
-  bufferptr prepare_header();
+  ceph::bufferptr prepare_header();
   void start_writer();
   void stop_writer();
   void write_thread_entry();
@@ -349,25 +349,25 @@ private:
   void queue_completions_thru(uint64_t seq);
 
   int check_for_full(uint64_t seq, off64_t pos, off64_t size);
-  int prepare_multi_write(bufferlist& bl, uint64_t& orig_ops, uint64_t& orig_bytee);
-  int prepare_single_write(write_item &next_write, bufferlist& bl, off64_t& queue_pos,
+  int prepare_multi_write(ceph::buffer::list& bl, uint64_t& orig_ops, uint64_t& orig_bytee);
+  int prepare_single_write(write_item &next_write, ceph::buffer::list& bl, off64_t& queue_pos,
     uint64_t& orig_ops, uint64_t& orig_bytes);
-  void do_write(bufferlist& bl);
+  void do_write(ceph::buffer::list& bl);
 
   void write_finish_thread_entry();
   void check_aio_completion();
-  void do_aio_write(bufferlist& bl);
-  int write_aio_bl(off64_t& pos, bufferlist& bl, uint64_t seq);
+  void do_aio_write(ceph::buffer::list& bl);
+  int write_aio_bl(off64_t& pos, ceph::buffer::list& bl, uint64_t seq);
 
 
-  void check_align(off64_t pos, bufferlist& bl);
-  int write_bl(off64_t& pos, bufferlist& bl);
+  void check_align(off64_t pos, ceph::buffer::list& bl);
+  int write_bl(off64_t& pos, ceph::buffer::list& bl);
 
   /// read len from journal starting at in_pos and wrapping up to len
   void wrap_read_bl(
     off64_t in_pos,   ///< [in] start position
     int64_t len,      ///< [in] length to read
-    bufferlist* bl,   ///< [out] result
+    ceph::buffer::list* bl,   ///< [out] result
     off64_t *out_pos  ///< [out] next position to read, will be wrapped
     ) const;
 
@@ -449,14 +449,14 @@ private:
   void close() override;
   int peek_fsid(uuid_d& fsid);
 
-  int dump(ostream& out) override;
-  int simple_dump(ostream& out);
-  int _fdump(Formatter &f, bool simple);
+  int dump(std::ostream& out) override;
+  int simple_dump(std::ostream& out);
+  int _fdump(ceph::Formatter &f, bool simple);
 
   void flush() override;
 
-  void get_devices(set<string> *ls) override;
-  void collect_metadata(map<string,string> *pm) override;
+  void get_devices(std::set<std::string> *ls) override;
+  void collect_metadata(std::map<std::string,std::string> *pm) override;
 
   void reserve_throttle_and_backoff(uint64_t count) override;
 
@@ -476,7 +476,7 @@ private:
 
   void set_wait_on_full(bool b) { wait_on_full = b; }
 
-  off64_t get_journal_size_estimate();
+  off64_t get_journal_size_estimate() override;
 
   // reads
 
@@ -504,20 +504,20 @@ private:
   read_entry_result do_read_entry(
     off64_t pos,          ///< [in] position to read
     off64_t *next_pos,    ///< [out] next position to read
-    bufferlist* bl,       ///< [out] payload for successful read
+    ceph::buffer::list* bl,       ///< [out] payload for successful read
     uint64_t *seq,        ///< [out] seq of successful read
-    ostream *ss,          ///< [out] error output
+    std::ostream *ss,          ///< [out] error output
     entry_header_t *h = 0 ///< [out] header
     ) const; ///< @return result code
 
   bool read_entry(
-    bufferlist &bl,
+    ceph::buffer::list &bl,
     uint64_t &last_seq,
     bool *corrupt
     );
 
   bool read_entry(
-    bufferlist &bl,
+    ceph::buffer::list &bl,
     uint64_t &last_seq) override {
     return read_entry(bl, last_seq, 0);
   }

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -73,7 +73,6 @@
 #include "kv/KeyValueDB.h"
 
 #include "common/ceph_crypto.h"
-using ceph::crypto::SHA1;
 
 #include "include/ceph_assert.h"
 
@@ -108,6 +107,26 @@ using ceph::crypto::SHA1;
 #define XATTR_NO_SPILL_OUT "0"
 #define XATTR_SPILL_OUT "1"
 #define __FUNC__ __func__ << "(" << __LINE__ << ")"
+
+using std::cerr;
+using std::list;
+using std::make_pair;
+using std::map;
+using std::ostream;
+using std::ostringstream;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::vector;
+
+using ceph::crypto::SHA1;
+using ceph::BackTrace;
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::decode;
+using ceph::encode;
+using ceph::Formatter;
+using ceph::JSONFormatter;
 
 //Initial features in new superblock.
 static CompatSet get_fs_initial_compat_set() {
@@ -650,11 +669,11 @@ FileStore::FileStore(CephContext* cct, const std::string &base,
 
 FileStore::~FileStore()
 {
-  for (vector<Finisher*>::iterator it = ondisk_finishers.begin(); it != ondisk_finishers.end(); ++it) {
+  for (auto it = ondisk_finishers.begin(); it != ondisk_finishers.end(); ++it) {
     delete *it;
     *it = nullptr;
   }
-  for (vector<Finisher*>::iterator it = apply_finishers.begin(); it != apply_finishers.end(); ++it) {
+  for (auto it = apply_finishers.begin(); it != apply_finishers.end(); ++it) {
     delete *it;
     *it = nullptr;
   }
@@ -4435,12 +4454,12 @@ int FileStore::_fgetattr(int fd, const char *name, bufferptr& bp)
   char val[CHAIN_XATTR_MAX_BLOCK_LEN];
   int l = chain_fgetxattr(fd, name, val, sizeof(val));
   if (l >= 0) {
-    bp = buffer::create(l);
+    bp = ceph::buffer::create(l);
     memcpy(bp.c_str(), val, l);
   } else if (l == -ERANGE) {
     l = chain_fgetxattr(fd, name, 0, 0);
     if (l > 0) {
-      bp = buffer::create(l);
+      bp = ceph::buffer::create(l);
       l = chain_fgetxattr(fd, name, bp.c_str(), l);
     }
   }

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -94,18 +94,18 @@ enum {
 class FSSuperblock {
 public:
   CompatSet compat_features;
-  string omap_backend;
+  std::string omap_backend;
 
   FSSuperblock() { }
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &bl);
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<FSSuperblock*>& o);
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &bl);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<FSSuperblock*>& o);
 };
 WRITE_CLASS_ENCODER(FSSuperblock)
 
-inline ostream& operator<<(ostream& out, const FSSuperblock& sb)
+inline std::ostream& operator<<(std::ostream& out, const FSSuperblock& sb)
 {
   return out << "sb(" << sb.compat_features << "): "
              << sb.omap_backend;
@@ -120,7 +120,7 @@ public:
     return target_version;
   }
 
-  static int get_block_device_fsid(CephContext* cct, const string& path,
+  static int get_block_device_fsid(CephContext* cct, const std::string& path,
 				   uuid_d *fsid);
   struct FSPerfTracker {
     PerfCounters::avg_tracker<uint64_t> os_commit_latency_ns;
@@ -144,8 +144,8 @@ public:
   }
 
 private:
-  string internal_name;         ///< internal name, used to name the perfcounter instance
-  string basedir, journalpath;
+  std::string internal_name;         ///< internal name, used to name the perfcounter instance
+  std::string basedir, journalpath;
   osflagbits_t generic_flags;
   std::string current_fn;
   std::string current_op_seq_fn;
@@ -160,10 +160,10 @@ private:
 
   void create_backend(unsigned long f_type);
 
-  string devname;
+  std::string devname;
 
   int vdo_fd = -1;
-  string vdo_name;
+  std::string vdo_name;
 
   deque<uint64_t> snaps;
 
@@ -201,7 +201,7 @@ private:
   ceph::mutex sync_entry_timeo_lock = ceph::make_mutex("FileStore::sync_entry_timeo_lock");
   SafeTimer timer;
 
-  list<Context*> sync_waiters;
+  std::list<Context*> sync_waiters;
   bool stop;
   void sync_entry();
   struct SyncThread : public Thread {
@@ -217,7 +217,7 @@ private:
   struct Op {
     utime_t start;
     uint64_t op;
-    vector<Transaction> tls;
+    std::vector<Transaction> tls;
     Context *onreadable, *onreadable_sync;
     uint64_t ops, bytes;
     TrackedOpRef osd_op;
@@ -229,13 +229,13 @@ private:
     // to protect q, for benefit of flush (peek/dequeue also protected by lock)
     ceph::mutex qlock =
       ceph::make_mutex("FileStore::OpSequencer::qlock", false);
-    list<Op*> q;
-    list<uint64_t> jq;
-    list<pair<uint64_t, Context*> > flush_commit_waiters;
+    std::list<Op*> q;
+    std::list<uint64_t> jq;
+    std::list<std::pair<uint64_t, Context*> > flush_commit_waiters;
     ceph::condition_variable cond;
-    string osr_name_str;
+    std::string osr_name_str;
     /// hash of pointers to ghobject_t's for in-flight writes
-    unordered_multimap<uint32_t,const ghobject_t*> applying;
+    std::unordered_multimap<uint32_t,const ghobject_t*> applying;
   public:
     // for apply mutual exclusion
     ceph::mutex apply_lock =
@@ -277,13 +277,12 @@ private:
       return false;
     } /// @returns true if both queues are empty
 
-    void _wake_flush_waiters(list<Context*> *to_queue) {
+    void _wake_flush_waiters(std::list<Context*> *to_queue) {
       uint64_t seq;
       if (_get_min_uncompleted(&seq))
 	seq = -1;
 
-      for (list<pair<uint64_t, Context*> >::iterator i =
-	     flush_commit_waiters.begin();
+      for (auto i = flush_commit_waiters.begin();
 	   i != flush_commit_waiters.end() && i->first < seq;
 	   flush_commit_waiters.erase(i++)) {
 	to_queue->push_back(i->second);
@@ -295,7 +294,7 @@ private:
       jq.push_back(o->op);
       _register_apply(o);
     }
-    void dequeue_journal(list<Context*> *to_queue) {
+    void dequeue_journal(std::list<Context*> *to_queue) {
       std::lock_guard l{qlock};
       jq.pop_front();
       cond.notify_all();
@@ -316,7 +315,7 @@ private:
       return q.front();
     }
 
-    Op *dequeue(list<Context*> *to_queue) {
+    Op *dequeue(std::list<Context*> *to_queue) {
       ceph_assert(to_queue);
       ceph_assert(ceph_mutex_is_locked(apply_lock));
       std::lock_guard l{qlock};
@@ -354,7 +353,7 @@ private:
       if (_get_max_uncompleted(&seq)) {
 	return true;
       } else {
-	flush_commit_waiters.push_back(make_pair(seq, c));
+	flush_commit_waiters.push_back(std::make_pair(seq, c));
 	return false;
       }
     }
@@ -374,9 +373,9 @@ private:
   typedef boost::intrusive_ptr<OpSequencer> OpSequencerRef;
 
   ceph::mutex coll_lock = ceph::make_mutex("FileStore::coll_lock");
-  map<coll_t,OpSequencerRef> coll_map;
+  std::map<coll_t,OpSequencerRef> coll_map;
 
-  friend ostream& operator<<(ostream& out, const OpSequencer& s);
+  friend std::ostream& operator<<(std::ostream& out, const OpSequencer& s);
 
   FDCache fdcache;
   WBThrottle wbthrottle;
@@ -387,8 +386,8 @@ private:
   BackoffThrottle throttle_ops, throttle_bytes;
   const int m_ondisk_finisher_num;
   const int m_apply_finisher_num;
-  vector<Finisher*> ondisk_finishers;
-  vector<Finisher*> apply_finishers;
+  std::vector<Finisher*> ondisk_finishers;
+  std::vector<Finisher*> apply_finishers;
 
   ThreadPool op_tp;
   struct OpWQ : public ThreadPool::WorkQueue<OpSequencer> {
@@ -426,7 +425,7 @@ private:
 
   void _do_op(OpSequencer *o, ThreadPool::TPHandle &handle);
   void _finish_op(OpSequencer *o);
-  Op *build_op(vector<Transaction>& tls,
+  Op *build_op(std::vector<Transaction>& tls,
 	       Context *onreadable, Context *onreadable_sync,
 	       TrackedOpRef osd_op);
   void queue_op(OpSequencer *osr, Op *o);
@@ -464,7 +463,7 @@ public:
     const char *internal_name = "filestore", bool update_to=false);
   ~FileStore() override;
 
-  string get_type() override {
+  std::string get_type() override {
     return "filestore";
   }
 
@@ -503,13 +502,13 @@ public:
   bool is_rotational() override;
   bool is_journal_rotational() override;
 
-  void dump_perf_counters(Formatter *f) override {
+  void dump_perf_counters(ceph::Formatter *f) override {
     f->open_object_section("perf_counters");
     logger->dump_formatted(f, false);
     f->close_section();
   }
 
-  int flush_cache(ostream *os = NULL) override;
+  int flush_cache(std::ostream *os = NULL) override;
   int write_version_stamp();
   int version_stamp_is_valid(uint32_t *version);
   int update_version_stamp();
@@ -519,8 +518,8 @@ public:
     return true;    // i support legacy sort order
   }
 
-  void collect_metadata(map<string,string> *pm) override;
-  int get_devices(set<string> *ls) override;
+  void collect_metadata(std::map<std::string,std::string> *pm) override;
+  int get_devices(std::set<std::string> *ls) override;
 
   int statfs(struct store_statfs_t *buf,
              osd_alert_list_t* alerts = nullptr) override;
@@ -528,10 +527,10 @@ public:
 		  bool *per_pool_omap) override;
 
   int _do_transactions(
-    vector<Transaction> &tls, uint64_t op_seq,
+    std::vector<Transaction> &tls, uint64_t op_seq,
     ThreadPool::TPHandle *handle,
     const char *osr_name);
-  int do_transactions(vector<Transaction> &tls, uint64_t op_seq) override {
+  int do_transactions(std::vector<Transaction> &tls, uint64_t op_seq) override {
     return _do_transactions(tls, op_seq, nullptr, "replay");
   }
   void _do_transaction(
@@ -544,7 +543,7 @@ public:
 				   ContextQueue *commit_queue) override {
   }
 
-  int queue_transactions(CollectionHandle& ch, vector<Transaction>& tls,
+  int queue_transactions(CollectionHandle& ch, std::vector<Transaction>& tls,
 			 TrackedOpRef op = TrackedOpRef(),
 			 ThreadPool::TPHandle *handle = nullptr) override;
 
@@ -616,19 +615,19 @@ public:
     const ghobject_t& oid,
     uint64_t offset,
     size_t len,
-    bufferlist& bl,
+    ceph::buffer::list& bl,
     uint32_t op_flags = 0) override;
   int _do_fiemap(int fd, uint64_t offset, size_t len,
-                 map<uint64_t, uint64_t> *m);
+                 std::map<uint64_t, uint64_t> *m);
   int _do_seek_hole_data(int fd, uint64_t offset, size_t len,
-                         map<uint64_t, uint64_t> *m);
+                         std::map<uint64_t, uint64_t> *m);
   using ObjectStore::fiemap;
-  int fiemap(CollectionHandle& c, const ghobject_t& oid, uint64_t offset, size_t len, bufferlist& bl) override;
-  int fiemap(CollectionHandle& c, const ghobject_t& oid, uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap) override;
+  int fiemap(CollectionHandle& c, const ghobject_t& oid, uint64_t offset, size_t len, ceph::buffer::list& bl) override;
+  int fiemap(CollectionHandle& c, const ghobject_t& oid, uint64_t offset, size_t len, std::map<uint64_t, uint64_t>& destmap) override;
 
   int _touch(const coll_t& cid, const ghobject_t& oid);
   int _write(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len,
-	      const bufferlist& bl, uint32_t fadvise_flags = 0);
+	      const ceph::buffer::list& bl, uint32_t fadvise_flags = 0);
   int _zero(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len);
   int _truncate(const coll_t& cid, const ghobject_t& oid, uint64_t size);
   int _clone(const coll_t& cid, const ghobject_t& oldoid, const ghobject_t& newoid,
@@ -641,9 +640,9 @@ public:
   int _do_copy_range(int from, int to, uint64_t srcoff, uint64_t len, uint64_t dstoff, bool skip_sloppycrc=false);
   int _remove(const coll_t& cid, const ghobject_t& oid, const SequencerPosition &spos);
 
-  int _fgetattr(int fd, const char *name, bufferptr& bp);
-  int _fgetattrs(int fd, map<string,bufferptr>& aset);
-  int _fsetattrs(int fd, map<string, bufferptr> &aset);
+  int _fgetattr(int fd, const char *name, ceph::bufferptr& bp);
+  int _fgetattrs(int fd, std::map<std::string, ceph::bufferptr>& aset);
+  int _fsetattrs(int fd, std::map<std::string, ceph::bufferptr> &aset);
 
   void do_force_sync();
   void start_sync(Context *onsafe);
@@ -653,7 +652,7 @@ public:
   void sync_and_flush();
 
   int flush_journal() override;
-  int dump_journal(ostream& out) override;
+  int dump_journal(std::ostream& out) override;
 
   void set_fsid(uuid_d u) override {
     fsid = u;
@@ -664,8 +663,8 @@ public:
 
   // DEBUG read error injection, an object is removed from both on delete()
   ceph::mutex read_error_lock = ceph::make_mutex("FileStore::read_error_lock");
-  set<ghobject_t> data_error_set; // read() will return -EIO
-  set<ghobject_t> mdata_error_set; // getattr(),stat() will return -EIO
+  std::set<ghobject_t> data_error_set; // read() will return -EIO
+  std::set<ghobject_t> mdata_error_set; // getattr(),stat() will return -EIO
   void inject_data_error(const ghobject_t &oid) override;
   void inject_mdata_error(const ghobject_t &oid) override;
 
@@ -682,15 +681,15 @@ public:
   bool debug_data_eio(const ghobject_t &oid);
   bool debug_mdata_eio(const ghobject_t &oid);
 
-  int snapshot(const string& name) override;
+  int snapshot(const std::string& name) override;
 
   // attrs
   using ObjectStore::getattr;
   using ObjectStore::getattrs;
-  int getattr(CollectionHandle& c, const ghobject_t& oid, const char *name, bufferptr &bp) override;
-  int getattrs(CollectionHandle& c, const ghobject_t& oid, map<string,bufferptr>& aset) override;
+  int getattr(CollectionHandle& c, const ghobject_t& oid, const char *name, ceph::bufferptr &bp) override;
+  int getattrs(CollectionHandle& c, const ghobject_t& oid, std::map<std::string,ceph::bufferptr>& aset) override;
 
-  int _setattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& aset,
+  int _setattrs(const coll_t& cid, const ghobject_t& oid, std::map<std::string,ceph::bufferptr>& aset,
 		const SequencerPosition &spos);
   int _rmattr(const coll_t& cid, const ghobject_t& oid, const char *name,
 	      const SequencerPosition &spos);
@@ -707,15 +706,15 @@ public:
   int collection_bits(CollectionHandle& c) override;
   int collection_list(CollectionHandle& c,
 		      const ghobject_t& start, const ghobject_t& end, int max,
-		      vector<ghobject_t> *ls, ghobject_t *next) override {
+		      std::vector<ghobject_t> *ls, ghobject_t *next) override {
     c->flush();
     return collection_list(c->cid, start, end, max, ls, next);
   }
   int collection_list(const coll_t& cid,
 		      const ghobject_t& start, const ghobject_t& end, int max,
-		      vector<ghobject_t> *ls, ghobject_t *next);
-  int list_collections(vector<coll_t>& ls) override;
-  int list_collections(vector<coll_t>& ls, bool include_temp);
+		      std::vector<ghobject_t> *ls, ghobject_t *next);
+  int list_collections(std::vector<coll_t>& ls) override;
+  int list_collections(std::vector<coll_t>& ls, bool include_temp);
   int collection_stat(const coll_t& c, struct stat *st);
   bool collection_exists(const coll_t& c) override;
   int collection_empty(CollectionHandle& c, bool *empty) override {
@@ -726,22 +725,22 @@ public:
 
   // omap (see ObjectStore.h for documentation)
   using ObjectStore::omap_get;
-  int omap_get(CollectionHandle& c, const ghobject_t &oid, bufferlist *header,
-	       map<string, bufferlist> *out) override;
+  int omap_get(CollectionHandle& c, const ghobject_t &oid, ceph::buffer::list *header,
+	       std::map<std::string, ceph::buffer::list> *out) override;
   using ObjectStore::omap_get_header;
   int omap_get_header(
     CollectionHandle& c,
     const ghobject_t &oid,
-    bufferlist *out,
+    ceph::buffer::list *out,
     bool allow_eio = false) override;
   using ObjectStore::omap_get_keys;
-  int omap_get_keys(CollectionHandle& c, const ghobject_t &oid, set<string> *keys) override;
+  int omap_get_keys(CollectionHandle& c, const ghobject_t &oid, std::set<std::string> *keys) override;
   using ObjectStore::omap_get_values;
-  int omap_get_values(CollectionHandle& c, const ghobject_t &oid, const set<string> &keys,
-		      map<string, bufferlist> *out) override;
+  int omap_get_values(CollectionHandle& c, const ghobject_t &oid, const std::set<std::string> &keys,
+		      std::map<std::string, ceph::buffer::list> *out) override;
   using ObjectStore::omap_check_keys;
-  int omap_check_keys(CollectionHandle& c, const ghobject_t &oid, const set<string> &keys,
-		      set<string> *out) override;
+  int omap_check_keys(CollectionHandle& c, const ghobject_t &oid, const std::set<std::string> &keys,
+		      std::set<std::string> *out) override;
   using ObjectStore::get_omap_iterator;
   ObjectMap::ObjectMapIterator get_omap_iterator(CollectionHandle& c, const ghobject_t &oid) override;
   ObjectMap::ObjectMapIterator get_omap_iterator(const coll_t& cid, const ghobject_t &oid);
@@ -775,11 +774,11 @@ public:
 
   void dump_start(const std::string& file);
   void dump_stop();
-  void dump_transactions(vector<Transaction>& ls, uint64_t seq, OpSequencer *osr);
+  void dump_transactions(std::vector<Transaction>& ls, uint64_t seq, OpSequencer *osr);
 
   virtual int apply_layout_settings(const coll_t &cid, int target_level);
 
-  void get_db_statistics(Formatter* f) override;
+  void get_db_statistics(ceph::Formatter* f) override;
 
 private:
   void _inject_failure();
@@ -788,14 +787,14 @@ private:
   int _omap_clear(const coll_t& cid, const ghobject_t &oid,
 		  const SequencerPosition &spos);
   int _omap_setkeys(const coll_t& cid, const ghobject_t &oid,
-		    const map<string, bufferlist> &aset,
+		    const std::map<std::string, ceph::buffer::list> &aset,
 		    const SequencerPosition &spos);
-  int _omap_rmkeys(const coll_t& cid, const ghobject_t &oid, const set<string> &keys,
+  int _omap_rmkeys(const coll_t& cid, const ghobject_t &oid, const std::set<std::string> &keys,
 		   const SequencerPosition &spos);
   int _omap_rmkeyrange(const coll_t& cid, const ghobject_t &oid,
-		       const string& first, const string& last,
+		       const std::string& first, const std::string& last,
 		       const SequencerPosition &spos);
-  int _omap_setheader(const coll_t& cid, const ghobject_t &oid, const bufferlist &bl,
+  int _omap_setheader(const coll_t& cid, const ghobject_t &oid, const ceph::buffer::list &bl,
 		      const SequencerPosition &spos);
   int _split_collection(const coll_t& cid, uint32_t bits, uint32_t rem, coll_t dest,
                         const SequencerPosition &spos);
@@ -821,7 +820,7 @@ private:
   bool m_osd_use_stale_snap;
   bool m_filestore_do_dump;
   std::ofstream m_filestore_dump;
-  JSONFormatter m_filestore_dump_fmt;
+  ceph::JSONFormatter m_filestore_dump_fmt;
   std::atomic<int64_t> m_filestore_kill_at = { 0 };
   bool m_filestore_sloppy_crc;
   int m_filestore_sloppy_crc_block_size;
@@ -858,7 +857,7 @@ private:
   friend class TestFileStore;
 };
 
-ostream& operator<<(ostream& out, const FileStore::OpSequencer& s);
+std::ostream& operator<<(std::ostream& out, const FileStore::OpSequencer& s);
 
 struct fiemap;
 
@@ -878,13 +877,13 @@ protected:
   size_t get_blksize() {
     return filestore->blk_size;
   }
-  const string& get_basedir_path() {
+  const std::string& get_basedir_path() {
     return filestore->basedir;
   }
-  const string& get_journal_path() {
+  const std::string& get_journal_path() {
     return filestore->journalpath;
   }
-  const string& get_current_path() {
+  const std::string& get_current_path() {
     return filestore->current_fn;
   }
   int _copy_range(int from, int to, uint64_t srcoff, uint64_t len, uint64_t dstoff) {
@@ -912,11 +911,11 @@ public:
   virtual int detect_features() = 0;
   virtual int create_current() = 0;
   virtual bool can_checkpoint() = 0;
-  virtual int list_checkpoints(list<string>& ls) = 0;
-  virtual int create_checkpoint(const string& name, uint64_t *cid) = 0;
+  virtual int list_checkpoints(std::list<std::string>& ls) = 0;
+  virtual int create_checkpoint(const std::string& name, uint64_t *cid) = 0;
   virtual int sync_checkpoint(uint64_t id) = 0;
-  virtual int rollback_to(const string& name) = 0;
-  virtual int destroy_checkpoint(const string& name) = 0;
+  virtual int rollback_to(const std::string& name) = 0;
+  virtual int destroy_checkpoint(const std::string& name) = 0;
   virtual int syncfs() = 0;
   virtual bool has_fiemap() = 0;
   virtual bool has_seek_data_hole() = 0;
@@ -928,13 +927,13 @@ public:
   virtual bool has_splice() const = 0;
 
   // hooks for (sloppy) crc tracking
-  virtual int _crc_update_write(int fd, loff_t off, size_t len, const bufferlist& bl) = 0;
+  virtual int _crc_update_write(int fd, loff_t off, size_t len, const ceph::buffer::list& bl) = 0;
   virtual int _crc_update_truncate(int fd, loff_t off) = 0;
   virtual int _crc_update_zero(int fd, loff_t off, size_t len) = 0;
   virtual int _crc_update_clone_range(int srcfd, int destfd,
 				      loff_t srcoff, size_t len, loff_t dstoff) = 0;
-  virtual int _crc_verify_read(int fd, loff_t off, size_t len, const bufferlist& bl,
-			       ostream *out) = 0;
+  virtual int _crc_verify_read(int fd, loff_t off, size_t len, const ceph::buffer::list& bl,
+			       std::ostream *out) = 0;
 };
 
 #endif

--- a/src/os/filestore/GenericFileStoreBackend.cc
+++ b/src/os/filestore/GenericFileStoreBackend.cc
@@ -56,6 +56,13 @@
 #define ALIGNED(x, by) (!((x) % (by)))
 #define ALIGN_UP(x, by) (ALIGNED((x), (by)) ? (x) : (ALIGN_DOWN((x), (by)) + (by)))
 
+using std::ostream;
+using std::ostringstream;
+using std::string;
+
+using ceph::bufferptr;
+using ceph::bufferlist;
+
 GenericFileStoreBackend::GenericFileStoreBackend(FileStore *fs):
   FileStoreBackend(fs),
   ioctl_fiemap(false),
@@ -371,12 +378,12 @@ int GenericFileStoreBackend::_crc_load_or_init(int fd, SloppyCRCMap *cm)
     return 0;
   }
   if (l >= 0) {
-    bp = buffer::create(l);
+    bp = ceph::buffer::create(l);
     memcpy(bp.c_str(), buf, l);
   } else if (l == -ERANGE) {
     l = chain_fgetxattr(fd, SLOPPY_CRC_XATTR, 0, 0);
     if (l > 0) {
-      bp = buffer::create(l);
+      bp = ceph::buffer::create(l);
       l = chain_fgetxattr(fd, SLOPPY_CRC_XATTR, bp.c_str(), l);
     }
   }
@@ -386,7 +393,7 @@ int GenericFileStoreBackend::_crc_load_or_init(int fd, SloppyCRCMap *cm)
   try {
     decode(*cm, p);
   }
-  catch (buffer::error &e) {
+  catch (ceph::buffer::error &e) {
     r = -EIO;
   }
   if (r < 0)

--- a/src/os/filestore/GenericFileStoreBackend.h
+++ b/src/os/filestore/GenericFileStoreBackend.h
@@ -46,11 +46,11 @@ public:
   bool is_journal_rotational() override {
     return m_journal_rotational;
   }
-  int list_checkpoints(list<string>& ls) override { return 0; }
-  int create_checkpoint(const string& name, uint64_t *cid) override { return -EOPNOTSUPP; }
+  int list_checkpoints(std::list<std::string>& ls) override { return 0; }
+  int create_checkpoint(const std::string& name, uint64_t *cid) override { return -EOPNOTSUPP; }
   int sync_checkpoint(uint64_t id) override { return -EOPNOTSUPP; }
-  int rollback_to(const string& name) override { return -EOPNOTSUPP; }
-  int destroy_checkpoint(const string& name) override { return -EOPNOTSUPP; }
+  int rollback_to(const std::string& name) override { return -EOPNOTSUPP; }
+  int destroy_checkpoint(const std::string& name) override { return -EOPNOTSUPP; }
   int syncfs() override;
   bool has_fiemap() override { return ioctl_fiemap; }
   bool has_seek_data_hole() override { return seek_data_hole; }
@@ -64,12 +64,12 @@ private:
   int _crc_load_or_init(int fd, SloppyCRCMap *cm);
   int _crc_save(int fd, SloppyCRCMap *cm);
 public:
-  int _crc_update_write(int fd, loff_t off, size_t len, const bufferlist& bl) override;
+  int _crc_update_write(int fd, loff_t off, size_t len, const ceph::buffer::list& bl) override;
   int _crc_update_truncate(int fd, loff_t off) override;
   int _crc_update_zero(int fd, loff_t off, size_t len) override;
   int _crc_update_clone_range(int srcfd, int destfd,
 				      loff_t srcoff, size_t len, loff_t dstoff) override;
-  int _crc_verify_read(int fd, loff_t off, size_t len, const bufferlist& bl,
-			       ostream *out) override;
+  int _crc_verify_read(int fd, loff_t off, size_t len, const ceph::buffer::list& bl,
+		       std::ostream *out) override;
 };
 #endif

--- a/src/os/filestore/HashIndex.cc
+++ b/src/os/filestore/HashIndex.cc
@@ -25,6 +25,15 @@
 #define dout_context cct
 #define dout_subsys ceph_subsys_filestore
 
+using std::map;
+using std::pair;
+using std::set;
+using std::string;
+using std::vector;
+
+using ceph::bufferptr;
+using ceph::bufferlist;
+
 const string HashIndex::SUBDIR_ATTR = "contents";
 const string HashIndex::SETTINGS_ATTR = "settings";
 const string HashIndex::IN_PROGRESS_OP_TAG = "in_progress_op";

--- a/src/os/filestore/HashIndex.h
+++ b/src/os/filestore/HashIndex.h
@@ -19,7 +19,7 @@
 #include "include/encoding.h"
 #include "LFNIndex.h"
 
-extern string reverse_hexdigit_bits_string(string l);
+extern std::string reverse_hexdigit_bits_string(std::string l);
 
 /**
  * Implements collection prehashing.
@@ -51,11 +51,11 @@ extern string reverse_hexdigit_bits_string(string l);
 class HashIndex : public LFNIndex {
 private:
   /// Attribute name for storing subdir info @see subdir_info_s
-  static const string SUBDIR_ATTR;
+  static const std::string SUBDIR_ATTR;
   /// Attribute name for storing index-wide settings
-  static const string SETTINGS_ATTR;
+  static const std::string SETTINGS_ATTR;
   /// Attribute name for storing in progress op tag
-  static const string IN_PROGRESS_OP_TAG;
+  static const std::string IN_PROGRESS_OP_TAG;
   /// Size (bits) in object hash
   static const int PATH_HASH_LEN = 32;
   /// Max length of hashed path
@@ -82,7 +82,7 @@ private:
 
     subdir_info_s() : objs(0), subdirs(0), hash_level(0) {}
 
-    void encode(bufferlist &bl) const
+    void encode(ceph::buffer::list &bl) const
     {
       using ceph::encode;
       __u8 v = 1;
@@ -92,7 +92,7 @@ private:
       encode(hash_level, bl);
     }
 
-    void decode(bufferlist::const_iterator &bl)
+    void decode(ceph::buffer::list::const_iterator &bl)
     {
       using ceph::decode;
       __u8 v;
@@ -107,14 +107,14 @@ private:
   struct settings_s {
     uint32_t split_rand_factor; ///< random factor added to split threshold (only on root of collection)
     settings_s() : split_rand_factor(0) {}
-    void encode(bufferlist &bl) const
+    void encode(ceph::buffer::list &bl) const
     {
       using ceph::encode;
       __u8 v = 1;
       encode(v, bl);
       encode(split_rand_factor, bl);
     }
-    void decode(bufferlist::const_iterator &bl)
+    void decode(ceph::buffer::list::const_iterator &bl)
     {
       using ceph::decode;
       __u8 v;
@@ -129,12 +129,12 @@ private:
     static const int MERGE = 1;
     static const int COL_SPLIT = 2;
     int op;
-    vector<string> path;
+    std::vector<std::string> path;
 
-    InProgressOp(int op, const vector<string> &path)
+    InProgressOp(int op, const std::vector<std::string> &path)
       : op(op), path(path) {}
 
-    explicit InProgressOp(bufferlist::const_iterator &bl) {
+    explicit InProgressOp(ceph::buffer::list::const_iterator &bl) {
       decode(bl);
     }
 
@@ -142,7 +142,7 @@ private:
     bool is_col_split() const { return op == COL_SPLIT; }
     bool is_merge() const { return op == MERGE; }
 
-    void encode(bufferlist &bl) const {
+    void encode(ceph::buffer::list &bl) const {
       using ceph::encode;
       __u8 v = 1;
       encode(v, bl);
@@ -150,7 +150,7 @@ private:
       encode(path, bl);
     }
 
-    void decode(bufferlist::const_iterator &bl) {
+    void decode(ceph::buffer::list::const_iterator &bl) {
       using ceph::decode;
       __u8 v;
       decode(v, bl);
@@ -203,7 +203,7 @@ public:
   int _merge_dirs(
     HashIndex& from,
     HashIndex& to,
-    const vector<string>& path);
+    const std::vector<std::string>& path);
 
   /// @see CollectionIndex
   int apply_layout_settings(int target_level) override;
@@ -212,19 +212,19 @@ protected:
   int _init() override;
 
   int _created(
-    const vector<string> &path,
+    const std::vector<std::string> &path,
     const ghobject_t &oid,
-    const string &mangled_name
+    const std::string &mangled_name
     ) override;
   int _remove(
-    const vector<string> &path,
+    const std::vector<std::string> &path,
     const ghobject_t &oid,
-    const string &mangled_name
+    const std::string &mangled_name
     ) override;
   int _lookup(
     const ghobject_t &oid,
-    vector<string> *path,
-    string *mangled_name,
+    std::vector<std::string> *path,
+    std::string *mangled_name,
     int *hardlink
     ) override;
 
@@ -241,44 +241,44 @@ protected:
     const ghobject_t &start,
     const ghobject_t &end,
     int max_count,
-    vector<ghobject_t> *ls,
+    std::vector<ghobject_t> *ls,
     ghobject_t *next
     ) override;
 private:
   /// Internal recursively remove path and its subdirs
   int _recursive_remove(
-    const vector<string> &path, ///< [in] path to remove
+    const std::vector<std::string> &path, ///< [in] path to remove
     bool top			///< [in] internal tracking of first caller
     ); /// @return Error Code, 0 on success
   /// Recursively remove path and its subdirs
   int recursive_remove(
-    const vector<string> &path ///< [in] path to remove
+    const std::vector<std::string> &path ///< [in] path to remove
     ); /// @return Error Code, 0 on success
   /// Tag root directory at beginning of col_split
   int start_col_split(
-    const vector<string> &path ///< [in] path to split
+    const std::vector<std::string> &path ///< [in] path to split
     ); ///< @return Error Code, 0 on success
   /// Tag root directory at beginning of split
   int start_split(
-    const vector<string> &path ///< [in] path to split
+    const std::vector<std::string> &path ///< [in] path to split
     ); ///< @return Error Code, 0 on success
   /// Tag root directory at beginning of split
   int start_merge(
-    const vector<string> &path ///< [in] path to merge
+    const std::vector<std::string> &path ///< [in] path to merge
     ); ///< @return Error Code, 0 on success
   /// Remove tag at end of split or merge
   int end_split_or_merge(
-    const vector<string> &path ///< [in] path to split or merged
+    const std::vector<std::string> &path ///< [in] path to split or merged
     ); ///< @return Error Code, 0 on success
   /// Gets info from the xattr on the subdir represented by path
   int get_info(
-    const vector<string> &path, ///< [in] Path from which to read attribute.
+    const std::vector<std::string> &path, ///< [in] Path from which to read attribute.
     subdir_info_s *info		///< [out] Attribute value
     ); /// @return Error Code, 0 on success
 
   /// Sets info to the xattr on the subdir represented by path
   int set_info(
-    const vector<string> &path, ///< [in] Path on which to set attribute.
+    const std::vector<std::string> &path, ///< [in] Path on which to set attribute.
     const subdir_info_s &info  	///< [in] Value to set
     ); /// @return Error Code, 0 on success
 
@@ -295,37 +295,37 @@ private:
 
   /// Initiates merge
   int initiate_merge(
-    const vector<string> &path, ///< [in] Subdir to merge
+    const std::vector<std::string> &path, ///< [in] Subdir to merge
     subdir_info_s info		///< [in] Info attached to path
     ); /// @return Error Code, 0 on success
 
   /// Completes merge
   int complete_merge(
-    const vector<string> &path, ///< [in] Subdir to merge
+    const std::vector<std::string> &path, ///< [in] Subdir to merge
     subdir_info_s info		///< [in] Info attached to path
     ); /// @return Error Code, 0 on success
 
   /// Resets attr to match actual subdir contents
   int reset_attr(
-    const vector<string> &path ///< [in] path to cleanup
+    const std::vector<std::string> &path ///< [in] path to cleanup
     );
 
   /// Initiate Split
   int initiate_split(
-    const vector<string> &path, ///< [in] Subdir to split
+    const std::vector<std::string> &path, ///< [in] Subdir to split
     subdir_info_s info		///< [in] Info attached to path
     ); /// @return Error Code, 0 on success
 
   /// Completes Split
   int complete_split(
-    const vector<string> &path, ///< [in] Subdir to split
+    const std::vector<std::string> &path, ///< [in] Subdir to split
     subdir_info_s info	       ///< [in] Info attached to path
     ); /// @return Error Code, 0 on success
 
   /// Determine path components from hoid hash
   void get_path_components(
     const ghobject_t &oid, ///< [in] Object for which to get path components
-    vector<string> *path   ///< [out] Path components for hoid.
+    std::vector<std::string> *path   ///< [out] Path components for hoid.
     );
 
   /// Pre-hash and split folders to avoid runtime splitting
@@ -334,13 +334,13 @@ private:
 
   /// Initialize the folder (dir info) with the given hash
   /// level and number of its subdirs.
-  int init_split_folder(vector<string> &path, uint32_t hash_level);
+  int init_split_folder(std::vector<std::string> &path, uint32_t hash_level);
 
   /// do collection split for path
   static int col_split_level(
     HashIndex &from,            ///< [in] from index
     HashIndex &dest,            ///< [in] to index
-    const vector<string> &path, ///< [in] path to split
+    const std::vector<std::string> &path, ///< [in] path to split
     uint32_t bits,              ///< [in] num bits to match
     uint32_t match,             ///< [in] bits to match
     unsigned *mkdirred          ///< [in,out] path[:mkdirred] has been mkdirred
@@ -348,34 +348,32 @@ private:
 
 
   /**
-   * Get string representation of ghobject_t/hash
+   * Get std::string representation of ghobject_t/hash
    *
    * e.g: 0x01234567 -> "76543210"
    */
-  static string get_path_str(
-    const ghobject_t &oid ///< [in] Object to get hash string for
-    ); ///< @return Hash string for hoid.
+  static std::string get_path_str(
+    const ghobject_t &oid ///< [in] Object to get hash std::string for
+    ); ///< @return Hash std::string for hoid.
 
-  /// Get string from hash, @see get_path_str
-  static string get_hash_str(
+  /// Get std::string from hash, @see get_path_str
+  static std::string get_hash_str(
     uint32_t hash ///< [in] Hash to convert to a string.
-    ); ///< @return String representation of hash
+    ); ///< @return std::string representation of hash
 
-  /// Get hash from hash prefix string e.g. "FFFFAB" -> 0xFFFFAB00
+  /// Get hash from hash prefix std::string e.g. "FFFFAB" -> 0xFFFFAB00
   static uint32_t hash_prefix_to_hash(
-    string prefix ///< [in] string to convert
+    std::string prefix ///< [in] std::string to convert
     ); ///< @return Hash
 
   /// Get hash mod from path
   static void path_to_hobject_hash_prefix(
-    const vector<string> &path,///< [in] path to convert
+    const std::vector<std::string> &path,///< [in] path to convert
     uint32_t *bits,            ///< [out] bits
     uint32_t *hash             ///< [out] hash
     ) {
-    string hash_str;
-    for (vector<string>::const_iterator i = path.begin();
-	 i != path.end();
-	 ++i) {
+    std::string hash_str;
+    for (auto i = path.begin(); i != path.end(); ++i) {
       hash_str.push_back(*i->begin());
     }
     uint32_t rev_hash = hash_prefix_to_hash(hash_str);
@@ -395,18 +393,18 @@ private:
     return ret;
   }
 
-  /// Convert a number to hex string (upper case).
-  static string to_hex(int n) {
+  /// Convert a number to hex std::string (upper case).
+  static std::string to_hex(int n) {
     ceph_assert(n >= 0 && n < 16);
     char c = (n <= 9 ? ('0' + n) : ('A' + n - 10));
-    string str;
+    std::string str;
     str.append(1, c);
     return str;
   }
 
   struct CmpPairBitwise {
-    bool operator()(const pair<string, ghobject_t>& l,
-		    const pair<string, ghobject_t>& r) const
+    bool operator()(const std::pair<std::string, ghobject_t>& l,
+		    const std::pair<std::string, ghobject_t>& r) const
     {
       if (l.first < r.first)
 	return true;
@@ -419,42 +417,42 @@ private:
   };
 
   struct CmpHexdigitStringBitwise {
-    bool operator()(const string& l, const string& r) const {
+    bool operator()(const std::string& l, const std::string& r) const {
       return reverse_hexdigit_bits_string(l) < reverse_hexdigit_bits_string(r);
     }
   };
 
   /// Get path contents by hash
   int get_path_contents_by_hash_bitwise(
-    const vector<string> &path,             /// [in] Path to list
+    const std::vector<std::string> &path,             /// [in] Path to list
     const ghobject_t *next_object,          /// [in] list > *next_object
-    set<string, CmpHexdigitStringBitwise> *hash_prefixes, /// [out] prefixes in dir
-    set<pair<string, ghobject_t>, CmpPairBitwise> *objects /// [out] objects
+    std::set<std::string, CmpHexdigitStringBitwise> *hash_prefixes, /// [out] prefixes in dir
+    std::set<std::pair<std::string, ghobject_t>, CmpPairBitwise> *objects /// [out] objects
     );
 
   /// List objects in collection in ghobject_t order
   int list_by_hash(
-    const vector<string> &path, /// [in] Path to list
+    const std::vector<std::string> &path, /// [in] Path to list
     const ghobject_t &end,      /// [in] List only objects < end
     int max_count,              /// [in] List at most max_count
     ghobject_t *next,            /// [in,out] List objects >= *next
-    vector<ghobject_t> *out      /// [out] Listed objects
+    std::vector<ghobject_t> *out      /// [out] Listed objects
     ); ///< @return Error Code, 0 on success
   /// List objects in collection in ghobject_t order
   int list_by_hash_bitwise(
-    const vector<string> &path, /// [in] Path to list
+    const std::vector<std::string> &path, /// [in] Path to list
     const ghobject_t &end,      /// [in] List only objects < end
     int max_count,              /// [in] List at most max_count
     ghobject_t *next,            /// [in,out] List objects >= *next
-    vector<ghobject_t> *out      /// [out] Listed objects
+    std::vector<ghobject_t> *out      /// [out] Listed objects
     ); ///< @return Error Code, 0 on success
 
   /// Create the given levels of sub directories from the given root.
   /// The contents of *path* is not changed after calling this function.
-  int recursive_create_path(vector<string>& path, int level);
+  int recursive_create_path(std::vector<std::string>& path, int level);
 
   /// split each dir below the given path
-  int split_dirs(const vector<string> &path, int target_level = 0);
+  int split_dirs(const std::vector<std::string> &path, int target_level = 0);
 
   int write_settings();
 };

--- a/src/os/filestore/IndexManager.cc
+++ b/src/os/filestore/IndexManager.cc
@@ -31,6 +31,13 @@
 
 #include "chain_xattr.h"
 
+using std::string;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::decode;
+using ceph::encode;
+
 static int set_version(const char *path, uint32_t version) {
   bufferlist bl;
   encode(version, bl);

--- a/src/os/filestore/IndexManager.h
+++ b/src/os/filestore/IndexManager.h
@@ -83,7 +83,7 @@ public:
    * @param [out] index Index for c
    * @return error code
    */
-  int get_index(coll_t c, const string& baseDir, Index *index);
+  int get_index(coll_t c, const std::string& baseDir, Index *index);
 
   /**
    * Initialize index for collection c at path

--- a/src/os/filestore/Journal.h
+++ b/src/os/filestore/Journal.h
@@ -52,8 +52,8 @@ public:
 
   virtual void flush() = 0;
 
-  virtual void get_devices(set<string> *ls) {}
-  virtual void collect_metadata(map<string,string> *pm) {}
+  virtual void get_devices(std::set<std::string> *ls) {}
+  virtual void collect_metadata(std::map<std::string,std::string> *pm) {}
   /**
    * reserve_throttle_and_backoff
    *
@@ -62,14 +62,14 @@ public:
    */
   virtual void reserve_throttle_and_backoff(uint64_t count) = 0;
 
-  virtual int dump(ostream& out) { return -EOPNOTSUPP; }
+  virtual int dump(std::ostream& out) { return -EOPNOTSUPP; }
 
   void set_wait_on_full(bool b) { wait_on_full = b; }
 
   // writes
   virtual bool is_writeable() = 0;
   virtual int make_writeable() = 0;
-  virtual void submit_entry(uint64_t seq, bufferlist& e, uint32_t orig_len,
+  virtual void submit_entry(uint64_t seq, ceph::buffer::list& e, uint32_t orig_len,
 			    Context *oncommit,
 			    TrackedOpRef osd_op = TrackedOpRef()) = 0;
   virtual void commit_start(uint64_t seq) = 0;
@@ -77,13 +77,13 @@ public:
 
   /// Read next journal entry - asserts on invalid journal
   virtual bool read_entry(
-    bufferlist &bl, ///< [out] payload on successful read
+    ceph::buffer::list &bl, ///< [out] payload on successful read
     uint64_t &seq   ///< [in,out] sequence number on last successful read
     ) = 0; ///< @return true on successful read, false on journal end
 
   virtual bool should_commit_now() = 0;
 
-  virtual int prepare_entry(vector<ObjectStore::Transaction>& tls, bufferlist* tbl) = 0;
+  virtual int prepare_entry(std::vector<ObjectStore::Transaction>& tls, ceph::buffer::list* tbl) = 0;
 
   virtual off64_t get_journal_size_estimate() { return 0; }
 

--- a/src/os/filestore/JournalThrottle.cc
+++ b/src/os/filestore/JournalThrottle.cc
@@ -53,7 +53,7 @@ std::pair<uint64_t, uint64_t> JournalThrottle::flush(uint64_t mono_id)
     }
   }
   throttle.put(to_put_bytes);
-  return make_pair(to_put_ops, to_put_bytes);
+  return std::make_pair(to_put_ops, to_put_bytes);
 }
 
 uint64_t JournalThrottle::get_current()

--- a/src/os/filestore/JournalingObjectStore.cc
+++ b/src/os/filestore/JournalingObjectStore.cc
@@ -10,7 +10,11 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "journal "
 
+using std::map;
+using std::vector;
 
+using ceph::bufferptr;
+using ceph::bufferlist;
 
 void JournalingObjectStore::journal_start()
 {

--- a/src/os/filestore/JournalingObjectStore.h
+++ b/src/os/filestore/JournalingObjectStore.h
@@ -60,7 +60,7 @@ protected:
     uint64_t max_applied_seq;
 
     ceph::mutex com_lock = ceph::make_mutex("JOS::ApplyManager::com_lock");
-    map<version_t, vector<Context*> > commit_waiters;
+    std::map<version_t, std::vector<Context*> > commit_waiters;
     uint64_t committing_seq, committed_seq;
 
   public:
@@ -116,10 +116,10 @@ protected:
   void journal_write_close();
   int journal_replay(uint64_t fs_op_seq);
 
-  void _op_journal_transactions(bufferlist& tls, uint32_t orig_len, uint64_t op,
+  void _op_journal_transactions(ceph::buffer::list& tls, uint32_t orig_len, uint64_t op,
 				Context *onjournal, TrackedOpRef osd_op);
 
-  virtual int do_transactions(vector<ObjectStore::Transaction>& tls, uint64_t op_seq) = 0;
+  virtual int do_transactions(std::vector<ObjectStore::Transaction>& tls, uint64_t op_seq) = 0;
 
 public:
   bool is_committing() {

--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -34,13 +34,22 @@
 #include "chain_xattr.h"
 
 #include "LFNIndex.h"
-using ceph::crypto::SHA1;
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "LFNIndex(" << get_base_path() << ") "
 
+using std::map;
+using std::pair;
+using std::set;
+using std::string;
+using std::vector;
+
+using ceph::crypto::SHA1;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
 
 const string LFNIndex::LFN_ATTR = "user.cephos.lfn";
 const string LFNIndex::PHASH_ATTR_PREFIX = "user.cephos.phash.";

--- a/src/os/filestore/LFNIndex.h
+++ b/src/os/filestore/LFNIndex.h
@@ -87,22 +87,22 @@ class LFNIndex : public CollectionIndex {
   /// Length of hashed filename cookie.
   static const int FILENAME_EXTRA = 4;
   /// Lfn cookie value.
-  static const string FILENAME_COOKIE;
+  static const std::string FILENAME_COOKIE;
   /// Name of LFN attribute for storing full name.
-  static const string LFN_ATTR;
+  static const std::string LFN_ATTR;
   /// Prefix for subdir index attributes.
-  static const string PHASH_ATTR_PREFIX;
+  static const std::string PHASH_ATTR_PREFIX;
   /// Prefix for index subdirectories.
-  static const string SUBDIR_PREFIX;
+  static const std::string SUBDIR_PREFIX;
 
   /// Path to Index base.
-  const string base_path;
+  const std::string base_path;
 
 protected:
   const uint32_t index_version;
 
   /// true if retry injection is enabled
-  struct RetryException : public exception {};
+  struct RetryException : public std::exception {};
   bool error_injection_enabled;
   bool error_injection_on;
   double error_injection_probability;
@@ -120,7 +120,7 @@ protected:
   }
 
 private:
-  string lfn_attribute, lfn_alt_attribute;
+  std::string lfn_attribute, lfn_alt_attribute;
   coll_t collection;
 
 public:
@@ -144,8 +144,8 @@ public:
     } else {
       char buf[100];
       snprintf(buf, sizeof(buf), "%d", index_version);
-      lfn_attribute = LFN_ATTR + string(buf);
-      lfn_alt_attribute = LFN_ATTR + string(buf) + "-alt";
+      lfn_attribute = LFN_ATTR + std::string(buf);
+      lfn_alt_attribute = LFN_ATTR + std::string(buf) + "-alt";
    }
   }
 
@@ -189,7 +189,7 @@ public:
     const ghobject_t &start,
     const ghobject_t &end,
     int max_count,
-    vector<ghobject_t> *ls,
+    std::vector<ghobject_t> *ls,
     ghobject_t *next
     ) override;
 
@@ -237,23 +237,23 @@ protected:
 
   /// Will be called upon object creation
   virtual int _created(
-    const vector<string> &path, ///< [in] Path to subdir.
+    const std::vector<std::string> &path, ///< [in] Path to subdir.
     const ghobject_t &oid,      ///< [in] Object created.
-    const string &mangled_name  ///< [in] Mangled filename.
+    const std::string &mangled_name  ///< [in] Mangled filename.
     ) = 0;
 
   /// Will be called to remove an object
   virtual int _remove(
-    const vector<string> &path,     ///< [in] Path to subdir.
+    const std::vector<std::string> &path,     ///< [in] Path to subdir.
     const ghobject_t &oid,          ///< [in] Object to remove.
-    const string &mangled_name	    ///< [in] Mangled filename.
+    const std::string &mangled_name	    ///< [in] Mangled filename.
     ) = 0;
 
   /// Return the path and mangled_name for oid.
   virtual int _lookup(
     const ghobject_t &oid,///< [in] Object for lookup.
-    vector<string> *path, ///< [out] Path to the object.
-    string *mangled_name, ///< [out] Mangled filename.
+    std::vector<std::string> *path, ///< [out] Path to the object.
+    std::string *mangled_name, ///< [out] Mangled filename.
     int *exists		  ///< [out] True if the object exists.
     ) = 0;
 
@@ -269,7 +269,7 @@ protected:
     const ghobject_t &start,
     const ghobject_t &end,
     int max_count,
-    vector<ghobject_t> *ls,
+    std::vector<ghobject_t> *ls,
     ghobject_t *next
     ) = 0;
 
@@ -279,15 +279,15 @@ protected:
 
   /// Sync a subdirectory
   int fsync_dir(
-    const vector<string> &path ///< [in] Path to sync
+    const std::vector<std::string> &path ///< [in] Path to sync
     ); ///< @return Error Code, 0 on success
 
   /// Link an object from from into to
   int link_object(
-    const vector<string> &from,   ///< [in] Source subdirectory.
-    const vector<string> &to,     ///< [in] Dest subdirectory.
+    const std::vector<std::string> &from,   ///< [in] Source subdirectory.
+    const std::vector<std::string> &to,     ///< [in] Dest subdirectory.
     const ghobject_t &oid,        ///< [in] Object to move.
-    const string &from_short_name ///< [in] Mangled filename of oid.
+    const std::string &from_short_name ///< [in] Mangled filename of oid.
     ); ///< @return Error Code, 0 on success
 
   /**
@@ -303,9 +303,9 @@ protected:
    * @return Error Code, 0 on success.
    */
   int remove_objects(
-    const vector<string> &dir,
-    const map<string, ghobject_t> &to_remove,
-    map<string, ghobject_t> *remaining
+    const std::vector<std::string> &dir,
+    const std::map<std::string, ghobject_t> &to_remove,
+    std::map<std::string, ghobject_t> *remaining
     );
 
 
@@ -318,8 +318,8 @@ protected:
    * @return Error Code, 0 on success
    */
   int move_objects(
-    const vector<string> &from, ///< [in] Source subdirectory.
-    const vector<string> &to    ///< [in] Dest subdirectory.
+    const std::vector<std::string> &from, ///< [in] Source subdirectory.
+    const std::vector<std::string> &to    ///< [in] Dest subdirectory.
     );
 
   /**
@@ -329,7 +329,7 @@ protected:
    * @return Error Code, 0 on success
    */
   int remove_object(
-    const vector<string> &from,  ///< [in] Directory from which to remove.
+    const std::vector<std::string> &from,  ///< [in] Directory from which to remove.
     const ghobject_t &to_remove   ///< [in] Object to remove.
     );
 
@@ -341,9 +341,9 @@ protected:
    * @return Error code on failure, 0 on success
    */
   int get_mangled_name(
-    const vector<string> &from, ///< [in] Subdirectory
+    const std::vector<std::string> &from, ///< [in] Subdirectory
     const ghobject_t &oid,	///< [in] Object
-    string *mangled_name,	///< [out] Filename
+    std::string *mangled_name,	///< [out] Filename
     int *hardlink		///< [out] hardlink for this file, hardlink=0 mean no-exist
     );
 
@@ -351,16 +351,16 @@ protected:
   static int move_subdir(
     LFNIndex &from,             ///< [in] from index
     LFNIndex &dest,             ///< [in] to index
-    const vector<string> &path, ///< [in] path containing dir
-    string dir                  ///< [in] dir to move
+    const std::vector<std::string> &path, ///< [in] path containing dir
+    std::string dir                  ///< [in] dir to move
     );
 
   /// do move object from from to dest
   static int move_object(
     LFNIndex &from,             ///< [in] from index
     LFNIndex &dest,             ///< [in] to index
-    const vector<string> &path, ///< [in] path to split
-    const pair<string, ghobject_t> &obj ///< [in] obj to move
+    const std::vector<std::string> &path, ///< [in] path to split
+    const std::pair<std::string, ghobject_t> &obj ///< [in] obj to move
     );
 
   /**
@@ -374,52 +374,52 @@ protected:
    * @return Error code on failure, 0 on success
    */
   int list_objects(
-    const vector<string> &to_list,
+    const std::vector<std::string> &to_list,
     int max_objects,
     long *handle,
-    map<string, ghobject_t> *out
+    std::map<std::string, ghobject_t> *out
     );
 
   /// Lists subdirectories.
   int list_subdirs(
-    const vector<string> &to_list, ///< [in] Directory to list.
-    vector<string> *out		   ///< [out] Subdirectories listed.
+    const std::vector<std::string> &to_list, ///< [in] Directory to list.
+    std::vector<std::string> *out		   ///< [out] Subdirectories listed.
     );
 
   /// Create subdirectory.
   int create_path(
-    const vector<string> &to_create ///< [in] Subdirectory to create.
+    const std::vector<std::string> &to_create ///< [in] Subdirectory to create.
     );
 
   /// Remove subdirectory.
   int remove_path(
-    const vector<string> &to_remove ///< [in] Subdirectory to remove.
+    const std::vector<std::string> &to_remove ///< [in] Subdirectory to remove.
     );
 
   /// Check whether to_check exists.
   int path_exists(
-    const vector<string> &to_check, ///< [in] Subdirectory to check.
+    const std::vector<std::string> &to_check, ///< [in] Subdirectory to check.
     int *exists			    ///< [out] 1 if it exists, 0 else
     );
 
   /// Save attr_value to attr_name attribute on path.
   int add_attr_path(
-    const vector<string> &path, ///< [in] Path to modify.
-    const string &attr_name, 	///< [in] Name of attribute.
-    bufferlist &attr_value	///< [in] Value to save.
+    const std::vector<std::string> &path, ///< [in] Path to modify.
+    const std::string &attr_name, 	///< [in] Name of attribute.
+    ceph::buffer::list &attr_value	///< [in] Value to save.
     );
 
   /// Read into attr_value attribute attr_name on path.
   int get_attr_path(
-    const vector<string> &path, ///< [in] Path to read.
-    const string &attr_name, 	///< [in] Attribute to read.
-    bufferlist &attr_value	///< [out] Attribute value read.
+    const std::vector<std::string> &path, ///< [in] Path to read.
+    const std::string &attr_name, 	///< [in] Attribute to read.
+    ceph::buffer::list &attr_value	///< [out] Attribute value read.
     );
 
   /// Remove attr from path
   int remove_attr_path(
-    const vector<string> &path, ///< [in] path from which to remove attr
-    const string &attr_name	///< [in] attr to remove
+    const std::vector<std::string> &path, ///< [in] path from which to remove attr
+    const std::string &attr_name	///< [in] attr to remove
     ); ///< @return Error code, 0 on success
 
 private:
@@ -428,10 +428,10 @@ private:
   /**
    * Gets the version specific lfn attribute tag
    */
-  const string &get_lfn_attr() const {
+  const std::string &get_lfn_attr() const {
     return lfn_attribute;
   }
-  const string &get_alt_lfn_attr() const {
+  const std::string &get_alt_lfn_attr() const {
     return lfn_alt_attribute;
   }
 
@@ -447,63 +447,63 @@ private:
    * @return Error Code, 0 on success.
    */
   int lfn_get_name(
-    const vector<string> &path,
+    const std::vector<std::string> &path,
     const ghobject_t &oid,
-    string *mangled_name,
-    string *full_path,
+    std::string *mangled_name,
+    std::string *full_path,
     int *hardlink
     );
 
   /// Adjusts path contents when oid is created at name mangled_name.
   int lfn_created(
-    const vector<string> &path, ///< [in] Path to adjust.
+    const std::vector<std::string> &path, ///< [in] Path to adjust.
     const ghobject_t &oid,	///< [in] Object created.
-    const string &mangled_name  ///< [in] Filename of created object.
+    const std::string &mangled_name  ///< [in] Filename of created object.
     );
 
   /// Removes oid from path while adjusting path contents
   int lfn_unlink(
-    const vector<string> &path, ///< [in] Path containing oid.
+    const std::vector<std::string> &path, ///< [in] Path containing oid.
     const ghobject_t &oid,	///< [in] Object to remove.
-    const string &mangled_name	///< [in] Filename of object to remove.
+    const std::string &mangled_name	///< [in] Filename of object to remove.
     );
 
   ///Transate a file into and ghobject_t.
   int lfn_translate(
-    const vector<string> &path, ///< [in] Path containing the file.
-    const string &short_name,	///< [in] Filename to translate.
+    const std::vector<std::string> &path, ///< [in] Path containing the file.
+    const std::string &short_name,	///< [in] Filename to translate.
     ghobject_t *out		///< [out] Object found.
     ); ///< @return Negative error code on error, 0 if not an object, 1 else
 
   /* manglers/demanglers */
   /// Filters object filenames
   bool lfn_is_object(
-    const string &short_name ///< [in] Filename to check
+    const std::string &short_name ///< [in] Filename to check
     ); ///< True if short_name is an object, false otherwise
 
   /// Filters subdir filenames
   bool lfn_is_subdir(
-    const string &short_name, ///< [in] Filename to check.
-    string *demangled_name    ///< [out] Demangled subdir name.
+    const std::string &short_name, ///< [in] Filename to check.
+    std::string *demangled_name    ///< [out] Demangled subdir name.
     ); ///< @return True if short_name is a subdir, false otherwise
 
   /// Generate object name
-  string lfn_generate_object_name_keyless(
+  std::string lfn_generate_object_name_keyless(
     const ghobject_t &oid ///< [in] Object for which to generate.
     ); ///< @return Generated object name.
 
   /// Generate object name
-  string lfn_generate_object_name_poolless(
+  std::string lfn_generate_object_name_poolless(
     const ghobject_t &oid ///< [in] Object for which to generate.
     ); ///< @return Generated object name.
 
   /// Generate object name
-  static string lfn_generate_object_name_current(
+  static std::string lfn_generate_object_name_current(
     const ghobject_t &oid ///< [in] Object for which to generate.
     ); ///< @return Generated object name.
 
   /// Generate object name
-  string lfn_generate_object_name(
+  std::string lfn_generate_object_name(
     const ghobject_t &oid ///< [in] Object for which to generate.
     ) {
     if (index_version == HASH_INDEX_TAG)
@@ -516,74 +516,74 @@ private:
 
   /// Parse object name
   int lfn_parse_object_name_keyless(
-    const string &long_name, ///< [in] Name to parse
+    const std::string &long_name, ///< [in] Name to parse
     ghobject_t *out	     ///< [out] Resulting Object
     ); ///< @return True if successful, False otherwise.
 
   /// Parse object name
   int lfn_parse_object_name_poolless(
-    const string &long_name, ///< [in] Name to parse
+    const std::string &long_name, ///< [in] Name to parse
     ghobject_t *out	     ///< [out] Resulting Object
     ); ///< @return True if successful, False otherwise.
 
   /// Parse object name
   int lfn_parse_object_name(
-    const string &long_name, ///< [in] Name to parse
+    const std::string &long_name, ///< [in] Name to parse
     ghobject_t *out	     ///< [out] Resulting Object
     ); ///< @return True if successful, False otherwise.
 
   /// Checks whether short_name is a hashed filename.
   bool lfn_is_hashed_filename(
-    const string &short_name ///< [in] Name to check.
+    const std::string &short_name ///< [in] Name to check.
     ); ///< @return True if short_name is hashed, False otherwise.
 
   /// Checks whether long_name must be hashed.
   bool lfn_must_hash(
-    const string &long_name ///< [in] Name to check.
+    const std::string &long_name ///< [in] Name to check.
     ); ///< @return True if long_name must be hashed, False otherwise.
 
   /// Generate hashed name.
-  string lfn_get_short_name(
+  std::string lfn_get_short_name(
     const ghobject_t &oid, ///< [in] Object for which to generate.
     int i		   ///< [in] Index of hashed name to generate.
     ); ///< @return Hashed filename.
 
   /* other common methods */
   /// Gets the base path
-  const string &get_base_path(); ///< @return Index base_path
+  const std::string &get_base_path(); ///< @return Index base_path
 
   /// Get full path the subdir
-  string get_full_path_subdir(
-    const vector<string> &rel ///< [in] The subdir.
+  std::string get_full_path_subdir(
+    const std::vector<std::string> &rel ///< [in] The subdir.
     ); ///< @return Full path to rel.
 
   /// Get full path to object
-  string get_full_path(
-    const vector<string> &rel, ///< [in] Path to object.
-    const string &name	       ///< [in] Filename of object.
+  std::string get_full_path(
+    const std::vector<std::string> &rel, ///< [in] Path to object.
+    const std::string &name	       ///< [in] Filename of object.
     ); ///< @return Fullpath to object at name in rel.
 
   /// Get mangled path component
-  string mangle_path_component(
-    const string &component ///< [in] Component to mangle
+  std::string mangle_path_component(
+    const std::string &component ///< [in] Component to mangle
     ); /// @return Mangled component
 
   /// Demangle component
-  string demangle_path_component(
-    const string &component ///< [in] Subdir name to demangle
+  std::string demangle_path_component(
+    const std::string &component ///< [in] Subdir name to demangle
     ); ///< @return Demangled path component.
 
   /// Decompose full path into object name and filename.
   int decompose_full_path(
     const char *in,      ///< [in] Full path to object.
-    vector<string> *out, ///< [out] Path to object at in.
+    std::vector<std::string> *out, ///< [out] Path to object at in.
     ghobject_t *oid,	 ///< [out] Object at in.
-    string *shortname	 ///< [out] Filename of object at in.
+    std::string *shortname	 ///< [out] Filename of object at in.
     ); ///< @return Error Code, 0 on success.
 
   /// Mangle attribute name
-  string mangle_attr_name(
-    const string &attr ///< [in] Attribute to mangle.
+  std::string mangle_attr_name(
+    const std::string &attr ///< [in] Attribute to mangle.
     ); ///< @return Mangled attribute name.
 
   /// checks whether long_name could hash to short_name

--- a/src/os/filestore/SequencerPosition.h
+++ b/src/os/filestore/SequencerPosition.h
@@ -21,26 +21,26 @@ struct SequencerPosition {
 
   SequencerPosition(uint64_t s=0, int32_t t=0, int32_t o=0) : seq(s), trans(t), op(o) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(seq, bl);
     encode(trans, bl);
     encode(op, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator& p) {
+  void decode(ceph::buffer::list::const_iterator& p) {
     DECODE_START(1, p);
     decode(seq, p);
     decode(trans, p);
     decode(op, p);
     DECODE_FINISH(p);
   }
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->dump_unsigned("seq", seq);
     f->dump_unsigned("trans", trans);
     f->dump_unsigned("op", op);
   }
-  static void generate_test_instances(list<SequencerPosition*>& o) {
+  static void generate_test_instances(std::list<SequencerPosition*>& o) {
     o.push_back(new SequencerPosition);
     o.push_back(new SequencerPosition(1, 2, 3));
     o.push_back(new SequencerPosition(4, 5, 6));
@@ -48,7 +48,7 @@ struct SequencerPosition {
 };
 WRITE_CLASS_ENCODER(SequencerPosition)
 
-inline ostream& operator<<(ostream& out, const SequencerPosition& t) {
+inline std::ostream& operator<<(std::ostream& out, const SequencerPosition& t) {
   return out << t.seq << "." << t.trans << "." << t.op;
 }
 

--- a/src/os/filestore/WBThrottle.cc
+++ b/src/os/filestore/WBThrottle.cc
@@ -7,6 +7,9 @@
 #include "common/perf_counters.h"
 #include "common/errno.h"
 
+using std::pair;
+using std::string;
+
 WBThrottle::WBThrottle(CephContext *cct) :
   cur_ios(0), cur_size(0),
   cct(cct),

--- a/src/os/filestore/WBThrottle.h
+++ b/src/os/filestore/WBThrottle.h
@@ -48,13 +48,13 @@ class WBThrottle : Thread, public md_config_obs_t {
    */
 
   /// Limits on unflushed bytes
-  pair<uint64_t, uint64_t> size_limits;
+  std::pair<uint64_t, uint64_t> size_limits;
 
   /// Limits on unflushed ios
-  pair<uint64_t, uint64_t> io_limits;
+  std::pair<uint64_t, uint64_t> io_limits;
 
   /// Limits on unflushed objects
-  pair<uint64_t, uint64_t> fd_limits;
+  std::pair<uint64_t, uint64_t> fd_limits;
 
   uint64_t cur_ios;  /// Currently unflushed IOs
   uint64_t cur_size; /// Currently unflushed bytes
@@ -86,11 +86,11 @@ class WBThrottle : Thread, public md_config_obs_t {
   /**
    * Flush objects in lru order
    */
-  list<ghobject_t> lru;
-  ceph::unordered_map<ghobject_t, list<ghobject_t>::iterator> rev_lru;
+  std::list<ghobject_t> lru;
+  ceph::unordered_map<ghobject_t, std::list<ghobject_t>::iterator> rev_lru;
   void remove_object(const ghobject_t &oid) {
     ceph_assert(ceph_mutex_is_locked(lock));
-    ceph::unordered_map<ghobject_t, list<ghobject_t>::iterator>::iterator iter =
+    ceph::unordered_map<ghobject_t, std::list<ghobject_t>::iterator>::iterator iter =
       rev_lru.find(oid);
     if (iter == rev_lru.end())
       return;
@@ -111,7 +111,7 @@ class WBThrottle : Thread, public md_config_obs_t {
     rev_lru.insert(make_pair(oid, --lru.end()));
   }
 
-  ceph::unordered_map<ghobject_t, pair<PendingWB, FDRef> > pending_wbs;
+  ceph::unordered_map<ghobject_t, std::pair<PendingWB, FDRef> > pending_wbs;
 
   /// get next flush to perform
   bool get_next_should_flush(

--- a/src/os/filestore/chain_xattr.cc
+++ b/src/os/filestore/chain_xattr.cc
@@ -15,6 +15,8 @@
 
 #include "include/ceph_assert.h"
 
+using ceph::bufferptr;
+
 /*
  * chaining xattrs
  *

--- a/src/os/filestore/chain_xattr.h
+++ b/src/os/filestore/chain_xattr.h
@@ -32,45 +32,45 @@
 
 // wrappers to hide annoying errno handling.
 
-static inline int sys_fgetxattr(int fd, const char *name, void *val, size_t size)
+inline int sys_fgetxattr(int fd, const char *name, void *val, size_t size)
 {
   int r = ::ceph_os_fgetxattr(fd, name, val, size);
   return (r < 0 ? -errno : r);
 }
-static inline int sys_getxattr(const char *fn, const char *name, void *val, size_t size)
+inline int sys_getxattr(const char *fn, const char *name, void *val, size_t size)
 {
   int r = ::ceph_os_getxattr(fn, name, val, size);
   return (r < 0 ? -errno : r);
 }
 
-static inline int sys_setxattr(const char *fn, const char *name, const void *val, size_t size)
+inline int sys_setxattr(const char *fn, const char *name, const void *val, size_t size)
 {
   int r = ::ceph_os_setxattr(fn, name, val, size);
   return (r < 0 ? -errno : r);
 }
-static inline int sys_fsetxattr(int fd, const char *name, const void *val, size_t size)
+inline int sys_fsetxattr(int fd, const char *name, const void *val, size_t size)
 {
   int r = ::ceph_os_fsetxattr(fd, name, val, size);
   return (r < 0 ? -errno : r);
 }
 
-static inline int sys_listxattr(const char *fn, char *names, size_t len)
+inline int sys_listxattr(const char *fn, char *names, size_t len)
 {
   int r = ::ceph_os_listxattr(fn, names, len);
   return (r < 0 ? -errno : r);
 }
-static inline int sys_flistxattr(int fd, char *names, size_t len)
+inline int sys_flistxattr(int fd, char *names, size_t len)
 {
   int r = ::ceph_os_flistxattr(fd, names, len);
   return (r < 0 ? -errno : r);
 }
 
-static inline int sys_removexattr(const char *fn, const char *name)
+inline int sys_removexattr(const char *fn, const char *name)
 {
   int r = ::ceph_os_removexattr(fn, name);
   return (r < 0 ? -errno : r);
 }
-static inline int sys_fremovexattr(int fd, const char *name)
+inline int sys_fremovexattr(int fd, const char *name)
 {
   int r = ::ceph_os_fremovexattr(fd, name);
   return (r < 0 ? -errno : r);
@@ -80,7 +80,7 @@ static inline int sys_fremovexattr(int fd, const char *name)
 // wrappers to chain large values across multiple xattrs
 
 int chain_getxattr(const char *fn, const char *name, void *val, size_t size);
-int chain_getxattr_buf(const char *fn, const char *name, bufferptr *bp);
+int chain_getxattr_buf(const char *fn, const char *name, ceph::buffer::ptr *bp);
 int chain_fgetxattr(int fd, const char *name, void *val, size_t size);
 
 int get_xattr_block_size(size_t size);

--- a/src/os/fs/FS.cc
+++ b/src/os/fs/FS.cc
@@ -168,7 +168,7 @@ int FS::zero(int fd, uint64_t offset, uint64_t length)
 
   {
     // fall back to writing zeros
-    bufferlist bl;
+    ceph::bufferlist bl;
     bl.append_zero(length);
     r = ::lseek64(fd, offset, SEEK_SET);
     if (r < 0) {

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -45,6 +45,21 @@
 
  */
 
+using std::list;
+using std::make_pair;
+using std::map;
+using std::pair;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::decode;
+using ceph::encode;
+using ceph::JSONFormatter;
+
 const string PREFIX_SUPER = "S"; // field -> value
 const string PREFIX_COLL = "C"; // collection name -> (nothing)
 const string PREFIX_OBJ = "O";  // object name -> onode
@@ -900,7 +915,7 @@ int KStore::_open_collections(int *errors)
       auto p = bl.cbegin();
       try {
         decode(c->cnode, p);
-      } catch (buffer::error& e) {
+      } catch (ceph::buffer::error& e) {
         derr << __func__ << " failed to decode cnode, key:"
              << pretty_binary_string(it->key()) << dendl;
         return -EIO;
@@ -1900,7 +1915,7 @@ int KStore::_open_super_meta()
     auto p = bl.cbegin();
     try {
       decode(nid_max, p);
-    } catch (buffer::error& e) {
+    } catch (ceph::buffer::error& e) {
     }
     dout(10) << __func__ << " old nid_max " << nid_max << dendl;
     nid_last = nid_max;

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -53,7 +53,7 @@ class KStore : public ObjectStore {
   // types
 public:
 
-  class TransContext;
+  struct TransContext;
 
   /// an in-memory object
   struct Onode {
@@ -61,7 +61,7 @@ public:
     std::atomic_int nref;  ///< reference count
 
     ghobject_t oid;
-    string key;     ///< key under PREFIX_OBJ where we are stored
+    std::string key;     ///< key under PREFIX_OBJ where we are stored
     boost::intrusive::list_member_hook<> lru_item;
 
     kstore_onode_t onode;  ///< metadata stored as value in kv store
@@ -70,14 +70,14 @@ public:
 
     std::mutex flush_lock;  ///< protect flush_txns
     std::condition_variable flush_cond;   ///< wait here for unapplied txns
-    set<TransContext*> flush_txns;   ///< committing txns
+    std::set<TransContext*> flush_txns;   ///< committing txns
 
     uint64_t tail_offset;
-    bufferlist tail_bl;
+    ceph::buffer::list tail_bl;
 
-    map<uint64_t,bufferlist> pending_stripes;  ///< unwritten stripes
+    std::map<uint64_t,ceph::buffer::list> pending_stripes;  ///< unwritten stripes
 
-    Onode(CephContext* cct, const ghobject_t& o, const string& k)
+    Onode(CephContext* cct, const ghobject_t& o, const std::string& k)
       : cct(cct),
 	nref(0),
 	oid(o),
@@ -126,7 +126,7 @@ public:
     OnodeRef lookup(const ghobject_t& o);
     void rename(const ghobject_t& old_oid, const ghobject_t& new_oid);
     void clear();
-    bool get_next(const ghobject_t& after, pair<ghobject_t,OnodeRef> *next);
+    bool get_next(const ghobject_t& after, std::pair<ghobject_t,OnodeRef> *next);
     int trim(int max=-1);
   };
 
@@ -171,16 +171,16 @@ public:
     CollectionRef c;
     OnodeRef o;
     KeyValueDB::Iterator it;
-    string head, tail;
+    std::string head, tail;
   public:
     OmapIteratorImpl(CollectionRef c, OnodeRef o, KeyValueDB::Iterator it);
     int seek_to_first() override;
-    int upper_bound(const string &after) override;
-    int lower_bound(const string &to) override;
+    int upper_bound(const std::string &after) override;
+    int lower_bound(const std::string &to) override;
     bool valid() override;
     int next() override;
-    string key() override;
-    bufferlist value() override;
+    std::string key() override;
+    ceph::buffer::list value() override;
     int status() override {
       return 0;
     }
@@ -227,13 +227,13 @@ public:
 
     uint64_t ops, bytes;
 
-    set<OnodeRef> onodes;     ///< these onodes need to be updated/written
+    std::set<OnodeRef> onodes;     ///< these onodes need to be updated/written
     KeyValueDB::Transaction t; ///< then we will commit this
     Context *oncommit;         ///< signal on commit
     Context *onreadable;         ///< signal on readable
     Context *onreadable_sync;         ///< signal on readable
-    list<Context*> oncommits;  ///< more commit completions
-    list<CollectionRef> removed_collections; ///< colls we removed
+    std::list<Context*> oncommits;  ///< more commit completions
+    std::list<CollectionRef> removed_collections; ///< colls we removed
 
     CollectionRef first_collection;  ///< first referenced collection
     utime_t start;
@@ -313,7 +313,7 @@ public:
 private:
   KeyValueDB *db;
   uuid_d fsid;
-  string basedir;
+  std::string basedir;
   int path_fd;  ///< open handle to $path
   int fsid_fd;  ///< open handle (locked) to $path/fsid
   bool mounted;
@@ -321,7 +321,7 @@ private:
   /// rwlock to protect coll_map
   ceph::shared_mutex coll_lock = ceph::make_shared_mutex("KStore::coll_lock");
   ceph::unordered_map<coll_t, CollectionRef> coll_map;
-  map<coll_t,CollectionRef> new_coll_map;
+  std::map<coll_t,CollectionRef> new_coll_map;
 
   std::mutex nid_lock;
   uint64_t nid_last;
@@ -335,12 +335,12 @@ private:
   std::mutex kv_lock;
   std::condition_variable kv_cond, kv_sync_cond;
   bool kv_stop;
-  deque<TransContext*> kv_queue, kv_committing;
+  std::deque<TransContext*> kv_queue, kv_committing;
 
   //Logger *logger;
   PerfCounters *logger;
   std::mutex reap_lock;
-  list<CollectionRef> removed_collections;
+  std::list<CollectionRef> removed_collections;
 
 
   // --------------------------------------------------------
@@ -392,20 +392,20 @@ private:
     kv_stop = false;
   }
 
-  void _do_read_stripe(OnodeRef o, uint64_t offset, bufferlist *pbl, bool do_cache);
+  void _do_read_stripe(OnodeRef o, uint64_t offset, ceph::buffer::list *pbl, bool do_cache);
   void _do_write_stripe(TransContext *txc, OnodeRef o,
-			uint64_t offset, bufferlist& bl);
+			uint64_t offset, ceph::buffer::list& bl);
   void _do_remove_stripe(TransContext *txc, OnodeRef o, uint64_t offset);
 
   int _collection_list(
     Collection *c, const ghobject_t& start, const ghobject_t& end,
-    int max, vector<ghobject_t> *ls, ghobject_t *next);
+    int max, std::vector<ghobject_t> *ls, ghobject_t *next);
 
 public:
-  KStore(CephContext *cct, const string& path);
+  KStore(CephContext *cct, const std::string& path);
   ~KStore() override;
 
-  string get_type() override {
+  std::string get_type() override {
     return "kstore";
   }
 
@@ -413,7 +413,7 @@ public:
   bool wants_journal() override { return false; };
   bool allows_journal() override { return false; };
 
-  static int get_block_device_fsid(const string& path, uuid_d *fsid);
+  static int get_block_device_fsid(const std::string& path, uuid_d *fsid);
 
   bool test_mount_in_use() override;
 
@@ -435,12 +435,12 @@ public:
   int mkjournal() override {
     return 0;
   }
-  void dump_perf_counters(Formatter *f) override {
+  void dump_perf_counters(ceph::Formatter *f) override {
     f->open_object_section("perf_counters");
     logger->dump_formatted(f, false);
     f->close_section();
   }
-  void get_db_statistics(Formatter *f) override {
+  void get_db_statistics(ceph::Formatter *f) override {
     db->get_statistics(f);
   }
   int statfs(struct store_statfs_t *buf,
@@ -471,39 +471,39 @@ public:
     const ghobject_t& oid,
     uint64_t offset,
     size_t len,
-    bufferlist& bl,
+    ceph::buffer::list& bl,
     uint32_t op_flags = 0) override;
   int _do_read(
     OnodeRef o,
     uint64_t offset,
     size_t len,
-    bufferlist& bl,
+    ceph::buffer::list& bl,
     bool do_cache,
     uint32_t op_flags = 0);
 
   using ObjectStore::fiemap;
-  int fiemap(CollectionHandle& c, const ghobject_t& oid, uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap) override;
-  int fiemap(CollectionHandle& c, const ghobject_t& oid, uint64_t offset, size_t len, bufferlist& outbl) override;
+  int fiemap(CollectionHandle& c, const ghobject_t& oid, uint64_t offset, size_t len, std::map<uint64_t, uint64_t>& destmap) override;
+  int fiemap(CollectionHandle& c, const ghobject_t& oid, uint64_t offset, size_t len, ceph::buffer::list& outbl) override;
   using ObjectStore::getattr;
-  int getattr(CollectionHandle& c, const ghobject_t& oid, const char *name, bufferptr& value) override;
+  int getattr(CollectionHandle& c, const ghobject_t& oid, const char *name, ceph::buffer::ptr& value) override;
   using ObjectStore::getattrs;
-  int getattrs(CollectionHandle& c, const ghobject_t& oid, map<string,bufferptr>& aset) override;
+  int getattrs(CollectionHandle& c, const ghobject_t& oid, std::map<std::string,ceph::buffer::ptr>& aset) override;
 
-  int list_collections(vector<coll_t>& ls) override;
+  int list_collections(std::vector<coll_t>& ls) override;
   bool collection_exists(const coll_t& c) override;
   int collection_empty(CollectionHandle& c, bool *empty) override;
   int collection_bits(CollectionHandle& c) override;
   int collection_list(
     CollectionHandle &c, const ghobject_t& start, const ghobject_t& end,
     int max,
-    vector<ghobject_t> *ls, ghobject_t *next) override;
+    std::vector<ghobject_t> *ls, ghobject_t *next) override;
 
   using ObjectStore::omap_get;
   int omap_get(
     CollectionHandle& c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
-    bufferlist *header,      ///< [out] omap header
-    map<string, bufferlist> *out /// < [out] Key to value map
+    ceph::buffer::list *header,      ///< [out] omap header
+    std::map<std::string, ceph::buffer::list> *out /// < [out] Key to value std::map
     ) override;
 
   using ObjectStore::omap_get_header;
@@ -511,7 +511,7 @@ public:
   int omap_get_header(
     CollectionHandle& c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
-    bufferlist *header,      ///< [out] omap header
+    ceph::buffer::list *header,      ///< [out] omap header
     bool allow_eio = false ///< [in] don't assert on eio
     ) override;
 
@@ -520,7 +520,7 @@ public:
   int omap_get_keys(
     CollectionHandle& c,              ///< [in] Collection containing oid
     const ghobject_t &oid, ///< [in] Object containing omap
-    set<string> *keys      ///< [out] Keys defined on oid
+    std::set<std::string> *keys      ///< [out] Keys defined on oid
     ) override;
 
   using ObjectStore::omap_get_values;
@@ -528,8 +528,8 @@ public:
   int omap_get_values(
     CollectionHandle& c,                    ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
-    const set<string> &keys,     ///< [in] Keys to get
-    map<string, bufferlist> *out ///< [out] Returned keys and values
+    const std::set<std::string> &keys,     ///< [in] Keys to get
+    std::map<std::string, ceph::buffer::list> *out ///< [out] Returned keys and values
     ) override;
 
   using ObjectStore::omap_check_keys;
@@ -537,8 +537,8 @@ public:
   int omap_check_keys(
     CollectionHandle& c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
-    const set<string> &keys, ///< [in] Keys to check
-    set<string> *out         ///< [out] Subset of keys defined on oid
+    const std::set<std::string> &keys, ///< [in] Keys to check
+    std::set<std::string> *out         ///< [out] Subset of keys defined on oid
     ) override;
 
   using ObjectStore::get_omap_iterator;
@@ -568,7 +568,7 @@ public:
 
   int queue_transactions(
     CollectionHandle& ch,
-    vector<Transaction>& tls,
+    std::vector<Transaction>& tls,
     TrackedOpRef op = TrackedOpRef(),
     ThreadPool::TPHandle *handle = NULL) override;
 
@@ -585,12 +585,12 @@ private:
 	     CollectionRef& c,
 	     OnodeRef& o,
 	     uint64_t offset, size_t len,
-	     bufferlist& bl,
+	     ceph::buffer::list& bl,
 	     uint32_t fadvise_flags);
   int _do_write(TransContext *txc,
 		OnodeRef o,
 		uint64_t offset, uint64_t length,
-		bufferlist& bl,
+		ceph::buffer::list& bl,
 		uint32_t fadvise_flags);
   int _touch(TransContext *txc,
 	     CollectionRef& c,
@@ -614,16 +614,16 @@ private:
   int _setattr(TransContext *txc,
 	       CollectionRef& c,
 	       OnodeRef& o,
-	       const string& name,
-	       bufferptr& val);
+	       const std::string& name,
+	       ceph::buffer::ptr& val);
   int _setattrs(TransContext *txc,
 		CollectionRef& c,
 		OnodeRef& o,
-		const map<string,bufferptr>& aset);
+		const std::map<std::string,ceph::buffer::ptr>& aset);
   int _rmattr(TransContext *txc,
 	      CollectionRef& c,
 	      OnodeRef& o,
-	      const string& name);
+	      const std::string& name);
   int _rmattrs(TransContext *txc,
 	       CollectionRef& c,
 	       OnodeRef& o);
@@ -634,19 +634,19 @@ private:
   int _omap_setkeys(TransContext *txc,
 		    CollectionRef& c,
 		    OnodeRef& o,
-		    bufferlist& bl);
+		    ceph::buffer::list& bl);
   int _omap_setheader(TransContext *txc,
 		      CollectionRef& c,
 		      OnodeRef& o,
-		      bufferlist& header);
+		      ceph::buffer::list& header);
   int _omap_rmkeys(TransContext *txc,
 		   CollectionRef& c,
 		   OnodeRef& o,
-		   const bufferlist& bl);
+		   const ceph::buffer::list& bl);
   int _omap_rmkey_range(TransContext *txc,
 			CollectionRef& c,
 			OnodeRef& o,
-			const string& first, const string& last);
+			const std::string& first, const std::string& last);
   int _setallochint(TransContext *txc,
 		    CollectionRef& c,
 		    OnodeRef& o,

--- a/src/os/kstore/kstore_types.cc
+++ b/src/os/kstore/kstore_types.cc
@@ -16,6 +16,11 @@
 #include "common/Formatter.h"
 #include "include/stringify.h"
 
+using std::list;
+
+using ceph::bufferlist;
+using ceph::Formatter;
+
 // cnode_t
 
 void kstore_cnode_t::encode(bufferlist& bl) const
@@ -80,8 +85,7 @@ void kstore_onode_t::dump(Formatter *f) const
   f->dump_unsigned("nid", nid);
   f->dump_unsigned("size", size);
   f->open_object_section("attrs");
-  for (map<string,bufferptr>::const_iterator p = attrs.begin();
-       p != attrs.end(); ++p) {
+  for (auto p = attrs.begin(); p != attrs.end(); ++p) {
     f->open_object_section("attr");
     f->dump_string("name", p->first);
     f->dump_unsigned("len", p->second.length());

--- a/src/os/kstore/kstore_types.h
+++ b/src/os/kstore/kstore_types.h
@@ -30,10 +30,10 @@ struct kstore_cnode_t {
 
   explicit kstore_cnode_t(int b=0) : bits(b) {}
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<kstore_cnode_t*>& o);
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<kstore_cnode_t*>& o);
 };
 WRITE_CLASS_ENCODER(kstore_cnode_t)
 
@@ -41,7 +41,7 @@ WRITE_CLASS_ENCODER(kstore_cnode_t)
 struct kstore_onode_t {
   uint64_t nid;                        ///< numeric id (locally unique)
   uint64_t size;                       ///< object size
-  map<string, bufferptr> attrs;        ///< attrs
+  std::map<std::string, ceph::buffer::ptr> attrs;        ///< attrs
   uint64_t omap_head;                  ///< id for omap root node
   uint32_t stripe_size;                ///< stripe size
 
@@ -58,10 +58,10 @@ struct kstore_onode_t {
       expected_write_size(0),
       alloc_hint_flags(0) {}
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& p);
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<kstore_onode_t*>& o);
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<kstore_onode_t*>& o);
 };
 WRITE_CLASS_ENCODER(kstore_onode_t)
 

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -33,6 +33,9 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "memstore(" << path << ") "
 
+using ceph::decode;
+using ceph::encode;
+
 // for comparing collections for lock ordering
 bool operator>(const MemStore::CollectionRef& l,
 	       const MemStore::CollectionRef& r)
@@ -61,23 +64,21 @@ int MemStore::_save()
 {
   dout(10) << __func__ << dendl;
   dump_all();
-  set<coll_t> collections;
-  for (ceph::unordered_map<coll_t,CollectionRef>::iterator p = coll_map.begin();
-       p != coll_map.end();
-       ++p) {
+  std::set<coll_t> collections;
+  for (auto p = coll_map.begin(); p != coll_map.end(); ++p) {
     dout(20) << __func__ << " coll " << p->first << " " << p->second << dendl;
     collections.insert(p->first);
-    bufferlist bl;
+    ceph::buffer::list bl;
     ceph_assert(p->second);
     p->second->encode(bl);
-    string fn = path + "/" + stringify(p->first);
+    std::string fn = path + "/" + stringify(p->first);
     int r = bl.write_file(fn.c_str());
     if (r < 0)
       return r;
   }
 
-  string fn = path + "/collections";
-  bufferlist bl;
+  std::string fn = path + "/collections";
+  ceph::buffer::list bl;
   encode(collections, bl);
   int r = bl.write_file(fn.c_str());
   if (r < 0)
@@ -88,7 +89,7 @@ int MemStore::_save()
 
 void MemStore::dump_all()
 {
-  Formatter *f = Formatter::create("json-pretty");
+  auto f = ceph::Formatter::create("json-pretty");
   f->open_object_section("store");
   dump(f);
   f->close_section();
@@ -98,17 +99,15 @@ void MemStore::dump_all()
   delete f;
 }
 
-void MemStore::dump(Formatter *f)
+void MemStore::dump(ceph::Formatter *f)
 {
   f->open_array_section("collections");
-  for (ceph::unordered_map<coll_t,CollectionRef>::iterator p = coll_map.begin();
-       p != coll_map.end();
-       ++p) {
+  for (auto p = coll_map.begin(); p != coll_map.end(); ++p) {
     f->open_object_section("collection");
     f->dump_string("name", stringify(p->first));
 
     f->open_array_section("xattrs");
-    for (map<string,bufferptr>::iterator q = p->second->xattr.begin();
+    for (auto q = p->second->xattr.begin();
 	 q != p->second->xattr.end();
 	 ++q) {
       f->open_object_section("xattr");
@@ -119,7 +118,7 @@ void MemStore::dump(Formatter *f)
     f->close_section();
 
     f->open_array_section("objects");
-    for (map<ghobject_t,ObjectRef>::iterator q = p->second->object_map.begin();
+    for (auto q = p->second->object_map.begin();
 	 q != p->second->object_map.end();
 	 ++q) {
       f->open_object_section("object");
@@ -138,22 +137,22 @@ void MemStore::dump(Formatter *f)
 int MemStore::_load()
 {
   dout(10) << __func__ << dendl;
-  bufferlist bl;
-  string fn = path + "/collections";
-  string err;
+  ceph::buffer::list bl;
+  std::string fn = path + "/collections";
+  std::string err;
   int r = bl.read_file(fn.c_str(), &err);
   if (r < 0)
     return r;
 
-  set<coll_t> collections;
+  std::set<coll_t> collections;
   auto p = bl.cbegin();
   decode(collections, p);
 
-  for (set<coll_t>::iterator q = collections.begin();
+  for (auto q = collections.begin();
        q != collections.end();
        ++q) {
-    string fn = path + "/" + stringify(*q);
-    bufferlist cbl;
+    std::string fn = path + "/" + stringify(*q);
+    ceph::buffer::list cbl;
     int r = cbl.read_file(fn.c_str(), &err);
     if (r < 0)
       return r;
@@ -177,7 +176,7 @@ void MemStore::set_fsid(uuid_d u)
 
 uuid_d MemStore::get_fsid()
 {
-  string fsid_str;
+  std::string fsid_str;
   int r = read_meta("fsid", &fsid_str);
   ceph_assert(r >= 0);
   uuid_d uuid;
@@ -188,7 +187,7 @@ uuid_d MemStore::get_fsid()
 
 int MemStore::mkfs()
 {
-  string fsid_str;
+  std::string fsid_str;
   int r = read_meta("fsid", &fsid_str);
   if (r == -ENOENT) {
     uuid_d fsid;
@@ -204,10 +203,10 @@ int MemStore::mkfs()
     dout(1) << __func__ << " had fsid " << fsid_str << dendl;
   }
 
-  string fn = path + "/collections";
+  std::string fn = path + "/collections";
   derr << path << dendl;
-  bufferlist bl;
-  set<coll_t> collections;
+  ceph::buffer::list bl;
+  std::set<coll_t> collections;
   encode(collections, bl);
   r = bl.write_file(fn.c_str());
   if (r < 0)
@@ -311,7 +310,7 @@ int MemStore::read(
   const ghobject_t& oid,
   uint64_t offset,
   size_t len,
-  bufferlist& bl,
+  ceph::buffer::list& bl,
   uint32_t op_flags)
 {
   Collection *c = static_cast<Collection*>(c_.get());
@@ -334,9 +333,9 @@ int MemStore::read(
 }
 
 int MemStore::fiemap(CollectionHandle& ch, const ghobject_t& oid,
-		     uint64_t offset, size_t len, bufferlist& bl)
+		     uint64_t offset, size_t len, ceph::buffer::list& bl)
 {
-  map<uint64_t, uint64_t> destmap;
+  std::map<uint64_t, uint64_t> destmap;
   int r = fiemap(ch, oid, offset, len, destmap);
   if (r >= 0)
     encode(destmap, bl);
@@ -344,7 +343,7 @@ int MemStore::fiemap(CollectionHandle& ch, const ghobject_t& oid,
 }
 
 int MemStore::fiemap(CollectionHandle& ch, const ghobject_t& oid,
-		     uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap)
+		     uint64_t offset, size_t len, std::map<uint64_t, uint64_t>& destmap)
 {
   dout(10) << __func__ << " " << ch->cid << " " << oid << " " << offset << "~"
 	   << len << dendl;
@@ -366,7 +365,7 @@ int MemStore::fiemap(CollectionHandle& ch, const ghobject_t& oid,
 }
 
 int MemStore::getattr(CollectionHandle &c_, const ghobject_t& oid,
-		      const char *name, bufferptr& value)
+		      const char *name, ceph::buffer::ptr& value)
 {
   Collection *c = static_cast<Collection*>(c_.get());
   dout(10) << __func__ << " " << c->cid << " " << oid << " " << name << dendl;
@@ -375,7 +374,7 @@ int MemStore::getattr(CollectionHandle &c_, const ghobject_t& oid,
   ObjectRef o = c->get_object(oid);
   if (!o)
     return -ENOENT;
-  string k(name);
+  std::string k(name);
   std::lock_guard lock{o->xattr_mutex};
   if (!o->xattr.count(k)) {
     return -ENODATA;
@@ -385,7 +384,7 @@ int MemStore::getattr(CollectionHandle &c_, const ghobject_t& oid,
 }
 
 int MemStore::getattrs(CollectionHandle &c_, const ghobject_t& oid,
-		       map<string,bufferptr>& aset)
+		       std::map<std::string,ceph::buffer::ptr>& aset)
 {
   Collection *c = static_cast<Collection*>(c_.get());
   dout(10) << __func__ << " " << c->cid << " " << oid << dendl;
@@ -400,7 +399,7 @@ int MemStore::getattrs(CollectionHandle &c_, const ghobject_t& oid,
   return 0;
 }
 
-int MemStore::list_collections(vector<coll_t>& ls)
+int MemStore::list_collections(std::vector<coll_t>& ls)
 {
   dout(10) << __func__ << dendl;
   std::shared_lock l{coll_lock};
@@ -440,14 +439,14 @@ int MemStore::collection_list(CollectionHandle& ch,
 			      const ghobject_t& start,
 			      const ghobject_t& end,
 			      int max,
-			      vector<ghobject_t> *ls, ghobject_t *next)
+			      std::vector<ghobject_t> *ls, ghobject_t *next)
 {
   Collection *c = static_cast<Collection*>(ch.get());
   std::shared_lock l{c->lock};
 
   dout(10) << __func__ << " cid " << ch->cid << " start " << start
 	   << " end " << end << dendl;
-  map<ghobject_t,ObjectRef>::iterator p = c->object_map.lower_bound(start);
+  auto p = c->object_map.lower_bound(start);
   while (p != c->object_map.end() &&
 	 ls->size() < (unsigned)max &&
 	 p->first < end) {
@@ -467,8 +466,8 @@ int MemStore::collection_list(CollectionHandle& ch,
 int MemStore::omap_get(
   CollectionHandle& ch,                ///< [in] Collection containing oid
   const ghobject_t &oid,   ///< [in] Object containing omap
-  bufferlist *header,      ///< [out] omap header
-  map<string, bufferlist> *out /// < [out] Key to value map
+  ceph::buffer::list *header,      ///< [out] omap header
+  std::map<std::string, ceph::buffer::list> *out /// < [out] Key to value map
   )
 {
   dout(10) << __func__ << " " << ch->cid << " " << oid << dendl;
@@ -486,7 +485,7 @@ int MemStore::omap_get(
 int MemStore::omap_get_header(
   CollectionHandle& ch,                ///< [in] Collection containing oid
   const ghobject_t &oid,   ///< [in] Object containing omap
-  bufferlist *header,      ///< [out] omap header
+  ceph::buffer::list *header,      ///< [out] omap header
   bool allow_eio ///< [in] don't assert on eio
   )
 {
@@ -503,7 +502,7 @@ int MemStore::omap_get_header(
 int MemStore::omap_get_keys(
   CollectionHandle& ch,              ///< [in] Collection containing oid
   const ghobject_t &oid, ///< [in] Object containing omap
-  set<string> *keys      ///< [out] Keys defined on oid
+  std::set<std::string> *keys      ///< [out] Keys defined on oid
   )
 {
   dout(10) << __func__ << " " << ch->cid << " " << oid << dendl;
@@ -512,9 +511,7 @@ int MemStore::omap_get_keys(
   if (!o)
     return -ENOENT;
   std::lock_guard lock{o->omap_mutex};
-  for (map<string,bufferlist>::iterator p = o->omap.begin();
-       p != o->omap.end();
-       ++p)
+  for (auto p = o->omap.begin(); p != o->omap.end(); ++p)
     keys->insert(p->first);
   return 0;
 }
@@ -522,8 +519,8 @@ int MemStore::omap_get_keys(
 int MemStore::omap_get_values(
   CollectionHandle& ch,                    ///< [in] Collection containing oid
   const ghobject_t &oid,       ///< [in] Object containing omap
-  const set<string> &keys,     ///< [in] Keys to get
-  map<string, bufferlist> *out ///< [out] Returned keys and values
+  const std::set<std::string> &keys,     ///< [in] Keys to get
+  std::map<std::string, ceph::buffer::list> *out ///< [out] Returned keys and values
   )
 {
   dout(10) << __func__ << " " << ch->cid << " " << oid << dendl;
@@ -532,10 +529,8 @@ int MemStore::omap_get_values(
   if (!o)
     return -ENOENT;
   std::lock_guard lock{o->omap_mutex};
-  for (set<string>::const_iterator p = keys.begin();
-       p != keys.end();
-       ++p) {
-    map<string,bufferlist>::iterator q = o->omap.find(*p);
+  for (auto p = keys.begin(); p != keys.end(); ++p) {
+    auto q = o->omap.find(*p);
     if (q != o->omap.end())
       out->insert(*q);
   }
@@ -545,8 +540,8 @@ int MemStore::omap_get_values(
 int MemStore::omap_check_keys(
   CollectionHandle& ch,                ///< [in] Collection containing oid
   const ghobject_t &oid,   ///< [in] Object containing omap
-  const set<string> &keys, ///< [in] Keys to check
-  set<string> *out         ///< [out] Subset of keys defined on oid
+  const std::set<std::string> &keys, ///< [in] Keys to check
+  std::set<std::string> *out         ///< [out] Subset of keys defined on oid
   )
 {
   dout(10) << __func__ << " " << ch->cid << " " << oid << dendl;
@@ -555,10 +550,8 @@ int MemStore::omap_check_keys(
   if (!o)
     return -ENOENT;
   std::lock_guard lock{o->omap_mutex};
-  for (set<string>::const_iterator p = keys.begin();
-       p != keys.end();
-       ++p) {
-    map<string,bufferlist>::iterator q = o->omap.find(*p);
+  for (auto p = keys.begin(); p != keys.end(); ++p) {
+    auto q = o->omap.find(*p);
     if (q != o->omap.end())
       out->insert(*p);
   }
@@ -568,7 +561,7 @@ int MemStore::omap_check_keys(
 class MemStore::OmapIteratorImpl : public ObjectMap::ObjectMapIteratorImpl {
   CollectionRef c;
   ObjectRef o;
-  map<string,bufferlist>::iterator it;
+  std::map<std::string,ceph::buffer::list>::iterator it;
 public:
   OmapIteratorImpl(CollectionRef c, ObjectRef o)
     : c(c), o(o), it(o->omap.begin()) {}
@@ -578,12 +571,12 @@ public:
     it = o->omap.begin();
     return 0;
   }
-  int upper_bound(const string &after) override {
+  int upper_bound(const std::string &after) override {
     std::lock_guard lock{o->omap_mutex};
     it = o->omap.upper_bound(after);
     return 0;
   }
-  int lower_bound(const string &to) override {
+  int lower_bound(const std::string &to) override {
     std::lock_guard lock{o->omap_mutex};
     it = o->omap.lower_bound(to);
     return 0;
@@ -597,11 +590,11 @@ public:
     ++it;
     return 0;
   }
-  string key() override {
+  std::string key() override {
     std::lock_guard lock{o->omap_mutex};
     return it->first;
   }
-  bufferlist value() override {
+  ceph::buffer::list value() override {
     std::lock_guard lock{o->omap_mutex};
     return it->second;
   }
@@ -628,7 +621,7 @@ ObjectMap::ObjectMapIterator MemStore::get_omap_iterator(
 
 int MemStore::queue_transactions(
   CollectionHandle& ch,
-  vector<Transaction>& tls,
+  std::vector<Transaction>& tls,
   TrackedOpRef op,
   ThreadPool::TPHandle *handle)
 {
@@ -638,7 +631,7 @@ int MemStore::queue_transactions(
   Collection *c = static_cast<Collection*>(ch.get());
   std::unique_lock lock{c->sequencer_mutex};
 
-  for (vector<Transaction>::iterator p = tls.begin(); p != tls.end(); ++p) {
+  for (auto p = tls.begin(); p != tls.end(); ++p) {
     // poke the TPHandle heartbeat just to exercise that code path
     if (handle)
       handle->reset_tp_timeout();
@@ -686,7 +679,7 @@ void MemStore::_do_transaction(Transaction& t)
         uint64_t off = op->off;
         uint64_t len = op->len;
 	uint32_t fadvise_flags = i.get_fadvise_flags();
-        bufferlist bl;
+        ceph::buffer::list bl;
         i.decode_bl(bl);
 	r = _write(cid, oid, off, len, bl, fadvise_flags);
       }
@@ -729,11 +722,11 @@ void MemStore::_do_transaction(Transaction& t)
       {
         coll_t cid = i.get_cid(op->cid);
         ghobject_t oid = i.get_oid(op->oid);
-        string name = i.decode_string();
-        bufferlist bl;
+        std::string name = i.decode_string();
+        ceph::buffer::list bl;
         i.decode_bl(bl);
-	map<string, bufferptr> to_set;
-	to_set[name] = bufferptr(bl.c_str(), bl.length());
+	std::map<std::string, ceph::buffer::ptr> to_set;
+	to_set[name] = ceph::buffer::ptr(bl.c_str(), bl.length());
 	r = _setattrs(cid, oid, to_set);
       }
       break;
@@ -742,7 +735,7 @@ void MemStore::_do_transaction(Transaction& t)
       {
         coll_t cid = i.get_cid(op->cid);
         ghobject_t oid = i.get_oid(op->oid);
-        map<string, bufferptr> aset;
+	std::map<std::string, ceph::buffer::ptr> aset;
         i.decode_attrset(aset);
 	r = _setattrs(cid, oid, aset);
       }
@@ -752,7 +745,7 @@ void MemStore::_do_transaction(Transaction& t)
       {
         coll_t cid = i.get_cid(op->cid);
         ghobject_t oid = i.get_oid(op->oid);
-        string name = i.decode_string();
+        std::string name = i.decode_string();
 	r = _rmattr(cid, oid, name.c_str());
       }
       break;
@@ -808,7 +801,7 @@ void MemStore::_do_transaction(Transaction& t)
       {
         coll_t cid = i.get_cid(op->cid);
         uint32_t type = op->hint_type;
-        bufferlist hint;
+        ceph::buffer::list hint;
         i.decode_bl(hint);
         auto hiter = hint.cbegin();
         if (type == Transaction::COLL_HINT_EXPECTED_NUM_OBJECTS) {
@@ -904,7 +897,7 @@ void MemStore::_do_transaction(Transaction& t)
       {
         coll_t cid = i.get_cid(op->cid);
         ghobject_t oid = i.get_oid(op->oid);
-        bufferlist aset_bl;
+        ceph::buffer::list aset_bl;
         i.decode_attrset_bl(&aset_bl);
 	r = _omap_setkeys(cid, oid, aset_bl);
       }
@@ -913,7 +906,7 @@ void MemStore::_do_transaction(Transaction& t)
       {
         coll_t cid = i.get_cid(op->cid);
         ghobject_t oid = i.get_oid(op->oid);
-        bufferlist keys_bl;
+        ceph::buffer::list keys_bl;
         i.decode_keyset_bl(&keys_bl);
 	r = _omap_rmkeys(cid, oid, keys_bl);
       }
@@ -922,7 +915,7 @@ void MemStore::_do_transaction(Transaction& t)
       {
         coll_t cid = i.get_cid(op->cid);
         ghobject_t oid = i.get_oid(op->oid);
-        string first, last;
+        std::string first, last;
         first = i.decode_string();
         last = i.decode_string();
 	r = _omap_rmkeyrange(cid, oid, first, last);
@@ -932,7 +925,7 @@ void MemStore::_do_transaction(Transaction& t)
       {
         coll_t cid = i.get_cid(op->cid);
         ghobject_t oid = i.get_oid(op->oid);
-        bufferlist bl;
+        ceph::buffer::list bl;
         i.decode_bl(bl);
 	r = _omap_setheader(cid, oid, bl);
       }
@@ -1009,7 +1002,7 @@ void MemStore::_do_transaction(Transaction& t)
 		<< " (op " << pos << ", counting from 0)" << dendl;
 	dout(0) << msg << dendl;
 	dout(0) << " transaction dump:\n";
-	JSONFormatter f(true);
+	ceph::JSONFormatter f(true);
 	f.open_object_section("transaction");
 	t.dump(&f);
 	f.close_section();
@@ -1035,7 +1028,7 @@ int MemStore::_touch(const coll_t& cid, const ghobject_t& oid)
 }
 
 int MemStore::_write(const coll_t& cid, const ghobject_t& oid,
-		     uint64_t offset, size_t len, const bufferlist& bl,
+		     uint64_t offset, size_t len, const ceph::buffer::list& bl,
 		     uint32_t fadvise_flags)
 {
   dout(10) << __func__ << " " << cid << " " << oid << " "
@@ -1061,7 +1054,7 @@ int MemStore::_zero(const coll_t& cid, const ghobject_t& oid,
 {
   dout(10) << __func__ << " " << cid << " " << oid << " " << offset << "~"
 	   << len << dendl;
-  bufferlist bl;
+  ceph::buffer::list bl;
   bl.append_zero(len);
   return _write(cid, oid, offset, len, bl);
 }
@@ -1103,7 +1096,7 @@ int MemStore::_remove(const coll_t& cid, const ghobject_t& oid)
 }
 
 int MemStore::_setattrs(const coll_t& cid, const ghobject_t& oid,
-			map<string,bufferptr>& aset)
+			std::map<std::string,ceph::buffer::ptr>& aset)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
   CollectionRef c = get_collection(cid);
@@ -1114,7 +1107,7 @@ int MemStore::_setattrs(const coll_t& cid, const ghobject_t& oid,
   if (!o)
     return -ENOENT;
   std::lock_guard lock{o->xattr_mutex};
-  for (map<string,bufferptr>::const_iterator p = aset.begin(); p != aset.end(); ++p)
+  for (auto p = aset.begin(); p != aset.end(); ++p)
     o->xattr[p->first] = p->second;
   return 0;
 }
@@ -1225,7 +1218,7 @@ int MemStore::_omap_clear(const coll_t& cid, const ghobject_t &oid)
 }
 
 int MemStore::_omap_setkeys(const coll_t& cid, const ghobject_t &oid,
-			    bufferlist& aset_bl)
+			    ceph::buffer::list& aset_bl)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
   CollectionRef c = get_collection(cid);
@@ -1240,7 +1233,7 @@ int MemStore::_omap_setkeys(const coll_t& cid, const ghobject_t &oid,
   __u32 num;
   decode(num, p);
   while (num--) {
-    string key;
+    std::string key;
     decode(key, p);
     decode(o->omap[key], p);
   }
@@ -1248,7 +1241,7 @@ int MemStore::_omap_setkeys(const coll_t& cid, const ghobject_t &oid,
 }
 
 int MemStore::_omap_rmkeys(const coll_t& cid, const ghobject_t &oid,
-			   bufferlist& keys_bl)
+			   ceph::buffer::list& keys_bl)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
   CollectionRef c = get_collection(cid);
@@ -1263,7 +1256,7 @@ int MemStore::_omap_rmkeys(const coll_t& cid, const ghobject_t &oid,
   __u32 num;
   decode(num, p);
   while (num--) {
-    string key;
+    std::string key;
     decode(key, p);
     o->omap.erase(key);
   }
@@ -1271,7 +1264,7 @@ int MemStore::_omap_rmkeys(const coll_t& cid, const ghobject_t &oid,
 }
 
 int MemStore::_omap_rmkeyrange(const coll_t& cid, const ghobject_t &oid,
-			       const string& first, const string& last)
+			       const std::string& first, const std::string& last)
 {
   dout(10) << __func__ << " " << cid << " " << oid << " " << first
 	   << " " << last << dendl;
@@ -1283,14 +1276,14 @@ int MemStore::_omap_rmkeyrange(const coll_t& cid, const ghobject_t &oid,
   if (!o)
     return -ENOENT;
   std::lock_guard lock{o->omap_mutex};
-  map<string,bufferlist>::iterator p = o->omap.lower_bound(first);
-  map<string,bufferlist>::iterator e = o->omap.lower_bound(last);
+  auto p = o->omap.lower_bound(first);
+  auto e = o->omap.lower_bound(last);
   o->omap.erase(p, e);
   return 0;
 }
 
 int MemStore::_omap_setheader(const coll_t& cid, const ghobject_t &oid,
-			      const bufferlist &bl)
+			      const ceph::buffer::list &bl)
 {
   dout(10) << __func__ << " " << cid << " " << oid << dendl;
   CollectionRef c = get_collection(cid);
@@ -1406,12 +1399,12 @@ int MemStore::_split_collection(const coll_t& cid, uint32_t bits, uint32_t match
   std::scoped_lock l{std::min(&(*sc), &(*dc))->lock,
                      std::max(&(*sc), &(*dc))->lock};
 
-  map<ghobject_t,ObjectRef>::iterator p = sc->object_map.begin();
+  auto p = sc->object_map.begin();
   while (p != sc->object_map.end()) {
     if (p->first.match(bits, match)) {
       dout(20) << " moving " << p->first << dendl;
-      dc->object_map.insert(make_pair(p->first, p->second));
-      dc->object_hash.insert(make_pair(p->first, p->second));
+      dc->object_map.insert(std::make_pair(p->first, p->second));
+      dc->object_hash.insert(std::make_pair(p->first, p->second));
       sc->object_hash.erase(p->first);
       sc->object_map.erase(p++);
     } else {
@@ -1439,11 +1432,11 @@ int MemStore::_merge_collection(const coll_t& cid, uint32_t bits, coll_t dest)
     std::scoped_lock l{std::min(&(*sc), &(*dc))->lock,
                        std::max(&(*sc), &(*dc))->lock};
 
-    map<ghobject_t,ObjectRef>::iterator p = sc->object_map.begin();
+    auto p = sc->object_map.begin();
     while (p != sc->object_map.end()) {
       dout(20) << " moving " << p->first << dendl;
-      dc->object_map.insert(make_pair(p->first, p->second));
-      dc->object_hash.insert(make_pair(p->first, p->second));
+      dc->object_map.insert(std::make_pair(p->first, p->second));
+      dc->object_hash.insert(std::make_pair(p->first, p->second));
       sc->object_hash.erase(p->first);
       sc->object_map.erase(p++);
     }
@@ -1465,23 +1458,23 @@ int MemStore::_merge_collection(const coll_t& cid, uint32_t bits, coll_t dest)
 namespace {
 struct BufferlistObject : public MemStore::Object {
   ceph::spinlock mutex;
-  bufferlist data;
+  ceph::buffer::list data;
 
   size_t get_size() const override { return data.length(); }
 
-  int read(uint64_t offset, uint64_t len, bufferlist &bl) override;
-  int write(uint64_t offset, const bufferlist &bl) override;
+  int read(uint64_t offset, uint64_t len, ceph::buffer::list &bl) override;
+  int write(uint64_t offset, const ceph::buffer::list &bl) override;
   int clone(Object *src, uint64_t srcoff, uint64_t len,
             uint64_t dstoff) override;
   int truncate(uint64_t offset) override;
 
-  void encode(bufferlist& bl) const override {
+  void encode(ceph::buffer::list& bl) const override {
     ENCODE_START(1, 1, bl);
     encode(data, bl);
     encode_base(bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator& p) override {
+  void decode(ceph::buffer::list::const_iterator& p) override {
     DECODE_START(1, p);
     decode(data, p);
     decode_base(p);
@@ -1491,21 +1484,21 @@ struct BufferlistObject : public MemStore::Object {
 }
 // BufferlistObject
 int BufferlistObject::read(uint64_t offset, uint64_t len,
-                                     bufferlist &bl)
+                                     ceph::buffer::list &bl)
 {
   std::lock_guard<decltype(mutex)> lock(mutex);
   bl.substr_of(data, offset, len);
   return bl.length();
 }
 
-int BufferlistObject::write(uint64_t offset, const bufferlist &src)
+int BufferlistObject::write(uint64_t offset, const ceph::buffer::list &src)
 {
   unsigned len = src.length();
 
   std::lock_guard<decltype(mutex)> lock(mutex);
 
   // before
-  bufferlist newdata;
+  ceph::buffer::list newdata;
   if (get_size() >= offset) {
     newdata.substr_of(data, 0, offset);
   } else {
@@ -1519,7 +1512,7 @@ int BufferlistObject::write(uint64_t offset, const bufferlist &src)
 
   // after
   if (get_size() > offset + len) {
-    bufferlist tail;
+    ceph::buffer::list tail;
     tail.substr_of(data, offset + len, get_size() - (offset + len));
     newdata.append(tail);
   }
@@ -1535,7 +1528,7 @@ int BufferlistObject::clone(Object *src, uint64_t srcoff,
   if (srcbl == nullptr)
     return -ENOTSUP;
 
-  bufferlist bl;
+  ceph::buffer::list bl;
   {
     std::lock_guard<decltype(srcbl->mutex)> lock(srcbl->mutex);
     if (srcoff == dstoff && len == src->get_size()) {
@@ -1551,7 +1544,7 @@ int BufferlistObject::truncate(uint64_t size)
 {
   std::lock_guard<decltype(mutex)> lock(mutex);
   if (get_size() > size) {
-    bufferlist bl;
+    ceph::buffer::list bl;
     bl.substr_of(data, 0, size);
     data.claim(bl);
   } else if (get_size() == size) {
@@ -1575,20 +1568,20 @@ struct MemStore::PageSetObject : public Object {
 
   size_t get_size() const override { return data_len; }
 
-  int read(uint64_t offset, uint64_t len, bufferlist &bl) override;
-  int write(uint64_t offset, const bufferlist &bl) override;
+  int read(uint64_t offset, uint64_t len, ceph::buffer::list &bl) override;
+  int write(uint64_t offset, const ceph::buffer::list &bl) override;
   int clone(Object *src, uint64_t srcoff, uint64_t len,
             uint64_t dstoff) override;
   int truncate(uint64_t offset) override;
 
-  void encode(bufferlist& bl) const override {
+  void encode(ceph::buffer::list& bl) const override {
     ENCODE_START(1, 1, bl);
     encode(data_len, bl);
     data.encode(bl);
     encode_base(bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator& p) override {
+  void decode(ceph::buffer::list::const_iterator& p) override {
     DECODE_START(1, p);
     decode(data_len, p);
     data.decode(p);
@@ -1610,7 +1603,7 @@ thread_local PageSet::page_vector MemStore::PageSetObject::tls_pages;
 #define DEFINE_PAGE_VECTOR(name) PageSet::page_vector name;
 #endif
 
-int MemStore::PageSetObject::read(uint64_t offset, uint64_t len, bufferlist& bl)
+int MemStore::PageSetObject::read(uint64_t offset, uint64_t len, ceph::buffer::list& bl)
 {
   const auto start = offset;
   const auto end = offset + len;
@@ -1620,7 +1613,7 @@ int MemStore::PageSetObject::read(uint64_t offset, uint64_t len, bufferlist& bl)
   data.get_range(offset, len, tls_pages);
 
   // allocate a buffer for the data
-  buffer::ptr buf(len);
+  ceph::buffer::ptr buf(len);
 
   auto p = tls_pages.begin();
   while (remaining) {
@@ -1643,7 +1636,7 @@ int MemStore::PageSetObject::read(uint64_t offset, uint64_t len, bufferlist& bl)
 
     // read from page
     const auto page_offset = offset - page->offset;
-    const auto count = min(remaining, data.get_page_size() - page_offset);
+    const auto count = std::min(remaining, data.get_page_size() - page_offset);
 
     buf.copy_in(offset - start, count, page->data + page_offset);
 
@@ -1659,7 +1652,7 @@ int MemStore::PageSetObject::read(uint64_t offset, uint64_t len, bufferlist& bl)
   return len;
 }
 
-int MemStore::PageSetObject::write(uint64_t offset, const bufferlist &src)
+int MemStore::PageSetObject::write(uint64_t offset, const ceph::buffer::list &src)
 {
   unsigned len = src.length();
 
@@ -1673,7 +1666,7 @@ int MemStore::PageSetObject::write(uint64_t offset, const bufferlist &src)
   while (len > 0) {
     unsigned page_offset = offset - (*page)->offset;
     unsigned pageoff = data.get_page_size() - page_offset;
-    unsigned count = min(len, pageoff);
+    unsigned count = std::min(len, pageoff);
     p.copy(count, (*page)->data + page_offset);
     offset += count;
     len -= count;

--- a/src/os/memstore/PageSet.h
+++ b/src/os/memstore/PageSet.h
@@ -51,12 +51,12 @@ struct Page {
       return lhs.offset < rhs.offset;
     }
   };
-  void encode(bufferlist &bl, size_t page_size) const {
+  void encode(ceph::buffer::list &bl, size_t page_size) const {
     using ceph::encode;
-    bl.append(buffer::copy(data, page_size));
+    bl.append(ceph::buffer::copy(data, page_size));
     encode(offset, bl);
   }
-  void decode(bufferlist::const_iterator &p, size_t page_size) {
+  void decode(ceph::buffer::list::const_iterator &p, size_t page_size) {
     using ceph::decode;
     p.copy(page_size, data);
     decode(offset, p);
@@ -206,7 +206,7 @@ class PageSet {
     free_pages(cur, pages.end());
   }
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     using ceph::encode;
     encode(page_size, bl);
     unsigned count = pages.size();
@@ -214,7 +214,7 @@ class PageSet {
     for (auto p = pages.rbegin(); p != pages.rend(); ++p)
       p->encode(bl, page_size);
   }
-  void decode(bufferlist::const_iterator &p) {
+  void decode(ceph::buffer::list::const_iterator &p) {
     using ceph::decode;
     ceph_assert(empty());
     decode(page_size, p);

--- a/src/osd/ECMsgTypes.h
+++ b/src/osd/ECMsgTypes.h
@@ -30,7 +30,7 @@ struct ECSubWrite {
   eversion_t at_version;
   eversion_t trim_to;
   eversion_t roll_forward_to;
-  vector<pg_log_entry_t> log_entries;
+  std::vector<pg_log_entry_t> log_entries;
   std::set<hobject_t> temp_added;
   std::set<hobject_t> temp_removed;
   std::optional<pg_hit_set_history_t> updated_hit_set_history;
@@ -46,7 +46,7 @@ struct ECSubWrite {
     eversion_t at_version,
     eversion_t trim_to,
     eversion_t roll_forward_to,
-    vector<pg_log_entry_t> log_entries,
+    std::vector<pg_log_entry_t> log_entries,
     std::optional<pg_hit_set_history_t> updated_hit_set_history,
     const std::set<hobject_t> &temp_added,
     const std::set<hobject_t> &temp_removed,
@@ -119,7 +119,7 @@ struct ECSubReadReply {
   pg_shard_t from;
   ceph_tid_t tid;
   std::map<hobject_t, std::list<std::pair<uint64_t, ceph::buffer::list> >> buffers_read;
-  std::map<hobject_t, std::map<string, ceph::buffer::list>> attrs_read;
+  std::map<hobject_t, std::map<std::string, ceph::buffer::list>> attrs_read;
   std::map<hobject_t, int> errors;
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);

--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -24,6 +24,7 @@
 #include "include/ipaddr.h"
 
 using std::ostream;
+using std::string;
 using std::vector;
 
 ostream& operator<<(ostream& out, const osd_rwxa_t& p)

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -179,7 +179,7 @@ struct OSDCapGrant {
   OSDCapMatch match;
   OSDCapSpec spec;
   OSDCapProfile profile;
-  string network;
+  std::string network;
   entity_addr_t network_parsed;
   unsigned network_prefix = 0;
   bool network_valid = true;
@@ -190,14 +190,14 @@ struct OSDCapGrant {
 
   OSDCapGrant() {}
   OSDCapGrant(const OSDCapMatch& m, const OSDCapSpec& s,
-	      boost::optional<string> n = {})
+	      boost::optional<std::string> n = {})
     : match(m), spec(s) {
     if (n) {
       set_network(*n);
     }
   }
   explicit OSDCapGrant(const OSDCapProfile& profile,
-		       boost::optional<string> n = {})
+		       boost::optional<std::string> n = {})
     : profile(profile) {
     if (n) {
       set_network(*n);
@@ -205,12 +205,12 @@ struct OSDCapGrant {
     expand_profile();
   }
 
-  void set_network(const string& n);
+  void set_network(const std::string& n);
 
   bool allow_all() const;
-  bool is_capable(const string& pool_name, const string& ns,
+  bool is_capable(const std::string& pool_name, const std::string& ns,
 		  const OSDCapPoolTag::app_map_t& application_metadata,
-                  const string& object, bool op_may_read, bool op_may_write,
+                  const std::string& object, bool op_may_read, bool op_may_write,
                   const std::vector<OpInfo::ClassInfo>& classes,
 		  const entity_addr_t& addr,
                   std::vector<bool>* class_allowed) const;
@@ -246,14 +246,14 @@ struct OSDCap {
    * @param classes (class-name, rd, wr, whitelisted-flag) tuples
    * @return true if the operation is allowed, false otherwise
    */
-  bool is_capable(const string& pool_name, const string& ns,
+  bool is_capable(const std::string& pool_name, const std::string& ns,
 		  const OSDCapPoolTag::app_map_t& application_metadata,
-		  const string& object, bool op_may_read, bool op_may_write,
+		  const std::string& object, bool op_may_read, bool op_may_write,
 		  const std::vector<OpInfo::ClassInfo>& classes,
 		  const entity_addr_t& addr) const;
 };
 
-static inline ostream& operator<<(ostream& out, const OSDCap& cap) 
+inline std::ostream& operator<<(std::ostream& out, const OSDCap& cap) 
 {
   return out << "osdcap" << cap.grants;
 }

--- a/src/perfglue/disabled_heap_profiler.cc
+++ b/src/perfglue/disabled_heap_profiler.cc
@@ -44,4 +44,4 @@ bool ceph_heap_set_numeric_property(const char *property, size_t value)
 }
 
 void ceph_heap_profiler_handle_command(const std::vector<std::string>& cmd,
-                                       ostream& out) { return; }
+                                       std::ostream& out) { return; }

--- a/src/perfglue/heap_profiler.h
+++ b/src/perfglue/heap_profiler.h
@@ -52,6 +52,6 @@ bool ceph_heap_get_numeric_property(const char *property, size_t *value);
 bool ceph_heap_set_numeric_property(const char *property, size_t value);
 
 void ceph_heap_profiler_handle_command(const std::vector<std::string> &cmd,
-                                       ostream& out);
+                                       std::ostream& out);
 
 #endif /* HEAP_PROFILER_H_ */


### PR DESCRIPTION
Since the last one merged, I did another. This time for ceph-mon.

More to come.