### PR TITLE
cephfs-shell: Fix flake8 errors (F841, E302, E502, E128, E305 and E222)

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1485,7 +1485,7 @@ def setup_cephfs(config_file):
     try:
         cephfs = libcephfs.LibCephFS(conffile=config_file)
         cephfs.mount()
-    except libcephfs.ObjectNotFound as e:
+    except libcephfs.ObjectNotFound:
         print('couldn\'t find ceph configuration not found')
         sys.exit(1)
     except libcephfs.Error as e:

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1509,18 +1509,18 @@ def get_bool_vals_for_boolopts(val):
 def read_ceph_conf(shell, config_file):
     try:
         shell.debug = get_bool_vals_for_boolopts(cephfs.
-            conf_get('debug_shell'))
+                                                 conf_get('debug_shell'))
         shell.allow_ansi = get_bool_vals_for_boolopts(cephfs.
-            conf_get('allow_ansi'))
+                                                      conf_get('allow_ansi'))
         shell.echo = get_bool_vals_for_boolopts(cephfs.conf_get('echo'))
         shell.continuation_prompt = get_bool_vals_for_boolopts(cephfs.
-            conf_get('continuation_prompt'))
+                                                               conf_get('continuation_prompt'))
         shell.colors = get_bool_vals_for_boolopts(cephfs.conf_get('colors'))
         shell.editor = get_bool_vals_for_boolopts(cephfs.conf_get('editor'))
         shell.feedback_to_output = get_bool_vals_for_boolopts(cephfs.
-            conf_get('feedback_to_output'))
+                                                              conf_get('feedback_to_output'))
         shell.max_completion_items = get_bool_vals_for_boolopts(cephfs.
-            conf_get('max_completion_items'))
+                                                                conf_get('max_completion_items'))
         shell.prompt = get_bool_vals_for_boolopts(cephfs.conf_get('prompt'))
         shell.quiet = get_bool_vals_for_boolopts(cephfs.conf_get('quiet'))
         shell.timing = get_bool_vals_for_boolopts(cephfs.conf_get('timing'))

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1528,6 +1528,7 @@ def read_ceph_conf(shell, config_file):
         perror(e)
         shell.exit_code = e.get_error_code()
 
+
 if __name__ == '__main__':
     config_file = ''
 

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1508,18 +1508,18 @@ def get_bool_vals_for_boolopts(val):
 
 def read_ceph_conf(shell, config_file):
     try:
-        shell.debug = get_bool_vals_for_boolopts(cephfs.\
+        shell.debug = get_bool_vals_for_boolopts(cephfs.
             conf_get('debug_shell'))
-        shell.allow_ansi = get_bool_vals_for_boolopts(cephfs.\
+        shell.allow_ansi = get_bool_vals_for_boolopts(cephfs.
             conf_get('allow_ansi'))
         shell.echo = get_bool_vals_for_boolopts(cephfs.conf_get('echo'))
-        shell.continuation_prompt = get_bool_vals_for_boolopts(cephfs.\
+        shell.continuation_prompt = get_bool_vals_for_boolopts(cephfs.
             conf_get('continuation_prompt'))
         shell.colors = get_bool_vals_for_boolopts(cephfs.conf_get('colors'))
         shell.editor = get_bool_vals_for_boolopts(cephfs.conf_get('editor'))
-        shell.feedback_to_output = get_bool_vals_for_boolopts(cephfs.\
+        shell.feedback_to_output = get_bool_vals_for_boolopts(cephfs.
             conf_get('feedback_to_output'))
-        shell.max_completion_items = get_bool_vals_for_boolopts(cephfs.\
+        shell.max_completion_items = get_bool_vals_for_boolopts(cephfs.
             conf_get('max_completion_items'))
         shell.prompt = get_bool_vals_for_boolopts(cephfs.conf_get('prompt'))
         shell.quiet = get_bool_vals_for_boolopts(cephfs.conf_get('quiet'))

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1551,7 +1551,7 @@ if __name__ == '__main__':
         if LooseVersion(cmd2_version) <= LooseVersion("0.9.13"):
             args.commands = ['load ' + args.batch, ',quit']
         else:
-            args.commands = ['run_script ' +  args.batch, ',quit']
+            args.commands = ['run_script ' + args.batch, ',quit']
     if args.test:
         args.commands.extend(['-t,'] + [arg + ',' for arg in args.test])
 

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1492,6 +1492,7 @@ def setup_cephfs(config_file):
         print(e)
         sys.exit(1)
 
+
 def get_bool_vals_for_boolopts(val):
     if not isinstance(val, str):
         return val
@@ -1503,6 +1504,7 @@ def get_bool_vals_for_boolopts(val):
         return False
     else:
         return val
+
 
 def read_ceph_conf(shell, config_file):
     try:


### PR DESCRIPTION
cephfs-shell: Fixed cephfs-shell flake8 errors (F841, E302, E502, E128, E305 and E222)

![image](https://user-images.githubusercontent.com/39651310/77331192-66ea7080-6d46-11ea-9e33-2c033f69c203.png)
Fixes: https://tracker.ceph.com/issues/44657
Signed-off-by: Aditya Srivastava <adityasrivastava301199@gmail.com>

## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
