### PR TITLE
nautilus: mds: just delete MDSIOContextBase during shutdown

### DIFF
--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -90,6 +90,9 @@ void MDSIOContextBase::complete(int r) {
 
   dout(10) << "MDSIOContextBase::complete: " << typeid(*this).name() << dendl;
   ceph_assert(mds != NULL);
+  // Note, MDSIOContext is passed outside the MDS and, strangely, we grab the
+  // lock here when MDSContext::complete would otherwise assume the lock is
+  // already acquired.
   std::lock_guard l(mds->mds_lock);
 
   if (mds->is_daemon_stopping()) {

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -98,11 +98,8 @@ void MDSIOContextBase::complete(int r) {
   if (mds->is_daemon_stopping()) {
     dout(4) << "MDSIOContextBase::complete: dropping for stopping "
             << typeid(*this).name() << dendl;
-    MDSContext::complete(r);
-    return;
-  }
-
-  if (r == -EBLACKLISTED) {
+    delete this;
+  } else if (r == -EBLACKLISTED) {
     derr << "MDSIOContextBase: blacklisted!  Restarting..." << dendl;
     mds->respawn();
   } else {

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -98,7 +98,6 @@ void MDSIOContextBase::complete(int r) {
   if (mds->is_daemon_stopping()) {
     dout(4) << "MDSIOContextBase::complete: dropping for stopping "
             << typeid(*this).name() << dendl;
-    MDSContext::complete(r);
     return;
   }
 

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -98,8 +98,11 @@ void MDSIOContextBase::complete(int r) {
   if (mds->is_daemon_stopping()) {
     dout(4) << "MDSIOContextBase::complete: dropping for stopping "
             << typeid(*this).name() << dendl;
-    delete this;
-  } else if (r == -EBLACKLISTED) {
+    MDSContext::complete(r);
+    return;
+  }
+
+  if (r == -EBLACKLISTED) {
     derr << "MDSIOContextBase: blacklisted!  Restarting..." << dendl;
     mds->respawn();
   } else {

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -34,24 +34,30 @@ void MDSInternalContextWrapper::finish(int r)
   fin->complete(r);
 }
 
-elist<MDSIOContextBase*> MDSIOContextBase::ctx_list(member_offset(MDSIOContextBase, list_item));
-ceph::spinlock MDSIOContextBase::ctx_list_lock;
+struct MDSIOContextList {
+  elist<MDSIOContextBase*> list;
+  ceph::spinlock lock;
+  MDSIOContextList() : list(member_offset(MDSIOContextBase, list_item)) {}
+  ~MDSIOContextList() {
+    list.clear(); // avoid assertion in elist's destructor
+  }
+} ioctx_list;
 
 MDSIOContextBase::MDSIOContextBase(bool track)
 {
   created_at = ceph::coarse_mono_clock::now();
   if (track) {
-    ctx_list_lock.lock();
-    ctx_list.push_back(&list_item);
-    ctx_list_lock.unlock();
+    ioctx_list.lock.lock();
+    ioctx_list.list.push_back(&list_item);
+    ioctx_list.lock.unlock();
   }
 }
 
 MDSIOContextBase::~MDSIOContextBase()
 {
-  ctx_list_lock.lock();
+  ioctx_list.lock.lock();
   list_item.remove_myself();
-  ctx_list_lock.unlock();
+  ioctx_list.lock.unlock();
 }
 
 bool MDSIOContextBase::check_ios_in_flight(ceph::coarse_mono_time cutoff,
@@ -61,8 +67,8 @@ bool MDSIOContextBase::check_ios_in_flight(ceph::coarse_mono_time cutoff,
   static const unsigned MAX_COUNT = 100;
   unsigned slow = 0;
 
-  ctx_list_lock.lock();
-  for (elist<MDSIOContextBase*>::iterator p = ctx_list.begin(); !p.end(); ++p) {
+  ioctx_list.lock.lock();
+  for (elist<MDSIOContextBase*>::iterator p = ioctx_list.list.begin(); !p.end(); ++p) {
     MDSIOContextBase *c = *p;
     if (c->created_at >= cutoff)
       break;
@@ -72,7 +78,7 @@ bool MDSIOContextBase::check_ios_in_flight(ceph::coarse_mono_time cutoff,
     if (slow == 1)
       oldest = c->created_at;
   }
-  ctx_list_lock.unlock();
+  ioctx_list.lock.unlock();
 
   if (slow > 0) {
     if (slow > MAX_COUNT)

--- a/src/mds/MDSContext.h
+++ b/src/mds/MDSContext.h
@@ -111,9 +111,8 @@ public:
 private:
   ceph::coarse_mono_time created_at;
   elist<MDSIOContextBase*>::item list_item;
-
-  static elist<MDSIOContextBase*> ctx_list;
-  static ceph::spinlock ctx_list_lock;
+  
+  friend struct MDSIOContextList;
 };
 
 /**


### PR DESCRIPTION
backport tracker:

* https://tracker.ceph.com/issues/44480
* https://tracker.ceph.com/issues/45027

---

backport of 

* https://github.com/ceph/ceph/pull/33538
* https://github.com/ceph/ceph/pull/34110

parent trackers:

* https://tracker.ceph.com/issues/44295
* https://tracker.ceph.com/issues/44680

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh