### PR TITLE
crimson/osd: support 1 lossy connection between a heartbeat peer

### DIFF
--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -51,9 +51,9 @@ seastar::future<> Heartbeat::start(entity_addrvec_t front_addrs,
 
   using crimson::net::SocketPolicy;
   front_msgr->set_policy(entity_name_t::TYPE_OSD,
-                         SocketPolicy::stateless_server(0));
+                         SocketPolicy::lossy_client(0));
   back_msgr->set_policy(entity_name_t::TYPE_OSD,
-                        SocketPolicy::stateless_server(0));
+                        SocketPolicy::lossy_client(0));
   auto chained_dispatchers = seastar::make_lw_shared<ChainedDispatchers>();
   chained_dispatchers->push_back(*this);
   return seastar::when_all_succeed(start_messenger(*front_msgr,

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -203,10 +203,14 @@ seastar::future<> Heartbeat::ms_dispatch(crimson::net::Connection* conn,
 
 void Heartbeat::ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace)
 {
-  // TODO: we should already have enough information to know which peer the
-  // conn belongs, so no need to do linear search here.
-  for (auto& [osd, peer] : peers) {
-    peer.handle_reset(conn);
+  auto peer = conn->get_peer_id();
+  if (conn->get_peer_type() != entity_name_t::TYPE_OSD ||
+      peer == entity_name_t::NEW) {
+    return;
+  }
+  if (auto found = peers.find(peer);
+      found != peers.end()) {
+    found->second.handle_reset(conn);
   }
 }
 
@@ -324,9 +328,11 @@ void Heartbeat::Peer::connect()
   auto osdmap = heartbeat.service.get_osdmap_service().get_map();
   // TODO: use addrs
   con_front = heartbeat.front_msgr->connect(
-      osdmap->get_hb_front_addrs(peer).front(), CEPH_ENTITY_TYPE_OSD);
+      osdmap->get_hb_front_addrs(peer).front(),
+      entity_name_t(CEPH_ENTITY_TYPE_OSD, peer));
   con_back = heartbeat.back_msgr->connect(
-      osdmap->get_hb_back_addrs(peer).front(), CEPH_ENTITY_TYPE_OSD);
+      osdmap->get_hb_back_addrs(peer).front(),
+      entity_name_t(CEPH_ENTITY_TYPE_OSD, peer));
 }
 
 Heartbeat::Peer::Peer(Heartbeat& heartbeat, osd_id_t peer)

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -372,55 +372,57 @@ void Heartbeat::Peer::disconnect()
 Heartbeat::Peer::~Peer()
 { disconnect(); }
 
-bool Heartbeat::Peer::is_unhealthy(clock::time_point now) const
+bool Heartbeat::Peer::pinged() const
 {
-  if (ping_history.empty()) {
-    // we haven't sent a ping yet or we have got all replies,
-    // in either way we are safe and healthy for now
+  if (clock::is_zero(first_tx)) {
+    // i can never receive a pong without sending any ping message first.
+    assert(clock::is_zero(last_rx_front) &&
+	   clock::is_zero(last_rx_back));
     return false;
   } else {
-    auto oldest_ping = ping_history.begin();
-    return now > oldest_ping->second.deadline;
+    return true;
   }
 }
 
-bool Heartbeat::Peer::is_healthy(clock::time_point now) const
+Heartbeat::Peer::health_state
+Heartbeat::Peer::do_health_screen(clock::time_point now) const
 {
-  if (clock::is_zero(last_rx_front)) {
-    return false;
+  if (!pinged()) {
+    // we are not healty nor unhealty because we haven't sent anything yet
+    return health_state::UNKNOWN;
+  } else if (!ping_history.empty() && ping_history.begin()->second.deadline < now) {
+    return health_state::UNHEALTHY;
+  } else if (!clock::is_zero(last_rx_front) &&
+             !clock::is_zero(last_rx_back)) {
+    // only declare to be healthy until we have received the first
+    // replies from both front/back connections
+    return health_state::HEALTHY;
+  } else {
+    return health_state::UNKNOWN;
   }
-  if (clock::is_zero(last_rx_back)) {
-    return false;
-  }
-  // only declare to be healthy until we have received the first
-  // replies from both front/back connections
-  return !is_unhealthy(now);
 }
 
 Heartbeat::clock::time_point
 Heartbeat::Peer::failed_since(clock::time_point now) const
 {
-  if (clock::is_zero(first_tx)) {
-    return clock::zero();
-  }
-  if (!is_unhealthy(now)) {
-    return clock::zero();
-  }
-
-  auto oldest_deadline = ping_history.begin()->second.deadline;
-  auto failed_since = std::min(last_rx_back, last_rx_front);
-  if (clock::is_zero(failed_since)) {
-    logger().error("failed_since: no reply from osd.{} "
-                   "ever on either front or back, first ping sent {} "
-                   "(oldest deadline {})",
-                   peer, first_tx, oldest_deadline);
-    failed_since = first_tx;
+  if (do_health_screen(now) == health_state::UNHEALTHY) {
+    auto oldest_deadline = ping_history.begin()->second.deadline;
+    auto failed_since = std::min(last_rx_back, last_rx_front);
+    if (clock::is_zero(failed_since)) {
+      logger().error("failed_since: no reply from osd.{} "
+                     "ever on either front or back, first ping sent {} "
+                     "(oldest deadline {})",
+                     peer, first_tx, oldest_deadline);
+      failed_since = first_tx;
+    } else {
+      logger().error("failed_since: no reply from osd.{} "
+                     "since back {} front {} (oldest deadline {})",
+                     peer, last_rx_back, last_rx_front, oldest_deadline);
+    }
+    return failed_since;
   } else {
-    logger().error("failed_since: no reply from osd.{} "
-                   "since back {} front {} (oldest deadline {})",
-                   peer, last_rx_back, last_rx_front, oldest_deadline);
+    return clock::zero();
   }
-  return failed_since;
 }
 
 void Heartbeat::Peer::send_heartbeat(
@@ -428,7 +430,7 @@ void Heartbeat::Peer::send_heartbeat(
     ceph::signedspan mnow,
     std::vector<seastar::future<>>& futures)
 {
-  if (clock::is_zero(first_tx)) {
+  if (!pinged()) {
     first_tx = now;
   }
   last_tx = now;
@@ -475,7 +477,7 @@ seastar::future<> Heartbeat::Peer::handle_reply(
   if (unacked == 0) {
     ping_history.erase(ping_history.begin(), ++ping);
   }
-  if (is_healthy(now)) {
+  if (do_health_screen(now) == health_state::HEALTHY) {
     // cancel false reports
     if (auto pending = heartbeat.failure_pending.find(peer);
         pending != heartbeat.failure_pending.end()) {

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -137,7 +137,7 @@ Heartbeat::osds_t Heartbeat::remove_down_peers()
     auto osdmap = service.get_osdmap_service().get_map();
     if (!osdmap->is_up(osd)) {
       remove_peer(osd);
-    } else if (peers[osd].epoch < osdmap->get_epoch()) {
+    } else if (peer.epoch < osdmap->get_epoch()) {
       osds.push_back(osd);
     }
   }

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -113,31 +113,21 @@ void Heartbeat::set_require_authorizer(bool require_authorizer)
   }
 }
 
-void Heartbeat::add_peer(osd_id_t peer, epoch_t epoch)
+void Heartbeat::add_peer(osd_id_t _peer, epoch_t epoch)
 {
-  auto [peer_info, added] = peers.try_emplace(peer);
-  auto& info = peer_info->second;
-  info.epoch = epoch;
-  if (added) {
-    logger().info("add_peer({})", peer);
-    auto osdmap = service.get_osdmap_service().get_map();
-    // TODO: use addrs
-    peer_info->second.con_front = front_msgr->connect(
-        osdmap->get_hb_front_addrs(peer).front(), CEPH_ENTITY_TYPE_OSD);
-    peer_info->second.con_back = back_msgr->connect(
-        osdmap->get_hb_back_addrs(peer).front(), CEPH_ENTITY_TYPE_OSD);
-  }
+  auto [iter, added] = peers.try_emplace(_peer, *this, _peer);
+  auto& peer = iter->second;
+  peer.set_epoch(epoch);
 }
 
 Heartbeat::osds_t Heartbeat::remove_down_peers()
 {
   osds_t osds;
-  for (auto& peer : peers) {
-    auto osd = peer.first;
+  for (auto& [osd, peer] : peers) {
     auto osdmap = service.get_osdmap_service().get_map();
     if (!osdmap->is_up(osd)) {
       remove_peer(osd);
-    } else if (peer.epoch < osdmap->get_epoch()) {
+    } else if (peer.get_epoch() < osdmap->get_epoch()) {
       osds.push_back(osd);
     }
   }
@@ -192,11 +182,8 @@ void Heartbeat::update_peers(int whoami)
 
 void Heartbeat::remove_peer(osd_id_t peer)
 {
-  logger().info("remove_peer({})", peer);
   auto found = peers.find(peer);
   assert(found != peers.end());
-  found->second.con_front->mark_down();
-  found->second.con_back->mark_down();
   peers.erase(peer);
 }
 
@@ -215,18 +202,11 @@ seastar::future<> Heartbeat::ms_dispatch(crimson::net::Connection* conn,
 
 void Heartbeat::ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace)
 {
-  auto found = std::find_if(peers.begin(), peers.end(),
-                            [conn](const peers_map_t::value_type& peer) {
-                              return (peer.second.con_front == conn ||
-                                      peer.second.con_back == conn);
-                            });
-  if (found == peers.end()) {
-    return;
+  // TODO: we should already have enough information to know which peer the
+  // conn belongs, so no need to do linear search here.
+  for (auto& [osd, peer] : peers) {
+    peer.handle_reset(conn);
   }
-  const auto peer = found->first;
-  const auto epoch = found->second.epoch;
-  remove_peer(peer);
-  add_peer(peer, epoch);
 }
 
 seastar::future<> Heartbeat::handle_osd_ping(crimson::net::Connection* conn,
@@ -272,31 +252,7 @@ seastar::future<> Heartbeat::handle_reply(crimson::net::Connection* conn,
     return seastar::now();
   }
   auto& peer = found->second;
-  auto ping = peer.ping_history.find(m->ping_stamp);
-  if (ping == peer.ping_history.end()) {
-    // old replies, deprecated by newly sent pings.
-    return seastar::now();
-  }
-  const auto now = clock::now();
-  auto& unacked = ping->second.unacknowledged;
-  if (conn == peer.con_back.get()) {
-    peer.last_rx_back = now;
-    unacked--;
-  } else if (conn == peer.con_front.get()) {
-    peer.last_rx_front = now;
-    unacked--;
-  }
-  if (unacked == 0) {
-    peer.ping_history.erase(peer.ping_history.begin(), ++ping);
-  }
-  if (peer.is_healthy(now)) {
-    // cancel false reports
-    if (auto pending = failure_pending.find(from);
-        pending != failure_pending.end()) {
-      return send_still_alive(from, pending->second.addrs);
-    }
-  }
-  return seastar::now();
+  return peer.handle_reply(conn, m);
 }
 
 seastar::future<> Heartbeat::handle_you_died()
@@ -309,27 +265,9 @@ void Heartbeat::heartbeat_check()
 {
   failure_queue_t failure_queue;
   const auto now = clock::now();
-  for (const auto& [osd, peer_info]: peers) {
-    if (clock::is_zero(peer_info.first_tx)) {
-      continue;
-    }
-
-    if (peer_info.is_unhealthy(now)) {
-      auto oldest_deadline = peer_info.ping_history.begin()->second.deadline;
-      auto failed_since = std::min(peer_info.last_rx_back,
-                                   peer_info.last_rx_front);
-      if (clock::is_zero(failed_since)) {
-        logger().error("heartbeat_check: no reply from osd.{} "
-                       "ever on either front or back, first ping sent {} "
-                       "(oldest deadline {})",
-                       osd, peer_info.first_tx, oldest_deadline);
-        failed_since = peer_info.first_tx;
-      } else {
-        logger().error("heartbeat_check: no reply from osd.{} "
-                       "since back {} front {} (oldest deadline {})",
-                       osd, peer_info.last_rx_back, peer_info.last_rx_front,
-                       oldest_deadline);
-      }
+  for (const auto& [osd, peer] : peers) {
+    auto failed_since = peer.failed_since(now);
+    if (!clock::is_zero(failed_since)) {
       failure_queue.emplace(osd, failed_since);
     }
   }
@@ -355,37 +293,10 @@ seastar::future<> Heartbeat::send_heartbeats()
 {
   const auto mnow = service.get_mnow();
   const auto now = clock::now();
-  const auto deadline =
-    now + std::chrono::seconds(local_conf()->osd_heartbeat_grace);
-  const utime_t sent_stamp{now};
 
   std::vector<seastar::future<>> futures;
-  for (auto& item : peers) {
-    auto& info = item.second;
-    info.last_tx = now;
-    if (clock::is_zero(info.first_tx)) {
-      info.first_tx = now;
-    }
-    [[maybe_unused]] auto [reply, added] =
-      info.ping_history.emplace(sent_stamp, reply_t{deadline, 0});
-    crimson::net::ConnectionRef conns[] = {info.con_front, info.con_back};
-    for (auto& con : conns) {
-      if (con) {
-        auto min_message = static_cast<uint32_t>(
-          local_conf()->osd_heartbeat_min_size);
-        auto ping = make_message<MOSDPing>(
-          monc.get_fsid(),
-          service.get_osdmap_service().get_map()->get_epoch(),
-          MOSDPing::PING,
-          sent_stamp,
-          mnow,
-          mnow,
-          service.get_osdmap_service().get_up_epoch(),
-          min_message);
-        reply->second.unacknowledged++;
-        futures.push_back(con->send(std::move(ping)));
-      }
-    }
+  for (auto& [osd, peer] : peers) {
+    peer.send_heartbeat(now, mnow, futures);
   }
   return seastar::when_all_succeed(futures.begin(), futures.end());
 }
@@ -431,7 +342,37 @@ seastar::future<> Heartbeat::send_still_alive(osd_id_t osd,
   });
 }
 
-bool Heartbeat::PeerInfo::is_unhealthy(clock::time_point now) const
+void Heartbeat::print(std::ostream& out) const
+{
+  out << "heartbeat";
+}
+
+void Heartbeat::Peer::connect()
+{
+  logger().info("peer osd.{} added", peer);
+  auto osdmap = heartbeat.service.get_osdmap_service().get_map();
+  // TODO: use addrs
+  con_front = heartbeat.front_msgr->connect(
+      osdmap->get_hb_front_addrs(peer).front(), CEPH_ENTITY_TYPE_OSD);
+  con_back = heartbeat.back_msgr->connect(
+      osdmap->get_hb_back_addrs(peer).front(), CEPH_ENTITY_TYPE_OSD);
+}
+
+Heartbeat::Peer::Peer(Heartbeat& heartbeat, osd_id_t peer)
+  : heartbeat(heartbeat), peer(peer)
+{ connect(); }
+
+void Heartbeat::Peer::disconnect()
+{
+  logger().info("peer osd.{} removed", peer);
+  con_front->mark_down();
+  con_back->mark_down();
+}
+
+Heartbeat::Peer::~Peer()
+{ disconnect(); }
+
+bool Heartbeat::Peer::is_unhealthy(clock::time_point now) const
 {
   if (ping_history.empty()) {
     // we haven't sent a ping yet or we have got all replies,
@@ -443,7 +384,7 @@ bool Heartbeat::PeerInfo::is_unhealthy(clock::time_point now) const
   }
 }
 
-bool Heartbeat::PeerInfo::is_healthy(clock::time_point now) const
+bool Heartbeat::Peer::is_healthy(clock::time_point now) const
 {
   if (con_front && clock::is_zero(last_rx_front)) {
     return false;
@@ -456,7 +397,106 @@ bool Heartbeat::PeerInfo::is_healthy(clock::time_point now) const
   return !is_unhealthy(now);
 }
 
-void Heartbeat::print(std::ostream& out) const
+Heartbeat::clock::time_point
+Heartbeat::Peer::failed_since(clock::time_point now) const
 {
-  out << "heartbeat";
+  if (clock::is_zero(first_tx)) {
+    return clock::zero();
+  }
+  if (!is_unhealthy(now)) {
+    return clock::zero();
+  }
+
+  auto oldest_deadline = ping_history.begin()->second.deadline;
+  auto failed_since = std::min(last_rx_back, last_rx_front);
+  if (clock::is_zero(failed_since)) {
+    logger().error("failed_since: no reply from osd.{} "
+                   "ever on either front or back, first ping sent {} "
+                   "(oldest deadline {})",
+                   peer, first_tx, oldest_deadline);
+    failed_since = first_tx;
+  } else {
+    logger().error("failed_since: no reply from osd.{} "
+                   "since back {} front {} (oldest deadline {})",
+                   peer, last_rx_back, last_rx_front, oldest_deadline);
+  }
+  return failed_since;
+}
+
+void Heartbeat::Peer::send_heartbeat(
+    clock::time_point now,
+    ceph::signedspan mnow,
+    std::vector<seastar::future<>>& futures)
+{
+  if (clock::is_zero(first_tx)) {
+    first_tx = now;
+  }
+  last_tx = now;
+
+  const utime_t sent_stamp{now};
+  const auto deadline =
+    now + std::chrono::seconds(local_conf()->osd_heartbeat_grace);
+  [[maybe_unused]] auto [reply, added] =
+    ping_history.emplace(sent_stamp, reply_t{deadline, 0});
+  for (auto& con : {con_front, con_back}) {
+    if (con) {
+      auto min_message = static_cast<uint32_t>(
+        local_conf()->osd_heartbeat_min_size);
+      auto ping = make_message<MOSDPing>(
+        heartbeat.monc.get_fsid(),
+        heartbeat.service.get_osdmap_service().get_map()->get_epoch(),
+        MOSDPing::PING,
+        sent_stamp,
+        mnow,
+        mnow,
+        heartbeat.service.get_osdmap_service().get_up_epoch(),
+        min_message);
+      reply->second.unacknowledged++;
+      futures.push_back(con->send(std::move(ping)));
+    }
+  }
+}
+
+seastar::future<> Heartbeat::Peer::handle_reply(
+    crimson::net::Connection* conn, Ref<MOSDPing> m)
+{
+  auto ping = ping_history.find(m->ping_stamp);
+  if (ping == ping_history.end()) {
+    // old replies, deprecated by newly sent pings.
+    return seastar::now();
+  }
+  const auto now = clock::now();
+  auto& unacked = ping->second.unacknowledged;
+  if (conn == con_back.get()) {
+    last_rx_back = now;
+    unacked--;
+  } else if (conn == con_front.get()) {
+    last_rx_front = now;
+    unacked--;
+  }
+  if (unacked == 0) {
+    ping_history.erase(ping_history.begin(), ++ping);
+  }
+  if (is_healthy(now)) {
+    // cancel false reports
+    if (auto pending = heartbeat.failure_pending.find(peer);
+        pending != heartbeat.failure_pending.end()) {
+      return heartbeat.send_still_alive(peer, pending->second.addrs);
+    }
+  }
+  return seastar::now();
+}
+
+void Heartbeat::Peer::handle_reset(crimson::net::ConnectionRef conn)
+{
+  if (con_front != conn && con_back != conn) {
+    return;
+  }
+  disconnect();
+  first_tx = {};
+  last_tx = {};
+  last_rx_front = {};
+  last_rx_back = {};
+  ping_history = {};
+  connect();
 }

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -83,6 +83,9 @@ private:
   // use real_clock so it can be converted to utime_t
   using clock = ceph::coarse_real_clock;
 
+  class Connector;
+  class Connection;
+  class Session;
   class Peer;
   using peers_map_t = std::map<osd_id_t, Peer>;
   peers_map_t peers;
@@ -127,56 +130,190 @@ inline std::ostream& operator<<(std::ostream& out, const Heartbeat& hb) {
   return out;
 }
 
-class Heartbeat::Peer {
+class Heartbeat::Connector {
  public:
-  Peer(Heartbeat&, osd_id_t);
-  ~Peer();
-  Peer(Peer&&) = delete;
-  Peer(const Peer&) = delete;
-  Peer& operator=(const Peer&) = delete;
+  Connector(size_t connections) : connections{connections} {}
+
+  void increase_connected() {
+    assert(connected < connections);
+    ++connected;
+    if (connected == connections) {
+      all_connected();
+    }
+  }
+  void decrease_connected() {
+    assert(connected > 0);
+    if (connected == connections) {
+      connection_lost();
+    }
+    --connected;
+  }
+  enum class type_t { front, back };
+  virtual entity_addr_t get_peer_addr(type_t) = 0;
+
+ protected:
+  virtual void all_connected() = 0;
+  virtual void connection_lost() = 0;
+
+ private:
+  const size_t connections;
+  size_t connected = 0;
+};
+
+class Heartbeat::Connection {
+ public:
+  using type_t = Connector::type_t;
+  Connection(osd_id_t peer, bool is_winner_side, type_t type,
+             crimson::net::Messenger& msgr, Connector& connector)
+    : peer{peer}, is_winner_side{is_winner_side}, type{type},
+      msgr{msgr}, connector{connector} {
+    connect();
+  }
+  ~Connection();
+
+  bool match(crimson::net::Connection* _conn) const;
+  bool match(crimson::net::ConnectionRef conn) const {
+    return match(conn.get());
+  }
+  void connected() {
+    set_connected();
+  }
+  void accepted(crimson::net::ConnectionRef);
+  void replaced();
+  void reset();
+  seastar::future<> send(MessageRef msg);
+  void validate();
+  // retry connection if still pending
+  void retry();
+
+ private:
+  void set_connected();
+  void connect();
+
+  const osd_id_t peer;
+  const bool is_winner_side;
+  const type_t type;
+  crimson::net::Messenger& msgr;
+  Connector& connector;
+
+  crimson::net::ConnectionRef conn;
+  bool is_connected = false;
+  bool racing_detected = false;
+
+ friend std::ostream& operator<<(std::ostream& os, const Connection c) {
+   if (c.type == type_t::front) {
+     return os << "con_front(osd." << c.peer << ")";
+   } else {
+     return os << "con_back(osd." << c.peer << ")";
+   }
+ }
+};
+
+class Heartbeat::Session {
+ public:
+  Session(osd_id_t peer) : peer{peer} {}
 
   void set_epoch(epoch_t epoch_) { epoch = epoch_; }
   epoch_t get_epoch() const { return epoch; }
+  bool is_started() const { return started; }
+  bool pinged() const {
+    if (clock::is_zero(first_tx)) {
+      // i can never receive a pong without sending any ping message first.
+      assert(clock::is_zero(last_rx_front) &&
+             clock::is_zero(last_rx_back));
+      return false;
+    } else {
+      return true;
+    }
+  }
 
-  // if failure, return time_point since last active
-  // else, return clock::zero()
-  clock::time_point failed_since(clock::time_point now) const;
-  void send_heartbeat(clock::time_point now,
-                      ceph::signedspan mnow,
-                      std::vector<seastar::future<>>&);
-  seastar::future<> handle_reply(crimson::net::Connection*, Ref<MOSDPing>);
-  void handle_reset(crimson::net::ConnectionRef, bool is_replace);
-  void handle_connect(crimson::net::ConnectionRef);
-  void handle_accept(crimson::net::ConnectionRef);
-
- private:
-  bool pinged() const;
   enum class health_state {
     UNKNOWN,
     UNHEALTHY,
     HEALTHY,
   };
-  health_state do_health_screen(clock::time_point now) const;
+  health_state do_health_screen(clock::time_point now) const {
+    if (!pinged()) {
+      // we are not healty nor unhealty because we haven't sent anything yet
+      return health_state::UNKNOWN;
+    } else if (!ping_history.empty() && ping_history.begin()->second.deadline < now) {
+      return health_state::UNHEALTHY;
+    } else if (!clock::is_zero(last_rx_front) &&
+               !clock::is_zero(last_rx_back)) {
+      // only declare to be healthy until we have received the first
+      // replies from both front/back connections
+      return health_state::HEALTHY;
+    } else {
+      return health_state::UNKNOWN;
+    }
+  }
 
-  // a session starts when con_front and con_back are both connected
-  void start_session();
-  // a session resets when either con_front or con_back is reset
-  void reset_session();
-  // notify when con_front becomes ready, possibly start session
-  void notify_front_ready();
-  void connect_front();
-  // notify when con_back becomes ready, possibly start session
-  void notify_back_ready();
-  void connect_back();
+  clock::time_point failed_since(clock::time_point now) const;
 
-  void do_send_heartbeat(clock::time_point now,
-                         ceph::signedspan mnow,
-                         std::vector<seastar::future<>>*);
+  void set_tx(clock::time_point now) {
+    if (!pinged()) {
+      first_tx = now;
+    }
+    last_tx = now;
+  }
+
+  void start() {
+    assert(!started);
+    started = true;
+    ping_history.clear();
+  }
+
+  void emplace_history(const utime_t& sent_stamp,
+                       const clock::time_point& deadline) {
+    assert(started);
+    [[maybe_unused]] auto [reply, added] =
+      ping_history.emplace(sent_stamp, reply_t{deadline, 2});
+  }
+
+  bool handle_reply(const utime_t& ping_stamp,
+                    Connection::type_t type,
+                    clock::time_point now) {
+    assert(started);
+    auto ping = ping_history.find(ping_stamp);
+    if (ping == ping_history.end()) {
+      // old replies, deprecated by newly sent pings.
+      return false;
+    }
+    auto& unacked = ping->second.unacknowledged;
+    assert(unacked);
+    if (type == Connection::type_t::front) {
+      last_rx_front = now;
+      unacked--;
+    } else {
+      last_rx_back = now;
+      unacked--;
+    }
+    if (unacked == 0) {
+      ping_history.erase(ping_history.begin(), ++ping);
+    }
+    return true;
+  }
+
+  void lost() {
+    assert(started);
+    started = false;
+    if (!ping_history.empty()) {
+      // we lost our ping_history of the last session, but still need to keep
+      // the oldest deadline for unhealthy check.
+      auto oldest = ping_history.begin();
+      auto sent_stamp = oldest->first;
+      auto deadline = oldest->second.deadline;
+      ping_history.clear();
+      ping_history.emplace(sent_stamp, reply_t{deadline, 0});
+    }
+  }
+
+  // maintain an entry in ping_history for unhealthy check
+  void set_inactive_history(clock::time_point);
 
  private:
-  Heartbeat& heartbeat;
   const osd_id_t peer;
-
+  bool started = false;
   // time we sent our first ping request
   clock::time_point first_tx;
   // last time we sent a ping request
@@ -188,20 +325,6 @@ class Heartbeat::Peer {
   // most recent epoch we wanted this peer
   epoch_t epoch;
 
-  // if racing happened
-  bool has_racing = false;
-  // peer connection (front)
-  crimson::net::ConnectionRef con_front;
-  bool front_ready = false;
-  // peer connection (back)
-  crimson::net::ConnectionRef con_back;
-  bool back_ready = false;
-
-  // start to send pings and track ping_history
-  bool session_started = false;
-  // if need to send heartbeat when session started
-  bool pending_send = false;
-
   struct reply_t {
     clock::time_point deadline;
     // one sent over front conn, another sent over back conn
@@ -209,4 +332,69 @@ class Heartbeat::Peer {
   };
   // history of inflight pings, arranging by timestamp we sent
   std::map<utime_t, reply_t> ping_history;
+};
+
+class Heartbeat::Peer final : private Heartbeat::Connector {
+ public:
+  Peer(Heartbeat&, osd_id_t);
+  ~Peer();
+  Peer(Peer&&) = delete;
+  Peer(const Peer&) = delete;
+  Peer& operator=(const Peer&) = delete;
+
+  void set_epoch(epoch_t epoch) { session.set_epoch(epoch); }
+  epoch_t get_epoch() const { return session.get_epoch(); }
+
+  // if failure, return time_point since last active
+  // else, return clock::zero()
+  clock::time_point failed_since(clock::time_point now) const {
+    return session.failed_since(now);
+  }
+  void send_heartbeat(
+      clock::time_point, ceph::signedspan, std::vector<seastar::future<>>&);
+  seastar::future<> handle_reply(crimson::net::Connection*, Ref<MOSDPing>);
+  void handle_reset(crimson::net::ConnectionRef conn, bool is_replace) {
+    for_each_conn([&] (auto& _conn) {
+      if (_conn.match(conn)) {
+        if (is_replace) {
+          _conn.replaced();
+        } else {
+          _conn.reset();
+        }
+      }
+    });
+  }
+  void handle_connect(crimson::net::ConnectionRef conn) {
+    for_each_conn([&] (auto& _conn) {
+      if (_conn.match(conn)) {
+        _conn.connected();
+      }
+    });
+  }
+  void handle_accept(crimson::net::ConnectionRef conn) {
+    for_each_conn([&] (auto& _conn) {
+      _conn.accepted(conn);
+    });
+  }
+
+ private:
+  entity_addr_t get_peer_addr(type_t type) override;
+  void all_connected() override;
+  void connection_lost() override;
+  void do_send_heartbeat(
+      clock::time_point, ceph::signedspan, std::vector<seastar::future<>>*);
+
+  template <typename Func>
+  void for_each_conn(Func&& f) {
+    f(con_front);
+    f(con_back);
+  }
+
+  Heartbeat& heartbeat;
+  const osd_id_t peer;
+  Session session;
+  // if need to send heartbeat when session started
+  bool pending_send = false;
+  Connection con_front;
+  Connection con_back;
 };

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -130,9 +130,13 @@ class Heartbeat::Peer {
   void handle_reset(crimson::net::ConnectionRef);
 
  private:
-  bool is_unhealthy(clock::time_point now) const;
-  bool is_healthy(clock::time_point now) const;
-
+  bool pinged() const;
+  enum class health_state {
+    UNKNOWN,
+    UNHEALTHY,
+    HEALTHY,
+  };
+  health_state do_health_screen(clock::time_point now) const;
   void connect();
   void disconnect();
 

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -111,6 +111,7 @@ private:
   peers_map_t peers;
   // osds which are considered failed
   // osd_id => when was the last time that both front and back pings were acked
+  //           or sent.
   //           use for calculating how long the OSD has been unresponsive
   using failure_queue_t = std::map<osd_id_t, clock::time_point>;
   seastar::future<> send_failures(failure_queue_t&& failure_queue);

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -82,7 +82,7 @@ OSD::OSD(int id, uint32_t nonce,
       local_conf().get_val<std::string>("osd_data"),
       local_conf().get_config_values())},
     shard_services{*this, *cluster_msgr, *public_msgr, *monc, *mgrc, *store},
-    heartbeat{new Heartbeat{shard_services, *monc, hb_front_msgr, hb_back_msgr}},
+    heartbeat{new Heartbeat{whoami, shard_services, *monc, hb_front_msgr, hb_back_msgr}},
     // do this in background
     heartbeat_timer{[this] { update_heartbeat_peers(); }},
     asok{seastar::make_lw_shared<crimson::admin::AdminSocket>()},


### PR DESCRIPTION
Resolve deadlocks identified by https://github.com/ceph/ceph/pull/33909#issuecomment-599380821 to support single connection between a heartbeat peer.

Please refer to commit `crimson/osd: support 1 lossy connection between a heartbeat peer` for major changes. The others are mostly cleanup and refactorings in crimson heartbeat as preparations for the changes.

The required supports from crimson messenger are proposed in https://github.com/ceph/ceph/pull/34332.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
