### PR TITLE
octopus: mgr/dashboard: do not fail on user creation (CLI)

### DIFF
--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -727,7 +727,7 @@ def ac_user_create_cmd(_, username, password=None, rolename=None, name=None,
     except PasswordPolicyException as ex:
         return -errno.EINVAL, '', str(ex)
     except UserAlreadyExists as ex:
-        return -errno.EEXIST, '', str(ex)
+        return 0, str(ex), ''
 
     if role:
         user.set_roles([role])

--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -328,13 +328,9 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
 
     def test_create_duplicate_user(self):
         self.test_create_user()
-
-        with self.assertRaises(CmdException) as ctx:
-            self.exec_cmd('ac-user-create', username='admin', password='admin',
-                          force_password=True)
-
-        self.assertEqual(ctx.exception.retcode, -errno.EEXIST)
-        self.assertEqual(str(ctx.exception), "User 'admin' already exists")
+        ret = self.exec_cmd('ac-user-create', username='admin', password='admin',
+                            force_password=True)
+        self.assertEqual(ret, "User 'admin' already exists")
 
     def test_create_users_with_dne_role(self):
         # one time call to setup our persistent db


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44796

---

backport of https://github.com/ceph/ceph/pull/34247
parent tracker: https://tracker.ceph.com/issues/44502

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh