### PR TITLE
octopus: qa/distros: add SLE-15-SP2

### DIFF
--- a/qa/distros/all/sle_15.2.yaml
+++ b/qa/distros/all/sle_15.2.yaml
@@ -1,0 +1,2 @@
+os_type: sle
+os_version: "15.2"


### PR DESCRIPTION
Ceph octopus is known to run on SLE-15-SP2 so add it to
qa/distros/all.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>
(cherry picked from commit 3261e24636474a3e274c65b859e9325299470f11)
