### PR TITLE
crimson/osd: OP_CALL does support RETURNVEC now.

### DIFF
--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -880,6 +880,7 @@ namespace ct_error {
     ct_error_code<std::errc::operation_not_supported>;
   using not_connected = ct_error_code<std::errc::not_connected>;
   using timed_out = ct_error_code<std::errc::timed_out>;
+  using value_too_large = ct_error_code<std::errc::value_too_large>;
 
   struct pass_further_all {
     template <class ErrorT>

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -42,7 +42,8 @@ class OpsExecuter {
     crimson::ct_error::invarg,
     crimson::ct_error::permission_denied,
     crimson::ct_error::operation_not_supported,
-    crimson::ct_error::input_output_error>;
+    crimson::ct_error::input_output_error,
+    crimson::ct_error::value_too_large>;
   using read_errorator = PGBackend::read_errorator;
   using get_attr_errorator = PGBackend::get_attr_errorator;
   using watch_errorator = crimson::errorator<
@@ -79,6 +80,7 @@ private:
   };
 
   ObjectContextRef obc;
+  const OpInfo* op_info;
   PG& pg;
   PGBackend& backend;
   Ref<MOSDOp> msg;
@@ -163,14 +165,15 @@ private:
   }
 
 public:
-  OpsExecuter(ObjectContextRef obc, PG& pg, Ref<MOSDOp> msg)
+  OpsExecuter(ObjectContextRef obc, const OpInfo* op_info, PG& pg, Ref<MOSDOp> msg)
     : obc(std::move(obc)),
+      op_info(op_info),
       pg(pg),
       backend(pg.get_backend()),
       msg(std::move(msg)) {
   }
   OpsExecuter(PG& pg, Ref<MOSDOp> msg)
-    : OpsExecuter{ObjectContextRef(), pg, std::move(msg)}
+    : OpsExecuter{ObjectContextRef(), nullptr, pg, std::move(msg)}
   {}
 
   osd_op_errorator::future<> execute_osd_op(class OSDOp& osd_op);

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -114,7 +114,7 @@ seastar::future<> ClientRequest::process_op(
       [this, &pg](auto obc) {
 	return with_blocking_future(handle.enter(pp(pg).process)
 	).then([this, &pg, obc]() {
-	  return pg.do_osd_ops(m, obc);
+	  return pg.do_osd_ops(m, obc, op_info);
 	}).then([this](Ref<MOSDOpReply> reply) {
 	  return conn->send(reply);
 	});

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -481,7 +481,8 @@ private:
     PeeringCtx &rctx);
   seastar::future<Ref<MOSDOpReply>> do_osd_ops(
     Ref<MOSDOp> m,
-    ObjectContextRef obc);
+    ObjectContextRef obc,
+    const OpInfo &op_info);
   seastar::future<Ref<MOSDOpReply>> do_pg_ops(Ref<MOSDOp> m);
   seastar::future<> do_osd_op(
     ObjectState& os,

--- a/src/test/cls_hello/test_cls_hello.cc
+++ b/src/test/cls_hello/test_cls_hello.cc
@@ -118,7 +118,7 @@ TEST(ClsHello, WriteReturnData) {
     return;
   }
 
-  // this will return nothing -- not flag set
+  // this will return nothing -- no flag is set
   bufferlist in, out;
   ASSERT_EQ(0, ioctx.exec("myobject", "hello", "write_return_data", in, out));
   ASSERT_EQ(std::string(), std::string(out.c_str(), out.length()));


### PR DESCRIPTION
This makes the `ceph_test_cls_hello` green again:
```
$ ./bin/ceph_test_cls_hello
Running main() from gmock_main.cc
[==========] Running 6 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from ClsHello
[ RUN      ] ClsHello.SayHello
[       OK ] ClsHello.SayHello (2222 ms)
[ RUN      ] ClsHello.RecordHello
[       OK ] ClsHello.RecordHello (3071 ms)
[ RUN      ] ClsHello.WriteReturnData
require_osd_release = octopus
0
1
00000000  79 6f 75 20 6d 69 67 68  74 20 73 65 65 20 74 68  |you might see th|
00000010  69 73                                             |is|
00000012
00000000  79 6f 75 20 6d 69 67 68  74 20 73 65 65 20 74 68  |you might see th|
00000010  69 73                                             |is|
00000012
[       OK ] ClsHello.WriteReturnData (3098 ms)
[ RUN      ] ClsHello.Loud
[       OK ] ClsHello.Loud (3088 ms)
[ RUN      ] ClsHello.BadMethods
[       OK ] ClsHello.BadMethods (3096 ms)
[ RUN      ] ClsHello.Filter
[       OK ] ClsHello.Filter (3089 ms)
[----------] 6 tests from ClsHello (17666 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (17666 ms total)
[  PASSED  ] 6 tests.
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>
CC: @AmnonHanuhov.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
