### PR TITLE
mimic: qa/suites/rados/multimon/tasks/mon_clock_with_skews: disable ntpd etc

### DIFF
--- a/qa/suites/rados/multimon/clusters/21.yaml
+++ b/qa/suites/rados/multimon/clusters/21.yaml
@@ -1,7 +1,7 @@
 roles:
-- [mon.a, mon.d, mon.g, mon.j, mon.m, mon.p, mon.s, osd.0]
+- [mon.a, mon.d, mon.g, mon.j, mon.m, mon.p, mon.s]
 - [mon.b, mon.e, mon.h, mon.k, mon.n, mon.q, mon.t, mgr.x]
-- [mon.c, mon.f, mon.i, mon.l, mon.o, mon.r, mon.u, osd.1]
+- [mon.c, mon.f, mon.i, mon.l, mon.o, mon.r, mon.u]
 openstack:
 - volumes: # attached to each instance
     count: 1

--- a/qa/suites/rados/multimon/clusters/3.yaml
+++ b/qa/suites/rados/multimon/clusters/3.yaml
@@ -1,6 +1,6 @@
 roles:
-- [mon.a, mon.c, osd.0]
-- [mon.b, mgr.x, osd.1]
+- [mon.a, mon.c]
+- [mon.b, mgr.x]
 openstack:
 - volumes: # attached to each instance
     count: 2

--- a/qa/suites/rados/multimon/clusters/6.yaml
+++ b/qa/suites/rados/multimon/clusters/6.yaml
@@ -1,6 +1,6 @@
 roles:
-- [mon.a, mon.c, mon.e, mgr.x, osd.0]
-- [mon.b, mon.d, mon.f, mgr.y, osd.1]
+- [mon.a, mon.c, mon.e, mgr.x]
+- [mon.b, mon.d, mon.f, mgr.y]
 openstack:
 - volumes: # attached to each instance
     count: 1

--- a/qa/suites/rados/multimon/clusters/9.yaml
+++ b/qa/suites/rados/multimon/clusters/9.yaml
@@ -1,7 +1,7 @@
 roles:
-- [mon.a, mon.d, mon.g, osd.0]
+- [mon.a, mon.d, mon.g]
 - [mon.b, mon.e, mon.h, mgr.x]
-- [mon.c, mon.f, mon.i, osd.1]
+- [mon.c, mon.f, mon.i]
 openstack:
 - volumes: # attached to each instance
     count: 1

--- a/qa/suites/rados/multimon/no_pools.yaml
+++ b/qa/suites/rados/multimon/no_pools.yaml
@@ -1,0 +1,3 @@
+overrides:
+  ceph:
+    create_rbd_pool: false

--- a/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
@@ -2,7 +2,7 @@ tasks:
 - install:
 - exec:
     mon.b:
-    - date -u -s @$(expr $(date -u +%s) + 10)
+    - date -u -s @$(expr $(date -u +%s) + 2)
 - ceph:
     wait-for-healthy: false
     log-whitelist:

--- a/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
@@ -2,6 +2,10 @@ tasks:
 - install:
 - exec:
     mon.b:
+    - sudo systemctl stop chronyd.service || true
+    - sudo systemctl stop systemd-timesync.service || true
+    - sudo systemctl stop ntpd.service || true
+    - sudo systemctl stop ntp.service || true
     - date -u -s @$(expr $(date -u +%s) + 2)
 - ceph:
     wait-for-healthy: false

--- a/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
@@ -15,6 +15,7 @@ tasks:
     - overall HEALTH_
     - \(MON_CLOCK_SKEW\)
     - \(MGR_DOWN\)
+    - \(MON_DOWN\)
     - \(PG_
     - \(SLOW_OPS\)
     - No standby daemons available


### PR DESCRIPTION
backport trackers: 

* https://tracker.ceph.com/issues/44083
* https://tracker.ceph.com/issues/44908

---

backport of

* https://github.com/ceph/ceph/pull/28353
* https://github.com/ceph/ceph/pull/33184

parent trackers: 

* https://tracker.ceph.com/issues/40112
* https://tracker.ceph.com/issues/43889

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh