### PR TITLE
mgr/cephadm: DriveGroupSpec needs to support/ignore _unmanaged_

### DIFF
--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -149,6 +149,7 @@ class DriveGroupSpec(ServiceSpec):
                  block_wal_size=None,  # type: Optional[int]
                  journal_size=None,  # type: Optional[int]
                  service_type=None,  # type: Optional[str]
+                 unmanaged=None,  # type: Optional[bool]
                  ):
         assert service_type is None or service_type == 'osd'
         super(DriveGroupSpec, self).__init__('osd', service_id=service_id, placement=placement)

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -128,7 +128,7 @@ class DriveGroupSpec(ServiceSpec):
         "db_slots", "wal_slots", "block_db_size", "placement", "service_id", "service_type",
         "data_devices", "db_devices", "wal_devices", "journal_devices",
         "data_directories", "osds_per_device", "objectstore", "osd_id_claims",
-        "journal_size"
+        "journal_size", "unmanaged"
     ]
 
     def __init__(self,


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

logs trimmed for readability
```
cephadm [INF] Saving service osd.test_rm spec with placement *
cephadm [INF] Applying osd.test_rm on host master...
cephadm [WRN] unable to load spec for osd.test_rm: Failed to validate Drive Group: Feature <unmanaged> is not supported 
```

with a drivegroup _not_ explicitly specifying `unmanaged` 

fails due to the implicit setting of `unmanaged` here:

https://github.com/ceph/ceph/blob/243cbd6224921f7f5c2463705c75cb9eafd0db5c/src/python-common/ceph/deployment/service_spec.py#L334

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
