### PR TITLE
mds: don't assert empty io context list when shutting down

### DIFF
--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -98,7 +98,6 @@ void MDSIOContextBase::complete(int r) {
   if (mds->is_daemon_stopping()) {
     dout(4) << "MDSIOContextBase::complete: dropping for stopping "
             << typeid(*this).name() << dendl;
-    MDSContext::complete(r);
     return;
   }
 

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -98,8 +98,11 @@ void MDSIOContextBase::complete(int r) {
   if (mds->is_daemon_stopping()) {
     dout(4) << "MDSIOContextBase::complete: dropping for stopping "
             << typeid(*this).name() << dendl;
-    delete this;
-  } else if (r == -EBLACKLISTED) {
+    MDSContext::complete(r);
+    return;
+  }
+
+  if (r == -EBLACKLISTED) {
     derr << "MDSIOContextBase: blacklisted!  Restarting..." << dendl;
     mds->respawn();
   } else {

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -34,24 +34,30 @@ void MDSInternalContextWrapper::finish(int r)
   fin->complete(r);
 }
 
-elist<MDSIOContextBase*> MDSIOContextBase::ctx_list(member_offset(MDSIOContextBase, list_item));
-ceph::spinlock MDSIOContextBase::ctx_list_lock;
+struct MDSIOContextList {
+  elist<MDSIOContextBase*> list;
+  ceph::spinlock lock;
+  MDSIOContextList() : list(member_offset(MDSIOContextBase, list_item)) {}
+  ~MDSIOContextList() {
+    list.clear(); // avoid assertion in elist's destructor
+  }
+} ioctx_list;
 
 MDSIOContextBase::MDSIOContextBase(bool track)
 {
   created_at = ceph::coarse_mono_clock::now();
   if (track) {
-    ctx_list_lock.lock();
-    ctx_list.push_back(&list_item);
-    ctx_list_lock.unlock();
+    ioctx_list.lock.lock();
+    ioctx_list.list.push_back(&list_item);
+    ioctx_list.lock.unlock();
   }
 }
 
 MDSIOContextBase::~MDSIOContextBase()
 {
-  ctx_list_lock.lock();
+  ioctx_list.lock.lock();
   list_item.remove_myself();
-  ctx_list_lock.unlock();
+  ioctx_list.lock.unlock();
 }
 
 bool MDSIOContextBase::check_ios_in_flight(ceph::coarse_mono_time cutoff,
@@ -61,8 +67,8 @@ bool MDSIOContextBase::check_ios_in_flight(ceph::coarse_mono_time cutoff,
   static const unsigned MAX_COUNT = 100;
   unsigned slow = 0;
 
-  ctx_list_lock.lock();
-  for (elist<MDSIOContextBase*>::iterator p = ctx_list.begin(); !p.end(); ++p) {
+  ioctx_list.lock.lock();
+  for (elist<MDSIOContextBase*>::iterator p = ioctx_list.list.begin(); !p.end(); ++p) {
     MDSIOContextBase *c = *p;
     if (c->created_at >= cutoff)
       break;
@@ -72,7 +78,7 @@ bool MDSIOContextBase::check_ios_in_flight(ceph::coarse_mono_time cutoff,
     if (slow == 1)
       oldest = c->created_at;
   }
-  ctx_list_lock.unlock();
+  ioctx_list.lock.unlock();
 
   if (slow > 0) {
     if (slow > MAX_COUNT)

--- a/src/mds/MDSContext.h
+++ b/src/mds/MDSContext.h
@@ -111,9 +111,8 @@ public:
 private:
   ceph::coarse_mono_time created_at;
   elist<MDSIOContextBase*>::item list_item;
-
-  static elist<MDSIOContextBase*> ctx_list;
-  static ceph::spinlock ctx_list_lock;
+  
+  friend struct MDSIOContextList;
 };
 
 /**


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44680
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
