### PR TITLE
common/options: Disable bluefs_buffered_io by default again.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4006,8 +4006,9 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("bluefs_buffered_io", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
-    .set_description(""),
+    .set_default(false)
+    .set_description("Enabled buffered IO for bluefs reads.")
+    .set_long_description("When this option is enabled, bluefs will in some cases perform buffered reads.  This allows the kernel page cache to act as a secondary cache for things like RocksDB compaction.  For example, if the rocksdb block cache isn't large enough to hold blocks from the compressed SST files itself, they can be read from page cache instead of from the disk.  This option previously was enabled by default, however in some test cases it appears to cause excessive swap utilization by the linux kernel and a large negative performance impact after several hours of run time.  Please exercise caution when enabling."),
 
     Option("bluefs_sync_write", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)


### PR DESCRIPTION
About 2 years ago we enabled bluefs buffered reads by default in #20542 to improve rocksdb performance during compaction when the block cache is too small.

During recent testing the RGW and Perf&Scale teams at Red Hat discovered that after the OSD caused page cache growth due to rocksdb SST file reads, swap began to be aggressively invoked by the kernel causing significant performance degradation on the node that did not appear to resolve over time.  Subsequent testing with bluefs_buffered_io disabled showed a very slight initial performance loss due to the lack of the secondary page cache but significantly better long term (1-2 hour) behavior as the page cache and swap were never invoked.

After discussion during the 3/26 performance meeting we decided that bluefs_buffered_io should be disabled by default, at least until we better understand under what circumstances the kernel may cause excessive swapping due to page cache usage.

Signed-off-by: Mark Nelson <mnelson@redhat.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
