### PR TITLE
mon/MgrMonitor: show different error message when disabling a dne module

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -1158,8 +1158,8 @@ bool MgrMonitor::prepare_command(MonOpRequestRef op)
       r = 0;
       goto out;
     }
-    if (!pending_map.any_supports_module(module)) {
-      ss << "module '" << module << "' does not exist";
+    if (!pending_map.modules.count(module)) {
+      ss << "module '" << module << "' is not enabled";
     }
     pending_map.modules.erase(module);
   } else {


### PR DESCRIPTION
this is a regression introduced by
a7677c76a54bdbc68ea9ba60efe7cec013d5afda

per Sage, we can enable a module when the mgr is not started yet using
"--force" command, but we should be allowed to disable it if the
non-existent module is added. this change just changes the condition and
error message so that the error message is printed if the module is not
loaded at all. because the operation should be idempotent, so the
operation is always finished without returning an error.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
