### PR TITLE
[osdc] fastfail of client requests for homeless session scenario

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1553,3 +1553,6 @@ OPTION(debug_allow_any_pool_priority, OPT_BOOL)
 OPTION(rgw_gc_max_deferred_entries_size, OPT_U64) // GC deferred entries size in queue head
 OPTION(rgw_gc_max_queue_size, OPT_U64) // GC max queue size
 OPTION(rgw_gc_max_deferred, OPT_U64) // GC max number of deferred entries
+
+/* Fastfail tunables */
+OPTION(rgw_fastfail_homeless_timeout, OPT_FLOAT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6846,6 +6846,11 @@ std::vector<Option> get_rgw_options() {
 			  "of RGW instances under heavy use. If you would like "
 			  "to turn off cache expiry, set this value to zero."),
 
+Option("rgw_fastfail_homeless_timeout", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+.set_default(0.01)
+.set_description("Fastfail homeless session : Duration (in millisecondss) after which the op is cancelled")
+.set_long_description("It will cancel the op associated with a homeless session after the specified  duration. This will unblock the radosgw thread to take new client requests."),
+
     Option("rgw_inject_notify_timeout_probability", Option::TYPE_FLOAT,
 	   Option::LEVEL_DEV)
     .set_default(0)

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2460,6 +2460,10 @@ void Objecter::_op_submit(Op *op, shunique_lock& sul, ceph_tid_t *ptid)
   sl.unlock();
   put_session(s);
 
+ if ((cct->_conf->rgw_fastfail_homeless_timeout > 0) && s->is_homeless()) { 
+     uint64_t t = timer.add_event(ceph::make_timespan(cct->_conf->rgw_fastfail_homeless_timeout), [this, tid]() {_op_cancel(tid, -ETIMEDOUT);});
+     ldout(cct, 0) << __func__ << " Op cancellation due to homeless session. t =" << t << dendl;
+  }
   ldout(cct, 5) << num_in_flight << " in flight" << dendl;
 }
 


### PR DESCRIPTION
[Problem] As per the current radosgw behaviour, for any client request, a blocking call is made to the osd to fetch the object. But in case of homeless session i.e when no osd's for that object is available to serve data, the rgw thread hangs indefinitely waiting for an osd to come active. If multiple such requests come, all the radosgw thread gets exhausted, each waiting indefinitely for the osd to come back. This creates a complete service unavailability. Even though there are many other active osd to serve valid client requests, the rgw threads are simply not free to take incoming request.

[Solution] There is no point in indefinitely waiting when all the osd's for an object are down. It is appropriate to cancel the op in such scenarios so that the radosgw thread is free to take more incoming valid requests. Also, this tunable should be configurable from the ceph.conf as to enable or disable this feature.

[Test] Keeping rgw front-end thread to 1, I have tested the homeless session scenario with and without the fix. The rgw thread hangs indefinitely without the fix. With the fix, the rgw thread times out with http 408 error. The default timer is 10ms which can be overridden from ceph.conf tunables.

Signed-off-by: Biswajeet <biswajeet.patra@flipkart.com>