### PR TITLE
mgr/cephadm: allow config for an nfs `container_image`

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1519,7 +1519,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             assert image or entity
             if not image:
                 daemon_type = entity.split('.', 1)[0] # type: ignore
-                if daemon_type in CEPH_TYPES:
+                if daemon_type in CEPH_TYPES or \
+                        daemon_type == 'nfs':
                     # get container image
                     ret, image, err = self.mon_command({
                         'prefix': 'config get',


### PR DESCRIPTION
For example, to apply a custom container image for all nfs services:

```
ceph config set client.nfs container_image <container_image>
```

Signed-off-by: Michael Fritch <mfritch@suse.com>

**Depends on**

- [x] #34406


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
