### PR TITLE
cmake: really stop at top of source code tree

### DIFF
--- a/cmake/modules/GetGitRevisionDescription.cmake
+++ b/cmake/modules/GetGitRevisionDescription.cmake
@@ -42,11 +42,12 @@ get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
 function(get_git_head_revision _refspecvar _hashvar)
 	set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 	set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+	set(TOP_LEVEL_DIR "${CMAKE_SOURCE_DIR}")
 	while(NOT EXISTS "${GIT_DIR}")	# .git dir not found, search parent directories
 		set(GIT_PREVIOUS_PARENT "${GIT_PARENT_DIR}")
 		get_filename_component(GIT_PARENT_DIR ${GIT_PARENT_DIR} PATH)
-		if(GIT_PARENT_DIR STREQUAL GIT_PREVIOUS_PARENT)
-			# We have reached the root directory, we are not in git
+		if(GIT_PARENT_DIR STREQUAL TOP_LEVEL_DIR)
+			# We have reached the top of the source tree, we are not in git
 			set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
 			set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
 			return()


### PR DESCRIPTION
Previously, we were recursing right up to /

Patch submitted by Tony Davies via https://tracker.ceph.com

Fixes: https://tracker.ceph.com/issues/43895
Signed-off-by: Tony Davies <anthony.t.davies@gmail.com>
