### PR TITLE
monitoring: alert for prediction of disk and pool fill up broken

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -199,15 +199,10 @@ groups:
             Node {{ $labels.instance }} experiences packet errors > 1
             packet/s on interface {{ $labels.device }}.
 
-      # predict fs fill-up times
-      - alert: storage filling
+      - alert: storage filling up
         expr: |
-          (
-            (
-              node_filesystem_free_bytes / deriv(node_filesystem_free_bytes[2d])
-              * on(instance) group_left(nodename) node_uname_info
-            ) <= 5
-          ) > 0
+          predict_linear(node_filesystem_free_bytes[2d], 3600 * 24 * 5) *
+          on(instance) group_left(nodename) node_uname_info < 0
         labels:
           severity: warning
           type: ceph_default
@@ -234,10 +229,9 @@ groups:
       - alert: pool filling up
         expr: |
           (
-            (
-              ceph_pool_max_avail / deriv(ceph_pool_max_avail[2d])
-            ) * on(pool_id) group_right ceph_pool_metadata <= 5
-          ) > 0
+            predict_linear(ceph_pool_stored[2d], 3600 * 24 * 5) >=
+            ceph_pool_max_avail
+          ) * on(pool_id) group_right(name) ceph_pool_metadata
         labels:
           severity: warning
           type: ceph_default


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44776

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
