### PR TITLE
octopus: vstart_runner.py: fix OSError when checking if non-existent path is m…

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1408,11 +1408,11 @@ def exec_test():
             mount = LocalFuseMount(ctx, test_dir, client_id)
 
         mounts.append(mount)
-        if mount.is_mounted():
-            log.warn("unmounting {0}".format(mount.mountpoint))
-            mount.umount_wait()
-        else:
-            if os.path.exists(mount.mountpoint):
+        if os.path.exists(mount.mountpoint):
+            if mount.is_mounted():
+                log.warn("unmounting {0}".format(mount.mountpoint))
+                mount.umount_wait()
+            else:
                 os.rmdir(mount.mountpoint)
 
     from tasks.cephfs_test_runner import DecoratingLoader


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44649

---

backport of https://github.com/ceph/ceph/pull/33856
parent tracker: https://tracker.ceph.com/issues/44545

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh