### PR TITLE
WIP: ceph-volume: support crypt type device that is already encrypted by user

### DIFF
--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -144,7 +144,7 @@ class Device(object):
             self.disk_api = dev
             device_type = dev.get('TYPE', '')
             # always check is this is an lvm member
-            if device_type in ['part', 'disk']:
+            if device_type in ['part', 'disk', 'crypt']:
                 self._set_lvm_membership()
 
         self.ceph_disk = CephDiskDevice(self)
@@ -345,7 +345,8 @@ class Device(object):
         if self.disk_api:
             is_device = self.disk_api['TYPE'] == 'device'
             is_disk = self.disk_api['TYPE'] == 'disk'
-            if is_device or is_disk:
+            is_crypt = self.disk_api['TYPE'] == 'crypt'
+            if is_device or is_disk or is_crypt:
                 return True
         return False
 

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -330,7 +330,7 @@ def is_device(dev):
     # use lsblk first, fall back to using stat
     TYPE = lsblk(dev).get('TYPE')
     if TYPE:
-        return TYPE == 'disk'
+        return TYPE == 'disk' or TYPE == 'crypt'
 
     # fallback to stat
     return _stat_is_device(os.lstat(dev).st_mode)
@@ -747,7 +747,7 @@ def get_devices(_sys_block_path='/sys/block'):
     for block in block_devs:
         devname = os.path.basename(block[0])
         diskname = block[1]
-        if block[2] != 'disk':
+        if block[2] != 'disk' and block[2] != 'crypt':
             continue
         sysdir = os.path.join(_sys_block_path, devname)
         metadata = {}


### PR DESCRIPTION
> NOTE: This PR is work in progress. I have not verified yet whether this feature can co-exist with ceph-volume --dmcrypt. So, in the current implementation,  there is a possibility that a OSD encrypted by ceph-volume is mis-recognized as a OSD encrypted by user, or vice verse.

ceph-volume has --dmcrypt option to support encrypted OSD. However, it can't tweak encryption method. So it's impossible to use variety of encryption methods. For example, TPM can be used to manage encrypt key. In fact, I use TPM as follows.

https://github.com/cybozu-go/sabakan/blob/9093551170dfcffe9be47e95af3748a21b479be0/docs/disk_encryption.md#disk-encryption

I consider it's better to allow crypt type device that is already encrypted by users, instead of complicating ceph-volume to support many encryption methods one by one.

Fixes: https://tracker.ceph.com/issues/44911

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
