### PR TITLE
cephfs-shell: Fix flake8 errors (E302, E502, E128, F821, W605, 5128, E122)

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1401,7 +1401,7 @@ class CephFSShell(Cmd):
 
                 poutput("File: {}\nSize: {:d}\nBlocks: {:d}\nIO Block: {:d}\n"
                         "Device: {:d}\tInode: {:d}\tLinks: {:d}\nPermission: "
-                        "{:o}/{}\tUid: {:d}\tGid: {:d}\n\Access: {}\nModify: "
+                        "{:o}/{}\tUid: {:d}\tGid: {:d}\nAccess: {}\nModify: "
                         "{}\nChange: {}".format(path.decode('utf-8'),
                         stat.st_size, stat.st_blocks, stat.st_blksize,
                         stat.st_dev, stat.st_ino, stat.st_nlink, stat.st_mode,

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -112,7 +112,7 @@ def to_bytes(param):
     elif isinstance(param, str):
         return bytes(param, encoding='utf-8')
     elif isinstance(param, list):
-        return [i.encode('utf-8') if isinstance(i, str) else to_bytes(i) for \
+        return [i.encode('utf-8') if isinstance(i, str) else to_bytes(i) for
                 i in param]
     elif isinstance(param, int) or isinstance(param, float):
         return str(param).encode('utf-8')

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1402,10 +1402,11 @@ class CephFSShell(Cmd):
                 poutput("File: {}\nSize: {:d}\nBlocks: {:d}\nIO Block: {:d}\n"
                         "Device: {:d}\tInode: {:d}\tLinks: {:d}\nPermission: "
                         "{:o}/{}\tUid: {:d}\tGid: {:d}\nAccess: {}\nModify: "
-                        "{}\nChange: {}".format(path.decode('utf-8'),
-                        stat.st_size, stat.st_blocks, stat.st_blksize,
-                        stat.st_dev, stat.st_ino, stat.st_nlink, stat.st_mode,
-                        mode_notation(stat.st_mode), stat.st_uid, stat.st_gid,
+                        "{}\nChange: {}".format(
+                            path.decode('utf-8'),
+                            stat.st_size, stat.st_blocks, stat.st_blksize,
+                            stat.st_dev, stat.st_ino, stat.st_nlink, stat.st_mode,
+                            mode_notation(stat.st_mode), stat.st_uid, stat.st_gid,
                         atime, mtime, ctime))
             except libcephfs.Error as e:
                 perror(e)

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1407,7 +1407,8 @@ class CephFSShell(Cmd):
                             stat.st_size, stat.st_blocks, stat.st_blksize,
                             stat.st_dev, stat.st_ino, stat.st_nlink, stat.st_mode,
                             mode_notation(stat.st_mode), stat.st_uid, stat.st_gid,
-                        atime, mtime, ctime))
+                            atime, mtime, ctime),
+                        )
             except libcephfs.Error as e:
                 perror(e)
                 self.exit_code = e.get_error_code()

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1357,7 +1357,6 @@ class CephFSShell(Cmd):
         else:
             self.perror("snapshot can only be created or deleted; check - "
                         "help snap")
-            self.exit_code = e.get_error_code()
 
     def do_help(self, line):
         """

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -64,6 +64,7 @@ shell = None    # holds instance of class CephFSShell
 #
 #######################################################################
 
+
 def poutput(s, end='\n'):
     shell.poutput(s, end=end)
 

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -136,6 +136,7 @@ def ls(path, opts=''):
         perror(e)
         shell.exit_code = e.get_error_code()
 
+
 def glob(path, pattern):
     paths = []
     parent_dir = os.path.dirname(path)
@@ -1222,7 +1223,7 @@ class CephFSShell(Cmd):
                     if f[0] is ord('/'):
                         f = b'.' + f
                     poutput('{:10s} {}'.format(humansize(dusage),
-                        f.decode('utf-8')))
+                            f.decode('utf-8')))
                 except libcephfs.Error as e:
                     perror(e)
                     self.exit_code = e.get_error_code()

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -119,6 +119,7 @@ def to_bytes(param):
     elif param is None:
         return None
 
+
 def ls(path, opts=''):
     # opts tries to be like /bin/ls opts
     almost_all = 'A' in opts


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
cephfs-shell: Fix flake8 errors (E302, E502, E128, F821, W605, 5128, E122)

Before errors in file cephfs-shell:
![first](https://user-images.githubusercontent.com/39561007/77804407-6edb4500-70a5-11ea-9762-c055cbe47318.png)

After Fix:
![last](https://user-images.githubusercontent.com/39561007/77804117-ccbb5d00-70a4-11ea-8cab-d3dab77b7fb5.png)

Fixes: https://tracker.ceph.com/issues/44645
Signed-off-by: Dandamudi Rohit <rohitdandamudi.1100@gmail.com>
## Checklist
- [X] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
