### PR TITLE
octopus: mgr/dashboard: add crush rule test suite

### DIFF
--- a/qa/suites/rados/dashboard/tasks/dashboard.yaml
+++ b/qa/suites/rados/dashboard/tasks/dashboard.yaml
@@ -33,6 +33,7 @@ tasks:
         - tasks.mgr.dashboard.test_auth
         - tasks.mgr.dashboard.test_cephfs
         - tasks.mgr.dashboard.test_cluster_configuration
+        - tasks.mgr.dashboard.test_crush_rule
         - tasks.mgr.dashboard.test_erasure_code_profile
         - tasks.mgr.dashboard.test_ganesha
         - tasks.mgr.dashboard.test_health


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44712

---

backport of https://github.com/ceph/ceph/pull/34063
parent tracker: https://tracker.ceph.com/issues/44679

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh