### PR TITLE
refine bufferlist implementation

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -2165,15 +2165,15 @@ std::ostream& buffer::operator<<(std::ostream& out, const buffer::ptr& bp) {
 }
 
 std::ostream& buffer::operator<<(std::ostream& out, const buffer::list& bl) {
-  out << "buffer::list(len=" << bl.length() << "," << std::endl;
+  out << "buffer::list(len=" << bl.length() << ",\n";
 
   for (const auto& node : bl.buffers()) {
     out << "\t" << node;
     if (&node != &bl.buffers().back()) {
-      out << "," << std::endl;
+      out << ",\n";
     }
   }
-  out << std::endl << ")";
+  out << "\n)";
   return out;
 }
 

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -995,12 +995,12 @@ static ceph::spinlock debug_lock;
 
     const auto* other_buf = reinterpret_cast<const char*>(other);
     for (const auto& bp : buffers()) {
-      const auto round_length = std::min<size_t>(length, bp.length());
-      if (std::memcmp(bp.c_str(), other_buf, round_length) != 0) {
+      assert(bp.length() <= length);
+      if (std::memcmp(bp.c_str(), other_buf, bp.length()) != 0) {
         return false;
       } else {
-        length -= round_length;
-        other_buf += round_length;
+        length -= bp.length();
+        other_buf += bp.length();
       }
     }
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -1132,7 +1132,7 @@ struct error_code;
     void append_zero(unsigned len);
     void prepend_zero(unsigned len);
 
-    reserve_t obtain_contiguous_space(unsigned len);
+    reserve_t obtain_contiguous_space(const unsigned len);
 
     /*
      * get a char


### PR DESCRIPTION
1. replace endl manipulator with '\n' when outputing bufferlist
2. refine some function in bufferlist

Signed-off-by: Changcheng Liu <changcheng.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
