### PR TITLE
ceph-volume: update functional testing deploy.yml playbook

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
@@ -91,6 +91,8 @@
     - import_role:
         name: ceph-defaults
     - import_role:
+        name: ceph-facts
+    - import_role:
         name: ceph-validate
 
 - hosts:


### PR DESCRIPTION
This commit adds a call to `ceph-facts` role in the first play of this
playbook. This is needed so `ceph-validate` won't fail because of
following error:

```
fatal: [osd0]: FAILED! => {}

MSG:

'osd_pool_default_size' is undefined
```

`osd_pool_default_size` is set in ceph-facts.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>