### PR TITLE
octopus: mgr/dashboard: correct Orchestrator documentation link

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-panel/orchestrator-doc-panel.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-panel/orchestrator-doc-panel.component.ts
@@ -23,7 +23,7 @@ export class OrchestratorDocPanelComponent implements OnInit {
       }
 
       const releaseName = this.cephReleaseNamePipe.transform(summary.version);
-      this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/orchestrator_cli/`;
+      this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/orchestrator/`;
 
       setTimeout(() => {
         subs.unsubscribe();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44709

---

backport of https://github.com/ceph/ceph/pull/34113
parent tracker: https://tracker.ceph.com/issues/44708

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh