### PR TITLE
osd/PeeringState: drop mimic assert

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -106,7 +106,6 @@ void PGPool::update(CephContext *cct, OSDMapRef map)
     updated = true;
   }
 
-  assert(map->require_osd_release >= ceph_release_t::mimic);
   if (info.is_pool_snaps_mode() && updated) {
     snapc = pi->get_snap_context();
   }


### PR DESCRIPTION
This code can still execute for a cluster that has require_osd_release >=
nautilus because a PG is processing an older OSDMap.  Drop this assert
since the osd boot checks on require_osd_release are sufficient.

Fixes: https://tracker.ceph.com/issues/44759
Signed-off-by: Sage Weil <sage@redhat.com>