### PR TITLE
octopus: mds: fix 'if there is lock cache on dir' check

### DIFF
--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -578,7 +578,7 @@ void MDLockCache::attach_dirfrags(std::vector<CDir*>&& dfv)
   }
 }
 
-void MDLockCache::detach_all()
+void MDLockCache::detach_locks()
 {
   ceph_assert(items_lock);
   int i = 0;
@@ -588,9 +588,12 @@ void MDLockCache::detach_all()
     ++i;
   }
   items_lock.reset();
+}
 
+void MDLockCache::detach_dirfrags()
+{
   ceph_assert(items_dir);
-  i = 0;
+  int i = 0;
   for (auto dir : auth_pinned_dirfrags) {
     (void)dir;
     items_dir[i].item_dir.remove_myself();

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -496,7 +496,8 @@ struct MDLockCache : public MutationImpl {
 
   void attach_locks();
   void attach_dirfrags(std::vector<CDir*>&& dfv);
-  void detach_all();
+  void detach_locks();
+  void detach_dirfrags();
 
   CInode *diri;
   Capability *client_cap;

--- a/src/mds/SimpleLock.cc
+++ b/src/mds/SimpleLock.cc
@@ -95,12 +95,14 @@ void SimpleLock::remove_cache(MDLockCacheItem& item) {
   }
 }
 
-MDLockCache* SimpleLock::get_first_cache() {
+std::vector<MDLockCache*> SimpleLock::get_active_caches() {
+  std::vector<MDLockCache*> result;
   if (have_more()) {
-    auto& lock_caches = more()->lock_caches;
-    if (!lock_caches.empty()) {
-      return lock_caches.front()->parent;
+    for (auto it = more()->lock_caches.begin_use_current(); !it.end(); ++it) {
+      auto lock_cache = (*it)->parent;
+      if (!lock_cache->invalidating)
+	result.push_back(lock_cache);
     }
   }
-  return nullptr;
+  return result;
 }

--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -228,7 +228,7 @@ public:
   }
   void add_cache(MDLockCacheItem& item);
   void remove_cache(MDLockCacheItem& item);
-  MDLockCache* get_first_cache();
+  std::vector<MDLockCache*> get_active_caches();
 
   // state
   int get_state() const { return state; }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44800

---

When invalidating lock cache, current code detach lock cache from all
its locks immediately. So diri->filelock.is_cached() only tells us if
there is active (not being invalidated) lock cache on a dir.

But MDCache::path_traverse() and Server::_dir_is_nonempty_unlocked() use
diri->filelock.is_cached() to check if there is any lock cache on a dir.
This bug can result in processing async requests and normal requests out
of order.

The fix is detaching lock cache from its locks when lock cache is
completely invalidated .

Fixes: https://tracker.ceph.com/issues/44448
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>
(cherry picked from commit 20d21cff89e1bb2bd6d7af311b4cc3272ce5fe65)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
