### PR TITLE
tools: remove all deprecated options from the help output

### DIFF
--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -151,15 +151,13 @@
       watch                             Watch events on image.
   
   Optional arguments:
-    -c [ --conf ] arg     path to cluster configuration
-    --cluster arg         cluster name
-    --id arg              client id (without 'client.' prefix)
-    --user arg            client id (without 'client.' prefix)
-    -n [ --name ] arg     client name
-    -m [ --mon_host ] arg monitor host
-    --secret arg          path to secret key (deprecated)
-    -K [ --keyfile ] arg  path to secret key
-    -k [ --keyring ] arg  path to keyring
+    -c [ --conf ] arg                   path to cluster configuration
+    --cluster arg                       cluster name
+    --id arg                            client id (without 'client.' prefix)
+    -n [ --name ] arg                   client name
+    -m [ --mon_host ] arg               monitor host
+    -K [ --keyfile ] arg                path to secret key
+    -k [ --keyring ] arg                path to keyring
   
   See 'rbd help <command>' for help on a specific command.
   $ rbd help | grep '^    [a-z]' | sed 's/^    \([a-z -]*[a-z]\).*/\1/g' | while read -r line; do echo rbd help $line ; rbd help $line; done
@@ -243,7 +241,6 @@
     --dest-pool arg           destination pool name
     --dest-namespace arg      destination namespace name
     --dest arg                destination image name
-    --order arg               object order [12 <= order <= 25] (deprecated)
     --object-size arg         object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg       image features
                               [layering(+), exclusive-lock(+*), object-map(+*),
@@ -447,7 +444,6 @@
     --dest-pool arg              destination pool name
     --dest-namespace arg         destination namespace name
     --dest arg                   destination image name
-    --order arg                  object order [12 <= order <= 25] (deprecated)
     --object-size arg            object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg          image features
                                  [layering(+), exclusive-lock(+*),
@@ -490,10 +486,7 @@
     -p [ --pool ] arg         pool name
     --namespace arg           namespace name
     --image arg               image name
-    --image-format arg        image format [1 (deprecated) or 2]
-    --new-format              use image format 2
-                              (deprecated)
-    --order arg               object order [12 <= order <= 25] (deprecated)
+    --image-format arg        image format [default: 2]
     --object-size arg         object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg       image features
                               [layering(+), exclusive-lock(+*), object-map(+*),
@@ -548,7 +541,6 @@
     --dest-pool arg              destination pool name
     --dest-namespace arg         destination namespace name
     --dest arg                   destination image name
-    --order arg                  object order [12 <= order <= 25] (deprecated)
     --object-size arg            object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg          image features
                                  [layering(+), exclusive-lock(+*),
@@ -1119,10 +1111,7 @@
     --dest-pool arg           destination pool name
     --dest-namespace arg      destination namespace name
     --dest arg                destination image name
-    --image-format arg        image format [1 (deprecated) or 2]
-    --new-format              use image format 2
-                              (deprecated)
-    --order arg               object order [12 <= order <= 25] (deprecated)
+    --image-format arg        image format [default: 2]
     --object-size arg         object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg       image features
                               [layering(+), exclusive-lock(+*), object-map(+*),
@@ -1137,8 +1126,6 @@
     --sparse-size arg         sparse size in B/K/M [default: 4K]
     --no-progress             disable progress output
     --export-format arg       format of image file
-    -p [ --pool ] arg         pool name (deprecated)
-    --image arg               image name (deprecated)
   
   Image Features:
     (*) supports enabling/disabling on existing images
@@ -1497,10 +1484,7 @@
     --dest-pool arg           destination pool name
     --dest-namespace arg      destination namespace name
     --dest arg                destination image name
-    --image-format arg        image format [1 (deprecated) or 2]
-    --new-format              use image format 2
-                              (deprecated)
-    --order arg               object order [12 <= order <= 25] (deprecated)
+    --image-format arg        image format [default: 2]
     --object-size arg         object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg       image features
                               [layering(+), exclusive-lock(+*), object-map(+*),

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -243,7 +243,7 @@
     --dest-pool arg           destination pool name
     --dest-namespace arg      destination namespace name
     --dest arg                destination image name
-    --order arg               object order [12 <= order <= 25]
+    --order arg               object order [12 <= order <= 25] (deprecated)
     --object-size arg         object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg       image features
                               [layering(+), exclusive-lock(+*), object-map(+*),
@@ -447,7 +447,7 @@
     --dest-pool arg              destination pool name
     --dest-namespace arg         destination namespace name
     --dest arg                   destination image name
-    --order arg                  object order [12 <= order <= 25]
+    --order arg                  object order [12 <= order <= 25] (deprecated)
     --object-size arg            object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg          image features
                                  [layering(+), exclusive-lock(+*),
@@ -493,7 +493,7 @@
     --image-format arg        image format [1 (deprecated) or 2]
     --new-format              use image format 2
                               (deprecated)
-    --order arg               object order [12 <= order <= 25]
+    --order arg               object order [12 <= order <= 25] (deprecated)
     --object-size arg         object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg       image features
                               [layering(+), exclusive-lock(+*), object-map(+*),
@@ -548,7 +548,7 @@
     --dest-pool arg              destination pool name
     --dest-namespace arg         destination namespace name
     --dest arg                   destination image name
-    --order arg                  object order [12 <= order <= 25]
+    --order arg                  object order [12 <= order <= 25] (deprecated)
     --object-size arg            object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg          image features
                                  [layering(+), exclusive-lock(+*),
@@ -1122,7 +1122,7 @@
     --image-format arg        image format [1 (deprecated) or 2]
     --new-format              use image format 2
                               (deprecated)
-    --order arg               object order [12 <= order <= 25]
+    --order arg               object order [12 <= order <= 25] (deprecated)
     --object-size arg         object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg       image features
                               [layering(+), exclusive-lock(+*), object-map(+*),
@@ -1500,7 +1500,7 @@
     --image-format arg        image format [1 (deprecated) or 2]
     --new-format              use image format 2
                               (deprecated)
-    --order arg               object order [12 <= order <= 25]
+    --order arg               object order [12 <= order <= 25] (deprecated)
     --object-size arg         object size in B/K/M [4K <= object size <= 32M]
     --image-feature arg       image features
                               [layering(+), exclusive-lock(+*), object-map(+*),

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -227,15 +227,15 @@ void add_create_image_options(po::options_description *opt,
   if (include_format) {
     opt->add_options()
       (IMAGE_FORMAT.c_str(), po::value<ImageFormat>(),
-       "image format [1 (deprecated) or 2]")
+       "image format [default: 2]")
       (IMAGE_NEW_FORMAT.c_str(),
        po::value<ImageNewFormat>()->zero_tokens(),
-       "use image format 2\n(deprecated)");
+       "deprecated[:image-format 2]");
   }
 
   opt->add_options()
     (IMAGE_ORDER.c_str(), po::value<ImageOrder>(),
-     "object order [12 <= order <= 25] (deprecated)")
+     "deprecated[:object-size]")
     (IMAGE_OBJECT_SIZE.c_str(), po::value<ImageObjectSize>(),
      "object size in B/K/M [4K <= object size <= 32M]")
     (IMAGE_FEATURES.c_str(), po::value<ImageFeatures>()->composing(),
@@ -431,8 +431,6 @@ void validate(boost::any& v, const std::vector<std::string>& values,
 
 void validate(boost::any& v, const std::vector<std::string>& values,
               ImageNewFormat *target_type, int dummy) {
-  std::cout << "rbd: --new-format is deprecated, use --image-format"
-            << std::endl;
   v = boost::any(true);
 }
 
@@ -504,7 +502,6 @@ void validate(boost::any& v, const std::vector<std::string>& values,
 
 void validate(boost::any& v, const std::vector<std::string>& values,
               Secret *target_type, int) {
-  std::cerr << "rbd: --secret is deprecated, use --keyfile" << std::endl;
 
   po::validators::check_first_occurrence(v);
   const std::string &s = po::validators::get_single_string(values);

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -235,7 +235,7 @@ void add_create_image_options(po::options_description *opt,
 
   opt->add_options()
     (IMAGE_ORDER.c_str(), po::value<ImageOrder>(),
-     "object order [12 <= order <= 25]")
+     "object order [12 <= order <= 25] (deprecated)")
     (IMAGE_OBJECT_SIZE.c_str(), po::value<ImageObjectSize>(),
      "object size in B/K/M [4K <= object size <= 32M]")
     (IMAGE_FEATURES.c_str(), po::value<ImageFeatures>()->composing(),

--- a/src/tools/rbd/OptionPrinter.cc
+++ b/src/tools/rbd/OptionPrinter.cc
@@ -56,6 +56,28 @@ void OptionPrinter::print_short(std::ostream &os, size_t initial_offset) {
   }
 }
 
+void OptionPrinter::print_optional(const OptionsDescription &global_opts,
+                                   size_t &name_width, std::ostream &os) {
+  std::string indent2(2, ' ');
+
+  for (size_t i = 0; i < global_opts.options().size(); ++i) {
+    std::string description = global_opts.options()[i]->description();
+    auto result = boost::find_first(description, "deprecated");
+    if (!result.empty()) {
+      continue;
+    }
+    std::stringstream ss;
+    ss << indent2
+       << global_opts.options()[i]->format_name() << " "
+       << global_opts.options()[i]->format_parameter();
+
+    std::cout << ss.str();
+    IndentStream indent_stream(name_width, ss.str().size(), LINE_WIDTH, std::cout);
+    indent_stream << global_opts.options()[i]->description() << std::endl;
+  }
+
+}
+
 void OptionPrinter::print_detailed(std::ostream &os) {
   std::string indent_prefix(2, ' ');
   size_t name_width = compute_name_width(indent_prefix.size());
@@ -76,16 +98,7 @@ void OptionPrinter::print_detailed(std::ostream &os) {
 
   if (m_optional.options().size() > 0) {
     std::cout << OPTIONAL_ARGUMENTS << std::endl;
-    for (size_t i = 0; i < m_optional.options().size(); ++i) {
-      std::stringstream ss;
-      ss << indent_prefix
-         << m_optional.options()[i]->format_name() << " "
-         << m_optional.options()[i]->format_parameter();
-
-      std::cout << ss.str();
-      IndentStream indent_stream(name_width, ss.str().size(), LINE_WIDTH, os);
-      indent_stream << m_optional.options()[i]->description() << std::endl;
-    }
+    print_optional(m_optional, name_width, os);
     std::cout << std::endl;
   }
 }

--- a/src/tools/rbd/OptionPrinter.h
+++ b/src/tools/rbd/OptionPrinter.h
@@ -7,6 +7,7 @@
 #include "include/int_types.h"
 #include <string>
 #include <vector>
+#include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
 
 namespace rbd {
@@ -27,6 +28,8 @@ public:
 
   void print_short(std::ostream &os, size_t initial_offset);
   void print_detailed(std::ostream &os);
+  static void print_optional(const OptionsDescription &global_opts,
+                             size_t &name_width, std::ostream &os);
 
 private:
   const OptionsDescription &m_positional;

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -439,8 +439,6 @@ int get_image_options(const boost::program_options::variables_map &vm,
 
   if (vm.count(at::IMAGE_ORDER)) {
     order = vm[at::IMAGE_ORDER].as<uint64_t>();
-    std::cerr << "rbd: --order is deprecated, use --object-size"
-	      << std::endl;
   } else if (vm.count(at::IMAGE_OBJECT_SIZE)) {
     object_size = vm[at::IMAGE_OBJECT_SIZE].as<uint64_t>();
     order = std::round(std::log2(object_size));

--- a/src/tools/rbd/action/Import.cc
+++ b/src/tools/rbd/action/Import.cc
@@ -945,8 +945,8 @@ void get_arguments(po::options_description *positional,
 
   // TODO legacy rbd allowed import to accept both 'image'/'dest' and
   //      'pool'/'dest-pool'
-  at::add_pool_option(options, at::ARGUMENT_MODIFIER_NONE, " (deprecated)");
-  at::add_image_option(options, at::ARGUMENT_MODIFIER_NONE, " (deprecated)");
+  at::add_pool_option(options, at::ARGUMENT_MODIFIER_NONE, " deprecated[:dest-pool]");
+  at::add_image_option(options, at::ARGUMENT_MODIFIER_NONE, " deprecated[:dest]");
 }
 
 int execute(const po::variables_map &vm,
@@ -962,15 +962,11 @@ int execute(const po::variables_map &vm,
   std::string deprecated_pool_name;
   if (vm.count(at::POOL_NAME)) {
     deprecated_pool_name = vm[at::POOL_NAME].as<std::string>();
-    std::cerr << "rbd: --pool is deprecated for import, use --dest-pool"
-              << std::endl;
   }
 
   std::string deprecated_image_name;
   if (vm.count(at::IMAGE_NAME)) {
     deprecated_image_name = vm[at::IMAGE_NAME].as<std::string>();
-    std::cerr << "rbd: --image is deprecated for import, use --dest"
-              << std::endl;
   } else {
     deprecated_image_name = path.substr(path.find_last_of("/") + 1);
   }


### PR DESCRIPTION
Signed-off-by: Zheng Yin <zhengyin@cmss.chinamobile.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
