### PR TITLE
mgr/orch: fix python3 DeprecationWarning

### DIFF
--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -178,7 +178,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
                 raise AssertionError('Fail to determine daemon type from {}'.format(p))
 
             # parse daemon ID. Possible options: `-i <id>`, `--id=<id>`, `--id <id>`
-            patterns = ['-i\s(\w+)', '--id[\s=](\w+)']
+            patterns = [r'-i\s(\w+)', r'--id[\s=](\w+)']
             daemon_id = None
             for pattern in patterns:
                 m = re.search(pattern, p)


### PR DESCRIPTION
Fixes deprecation warning:

```
test_orchestrator/module.py:181: DeprecationWarning: invalid escape sequence \s
    patterns = ['-i\s(\w+)', '--id[\s=](\w+)']
```

This only occasionally appears when `test_orchestrator/__pycache__` is changed or the cache dir is removed

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
