### PR TITLE
mgr/cephadm: nfs common config

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1261,7 +1261,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         Returns the generic service name
         """
         p = re.compile(r'(.*)\.%s.*' % (host))
-        p.sub(r'\1', daemon_id)
         return '%s.%s' % (daemon_type, p.sub(r'\1', daemon_id))
 
     def _save_inventory(self):

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1888,6 +1888,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 if dd.service_name() in self.spec_store.specs:
                     sm[n].size = self._get_spec_size(spec)
                     sm[n].created = self.spec_store.spec_created[dd.service_name()]
+                    if service_type == 'nfs':
+                        spec = cast(NFSServiceSpec, spec)
+                        sm[n].rados_config_location = spec.rados_config_location()
                 else:
                     sm[n].size = 0
                 if dd.status == 1:
@@ -1910,6 +1913,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 size=self._get_spec_size(spec),
                 running=0,
             )
+            if service_type == 'nfs':
+                spec = cast(NFSServiceSpec, spec)
+                sm[n].rados_config_location = spec.rados_config_location()
         return list(sm.values())
 
     @trivial_completion

--- a/src/pybind/mgr/cephadm/nfs.py
+++ b/src/pybind/mgr/cephadm/nfs.py
@@ -26,18 +26,6 @@ class NFSGanesha(object):
         # type: () -> str
         return '%s.%s' % (self.spec.service_type, self.daemon_id)
 
-    def get_rados_config_name(self):
-        # type: () -> str
-        return 'conf-' + self.spec.service_name()
-
-    def get_rados_config_url(self):
-        # type: () -> str
-        url = 'rados://' + self.spec.pool + '/'
-        if self.spec.namespace:
-            url += self.spec.namespace + '/'
-        url += self.get_rados_config_name()
-        return url
-
     def get_keyring_entity(self):
         # type: () -> str
         return utils.name_to_config_section(self.get_rados_user())
@@ -84,7 +72,7 @@ class NFSGanesha(object):
 
     def create_rados_config_obj(self, clobber=False):
         # type: (Optional[bool]) -> None
-        obj = self.get_rados_config_name()
+        obj = self.spec.rados_config_name()
 
         with self.mgr.rados.open_ioctx(self.spec.pool) as ioctx:
             if self.spec.namespace:
@@ -114,7 +102,7 @@ RADOS_URLS {{
 
 %url    {url}
 '''.format(user=self.get_rados_user(),
-           url=self.get_rados_config_url())
+           url=self.spec.rados_config_location())
 
     def get_cephadm_config(self):
         # type: () -> Dict

--- a/src/pybind/mgr/cephadm/nfs.py
+++ b/src/pybind/mgr/cephadm/nfs.py
@@ -28,7 +28,7 @@ class NFSGanesha(object):
 
     def get_rados_config_name(self):
         # type: () -> str
-        return 'conf-' + self.get_rados_user()
+        return 'conf-' + self.spec.service_name()
 
     def get_rados_config_url(self):
         # type: () -> str

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -488,6 +488,18 @@ class NFSServiceSpec(ServiceSpec):
         if not self.pool:
             raise ServiceSpecValidationError('Cannot add NFS: No Pool specified')
 
+    def rados_config_name(self):
+        # type: () -> str
+        return 'conf-' + self.service_name()
+
+    def rados_config_location(self):
+        # type: () -> str
+        url = 'rados://' + self.pool + '/'
+        if self.namespace:
+            url += self.namespace + '/'
+        url += self.rados_config_name()
+        return url
+
 
 class RGWSpec(ServiceSpec):
     """


### PR DESCRIPTION
Removes the per-daemon RADOS config in favor of a simplified approach using a single RADOS common config.

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
