### PR TITLE
doc: fix broken link for cephfs kernel recommendations

### DIFF
--- a/doc/start/os-recommendations.rst
+++ b/doc/start/os-recommendations.rst
@@ -24,8 +24,8 @@ Linux Kernel
   - 4.19.z
   - 4.14.z
 
-  For CephFS, see `Mount CephFS using Kernel Driver`_ for kernel version
-  guidance.
+  For CephFS, see the section about `Mounting CephFS using Kernel Driver`_
+  for kernel version guidance.
 
   Older kernel client versions may not support your `CRUSH tunables`_ profile
   or other newer features of the Ceph cluster, requiring the storage cluster
@@ -118,4 +118,4 @@ Testing
 
 .. _CRUSH Tunables: ../../rados/operations/crush-map#tunables
 
-.. _Mount CephFS using Kernel Driver: ../../cephfs/mount-using-kernel-driver
+.. _Mounting CephFS using Kernel Driver: ../../cephfs/mount-using-kernel-driver#which-kernel-version

--- a/doc/start/os-recommendations.rst
+++ b/doc/start/os-recommendations.rst
@@ -24,7 +24,8 @@ Linux Kernel
   - 4.19.z
   - 4.14.z
 
-  For CephFS, see `CephFS best practices`_ for kernel version guidance.
+  For CephFS, see `Mount CephFS using Kernel Driver`_ for kernel version
+  guidance.
 
   Older kernel client versions may not support your `CRUSH tunables`_ profile
   or other newer features of the Ceph cluster, requiring the storage cluster
@@ -117,4 +118,4 @@ Testing
 
 .. _CRUSH Tunables: ../../rados/operations/crush-map#tunables
 
-.. _CephFS best practices: ../../cephfs/mount-using-kernel-driver
+.. _Mount CephFS using Kernel Driver: ../../cephfs/mount-using-kernel-driver

--- a/doc/start/os-recommendations.rst
+++ b/doc/start/os-recommendations.rst
@@ -117,4 +117,4 @@ Testing
 
 .. _CRUSH Tunables: ../../rados/operations/crush-map#tunables
 
-.. _CephFS best practices: ../../cephfs/best-practices
+.. _CephFS best practices: ../../cephfs/mount-using-kernel-driver


### PR DESCRIPTION
Content was moved around in commit c74a261e5b, this
commit updates the name of the file that contains the
kernel recommendations for cephfs users.

Signed-off-by: Goutham Pacha Ravi <gouthampravi@gmail.com>