### PR TITLE
tests: Reinstate "opts" as final argument

### DIFF
--- a/src/test/docker-test-helper.sh
+++ b/src/test/docker-test-helper.sh
@@ -24,8 +24,8 @@ function get_image_name() {
 function setup_container() {
     local os_type=$1
     local os_version=$2
-    local opts="$3"
-    local dockercmd=$4
+    local dockercmd=$3
+    local opts="$4"
 
     local image=$(get_image_name $os_type $os_version)
     local build=true
@@ -108,14 +108,14 @@ function run_in_docker() {
     shift
     local ref=$1
     shift
+    local dockercmd=$1
+    shift
     local opts="$1"
     shift
     local script=$1
-    shift
-    local dockercmd=$1
 
     setup_downstream $os_type $os_version $ref || return 1
-    setup_container $os_type $os_version "$opts" $dockercmd || return 1
+    setup_container $os_type $os_version $dockercmd "$opts" || return 1
     local downstream=$(get_downstream $os_type $os_version)
     local image=$(get_image_name $os_type $os_version)
     local upstream=$(get_upstream)
@@ -327,9 +327,9 @@ function main_docker() {
             if $remove ; then
                 remove_all $os_type $os_version $dockercmd || return 1
             elif $shell ; then
-                run_in_docker $os_type $os_version $ref "$opts" SHELL $dockercmd || return 1
+                run_in_docker $os_type $os_version $ref $dockercmd "$opts" SHELL || return 1
             else
-                run_in_docker $os_type $os_version $ref "$opts" "$@" $dockercmd || return 1
+                run_in_docker $os_type $os_version $ref $dockercmd "$opts" "$@" || return 1
             fi
         done
     done


### PR DESCRIPTION
a1e8f61cb72 broke the "opts" argument.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
