### PR TITLE
rbd/cache: fix PMDK link issue in unittest_librbd

### DIFF
--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -147,6 +147,11 @@ target_link_libraries(unittest_librbd
   global
   ${UNITTEST_LIBS})
 
+if(WITH_RBD_RWL)
+  target_link_libraries(unittest_librbd
+    pmem::pmemobj)
+endif()
+
 add_executable(ceph_test_librbd
   test_main.cc
   $<TARGET_OBJECTS:common_texttable_obj>)


### PR DESCRIPTION
Without using system-installed PMDK, it will hit a compile error when building unittest_librbd where it complains it can't locate the libpmemobj.h.

This issue is related to PR: https://github.com/ceph/ceph/pull/33502

Reproducing steps:
1. without system-installed PMDK
2. remove build folder
3. git submodule update --init --recursive
4. ./install-deps.sh
5. ./do_cmake.sh -DWITH_RBD_RWL=ON -DWITH_MGR_DASHBOARD_FRONTEND=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
6. cd build
7. make unittest_librbd

Error message:
ceph/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc:11:
 86 /root/luyuan/community/github/ceph/src/librbd/cache/rwl/Types.h:8:10: fatal error: libpmemobj.h: No such file or directory
 87     8 | #include <libpmemobj.h>
 88       |          ^~~~~~~~~~~~~~
 89 compilation terminated.
 90 src/test/librbd/CMakeFiles/unittest_librbd.dir/build.make:1814: recipe for target 'src/test/librbd/CMakeFiles/unittest_librbd.dir/cache/test_mock_ReplicatedWriteLog.cc.o' failed
 91 make[3]: *** [src/test/librbd/CMakeFiles/unittest_librbd.dir/cache/test_mock_ReplicatedWriteLog.cc.o] Error 1
 92 make[3]: *** Waiting for unfinished jobs....
 93 CMakeFiles/Makefile2:20379: recipe for target 'src/test/librbd/CMakeFiles/unittest_librbd.dir/all' failed
 94 make[2]: *** [src/test/librbd/CMakeFiles/unittest_librbd.dir/all] Error 2
 95 CMakeFiles/Makefile2:20391: recipe for target 'src/test/librbd/CMakeFiles/unittest_librbd.dir/rule' failed
 96 make[1]: *** [src/test/librbd/CMakeFiles/unittest_librbd.dir/rule] Error 2
 97 Makefile:5375: recipe for target 'unittest_librbd' failed

Signed-off-by: Yuan Lu <yuan.y.lu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
