### PR TITLE
octopus: monitoring: alert for prediction of disk and pool fill up broken

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -199,15 +199,10 @@ groups:
             Node {{ $labels.instance }} experiences packet errors > 1
             packet/s on interface {{ $labels.device }}.
 
-      # predict fs fill-up times
-      - alert: storage filling
+      - alert: storage filling up
         expr: |
-          (
-            (
-              node_filesystem_free_bytes / deriv(node_filesystem_free_bytes[2d])
-              * on(instance) group_left(nodename) node_uname_info
-            ) <= 5
-          ) > 0
+          predict_linear(node_filesystem_free_bytes[2d], 3600 * 24 * 5) *
+          on(instance) group_left(nodename) node_uname_info < 0
         labels:
           severity: warning
           type: ceph_default
@@ -234,10 +229,9 @@ groups:
       - alert: pool filling up
         expr: |
           (
-            (
-              (ceph_pool_max_avail - ceph_pool_stored) / deriv(ceph_pool_max_avail[2d])
-            ) * on(pool_id) group_right ceph_pool_metadata <= 5
-          ) > 0
+            predict_linear(ceph_pool_stored[2d], 3600 * 24 * 5) >=
+            ceph_pool_max_avail
+          ) * on(pool_id) group_right(name) ceph_pool_metadata
         labels:
           severity: warning
           type: ceph_default


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44918

---

backport of https://github.com/ceph/ceph/pull/34227
parent tracker: https://tracker.ceph.com/issues/44776

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh