### PR TITLE
octopus: doc/cephadm: replace `osd create` with `apply osd`

### DIFF
--- a/doc/cephadm/drivegroups.rst
+++ b/doc/cephadm/drivegroups.rst
@@ -10,7 +10,7 @@ with which configuration without knowing the specifics of device names and paths
 
 Instead of doing this::
 
-  [monitor 1] # ceph orchestrator osd create *<host>*:*<path-to-device>*
+  [monitor 1] # ceph orch daemon add osd *<host>*:*<path-to-device>*
 
 for each device and each host, we can define a yaml|json file that allows us to describe
 the layout. Here's the most basic example.
@@ -32,7 +32,7 @@ There will be a more detailed section on host_pattern down below.
 
 and pass it to `osd create` like so::
 
-  [monitor 1] # ceph orchestrator osd create -i /path/to/drivegroup.yml
+  [monitor 1] # ceph orch apply osd -i /path/to/drivegroup.yml
 
 This will go out on all the matching hosts and deploy these OSDs.
 

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -289,7 +289,7 @@ There are a few ways to create new OSDs:
   based on their properties, such device type (SSD or HDD), device
   model names, size, or the hosts on which the devices exist::
 
-    # ceph orch osd create -i spec.yml
+    # ceph orch apply osd -i spec.yml
 
 
 Deploy MDSs


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44710

---

backport of https://github.com/ceph/ceph/pull/34080
parent tracker: https://tracker.ceph.com/issues/44692

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh