### PR TITLE
doc/SubmittingPatches: Fix 'Fixes line' hyperlink

### DIFF
--- a/SubmittingPatches.rst
+++ b/SubmittingPatches.rst
@@ -133,7 +133,7 @@ Some negative examples (how *not* to title a commit message)::
      bug fix for driver X
      fix issue 99999
 
-Further to the last negative example ("fix issue 99999"), see `Fixes line`_.
+Further to the last negative example ("fix issue 99999"), see `Fixes line(s)`_.
 
 Commit message
 ^^^^^^^^^^^^^^
@@ -148,8 +148,6 @@ body to explain not just the "what", but also the "why".
 For positive examples, peruse ``git log`` in the ``master`` branch. A negative
 example would be a commit message that merely states the obvious. For example:
 "this patch includes updates for subsystem X. Please apply."
-
-.. _`fixes line`:
 
 Fixes line(s)
 ^^^^^^^^^^^^^


### PR DESCRIPTION
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
