### PR TITLE
doc: Fix inconsistency in logging settings

### DIFF
--- a/doc/rados/troubleshooting/log-and-debug.rst
+++ b/doc/rados/troubleshooting/log-and-debug.rst
@@ -330,12 +330,20 @@ settings:
 :Default: ``10000``
 
 
+``log to file``
+
+:Description: Determines if logging messages should appear in a file.
+:Type: Boolean
+:Required: No
+:Default: ``true``
+
+
 ``log to stderr``
 
 :Description: Determines if logging messages should appear in ``stderr``.
 :Type: Boolean
 :Required: No
-:Default: ``true``
+:Default: ``false``
 
 
 ``err to stderr``
@@ -367,7 +375,7 @@ settings:
 :Description: Determines if Ceph should flush the log files after exit.
 :Type: Boolean
 :Required: No
-:Default: ``true``
+:Default: ``false``
 
 
 ``clog to monitors``


### PR DESCRIPTION
This patch fixes inconsistency in doc of logging settings with options, namely `log_flush_on_exit` and `log_to_stderr`. This patch also adds `log_to_file` to the section.

Signed-off-by: John Law <johnlaw.po@gmail.com>