### PR TITLE
mgr/cephadm: disable dashboard's grafana cert ssl_verify if we generate it

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2993,6 +2993,12 @@ datasources:
             cert, pkey = create_self_signed_cert('Ceph', 'cephadm')
             self.set_store('grafana_crt', cert)
             self.set_store('grafana_key', pkey)
+            self.mon_command({
+                'prefix': 'dashboard set-grafana-api-ssl-verify',
+                'value': 'false',
+            })
+
+
 
         config_file = {
             'files': {


### PR DESCRIPTION
This will help dashboard work out of the box.

Signed-off-by: Sage Weil <sage@redhat.com>