### PR TITLE
rgw/notifications: add persistent delivery to notifications

### DIFF
--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -30,6 +30,23 @@ mechanism. This API is similar to the one defined as the S3-compatible API of th
    S3 Bucket Notification Compatibility <s3-notification-compatibility>
 
 
+Notification Reliability
+------------------------
+
+Notifications may be sent synchronously, as part of the operation that triggered them. 
+In this mode, the operation is acked only after the notification is sent to the topic's configured endpoint, which means that the
+round trip time of the notification is added to the latency of the operation itself.
+
+.. note:: The original triggering operation will still be considered as sucessful even if the notification fail with an error, cannot be deliverd or times out
+
+Notifications may also be sent asynchronously. They will be committed into persistent storage and then asynchronously sent to the topic's configured endpoint.
+In this case, the only latency added to the original operation is of committing the notification to persistent storage.
+
+.. note:: If the notification fail with an error, cannot be deliverd or times out, it will be retried until successfully acked
+
+.. tip:: To minimize the added latency in case of asynchronous notifications, it is recommended to place the "log" pool on fast media
+
+
 Topic Management via CLI
 ------------------------
 
@@ -103,11 +120,13 @@ To update a topic, use the same command used for topic creation, with the topic 
    [&Attributes.entry.6.key=ca-location&Attributes.entry.6.value=<file path>]
    [&Attributes.entry.7.key=OpaqueData&Attributes.entry.7.value=<opaque data>]
    [&Attributes.entry.8.key=push-endpoint&Attributes.entry.8.value=<endpoint>]
+   [&Attributes.entry.9.key=persistent&Attributes.entry.9.value=true|false]
 
 Request parameters:
 
 - push-endpoint: URI of an endpoint to send push notification to
 - OpaqueData: opaque data is set in the topic configuration and added to all notifications triggered by the topic
+- persistent: indication whether notifications to this endpoint are persistent (=asynchronous) or not ("false" by default)
 
 - HTTP endpoint 
 
@@ -206,9 +225,9 @@ Response will have the following format:
 
 - User: name of the user that created the topic
 - Name: name of the topic
-- EndPoinjtAddress: the push-endpoint URL
+- EndpointAddress: the push-endpoint URL
 - if endpoint URL contain user/password information, request must be made over HTTPS. Topic get request will be rejected if not 
-- EndPointArgs: the push-endpoint args
+- EndpointArgs: the push-endpoint args
 - EndpointTopic: the topic name that should be sent to the endpoint (mat be different than the above topic name)
 - TopicArn: topic ARN
 

--- a/src/cls/2pc_queue/cls_2pc_queue.cc
+++ b/src/cls/2pc_queue/cls_2pc_queue.cc
@@ -450,6 +450,7 @@ static int cls_2pc_queue_expire_reservations(cls_method_context_t hctx, bufferli
   }
   
   CLS_LOG(20, "INFO: cls_2pc_queue_expire_reservations: %lu reservation entries found", urgent_data.reservations.size());
+  CLS_LOG(20, "INFO: cls_2pc_queue_expire_reservations: current reservations: %lu (bytes)", urgent_data.reserved_size);
 
   uint64_t reservation_size = 0U;
   auto stale_found = false;
@@ -509,7 +510,7 @@ static int cls_2pc_queue_expire_reservations(cls_method_context_t hctx, bufferli
 
   if (stale_found || xattr_stale_found) { 
     urgent_data.reserved_size -= reservation_size;
-    CLS_LOG(20, "INFO: cls_2pc_queue_expire_reservations: current reservations: %lu (bytes)", urgent_data.reserved_size);
+    CLS_LOG(20, "INFO: cls_2pc_queue_expire_reservations: reservations after cleanup: %lu (bytes)", urgent_data.reserved_size);
     // write back head without stale reservations
     head.bl_urgent_data.clear();
     encode(urgent_data, head.bl_urgent_data);

--- a/src/cls/2pc_queue/cls_2pc_queue.cc
+++ b/src/cls/2pc_queue/cls_2pc_queue.cc
@@ -112,7 +112,7 @@ static int cls_2pc_queue_reserve(cls_method_context_t hctx, bufferlist *in, buff
   cls_2pc_reservations::iterator last_reservation;
   std::tie(last_reservation, result) = urgent_data.reservations.emplace(std::piecewise_construct,
           std::forward_as_tuple(urgent_data.last_id),
-          std::forward_as_tuple(res_op.size, ceph::real_clock::now()));
+          std::forward_as_tuple(res_op.size, ceph::coarse_real_clock::now()));
   if (!result) {
     // an old reservation that was never committed or aborted is in the map
     // caller should try again assuming other IDs are ok
@@ -125,7 +125,6 @@ static int cls_2pc_queue_reserve(cls_method_context_t hctx, bufferlist *in, buff
   encode(urgent_data, head.bl_urgent_data);
 
   const uint64_t urgent_data_length = head.bl_urgent_data.length();
-  auto total_entries = urgent_data.reservations.size();
 
   if (head.max_urgent_data_size < urgent_data_length) {
     CLS_LOG(10, "INFO: cls_2pc_queue_reserve: urgent data size: %lu exceeded maximum: %lu using xattrs", urgent_data_length, head.max_urgent_data_size);
@@ -149,7 +148,7 @@ static int cls_2pc_queue_reserve(cls_method_context_t hctx, bufferlist *in, buff
     }
     std::tie(std::ignore, result) = xattr_reservations.emplace(std::piecewise_construct,
           std::forward_as_tuple(urgent_data.last_id),
-          std::forward_as_tuple(res_op.size, ceph::real_clock::now()));
+          std::forward_as_tuple(res_op.size, ceph::coarse_real_clock::now()));
     if (!result) {
       // an old reservation that was never committed or aborted is in the map
       // caller should try again assuming other IDs are ok
@@ -180,7 +179,6 @@ static int cls_2pc_queue_reserve(cls_method_context_t hctx, bufferlist *in, buff
   CLS_LOG(20, "INFO: cls_2pc_queue_reserve: current reservations: %lu (bytes)", urgent_data.reserved_size);
   CLS_LOG(20, "INFO: cls_2pc_queue_reserve: requested size: %lu (bytes)", res_op.size);
   CLS_LOG(20, "INFO: cls_2pc_queue_reserve: urgent data size: %lu (bytes)", urgent_data_length);
-  CLS_LOG(20, "INFO: cls_2pc_queue_reserve: current reservation entries: %lu", total_entries);
 
   cls_2pc_queue_reserve_ret op_ret;
   op_ret.id = urgent_data.last_id;
@@ -322,7 +320,6 @@ static int cls_2pc_queue_abort(cls_method_context_t hctx, bufferlist *in, buffer
     return -EINVAL;
   }
  
-  auto total_entries = urgent_data.reservations.size();
   auto it = urgent_data.reservations.find(abort_op.id);
   uint64_t reservation_size;
   if (it == urgent_data.reservations.end()) {
@@ -355,7 +352,6 @@ static int cls_2pc_queue_abort(cls_method_context_t hctx, bufferlist *in, buffer
       CLS_LOG(20, "INFO: cls_2pc_queue_abort: reservation does not exist: %u", abort_op.id);
       return 0;
     }
-    total_entries += xattr_reservations.size();
     reservation_size = it->second.size;
     xattr_reservations.erase(it);
     bl_xattrs.clear();
@@ -374,7 +370,6 @@ static int cls_2pc_queue_abort(cls_method_context_t hctx, bufferlist *in, buffer
   urgent_data.reserved_size -= reservation_size;
 
   CLS_LOG(20, "INFO: cls_2pc_queue_abort: current reservations: %lu (bytes)", urgent_data.reserved_size);
-  CLS_LOG(20, "INFO: cls_2pc_queue_abort: current reservation entries: %lu", total_entries-1); 
 
   // write back head
   head.bl_urgent_data.clear();
@@ -424,6 +419,102 @@ static int cls_2pc_queue_list_reservations(cls_method_context_t hctx, bufferlist
     }
   }
   encode(op_ret, *out);
+
+  return 0;
+}
+
+static int cls_2pc_queue_expire_reservations(cls_method_context_t hctx, bufferlist *in, bufferlist *out) {
+  cls_2pc_queue_expire_op expire_op;
+  try {
+    auto in_iter = in->cbegin();
+    decode(expire_op, in_iter);
+  } catch (ceph::buffer::error& err) {
+    CLS_LOG(1, "ERROR: cls_2pc_queue_expire_reservations: failed to decode entry: %s", err.what());
+    return -EINVAL;
+  }
+
+  //get head
+  cls_queue_head head;
+  auto ret = queue_read_head(hctx, head);
+  if (ret < 0) {
+    return ret;
+  }
+
+  cls_2pc_urgent_data urgent_data;
+  try {
+    auto in_iter = head.bl_urgent_data.cbegin();
+    decode(urgent_data, in_iter);
+  } catch (ceph::buffer::error& err) {
+    CLS_LOG(1, "ERROR: cls_2pc_queue_expire_reservations: failed to decode entry: %s", err.what());
+    return -EINVAL;
+  }
+  
+  CLS_LOG(20, "INFO: cls_2pc_queue_expire_reservations: %lu reservation entries found", urgent_data.reservations.size());
+
+  uint64_t reservation_size = 0U;
+  auto stale_found = false;
+  auto xattr_stale_found = false;
+
+  for (auto it = urgent_data.reservations.begin(); it != urgent_data.reservations.end();) {
+    if (it->second.timestamp < expire_op.stale_time) {
+      CLS_LOG(5, "WARNING: cls_2pc_queue_expire_reservations: stale reservation %u will be removed", it->first);
+      reservation_size += it->second.size;
+      it = urgent_data.reservations.erase(it);
+      stale_found = true;
+    } else {
+      ++it;
+    }
+  }
+
+  if (urgent_data.has_xattrs) {
+    // try to look for the reservation in xattrs
+    cls_2pc_reservations xattr_reservations;
+    bufferlist bl_xattrs;
+    ret = cls_cxx_getxattr(hctx, CLS_QUEUE_URGENT_DATA_XATTR_NAME, &bl_xattrs);
+    if (ret < 0 && (ret != -ENOENT && ret != -ENODATA)) {
+      CLS_LOG(1, "ERROR: cls_2pc_queue_expire_reservations: failed to read xattrs with: %d", ret);
+      return ret;
+    }
+    if (ret >= 0) {
+      auto iter = bl_xattrs.cbegin();
+      try {
+        decode(xattr_reservations, iter);
+      } catch (ceph::buffer::error& err) {
+        CLS_LOG(1, "ERROR: cls_2pc_queue_expire_reservations: failed to decode xattrs urgent data map");
+        return -EINVAL;
+      } //end - catch
+      CLS_LOG(20, "INFO: cls_2pc_queue_expire_reservations: %lu reservation entries found in xatts", xattr_reservations.size());
+      for (auto it = xattr_reservations.begin(); it != xattr_reservations.end();) {
+        if (it->second.timestamp < expire_op.stale_time) {
+          CLS_LOG(5, "WARNING: cls_2pc_queue_expire_reservations: stale reservation %u will be removed", it->first);
+          reservation_size += it->second.size;
+          it = xattr_reservations.erase(it);
+          xattr_stale_found = true;
+        } else {
+          ++it;
+        }
+      }
+      if (xattr_stale_found) {
+        // write xattr back without stale reservations
+        bl_xattrs.clear();
+        encode(xattr_reservations, bl_xattrs);
+        ret = cls_cxx_setxattr(hctx, CLS_QUEUE_URGENT_DATA_XATTR_NAME, &bl_xattrs);
+        if (ret < 0) {
+          CLS_LOG(1, "ERROR: cls_2pc_queue_expire_reservations: failed to write xattrs with: %d", ret);
+          return ret;
+        }
+      }
+    }
+  }
+
+  if (stale_found || xattr_stale_found) { 
+    urgent_data.reserved_size -= reservation_size;
+    CLS_LOG(20, "INFO: cls_2pc_queue_expire_reservations: current reservations: %lu (bytes)", urgent_data.reserved_size);
+    // write back head without stale reservations
+    head.bl_urgent_data.clear();
+    encode(urgent_data, head.bl_urgent_data);
+    return queue_write_head(hctx, head);
+  }
 
   return 0;
 }
@@ -491,6 +582,7 @@ CLS_INIT(2pc_queue)
   cls_method_handle_t h_2pc_queue_list_reservations;
   cls_method_handle_t h_2pc_queue_list_entries;
   cls_method_handle_t h_2pc_queue_remove_entries;
+  cls_method_handle_t h_2pc_queue_expire_reservations;
 
   cls_register(TPC_QUEUE_CLASS, &h_class);
 
@@ -502,6 +594,7 @@ CLS_INIT(2pc_queue)
   cls_register_cxx_method(h_class, TPC_QUEUE_LIST_RESERVATIONS, CLS_METHOD_RD, cls_2pc_queue_list_reservations, &h_2pc_queue_list_reservations);
   cls_register_cxx_method(h_class, TPC_QUEUE_LIST_ENTRIES, CLS_METHOD_RD, cls_2pc_queue_list_entries, &h_2pc_queue_list_entries);
   cls_register_cxx_method(h_class, TPC_QUEUE_REMOVE_ENTRIES, CLS_METHOD_RD | CLS_METHOD_WR, cls_2pc_queue_remove_entries, &h_2pc_queue_remove_entries);
+  cls_register_cxx_method(h_class, TPC_QUEUE_EXPIRE_RESERVATIONS, CLS_METHOD_RD | CLS_METHOD_WR, cls_2pc_queue_expire_reservations, &h_2pc_queue_expire_reservations);
 
   return;
 }

--- a/src/cls/2pc_queue/cls_2pc_queue_client.cc
+++ b/src/cls/2pc_queue/cls_2pc_queue_client.cc
@@ -198,3 +198,11 @@ void cls_2pc_queue_remove_entries(ObjectWriteOperation& op, const std::string& e
   op.exec(TPC_QUEUE_CLASS, TPC_QUEUE_REMOVE_ENTRIES, in);
 }
 
+void cls_2pc_queue_expire_reservations(librados::ObjectWriteOperation& op, ceph::coarse_real_time stale_time) {
+  bufferlist in;
+  cls_2pc_queue_expire_op expire_op;
+  expire_op.stale_time = stale_time;
+  encode(expire_op, in);
+  op.exec(TPC_QUEUE_CLASS, TPC_QUEUE_EXPIRE_RESERVATIONS, in);
+}
+

--- a/src/cls/2pc_queue/cls_2pc_queue_client.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_client.h
@@ -75,6 +75,10 @@ void cls_2pc_queue_list_reservations(librados::ObjectReadOperation& op, bufferli
 
 int cls_2pc_queue_list_reservations_result(const librados::bufferlist& bl, cls_2pc_reservations& reservations);
 
+// expire stale reservations (older than the given time)
+void cls_2pc_queue_expire_reservations(librados::ObjectWriteOperation& op, 
+        ceph::coarse_real_time stale_time);
+
 // remove all entries up to the given marker
 void cls_2pc_queue_remove_entries(librados::ObjectWriteOperation& op, const std::string& end_marker);
 

--- a/src/cls/2pc_queue/cls_2pc_queue_const.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_const.h
@@ -10,4 +10,5 @@
 #define TPC_QUEUE_LIST_RESERVATIONS "2pc_queue_list_reservations"
 #define TPC_QUEUE_LIST_ENTRIES "2pc_queue_list_entries"
 #define TPC_QUEUE_REMOVE_ENTRIES "2pc_queue_remove_entries"
+#define TPC_QUEUE_EXPIRE_RESERVATIONS "2pc_queue_expire_reservations"
 

--- a/src/cls/2pc_queue/cls_2pc_queue_ops.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_ops.h
@@ -81,6 +81,24 @@ struct cls_2pc_queue_abort_op {
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_abort_op)
 
+struct cls_2pc_queue_expire_op {
+  // any reservation older than this time should expire
+  ceph::coarse_real_time stale_time;
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(stale_time, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(stale_time, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_2pc_queue_expire_op)
+
 struct cls_2pc_queue_reservations_ret {
   cls_2pc_reservations reservations; // reservation list (keyed by id)
 

--- a/src/cls/2pc_queue/cls_2pc_queue_types.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_types.h
@@ -9,9 +9,9 @@ struct cls_2pc_reservation
   using id_t = uint32_t;
   inline static const id_t NO_ID{0};
   uint64_t size;        // how many entries are reserved
-  ceph::real_time timestamp;  // when the reservation was done (used for cleaning stale reservations)
+  ceph::coarse_real_time timestamp;  // when the reservation was done (used for cleaning stale reservations)
 
-  cls_2pc_reservation(uint64_t _size, ceph::real_time _timestamp) :
+  cls_2pc_reservation(uint64_t _size, ceph::coarse_real_time _timestamp) :
       size(_size), timestamp(_timestamp) {}
 
   cls_2pc_reservation() = default;

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -239,7 +239,7 @@ target_link_libraries(rgw_a
   PRIVATE
   librados cls_otp_client cls_lock_client cls_rgw_client cls_refcount_client
   cls_log_client cls_timeindex_client cls_version_client cls_cmpomap_client
-  cls_user_client cls_rgw_gc_client ceph-common common_utf8 global
+  cls_user_client cls_rgw_gc_client cls_2pc_queue_client ceph-common common_utf8 global
   ${CURL_LIBRARIES}
   ${EXPAT_LIBRARIES}
   ${OPENLDAP_LIBRARIES} ${CRYPTO_LIBS}

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1259,6 +1259,7 @@ void RGWZoneParams::dump(Formatter *f) const
   encode_json("placement_pools", placement_pools, f);
   encode_json("tier_config", tier_config, f);
   encode_json("realm_id", realm_id, f);
+  encode_json("notif_pool", notif_pool, f);
 }
 
 void RGWZoneStorageClass::dump(Formatter *f) const
@@ -1355,6 +1356,7 @@ void RGWZoneParams::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("placement_pools", placement_pools, obj);
   JSONDecoder::decode_json("tier_config", tier_config, obj);
   JSONDecoder::decode_json("realm_id", realm_id, obj);
+  JSONDecoder::decode_json("notif_pool", notif_pool, obj);
 
 }
 

--- a/src/rgw/rgw_notify.cc
+++ b/src/rgw/rgw_notify.cc
@@ -2,20 +2,530 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "rgw_notify.h"
+#include "cls/2pc_queue/cls_2pc_queue_client.h"
+#include "cls/lock/cls_lock_client.h"
 #include <memory>
 #include <boost/algorithm/hex.hpp>
+#include <spawn/spawn.hpp>
 #include "rgw_pubsub.h"
 #include "rgw_pubsub_push.h"
 #include "rgw_perf_counters.h"
 #include "common/dout.h"
+#include <chrono>
 
 #define dout_subsys ceph_subsys_rgw
 
 namespace rgw::notify {
 
+struct record_with_endpoint_t {
+  rgw_pubsub_s3_record record;
+  std::string push_endpoint;
+  std::string push_endpoint_args;
+  std::string arn_topic;
+  
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(record, bl);
+    encode(push_endpoint, bl);
+    encode(push_endpoint_args, bl);
+    encode(arn_topic, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(record, bl);
+    decode(push_endpoint, bl);
+    decode(push_endpoint_args, bl);
+    decode(arn_topic, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(record_with_endpoint_t)
+
+using queues_t = std::set<std::string>;
+
+class Manager {
+  const size_t max_queue_size;
+  const uint32_t queues_update_period_ms;
+  const uint32_t queues_update_retry_ms;
+  const uint32_t queue_idle_sleep_us;
+  const utime_t failover_time;
+  CephContext* const cct;
+  librados::IoCtx& rados_ioctx;
+  static constexpr auto COOKIE_LEN = 16;
+  const std::string lock_cookie;
+  boost::asio::io_context io_context;
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work_guard;
+  const uint32_t worker_count;
+  std::vector<std::thread> workers;
+ 
+  const std::string Q_LIST_OBJECT_NAME = "queues_list_object";
+
+  // read the list of queues from the queue list object
+  int read_queue_list(queues_t& queues, optional_yield y) {
+    constexpr auto max_chunk = 1024U;
+    std::string start_after;
+    bool more = true;
+    int rval;
+    while (more) {
+      librados::ObjectReadOperation op;
+      queues_t queues_chunk;
+      op.omap_get_keys2(start_after, max_chunk, &queues_chunk, &more, &rval);
+      const auto ret = rgw_rados_operate(rados_ioctx, Q_LIST_OBJECT_NAME, &op, nullptr, y);
+      if (ret == -ENOENT) {
+        // queue list object was not created - nothing to do
+        return 0;
+      }
+      if (ret < 0) {
+        // TODO: do we need to check on rval as well as ret?
+        ldout(cct, 1) << "ERROR: failed to read queue list. error: " << ret << dendl;
+        return ret;
+      }
+      queues.merge(queues_chunk);
+    }
+    return 0;
+  }
+
+  // set m1 to be the minimum between m1 and m2
+  static int set_min_marker(std::string& m1, const std::string m2) {
+    cls_queue_marker mr1;
+    cls_queue_marker mr2;
+    if (mr1.from_str(m1.c_str()) < 0 || mr2.from_str(m2.c_str()) < 0) {
+      return -EINVAL;
+    }
+    if (mr2.gen <= mr1.gen && mr2.offset < mr1.offset) {
+      m1 = m2;
+    }
+    return 0;
+  }
+
+  using Clock = ceph::coarse_mono_clock;
+  using Executor = boost::asio::io_context::executor_type;
+  using Timer = boost::asio::basic_waitable_timer<Clock,
+        boost::asio::wait_traits<Clock>, Executor>;
+
+  class tokens_waiter {
+    const std::chrono::hours infinite_duration;
+    size_t pending_tokens;
+    Timer timer;
+ 
+    struct token {
+      tokens_waiter& waiter;
+      token(tokens_waiter& _waiter) : waiter(_waiter) {
+        ++waiter.pending_tokens;
+      }
+      
+      ~token() {
+        --waiter.pending_tokens;
+        if (waiter.pending_tokens == 0) {
+          waiter.timer.cancel();
+        }   
+      }   
+    };
+  
+  public:
+
+    tokens_waiter(boost::asio::io_context& io_context) :
+      infinite_duration(1000),
+      pending_tokens(0),
+      timer(io_context) {}  
+ 
+    void async_wait(spawn::yield_context yield) { 
+      timer.expires_from_now(infinite_duration);
+      boost::system::error_code ec; 
+      timer.async_wait(yield[ec]);
+      ceph_assert(ec == boost::system::errc::operation_canceled);
+    }   
+ 
+    token make_token() {    
+      return token(*this);
+    }   
+  };
+
+  // processing of a specific entry
+  // return whether processing was successfull (true) or not (false)
+  bool process_entry(const cls_queue_entry& entry, spawn::yield_context yield) {
+    record_with_endpoint_t record_with_endpoint;
+    auto iter = entry.data.cbegin();
+    try {
+      decode(record_with_endpoint, iter);
+    } catch (buffer::error& err) {
+      ldout(cct, 5) << "WARNING: failed to decode entry. error: " << err.what() << dendl;
+      return false;
+    }
+    try {
+      // TODO move endpoint creation to queue level
+      const auto push_endpoint = RGWPubSubEndpoint::create(record_with_endpoint.push_endpoint, record_with_endpoint.arn_topic,
+          RGWHTTPArgs(record_with_endpoint.push_endpoint_args), 
+          cct);
+      ldout(cct, 20) << "INFO: push endpoint created: " << record_with_endpoint.push_endpoint <<
+        " for entry: " << entry.marker << dendl;
+      const auto ret = push_endpoint->send_to_completion_async(cct, record_with_endpoint.record, optional_yield(io_context, yield));
+      if (ret < 0) {
+        ldout(cct, 5) << "WARNING: push entry: " << entry.marker << " to endpoint: " << record_with_endpoint.push_endpoint 
+          << " failed. error: " << ret << " (will retry)" << dendl;
+        return false;
+      } else {
+        ldout(cct, 20) << "INFO: push entry: " << entry.marker << " to endpoint: " << record_with_endpoint.push_endpoint 
+          << " ok" <<  dendl;
+        if (perfcounter) perfcounter->inc(l_rgw_pubsub_push_ok);
+        return true;
+      }
+    } catch (const RGWPubSubEndpoint::configuration_error& e) {
+      ldout(cct, 5) << "WARNING: failed to create push endpoint: " 
+          << record_with_endpoint.push_endpoint << " for entry: " << entry.marker << ". error: " << e.what() << " (will retry) " << dendl;
+      return false;
+    }
+  }
+
+  // processing of a specific queue
+  void process_queue(const std::string& queue_name, const bool& owned, spawn::yield_context yield) {
+    constexpr auto max_elements = 1024;
+    auto is_idle = false;
+    const std::string start_marker;
+    while (owned) {
+      if (is_idle) {
+        Timer timer(io_context);
+        timer.expires_from_now(std::chrono::microseconds(queue_idle_sleep_us));
+        boost::system::error_code ec;
+	      timer.async_wait(yield[ec]);
+      }
+      is_idle = true;
+
+      bool truncated = false;
+      std::string end_marker;
+      std::vector<cls_queue_entry> entries;
+      auto total_entries = 0U;
+
+      {
+        librados::ObjectReadOperation op;
+        bufferlist obl;
+        int rval;
+        cls_2pc_queue_list_entries(op, start_marker, max_elements, &obl, &rval);
+        auto ret = rgw_rados_operate(rados_ioctx, queue_name, &op, nullptr, optional_yield(io_context, yield));
+        if (ret == -ENOENT) {
+          // queue was deleted
+          ldout(cct, 5) << "INFO: queue: " 
+            << queue_name << ". was removed. processing will stop" << dendl;
+          return;
+        }
+        if (ret < 0) {
+          ldout(cct, 5) << "WARNING: failed to get list of entries in queue: " 
+            << queue_name << ". error: " << ret << " (will retry)" << dendl;
+          continue;
+        }
+        ret = cls_2pc_queue_list_entries_result(obl, entries, &truncated, end_marker);
+        if (ret < 0) {
+          ldout(cct, 5) << "WARNING: failed to parse list of entries in queue: " 
+            << queue_name << ". error: " << ret << " (will retry)" << dendl;
+          continue;
+        }
+      }
+      total_entries = entries.size();
+      if (total_entries == 0) {
+        // nothing in the queue
+        continue;
+      }
+      // log when queue is not idle
+      ldout(cct, 20) << "INFO: found: " << total_entries << " entries in: " << queue_name <<
+        ". end marker is: " << end_marker << dendl;
+      
+      is_idle = false;
+      auto has_error = false;
+      auto remove_entries = false;
+      auto entry_idx = 1U;
+      tokens_waiter waiter(io_context);
+      for (auto& entry : entries) {
+        if (has_error) {
+          // bail out on first error
+          break;
+        }
+        // TODO pass entry pointer instead of by-value
+        spawn::spawn(yield, [this, &queue_name, entry_idx, total_entries, &end_marker, &remove_entries, &has_error, &waiter, entry](spawn::yield_context yield) {
+            const auto token = waiter.make_token();
+            if (process_entry(entry, yield)) {
+              ldout(cct, 20) << "INFO: processing of entry: " << 
+                entry.marker << " (" << entry_idx << "/" << total_entries << ") from: " << queue_name << " ok" << dendl;
+              remove_entries = true;
+            }  else {
+              if (set_min_marker(end_marker, entry.marker) < 0) {
+                ldout(cct, 1) << "ERROR: cannot determin minimum between malformed markers: " << end_marker << ", " << entry.marker << dendl;
+              } else {
+                ldout(cct, 20) << "INFO: new end marker for removal: " << end_marker << " from: " << queue_name << dendl;
+              }
+              has_error = true;
+              ldout(cct, 20) << "INFO: processing of entry: " << 
+                entry.marker << " (" << entry_idx << "/" << total_entries << ") from: " << queue_name << " failed" << dendl;
+            } 
+        });
+        ++entry_idx;
+      }
+
+      // wait for all pending work to finish
+      waiter.async_wait(yield);
+
+      // delete all published entries from queue
+      if (remove_entries) {
+        librados::ObjectWriteOperation delete_op;
+        cls_2pc_queue_remove_entries(delete_op, end_marker); 
+        const auto ret = rgw_rados_operate(rados_ioctx, queue_name, &delete_op, optional_yield(io_context, yield)); 
+        if (ret < 0) {
+          ldout(cct, 1) << "ERROR: failed to remove entries up to: " << end_marker <<  " from queue: " 
+            << queue_name << ". error: " << ret << dendl;
+        } else {
+          ldout(cct, 20) << "INFO: removed entries up to: " << end_marker <<  " from queue: " 
+          << queue_name << dendl;
+        }
+      }
+      // TODO: cleanup expired reservations
+    }
+  }
+
+  // lits of queue names with an indication it is currently owned
+  using owned_queues_t = std::unordered_map<std::string, bool>;
+
+  // process all queues
+  // find which of the queues is owned by this daemon and process it
+  void process_queues(spawn::yield_context yield) {
+    auto has_error = false;
+    owned_queues_t owned_queues;
+
+    // add randomness to the duration between queue checking
+    // to make sure that different daemons are not synced
+    std::random_device seed;
+    std::mt19937 rnd_gen(seed());
+    const auto min_jitter = 100; // ms
+    const auto max_jitter = 500; // ms
+    std::uniform_int_distribution<> duration_jitter(min_jitter, max_jitter);
+
+    while (true) {
+      Timer timer(io_context);
+      const auto duration = (has_error ? 
+        std::chrono::milliseconds(queues_update_retry_ms) : std::chrono::milliseconds(queues_update_period_ms)) + 
+        std::chrono::milliseconds(duration_jitter(rnd_gen));
+      timer.expires_from_now(duration);
+      const auto tp = ceph::coarse_real_time::clock::to_time_t(ceph::coarse_real_time::clock::now() + duration);
+      ldout(cct, 20) << "INFO: next queues processing will happen at: " << std::ctime(&tp)  << dendl;
+      boost::system::error_code ec;
+      timer.async_wait(yield[ec]);
+
+      queues_t queues;
+      auto ret = read_queue_list(queues, optional_yield(io_context, yield));
+      if (ret < 0) {
+        has_error = true;
+        continue;
+      }
+
+      std::vector<std::string> queue_gc;
+      std::mutex queue_gc_lock;
+      for (const auto& queue_name : queues) {
+        // try to lock the queue to check if it is owned by this rgw
+        // or if ownershif needs to be taken
+        librados::ObjectWriteOperation op;
+        op.assert_exists();
+        rados::cls::lock::lock(&op, queue_name+"_lock", 
+              ClsLockType::EXCLUSIVE,
+              lock_cookie, 
+              "" /*no tag*/,
+              "" /*no description*/,
+              failover_time,
+              LOCK_FLAG_MAY_RENEW);
+
+        ret = rgw_rados_operate(rados_ioctx, queue_name, &op, optional_yield(io_context, yield));
+        if (ret == -EBUSY) {
+          // lock is already taken by another RGW
+          ldout(cct, 20) << "INFO: queue: " << queue_name << " owned (locked) by another daemon" << dendl;
+          // if queue is owned, processing should be stopped
+          auto it = owned_queues.find(queue_name);
+          if (it != owned_queues.end() && it->second) {
+            it->second = false;
+            ldout(cct, 5) << "WARNING: queue: " << queue_name << " ownership lost. processing will stop" << dendl;
+          }
+          continue;
+        }
+        if (ret == -ENOENT) {
+          // queue is deleted - processing will stop the next time we try to read from the queue
+          ldout(cct, 10) << "INFO: queue: " << queue_name << " should not be locked - already deleted" << dendl;
+          continue;
+        }
+        if (ret < 0) {
+          // failed to lock for another reason, continue to process other queues
+          ldout(cct, 1) << "ERROR: failed to lock queue: " << queue_name << ". error: " << ret << dendl;
+          has_error = true;
+          continue;
+        }
+        // add queue to list of owned queues
+        const auto insert_result = owned_queues.insert(std::make_pair(queue_name, true));
+        if (insert_result.second) {
+          ldout(cct, 10) << "INFO: queue: " << queue_name << " now owned (locked) by this daemon" << dendl;
+          // start processing this queue
+          const auto& owned = insert_result.first->second;
+          spawn::spawn(io_context, [this, &queue_gc, &queue_gc_lock, &owned, queue_name](spawn::yield_context yield) {
+            process_queue(queue_name, owned, yield);
+            // if queue processing ended, it measn that the queue was removed or not owned anymore
+            // mark it for deletion
+            std::lock_guard lock_guard(queue_gc_lock);
+            queue_gc.push_back(queue_name);
+            ldout(cct, 10) << "INFO: queue: " << queue_name << " marked for removal" << dendl;
+          });
+        } else {
+          ldout(cct, 20) << "INFO: queue: " << queue_name << " ownership (lock) renewed" << dendl;
+        }
+      }
+      // erase all queue that were deleted
+      {
+        std::lock_guard lock_guard(queue_gc_lock);
+        std::for_each(queue_gc.begin(), queue_gc.end(), [this, &owned_queues](const std::string& queue_name) {
+          owned_queues.erase(queue_name);
+          ldout(cct, 20) << "INFO: queue: " << queue_name << " removed" << dendl;
+        });
+        queue_gc.clear();
+      }
+    }
+  }
+
+public:
+
+  ~Manager() {
+    work_guard.reset();
+    io_context.stop();
+    std::for_each(workers.begin(), workers.end(), [] (auto& worker) { worker.join(); });
+  }
+
+  // ctor: start all threads
+  Manager(CephContext* _cct, uint32_t _max_queue_size, uint32_t _queues_update_period_ms, 
+          uint32_t _queues_update_retry_ms, uint32_t _queue_idle_sleep_us, uint32_t failover_time_ms, uint32_t _worker_count, rgw::sal::RGWRadosStore* store) : 
+    max_queue_size(_max_queue_size),
+    queues_update_period_ms(_queues_update_period_ms),
+    queues_update_retry_ms(_queues_update_retry_ms),
+    queue_idle_sleep_us(_queue_idle_sleep_us),
+    failover_time(std::chrono::milliseconds(failover_time_ms)),
+    cct(_cct),
+    rados_ioctx(store->getRados()->get_notif_pool_ctx()),
+    //list_of_queues_object_created(false),
+    lock_cookie(gen_rand_alphanumeric(cct, COOKIE_LEN)),
+    work_guard(boost::asio::make_work_guard(io_context)),
+    worker_count(_worker_count)
+    {
+      spawn::spawn(io_context, [this](spawn::yield_context yield) {
+            process_queues(yield);
+          });
+
+      // start the worker threads to do the actual queue processing
+      const std::string WORKER_THREAD_NAME = "notif-worker";
+      for (auto worker_id = 0U; worker_id < worker_count; ++worker_id) {
+        workers.emplace_back([this]() { io_context.run(); });
+        const auto rc = ceph_pthread_setname(workers.back().native_handle(), 
+            (WORKER_THREAD_NAME+std::to_string(worker_id)).c_str());
+        ceph_assert(rc == 0);
+      }
+    }
+
+  int add_persistent_topic(const std::string& topic_name, optional_yield y) {
+    if (topic_name == Q_LIST_OBJECT_NAME) {
+      ldout(cct, 1) << "ERROR: topic name cannot be: " << Q_LIST_OBJECT_NAME << " (conflict with queue list object name)" << dendl;
+      return -EINVAL;
+    }
+    librados::ObjectWriteOperation op;
+    op.create(true);
+    cls_2pc_queue_init(op, topic_name, max_queue_size);
+    auto ret = rgw_rados_operate(rados_ioctx, topic_name, &op, y);
+    if (ret == -EEXIST) {
+      // queue already exists - nothing to do
+      ldout(cct, 20) << "INFO: queue for topic: " << topic_name << " already exists. nothing to do" << dendl;
+      return 0;
+    }
+    if (ret < 0) {
+      // failed to create queue
+      ldout(cct, 1) << "ERROR: failed to create queue for topic: " << topic_name << ". error: " << ret << dendl;
+      return ret;
+    }
+   
+    bufferlist empty_bl;
+    std::map<std::string, bufferlist> new_topic{{topic_name, empty_bl}};
+    op.omap_set(new_topic);
+    ret = rgw_rados_operate(rados_ioctx, Q_LIST_OBJECT_NAME, &op, y);
+    if (ret < 0) {
+      ldout(cct, 1) << "ERROR: failed to add queue: " << topic_name << " to queue list. error: " << ret << dendl;
+      return ret;
+    } 
+    ldout(cct, 20) << "INFO: queue: " << topic_name << " added to queue list"  << dendl;
+    return 0;
+  }
+  
+  int remove_persistent_topic(const std::string& topic_name, optional_yield y) {
+    librados::ObjectWriteOperation op;
+    op.remove();
+    auto ret = rgw_rados_operate(rados_ioctx, topic_name, &op, y);
+    if (ret == -ENOENT) {
+      // queue already removed - nothing to do
+      ldout(cct, 20) << "INFO: queue for topic: " << topic_name << " already removed. nothing to do" << dendl;
+      return 0;
+    }
+    if (ret < 0) {
+      // failed to remove queue
+      ldout(cct, 1) << "ERROR: failed to remove queue for topic: " << topic_name << ". error: " << ret << dendl;
+      return ret;
+    }
+  
+    std::set<std::string> topic_to_remove{{topic_name}};
+    op.omap_rm_keys(topic_to_remove);
+    ret = rgw_rados_operate(rados_ioctx, Q_LIST_OBJECT_NAME, &op, y);
+    if (ret < 0) {
+      ldout(cct, 1) << "ERROR: failed to remove queue: " << topic_name << " from queue list. error: " << ret << dendl;
+      return ret;
+    } 
+    ldout(cct, 20) << "INFO: queue: " << topic_name << " removed from queue list"  << dendl;
+    return 0;
+  }
+};
+
+// singleton manager
+// note that the manager itself is not a singleton, and multiple instances may co-exist
+// TODO make the pointer atomic in allocation and deallocation to avoid race conditions
+static Manager* s_manager = nullptr;
+
+constexpr size_t MAX_QUEUE_SIZE = 128*1000*1000; // 128MB
+constexpr uint32_t Q_LIST_UPDATE_MSEC = 1000*30;     // check queue list every 30seconds
+constexpr uint32_t Q_LIST_RETRY_MSEC = 1000;         // retry every second if queue list update failed
+constexpr uint32_t IDLE_TIMEOUT_USEC = 100*1000;     // idle sleep 100ms
+constexpr uint32_t FAILOVER_TIME_MSEC = 3*Q_LIST_UPDATE_MSEC; // FAILOVER TIME 3x renew time
+constexpr uint32_t WORKER_COUNT = 1;                 // 1 worker thread
+
+bool init(CephContext* cct, rgw::sal::RGWRadosStore* store) {
+  if (s_manager) {
+    return false;
+  }
+  // TODO: take conf from CephContext
+  s_manager = new Manager(cct, MAX_QUEUE_SIZE, Q_LIST_UPDATE_MSEC, Q_LIST_RETRY_MSEC,
+          IDLE_TIMEOUT_USEC, FAILOVER_TIME_MSEC, WORKER_COUNT, store);
+  return true;
+}
+
+void shutdown() {
+  delete s_manager;
+  s_manager = nullptr;
+}
+
+int add_persistent_topic(const std::string& topic_name, optional_yield y) {
+  if (!s_manager) {
+    return -EAGAIN;
+  }
+  return s_manager->add_persistent_topic(topic_name, y);
+}
+
+int remove_persistent_topic(const std::string& topic_name, optional_yield y) {
+  if (!s_manager) {
+    return -EAGAIN;
+  }
+  return s_manager->remove_persistent_topic(topic_name, y);
+}
+
 // populate record from request
 void populate_record_from_request(const req_state *s, 
         const rgw::sal::RGWObject* obj,
+        uint64_t size,
         const ceph::real_time& mtime, 
         const std::string& etag, 
         EventType event_type,
@@ -30,7 +540,7 @@ void populate_record_from_request(const req_state *s,
   record.bucket_ownerIdentity = s->bucket_owner.get_id().id;
   record.bucket_arn = to_string(rgw::ARN(s->bucket->get_key()));
   record.object_key = obj->get_name();
-  record.object_size = obj->get_obj_size();
+  record.object_size = size;
   record.object_etag = etag;
   record.object_versionId = obj->get_instance();
   // use timestamp as per key sequence id (hex encoded)
@@ -62,77 +572,177 @@ bool match(const rgw_pubsub_topic_filter& filter, const req_state* s, const rgw:
   return true;
 }
 
-int publish(const req_state* s, 
-        rgw::sal::RGWObject* obj,
+int publish_reserve(EventType event_type,
+      reservation_t& res) 
+{
+  RGWUserPubSub ps_user(res.store, res.s->user->get_id());
+  RGWUserPubSub::Bucket ps_bucket(&ps_user, res.s->bucket->get_key());
+  rgw_pubsub_bucket_topics bucket_topics;
+  auto rc = ps_bucket.get_topics(&bucket_topics);
+  if (rc < 0) {
+    // failed to fetch bucket topics
+    return rc;
+  }
+  for (const auto& bucket_topic : bucket_topics.topics) {
+    const rgw_pubsub_topic_filter& topic_filter = bucket_topic.second;
+    const rgw_pubsub_topic& topic_cfg = topic_filter.topic;
+    if (!match(topic_filter, res.s, res.object, event_type)) {
+      // topic does not apply to req_state
+      continue;
+    }
+    ldout(res.s->cct, 20) << "INFO: notification: '" << topic_filter.s3_id << 
+        "' on topic: '" << topic_cfg.dest.arn_topic << 
+        "' and bucket: '" << res.s->bucket->get_name() << 
+        "' (unique topic: '" << topic_cfg.name <<
+        "') apply to event of type: '" << to_string(event_type) << "'" << dendl;
+
+    cls_2pc_reservation::id_t res_id;
+    if (topic_cfg.dest.persistent) {
+      // TODO: take default reservation size from conf
+      constexpr auto DEFAULT_RESERVATION = 4*1024U; // 4K
+      res.size = DEFAULT_RESERVATION;
+      librados::ObjectWriteOperation op;
+      bufferlist obl;
+      int rval;
+      const auto& queue_name = topic_cfg.dest.arn_topic;
+      cls_2pc_queue_reserve(op, res.size, 1, &obl, &rval);
+      auto ret = rgw_rados_operate(res.store->getRados()->get_notif_pool_ctx(), 
+          queue_name, &op, res.s->yield, librados::OPERATION_RETURNVEC);
+      if (ret < 0) {
+        ldout(res.s->cct, 1) << "ERROR: failed to reserve notification on queue: " << queue_name 
+          << ". error: " << ret << dendl;
+        // if no space is left in queue we ask client to slow down
+        return (ret == -ENOSPC) ? -ERR_RATE_LIMITED : ret;
+      }
+      ret = cls_2pc_queue_reserve_result(obl, res_id);
+      if (ret < 0) {
+        ldout(res.s->cct, 1) << "ERROR: failed to parse reservation id. error: " << ret << dendl;
+        return ret;
+      }
+    }
+    res.topics.emplace_back(topic_filter.s3_id, topic_cfg, res_id);
+  }
+  return 0;
+}
+
+int publish_commit(const rgw::sal::RGWObject* obj,
+        uint64_t size,
         const ceph::real_time& mtime, 
         const std::string& etag, 
         EventType event_type,
-        rgw::sal::RGWRadosStore* store) {
-    RGWUserPubSub ps_user(store, s->user->get_id());
-    RGWUserPubSub::Bucket ps_bucket(&ps_user, s->bucket->get_key());
-    rgw_pubsub_bucket_topics bucket_topics;
-    auto rc = ps_bucket.get_topics(&bucket_topics);
-    if (rc < 0) {
-        // failed to fetch bucket topics
-        return rc;
+        reservation_t& res) 
+{
+  for (auto& topic : res.topics) {
+    if (topic.cfg.dest.persistent && topic.res_id == cls_2pc_reservation::NO_ID) {
+      // nothing to commit or already committed/aborted
+      continue;
     }
-    rgw_pubsub_s3_record record;
-    populate_record_from_request(s, obj, mtime, etag, event_type, record);
-    bool event_handled = false;
-    bool event_should_be_handled = false;
-    for (const auto& bucket_topic : bucket_topics.topics) {
-        const rgw_pubsub_topic_filter& topic_filter = bucket_topic.second;
-        const rgw_pubsub_topic& topic_cfg = topic_filter.topic;
-        if (!match(topic_filter, s, obj, event_type)) {
-            // topic does not apply to req_state
-            continue;
+    record_with_endpoint_t record_with_endpoint;
+    populate_record_from_request(res.s, obj, size, mtime, etag, event_type, record_with_endpoint.record);
+    record_with_endpoint.record.configurationId = topic.configurationId;
+    record_with_endpoint.record.opaque_data = topic.cfg.opaque_data;
+    if (topic.cfg.dest.persistent) { 
+      record_with_endpoint.push_endpoint = std::move(topic.cfg.dest.push_endpoint);
+      record_with_endpoint.push_endpoint_args = std::move(topic.cfg.dest.push_endpoint_args);
+      record_with_endpoint.arn_topic = std::move(topic.cfg.dest.arn_topic);
+      bufferlist bl;
+      encode(record_with_endpoint, bl);
+      const auto& queue_name = topic.cfg.dest.arn_topic;
+      if (bl.length() > res.size) {
+        // try to make a larger reservation, fail only if this is not possible
+        ldout(res.s->cct, 5) << "WARNING: committed size: " << bl.length() << " exceeded reserved size: " << res.size <<
+          " . trying to make a larger reservation on queue:" << queue_name << dendl;
+        // first cancel the existing reservation
+        librados::ObjectWriteOperation op;
+        cls_2pc_queue_abort(op, topic.res_id);
+        auto ret = rgw_rados_operate(res.store->getRados()->get_notif_pool_ctx(),
+            topic.cfg.dest.arn_topic, &op,
+            res.s->yield);
+        if (ret < 0) {
+          ldout(res.s->cct, 1) << "ERROR: failed to abort reservation: " << topic.res_id << 
+            " when trying to make a larger reservation on queue: " << queue_name
+            << ". error: " << ret << dendl;
+          return ret;
         }
-        event_should_be_handled = true;
-        record.configurationId = topic_filter.s3_id;
-        record.opaque_data = topic_cfg.opaque_data;
-        ldout(s->cct, 20) << "notification: '" << topic_filter.s3_id << 
-            "' on topic: '" << topic_cfg.dest.arn_topic << 
-            "' and bucket: '" << s->bucket->get_name() <<
-            "' (unique topic: '" << topic_cfg.name <<
-            "') apply to event of type: '" << to_string(event_type) << "'" << dendl;
-        try {
-            // TODO add endpoint LRU cache
-            const auto push_endpoint = RGWPubSubEndpoint::create(topic_cfg.dest.push_endpoint, 
-                    topic_cfg.dest.arn_topic,
-                    RGWHTTPArgs(topic_cfg.dest.push_endpoint_args), 
-                    s->cct);
-            const std::string push_endpoint_str = push_endpoint->to_str();
-            ldout(s->cct, 20) << "push endpoint created: " << push_endpoint_str << dendl;
-            auto rc = push_endpoint->send_to_completion_async(s->cct, record, s->yield);
-            if (rc < 0) {
-                // bail out on first error
-                // TODO: add conf for bail out policy
-                ldout(s->cct, 1) << "push to endpoint " << push_endpoint_str << " failed, with error: " << rc << dendl;
-                if (perfcounter) perfcounter->inc(l_rgw_pubsub_push_failed);
-                return rc;
-            }
-            if (perfcounter) perfcounter->inc(l_rgw_pubsub_push_ok);
-            ldout(s->cct, 20) << "successfull push to endpoint " << push_endpoint_str << dendl;
-            event_handled = true;
-        } catch (const RGWPubSubEndpoint::configuration_error& e) {
-            ldout(s->cct, 1) << "ERROR: failed to create push endpoint: " 
-                << topic_cfg.dest.push_endpoint << " due to: " << e.what() << dendl;
-            if (perfcounter) perfcounter->inc(l_rgw_pubsub_push_failed);
-            return -EINVAL;
+        // now try to make a bigger one
+        bufferlist obl;
+        int rval;
+        cls_2pc_queue_reserve(op, bl.length(), 1, &obl, &rval);
+        ret = rgw_rados_operate(res.store->getRados()->get_notif_pool_ctx(), 
+          queue_name, &op, res.s->yield, librados::OPERATION_RETURNVEC);
+        if (ret < 0) {
+          ldout(res.s->cct, 1) << "ERROR: failed to reserve extra space on queue: " << queue_name
+            << ". error: " << ret << dendl;
+          return (ret == -ENOSPC) ? -ERR_RATE_LIMITED : ret;
         }
+        ret = cls_2pc_queue_reserve_result(obl, topic.res_id);
+        if (ret < 0) {
+          ldout(res.s->cct, 1) << "ERROR: failed to parse reservation id for extra space. error: " << ret << dendl;
+          return ret;
+        }
+      }
+      std::vector<bufferlist> bl_data_vec{std::move(bl)};
+      librados::ObjectWriteOperation op;
+      cls_2pc_queue_commit(op, bl_data_vec, topic.res_id);
+      const auto ret = rgw_rados_operate(res.store->getRados()->get_notif_pool_ctx(),
+            queue_name, &op,
+            res.s->yield);
+      topic.res_id = cls_2pc_reservation::NO_ID;
+      if (ret < 0) {
+        ldout(res.s->cct, 1) << "ERROR: failed to commit reservation to queue: " << queue_name
+          << ". error: " << ret << dendl;
+        return ret;
+      }
+    } else {
+      try {
+        // TODO add endpoint LRU cache
+        const auto push_endpoint = RGWPubSubEndpoint::create(topic.cfg.dest.push_endpoint, 
+                topic.cfg.dest.arn_topic,
+                RGWHTTPArgs(topic.cfg.dest.push_endpoint_args), 
+                res.s->cct);
+        ldout(res.s->cct, 20) << "INFO: push endpoint created: " << topic.cfg.dest.push_endpoint << dendl;
+        const auto ret = push_endpoint->send_to_completion_async(res.s->cct, record_with_endpoint.record, res.s->yield);
+        if (ret < 0) {
+          ldout(res.s->cct, 1) << "ERROR: push to endpoint " << topic.cfg.dest.push_endpoint << " failed. error: " << ret << dendl;
+          if (perfcounter) perfcounter->inc(l_rgw_pubsub_push_failed);
+          return ret;
+        }
+        if (perfcounter) perfcounter->inc(l_rgw_pubsub_push_ok);
+      } catch (const RGWPubSubEndpoint::configuration_error& e) {
+        ldout(res.s->cct, 1) << "ERROR: failed to create push endpoint: " 
+            << topic.cfg.dest.push_endpoint << ". error: " << e.what() << dendl;
+        if (perfcounter) perfcounter->inc(l_rgw_pubsub_push_failed);
+        return -EINVAL;
+      }
     }
+  }
+  return 0;
+}
 
-    if (event_should_be_handled) {
-        // not counting events with no notifications or events that are filtered
-        // counting a single event, regardless of the number of notifications it sends
-        if (perfcounter) perfcounter->inc(l_rgw_pubsub_event_triggered);
-        if (!event_handled) {
-            // all notifications for this event failed
-            if (perfcounter) perfcounter->inc(l_rgw_pubsub_event_lost);
-        }
+int publish_abort(reservation_t& res) {
+  for (auto& topic : res.topics) {
+    if (!topic.cfg.dest.persistent || topic.res_id == cls_2pc_reservation::NO_ID) {
+      // nothing to abort or already committed/aborted
+      continue;
     }
+    const auto& queue_name = topic.cfg.dest.arn_topic;
+    librados::ObjectWriteOperation op;
+    cls_2pc_queue_abort(op, topic.res_id);
+    const auto ret = rgw_rados_operate(res.store->getRados()->get_notif_pool_ctx(),
+      queue_name, &op,
+      res.s->yield);
+    if (ret < 0) {
+      ldout(res.s->cct, 1) << "ERROR: failed to abort reservation: " << topic.res_id << 
+        " from queue: " << queue_name << ". error: " << ret << dendl;
+      return ret;
+    }
+    topic.res_id = cls_2pc_reservation::NO_ID;
+  }
+  return 0;
+}
 
-    return 0;
+reservation_t::~reservation_t() {
+  publish_abort(*this);
 }
 
 }

--- a/src/rgw/rgw_notify.h
+++ b/src/rgw/rgw_notify.h
@@ -7,25 +7,79 @@
 #include "common/ceph_time.h"
 #include "include/common_fwd.h"
 #include "rgw_notify_event_type.h"
+#include "common/async/yield_context.h"
+#include "cls/2pc_queue/cls_2pc_queue_types.h"
+#include "rgw_pubsub.h"
 
 // forward declarations
 namespace rgw::sal {
     class RGWRadosStore;
     class RGWObject;
 }
+
 class RGWRados;
-class req_state;
 struct rgw_obj_key;
 
 namespace rgw::notify {
 
-// publish notification
-int publish(const req_state* s, 
-        rgw::sal::RGWObject* obj,
+// initialize the notification manager
+// notification manager is dequeing the 2-phase-commit queues
+// and send the notifications to the endpoints
+bool init(CephContext* cct, rgw::sal::RGWRadosStore* store);
+
+// shutdown the notification manager
+void shutdown();
+
+// create persistent delivery queue for a topic (endpoint)
+// this operation also add a topic name to the common (to all RGWs) list of all topics
+int add_persistent_topic(const std::string& topic_name, optional_yield y);
+
+// remove persistent delivery queue for a topic (endpoint)
+// this operation also remove the topic name from the common (to all RGWs) list of all topics
+int remove_persistent_topic(const std::string& topic_name, optional_yield y);
+
+// struct holding reservation information
+// populated in the publish_reserve call
+// then used to commit or abort the reservation
+struct reservation_t {
+  struct topic_t {
+    topic_t(const std::string& _configurationId, const rgw_pubsub_topic& _cfg, cls_2pc_reservation::id_t _res_id) :
+        configurationId(_configurationId), cfg(_cfg), res_id(_res_id) {}
+
+    const std::string configurationId;
+    const rgw_pubsub_topic cfg;
+    // res_id is reset after topic is committed/aborted
+    cls_2pc_reservation::id_t res_id;
+  };
+
+  std::vector<topic_t> topics;
+  rgw::sal::RGWRadosStore* const store;
+  const req_state* const s;
+  size_t size;
+  const rgw::sal::RGWObject* const object;
+
+  reservation_t(rgw::sal::RGWRadosStore* _store, const req_state* _s, const rgw::sal::RGWObject* _object) : 
+      store(_store), s(_s), object(_object) {}
+
+  // dtor doing resource leak guarding
+  // aborting the reservation if not already committed or aborted
+  ~reservation_t();
+};
+
+// create a reservation on the 2-phase-commit queue
+int publish_reserve(EventType event_type,
+        reservation_t& reservation);
+
+// commit the reservation to the queue
+int publish_commit(const rgw::sal::RGWObject* obj,
+        uint64_t size,
         const ceph::real_time& mtime, 
         const std::string& etag, 
         EventType event_type,
-        rgw::sal::RGWRadosStore* store);
+        reservation_t& reservation);
+
+// cancel the reservation
+int publish_abort(reservation_t& reservation);
 
 }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -962,21 +962,23 @@ int RGWGetObj::verify_permission()
 
 // cache the objects tags into the requests
 // use inside try/catch as "decode()" may throw
-void populate_tags_in_request(req_state* s, const std::map<std::string, bufferlist>& attrs) {
-  const auto attr_iter = attrs.find(RGW_ATTR_TAGS);
-  if (attr_iter != attrs.end()) {
+void populate_tags_in_request(req_state* s, const rgw::sal::RGWAttrs& attrs) {
+  const auto attr_iter = attrs.attrs.find(RGW_ATTR_TAGS);
+  if (attr_iter != attrs.attrs.end()) {
     auto bliter = attr_iter->second.cbegin();
     decode(s->tagset, bliter);
   }
 }
 
 // cache the objects metadata into the request
-void populate_metadata_in_request(req_state* s, std::map<std::string, bufferlist>& attrs) {
-  for (auto& attr : attrs) {
+void populate_metadata_in_request(req_state* s, const rgw::sal::RGWAttrs& attrs) {
+  for (auto& attr : attrs.attrs) {
     if (boost::algorithm::starts_with(attr.first, RGW_ATTR_META_PREFIX)) {
       std::string_view key(attr.first);
       key.remove_prefix(sizeof(RGW_ATTR_PREFIX)-1);
-      s->info.x_meta_map.emplace(key, attr.second.c_str());
+      // we want to pass a null terminated version
+      // of the bufferlist, hence "to_str().c_str()"
+      s->info.x_meta_map.emplace(key, attr.second.to_str().c_str());
     }
   }
 }
@@ -3721,6 +3723,14 @@ void RGWPutObj::execute()
     }
   }
 
+  // make reservation for notification if needed
+  rgw::notify::reservation_t res(store, s, s->object.get());
+  const auto event_type = rgw::notify::ObjectCreatedPut;
+  op_ret = rgw::notify::publish_reserve(event_type, res);
+  if (op_ret < 0) {
+    return;
+  }
+
   // create the object processor
   auto aio = rgw::make_throttle(s->cct->_conf->rgw_put_obj_min_window_size,
                                 s->yield);
@@ -4000,12 +4010,10 @@ void RGWPutObj::execute()
   }
 
   // send request to notification manager
-  const auto ret = rgw::notify::publish(s, s->object.get(), mtime, etag, rgw::notify::ObjectCreatedPut, store);
+  const auto ret = rgw::notify::publish_commit(s->object.get(), s->obj_size, mtime, etag, event_type, res);
   if (ret < 0) {
-    ldpp_dout(this, 5) << "WARNING: publishing notification failed, with error: " << ret << dendl;
-	// TODO: we should have conf to make send a blocking coroutine and reply with error in case sending failed
-	// this should be global conf (probably returnign a different handler)
-    // so we don't need to read the configured values before we perform it
+    ldpp_dout(this, 1) << "ERROR: publishing notification failed, with error: " << ret << dendl;
+    // too late to rollback operation, hence op_ret is not set here
   }
 }
 
@@ -4061,6 +4069,14 @@ void RGWPostObj::execute()
     }
   } else if (!verify_bucket_permission_no_policy(this, s, RGW_PERM_WRITE)) {
     op_ret = -EACCES;
+    return;
+  }
+
+  // make reservation for notification if needed
+  rgw::notify::reservation_t res(store, s, s->object.get());
+  const auto event_type = rgw::notify::ObjectCreatedPost;
+  op_ret = rgw::notify::publish_reserve(event_type, res);
+  if (op_ret < 0) {
     return;
   }
 
@@ -4226,12 +4242,11 @@ void RGWPostObj::execute()
     }
   } while (is_next_file_to_upload());
 
-  const auto ret = rgw::notify::publish(s, s->object.get(), ceph::real_clock::now(), etag, rgw::notify::ObjectCreatedPost, store);
+  // send request to notification manager
+  const auto ret = rgw::notify::publish_commit(s->object.get(), ofs, ceph::real_clock::now(), etag, event_type, res);
   if (ret < 0) {
-    ldpp_dout(this, 5) << "WARNING: publishing notification failed, with error: " << ret << dendl;
-	// TODO: we should have conf to make send a blocking coroutine and reply with error in case sending failed
-	// this should be global conf (probably returnign a different handler)
-    // so we don't need to read the configured values before we perform it
+    ldpp_dout(this, 1) << "ERROR: publishing notification failed, with error: " << ret << dendl;
+    // too late to rollback operation, hence op_ret is not set here
   }
 }
 
@@ -4720,6 +4735,26 @@ void RGWDeleteObj::execute()
       return;
     }
 
+    // cache the objects tags and metadata into the requests
+    // so it could be used in the notification mechanism
+    try {
+      populate_tags_in_request(s, attrs);
+    } catch (buffer::error& err) {
+      ldpp_dout(this, 5) << "WARNING: failed to populate delete request with object tags: " << err.what() << dendl;
+    }
+    populate_metadata_in_request(s, attrs);
+
+    // make reservation for notification if needed
+    // TODO: delete marker is set only after object is deleted
+    rgw::notify::reservation_t res(store, s, s->object.get());
+    const auto versioned_object = s->bucket->versioning_enabled();
+    const auto event_type = versioned_object && s->object->get_instance().empty() ? 
+        rgw::notify::ObjectRemovedDeleteMarkerCreated : rgw::notify::ObjectRemovedDelete;
+    op_ret = rgw::notify::publish_reserve(event_type, res);
+    if (op_ret < 0) {
+      return;
+    }
+
     RGWObjectCtx *obj_ctx = static_cast<RGWObjectCtx *>(s->obj_ctx);
     s->object->set_atomic(s->obj_ctx);
 
@@ -4773,15 +4808,12 @@ void RGWDeleteObj::execute()
     }
     populate_metadata_in_request(s, attrs.attrs);
     const auto obj_state = obj_ctx->get_state(s->object->get_obj());
-    s->object->set_obj_size(obj_state->size);
-    const auto ret = rgw::notify::publish(s, s->object.get(), ceph::real_clock::now(), attrs.attrs[RGW_ATTR_ETAG].to_str(),
-          delete_marker && s->object->get_instance().empty() ? rgw::notify::ObjectRemovedDeleteMarkerCreated : rgw::notify::ObjectRemovedDelete,
-          store);
+
+    // send request to notification manager
+    const auto ret = rgw::notify::publish_commit(s->object.get(), obj_state->size, obj_state->mtime, attrs.attrs[RGW_ATTR_ETAG].to_str(), event_type, res);
     if (ret < 0) {
-      ldpp_dout(this, 5) << "WARNING: publishing notification failed, with error: " << ret << dendl;
-	    // TODO: we should have conf to make send a blocking coroutine and reply with error in case sending failed
-	    // this should be global conf (probably returnign a different handler)
-      // so we don't need to read the configured values before we perform it
+      ldpp_dout(this, 1) << "ERROR: publishing notification failed, with error: " << ret << dendl;
+      // too late to rollback operation, hence op_ret is not set here
     }
   } else {
     op_ret = -EINVAL;
@@ -5040,6 +5072,14 @@ void RGWCopyObj::execute()
   if (init_common() < 0)
     return;
 
+  // make reservation for notification if needed
+  rgw::notify::reservation_t res(store, s, s->object.get());
+  const auto event_type = rgw::notify::ObjectCreatedCopy; 
+  op_ret = rgw::notify::publish_reserve(event_type, res);
+  if (op_ret < 0) {
+    return;
+  }
+
   RGWObjectCtx& obj_ctx = *static_cast<RGWObjectCtx *>(s->obj_ctx);
   if ( ! version_id.empty()) {
     dest_object->set_instance(version_id);
@@ -5110,12 +5150,11 @@ void RGWCopyObj::execute()
 	   this,
 	   s->yield);
 
-  const auto ret = rgw::notify::publish(s, s->object.get(), mtime, etag, rgw::notify::ObjectCreatedCopy, store);
+  // send request to notification manager
+  const auto ret = rgw::notify::publish_commit(s->object.get(), s->obj_size, mtime, etag, event_type, res);
   if (ret < 0) {
-    ldpp_dout(this, 5) << "WARNING: publishing notification failed, with error: " << ret << dendl;
-	// TODO: we should have conf to make send a blocking coroutine and reply with error in case sending failed
-	// this should be global conf (probably returnign a different handler)
-    // so we don't need to read the configured values before we perform it
+    ldpp_dout(this, 1) << "ERROR: publishing notification failed, with error: " << ret << dendl;
+    // too late to rollback operation, hence op_ret is not set here
   }
 }
 
@@ -5731,6 +5770,14 @@ void RGWInitMultipart::execute()
     return;
   }
 
+  // make reservation for notification if needed
+  rgw::notify::reservation_t res(store, s, s->object.get());
+  const auto event_type = rgw::notify::ObjectCreatedPost;
+  op_ret = rgw::notify::publish_reserve(event_type, res);
+  if (op_ret < 0) {
+    return;
+  }
+
   do {
     char buf[33];
     gen_rand_alphanumeric(s->cct, buf, sizeof(buf) - 1);
@@ -5766,12 +5813,11 @@ void RGWInitMultipart::execute()
     op_ret = obj_op.write_meta(bl.length(), 0, attrs, s->yield);
   } while (op_ret == -EEXIST);
   
-  const auto ret = rgw::notify::publish(s, s->object.get(), ceph::real_clock::now(), attrs[RGW_ATTR_ETAG].to_str(), rgw::notify::ObjectCreatedPost, store);
+  // send request to notification manager
+  const auto ret = rgw::notify::publish_commit(s->object.get(), s->obj_size, ceph::real_clock::now(), attrs[RGW_ATTR_ETAG].to_str(), event_type, res);
   if (ret < 0) {
-    ldpp_dout(this, 5) << "WARNING: publishing notification failed, with error: " << ret << dendl;
-	// TODO: we should have conf to make send a blocking coroutine and reply with error in case sending failed
-	// this should be global conf (probably returnign a different handler)
-    // so we don't need to read the configured values before we perform it
+    ldpp_dout(this, 1) << "ERROR: publishing notification failed, with error: " << ret << dendl;
+    // too late to rollback operation, hence op_ret is not set here
   }
 }
 
@@ -5869,6 +5915,15 @@ void RGWCompleteMultipart::execute()
   }
 
   mp.init(s->object->get_name(), upload_id);
+
+  // make reservation for notification if needed
+  rgw::notify::reservation_t res(store, s, s->object.get());
+  const auto event_type = rgw::notify::ObjectCreatedCompleteMultipartUpload;
+  op_ret = rgw::notify::publish_reserve(event_type, res);
+  if (op_ret < 0) {
+    return;
+  }
+
   meta_oid = mp.get_meta();
 
   int total_parts = 0;
@@ -6081,13 +6136,11 @@ void RGWCompleteMultipart::execute()
     ldpp_dout(this, 0) << "WARNING: failed to remove object " << meta_obj << dendl;
   }
 
-  s->object->set_obj_size(ofs);
-  const auto ret = rgw::notify::publish(s, s->object.get(), ceph::real_clock::now(), etag, rgw::notify::ObjectCreatedCompleteMultipartUpload, store);
+  // send request to notification manager
+  const auto ret = rgw::notify::publish_commit(s->object.get(), ofs, ceph::real_clock::now(), final_etag_str, event_type, res);
   if (ret < 0) {
-    ldpp_dout(this, 5) << "WARNING: publishing notification failed, with error: " << ret << dendl;
-	// TODO: we should have conf to make send a blocking coroutine and reply with error in case sending failed
-	// this should be global conf (probably returnign a different handler)
-    // so we don't need to read the configured values before we perform it
+    ldpp_dout(this, 1) << "ERROR: publishing notification failed, with error: " << ret << dendl;
+    // too late to rollback operation, hence op_ret is not set here
   }
 }
 
@@ -6416,11 +6469,22 @@ void RGWDeleteMultiObj::execute()
 				   rgw::IAM::s3DeleteObjectVersion,
 				   ARN(obj->get_obj()));
       }
-      if ((e == Effect::Deny) ||
-	  (usr_policy_res == Effect::Pass && e == Effect::Pass && !acl_allowed)) {
-	send_partial_response(*iter, false, "", -EACCES);
-	continue;
+      if ((e == Effect::Deny) || 
+          (usr_policy_res == Effect::Pass && e == Effect::Pass && !acl_allowed)) {
+	      send_partial_response(*iter, false, "", -EACCES);
+	      continue;
       }
+    }
+    
+    // make reservation for notification if needed
+    const auto versioned_object = s->bucket->versioning_enabled();
+    rgw::notify::reservation_t res(store, s, obj.get());
+    const auto event_type = versioned_object && obj->get_instance().empty() ? 
+        rgw::notify::ObjectRemovedDeleteMarkerCreated : rgw::notify::ObjectRemovedDelete;
+    op_ret = rgw::notify::publish_reserve(event_type, res);
+    if (op_ret < 0) {
+      send_partial_response(*iter, false, "", op_ret);
+      continue;
     }
 
     obj->set_atomic(obj_ctx);
@@ -6436,16 +6500,12 @@ void RGWDeleteMultiObj::execute()
     const auto obj_state = obj_ctx->get_state(obj->get_obj());
     bufferlist etag_bl;
     const auto etag = obj_state->get_attr(RGW_ATTR_ETAG, etag_bl) ? etag_bl.to_str() : "";
-    obj->set_obj_size(obj_state->size);
 
-    const auto ret = rgw::notify::publish(s, obj.get(), ceph::real_clock::now(), etag,
-            obj->get_delete_marker() && s->object->get_instance().empty() ? rgw::notify::ObjectRemovedDeleteMarkerCreated : rgw::notify::ObjectRemovedDelete,
-            store);
+    // send request to notification manager
+    const auto ret = rgw::notify::publish_commit(obj.get(), obj_state->size, obj_state->mtime, etag, event_type, res);
     if (ret < 0) {
-        ldpp_dout(this, 5) << "WARNING: publishing notification failed, with error: " << ret << dendl;
-	    // TODO: we should have conf to make send a blocking coroutine and reply with error in case sending failed
-	    // this should be global conf (probably returnign a different handler)
-        // so we don't need to read the configured values before we perform it
+      ldpp_dout(this, 1) << "ERROR: publishing notification failed, with error: " << ret << dendl;
+      // too late to rollback operation, hence op_ret is not set here
     }
   }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4745,7 +4745,6 @@ void RGWDeleteObj::execute()
     populate_metadata_in_request(s, attrs);
 
     // make reservation for notification if needed
-    // TODO: delete marker is set only after object is deleted
     rgw::notify::reservation_t res(store, s, s->object.get());
     const auto versioned_object = s->bucket->versioning_enabled();
     const auto event_type = versioned_object && s->object->get_instance().empty() ? 

--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -362,13 +362,19 @@ void rgw_pubsub_sub_dest::dump(Formatter *f) const
   encode_json("push_endpoint", push_endpoint, f);
   encode_json("push_endpoint_args", push_endpoint_args, f);
   encode_json("push_endpoint_topic", arn_topic, f);
+  encode_json("stored_secret", stored_secret, f);
+  encode_json("persistent", persistent, f);
 }
 
 void rgw_pubsub_sub_dest::dump_xml(Formatter *f) const
 {
+  // first 2 members are omitted here since they
+  // dont apply to AWS compliant topics
   encode_xml("EndpointAddress", push_endpoint, f);
   encode_xml("EndpointArgs", push_endpoint_args, f);
   encode_xml("EndpointTopic", arn_topic, f);
+  encode_xml("HasStoredSecret", stored_secret, f);
+  encode_xml("Persistent", persistent, f);
 }
 
 void rgw_pubsub_sub_config::dump(Formatter *f) const

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -367,20 +367,22 @@ struct rgw_pubsub_sub_dest {
   std::string push_endpoint_args;
   std::string arn_topic;
   bool stored_secret = false;
+  bool persistent = false;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(4, 1, bl);
+    ENCODE_START(5, 1, bl);
     encode(bucket_name, bl);
     encode(oid_prefix, bl);
     encode(push_endpoint, bl);
     encode(push_endpoint_args, bl);
     encode(arn_topic, bl);
     encode(stored_secret, bl);
+    encode(persistent, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(4, bl);
+    DECODE_START(5, bl);
     decode(bucket_name, bl);
     decode(oid_prefix, bl);
     decode(push_endpoint, bl);
@@ -392,6 +394,9 @@ struct rgw_pubsub_sub_dest {
     }
     if (struct_v >= 4) {
         decode(stored_secret, bl);
+    }
+    if (struct_v >= 5) {
+        decode(persistent, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -45,6 +45,7 @@
 #include "rgw_compression.h"
 #include "rgw_etag_verifier.h"
 #include "rgw_worker.h"
+#include "rgw_notify.h"
 
 #undef fork // fails to compile RGWPeriod::fork() below
 
@@ -1073,6 +1074,8 @@ void RGWRados::finalize()
   }
   delete reshard;
   delete index_completion_manager;
+
+  rgw::notify::shutdown();
 }
 
 /** 
@@ -1165,6 +1168,10 @@ int RGWRados::init_complete()
     return ret;
 
   ret = open_reshard_pool_ctx();
+  if (ret < 0)
+    return ret;
+
+  ret = open_notif_pool_ctx();
   if (ret < 0)
     return ret;
 
@@ -1299,6 +1306,13 @@ int RGWRados::init_complete()
 
   index_completion_manager = new RGWIndexCompletionManager(this);
   ret = index_completion_manager->start();
+  if (ret < 0) {
+    return ret;
+  }
+  ret = rgw::notify::init(cct, store);
+  if (ret < 0 ) {
+    ldout(cct, 1) << "ERROR: failed to initialize notification manager" << dendl;
+  }
 
   return ret;
 }
@@ -1377,6 +1391,11 @@ int RGWRados::open_objexp_pool_ctx()
 int RGWRados::open_reshard_pool_ctx()
 {
   return rgw_init_ioctx(get_rados_handle(), svc.zone->get_zone_params().reshard_pool, reshard_pool_ctx, true, true);
+}
+
+int RGWRados::open_notif_pool_ctx()
+{
+  return rgw_init_ioctx(get_rados_handle(), svc.zone->get_zone_params().notif_pool, notif_pool_ctx, true, true);
 }
 
 int RGWRados::open_pool_ctx(const rgw_pool& pool, librados::IoCtx& io_ctx,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -419,6 +419,7 @@ class RGWRados
   int open_lc_pool_ctx();
   int open_objexp_pool_ctx();
   int open_reshard_pool_ctx();
+  int open_notif_pool_ctx();
 
   int open_pool_ctx(const rgw_pool& pool, librados::IoCtx&  io_ctx,
 		    bool mostly_omap);
@@ -493,6 +494,7 @@ protected:
   librados::IoCtx lc_pool_ctx;        // .rgw.lc
   librados::IoCtx objexp_pool_ctx;
   librados::IoCtx reshard_pool_ctx;
+  librados::IoCtx notif_pool_ctx;     // .rgw.notif
 
   bool pools_initialized;
 
@@ -563,6 +565,11 @@ public:
   librados::IoCtx* get_lc_pool_ctx() {
     return &lc_pool_ctx;
   }
+
+  librados::IoCtx& get_notif_pool_ctx() {
+    return notif_pool_ctx;
+  }
+
   void set_context(CephContext *_cct) {
     cct = _cct;
   }

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -14,6 +14,7 @@
 #include "rgw_rest_s3.h"
 #include "rgw_arn.h"
 #include "rgw_auth_s3.h"
+#include "rgw_notify.h"
 #include "services/svc_zone.h"
 
 #define dout_context g_ceph_context
@@ -22,7 +23,7 @@
 
 // command (AWS compliant): 
 // POST
-// Action=CreateTopic&Name=<topic-name>[&push-endpoint=<endpoint>[&<arg1>=<value1>]]
+// Action=CreateTopic&Name=<topic-name>[&OpaqueData=data][&push-endpoint=<endpoint>[&persistent][&<arg1>=<value1>]]
 class RGWPSCreateTopic_ObjStore_AWS : public RGWPSCreateTopicOp {
 public:
   int get_params() override {
@@ -35,6 +36,7 @@ public:
     opaque_data = s->info.args.get("OpaqueData");
 
     dest.push_endpoint = s->info.args.get("push-endpoint");
+    dest.persistent = s->info.args.exists("persistent");
 
     if (!validate_and_update_endpoint_secret(dest, s->cct, *(s->info.env))) {
       return -EINVAL;
@@ -49,6 +51,13 @@ public:
     if (!dest.push_endpoint_args.empty()) {
       // remove last separator
       dest.push_endpoint_args.pop_back();
+    }
+    if (!dest.push_endpoint.empty() && dest.persistent) {
+      const auto ret = rgw::notify::add_persistent_topic(topic_name, s->yield);
+      if (ret < 0) {
+        ldout(s->cct, 1) << "CreateTopic Action failed to create queue for persistent topics. error:" << ret << dendl;
+        return ret;
+      }
     }
     
     // dest object only stores endpoint info
@@ -172,6 +181,19 @@ public:
     }
 
     topic_name = topic_arn->resource;
+
+    // upon deletion it is not known if topic is persistent or not
+    // will try to delete the persistent topic anyway
+    const auto ret = rgw::notify::remove_persistent_topic(topic_name, s->yield);
+    if (ret == -ENOENT) {
+      // topic was not persistent, or already deleted
+      return 0;
+    }
+    if (ret < 0) {
+      ldout(s->cct, 1) << "DeleteTopic Action failed to remove queue for persistent topics. error:" << ret << dendl;
+      return ret;
+    }
+
     return 0;
   }
   

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -1548,6 +1548,7 @@ int get_zones_pool_set(CephContext* cct,
       pool_names.insert(zone.otp_pool);
       pool_names.insert(zone.roles_pool);
       pool_names.insert(zone.reshard_pool);
+      pool_names.insert(zone.notif_pool);
       for(auto& iter : zone.placement_pools) {
 	pool_names.insert(iter.second.index_pool);
         for (auto& pi : iter.second.storage_classes.get_all()) {
@@ -1623,6 +1624,7 @@ int RGWZoneParams::fix_pool_names()
   reshard_pool = fix_zone_pool_dup(pools, name, ".rgw.log:reshard", reshard_pool);
   otp_pool = fix_zone_pool_dup(pools, name, ".rgw.otp", otp_pool);
   oidc_pool = fix_zone_pool_dup(pools, name, ".rgw.meta:oidc", oidc_pool);
+  notif_pool = fix_zone_pool_dup(pools, name ,".rgw.log:notif", notif_pool);
 
   for(auto& iter : placement_pools) {
     iter.second.index_pool = fix_zone_pool_dup(pools, name, "." + default_bucket_index_pool_suffix,

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -382,6 +382,8 @@ struct RGWZoneParams : RGWSystemMetaObj {
 
   JSONFormattable tier_config;
 
+  rgw_pool notif_pool;
+
   RGWZoneParams() : RGWSystemMetaObj() {}
   explicit RGWZoneParams(const std::string& name) : RGWSystemMetaObj(name){}
   RGWZoneParams(const rgw_zone_id& id, const std::string& name) : RGWSystemMetaObj(id.id, name) {}
@@ -406,7 +408,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
   const string& get_compression_type(const rgw_placement_rule& placement_rule) const;
   
   void encode(bufferlist& bl) const override {
-    ENCODE_START(13, 1, bl);
+    ENCODE_START(14, 1, bl);
     encode(domain_root, bl);
     encode(control_pool, bl);
     encode(gc_pool, bl);
@@ -431,11 +433,12 @@ struct RGWZoneParams : RGWSystemMetaObj {
     encode(otp_pool, bl);
     encode(tier_config, bl);
     encode(oidc_pool, bl);
+    encode(notif_pool, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) override {
-    DECODE_START(13, bl);
+    DECODE_START(14, bl);
     decode(domain_root, bl);
     decode(control_pool, bl);
     decode(gc_pool, bl);
@@ -498,6 +501,11 @@ struct RGWZoneParams : RGWSystemMetaObj {
       ::decode(oidc_pool, bl);
     } else {
       oidc_pool = name + ".rgw.meta:oidc";
+    }
+    if (struct_v >= 14) {
+      decode(notif_pool, bl);
+    } else {
+      notif_pool = log_pool.name + ":notif";
     }
     DECODE_FINISH(bl);
   }

--- a/src/test/cls_2pc_queue/test_cls_2pc_queue.cc
+++ b/src/test/cls_2pc_queue/test_cls_2pc_queue.cc
@@ -653,7 +653,7 @@ TEST_F(TestCls2PCQueue, Cleanup)
   for (const auto& r : all_reservations) {
     if (good_reservations.find(r.first) == good_reservations.end()) {
       // not in the "good" list
-      ASSERT_GT(stale_time.time_since_epoch().count(), 
+      ASSERT_GE(stale_time.time_since_epoch().count(), 
           r.second.timestamp.time_since_epoch().count());
     }
   }

--- a/src/test/rgw/rgw_multi/multisite.py
+++ b/src/test/rgw/rgw_multi/multisite.py
@@ -184,6 +184,11 @@ class ZoneConn(object):
         if self.zone.gateways is not None:
             self.conn = get_gateway_connection(self.zone.gateways[0], self.credentials)
             self.secure_conn = get_gateway_secure_connection(self.zone.gateways[0], self.credentials)
+            # create connections for the rest of the gateways (if exist)
+            for gw in list(self.zone.gateways):
+                get_gateway_connection(gw, self.credentials)
+                get_gateway_secure_connection(gw, self.credentials)
+
 
     def get_connection(self):
         return self.conn

--- a/src/test/rgw/rgw_multi/tests_ps.py
+++ b/src/test/rgw/rgw_multi/tests_ps.py
@@ -67,17 +67,23 @@ class HTTPPostHandler(http_server.BaseHTTPRequestHandler):
             log.error('HTTP Server received empty event')
             self.send_response(400)
         else:
-            self.send_response(100)
+            if self.headers.get('Expect') == '100-continue':
+                self.send_response(100)
+            else:
+                self.send_response(200)
         finally:
+            if self.server.delay > 0:
+                time.sleep(self.server.delay)
             self.end_headers()
 
 
 class HTTPServerWithEvents(http_server.HTTPServer):
     """HTTP server used by the handler to store events"""
-    def __init__(self, addr, handler, worker_id):
+    def __init__(self, addr, handler, worker_id, delay=0):
         http_server.HTTPServer.__init__(self, addr, handler, False)
         self.worker_id = worker_id
         self.events = []
+        self.delay = delay
 
     def append(self, event):
         self.events.append(event)
@@ -85,11 +91,11 @@ class HTTPServerWithEvents(http_server.HTTPServer):
 
 class HTTPServerThread(threading.Thread):
     """thread for running the HTTP server. reusing the same socket for all threads"""
-    def __init__(self, i, sock, addr):
+    def __init__(self, i, sock, addr, delay=0):
         threading.Thread.__init__(self)
         self.i = i
         self.daemon = True
-        self.httpd = HTTPServerWithEvents(addr, HTTPPostHandler, i)
+        self.httpd = HTTPServerWithEvents(addr, HTTPPostHandler, i, delay)
         self.httpd.socket = sock
         # prevent the HTTP server from re-binding every handler
         self.httpd.server_bind = self.server_close = lambda self: None
@@ -117,13 +123,13 @@ class HTTPServerThread(threading.Thread):
 class StreamingHTTPServer:
     """multi-threaded http server class also holding list of events received into the handler
     each thread has its own server, and all servers share the same socket"""
-    def __init__(self, host, port, num_workers=100):
+    def __init__(self, host, port, num_workers=100, delay=0):
         addr = (host, port)
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.bind(addr)
         self.sock.listen(num_workers)
-        self.workers = [HTTPServerThread(i, self.sock, addr) for i in range(num_workers)]
+        self.workers = [HTTPServerThread(i, self.sock, addr, delay) for i in range(num_workers)]
 
     def verify_s3_events(self, keys, exact_match=False, deletions=False, expected_sizes={}):
         """verify stored s3 records agains a list of keys"""
@@ -158,6 +164,7 @@ class StreamingHTTPServer:
         for worker in self.workers:
             worker.close()
             worker.join()
+
 
 # AMQP endpoint functions
 
@@ -1451,6 +1458,615 @@ def test_ps_s3_notification_push_amqp_on_master():
     # delete the bucket
     master_zone.delete_bucket(bucket_name)
     clean_rabbitmq(proc)
+
+
+def test_ps_s3_persistent_gateways_recovery():
+    """ test gateway recovery of persistent notifications """
+    if skip_push_tests:
+        return SkipTest("PubSub push tests don't run in teuthology")
+    master_zone, _ = init_env(require_ps=False)
+    realm = get_realm()
+    zonegroup = realm.master_zonegroup()
+    if len(zonegroup.master_zone.gateways) < 2:
+        return SkipTest("this test requires two gateways")
+
+    # create random port for the http server
+    host = get_ip()
+    port = random.randint(10000, 20000)
+    # start an http server in a separate thread
+    number_of_objects = 10
+    http_server = StreamingHTTPServer(host, port, num_workers=number_of_objects)
+
+    gw1 = master_zone
+    gw2 = zonegroup.master_zone.gateways[1]
+    
+    # create bucket
+    bucket_name = gen_bucket_name()
+    bucket = gw1.create_bucket(bucket_name)
+    topic_name = bucket_name + TOPIC_SUFFIX
+    
+    # create two s3 topics
+    endpoint_address = 'http://'+host+':'+str(port)
+    endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'
+    topic_conf1 = PSTopicS3(gw1.conn, topic_name+'_1', zonegroup.name, endpoint_args=endpoint_args+'&OpaqueData=fromgw1')
+    topic_arn1 = topic_conf1.set_config()
+    topic_conf2 = PSTopicS3(gw2.connection, topic_name+'_2', zonegroup.name, endpoint_args=endpoint_args+'&OpaqueData=fromgw2')
+    topic_arn2 = topic_conf2.set_config()
+
+    # create two s3 notifications
+    notification_name = bucket_name + NOTIFICATION_SUFFIX+'_1'
+    topic_conf_list = [{'Id': notification_name, 'TopicArn': topic_arn1,
+        'Events': ['s3:ObjectCreated:Put']
+        }]
+    s3_notification_conf1 = PSNotificationS3(gw1.conn, bucket_name, topic_conf_list)
+    response, status = s3_notification_conf1.set_config()
+    assert_equal(status/100, 2)
+    notification_name = bucket_name + NOTIFICATION_SUFFIX+'_2'
+    topic_conf_list = [{'Id': notification_name, 'TopicArn': topic_arn2,
+        'Events': ['s3:ObjectRemoved:Delete']
+        }]
+    s3_notification_conf2 = PSNotificationS3(gw2.connection, bucket_name, topic_conf_list)
+    response, status = s3_notification_conf2.set_config()
+    assert_equal(status/100, 2)
+
+    # stop gateway 2
+    gw2.stop()
+
+    client_threads = []
+    start_time = time.time()
+    for i in range(number_of_objects):
+        key = bucket.new_key(str(i))
+        content = str(os.urandom(1024*1024))
+        thr = threading.Thread(target = set_contents_from_string, args=(key, content,))
+        thr.start()
+        client_threads.append(thr)
+    [thr.join() for thr in client_threads] 
+   
+    keys = list(bucket.list())
+
+    # delete objects from the bucket
+    client_threads = []
+    start_time = time.time()
+    for key in bucket.list():
+        thr = threading.Thread(target = key.delete, args=())
+        thr.start()
+        client_threads.append(thr)
+    [thr.join() for thr in client_threads] 
+
+    print('wait for 60 sec for before restarting the gateway')
+    time.sleep(60)
+    gw2.start()
+    
+    # check http receiver
+    events = http_server.get_and_reset_events()
+    for key in keys:
+        creations = 0
+        deletions = 0
+        for event in events:
+            if event['Records'][0]['eventName'] == 's3:ObjectCreated:Put' and \
+                    key.name == event['Records'][0]['s3']['object']['key']:
+                creations += 1
+            elif event['Records'][0]['eventName'] == 's3:ObjectRemoved:Delete' and \
+                    key.name == event['Records'][0]['s3']['object']['key']:
+                deletions += 1
+        assert_equal(creations, 1)
+        assert_equal(deletions, 1)
+
+    # cleanup
+    s3_notification_conf1.del_config()
+    topic_conf1.del_config()
+    gw1.delete_bucket(bucket_name)
+    time.sleep(10)
+    s3_notification_conf2.del_config()
+    topic_conf2.del_config()
+    http_server.close()
+
+
+def test_ps_s3_persistent_multiple_gateways():
+    """ test pushing persistent notification via two gateways """
+    if skip_push_tests:
+        return SkipTest("PubSub push tests don't run in teuthology")
+    master_zone, _ = init_env(require_ps=False)
+    realm = get_realm()
+    zonegroup = realm.master_zonegroup()
+    if len(zonegroup.master_zone.gateways) < 2:
+        return SkipTest("this test requires two gateways")
+
+    # create random port for the http server
+    host = get_ip()
+    port = random.randint(10000, 20000)
+    # start an http server in a separate thread
+    number_of_objects = 10
+    http_server = StreamingHTTPServer(host, port, num_workers=number_of_objects)
+
+    gw1 = master_zone
+    gw2 = zonegroup.master_zone.gateways[1]
+    
+    # create bucket
+    bucket_name = gen_bucket_name()
+    bucket1 = gw1.create_bucket(bucket_name)
+    bucket2 = gw2.connection.get_bucket(bucket_name)
+    topic_name = bucket_name + TOPIC_SUFFIX
+    
+    # create two s3 topics
+    endpoint_address = 'http://'+host+':'+str(port)
+    endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'
+    topic1_opaque = 'fromgw1'
+    topic_conf1 = PSTopicS3(gw1.conn, topic_name+'_1', zonegroup.name, endpoint_args=endpoint_args+'&OpaqueData='+topic1_opaque)
+    topic_arn1 = topic_conf1.set_config()
+    topic2_opaque = 'fromgw2'
+    topic_conf2 = PSTopicS3(gw2.connection, topic_name+'_2', zonegroup.name, endpoint_args=endpoint_args+'&OpaqueData='+topic2_opaque)
+    topic_arn2 = topic_conf2.set_config()
+
+    # create two s3 notifications
+    notification_name = bucket_name + NOTIFICATION_SUFFIX+'_1'
+    topic_conf_list = [{'Id': notification_name, 'TopicArn': topic_arn1,
+                         'Events': []
+                       }]
+    s3_notification_conf1 = PSNotificationS3(gw1.conn, bucket_name, topic_conf_list)
+    response, status = s3_notification_conf1.set_config()
+    assert_equal(status/100, 2)
+    notification_name = bucket_name + NOTIFICATION_SUFFIX+'_2'
+    topic_conf_list = [{'Id': notification_name, 'TopicArn': topic_arn2,
+                         'Events': []
+                       }]
+    s3_notification_conf2 = PSNotificationS3(gw2.connection, bucket_name, topic_conf_list)
+    response, status = s3_notification_conf2.set_config()
+    assert_equal(status/100, 2)
+
+    client_threads = []
+    start_time = time.time()
+    for i in range(number_of_objects):
+        key = bucket1.new_key('gw1_'+str(i))
+        content = str(os.urandom(1024*1024))
+        thr = threading.Thread(target = set_contents_from_string, args=(key, content,))
+        thr.start()
+        client_threads.append(thr)
+        key = bucket2.new_key('gw2_'+str(i))
+        content = str(os.urandom(1024*1024))
+        thr = threading.Thread(target = set_contents_from_string, args=(key, content,))
+        thr.start()
+        client_threads.append(thr)
+    [thr.join() for thr in client_threads] 
+    
+    keys = list(bucket1.list())
+
+    delay = 30
+    print('wait for '+str(delay)+'sec for the messages...')
+    time.sleep(delay)
+
+    events = http_server.get_and_reset_events()
+    for key in keys:
+        topic1_count = 0
+        topic2_count = 0
+        for event in events:
+            if event['Records'][0]['eventName'] == 's3:ObjectCreated:Put' and \
+                    key.name == event['Records'][0]['s3']['object']['key'] and \
+                    topic1_opaque == event['Records'][0]['opaqueData']:
+                topic1_count += 1
+            elif event['Records'][0]['eventName'] == 's3:ObjectCreated:Put' and \
+                    key.name == event['Records'][0]['s3']['object']['key'] and \
+                    topic2_opaque == event['Records'][0]['opaqueData']:
+                topic2_count += 1
+        assert_equal(topic1_count, 1)
+        assert_equal(topic2_count, 1)
+
+    # delete objects from the bucket
+    client_threads = []
+    start_time = time.time()
+    for key in bucket1.list():
+        thr = threading.Thread(target = key.delete, args=())
+        thr.start()
+        client_threads.append(thr)
+    [thr.join() for thr in client_threads] 
+    
+    print('wait for '+str(delay)+'sec for the messages...')
+    time.sleep(delay)
+
+    events = http_server.get_and_reset_events()
+    for key in keys:
+        topic1_count = 0
+        topic2_count = 0
+        for event in events:
+            if event['Records'][0]['eventName'] == 's3:ObjectRemoved:Delete' and \
+                    key.name == event['Records'][0]['s3']['object']['key'] and \
+                    topic1_opaque == event['Records'][0]['opaqueData']:
+                topic1_count += 1
+            elif event['Records'][0]['eventName'] == 's3:ObjectRemoved:Delete' and \
+                    key.name == event['Records'][0]['s3']['object']['key'] and \
+                    topic2_opaque == event['Records'][0]['opaqueData']:
+                topic2_count += 1
+        assert_equal(topic1_count, 1)
+        assert_equal(topic2_count, 1)
+    
+    # cleanup
+    s3_notification_conf1.del_config()
+    topic_conf1.del_config()
+    s3_notification_conf2.del_config()
+    topic_conf2.del_config()
+    gw1.delete_bucket(bucket_name)
+    http_server.close()
+
+
+def test_ps_s3_persistent_multiple_endpoints():
+    """ test pushing persistent notification when one of the endpoints has error """
+    if skip_push_tests:
+        return SkipTest("PubSub push tests don't run in teuthology")
+    master_zone, _ = init_env(require_ps=False)
+    realm = get_realm()
+    zonegroup = realm.master_zonegroup()
+
+    # create random port for the http server
+    host = get_ip()
+    port = random.randint(10000, 20000)
+    # start an http server in a separate thread
+    number_of_objects = 10
+    http_server = StreamingHTTPServer(host, port, num_workers=number_of_objects)
+
+    # create bucket
+    bucket_name = gen_bucket_name()
+    bucket = master_zone.create_bucket(bucket_name)
+    topic_name = bucket_name + TOPIC_SUFFIX
+    
+    # create two s3 topics
+    endpoint_address = 'http://'+host+':'+str(port)
+    endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'
+    topic_conf1 = PSTopicS3(master_zone.conn, topic_name+'_1', zonegroup.name, endpoint_args=endpoint_args)
+    topic_arn1 = topic_conf1.set_config()
+    endpoint_address = 'http://kaboom:9999'
+    endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'
+    topic_conf2 = PSTopicS3(master_zone.conn, topic_name+'_2', zonegroup.name, endpoint_args=endpoint_args)
+    topic_arn2 = topic_conf2.set_config()
+
+    # create two s3 notifications
+    notification_name = bucket_name + NOTIFICATION_SUFFIX+'_1'
+    topic_conf_list = [{'Id': notification_name, 'TopicArn': topic_arn1,
+                         'Events': []
+                       }]
+    s3_notification_conf1 = PSNotificationS3(master_zone.conn, bucket_name, topic_conf_list)
+    response, status = s3_notification_conf1.set_config()
+    assert_equal(status/100, 2)
+    notification_name = bucket_name + NOTIFICATION_SUFFIX+'_2'
+    topic_conf_list = [{'Id': notification_name, 'TopicArn': topic_arn2,
+                         'Events': []
+                       }]
+    s3_notification_conf2 = PSNotificationS3(master_zone.conn, bucket_name, topic_conf_list)
+    response, status = s3_notification_conf2.set_config()
+    assert_equal(status/100, 2)
+
+    client_threads = []
+    start_time = time.time()
+    for i in range(number_of_objects):
+        key = bucket.new_key(str(i))
+        content = str(os.urandom(1024*1024))
+        thr = threading.Thread(target = set_contents_from_string, args=(key, content,))
+        thr.start()
+        client_threads.append(thr)
+    [thr.join() for thr in client_threads] 
+    
+    keys = list(bucket.list())
+
+    delay = 30
+    print('wait for '+str(delay)+'sec for the messages...')
+    time.sleep(delay)
+    
+    http_server.verify_s3_events(keys, exact_match=False, deletions=False)
+
+    # delete objects from the bucket
+    client_threads = []
+    start_time = time.time()
+    for key in bucket.list():
+        thr = threading.Thread(target = key.delete, args=())
+        thr.start()
+        client_threads.append(thr)
+    [thr.join() for thr in client_threads] 
+    
+    print('wait for '+str(delay)+'sec for the messages...')
+    time.sleep(delay)
+    
+    http_server.verify_s3_events(keys, exact_match=False, deletions=True)
+
+    # cleanup
+    s3_notification_conf1.del_config()
+    topic_conf1.del_config()
+    s3_notification_conf2.del_config()
+    topic_conf2.del_config()
+    master_zone.delete_bucket(bucket_name)
+    http_server.close()
+
+
+def persistent_notification(endpoint_type):
+    """ test pushing persistent notification """
+    if skip_push_tests:
+        return SkipTest("PubSub push tests don't run in teuthology")
+    master_zone, _ = init_env(require_ps=False)
+    realm = get_realm()
+    zonegroup = realm.master_zonegroup()
+
+    # create bucket
+    bucket_name = gen_bucket_name()
+    bucket = master_zone.create_bucket(bucket_name)
+    topic_name = bucket_name + TOPIC_SUFFIX
+
+    receiver = {}
+    host = get_ip()
+    if endpoint_type == 'http':
+        # create random port for the http server
+        port = random.randint(10000, 20000)
+        # start an http server in a separate thread
+        receiver = StreamingHTTPServer(host, port, num_workers=10)
+        endpoint_address = 'http://'+host+':'+str(port)
+        endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'
+        # the http server does not guarantee order, so duplicates are expected
+        exact_match = False
+    elif endpoint_type == 'amqp':
+        proc = init_rabbitmq()
+        if proc is None:
+            return SkipTest('end2end amqp tests require rabbitmq-server installed')
+        # start amqp receiver
+        exchange = 'ex1'
+        task, receiver = create_amqp_receiver_thread(exchange, topic_name)
+        task.start()
+        endpoint_address = 'amqp://' + host
+        endpoint_args = 'push-endpoint='+endpoint_address+'&amqp-exchange='+exchange+'&amqp-ack-level=broker'+'&persistent=true'
+        # amqp broker guarantee ordering
+        exact_match = True
+    else:
+        return SkipTest('Unknown endpoint type: ' + endpoint_type)
+
+
+    # create s3 topic
+    topic_conf = PSTopicS3(master_zone.conn, topic_name, zonegroup.name, endpoint_args=endpoint_args)
+    topic_arn = topic_conf.set_config()
+    # create s3 notification
+    notification_name = bucket_name + NOTIFICATION_SUFFIX
+    topic_conf_list = [{'Id': notification_name, 'TopicArn': topic_arn,
+                         'Events': []
+                       }]
+
+    s3_notification_conf = PSNotificationS3(master_zone.conn, bucket_name, topic_conf_list)
+    response, status = s3_notification_conf.set_config()
+    assert_equal(status/100, 2)
+
+    # create objects in the bucket (async)
+    number_of_objects = 100
+    client_threads = []
+    start_time = time.time()
+    for i in range(number_of_objects):
+        key = bucket.new_key(str(i))
+        content = str(os.urandom(1024*1024))
+        thr = threading.Thread(target = set_contents_from_string, args=(key, content,))
+        thr.start()
+        client_threads.append(thr)
+    [thr.join() for thr in client_threads] 
+
+    time_diff = time.time() - start_time
+    print('average time for creation + async http notification is: ' + str(time_diff*1000/number_of_objects) + ' milliseconds')
+    
+    keys = list(bucket.list())
+
+    delay = 40
+    print('wait for '+str(delay)+'sec for the messages...')
+    time.sleep(delay)
+
+    receiver.verify_s3_events(keys, exact_match=exact_match, deletions=False)
+
+    # delete objects from the bucket
+    client_threads = []
+    start_time = time.time()
+    for key in bucket.list():
+        thr = threading.Thread(target = key.delete, args=())
+        thr.start()
+        client_threads.append(thr)
+    [thr.join() for thr in client_threads] 
+    
+    time_diff = time.time() - start_time
+    print('average time for deletion + async http notification is: ' + str(time_diff*1000/number_of_objects) + ' milliseconds')
+
+    print('wait for '+str(delay)+'sec for the messages...')
+    time.sleep(delay)
+    
+    receiver.verify_s3_events(keys, exact_match=exact_match, deletions=True)
+
+    # cleanup
+    s3_notification_conf.del_config()
+    topic_conf.del_config()
+    # delete the bucket
+    master_zone.delete_bucket(bucket_name)
+    if endpoint_type == 'http':
+        receiver.close()
+    else:
+        stop_amqp_receiver(receiver, task)
+        clean_rabbitmq(proc)
+
+
+def test_ps_s3_persistent_notification_http():
+    """ test pushing persistent notification http """
+    persistent_notification('http')
+
+
+def test_ps_s3_persistent_notification_amqp():
+    """ test pushing persistent notification amqp """
+    persistent_notification('amqp')
+
+
+def random_string(length):
+    import string
+    letters = string.ascii_letters
+    return ''.join(random.choice(letters) for i in range(length))
+
+
+def test_ps_s3_persistent_notification_large():
+    """ test pushing persistent notification of large notifications """
+    if skip_push_tests:
+        return SkipTest("PubSub push tests don't run in teuthology")
+    master_zone, _ = init_env(require_ps=False)
+    realm = get_realm()
+    zonegroup = realm.master_zonegroup()
+
+    # create bucket
+    bucket_name = gen_bucket_name()
+    bucket = master_zone.create_bucket(bucket_name)
+    topic_name = bucket_name + TOPIC_SUFFIX
+
+    receiver = {}
+    host = get_ip()
+    proc = init_rabbitmq()
+    if proc is None:
+        return SkipTest('end2end amqp tests require rabbitmq-server installed')
+    # start amqp receiver
+    exchange = 'ex1'
+    task, receiver = create_amqp_receiver_thread(exchange, topic_name)
+    task.start()
+    endpoint_address = 'amqp://' + host
+    opaque_data = random_string(1024*2)
+    endpoint_args = 'push-endpoint='+endpoint_address+'&OpaqueData='+opaque_data+'&amqp-exchange='+exchange+'&amqp-ack-level=broker'+'&persistent=true'
+    # amqp broker guarantee ordering
+    exact_match = True
+
+    # create s3 topic
+    topic_conf = PSTopicS3(master_zone.conn, topic_name, zonegroup.name, endpoint_args=endpoint_args)
+    topic_arn = topic_conf.set_config()
+    # create s3 notification
+    notification_name = bucket_name + NOTIFICATION_SUFFIX
+    topic_conf_list = [{'Id': notification_name, 'TopicArn': topic_arn,
+                         'Events': []
+                       }]
+
+    s3_notification_conf = PSNotificationS3(master_zone.conn, bucket_name, topic_conf_list)
+    response, status = s3_notification_conf.set_config()
+    assert_equal(status/100, 2)
+
+    # create objects in the bucket (async)
+    number_of_objects = 100
+    client_threads = []
+    start_time = time.time()
+    for i in range(number_of_objects):
+        key_value = random_string(63)
+        key = bucket.new_key(key_value)
+        content = str(os.urandom(1024*1024))
+        thr = threading.Thread(target = set_contents_from_string, args=(key, content,))
+        thr.start()
+        client_threads.append(thr)
+    [thr.join() for thr in client_threads] 
+
+    time_diff = time.time() - start_time
+    print('average time for creation + async http notification is: ' + str(time_diff*1000/number_of_objects) + ' milliseconds')
+    
+    keys = list(bucket.list())
+
+    delay = 40
+    print('wait for '+str(delay)+'sec for the messages...')
+    time.sleep(delay)
+
+    receiver.verify_s3_events(keys, exact_match=exact_match, deletions=False)
+
+    # delete objects from the bucket
+    client_threads = []
+    start_time = time.time()
+    for key in bucket.list():
+        thr = threading.Thread(target = key.delete, args=())
+        thr.start()
+        client_threads.append(thr)
+    [thr.join() for thr in client_threads] 
+    
+    time_diff = time.time() - start_time
+    print('average time for deletion + async http notification is: ' + str(time_diff*1000/number_of_objects) + ' milliseconds')
+
+    print('wait for '+str(delay)+'sec for the messages...')
+    time.sleep(delay)
+    
+    receiver.verify_s3_events(keys, exact_match=exact_match, deletions=True)
+
+    # cleanup
+    s3_notification_conf.del_config()
+    topic_conf.del_config()
+    # delete the bucket
+    master_zone.delete_bucket(bucket_name)
+    stop_amqp_receiver(receiver, task)
+    clean_rabbitmq(proc)
+
+
+def test_ps_s3_persistent_notification_pushback():
+    """ test pushing persistent notification pushback """
+    return SkipTest("only used in manual testing")
+    master_zone, _ = init_env(require_ps=False)
+    realm = get_realm()
+    zonegroup = realm.master_zonegroup()
+    
+    # create random port for the http server
+    host = get_ip()
+    port = random.randint(10000, 20000)
+    # start an http server in a separate thread
+    http_server = StreamingHTTPServer(host, port, num_workers=10, delay=0.5)
+
+    # create bucket
+    bucket_name = gen_bucket_name()
+    bucket = master_zone.create_bucket(bucket_name)
+    topic_name = bucket_name + TOPIC_SUFFIX
+
+    # create s3 topic
+    endpoint_address = 'http://'+host+':'+str(port)
+    endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'
+    topic_conf = PSTopicS3(master_zone.conn, topic_name, zonegroup.name, endpoint_args=endpoint_args)
+    topic_arn = topic_conf.set_config()
+    # create s3 notification
+    notification_name = bucket_name + NOTIFICATION_SUFFIX
+    topic_conf_list = [{'Id': notification_name, 'TopicArn': topic_arn,
+                         'Events': []
+                       }]
+
+    s3_notification_conf = PSNotificationS3(master_zone.conn, bucket_name, topic_conf_list)
+    response, status = s3_notification_conf.set_config()
+    assert_equal(status/100, 2)
+
+    # create objects in the bucket (async)
+    for j in range(100):
+        number_of_objects = randint(500, 1000)
+        client_threads = []
+        start_time = time.time()
+        for i in range(number_of_objects):
+            key = bucket.new_key(str(j)+'-'+str(i))
+            content = str(os.urandom(1024*1024))
+            thr = threading.Thread(target = set_contents_from_string, args=(key, content,))
+            thr.start()
+            client_threads.append(thr)
+        [thr.join() for thr in client_threads]
+        time_diff = time.time() - start_time
+        print('average time for creation + async http notification is: ' + str(time_diff*1000/number_of_objects) + ' milliseconds')
+    
+    keys = list(bucket.list())
+
+    delay = 30
+    print('wait for '+str(delay)+'sec for the messages...')
+    time.sleep(delay)
+
+    # delete objects from the bucket
+    client_threads = []
+    start_time = time.time()
+    count = 0
+    for key in bucket.list():
+        count += 1
+        thr = threading.Thread(target = key.delete, args=())
+        thr.start()
+        client_threads.append(thr)
+        if count%100 == 0:
+            [thr.join() for thr in client_threads]
+            time_diff = time.time() - start_time
+            print('average time for deletion + async http notification is: ' + str(time_diff*1000/number_of_objects) + ' milliseconds')
+            client_threads = []
+            start_time = time.time()
+
+    print('wait for '+str(delay)+'sec for the messages...')
+    time.sleep(delay)
+    
+    # cleanup
+    s3_notification_conf.del_config()
+    topic_conf.del_config()
+    # delete the bucket
+    master_zone.delete_bucket(bucket_name)
+    time.sleep(delay)
+    http_server.close()
 
 
 def test_ps_s3_notification_push_kafka():

--- a/src/test/rgw/test_multi.py
+++ b/src/test/rgw/test_multi.py
@@ -108,7 +108,7 @@ class Gateway(multisite.Gateway):
     def stop(self):
         """ stop the gateway """
         assert(self.cluster)
-        cmd = [mstart_path + 'mstop.sh', self.cluster.cluster_id, 'radosgw', self.id]
+        cmd = [mstart_path + 'mstop.sh', self.cluster.cluster_id, 'radosgw', str(self.port)]
         bash(cmd)
 
 def gen_access_key():


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

## Remaining Work:
- [x] squash commits
- [x] add coroutines to notify manager context
- [x] allow yielding on rados operation
- [x] allow yielding on cls_2pc_queue operation (has dependency with [this PR](https://github.com/ceph/ceph/pull/35020) and [this PR](https://github.com/ceph/ceph/pull/35172))
- [x] reply 503 to client when queue is full
- [x] remove queue and stop processing when topic is deleted
- [x] use omap for queue list object
- [x] cleanup expired reservations
- [x] allow yielding on topic/notification REST calls
- [x] documentation

## Remaining Tests:
- [x] multiple gateways
- [x] endpoint failure, retry and recovery
- [x] endpoint failure, push back to clients
- [x] co-existence of good and bad endpoints
- [x] rgw failover

## Remaining Work (other PRs):

- work fairness (queue level) among RGWs should be based on [sync fairness](https://github.com/ceph/ceph/pull/28119)
- take configuration from Ceph