### PR TITLE
rgw: more multisite dynamic resharding pieces.

### DIFF
--- a/qa/suites/rgw/verify/tasks/reshard.yaml
+++ b/qa/suites/rgw/verify/tasks/reshard.yaml
@@ -1,0 +1,5 @@
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rgw/test_rgw_reshard.py

--- a/qa/suites/rgw/verify/tasks/reshard.yaml
+++ b/qa/suites/rgw/verify/tasks/reshard.yaml
@@ -2,4 +2,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rgw/test_rgw_reshard.py
+        - rgw/run-reshard.sh

--- a/qa/workunits/rgw/run-reshard.sh
+++ b/qa/workunits/rgw/run-reshard.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -ex
+
+#assume working ceph environment (radosgw-admin in path) and rgw on localhost:80
+
+mydir=`dirname $0`
+
+python3 -m venv $mydir
+source $mydir/bin/activate
+pip install pip --upgrade
+pip install boto3
+
+## run test
+$mydir/bin/python3 $mydir/test_rgw_reshard.py
+
+deactivate
+echo OK.
+

--- a/qa/workunits/rgw/test_rgw_reshard.py
+++ b/qa/workunits/rgw/test_rgw_reshard.py
@@ -48,21 +48,6 @@ def exec_cmd(cmd):
         return False
 
 
-def install_reqs():
-    out = exec_cmd('cat /etc/*release')
-    result = {}
-    for row in out.decode('utf8').split('\n'):
-        if '=' in row:
-            k, v = row.split('=')
-            result[k.strip()] = v.strip('""')
-    if result['NAME'] == 'Ubuntu':
-        exec_cmd('sudo apt install -y python3-pip')
-    else:
-        exec_cmd('sudo yum install -y python3-pip')
-    exec_cmd('sudo pip3 install boto3')
-
-
-install_reqs()
 import boto3
 
 

--- a/qa/workunits/rgw/test_rgw_reshard.py
+++ b/qa/workunits/rgw/test_rgw_reshard.py
@@ -1,0 +1,234 @@
+#!/usr/bin/python3
+
+import logging as log
+import time
+import subprocess
+import json
+
+"""
+Rgw manual and dynamic resharding  testing against a running instance
+"""
+# The test cases in this file have been annotated for inventory.
+# To extract the inventory (in csv format) use the command:
+#
+#   grep '^ *# TESTCASE' | sed 's/^ *# TESTCASE //'
+#
+#
+
+log.basicConfig(level=log.DEBUG)
+log.getLogger('botocore').setLevel(log.CRITICAL)
+log.getLogger('boto3').setLevel(log.CRITICAL)
+log.getLogger('urllib3').setLevel(log.CRITICAL)
+
+
+""" Constants """
+USER = 'tester'
+DISPLAY_NAME = 'Testing'
+ACCESS_KEY = 'NX5QOQKC6BH2IDN8HC7A'
+SECRET_KEY = 'LnEsqNNqZIpkzauboDcLXLcYaWwLQ3Kop0zAnKIn'
+BUCKET_NAME1 = 'myfoo'
+BUCKET_NAME2 = 'mybar'
+VER_BUCKET_NAME = 'myver'
+ENDPOINT = 'http://localhost:80'
+
+
+def exec_cmd(cmd):
+    try:
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        out, err = proc.communicate()
+        if proc.returncode == 0:
+            log.info('command succeeded')
+            if out is not None: log.info(out)
+            return out
+        else:
+            raise Exception("error: %s \nreturncode: %s" % (err, proc.returncode))
+    except Exception as e:
+        log.error('command failed')
+        log.error(e)
+        return False
+
+
+def install_reqs():
+    out = exec_cmd('cat /etc/*release')
+    result = {}
+    for row in out.decode('utf8').split('\n'):
+        if '=' in row:
+            k, v = row.split('=')
+            result[k.strip()] = v.strip('""')
+    if result['NAME'] == 'Ubuntu':
+        exec_cmd('sudo apt install -y python3-pip')
+    else:
+        exec_cmd('sudo yum install -y python3-pip')
+    exec_cmd('sudo pip3 install boto3')
+
+
+install_reqs()
+import boto3
+
+
+class BucketStats:
+    def __init__(self, bucket_name, bucket_id, num_objs=0, size_kb=0, num_shards=0):
+        self.bucket_name = bucket_name
+        self.bucket_id = bucket_id
+        self.num_objs = num_objs
+        self.size_kb = size_kb
+        self.num_shards = num_shards if num_shards > 0 else 1
+
+    def get_num_shards(self):
+        self.num_shards = get_bucket_num_shards(self.bucket_name, self.bucket_id)
+
+
+def get_bucket_stats(bucket_name):
+    """
+    function to get bucket stats
+    """
+    cmd = exec_cmd("radosgw-admin bucket stats --bucket %s" % bucket_name)
+    json_op = json.loads(cmd)
+    bucket_id = json_op['id']
+    num_shards_op = json_op['num_shards']
+    if len(json_op['usage']) > 0:
+        num_objects = json_op['usage']['rgw.main']['num_objects']
+        size_kb = json_op['usage']['rgw.main']['size_kb']
+    else:
+        num_objects = 0
+        size_kb = 0
+    log.debug("bucket %s id %s num_objects %d size_kb %d num_shards %d", bucket_name, bucket_id,
+              num_objects, size_kb, num_shards_op)
+    return BucketStats(bucket_name, bucket_id, num_objects, size_kb, num_shards_op)
+
+
+def get_bucket_num_shards(bucket_name, bucket_id):
+    """
+    function to get bucket num shards
+    """
+    metadata = 'bucket.instance:' + bucket_name + ':' + bucket_id
+    log.debug("metadata %s", metadata)
+    cmd = exec_cmd('radosgw-admin metadata get %s' % metadata)
+    json_op = json.loads(cmd)
+    num_shards = json_op['data']['bucket_info']['num_shards']
+    log.debug("bucket %s id %s num_shards %d", bucket_name, bucket_id, num_shards)
+    return num_shards
+
+
+def main():
+    """
+    execute manual and dynamic resharding commands
+    """
+    # create user
+    cmd = exec_cmd('radosgw-admin user create --uid %s --display-name %s --access-key %s --secret %s'
+                   % (USER, DISPLAY_NAME, ACCESS_KEY, SECRET_KEY))
+
+    connection = boto3.resource('s3',
+        aws_access_key_id=ACCESS_KEY,
+        aws_secret_access_key=SECRET_KEY,
+        use_ssl=False,
+        endpoint_url=ENDPOINT,
+        verify=False,
+        config=None,
+        )
+
+    # create a bucket
+    bucket1 = connection.create_bucket(Bucket=BUCKET_NAME1)
+    bucket2 = connection.create_bucket(Bucket=BUCKET_NAME2)
+    ver_bucket = connection.create_bucket(Bucket=VER_BUCKET_NAME)
+    connection.BucketVersioning('ver_bucket')
+
+    bucket_stats1 = get_bucket_stats(BUCKET_NAME1)
+    bucket_stats2 = get_bucket_stats(BUCKET_NAME2)
+    ver_bucket_stats = get_bucket_stats(VER_BUCKET_NAME)
+
+    bucket1_acl = connection.BucketAcl(BUCKET_NAME1).load()
+    bucket2_acl = connection.BucketAcl(BUCKET_NAME2).load()
+    ver_bucket_acl = connection.BucketAcl(VER_BUCKET_NAME).load()
+
+    # TESTCASE 'reshard-add','reshard','add','add bucket to resharding queue','succeeds'
+    log.debug(' test: reshard add')
+    num_shards_expected = bucket_stats1.num_shards + 1
+    cmd = exec_cmd('radosgw-admin reshard add --bucket %s --num-shards %s' % (BUCKET_NAME1, num_shards_expected))
+    cmd = exec_cmd('radosgw-admin reshard list')
+    json_op = json.loads(cmd)
+    log.debug('bucket name %s', json_op[0]['bucket_name'])
+    assert json_op[0]['bucket_name'] == BUCKET_NAME1
+    assert json_op[0]['new_num_shards'] == num_shards_expected
+
+    # TESTCASE 'reshard-process','reshard','','process bucket resharding','succeeds'
+    log.debug(' test: reshard process')
+    cmd = exec_cmd('radosgw-admin reshard process')
+    time.sleep(5)
+    # check bucket shards num
+    bucket_stats1 = get_bucket_stats(BUCKET_NAME1)
+    bucket_stats1.get_num_shards()
+    if bucket_stats1.num_shards != num_shards_expected:
+        log.error("Resharding failed on bucket %s. Expected number of shards are not created" % BUCKET_NAME1)
+
+    # TESTCASE 'reshard-add','reshard','add','add non empty bucket to resharding queue','succeeds'
+    log.debug(' test: reshard add non empty bucket')
+    # create objs
+    num_objs = 8
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME1, ('key'+str(i))).put(Body=b"some_data")
+
+    num_shards_expected = bucket_stats1.num_shards + 1
+    cmd = exec_cmd('radosgw-admin reshard add --bucket %s --num-shards %s' % (BUCKET_NAME1, num_shards_expected))
+    cmd = exec_cmd('radosgw-admin reshard list')
+    json_op = json.loads(cmd)
+    log.debug('bucket name %s', json_op[0]['bucket_name'])
+    assert json_op[0]['bucket_name'] == BUCKET_NAME1
+    assert json_op[0]['new_num_shards'] == num_shards_expected
+
+    # TESTCASE 'reshard process ,'reshard','process','reshard non empty bucket','succeeds'
+    log.debug(' test: reshard process non empty bucket')
+    cmd = exec_cmd('radosgw-admin reshard process')
+    # check bucket shards num
+    bucket_stats1 = get_bucket_stats(BUCKET_NAME1)
+    bucket_stats1.get_num_shards()
+    if bucket_stats1.num_shards != num_shards_expected:
+        log.error("Resharding failed on bucket %s. Expected number of shards are not created" % BUCKET_NAME1)
+
+    # TESTCASE 'manual resharding','bucket', 'reshard','','manual bucket resharding','succeeds'
+    log.debug(' test: manual reshard bucket')
+    # create objs
+    num_objs = 11
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME2, ('key' + str(i))).put(Body=b"some_data")
+
+    time.sleep(10)
+    num_shards_expected = bucket_stats2.num_shards + 1
+    cmd = exec_cmd('radosgw-admin bucket reshard --bucket %s --num-shards %s' % (BUCKET_NAME2,
+                                                                                 num_shards_expected))
+    # check bucket shards num
+    bucket_stats2 = get_bucket_stats(BUCKET_NAME2)
+    bucket_stats2.get_num_shards()
+    if bucket_stats2.num_shards != num_shards_expected:
+        log.error("Resharding failed on bucket %s. Expected number of shards are not created" % BUCKET_NAME2)
+
+    # TESTCASE 'versioning reshard-','bucket', reshard','versioning reshard','succeeds'
+    log.debug(' test: reshard versioned bucket')
+    num_shards_expected = ver_bucket_stats.num_shards + 1
+    cmd = exec_cmd('radosgw-admin bucket reshard --bucket %s --num-shards %s' % (VER_BUCKET_NAME,
+                                                                                 num_shards_expected))
+    # check bucket shards num
+    ver_bucket_stats = get_bucket_stats(VER_BUCKET_NAME)
+    assert ver_bucket_stats.num_shards == num_shards_expected
+
+    # TESTCASE 'check acl'
+    new_bucket1_acl = connection.BucketAcl(BUCKET_NAME1).load()
+    assert new_bucket1_acl == bucket1_acl
+    new_bucket2_acl = connection.BucketAcl(BUCKET_NAME2).load()
+    assert new_bucket2_acl == bucket2_acl
+    new_ver_bucket_acl = connection.BucketAcl(VER_BUCKET_NAME).load()
+    assert new_ver_bucket_acl == ver_bucket_acl
+
+    # Clean up
+    log.debug("Deleting bucket %s", BUCKET_NAME1)
+    bucket1.objects.all().delete()
+    bucket1.delete()
+    log.debug("Deleting bucket %s", BUCKET_NAME2)
+    bucket2.objects.all().delete()
+    bucket2.delete()
+    log.debug("Deleting bucket %s", VER_BUCKET_NAME)
+    ver_bucket.delete()
+
+
+main()
+log.info("Completed resharding tests")

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6521,7 +6521,8 @@ next:
     for (; i < max_shards; i++) {
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-      int ret = bs.init(bucket, shard_id, nullptr /* no RGWBucketInfo */);
+
+      int ret = bs.init(bucket, shard_id, bucket_info.layout.current_index, nullptr /* no RGWBucketInfo */);
       marker.clear();
 
       if (ret < 0) {
@@ -6585,7 +6586,7 @@ next:
     for (int i = 0; i < max_shards; i++) {
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-      int ret = bs.init(bucket, shard_id, nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket, shard_id, bucket_info.layout.current_index, nullptr /* no RGWBucketInfo */);
       if (ret < 0) {
         cerr << "ERROR: bs.init(bucket=" << bucket << ", shard=" << shard_id << "): " << cpp_strerror(-ret) << std::endl;
         return -ret;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1641,7 +1641,7 @@ static int purge_bucket_instance(rgw::sal::RGWRadosStore *store, const RGWBucket
   for (int i = 0; i < max_shards; i++) {
     RGWRados::BucketShard bs(store->getRados());
     int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-    int ret = bs.init(bucket_info.bucket, shard_id, nullptr);
+    int ret = bs.init(bucket_info.bucket, shard_id, bucket_info.layout.current_index, nullptr);
     if (ret < 0) {
       cerr << "ERROR: bs.init(bucket=" << bucket_info.bucket << ", shard=" << shard_id
            << "): " << cpp_strerror(-ret) << std::endl;

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -602,7 +602,7 @@ RGWRadosBILogTrimCR::RGWRadosBILogTrimCR(rgw::sal::RGWRadosStore *store,
     start_marker(BucketIndexShardsManager::get_shard_marker(start_marker)),
     end_marker(BucketIndexShardsManager::get_shard_marker(end_marker))
 {
-  bs.init(bucket_info, shard_id);
+  bs.init(bucket_info, bucket_info.layout.current_index, shard_id);
 }
 
 int RGWRadosBILogTrimCR::send_request()

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2634,6 +2634,9 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 
   auto obj_ctx = store->svc.sysobj->init_obj_ctx();
 
+  rgw::bucket_index_layout_generation generator;
+  uint64_t gen_number = generator.gen;
+
   RGWBucketInfo bucket_info;
   RGWBucketInfo* bucket_info_p =
     bucket_info_out ? bucket_info_out : &bucket_info;
@@ -2644,7 +2647,7 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 
   string oid;
 
-  ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, &bucket_obj);
+  ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, gen_number, &bucket_obj);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;
@@ -2676,8 +2679,10 @@ int RGWRados::BucketShard::init(const RGWBucketInfo& bucket_info, int sid)
 {
   bucket = bucket_info.bucket;
   shard_id = sid;
+  rgw::bucket_index_layout_generation generator;
+  uint64_t gen_number = generator.gen;
 
-  int ret = store->svc.bi_rados->open_bucket_index_shard(bucket_info, shard_id, &bucket_obj);
+  int ret = store->svc.bi_rados->open_bucket_index_shard(bucket_info, shard_id, gen_number, &bucket_obj);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8003,7 +8003,7 @@ int RGWRados::bi_remove(BucketShard& bs)
   return 0;
 }
 
-int RGWRados::bi_list(RGWBucketInfo& bucket_info, int shard_id, const string& filter_obj, const string& marker, uint32_t max, list<rgw_cls_bi_entry> *entries, bool *is_truncated)
+int RGWRados::bi_list(const RGWBucketInfo& bucket_info, int shard_id, const string& filter_obj, const string& marker, uint32_t max, list<rgw_cls_bi_entry> *entries, bool *is_truncated)
 {
   BucketShard bs(this);
   int ret = bs.init(bucket_info.bucket, shard_id, bucket_info.layout.current_index, nullptr /* no RGWBucketInfo */);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2626,7 +2626,7 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 }
 
 int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
-				int sid,
+				int sid, const rgw::bucket_index_layout_generation& idx_layout,
 				RGWBucketInfo* bucket_info_out)
 {
   bucket = _bucket;
@@ -2634,8 +2634,6 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 
   auto obj_ctx = store->svc.sysobj->init_obj_ctx();
 
-  rgw::bucket_index_layout_generation generator;
-  uint64_t gen_number = generator.gen;
 
   RGWBucketInfo bucket_info;
   RGWBucketInfo* bucket_info_p =
@@ -2647,7 +2645,7 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 
   string oid;
 
-  ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, gen_number, &bucket_obj);
+  ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, idx_layout, &bucket_obj);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;
@@ -2675,14 +2673,12 @@ int RGWRados::BucketShard::init(const RGWBucketInfo& bucket_info,
   return 0;
 }
 
-int RGWRados::BucketShard::init(const RGWBucketInfo& bucket_info, int sid)
+int RGWRados::BucketShard::init(const RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int sid)
 {
   bucket = bucket_info.bucket;
   shard_id = sid;
-  rgw::bucket_index_layout_generation generator;
-  uint64_t gen_number = generator.gen;
 
-  int ret = store->svc.bi_rados->open_bucket_index_shard(bucket_info, shard_id, gen_number, &bucket_obj);
+  int ret = store->svc.bi_rados->open_bucket_index_shard(bucket_info, shard_id, idx_layout, &bucket_obj);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;
@@ -8007,10 +8003,10 @@ int RGWRados::bi_remove(BucketShard& bs)
   return 0;
 }
 
-int RGWRados::bi_list(rgw_bucket& bucket, int shard_id, const string& filter_obj, const string& marker, uint32_t max, list<rgw_cls_bi_entry> *entries, bool *is_truncated)
+int RGWRados::bi_list(RGWBucketInfo& bucket_info, int shard_id, const string& filter_obj, const string& marker, uint32_t max, list<rgw_cls_bi_entry> *entries, bool *is_truncated)
 {
   BucketShard bs(this);
-  int ret = bs.init(bucket, shard_id, nullptr /* no RGWBucketInfo */);
+  int ret = bs.init(bucket_info.bucket, shard_id, bucket_info.layout.current_index, nullptr /* no RGWBucketInfo */);
   if (ret < 0) {
     ldout(cct, 5) << "bs.init() returned ret=" << ret << dendl;
     return ret;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -682,9 +682,9 @@ public:
 
     explicit BucketShard(RGWRados *_store) : store(_store), shard_id(-1) {}
     int init(const rgw_bucket& _bucket, const rgw_obj& obj, RGWBucketInfo* out);
-    int init(const rgw_bucket& _bucket, int sid, RGWBucketInfo* out);
+    int init(const rgw_bucket& _bucket, int sid, const rgw::bucket_index_layout_generation& idx_layout, RGWBucketInfo* out);
     int init(const RGWBucketInfo& bucket_info, const rgw_obj& obj);
-    int init(const RGWBucketInfo& bucket_info, int sid);
+    int init(const RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int sid);
   };
 
   class Object {
@@ -1411,7 +1411,7 @@ public:
   void bi_put(librados::ObjectWriteOperation& op, BucketShard& bs, rgw_cls_bi_entry& entry);
   int bi_put(BucketShard& bs, rgw_cls_bi_entry& entry);
   int bi_put(rgw_bucket& bucket, rgw_obj& obj, rgw_cls_bi_entry& entry);
-  int bi_list(rgw_bucket& bucket, int shard_id, const string& filter_obj, const string& marker, uint32_t max, list<rgw_cls_bi_entry> *entries, bool *is_truncated);
+  int bi_list(RGWBucketInfo& bucket_info, int shard_id, const string& filter_obj, const string& marker, uint32_t max, list<rgw_cls_bi_entry> *entries, bool *is_truncated);
   int bi_list(BucketShard& bs, const string& filter_obj, const string& marker, uint32_t max, list<rgw_cls_bi_entry> *entries, bool *is_truncated);
   int bi_list(rgw_bucket& bucket, const string& obj_name, const string& marker, uint32_t max,
               list<rgw_cls_bi_entry> *entries, bool *is_truncated);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1411,7 +1411,7 @@ public:
   void bi_put(librados::ObjectWriteOperation& op, BucketShard& bs, rgw_cls_bi_entry& entry);
   int bi_put(BucketShard& bs, rgw_cls_bi_entry& entry);
   int bi_put(rgw_bucket& bucket, rgw_obj& obj, rgw_cls_bi_entry& entry);
-  int bi_list(RGWBucketInfo& bucket_info, int shard_id, const string& filter_obj, const string& marker, uint32_t max, list<rgw_cls_bi_entry> *entries, bool *is_truncated);
+  int bi_list(const RGWBucketInfo& bucket_info, int shard_id, const string& filter_obj, const string& marker, uint32_t max, list<rgw_cls_bi_entry> *entries, bool *is_truncated);
   int bi_list(BucketShard& bs, const string& filter_obj, const string& marker, uint32_t max, list<rgw_cls_bi_entry> *entries, bool *is_truncated);
   int bi_list(rgw_bucket& bucket, const string& obj_name, const string& marker, uint32_t max,
               list<rgw_cls_bi_entry> *entries, bool *is_truncated);

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -196,9 +196,10 @@ void RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_b
   } else {
     char buf[bucket_oid_base.size() + 64];
     if (gen_id != 0) {
-      snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id);
+      snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id); 
       (*bucket_obj) = buf;
     } else {
+      // for backward compatibility, gen_id(0) will not be added in the object name
       snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), shard_id);
       (*bucket_obj) = buf;
     }
@@ -266,7 +267,7 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket
 
 int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket_info,
                                                      int shard_id,
-                                                     uint64_t gen_id,
+                                                     const rgw::bucket_index_layout_generation& idx_layout,
                                                      RGWSI_RADOS::Obj *bucket_obj)
 {
   RGWSI_RADOS::Pool index_pool;
@@ -280,8 +281,8 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket
 
   string oid;
 
-  get_bucket_index_object(bucket_oid_base, bucket_info.layout.current_index.layout.normal.num_shards,
-                          shard_id, gen_id, &oid);
+  get_bucket_index_object(bucket_oid_base, idx_layout.layout.normal.num_shards,
+                          shard_id, idx_layout.gen, &oid);
 
   *bucket_obj = svc.rados->obj(index_pool, oid);
 

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -50,6 +50,7 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
   void get_bucket_index_object(const string& bucket_oid_base,
                                uint32_t num_shards,
                                int shard_id,
+                               uint64_t gen_id,
                                string *bucket_obj);
   int get_bucket_index_object(const string& bucket_oid_base, const string& obj_key,
                               uint32_t num_shards, rgw::BucketHashType hash_type,
@@ -114,7 +115,7 @@ public:
                               int *shard_id);
 
   int open_bucket_index_shard(const RGWBucketInfo& bucket_info,
-                              int shard_id,
+                              int shard_id, uint64_t gen_id,
                               RGWSI_RADOS::Obj *bucket_obj);
 
   int open_bucket_index(const RGWBucketInfo& bucket_info,

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -115,7 +115,8 @@ public:
                               int *shard_id);
 
   int open_bucket_index_shard(const RGWBucketInfo& bucket_info,
-                              int shard_id, uint64_t gen_id,
+                              int shard_id,
+                              const rgw::bucket_index_layout_generation& idx_layout,
                               RGWSI_RADOS::Obj *bucket_obj);
 
   int open_bucket_index(const RGWBucketInfo& bucket_info,


### PR DESCRIPTION
rados object names of bi shard to take a unique id called
generation number. 
 
Signed-off-by: Shilpa Jagannath <smanjara@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
