### PR TITLE
mgr/dashboard: 'Prometheus / All Alerts' page shows progress bar

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.html
@@ -1,8 +1,14 @@
 <cd-table [data]="data"
           [columns]="columns"
           (updateSelection)="selectionUpdated($event)"
-          [selectionType]="'single'"></cd-table>
-
-<cd-table-key-value [data]="selectedRule"
-                    [renderObjects]="true"
-                    [hideKeys]="hideKeys"></cd-table-key-value>
+          [selectionType]="'single'">
+  <tabset cdTableDetail
+          *ngIf="selectedRule">
+    <tab i18n-heading
+         heading="Details">
+      <cd-table-key-value [data]="selectedRule"
+                          [renderObjects]="true"
+                          [hideKeys]="hideKeys"></cd-table-key-value>
+    </tab>
+  </tabset>
+</cd-table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.spec.ts
@@ -1,6 +1,8 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { TabsModule } from 'ngx-bootstrap/tabs';
+
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
 import { PrometheusService } from '../../../../shared/api/prometheus.service';
 import { SettingsService } from '../../../../shared/api/settings.service';
@@ -13,7 +15,7 @@ describe('RulesListComponent', () => {
 
   configureTestBed({
     declarations: [RulesListComponent],
-    imports: [HttpClientTestingModule, SharedModule],
+    imports: [HttpClientTestingModule, SharedModule, TabsModule.forRoot()],
     providers: [PrometheusService, SettingsService, i18nProviders]
   });
 


### PR DESCRIPTION
The 'Prometheus / All Alerts' page shows a progress bar if no rule is selected.
Additionally the page does not show the 'Details' tab as all other pages with tables does this accross the Dashboard UI.
The progress bar issue will be fixed by embedding the details table in a tab.

Before:
![alerts_progress_bar](https://user-images.githubusercontent.com/1897962/77890757-4489b300-7270-11ea-9c76-831e4315c35b.png)
![alerts_wo_details_tab](https://user-images.githubusercontent.com/1897962/77890790-510e0b80-7270-11ea-83f9-4c2a8c1dc014.png)

After:
![Bildschirmfoto vom 2020-03-30 10-20-34](https://user-images.githubusercontent.com/1897962/77890688-2de35c00-7270-11ea-8685-5d9a38e5cfab.png)


Fixes: https://tracker.ceph.com/issues/44805

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
