### PR TITLE
octopus: qa/tasks/mgr/dashboard/test_rbd: wait longer when purging

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rbd.py
+++ b/qa/tasks/mgr/dashboard/test_rbd.py
@@ -844,15 +844,14 @@ class RbdTest(DashboardTestCase):
         time.sleep(1)
 
         self.purge_trash('rbd')
-        self.assertStatus(200)
+        self.assertStatus([200, 201])
 
         time.sleep(1)
 
         trash_not_expired = self.get_trash('rbd', id_not_expired)
         self.assertIsNotNone(trash_not_expired)
 
-        trash_expired = self.get_trash('rbd', id_expired)
-        self.assertIsNone(trash_expired)
+        self.wait_until_equal(lambda: self.get_trash('rbd', id_expired), None, 60)
 
     def test_list_namespaces(self):
         self.create_namespace('rbd', 'ns')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44872

---

backport of https://github.com/ceph/ceph/pull/34232
parent tracker: https://tracker.ceph.com/issues/44743

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh