### PR TITLE
nautilus: mds: Using begin() and empty() to iterate the xlist

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -9573,7 +9573,8 @@ void MDCache::request_kill(MDRequestRef& mdr)
   mdr->mark_event("killing request");
 
   if (mdr->committing) {
-    dout(10) << "request_kill " << *mdr << " -- already committing, no-op" << dendl;
+    dout(10) << "request_kill " << *mdr << " -- already committing, remove it from sesssion requests" << dendl;
+    mdr->item_session_request.remove_myself();
   } else {
     dout(10) << "request_kill " << *mdr << dendl;
     request_cleanup(mdr);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1205,11 +1205,8 @@ void Server::journal_close_session(Session *session, int state, Context *on_safe
   mdlog->flush();
 
   // clean up requests, too
-  elist<MDRequestImpl*>::iterator p =
-    session->requests.begin(member_offset(MDRequestImpl,
-					  item_session_request));
-  while (!p.end()) {
-    MDRequestRef mdr = mdcache->request_get((*p)->reqid);
+  for (auto p = session->requests.begin(); !p.end(); ) {
+    MDRequestRef mdr(*p);
     ++p;
     mdcache->request_kill(mdr);
   }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1205,9 +1205,8 @@ void Server::journal_close_session(Session *session, int state, Context *on_safe
   mdlog->flush();
 
   // clean up requests, too
-  for (auto p = session->requests.begin(); !p.end(); ) {
-    MDRequestRef mdr(*p);
-    ++p;
+  while(!session->requests.empty()) {
+    auto mdr = MDRequestRef(*session->requests.begin());
     mdcache->request_kill(mdr);
   }
 

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -891,13 +891,8 @@ void SessionMap::save_if_dirty(const std::set<entity_name_t> &tgt_sessions,
 size_t Session::get_request_count() const
 {
   size_t result = 0;
-
-  auto it = requests.begin(member_offset(MDRequestImpl, item_session_request));
-  while (!it.end()) {
+  for (auto p = requests.begin(); !p.end(); ++p)
     ++result;
-    ++it;
-  }
-
   return result;
 }
 

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -425,7 +425,7 @@ public:
     birth_time(clock::now()),
     auth_caps(g_ceph_context),
     item_session_list(this),
-    requests(0)  // member_offset passed to front() manually
+    requests(member_offset(MDRequestImpl, item_session_request))
   {
     set_connection(std::move(con));
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44478

---

backport of https://github.com/ceph/ceph/pull/33570
parent tracker: https://tracker.ceph.com/issues/44316

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh