### PR TITLE
octopus: pybind/mgr/*: fix config_notify handling of default values

### DIFF
--- a/src/pybind/mgr/diskprediction_cloud/module.py
+++ b/src/pybind/mgr/diskprediction_cloud/module.py
@@ -246,7 +246,7 @@ class Module(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_module_option(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']))
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
 
     def _status(self,  cmd):

--- a/src/pybind/mgr/diskprediction_local/module.py
+++ b/src/pybind/mgr/diskprediction_local/module.py
@@ -63,7 +63,7 @@ class Module(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_module_option(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']))
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
 
     def handle_command(self, _, cmd):

--- a/src/pybind/mgr/osd_support/module.py
+++ b/src/pybind/mgr/osd_support/module.py
@@ -55,7 +55,7 @@ class OSDSupport(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_module_option(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']))
             self.log.debug(' mgr option %s = %s',
                            opt['name'], getattr(self, opt['name']))
         # Do the same for the native options.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44754

---

backport of follow-on fix https://github.com/ceph/ceph/pull/34117
(NOTE: https://github.com/ceph/ceph/pull/32755 already merged to octopus, so cherry-pick not needed)
parent tracker: https://tracker.ceph.com/issues/43746
