### PR TITLE
mds: Handle blacklisted error in purge queue

### DIFF
--- a/src/osdc/Filer.cc
+++ b/src/osdc/Filer.cc
@@ -301,6 +301,7 @@ struct PurgeRange {
   int flags;
   Context *oncommit;
   int uncommitted;
+  int err = 0;
   PurgeRange(inodeno_t i, const file_layout_t& l, const SnapContext& sc,
 	     uint64_t fo, uint64_t no, ceph::real_time t, int fl,
 	     Context *fin)
@@ -330,7 +331,7 @@ int Filer::purge_range(inodeno_t ino,
   PurgeRange *pr = new PurgeRange(ino, *layout, snapc, first_obj,
 				  num_obj, mtime, flags, oncommit);
 
-  _do_purge_range(pr, 0);
+  _do_purge_range(pr, 0, 0);
   return 0;
 }
 
@@ -339,20 +340,22 @@ struct C_PurgeRange : public Context {
   PurgeRange *pr;
   C_PurgeRange(Filer *f, PurgeRange *p) : filer(f), pr(p) {}
   void finish(int r) override {
-    filer->_do_purge_range(pr, 1);
+    filer->_do_purge_range(pr, 1, r);
   }
 };
 
-void Filer::_do_purge_range(PurgeRange *pr, int fin)
+void Filer::_do_purge_range(PurgeRange *pr, int fin, int err)
 {
   PurgeRange::unique_lock prl(pr->lock);
+  if (err && err != -ENOENT)
+    pr->err = err;
   pr->uncommitted -= fin;
   ldout(cct, 10) << "_do_purge_range " << pr->ino << " objects " << pr->first
 		 << "~" << pr->num << " uncommitted " << pr->uncommitted
 		 << dendl;
 
   if (pr->num == 0 && pr->uncommitted == 0) {
-    pr->oncommit->complete(0);
+    pr->oncommit->complete(pr->err);
     prl.unlock();
     delete pr;
     return;

--- a/src/osdc/Filer.h
+++ b/src/osdc/Filer.h
@@ -253,7 +253,7 @@ class Filer {
 		  uint64_t first_obj, uint64_t num_obj,
 		  ceph::real_time mtime,
 		  int flags, Context *oncommit);
-  void _do_purge_range(struct PurgeRange *pr, int fin);
+  void _do_purge_range(struct PurgeRange *pr, int fin, int err);
 
   /*
    * probe


### PR DESCRIPTION
This patch adds check to catch blacklisted error from filer. On catching this
error, mds will respawn.

Fixes: https://tracker.ceph.com/issues/43598
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
