### PR TITLE
crimson/osd: record op's outdata and rval in pg log

### DIFF
--- a/cmake/modules/GetGitRevisionDescription.cmake
+++ b/cmake/modules/GetGitRevisionDescription.cmake
@@ -40,20 +40,13 @@ set(__get_git_revision_description YES)
 get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
 
 function(get_git_head_revision _refspecvar _hashvar)
-	set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-	set(GIT_DIR "${GIT_PARENT_DIR}/.git")
-	set(TOP_LEVEL_DIR "${CMAKE_SOURCE_DIR}")
-	while(NOT EXISTS "${GIT_DIR}")	# .git dir not found, search parent directories
-		set(GIT_PREVIOUS_PARENT "${GIT_PARENT_DIR}")
-		get_filename_component(GIT_PARENT_DIR ${GIT_PARENT_DIR} PATH)
-		if(GIT_PARENT_DIR STREQUAL TOP_LEVEL_DIR)
-			# We have reached the top of the source tree, we are not in git
-			set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
-			set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
-			return()
-		endif()
-		set(GIT_DIR "${GIT_PARENT_DIR}/.git")
-	endwhile()
+	set(GIT_DIR "${CMAKE_SOURCE_DIR}/.git")
+	if(NOT EXISTS "${GIT_DIR}")	# .git dir not found
+	  # We have reached the top of the source tree, we are not in git
+	  set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+	  set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+	  return()
+	endif()
 	# check if this is a submodule or git-worktree
 	if(NOT IS_DIRECTORY ${GIT_DIR})
 		file(READ ${GIT_DIR} gitdirfile)

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -491,7 +491,9 @@ private:
   seastar::future<ceph::bufferlist> do_pgnls(ceph::bufferlist& indata,
 					     const std::string& nspace,
 					     uint64_t limit);
-  seastar::future<> submit_transaction(ObjectContextRef&& obc,
+  seastar::future<> submit_transaction(const OpInfo& op_info,
+				       const std::vector<OSDOp>& ops,
+				       ObjectContextRef&& obc,
 				       ceph::os::Transaction&& txn,
 				       const osd_op_params_t& oop);
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4157,7 +4157,7 @@ struct pg_log_entry_t {
       (op == MODIFY || op == DELETE || op == ERROR);
   }
 
-  void set_op_returns(std::vector<OSDOp>& ops) {
+  void set_op_returns(const std::vector<OSDOp>& ops) {
     op_returns.resize(ops.size());
     for (unsigned i = 0; i < ops.size(); ++i) {
       op_returns[i].rval = ops[i].rval;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
