### PR TITLE
nautilus: ceph-volume: prepare: use *-slots arguments for implicit sizing

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -649,7 +649,7 @@ class VolumeGroup(object):
         '''
         Return how many extents fit the VG slot times
         '''
-        return int(int(self.vg_free_count) / slots)
+        return int(int(self.vg_extent_count) / slots)
 
 
 class VolumeGroups(list):

--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -66,6 +66,7 @@ def common_parser(prog, description):
         '--data-slots',
         help=('Intended number of slots on data device. The new OSD gets one'
               'of those slots or 1/nth of the available capacity'),
+        type=int,
         default=1,
     )
 
@@ -110,6 +111,7 @@ def common_parser(prog, description):
         dest='block_db_slots',
         help=('Intended number of slots on db device. The new OSD gets one'
               'of those slots or 1/nth of the available capacity'),
+        type=int,
         default=1,
     )
 
@@ -131,6 +133,7 @@ def common_parser(prog, description):
         dest='block_wal_slots',
         help=('Intended number of slots on wal device. The new OSD gets one'
               'of those slots or 1/nth of the available capacity'),
+        type=int,
         default=1,
     )
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -178,6 +178,9 @@ class Prepare(object):
             kwargs = {
                 'device': device_name,
                 'tags': tags,
+                'slots': getattr(self.args,
+                                 'block_{}_slots'.format(device_type),
+                                 1),
             }
             if size != 0:
                 kwargs['size'] = disk.Size.parse(size)
@@ -213,6 +216,7 @@ class Prepare(object):
             lv_name_prefix = "osd-{}".format(device_type)
             kwargs = {'device': device,
                       'tags': {'ceph.type': device_type},
+                      'slots': self.args.data_slots,
                      }
             logger.debug('data device size: {}'.format(self.args.data_size))
             if self.args.data_size != 0:

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -533,6 +533,7 @@ class TestCreateLV(object):
         self.foo_volume = api.Volume(lv_name='foo', lv_path='/path', vg_name='foo_group', lv_tags='')
         self.foo_group = api.VolumeGroup(vg_name='foo_group',
                                          vg_extent_size=4194304,
+                                         vg_extent_count=100,
                                          vg_free_count=100)
 
     @patch('ceph_volume.api.lvm.process.run')

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -403,10 +403,15 @@ class Device(object):
         return rejected
 
     def _check_lvm_reject_reasons(self):
-        rejected = self._check_generic_reject_reasons()
+        rejected = []
         available_vgs = [vg for vg in self.vgs if vg.free >= 5368709120]
         if self.vgs and not available_vgs:
             rejected.append('Insufficient space (<5GB) on vgs')
+
+        if not self.vgs:
+            # only check generic if no vgs are present. Vgs might hold lvs and
+            # that might cause 'locked' to trigger
+            rejected.extend(self._check_generic_reject_reasons())
 
         return len(rejected) == 0, rejected
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44688

---

backport of https://github.com/ceph/ceph/pull/33787
parent tracker: https://tracker.ceph.com/issues/44494

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh