### PR TITLE
pybind/rbd: fix no lockers are obtained, ImageNotFound exception will be output

### DIFF
--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -5393,6 +5393,9 @@ cdef class LockOwnerIterator(object):
                                           &self.num_lock_owners)
             if ret >= 0:
                 break
+            elif ret == -errno.ENOENT:
+                self.num_lock_owners = 0
+                break
             elif ret != -errno.ERANGE:
                 raise make_ex(ret, 'error listing lock owners for image %s' % image.name)
 

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -1855,10 +1855,13 @@ class TestExclusiveLock(object):
                 rados2.conf_set('rbd_blacklist_on_break_lock', 'true')
                 with Image(ioctx2, image_name) as image, \
                      Image(blacklist_ioctx, image_name) as blacklist_image:
+
+                    lock_owners = list(image.lock_get_owners())
+                    eq(0, len(lock_owners))
+
                     blacklist_image.lock_acquire(RBD_LOCK_MODE_EXCLUSIVE)
                     assert_raises(ReadOnlyImage, image.lock_acquire,
                                   RBD_LOCK_MODE_EXCLUSIVE)
-
                     lock_owners = list(image.lock_get_owners())
                     eq(1, len(lock_owners))
                     eq(RBD_LOCK_MODE_EXCLUSIVE, lock_owners[0]['mode'])


### PR DESCRIPTION
pybind/rbd: fix no lockers are obtained, ImageNotFound exception will be output

No lockers are obtained, ImageNotFound exception will be output,but tht image is always exist.
when lockers number is zero, Should not output any exceptions。

Fixes: https://tracker.ceph.com/issues/44613

Signed-off-by: zhang daolong <zhangdaolong@fiberhome.com>