### PR TITLE
doc/mgr/orchestrator: Add "Service Specification"

### DIFF
--- a/doc/cephadm/drivegroups.rst
+++ b/doc/cephadm/drivegroups.rst
@@ -19,10 +19,12 @@ Create a file called i.e. drivegroups.yml
 
 .. code-block:: yaml
 
-    default_drive_group:    <- name of the drive_group (name can be custom)
-      host_pattern: '*'     <- which hosts to target, currently only supports globs
-      data_devices:         <- the type of devices you are applying specs to
-        all: true           <- a filter, check below for a full list
+    service_type: osd
+    service_id: default_drive_group  <- name of the drive_group (name can be custom)
+    placement:
+      host_pattern: '*'              <- which hosts to target, currently only supports globs
+    data_devices:                    <- the type of devices you are applying specs to
+      all: true                      <- a filter, check below for a full list
 
 This would translate to:
 
@@ -165,9 +167,12 @@ This example would deploy all OSDs with encryption enabled.
 
 .. code-block:: yaml
 
-    example_drive_group:
-      data_devices:
-        all: true
+    service_type: osd
+    service_id: example_drive_group
+    placement:
+      host_pattern: '*'
+    data_devices:
+      all: true
       encrypted: true
 
 See a full list in the DriveGroupSpecs
@@ -200,23 +205,27 @@ This is a common setup and can be described quite easily:
 
 .. code-block:: yaml
 
-    drive_group_default:
+    service_type: osd
+    service_id: drive_group_default
+    placement:
       host_pattern: '*'
-      data_devices:
-        model: HDD-123-foo <- note that HDD-123 would also be valid
-      db_devices:
-        model: MC-55-44-XZ <- same here, MC-55-44 is valid
+    data_devices:
+      model: HDD-123-foo <- note that HDD-123 would also be valid
+    db_devices:
+      model: MC-55-44-XZ <- same here, MC-55-44 is valid
 
 However, we can improve it by reducing the filters on core properties of the drives:
 
 .. code-block:: yaml
 
-    drive_group_default:
+    service_type: osd
+    service_id: drive_group_default
+    placement:
       host_pattern: '*'
-      data_devices:
-        rotational: 1
-      db_devices:
-        rotational: 0
+    data_devices:
+      rotational: 1
+    db_devices:
+      rotational: 0
 
 Now, we enforce all rotating devices to be declared as 'data devices' and all non-rotating devices will be used as shared_devices (wal, db)
 
@@ -224,12 +233,14 @@ If you know that drives with more than 2TB will always be the slower data device
 
 .. code-block:: yaml
 
-    drive_group_default:
+    service_type: osd
+    service_id: drive_group_default
+    placement:
       host_pattern: '*'
-      data_devices:
-        size: '2TB:'
-      db_devices:
-        size: ':2TB'
+    data_devices:
+      size: '2TB:'
+    db_devices:
+      size: ':2TB'
 
 Note: All of the above DriveGroups are equally valid. Which of those you want to use depends on taste and on how much you expect your node layout to change.
 
@@ -262,20 +273,24 @@ This can be described with two layouts.
 
 .. code-block:: yaml
 
-    drive_group_hdd:
+    service_type: osd
+    service_id: drive_group_hdd
+    placement:
       host_pattern: '*'
-      data_devices:
-        rotational: 0
-      db_devices:
-        model: MC-55-44-XZ
-        limit: 2 (db_slots is actually to be favoured here, but it's not implemented yet)
-
-    drive_group_ssd:
+    data_devices:
+      rotational: 0
+    db_devices:
+      model: MC-55-44-XZ
+      limit: 2 (db_slots is actually to be favoured here, but it's not implemented yet)
+      
+    service_type: osd
+    service_id: drive_group_ssd
+    placement:
       host_pattern: '*'
-      data_devices:
-        model: MC-55-44-XZ
-      db_devices:
-        vendor: VendorC
+    data_devices:
+      model: MC-55-44-XZ
+    db_devices:
+      vendor: VendorC
 
 This would create the desired layout by using all HDDs as data_devices with two SSD assigned as dedicated db/wal devices.
 The remaining SSDs(8) will be data_devices that have the 'VendorC' NVMEs assigned as dedicated db/wal devices.
@@ -312,19 +327,24 @@ You can use the 'host_pattern' key in the layout to target certain nodes. Salt t
 
 .. code-block:: yaml
 
-    drive_group_node_one_to_five:
+    service_type: osd
+    service_id: drive_group_node_one_to_five
+    placement:
       host_pattern: 'node[1-5]'
-      data_devices:
-        rotational: 1
-      db_devices:
-        rotational: 0
-
-    drive_group_six_to_ten:
+    data_devices:
+      rotational: 1
+    db_devices:
+      rotational: 0
+      
+      
+    service_type: osd
+    service_id: drive_group_six_to_ten
+    placement:
       host_pattern: 'node[6-10]'
-      data_devices:
-        model: MC-55-44-XZ
-      db_devices:
-        model: SSD-123-foo
+    data_devices:
+      model: MC-55-44-XZ
+    db_devices:
+      model: SSD-123-foo
 
 This will apply different drive groups to different hosts depending on the `host_pattern` key.
 
@@ -356,14 +376,16 @@ The drivegroup for this case would look like this (using the `model` filter)
 
 .. code-block:: yaml
 
-    drive_group_default:
+    service_type: osd
+    service_id: drive_group_default
+    placement:
       host_pattern: '*'
-      data_devices:
-        model: MC-55-44-XZ
-      db_devices:
-        model: SSD-123-foo
-      wal_devices:
-        model: NVME-QQQQ-987
+    data_devices:
+      model: MC-55-44-XZ
+    db_devices:
+      model: SSD-123-foo
+    wal_devices:
+      model: NVME-QQQQ-987
 
 
 This can easily be done with other filters, like `size` or `vendor` as well.

--- a/doc/cephadm/drivegroups.rst
+++ b/doc/cephadm/drivegroups.rst
@@ -1,10 +1,10 @@
 .. _drivegroups:
 
-===========
-DriveGroups
-===========
+=========================
+OSD Service Specification
+=========================
 
-DriveGroups are a way to describe a cluster layout using the properties of disks.
+:ref:`orchestrator-cli-service-spec` of type ``osd`` are a way to describe a cluster layout using the properties of disks.
 It gives the user an abstract way tell ceph which disks should turn into an OSD
 with which configuration without knowing the specifics of device names and paths.
 
@@ -15,7 +15,7 @@ Instead of doing this::
 for each device and each host, we can define a yaml|json file that allows us to describe
 the layout. Here's the most basic example.
 
-Create a file called i.e. drivegroups.yml
+Create a file called i.e. osd_spec.yml
 
 .. code-block:: yaml
 
@@ -34,7 +34,7 @@ There will be a more detailed section on host_pattern down below.
 
 and pass it to `osd create` like so::
 
-  [monitor 1] # ceph orch apply osd -i /path/to/drivegroup.yml
+  [monitor 1] # ceph orch apply osd -i /path/to/osd_spec.yml
 
 This will go out on all the matching hosts and deploy these OSDs.
 
@@ -168,7 +168,7 @@ This example would deploy all OSDs with encryption enabled.
 .. code-block:: yaml
 
     service_type: osd
-    service_id: example_drive_group
+    service_id: example_osd_spec
     placement:
       host_pattern: '*'
     data_devices:
@@ -206,7 +206,7 @@ This is a common setup and can be described quite easily:
 .. code-block:: yaml
 
     service_type: osd
-    service_id: drive_group_default
+    service_id: osd_spec_default
     placement:
       host_pattern: '*'
     data_devices:
@@ -219,7 +219,7 @@ However, we can improve it by reducing the filters on core properties of the dri
 .. code-block:: yaml
 
     service_type: osd
-    service_id: drive_group_default
+    service_id: osd_spec_default
     placement:
       host_pattern: '*'
     data_devices:
@@ -234,7 +234,7 @@ If you know that drives with more than 2TB will always be the slower data device
 .. code-block:: yaml
 
     service_type: osd
-    service_id: drive_group_default
+    service_id: osd_spec_default
     placement:
       host_pattern: '*'
     data_devices:
@@ -274,7 +274,7 @@ This can be described with two layouts.
 .. code-block:: yaml
 
     service_type: osd
-    service_id: drive_group_hdd
+    service_id: osd_spec_hdd
     placement:
       host_pattern: '*'
     data_devices:
@@ -284,7 +284,7 @@ This can be described with two layouts.
       limit: 2 (db_slots is actually to be favoured here, but it's not implemented yet)
       
     service_type: osd
-    service_id: drive_group_ssd
+    service_id: osd_spec_ssd
     placement:
       host_pattern: '*'
     data_devices:
@@ -328,7 +328,7 @@ You can use the 'host_pattern' key in the layout to target certain nodes. Salt t
 .. code-block:: yaml
 
     service_type: osd
-    service_id: drive_group_node_one_to_five
+    service_id: osd_spec_node_one_to_five
     placement:
       host_pattern: 'node[1-5]'
     data_devices:
@@ -338,7 +338,7 @@ You can use the 'host_pattern' key in the layout to target certain nodes. Salt t
       
       
     service_type: osd
-    service_id: drive_group_six_to_ten
+    service_id: osd_spec_six_to_ten
     placement:
       host_pattern: 'node[6-10]'
     data_devices:
@@ -346,7 +346,7 @@ You can use the 'host_pattern' key in the layout to target certain nodes. Salt t
     db_devices:
       model: SSD-123-foo
 
-This will apply different drive groups to different hosts depending on the `host_pattern` key.
+This applies different OSD specs to different hosts depending on the `host_pattern` key.
 
 Dedicated wal + db
 ------------------
@@ -372,12 +372,12 @@ It's however possible to deploy the WAL on a dedicated device as well, if it mak
     Size: 256GB
 
 
-The drivegroup for this case would look like this (using the `model` filter)
+The OSD spec for this case would look like the following (using the `model` filter):
 
 .. code-block:: yaml
 
     service_type: osd
-    service_id: drive_group_default
+    service_id: osd_spec_default
     placement:
       host_pattern: '*'
     data_devices:

--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -406,7 +406,7 @@ Placement by pattern matching
 
 Daemons can be placed on hosts as well::
 
-    orch apply prometheus '*'
+    orch apply prometheus 'myhost[1-3]'
 
 Or in yaml:
 
@@ -414,9 +414,21 @@ Or in yaml:
 
     service_type: prometheus
     placement:
-      all_hosts: true
+      host_pattern: "myhost[1-3]"
 
+To place a service on *all* hosts, use ``"*"``::
 
+    orch apply crash '*'
+
+Or in yaml:
+
+.. code-block:: yaml
+
+    service_type: node-exporter
+    placement:
+      host_pattern: "*"
+
+    
 Setting a limit
 ---------------
 

--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -276,6 +276,76 @@ Start/stop/reload::
 
     ceph orch daemon {start,stop,reload} <type> <daemon-id>
     
+.. _orchestrator-cli-service-spec:
+    
+Service Specification
+=====================
+
+As *Service Specification* is a data structure often represented as YAML 
+to specify the deployment of services. For example::
+
+    service_type: rgw
+    service_id: realm.zone
+    placement: 
+      hosts: 
+        - host1
+        - host2
+        - host3
+    spec: ...
+        
+Where the properties of a service specification are the following:
+
+* ``service_type`` is the type of the service. Needs to be either a Ceph
+   service (``mon``, ``crash``, ``mds``, ``mgr``, ``osd`` or 
+   ``rbd-mirror``), a gateway (``nfs`` or ``rgw``), or part of the
+   monitoring stack (``alertmanager``, ``grafana``, ``node-exporter`` or
+   ``prometheus``).
+* ``service_id`` is the name of the service. Omit the service time
+* ``placement`` is a :ref:`orchestrator-cli-placement-spec`
+* ``spec``: additional specifications for a specific service.
+
+Each service type can have different requirements for the spec.
+
+Service specifications of type ``mon``, ``mgr``, and the monitoring
+types do not require a ``service_id``
+
+A service of type ``nfs`` requires a pool name and contain
+an optional namespace::
+
+    service_type: nfs
+    service_id: realm.zone
+    placement: 
+      hosts: 
+        - host1
+        - host2
+    spec:
+      pool: mypool
+      namespace: mynamespace
+
+Where ``pool`` is a RADOS pool where NFS client recovery data is stored
+and ``namespace`` is a RADOS namespace where NFS client recovery
+data is stored in the pool.
+
+A service of type ``osd`` is in detail described in :ref:`drivegroups`
+
+Many service specifications can then be applied at once using
+``ceph orch apply -i`` by submitting a multi-document YAML file::
+
+    cat <<EOF | ceph orch apply -i -
+    service_type: mon
+    placement:
+      host_pattern: "mon*"
+    ---
+    service_type: mgr
+    placement:
+      host_pattern: "mgr*"
+    ---
+    service_type: osd
+    placement:
+      host_pattern: "osd*"
+    data_devices:
+      all: true
+    EOF
 
 .. _orchestrator-cli-placement-spec:
     

--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -282,7 +282,9 @@ Service Specification
 =====================
 
 As *Service Specification* is a data structure often represented as YAML 
-to specify the deployment of services. For example::
+to specify the deployment of services. For example:
+
+.. code-block:: yaml
 
     service_type: rgw
     service_id: realm.zone
@@ -310,10 +312,12 @@ Service specifications of type ``mon``, ``mgr``, and the monitoring
 types do not require a ``service_id``
 
 A service of type ``nfs`` requires a pool name and contain
-an optional namespace::
+an optional namespace:
+
+.. code-block:: yaml
 
     service_type: nfs
-    service_id: realm.zone
+    service_id: mynfs
     placement: 
       hosts: 
         - host1
@@ -363,7 +367,9 @@ Daemons can be explictly placed on hosts by simply specifying them::
 
     orch apply prometheus "host1 host2 host3"
     
-Or in yaml::
+Or in yaml:
+
+.. code-block:: yaml
   
     service_type: prometheus
     placement:
@@ -386,7 +392,9 @@ Daemons can be explictly placed on hosts that match a specifc label::
 
     orch apply prometheus label:mylabel
 
-Or in yaml::
+Or in yaml:
+
+.. code-block:: yaml
 
     service_type: prometheus
     placement:
@@ -400,7 +408,9 @@ Daemons can be placed on hosts as well::
 
     orch apply prometheus '*'
 
-Or in yaml::
+Or in yaml:
+
+.. code-block:: yaml
 
     service_type: prometheus
     placement:
@@ -422,13 +432,17 @@ If the count is bigger than the amount of hosts, cephadm still deploys two daemo
 
     orch apply prometheus "3 host1 host2"
 
-Or in yaml::
+Or in yaml:
+
+.. code-block:: yaml
 
     service_type: prometheus
     placement:
       count: 3
       
-Or with hosts::
+Or with hosts:
+
+.. code-block:: yaml
 
     service_type: prometheus
     placement:


### PR DESCRIPTION
Also:

1. doc/cephadm/drivegroups: Update to new yaml
1. doc/cephadm/drivegroup: Don't introduce DriveGroups
    
    We already have a name for it: a Service Specification of
    type `osd`. We don't need to introduce a new name for it.
    
    Well, they are "DriveGroups", but users don't need to know it.

    Note: **this is RFC and I'm happy to omit this commit**
  

Fixes: https://tracker.ceph.com/issues/44716?issue_count=93&issue_position=5&next_issue_id=44739&prev_issue_id=44598

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
