### PR TITLE
doc/releases/octopus: fix indents

### DIFF
--- a/doc/releases/octopus.rst
+++ b/doc/releases/octopus.rst
@@ -144,15 +144,19 @@ RGW object storage
   
 * New `Multisite Sync Policy`_ primitives for per-bucket replication. (EXPERIMENTAL)
 * S3 feature support:
-    - Bucket Replication (EXPERIMENTAL)
-    - `Bucket Notifications`_ via HTTP/S, AMQP and Kafka
-    - Bucket Tagging
-    - Object Lock
-    - Public Access Block for buckets
+
+  - Bucket Replication (EXPERIMENTAL)
+  - `Bucket Notifications`_ via HTTP/S, AMQP and Kafka
+  - Bucket Tagging
+  - Object Lock
+  - Public Access Block for buckets
+
 * Bucket sharding:
-    - Significantly improved listing performance on buckets with many shards.
-    - Dynamic resharding prefers prime shard counts for improved distribution.
-    - Raised the default number of bucket shards to 11.
+
+  - Significantly improved listing performance on buckets with many shards.
+  - Dynamic resharding prefers prime shard counts for improved distribution.
+  - Raised the default number of bucket shards to 11.
+
 * Added `HashiCorp Vault Integration`_ for SSE-KMS.
 * Added Keystone token cache for S3 requests.
 


### PR DESCRIPTION
reduce the indent in subsection of "RGW object storage", some of the
nested items should be indented with two spaces instead of four.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
