### PR TITLE
python-common: raise on emtpy drive selections

### DIFF
--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 import pytest
+import yaml
 
 from ceph.deployment import drive_selection, translate
 from ceph.deployment.inventory import Device
@@ -28,10 +29,26 @@ def test_DriveGroup(test_input):
     assert all([isinstance(x, Device) for x in dg.data_devices.paths])
     assert dg.data_devices.paths[0].path == '/dev/sda'
 
-
-def test_DriveGroup_fail():
+@pytest.mark.parametrize("test_input",
+[
+    (
+        {}
+    ),
+    (
+        yaml.safe_load("""
+service_type: osd
+service_id: mydg
+placement:
+  host_pattern: '*'
+data_devices:
+  limit: 1
+""")
+    )
+])
+def test_DriveGroup_fail(test_input):
     with pytest.raises(ServiceSpecValidationError):
-        DriveGroupSpec.from_json({})
+        DriveGroupSpec.from_json(test_input)
+
 
 
 def test_drivegroup_pattern():

--- a/src/python-common/requirements.txt
+++ b/src/python-common/requirements.txt
@@ -4,3 +4,4 @@ mock; python_version < '3.3'
 mypy==0.770; python_version >= '3'
 pytest-mypy; python_version >= '3'
 pytest >= 2.1.3; python_version >= '3'
+pyyaml


### PR DESCRIPTION
adds a test for https://tracker.ceph.com/issues/44758

(it actually did raise already!)

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

Note: this PR only affects `make check`

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
