### PR TITLE
nautilus: qa/suites: use "nautilus" branch for cbt based testing

### DIFF
--- a/qa/suites/perf-basic/workloads/cosbench_64K_write.yaml
+++ b/qa/suites/perf-basic/workloads/cosbench_64K_write.yaml
@@ -9,6 +9,7 @@ overrides:
     index_pool_pg_size: 64
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       cosbench:
         obj_size: [64KB]

--- a/qa/suites/perf-basic/workloads/fio_4K_rand_write.yaml
+++ b/qa/suites/perf-basic/workloads/fio_4K_rand_write.yaml
@@ -5,6 +5,7 @@ meta:
 
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       librbdfio:
         op_size: [4096]

--- a/qa/suites/perf-basic/workloads/radosbench_4K_write.yaml
+++ b/qa/suites/perf-basic/workloads/radosbench_4K_write.yaml
@@ -5,6 +5,7 @@ meta:
 
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       radosbench:
         concurrent_ops: 4

--- a/qa/suites/rados/perf/workloads/cosbench_64K_read_write.yaml
+++ b/qa/suites/rados/perf/workloads/cosbench_64K_read_write.yaml
@@ -4,6 +4,7 @@ overrides:
     index_pool_pg_size: 64
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       cosbench:
         obj_size: [64KB]

--- a/qa/suites/rados/perf/workloads/cosbench_64K_write.yaml
+++ b/qa/suites/rados/perf/workloads/cosbench_64K_write.yaml
@@ -4,6 +4,7 @@ overrides:
     index_pool_pg_size: 64
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       cosbench:
         obj_size: [64KB]

--- a/qa/suites/rados/perf/workloads/fio_4K_rand_read.yaml
+++ b/qa/suites/rados/perf/workloads/fio_4K_rand_read.yaml
@@ -1,5 +1,6 @@
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       librbdfio:
         op_size: [4096]

--- a/qa/suites/rados/perf/workloads/fio_4K_rand_rw.yaml
+++ b/qa/suites/rados/perf/workloads/fio_4K_rand_rw.yaml
@@ -1,5 +1,6 @@
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       librbdfio:
         op_size: [4096]

--- a/qa/suites/rados/perf/workloads/fio_4M_rand_read.yaml
+++ b/qa/suites/rados/perf/workloads/fio_4M_rand_read.yaml
@@ -1,5 +1,6 @@
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       librbdfio:
         op_size: [4194304]

--- a/qa/suites/rados/perf/workloads/fio_4M_rand_rw.yaml
+++ b/qa/suites/rados/perf/workloads/fio_4M_rand_rw.yaml
@@ -1,5 +1,6 @@
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       librbdfio:
         op_size: [4194304]

--- a/qa/suites/rados/perf/workloads/fio_4M_rand_write.yaml
+++ b/qa/suites/rados/perf/workloads/fio_4M_rand_write.yaml
@@ -1,5 +1,6 @@
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       librbdfio:
         op_size: [4194304]

--- a/qa/suites/rados/perf/workloads/radosbench_4K_rand_read.yaml
+++ b/qa/suites/rados/perf/workloads/radosbench_4K_rand_read.yaml
@@ -1,5 +1,6 @@
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       radosbench:
         concurrent_ops: 4

--- a/qa/suites/rados/perf/workloads/radosbench_4K_seq_read.yaml
+++ b/qa/suites/rados/perf/workloads/radosbench_4K_seq_read.yaml
@@ -1,5 +1,6 @@
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       radosbench:
         concurrent_ops: 4

--- a/qa/suites/rados/perf/workloads/radosbench_4M_rand_read.yaml
+++ b/qa/suites/rados/perf/workloads/radosbench_4M_rand_read.yaml
@@ -1,5 +1,6 @@
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       radosbench:
         concurrent_ops: 4

--- a/qa/suites/rados/perf/workloads/radosbench_4M_seq_read.yaml
+++ b/qa/suites/rados/perf/workloads/radosbench_4M_seq_read.yaml
@@ -1,5 +1,6 @@
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       radosbench:
         concurrent_ops: 4

--- a/qa/suites/rados/perf/workloads/radosbench_4M_write.yaml
+++ b/qa/suites/rados/perf/workloads/radosbench_4M_write.yaml
@@ -1,5 +1,6 @@
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       radosbench:
         concurrent_ops: 4

--- a/qa/suites/rados/perf/workloads/sample_fio.yaml
+++ b/qa/suites/rados/perf/workloads/sample_fio.yaml
@@ -1,5 +1,6 @@
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       librbdfio:
         op_size: [4096]

--- a/qa/suites/rados/perf/workloads/sample_radosbench.yaml
+++ b/qa/suites/rados/perf/workloads/sample_radosbench.yaml
@@ -1,5 +1,6 @@
 tasks:
 - cbt:
+    branch: 'nautilus'
     benchmarks:
       radosbench:
         concurrent_ops: 4


### PR DESCRIPTION
cbt is using features like the f string introduced by python3.6, so we
need either stop testing on ubuntu 16.04, which came with python3.5, or
specify the a cbt branch which support python3.5. to address this issue
once and for all, it's simpler just pin the branch to "nautilus" when
performing cbt based tests.

this change is not cherry-picked from master, as in master, we only
tests on distros which offers python3.6 and up.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
