### PR TITLE
mgr/cephadm: monitoring: fix Prometheus "root fs full" alert

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -131,6 +131,10 @@ class Monitoring(object):
             "memory": "1GB",
             "args": [
                 "--no-collector.timex",
+                "--path.rootfs=/rootfs",
+                "--path.sysfs=/host/sys",
+                "--path.procfs=/host/proc",
+                "'--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'"
             ],
         },
         "grafana": {


### PR DESCRIPTION
which would never be triggered due to the file system being mounted on
"/rootfs" (instead of "/") and also exported as such in the metric
labels.

Fixes metrics exported that aren't where they would expected to be.
After fix, they appear as they would on a node-exporter instance running
directly on a host.

Fixes: https://tracker.ceph.com/issues/44781

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
