### PR TITLE
mgr/cephadm: fix 'orch ps --refresh'

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1915,8 +1915,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             if host:
                 self._refresh_host_daemons(host)
             else:
-                for host, hi in self.inventory.items():
-                    self._refresh_host_daemons(host)
+                for hostname, hi in self.inventory.items():
+                    self._refresh_host_daemons(hostname)
         result = []
         for h, dm in self.cache.daemons.items():
             if host and h != host:


### PR DESCRIPTION
The use of host in the refresh loop was clobbering the argument value.

Fixes: https://tracker.ceph.com/issues/44513
Signed-off-by: Sage Weil <sage@redhat.com>