### PR TITLE
doc/mgr/orchestrator: add path to ssh-copy-id instructions

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -150,12 +150,12 @@ To add each new host to the cluster, perform two steps:
 #. Install the cluster's public SSH key in the new host's root user's
    ``authorized_keys`` file::
 
-     # ssh-copy-id -f -i ceph.pub root@*<new-host>*
+     # ssh-copy-id -f -i /etc/ceph/ceph.pub root@*<new-host>*
 
    For example::
 
-     # ssh-copy-id -f -i ceph.pub root@host2
-     # ssh-copy-id -f -i ceph.pub root@host3
+     # ssh-copy-id -f -i /etc/ceph/ceph.pub root@host2
+     # ssh-copy-id -f -i /etc/ceph/ceph.pub root@host3
 
 #. Tell Ceph that the new node is part of the cluster::
 


### PR DESCRIPTION
by default ssh key will be placed under /etc/ceph - so it should be included in examples

Signed-off-by: Tobias Fischer tobias.fischer@clyso.com

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
