### PR TITLE
qa/*/osd-backfill-recovery-log.sh: flush_pg_stats before checking log length

### DIFF
--- a/qa/standalone/osd/osd-backfill-recovery-log.sh
+++ b/qa/standalone/osd/osd-backfill-recovery-log.sh
@@ -74,6 +74,8 @@ function _common_test() {
     sleep 1
     wait_for_clean
 
+    flush_pg_stats
+
     newprimary=$(ceph pg dump pgs --format=json | jq '.pg_stats[0].up_primary')
     kill_daemons
 


### PR DESCRIPTION
It is possible for the pg dump to not be the latest when we check for newprimary
in _common_test(). This is because mgr_stats_period is 5 seconds, and we may not
have fetched the latest stats just yet. This causes the test to look at the same
stats before and after wait_for_clean.

Fixes: https://tracker.ceph.com/issues/43807 (2)
Signed-off-by: Neha Ojha <nojha@redhat.com>