### PR TITLE
librbd: API for quiesce callbacks

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7478,6 +7478,11 @@ static std::vector<Option> get_rbd_options() {
     Option("rbd_rwl_path", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("/tmp")
     .set_description("location of the persistent write back cache in a DAX-enabled filesystem on persistent memory"),
+
+    Option("rbd_quiesce_notification_attempts", Option::TYPE_UINT, Option::LEVEL_DEV)
+    .set_default(10)
+    .set_min(1)
+    .set_description("the number of quiesce notification attempts"),
   });
 }
 

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -1366,6 +1366,38 @@ CEPH_RBD_API int rbd_pool_stats_option_add_uint64(rbd_pool_stats_t stats,
                                                   uint64_t* stat_val);
 CEPH_RBD_API int rbd_pool_stats_get(rados_ioctx_t io, rbd_pool_stats_t stats);
 
+/**
+ * Register a quiesce/unquiesce watcher.
+ *
+ * @param image the image to watch
+ * @param quiesce_cb what to do when librbd wants to quiesce
+ * @param unquiesce_cb what to do when librbd wants to unquiesce
+ * @param arg opaque value to pass to the callbacks
+ * @param handle where to store the internal id assigned to this watch
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RBD_API int rbd_quiesce_watch(rbd_image_t image,
+                                   rbd_update_callback_t quiesce_cb,
+                                   rbd_update_callback_t unquiesce_cb,
+                                   void *arg, uint64_t *handle);
+
+/**
+ * Notify quiesce is complete
+ *
+ * @param image the image to notify
+ * @returns 0 on success
+ */
+CEPH_RADOS_API void rbd_quiesce_complete(rbd_image_t image);
+
+/**
+ * Unregister a quiesce/unquiesce watcher.
+ *
+ * @param image the image to unwatch
+ * @param handle which watch to unregister
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RBD_API int rbd_quiesce_unwatch(rbd_image_t image, uint64_t handle);
+
 #if __GNUC__ >= 4
   #pragma GCC diagnostic pop
 #endif

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -489,6 +489,20 @@ public:
   virtual void handle_notify() = 0;
 };
 
+class CEPH_RBD_API QuiesceWatchCtx {
+public:
+  virtual ~QuiesceWatchCtx() {}
+  /**
+   * Callback activated when we want to quiesce.
+   */
+  virtual void handle_quiesce() = 0;
+
+  /**
+   * Callback activated when we want to unquiesce.
+   */
+  virtual void handle_unquiesce() = 0;
+};
+
 class CEPH_RBD_API Image
 {
 public:
@@ -767,6 +781,10 @@ public:
   int list_watchers(std::list<image_watcher_t> &watchers);
 
   int config_list(std::vector<config_option_t> *options);
+
+  int quiesce_watch(QuiesceWatchCtx *ctx, uint64_t *handle);
+  int quiesce_unwatch(uint64_t handle);
+  void quiesce_complete();
 
 private:
   friend class RBD;

--- a/src/librbd/ImageState.cc
+++ b/src/librbd/ImageState.cc
@@ -76,7 +76,8 @@ public:
   }
 
   void register_watcher(UpdateWatchCtx *watcher, uint64_t *handle) {
-    ldout(m_cct, 20) << __func__ << ": watcher=" << watcher << dendl;
+    ldout(m_cct, 20) << "ImageUpdateWatchers::" << __func__ << ": watcher="
+                     << watcher << dendl;
 
     std::lock_guard locker{m_lock};
     ceph_assert(m_on_shut_down_finish == nullptr);
@@ -229,18 +230,207 @@ private:
   }
 };
 
+class QuiesceWatchers {
+public:
+  explicit QuiesceWatchers(CephContext *cct)
+    : m_cct(cct),
+      m_lock(ceph::make_mutex(util::unique_lock_name(
+        "librbd::QuiesceWatchers::m_lock", this))) {
+    ThreadPool *thread_pool;
+    ImageCtx::get_thread_pool_instance(m_cct, &thread_pool, &m_work_queue);
+  }
+
+  ~QuiesceWatchers() {
+    ceph_assert(m_pending_unregister.empty());
+    ceph_assert(m_on_notify == nullptr);
+  }
+
+  void register_watcher(QuiesceWatchCtx *watcher, uint64_t *handle) {
+    ldout(m_cct, 20) << "QuiesceWatchers::" << __func__ << ": watcher="
+                     << watcher << dendl;
+
+    std::lock_guard locker{m_lock};
+
+    *handle = m_next_handle++;
+    m_watchers[*handle] = watcher;
+  }
+
+  void unregister_watcher(uint64_t handle, Context *on_finish) {
+    int r = 0;
+    {
+      std::lock_guard locker{m_lock};
+      auto it = m_watchers.find(handle);
+      if (it == m_watchers.end()) {
+        r = -ENOENT;
+      } else {
+        if (m_on_notify != nullptr) {
+          ceph_assert(!m_pending_unregister.count(handle));
+          m_pending_unregister[handle] = on_finish;
+          on_finish = nullptr;
+        }
+        m_watchers.erase(it);
+      }
+    }
+
+    if (on_finish) {
+      ldout(m_cct, 20) << "QuiesceWatchers::" << __func__
+                       << ": completing unregister " << handle << dendl;
+      on_finish->complete(r);
+    }
+  }
+
+  void notify_quiesce(Context *on_finish) {
+    std::lock_guard locker{m_lock};
+    if (m_on_notify != nullptr) {
+      m_pending_notify.push_back(on_finish);
+      return;
+    }
+
+    notify(QUIESCE, on_finish);
+  }
+
+  void notify_unquiesce(Context *on_finish) {
+    std::lock_guard locker{m_lock};
+
+    notify(UNQUIESCE, on_finish);
+  }
+
+  void quiesce_complete() {
+    Context *on_notify = nullptr;
+    {
+      std::lock_guard locker{m_lock};
+      ceph_assert(m_on_notify != nullptr);
+      ceph_assert(m_handle_quiesce_cnt > 0);
+
+      m_handle_quiesce_cnt--;
+
+      if (m_handle_quiesce_cnt > 0) {
+        return;
+      }
+
+      std::swap(on_notify, m_on_notify);
+    }
+
+    on_notify->complete(0);
+  }
+
+private:
+  enum EventType {QUIESCE, UNQUIESCE};
+
+  CephContext *m_cct;
+  ContextWQ *m_work_queue;
+
+  ceph::mutex m_lock;
+  std::map<uint64_t, QuiesceWatchCtx*> m_watchers;
+  uint64_t m_next_handle = 0;
+  Context *m_on_notify = nullptr;
+  std::list<Context *> m_pending_notify;
+  std::map<uint64_t, Context*> m_pending_unregister;
+  uint64_t m_handle_quiesce_cnt = 0;
+
+  void notify(EventType event_type, Context *on_finish) {
+    ceph_assert(ceph_mutex_is_locked(m_lock));
+
+    if (m_watchers.empty()) {
+      m_work_queue->queue(on_finish);
+      return;
+    }
+
+    ldout(m_cct, 20) << "QuiesceWatchers::" << __func__ << " event: "
+                     << event_type << dendl;
+
+    Context *ctx = nullptr;
+    if (event_type == UNQUIESCE) {
+      ctx = create_async_context_callback(
+        m_work_queue, create_context_callback<
+          QuiesceWatchers, &QuiesceWatchers::handle_notify_unquiesce>(this));
+    }
+    auto gather_ctx = new C_Gather(m_cct, ctx);
+
+    ceph_assert(m_on_notify == nullptr);
+    ceph_assert(m_handle_quiesce_cnt == 0);
+
+    m_on_notify = on_finish;
+
+    for (auto it : m_watchers) {
+      send_notify(it.first, it.second, event_type, gather_ctx->new_sub());
+    }
+
+    gather_ctx->activate();
+  }
+
+  void send_notify(uint64_t handle, QuiesceWatchCtx *watcher,
+                   EventType event_type, Context *on_finish) {
+    auto ctx = new LambdaContext(
+      [this, handle, watcher, event_type, on_finish](int) {
+        ldout(m_cct, 20) << "QuiesceWatchers::" << __func__ << ": handle="
+                         << handle << ", event_type=" << event_type << dendl;
+        switch (event_type) {
+        case QUIESCE:
+          m_handle_quiesce_cnt++;
+          watcher->handle_quiesce();
+          break;
+        case UNQUIESCE:
+          watcher->handle_unquiesce();
+          break;
+        default:
+          ceph_abort_msgf("invalid event_type %d", event_type);
+        }
+
+        on_finish->complete(0);
+      });
+
+    m_work_queue->queue(ctx);
+  }
+
+  void handle_notify_unquiesce(int r) {
+    ldout(m_cct, 20) << "QuiesceWatchers::" << __func__ << ": r=" << r
+                     << dendl;
+
+    ceph_assert(r == 0);
+
+    std::unique_lock locker{m_lock};
+
+    if (!m_pending_unregister.empty()) {
+      std::map<uint64_t, Context*> pending_unregister;
+      std::swap(pending_unregister, m_pending_unregister);
+      locker.unlock();
+      for (auto &it : pending_unregister) {
+        ldout(m_cct, 20) << "QuiesceWatchers::" << __func__
+                         << ": completing unregister " << it.first << dendl;
+        it.second->complete(0);
+      }
+      locker.lock();
+    }
+
+    Context *on_notify = nullptr;
+    std::swap(on_notify, m_on_notify);
+
+    if (!m_pending_notify.empty()) {
+      auto on_finish = m_pending_notify.front();
+      m_pending_notify.pop_front();
+      notify(QUIESCE, on_finish);
+    }
+
+    locker.unlock();
+    on_notify->complete(0);
+  }
+};
+
 template <typename I>
 ImageState<I>::ImageState(I *image_ctx)
   : m_image_ctx(image_ctx), m_state(STATE_UNINITIALIZED),
     m_lock(ceph::make_mutex(util::unique_lock_name("librbd::ImageState::m_lock", this))),
     m_last_refresh(0), m_refresh_seq(0),
-    m_update_watchers(new ImageUpdateWatchers(image_ctx->cct)) {
+    m_update_watchers(new ImageUpdateWatchers(image_ctx->cct)),
+    m_quiesce_watchers(new QuiesceWatchers(image_ctx->cct)) {
 }
 
 template <typename I>
 ImageState<I>::~ImageState() {
   ceph_assert(m_state == STATE_UNINITIALIZED || m_state == STATE_CLOSED);
   delete m_update_watchers;
+  delete m_quiesce_watchers;
 }
 
 template <typename I>
@@ -749,6 +939,49 @@ void ImageState<I>::send_prepare_lock_unlock() {
 
   // wake up the lock handler now that its safe to proceed
   on_ready->complete(0);
+}
+
+template <typename I>
+int ImageState<I>::register_quiesce_watcher(QuiesceWatchCtx *watcher,
+                                                uint64_t *handle) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 20) << __func__ << dendl;
+
+  m_quiesce_watchers->register_watcher(watcher, handle);
+
+  ldout(cct, 20) << __func__ << ": handle=" << *handle << dendl;
+  return 0;
+}
+
+template <typename I>
+int ImageState<I>::unregister_quiesce_watcher(uint64_t handle) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 20) << __func__ << ": handle=" << handle << dendl;
+
+  C_SaferCond ctx;
+  m_quiesce_watchers->unregister_watcher(handle, &ctx);
+  return ctx.wait();
+}
+
+template <typename I>
+void ImageState<I>::notify_quiesce(Context *on_finish) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 20) << __func__ << dendl;
+
+  m_quiesce_watchers->notify_quiesce(on_finish);
+}
+
+template <typename I>
+void ImageState<I>::notify_unquiesce(Context *on_finish) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 20) << __func__ << dendl;
+
+  m_quiesce_watchers->notify_unquiesce(on_finish);
+}
+
+template <typename I>
+void ImageState<I>::quiesce_complete() {
+  m_quiesce_watchers->quiesce_complete();
 }
 
 } // namespace librbd

--- a/src/librbd/ImageState.h
+++ b/src/librbd/ImageState.h
@@ -16,6 +16,8 @@ class RWLock;
 
 namespace librbd {
 
+class QuiesceWatchCtx;
+class QuiesceWatchers;
 class ImageCtx;
 class ImageUpdateWatchers;
 class UpdateWatchCtx;
@@ -50,6 +52,12 @@ public:
   int unregister_update_watcher(uint64_t handle);
   void flush_update_watchers(Context *on_finish);
   void shut_down_update_watchers(Context *on_finish);
+
+  int register_quiesce_watcher(QuiesceWatchCtx *watcher, uint64_t *handle);
+  int unregister_quiesce_watcher(uint64_t handle);
+  void notify_quiesce(Context *on_finish);
+  void notify_unquiesce(Context *on_finish);
+  void quiesce_complete();
 
 private:
   enum State {
@@ -110,6 +118,7 @@ private:
   uint64_t m_refresh_seq;
 
   ImageUpdateWatchers *m_update_watchers;
+  QuiesceWatchers *m_quiesce_watchers;
 
   uint64_t m_open_flags;
 

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -18,18 +18,11 @@ class entity_name_t;
 
 namespace librbd {
 
-namespace watcher {
-namespace util {
-template <typename> struct HandlePayloadVisitor;
-}
-}
-
 class ImageCtx;
 template <typename> class TaskFinisher;
 
 template <typename ImageCtxT = ImageCtx>
 class ImageWatcher : public Watcher {
-  friend struct watcher::util::HandlePayloadVisitor<ImageWatcher<ImageCtxT>>;
 
 public:
   ImageWatcher(ImageCtxT& image_ctx);
@@ -182,14 +175,13 @@ private:
   void handle_request_lock(int r);
   void schedule_request_lock(bool use_timer, int timer_delay = -1);
 
-  void notify_lock_owner(const watch_notify::Payload& payload,
-                         Context *on_finish);
+  void notify_lock_owner(watch_notify::Payload *payload, Context *on_finish);
 
   Context *remove_async_request(const watch_notify::AsyncRequestId &id);
   void schedule_async_request_timed_out(const watch_notify::AsyncRequestId &id);
   void async_request_timed_out(const watch_notify::AsyncRequestId &id);
   void notify_async_request(const watch_notify::AsyncRequestId &id,
-                            const watch_notify::Payload &payload,
+                            watch_notify::Payload *payload,
                             ProgressContext& prog_ctx,
                             Context *on_finish);
 
@@ -245,15 +237,14 @@ private:
   bool handle_payload(const watch_notify::UnknownPayload& payload,
                       C_NotifyAck *ctx);
   void process_payload(uint64_t notify_id, uint64_t handle,
-                       const watch_notify::Payload &payload);
+                       watch_notify::Payload *payload);
 
   void handle_notify(uint64_t notify_id, uint64_t handle,
                      uint64_t notifier_id, bufferlist &bl) override;
   void handle_error(uint64_t cookie, int err) override;
   void handle_rewatch_complete(int r) override;
 
-  void send_notify(const watch_notify::Payload& payload,
-                   Context *ctx = nullptr);
+  void send_notify(watch_notify::Payload *payload, Context *ctx = nullptr);
 
 };
 

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -34,8 +34,10 @@ public:
                       Context *on_finish);
   void notify_resize(uint64_t request_id, uint64_t size, bool allow_shrink,
                      ProgressContext &prog_ctx, Context *on_finish);
-  void notify_snap_create(const cls::rbd::SnapshotNamespace &snap_namespace,
+  void notify_snap_create(uint64_t request_id,
+                          const cls::rbd::SnapshotNamespace &snap_namespace,
 			  const std::string &snap_name,
+                          ProgressContext &prog_ctx,
 			  Context *on_finish);
   void notify_snap_rename(const snapid_t &src_snap_id,
                           const std::string &dst_snap_name,
@@ -70,7 +72,8 @@ public:
   static void notify_header_update(librados::IoCtx &io_ctx,
                                    const std::string &oid);
 
-  void notify_quiesce(uint64_t request_id, Context *on_finish);
+  void notify_quiesce(uint64_t request_id, ProgressContext &prog_ctx,
+                      Context *on_finish);
   void notify_unquiesce(uint64_t request_id, Context *on_finish);
 
 private:
@@ -206,7 +209,8 @@ private:
   Context *prepare_unquiesce_request(const watch_notify::AsyncRequestId &request);
 
   void notify_quiesce(const watch_notify::AsyncRequestId &async_request_id,
-                      size_t attempts, Context *on_finish);
+                      size_t attempts, ProgressContext &prog_ctx,
+                      Context *on_finish);
 
   bool handle_payload(const watch_notify::HeaderUpdatePayload& payload,
                       C_NotifyAck *ctx);

--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -730,13 +730,22 @@ void Operations<I>::snap_create(const cls::rbd::SnapshotNamespace &snap_namespac
   }
   m_image_ctx.image_lock.unlock_shared();
 
+  auto prog_ctx = new NoOpProgressContext();
+  on_finish = new LambdaContext(
+    [prog_ctx, on_finish](int r) {
+      delete prog_ctx;
+      on_finish->complete(r);
+    });
+
+  uint64_t request_id = ++m_async_request_seq;
   C_InvokeAsyncRequest<I> *req = new C_InvokeAsyncRequest<I>(
     m_image_ctx, "snap_create", exclusive_lock::OPERATION_REQUEST_TYPE_GENERAL,
     true,
     boost::bind(&Operations<I>::execute_snap_create, this, snap_namespace, snap_name,
-		_1, 0, false),
+		_1, 0, false, boost::ref(*prog_ctx)),
     boost::bind(&ImageWatcher<I>::notify_snap_create, m_image_ctx.image_watcher,
-                snap_namespace, snap_name, _1),
+                request_id, snap_namespace, snap_name, boost::ref(*prog_ctx),
+                _1),
     {-EEXIST}, on_finish);
   req->send();
 }
@@ -746,7 +755,8 @@ void Operations<I>::execute_snap_create(const cls::rbd::SnapshotNamespace &snap_
 					const std::string &snap_name,
                                         Context *on_finish,
                                         uint64_t journal_op_tid,
-                                        bool skip_object_map) {
+                                        bool skip_object_map,
+                                        ProgressContext &prog_ctx) {
   ceph_assert(ceph_mutex_is_locked(m_image_ctx.owner_lock));
   ceph_assert(m_image_ctx.exclusive_lock == nullptr ||
               m_image_ctx.exclusive_lock->is_lock_owner());
@@ -772,7 +782,8 @@ void Operations<I>::execute_snap_create(const cls::rbd::SnapshotNamespace &snap_
   operation::SnapshotCreateRequest<I> *req =
     new operation::SnapshotCreateRequest<I>(
       m_image_ctx, new C_NotifyUpdate<I>(m_image_ctx, on_finish),
-      snap_namespace, snap_name, journal_op_tid, request_id, skip_object_map);
+      snap_namespace, snap_name, journal_op_tid, request_id, skip_object_map,
+      prog_ctx);
   req->send();
 }
 

--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -768,10 +768,11 @@ void Operations<I>::execute_snap_create(const cls::rbd::SnapshotNamespace &snap_
   }
   m_image_ctx.image_lock.unlock_shared();
 
+  uint64_t request_id = ++m_async_request_seq;
   operation::SnapshotCreateRequest<I> *req =
     new operation::SnapshotCreateRequest<I>(
       m_image_ctx, new C_NotifyUpdate<I>(m_image_ctx, on_finish),
-      snap_namespace, snap_name, journal_op_tid, skip_object_map);
+      snap_namespace, snap_name, journal_op_tid, request_id, skip_object_map);
   req->send();
 }
 

--- a/src/librbd/Operations.h
+++ b/src/librbd/Operations.h
@@ -52,7 +52,8 @@ public:
   void execute_snap_create(const cls::rbd::SnapshotNamespace &snap_namespace,
 			   const std::string &snap_name,
 			   Context *on_finish,
-                           uint64_t journal_op_tid, bool skip_object_map);
+                           uint64_t journal_op_tid, bool skip_object_map,
+                           ProgressContext &prog_ctx);
 
   int snap_rollback(const cls::rbd::SnapshotNamespace& snap_namespace,
 		    const std::string& snap_name,

--- a/src/librbd/WatchNotifyTypes.cc
+++ b/src/librbd/WatchNotifyTypes.cc
@@ -356,6 +356,12 @@ void NotifyMessage::decode(bufferlist::const_iterator& iter) {
   case NOTIFY_OP_SPARSIFY:
     payload.reset(new SparsifyPayload());
     break;
+  case NOTIFY_OP_QUIESCE:
+    payload.reset(new QuiescePayload());
+    break;
+  case NOTIFY_OP_UNQUIESCE:
+    payload.reset(new UnquiescePayload());
+    break;
   }
 
   payload->decode(struct_v, iter);
@@ -389,6 +395,8 @@ void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {
   o.push_back(new NotifyMessage(new UpdateFeaturesPayload(1, true)));
   o.push_back(new NotifyMessage(new MigratePayload(AsyncRequestId(ClientId(0, 1), 2))));
   o.push_back(new NotifyMessage(new SparsifyPayload(AsyncRequestId(ClientId(0, 1), 2), 1)));
+  o.push_back(new NotifyMessage(new QuiescePayload(AsyncRequestId(ClientId(0, 1), 2))));
+  o.push_back(new NotifyMessage(new UnquiescePayload(AsyncRequestId(ClientId(0, 1), 2))));
 }
 
 void ResponseMessage::encode(bufferlist& bl) const {
@@ -469,6 +477,12 @@ std::ostream &operator<<(std::ostream &out,
     break;
   case NOTIFY_OP_SPARSIFY:
     out << "Sparsify";
+    break;
+  case NOTIFY_OP_QUIESCE:
+    out << "Quiesce";
+    break;
+  case NOTIFY_OP_UNQUIESCE:
+    out << "Unquiesce";
     break;
   default:
     out << "Unknown (" << static_cast<uint32_t>(op) << ")";

--- a/src/librbd/WatchNotifyTypes.cc
+++ b/src/librbd/WatchNotifyTypes.cc
@@ -6,45 +6,9 @@
 #include "include/ceph_assert.h"
 #include "include/stringify.h"
 #include "librbd/WatchNotifyTypes.h"
-#include "librbd/watcher/Utils.h"
 
 namespace librbd {
 namespace watch_notify {
-
-namespace {
-
-class CheckForRefreshVisitor  : public boost::static_visitor<bool> {
-public:
-  template <typename Payload>
-  inline bool operator()(const Payload &payload) const {
-    return Payload::CHECK_FOR_REFRESH;
-  }
-};
-
-class GetNotifyOpVisitor  : public boost::static_visitor<NotifyOp> {
-public:
-  template <typename Payload>
-  NotifyOp operator()(const Payload &payload) const {
-    return Payload::NOTIFY_OP;
-  }
-};
-
-class DumpPayloadVisitor : public boost::static_visitor<void> {
-public:
-  explicit DumpPayloadVisitor(Formatter *formatter) : m_formatter(formatter) {}
-
-  template <typename Payload>
-  inline void operator()(const Payload &payload) const {
-    NotifyOp notify_op = Payload::NOTIFY_OP;
-    m_formatter->dump_string("notify_op", stringify(notify_op));
-    payload.dump(m_formatter);
-  }
-
-private:
-  ceph::Formatter *m_formatter;
-};
-
-} // anonymous namespace
 
 void AsyncRequestId::encode(bufferlist &bl) const {
   using ceph::encode;
@@ -320,12 +284,13 @@ void UnknownPayload::dump(Formatter *f) const {
 }
 
 bool NotifyMessage::check_for_refresh() const {
-  return boost::apply_visitor(CheckForRefreshVisitor(), payload);
+  return payload->check_for_refresh();
 }
 
 void NotifyMessage::encode(bufferlist& bl) const {
   ENCODE_START(6, 1, bl);
-  boost::apply_visitor(watcher::util::EncodePayloadVisitor(bl), payload);
+  encode(static_cast<uint32_t>(payload->get_notify_op()), bl);
+  payload->encode(bl);
   ENCODE_FINISH(bl);
 }
 
@@ -338,95 +303,92 @@ void NotifyMessage::decode(bufferlist::const_iterator& iter) {
   // select the correct payload variant based upon the encoded op
   switch (notify_op) {
   case NOTIFY_OP_ACQUIRED_LOCK:
-    payload = AcquiredLockPayload();
+    payload.reset(new AcquiredLockPayload());
     break;
   case NOTIFY_OP_RELEASED_LOCK:
-    payload = ReleasedLockPayload();
+    payload.reset(new ReleasedLockPayload());
     break;
   case NOTIFY_OP_REQUEST_LOCK:
-    payload = RequestLockPayload();
+    payload.reset(new RequestLockPayload());
     break;
   case NOTIFY_OP_HEADER_UPDATE:
-    payload = HeaderUpdatePayload();
+    payload.reset(new HeaderUpdatePayload());
     break;
   case NOTIFY_OP_ASYNC_PROGRESS:
-    payload = AsyncProgressPayload();
+    payload.reset(new AsyncProgressPayload());
     break;
   case NOTIFY_OP_ASYNC_COMPLETE:
-    payload = AsyncCompletePayload();
+    payload.reset(new AsyncCompletePayload());
     break;
   case NOTIFY_OP_FLATTEN:
-    payload = FlattenPayload();
+    payload.reset(new FlattenPayload());
     break;
   case NOTIFY_OP_RESIZE:
-    payload = ResizePayload();
+    payload.reset(new ResizePayload());
     break;
   case NOTIFY_OP_SNAP_CREATE:
-    payload = SnapCreatePayload();
+    payload.reset(new SnapCreatePayload());
     break;
   case NOTIFY_OP_SNAP_REMOVE:
-    payload = SnapRemovePayload();
+    payload.reset(new SnapRemovePayload());
     break;
   case NOTIFY_OP_SNAP_RENAME:
-    payload = SnapRenamePayload();
+    payload.reset(new SnapRenamePayload());
     break;
   case NOTIFY_OP_SNAP_PROTECT:
-    payload = SnapProtectPayload();
+    payload.reset(new SnapProtectPayload());
     break;
   case NOTIFY_OP_SNAP_UNPROTECT:
-    payload = SnapUnprotectPayload();
+    payload.reset(new SnapUnprotectPayload());
     break;
   case NOTIFY_OP_REBUILD_OBJECT_MAP:
-    payload = RebuildObjectMapPayload();
+    payload.reset(new RebuildObjectMapPayload());
     break;
   case NOTIFY_OP_RENAME:
-    payload = RenamePayload();
+    payload.reset(new RenamePayload());
     break;
   case NOTIFY_OP_UPDATE_FEATURES:
-    payload = UpdateFeaturesPayload();
+    payload.reset(new UpdateFeaturesPayload());
     break;
   case NOTIFY_OP_MIGRATE:
-    payload = MigratePayload();
+    payload.reset(new MigratePayload());
     break;
   case NOTIFY_OP_SPARSIFY:
-    payload = SparsifyPayload();
-    break;
-  default:
-    payload = UnknownPayload();
+    payload.reset(new SparsifyPayload());
     break;
   }
 
-  apply_visitor(watcher::util::DecodePayloadVisitor(struct_v, iter), payload);
+  payload->decode(struct_v, iter);
   DECODE_FINISH(iter);
 }
 
 void NotifyMessage::dump(Formatter *f) const {
-  apply_visitor(DumpPayloadVisitor(f), payload);
+  payload->dump(f);
 }
 
 NotifyOp NotifyMessage::get_notify_op() const {
-  return apply_visitor(GetNotifyOpVisitor(), payload);
+  return payload->get_notify_op();
 }
 
 void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {
-  o.push_back(new NotifyMessage(AcquiredLockPayload(ClientId(1, 2))));
-  o.push_back(new NotifyMessage(ReleasedLockPayload(ClientId(1, 2))));
-  o.push_back(new NotifyMessage(RequestLockPayload(ClientId(1, 2), true)));
-  o.push_back(new NotifyMessage(HeaderUpdatePayload()));
-  o.push_back(new NotifyMessage(AsyncProgressPayload(AsyncRequestId(ClientId(0, 1), 2), 3, 4)));
-  o.push_back(new NotifyMessage(AsyncCompletePayload(AsyncRequestId(ClientId(0, 1), 2), 3)));
-  o.push_back(new NotifyMessage(FlattenPayload(AsyncRequestId(ClientId(0, 1), 2))));
-  o.push_back(new NotifyMessage(ResizePayload(123, true, AsyncRequestId(ClientId(0, 1), 2))));
-  o.push_back(new NotifyMessage(SnapCreatePayload(cls::rbd::UserSnapshotNamespace(),
-						  "foo")));
-  o.push_back(new NotifyMessage(SnapRemovePayload(cls::rbd::UserSnapshotNamespace(), "foo")));
-  o.push_back(new NotifyMessage(SnapProtectPayload(cls::rbd::UserSnapshotNamespace(), "foo")));
-  o.push_back(new NotifyMessage(SnapUnprotectPayload(cls::rbd::UserSnapshotNamespace(), "foo")));
-  o.push_back(new NotifyMessage(RebuildObjectMapPayload(AsyncRequestId(ClientId(0, 1), 2))));
-  o.push_back(new NotifyMessage(RenamePayload("foo")));
-  o.push_back(new NotifyMessage(UpdateFeaturesPayload(1, true)));
-  o.push_back(new NotifyMessage(MigratePayload(AsyncRequestId(ClientId(0, 1), 2))));
-  o.push_back(new NotifyMessage(SparsifyPayload(AsyncRequestId(ClientId(0, 1), 2), 1)));
+  o.push_back(new NotifyMessage(new AcquiredLockPayload(ClientId(1, 2))));
+  o.push_back(new NotifyMessage(new ReleasedLockPayload(ClientId(1, 2))));
+  o.push_back(new NotifyMessage(new RequestLockPayload(ClientId(1, 2), true)));
+  o.push_back(new NotifyMessage(new HeaderUpdatePayload()));
+  o.push_back(new NotifyMessage(new AsyncProgressPayload(AsyncRequestId(ClientId(0, 1), 2), 3, 4)));
+  o.push_back(new NotifyMessage(new AsyncCompletePayload(AsyncRequestId(ClientId(0, 1), 2), 3)));
+  o.push_back(new NotifyMessage(new FlattenPayload(AsyncRequestId(ClientId(0, 1), 2))));
+  o.push_back(new NotifyMessage(new ResizePayload(123, true, AsyncRequestId(ClientId(0, 1), 2))));
+  o.push_back(new NotifyMessage(new SnapCreatePayload(cls::rbd::UserSnapshotNamespace(),
+                                                      "foo")));
+  o.push_back(new NotifyMessage(new SnapRemovePayload(cls::rbd::UserSnapshotNamespace(), "foo")));
+  o.push_back(new NotifyMessage(new SnapProtectPayload(cls::rbd::UserSnapshotNamespace(), "foo")));
+  o.push_back(new NotifyMessage(new SnapUnprotectPayload(cls::rbd::UserSnapshotNamespace(), "foo")));
+  o.push_back(new NotifyMessage(new RebuildObjectMapPayload(AsyncRequestId(ClientId(0, 1), 2))));
+  o.push_back(new NotifyMessage(new RenamePayload("foo")));
+  o.push_back(new NotifyMessage(new UpdateFeaturesPayload(1, true)));
+  o.push_back(new NotifyMessage(new MigratePayload(AsyncRequestId(ClientId(0, 1), 2))));
+  o.push_back(new NotifyMessage(new SparsifyPayload(AsyncRequestId(ClientId(0, 1), 2), 1)));
 }
 
 void ResponseMessage::encode(bufferlist& bl) const {

--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -47,6 +47,9 @@ struct AsyncRequestId {
   inline bool operator!=(const AsyncRequestId &rhs) const {
     return (client_id != rhs.client_id || request_id != rhs.request_id);
   }
+  inline operator bool() const {
+    return (*this != AsyncRequestId());
+  }
 };
 
 enum NotifyOp {
@@ -258,10 +261,14 @@ protected:
 };
 
 struct SnapCreatePayload : public SnapPayloadBase {
+  AsyncRequestId async_request_id;
+
   SnapCreatePayload() {}
-  SnapCreatePayload(const cls::rbd::SnapshotNamespace &_snap_namespace,
+  SnapCreatePayload(const AsyncRequestId &id,
+                    const cls::rbd::SnapshotNamespace &snap_namespace,
 		    const std::string &name)
-    : SnapPayloadBase(_snap_namespace, name) {}
+    : SnapPayloadBase(snap_namespace, name), async_request_id(id) {
+  }
 
   NotifyOp get_notify_op() const override {
     return NOTIFY_OP_SNAP_CREATE;

--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -10,6 +10,7 @@
 #include "librbd/watcher/Types.h"
 #include <iosfwd>
 #include <list>
+#include <memory>
 #include <string>
 #include <boost/variant.hpp>
 
@@ -69,67 +70,94 @@ enum NotifyOp {
   NOTIFY_OP_SPARSIFY           = 17,
 };
 
-struct AcquiredLockPayload {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_ACQUIRED_LOCK;
-  static const bool CHECK_FOR_REFRESH = false;
+struct Payload {
+  virtual ~Payload() {}
 
+  virtual NotifyOp get_notify_op() const = 0;
+  virtual bool check_for_refresh() const = 0;
+
+  virtual void encode(bufferlist &bl) const = 0;
+  virtual void decode(__u8 version, bufferlist::const_iterator &iter) = 0;
+  virtual void dump(Formatter *f) const = 0;
+};
+
+struct AcquiredLockPayload : public Payload {
   ClientId client_id;
 
   AcquiredLockPayload() {}
-  AcquiredLockPayload(const ClientId &client_id_) : client_id(client_id_) {}
+  AcquiredLockPayload(const ClientId &client_id) : client_id(client_id) {}
 
-  void encode(bufferlist &bl) const;
-  void decode(__u8 version, bufferlist::const_iterator &iter);
-  void dump(Formatter *f) const;
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_ACQUIRED_LOCK;
+  }
+  bool check_for_refresh() const override {
+    return false;
+  }
+
+  void encode(bufferlist &bl) const override;
+  void decode(__u8 version, bufferlist::const_iterator &iter) override;
+  void dump(Formatter *f) const override;
 };
 
-struct ReleasedLockPayload {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_RELEASED_LOCK;
-  static const bool CHECK_FOR_REFRESH = false;
-
+struct ReleasedLockPayload : public Payload {
   ClientId client_id;
 
   ReleasedLockPayload() {}
-  ReleasedLockPayload(const ClientId &client_id_) : client_id(client_id_) {}
+  ReleasedLockPayload(const ClientId &client_id) : client_id(client_id) {}
 
-  void encode(bufferlist &bl) const;
-  void decode(__u8 version, bufferlist::const_iterator &iter);
-  void dump(Formatter *f) const;
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_RELEASED_LOCK;
+  }
+  bool check_for_refresh() const override {
+    return false;
+  }
+
+  void encode(bufferlist &bl) const override;
+  void decode(__u8 version, bufferlist::const_iterator &iter) override;
+  void dump(Formatter *f) const override;
 };
 
-struct RequestLockPayload {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_REQUEST_LOCK;
-  static const bool CHECK_FOR_REFRESH = false;
-
+struct RequestLockPayload : public Payload {
   ClientId client_id;
   bool force = false;
 
   RequestLockPayload() {}
-  RequestLockPayload(const ClientId &client_id_, bool force_)
-    : client_id(client_id_), force(force_) {
+  RequestLockPayload(const ClientId &client_id, bool force)
+    : client_id(client_id), force(force) {
   }
 
-  void encode(bufferlist &bl) const;
-  void decode(__u8 version, bufferlist::const_iterator &iter);
-  void dump(Formatter *f) const;
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_REQUEST_LOCK;
+  }
+  bool check_for_refresh() const override {
+    return false;
+  }
+
+  void encode(bufferlist &bl) const override;
+  void decode(__u8 version, bufferlist::const_iterator &iter) override;
+  void dump(Formatter *f) const override;
 };
 
-struct HeaderUpdatePayload {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_HEADER_UPDATE;
-  static const bool CHECK_FOR_REFRESH = false;
+struct HeaderUpdatePayload : public Payload {
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_HEADER_UPDATE;
+  }
+  bool check_for_refresh() const override {
+    return false;
+  }
 
-  void encode(bufferlist &bl) const;
-  void decode(__u8 version, bufferlist::const_iterator &iter);
-  void dump(Formatter *f) const;
+  void encode(bufferlist &bl) const override;
+  void decode(__u8 version, bufferlist::const_iterator &iter) override;
+  void dump(Formatter *f) const override;
 };
 
-struct AsyncRequestPayloadBase {
+struct AsyncRequestPayloadBase : public Payload {
 public:
   AsyncRequestId async_request_id;
 
-  void encode(bufferlist &bl) const;
-  void decode(__u8 version, bufferlist::const_iterator &iter);
-  void dump(Formatter *f) const;
+  void encode(bufferlist &bl) const override;
+  void decode(__u8 version, bufferlist::const_iterator &iter) override;
+  void dump(Formatter *f) const override;
 
 protected:
   AsyncRequestPayloadBase() {}
@@ -137,229 +165,262 @@ protected:
 };
 
 struct AsyncProgressPayload : public AsyncRequestPayloadBase {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_ASYNC_PROGRESS;
-  static const bool CHECK_FOR_REFRESH = false;
+  uint64_t offset = 0;
+  uint64_t total = 0;
 
-  AsyncProgressPayload() : offset(0), total(0) {}
-  AsyncProgressPayload(const AsyncRequestId &id, uint64_t offset_, uint64_t total_)
-    : AsyncRequestPayloadBase(id), offset(offset_), total(total_) {}
+  AsyncProgressPayload() {}
+  AsyncProgressPayload(const AsyncRequestId &id, uint64_t offset, uint64_t total)
+    : AsyncRequestPayloadBase(id), offset(offset), total(total) {}
 
-  uint64_t offset;
-  uint64_t total;
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_ASYNC_PROGRESS;
+  }
+  bool check_for_refresh() const override {
+    return false;
+  }
 
-  void encode(bufferlist &bl) const;
-  void decode(__u8 version, bufferlist::const_iterator &iter);
-  void dump(Formatter *f) const;
+  void encode(bufferlist &bl) const override;
+  void decode(__u8 version, bufferlist::const_iterator &iter) override;
+  void dump(Formatter *f) const override;
 };
 
 struct AsyncCompletePayload : public AsyncRequestPayloadBase {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_ASYNC_COMPLETE;
-  static const bool CHECK_FOR_REFRESH = false;
+  int result = 0;
 
-  AsyncCompletePayload() : result(0) {}
+  AsyncCompletePayload() {}
   AsyncCompletePayload(const AsyncRequestId &id, int r)
     : AsyncRequestPayloadBase(id), result(r) {}
 
-  int result;
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_ASYNC_COMPLETE;
+  }
+  bool check_for_refresh() const override {
+    return false;
+  }
 
-  void encode(bufferlist &bl) const;
-  void decode(__u8 version, bufferlist::const_iterator &iter);
-  void dump(Formatter *f) const;
+  void encode(bufferlist &bl) const override;
+  void decode(__u8 version, bufferlist::const_iterator &iter) override;
+  void dump(Formatter *f) const override;
 };
 
 struct FlattenPayload : public AsyncRequestPayloadBase {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_FLATTEN;
-  static const bool CHECK_FOR_REFRESH = true;
-
   FlattenPayload() {}
   FlattenPayload(const AsyncRequestId &id) : AsyncRequestPayloadBase(id) {}
+
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_FLATTEN;
+  }
+  bool check_for_refresh() const override {
+    return true;
+  }
 };
 
 struct ResizePayload : public AsyncRequestPayloadBase {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_RESIZE;
-  static const bool CHECK_FOR_REFRESH = true;
+  uint64_t size = 0;
+  bool allow_shrink = true;
 
-  ResizePayload() : size(0), allow_shrink(true) {}
-  ResizePayload(uint64_t size_, bool allow_shrink_, const AsyncRequestId &id)
-    : AsyncRequestPayloadBase(id), size(size_), allow_shrink(allow_shrink_) {}
+  ResizePayload() {}
+  ResizePayload(uint64_t size, bool allow_shrink, const AsyncRequestId &id)
+    : AsyncRequestPayloadBase(id), size(size), allow_shrink(allow_shrink) {}
 
-  uint64_t size;
-  bool allow_shrink;
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_RESIZE;
+  }
+  bool check_for_refresh() const override {
+    return true;
+  }
 
-  void encode(bufferlist &bl) const;
-  void decode(__u8 version, bufferlist::const_iterator &iter);
-  void dump(Formatter *f) const;
+  void encode(bufferlist &bl) const override;
+  void decode(__u8 version, bufferlist::const_iterator &iter) override;
+  void dump(Formatter *f) const override;
 };
 
-struct SnapPayloadBase {
+struct SnapPayloadBase : public Payload {
 public:
-  static const bool CHECK_FOR_REFRESH = true;
-
   cls::rbd::SnapshotNamespace snap_namespace;
   std::string snap_name;
 
-  void encode(bufferlist &bl) const;
-  void decode(__u8 version, bufferlist::const_iterator &iter);
-  void dump(Formatter *f) const;
+  bool check_for_refresh() const override {
+    return true;
+  }
+
+  void encode(bufferlist &bl) const override;
+  void decode(__u8 version, bufferlist::const_iterator &iter) override;
+  void dump(Formatter *f) const override;
 
 protected:
   SnapPayloadBase() {}
-  SnapPayloadBase(const cls::rbd::SnapshotNamespace& _snap_namespace,
+  SnapPayloadBase(const cls::rbd::SnapshotNamespace& snap_namespace,
 		  const std::string &name)
-    : snap_namespace(_snap_namespace), snap_name(name) {}
+    : snap_namespace(snap_namespace), snap_name(name) {}
 };
 
 struct SnapCreatePayload : public SnapPayloadBase {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_SNAP_CREATE;
-
   SnapCreatePayload() {}
   SnapCreatePayload(const cls::rbd::SnapshotNamespace &_snap_namespace,
 		    const std::string &name)
     : SnapPayloadBase(_snap_namespace, name) {}
 
-  void encode(bufferlist &bl) const;
-  void decode(__u8 version, bufferlist::const_iterator &iter);
-  void dump(Formatter *f) const;
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_SNAP_CREATE;
+  }
+
+  void encode(bufferlist &bl) const override;
+  void decode(__u8 version, bufferlist::const_iterator &iter) override;
+  void dump(Formatter *f) const override;
 };
 
 struct SnapRenamePayload : public SnapPayloadBase {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_SNAP_RENAME;
+  uint64_t snap_id = 0;
 
   SnapRenamePayload() {}
   SnapRenamePayload(const uint64_t &src_snap_id,
 		    const std::string &dst_name)
     : SnapPayloadBase(cls::rbd::UserSnapshotNamespace(), dst_name), snap_id(src_snap_id) {}
 
-  uint64_t snap_id = 0;
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_SNAP_RENAME;
+  }
 
-  void encode(bufferlist &bl) const;
-  void decode(__u8 version, bufferlist::const_iterator &iter);
-  void dump(Formatter *f) const;
+  void encode(bufferlist &bl) const override;
+  void decode(__u8 version, bufferlist::const_iterator &iter) override;
+  void dump(Formatter *f) const override;
 };
 
 struct SnapRemovePayload : public SnapPayloadBase {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_SNAP_REMOVE;
-
   SnapRemovePayload() {}
   SnapRemovePayload(const cls::rbd::SnapshotNamespace& snap_namespace,
 		    const std::string &name)
     : SnapPayloadBase(snap_namespace, name) {}
+
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_SNAP_REMOVE;
+  }
 };
 
 struct SnapProtectPayload : public SnapPayloadBase {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_SNAP_PROTECT;
-
   SnapProtectPayload() {}
   SnapProtectPayload(const cls::rbd::SnapshotNamespace& snap_namespace,
 		     const std::string &name)
     : SnapPayloadBase(snap_namespace, name) {}
+
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_SNAP_PROTECT;
+  }
 };
 
 struct SnapUnprotectPayload : public SnapPayloadBase {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_SNAP_UNPROTECT;
-
   SnapUnprotectPayload() {}
   SnapUnprotectPayload(const cls::rbd::SnapshotNamespace& snap_namespace,
 		       const std::string &name)
     : SnapPayloadBase(snap_namespace, name) {}
+
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_SNAP_UNPROTECT;
+  }
 };
 
 struct RebuildObjectMapPayload : public AsyncRequestPayloadBase {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_REBUILD_OBJECT_MAP;
-  static const bool CHECK_FOR_REFRESH = true;
-
   RebuildObjectMapPayload() {}
   RebuildObjectMapPayload(const AsyncRequestId &id)
     : AsyncRequestPayloadBase(id) {}
+
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_REBUILD_OBJECT_MAP;
+  }
+  bool check_for_refresh() const override {
+    return true;
+  }
 };
 
-struct RenamePayload {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_RENAME;
-  static const bool CHECK_FOR_REFRESH = true;
+struct RenamePayload : public Payload {
+  std::string image_name;
 
   RenamePayload() {}
   RenamePayload(const std::string _image_name) : image_name(_image_name) {}
 
-  std::string image_name;
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_RENAME;
+  }
+  bool check_for_refresh() const override {
+    return true;
+  }
 
   void encode(bufferlist &bl) const;
   void decode(__u8 version, bufferlist::const_iterator &iter);
   void dump(Formatter *f) const;
 };
 
-struct UpdateFeaturesPayload {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_UPDATE_FEATURES;
-  static const bool CHECK_FOR_REFRESH = true;
+struct UpdateFeaturesPayload : public Payload {
+  uint64_t features = 0;
+  bool enabled = false;
 
-  UpdateFeaturesPayload() : features(0), enabled(false) {}
-  UpdateFeaturesPayload(uint64_t features_, bool enabled_)
-    : features(features_), enabled(enabled_) {}
+  UpdateFeaturesPayload() {}
+  UpdateFeaturesPayload(uint64_t features, bool enabled)
+    : features(features), enabled(enabled) {}
 
-  uint64_t features;
-  bool enabled;
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_UPDATE_FEATURES;
+  }
+  bool check_for_refresh() const override {
+    return true;
+  }
 
-  void encode(bufferlist &bl) const;
-  void decode(__u8 version, bufferlist::const_iterator &iter);
-  void dump(Formatter *f) const;
+  void encode(bufferlist &bl) const override;
+  void decode(__u8 version, bufferlist::const_iterator &iter) override;
+  void dump(Formatter *f) const override;
 };
 
 struct MigratePayload : public AsyncRequestPayloadBase {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_MIGRATE;
-  static const bool CHECK_FOR_REFRESH = true;
-
   MigratePayload() {}
   MigratePayload(const AsyncRequestId &id) : AsyncRequestPayloadBase(id) {}
+
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_MIGRATE;
+  }
+  bool check_for_refresh() const override {
+    return true;
+  }
 };
 
 struct SparsifyPayload : public AsyncRequestPayloadBase {
-  static const NotifyOp NOTIFY_OP = NOTIFY_OP_SPARSIFY;
-  static const bool CHECK_FOR_REFRESH = true;
+  size_t sparse_size = 0;
 
   SparsifyPayload() {}
   SparsifyPayload(const AsyncRequestId &id, size_t sparse_size)
-    : AsyncRequestPayloadBase(id), sparse_size(sparse_size) {}
+    : AsyncRequestPayloadBase(id), sparse_size(sparse_size) {
+  }
 
-  size_t sparse_size = 0;
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_SPARSIFY;
+  }
+  bool check_for_refresh() const override {
+    return true;
+  }
 
-  void encode(bufferlist &bl) const;
-  void decode(__u8 version, bufferlist::const_iterator &iter);
-  void dump(Formatter *f) const;
+  void encode(bufferlist &bl) const override;
+  void decode(__u8 version, bufferlist::const_iterator &iter) override;
+  void dump(Formatter *f) const override;
 };
 
-struct UnknownPayload {
-  static const NotifyOp NOTIFY_OP = static_cast<NotifyOp>(-1);
-  static const bool CHECK_FOR_REFRESH = false;
+struct UnknownPayload : public Payload {
+  NotifyOp get_notify_op() const override {
+    return static_cast<NotifyOp>(-1);
+  }
+  bool check_for_refresh() const override {
+    return false;
+  }
 
-  void encode(bufferlist &bl) const;
-  void decode(__u8 version, bufferlist::const_iterator &iter);
-  void dump(Formatter *f) const;
+  void encode(bufferlist &bl) const override;
+  void decode(__u8 version, bufferlist::const_iterator &iter) override;
+  void dump(Formatter *f) const override;
 };
-
-typedef boost::variant<AcquiredLockPayload,
-                       ReleasedLockPayload,
-                       RequestLockPayload,
-                       HeaderUpdatePayload,
-                       AsyncProgressPayload,
-                       AsyncCompletePayload,
-                       FlattenPayload,
-                       ResizePayload,
-                       SnapCreatePayload,
-                       SnapRemovePayload,
-                       SnapRenamePayload,
-                       SnapProtectPayload,
-                       SnapUnprotectPayload,
-                       RebuildObjectMapPayload,
-                       RenamePayload,
-                       UpdateFeaturesPayload,
-                       MigratePayload,
-                       SparsifyPayload,
-                       UnknownPayload> Payload;
 
 struct NotifyMessage {
-  NotifyMessage() : payload(UnknownPayload()) {}
-  NotifyMessage(const Payload &payload_) : payload(payload_) {}
+  NotifyMessage() : payload(new UnknownPayload()) {}
+  NotifyMessage(Payload *payload) : payload(payload) {}
 
-  Payload payload;
+  std::unique_ptr<Payload> payload;
 
   bool check_for_refresh() const;
 

--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -68,6 +68,8 @@ enum NotifyOp {
   NOTIFY_OP_UPDATE_FEATURES    = 15,
   NOTIFY_OP_MIGRATE            = 16,
   NOTIFY_OP_SPARSIFY           = 17,
+  NOTIFY_OP_QUIESCE            = 18,
+  NOTIFY_OP_UNQUIESCE          = 19,
 };
 
 struct Payload {
@@ -401,6 +403,30 @@ struct SparsifyPayload : public AsyncRequestPayloadBase {
   void encode(bufferlist &bl) const override;
   void decode(__u8 version, bufferlist::const_iterator &iter) override;
   void dump(Formatter *f) const override;
+};
+
+struct QuiescePayload : public AsyncRequestPayloadBase {
+  QuiescePayload() {}
+  QuiescePayload(const AsyncRequestId &id) : AsyncRequestPayloadBase(id) {}
+
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_QUIESCE;
+  }
+  bool check_for_refresh() const override {
+    return false;
+  }
+};
+
+struct UnquiescePayload : public AsyncRequestPayloadBase {
+  UnquiescePayload() {}
+  UnquiescePayload(const AsyncRequestId &id) : AsyncRequestPayloadBase(id) {}
+
+  NotifyOp get_notify_op() const override {
+    return NOTIFY_OP_UNQUIESCE;
+  }
+  bool check_for_refresh() const override {
+    return false;
+  }
 };
 
 struct UnknownPayload : public Payload {

--- a/src/librbd/deep_copy/SnapshotCreateRequest.cc
+++ b/src/librbd/deep_copy/SnapshotCreateRequest.cc
@@ -82,9 +82,8 @@ void SnapshotCreateRequest<I>::send_create_snap() {
     });
   std::shared_lock owner_locker{m_dst_image_ctx->owner_lock};
   m_dst_image_ctx->operations->execute_snap_create(m_snap_namespace,
-                                                   m_snap_name.c_str(),
-                                                   ctx,
-                                                   0U, true);
+                                                   m_snap_name.c_str(), ctx, 0U,
+                                                   true, m_prog_ctx);
 }
 
 template <typename I>

--- a/src/librbd/deep_copy/SnapshotCreateRequest.h
+++ b/src/librbd/deep_copy/SnapshotCreateRequest.h
@@ -9,6 +9,8 @@
 #include "common/snap_types.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/Types.h"
+#include "librbd/internal.h"
+
 #include <map>
 #include <set>
 #include <string>
@@ -72,6 +74,7 @@ private:
   Context *m_on_finish;
 
   CephContext *m_cct;
+  NoOpProgressContext m_prog_ctx;
 
   void send_set_head();
   void handle_set_head(int r);

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -42,7 +42,8 @@ struct ExecuteOp : public Context {
     image_ctx.operations->execute_snap_create(event.snap_namespace,
 					      event.snap_name,
                                               on_op_complete,
-                                              event.op_tid, false);
+                                              event.op_tid, false,
+                                              no_op_progress_callback);
   }
 
   void execute(const journal::SnapRemoveEvent &_) {

--- a/src/librbd/mirror/snapshot/ImageMeta.cc
+++ b/src/librbd/mirror/snapshot/ImageMeta.cc
@@ -142,7 +142,8 @@ void ImageMeta<I>::notify_update(Context* on_finish) {
   // open a non-primary image read/write and therefore cannot re-use
   // the ImageWatcher to send the notification
   bufferlist bl;
-  encode(watch_notify::NotifyMessage(watch_notify::HeaderUpdatePayload()), bl);
+  encode(watch_notify::NotifyMessage(new watch_notify::HeaderUpdatePayload()),
+         bl);
 
   m_out_bl.clear();
   auto ctx = new LambdaContext([this, on_finish](int r) {

--- a/src/librbd/operation/SnapshotCreateRequest.cc
+++ b/src/librbd/operation/SnapshotCreateRequest.cc
@@ -7,6 +7,7 @@
 #include "common/errno.h"
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
+#include "librbd/ImageWatcher.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/Utils.h"
 #include "librbd/io/ImageRequestWQ.h"
@@ -29,10 +30,11 @@ SnapshotCreateRequest<I>::SnapshotCreateRequest(I &image_ctx,
 						const cls::rbd::SnapshotNamespace &snap_namespace,
                                                 const std::string &snap_name,
                                                 uint64_t journal_op_tid,
+                                                uint64_t request_id,
                                                 bool skip_object_map)
   : Request<I>(image_ctx, on_finish, journal_op_tid),
     m_snap_namespace(snap_namespace), m_snap_name(snap_name),
-    m_skip_object_map(skip_object_map), m_ret_val(0), m_snap_id(CEPH_NOSNAP) {
+    m_request_id(request_id), m_skip_object_map(skip_object_map) {
 }
 
 template <typename I>
@@ -46,7 +48,36 @@ void SnapshotCreateRequest<I>::send_op() {
     return;
   }
 
+  send_notify_quiesce();
+}
+
+template <typename I>
+void SnapshotCreateRequest<I>::send_notify_quiesce() {
+  I &image_ctx = this->m_image_ctx;
+
+  CephContext *cct = image_ctx.cct;
+  ldout(cct, 5) << this << " " << __func__ << dendl;
+
+  image_ctx.image_watcher->notify_quiesce(
+    m_request_id, create_async_context_callback(
+      image_ctx, create_context_callback<SnapshotCreateRequest<I>,
+      &SnapshotCreateRequest<I>::handle_notify_quiesce>(this)));
+}
+
+template <typename I>
+Context *SnapshotCreateRequest<I>::handle_notify_quiesce(int *result) {
+  I &image_ctx = this->m_image_ctx;
+  CephContext *cct = image_ctx.cct;
+  ldout(cct, 5) << this << " " << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to notify quiesce: " << cpp_strerror(*result)
+               << dendl;
+    return this->create_context_finisher(*result);
+  }
+
   send_suspend_requests();
+  return nullptr;
 }
 
 template <typename I>
@@ -73,7 +104,7 @@ Context *SnapshotCreateRequest<I>::handle_suspend_requests(int *result) {
 template <typename I>
 void SnapshotCreateRequest<I>::send_suspend_aio() {
   I &image_ctx = this->m_image_ctx;
-  ceph_assert(ceph_mutex_is_locked(image_ctx.owner_lock));
+  std::shared_lock owner_locker{image_ctx.owner_lock};
 
   CephContext *cct = image_ctx.cct;
   ldout(cct, 5) << this << " " << __func__ << dendl;
@@ -91,8 +122,9 @@ Context *SnapshotCreateRequest<I>::handle_suspend_aio(int *result) {
 
   if (*result < 0) {
     lderr(cct) << "failed to block writes: " << cpp_strerror(*result) << dendl;
-    image_ctx.io_work_queue->unblock_writes();
-    return this->create_context_finisher(*result);
+    save_result(result);
+    send_notify_unquiesce();
+    return nullptr;
   }
 
   send_append_op_event();
@@ -120,10 +152,11 @@ Context *SnapshotCreateRequest<I>::handle_append_op_event(int *result) {
   ldout(cct, 5) << this << " " << __func__ << ": r=" << *result << dendl;
 
   if (*result < 0) {
-    image_ctx.io_work_queue->unblock_writes();
     lderr(cct) << "failed to commit journal entry: " << cpp_strerror(*result)
                << dendl;
-    return this->create_context_finisher(*result);
+    save_result(result);
+    send_notify_unquiesce();
+    return nullptr;
   }
 
   send_allocate_snap_id();
@@ -151,11 +184,11 @@ Context *SnapshotCreateRequest<I>::handle_allocate_snap_id(int *result) {
                 << "snap_id=" << m_snap_id << dendl;
 
   if (*result < 0) {
-    save_result(result);
-    image_ctx.io_work_queue->unblock_writes();
     lderr(cct) << "failed to allocate snapshot id: " << cpp_strerror(*result)
                << dendl;
-    return this->create_context_finisher(*result);
+    save_result(result);
+    send_notify_unquiesce();
+    return nullptr;
   }
 
   send_create_snap();
@@ -245,9 +278,10 @@ Context *SnapshotCreateRequest<I>::handle_create_object_map(int *result) {
     lderr(cct) << this << " " << __func__ << ": failed to snapshot object map: "
                << cpp_strerror(*result) << dendl;
 
+    save_result(result);
     update_snap_context();
-    image_ctx.io_work_queue->unblock_writes();
-    return this->create_context_finisher(*result);
+    send_notify_unquiesce();
+    return nullptr;
   }
 
   return send_create_image_state();
@@ -260,8 +294,8 @@ Context *SnapshotCreateRequest<I>::send_create_image_state() {
     &m_snap_namespace);
   if (mirror_ns == nullptr || !mirror_ns->is_primary()) {
     update_snap_context();
-    image_ctx.io_work_queue->unblock_writes();
-    return this->create_context_finisher(0);
+    send_notify_unquiesce();
+    return nullptr;
   }
 
   CephContext *cct = image_ctx.cct;
@@ -282,14 +316,14 @@ Context *SnapshotCreateRequest<I>::handle_create_image_state(int *result) {
   ldout(cct, 5) << this << " " << __func__ << ": r=" << *result << dendl;
 
   update_snap_context();
-  image_ctx.io_work_queue->unblock_writes();
   if (*result < 0) {
     lderr(cct) << this << " " << __func__ << ": failed to snapshot object map: "
                << cpp_strerror(*result) << dendl;
-    return this->create_context_finisher(*result);
+    save_result(result);
   }
 
-  return this->create_context_finisher(0);
+  send_notify_unquiesce();
+  return nullptr;
 }
 
 template <typename I>
@@ -313,10 +347,38 @@ Context *SnapshotCreateRequest<I>::handle_release_snap_id(int *result) {
   CephContext *cct = image_ctx.cct;
   ldout(cct, 5) << this << " " << __func__ << ": r=" << *result << dendl;
 
-  ceph_assert(m_ret_val < 0);
-  *result = m_ret_val;
+  send_notify_unquiesce();
+  return nullptr;
+}
+
+template <typename I>
+void SnapshotCreateRequest<I>::send_notify_unquiesce() {
+  I &image_ctx = this->m_image_ctx;
+
+  CephContext *cct = image_ctx.cct;
+  ldout(cct, 5) << this << " " << __func__ << dendl;
 
   image_ctx.io_work_queue->unblock_writes();
+
+  image_ctx.image_watcher->notify_unquiesce(
+    m_request_id, create_context_callback<
+      SnapshotCreateRequest<I>,
+      &SnapshotCreateRequest<I>::handle_notify_unquiesce>(this));
+}
+
+template <typename I>
+Context *SnapshotCreateRequest<I>::handle_notify_unquiesce(int *result) {
+  I &image_ctx = this->m_image_ctx;
+  CephContext *cct = image_ctx.cct;
+  ldout(cct, 5) << this << " " << __func__ << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    lderr(cct) << "failed to notify unquiesce: " << cpp_strerror(*result)
+               << dendl;
+    // ignore error
+  }
+
+  *result = m_ret_val;
   return this->create_context_finisher(m_ret_val);
 }
 

--- a/src/librbd/operation/SnapshotCreateRequest.cc
+++ b/src/librbd/operation/SnapshotCreateRequest.cc
@@ -31,10 +31,12 @@ SnapshotCreateRequest<I>::SnapshotCreateRequest(I &image_ctx,
                                                 const std::string &snap_name,
                                                 uint64_t journal_op_tid,
                                                 uint64_t request_id,
-                                                bool skip_object_map)
+                                                bool skip_object_map,
+                                                ProgressContext &prog_ctx)
   : Request<I>(image_ctx, on_finish, journal_op_tid),
     m_snap_namespace(snap_namespace), m_snap_name(snap_name),
-    m_request_id(request_id), m_skip_object_map(skip_object_map) {
+    m_request_id(request_id), m_skip_object_map(skip_object_map),
+    m_prog_ctx(prog_ctx) {
 }
 
 template <typename I>
@@ -59,7 +61,7 @@ void SnapshotCreateRequest<I>::send_notify_quiesce() {
   ldout(cct, 5) << this << " " << __func__ << dendl;
 
   image_ctx.image_watcher->notify_quiesce(
-    m_request_id, create_async_context_callback(
+    m_request_id, m_prog_ctx, create_async_context_callback(
       image_ctx, create_context_callback<SnapshotCreateRequest<I>,
       &SnapshotCreateRequest<I>::handle_notify_quiesce>(this)));
 }

--- a/src/librbd/operation/SnapshotCreateRequest.h
+++ b/src/librbd/operation/SnapshotCreateRequest.h
@@ -28,33 +28,38 @@ public:
    *            <start>
    *               |
    *               v
+   *           STATE_NOTIFY_QUIESCE
+   *               |
+   *               v
    *           STATE_SUSPEND_REQUESTS
    *               |
    *               v
-   *           STATE_SUSPEND_AIO * * * * * * * * * * * * *
-   *               |                                     *
-   *               v                                     *
-   *           STATE_APPEND_OP_EVENT (skip if journal    *
-   *               |                  disabled)          *
-   *   (retry)     v                                     *
-   *   . . . > STATE_ALLOCATE_SNAP_ID                    *
-   *   .           |                                     *
-   *   .           v                                     *
-   *   . . . . STATE_CREATE_SNAP * * * * * * * * * * *   *
-   *               |                                 *   *
-   *               v                                 *   *
-   *           STATE_CREATE_OBJECT_MAP (skip if      *   *
-   *               |                    disabled)    *   *
-   *               v                                 *   *
-   *           STATE_CREATE_IMAGE_STATE (skip if     *   *
-   *               |                     not mirror  *   *
-   *               |                     snapshot)   *   *
-   *               |                                 v   *
-   *               |              STATE_RELEASE_SNAP_ID  *
-   *               |                     |               *
-   *               |                     v               *
-   *               \----------------> <finish> < * * * * *
-   *
+   *           STATE_SUSPEND_AIO * * * * * * * * * * * * * * *
+   *               |                                         *
+   *               v                                         *
+   *           STATE_APPEND_OP_EVENT (skip if journal        *
+   *               |                  disabled)              *
+   *   (retry)     v                                         *
+   *   . . . > STATE_ALLOCATE_SNAP_ID                        *
+   *   .           |                                         *
+   *   .           v                                         *
+   *   . . . . STATE_CREATE_SNAP * * * * * * * * * * *       *
+   *               |                                 *       *
+   *               v                                 *       *
+   *           STATE_CREATE_OBJECT_MAP (skip if      *       *
+   *               |                    disabled)    *       *
+   *               v                                 *       *
+   *           STATE_CREATE_IMAGE_STATE (skip if     *       *
+   *               |                     not mirror  *       *
+   *               |                     snapshot)   *       *
+   *               |                                 v       *
+   *               |              STATE_RELEASE_SNAP_ID      *
+   *               |                     |                   *
+   *               |                     v                   *
+   *               \------------> STATE_NOTIFY_UNQUIESCE < * *
+   *                                     |
+   *                                     v
+   *                                  <finish>
    * @endverbatim
    *
    * The _CREATE_STATE state may repeat back to the _ALLOCATE_SNAP_ID state
@@ -63,10 +68,9 @@ public:
    * (if enabled) and bubble the originating error code back to the client.
    */
   SnapshotCreateRequest(ImageCtxT &image_ctx, Context *on_finish,
-			const cls::rbd::SnapshotNamespace &snap_namespace,
-		        const std::string &snap_name,
-			uint64_t journal_op_tid,
-                        bool skip_object_map);
+                        const cls::rbd::SnapshotNamespace &snap_namespace,
+                        const std::string &snap_name, uint64_t journal_op_tid,
+                        uint64_t request_id, bool skip_object_map);
 
 protected:
   void send_op() override;
@@ -83,13 +87,17 @@ protected:
 private:
   cls::rbd::SnapshotNamespace m_snap_namespace;
   std::string m_snap_name;
+  uint64_t m_request_id;
   bool m_skip_object_map;
 
-  int m_ret_val;
+  int m_ret_val = 0;
 
-  uint64_t m_snap_id;
+  uint64_t m_snap_id = CEPH_NOSNAP;
   uint64_t m_size;
   ParentImageInfo m_parent_info;
+
+  void send_notify_quiesce();
+  Context *handle_notify_quiesce(int *result);
 
   void send_suspend_requests();
   Context *handle_suspend_requests(int *result);
@@ -114,6 +122,9 @@ private:
 
   void send_release_snap_id();
   Context *handle_release_snap_id(int *result);
+
+  void send_notify_unquiesce();
+  Context *handle_notify_unquiesce(int *result);
 
   void update_snap_context();
 

--- a/src/librbd/operation/SnapshotCreateRequest.h
+++ b/src/librbd/operation/SnapshotCreateRequest.h
@@ -14,6 +14,7 @@ class Context;
 namespace librbd {
 
 class ImageCtx;
+class ProgressContext;
 
 namespace operation {
 
@@ -70,7 +71,8 @@ public:
   SnapshotCreateRequest(ImageCtxT &image_ctx, Context *on_finish,
                         const cls::rbd::SnapshotNamespace &snap_namespace,
                         const std::string &snap_name, uint64_t journal_op_tid,
-                        uint64_t request_id, bool skip_object_map);
+                        uint64_t request_id, bool skip_object_map,
+                        ProgressContext &prog_ctx);
 
 protected:
   void send_op() override;
@@ -89,6 +91,7 @@ private:
   std::string m_snap_name;
   uint64_t m_request_id;
   bool m_skip_object_map;
+  ProgressContext &m_prog_ctx;
 
   int m_ret_val = 0;
 

--- a/src/test/librbd/deep_copy/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SnapshotCreateRequest.cc
@@ -107,7 +107,8 @@ public:
 
   void expect_snap_create(librbd::MockTestImageCtx &mock_image_ctx,
                           const std::string &snap_name, uint64_t snap_id, int r) {
-    EXPECT_CALL(*mock_image_ctx.operations, execute_snap_create(_, StrEq(snap_name), _, 0, true))
+    EXPECT_CALL(*mock_image_ctx.operations,
+                execute_snap_create(_, StrEq(snap_name), _, 0, true, _))
                   .WillOnce(DoAll(InvokeWithoutArgs([&mock_image_ctx, snap_id, snap_name]() {
                                     inject_snap(mock_image_ctx, snap_id, snap_name);
                                   }),

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -219,7 +219,7 @@ public:
                           Context **on_finish, const char *snap_name,
                           uint64_t op_tid) {
     EXPECT_CALL(*mock_image_ctx.operations, execute_snap_create(_, StrEq(snap_name), _,
-                                                                op_tid, false))
+                                                                op_tid, false, _))
                   .WillOnce(DoAll(SaveArg<2>(on_finish),
                                   NotifyInvoke(&m_invoke_lock, &m_invoke_cond)));
   }

--- a/src/test/librbd/mock/MockImageState.h
+++ b/src/test/librbd/mock/MockImageState.h
@@ -29,7 +29,7 @@ struct MockImageState {
   MOCK_METHOD0(handle_prepare_lock_complete, void());
 
   MOCK_METHOD2(register_update_watcher, int(UpdateWatchCtx *, uint64_t *));
-  MOCK_METHOD2(unregister_update_watcher, void(uint64_t, Context *));  
+  MOCK_METHOD2(unregister_update_watcher, void(uint64_t, Context *));
 };
 
 } // namespace librbd

--- a/src/test/librbd/mock/MockImageWatcher.h
+++ b/src/test/librbd/mock/MockImageWatcher.h
@@ -22,6 +22,9 @@ struct MockImageWatcher {
   MOCK_METHOD0(notify_acquired_lock, void());
   MOCK_METHOD0(notify_released_lock, void());
   MOCK_METHOD0(notify_request_lock, void());
+  
+  MOCK_METHOD2(notify_quiesce, void(uint64_t, Context *));
+  MOCK_METHOD2(notify_unquiesce, void(uint64_t, Context *));
 };
 
 } // namespace librbd

--- a/src/test/librbd/mock/MockImageWatcher.h
+++ b/src/test/librbd/mock/MockImageWatcher.h
@@ -10,6 +10,8 @@ class Context;
 
 namespace librbd {
 
+class ProgressContext;
+
 struct MockImageWatcher {
   MOCK_METHOD0(is_registered, bool());
   MOCK_METHOD0(is_unregistered, bool());
@@ -22,8 +24,8 @@ struct MockImageWatcher {
   MOCK_METHOD0(notify_acquired_lock, void());
   MOCK_METHOD0(notify_released_lock, void());
   MOCK_METHOD0(notify_request_lock, void());
-  
-  MOCK_METHOD2(notify_quiesce, void(uint64_t, Context *));
+
+  MOCK_METHOD3(notify_quiesce, void(uint64_t, ProgressContext &, Context *));
   MOCK_METHOD2(notify_unquiesce, void(uint64_t, Context *));
 };
 

--- a/src/test/librbd/mock/MockOperations.h
+++ b/src/test/librbd/mock/MockOperations.h
@@ -28,11 +28,12 @@ struct MockOperations {
   MOCK_METHOD3(snap_create, void(const cls::rbd::SnapshotNamespace &snapshot_namespace,
 				 const std::string &snap_name,
                                  Context *on_finish));
-  MOCK_METHOD5(execute_snap_create, void(const cls::rbd::SnapshotNamespace &snapshot_namespace,
+  MOCK_METHOD6(execute_snap_create, void(const cls::rbd::SnapshotNamespace &snapshot_namespace,
 					 const std::string &snap_name,
                                          Context *on_finish,
                                          uint64_t journal_op_tid,
-                                         bool skip_object_map));
+                                         bool skip_object_map,
+                                         ProgressContext &prog_ctx));
   MOCK_METHOD3(snap_remove, void(const cls::rbd::SnapshotNamespace &snap_namespace,
 				 const std::string &snap_name,
                                  Context *on_finish));

--- a/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
@@ -62,6 +62,12 @@ public:
   typedef SnapshotCreateRequest<MockImageCtx> MockSnapshotCreateRequest;
   typedef mirror::snapshot::SetImageStateRequest<MockImageCtx> MockSetImageStateRequest;
 
+  void expect_notify_quiesce(MockImageCtx &mock_image_ctx, int r) {
+    EXPECT_CALL(*mock_image_ctx.image_watcher, notify_quiesce(_, _))
+      .WillOnce(WithArg<1>(
+                  CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue)));
+  }
+
   void expect_block_writes(MockImageCtx &mock_image_ctx) {
     EXPECT_CALL(*mock_image_ctx.io_work_queue, block_writes(_))
                   .WillOnce(CompleteContext(0, mock_image_ctx.image_ctx->op_work_queue));
@@ -136,6 +142,12 @@ public:
     EXPECT_CALL(*mock_image_ctx.io_work_queue, unblock_writes())
                   .Times(1);
   }
+
+  void expect_notify_unquiesce(MockImageCtx &mock_image_ctx, int r) {
+    EXPECT_CALL(*mock_image_ctx.image_watcher, notify_unquiesce(_, _))
+      .WillOnce(WithArg<1>(
+                  CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue)));
+  }
 };
 
 TEST_F(TestMockOperationSnapshotCreateRequest, Success) {
@@ -160,6 +172,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, Success) {
   expect_op_work_queue(mock_image_ctx);
 
   ::testing::InSequence seq;
+  expect_notify_quiesce(mock_image_ctx, 0);
   expect_block_writes(mock_image_ctx);
   expect_allocate_snap_id(mock_image_ctx, 0);
   expect_snap_create(mock_image_ctx, 0);
@@ -168,16 +181,39 @@ TEST_F(TestMockOperationSnapshotCreateRequest, Success) {
     expect_update_snap_context(mock_image_ctx);
   }
   expect_unblock_writes(mock_image_ctx);
+  expect_notify_unquiesce(mock_image_ctx, -EINVAL);
 
   C_SaferCond cond_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-      "snap1", 0, false);
+      "snap1", 0, 0, false);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
   }
   ASSERT_EQ(0, cond_ctx.wait());
+}
+
+TEST_F(TestMockOperationSnapshotCreateRequest, NotifyQuiesceError) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+
+  expect_op_work_queue(mock_image_ctx);
+
+  ::testing::InSequence seq;
+  expect_notify_quiesce(mock_image_ctx, -EINVAL);
+
+  C_SaferCond cond_ctx;
+  MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
+    mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
+    "snap1", 0, 0, false);
+  {
+    std::shared_lock owner_locker{mock_image_ctx.owner_lock};
+    req->send();
+  }
+  ASSERT_EQ(-EINVAL, cond_ctx.wait());
 }
 
 TEST_F(TestMockOperationSnapshotCreateRequest, AllocateSnapIdError) {
@@ -195,14 +231,16 @@ TEST_F(TestMockOperationSnapshotCreateRequest, AllocateSnapIdError) {
   expect_op_work_queue(mock_image_ctx);
 
   ::testing::InSequence seq;
+  expect_notify_quiesce(mock_image_ctx, 0);
   expect_block_writes(mock_image_ctx);
   expect_allocate_snap_id(mock_image_ctx, -EINVAL);
   expect_unblock_writes(mock_image_ctx);
+  expect_notify_unquiesce(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-      "snap1", 0, false);
+    "snap1", 0, 0, false);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -229,6 +267,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, CreateSnapStale) {
   expect_verify_lock_ownership(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
+  expect_notify_quiesce(mock_image_ctx, 0);
   expect_block_writes(mock_image_ctx);
   expect_allocate_snap_id(mock_image_ctx, -ESTALE);
   expect_snap_create(mock_image_ctx, -ESTALE);
@@ -237,11 +276,12 @@ TEST_F(TestMockOperationSnapshotCreateRequest, CreateSnapStale) {
     expect_update_snap_context(mock_image_ctx);
   }
   expect_unblock_writes(mock_image_ctx);
+  expect_notify_unquiesce(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-      "snap1", 0, false);
+    "snap1", 0, 0, false);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -263,16 +303,18 @@ TEST_F(TestMockOperationSnapshotCreateRequest, CreateSnapError) {
   expect_verify_lock_ownership(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
+  expect_notify_quiesce(mock_image_ctx, 0);
   expect_block_writes(mock_image_ctx);
   expect_allocate_snap_id(mock_image_ctx, 0);
   expect_snap_create(mock_image_ctx, -EINVAL);
   expect_release_snap_id(mock_image_ctx, 0);
   expect_unblock_writes(mock_image_ctx);
+  expect_notify_unquiesce(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-      "snap1", 0, false);
+    "snap1", 0, 0, false);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -294,16 +336,18 @@ TEST_F(TestMockOperationSnapshotCreateRequest, ReleaseSnapIdError) {
   expect_verify_lock_ownership(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
+  expect_notify_quiesce(mock_image_ctx, 0);
   expect_block_writes(mock_image_ctx);
   expect_allocate_snap_id(mock_image_ctx, 0);
   expect_snap_create(mock_image_ctx, -EINVAL);
   expect_release_snap_id(mock_image_ctx, -ESTALE);
   expect_unblock_writes(mock_image_ctx);
+  expect_notify_unquiesce(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-      "snap1", 0, false);
+    "snap1", 0, 0, false);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -331,16 +375,18 @@ TEST_F(TestMockOperationSnapshotCreateRequest, SkipObjectMap) {
   expect_op_work_queue(mock_image_ctx);
 
   ::testing::InSequence seq;
+  expect_notify_quiesce(mock_image_ctx, 0);
   expect_block_writes(mock_image_ctx);
   expect_allocate_snap_id(mock_image_ctx, 0);
   expect_snap_create(mock_image_ctx, 0);
   expect_update_snap_context(mock_image_ctx);
   expect_unblock_writes(mock_image_ctx);
+  expect_notify_unquiesce(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-      "snap1", 0, true);
+    "snap1", 0, 0, true);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -370,6 +416,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, SetImageState) {
   expect_op_work_queue(mock_image_ctx);
 
   ::testing::InSequence seq;
+  expect_notify_quiesce(mock_image_ctx, 0);
   expect_block_writes(mock_image_ctx);
   expect_allocate_snap_id(mock_image_ctx, 0);
   expect_snap_create(mock_image_ctx, 0);
@@ -378,13 +425,14 @@ TEST_F(TestMockOperationSnapshotCreateRequest, SetImageState) {
   expect_set_image_state(mock_image_ctx, mock_set_image_state_request, 0);
   expect_update_snap_context(mock_image_ctx);
   expect_unblock_writes(mock_image_ctx);
+  expect_notify_unquiesce(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx,
     cls::rbd::MirrorSnapshotNamespace{
       cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY, {}, "", CEPH_NOSNAP},
-    "snap1", 0, false);
+    "snap1", 0, 0, false);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();

--- a/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
@@ -63,8 +63,8 @@ public:
   typedef mirror::snapshot::SetImageStateRequest<MockImageCtx> MockSetImageStateRequest;
 
   void expect_notify_quiesce(MockImageCtx &mock_image_ctx, int r) {
-    EXPECT_CALL(*mock_image_ctx.image_watcher, notify_quiesce(_, _))
-      .WillOnce(WithArg<1>(
+    EXPECT_CALL(*mock_image_ctx.image_watcher, notify_quiesce(_, _, _))
+      .WillOnce(WithArg<2>(
                   CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue)));
   }
 
@@ -184,9 +184,10 @@ TEST_F(TestMockOperationSnapshotCreateRequest, Success) {
   expect_notify_unquiesce(mock_image_ctx, -EINVAL);
 
   C_SaferCond cond_ctx;
+  librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-      "snap1", 0, 0, false);
+    "snap1", 0, 0, false, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -206,9 +207,10 @@ TEST_F(TestMockOperationSnapshotCreateRequest, NotifyQuiesceError) {
   expect_notify_quiesce(mock_image_ctx, -EINVAL);
 
   C_SaferCond cond_ctx;
+  librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, 0, false);
+    "snap1", 0, 0, false, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -238,9 +240,10 @@ TEST_F(TestMockOperationSnapshotCreateRequest, AllocateSnapIdError) {
   expect_notify_unquiesce(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
+  librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, 0, false);
+    "snap1", 0, 0, false, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -279,9 +282,10 @@ TEST_F(TestMockOperationSnapshotCreateRequest, CreateSnapStale) {
   expect_notify_unquiesce(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
+  librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, 0, false);
+    "snap1", 0, 0, false, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -312,9 +316,10 @@ TEST_F(TestMockOperationSnapshotCreateRequest, CreateSnapError) {
   expect_notify_unquiesce(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
+  librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, 0, false);
+    "snap1", 0, 0, false, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -345,9 +350,10 @@ TEST_F(TestMockOperationSnapshotCreateRequest, ReleaseSnapIdError) {
   expect_notify_unquiesce(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
+  librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, 0, false);
+    "snap1", 0, 0, false, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -384,9 +390,10 @@ TEST_F(TestMockOperationSnapshotCreateRequest, SkipObjectMap) {
   expect_notify_unquiesce(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
+  librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, 0, true);
+    "snap1", 0, 0, true, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -428,11 +435,12 @@ TEST_F(TestMockOperationSnapshotCreateRequest, SetImageState) {
   expect_notify_unquiesce(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
+  librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx,
     cls::rbd::MirrorSnapshotNamespace{
       cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY, {}, "", CEPH_NOSNAP},
-    "snap1", 0, 0, false);
+    "snap1", 0, 0, false, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();

--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -186,14 +186,14 @@ public:
   int notify_async_progress(librbd::ImageCtx *ictx, const AsyncRequestId &id,
                             uint64_t offset, uint64_t total) {
     bufferlist bl;
-    encode(NotifyMessage(AsyncProgressPayload(id, offset, total)), bl);
+    encode(NotifyMessage(new AsyncProgressPayload(id, offset, total)), bl);
     return m_ioctx.notify2(ictx->header_oid, bl, 5000, NULL);
   }
 
   int notify_async_complete(librbd::ImageCtx *ictx, const AsyncRequestId &id,
                             int r) {
     bufferlist bl;
-    encode(NotifyMessage(AsyncCompletePayload(id, r)), bl);
+    encode(NotifyMessage(new AsyncCompletePayload(id, r)), bl);
     return m_ioctx.notify2(ictx->header_oid, bl, 5000, NULL);
   }
 

--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -154,7 +154,7 @@ public:
 
     bufferlist payload = m_notify_payloads[op];
     auto iter = payload.cbegin();
-    
+
     switch (op) {
     case NOTIFY_OP_FLATTEN:
       {
@@ -167,6 +167,13 @@ public:
       {
         ResizePayload payload;
         payload.decode(2, iter);
+        *id = payload.async_request_id;
+      }
+      return true;
+    case NOTIFY_OP_SNAP_CREATE:
+      {
+        SnapCreatePayload payload;
+        payload.decode(7, iter);
         *id = payload.async_request_id;
       }
       return true;
@@ -272,6 +279,23 @@ struct ResizeTask {
     C_SaferCond ctx;
     ictx->image_watcher->notify_resize(0, 0, true, *progress_context, &ctx);
     result = ctx.wait();
+  }
+};
+
+struct SnapCreateTask {
+  librbd::ImageCtx *ictx;
+  ProgressContext *progress_context;
+  int result;
+
+  SnapCreateTask(librbd::ImageCtx *ictx_, ProgressContext *ctx)
+    : ictx(ictx_), progress_context(ctx), result(0) {}
+
+  void operator()() {
+    std::shared_lock l{ictx->owner_lock};
+    C_SaferCond ctx;
+    ictx->image_watcher->notify_snap_create(0, cls::rbd::UserSnapshotNamespace(),
+                                            "snap", *progress_context, &ctx);
+    ASSERT_EQ(0, ctx.wait());
   }
 };
 
@@ -424,15 +448,27 @@ TEST_F(TestImageWatcher, NotifySnapCreate) {
 
   m_notify_acks = {{NOTIFY_OP_SNAP_CREATE, create_response_message(0)}};
 
-  std::shared_lock l{ictx->owner_lock};
-  C_SaferCond notify_ctx;
-  ictx->image_watcher->notify_snap_create(cls::rbd::UserSnapshotNamespace(),
-	"snap", &notify_ctx);
-  ASSERT_EQ(0, notify_ctx.wait());
+  ProgressContext progress_context;
+  SnapCreateTask snap_create_task(ictx, &progress_context);
+  boost::thread thread(boost::ref(snap_create_task));
+
+  ASSERT_TRUE(wait_for_notifies(*ictx));
 
   NotifyOps expected_notify_ops;
   expected_notify_ops += NOTIFY_OP_SNAP_CREATE;
   ASSERT_EQ(expected_notify_ops, m_notifies);
+
+  AsyncRequestId async_request_id;
+  ASSERT_TRUE(extract_async_request_id(NOTIFY_OP_SNAP_CREATE,
+                                       &async_request_id));
+
+  ASSERT_EQ(0, notify_async_progress(ictx, async_request_id, 1, 10));
+  ASSERT_TRUE(progress_context.wait(ictx, 1, 10));
+
+  ASSERT_EQ(0, notify_async_complete(ictx, async_request_id, 0));
+
+  ASSERT_TRUE(thread.timed_join(boost::posix_time::seconds(10)));
+  ASSERT_EQ(0, snap_create_task.result);
 }
 
 TEST_F(TestImageWatcher, NotifySnapCreateError) {
@@ -449,8 +485,9 @@ TEST_F(TestImageWatcher, NotifySnapCreateError) {
 
   std::shared_lock l{ictx->owner_lock};
   C_SaferCond notify_ctx;
-  ictx->image_watcher->notify_snap_create(cls::rbd::UserSnapshotNamespace(),
-       "snap", &notify_ctx);
+  librbd::NoOpProgressContext prog_ctx;
+  ictx->image_watcher->notify_snap_create(0, cls::rbd::UserSnapshotNamespace(),
+       "snap", prog_ctx, &notify_ctx);
   ASSERT_EQ(-EEXIST, notify_ctx.wait());
 
   NotifyOps expected_notify_ops;

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -8175,6 +8175,257 @@ TEST_F(TestLibRBD, SnapRemoveWithChildMissing)
   rados_ioctx_destroy(ioctx1);
 }
 
+TEST_F(TestLibRBD, QuiesceWatch)
+{
+  rados_ioctx_t ioctx;
+  rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx);
+
+  int order = 0;
+  std::string name = get_temp_image_name();
+  uint64_t size = 2 << 20;
+  ASSERT_EQ(0, create_image(ioctx, name.c_str(), size, &order));
+
+  uint64_t handle1, handle2;
+  rbd_image_t image1, image2;
+  ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image1, NULL));
+  ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image2, NULL));
+
+  struct Watcher {
+    static void quiesce_cb(void *arg) {
+      Watcher *watcher = static_cast<Watcher *>(arg);
+      watcher->handle_quiesce();
+    }
+    static void unquiesce_cb(void *arg) {
+      Watcher *watcher = static_cast<Watcher *>(arg);
+      watcher->handle_unquiesce();
+    }
+
+    rbd_image_t &image;
+    size_t quiesce_count = 0;
+    size_t unquiesce_count = 0;
+
+    Watcher(rbd_image_t &image) : image(image) {
+    }
+
+    void handle_quiesce() {
+      ASSERT_EQ(quiesce_count, unquiesce_count);
+      quiesce_count++;
+      rbd_quiesce_complete(image);
+    }
+    void handle_unquiesce() {
+      unquiesce_count++;
+      ASSERT_EQ(quiesce_count, unquiesce_count);
+    }
+  } watcher1(image1), watcher2(image2);
+
+  ASSERT_EQ(0, rbd_quiesce_watch(image1, Watcher::quiesce_cb,
+                                 Watcher::unquiesce_cb, &watcher1, &handle1));
+  ASSERT_EQ(0, rbd_quiesce_watch(image2, Watcher::quiesce_cb,
+                                 Watcher::unquiesce_cb, &watcher2, &handle2));
+
+  ASSERT_EQ(0, rbd_snap_create(image1, "snap1"));
+  ASSERT_EQ(1U, watcher1.quiesce_count);
+  ASSERT_EQ(1U, watcher1.unquiesce_count);
+  ASSERT_EQ(1U, watcher2.quiesce_count);
+  ASSERT_EQ(1U, watcher2.unquiesce_count);
+
+  ASSERT_EQ(0, rbd_snap_create(image2, "snap2"));
+  ASSERT_EQ(2U, watcher1.quiesce_count);
+  ASSERT_EQ(2U, watcher1.unquiesce_count);
+  ASSERT_EQ(2U, watcher2.quiesce_count);
+  ASSERT_EQ(2U, watcher2.unquiesce_count);
+
+  ASSERT_EQ(0, rbd_quiesce_unwatch(image1, handle1));
+
+  ASSERT_EQ(0, rbd_snap_create(image1, "snap3"));
+  ASSERT_EQ(2U, watcher1.quiesce_count);
+  ASSERT_EQ(2U, watcher1.unquiesce_count);
+  ASSERT_EQ(3U, watcher2.quiesce_count);
+  ASSERT_EQ(3U, watcher2.unquiesce_count);
+
+  ASSERT_EQ(0, rbd_quiesce_unwatch(image2, handle2));
+
+  ASSERT_EQ(0, rbd_snap_remove(image1, "snap1"));
+  ASSERT_EQ(0, rbd_snap_remove(image1, "snap2"));
+  ASSERT_EQ(0, rbd_snap_remove(image1, "snap3"));
+  ASSERT_EQ(0, rbd_close(image1));
+  ASSERT_EQ(0, rbd_close(image2));
+  ASSERT_EQ(0, rbd_remove(ioctx, name.c_str()));
+  rados_ioctx_destroy(ioctx);
+}
+
+TEST_F(TestLibRBD, QuiesceWatchPP)
+{
+  librbd::RBD rbd;
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+  std::string name = get_temp_image_name();
+  int order = 0;
+  uint64_t size = 2 << 20;
+  ASSERT_EQ(0, create_image_pp(rbd, ioctx, name.c_str(), size, &order));
+
+  {
+    librbd::Image image1, image2;
+    ASSERT_EQ(0, rbd.open(ioctx, image1, name.c_str(), NULL));
+    ASSERT_EQ(0, rbd.open(ioctx, image2, name.c_str(), NULL));
+
+    struct Watcher : public librbd::QuiesceWatchCtx {
+      librbd::Image &image;
+      size_t quiesce_count = 0;
+      size_t unquiesce_count = 0;
+
+      Watcher(librbd::Image &image) : image(image) {
+      }
+
+      void handle_quiesce() override {
+        ASSERT_EQ(quiesce_count, unquiesce_count);
+        quiesce_count++;
+        image.quiesce_complete();
+      }
+      void handle_unquiesce() override {
+        unquiesce_count++;
+        ASSERT_EQ(quiesce_count, unquiesce_count);
+      }
+    } watcher1(image1), watcher2(image2);
+    uint64_t handle1, handle2;
+
+    ASSERT_EQ(0, image1.quiesce_watch(&watcher1, &handle1));
+    ASSERT_EQ(0, image2.quiesce_watch(&watcher2, &handle2));
+
+    ASSERT_EQ(0, image1.snap_create("snap1"));
+    ASSERT_EQ(1U, watcher1.quiesce_count);
+    ASSERT_EQ(1U, watcher1.unquiesce_count);
+    ASSERT_EQ(1U, watcher2.quiesce_count);
+    ASSERT_EQ(1U, watcher2.unquiesce_count);
+
+    ASSERT_EQ(0, image2.snap_create("snap2"));
+    ASSERT_EQ(2U, watcher1.quiesce_count);
+    ASSERT_EQ(2U, watcher1.unquiesce_count);
+    ASSERT_EQ(2U, watcher2.quiesce_count);
+    ASSERT_EQ(2U, watcher2.unquiesce_count);
+
+    ASSERT_EQ(0, image1.quiesce_unwatch(handle1));
+
+    ASSERT_EQ(0, image1.snap_create("snap3"));
+    ASSERT_EQ(2U, watcher1.quiesce_count);
+    ASSERT_EQ(2U, watcher1.unquiesce_count);
+    ASSERT_EQ(3U, watcher2.quiesce_count);
+    ASSERT_EQ(3U, watcher2.unquiesce_count);
+
+    ASSERT_EQ(0, image2.quiesce_unwatch(handle2));
+
+    ASSERT_EQ(0, image1.snap_remove("snap1"));
+    ASSERT_EQ(0, image1.snap_remove("snap2"));
+    ASSERT_EQ(0, image1.snap_remove("snap3"));
+  }
+
+  ASSERT_EQ(0, rbd.remove(ioctx, name.c_str()));
+  ioctx.close();
+}
+
+TEST_F(TestLibRBD, QuiesceWatchTimeout)
+{
+  REQUIRE(!is_librados_test_stub(_rados));
+
+  ASSERT_EQ(0, _rados.conf_set("rbd_quiesce_notification_attempts", "2"));
+
+  librbd::RBD rbd;
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+  std::string name = get_temp_image_name();
+  int order = 0;
+  uint64_t size = 2 << 20;
+  ASSERT_EQ(0, create_image_pp(rbd, ioctx, name.c_str(), size, &order));
+
+  {
+    librbd::Image image;
+    ASSERT_EQ(0, rbd.open(ioctx, image, name.c_str(), NULL));
+
+    struct Watcher : public librbd::QuiesceWatchCtx {
+      librbd::Image &image;
+      mutex m_lock;
+      condition_variable m_cond;
+      size_t quiesce_count = 0;
+      size_t unquiesce_count = 0;
+
+      Watcher(librbd::Image &image) : image(image) {
+      }
+
+      void handle_quiesce() override {
+        lock_guard<mutex> locker(m_lock);
+        quiesce_count++;
+        m_cond.notify_one();
+      }
+
+      void handle_unquiesce() override {
+        lock_guard<mutex> locker(m_lock);
+        unquiesce_count++;
+        m_cond.notify_one();
+      }
+
+      void wait_for_quiesce_count(size_t count) {
+        unique_lock<mutex> locker(m_lock);
+        ASSERT_TRUE(m_cond.wait_for(locker, seconds(60),
+                                    [this, count] {
+                                      return this->quiesce_count == count;
+                                    }));
+      }
+
+      void wait_for_unquiesce_count(size_t count) {
+        unique_lock<mutex> locker(m_lock);
+        ASSERT_TRUE(m_cond.wait_for(locker, seconds(60),
+                                    [this, count] {
+                                      return this->unquiesce_count == count;
+                                    }));
+      }
+    } watcher(image);
+    uint64_t handle;
+
+    ASSERT_EQ(0, image.quiesce_watch(&watcher, &handle));
+
+    thread quiesce1([&image, &watcher]() {
+      watcher.wait_for_quiesce_count(1);
+      sleep(8);
+      image.quiesce_complete();
+    });
+
+    ASSERT_EQ(0, image.snap_create("snap1"));
+    quiesce1.join();
+    ASSERT_EQ(1U, watcher.quiesce_count);
+    watcher.wait_for_unquiesce_count(1);
+    ASSERT_EQ(1U, watcher.unquiesce_count);
+
+    thread quiesce2([&image, &watcher]() {
+      watcher.wait_for_quiesce_count(2);
+      sleep(13);
+      image.quiesce_complete();
+    });
+
+    ASSERT_EQ(-ETIMEDOUT, image.snap_create("snap2"));
+    quiesce2.join();
+    ASSERT_EQ(2U, watcher.quiesce_count);
+    watcher.wait_for_unquiesce_count(2);
+    ASSERT_EQ(2U, watcher.unquiesce_count);
+
+    thread quiesce3([&image, &watcher]() {
+      watcher.wait_for_quiesce_count(3);
+      image.quiesce_complete();
+    });
+
+    ASSERT_EQ(0, image.snap_create("snap2"));
+    quiesce3.join();
+    ASSERT_EQ(3U, watcher.quiesce_count);
+    watcher.wait_for_unquiesce_count(3);
+    ASSERT_EQ(3U, watcher.unquiesce_count);
+
+    ASSERT_EQ(0, image.snap_remove("snap1"));
+    ASSERT_EQ(0, image.snap_remove("snap2"));
+  }
+
+  ASSERT_EQ(0, rbd.remove(ioctx, name.c_str()));
+  ioctx.close();
+}
+
 // poorman's ceph_assert()
 namespace ceph {
   void __ceph_assert_fail(const char *assertion, const char *file, int line,

--- a/src/tools/ceph-dencoder/rbd_types.h
+++ b/src/tools/ceph-dencoder/rbd_types.h
@@ -8,7 +8,7 @@ TYPE(librbd::mirroring_watcher::NotifyMessage)
 #include "librbd/trash_watcher/Types.h"
 TYPE(librbd::mirroring_watcher::NotifyMessage)
 #include "librbd/WatchNotifyTypes.h"
-TYPE(librbd::watch_notify::NotifyMessage)
+TYPE_NOCOPY(librbd::watch_notify::NotifyMessage)
 TYPE(librbd::watch_notify::ResponseMessage)
 
 #include "rbd_replay/ActionTypes.h"

--- a/src/tools/rbd/action/Watch.cc
+++ b/src/tools/rbd/action/Watch.cc
@@ -34,7 +34,7 @@ public:
     using namespace librbd::watch_notify;
     NotifyMessage notify_message;
     if (bl.length() == 0) {
-      notify_message = NotifyMessage(HeaderUpdatePayload());
+      notify_message = NotifyMessage(new HeaderUpdatePayload());
     } else {
       try {
         auto iter = bl.cbegin();


### PR DESCRIPTION
The callbacks are fired by librbd before/after creating a
snapshot. The callback users like QEMU could attempt to freeze
the FS before allowing librbd to actually perform the snapshot.

Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
