### PR TITLE
nautilus: mgr/dashboard: Tabs does not handle click events

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-tabs/iscsi-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-tabs/iscsi-tabs.component.html
@@ -2,11 +2,11 @@
   <tab heading="Overview"
        i18n-heading
        [active]="url === '/block/iscsi/overview'"
-       (select)="navigateTo('/block/iscsi/overview')">
+       (selectTab)="navigateTo('/block/iscsi/overview')">
   </tab>
   <tab heading="Targets"
        i18n-heading
        [active]="url === '/block/iscsi/targets'"
-       (select)="navigateTo('/block/iscsi/targets')">
+       (selectTab)="navigateTo('/block/iscsi/targets')">
   </tab>
 </tabset>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
@@ -35,7 +35,7 @@
   </tab>
   <tab i18n-heading
        heading="Clients: {{ clientCount }}"
-       (select)="clientsSelect=true"
+       (selectTab)="clientsSelect=true"
        (deselect)="clientsSelect=false">
     <cd-cephfs-clients [id]="id"
                        *ngIf="clientsSelect">

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-tabs/user-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-tabs/user-tabs.component.html
@@ -2,11 +2,11 @@
   <tab heading="Users"
        i18n-heading
        [active]="url === '/user-management/users'"
-       (select)="navigateTo('/user-management/users')">
+       (selectTab)="navigateTo('/user-management/users')">
   </tab>
   <tab heading="Roles"
        i18n-heading
        [active]="url === '/user-management/roles'"
-       (select)="navigateTo('/user-management/roles')">
+       (selectTab)="navigateTo('/user-management/roles')">
   </tab>
 </tabset>


### PR DESCRIPTION
Various tabs pages do not handle click events in the tab header, thus it is not possible to switch between the tabs.

Before:
![screenshot](https://user-images.githubusercontent.com/1897962/77905234-2c249300-7286-11ea-85b6-4ada59f2d086.gif)

After:
![after](https://user-images.githubusercontent.com/1897962/77905290-45c5da80-7286-11ea-99bd-1b89393ab9e4.gif)

Fixes: https://tracker.ceph.com/issues/44809

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
