### PR TITLE
octopus: pybind/rbd: fix no lockers are obtained, ImageNotFound exception will be output

### DIFF
--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -5393,6 +5393,9 @@ cdef class LockOwnerIterator(object):
                                           &self.num_lock_owners)
             if ret >= 0:
                 break
+            elif ret == -errno.ENOENT:
+                self.num_lock_owners = 0
+                break
             elif ret != -errno.ERANGE:
                 raise make_ex(ret, 'error listing lock owners for image %s' % image.name)
 

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -1855,10 +1855,13 @@ class TestExclusiveLock(object):
                 rados2.conf_set('rbd_blacklist_on_break_lock', 'true')
                 with Image(ioctx2, image_name) as image, \
                      Image(blacklist_ioctx, image_name) as blacklist_image:
+
+                    lock_owners = list(image.lock_get_owners())
+                    eq(0, len(lock_owners))
+
                     blacklist_image.lock_acquire(RBD_LOCK_MODE_EXCLUSIVE)
                     assert_raises(ReadOnlyImage, image.lock_acquire,
                                   RBD_LOCK_MODE_EXCLUSIVE)
-
                     lock_owners = list(image.lock_get_owners())
                     eq(1, len(lock_owners))
                     eq(RBD_LOCK_MODE_EXCLUSIVE, lock_owners[0]['mode'])


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44897

---

backport of https://github.com/ceph/ceph/pull/34134
parent tracker: https://tracker.ceph.com/issues/44613

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh