### PR TITLE
octopus: qa/standalone/osd/osd-backfill-recovery-log.sh: fix TEST_backfill_log_[1, 2]

### DIFF
--- a/qa/standalone/osd/osd-backfill-recovery-log.sh
+++ b/qa/standalone/osd/osd-backfill-recovery-log.sh
@@ -74,6 +74,8 @@ function _common_test() {
     sleep 1
     wait_for_clean
 
+    flush_pg_stats
+
     newprimary=$(ceph pg dump pgs --format=json | jq '.pg_stats[0].up_primary')
     kill_daemons
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44847

---

backport of

* https://github.com/ceph/ceph/pull/34126
* NOTE: https://github.com/ceph/ceph/pull/32851 was merged to octopus before octopus backporting started
parent tracker: https://tracker.ceph.com/issues/43807

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh