### PR TITLE
crimson/net: enable features for lossy peer connections of heartbeat

### DIFF
--- a/src/crimson/mgr/client.cc
+++ b/src/crimson/mgr/client.cc
@@ -70,7 +70,7 @@ seastar::future<> Client::ms_handle_connect(crimson::net::ConnectionRef c)
   }
 }
 
-seastar::future<> Client::ms_handle_reset(crimson::net::ConnectionRef c)
+seastar::future<> Client::ms_handle_reset(crimson::net::ConnectionRef c, bool is_replace)
 {
   if (conn == c) {
     report_timer.cancel();

--- a/src/crimson/mgr/client.h
+++ b/src/crimson/mgr/client.h
@@ -39,7 +39,7 @@ public:
 private:
   seastar::future<> ms_dispatch(crimson::net::Connection* conn,
 				Ref<Message> m) override;
-  seastar::future<> ms_handle_reset(crimson::net::ConnectionRef conn) final;
+  seastar::future<> ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) final;
   seastar::future<> ms_handle_connect(crimson::net::ConnectionRef conn) final;
   seastar::future<> handle_mgr_map(crimson::net::Connection* conn,
 				   Ref<MMgrMap> m);

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -541,7 +541,7 @@ Client::ms_dispatch(crimson::net::Connection* conn, MessageRef m)
   }
 }
 
-seastar::future<> Client::ms_handle_reset(crimson::net::ConnectionRef conn)
+seastar::future<> Client::ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace)
 {
   auto found = std::find_if(pending_conns.begin(), pending_conns.end(),
                             [peer_addr = conn->get_peer_addr()](auto& mc) {

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -141,7 +141,7 @@ private:
 
   seastar::future<> ms_dispatch(crimson::net::Connection* conn,
 				MessageRef m) override;
-  seastar::future<> ms_handle_reset(crimson::net::ConnectionRef conn) override;
+  seastar::future<> ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) override;
 
   seastar::future<> handle_monmap(crimson::net::Connection* conn,
 				  Ref<MMonMap> m);

--- a/src/crimson/net/Dispatcher.h
+++ b/src/crimson/net/Dispatcher.h
@@ -39,7 +39,11 @@ class Dispatcher {
     return seastar::make_ready_future<>();
   }
 
-  virtual seastar::future<> ms_handle_reset(ConnectionRef conn) {
+  // a reset event is dispatched when the connection is closed unexpectedly.
+  // is_replace=true means the reset connection is going to be replaced by
+  // another accepting connection with the same peer_addr, which currently only
+  // happens under lossy policy when both sides wish to connect to each other.
+  virtual seastar::future<> ms_handle_reset(ConnectionRef conn, bool is_replace) {
     return seastar::make_ready_future<>();
   }
 

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -78,7 +78,13 @@ public:
   /// or a new pending connection
   virtual ConnectionRef
   connect(const entity_addr_t& peer_addr,
-          const entity_type_t& peer_type) = 0;
+          const entity_name_t& peer_name) = 0;
+
+  ConnectionRef
+  connect(const entity_addr_t& peer_addr,
+          const entity_type_t& peer_type) {
+    return connect(peer_addr, entity_name_t(peer_type, -1));
+  }
 
   // wait for messenger shutdown
   virtual seastar::future<> wait() = 0;

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -48,9 +48,10 @@ void Protocol::close(bool dispatch_reset,
     return;
   }
 
+  bool is_replace = f_accept_new ? true : false;
   logger().info("{} closing: reset {}, replace {}", conn,
                 dispatch_reset ? "yes" : "no",
-                f_accept_new ? "yes" : "no");
+                is_replace ? "yes" : "no");
 
   // unregister_conn() drops a reference, so hold another until completion
   auto cleanup = [conn_ref = conn.shared_from_this(), this] {
@@ -74,10 +75,11 @@ void Protocol::close(bool dispatch_reset,
   }
   set_write_state(write_state_t::drop);
   auto gate_closed = pending_dispatch.close();
-  auto reset_dispatched = seastar::futurize_apply([this, dispatch_reset] {
+  auto reset_dispatched = seastar::futurize_apply([this, dispatch_reset, is_replace] {
     if (dispatch_reset) {
       return dispatcher.ms_handle_reset(
-          seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()));
+          seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()),
+          is_replace);
     }
     return seastar::now();
   }).handle_exception([this] (std::exception_ptr eptr) {

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -35,11 +35,6 @@ Protocol::~Protocol()
   assert(!exit_open);
 }
 
-bool Protocol::is_connected() const
-{
-  return write_state == write_state_t::open;
-}
-
 void Protocol::close(bool dispatch_reset,
                      std::optional<std::function<void()>> f_accept_new)
 {

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -41,7 +41,7 @@ class Protocol {
   }
 
   virtual void start_connect(const entity_addr_t& peer_addr,
-                             const entity_type_t& peer_type) = 0;
+                             const entity_name_t& peer_name) = 0;
 
   virtual void start_accept(SocketRef&& socket,
                             const entity_addr_t& peer_addr) = 0;

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -23,7 +23,7 @@ class Protocol {
   Protocol(Protocol&&) = delete;
   virtual ~Protocol();
 
-  bool is_connected() const;
+  virtual bool is_connected() const = 0;
 
 #ifdef UNIT_TESTS_BUILT
   bool is_closed_clean = false;

--- a/src/crimson/net/ProtocolV1.h
+++ b/src/crimson/net/ProtocolV1.h
@@ -18,6 +18,8 @@ class ProtocolV1 final : public Protocol {
   ~ProtocolV1() override;
 
  private:
+  bool is_connected() const override;
+
   void start_connect(const entity_addr_t& peer_addr,
                      const entity_name_t& peer_name) override;
 
@@ -110,7 +112,12 @@ class ProtocolV1 final : public Protocol {
   seastar::future<> maybe_throttle();
   seastar::future<> read_message();
   seastar::future<> handle_tags();
-  void execute_open();
+
+  enum class open_t {
+    connected,
+    accepted
+  };
+  void execute_open(open_t type);
 
   // replacing
   // the number of connections initiated in this session, increment when a

--- a/src/crimson/net/ProtocolV1.h
+++ b/src/crimson/net/ProtocolV1.h
@@ -19,7 +19,7 @@ class ProtocolV1 final : public Protocol {
 
  private:
   void start_connect(const entity_addr_t& peer_addr,
-                     const entity_type_t& peer_type) override;
+                     const entity_name_t& peer_name) override;
 
   void start_accept(SocketRef&& socket,
                     const entity_addr_t& peer_addr) override;

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -19,6 +19,8 @@ class ProtocolV2 final : public Protocol {
   ~ProtocolV2() override;
 
  private:
+  bool is_connected() const override;
+
   void start_connect(const entity_addr_t& peer_addr,
                      const entity_name_t& peer_name) override;
 
@@ -204,7 +206,7 @@ class ProtocolV2 final : public Protocol {
 
   // READY
   seastar::future<> read_message(utime_t throttle_stamp);
-  void execute_ready();
+  void execute_ready(bool dispatch_connect);
 
   // STANDBY
   void execute_standby();

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -20,7 +20,7 @@ class ProtocolV2 final : public Protocol {
 
  private:
   void start_connect(const entity_addr_t& peer_addr,
-                     const entity_type_t& peer_type) override;
+                     const entity_name_t& peer_name) override;
 
   void start_accept(SocketRef&& socket,
                     const entity_addr_t& peer_addr) override;
@@ -159,6 +159,7 @@ class ProtocolV2 final : public Protocol {
   seastar::future<> _handle_auth_request(bufferlist& auth_payload, bool more);
   seastar::future<> server_auth();
 
+  bool validate_peer_name(const entity_name_t& peer_name) const;
   seastar::future<next_step_t> send_wait();
   seastar::future<next_step_t> reuse_connection(ProtocolV2* existing_proto,
                                                 bool do_reset=false,

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -114,9 +114,9 @@ bool SocketConnection::update_rx_seq(seq_num_t seq)
 
 void
 SocketConnection::start_connect(const entity_addr_t& _peer_addr,
-                                const entity_type_t& _peer_type)
+                                const entity_name_t& _peer_name)
 {
-  protocol->start_connect(_peer_addr, _peer_type);
+  protocol->start_connect(_peer_addr, _peer_name);
 }
 
 void

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -83,7 +83,7 @@ class SocketConnection : public Connection {
   /// start a handshake from the client's perspective,
   /// only call when SocketConnection first construct
   void start_connect(const entity_addr_t& peer_addr,
-                     const entity_type_t& peer_type);
+                     const entity_name_t& peer_name);
   /// start a handshake from the server's perspective,
   /// only call when SocketConnection first construct
   void start_accept(SocketRef&& socket,

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -132,7 +132,7 @@ seastar::future<> SocketMessenger::start(Dispatcher *disp) {
 }
 
 crimson::net::ConnectionRef
-SocketMessenger::connect(const entity_addr_t& peer_addr, const entity_type_t& peer_type)
+SocketMessenger::connect(const entity_addr_t& peer_addr, const entity_name_t& peer_name)
 {
   assert(seastar::engine().cpu_id() == master_sid);
 
@@ -146,7 +146,7 @@ SocketMessenger::connect(const entity_addr_t& peer_addr, const entity_type_t& pe
   }
   SocketConnectionRef conn = seastar::make_shared<SocketConnection>(
       *this, *dispatcher, peer_addr.is_msgr2());
-  conn->start_connect(peer_addr, peer_type);
+  conn->start_connect(peer_addr, peer_name);
   return conn->shared_from_this();
 }
 

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -141,7 +141,7 @@ SocketMessenger::connect(const entity_addr_t& peer_addr, const entity_name_t& pe
   ceph_assert(peer_addr.get_port() > 0);
 
   if (auto found = lookup_conn(peer_addr); found) {
-    logger().info("{} connect to existing", *found);
+    logger().debug("{} connect to existing", *found);
     return found->shared_from_this();
   }
   SocketConnectionRef conn = seastar::make_shared<SocketConnection>(

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -66,7 +66,7 @@ class SocketMessenger final : public Messenger {
   seastar::future<> start(Dispatcher *dispatcher) override;
 
   ConnectionRef connect(const entity_addr_t& peer_addr,
-                        const entity_type_t& peer_type) override;
+                        const entity_name_t& peer_name) override;
   // can only wait once
   seastar::future<> wait() override {
     assert(seastar::engine().cpu_id() == master_sid);

--- a/src/crimson/osd/chained_dispatchers.cc
+++ b/src/crimson/osd/chained_dispatchers.cc
@@ -26,9 +26,9 @@ ChainedDispatchers::ms_handle_connect(crimson::net::ConnectionRef conn) {
 }
 
 seastar::future<>
-ChainedDispatchers::ms_handle_reset(crimson::net::ConnectionRef conn) {
-  return seastar::do_for_each(dispatchers, [conn](Dispatcher* dispatcher) {
-    return dispatcher->ms_handle_reset(conn);
+ChainedDispatchers::ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) {
+  return seastar::do_for_each(dispatchers, [conn, is_replace](Dispatcher* dispatcher) {
+    return dispatcher->ms_handle_reset(conn, is_replace);
   });
 }
 

--- a/src/crimson/osd/chained_dispatchers.h
+++ b/src/crimson/osd/chained_dispatchers.h
@@ -25,6 +25,6 @@ public:
   seastar::future<> ms_dispatch(crimson::net::Connection* conn, MessageRef m) override;
   seastar::future<> ms_handle_accept(crimson::net::ConnectionRef conn) override;
   seastar::future<> ms_handle_connect(crimson::net::ConnectionRef conn) override;
-  seastar::future<> ms_handle_reset(crimson::net::ConnectionRef conn) override;
+  seastar::future<> ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) override;
   seastar::future<> ms_handle_remote_reset(crimson::net::ConnectionRef conn) override;
 };

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -195,7 +195,7 @@ seastar::future<> Heartbeat::ms_dispatch(crimson::net::Connection* conn,
   }
 }
 
-seastar::future<> Heartbeat::ms_handle_reset(crimson::net::ConnectionRef conn)
+seastar::future<> Heartbeat::ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace)
 {
   auto found = std::find_if(peers.begin(), peers.end(),
                             [conn](const peers_map_t::value_type& peer) {

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -46,7 +46,7 @@ public:
   // Dispatcher methods
   seastar::future<> ms_dispatch(crimson::net::Connection* conn,
 				MessageRef m) override;
-  seastar::future<> ms_handle_reset(crimson::net::ConnectionRef conn) override;
+  seastar::future<> ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) override;
 
 private:
   seastar::future<> handle_osd_ping(crimson::net::Connection* conn,

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -614,7 +614,7 @@ seastar::future<> OSD::ms_handle_connect(crimson::net::ConnectionRef conn)
   }
 }
 
-seastar::future<> OSD::ms_handle_reset(crimson::net::ConnectionRef conn)
+seastar::future<> OSD::ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace)
 {
   // TODO: cleanup the session attached to this connection
   logger().warn("ms_handle_reset");

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -100,7 +100,7 @@ class OSD final : public crimson::net::Dispatcher,
   // Dispatcher methods
   seastar::future<> ms_dispatch(crimson::net::Connection* conn, MessageRef m) final;
   seastar::future<> ms_handle_connect(crimson::net::ConnectionRef conn) final;
-  seastar::future<> ms_handle_reset(crimson::net::ConnectionRef conn) final;
+  seastar::future<> ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) final;
   seastar::future<> ms_handle_remote_reset(crimson::net::ConnectionRef conn) final;
 
   // mgr::WithStats methods

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -846,7 +846,7 @@ class FailoverSuite : public Dispatcher {
     return seastar::now();
   }
 
-  seastar::future<> ms_handle_reset(ConnectionRef conn) override {
+  seastar::future<> ms_handle_reset(ConnectionRef conn, bool is_replace) override {
     auto result = interceptor.find_result(conn);
     if (result == nullptr) {
       logger().error("Untracked reset connection: {}", *conn);
@@ -1384,7 +1384,7 @@ class FailoverSuitePeer : public Dispatcher {
     return flush_pending_send();
   }
 
-  seastar::future<> ms_handle_reset(ConnectionRef conn) override {
+  seastar::future<> ms_handle_reset(ConnectionRef conn, bool is_replace) override {
     logger().info("[TestPeer] got reset from Test");
     ceph_assert(tracked_conn == conn);
     tracked_conn = nullptr;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
