### PR TITLE
mgr/cephadm: add useful error if python3 is not on remote host

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1514,7 +1514,13 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             addr = self.inventory[host].get('addr', host)
 
         try:
-            conn, connr = self._get_connection(addr)
+            try:
+                conn, connr = self._get_connection(addr)
+            except IOError as e:
+                if error_ok:
+                    self.log.exception('failed to establish ssh connection')
+                    return [], [str("Can't communicate with remote host, possibly because python3 is not installed there")], 1
+                raise
 
             assert image or entity
             if not image:


### PR DESCRIPTION
show 

```
Error ENOENT: New host example (example) failed check: ["Can't communicate with
remote host, possibly because python3 is not installed there"]
```

instead of traceback with

```
OSError: cannot send(already closed?)
```

when adding host if python3 is not on host

Fixes: https://tracker.ceph.com/issues/44598

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>
