### PR TITLE
src/script/build_in_container.py: Automate a container build

### DIFF
--- a/src/script/build_in_container.py
+++ b/src/script/build_in_container.py
@@ -1,0 +1,37 @@
+#! /usr/bin/python3
+
+import os
+import sys
+import pexpect
+import argparse
+import multiprocessing
+
+os.chdir('{}/..'.format(os.path.dirname(os.path.abspath(__file__))))
+
+parser = argparse.ArgumentParser(description="Build HEAD in a container")
+parser.add_argument('-c', '--cpus', default=multiprocessing.cpu_count(),
+                    help="Number of cpus to pass to make/ctest")
+parser.add_argument('-t', '--test', default=False, action='store_true', help="Run ctest tests")
+parser.add_argument('-o', '--os', default="fedora", help="Distro to build")
+parser.add_argument('-v', '--version', default="31", help="Version to build")
+args = parser.parse_args()
+
+child = pexpect.spawn(
+        './test/docker-test.sh --os-type {} --os-version {} --shell'.format(
+            args.os, args.version))
+child.timeout=21600 # six hours
+child.logfile_read = sys.stdout.buffer
+child.expect(['bash-5.0\$ ', '~/working/src/ceph-ubuntu-18.04-.*\$ '])
+child.sendline('./do_cmake.sh')
+child.expect(['bash-5.0\$ ', '~/working/src/ceph-ubuntu-18.04-.*\$ '])
+child.sendline('cd build')
+child.expect(['bash-5.0\$ ', '~/working/src/ceph-ubuntu-18.04-.*\$ '])
+child.sendline('make -j{} all tests'.format(args.cpus))
+child.expect(['bash-5.0\$ ', '~/working/src/ceph-ubuntu-18.04-.*\$ '])
+if (args.test):
+    child.sendline('ctest -j{}'.format(args.cpus))
+    child.expect(['bash-5.0\$ ', '~/working/src/ceph-ubuntu-18.04-.*\$ '])
+child.logfile_read = None
+child.interact()
+if child.isalive():
+    child.close()


### PR DESCRIPTION
Leverage the docker-test.sh script to build the current commit in a
Fedora or Ubuntu container.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
