### PR TITLE
nautilus: mgr/dashboard: fix error when enabling SSO with cert. file

### DIFF
--- a/src/pybind/mgr/dashboard/services/sso.py
+++ b/src/pybind/mgr/dashboard/services/sso.py
@@ -6,6 +6,7 @@ import errno
 import json
 import sys
 import threading
+import six
 
 try:
     from onelogin.saml2.settings import OneLogin_Saml2_Settings
@@ -186,13 +187,15 @@ def handle_sso_command(cmd):
             # pylint: disable=redefined-builtin
             FileNotFoundError = IOError
         try:
-            f = open(sp_x_509_cert, 'r')
+            f = open(sp_x_509_cert, 'r', encoding='utf-8') if six.PY3 else \
+                open(sp_x_509_cert, 'rb')
             sp_x_509_cert = f.read()
             f.close()
         except FileNotFoundError:
             pass
         try:
-            f = open(sp_private_key, 'r')
+            f = open(sp_private_key, 'r', encoding='utf-8') if six.PY3 else \
+                open(sp_private_key, 'rb')
             sp_private_key = f.read()
             f.close()
         except FileNotFoundError:
@@ -204,7 +207,8 @@ def handle_sso_command(cmd):
         # pylint: disable=broad-except
         except Exception:
             try:
-                f = open(idp_metadata, 'r')
+                f = open(idp_metadata, 'r', encoding='utf-8') if six.PY3 else \
+                    open(idp_metadata, 'rb')
                 idp_metadata = f.read()
                 f.close()
             except FileNotFoundError:
@@ -250,7 +254,7 @@ def handle_sso_command(cmd):
                 "wantMessagesSigned": has_sp_cert,
                 "wantAssertionsSigned": has_sp_cert,
                 "wantAssertionsEncrypted": has_sp_cert,
-                "wantNameIdEncrypted": has_sp_cert,
+                "wantNameIdEncrypted": False,  # Not all Identity Providers support this.
                 "metadataValidUntil": '',
                 "wantAttributeStatement": False
             }


### PR DESCRIPTION
Since in master the solution is pure py3 code,
instead of backporting I've created this commit that provides py2 compatibility code.

Fixes: https://tracker.ceph.com/issues/44666


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
