### PR TITLE
qa/tasks/mgr: partial revert of 'import with full path'

### DIFF
--- a/qa/tasks/mgr/dashboard/test_auth.py
+++ b/qa/tasks/mgr/dashboard/test_auth.py
@@ -6,7 +6,7 @@ import time
 
 import jwt
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JObj, JLeaf
+from .helper import DashboardTestCase, JObj, JLeaf
 
 
 class AuthTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_cephfs.py
+++ b/qa/tasks/mgr/dashboard/test_cephfs.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import six
 from contextlib import contextmanager
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JObj, JList, JLeaf
+from .helper import DashboardTestCase, JObj, JList, JLeaf
 
 
 class CephfsTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_cluster_configuration.py
+++ b/qa/tasks/mgr/dashboard/test_cluster_configuration.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import time
 
-from tasks.mgr.dashboard.helper import DashboardTestCase
+from .helper import DashboardTestCase
 
 
 class ClusterConfigurationTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_crush_rule.py
+++ b/qa/tasks/mgr/dashboard/test_crush_rule.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 import six
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JObj, JList
+from .helper import DashboardTestCase, JObj, JList
 
 
 class CrushRuleTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_erasure_code_profile.py
+++ b/qa/tasks/mgr/dashboard/test_erasure_code_profile.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 import six
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JObj, JList
+from .helper import DashboardTestCase, JObj, JList
 
 
 class ECPTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_ganesha.py
+++ b/qa/tasks/mgr/dashboard/test_ganesha.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import
 
 
-from tasks.mgr.dashboard.helper import DashboardTestCase
+from .helper import DashboardTestCase
 
 
 class GaneshaTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JAny, JLeaf, JList, JObj
+from .helper import DashboardTestCase, JAny, JLeaf, JList, JObj
 
 
 class HealthTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_host.py
+++ b/qa/tasks/mgr/dashboard/test_host.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import
 import json
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JList, JObj
-from tasks.mgr.dashboard.test_orchestrator import test_data
+from .helper import DashboardTestCase, JList, JObj
+from .test_orchestrator import test_data
 
 
 class HostControllerTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_logs.py
+++ b/qa/tasks/mgr/dashboard/test_logs.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JList, JObj
+from .helper import DashboardTestCase, JList, JObj
 
 
 class LogsTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_mgr_module.py
+++ b/qa/tasks/mgr/dashboard/test_mgr_module.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import logging
 import requests
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JAny, JObj, JList, JLeaf
+from .helper import DashboardTestCase, JAny, JObj, JList, JLeaf
 
 logger = logging.getLogger(__name__)
 

--- a/qa/tasks/mgr/dashboard/test_monitor.py
+++ b/qa/tasks/mgr/dashboard/test_monitor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from tasks.mgr.dashboard.helper import DashboardTestCase
+from .helper import DashboardTestCase
 
 
 class MonitorTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_orchestrator.py
+++ b/qa/tasks/mgr/dashboard/test_orchestrator.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 import json
 
-from tasks.mgr.dashboard.helper import DashboardTestCase
+from .helper import DashboardTestCase
 
 
 test_data = {

--- a/qa/tasks/mgr/dashboard/test_osd.py
+++ b/qa/tasks/mgr/dashboard/test_osd.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 import json
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JObj, JAny, JList, JLeaf, JTuple
+from .helper import DashboardTestCase, JObj, JAny, JList, JLeaf, JTuple
 
 
 class OsdTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_perf_counters.py
+++ b/qa/tasks/mgr/dashboard/test_perf_counters.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JObj
+from .helper import DashboardTestCase, JObj
 
 
 class PerfCountersControllerTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -6,7 +6,7 @@ import six
 import time
 from contextlib import contextmanager
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JAny, JList, JObj
+from .helper import DashboardTestCase, JAny, JList, JObj
 
 log = logging.getLogger(__name__)
 

--- a/qa/tasks/mgr/dashboard/test_rbd.py
+++ b/qa/tasks/mgr/dashboard/test_rbd.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import time
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JObj, JLeaf, JList
+from .helper import DashboardTestCase, JObj, JLeaf, JList
 
 
 class RbdTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_rbd_mirroring.py
+++ b/qa/tasks/mgr/dashboard/test_rbd_mirroring.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import
 
-from tasks.mgr.dashboard.helper import DashboardTestCase
+from .helper import DashboardTestCase
 
 
 class RbdMirroringTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_requests.py
+++ b/qa/tasks/mgr/dashboard/test_requests.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-from tasks.mgr.dashboard.helper import DashboardTestCase
+from .helper import DashboardTestCase
 
 
 class RequestsTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_rgw.py
+++ b/qa/tasks/mgr/dashboard/test_rgw.py
@@ -10,7 +10,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.twofactor.totp import TOTP
 from cryptography.hazmat.primitives.hashes import SHA1
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JObj, JList, JLeaf
+from .helper import DashboardTestCase, JObj, JList, JLeaf
 
 logger = logging.getLogger(__name__)
 

--- a/qa/tasks/mgr/dashboard/test_role.py
+++ b/qa/tasks/mgr/dashboard/test_role.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-from tasks.mgr.dashboard.helper import DashboardTestCase
+from .helper import DashboardTestCase
 
 
 class RoleTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_settings.py
+++ b/qa/tasks/mgr/dashboard/test_settings.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JList, JObj, JAny
+from .helper import DashboardTestCase, JList, JObj, JAny
 
 
 class SettingsTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_summary.py
+++ b/qa/tasks/mgr/dashboard/test_summary.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from tasks.mgr.dashboard.helper import DashboardTestCase
+from .helper import DashboardTestCase
 
 
 class SummaryTest(DashboardTestCase):

--- a/qa/tasks/mgr/dashboard/test_user.py
+++ b/qa/tasks/mgr/dashboard/test_user.py
@@ -6,7 +6,7 @@ import time
 
 from datetime import datetime, timedelta
 
-from tasks.mgr.dashboard.helper import DashboardTestCase, JObj, JLeaf
+from .helper import DashboardTestCase, JObj, JLeaf
 
 
 class UserTest(DashboardTestCase):


### PR DESCRIPTION
this change partially reverts #34139

using relative import helps with readability and ease the pain to write
down the full parent module name

in #34139, all relative imports were replaced with full path, because we
were using following code to verify if the code is python3 compatible:

```
  mod_spec = importlib.util.spec_from_file_location(mod_name, path)
  mod = importlib.util.module_from_spec(mod_spec)
  mod_spec.loader.exec_module(mod)
```

but this does not work with submodule which can import using relative
import without specifying the name of the package and its parent module.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
