### PR TITLE
nautilus: client: fix bad error handling in lseek SEEK_HOLE / SEEK_DATA

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8880,14 +8880,12 @@ loff_t Client::lseek(int fd, loff_t offset, int whence)
 loff_t Client::_lseek(Fh *f, loff_t offset, int whence)
 {
   Inode *in = f->inode.get();
-  int r;
   loff_t pos = -1;
 
   if (whence == SEEK_END || whence == SEEK_DATA || whence == SEEK_HOLE) {
-    r = _getattr(in, CEPH_STAT_CAP_SIZE, f->actor_perms);
-    if (r < 0) {
+    int r = _getattr(in, CEPH_STAT_CAP_SIZE, f->actor_perms);
+    if (r < 0)
       return r;
-    }
   }
 
   switch (whence) {
@@ -8904,20 +8902,15 @@ loff_t Client::_lseek(Fh *f, loff_t offset, int whence)
     break;
 
   case SEEK_DATA:
-    if (offset < 0 || offset >= in->size) {
-      r = -ENXIO;
-      return offset; 
-    }
+    if (offset < 0 || offset >= in->size)
+      return -ENXIO;
     pos = offset;
     break;
 
   case SEEK_HOLE:
-    if (offset < 0 || offset >= in->size) {
-      r = -ENXIO;
-      pos = offset; 
-    } else {
-      pos = in->size;
-    }
+    if (offset < 0 || offset >= in->size)
+      return -ENXIO;
+    pos = in->size;
     break;
 
   default:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44328

---

backport of https://github.com/ceph/ceph/pull/33480
parent tracker: https://tracker.ceph.com/issues/44021

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh