### PR TITLE
octopus: cephadm: Fix trucated output of `mgr dump` 

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -638,6 +638,12 @@ def call(command,  # type: List[str]
                     message = message_b.decode('utf-8')
                 if isinstance(message_b, str):
                     message = message_b
+                if stop and message:
+                    # process has terminated, but have more to read still, so not stopping yet
+                    # (os.read returns '' when it encounters EOF)
+                    stop = False
+                if not message:
+                    continue
                 if fd == process.stdout.fileno():
                     out += message
                     message = out_buffer + message


### PR DESCRIPTION

Backport of #34215

Original description:
> i.e. don't call `poll()` while we still can read a lot of output
> 
> @tim this fixes the truncated output for me. wdyt?
> 
> This is an alternative for #34031
> 
> Fixes: https://tracker.ceph.com/issues/44642
> Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>
> 
> 
> <!--
> Thank you for opening a pull request!  Here are some tips on creating
> a well formatted contribution.
> 
> Please give your pull request a title like "[component]: [short description]"
> 
> This is the format for commit messages:
> 
> """
> [component]: [short description]
> 
> [A longer multiline description]
> 
> Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
> Signed-off-by: [Your Name] <[your email]>
> """
> 
> The Signed-off-by line is important, and it is your certification that
> your contributions satisfy the Developers Certificate or Origin.  For
> more detail, see SubmittingPatches.rst.
> 
> The component is the short name of a major daemon or subsystem,
> something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
> give the component as "mgr/<module name>" rather than a path into pybind.
> 
> For more examples, simply use "git log" and look at some historical commits.
> 
> This was just a quick overview.  More information for contributors is available here:
> https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst
> 
> -->
> ## Checklist
> - [ ] References tracker ticket
> - [ ] Updates documentation if necessary
> - [ ] Includes tests for new functionality or reproducer for bug
> 
> ---
> 
> <details>
> <summary>Show available Jenkins commands</summary>
> 
> - `jenkins retest this please`
> - `jenkins test crimson perf`
> - `jenkins test signed`
> - `jenkins test make check`
> - `jenkins test make check arm64`
> - `jenkins test submodules`
> - `jenkins test dashboard`
> - `jenkins test dashboard backend`
> - `jenkins test docs`
> - `jenkins render docs`
> - `jenkins test ceph-volume all`
> - `jenkins test ceph-volume tox`
> 
> </details>
