### PR TITLE
nautilus: mgr: synchronize ClusterState's health and mon_status.

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -379,18 +379,19 @@ PyObject *ActivePyModules::get_python(const std::string &what)
         f.close_section();
     });
     return f.get();
-  } else if (what == "health" || what == "mon_status") {
-    bufferlist json;
-    if (what == "health") {
-      json = cluster_state.get_health();
-    } else if (what == "mon_status") {
-      json = cluster_state.get_mon_status();
-    } else {
-      ceph_abort();
-    }
-
-    PyEval_RestoreThread(tstate);
-    f.dump_string("json", json.to_str());
+  } else if (what == "health") {
+    cluster_state.with_health(
+        [&f, &tstate](const ceph::bufferlist &health_json) {
+      PyEval_RestoreThread(tstate);
+      f.dump_string("json", health_json.to_str());
+    });
+    return f.get();
+  } else if (what == "mon_status") {
+    cluster_state.with_mon_status(
+        [&f, &tstate](const ceph::bufferlist &mon_status_json) {
+      PyEval_RestoreThread(tstate);
+      f.dump_string("json", mon_status_json.to_str());
+    });
     return f.get();
   } else if (what == "mgr_map") {
     cluster_state.with_mgrmap([&f, &tstate](const MgrMap &mgr_map) {

--- a/src/mgr/ClusterState.cc
+++ b/src/mgr/ClusterState.cc
@@ -63,6 +63,7 @@ void ClusterState::set_service_map(ServiceMap const &new_service_map)
 
 void ClusterState::load_digest(MMgrDigest *m)
 {
+  std::lock_guard l(lock);
   health_json = std::move(m->health_json);
   mon_status_json = std::move(m->mon_status_json);
 }

--- a/src/mgr/ClusterState.h
+++ b/src/mgr/ClusterState.h
@@ -59,9 +59,6 @@ public:
 
   void update_delta_stats();
 
-  const bufferlist &get_health() const {return health_json;}
-  const bufferlist &get_mon_status() const {return mon_status_json;}
-
   ClusterState(MonClient *monc_, Objecter *objecter_, const MgrMap& mgrmap);
 
   void set_objecter(Objecter *objecter_);
@@ -139,6 +136,21 @@ public:
       pg_map,
       std::forward<Args>(args)...);
   }
+
+  template<typename Callback, typename...Args>
+  void with_health(Callback&& cb, Args&&...args) const
+  {
+    std::lock_guard l(lock);
+    std::forward<Callback>(cb)(health_json, std::forward<Args>(args)...);
+  }
+
+  template<typename Callback, typename...Args>
+  void with_mon_status(Callback&& cb, Args&&...args) const
+  {
+    std::lock_guard l(lock);
+    std::forward<Callback>(cb)(mon_status_json, std::forward<Args>(args)...);
+  }
+
   void final_init();
   void shutdown();
   bool asok_command(std::string_view admin_command, const cmdmap_t& cmdmap,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44868

---

Fixes: https://tracker.ceph.com/issues/24995
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>
(cherry picked from commit da362675da51de8b20a12e4cec479a77c7f5442b)

PR for `master`: https://github.com/ceph/ceph/pull/34245.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
