### PR TITLE
doc/rgw: add documentation for bucket notifications filters and supported push endpoints

### DIFF
--- a/doc/radosgw/s3-notification-compatibility.rst
+++ b/doc/radosgw/s3-notification-compatibility.rst
@@ -13,9 +13,9 @@ Supported Destination
 ---------------------
 
 AWS supports: **SNS**, **SQS** and **Lambda** as possible destinations (AWS internal destinations). 
-Currently, we support: **HTTP/S** and **AMQP**. And also support pulling and acking of events stored in Ceph (as an intenal destination).
+Currently, we support: **HTTP/S**, **Kafka** and **AMQP**. And also support pulling and acking of events stored in Ceph (as an intrenal destination).
 
-We are using the **SNS** ARNs to represent the **HTTP/S** and **AMQP** destinations.
+We are using the **SNS** ARNs to represent the **HTTP/S**, **Kafka** and **AMQP** destinations.
 
 Notification Configuration XML
 ------------------------------
@@ -50,6 +50,8 @@ Ceph's bucket notification API has the following extensions:
   - Filtering based on metadata attributes attached to the object
 
   - Filtering based on object tags
+
+- Each one of the additional filters extends the S3 API and using it will cause extension of the client SDK as well (unless you are using plain HTTP). 
 
 - Filtering overlapping is allowed, so that same event could be sent as different notification
 
@@ -126,3 +128,4 @@ We also have the following extensions to topic configuration:
 .. _Event Message Structure: https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
 .. _`PubSub Module`: ../pubsub-module
 .. _`Bucket Notifications`: ../notifications
+.. _`boto3 SDK filter extensions`: https://github.com/ceph/ceph/tree/master/examples/boto3

--- a/doc/radosgw/s3-notification-compatibility.rst
+++ b/doc/radosgw/s3-notification-compatibility.rst
@@ -51,7 +51,7 @@ Ceph's bucket notification API has the following extensions:
 
   - Filtering based on object tags
 
-- Each one of the additional filters extends the S3 API and using it will cause extension of the client SDK as well (unless you are using plain HTTP). 
+- Each one of the additional filters extends the S3 API and using it will require extension of the client SDK (unless you are using plain HTTP). 
 
 - Filtering overlapping is allowed, so that same event could be sent as different notification
 


### PR DESCRIPTION
We already have Kafka supported as a push endpoint (has been merged lately), in addition it is important to know that although we have extra filters AWS S3 notifications doesn't have, it will cost in extending the AWS SDKs with the new capabilities.

Signed-off-by: Shon Paz <spaz@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
