### PR TITLE
doc/rgw: add documentation for allowed storage classes for client SDKs

### DIFF
--- a/doc/radosgw/placement.rst
+++ b/doc/radosgw/placement.rst
@@ -126,7 +126,7 @@ Then provide the zone placement info for that target:
 Adding a Storage Class
 ----------------------
 
-To add a new storage class named ``COLD`` to the ``default-placement`` target,
+To add a new storage class named ``GLACIER`` to the ``default-placement`` target,
 start by adding it to the zonegroup:
 
 ::
@@ -134,7 +134,7 @@ start by adding it to the zonegroup:
   $ radosgw-admin zonegroup placement add \
         --rgw-zonegroup default \
         --placement-id default-placement \
-        --storage-class COLD
+        --storage-class GLACIER
 
 Then provide the zone placement info for that storage class:
 
@@ -143,7 +143,7 @@ Then provide the zone placement info for that storage class:
   $ radosgw-admin zone placement add \
         --rgw-zone default \
         --placement-id default-placement \
-        --storage-class COLD \
+        --storage-class GLACIER \
         --data-pool default.rgw.cold.data \
         --compression lz4
 
@@ -237,6 +237,10 @@ To create an object in a non-default storage class, provide that storage class
 name in an HTTP header with the request. The S3 protocol uses the
 ``X-Amz-Storage-Class`` header, while the Swift protocol uses the
 ``X-Object-Storage-Class`` header.
+
+When using AWS S3 SDKs such as python boto3, it is important that the non-default
+storage class will be called as one on of the AWS S3 allowed storage classes, or else the SDK
+will drop the request and raise an exception.
 
 S3 Object Lifecycle Management can then be used to move object data between
 storage classes using ``Transition`` actions.


### PR DESCRIPTION
When trying to use AWS S3 SDKs with a non-default storage class, clients should call their storage class as one of the generic storage class names provided by Amazon (such as STANDARD_IA, ONEZONE_IA, GLACIER etc), or else the SDK will drop the request complaining the storage class name is not allowed

Signed-off-by: Shon Paz <spaz@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
