### PR TITLE
octopus: mgr/dashboard: fix error when enabling SSO with cert. file

### DIFF
--- a/src/pybind/mgr/dashboard/services/sso.py
+++ b/src/pybind/mgr/dashboard/services/sso.py
@@ -191,12 +191,12 @@ def handle_sso_command(cmd):
         has_sp_cert = sp_x_509_cert_path != "" and sp_private_key_path != ""
         if has_sp_cert:
             try:
-                with open(sp_x_509_cert_path, 'r') as f:
+                with open(sp_x_509_cert_path, 'r', encoding='utf-8') as f:
                     sp_x_509_cert = f.read()
             except FileNotFoundError:
                 return -errno.EINVAL, '', '`{}` not found.'.format(sp_x_509_cert_path)
             try:
-                with open(sp_private_key_path, 'r') as f:
+                with open(sp_private_key_path, 'r', encoding='utf-8') as f:
                     sp_private_key = f.read()
             except FileNotFoundError:
                 return -errno.EINVAL, '', '`{}` not found.'.format(sp_private_key_path)
@@ -207,7 +207,7 @@ def handle_sso_command(cmd):
         if os.path.isfile(idp_metadata):
             warnings.warn(
                 "Please prepend 'file://' to indicate a local SAML2 IdP file", DeprecationWarning)
-            with open(idp_metadata, 'r') as f:
+            with open(idp_metadata, 'r', encoding='utf-8') as f:
                 idp_settings = Saml2Parser.parse(f.read(), entity_id=idp_entity_id)
         elif parse.urlparse(idp_metadata)[0] in ('http', 'https', 'file'):
             idp_settings = Saml2Parser.parse_remote(
@@ -249,7 +249,7 @@ def handle_sso_command(cmd):
                 "wantMessagesSigned": has_sp_cert,
                 "wantAssertionsSigned": has_sp_cert,
                 "wantAssertionsEncrypted": has_sp_cert,
-                "wantNameIdEncrypted": has_sp_cert,
+                "wantNameIdEncrypted": False,  # Not all Identity Providers support this.
                 "metadataValidUntil": '',
                 "wantAttributeStatement": False
             }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44932

---

backport of https://github.com/ceph/ceph/pull/34033
parent tracker: https://tracker.ceph.com/issues/44666

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh