### PR TITLE
mgr/dashboard: Add button to copy the bootstrap token into the clipboard

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-create-modal/bootstrap-create-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-create-modal/bootstrap-create-modal.component.html
@@ -71,6 +71,14 @@
                     readonly>
           </textarea>
         </div>
+        <button class="btn btn-primary mb-3 float-right"
+                aria-label="Copy to Clipboard"
+                i18n-aria-label
+                title="Copy to Clipboard"
+                i18n-title
+                cdCopy2ClipboardButton="token">
+          <ng-container i18n>Copy to Clipboard</ng-container>
+        </button>
       </div>
 
       <div class="modal-footer">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/copy2clipboard-button.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/copy2clipboard-button.directive.ts
@@ -9,8 +9,6 @@ import { ToastrService } from 'ngx-toastr';
 export class Copy2ClipboardButtonDirective implements OnInit {
   @Input()
   private cdCopy2ClipboardButton: string;
-  @Input()
-  private formatted = 'no';
 
   constructor(
     private elementRef: ElementRef,
@@ -34,17 +32,15 @@ export class Copy2ClipboardButtonDirective implements OnInit {
   @HostListener('click')
   onClick() {
     try {
-      const tagName = this.formatted === '' ? 'textarea' : 'input';
-      // Create the input to hold our text.
-      const tmpInputElement = document.createElement(tagName);
-      tmpInputElement.value = this.getInputElement().value;
-      document.body.appendChild(tmpInputElement);
-      // Copy text to clipboard.
-      tmpInputElement.select();
-      document.execCommand('copy');
-      // Finally remove the element.
-      document.body.removeChild(tmpInputElement);
-
+      // Checking if we have the clipboard-write permission
+      navigator.permissions
+        .query({ name: 'clipboard-write' as PermissionName })
+        .then((result: any) => {
+          if (result.state === 'granted' || result.state === 'prompt') {
+            // Copy text to clipboard.
+            navigator.clipboard.writeText(this.getInputElement().value);
+          }
+        });
       this.toastr.success('Copied text to the clipboard successfully.');
     } catch (err) {
       this.toastr.error('Failed to copy text to the clipboard.');


### PR DESCRIPTION
Fixes issue: https://tracker.ceph.com/issues/44681

Signed-off-by: Ishan Rai <ishanrai05@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
