### PR TITLE
client: fix read file cached data when we recover from the blacklist

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -14038,6 +14038,7 @@ void Client::ms_handle_remote_reset(Connection *con)
 	    const auto& conf = cct->_conf;
 	    if (conf->client_reconnect_stale) {
 	      ldout(cct, 1) << "reset from mds we were open; close mds session for reconnect" << dendl;
+	      trim_cache_for_reconnect(s);
 	      _closed_mds_session(s);
 	    } else {
 	      ldout(cct, 1) << "reset from mds we were open; mark session as stale" << dendl;


### PR DESCRIPTION
if other clients have modified the file content(new size >= old size),
when we recover from the blacklist, the cached data will be read.

because inode cache and file cache are not trimmed.

Fixes: https://tracker.ceph.com/issues/44902

Signed-off-by: Yanhu Cao <gmayyyha@gmail.com>
