### PR TITLE
os/bluestore: Optimizing the lock of bluestore writing process

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -703,6 +703,7 @@ void BlueFS::umount()
 
 int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
 {
+  std::unique_lock l(lock);
   dout(1) << __func__ << dendl;
 
   if(id == BDEV_NEWDB) {
@@ -1551,6 +1552,7 @@ int BlueFS::device_migrate_to_existing(
   int dev_target,
   const bluefs_layout_t& layout)
 {
+  std::unique_lock l(lock);
   vector<byte> buf;
   bool buffered = cct->_conf->bluefs_buffered_io;
 
@@ -1691,6 +1693,7 @@ int BlueFS::device_migrate_to_new(
   int dev_target,
   const bluefs_layout_t& layout)
 {
+  std::unique_lock l(lock);
   vector<byte> buf;
   bool buffered = cct->_conf->bluefs_buffered_io;
 
@@ -2813,11 +2816,15 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
     uint64_t x_len = std::min(p->length - x_off, length);
     bufferlist t;
     t.substr_of(bl, bloff, x_len);
+    h->lock.lock();
+    lock.unlock();
     if (cct->_conf->bluefs_sync_write) {
       bdev[p->bdev]->write(p->offset + x_off, t, buffered, h->write_hint);
     } else {
       bdev[p->bdev]->aio_write(p->offset + x_off, t, h->iocv[p->bdev], buffered, h->write_hint);
     }
+    lock.lock();
+    h->lock.unlock();
     h->dirty_devs[p->bdev] = true;
     if (p->bdev == BDEV_SLOW) {
       bytes_written_slow += t.length();


### PR DESCRIPTION
Unlock global lock and use FileWriter lock to improve performance and tail latency

Signed-off-by: Yin Congmin <congmin.yin@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
