### PR TITLE
nautilus: tests: qa/tasks/ceph.py: fail if any osd role doesn't get a device

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -607,13 +607,13 @@ def cluster(ctx, config):
         devs = teuthology.get_scratch_devices(remote)
         roles_to_devs = {}
         if config.get('fs'):
-            log.info('fs option selected, checking for scratch devs')
-            log.info('found devs: %s' % (str(devs),))
+            log.info('fs option selected, checking for "scratch" (osd) devs')
+            log.info('found "scratch" (osd) devs: {}'.format(devs))
             roles_to_devs = assign_devs(
                 teuthology.cluster_roles_of_type(roles_for_host, 'osd', cluster_name), devs
             )
             devs_to_clean[remote] = []
-        log.info('dev map: %s' % (str(roles_to_devs),))
+        log.info('osd dev map: {}'.format(roles_to_devs))
         remote_to_roles_to_devs[remote] = roles_to_devs
 
     log.info('Generating config...')
@@ -834,8 +834,8 @@ def cluster(ctx, config):
                     '-p',
                     mnt_point,
                 ])
-            log.info(str(roles_to_devs))
-            log.info(role)
+            log.info('roles_to_devs: {}'.format(roles_to_devs))
+            log.info('role: {}'.format(role))
             if roles_to_devs.get(role):
                 dev = roles_to_devs[role]
                 fs = config.get('fs')

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -605,16 +605,17 @@ def cluster(ctx, config):
     osds = ctx.cluster.only(teuthology.is_type('osd', cluster_name))
     for remote, roles_for_host in osds.remotes.iteritems():
         devs = teuthology.get_scratch_devices(remote)
-        roles_to_devs = {}
-        if config.get('fs'):
-            log.info('fs option selected, checking for "scratch" (osd) devs')
-            log.info('found "scratch" (osd) devs: {}'.format(devs))
-            roles_to_devs = assign_devs(
-                teuthology.cluster_roles_of_type(roles_for_host, 'osd', cluster_name), devs
-            )
-            devs_to_clean[remote] = []
+        roles_to_devs = assign_devs(
+            teuthology.cluster_roles_of_type(roles_for_host, 'osd', cluster_name), devs
+        )
+        devs_to_clean[remote] = []
         log.info('osd dev map: {}'.format(roles_to_devs))
+        assert roles_to_devs, \
+            "remote {} has osd roles, but no osd devices were specified!".format(remote.hostname)
         remote_to_roles_to_devs[remote] = roles_to_devs
+    log.info("remote_to_roles_to_devs: {}".format(remote_to_roles_to_devs))
+    for osd_role, dev_name in remote_to_roles_to_devs.items():
+        assert dev_name, "{} has no associated device!".format(osd_role)
 
     log.info('Generating config...')
     remotes_and_roles = ctx.cluster.remotes.items()

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -611,19 +611,17 @@ def cluster(ctx, config):
         if config.get('fs'):
             log.info('fs option selected, checking for scratch devs')
             log.info('found devs: %s' % (str(devs),))
-            devs_id_map = teuthology.get_wwn_id_map(remote, devs)
-            iddevs = devs_id_map.values()
             roles_to_devs = assign_devs(
-                teuthology.cluster_roles_of_type(roles_for_host, 'osd', cluster_name), iddevs
+                teuthology.cluster_roles_of_type(roles_for_host, 'osd', cluster_name), devs
             )
-            if len(roles_to_devs) < len(iddevs):
-                iddevs = iddevs[len(roles_to_devs):]
+            if len(roles_to_devs) < len(devs):
+                devs = devs[len(roles_to_devs):]
             devs_to_clean[remote] = []
 
         if config.get('block_journal'):
             log.info('block journal enabled')
             roles_to_journals = assign_devs(
-                teuthology.cluster_roles_of_type(roles_for_host, 'osd', cluster_name), iddevs
+                teuthology.cluster_roles_of_type(roles_for_host, 'osd', cluster_name), devs
             )
             log.info('journal map: %s', roles_to_journals)
 

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -602,12 +602,10 @@ def cluster(ctx, config):
 
     devs_to_clean = {}
     remote_to_roles_to_devs = {}
-    remote_to_roles_to_journals = {}
     osds = ctx.cluster.only(teuthology.is_type('osd', cluster_name))
     for remote, roles_for_host in osds.remotes.iteritems():
         devs = teuthology.get_scratch_devices(remote)
         roles_to_devs = {}
-        roles_to_journals = {}
         if config.get('fs'):
             log.info('fs option selected, checking for scratch devs')
             log.info('found devs: %s' % (str(devs),))
@@ -617,7 +615,6 @@ def cluster(ctx, config):
             devs_to_clean[remote] = []
         log.info('dev map: %s' % (str(roles_to_devs),))
         remote_to_roles_to_devs[remote] = roles_to_devs
-        remote_to_roles_to_journals[remote] = roles_to_journals
 
     log.info('Generating config...')
     remotes_and_roles = ctx.cluster.remotes.items()
@@ -632,12 +629,6 @@ def cluster(ctx, config):
     conf = skeleton_config(
         ctx, roles=roles, ips=ips, mons=mons, cluster=cluster_name,
     )
-    for remote, roles_to_journals in remote_to_roles_to_journals.iteritems():
-        for role, journal in roles_to_journals.iteritems():
-            name = teuthology.ceph_role(role)
-            if name not in conf:
-                conf[name] = {}
-            conf[name]['osd journal'] = journal
     for section, keys in config['conf'].iteritems():
         for key, value in keys.iteritems():
             log.info("[%s] %s = %s" % (section, key, value))
@@ -821,20 +812,16 @@ def cluster(ctx, config):
         ctx.disk_config = argparse.Namespace()
     if not hasattr(ctx.disk_config, 'remote_to_roles_to_dev'):
         ctx.disk_config.remote_to_roles_to_dev = {}
-    if not hasattr(ctx.disk_config, 'remote_to_roles_to_journals'):
-        ctx.disk_config.remote_to_roles_to_journals = {}
     if not hasattr(ctx.disk_config, 'remote_to_roles_to_dev_mount_options'):
         ctx.disk_config.remote_to_roles_to_dev_mount_options = {}
     if not hasattr(ctx.disk_config, 'remote_to_roles_to_dev_fstype'):
         ctx.disk_config.remote_to_roles_to_dev_fstype = {}
 
     teuthology.deep_merge(ctx.disk_config.remote_to_roles_to_dev, remote_to_roles_to_devs)
-    teuthology.deep_merge(ctx.disk_config.remote_to_roles_to_journals, remote_to_roles_to_journals)
 
     log.info("ctx.disk_config.remote_to_roles_to_dev: {r}".format(r=str(ctx.disk_config.remote_to_roles_to_dev)))
     for remote, roles_for_host in osds.remotes.iteritems():
         roles_to_devs = remote_to_roles_to_devs[remote]
-        roles_to_journals = remote_to_roles_to_journals[remote]
 
         for role in teuthology.cluster_roles_of_type(roles_for_host, 'osd', cluster_name):
             _, _, id_ = teuthology.split_role(role)
@@ -848,7 +835,6 @@ def cluster(ctx, config):
                     mnt_point,
                 ])
             log.info(str(roles_to_devs))
-            log.info(str(roles_to_journals))
             log.info(role)
             if roles_to_devs.get(role):
                 dev = roles_to_devs[role]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44793

---

backport of https://github.com/ceph/ceph/pull/31055
parent tracker: https://tracker.ceph.com/issues/42357

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh