### PR TITLE
crimson/osd: restore ObjectState when op execution fails.

### DIFF
--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -452,6 +452,9 @@ public:
     Operation *op,
     const hobject_t &oid,
     RWState::State type);
+  load_obc_ertr::future<> reload_obc(
+    crimson::osd::ObjectContext& obc);
+
 public:
   template <typename F>
   auto with_locked_obc(

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -227,6 +227,8 @@ bool PGBackend::maybe_create_new_object(
   ceph::os::Transaction& txn)
 {
   if (!os.exists) {
+    logger().debug("{} on non-existent obj={}",
+                   __func__, os.oi.soid);
     ceph_assert(!os.oi.is_whiteout());
     os.exists = true;
     os.oi.new_object();
@@ -235,6 +237,8 @@ bool PGBackend::maybe_create_new_object(
     // TODO: delta_stats.num_objects++
     return false;
   } else if (os.oi.is_whiteout()) {
+    logger().debug("{} on existing obj={}",
+                   __func__, os.oi.soid);
     os.oi.clear_flag(object_info_t::FLAG_WHITEOUT);
     // TODO: delta_stats.num_whiteouts--
   }


### PR DESCRIPTION
On the way to OBC we lost `PGBackend::evict_object_state()` which was vital for e.g. `PGBackend::maybe_create_new_object()`. This patch brings similar mechanism to fix the regression.

CC: @AmnonHanuhov.
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
