### PR TITLE
cephadm: add `extra_args` to nfs daemon

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -190,6 +190,7 @@ class NFSGanesha(object):
         # config-json options
         self.pool = json_get('pool', require=True)
         self.namespace = json_get('namespace')
+        self.extra_args = json_get('extra_args', [])
         self.files = json_get('files', {})
 
         # validate the supplied args
@@ -263,6 +264,10 @@ class NFSGanesha(object):
         if desc:
             cname = '%s-%s' % (cname, desc)
         return cname
+
+    def get_daemon_args(self):
+        # type: () -> List[str]
+        return self.daemon_args + self.extra_args
 
     def get_file_content(self, fname):
         # type: (str) -> str
@@ -1276,7 +1281,8 @@ def get_daemon_args(fsid, daemon_type, daemon_id):
             for peer in peers:
                 r += ["--cluster.peer={}".format(peer)]
     elif daemon_type == NFSGanesha.daemon_type:
-        r += NFSGanesha.daemon_args
+        nfs_ganesha = NFSGanesha.init(fsid, daemon_id)
+        r += nfs_ganesha.get_daemon_args()
 
     return r
 

--- a/src/pybind/mgr/cephadm/nfs.py
+++ b/src/pybind/mgr/cephadm/nfs.py
@@ -121,6 +121,7 @@ RADOS_URLS {{
         config = {'pool' : self.spec.pool} # type: Dict
         if self.spec.namespace:
             config['namespace'] = self.spec.namespace
+        config['extra_args'] = ['-N', 'NIV_EVENT']
         config['files'] = {
             'ganesha.conf' : self.get_ganesha_conf(),
         }


### PR DESCRIPTION
Make it somewhat easier to send extra args for items such as the default log level `NIV_DEBUG` etc.

Follows a pattern similar to the `sysconfig` file that was used with systemd:
https://github.com/nfs-ganesha/nfs-ganesha/blob/091816d25a38eb7e75ec7b60ba43fea30f3994b3/src/scripts/systemd/sysconfig/nfs-ganesha#L1

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
