### PR TITLE
test/crimson: increase variance of stdev to 0.20

### DIFF
--- a/src/test/crimson/cbt/radosbench_4K_read.yaml
+++ b/src/test/crimson/cbt/radosbench_4K_read.yaml
@@ -18,7 +18,7 @@ tasks:
         acceptable:
           bandwidth: '(or (greater) (near 0.05))'
           iops_avg: '(or (greater) (near 0.05))'
-          iops_stddev: '(or (less) (near 0.50))'
+          iops_stddev: '(or (less) (near 0.20))'
           latency_avg: '(or (less) (near 0.05))'
     monitoring_profiles:
       perf:

--- a/src/test/crimson/cbt/radosbench_4K_write.yaml
+++ b/src/test/crimson/cbt/radosbench_4K_write.yaml
@@ -16,7 +16,7 @@ tasks:
         acceptable:
           bandwidth: '(or (greater) (near 0.05))'
           iops_avg: '(or (greater) (near 0.05))'
-          iops_stddev: '(or (less) (near 0.05))'
+          iops_stddev: '(or (less) (near 0.20))'
           latency_avg: '(or (less) (near 0.05))'
     monitoring_profiles:
       perf:


### PR DESCRIPTION
per Mark Nelson,

> yeah, 5% variation is way too low
> Sometimes we can stay within 5%, but especially if we are pushing the
> system hard we can see closer to 10-20% sometimes.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
