### PR TITLE
octopus: mgr/dashboard: fix notifications E2E tests

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/e2e/page-helper.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/page-helper.po.ts
@@ -288,8 +288,8 @@ export abstract class PageHelper {
     return browser.wait(EC.not(EC.textToBePresentInElement(elem, text)), TIMEOUT, message);
   }
 
-  async waitFn(func: Function, message?: string) {
-    return browser.wait(func, TIMEOUT, message);
+  async waitFn(func: Function, message?: string, timeout: number = TIMEOUT) {
+    return browser.wait(func, timeout, message);
   }
 
   getFirstCell(): ElementFinder {

--- a/src/pybind/mgr/dashboard/frontend/e2e/ui/notification.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/ui/notification.e2e-spec.ts
@@ -24,14 +24,27 @@ describe('Notification page', () => {
     const poolName = 'e2e_notification_pool';
 
     await pools.navigateTo('create');
-    await pools.create(poolName, 16);
-    await pools.edit_pool_pg(poolName, 8, false);
+    await pools.create(poolName, 8);
+    await pools.edit_pool_pg(poolName, 4, false);
     await notification.waitStaleness(notification.getToast());
 
+    // Check that running task is shown.
     await notification.open();
-    await notification.waitVisibility(notification.getTasks().first());
-    await expect((await notification.getTasks()).length).toBeGreaterThan(0);
+    await notification.waitFn(async () => {
+      const task = await notification.getTasks().first();
+      const text = await task.getText();
+      return text.includes(poolName);
+    }, 'Timed out verifying task.');
 
+    // Delete pool after task is complete (otherwise we get an error).
+    await notification.waitFn(
+      async () => {
+        const tasks = await notification.getTasks();
+        return tasks.length === 0 ? true : !(await tasks[0].getText()).includes(poolName);
+      },
+      'Timed out waiting for task to complete.',
+      40000
+    );
     await pools.delete(poolName);
   });
 
@@ -44,8 +57,17 @@ describe('Notification page', () => {
     await notification.waitStaleness(notification.getToast());
     await expect((await notification.getNotifications()).length).toBeGreaterThan(0);
     await notification.waitVisibility(notification.getClearNotficationsBtn());
+
+    // It can happen that although notifications are cleared, by the time we check the
+    // notifications amount, another notification can appear, so we check it more than once (if needed).
     await notification.waitClickableAndClick(notification.getClearNotficationsBtn());
-    await notification.waitStaleness(notification.getNotifications().first());
-    await expect((await notification.getNotifications()).length).toBe(0);
+    await notification.waitFn(async () => {
+      const notifications = await notification.getNotifications();
+      if (notifications.length > 0) {
+        await notification.waitClickableAndClick(notification.getClearNotficationsBtn());
+        return false;
+      }
+      return true;
+    }, 'Timed out checking that notifications are cleared.');
   });
 });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44933

---

backport of https://github.com/ceph/ceph/pull/33992
parent tracker: https://tracker.ceph.com/issues/44626

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh