### PR TITLE
mds: resolve type mismatches on 32 bit archs

### DIFF
--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -501,7 +501,8 @@ void PurgeQueue::_execute_item(
 
   in_flight[expire_to] = item;
   logger->set(l_pq_executing, in_flight.size());
-  files_high_water = std::max(files_high_water, in_flight.size());
+  files_high_water = std::max(files_high_water,
+                              static_cast<uint64_t>(in_flight.size()));
   logger->set(l_pq_executing_high_water, files_high_water);
   auto ops = _calculate_ops(item);
   ops_in_flight += ops;
@@ -579,7 +580,8 @@ void PurgeQueue::_execute_item(
     logger->set(l_pq_executing_ops_high_water, ops_high_water);
     in_flight.erase(expire_to);
     logger->set(l_pq_executing, in_flight.size());
-    files_high_water = std::max(files_high_water, in_flight.size());
+    files_high_water = std::max(files_high_water,
+                                static_cast<uint64_t>(in_flight.size()));
     logger->set(l_pq_executing_high_water, files_high_water);
     return;
   }
@@ -651,7 +653,8 @@ void PurgeQueue::_execute_item_complete(
 
   in_flight.erase(iter);
   logger->set(l_pq_executing, in_flight.size());
-  files_high_water = std::max(files_high_water, in_flight.size());
+  files_high_water = std::max(files_high_water,
+                              static_cast<uint64_t>(in_flight.size()));
   logger->set(l_pq_executing_high_water, files_high_water);
   dout(10) << "in_flight.size() now " << in_flight.size() << dendl;
 


### PR DESCRIPTION
Ensure that size_t is cast to uint64_t on 32 bit architectures
to avoid compilation failures due mismatches between uint64_t
and size_t.

Signed-off-by: James Page <james.page@ubuntu.com>
