### PR TITLE
osd: build without `using namespace` declarations in headers

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -53,6 +53,15 @@
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 
+using std::cerr;
+using std::cout;
+using std::map;
+using std::ostringstream;
+using std::string;
+using std::vector;
+
+using ceph::bufferlist;
+
 namespace {
 
 TracepointProvider::Traits osd_tracepoint_traits("libosd_tp.so",
@@ -241,7 +250,7 @@ int main(int argc, const char **argv)
 	try {
 	  decode(e, p);
 	}
-	catch (const buffer::error &e) {
+	catch (const ceph::buffer::error &e) {
 	  derr << "failed to decode LogEntry at offset " << pos << dendl;
 	  forker.exit(1);
 	}

--- a/src/cls/2pc_queue/cls_2pc_queue.cc
+++ b/src/cls/2pc_queue/cls_2pc_queue.cc
@@ -13,6 +13,10 @@
 CLS_VER(1,0)
 CLS_NAME(2pc_queue)
 
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+
 constexpr auto CLS_QUEUE_URGENT_DATA_XATTR_NAME = "cls_queue_urgent_data";
 
 static int cls_2pc_queue_init(cls_method_context_t hctx, bufferlist *in, bufferlist *out) {
@@ -21,7 +25,7 @@ static int cls_2pc_queue_init(cls_method_context_t hctx, bufferlist *in, bufferl
   cls_queue_init_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_2pc_queue_init: failed to decode entry: %s", err.what());
     return -EINVAL;
   }
@@ -44,7 +48,7 @@ static int cls_2pc_queue_reserve(cls_method_context_t hctx, bufferlist *in, buff
   try {
     auto in_iter = in->cbegin();
     decode(res_op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_2pc_queue_reserve: failed to decode entry: %s", err.what());
     return -EINVAL;
   }
@@ -69,7 +73,7 @@ static int cls_2pc_queue_reserve(cls_method_context_t hctx, bufferlist *in, buff
   try {
     auto in_iter = head.bl_urgent_data.cbegin();
     decode(urgent_data, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_2pc_queue_reserve: failed to decode entry: %s", err.what());
     return -EINVAL;
   }
@@ -126,7 +130,7 @@ static int cls_2pc_queue_reserve(cls_method_context_t hctx, bufferlist *in, buff
       auto iter = bl_xattrs.cbegin();
       try {
         decode(xattr_reservations, iter);
-      } catch (buffer::error& err) {
+      } catch (ceph::buffer::error& err) {
         CLS_LOG(1, "ERROR: cls_2pc_queue_reserve: failed to decode xattrs urgent data map");
         return -EINVAL;
       } //end - catch
@@ -178,7 +182,7 @@ static int cls_2pc_queue_commit(cls_method_context_t hctx, bufferlist *in, buffe
   try {
     auto in_iter = in->cbegin();
     decode(commit_op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_2pc_queue_commit: failed to decode entry: %s", err.what());
     return -EINVAL;
   }
@@ -194,7 +198,7 @@ static int cls_2pc_queue_commit(cls_method_context_t hctx, bufferlist *in, buffe
   try {
     auto in_iter = head.bl_urgent_data.cbegin();
     decode(urgent_data, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_2pc_queue_commit: failed to decode entry: %s", err.what());
     return -EINVAL;
   }
@@ -221,7 +225,7 @@ static int cls_2pc_queue_commit(cls_method_context_t hctx, bufferlist *in, buffe
     auto iter = bl_xattrs.cbegin();
     try {
       decode(xattr_reservations, iter);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       CLS_LOG(1, "ERROR: cls_2pc_queue_commit: failed to decode xattrs urgent data map");
       return -EINVAL;
     } //end - catch
@@ -285,7 +289,7 @@ static int cls_2pc_queue_abort(cls_method_context_t hctx, bufferlist *in, buffer
   try {
     auto in_iter = in->cbegin();
     decode(abort_op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_2pc_queue_abort: failed to decode entry: %s", err.what());
     return -EINVAL;
   }
@@ -301,7 +305,7 @@ static int cls_2pc_queue_abort(cls_method_context_t hctx, bufferlist *in, buffer
   try {
     auto in_iter = head.bl_urgent_data.cbegin();
     decode(urgent_data, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_2pc_queue_abort: failed to decode entry: %s", err.what());
     return -EINVAL;
   }
@@ -329,7 +333,7 @@ static int cls_2pc_queue_abort(cls_method_context_t hctx, bufferlist *in, buffer
     cls_2pc_reservations xattr_reservations;
     try {
       decode(xattr_reservations, iter);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       CLS_LOG(1, "ERROR: cls_2pc_queue_abort: failed to decode xattrs urgent data map");
       return -EINVAL;
     } //end - catch
@@ -375,7 +379,7 @@ static int cls_2pc_queue_list_reservations(cls_method_context_t hctx, bufferlist
   try {
     auto in_iter = head.bl_urgent_data.cbegin();
     decode(urgent_data, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_2pc_queue_list_reservations: failed to decode entry: %s", err.what());
     return -EINVAL;
   }
@@ -396,7 +400,7 @@ static int cls_2pc_queue_list_reservations(cls_method_context_t hctx, bufferlist
       auto iter = bl_xattrs.cbegin();
       try {
         decode(xattr_reservations, iter);
-      } catch (buffer::error& err) {
+      } catch (ceph::buffer::error& err) {
         CLS_LOG(1, "ERROR: cls_2pc_queue_list_reservations: failed to decode xattrs urgent data map");
         return -EINVAL;
       } //end - catch

--- a/src/cls/2pc_queue/cls_2pc_queue_ops.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_ops.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #pragma once
 
 #include "include/types.h"
@@ -7,14 +10,14 @@ struct cls_2pc_queue_reserve_op {
   uint64_t size;
   uint32_t entries;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(size, bl);
     encode(entries, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(size, bl);
     decode(entries, bl);
@@ -26,13 +29,13 @@ WRITE_CLASS_ENCODER(cls_2pc_queue_reserve_op)
 struct cls_2pc_queue_reserve_ret {
   cls_2pc_reservation::id_t id; // allocated reservation id
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(id, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(id, bl);
     DECODE_FINISH(bl);
@@ -42,16 +45,16 @@ WRITE_CLASS_ENCODER(cls_2pc_queue_reserve_ret)
 
 struct cls_2pc_queue_commit_op {
   cls_2pc_reservation::id_t id; // reservation to commit
-  std::vector<bufferlist> bl_data_vec; // the data to enqueue
+  std::vector<ceph::buffer::list> bl_data_vec; // the data to enqueue
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(id, bl);
     encode(bl_data_vec, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(id, bl);
     decode(bl_data_vec, bl);
@@ -64,13 +67,13 @@ WRITE_CLASS_ENCODER(cls_2pc_queue_commit_op)
 struct cls_2pc_queue_abort_op {
   cls_2pc_reservation::id_t id; // reservation to abort
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(id, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(id, bl);
     DECODE_FINISH(bl);
@@ -81,17 +84,16 @@ WRITE_CLASS_ENCODER(cls_2pc_queue_abort_op)
 struct cls_2pc_queue_reservations_ret {
   cls_2pc_reservations reservations; // reservation list (keyed by id)
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(reservations, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(reservations, bl);
     DECODE_FINISH(bl);
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_reservations_ret)
-

--- a/src/cls/2pc_queue/cls_2pc_queue_types.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_types.h
@@ -1,3 +1,5 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 #pragma once
 
 #include "include/types.h"
@@ -14,14 +16,14 @@ struct cls_2pc_reservation
 
   cls_2pc_reservation() = default;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(size, bl);
     encode(timestamp, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(size, bl);
     decode(timestamp, bl);
@@ -39,7 +41,7 @@ struct cls_2pc_urgent_data
   cls_2pc_reservations reservations; // reservation list (keyed by id)
   bool has_xattrs{false};
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(reserved_size, bl);
     encode(last_id, bl);
@@ -48,7 +50,7 @@ struct cls_2pc_urgent_data
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(reserved_size, bl);
     decode(last_id, bl);
@@ -58,4 +60,3 @@ struct cls_2pc_urgent_data
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_urgent_data)
-

--- a/src/cls/cas/cls_cas.cc
+++ b/src/cls/cas/cls_cas.cc
@@ -1,4 +1,4 @@
-// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
 #include <errno.h>
@@ -8,6 +8,9 @@
 
 #include "include/compat.h"
 #include "osd/osd_types.h"
+
+using ceph::bufferlist;
+using ceph::decode;
 
 CLS_VER(1,0)
 CLS_NAME(cas)
@@ -28,7 +31,7 @@ static int chunk_read_refcount(cls_method_context_t hctx, chunk_obj_refcount *ob
   try {
     auto iter = bl.cbegin();
     decode(*objr, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: chunk_read_refcount(): failed to decode refcount entry\n");
     return -EIO;
   }
@@ -56,7 +59,7 @@ static int cls_rc_chunk_refcount_get(cls_method_context_t hctx, bufferlist *in, 
   cls_chunk_refcount_get_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_rc_refcount_get(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -84,7 +87,7 @@ static int cls_rc_chunk_refcount_put(cls_method_context_t hctx, bufferlist *in, 
   cls_chunk_refcount_put_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_rc_chunk_refcount_put(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -134,7 +137,7 @@ static int cls_rc_chunk_refcount_set(cls_method_context_t hctx, bufferlist *in, 
   cls_chunk_refcount_set_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_chunk_refcount_set(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -182,7 +185,7 @@ static int cls_rc_write_or_get(cls_method_context_t hctx, bufferlist *in, buffer
     decode(src_obj, in_iter);
     in_iter.copy(op.extent.length, indata);
   }
-  catch (buffer::error& e) {
+  catch (ceph::buffer::error& e) {
     return -EINVAL;
   }
 
@@ -215,12 +218,12 @@ static int cls_rc_write_or_get(cls_method_context_t hctx, bufferlist *in, buffer
 static int cls_rc_has_chunk(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 {
   auto in_iter = in->cbegin();
-  string fp_oid;
+  std::string fp_oid;
   bufferlist indata, outdata;
   try {
     decode (fp_oid, in_iter);
   }
-  catch (buffer::error& e) {
+  catch (ceph::buffer::error& e) {
     return -EINVAL;
   }
   CLS_LOG(10, " fp_oid: %s \n", fp_oid.c_str());

--- a/src/cls/cas/cls_cas_client.cc
+++ b/src/cls/cas/cls_cas_client.cc
@@ -1,10 +1,18 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include <errno.h>
 
 #include "cls/cas/cls_cas_client.h"
 #include "cls/cas/cls_cas_ops.h"
 #include "include/rados/librados.hpp"
 
-using namespace librados;
+using std::set;
+using std::string;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
 
 void cls_chunk_refcount_get(librados::ObjectWriteOperation& op, const hobject_t& soid)
 {
@@ -44,7 +52,7 @@ int cls_chunk_refcount_read(librados::IoCtx& io_ctx, string& oid, set<hobject_t>
   try {
     auto iter = out.cbegin();
     decode(ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
 

--- a/src/cls/cas/cls_cas_client.h
+++ b/src/cls/cas/cls_cas_client.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_CLS_CAS_CLIENT_H
 #define CEPH_CLS_CAS_CLIENT_H
 
@@ -5,9 +8,9 @@
 #include "include/rados/librados_fwd.hpp"
 #include "common/hobject.h"
 
-void cls_chunk_refcount_get(librados::ObjectWriteOperation& op, const hobject_t& soid);
+void cls_chunk_refcount_get(librados::ObjectWriteOperation& op,const hobject_t& soid);
 void cls_chunk_refcount_put(librados::ObjectWriteOperation& op, const hobject_t& soid);
-void cls_chunk_refcount_set(librados::ObjectWriteOperation& op, set<hobject_t>& refs);
-int cls_chunk_refcount_read(librados::IoCtx& io_ctx, string& oid, set<hobject_t> *refs);
-int cls_chunk_has_chunk(librados::IoCtx& io_ctx, string& oid, string& fp_oid);
+void cls_chunk_refcount_set(librados::ObjectWriteOperation& op, std::set<hobject_t>& refs);
+int cls_chunk_refcount_read(librados::IoCtx& io_ctx, std::string& oid, std::set<hobject_t> *refs);
+int cls_chunk_has_chunk(librados::IoCtx& io_ctx, std::string& oid, std::string& fp_oid);
 #endif

--- a/src/cls/cas/cls_cas_ops.h
+++ b/src/cls/cas/cls_cas_ops.h
@@ -14,19 +14,19 @@ struct cls_chunk_refcount_get_op {
 
   cls_chunk_refcount_get_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(source, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(source, bl);
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(list<cls_chunk_refcount_get_op*>& ls);
+  static void generate_test_instances(std::list<cls_chunk_refcount_get_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_chunk_refcount_get_op)
 
@@ -35,79 +35,79 @@ struct cls_chunk_refcount_put_op {
 
   cls_chunk_refcount_put_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(source, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(source, bl);
     DECODE_FINISH(bl);
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(list<cls_chunk_refcount_put_op*>& ls);
+  static void generate_test_instances(std::list<cls_chunk_refcount_put_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_chunk_refcount_put_op)
 
 struct cls_chunk_refcount_set_op {
-  set<hobject_t> refs;
+  std::set<hobject_t> refs;
 
   cls_chunk_refcount_set_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(refs, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(refs, bl);
     DECODE_FINISH(bl);
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(list<cls_chunk_refcount_set_op*>& ls);
+  static void generate_test_instances(std::list<cls_chunk_refcount_set_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_chunk_refcount_set_op)
 
 struct cls_chunk_refcount_read_ret {
-  set<hobject_t> refs;
+  std::set<hobject_t> refs;
 
   cls_chunk_refcount_read_ret() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(refs, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(refs, bl);
     DECODE_FINISH(bl);
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(list<cls_chunk_refcount_read_ret*>& ls);
+  static void generate_test_instances(std::list<cls_chunk_refcount_read_ret*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_chunk_refcount_read_ret)
 
 struct chunk_obj_refcount {
-  set<hobject_t> refs;
+  std::set<hobject_t> refs;
 
   chunk_obj_refcount() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(refs, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(refs, bl);
     DECODE_FINISH(bl);
@@ -116,19 +116,19 @@ struct chunk_obj_refcount {
 WRITE_CLASS_ENCODER(chunk_obj_refcount)
 
 struct obj_refcount {
-  map<string, bool> refs;
-  set<string> retired_refs;
+  std::map<std::string, bool> refs;
+  std::set<std::string> retired_refs;
 
   obj_refcount() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
     encode(refs, bl);
     encode(retired_refs, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
     decode(refs, bl);
     if (struct_v >= 2) {

--- a/src/cls/cephfs/cls_cephfs.cc
+++ b/src/cls/cephfs/cls_cephfs.cc
@@ -24,6 +24,9 @@
 CLS_VER(1,0)
 CLS_NAME(cephfs)
 
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
 
 std::ostream &operator<<(std::ostream &out, const ObjCeiling &in)
 {
@@ -65,7 +68,7 @@ static int set_if_greater(cls_method_context_t hctx,
         // Valid existing value, do comparison
         set_val = input_val > existing_val;
       }
-    } catch (const buffer::error &err) {
+    } catch (const ceph::buffer::error &err) {
       // Corrupt or empty existing value, overwrite it
       set_val = true;
     }
@@ -96,7 +99,7 @@ static int accumulate_inode_metadata(cls_method_context_t hctx,
   AccumulateArgs args;
   try {
     args.decode(q);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -132,7 +135,7 @@ public:
       InodeTagFilterArgs args;
       args.decode(params);
       scrub_tag = args.scrub_tag;
-    } catch (buffer::error &e) {
+    } catch (ceph::buffer::error &e) {
       return -EINVAL;
     }
 
@@ -173,7 +176,7 @@ bool PGLSCephFSFilter::filter(const hobject_t &obj,
       decode(tag_ondisk, q);
       if (tag_ondisk == scrub_tag)
 	return false;
-    } catch (const buffer::error &err) {
+    } catch (const ceph::buffer::error &err) {
     }
   }
 

--- a/src/cls/cephfs/cls_cephfs.h
+++ b/src/cls/cephfs/cls_cephfs.h
@@ -36,7 +36,7 @@ class ObjCeiling {
       return id > rhs.id;
     }
 
-    void encode(bufferlist &bl) const
+    void encode(ceph::buffer::list &bl) const
     {
       ENCODE_START(1, 1, bl);
       encode(id, bl);
@@ -44,7 +44,7 @@ class ObjCeiling {
       ENCODE_FINISH(bl);
     }
 
-    void decode(bufferlist::const_iterator &p)
+    void decode(ceph::buffer::list::const_iterator &p)
     {
       DECODE_START(1, p);
       decode(id, p);
@@ -83,7 +83,7 @@ public:
     : obj_index(0), obj_size(0), mtime(0)
   {}
 
-  void encode(bufferlist &bl) const
+  void encode(ceph::buffer::list &bl) const
   {
     ENCODE_START(1, 1, bl);
     encode(obj_xattr_name, bl);
@@ -95,7 +95,7 @@ public:
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator &bl)
+  void decode(ceph::buffer::list::const_iterator &bl)
   {
     DECODE_START(1, bl);
     decode(obj_xattr_name, bl);
@@ -113,14 +113,14 @@ class InodeTagFilterArgs
   public:
     std::string scrub_tag;
 
-  void encode(bufferlist &bl) const
+  void encode(ceph::buffer::list &bl) const
   {
     ENCODE_START(1, 1, bl);
     encode(scrub_tag, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator &bl)
+  void decode(ceph::buffer::list::const_iterator &bl)
   {
     DECODE_START(1, bl);
     decode(scrub_tag, bl);

--- a/src/cls/cephfs/cls_cephfs_client.cc
+++ b/src/cls/cephfs/cls_cephfs_client.cc
@@ -19,6 +19,9 @@
 
 #include "cls_cephfs_client.h"
 
+using ceph::bufferlist;
+using ceph::decode;
+
 #define XATTR_CEILING "scan_ceiling"
 #define XATTR_MAX_MTIME "scan_max_mtime"
 #define XATTR_MAX_SIZE "scan_max_size"
@@ -114,7 +117,7 @@ int ClsCephFSClient::fetch_inode_accumulate_result(
     ceiling.decode(scan_ceiling_bl_iter);
     result->ceiling_obj_index = ceiling.id;
     result->ceiling_obj_size = ceiling.size;
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     //dout(4) << "Invalid size attr on '" << oid << "'" << dendl;
     return -EINVAL;
   }
@@ -123,7 +126,7 @@ int ClsCephFSClient::fetch_inode_accumulate_result(
   try {
     auto scan_max_size_bl_iter = scan_max_size_bl.cbegin();
     decode(result->max_obj_size, scan_max_size_bl_iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     //dout(4) << "Invalid size attr on '" << oid << "'" << dendl;
     return -EINVAL;
   }
@@ -132,7 +135,7 @@ int ClsCephFSClient::fetch_inode_accumulate_result(
   try {
     auto scan_max_mtime_bl_iter = scan_max_mtime_bl.cbegin();
     decode(result->max_mtime, scan_max_mtime_bl_iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     //dout(4) << "Invalid size attr on '" << oid << "'" << dendl;
     return -EINVAL;
   }
@@ -142,7 +145,7 @@ int ClsCephFSClient::fetch_inode_accumulate_result(
     try {
       auto q = parent_bl.cbegin();
       backtrace->decode(q);
-    } catch (buffer::error &e) {
+    } catch (ceph::buffer::error &e) {
       //dout(4) << "Corrupt backtrace on '" << oid << "': " << e << dendl;
       return -EINVAL;
     }
@@ -153,7 +156,7 @@ int ClsCephFSClient::fetch_inode_accumulate_result(
     try {
       auto q = layout_bl.cbegin();
       decode(*layout, q);
-    } catch (buffer::error &e) {
+    } catch (ceph::buffer::error &e) {
       return -EINVAL;
     }
   }

--- a/src/cls/cephfs/cls_cephfs_client.h
+++ b/src/cls/cephfs/cls_cephfs_client.h
@@ -1,3 +1,5 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
 #include "include/rados/librados_fwd.hpp"
 #include "mds/mdstypes.h"
@@ -28,6 +30,5 @@ class ClsCephFSClient
 
   static void build_tag_filter(
       const std::string &scrub_tag,
-      bufferlist *out_bl);
+      ceph::buffer::list *out_bl);
 };
-

--- a/src/cls/hello/cls_hello.cc
+++ b/src/cls/hello/cls_hello.cc
@@ -37,8 +37,12 @@
 #include "objclass/objclass.h"
 #include "osd/osd_types.h"
 
-using ceph::bufferlist;
 using std::string;
+using std::ostringstream;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
 
 CLS_VER(1,0)
 CLS_NAME(hello)
@@ -278,7 +282,7 @@ public:
     try {
       decode(xattr, params);
       decode(val, params);
-    } catch (buffer::error &e) {
+    } catch (ceph::buffer::error &e) {
       return -EINVAL;
     }
     return 0;

--- a/src/cls/journal/cls_journal.cc
+++ b/src/cls/journal/cls_journal.cc
@@ -15,6 +15,12 @@
 CLS_VER(1, 0)
 CLS_NAME(journal)
 
+using std::string;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+
 namespace {
 
 static const uint64_t MAX_KEYS_READ = 64;
@@ -68,7 +74,7 @@ int read_key(cls_method_context_t hctx, const string &key, T *t,
   try {
     auto iter = bl.cbegin();
     decode(*t, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -127,7 +133,7 @@ int expire_tags(cls_method_context_t hctx, const std::string *skip_client_id) {
       auto iter = val.second.cbegin();
       try {
         decode(client, iter);
-      } catch (const buffer::error &err) {
+      } catch (const ceph::buffer::error &err) {
         CLS_ERR("error decoding registered client: %s",
                 val.first.c_str());
         return -EIO;
@@ -176,7 +182,7 @@ int expire_tags(cls_method_context_t hctx, const std::string *skip_client_id) {
       auto iter = val.second.cbegin();
       try {
         decode(tag, iter);
-      } catch (const buffer::error &err) {
+      } catch (const ceph::buffer::error &err) {
         CLS_ERR("error decoding tag: %s", val.first.c_str());
         return -EIO;
       }
@@ -239,7 +245,7 @@ int get_client_list_range(cls_method_context_t hctx,
       cls::journal::Client client;
       decode(client, iter);
       clients->insert(client);
-    } catch (const buffer::error &err) {
+    } catch (const ceph::buffer::error &err) {
       CLS_ERR("could not decode client '%s': %s", it->first.c_str(),
               err.what());
       return -EIO;
@@ -313,7 +319,7 @@ int journal_create(cls_method_context_t hctx, bufferlist *in, bufferlist *out) {
     decode(order, iter);
     decode(splay_width, iter);
     decode(pool_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -459,7 +465,7 @@ int journal_set_minimum_set(cls_method_context_t hctx, bufferlist *in,
   try {
     auto iter = in->cbegin();
     decode(object_set, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -530,7 +536,7 @@ int journal_set_active_set(cls_method_context_t hctx, bufferlist *in,
   try {
     auto iter = in->cbegin();
     decode(object_set, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -582,7 +588,7 @@ int journal_get_client(cls_method_context_t hctx, bufferlist *in,
   try {
     auto iter = in->cbegin();
     decode(id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -614,7 +620,7 @@ int journal_client_register(cls_method_context_t hctx, bufferlist *in,
     auto iter = in->cbegin();
     decode(id, iter);
     decode(data, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -664,7 +670,7 @@ int journal_client_update_data(cls_method_context_t hctx, bufferlist *in,
     auto iter = in->cbegin();
     decode(id, iter);
     decode(data, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -703,7 +709,7 @@ int journal_client_update_state(cls_method_context_t hctx, bufferlist *in,
     uint8_t state_raw;
     decode(state_raw, iter);
     state = static_cast<cls::journal::ClientState>(state_raw);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -736,7 +742,7 @@ int journal_client_unregister(cls_method_context_t hctx, bufferlist *in,
   try {
     auto iter = in->cbegin();
     decode(id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -779,7 +785,7 @@ int journal_client_commit(cls_method_context_t hctx, bufferlist *in,
     auto iter = in->cbegin();
     decode(id, iter);
     decode(commit_position, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -830,7 +836,7 @@ int journal_client_list(cls_method_context_t hctx, bufferlist *in,
     auto iter = in->cbegin();
     decode(start_after, iter);
     decode(max_return, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -877,7 +883,7 @@ int journal_get_tag(cls_method_context_t hctx, bufferlist *in,
   try {
     auto iter = in->cbegin();
     decode(tag_tid, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -912,7 +918,7 @@ int journal_tag_create(cls_method_context_t hctx, bufferlist *in,
     decode(tag_tid, iter);
     decode(tag_class, iter);
     decode(data, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -1007,7 +1013,7 @@ int journal_tag_list(cls_method_context_t hctx, bufferlist *in,
     decode(max_return, iter);
     decode(client_id, iter);
     decode(tag_class, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -1048,7 +1054,7 @@ int journal_tag_list(cls_method_context_t hctx, bufferlist *in,
       auto iter = val.second.cbegin();
       try {
         decode(tag, iter);
-      } catch (const buffer::error &err) {
+      } catch (const ceph::buffer::error &err) {
         CLS_ERR("error decoding tag: %s", val.first.c_str());
         return -EIO;
       }
@@ -1102,7 +1108,7 @@ int journal_object_guard_append(cls_method_context_t hctx, bufferlist *in,
   try {
     auto iter = in->cbegin();
     decode(soft_max_size, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }
@@ -1142,7 +1148,7 @@ int journal_object_append(cls_method_context_t hctx, bufferlist *in,
     auto iter = in->cbegin();
     decode(soft_max_size, iter);
     decode(data, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode input parameters: %s", err.what());
     return -EINVAL;
   }

--- a/src/cls/journal/cls_journal_types.cc
+++ b/src/cls/journal/cls_journal_types.cc
@@ -5,6 +5,9 @@
 #include "include/stringify.h"
 #include "common/Formatter.h"
 
+using ceph::bufferlist;
+using ceph::Formatter;
+
 namespace cls {
 namespace journal {
 

--- a/src/cls/lock/cls_lock.cc
+++ b/src/cls/lock/cls_lock.cc
@@ -26,9 +26,11 @@
 
 #include "include/compat.h"
 
+using std::map;
+using std::string;
 
+using ceph::bufferlist;
 using namespace rados::cls::lock;
-
 
 CLS_VER(1,0)
 CLS_NAME(lock)
@@ -67,7 +69,7 @@ static int read_lock(cls_method_context_t hctx,
   try {
     auto it = bl.cbegin();
     decode(*lock, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("error decoding %s", key.c_str());
     return -EIO;
   }
@@ -76,7 +78,7 @@ static int read_lock(cls_method_context_t hctx,
 
   utime_t now = ceph_clock_now();
 
-  map<locker_id_t, locker_info_t>::iterator iter = lock->lockers.begin();
+  auto iter = lock->lockers.begin();
 
   while (iter != lock->lockers.end()) {
     struct locker_info_t& info = iter->second;
@@ -167,8 +169,7 @@ static int lock_obj(cls_method_context_t hctx,
     return r;
   }
 
-  map<locker_id_t, locker_info_t>& lockers = linfo.lockers;
-  map<locker_id_t, locker_info_t>::iterator iter;
+  auto& lockers = linfo.lockers;
 
   locker_id_t id;
   id.cookie = cookie;
@@ -186,7 +187,7 @@ static int lock_obj(cls_method_context_t hctx,
 
   ClsLockType existing_lock_type = linfo.lock_type;
   CLS_LOG(20, "existing_lock_type=%s", cls_lock_type_str(existing_lock_type));
-  iter = lockers.find(id);
+  auto iter = lockers.find(id);
   if (iter != lockers.end()) {
     if (fail_if_exists && !fail_if_does_not_exist) {
       return -EEXIST;
@@ -259,7 +260,7 @@ static int lock_op(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(op, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -291,11 +292,11 @@ static int remove_lock(cls_method_context_t hctx,
     return r;
   }
 
-  map<locker_id_t, locker_info_t>& lockers = linfo.lockers;
+  auto& lockers = linfo.lockers;
   struct locker_id_t id(locker, cookie);
 
   // remove named locker from set
-  map<locker_id_t, locker_info_t>::iterator iter = lockers.find(id);
+  auto iter = lockers.find(id);
   if (iter == lockers.end()) { // no such key
     CLS_LOG(10, "locker %s [name: %s.%ld, cookie: %s] does not exist", name.c_str(), 
             locker.type_str(), locker.num(), cookie.c_str());
@@ -331,7 +332,7 @@ static int unlock_op(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(op, iter);
-  } catch (const buffer::error& err) {
+  } catch (const ceph::buffer::error& err) {
     return -EINVAL;
   }
 
@@ -359,7 +360,7 @@ static int break_lock(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(op, iter);
-  } catch (const buffer::error& err) {
+  } catch (const ceph::buffer::error& err) {
     return -EINVAL;
   }
 
@@ -385,7 +386,7 @@ static int get_info(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(op, iter);
-  } catch (const buffer::error& err) {
+  } catch (const ceph::buffer::error& err) {
     return -EINVAL;
   }
 
@@ -399,8 +400,7 @@ static int get_info(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 
   struct cls_lock_get_info_reply ret;
 
-  map<locker_id_t, locker_info_t>::iterator iter;
-  for (iter = linfo.lockers.begin(); iter != linfo.lockers.end(); ++iter) {
+  for (auto iter = linfo.lockers.begin(); iter != linfo.lockers.end(); ++iter) {
     ret.lockers[iter->first] = iter->second;
   }
   ret.lock_type = linfo.lock_type;
@@ -435,9 +435,8 @@ static int list_locks(cls_method_context_t hctx, bufferlist *in, bufferlist *out
 
   cls_lock_list_locks_reply ret;
 
-  map<string, bufferlist>::iterator iter;
   size_t pos = sizeof(LOCK_PREFIX) - 1;
-  for (iter = attrs.begin(); iter != attrs.end(); ++iter) {
+  for (auto iter = attrs.begin(); iter != attrs.end(); ++iter) {
     const string& attr = iter->first;
     if (attr.substr(0, pos).compare(LOCK_PREFIX) == 0) {
       ret.locks.push_back(attr.substr(pos));
@@ -468,7 +467,7 @@ int assert_locked(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(op, iter);
-  } catch (const buffer::error& err) {
+  } catch (const ceph::buffer::error& err) {
     return -EINVAL;
   }
 
@@ -513,7 +512,7 @@ int assert_locked(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   id.cookie = op.cookie;
   id.locker = inst.name;
 
-  map<locker_id_t, locker_info_t>::iterator iter = linfo.lockers.find(id);
+  auto iter = linfo.lockers.find(id);
   if (iter == linfo.lockers.end()) {
     CLS_LOG(20, "not locked by assert client");
     return -EBUSY;
@@ -540,7 +539,7 @@ int set_cookie(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(op, iter);
-  } catch (const buffer::error& err) {
+  } catch (const ceph::buffer::error& err) {
     return -EINVAL;
   }
 

--- a/src/cls/lock/cls_lock_client.cc
+++ b/src/cls/lock/cls_lock_client.cc
@@ -16,20 +16,23 @@
 #include "msg/msg_types.h"
 #include "include/rados/librados.hpp"
 #include "include/utime.h"
- 
-using namespace librados;
 
 #include "cls/lock/cls_lock_ops.h"
 #include "cls/lock/cls_lock_client.h"
+
+using std::map;
+
+using namespace librados;
+
 
 namespace rados {
   namespace cls {
     namespace lock {
 
       void lock(ObjectWriteOperation *rados_op,
-                const string& name, ClsLockType type,
-                const string& cookie, const string& tag,
-                const string& description,
+                const std::string& name, ClsLockType type,
+                const std::string& cookie, const std::string& tag,
+                const std::string& description,
                 const utime_t& duration, uint8_t flags)
       {
         cls_lock_lock_op op;
@@ -46,10 +49,10 @@ namespace rados {
       }
 
       int lock(IoCtx *ioctx,
-               const string& oid,
-               const string& name, ClsLockType type,
-               const string& cookie, const string& tag,
-               const string& description, const utime_t& duration,
+               const std::string& oid,
+               const std::string& name, ClsLockType type,
+               const std::string& cookie, const std::string& tag,
+               const std::string& description, const utime_t& duration,
 	       uint8_t flags)
       {
         ObjectWriteOperation op;
@@ -58,7 +61,7 @@ namespace rados {
       }
 
       void unlock(ObjectWriteOperation *rados_op,
-                  const string& name, const string& cookie)
+                  const std::string& name, const std::string& cookie)
       {
         cls_lock_unlock_op op;
         op.name = name;
@@ -69,16 +72,16 @@ namespace rados {
         rados_op->exec("lock", "unlock", in);
       }
 
-      int unlock(IoCtx *ioctx, const string& oid,
-                 const string& name, const string& cookie)
+      int unlock(IoCtx *ioctx, const std::string& oid,
+                 const std::string& name, const std::string& cookie)
       {
         ObjectWriteOperation op;
         unlock(&op, name, cookie);
         return ioctx->operate(oid, &op);
       }
 
-      int aio_unlock(IoCtx *ioctx, const string& oid,
-		     const string& name, const string& cookie,
+      int aio_unlock(IoCtx *ioctx, const std::string& oid,
+		     const std::string& name, const std::string& cookie,
 		     librados::AioCompletion *completion)
       {
         ObjectWriteOperation op;
@@ -87,7 +90,7 @@ namespace rados {
       }
 
       void break_lock(ObjectWriteOperation *rados_op,
-                      const string& name, const string& cookie,
+                      const std::string& name, const std::string& cookie,
                       const entity_name_t& locker)
       {
         cls_lock_break_op op;
@@ -99,8 +102,8 @@ namespace rados {
         rados_op->exec("lock", "break_lock", in);
       }
 
-      int break_lock(IoCtx *ioctx, const string& oid,
-                     const string& name, const string& cookie,
+      int break_lock(IoCtx *ioctx, const std::string& oid,
+                     const std::string& name, const std::string& cookie,
                      const entity_name_t& locker)
       {
         ObjectWriteOperation op;
@@ -108,7 +111,7 @@ namespace rados {
         return ioctx->operate(oid, &op);
       }
 
-      int list_locks(IoCtx *ioctx, const string& oid, list<string> *locks)
+      int list_locks(IoCtx *ioctx, const std::string& oid, std::list<std::string> *locks)
       {
         bufferlist in, out;
         int r = ioctx->exec(oid, "lock", "list_locks", in, out);
@@ -116,10 +119,10 @@ namespace rados {
           return r;
 
         cls_lock_list_locks_reply ret;
-        auto iter = cbegin(out);
+        auto iter = std::cbegin(out);
         try {
           decode(ret, iter);
-        } catch (buffer::error& err) {
+        } catch (ceph::buffer::error& err) {
 	  return -EBADMSG;
         }
 
@@ -129,7 +132,7 @@ namespace rados {
       }
 
       void get_lock_info_start(ObjectReadOperation *rados_op,
-			       const string& name)
+			       const std::string& name)
       {
         bufferlist in;
         cls_lock_get_info_op op;
@@ -140,12 +143,12 @@ namespace rados {
 
       int get_lock_info_finish(bufferlist::const_iterator *iter,
 			       map<locker_id_t, locker_info_t> *lockers,
-			       ClsLockType *type, string *tag)
+			       ClsLockType *type, std::string *tag)
       {
         cls_lock_get_info_reply ret;
         try {
           decode(ret, *iter);
-        } catch (buffer::error& err) {
+        } catch (ceph::buffer::error& err) {
 	  return -EBADMSG;
         }
 
@@ -164,9 +167,9 @@ namespace rados {
         return 0;
       }
 
-      int get_lock_info(IoCtx *ioctx, const string& oid, const string& name,
+      int get_lock_info(IoCtx *ioctx, const std::string& oid, const std::string& name,
                         map<locker_id_t, locker_info_t> *lockers,
-                        ClsLockType *type, string *tag)
+                        ClsLockType *type, std::string *tag)
       {
         ObjectReadOperation op;
         get_lock_info_start(&op, name);
@@ -229,7 +232,7 @@ namespace rados {
              cookie, tag, description, duration, flags);
       }
 
-      int Lock::lock_shared(IoCtx *ioctx, const string& oid)
+      int Lock::lock_shared(IoCtx *ioctx, const std::string& oid)
       {
         return lock(ioctx, oid, name, LOCK_SHARED,
                     cookie, tag, description, duration, flags);
@@ -241,7 +244,7 @@ namespace rados {
              cookie, tag, description, duration, flags);
       }
 
-      int Lock::lock_exclusive(IoCtx *ioctx, const string& oid)
+      int Lock::lock_exclusive(IoCtx *ioctx, const std::string& oid)
       {
         return lock(ioctx, oid, name, LOCK_EXCLUSIVE,
                     cookie, tag, description, duration, flags);
@@ -253,7 +256,7 @@ namespace rados {
              cookie, tag, description, duration, flags);
       }
 
-      int Lock::lock_exclusive_ephemeral(IoCtx *ioctx, const string& oid)
+      int Lock::lock_exclusive_ephemeral(IoCtx *ioctx, const std::string& oid)
       {
         return lock(ioctx, oid, name, LOCK_EXCLUSIVE_EPHEMERAL,
                     cookie, tag, description, duration, flags);
@@ -264,7 +267,7 @@ namespace rados {
 	rados::cls::lock::unlock(op, name, cookie);
       }
 
-      int Lock::unlock(IoCtx *ioctx, const string& oid)
+      int Lock::unlock(IoCtx *ioctx, const std::string& oid)
       {
         return rados::cls::lock::unlock(ioctx, oid, name, cookie);
       }
@@ -274,11 +277,10 @@ namespace rados {
 	rados::cls::lock::break_lock(op, name, cookie, locker);
       }
 
-      int Lock::break_lock(IoCtx *ioctx, const string& oid, const entity_name_t& locker)
+      int Lock::break_lock(IoCtx *ioctx, const std::string& oid, const entity_name_t& locker)
       {
           return rados::cls::lock::break_lock(ioctx, oid, name, cookie, locker);
       }
     } // namespace lock
   } // namespace cls
 } // namespace rados
-

--- a/src/cls/lock/cls_lock_client.h
+++ b/src/cls/lock/cls_lock_client.h
@@ -44,16 +44,16 @@ namespace rados {
 			    const entity_name_t& locker);
 
       extern int list_locks(librados::IoCtx *ioctx, const std::string& oid,
-			    list<std::string> *locks);
+			    std::list<std::string> *locks);
       extern void get_lock_info_start(librados::ObjectReadOperation *rados_op,
 				      const std::string& name);
       extern int get_lock_info_finish(ceph::bufferlist::const_iterator *out,
-				      map<locker_id_t, locker_info_t> *lockers,
+				      std::map<locker_id_t, locker_info_t> *lockers,
 				      ClsLockType *type, std::string *tag);
 
       extern int get_lock_info(librados::IoCtx *ioctx, const std::string& oid,
 			       const std::string& name,
-			       map<locker_id_t, locker_info_t> *lockers,
+			       std::map<locker_id_t, locker_info_t> *lockers,
 			       ClsLockType *type, std::string *tag);
 
       extern void assert_locked(librados::ObjectOperation *rados_op,

--- a/src/cls/lock/cls_lock_ops.h
+++ b/src/cls/lock/cls_lock_ops.h
@@ -10,17 +10,17 @@
 
 struct cls_lock_lock_op
 {
-  string name;
+  std::string name;
   ClsLockType type;
-  string cookie;
-  string tag;
-  string description;
+  std::string cookie;
+  std::string tag;
+  std::string description;
   utime_t duration;
   uint8_t flags;
 
   cls_lock_lock_op() : type(LOCK_NONE), flags(0) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(name, bl);
     uint8_t t = (uint8_t)type;
@@ -32,7 +32,7 @@ struct cls_lock_lock_op
     encode(flags, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
     decode(name, bl);
     uint8_t t;
@@ -45,92 +45,92 @@ struct cls_lock_lock_op
     decode(flags, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_lock_lock_op*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_lock_lock_op*>& o);
 };
 WRITE_CLASS_ENCODER(cls_lock_lock_op)
 
 struct cls_lock_unlock_op
 {
-  string name;
-  string cookie;
+  std::string name;
+  std::string cookie;
 
   cls_lock_unlock_op() {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(name, bl);
     encode(cookie, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
     decode(name, bl);
     decode(cookie, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_lock_unlock_op*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_lock_unlock_op*>& o);
 };
 WRITE_CLASS_ENCODER(cls_lock_unlock_op)
 
 struct cls_lock_break_op
 {
-  string name;
+  std::string name;
   entity_name_t locker;
-  string cookie;
+  std::string cookie;
 
   cls_lock_break_op() {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(name, bl);
     encode(locker, bl);
     encode(cookie, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
     decode(name, bl);
     decode(locker, bl);
     decode(cookie, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_lock_break_op*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_lock_break_op*>& o);
 };
 WRITE_CLASS_ENCODER(cls_lock_break_op)
 
 struct cls_lock_get_info_op
 {
-  string name;
+  std::string name;
 
   cls_lock_get_info_op() {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(name, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
     decode(name, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_lock_get_info_op*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_lock_get_info_op*>& o);
 };
 WRITE_CLASS_ENCODER(cls_lock_get_info_op)
 
 struct cls_lock_get_info_reply
 {
-  map<rados::cls::lock::locker_id_t, rados::cls::lock::locker_info_t> lockers;
+  std::map<rados::cls::lock::locker_id_t, rados::cls::lock::locker_info_t> lockers;
   ClsLockType lock_type;
-  string tag;
+  std::string tag;
 
   cls_lock_get_info_reply() : lock_type(LOCK_NONE) {}
 
-  void encode(bufferlist &bl, uint64_t features) const {
+  void encode(ceph::buffer::list &bl, uint64_t features) const {
     ENCODE_START(1, 1, bl);
     encode(lockers, bl, features);
     uint8_t t = (uint8_t)lock_type;
@@ -138,7 +138,7 @@ struct cls_lock_get_info_reply
     encode(tag, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
     decode(lockers, bl);
     uint8_t t;
@@ -147,42 +147,42 @@ struct cls_lock_get_info_reply
     decode(tag, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_lock_get_info_reply*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_lock_get_info_reply*>& o);
 };
 WRITE_CLASS_ENCODER_FEATURES(cls_lock_get_info_reply)
 
 struct cls_lock_list_locks_reply
 {
-  list<string> locks;
+  std::list<std::string> locks;
 
   cls_lock_list_locks_reply() {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(locks, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
     decode(locks, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_lock_list_locks_reply*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_lock_list_locks_reply*>& o);
 };
 WRITE_CLASS_ENCODER(cls_lock_list_locks_reply)
 
 struct cls_lock_assert_op
 {
-  string name;
+  std::string name;
   ClsLockType type;
-  string cookie;
-  string tag;
+  std::string cookie;
+  std::string tag;
 
   cls_lock_assert_op() : type(LOCK_NONE) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(name, bl);
     uint8_t t = (uint8_t)type;
@@ -191,7 +191,7 @@ struct cls_lock_assert_op
     encode(tag, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
     decode(name, bl);
     uint8_t t;
@@ -201,22 +201,22 @@ struct cls_lock_assert_op
     decode(tag, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_lock_assert_op*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_lock_assert_op*>& o);
 };
 WRITE_CLASS_ENCODER(cls_lock_assert_op)
 
 struct cls_lock_set_cookie_op
 {
-  string name;
+  std::string name;
   ClsLockType type;
-  string cookie;
-  string tag;
-  string new_cookie;
+  std::string cookie;
+  std::string tag;
+  std::string new_cookie;
 
   cls_lock_set_cookie_op() : type(LOCK_NONE) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(name, bl);
     uint8_t t = (uint8_t)type;
@@ -226,7 +226,7 @@ struct cls_lock_set_cookie_op
     encode(new_cookie, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
     decode(name, bl);
     uint8_t t;
@@ -237,8 +237,8 @@ struct cls_lock_set_cookie_op
     decode(new_cookie, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_lock_set_cookie_op*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_lock_set_cookie_op*>& o);
 };
 WRITE_CLASS_ENCODER(cls_lock_set_cookie_op)
 

--- a/src/cls/lock/cls_lock_types.cc
+++ b/src/cls/lock/cls_lock_types.cc
@@ -9,7 +9,7 @@
  * modify it under the terms of the GNU Lesser General Public
  * License version 2.1, as published by the Free Software 
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 #include "common/Formatter.h"
@@ -18,19 +18,19 @@
 
 using namespace rados::cls::lock;
 
-static void generate_lock_id(locker_id_t& i, int n, const string& cookie)
+static void generate_lock_id(locker_id_t& i, int n, const std::string& cookie)
 {
   i.locker = entity_name_t::CLIENT(n);
   i.cookie = cookie;
 }
 
-void locker_id_t::dump(Formatter *f) const
+void locker_id_t::dump(ceph::Formatter *f) const
 {
   f->dump_stream("locker") << locker;
   f->dump_string("cookie", cookie);
 }
 
-void locker_id_t::generate_test_instances(list<locker_id_t*>& o)
+void locker_id_t::generate_test_instances(std::list<locker_id_t*>& o)
 {
   locker_id_t *i = new locker_id_t;
   generate_lock_id(*i, 1, "cookie");
@@ -38,7 +38,7 @@ void locker_id_t::generate_test_instances(list<locker_id_t*>& o)
   o.push_back(new locker_id_t);
 }
 
-void locker_info_t::dump(Formatter *f) const
+void locker_info_t::dump(ceph::Formatter *f) const
 {
   f->dump_stream("expiration") << expiration;
   f->dump_string("addr", addr.get_legacy_str());
@@ -57,7 +57,7 @@ static void generate_test_addr(entity_addr_t& a, int nonce, int port)
   a.set_port(port);
 }
 
-void locker_info_t::generate_test_instances(list<locker_info_t*>& o)
+void locker_info_t::generate_test_instances(std::list<locker_info_t*>& o)
 {
   locker_info_t *i = new locker_info_t;
   i->expiration = utime_t(5, 0);
@@ -67,7 +67,7 @@ void locker_info_t::generate_test_instances(list<locker_info_t*>& o)
   o.push_back(new locker_info_t);
 }
 
-void lock_info_t::dump(Formatter *f) const
+void lock_info_t::dump(ceph::Formatter *f) const
 {
   f->dump_int("lock_type", lock_type);
   f->dump_string("tag", tag);
@@ -81,7 +81,7 @@ void lock_info_t::dump(Formatter *f) const
   f->close_section();
 }
 
-void lock_info_t::generate_test_instances(list<lock_info_t *>& o)
+void lock_info_t::generate_test_instances(std::list<lock_info_t *>& o)
 {
   lock_info_t *i = new lock_info_t;
   locker_id_t id;

--- a/src/cls/lock/cls_lock_types.h
+++ b/src/cls/lock/cls_lock_types.h
@@ -84,13 +84,13 @@ namespace rados {
             return true;
           return false;
         }
-        void dump(Formatter *f) const;
+        void dump(ceph::Formatter *f) const;
 	friend std::ostream& operator<<(std::ostream& out,
 					const locker_id_t& data) {
 	  out << data.locker;
 	  return out;
 	}
-        static void generate_test_instances(list<locker_id_t*>& o);
+        static void generate_test_instances(std::list<locker_id_t*>& o);
       };
       WRITE_CLASS_ENCODER(locker_id_t)
 
@@ -118,9 +118,10 @@ namespace rados {
           decode(description, bl);
           DECODE_FINISH(bl);
         }
-        void dump(Formatter *f) const;
+        void dump(ceph::Formatter *f) const;
 	friend std::ostream& operator<<(std::ostream& out,
 					const locker_info_t& data) {
+	  using ceph::operator <<;
 	  out << "{addr:" << data.addr << ", exp:";
 
 	  const auto& exp = data.expiration;
@@ -132,12 +133,12 @@ namespace rados {
 
 	  return out;
 	}
-        static void generate_test_instances(list<locker_info_t *>& o);
+        static void generate_test_instances(std::list<locker_info_t *>& o);
       };
       WRITE_CLASS_ENCODER_FEATURES(locker_info_t)
 
       struct lock_info_t {
-        map<locker_id_t, locker_info_t> lockers; // map of lockers
+	std::map<locker_id_t, locker_info_t> lockers; // map of lockers
         ClsLockType lock_type;                   // lock type (exclusive / shared)
 	std::string tag;                              // tag: operations on lock can only succeed with this tag
                                                  //      as long as set of non expired lockers
@@ -161,8 +162,8 @@ namespace rados {
           DECODE_FINISH(bl);
         }
         lock_info_t() : lock_type(LOCK_NONE) {}
-        void dump(Formatter *f) const;
-        static void generate_test_instances(list<lock_info_t *>& o);
+        void dump(ceph::Formatter *f) const;
+        static void generate_test_instances(std::list<lock_info_t *>& o);
       };
       WRITE_CLASS_ENCODER_FEATURES(lock_info_t);
     }

--- a/src/cls/log/cls_log.cc
+++ b/src/cls/log/cls_log.cc
@@ -11,6 +11,11 @@
 #include "global/global_context.h"
 #include "include/compat.h"
 
+using std::map;
+using std::string;
+
+using ceph::bufferlist;
+
 CLS_VER(1,0)
 CLS_NAME(log)
 
@@ -53,7 +58,7 @@ static int read_header(cls_method_context_t hctx, cls_log_header& header)
   auto iter = header_bl.cbegin();
   try {
     decode(header, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: read_header(): failed to decode header");
   }
 
@@ -90,7 +95,7 @@ static int cls_log_add(cls_method_context_t hctx, bufferlist *in, bufferlist *ou
   cls_log_add_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_log_add_op(): failed to decode op");
     return -EINVAL;
   }
@@ -101,8 +106,7 @@ static int cls_log_add(cls_method_context_t hctx, bufferlist *in, bufferlist *ou
   if (ret < 0)
     return ret;
 
-  for (list<cls_log_entry>::iterator iter = op.entries.begin();
-       iter != op.entries.end(); ++iter) {
+  for (auto iter = op.entries.begin(); iter != op.entries.end(); ++iter) {
     cls_log_entry& entry = *iter;
 
     string index;
@@ -145,7 +149,7 @@ static int cls_log_list(cls_method_context_t hctx, bufferlist *in, bufferlist *o
   cls_log_list_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_log_list_op(): failed to decode op");
     return -EINVAL;
   }
@@ -176,8 +180,8 @@ static int cls_log_list(cls_method_context_t hctx, bufferlist *in, bufferlist *o
   if (rc < 0)
     return rc;
 
-  list<cls_log_entry>& entries = ret.entries;
-  map<string, bufferlist>::iterator iter = keys.begin();
+  auto& entries = ret.entries;
+  auto iter = keys.begin();
 
   string marker;
 
@@ -195,7 +199,7 @@ static int cls_log_list(cls_method_context_t hctx, bufferlist *in, bufferlist *o
       cls_log_entry e;
       decode(e, biter);
       entries.push_back(e);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       CLS_LOG(0, "ERROR: cls_log_list: could not decode entry, index=%s", index.c_str());
     }
   }
@@ -215,7 +219,7 @@ static int cls_log_trim(cls_method_context_t hctx, bufferlist *in, bufferlist *o
   cls_log_trim_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: cls_log_trim(): failed to decode entry");
     return -EINVAL;
   }
@@ -280,7 +284,7 @@ static int cls_log_info(cls_method_context_t hctx, bufferlist *in, bufferlist *o
   cls_log_info_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_log_add_op(): failed to decode op");
     return -EINVAL;
   }

--- a/src/cls/log/cls_log_client.cc
+++ b/src/cls/log/cls_log_client.cc
@@ -1,9 +1,16 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 #include <errno.h>
 
 #include "cls/log/cls_log_ops.h"
 #include "include/rados/librados.hpp"
 #include "include/compat.h"
 
+
+using std::list;
+using std::string;
+
+using ceph::bufferlist;
 
 using namespace librados;
 
@@ -99,7 +106,7 @@ public:
           *truncated = ret.truncated;
         if (marker)
           *marker = std::move(ret.marker);
-      } catch (buffer::error& err) {
+      } catch (ceph::buffer::error& err) {
         // nothing we can do about it atm
       }
     }
@@ -135,7 +142,7 @@ public:
         decode(ret, iter);
         if (header)
 	  *header = ret.header;
-      } catch (buffer::error& err) {
+      } catch (ceph::buffer::error& err) {
         // nothing we can do about it atm
       }
     }
@@ -151,4 +158,3 @@ void cls_log_info(librados::ObjectReadOperation& op, cls_log_header *header)
 
   op.exec("log", "info", inbl, new LogInfoCtx(header));
 }
-

--- a/src/cls/log/cls_log_client.h
+++ b/src/cls/log/cls_log_client.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_CLS_LOG_CLIENT_H
 #define CEPH_CLS_LOG_CLIENT_H
 
@@ -9,26 +12,26 @@
  */
 
 void cls_log_add_prepare_entry(cls_log_entry& entry, const utime_t& timestamp,
-                 const string& section, const string& name, bufferlist& bl);
+                 const std::string& section, const std::string& name, ceph::buffer::list& bl);
 
-void cls_log_add(librados::ObjectWriteOperation& op, list<cls_log_entry>& entries, bool monotonic_inc);
+void cls_log_add(librados::ObjectWriteOperation& op, std::list<cls_log_entry>& entries, bool monotonic_inc);
 void cls_log_add(librados::ObjectWriteOperation& op, cls_log_entry& entry);
 void cls_log_add(librados::ObjectWriteOperation& op, const utime_t& timestamp,
-                 const string& section, const string& name, bufferlist& bl);
+                 const std::string& section, const std::string& name, ceph::buffer::list& bl);
 
 void cls_log_list(librados::ObjectReadOperation& op, utime_t& from, utime_t& to,
-                  const string& in_marker, int max_entries,
-		  list<cls_log_entry>& entries,
-                  string *out_marker, bool *truncated);
+                  const std::string& in_marker, int max_entries,
+		  std::list<cls_log_entry>& entries,
+                  std::string *out_marker, bool *truncated);
 
 void cls_log_trim(librados::ObjectWriteOperation& op, const utime_t& from_time, const utime_t& to_time,
-                  const string& from_marker, const string& to_marker);
+                  const std::string& from_marker, const std::string& to_marker);
 
 // these overloads which call io_ctx.operate() should not be called in the rgw.
 // rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
 #ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_log_trim(librados::IoCtx& io_ctx, const string& oid, const utime_t& from_time, const utime_t& to_time,
-                 const string& from_marker, const string& to_marker);
+int cls_log_trim(librados::IoCtx& io_ctx, const std::string& oid, const utime_t& from_time, const utime_t& to_time,
+                 const std::string& from_marker, const std::string& to_marker);
 #endif
 
 void cls_log_info(librados::ObjectReadOperation& op, cls_log_header *header);

--- a/src/cls/log/cls_log_ops.h
+++ b/src/cls/log/cls_log_ops.h
@@ -7,19 +7,19 @@
 #include "cls_log_types.h"
 
 struct cls_log_add_op {
-  list<cls_log_entry> entries;
+  std::list<cls_log_entry> entries;
   bool monotonic_inc;
 
   cls_log_add_op() : monotonic_inc(true) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
     encode(entries, bl);
     encode(monotonic_inc, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
     decode(entries, bl);
     if (struct_v >= 2) {
@@ -32,14 +32,14 @@ WRITE_CLASS_ENCODER(cls_log_add_op)
 
 struct cls_log_list_op {
   utime_t from_time;
-  string marker; /* if not empty, overrides from_time */
+  std::string marker; /* if not empty, overrides from_time */
   utime_t to_time; /* not inclusive */
   int max_entries; /* upperbound to returned num of entries
                       might return less than that and still be truncated */
 
   cls_log_list_op() : max_entries(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(from_time, bl);
     encode(marker, bl);
@@ -48,7 +48,7 @@ struct cls_log_list_op {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(from_time, bl);
     decode(marker, bl);
@@ -60,13 +60,13 @@ struct cls_log_list_op {
 WRITE_CLASS_ENCODER(cls_log_list_op)
 
 struct cls_log_list_ret {
-  list<cls_log_entry> entries;
-  string marker;
+  std::list<cls_log_entry> entries;
+  std::string marker;
   bool truncated;
 
   cls_log_list_ret() : truncated(false) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entries, bl);
     encode(marker, bl);
@@ -74,7 +74,7 @@ struct cls_log_list_ret {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entries, bl);
     decode(marker, bl);
@@ -92,12 +92,12 @@ WRITE_CLASS_ENCODER(cls_log_list_ret)
 struct cls_log_trim_op {
   utime_t from_time;
   utime_t to_time; /* inclusive */
-  string from_marker;
-  string to_marker;
+  std::string from_marker;
+  std::string to_marker;
 
   cls_log_trim_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
     encode(from_time, bl);
     encode(to_time, bl);
@@ -106,7 +106,7 @@ struct cls_log_trim_op {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
     decode(from_time, bl);
     decode(to_time, bl);
@@ -122,13 +122,13 @@ WRITE_CLASS_ENCODER(cls_log_trim_op)
 struct cls_log_info_op {
   cls_log_info_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     // currently empty request
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     // currently empty request
     DECODE_FINISH(bl);
@@ -139,13 +139,13 @@ WRITE_CLASS_ENCODER(cls_log_info_op)
 struct cls_log_info_ret {
   cls_log_header header;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(header, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(header, bl);
     DECODE_FINISH(bl);

--- a/src/cls/log/cls_log_types.h
+++ b/src/cls/log/cls_log_types.h
@@ -1,3 +1,5 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 #ifndef CEPH_CLS_LOG_TYPES_H
 #define CEPH_CLS_LOG_TYPES_H
 
@@ -10,15 +12,15 @@ class JSONObj;
 
 
 struct cls_log_entry {
-  string id;
-  string section;
-  string name;
+  std::string id;
+  std::string section;
+  std::string name;
   utime_t timestamp;
-  bufferlist data;
+  ceph::buffer::list data;
 
   cls_log_entry() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
     encode(section, bl);
     encode(name, bl);
@@ -28,7 +30,7 @@ struct cls_log_entry {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
     decode(section, bl);
     decode(name, bl);
@@ -42,17 +44,17 @@ struct cls_log_entry {
 WRITE_CLASS_ENCODER(cls_log_entry)
 
 struct cls_log_header {
-  string max_marker;
+  std::string max_marker;
   utime_t max_time;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(max_marker, bl);
     encode(max_time, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(max_marker, bl);
     decode(max_time, bl);

--- a/src/cls/numops/cls_numops.cc
+++ b/src/cls/numops/cls_numops.cc
@@ -1,3 +1,5 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
  *
@@ -44,7 +46,7 @@ static int add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     decode(key, iter);
     decode(diff_str, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_LOG(20, "add: invalid decode of input");
     return -EINVAL;
   }
@@ -99,7 +101,7 @@ static int mul(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     decode(key, iter);
     decode(diff_str, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_LOG(20, "mul: invalid decode of input");
     return -EINVAL;
   }

--- a/src/cls/otp/cls_otp.cc
+++ b/src/cls/otp/cls_otp.cc
@@ -26,6 +26,13 @@
 #include "cls/otp/cls_otp_ops.h"
 #include "cls/otp/cls_otp_types.h"
 
+using std::list;
+using std::string;
+using std::set;
+
+using ceph::bufferlist;
+using ceph::encode;
+using ceph::real_clock;
 
 using namespace rados::cls::otp;
 
@@ -147,7 +154,7 @@ bool otp_instance::verify(const ceph::real_time& timestamp, const string& val)
 
 void otp_instance::find(const string& token, otp_check_t *result)
 {
-  ceph::real_time now = real_clock::now();
+  auto now = real_clock::now();
   trim_expired(now);
 
   for (auto& entry : boost::adaptors::reverse(last_checks)) {
@@ -177,7 +184,7 @@ static int get_otp_instance(cls_method_context_t hctx, const string& id, otp_ins
   try {
     auto it = bl.cbegin();
     decode(*instance, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("ERROR: failed to decode %s", key.c_str());
     return -EIO;
   }
@@ -236,7 +243,7 @@ static int read_header(cls_method_context_t hctx, otp_header *h)
   auto iter = bl.cbegin();
   try {
     decode(*h, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_ERR("failed to decode otp_header");
     return -EIO;
   }
@@ -299,7 +306,7 @@ static int otp_set_op(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(op, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("ERROR: %s(): failed to decode request", __func__);
     return -EINVAL;
   }
@@ -348,7 +355,7 @@ static int otp_remove_op(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(op, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("ERROR: %s(): failed to decode request", __func__);
     return -EINVAL;
   }
@@ -394,7 +401,7 @@ static int otp_get_op(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(op, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("ERROR: %s(): failed to decode request", __func__);
     return -EINVAL;
   }
@@ -445,7 +452,7 @@ static int otp_check_op(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(op, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("ERROR: %s(): failed to decode request", __func__);
     return -EINVAL;
   }
@@ -481,7 +488,7 @@ static int otp_get_result(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(op, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("ERROR: %s(): failed to decode request", __func__);
     return -EINVAL;
   }
@@ -511,7 +518,7 @@ static int otp_get_current_time_op(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(op, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("ERROR: %s(): failed to decode request", __func__);
     return -EINVAL;
   }

--- a/src/cls/otp/cls_otp_client.cc
+++ b/src/cls/otp/cls_otp_client.cc
@@ -16,7 +16,9 @@
 #include "msg/msg_types.h"
 #include "include/rados/librados.hpp"
 #include "include/utime.h"
- 
+
+using std::list;
+using std::string;
 using namespace librados;
 
 #include "cls/otp/cls_otp_ops.h"
@@ -85,7 +87,7 @@ namespace rados {
         cls_otp_get_result_reply ret;
         try {
           decode(ret, iter);
-        } catch (buffer::error& err) {
+        } catch (ceph::buffer::error& err) {
 	  return -EBADMSG;
         }
 
@@ -123,7 +125,7 @@ namespace rados {
         auto iter = out.cbegin();
         try {
           decode(ret, iter);
-        } catch (buffer::error& err) {
+        } catch (ceph::buffer::error& err) {
 	  return -EBADMSG;
         }
 
@@ -176,7 +178,7 @@ namespace rados {
         auto iter = out.cbegin();
         try {
           decode(ret, iter);
-        } catch (buffer::error& err) {
+        } catch (ceph::buffer::error& err) {
 	  return -EBADMSG;
         }
 
@@ -187,4 +189,3 @@ namespace rados {
     } // namespace otp
   } // namespace cls
 } // namespace rados
-

--- a/src/cls/otp/cls_otp_client.h
+++ b/src/cls/otp/cls_otp_client.h
@@ -14,23 +14,23 @@ namespace rados {
       class OTP {
       public:
         static void create(librados::ObjectWriteOperation *op, const otp_info_t& config);
-        static void set(librados::ObjectWriteOperation *op, const list<otp_info_t>& entries);
-        static void remove(librados::ObjectWriteOperation *op, const string& id);
+        static void set(librados::ObjectWriteOperation *op, const std::list<otp_info_t>& entries);
+        static void remove(librados::ObjectWriteOperation *op, const std::string& id);
         static int get(librados::ObjectReadOperation *op,
-                       librados::IoCtx& ioctx, const string& oid,
-                       const string& id, otp_info_t *result);
+                       librados::IoCtx& ioctx, const std::string& oid,
+                       const std::string& id, otp_info_t *result);
         static int get_all(librados::ObjectReadOperation *op,
-                           librados::IoCtx& ioctx, const string& oid,
-                           list<otp_info_t> *result);
+                           librados::IoCtx& ioctx, const std::string& oid,
+                           std::list<otp_info_t> *result);
 // these overloads which call io_ctx.operate() or io_ctx.exec() should not be called in the rgw.
 // rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()/exec()
 #ifndef CLS_CLIENT_HIDE_IOCTX
         static int get(librados::ObjectReadOperation *op,
-                       librados::IoCtx& ioctx, const string& oid,
-                       const list<string> *ids, bool get_all, list<otp_info_t> *result);
-        static int check(CephContext *cct, librados::IoCtx& ioctx, const string& oid,
-                         const string& id, const string& val, otp_check_t *result);
-        static int get_current_time(librados::IoCtx& ioctx, const string& oid,
+                       librados::IoCtx& ioctx, const std::string& oid,
+                       const std::list<std::string> *ids, bool get_all, std::list<otp_info_t> *result);
+        static int check(CephContext *cct, librados::IoCtx& ioctx, const std::string& oid,
+                         const std::string& id, const std::string& val, otp_check_t *result);
+        static int get_current_time(librados::IoCtx& ioctx, const std::string& oid,
                                     ceph::real_time *result);
 #endif
       };
@@ -38,7 +38,7 @@ namespace rados {
       class TOTPConfig {
         otp_info_t config;
         public:
-          TOTPConfig(const string& id, const string& seed) {
+          TOTPConfig(const std::string& id, const std::string& seed) {
             config.type = OTP_TOTP;
             config.id = id;
             config.seed = seed;

--- a/src/cls/otp/cls_otp_ops.h
+++ b/src/cls/otp/cls_otp_ops.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_CLS_OTP_OPS_H
 #define CEPH_CLS_OTP_OPS_H
 
@@ -7,14 +10,14 @@
 
 struct cls_otp_set_otp_op
 {
-  list<rados::cls::otp::otp_info_t> entries;
+  std::list<rados::cls::otp::otp_info_t> entries;
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(entries, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(entries, bl);
     DECODE_FINISH(bl);
@@ -24,18 +27,18 @@ WRITE_CLASS_ENCODER(cls_otp_set_otp_op)
 
 struct cls_otp_check_otp_op
 {
-  string id;
-  string val;
-  string token;
+  std::string id;
+  std::string val;
+  std::string token;
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(id, bl);
     encode(val, bl);
     encode(token, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(id, bl);
     decode(val, bl);
@@ -47,14 +50,14 @@ WRITE_CLASS_ENCODER(cls_otp_check_otp_op)
 
 struct cls_otp_get_result_op
 {
-  string token;
+  std::string token;
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(token, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(token, bl);
     DECODE_FINISH(bl);
@@ -66,12 +69,12 @@ struct cls_otp_get_result_reply
 {
   rados::cls::otp::otp_check_t result;
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(result, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(result, bl);
     DECODE_FINISH(bl);
@@ -81,14 +84,14 @@ WRITE_CLASS_ENCODER(cls_otp_get_result_reply)
 
 struct cls_otp_remove_otp_op
 {
-  list<string> ids;
+  std::list<std::string> ids;
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(ids, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(ids, bl);
     DECODE_FINISH(bl);
@@ -99,15 +102,15 @@ WRITE_CLASS_ENCODER(cls_otp_remove_otp_op)
 struct cls_otp_get_otp_op
 {
   bool get_all{false};
-  list<string> ids;
+  std::list<std::string> ids;
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(get_all, bl);
     encode(ids, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(get_all, bl);
     decode(ids, bl);
@@ -118,14 +121,14 @@ WRITE_CLASS_ENCODER(cls_otp_get_otp_op)
 
 struct cls_otp_get_otp_reply
 {
-  list<rados::cls::otp::otp_info_t> found_entries;
+  std::list<rados::cls::otp::otp_info_t> found_entries;
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(found_entries, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(found_entries, bl);
     DECODE_FINISH(bl);
@@ -135,11 +138,11 @@ WRITE_CLASS_ENCODER(cls_otp_get_otp_reply)
 
 struct cls_otp_get_current_time_op
 {
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     DECODE_FINISH(bl);
   }
@@ -150,12 +153,12 @@ struct cls_otp_get_current_time_reply
 {
   ceph::real_time time;
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(time, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(time, bl);
     DECODE_FINISH(bl);

--- a/src/cls/otp/cls_otp_types.cc
+++ b/src/cls/otp/cls_otp_types.cc
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -7,9 +7,9 @@
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 #include "objclass/objclass.h"
@@ -20,6 +20,10 @@
 #include "include/utime.h"
 
 #include "cls/otp/cls_otp_types.h"
+
+using std::string;
+
+using ceph::Formatter;
 
 using namespace rados::cls::otp;
 

--- a/src/cls/otp/cls_otp_types.h
+++ b/src/cls/otp/cls_otp_types.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_CLS_OTP_TYPES_H
 #define CEPH_CLS_OTP_TYPES_H
 
@@ -27,10 +30,10 @@ namespace rados {
 
       struct otp_info_t {
         OTPType type{OTP_TOTP};
-        string id;
-        string seed;
+        std::string id;
+        std::string seed;
         SeedType seed_type{OTP_SEED_UNKNOWN};
-        bufferlist seed_bin; /* parsed seed, built automatically by otp_set_op,
+        ceph::buffer::list seed_bin; /* parsed seed, built automatically by otp_set_op,
                               * not being json encoded/decoded on purpose
                               */
         int32_t time_ofs{0};
@@ -39,7 +42,7 @@ namespace rados {
 
         otp_info_t() {}
 
-        void encode(bufferlist &bl) const {
+        void encode(ceph::buffer::list &bl) const {
           ENCODE_START(1, 1, bl);
           encode((uint8_t)type, bl);
           /* if we ever implement anything other than TOTP
@@ -53,7 +56,7 @@ namespace rados {
           encode(window, bl);
           ENCODE_FINISH(bl);
         }
-        void decode(bufferlist::const_iterator &bl) {
+        void decode(ceph::buffer::list::const_iterator &bl) {
           DECODE_START(1, bl);
           uint8_t t;
           decode(t, bl);
@@ -69,7 +72,7 @@ namespace rados {
           decode(window, bl);
           DECODE_FINISH(bl);
         }
-        void dump(Formatter *f) const;
+        void dump(ceph::Formatter *f) const;
         void decode_json(JSONObj *obj);
       };
       WRITE_CLASS_ENCODER(rados::cls::otp::otp_info_t)
@@ -81,18 +84,18 @@ namespace rados {
       };
 
       struct otp_check_t {
-        string token;
+        std::string token;
         ceph::real_time timestamp;
         OTPCheckResult result{OTP_CHECK_UNKNOWN};
 
-        void encode(bufferlist &bl) const {
+        void encode(ceph::buffer::list &bl) const {
           ENCODE_START(1, 1, bl);
           encode(token, bl);
           encode(timestamp, bl);
           encode((char)result, bl);
           ENCODE_FINISH(bl);
         }
-        void decode(bufferlist::const_iterator &bl) {
+        void decode(ceph::buffer::list::const_iterator &bl) {
           DECODE_START(1, bl);
           decode(token, bl);
           decode(timestamp, bl);
@@ -105,16 +108,16 @@ namespace rados {
       WRITE_CLASS_ENCODER(rados::cls::otp::otp_check_t)
 
       struct otp_repo_t {
-        map<string, otp_info_t> entries;
+        std::map<std::string, otp_info_t> entries;
 
         otp_repo_t() {}
 
-        void encode(bufferlist &bl) const {
+        void encode(ceph::buffer::list &bl) const {
           ENCODE_START(1, 1, bl);
           encode(entries, bl);
           ENCODE_FINISH(bl);
         }
-        void decode(bufferlist::const_iterator &bl) {
+        void decode(ceph::buffer::list::const_iterator &bl) {
           DECODE_START(1, bl);
           decode(entries, bl);
           DECODE_FINISH(bl);

--- a/src/cls/queue/cls_queue.cc
+++ b/src/cls/queue/cls_queue.cc
@@ -11,6 +11,10 @@
 #include "cls/queue/cls_queue_const.h"
 #include "cls/queue/cls_queue_src.h"
 
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+
 CLS_VER(1,0)
 CLS_NAME(queue)
 
@@ -20,7 +24,7 @@ static int cls_queue_init(cls_method_context_t hctx, bufferlist *in, bufferlist 
   cls_queue_init_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_queue_init_op(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -46,7 +50,7 @@ static int cls_queue_enqueue(cls_method_context_t hctx, bufferlist *in, bufferli
   cls_queue_enqueue_op op;
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_queue_enqueue: failed to decode input data \n");
     return -EINVAL;
   }
@@ -72,7 +76,7 @@ static int cls_queue_list_entries(cls_method_context_t hctx, bufferlist *in, buf
   cls_queue_list_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(5, "ERROR: cls_queue_list_entries(): failed to decode input data\n");
     return -EINVAL;
   }
@@ -99,7 +103,7 @@ static int cls_queue_remove_entries(cls_method_context_t hctx, bufferlist *in, b
   cls_queue_remove_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(5, "ERROR: cls_queue_remove_entries: failed to decode input data\n");
     return -EINVAL;
   }

--- a/src/cls/queue/cls_queue_ops.h
+++ b/src/cls/queue/cls_queue_ops.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_CLS_QUEUE_OPS_H
 #define CEPH_CLS_QUEUE_OPS_H
 
@@ -6,11 +9,11 @@
 struct cls_queue_init_op {
   uint64_t queue_size{0};
   uint64_t max_urgent_data_size{0};
-  bufferlist bl_urgent_data;
+  ceph::buffer::list bl_urgent_data;
 
   cls_queue_init_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(queue_size, bl);
     encode(max_urgent_data_size, bl);
@@ -18,7 +21,7 @@ struct cls_queue_init_op {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(queue_size, bl);
     decode(max_urgent_data_size, bl);
@@ -30,17 +33,17 @@ struct cls_queue_init_op {
 WRITE_CLASS_ENCODER(cls_queue_init_op)
 
 struct cls_queue_enqueue_op {
-  vector<bufferlist> bl_data_vec;
+  std::vector<ceph::buffer::list> bl_data_vec;
 
   cls_queue_enqueue_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(bl_data_vec, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(bl_data_vec, bl);
     DECODE_FINISH(bl);
@@ -50,18 +53,18 @@ WRITE_CLASS_ENCODER(cls_queue_enqueue_op)
 
 struct cls_queue_list_op {
   uint64_t max;
-  string start_marker;
+  std::string start_marker;
 
   cls_queue_list_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(max, bl);
     encode(start_marker, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(max, bl);
     decode(start_marker, bl);
@@ -72,12 +75,12 @@ WRITE_CLASS_ENCODER(cls_queue_list_op)
 
 struct cls_queue_list_ret {
   bool is_truncated;
-  string next_marker;
-  vector<cls_queue_entry> entries;
+  std::string next_marker;
+  std::vector<cls_queue_entry> entries;
 
   cls_queue_list_ret() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(is_truncated, bl);
     encode(next_marker, bl);
@@ -85,7 +88,7 @@ struct cls_queue_list_ret {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(is_truncated, bl);
     decode(next_marker, bl);
@@ -96,17 +99,17 @@ struct cls_queue_list_ret {
 WRITE_CLASS_ENCODER(cls_queue_list_ret)
 
 struct cls_queue_remove_op {
-  string end_marker;
+  std::string end_marker;
 
   cls_queue_remove_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(end_marker, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(end_marker, bl);
     DECODE_FINISH(bl);
@@ -119,13 +122,13 @@ struct cls_queue_get_capacity_ret {
 
   cls_queue_get_capacity_ret() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(queue_capacity, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(queue_capacity, bl);
     DECODE_FINISH(bl);

--- a/src/cls/queue/cls_queue_src.cc
+++ b/src/cls/queue/cls_queue_src.cc
@@ -9,6 +9,10 @@
 #include "cls/queue/cls_queue_const.h"
 #include "cls/queue/cls_queue_src.h"
 
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+
 int queue_write_head(cls_method_context_t hctx, cls_queue_head& head)
 {
   bufferlist bl;
@@ -52,7 +56,7 @@ int queue_read_head(cls_method_context_t hctx, cls_queue_head& head)
   uint16_t queue_head_start;
   try {
     decode(queue_head_start, it);
-  } catch (buffer::error& err) {
+  } catch (const ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: queue_read_head: failed to decode queue start: %s", err.what());
     return -EINVAL;
   }
@@ -64,7 +68,7 @@ int queue_read_head(cls_method_context_t hctx, cls_queue_head& head)
   uint64_t encoded_len;
   try {
     decode(encoded_len, it);
-  } catch (buffer::error& err) {
+  } catch (const ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: queue_read_head: failed to decode encoded head size: %s", err.what());
     return -EINVAL;
   }
@@ -83,7 +87,7 @@ int queue_read_head(cls_method_context_t hctx, cls_queue_head& head)
 
   try {
     decode(head, it);
-  } catch (buffer::error& err) {
+  } catch (const ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: queue_read_head: failed to decode head: %s", err.what());
     return -EINVAL;
   }
@@ -345,7 +349,7 @@ int queue_list_entries(cls_method_context_t hctx, const cls_queue_list_op& op, c
           // Decode magic number at start
           try {
             decode(entry_start, it);
-          } catch (buffer::error& err) {
+          } catch (const ceph::buffer::error& err) {
             CLS_LOG(10, "ERROR: queue_list_entries: failed to decode entry start: %s", err.what());
             return -EINVAL;
           }
@@ -358,7 +362,7 @@ int queue_list_entries(cls_method_context_t hctx, const cls_queue_list_op& op, c
           // Decode data size
           try {
             decode(data_size, it);
-          } catch (buffer::error& err) {
+          } catch (const ceph::buffer::error& err) {
             CLS_LOG(10, "ERROR: queue_list_entries: failed to decode data size: %s", err.what());
             return -EINVAL;
           }

--- a/src/cls/queue/cls_queue_types.h
+++ b/src/cls/queue/cls_queue_types.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_CLS_QUEUE_TYPES_H
 #define CEPH_CLS_QUEUE_TYPES_H
 
@@ -15,17 +18,17 @@ constexpr unsigned int QUEUE_ENTRY_OVERHEAD = sizeof(uint16_t) + sizeof(uint64_t
 
 struct cls_queue_entry
 {
-  bufferlist data;
+  ceph::buffer::list data;
   std::string marker;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(data, bl);
     encode(marker, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(data, bl);
     decode(marker, bl);
@@ -39,23 +42,22 @@ struct cls_queue_marker
   uint64_t offset{0};
   uint64_t gen{0};
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(gen, bl);
     encode(offset, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(gen, bl);
     decode(offset, bl);
     DECODE_FINISH(bl);
   }
 
-  string to_str() {
-    string marker = std::to_string(gen) + '/' + std::to_string(offset);
-    return marker;
+  std::string to_str() {
+    return std::to_string(gen) + '/' + std::to_string(offset);
   }
 
   int from_str(const char* str) {
@@ -89,9 +91,9 @@ struct cls_queue_head
   cls_queue_marker tail{QUEUE_START_OFFSET_1K, 0};
   uint64_t queue_size{0}; // size of queue requested by user, with head size added to it
   uint64_t max_urgent_data_size{0};
-  bufferlist bl_urgent_data;  // special data known to application using queue
+  ceph::buffer::list bl_urgent_data;  // special data known to application using queue
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(max_head_size, bl);
     encode(front, bl);
@@ -102,7 +104,7 @@ struct cls_queue_head
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(max_head_size, bl);
     decode(front, bl);

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -44,6 +44,19 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 
+using std::istringstream;
+using std::ostringstream;
+using std::map;
+using std::set;
+using std::string;
+using std::vector;
+
+using ceph::BitVector;
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::encode;
+using ceph::decode;
+
 /*
  * Object keys:
  *
@@ -173,7 +186,7 @@ static int read_key(cls_method_context_t hctx, const string &key, T *out)
   try {
     auto it = bl.cbegin();
     decode(*out, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("error decoding %s", key.c_str());
     return -EIO;
   }
@@ -528,7 +541,7 @@ int iterate(cls_method_context_t hctx, L& lambda) {
       auto iter = val.second.cbegin();
       try {
 	decode(snap_meta, iter);
-      } catch (const buffer::error &err) {
+      } catch (const ceph::buffer::error &err) {
 	CLS_ERR("error decoding snapshot metadata for snap : %s",
 	        val.first.c_str());
 	return -EIO;
@@ -767,7 +780,7 @@ int create(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     if (!iter.end()) {
       decode(data_pool_id, iter);
     }
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -862,7 +875,7 @@ int get_features(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     if (!iter.end()) {
       decode(read_only, iter);
     }
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -902,7 +915,7 @@ int set_features(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     decode(features, iter);
     decode(mask, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -971,7 +984,7 @@ int get_size(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   auto iter = in->cbegin();
   try {
     decode(snap_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -1020,7 +1033,7 @@ int set_size(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   auto iter = in->cbegin();
   try {
     decode(size, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -1086,7 +1099,7 @@ int get_protection_status(cls_method_context_t hctx, bufferlist *in,
   auto iter = in->cbegin();
   try {
     decode(snap_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_LOG(20, "get_protection_status: invalid decode");
     return -EINVAL;
   }
@@ -1141,7 +1154,7 @@ int set_protection_status(cls_method_context_t hctx, bufferlist *in,
   try {
     decode(snap_id, iter);
     decode(status, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_LOG(20, "set_protection_status: invalid decode");
     return -EINVAL;
   }
@@ -1255,7 +1268,7 @@ int set_stripe_unit_count(cls_method_context_t hctx, bufferlist *in, bufferlist 
   try {
     decode(stripe_unit, iter);
     decode(stripe_count, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_LOG(20, "set_stripe_unit_count: invalid decode");
     return -EINVAL;
   }
@@ -1319,7 +1332,7 @@ int get_create_timestamp(cls_method_context_t hctx, bufferlist *in, bufferlist *
     try {
       auto it = bl.cbegin();
       decode(timestamp, it);
-    } catch (const buffer::error &err) {
+    } catch (const ceph::buffer::error &err) {
       CLS_ERR("could not decode create_timestamp");
       return -EIO;
     }
@@ -1356,7 +1369,7 @@ int get_access_timestamp(cls_method_context_t hctx, bufferlist *in, bufferlist *
     try {
       auto it = bl.cbegin();
       decode(timestamp, it);
-    } catch (const buffer::error &err) {
+    } catch (const ceph::buffer::error &err) {
       CLS_ERR("could not decode access_timestamp");
       return -EIO;
     }
@@ -1393,7 +1406,7 @@ int get_modify_timestamp(cls_method_context_t hctx, bufferlist *in, bufferlist *
     try {
       auto it = bl.cbegin();
       decode(timestamp, it);
-    } catch (const buffer::error &err) {
+    } catch (const ceph::buffer::error &err) {
       CLS_ERR("could not decode modify_timestamp");
       return -EIO;
     }
@@ -1421,7 +1434,7 @@ int get_flags(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   auto iter = in->cbegin();
   try {
     decode(snap_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -1474,7 +1487,7 @@ int set_flags(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     if (!iter.end()) {
       decode(snap_id, iter);
     }
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -1564,7 +1577,7 @@ int op_features_set(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     decode(op_features, iter);
     decode(mask, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -1598,7 +1611,7 @@ int get_parent(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   auto iter = in->cbegin();
   try {
     decode(snap_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -1677,7 +1690,7 @@ int set_parent(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     uint64_t overlap;
     decode(overlap, iter);
     parent.head_overlap = overlap;
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_LOG(20, "cls_rbd::set_parent: invalid decode");
     return -EINVAL;
   }
@@ -1767,7 +1780,7 @@ int parent_overlap_get(cls_method_context_t hctx, bufferlist *in,
   auto iter = in->cbegin();
   try {
     decode(snap_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -1828,7 +1841,7 @@ int parent_attach(cls_method_context_t hctx, bufferlist *in, bufferlist *out) {
     if (!iter.end()) {
       decode(reattach, iter);
     }
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_LOG(20, "cls_rbd::parent_attach: invalid decode");
     return -EINVAL;
   }
@@ -1870,7 +1883,7 @@ static int decode_parent_common(bufferlist::const_iterator& it, uint64_t *pool_i
     decode(*pool_id, it);
     decode(*image_id, it);
     decode(*snap_id, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("error decoding parent spec");
     return -EINVAL;
   }
@@ -1894,7 +1907,7 @@ static int decode_parent_and_child(bufferlist *in, uint64_t *pool_id,
     return r;
   try {
     decode(*c_image_id, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("error decoding child image id");
     return -EINVAL;
   }
@@ -2096,8 +2109,7 @@ int get_snapcontext(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     if (r < 0)
       return r;
 
-    for (set<string>::const_iterator it = keys.begin();
-	 it != keys.end(); ++it) {
+    for (auto it = keys.begin(); it != keys.end(); ++it) {
       if ((*it).find(RBD_SNAP_KEY_PREFIX) != 0)
 	break;
       snapid_t snap_id = snap_id_from_key(*it);
@@ -2185,7 +2197,7 @@ int get_snapshot_name(cls_method_context_t hctx, bufferlist *in, bufferlist *out
   auto iter = in->cbegin();
   try {
     decode(snap_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -2223,7 +2235,7 @@ int get_snapshot_timestamp(cls_method_context_t hctx, bufferlist *in, bufferlist
   auto iter = in->cbegin();
   try {
     decode(snap_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -2260,7 +2272,7 @@ int snapshot_get(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   auto iter = in->cbegin();
   try {
     decode(snap_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -2310,7 +2322,7 @@ int snapshot_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     if (!iter.end()) {
       decode(snap_meta.snapshot_namespace, iter);
     }
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -2443,7 +2455,7 @@ int snapshot_rename(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto iter = in->cbegin();
     decode(src_snap_id, iter);
     decode(dst_snap_name, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -2505,7 +2517,7 @@ int snapshot_remove(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(snap_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -2614,7 +2626,7 @@ int snapshot_trash_add(cls_method_context_t hctx, bufferlist *in,
   try {
     auto iter = in->cbegin();
     decode(snap_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -2714,7 +2726,7 @@ int sparse_copyup(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto iter = in->cbegin();
     decode(extent_map, iter);
     decode(data, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_LOG(20, "sparse_copyup: invalid decode");
     return -EINVAL;
   }
@@ -2738,7 +2750,7 @@ int sparse_copyup(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     bufferlist tmpbl;
     try {
       tmpbl.substr_of(data, data_offset, len);
-    } catch (const buffer::error &err) {
+    } catch (const ceph::buffer::error &err) {
       CLS_LOG(20, "sparse_copyup: invalid data");
       return -EINVAL;
     }
@@ -2788,7 +2800,7 @@ int get_id(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = read_bl.cbegin();
     decode(id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EIO;
   }
 
@@ -2816,7 +2828,7 @@ int set_id(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3011,7 +3023,7 @@ int dir_rename_image(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     decode(src, iter);
     decode(dest, iter);
     decode(id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3040,7 +3052,7 @@ int dir_get_id(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(name, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3074,7 +3086,7 @@ int dir_get_name(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3115,7 +3127,7 @@ int dir_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto iter = in->cbegin();
     decode(start_after, iter);
     decode(max_return, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3136,13 +3148,12 @@ int dir_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
       return r;
     }
 
-    for (map<string, bufferlist>::iterator it = vals.begin();
-	 it != vals.end(); ++it) {
+    for (auto it = vals.begin(); it != vals.end(); ++it) {
       string id;
       auto iter = it->second.cbegin();
       try {
 	decode(id, iter);
-      } catch (const buffer::error &err) {
+      } catch (const ceph::buffer::error &err) {
 	CLS_ERR("could not decode id of image '%s'", it->first.c_str());
 	return -EIO;
       }
@@ -3187,7 +3198,7 @@ int dir_add_image(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto iter = in->cbegin();
     decode(name, iter);
     decode(id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3212,7 +3223,7 @@ int dir_remove_image(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto iter = in->cbegin();
     decode(name, iter);
     decode(id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3235,7 +3246,7 @@ int dir_state_assert(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(directory_state, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3267,7 +3278,7 @@ int dir_state_set(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(directory_state, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3329,7 +3340,7 @@ int object_map_read(cls_method_context_t hctx, BitVector<2> &object_map)
   try {
     auto iter = bl.cbegin();
     decode(object_map, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode object map: %s", err.what());
     return -EINVAL;
   }
@@ -3374,7 +3385,7 @@ int object_map_save(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(object_map, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3405,7 +3416,7 @@ int object_map_resize(cls_method_context_t hctx, bufferlist *in, bufferlist *out
     auto iter = in->cbegin();
     decode(object_count, iter);
     decode(default_state, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3473,7 +3484,7 @@ int object_map_update(cls_method_context_t hctx, bufferlist *in, bufferlist *out
     decode(end_object_no, iter);
     decode(new_object_state, iter);
     decode(current_object_state, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode message");
     return -EINVAL;
   }
@@ -3496,7 +3507,7 @@ int object_map_update(cls_method_context_t hctx, bufferlist *in, bufferlist *out
   try {
     auto it = header_bl.cbegin();
     object_map.decode_header(it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode object map header: %s", err.what());
     return -EINVAL;
   }
@@ -3516,7 +3527,7 @@ int object_map_update(cls_method_context_t hctx, bufferlist *in, bufferlist *out
   try {
     auto it = footer_bl.cbegin();
     object_map.decode_header_crc(it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode object map header CRC: %s", err.what());
   }
 
@@ -3540,7 +3551,7 @@ int object_map_update(cls_method_context_t hctx, bufferlist *in, bufferlist *out
   try {
     auto it = footer_bl.cbegin();
     object_map.decode_data_crcs(it, start_object_no);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode object map data CRCs: %s", err.what());
   }
 
@@ -3560,7 +3571,7 @@ int object_map_update(cls_method_context_t hctx, bufferlist *in, bufferlist *out
   try {
     auto it = data_bl.cbegin();
     object_map.decode_data(it, data_byte_offset);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("failed to decode data chunk [%" PRIu64 "]: %s",
 	    data_byte_offset, err.what());
     return -EINVAL;
@@ -3661,7 +3672,7 @@ int object_map_snap_remove(cls_method_context_t hctx, bufferlist *in,
   try {
     auto iter = in->cbegin();
     decode(src_object_map, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3724,7 +3735,7 @@ int metadata_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto iter = in->cbegin();
     decode(start_after, iter);
     decode(max_return, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3777,12 +3788,11 @@ int metadata_set(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   auto iter = in->cbegin();
   try {
     decode(data, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
-  for (map<string, bufferlist>::iterator it = data.begin();
-       it != data.end(); ++it) {
+  for (auto it = data.begin(); it != data.end(); ++it) {
     CLS_LOG(20, "metadata_set key=%s value=%.*s", it->first.c_str(),
 	    it->second.length(), it->second.c_str());
     raw_data[metadata_key_for_name(it->first)].swap(it->second);
@@ -3810,7 +3820,7 @@ int metadata_remove(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   auto iter = in->cbegin();
   try {
     decode(key, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3841,7 +3851,7 @@ int metadata_get(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   auto iter = in->cbegin();
   try {
     decode(key, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3887,7 +3897,7 @@ int snapshot_set_limit(cls_method_context_t hctx, bufferlist *in,
   try {
     auto iter = in->cbegin();
     decode(new_limit, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -3961,7 +3971,7 @@ int child_attach(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto it = in->cbegin();
     decode(snap_id, it);
     decode(child_image, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -4034,7 +4044,7 @@ int child_detach(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto it = in->cbegin();
     decode(snap_id, it);
     decode(child_image, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -4124,7 +4134,7 @@ int children_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto it = in->cbegin();
     decode(snap_id, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -4167,7 +4177,7 @@ int migration_set(cls_method_context_t hctx, bufferlist *in, bufferlist *out) {
   try {
     auto it = in->cbegin();
     decode(migration_spec, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -4198,7 +4208,7 @@ int migration_set_state(cls_method_context_t hctx, bufferlist *in,
     auto it = in->cbegin();
     decode(state, it);
     decode(description, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -4280,7 +4290,7 @@ int assert_snapc_seq(cls_method_context_t hctx, bufferlist *in,
     auto it = in->cbegin();
     decode(snapc_seq, it);
     decode(state, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -4362,7 +4372,7 @@ int old_snapshot_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     decode(s, iter);
     decode(snap_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
   snap_name = s.c_str();
@@ -4450,7 +4460,7 @@ int old_snapshot_remove(cls_method_context_t hctx, bufferlist *in, bufferlist *o
 
   try {
     decode(s, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
   snap_name = s.c_str();
@@ -4544,7 +4554,7 @@ int old_snapshot_rename(cls_method_context_t hctx, bufferlist *in, bufferlist *o
   try {
     decode(src_snap_id, iter);
     decode(dst, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
   dst_snap_name = dst.c_str();
@@ -4704,7 +4714,7 @@ int read_peers(cls_method_context_t hctx,
         cls::rbd::MirrorPeer peer;
 	decode(peer, bl_it);
         peers->push_back(peer);
-      } catch (const buffer::error &err) {
+      } catch (const ceph::buffer::error &err) {
 	CLS_ERR("could not decode peer '%s'", it.first.c_str());
 	return -EIO;
       }
@@ -4730,7 +4740,7 @@ int read_peer(cls_method_context_t hctx, const std::string &id,
   try {
     auto bl_it = bl.cbegin();
     decode(*peer, bl_it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("could not decode peer '%s'", id.c_str());
     return -EIO;
   }
@@ -4939,7 +4949,7 @@ int image_get(cls_method_context_t hctx, const string &image_id,
   try {
     auto it = bl.cbegin();
     decode(*mirror_image, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("could not decode mirrored image '%s'", image_id.c_str());
     return -EIO;
   }
@@ -5133,7 +5143,7 @@ int image_status_get(cls_method_context_t hctx, const string &global_image_id,
   try {
     auto it = bl.cbegin();
     decode(ondisk_status, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("could not decode status for mirrored image, global id '%s', "
             "site '%s'",
             global_image_id.c_str(), mirror_uuid.c_str());
@@ -5269,7 +5279,7 @@ int image_status_list(cls_method_context_t hctx,
       auto iter = it->second.cbegin();
       try {
 	decode(mirror_image, iter);
-      } catch (const buffer::error &err) {
+      } catch (const ceph::buffer::error &err) {
 	CLS_ERR("could not decode mirror image payload of image '%s'",
                 image_id.c_str());
 	return -EIO;
@@ -5390,7 +5400,7 @@ int image_status_get_summary(
       auto iter = list_it.second.cbegin();
       try {
 	decode(mirror_image, iter);
-      } catch (const buffer::error &err) {
+      } catch (const ceph::buffer::error &err) {
 	CLS_ERR("could not decode mirror image payload for key '%s'",
                 key.c_str());
 	return -EIO;
@@ -5450,7 +5460,7 @@ int image_status_remove_down(cls_method_context_t hctx) {
         try {
           auto it = list_it.second.cbegin();
           status.decode_meta(it);
-        } catch (const buffer::error &err) {
+        } catch (const ceph::buffer::error &err) {
           CLS_ERR("could not decode status metadata for mirrored image '%s'",
                   key.c_str());
           return -EIO;
@@ -5499,7 +5509,7 @@ int image_instance_get(cls_method_context_t hctx,
   try {
     auto it = bl.cbegin();
     decode(ondisk_status, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("could not decode status for mirrored image, global id '%s'",
             global_image_id.c_str());
     return -EIO;
@@ -5547,7 +5557,7 @@ int image_instance_list(cls_method_context_t hctx,
       auto iter = it->second.cbegin();
       try {
         decode(mirror_image, iter);
-      } catch (const buffer::error &err) {
+      } catch (const ceph::buffer::error &err) {
         CLS_ERR("could not decode mirror image payload of image '%s'",
                 image_id.c_str());
         return -EIO;
@@ -5651,7 +5661,7 @@ int mirror_image_map_list(cls_method_context_t hctx,
       auto iter = it->second.cbegin();
       try {
         decode(mirror_image_map, iter);
-      } catch (const buffer::error &err) {
+      } catch (const ceph::buffer::error &err) {
         CLS_ERR("could not decode image map payload: %s",
                 cpp_strerror(r).c_str());
         return -EINVAL;
@@ -5795,7 +5805,7 @@ int mirror_uuid_set(cls_method_context_t hctx, bufferlist *in,
   try {
     auto bl_it = in->cbegin();
     decode(mirror_uuid, bl_it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -5856,7 +5866,7 @@ int mirror_mode_set(cls_method_context_t hctx, bufferlist *in,
   try {
     auto bl_it = in->cbegin();
     decode(mirror_mode_decode, bl_it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -5940,7 +5950,7 @@ int mirror_peer_ping(cls_method_context_t hctx, bufferlist *in,
     decode(direction, it);
     mirror_peer_direction = static_cast<cls::rbd::MirrorPeerDirection>(
       direction);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -5989,7 +5999,7 @@ int mirror_peer_add(cls_method_context_t hctx, bufferlist *in,
   try {
     auto it = in->cbegin();
     decode(mirror_peer, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6014,7 +6024,7 @@ int mirror_peer_remove(cls_method_context_t hctx, bufferlist *in,
   try {
     auto it = in->cbegin();
     decode(uuid, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6041,7 +6051,7 @@ int mirror_peer_set_client(cls_method_context_t hctx, bufferlist *in,
     auto it = in->cbegin();
     decode(uuid, it);
     decode(client_name, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6075,7 +6085,7 @@ int mirror_peer_set_cluster(cls_method_context_t hctx, bufferlist *in,
     auto it = in->cbegin();
     decode(uuid, it);
     decode(site_name, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6125,7 +6135,7 @@ int mirror_peer_set_direction(cls_method_context_t hctx, bufferlist *in,
     decode(direction, it);
     mirror_peer_direction = static_cast<cls::rbd::MirrorPeerDirection>(
       direction);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6161,7 +6171,7 @@ int mirror_image_list(cls_method_context_t hctx, bufferlist *in,
     auto iter = in->cbegin();
     decode(start_after, iter);
     decode(max_return, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6190,7 +6200,7 @@ int mirror_image_list(cls_method_context_t hctx, bufferlist *in,
       auto iter = it->second.cbegin();
       try {
 	decode(mirror_image, iter);
-      } catch (const buffer::error &err) {
+      } catch (const ceph::buffer::error &err) {
 	CLS_ERR("could not decode mirror image payload of image '%s'",
                 image_id.c_str());
 	return -EIO;
@@ -6224,7 +6234,7 @@ int mirror_image_get_image_id(cls_method_context_t hctx, bufferlist *in,
   try {
     auto it = in->cbegin();
     decode(global_id, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6256,7 +6266,7 @@ int mirror_image_get(cls_method_context_t hctx, bufferlist *in,
   try {
     auto it = in->cbegin();
     decode(image_id, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6287,7 +6297,7 @@ int mirror_image_set(cls_method_context_t hctx, bufferlist *in,
     auto it = in->cbegin();
     decode(image_id, it);
     decode(mirror_image, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6311,7 +6321,7 @@ int mirror_image_remove(cls_method_context_t hctx, bufferlist *in,
   try {
     auto it = in->cbegin();
     decode(image_id, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6338,7 +6348,7 @@ int mirror_image_status_set(cls_method_context_t hctx, bufferlist *in,
     auto it = in->cbegin();
     decode(global_image_id, it);
     decode(status, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6364,7 +6374,7 @@ int mirror_image_status_remove(cls_method_context_t hctx, bufferlist *in,
   try {
     auto it = in->cbegin();
     decode(global_image_id, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6389,7 +6399,7 @@ int mirror_image_status_get(cls_method_context_t hctx, bufferlist *in,
   try {
     auto it = in->cbegin();
     decode(global_image_id, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6428,7 +6438,7 @@ int mirror_image_status_list(cls_method_context_t hctx, bufferlist *in,
     auto iter = in->cbegin();
     decode(start_after, iter);
     decode(max_return, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6461,7 +6471,7 @@ int mirror_image_status_get_summary(cls_method_context_t hctx, bufferlist *in,
     if (!iter.end()) {
       decode(peers, iter);
     }
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6524,7 +6534,7 @@ int mirror_image_instance_get(cls_method_context_t hctx, bufferlist *in,
   try {
     auto it = in->cbegin();
     decode(global_image_id, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6562,7 +6572,7 @@ int mirror_image_instance_list(cls_method_context_t hctx, bufferlist *in,
     auto iter = in->cbegin();
     decode(start_after, iter);
     decode(max_return, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6611,7 +6621,7 @@ int mirror_instances_add(cls_method_context_t hctx, bufferlist *in,
   try {
     auto iter = in->cbegin();
     decode(instance_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6635,7 +6645,7 @@ int mirror_instances_remove(cls_method_context_t hctx, bufferlist *in,
   try {
     auto iter = in->cbegin();
     decode(instance_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6663,7 +6673,7 @@ int mirror_image_map_list(cls_method_context_t hctx, bufferlist *in,
     auto it = in->cbegin();
     decode(start_after, it);
     decode(max_return, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6694,7 +6704,7 @@ int mirror_image_map_update(cls_method_context_t hctx, bufferlist *in,
     auto it = in->cbegin();
     decode(global_image_id, it);
     decode(image_map, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6726,7 +6736,7 @@ int mirror_image_map_remove(cls_method_context_t hctx, bufferlist *in,
   try {
     auto it = in->cbegin();
     decode(global_image_id, it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6758,7 +6768,7 @@ int mirror_image_snapshot_unlink_peer(cls_method_context_t hctx, bufferlist *in,
     auto iter = in->cbegin();
     decode(snap_id, iter);
     decode(mirror_peer_uuid, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6793,7 +6803,7 @@ int mirror_image_snapshot_set_copy_progress(cls_method_context_t hctx,
     decode(snap_id, iter);
     decode(complete, iter);
     decode(last_copied_object_number, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -6917,14 +6927,13 @@ int snap_list(cls_method_context_t hctx, cls::rbd::GroupSnapshot start_after,
     if (r < 0)
       return r;
 
-    for (map<string, bufferlist>::iterator it = vals.begin();
-	 it != vals.end() && group_snaps->size() < max_return; ++it) {
+    for (auto it = vals.begin(); it != vals.end() && group_snaps->size() < max_return; ++it) {
 
       auto iter = it->second.cbegin();
       cls::rbd::GroupSnapshot snap;
       try {
 	decode(snap, iter);
-      } catch (const buffer::error &err) {
+      } catch (const ceph::buffer::error &err) {
 	CLS_ERR("error decoding snapshot: %s", it->first.c_str());
 	return -EIO;
       }
@@ -6990,7 +6999,7 @@ int group_dir_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto iter = in->cbegin();
     decode(start_after, iter);
     decode(max_return, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7011,12 +7020,12 @@ int group_dir_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
       return r;
     }
 
-    for (pair<string, bufferlist> val: vals) {
+    for (auto val : vals) {
       string id;
       auto iter = val.second.cbegin();
       try {
 	decode(id, iter);
-      } catch (const buffer::error &err) {
+      } catch (const ceph::buffer::error &err) {
 	CLS_ERR("could not decode id of group '%s'", val.first.c_str());
 	return -EIO;
       }
@@ -7060,7 +7069,7 @@ int group_dir_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto iter = in->cbegin();
     decode(name, iter);
     decode(id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7086,7 +7095,7 @@ int group_dir_rename(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     decode(src, iter);
     decode(dest, iter);
     decode(id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7114,7 +7123,7 @@ int group_dir_remove(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto iter = in->cbegin();
     decode(name, iter);
     decode(id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7138,7 +7147,7 @@ int group_image_set(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(st, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7171,7 +7180,7 @@ int group_image_remove(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(spec, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7208,7 +7217,7 @@ int group_image_list(cls_method_context_t hctx,
     auto iter = in->cbegin();
     decode(start_after, iter);
     decode(max_return, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7224,14 +7233,13 @@ int group_image_list(cls_method_context_t hctx,
     if (r < 0)
       return r;
 
-    for (map<string, bufferlist>::iterator it = vals.begin();
-	 it != vals.end() && res.size() < max_return; ++it) {
+    for (auto it = vals.begin(); it != vals.end() && res.size() < max_return; ++it) {
 
       auto iter = it->second.cbegin();
       cls::rbd::GroupImageLinkState state;
       try {
 	decode(state, iter);
-      } catch (const buffer::error &err) {
+      } catch (const ceph::buffer::error &err) {
 	CLS_ERR("error decoding state for image: %s", it->first.c_str());
 	return -EIO;
       }
@@ -7273,7 +7281,7 @@ int image_group_add(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(new_group, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7287,7 +7295,7 @@ int image_group_add(cls_method_context_t hctx,
     try {
       auto iter = existing_refbl.cbegin();
       decode(old_group, iter);
-    } catch (const buffer::error &err) {
+    } catch (const ceph::buffer::error &err) {
       return -EINVAL;
     }
 
@@ -7337,7 +7345,7 @@ int image_group_remove(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(spec, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7351,7 +7359,7 @@ int image_group_remove(cls_method_context_t hctx,
   auto iter = refbl.cbegin();
   try {
     decode(ref_spec, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7398,7 +7406,7 @@ int image_group_get(cls_method_context_t hctx,
     auto iter = refbl.cbegin();
     try {
       decode(spec, iter);
-    } catch (const buffer::error &err) {
+    } catch (const ceph::buffer::error &err) {
       return -EINVAL;
     }
   }
@@ -7424,7 +7432,7 @@ int group_snap_set(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(group_snap, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7477,7 +7485,7 @@ int group_snap_remove(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(snap_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7507,7 +7515,7 @@ int group_snap_get_by_id(cls_method_context_t hctx,
   try {
     auto iter = in->cbegin();
     decode(snap_id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7522,7 +7530,7 @@ int group_snap_get_by_id(cls_method_context_t hctx,
   auto iter = snapbl.cbegin();
   try {
     decode(group_snap, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     CLS_ERR("error decoding snapshot: %s", snap_id.c_str());
     return -EIO;
   }
@@ -7555,7 +7563,7 @@ int group_snap_list(cls_method_context_t hctx,
     auto iter = in->cbegin();
     decode(start_after, iter);
     decode(max_return, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
   std::vector<cls::rbd::GroupSnapshot> group_snaps;
@@ -7606,7 +7614,7 @@ int trash_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto iter = in->cbegin();
     decode(id, iter);
     decode(trash_spec, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7651,7 +7659,7 @@ int trash_remove(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7699,7 +7707,7 @@ int trash_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto iter = in->cbegin();
     decode(start_after, iter);
     decode(max_return, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7725,8 +7733,7 @@ int trash_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
       break;
     }
 
-    map<string, bufferlist>::iterator it = raw_data.begin();
-    for (; it != raw_data.end(); ++it) {
+    for (auto it = raw_data.begin(); it != raw_data.end(); ++it) {
       decode(data[trash::image_id_from_key(it->first)], it->second);
     }
 
@@ -7759,7 +7766,7 @@ int trash_get(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(id, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7793,11 +7800,11 @@ int trash_state_set(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   cls::rbd::TrashImageState trash_state;
   cls::rbd::TrashImageState expect_state;
   try {
-    bufferlist::const_iterator iter = in->begin();
+    auto iter = in->cbegin();
     decode(id, iter);
     decode(trash_state, iter);
     decode(expect_state, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7862,7 +7869,7 @@ int namespace_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(name, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7899,7 +7906,7 @@ int namespace_remove(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   try {
     auto iter = in->cbegin();
     decode(name, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7938,7 +7945,7 @@ int namespace_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto iter = in->cbegin();
     decode(start_after, iter);
     decode(max_return, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -7995,7 +8002,7 @@ int sparsify(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     auto iter = in->cbegin();
     decode(sparse_size, iter);
     decode(remove_empty, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EINVAL;
   }
 
@@ -8033,7 +8040,7 @@ int sparsify(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     return 0;
   }
 
-  bl.rebuild(buffer::ptr_node::create(bl.length()));
+  bl.rebuild(ceph::buffer::ptr_node::create(bl.length()));
   size_t write_offset = 0;
   size_t write_length = 0;
   size_t offset = 0;
@@ -8050,10 +8057,10 @@ int sparsify(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
       CLS_LOG(20, "write%s %" PRIu64 "~%" PRIu64, (replace ? "(replace)" : ""),
               write_offset, write_length);
       bufferlist write_bl;
-      write_bl.push_back(buffer::ptr_node::create(ptr, write_offset,
-                                                  write_length));
+      write_bl.push_back(ceph::buffer::ptr_node::create(ptr, write_offset,
+							write_length));
       if (replace) {
-        r = cls_cxx_replace(hctx, write_offset, write_length, &write_bl);
+	r = cls_cxx_replace(hctx, write_offset, write_length, &write_bl);
         replace = false;
       } else {
         r = cls_cxx_write(hctx, write_offset, write_length, &write_bl);

--- a/src/cls/rbd/cls_rbd.h
+++ b/src/cls/rbd/cls_rbd.h
@@ -42,7 +42,7 @@ struct cls_rbd_parent {
     return !(*this == rhs);
   }
 
-  void encode(bufferlist& bl, uint64_t features) const {
+  void encode(ceph::buffer::list& bl, uint64_t features) const {
     // NOTE: remove support for version 1 after Nautilus EOLed
     uint8_t version = 1;
     if ((features & CEPH_FEATURE_SERVER_NAUTILUS) != 0ULL) {
@@ -65,7 +65,7 @@ struct cls_rbd_parent {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
     decode(pool_id, bl);
     if (struct_v >= 2) {
@@ -83,7 +83,7 @@ struct cls_rbd_parent {
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->dump_int("pool_id", pool_id);
     f->dump_string("pool_namespace", pool_namespace);
     f->dump_string("image_id", image_id);
@@ -93,7 +93,7 @@ struct cls_rbd_parent {
     }
   }
 
-  static void generate_test_instances(list<cls_rbd_parent*>& o) {
+  static void generate_test_instances(std::list<cls_rbd_parent*>& o) {
     o.push_back(new cls_rbd_parent{});
     o.push_back(new cls_rbd_parent{{1, "", "image id", 234}, {}});
     o.push_back(new cls_rbd_parent{{1, "", "image id", 234}, {123}});
@@ -134,7 +134,7 @@ struct cls_rbd_snap {
             (parent.exists()));
   }
 
-  void encode(bufferlist& bl, uint64_t features) const {
+  void encode(ceph::buffer::list& bl, uint64_t features) const {
     // NOTE: remove support for versions < 8 after Nautilus EOLed
     uint8_t min_version = 1;
     if ((features & CEPH_FEATURE_SERVER_NAUTILUS) != 0ULL) {
@@ -160,7 +160,7 @@ struct cls_rbd_snap {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& p) {
+  void decode(ceph::buffer::list::const_iterator& p) {
     DECODE_START(8, p);
     decode(id, p);
     decode(name, p);
@@ -193,7 +193,7 @@ struct cls_rbd_snap {
     DECODE_FINISH(p);
   }
 
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->dump_unsigned("id", id);
     f->dump_string("name", name);
     f->dump_unsigned("image_size", image_size);
@@ -221,7 +221,7 @@ struct cls_rbd_snap {
     }
   }
 
-  static void generate_test_instances(list<cls_rbd_snap*>& o) {
+  static void generate_test_instances(std::list<cls_rbd_snap*>& o) {
     o.push_back(new cls_rbd_snap{});
     o.push_back(new cls_rbd_snap{1, "snap", 123456,
                                  RBD_PROTECTION_STATUS_PROTECTED,

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -14,6 +14,14 @@
 namespace librbd {
 namespace cls_client {
 
+using std::map;
+using std::set;
+using std::string;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+
 void create_image(librados::ObjectWriteOperation *op, uint64_t size,
                   uint8_t order, uint64_t features,
                   const std::string &object_prefix, int64_t data_pool_id)
@@ -52,7 +60,7 @@ int get_features_finish(bufferlist::const_iterator *it, uint64_t *features,
   try {
     decode(*features, *it);
     decode(*incompatible_features, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
 
@@ -106,7 +114,7 @@ int get_object_prefix_finish(bufferlist::const_iterator *it,
 {
   try {
     decode(*object_prefix, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -136,7 +144,7 @@ void get_data_pool_start(librados::ObjectReadOperation *op) {
 int get_data_pool_finish(bufferlist::const_iterator *it, int64_t *data_pool_id) {
   try {
     decode(*data_pool_id, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -170,7 +178,7 @@ int get_size_finish(bufferlist::const_iterator *it, uint64_t *size,
   try {
     decode(*order, *it);
     decode(*size, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -216,7 +224,7 @@ void get_flags_start(librados::ObjectReadOperation *op, snapid_t snap_id) {
 int get_flags_finish(bufferlist::const_iterator *it, uint64_t *flags) {
   try {
     decode(*flags, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -258,7 +266,7 @@ int op_features_get_finish(bufferlist::const_iterator *it, uint64_t *op_features
 {
   try {
     decode(*op_features, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -315,7 +323,7 @@ int get_parent_finish(bufferlist::const_iterator *it,
     decode(pspec->image_id, *it);
     decode(pspec->snap_id, *it);
     decode(*parent_overlap, *it);
-  } catch (const buffer::error &) {
+  } catch (const ceph::buffer::error &) {
     return -EBADMSG;
   }
   return 0;
@@ -382,7 +390,7 @@ int parent_get_finish(bufferlist::const_iterator* it,
                       cls::rbd::ParentImageSpec* parent_image_spec) {
   try {
     decode(*parent_image_spec, *it);
-  } catch (const buffer::error &) {
+  } catch (const ceph::buffer::error &) {
     return -EBADMSG;
   }
   return 0;
@@ -418,7 +426,7 @@ int parent_overlap_get_finish(bufferlist::const_iterator* it,
                               std::optional<uint64_t>* parent_overlap) {
   try {
     decode(*parent_overlap, *it);
-  } catch (const buffer::error &) {
+  } catch (const ceph::buffer::error &) {
     return -EBADMSG;
   }
   return 0;
@@ -533,7 +541,7 @@ int get_children_finish(bufferlist::const_iterator *it,
                         std::set<std::string>* children) {
   try {
     decode(*children, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -567,7 +575,7 @@ int snapshot_get_finish(bufferlist::const_iterator* it,
 {
   try {
     decode(*snap_info, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -636,7 +644,7 @@ int get_snapcontext_finish(bufferlist::const_iterator *it,
 {
   try {
     decode(*snapc, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   if (!snapc->is_valid()) {
@@ -674,7 +682,7 @@ int get_snapshot_name_finish(bufferlist::const_iterator *it,
 {
   try {
     decode(*name, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -709,7 +717,7 @@ int get_snapshot_timestamp_finish(bufferlist::const_iterator *it,
 {
   try {
     decode(*timestamp, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -779,7 +787,7 @@ int old_snapshot_list_finish(bufferlist::const_iterator *it,
       decode((*sizes)[i], *it);
       decode((*names)[i], *it);
     }
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -812,7 +820,7 @@ int get_all_features_finish(bufferlist::const_iterator *it,
                             uint64_t *all_features) {
   try {
     decode(*all_features, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -876,7 +884,7 @@ int get_protection_status_finish(bufferlist::const_iterator *it,
 {
   try {
     decode(*protection_status, *it);
-  } catch (const buffer::error &) {
+  } catch (const ceph::buffer::error &) {
     return -EBADMSG;
   }
   return 0;
@@ -926,7 +934,7 @@ int snapshot_get_limit_finish(bufferlist::const_iterator *it, uint64_t *limit)
 {
   try {
     decode(*limit, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -969,7 +977,7 @@ int get_stripe_unit_count_finish(bufferlist::const_iterator *it,
   try {
     decode(*stripe_unit, *it);
     decode(*stripe_count, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -1021,7 +1029,7 @@ int get_create_timestamp_finish(bufferlist::const_iterator *it,
 
   try {
     decode(*timestamp, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -1054,7 +1062,7 @@ int get_access_timestamp_finish(bufferlist::const_iterator *it,
 
   try {
     decode(*timestamp, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -1100,7 +1108,7 @@ int get_modify_timestamp_finish(bufferlist::const_iterator *it,
 
   try {
     decode(*timestamp, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -1146,7 +1154,7 @@ void get_id_start(librados::ObjectReadOperation *op) {
 int get_id_finish(bufferlist::const_iterator *it, std::string *id) {
   try {
     decode(*id, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -1195,7 +1203,7 @@ void dir_get_id_start(librados::ObjectReadOperation *op,
 int dir_get_id_finish(bufferlist::const_iterator *iter, std::string *image_id) {
   try {
     decode(*image_id, *iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
 
@@ -1227,7 +1235,7 @@ void dir_get_name_start(librados::ObjectReadOperation *op,
 int dir_get_name_finish(bufferlist::const_iterator *it, std::string *name) {
   try {
     decode(*name, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -1262,7 +1270,7 @@ int dir_list_finish(bufferlist::const_iterator *it, map<string, string> *images)
 {
   try {
     decode(*images, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -1376,7 +1384,7 @@ int object_map_load_finish(bufferlist::const_iterator *it,
                            ceph::BitVector<2> *object_map) {
   try {
     decode(*object_map, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -1516,7 +1524,7 @@ int metadata_list_finish(bufferlist::const_iterator *it,
   ceph_assert(pairs);
   try {
     decode(*pairs, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -1534,7 +1542,7 @@ int metadata_get_finish(bufferlist::const_iterator *it,
                          std::string* value) {
   try {
     decode(*value, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -1621,7 +1629,7 @@ int children_list_finish(bufferlist::const_iterator *it,
   child_images->clear();
   try {
     decode(*child_images, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -1688,7 +1696,7 @@ int migration_get_finish(bufferlist::const_iterator *it,
                          cls::rbd::MigrationSpec *migration_spec) {
   try {
     decode(*migration_spec, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -1750,7 +1758,7 @@ int mirror_uuid_get_finish(bufferlist::const_iterator *it,
                            std::string *uuid) {
   try {
     decode(*uuid, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -1798,7 +1806,7 @@ int mirror_mode_get_finish(bufferlist::const_iterator *it,
     uint32_t mirror_mode_decode;
     decode(mirror_mode_decode, *it);
     *mirror_mode = static_cast<cls::rbd::MirrorMode>(mirror_mode_decode);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
 
@@ -1851,7 +1859,7 @@ int mirror_peer_list_finish(bufferlist::const_iterator *it,
   peers->clear();
   try {
     decode(*peers, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -1998,7 +2006,7 @@ int mirror_image_list_finish(bufferlist::const_iterator *it,
 {
   try {
     decode(*mirror_image_ids, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -2031,7 +2039,7 @@ int mirror_image_get_image_id_finish(bufferlist::const_iterator *it,
                                      std::string *image_id) {
   try {
     decode(*image_id, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -2084,7 +2092,7 @@ int mirror_image_get_finish(bufferlist::const_iterator *iter,
                             cls::rbd::MirrorImage *mirror_image) {
   try {
     decode(*mirror_image, *iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -2179,7 +2187,7 @@ int mirror_image_status_get_finish(bufferlist::const_iterator *iter,
                                    cls::rbd::MirrorImageStatus *status) {
   try {
     decode(*status, *iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -2223,7 +2231,7 @@ int mirror_image_status_list_finish(bufferlist::const_iterator *iter,
   try {
     decode(*images, *iter);
     decode(*statuses, *iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -2263,7 +2271,7 @@ int mirror_image_status_get_summary_finish(
     std::map<cls::rbd::MirrorImageStatusState, int32_t> *states) {
   try {
     decode(*states, *iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -2311,7 +2319,7 @@ int mirror_image_instance_get_finish(bufferlist::const_iterator *iter,
                                      entity_inst_t *instance) {
   try {
     decode(*instance, *iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -2352,7 +2360,7 @@ int mirror_image_instance_list_finish(
   instances->clear();
   try {
     decode(*instances, *iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -2368,7 +2376,7 @@ int mirror_instances_list_finish(bufferlist::const_iterator *iter,
   instance_ids->clear();
   try {
     decode(*instance_ids, *iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -2435,7 +2443,7 @@ int mirror_image_map_list_finish(bufferlist::const_iterator *iter,
                                  std::map<std::string, cls::rbd::MirrorImageMap> *image_mapping) {
   try {
     decode(*image_mapping, *iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -2531,7 +2539,7 @@ int group_dir_list(librados::IoCtx *ioctx, const std::string &oid,
   auto iter = out.cbegin();
   try {
     decode(*cgs, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
 
@@ -2593,7 +2601,7 @@ int group_image_list(librados::IoCtx *ioctx,
   auto iter = bl2.cbegin();
   try {
     decode(*images, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
 
@@ -2638,7 +2646,7 @@ int image_group_get_finish(bufferlist::const_iterator *iter,
 {
   try {
     decode(*group_spec, *iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
   return 0;
@@ -2696,7 +2704,7 @@ int group_snap_get_by_id(librados::IoCtx *ioctx, const std::string &oid,
   auto iter = outbl.cbegin();
   try {
     decode(*snapshot, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
 
@@ -2720,7 +2728,7 @@ int group_snap_list(librados::IoCtx *ioctx, const std::string &oid,
   auto iter = outbl.cbegin();
   try {
     decode(*snapshots, iter);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
 
@@ -2779,7 +2787,7 @@ int trash_list_finish(bufferlist::const_iterator *it,
 
   try {
     decode(*entries, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
 
@@ -2816,7 +2824,7 @@ int trash_get_finish(bufferlist::const_iterator *it,
   ceph_assert(trash_spec);
   try {
     decode(*trash_spec, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
 
@@ -2909,7 +2917,7 @@ int namespace_list_finish(bufferlist::const_iterator *it,
 
   try {
     decode(*entries, *it);
-  } catch (const buffer::error &err) {
+  } catch (const ceph::buffer::error &err) {
     return -EBADMSG;
   }
 

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -25,7 +25,7 @@ int create_image(librados::IoCtx *ioctx, const std::string &oid,
                  const std::string &object_prefix, int64_t data_pool_id);
 
 void get_features_start(librados::ObjectReadOperation *op, bool read_only);
-int get_features_finish(bufferlist::const_iterator *it, uint64_t *features,
+int get_features_finish(ceph::buffer::list::const_iterator *it, uint64_t *features,
                         uint64_t *incompatible_features);
 int get_features(librados::IoCtx *ioctx, const std::string &oid,
                  bool read_only, uint64_t *features,
@@ -36,18 +36,18 @@ int set_features(librados::IoCtx *ioctx, const std::string &oid,
                  uint64_t features, uint64_t mask);
 
 void get_object_prefix_start(librados::ObjectReadOperation *op);
-int get_object_prefix_finish(bufferlist::const_iterator *it,
+int get_object_prefix_finish(ceph::buffer::list::const_iterator *it,
                              std::string *object_prefix);
 int get_object_prefix(librados::IoCtx *ioctx, const std::string &oid,
                       std::string *object_prefix);
 
 void get_data_pool_start(librados::ObjectReadOperation *op);
-int get_data_pool_finish(bufferlist::const_iterator *it, int64_t *data_pool_id);
+int get_data_pool_finish(ceph::buffer::list::const_iterator *it, int64_t *data_pool_id);
 int get_data_pool(librados::IoCtx *ioctx, const std::string &oid,
                   int64_t *data_pool_id);
 
 void get_size_start(librados::ObjectReadOperation *op, snapid_t snap_id);
-int get_size_finish(bufferlist::const_iterator *it, uint64_t *size,
+int get_size_finish(ceph::buffer::list::const_iterator *it, uint64_t *size,
                     uint8_t *order);
 int get_size(librados::IoCtx *ioctx, const std::string &oid,
              snapid_t snap_id, uint64_t *size, uint8_t *order);
@@ -56,7 +56,7 @@ int set_size(librados::IoCtx *ioctx, const std::string &oid,
 void set_size(librados::ObjectWriteOperation *op, uint64_t size);
 
 void get_flags_start(librados::ObjectReadOperation *op, snapid_t snap_id);
-int get_flags_finish(bufferlist::const_iterator *it, uint64_t *flags);
+int get_flags_finish(ceph::buffer::list::const_iterator *it, uint64_t *flags);
 int get_flags(librados::IoCtx *ioctx, const std::string &oid,
               snapid_t snap_id, uint64_t *flags);
 
@@ -64,7 +64,7 @@ void set_flags(librados::ObjectWriteOperation *op, snapid_t snap_id,
                uint64_t flags, uint64_t mask);
 
 void op_features_get_start(librados::ObjectReadOperation *op);
-int op_features_get_finish(bufferlist::const_iterator *it,
+int op_features_get_finish(ceph::buffer::list::const_iterator *it,
                            uint64_t *op_features);
 int op_features_get(librados::IoCtx *ioctx, const std::string &oid,
                     uint64_t *op_features);
@@ -75,7 +75,7 @@ int op_features_set(librados::IoCtx *ioctx, const std::string &oid,
 
 // NOTE: deprecate v1 parent APIs after mimic EOLed
 void get_parent_start(librados::ObjectReadOperation *op, snapid_t snap_id);
-int get_parent_finish(bufferlist::const_iterator *it,
+int get_parent_finish(ceph::buffer::list::const_iterator *it,
                       cls::rbd::ParentImageSpec *pspec,
                       uint64_t *parent_overlap);
 int get_parent(librados::IoCtx *ioctx, const std::string &oid,
@@ -91,14 +91,14 @@ void remove_parent(librados::ObjectWriteOperation *op);
 
 // v2 parent APIs
 void parent_get_start(librados::ObjectReadOperation* op);
-int parent_get_finish(bufferlist::const_iterator* it,
+int parent_get_finish(ceph::buffer::list::const_iterator* it,
                       cls::rbd::ParentImageSpec* parent_image_spec);
 int parent_get(librados::IoCtx* ioctx, const std::string &oid,
                cls::rbd::ParentImageSpec* parent_image_spec);
 
 void parent_overlap_get_start(librados::ObjectReadOperation* op,
                               snapid_t snap_id);
-int parent_overlap_get_finish(bufferlist::const_iterator* it,
+int parent_overlap_get_finish(ceph::buffer::list::const_iterator* it,
                               std::optional<uint64_t>* parent_overlap);
 int parent_overlap_get(librados::IoCtx* ioctx, const std::string &oid,
                        snapid_t snap_id,
@@ -128,14 +128,14 @@ int remove_child(librados::IoCtx *ioctx, const std::string &oid,
                  const std::string &c_imageid);
 void get_children_start(librados::ObjectReadOperation *op,
                         const cls::rbd::ParentImageSpec &pspec);
-int get_children_finish(bufferlist::const_iterator *it,
-                        std::set<string> *children);
+int get_children_finish(ceph::buffer::list::const_iterator *it,
+                        std::set<std::string> *children);
 int get_children(librados::IoCtx *ioctx, const std::string &oid,
-                 const cls::rbd::ParentImageSpec& pspec, set<string>& children);
+                 const cls::rbd::ParentImageSpec& pspec, std::set<std::string>& children);
 
 void snapshot_get_start(librados::ObjectReadOperation* op,
                         snapid_t snap_id);
-int snapshot_get_finish(bufferlist::const_iterator* it,
+int snapshot_get_finish(ceph::buffer::list::const_iterator* it,
                         cls::rbd::SnapshotInfo* snap_info);
 int snapshot_get(librados::IoCtx *ioctx, const std::string &oid,
                  snapid_t snap_id, cls::rbd::SnapshotInfo* snap_info);
@@ -151,7 +151,7 @@ void snapshot_trash_add(librados::ObjectWriteOperation *op,
                         snapid_t snap_id);
 
 void get_snapcontext_start(librados::ObjectReadOperation *op);
-int get_snapcontext_finish(bufferlist::const_iterator *it,
+int get_snapcontext_finish(ceph::buffer::list::const_iterator *it,
                            ::SnapContext *snapc);
 int get_snapcontext(librados::IoCtx *ioctx, const std::string &oid,
                     ::SnapContext *snapc);
@@ -159,7 +159,7 @@ int get_snapcontext(librados::IoCtx *ioctx, const std::string &oid,
 /// NOTE: remove after Luminous is retired
 void get_snapshot_name_start(librados::ObjectReadOperation *op,
                              snapid_t snap_id);
-int get_snapshot_name_finish(bufferlist::const_iterator *it,
+int get_snapshot_name_finish(ceph::buffer::list::const_iterator *it,
                              std::string *name);
 int get_snapshot_name(librados::IoCtx *ioctx, const std::string &oid,
                       snapid_t snap_id, std::string *name);
@@ -167,13 +167,13 @@ int get_snapshot_name(librados::IoCtx *ioctx, const std::string &oid,
 /// NOTE: remove after Luminous is retired
 void get_snapshot_timestamp_start(librados::ObjectReadOperation *op,
                                   snapid_t snap_id);
-int get_snapshot_timestamp_finish(bufferlist::const_iterator *it,
+int get_snapshot_timestamp_finish(ceph::buffer::list::const_iterator *it,
                                   utime_t *timestamp);
 int get_snapshot_timestamp(librados::IoCtx *ioctx, const std::string &oid,
                            snapid_t snap_id, utime_t *timestamp);
 
 void get_all_features_start(librados::ObjectReadOperation *op);
-int get_all_features_finish(bufferlist::const_iterator *it,
+int get_all_features_finish(ceph::buffer::list::const_iterator *it,
                             uint64_t *all_features);
 int get_all_features(librados::IoCtx *ioctx, const std::string &oid,
                      uint64_t *all_features);
@@ -181,7 +181,7 @@ int get_all_features(librados::IoCtx *ioctx, const std::string &oid,
 /// NOTE: remove protection after clone v1 is retired
 void get_protection_status_start(librados::ObjectReadOperation *op,
                                  snapid_t snap_id);
-int get_protection_status_finish(bufferlist::const_iterator *it,
+int get_protection_status_finish(ceph::buffer::list::const_iterator *it,
                                  uint8_t *protection_status);
 int get_protection_status(librados::IoCtx *ioctx, const std::string &oid,
                           snapid_t snap_id, uint8_t *protection_status);
@@ -192,14 +192,14 @@ void set_protection_status(librados::ObjectWriteOperation *op,
                            snapid_t snap_id, uint8_t protection_status);
 
 void snapshot_get_limit_start(librados::ObjectReadOperation *op);
-int snapshot_get_limit_finish(bufferlist::const_iterator *it, uint64_t *limit);
+int snapshot_get_limit_finish(ceph::buffer::list::const_iterator *it, uint64_t *limit);
 int snapshot_get_limit(librados::IoCtx *ioctx, const std::string &oid,
                        uint64_t *limit);
 void snapshot_set_limit(librados::ObjectWriteOperation *op,
                         uint64_t limit);
 
 void get_stripe_unit_count_start(librados::ObjectReadOperation *op);
-int get_stripe_unit_count_finish(bufferlist::const_iterator *it,
+int get_stripe_unit_count_finish(ceph::buffer::list::const_iterator *it,
                                  uint64_t *stripe_unit,
                                  uint64_t *stripe_count);
 int get_stripe_unit_count(librados::IoCtx *ioctx, const std::string &oid,
@@ -211,13 +211,13 @@ int set_stripe_unit_count(librados::IoCtx *ioctx, const std::string &oid,
                           uint64_t stripe_unit, uint64_t stripe_count);
 
 void get_create_timestamp_start(librados::ObjectReadOperation *op);
-int get_create_timestamp_finish(bufferlist::const_iterator *it,
+int get_create_timestamp_finish(ceph::buffer::list::const_iterator *it,
                                 utime_t *timestamp);
 int get_create_timestamp(librados::IoCtx *ioctx, const std::string &oid,
                          utime_t *timestamp);
 
 void get_access_timestamp_start(librados::ObjectReadOperation *op);
-int get_access_timestamp_finish(bufferlist::const_iterator *it,
+int get_access_timestamp_finish(ceph::buffer::list::const_iterator *it,
                                 utime_t *timestamp);
 int get_access_timestamp(librados::IoCtx *ioctx, const std::string &oid,
                          utime_t *timestamp);
@@ -226,7 +226,7 @@ void set_access_timestamp(librados::ObjectWriteOperation *op);
 int set_access_timestamp(librados::IoCtx *ioctx, const std::string &oid);
 
 void get_modify_timestamp_start(librados::ObjectReadOperation *op);
-int get_modify_timestamp_finish(bufferlist::const_iterator *it,
+int get_modify_timestamp_finish(ceph::buffer::list::const_iterator *it,
                                 utime_t *timestamp);
 int get_modify_timestamp(librados::IoCtx *ioctx, const std::string &oid,
                          utime_t *timestamp);
@@ -236,25 +236,25 @@ int set_modify_timestamp(librados::IoCtx *ioctx, const std::string &oid);
 
 int metadata_list(librados::IoCtx *ioctx, const std::string &oid,
                   const std::string &start, uint64_t max_return,
-                  map<string, bufferlist> *pairs);
+                  std::map<std::string, ceph::buffer::list> *pairs);
 void metadata_list_start(librados::ObjectReadOperation *op,
                          const std::string &start, uint64_t max_return);
-int metadata_list_finish(bufferlist::const_iterator *it,
-                         std::map<std::string, bufferlist> *pairs);
+int metadata_list_finish(ceph::buffer::list::const_iterator *it,
+                         std::map<std::string, ceph::buffer::list> *pairs);
 void metadata_set(librados::ObjectWriteOperation *op,
-                  const map<std::string, bufferlist> &data);
+                  const std::map<std::string, ceph::buffer::list> &data);
 int metadata_set(librados::IoCtx *ioctx, const std::string &oid,
-                 const map<std::string, bufferlist> &data);
+                 const std::map<std::string, ceph::buffer::list> &data);
 void metadata_remove(librados::ObjectWriteOperation *op,
                      const std::string &key);
 int metadata_remove(librados::IoCtx *ioctx, const std::string &oid,
                     const std::string &key);
 void metadata_get_start(librados::ObjectReadOperation* op,
                  const std::string &key);
-int metadata_get_finish(bufferlist::const_iterator *it,
+int metadata_get_finish(ceph::buffer::list::const_iterator *it,
                         std::string* value);
 int metadata_get(librados::IoCtx *ioctx, const std::string &oid,
-                 const std::string &key, string *v);
+                 const std::string &key, std::string *v);
 
 void child_attach(librados::ObjectWriteOperation *op, snapid_t snap_id,
                   const cls::rbd::ChildImageSpec& child_image);
@@ -268,7 +268,7 @@ int child_detach(librados::IoCtx *ioctx, const std::string &oid,
                  const cls::rbd::ChildImageSpec& child_image);
 void children_list_start(librados::ObjectReadOperation *op,
                          snapid_t snap_id);
-int children_list_finish(bufferlist::const_iterator *it,
+int children_list_finish(ceph::buffer::list::const_iterator *it,
                          cls::rbd::ChildImageSpecs *child_images);
 int children_list(librados::IoCtx *ioctx, const std::string &oid,
                   snapid_t snap_id,
@@ -284,7 +284,7 @@ void migration_set_state(librados::ObjectWriteOperation *op,
                          cls::rbd::MigrationState state,
                          const std::string &description);
 void migration_get_start(librados::ObjectReadOperation *op);
-int migration_get_finish(bufferlist::const_iterator *it,
+int migration_get_finish(ceph::buffer::list::const_iterator *it,
                          cls::rbd::MigrationSpec *migration_spec);
 int migration_get(librados::IoCtx *ioctx, const std::string &oid,
                   cls::rbd::MigrationSpec *migration_spec);
@@ -293,7 +293,7 @@ void migration_remove(librados::ObjectWriteOperation *op);
 
 // operations on rbd_id objects
 void get_id_start(librados::ObjectReadOperation *op);
-int get_id_finish(bufferlist::const_iterator *it, std::string *id);
+int get_id_finish(ceph::buffer::list::const_iterator *it, std::string *id);
 int get_id(librados::IoCtx *ioctx, const std::string &oid, std::string *id);
 
 void set_id(librados::ObjectWriteOperation *op, const std::string &id);
@@ -304,18 +304,18 @@ int dir_get_id(librados::IoCtx *ioctx, const std::string &oid,
                const std::string &name, std::string *id);
 void dir_get_id_start(librados::ObjectReadOperation *op,
                       const std::string &image_name);
-int dir_get_id_finish(bufferlist::const_iterator *iter, std::string *image_id);
+int dir_get_id_finish(ceph::buffer::list::const_iterator *iter, std::string *image_id);
 void dir_get_name_start(librados::ObjectReadOperation *op,
                         const std::string &id);
-int dir_get_name_finish(bufferlist::const_iterator *it, std::string *name);
+int dir_get_name_finish(ceph::buffer::list::const_iterator *it, std::string *name);
 int dir_get_name(librados::IoCtx *ioctx, const std::string &oid,
                  const std::string &id, std::string *name);
 void dir_list_start(librados::ObjectReadOperation *op,
                     const std::string &start, uint64_t max_return);
-int dir_list_finish(bufferlist::const_iterator *it, map<string, string> *images);
+int dir_list_finish(ceph::buffer::list::const_iterator *it, std::map<std::string, std::string> *images);
 int dir_list(librados::IoCtx *ioctx, const std::string &oid,
              const std::string &start, uint64_t max_return,
-             map<string, string> *images);
+             std::map<std::string, std::string> *images);
 void dir_add_image(librados::ObjectWriteOperation *op,
                    const std::string &name, const std::string &id);
 int dir_add_image(librados::IoCtx *ioctx, const std::string &oid,
@@ -339,7 +339,7 @@ int dir_state_set(librados::IoCtx *ioctx, const std::string &oid,
 
 // operations on the rbd_object_map.$image_id object
 void object_map_load_start(librados::ObjectReadOperation *op);
-int object_map_load_finish(bufferlist::const_iterator *it,
+int object_map_load_finish(ceph::buffer::list::const_iterator *it,
                            ceph::BitVector<2> *object_map);
 int object_map_load(librados::IoCtx *ioctx, const std::string &oid,
                     ceph::BitVector<2> *object_map);
@@ -365,23 +365,23 @@ void old_snapshot_rename(librados::ObjectWriteOperation *rados_op,
                          snapid_t src_snap_id, const std::string &dst_name);
 
 void old_snapshot_list_start(librados::ObjectReadOperation *op);
-int old_snapshot_list_finish(bufferlist::const_iterator *it,
-                             std::vector<string> *names,
+int old_snapshot_list_finish(ceph::buffer::list::const_iterator *it,
+                             std::vector<std::string> *names,
                              std::vector<uint64_t> *sizes,
                              ::SnapContext *snapc);
 int old_snapshot_list(librados::IoCtx *ioctx, const std::string &oid,
-                      std::vector<string> *names,
+                      std::vector<std::string> *names,
                       std::vector<uint64_t> *sizes,
                       ::SnapContext *snapc);
 
 // operations on the rbd_mirroring object
 void mirror_uuid_get_start(librados::ObjectReadOperation *op);
-int mirror_uuid_get_finish(bufferlist::const_iterator *it,
+int mirror_uuid_get_finish(ceph::buffer::list::const_iterator *it,
                            std::string *uuid);
 int mirror_uuid_get(librados::IoCtx *ioctx, std::string *uuid);
 int mirror_uuid_set(librados::IoCtx *ioctx, const std::string &uuid);
 void mirror_mode_get_start(librados::ObjectReadOperation *op);
-int mirror_mode_get_finish(bufferlist::const_iterator *it,
+int mirror_mode_get_finish(ceph::buffer::list::const_iterator *it,
                            cls::rbd::MirrorMode *mirror_mode);
 int mirror_mode_get(librados::IoCtx *ioctx,
                     cls::rbd::MirrorMode *mirror_mode);
@@ -395,7 +395,7 @@ void mirror_peer_ping(librados::ObjectWriteOperation *op,
                       const std::string& site_name,
                       const std::string& fsid);
 void mirror_peer_list_start(librados::ObjectReadOperation *op);
-int mirror_peer_list_finish(bufferlist::const_iterator *it,
+int mirror_peer_list_finish(ceph::buffer::list::const_iterator *it,
                             std::vector<cls::rbd::MirrorPeer> *peers);
 int mirror_peer_list(librados::IoCtx *ioctx,
                      std::vector<cls::rbd::MirrorPeer> *peers);
@@ -417,14 +417,14 @@ int mirror_peer_set_direction(
 
 void mirror_image_list_start(librados::ObjectReadOperation *op,
                              const std::string &start, uint64_t max_return);
-int mirror_image_list_finish(bufferlist::const_iterator *it,
-                             std::map<string, string> *mirror_image_ids);
+int mirror_image_list_finish(ceph::buffer::list::const_iterator *it,
+                             std::map<std::string, std::string> *mirror_image_ids);
 int mirror_image_list(librados::IoCtx *ioctx,
                       const std::string &start, uint64_t max_return,
                       std::map<std::string, std::string> *mirror_image_ids);
 void mirror_image_get_image_id_start(librados::ObjectReadOperation *op,
                                      const std::string &global_image_id);
-int mirror_image_get_image_id_finish(bufferlist::const_iterator *it,
+int mirror_image_get_image_id_finish(ceph::buffer::list::const_iterator *it,
                                      std::string *image_id);
 int mirror_image_get_image_id(librados::IoCtx *ioctx,
                               const std::string &global_image_id,
@@ -433,7 +433,7 @@ int mirror_image_get(librados::IoCtx *ioctx, const std::string &image_id,
                      cls::rbd::MirrorImage *mirror_image);
 void mirror_image_get_start(librados::ObjectReadOperation *op,
                             const std::string &image_id);
-int mirror_image_get_finish(bufferlist::const_iterator *iter,
+int mirror_image_get_finish(ceph::buffer::list::const_iterator *iter,
                             cls::rbd::MirrorImage *mirror_image);
 void mirror_image_set(librados::ObjectWriteOperation *op,
                       const std::string &image_id,
@@ -455,7 +455,7 @@ int mirror_image_status_get(librados::IoCtx *ioctx,
                             cls::rbd::MirrorImageStatus *status);
 void mirror_image_status_get_start(librados::ObjectReadOperation *op,
                                    const std::string &global_image_id);
-int mirror_image_status_get_finish(bufferlist::const_iterator *iter,
+int mirror_image_status_get_finish(ceph::buffer::list::const_iterator *iter,
                                    cls::rbd::MirrorImageStatus *status);
 int mirror_image_status_list(librados::IoCtx *ioctx,
                              const std::string &start, uint64_t max_return,
@@ -464,7 +464,7 @@ int mirror_image_status_list(librados::IoCtx *ioctx,
 void mirror_image_status_list_start(librados::ObjectReadOperation *op,
                                     const std::string &start,
                                     uint64_t max_return);
-int mirror_image_status_list_finish(bufferlist::const_iterator *iter,
+int mirror_image_status_list_finish(ceph::buffer::list::const_iterator *iter,
                                     std::map<std::string, cls::rbd::MirrorImage> *images,
                                     std::map<std::string, cls::rbd::MirrorImageStatus> *statuses);
 int mirror_image_status_get_summary(
@@ -475,7 +475,7 @@ void mirror_image_status_get_summary_start(
     librados::ObjectReadOperation *op,
     const std::vector<cls::rbd::MirrorPeer>& mirror_peer_sites);
 int mirror_image_status_get_summary_finish(
-    bufferlist::const_iterator *iter,
+    ceph::buffer::list::const_iterator *iter,
     std::map<cls::rbd::MirrorImageStatusState, int32_t> *states);
 int mirror_image_status_remove_down(librados::IoCtx *ioctx);
 void mirror_image_status_remove_down(librados::ObjectWriteOperation *op);
@@ -485,7 +485,7 @@ int mirror_image_instance_get(librados::IoCtx *ioctx,
                               entity_inst_t *instance);
 void mirror_image_instance_get_start(librados::ObjectReadOperation *op,
                                      const std::string &global_image_id);
-int mirror_image_instance_get_finish(bufferlist::const_iterator *iter,
+int mirror_image_instance_get_finish(ceph::buffer::list::const_iterator *iter,
                                      entity_inst_t *instance);
 int mirror_image_instance_list(librados::IoCtx *ioctx,
                                const std::string &start, uint64_t max_return,
@@ -493,11 +493,11 @@ int mirror_image_instance_list(librados::IoCtx *ioctx,
 void mirror_image_instance_list_start(librados::ObjectReadOperation *op,
                                       const std::string &start,
                                       uint64_t max_return);
-int mirror_image_instance_list_finish(bufferlist::const_iterator *iter,
+int mirror_image_instance_list_finish(ceph::buffer::list::const_iterator *iter,
                                       std::map<std::string, entity_inst_t> *instances);
 
 void mirror_instances_list_start(librados::ObjectReadOperation *op);
-int mirror_instances_list_finish(bufferlist::const_iterator *iter,
+int mirror_instances_list_finish(ceph::buffer::list::const_iterator *iter,
                                  std::vector<std::string> *instance_ids);
 int mirror_instances_list(librados::IoCtx *ioctx,
                           std::vector<std::string> *instance_ids);
@@ -514,7 +514,7 @@ int mirror_instances_remove(librados::IoCtx *ioctx,
 void mirror_image_map_list_start(librados::ObjectReadOperation *op,
                                  const std::string &start_after,
                                  uint64_t max_read);
-int mirror_image_map_list_finish(bufferlist::const_iterator *iter,
+int mirror_image_map_list_finish(ceph::buffer::list::const_iterator *iter,
                                  std::map<std::string, cls::rbd::MirrorImageMap> *image_mapping);
 int mirror_image_map_list(librados::IoCtx *ioctx,
                           const std::string &start_after, uint64_t max_read,
@@ -543,7 +543,7 @@ int mirror_image_snapshot_set_copy_progress(librados::IoCtx *ioctx,
 // Groups functions
 int group_dir_list(librados::IoCtx *ioctx, const std::string &oid,
                    const std::string &start, uint64_t max_return,
-                   map<string, string> *groups);
+                   std::map<std::string, std::string> *groups);
 int group_dir_add(librados::IoCtx *ioctx, const std::string &oid,
                   const std::string &name, const std::string &id);
 int group_dir_rename(librados::IoCtx *ioctx, const std::string &oid,
@@ -564,7 +564,7 @@ int image_group_add(librados::IoCtx *ioctx, const std::string &oid,
 int image_group_remove(librados::IoCtx *ioctx, const std::string &oid,
                        const cls::rbd::GroupSpec &group_spec);
 void image_group_get_start(librados::ObjectReadOperation *op);
-int image_group_get_finish(bufferlist::const_iterator *iter,
+int image_group_get_finish(ceph::buffer::list::const_iterator *iter,
                            cls::rbd::GroupSpec *group_spec);
 int image_group_get(librados::IoCtx *ioctx, const std::string &oid,
                     cls::rbd::GroupSpec *group_spec);
@@ -591,14 +591,14 @@ void trash_remove(librados::ObjectWriteOperation *op,
 int trash_remove(librados::IoCtx *ioctx, const std::string &id);
 void trash_list_start(librados::ObjectReadOperation *op,
                       const std::string &start, uint64_t max_return);
-int trash_list_finish(bufferlist::const_iterator *it,
-                      map<string, cls::rbd::TrashImageSpec> *entries);
+int trash_list_finish(ceph::buffer::list::const_iterator *it,
+                      std::map<std::string, cls::rbd::TrashImageSpec> *entries);
 int trash_list(librados::IoCtx *ioctx,
                const std::string &start, uint64_t max_return,
-               map<string, cls::rbd::TrashImageSpec> *entries);
+               std::map<std::string, cls::rbd::TrashImageSpec> *entries);
 void trash_get_start(librados::ObjectReadOperation *op,
                      const std::string &id);
-int trash_get_finish(bufferlist::const_iterator *it,
+int trash_get_finish(ceph::buffer::list::const_iterator *it,
                      cls::rbd::TrashImageSpec *trash_spec);
 int trash_get(librados::IoCtx *ioctx, const std::string &id,
               cls::rbd::TrashImageSpec *trash_spec);
@@ -619,7 +619,7 @@ void namespace_remove(librados::ObjectWriteOperation *op,
 int namespace_remove(librados::IoCtx *ioctx, const std::string &name);
 void namespace_list_start(librados::ObjectReadOperation *op,
                           const std::string &start, uint64_t max_return);
-int namespace_list_finish(bufferlist::const_iterator *it,
+int namespace_list_finish(ceph::buffer::list::const_iterator *it,
                           std::list<std::string> *entries);
 int namespace_list(librados::IoCtx *ioctx,
                    const std::string &start, uint64_t max_return,
@@ -633,16 +633,16 @@ void assert_snapc_seq(librados::ObjectWriteOperation *op,
                       uint64_t snapc_seq,
                       cls::rbd::AssertSnapcSeqState state);
 
-void copyup(librados::ObjectWriteOperation *op, bufferlist data);
+void copyup(librados::ObjectWriteOperation *op, ceph::buffer::list data);
 int copyup(librados::IoCtx *ioctx, const std::string &oid,
-           bufferlist data);
+           ceph::buffer::list data);
 
 void sparse_copyup(librados::ObjectWriteOperation *op,
                    const std::map<uint64_t, uint64_t> &extent_map,
-                   bufferlist data);
+                   ceph::buffer::list data);
 int sparse_copyup(librados::IoCtx *ioctx, const std::string &oid,
                   const std::map<uint64_t, uint64_t> &extent_map,
-                  bufferlist data);
+                  ceph::buffer::list data);
 
 void sparsify(librados::ObjectWriteOperation *op, size_t sparse_size,
               bool remove_empty);

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -8,6 +8,13 @@
 namespace cls {
 namespace rbd {
 
+using std::istringstream;
+using std::ostringstream;
+using std::string;
+
+using ceph::bufferlist;
+using ceph::Formatter;
+
 std::ostream& operator<<(std::ostream& os,
                          MirrorPeerDirection mirror_peer_direction) {
   switch (mirror_peer_direction) {

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -23,20 +23,20 @@ namespace cls {
 namespace rbd {
 
 static const uint32_t MAX_OBJECT_MAP_OBJECT_COUNT = 256000000;
-static const string RBD_GROUP_IMAGE_KEY_PREFIX = "image_";
+static const std::string RBD_GROUP_IMAGE_KEY_PREFIX = "image_";
 
 enum DirectoryState {
   DIRECTORY_STATE_READY         = 0,
   DIRECTORY_STATE_ADD_DISABLED  = 1
 };
 
-inline void encode(DirectoryState state, bufferlist& bl,
+inline void encode(DirectoryState state, ceph::buffer::list& bl,
 		   uint64_t features=0)
 {
   ceph::encode(static_cast<uint8_t>(state), bl);
 }
 
-inline void decode(DirectoryState &state, bufferlist::const_iterator& it)
+inline void decode(DirectoryState &state, ceph::buffer::list::const_iterator& it)
 {
   uint8_t int_state;
   ceph::decode(int_state, it);
@@ -54,14 +54,14 @@ enum GroupImageLinkState {
   GROUP_IMAGE_LINK_STATE_INCOMPLETE
 };
 
-inline void encode(const GroupImageLinkState &state, bufferlist& bl,
+inline void encode(const GroupImageLinkState &state, ceph::buffer::list& bl,
 		   uint64_t features=0)
 {
   using ceph::encode;
   encode(static_cast<uint8_t>(state), bl);
 }
 
-inline void decode(GroupImageLinkState &state, bufferlist::const_iterator& it)
+inline void decode(GroupImageLinkState &state, ceph::buffer::list::const_iterator& it)
 {
   uint8_t int_state;
   using ceph::decode;
@@ -115,9 +115,9 @@ struct MirrorPeer {
     return (!uuid.empty() && !site_name.empty());
   }
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+  void dump(ceph::Formatter *f) const;
 
   static void generate_test_instances(std::list<MirrorPeer*> &o);
 
@@ -156,9 +156,9 @@ struct MirrorImage {
   std::string global_image_id;
   MirrorImageState state = MIRROR_IMAGE_STATE_DISABLING;
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+  void dump(ceph::Formatter *f) const;
 
   static void generate_test_instances(std::list<MirrorImage*> &o);
 
@@ -182,7 +182,7 @@ enum MirrorImageStatusState {
   MIRROR_IMAGE_STATUS_STATE_STOPPED         = 6,
 };
 
-inline void encode(const MirrorImageStatusState &state, bufferlist& bl,
+inline void encode(const MirrorImageStatusState &state, ceph::buffer::list& bl,
 		   uint64_t features=0)
 {
   using ceph::encode;
@@ -190,7 +190,7 @@ inline void encode(const MirrorImageStatusState &state, bufferlist& bl,
 }
 
 inline void decode(MirrorImageStatusState &state,
-                   bufferlist::const_iterator& it)
+                   ceph::buffer::list::const_iterator& it)
 {
   uint8_t int_state;
   using ceph::decode;
@@ -216,12 +216,12 @@ struct MirrorImageSiteStatus {
   utime_t last_update;
   bool up = false;
 
-  void encode_meta(uint8_t version, bufferlist &bl) const;
-  void decode_meta(uint8_t version, bufferlist::const_iterator &it);
+  void encode_meta(uint8_t version, ceph::buffer::list &bl) const;
+  void decode_meta(uint8_t version, ceph::buffer::list::const_iterator &it);
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+  void dump(ceph::Formatter *f) const;
 
   std::string state_to_string() const;
 
@@ -242,11 +242,11 @@ struct MirrorImageSiteStatusOnDisk : cls::rbd::MirrorImageSiteStatus {
     cls::rbd::MirrorImageSiteStatus(status) {
   }
 
-  void encode_meta(bufferlist &bl, uint64_t features) const;
-  void decode_meta(bufferlist::const_iterator &it);
+  void encode_meta(ceph::buffer::list &bl, uint64_t features) const;
+  void decode_meta(ceph::buffer::list::const_iterator &it);
 
-  void encode(bufferlist &bl, uint64_t features) const;
-  void decode(bufferlist::const_iterator &it);
+  void encode(ceph::buffer::list &bl, uint64_t features) const;
+  void decode(ceph::buffer::list::const_iterator &it);
 
   static void generate_test_instances(
       std::list<MirrorImageSiteStatusOnDisk*> &o);
@@ -265,9 +265,9 @@ struct MirrorImageStatus {
 
   int get_local_mirror_image_site_status(MirrorImageSiteStatus* status) const;
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+  void dump(ceph::Formatter *f) const;
 
   bool operator==(const MirrorImageStatus& rhs) const;
 
@@ -306,9 +306,9 @@ struct ParentImageSpec {
     return !(*this == rhs);
   }
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+  void dump(ceph::Formatter *f) const;
 
   static void generate_test_instances(std::list<ParentImageSpec*> &o);
 };
@@ -328,9 +328,9 @@ struct ChildImageSpec {
     : pool_id(pool_id), pool_namespace(pool_namespace), image_id(image_id) {
   }
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+  void dump(ceph::Formatter *f) const;
 
   static void generate_test_instances(std::list<ChildImageSpec*> &o);
 
@@ -366,9 +366,9 @@ struct GroupImageSpec {
   std::string image_id;
   int64_t pool_id = -1;
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+  void dump(ceph::Formatter *f) const;
 
   static void generate_test_instances(std::list<GroupImageSpec*> &o);
 
@@ -391,9 +391,9 @@ struct GroupImageStatus {
   GroupImageSpec spec;
   GroupImageLinkState state = GROUP_IMAGE_LINK_STATE_INCOMPLETE;
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+  void dump(ceph::Formatter *f) const;
 
   static void generate_test_instances(std::list<GroupImageStatus*> &o);
 
@@ -410,9 +410,9 @@ struct GroupSpec {
   std::string group_id;
   int64_t pool_id = -1;
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+  void dump(ceph::Formatter *f) const;
   bool is_valid() const;
 
   static void generate_test_instances(std::list<GroupSpec *> &o);
@@ -433,10 +433,10 @@ struct UserSnapshotNamespace {
 
   UserSnapshotNamespace() {}
 
-  void encode(bufferlist& bl) const {}
-  void decode(bufferlist::const_iterator& it) {}
+  void encode(ceph::buffer::list& bl) const {}
+  void decode(ceph::buffer::list::const_iterator& it) {}
 
-  void dump(Formatter *f) const {}
+  void dump(ceph::Formatter *f) const {}
 
   inline bool operator==(const UserSnapshotNamespace& usn) const {
     return true;
@@ -454,19 +454,19 @@ struct GroupSnapshotNamespace {
   GroupSnapshotNamespace() {}
 
   GroupSnapshotNamespace(int64_t _group_pool,
-			 const string &_group_id,
-			 const string &_group_snapshot_id)
+			 const std::string &_group_id,
+			 const std::string &_group_snapshot_id)
     : group_id(_group_id), group_pool(_group_pool),
       group_snapshot_id(_group_snapshot_id) {}
 
-  string group_id;
+  std::string group_id;
   int64_t group_pool = 0;
-  string group_snapshot_id;
+  std::string group_snapshot_id;
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& it);
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& it);
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
 
   inline bool operator==(const GroupSnapshotNamespace& gsn) const {
     return group_pool == gsn.group_pool &&
@@ -500,9 +500,9 @@ struct TrashSnapshotNamespace {
     : original_name(original_name),
       original_snapshot_namespace_type(original_snapshot_namespace_type) {}
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& it);
+  void dump(ceph::Formatter *f) const;
 
   inline bool operator==(const TrashSnapshotNamespace& usn) const {
     return true;
@@ -519,13 +519,13 @@ enum MirrorSnapshotState {
   MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED = 3,
 };
 
-inline void encode(const MirrorSnapshotState &state, bufferlist& bl,
+inline void encode(const MirrorSnapshotState &state, ceph::buffer::list& bl,
                    uint64_t features=0) {
   using ceph::encode;
   encode(static_cast<uint8_t>(state), bl);
 }
 
-inline void decode(MirrorSnapshotState &state, bufferlist::const_iterator& it) {
+inline void decode(MirrorSnapshotState &state, ceph::buffer::list::const_iterator& it) {
   using ceph::decode;
   uint8_t int_state;
   decode(int_state, it);
@@ -594,10 +594,10 @@ struct MirrorSnapshotNamespace {
             primary_snap_id == CEPH_NOSNAP);
   }
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& it);
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& it);
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
 
   inline bool operator==(const MirrorSnapshotNamespace& rhs) const {
     return state == rhs.state &&
@@ -634,9 +634,9 @@ struct UnknownSnapshotNamespace {
 
   UnknownSnapshotNamespace() {}
 
-  void encode(bufferlist& bl) const {}
-  void decode(bufferlist::const_iterator& it) {}
-  void dump(Formatter *f) const {}
+  void encode(ceph::buffer::list& bl) const {}
+  void decode(ceph::buffer::list::const_iterator& it) {}
+  void dump(ceph::Formatter *f) const {}
 
   inline bool operator==(const UnknownSnapshotNamespace& gsn) const {
     return true;
@@ -668,9 +668,9 @@ struct SnapshotNamespace : public SnapshotNamespaceVariant {
   SnapshotNamespace(T&& t) : SnapshotNamespaceVariant(std::forward<T>(t)) {
   }
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& it);
+  void dump(ceph::Formatter *f) const;
 
   static void generate_test_instances(std::list<SnapshotNamespace*> &o);
 
@@ -708,9 +708,9 @@ struct SnapshotInfo {
       child_count(child_count) {
   }
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& it);
+  void dump(ceph::Formatter *f) const;
 
   static void generate_test_instances(std::list<SnapshotInfo*> &o);
 };
@@ -721,13 +721,13 @@ enum GroupSnapshotState {
   GROUP_SNAPSHOT_STATE_COMPLETE = 1,
 };
 
-inline void encode(const GroupSnapshotState &state, bufferlist& bl, uint64_t features=0)
+inline void encode(const GroupSnapshotState &state, ceph::buffer::list& bl, uint64_t features=0)
 {
   using ceph::encode;
   encode(static_cast<uint8_t>(state), bl);
 }
 
-inline void decode(GroupSnapshotState &state, bufferlist::const_iterator& it)
+inline void decode(GroupSnapshotState &state, ceph::buffer::list::const_iterator& it)
 {
   using ceph::decode;
   uint8_t int_state;
@@ -737,20 +737,20 @@ inline void decode(GroupSnapshotState &state, bufferlist::const_iterator& it)
 
 struct ImageSnapshotSpec {
   int64_t pool;
-  string image_id;
+  std::string image_id;
   snapid_t snap_id;
 
   ImageSnapshotSpec() {}
   ImageSnapshotSpec(int64_t _pool,
-		    string _image_id,
+		    std::string _image_id,
 		    snapid_t _snap_id) : pool(_pool),
 					 image_id(_image_id),
 					 snap_id(_snap_id) {}
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& it);
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& it);
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
 
   static void generate_test_instances(std::list<ImageSnapshotSpec *> &o);
 };
@@ -768,11 +768,11 @@ struct GroupSnapshot {
 					     name(_name),
 					     state(_state) {}
 
-  vector<ImageSnapshotSpec> snaps;
+  std::vector<ImageSnapshotSpec> snaps;
 
-  void encode(bufferlist& bl) const;
-  void decode(bufferlist::const_iterator& it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& it);
+  void dump(ceph::Formatter *f) const;
 
   static void generate_test_instances(std::list<GroupSnapshot *> &o);
 };
@@ -807,14 +807,14 @@ inline std::ostream& operator<<(std::ostream& os,
   return os;
 }
 
-inline void encode(const TrashImageSource &source, bufferlist& bl,
+inline void encode(const TrashImageSource &source, ceph::buffer::list& bl,
 		   uint64_t features=0)
 {
   using ceph::encode;
   encode(static_cast<uint8_t>(source), bl);
 }
 
-inline void decode(TrashImageSource &source, bufferlist::const_iterator& it)
+inline void decode(TrashImageSource &source, ceph::buffer::list::const_iterator& it)
 {
   uint8_t int_source;
   using ceph::decode;
@@ -829,13 +829,13 @@ enum TrashImageState {
   TRASH_IMAGE_STATE_RESTORING = 3
 };
 
-inline void encode(const TrashImageState &state, bufferlist &bl)
+inline void encode(const TrashImageState &state, ceph::buffer::list &bl)
 {
   using ceph::encode;
   encode(static_cast<uint8_t>(state), bl);
 }
 
-inline void decode(TrashImageState &state, bufferlist::const_iterator &it)
+inline void decode(TrashImageState &state, ceph::buffer::list::const_iterator &it)
 {
   uint8_t int_state;
   using ceph::decode;
@@ -858,9 +858,9 @@ struct TrashImageSpec {
       deferment_end_time(deferment_end_time) {
   }
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator& it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator& it);
+  void dump(ceph::Formatter *f) const;
 
   inline bool operator==(const TrashImageSpec& rhs) const {
     return (source == rhs.source &&
@@ -876,7 +876,7 @@ struct MirrorImageMap {
   }
 
   MirrorImageMap(const std::string &instance_id, utime_t mapped_time,
-                 const bufferlist &data)
+                 const ceph::buffer::list &data)
     : instance_id(instance_id),
       mapped_time(mapped_time),
       data(data) {
@@ -884,11 +884,11 @@ struct MirrorImageMap {
 
   std::string instance_id;
   utime_t mapped_time;
-  bufferlist data;
+  ceph::buffer::list data;
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+  void dump(ceph::Formatter *f) const;
 
   static void generate_test_instances(std::list<MirrorImageMap*> &o);
 
@@ -905,12 +905,12 @@ enum MigrationHeaderType {
   MIGRATION_HEADER_TYPE_DST = 2,
 };
 
-inline void encode(const MigrationHeaderType &type, bufferlist& bl) {
+inline void encode(const MigrationHeaderType &type, ceph::buffer::list& bl) {
   using ceph::encode;
   encode(static_cast<uint8_t>(type), bl);
 }
 
-inline void decode(MigrationHeaderType &type, bufferlist::const_iterator& it) {
+inline void decode(MigrationHeaderType &type, ceph::buffer::list::const_iterator& it) {
   uint8_t int_type;
   using ceph::decode;
   decode(int_type, it);
@@ -925,12 +925,12 @@ enum MigrationState {
   MIGRATION_STATE_EXECUTED = 4,
 };
 
-inline void encode(const MigrationState &state, bufferlist& bl) {
+inline void encode(const MigrationState &state, ceph::buffer::list& bl) {
   using ceph::encode;
   encode(static_cast<uint8_t>(state), bl);
 }
 
-inline void decode(MigrationState &state, bufferlist::const_iterator& it) {
+inline void decode(MigrationState &state, ceph::buffer::list::const_iterator& it) {
   uint8_t int_state;
   using ceph::decode;
   decode(int_state, it);
@@ -970,9 +970,9 @@ struct MigrationSpec {
       state_description(state_description) {
   }
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator& it);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator& it);
+  void dump(ceph::Formatter *f) const;
 
   static void generate_test_instances(std::list<MigrationSpec*> &o);
 
@@ -995,12 +995,12 @@ enum AssertSnapcSeqState {
   ASSERT_SNAPC_SEQ_LE_SNAPSET_SEQ = 1,
 };
 
-inline void encode(const AssertSnapcSeqState &state, bufferlist& bl) {
+inline void encode(const AssertSnapcSeqState &state, ceph::buffer::list& bl) {
   using ceph::encode;
   encode(static_cast<uint8_t>(state), bl);
 }
 
-inline void decode(AssertSnapcSeqState &state, bufferlist::const_iterator& it) {
+inline void decode(AssertSnapcSeqState &state, ceph::buffer::list::const_iterator& it) {
   uint8_t int_state;
   using ceph::decode;
   decode(int_state, it);

--- a/src/cls/refcount/cls_refcount.cc
+++ b/src/cls/refcount/cls_refcount.cc
@@ -1,4 +1,4 @@
-// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
 #include <errno.h>
@@ -8,9 +8,12 @@
 
 #include "include/compat.h"
 
+using std::string;
+
+using ceph::bufferlist;
+
 CLS_VER(1,0)
 CLS_NAME(refcount)
-
 
 #define REFCOUNT_ATTR "refcount"
 
@@ -33,7 +36,7 @@ static int read_refcount(cls_method_context_t hctx, bool implicit_ref, obj_refco
   try {
     auto iter = bl.cbegin();
     decode(*objr, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: read_refcount(): failed to decode refcount entry\n");
     return -EIO;
   }
@@ -61,7 +64,7 @@ static int cls_rc_refcount_get(cls_method_context_t hctx, bufferlist *in, buffer
   cls_refcount_get_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_rc_refcount_get(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -89,7 +92,7 @@ static int cls_rc_refcount_put(cls_method_context_t hctx, bufferlist *in, buffer
   cls_refcount_put_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_rc_refcount_put(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -107,7 +110,7 @@ static int cls_rc_refcount_put(cls_method_context_t hctx, bufferlist *in, buffer
   CLS_LOG(10, "cls_rc_refcount_put() tag=%s\n", op.tag.c_str());
 
   bool found = false;
-  map<string, bool>::iterator iter = objr.refs.find(op.tag);
+  auto iter = objr.refs.find(op.tag);
   if (iter != objr.refs.end()) {
     found = true;
   } else if (op.implicit_ref) {
@@ -142,7 +145,7 @@ static int cls_rc_refcount_set(cls_method_context_t hctx, bufferlist *in, buffer
   cls_refcount_set_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_refcount_set(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -152,8 +155,7 @@ static int cls_rc_refcount_set(cls_method_context_t hctx, bufferlist *in, buffer
   }
 
   obj_refcount objr;
-  list<string>::iterator iter;
-  for (iter = op.refs.begin(); iter != op.refs.end(); ++iter) {
+  for (auto iter = op.refs.begin(); iter != op.refs.end(); ++iter) {
     objr.refs[*iter] = true;
   }
 
@@ -171,7 +173,7 @@ static int cls_rc_refcount_read(cls_method_context_t hctx, bufferlist *in, buffe
   cls_refcount_read_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_rc_refcount_read(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -183,8 +185,7 @@ static int cls_rc_refcount_read(cls_method_context_t hctx, bufferlist *in, buffe
   if (ret < 0)
     return ret;
 
-  map<string, bool>::iterator iter;
-  for (iter = objr.refs.begin(); iter != objr.refs.end(); ++iter) {
+  for (auto iter = objr.refs.begin(); iter != objr.refs.end(); ++iter) {
     read_ret.refs.push_back(iter->first);
   }
 

--- a/src/cls/refcount/cls_refcount_client.cc
+++ b/src/cls/refcount/cls_refcount_client.cc
@@ -1,11 +1,16 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include <errno.h>
 
 #include "cls/refcount/cls_refcount_client.h"
 #include "cls/refcount/cls_refcount_ops.h"
 #include "include/rados/librados.hpp"
 
-using namespace librados;
+using std::list;
+using std::string;
 
+using ceph::bufferlist;
 
 void cls_refcount_get(librados::ObjectWriteOperation& op, const string& tag, bool implicit_ref)
 {
@@ -50,7 +55,7 @@ int cls_refcount_read(librados::IoCtx& io_ctx, string& oid, list<string> *refs, 
   try {
     auto iter = out.cbegin();
     decode(ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
 
@@ -58,4 +63,3 @@ int cls_refcount_read(librados::IoCtx& io_ctx, string& oid, list<string> *refs, 
 
   return r;
 }
-

--- a/src/cls/refcount/cls_refcount_client.h
+++ b/src/cls/refcount/cls_refcount_client.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_CLS_REFCOUNT_CLIENT_H
 #define CEPH_CLS_REFCOUNT_CLIENT_H
 
@@ -26,13 +29,13 @@
  * as the relevant tag, and the refcount will be decreased.
  */
 
-void cls_refcount_get(librados::ObjectWriteOperation& op, const string& tag, bool implicit_ref = false);
-void cls_refcount_put(librados::ObjectWriteOperation& op, const string& tag, bool implicit_ref = false);
-void cls_refcount_set(librados::ObjectWriteOperation& op, list<string>& refs);
+void cls_refcount_get(librados::ObjectWriteOperation& op, const std::string& tag, bool implicit_ref = false);
+void cls_refcount_put(librados::ObjectWriteOperation& op, const std::string& tag, bool implicit_ref = false);
+void cls_refcount_set(librados::ObjectWriteOperation& op, std::list<std::string>& refs);
 // these overloads which call io_ctx.operate() or io_ctx.exec() should not be called in the rgw.
 // rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()/exec()
 #ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_refcount_read(librados::IoCtx& io_ctx, string& oid, list<string> *refs, bool implicit_ref = false);
+int cls_refcount_read(librados::IoCtx& io_ctx, std::string& oid, std::list<std::string> *refs, bool implicit_ref = false);
 #endif
 
 #endif

--- a/src/cls/refcount/cls_refcount_ops.cc
+++ b/src/cls/refcount/cls_refcount_ops.cc
@@ -5,6 +5,8 @@
 #include "common/Formatter.h"
 #include "common/ceph_json.h"
 
+using std::list;
+
 void cls_refcount_get_op::dump(ceph::Formatter *f) const
 {
   f->dump_string("tag", tag);
@@ -66,7 +68,7 @@ void cls_refcount_read_op::generate_test_instances(list<cls_refcount_read_op*>& 
 void cls_refcount_read_ret::dump(ceph::Formatter *f) const
 {
   f->open_array_section("refs");
-  for (list<string>::const_iterator p = refs.begin(); p != refs.end(); ++p)
+  for (auto p = refs.begin(); p != refs.end(); ++p)
     f->dump_string("ref", *p);
   f->close_section();
 }

--- a/src/cls/refcount/cls_refcount_ops.h
+++ b/src/cls/refcount/cls_refcount_ops.h
@@ -8,44 +8,44 @@
 #include "common/hobject.h"
 
 struct cls_refcount_get_op {
-  string tag;
+  std::string tag;
   bool implicit_ref;
 
   cls_refcount_get_op() : implicit_ref(false) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(tag, bl);
     encode(implicit_ref, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(tag, bl);
     decode(implicit_ref, bl);
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(list<cls_refcount_get_op*>& ls);
+  static void generate_test_instances(std::list<cls_refcount_get_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_refcount_get_op)
 
 struct cls_refcount_put_op {
-  string tag;
+  std::string tag;
   bool implicit_ref; // assume wildcard reference for
-                          // objects without a set ref
+                          // objects without a std::set ref
 
   cls_refcount_put_op() : implicit_ref(false) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(tag, bl);
     encode(implicit_ref, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(tag, bl);
     decode(implicit_ref, bl);
@@ -53,91 +53,91 @@ struct cls_refcount_put_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(list<cls_refcount_put_op*>& ls);
+  static void generate_test_instances(std::list<cls_refcount_put_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_refcount_put_op)
 
 struct cls_refcount_set_op {
-  list<string> refs;
+  std::list<std::string> refs;
 
   cls_refcount_set_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(refs, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(refs, bl);
     DECODE_FINISH(bl);
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(list<cls_refcount_set_op*>& ls);
+  static void generate_test_instances(std::list<cls_refcount_set_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_refcount_set_op)
 
 struct cls_refcount_read_op {
   bool implicit_ref; // assume wildcard reference for
-                          // objects without a set ref
+                          // objects without a std::set ref
 
   cls_refcount_read_op() : implicit_ref(false) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(implicit_ref, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(implicit_ref, bl);
     DECODE_FINISH(bl);
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(list<cls_refcount_read_op*>& ls);
+  static void generate_test_instances(std::list<cls_refcount_read_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_refcount_read_op)
 
 struct cls_refcount_read_ret {
-  list<string> refs;
+  std::list<std::string> refs;
 
   cls_refcount_read_ret() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(refs, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(refs, bl);
     DECODE_FINISH(bl);
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(list<cls_refcount_read_ret*>& ls);
+  static void generate_test_instances(std::list<cls_refcount_read_ret*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_refcount_read_ret)
 
 struct obj_refcount {
-  map<string, bool> refs;
-  set<string> retired_refs;
+  std::map<std::string, bool> refs;
+  std::set<std::string> retired_refs;
 
   obj_refcount() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
     encode(refs, bl);
     encode(retired_refs, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
     decode(refs, bl);
     if (struct_v >= 2) {
@@ -147,7 +147,7 @@ struct obj_refcount {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(list<obj_refcount*>& ls);
+  static void generate_test_instances(std::list<obj_refcount*>& ls);
 };
 WRITE_CLASS_ENCODER(obj_refcount)
 

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -17,6 +17,20 @@
 #include "include/compat.h"
 #include <boost/lexical_cast.hpp>
 
+using std::pair;
+using std::list;
+using std::map;
+using std::string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::make_timespan;
+using ceph::real_clock;
+using ceph::real_time;
+using ceph::timespan;
+
 CLS_VER(1,0)
 CLS_NAME(rgw)
 
@@ -389,7 +403,7 @@ static int decode_list_index_key(const string& index_key, cls_rgw_obj_key *key, 
     return -EIO;
   }
 
-  list<string>::iterator iter = vals.begin();
+  auto iter = vals.begin();
   key->name = *iter;
   ++iter;
 
@@ -431,7 +445,7 @@ static int read_bucket_header(cls_method_context_t hctx,
   auto iter = bl.cbegin();
   try {
     decode(*header, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: read_bucket_header(): failed to decode header\n");
     return -EIO;
   }
@@ -451,7 +465,7 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   rgw_cls_list_op op;
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: %s: failed to decode request\n", __func__);
     return -EINVAL;
   }
@@ -519,7 +533,7 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 	const bufferlist& entrybl = kiter->second;
 	auto eiter = entrybl.cbegin();
         decode(entry, eiter);
-      } catch (buffer::error& err) {
+      } catch (ceph::buffer::error& err) {
         CLS_LOG(1, "ERROR: %s: failed to decode entry, key=%s\n",
 		__func__, kiter->first.c_str());
         return -EINVAL;
@@ -637,8 +651,7 @@ static int check_index(cls_method_context_t hctx,
     if (rc < 0)
       return rc;
 
-    std::map<string, bufferlist>::iterator kiter = keys.begin();
-    for (; kiter != keys.end(); ++kiter) {
+    for (auto kiter = keys.begin(); kiter != keys.end(); ++kiter) {
       if (!bi_is_objs_index(kiter->first)) {
         done = true;
         break;
@@ -648,7 +661,7 @@ static int check_index(cls_method_context_t hctx,
       auto eiter = kiter->second.cbegin();
       try {
         decode(entry, eiter);
-      } catch (buffer::error& err) {
+      } catch (ceph::buffer::error& err) {
         CLS_LOG(1, "ERROR: rgw_bucket_list(): failed to decode entry, key=%s\n", kiter->first.c_str());
         return -EIO;
       }
@@ -706,7 +719,7 @@ int rgw_bucket_update_stats(cls_method_context_t hctx, bufferlist *in, bufferlis
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: %s(): failed to decode request\n", __func__);
     return -EINVAL;
   }
@@ -764,7 +777,7 @@ int rgw_bucket_set_tag_timeout(cls_method_context_t hctx, bufferlist *in, buffer
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_bucket_set_tag_timeout(): failed to decode request\n");
     return -EINVAL;
   }
@@ -792,7 +805,7 @@ int rgw_bucket_prepare_op(cls_method_context_t hctx, bufferlist *in, bufferlist 
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_bucket_prepare_op(): failed to decode request\n");
     return -EINVAL;
   }
@@ -874,7 +887,7 @@ static int read_omap_entry(cls_method_context_t hctx, const std::string& name,
   auto cur_iter = current_entry.cbegin();
   try {
     decode(*entry, cur_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: %s(): failed to decode entry\n", __func__);
     return -EIO;
   }
@@ -934,7 +947,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_bucket_complete_op(): failed to decode request\n");
     return -EINVAL;
   }
@@ -973,7 +986,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
 		 rgw_bucket_dir_entry::FLAG_VER);
 
   if (op.tag.size()) {
-    map<string, rgw_bucket_pending_info>::iterator pinter = entry.pending_map.find(op.tag);
+    auto pinter = entry.pending_map.find(op.tag);
     if (pinter == entry.pending_map.end()) {
       CLS_LOG(1, "ERROR: couldn't find tag for pending operation\n");
       return -EINVAL;
@@ -1056,9 +1069,8 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
       return rc;
   }
 
-  list<cls_rgw_obj_key>::iterator remove_iter;
   CLS_LOG(20, "rgw_bucket_complete_op(): remove_objs.size()=%d\n", (int)op.remove_objs.size());
-  for (remove_iter = op.remove_objs.begin(); remove_iter != op.remove_objs.end(); ++remove_iter) {
+  for (auto remove_iter = op.remove_objs.begin(); remove_iter != op.remove_objs.end(); ++remove_iter) {
     cls_rgw_obj_key& remove_key = *remove_iter;
     CLS_LOG(1, "rgw_bucket_complete_op(): removing entries, read_index_entry name=%s instance=%s\n",
             remove_key.name.c_str(), remove_key.instance.c_str());
@@ -1309,11 +1321,11 @@ public:
 
     rgw_bucket_dir_entry next_entry;
 
-    map<string, bufferlist>::reverse_iterator last = keys.rbegin();
+    auto last = keys.rbegin();
     try {
       auto iter = last->second.cbegin();
       decode(next_entry, iter);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       CLS_LOG(0, "ERROR; failed to decode entry: %s", last->first.c_str());
       return -EIO;
     }
@@ -1513,7 +1525,7 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: rgw_bucket_link_olh_op(): failed to decode request\n");
     return -EINVAL;
   }
@@ -1710,7 +1722,7 @@ static int rgw_bucket_unlink_instance(cls_method_context_t hctx, bufferlist *in,
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: rgw_bucket_rm_obj_instance_op(): failed to decode request\n");
     return -EINVAL;
   }
@@ -1857,7 +1869,7 @@ static int rgw_bucket_read_olh_log(cls_method_context_t hctx, bufferlist *in, bu
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: rgw_bucket_read_olh_log(): failed to decode request\n");
     return -EINVAL;
   }
@@ -1890,7 +1902,7 @@ static int rgw_bucket_read_olh_log(cls_method_context_t hctx, bufferlist *in, bu
     op_ret.log = log;
     op_ret.is_truncated = false;
   } else {
-    map<uint64_t, vector<rgw_bucket_olh_log_entry> >::iterator iter = log.upper_bound(op.ver_marker);
+    auto iter = log.upper_bound(op.ver_marker);
 
     for (int i = 0; i < MAX_OLH_LOG_ENTRIES && iter != log.end(); ++i, ++iter) {
       op_ret.log[iter->first] = iter->second;
@@ -1910,7 +1922,7 @@ static int rgw_bucket_trim_olh_log(cls_method_context_t hctx, bufferlist *in, bu
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: rgw_bucket_trim_olh_log(): failed to decode request\n");
     return -EINVAL;
   }
@@ -1936,10 +1948,10 @@ static int rgw_bucket_trim_olh_log(cls_method_context_t hctx, bufferlist *in, bu
   }
 
   /* remove all versions up to and including ver from the pending map */
-  map<uint64_t, vector<rgw_bucket_olh_log_entry> >& log = olh_data_entry.pending_log;
-  map<uint64_t, vector<rgw_bucket_olh_log_entry> >::iterator liter = log.begin();
+  auto& log = olh_data_entry.pending_log;
+  auto liter = log.begin();
   while (liter != log.end() && liter->first <= op.ver) {
-    map<uint64_t, vector<rgw_bucket_olh_log_entry> >::iterator rm_iter = liter;
+    auto rm_iter = liter;
     ++liter;
     log.erase(rm_iter);
   }
@@ -1961,7 +1973,7 @@ static int rgw_bucket_clear_olh(cls_method_context_t hctx, bufferlist *in, buffe
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: rgw_bucket_clear_olh(): failed to decode request\n");
     return -EINVAL;
   }
@@ -2047,7 +2059,7 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
     try {
       decode(op, in_iter);
       decode(cur_change, in_iter);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       CLS_LOG(1, "ERROR: rgw_dir_suggest_changes(): failed to decode request\n");
       return -EINVAL;
     }
@@ -2067,16 +2079,15 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
       auto cur_disk_iter = cur_disk_bl.cbegin();
       try {
         decode(cur_disk, cur_disk_iter);
-      } catch (buffer::error& error) {
+      } catch (ceph::buffer::error& error) {
         CLS_LOG(1, "ERROR: rgw_dir_suggest_changes(): failed to decode cur_disk\n");
         return -EINVAL;
       }
 
       real_time cur_time = real_clock::now();
-      map<string, rgw_bucket_pending_info>::iterator iter =
-                cur_disk.pending_map.begin();
+      auto iter = cur_disk.pending_map.begin();
       while(iter != cur_disk.pending_map.end()) {
-        map<string, rgw_bucket_pending_info>::iterator cur_iter=iter++;
+        auto cur_iter = iter++;
         if (cur_time > (cur_iter->second.timestamp + timespan(tag_timeout))) {
           cur_disk.pending_map.erase(cur_iter);
         }
@@ -2156,7 +2167,7 @@ static int rgw_obj_remove(cls_method_context_t hctx, bufferlist *in, bufferlist 
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: %s(): failed to decode request", __func__);
     return -EINVAL;
   }
@@ -2173,11 +2184,11 @@ static int rgw_obj_remove(cls_method_context_t hctx, bufferlist *in, bufferlist 
   }
 
   map<string, bufferlist> new_attrs;
-  for (list<string>::iterator iter = op.keep_attr_prefixes.begin();
+  for (auto iter = op.keep_attr_prefixes.begin();
        iter != op.keep_attr_prefixes.end(); ++iter) {
-    string& check_prefix = *iter;
+    auto& check_prefix = *iter;
 
-    for (map<string, bufferlist>::iterator aiter = attrset.lower_bound(check_prefix);
+    for (auto aiter = attrset.lower_bound(check_prefix);
          aiter != attrset.end(); ++aiter) {
       const string& attr = aiter->first;
 
@@ -2207,9 +2218,9 @@ static int rgw_obj_remove(cls_method_context_t hctx, bufferlist *in, bufferlist 
     return ret;
   }
 
-  for (map<string, bufferlist>::iterator aiter = new_attrs.begin();
+  for (auto aiter = new_attrs.begin();
        aiter != new_attrs.end(); ++aiter) {
-    const string& attr = aiter->first;
+    const auto& attr = aiter->first;
 
     ret = cls_cxx_setxattr(hctx, attr.c_str(), &aiter->second);
     CLS_LOG(20, "%s(): setting attr: %s", __func__, attr.c_str());
@@ -2229,7 +2240,7 @@ static int rgw_obj_store_pg_ver(cls_method_context_t hctx, bufferlist *in, buffe
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: %s(): failed to decode request", __func__);
     return -EINVAL;
   }
@@ -2253,7 +2264,7 @@ static int rgw_obj_check_attrs_prefix(cls_method_context_t hctx, bufferlist *in,
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: %s(): failed to decode request", __func__);
     return -EINVAL;
   }
@@ -2271,9 +2282,9 @@ static int rgw_obj_check_attrs_prefix(cls_method_context_t hctx, bufferlist *in,
 
   bool exist = false;
 
-  for (map<string, bufferlist>::iterator aiter = attrset.lower_bound(op.check_prefix);
+  for (auto aiter = attrset.lower_bound(op.check_prefix);
        aiter != attrset.end(); ++aiter) {
-    const string& attr = aiter->first;
+    const auto& attr = aiter->first;
 
     if (attr.substr(0, op.check_prefix.size()) > op.check_prefix) {
       break;
@@ -2296,7 +2307,7 @@ static int rgw_obj_check_mtime(cls_method_context_t hctx, bufferlist *in, buffer
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: %s(): failed to decode request", __func__);
     return -EINVAL;
   }
@@ -2359,7 +2370,7 @@ static int rgw_bi_get_op(cls_method_context_t hctx, bufferlist *in, bufferlist *
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: %s(): failed to decode request", __func__);
     return -EINVAL;
   }
@@ -2407,7 +2418,7 @@ static int rgw_bi_put_op(cls_method_context_t hctx, bufferlist *in, bufferlist *
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: %s(): failed to decode request", __func__);
     return -EINVAL;
   }
@@ -2443,8 +2454,7 @@ static int list_plain_entries(cls_method_context_t hctx,
     return ret;
   }
 
-  map<string, bufferlist>::iterator iter;
-  for (iter = keys.begin(); iter != keys.end(); ++iter) {
+  for (auto iter = keys.begin(); iter != keys.end(); ++iter) {
     if (iter->first >= end_key) {
       /* past the end of plain namespace */
       if (pmore) {
@@ -2463,7 +2473,7 @@ static int list_plain_entries(cls_method_context_t hctx,
     rgw_bucket_dir_entry e;
     try {
       decode(e, biter);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       CLS_LOG(0, "ERROR: %s(): failed to decode buffer", __func__);
       return -EIO;
     }
@@ -2536,8 +2546,7 @@ static int list_instance_entries(cls_method_context_t hctx,
     keys[start_after_key].claim(k);
   }
 
-  map<string, bufferlist>::iterator iter;
-  for (iter = keys.begin(); iter != keys.end(); ++iter) {
+  for (auto iter = keys.begin(); iter != keys.end(); ++iter) {
     rgw_cls_bi_entry entry;
     entry.type = BIIndexType::Instance;
     entry.idx = iter->first;
@@ -2558,7 +2567,7 @@ static int list_instance_entries(cls_method_context_t hctx,
     rgw_bucket_dir_entry e;
     try {
       decode(e, biter);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       CLS_LOG(0, "ERROR: %s(): failed to decode buffer (size=%d)", __func__, entry.data.length());
       return -EIO;
     }
@@ -2628,8 +2637,7 @@ static int list_olh_entries(cls_method_context_t hctx,
     keys[start_after_key].claim(k);
   }
 
-  map<string, bufferlist>::iterator iter;
-  for (iter = keys.begin(); iter != keys.end(); ++iter) {
+  for (auto iter = keys.begin(); iter != keys.end(); ++iter) {
     rgw_cls_bi_entry entry;
     entry.type = BIIndexType::OLH;
     entry.idx = iter->first;
@@ -2650,7 +2658,7 @@ static int list_olh_entries(cls_method_context_t hctx,
     rgw_bucket_olh_entry e;
     try {
       decode(e, biter);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       CLS_LOG(0, "ERROR: %s(): failed to decode buffer (size=%d)", __func__, entry.data.length());
       return -EIO;
     }
@@ -2680,7 +2688,7 @@ static int rgw_bi_list_op(cls_method_context_t hctx,
   auto iter = in->cbegin();
   try {
     decode(op, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: %s(): failed to decode request", __func__);
     return -EINVAL;
   }
@@ -2737,7 +2745,7 @@ int bi_log_record_decode(bufferlist& bl, rgw_bi_log_entry& e)
   auto iter = bl.cbegin();
   try {
     decode(e, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: failed to decode rgw_bi_log_entry");
     return -EIO;
   }
@@ -2793,7 +2801,7 @@ static int bi_log_iterate_entries(cls_method_context_t hctx,
   if (ret < 0)
     return ret;
 
-  map<string, bufferlist>::iterator iter = keys.begin();
+  auto iter = keys.begin();
   if (iter == keys.end())
     return 0;
 
@@ -2854,7 +2862,7 @@ static int rgw_bi_log_list(cls_method_context_t hctx, bufferlist *in, bufferlist
   cls_rgw_bi_log_list_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_bi_log_list(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -2876,7 +2884,7 @@ static int rgw_bi_log_trim(cls_method_context_t hctx, bufferlist *in, bufferlist
   cls_rgw_bi_log_trim_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_bi_log_list(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -3031,7 +3039,7 @@ static int usage_record_decode(bufferlist& record_bl, rgw_usage_log_entry& e)
   auto kiter = record_bl.cbegin();
   try {
     decode(e, kiter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: usage_record_decode(): failed to decode record_bl\n");
     return -EINVAL;
   }
@@ -3048,15 +3056,14 @@ int rgw_user_usage_log_add(cls_method_context_t hctx, bufferlist *in, bufferlist
 
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_user_usage_log_add(): failed to decode request\n");
     return -EINVAL;
   }
 
   rgw_usage_log_info& info = op.info;
-  vector<rgw_usage_log_entry>::iterator iter;
 
-  for (iter = info.entries.begin(); iter != info.entries.end(); ++iter) {
+  for (auto iter = info.entries.begin(); iter != info.entries.end(); ++iter) {
     rgw_usage_log_entry& entry = *iter;
     string key_by_time;
 
@@ -3136,8 +3143,8 @@ static int usage_iterate_range(cls_method_context_t hctx, uint64_t start, uint64
     return ret;
 
   *truncated = truncated_status;
-      
-  map<string, bufferlist>::iterator iter = keys.begin();
+
+  auto iter = keys.begin();
   if (iter == keys.end())
     return 0;
 
@@ -3208,7 +3215,7 @@ int rgw_user_usage_log_read(cls_method_context_t hctx, bufferlist *in, bufferlis
 
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_user_usage_log_read(): failed to decode request\n");
     return -EINVAL;
   }
@@ -3263,7 +3270,7 @@ int rgw_user_usage_log_trim(cls_method_context_t hctx, bufferlist *in, bufferlis
 
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_user_log_usage_log_trim(): failed to decode request\n");
     return -EINVAL;
   }
@@ -3434,7 +3441,7 @@ int gc_record_decode(bufferlist& bl, cls_rgw_gc_obj_info& e)
   auto iter = bl.cbegin();
   try {
     decode(e, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: failed to decode cls_rgw_gc_obj_info");
     return -EIO;
   }
@@ -3448,7 +3455,7 @@ static int rgw_cls_gc_set_entry(cls_method_context_t hctx, bufferlist *in, buffe
   cls_rgw_gc_set_entry_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_cls_gc_set_entry(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -3463,7 +3470,7 @@ static int rgw_cls_gc_defer_entry(cls_method_context_t hctx, bufferlist *in, buf
   cls_rgw_gc_defer_entry_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_cls_gc_defer_entry(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -3515,7 +3522,7 @@ static int gc_iterate_entries(cls_method_context_t hctx,
   if (ret < 0)
     return ret;
 
-  map<string, bufferlist>::iterator iter = keys.begin();
+  auto iter = keys.begin();
   if (iter == keys.end()) {
     // if keys empty must not come back as truncated
     ceph_assert(!truncated || !(*truncated));
@@ -3585,7 +3592,7 @@ static int rgw_cls_gc_list(cls_method_context_t hctx, bufferlist *in, bufferlist
   cls_rgw_gc_list_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_cls_gc_list(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -3640,7 +3647,7 @@ static int rgw_cls_gc_remove(cls_method_context_t hctx, bufferlist *in, bufferli
   cls_rgw_gc_remove_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_cls_gc_remove(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -3655,7 +3662,7 @@ static int rgw_cls_lc_get_entry(cls_method_context_t hctx, bufferlist *in, buffe
   cls_rgw_lc_get_entry_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_cls_lc_set_entry(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -3678,7 +3685,7 @@ static int rgw_cls_lc_set_entry(cls_method_context_t hctx, bufferlist *in, buffe
   cls_rgw_lc_set_entry_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_cls_lc_set_entry(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -3697,7 +3704,7 @@ static int rgw_cls_lc_rm_entry(cls_method_context_t hctx, bufferlist *in, buffer
   cls_rgw_lc_rm_entry_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_cls_lc_rm_entry(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -3713,7 +3720,7 @@ static int rgw_cls_lc_get_next_entry(cls_method_context_t hctx, bufferlist *in, 
   cls_rgw_lc_get_next_entry_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_cls_lc_get_next_entry: failed to decode op\n");
     return -EINVAL;
   }
@@ -3724,14 +3731,13 @@ static int rgw_cls_lc_get_next_entry(cls_method_context_t hctx, bufferlist *in, 
   int ret = cls_cxx_map_get_vals(hctx, op.marker, filter_prefix, 1, &vals, &more);
   if (ret < 0)
     return ret;
-  map<string, bufferlist>::iterator it;
   pair<string, int> entry;
   if (!vals.empty()) {
-    it=vals.begin();
+    auto it = vals.begin();
     in_iter = it->second.begin();
     try {
       decode(entry, in_iter);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       CLS_LOG(1, "ERROR: rgw_cls_lc_get_next_entry(): failed to decode entry\n");
       return -EIO;
     }
@@ -3747,25 +3753,23 @@ static int rgw_cls_lc_list_entries(cls_method_context_t hctx, bufferlist *in, bu
   auto in_iter = in->cbegin();
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_cls_lc_list_entries(): failed to decode op\n");
     return -EINVAL;
   }
 
   cls_rgw_lc_list_entries_ret op_ret;
-  bufferlist::const_iterator iter;
   map<string, bufferlist> vals;
   string filter_prefix;
   int ret = cls_cxx_map_get_vals(hctx, op.marker, filter_prefix, op.max_entries, &vals, &op_ret.is_truncated);
   if (ret < 0)
     return ret;
-  map<string, bufferlist>::iterator it;
   pair<string, int> entry;
-  for (it = vals.begin(); it != vals.end(); ++it) {
-    iter = it->second.cbegin();
+  for (auto it = vals.begin(); it != vals.end(); ++it) {
+    auto iter = it->second.cbegin();
     try {
-    decode(entry, iter);
-    } catch (buffer::error& err) {
+      decode(entry, iter);
+    } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_cls_lc_list_entries(): failed to decode entry\n");
     return -EIO;
    }
@@ -3782,7 +3786,7 @@ static int rgw_cls_lc_put_head(cls_method_context_t hctx, bufferlist *in, buffer
   cls_rgw_lc_put_head_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_cls_lc_put_head(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -3804,7 +3808,7 @@ static int rgw_cls_lc_get_head(cls_method_context_t hctx, bufferlist *in,  buffe
     auto iter = bl.cbegin();
     try {
       decode(head, iter);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       CLS_LOG(0, "ERROR: rgw_cls_lc_get_head(): failed to decode entry %s\n",err.what());
       return -EINVAL;
     }
@@ -3825,7 +3829,7 @@ static int rgw_reshard_add(cls_method_context_t hctx, bufferlist *in, bufferlist
   cls_rgw_reshard_add_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_reshard_add: failed to decode entry\n");
     return -EINVAL;
   }
@@ -3851,12 +3855,11 @@ static int rgw_reshard_list(cls_method_context_t hctx, bufferlist *in, bufferlis
   auto in_iter = in->cbegin();
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_cls_rehard_list(): failed to decode entry\n");
     return -EINVAL;
   }
   cls_rgw_reshard_list_ret op_ret;
-  bufferlist::const_iterator iter;
   map<string, bufferlist> vals;
   string filter_prefix;
 #define MAX_RESHARD_LIST_ENTRIES 1000
@@ -3865,14 +3868,13 @@ static int rgw_reshard_list(cls_method_context_t hctx, bufferlist *in, bufferlis
   int ret = cls_cxx_map_get_vals(hctx, op.marker, filter_prefix, max, &vals, &op_ret.is_truncated);
   if (ret < 0)
     return ret;
-  map<string, bufferlist>::iterator it;
   cls_rgw_reshard_entry entry;
   int i = 0;
-  for (it = vals.begin(); i < (int)op.max && it != vals.end(); ++it, ++i) {
-    iter = it->second.cbegin();
+  for (auto it = vals.begin(); i < (int)op.max && it != vals.end(); ++it, ++i) {
+    auto iter = it->second.cbegin();
     try {
       decode(entry, iter);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       CLS_LOG(1, "ERROR: rgw_cls_rehard_list(): failed to decode entry\n");
       return -EIO;
    }
@@ -3889,7 +3891,7 @@ static int rgw_reshard_get(cls_method_context_t hctx, bufferlist *in,  bufferlis
   cls_rgw_reshard_get_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_reshard_get: failed to decode entry\n");
     return -EINVAL;
   }
@@ -3915,7 +3917,7 @@ static int rgw_reshard_remove(cls_method_context_t hctx, bufferlist *in, bufferl
   cls_rgw_reshard_remove_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_cls_rehard_remove: failed to decode entry\n");
     return -EINVAL;
   }
@@ -3948,7 +3950,7 @@ static int rgw_set_bucket_resharding(cls_method_context_t hctx, bufferlist *in, 
   auto in_iter = in->cbegin();
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_rgw_set_bucket_resharding: failed to decode entry\n");
     return -EINVAL;
   }
@@ -3972,7 +3974,7 @@ static int rgw_clear_bucket_resharding(cls_method_context_t hctx, bufferlist *in
   auto in_iter = in->cbegin();
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_rgw_clear_bucket_resharding: failed to decode entry\n");
     return -EINVAL;
   }
@@ -3995,7 +3997,7 @@ static int rgw_guard_bucket_resharding(cls_method_context_t hctx, bufferlist *in
   auto in_iter = in->cbegin();
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: %s(): failed to decode entry\n", __func__);
     return -EINVAL;
   }
@@ -4022,7 +4024,7 @@ static int rgw_get_bucket_resharding(cls_method_context_t hctx,
   auto in_iter = in->cbegin();
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: %s(): failed to decode entry\n", __func__);
     return -EINVAL;
   }

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -8,6 +8,14 @@
 
 #include "common/debug.h"
 
+using std::list;
+using std::map;
+using std::pair;
+using std::string;
+using std::vector;
+
+using ceph::real_time;
+
 using namespace librados;
 
 const string BucketIndexShardsManager::KEY_VALUE_SEPARATOR = "#";
@@ -29,7 +37,7 @@ public:
       try {
         auto iter = outbl.cbegin();
         decode((*data), iter);
-      } catch (buffer::error& err) {
+      } catch (ceph::buffer::error& err) {
         r = -EIO;
       }
     }
@@ -42,14 +50,14 @@ public:
 void BucketIndexAioManager::do_completion(int id) {
   std::lock_guard l{lock};
 
-  map<int, librados::AioCompletion*>::iterator iter = pendings.find(id);
+  auto iter = pendings.find(id);
   ceph_assert(iter != pendings.end());
   completions[id] = iter->second;
   pendings.erase(iter);
 
   // If the caller needs a list of finished objects, store them
   // for further processing
-  map<int, string>::iterator miter = pending_objs.find(id);
+  auto miter = pending_objs.find(id);
   if (miter != pending_objs.end()) {
     completion_objs[id] = miter->second;
     pending_objs.erase(miter);
@@ -71,11 +79,11 @@ bool BucketIndexAioManager::wait_for_completions(int valid_ret_code,
   }
 
   // Clear the completed AIOs
-  map<int, librados::AioCompletion*>::iterator iter = completions.begin();
+  auto iter = completions.begin();
   for (; iter != completions.end(); ++iter) {
     int r = iter->second->get_return_value();
     if (objs && r == 0) { /* update list of successfully completed objs */
-      map<int, string>::iterator liter = completion_objs.find(iter->first);
+      auto liter = completion_objs.find(iter->first);
       if (liter != completion_objs.end()) {
         (*objs)[liter->first] = liter->second;
       }
@@ -309,7 +317,7 @@ int cls_rgw_bi_get(librados::IoCtx& io_ctx, const string oid,
   auto iter = out.cbegin();
   try {
     decode(op_ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
 
@@ -358,7 +366,7 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const string oid,
   auto iter = out.cbegin();
   try {
     decode(op_ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
 
@@ -634,7 +642,7 @@ public:
     try {
       auto iter = outbl.cbegin();
       decode(ret, iter);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       r = -EIO;
     }
 
@@ -690,7 +698,7 @@ int cls_rgw_usage_log_read(IoCtx& io_ctx, const string& oid, const string& user,
       *is_truncated = result.truncated;
 
     usage = result.usage;
-  } catch (buffer::error& e) {
+  } catch (ceph::buffer::error& e) {
     return -EINVAL;
   }
 
@@ -789,7 +797,7 @@ int cls_rgw_gc_list(IoCtx& io_ctx, string& oid, string& marker, uint32_t max, bo
   try {
     auto iter = out.cbegin();
     decode(ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
 
@@ -821,7 +829,7 @@ int cls_rgw_lc_get_head(IoCtx& io_ctx, const string& oid, cls_rgw_lc_obj_head& h
   try {
     auto iter = out.cbegin();
     decode(ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
   head = ret.head;
@@ -853,7 +861,7 @@ int cls_rgw_lc_get_next_entry(IoCtx& io_ctx, const string& oid, string& marker, 
   try {
     auto iter = out.cbegin();
     decode(ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
   entry = ret.entry;
@@ -896,7 +904,7 @@ int cls_rgw_lc_get_entry(IoCtx& io_ctx, const string& oid, const std::string& ma
   try {
     auto iter = out.cbegin();
     decode(ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
 
@@ -927,7 +935,7 @@ int cls_rgw_lc_list(IoCtx& io_ctx, const string& oid,
   try {
     auto iter = out.cbegin();
     decode(ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
   entries.insert(ret.entries.begin(),ret.entries.end());
@@ -960,7 +968,7 @@ int cls_rgw_reshard_list(librados::IoCtx& io_ctx, const string& oid, string& mar
   auto iter = out.cbegin();
   try {
     decode(op_ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
 
@@ -984,7 +992,7 @@ int cls_rgw_reshard_get(librados::IoCtx& io_ctx, const string& oid, cls_rgw_resh
   auto iter = out.cbegin();
   try {
     decode(op_ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
 
@@ -1036,7 +1044,7 @@ int cls_rgw_get_bucket_resharding(librados::IoCtx& io_ctx, const string& oid,
   auto iter = out.cbegin();
   try {
     decode(op_ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
 

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -1,4 +1,4 @@
-// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
 #ifndef CEPH_CLS_RGW_CLIENT_H
@@ -34,10 +34,10 @@ struct BucketIndexAioArg : public RefCountedObject {
  */
 class BucketIndexAioManager {
 private:
-  map<int, librados::AioCompletion*> pendings;
-  map<int, librados::AioCompletion*> completions;
-  map<int, string> pending_objs;
-  map<int, string> completion_objs;
+  std::map<int, librados::AioCompletion*> pendings;
+  std::map<int, librados::AioCompletion*> completions;
+  std::map<int, std::string> pending_objs;
+  std::map<int, std::string> completion_objs;
   int next = 0;
   ceph::mutex lock = ceph::make_mutex("BucketIndexAioManager::lock");
   ceph::condition_variable cond;
@@ -65,7 +65,7 @@ private:
    * @param oid        - the object id associated with the object, if it is NULL, we don't
    *                     track the object id per callback.
    */
-  void add_pending(int id, librados::AioCompletion* completion, const string& oid) {
+  void add_pending(int id, librados::AioCompletion* completion, const std::string& oid) {
     pendings[id] = completion;
     pending_objs[id] = oid;
   }
@@ -86,17 +86,17 @@ public:
    * valid_ret_code  - valid AIO return code.
    * num_completions - number of completions.
    * ret_code        - return code of failed AIO.
-   * objs            - a list of objects that has been finished the AIO.
+   * objs            - a std::list of objects that has been finished the AIO.
    *
    * Return false if there is no pending AIO, true otherwise.
    */
   bool wait_for_completions(int valid_ret_code, int *num_completions, int *ret_code,
-      map<int, string> *objs);
+      std::map<int, std::string> *objs);
 
   /**
    * Do aio read operation.
    */
-  bool aio_operate(librados::IoCtx& io_ctx, const string& oid, librados::ObjectReadOperation *op) {
+  bool aio_operate(librados::IoCtx& io_ctx, const std::string& oid, librados::ObjectReadOperation *op) {
     std::lock_guard l{lock};
     BucketIndexAioArg *arg = new BucketIndexAioArg(get_next(), this);
     librados::AioCompletion *c = librados::Rados::aio_create_completion((void*)arg, bucket_index_op_completion_cb);
@@ -113,7 +113,7 @@ public:
   /**
    * Do aio write operation.
    */
-  bool aio_operate(librados::IoCtx& io_ctx, const string& oid, librados::ObjectWriteOperation *op) {
+  bool aio_operate(librados::IoCtx& io_ctx, const std::string& oid, librados::ObjectWriteOperation *op) {
     std::lock_guard l{lock};
     BucketIndexAioArg *arg = new BucketIndexAioArg(get_next(), this);
     librados::AioCompletion *c = librados::Rados::aio_create_completion((void*)arg, bucket_index_op_completion_cb);
@@ -137,21 +137,21 @@ public:
 class BucketIndexShardsManager {
 private:
   // Per shard setting manager, for example, marker.
-  map<int, string> value_by_shards;
+  std::map<int, std::string> value_by_shards;
 public:
-  const static string KEY_VALUE_SEPARATOR;
-  const static string SHARDS_SEPARATOR;
+  const static std::string KEY_VALUE_SEPARATOR;
+  const static std::string SHARDS_SEPARATOR;
 
-  void add(int shard, const string& value) {
+  void add(int shard, const std::string& value) {
     value_by_shards[shard] = value;
   }
 
-  const string& get(int shard, const string& default_value) {
-    map<int, string>::iterator iter = value_by_shards.find(shard);
+  const std::string& get(int shard, const std::string& default_value) {
+    auto iter = value_by_shards.find(shard);
     return (iter == value_by_shards.end() ? default_value : iter->second);
   }
 
-  map<int, string>& get() {
+  std::map<int, std::string>& get() {
     return value_by_shards;
   }
 
@@ -159,13 +159,13 @@ public:
     return value_by_shards.empty();
   }
 
-  void to_string(string *out) const {
+  void to_string(std::string *out) const {
     if (!out) {
       return;
     }
     out->clear();
-    map<int, string>::const_iterator iter = value_by_shards.begin();
-    for (; iter != value_by_shards.end(); ++iter) {
+    for (auto iter = value_by_shards.begin();
+	 iter != value_by_shards.end(); ++iter) {
       if (out->length()) {
         // Not the first item, append a separator first
         out->append(SHARDS_SEPARATOR);
@@ -178,12 +178,12 @@ public:
     }
   }
 
-  static bool is_shards_marker(const string& marker) {
-    return marker.find(KEY_VALUE_SEPARATOR) != string::npos;
+  static bool is_shards_marker(const std::string& marker) {
+    return marker.find(KEY_VALUE_SEPARATOR) != std::string::npos;
   }
 
   /*
-   * convert from string. There are two options of how the string looks like:
+   * convert from std::string. There are two options of how the std::string looks like:
    *
    * 1. Single shard, no shard id specified, e.g. 000001.23.1
    *
@@ -193,17 +193,16 @@ public:
    * 2. One or more shards, shard id specified for each shard, e.g., 0#00002.12,1#00003.23.2
    *
    */
-  int from_string(const string& composed_marker, int shard_id) {
+  int from_string(const std::string& composed_marker, int shard_id) {
     value_by_shards.clear();
-    vector<string> shards;
+    std::vector<std::string> shards;
     get_str_vec(composed_marker, SHARDS_SEPARATOR.c_str(), shards);
     if (shards.size() > 1 && shard_id >= 0) {
       return -EINVAL;
     }
-    vector<string>::const_iterator iter = shards.begin();
-    for (; iter != shards.end(); ++iter) {
+    for (auto iter = shards.begin(); iter != shards.end(); ++iter) {
       size_t pos = iter->find(KEY_VALUE_SEPARATOR);
-      if (pos == string::npos) {
+      if (pos == std::string::npos) {
         if (!value_by_shards.empty()) {
           return -EINVAL;
         }
@@ -214,8 +213,8 @@ public:
         }
         return 0;
       }
-      string shard_str = iter->substr(0, pos);
-      string err;
+      std::string shard_str = iter->substr(0, pos);
+      std::string err;
       int shard = (int)strict_strtol(shard_str.c_str(), 10, &err);
       if (!err.empty()) {
         return -EINVAL;
@@ -241,12 +240,12 @@ void cls_rgw_bucket_init_index(librados::ObjectWriteOperation& o);
 class CLSRGWConcurrentIO {
 protected:
   librados::IoCtx& io_ctx;
-  map<int, string>& objs_container;
-  map<int, string>::iterator iter;
+  std::map<int, std::string>& objs_container;
+  std::map<int, std::string>::iterator iter;
   uint32_t max_aio;
   BucketIndexAioManager manager;
 
-  virtual int issue_op(int shard_id, const string& oid) = 0;
+  virtual int issue_op(int shard_id, const std::string& oid) = 0;
 
   virtual void cleanup() {}
   virtual int valid_ret_code() { return 0; }
@@ -254,13 +253,13 @@ protected:
   // OP needs to be re-send until a certain code is returned.
   virtual bool need_multiple_rounds() { return false; }
   // Add a new object to the end of the container.
-  virtual void add_object(int shard, const string& oid) {}
-  virtual void reset_container(map<int, string>& objs) {}
+  virtual void add_object(int shard, const std::string& oid) {}
+  virtual void reset_container(std::map<int, std::string>& objs) {}
 
 public:
 
   CLSRGWConcurrentIO(librados::IoCtx& ioc,
-		     map<int, string>& _objs_container,
+		     std::map<int, std::string>& _objs_container,
 		     uint32_t _max_aio) :
   io_ctx(ioc), objs_container(_objs_container), max_aio(_max_aio)
   {}
@@ -278,8 +277,8 @@ public:
     }
 
     int num_completions = 0, r = 0;
-    map<int, string> objs;
-    map<int, string> *pobjs = (need_multiple_rounds() ? &objs : NULL);
+    std::map<int, std::string> objs;
+    std::map<int, std::string> *pobjs = (need_multiple_rounds() ? &objs : NULL);
     while (manager.wait_for_completions(valid_ret_code(), &num_completions, &r, pobjs)) {
       if (r >= 0 && ret >= 0) {
         for (; num_completions && iter != objs_container.end(); --num_completions, ++iter) {
@@ -316,11 +315,11 @@ public:
 
 class CLSRGWIssueBucketIndexInit : public CLSRGWConcurrentIO {
 protected:
-  int issue_op(int shard_id, const string& oid) override;
+  int issue_op(int shard_id, const std::string& oid) override;
   int valid_ret_code() override { return -EEXIST; }
   void cleanup() override;
 public:
-  CLSRGWIssueBucketIndexInit(librados::IoCtx& ioc, map<int, string>& _bucket_objs,
+  CLSRGWIssueBucketIndexInit(librados::IoCtx& ioc, std::map<int, std::string>& _bucket_objs,
                      uint32_t _max_aio) :
     CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio) {}
 };
@@ -328,14 +327,14 @@ public:
 
 class CLSRGWIssueBucketIndexClean : public CLSRGWConcurrentIO {
 protected:
-  int issue_op(int shard_id, const string& oid) override;
+  int issue_op(int shard_id, const std::string& oid) override;
   int valid_ret_code() override {
     return -ENOENT;
   }
 
 public:
   CLSRGWIssueBucketIndexClean(librados::IoCtx& ioc,
-			      map<int, string>& _bucket_objs,
+			      std::map<int, std::string>& _bucket_objs,
 			      uint32_t _max_aio) :
   CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio)
   {}
@@ -345,76 +344,76 @@ public:
 class CLSRGWIssueSetTagTimeout : public CLSRGWConcurrentIO {
   uint64_t tag_timeout;
 protected:
-  int issue_op(int shard_id, const string& oid) override;
+  int issue_op(int shard_id, const std::string& oid) override;
 public:
-  CLSRGWIssueSetTagTimeout(librados::IoCtx& ioc, map<int, string>& _bucket_objs,
+  CLSRGWIssueSetTagTimeout(librados::IoCtx& ioc, std::map<int, std::string>& _bucket_objs,
                      uint32_t _max_aio, uint64_t _tag_timeout) :
     CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio), tag_timeout(_tag_timeout) {}
 };
 
 void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
                                  bool absolute,
-                                 const map<RGWObjCategory, rgw_bucket_category_stats>& stats);
+                                 const std::map<RGWObjCategory, rgw_bucket_category_stats>& stats);
 
-void cls_rgw_bucket_prepare_op(librados::ObjectWriteOperation& o, RGWModifyOp op, string& tag,
-                               const cls_rgw_obj_key& key, const string& locator, bool log_op,
+void cls_rgw_bucket_prepare_op(librados::ObjectWriteOperation& o, RGWModifyOp op, std::string& tag,
+                               const cls_rgw_obj_key& key, const std::string& locator, bool log_op,
                                uint16_t bilog_op, rgw_zone_set& zones_trace);
 
-void cls_rgw_bucket_complete_op(librados::ObjectWriteOperation& o, RGWModifyOp op, string& tag,
+void cls_rgw_bucket_complete_op(librados::ObjectWriteOperation& o, RGWModifyOp op, std::string& tag,
                                 rgw_bucket_entry_ver& ver,
                                 const cls_rgw_obj_key& key,
                                 rgw_bucket_dir_entry_meta& dir_meta,
-				list<cls_rgw_obj_key> *remove_objs, bool log_op,
+				std::list<cls_rgw_obj_key> *remove_objs, bool log_op,
                                 uint16_t bilog_op, rgw_zone_set *zones_trace);
 
-void cls_rgw_remove_obj(librados::ObjectWriteOperation& o, list<string>& keep_attr_prefixes);
-void cls_rgw_obj_store_pg_ver(librados::ObjectWriteOperation& o, const string& attr);
-void cls_rgw_obj_check_attrs_prefix(librados::ObjectOperation& o, const string& prefix, bool fail_if_exist);
+void cls_rgw_remove_obj(librados::ObjectWriteOperation& o, std::list<std::string>& keep_attr_prefixes);
+void cls_rgw_obj_store_pg_ver(librados::ObjectWriteOperation& o, const std::string& attr);
+void cls_rgw_obj_check_attrs_prefix(librados::ObjectOperation& o, const std::string& prefix, bool fail_if_exist);
 void cls_rgw_obj_check_mtime(librados::ObjectOperation& o, const ceph::real_time& mtime, bool high_precision_time, RGWCheckMTimeType type);
 
-int cls_rgw_bi_get(librados::IoCtx& io_ctx, const string oid,
+int cls_rgw_bi_get(librados::IoCtx& io_ctx, const std::string oid,
                    BIIndexType index_type, cls_rgw_obj_key& key,
                    rgw_cls_bi_entry *entry);
-int cls_rgw_bi_put(librados::IoCtx& io_ctx, const string oid, rgw_cls_bi_entry& entry);
-void cls_rgw_bi_put(librados::ObjectWriteOperation& op, const string oid, rgw_cls_bi_entry& entry);
-int cls_rgw_bi_list(librados::IoCtx& io_ctx, const string oid,
-                   const string& name, const string& marker, uint32_t max,
-                   list<rgw_cls_bi_entry> *entries, bool *is_truncated);
+int cls_rgw_bi_put(librados::IoCtx& io_ctx, const std::string oid, rgw_cls_bi_entry& entry);
+void cls_rgw_bi_put(librados::ObjectWriteOperation& op, const std::string oid, rgw_cls_bi_entry& entry);
+int cls_rgw_bi_list(librados::IoCtx& io_ctx, const std::string oid,
+                   const std::string& name, const std::string& marker, uint32_t max,
+                   std::list<rgw_cls_bi_entry> *entries, bool *is_truncated);
 
 
 void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op,
-                            const cls_rgw_obj_key& key, bufferlist& olh_tag,
-                            bool delete_marker, const string& op_tag, rgw_bucket_dir_entry_meta *meta,
+                            const cls_rgw_obj_key& key, ceph::buffer::list& olh_tag,
+                            bool delete_marker, const std::string& op_tag, rgw_bucket_dir_entry_meta *meta,
                             uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, rgw_zone_set& zones_trace);
 void cls_rgw_bucket_unlink_instance(librados::ObjectWriteOperation& op,
-                                   const cls_rgw_obj_key& key, const string& op_tag,
-                                   const string& olh_tag, uint64_t olh_epoch, bool log_op, rgw_zone_set& zones_trace);
-void cls_rgw_get_olh_log(librados::ObjectReadOperation& op, const cls_rgw_obj_key& olh, uint64_t ver_marker, const string& olh_tag, rgw_cls_read_olh_log_ret& log_ret, int& op_ret);
-void cls_rgw_trim_olh_log(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& olh, uint64_t ver, const string& olh_tag);
-void cls_rgw_clear_olh(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& olh, const string& olh_tag);
+                                   const cls_rgw_obj_key& key, const std::string& op_tag,
+                                   const std::string& olh_tag, uint64_t olh_epoch, bool log_op, rgw_zone_set& zones_trace);
+void cls_rgw_get_olh_log(librados::ObjectReadOperation& op, const cls_rgw_obj_key& olh, uint64_t ver_marker, const std::string& olh_tag, rgw_cls_read_olh_log_ret& log_ret, int& op_ret);
+void cls_rgw_trim_olh_log(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& olh, uint64_t ver, const std::string& olh_tag);
+void cls_rgw_clear_olh(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& olh, const std::string& olh_tag);
 
 // these overloads which call io_ctx.operate() should not be called in the rgw.
 // rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
 #ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_rgw_bucket_link_olh(librados::IoCtx& io_ctx, const string& oid,
-                            const cls_rgw_obj_key& key, bufferlist& olh_tag,
-                            bool delete_marker, const string& op_tag, rgw_bucket_dir_entry_meta *meta,
+int cls_rgw_bucket_link_olh(librados::IoCtx& io_ctx, const std::string& oid,
+                            const cls_rgw_obj_key& key, ceph::buffer::list& olh_tag,
+                            bool delete_marker, const std::string& op_tag, rgw_bucket_dir_entry_meta *meta,
                             uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, rgw_zone_set& zones_trace);
-int cls_rgw_bucket_unlink_instance(librados::IoCtx& io_ctx, const string& oid,
-                                   const cls_rgw_obj_key& key, const string& op_tag,
-                                   const string& olh_tag, uint64_t olh_epoch, bool log_op, rgw_zone_set& zones_trace);
-int cls_rgw_get_olh_log(librados::IoCtx& io_ctx, string& oid, const cls_rgw_obj_key& olh, uint64_t ver_marker,
-                        const string& olh_tag, rgw_cls_read_olh_log_ret& log_ret);
-int cls_rgw_clear_olh(librados::IoCtx& io_ctx, string& oid, const cls_rgw_obj_key& olh, const string& olh_tag);
-int cls_rgw_usage_log_trim(librados::IoCtx& io_ctx, const string& oid, const string& user, const string& bucket,
+int cls_rgw_bucket_unlink_instance(librados::IoCtx& io_ctx, const std::string& oid,
+                                   const cls_rgw_obj_key& key, const std::string& op_tag,
+                                   const std::string& olh_tag, uint64_t olh_epoch, bool log_op, rgw_zone_set& zones_trace);
+int cls_rgw_get_olh_log(librados::IoCtx& io_ctx, std::string& oid, const cls_rgw_obj_key& olh, uint64_t ver_marker,
+                        const std::string& olh_tag, rgw_cls_read_olh_log_ret& log_ret);
+int cls_rgw_clear_olh(librados::IoCtx& io_ctx, std::string& oid, const cls_rgw_obj_key& olh, const std::string& olh_tag);
+int cls_rgw_usage_log_trim(librados::IoCtx& io_ctx, const std::string& oid, const std::string& user, const std::string& bucket,
                            uint64_t start_epoch, uint64_t end_epoch);
 #endif
 
 
 /**
- * List the bucket with the starting object and filter prefix.
+ * Std::list the bucket with the starting object and filter prefix.
  * NOTE: this method do listing requests for each bucket index shards identified by
- *       the keys of the *list_results* map, which means the map should be popludated
+ *       the keys of the *list_results* std::map, which means the std::map should be popludated
  *       by the caller to fill with each bucket index object id.
  *
  * io_ctx        - IO context for rados.
@@ -422,7 +421,7 @@ int cls_rgw_usage_log_trim(librados::IoCtx& io_ctx, const string& oid, const str
  * filter_prefix - filter prefix.
  * num_entries   - number of entries to request for each object (note the total
  *                 amount of entries returned depends on the number of shardings).
- * list_results  - the list results keyed by bucket index object id.
+ * list_results  - the std::list results keyed by bucket index object id.
  * max_aio       - the maximum number of AIO (for throttling).
  *
  * Return 0 on success, a failure code otherwise.
@@ -430,22 +429,22 @@ int cls_rgw_usage_log_trim(librados::IoCtx& io_ctx, const string& oid, const str
 
 class CLSRGWIssueBucketList : public CLSRGWConcurrentIO {
   cls_rgw_obj_key start_obj;
-  string filter_prefix;
-  string delimiter;
+  std::string filter_prefix;
+  std::string delimiter;
   uint32_t num_entries;
   bool list_versions;
-  map<int, rgw_cls_list_ret>& result;
+  std::map<int, rgw_cls_list_ret>& result;
 protected:
-  int issue_op(int shard_id, const string& oid) override;
+  int issue_op(int shard_id, const std::string& oid) override;
 public:
   CLSRGWIssueBucketList(librados::IoCtx& io_ctx,
 			const cls_rgw_obj_key& _start_obj,
-                        const string& _filter_prefix,
-			const string& _delimiter,
+                        const std::string& _filter_prefix,
+			const std::string& _delimiter,
 			uint32_t _num_entries,
                         bool _list_versions,
-                        map<int, string>& oids,
-                        map<int, rgw_cls_list_ret>& list_results,
+                        std::map<int, std::string>& oids,
+                        std::map<int, rgw_cls_list_ret>& list_results,
                         uint32_t max_aio) :
   CLSRGWConcurrentIO(io_ctx, oids, max_aio),
     start_obj(_start_obj), filter_prefix(_filter_prefix), delimiter(_delimiter),
@@ -467,15 +466,15 @@ void cls_rgw_bilog_list(librados::ObjectReadOperation& op,
                         cls_rgw_bi_log_list_ret *pdata, int *ret = nullptr);
 
 class CLSRGWIssueBILogList : public CLSRGWConcurrentIO {
-  map<int, cls_rgw_bi_log_list_ret>& result;
+  std::map<int, cls_rgw_bi_log_list_ret>& result;
   BucketIndexShardsManager& marker_mgr;
   uint32_t max;
 protected:
-  int issue_op(int shard_id, const string& oid) override;
+  int issue_op(int shard_id, const std::string& oid) override;
 public:
   CLSRGWIssueBILogList(librados::IoCtx& io_ctx, BucketIndexShardsManager& _marker_mgr, uint32_t _max,
-                       map<int, string>& oids,
-                       map<int, cls_rgw_bi_log_list_ret>& bi_log_lists, uint32_t max_aio) :
+                       std::map<int, std::string>& oids,
+                       std::map<int, cls_rgw_bi_log_list_ret>& bi_log_lists, uint32_t max_aio) :
     CLSRGWConcurrentIO(io_ctx, oids, max_aio), result(bi_log_lists),
     marker_mgr(_marker_mgr), max(_max) {}
 };
@@ -488,19 +487,19 @@ class CLSRGWIssueBILogTrim : public CLSRGWConcurrentIO {
   BucketIndexShardsManager& start_marker_mgr;
   BucketIndexShardsManager& end_marker_mgr;
 protected:
-  int issue_op(int shard_id, const string& oid) override;
+  int issue_op(int shard_id, const std::string& oid) override;
   // Trim until -ENODATA is returned.
   int valid_ret_code() override { return -ENODATA; }
   bool need_multiple_rounds() override { return true; }
-  void add_object(int shard, const string& oid) override { objs_container[shard] = oid; }
-  void reset_container(map<int, string>& objs) override {
+  void add_object(int shard, const std::string& oid) override { objs_container[shard] = oid; }
+  void reset_container(std::map<int, std::string>& objs) override {
     objs_container.swap(objs);
     iter = objs_container.begin();
     objs.clear();
   }
 public:
   CLSRGWIssueBILogTrim(librados::IoCtx& io_ctx, BucketIndexShardsManager& _start_marker_mgr,
-      BucketIndexShardsManager& _end_marker_mgr, map<int, string>& _bucket_objs, uint32_t max_aio) :
+      BucketIndexShardsManager& _end_marker_mgr, std::map<int, std::string>& _bucket_objs, uint32_t max_aio) :
     CLSRGWConcurrentIO(io_ctx, _bucket_objs, max_aio),
     start_marker_mgr(_start_marker_mgr), end_marker_mgr(_end_marker_mgr) {}
 };
@@ -514,31 +513,31 @@ public:
  *
  * Return 0 on success, a failure code otherwise.
  */
-class CLSRGWIssueBucketCheck : public CLSRGWConcurrentIO /*<map<string, rgw_cls_check_index_ret> >*/ {
-  map<int, rgw_cls_check_index_ret>& result;
+class CLSRGWIssueBucketCheck : public CLSRGWConcurrentIO /*<std::map<std::string, rgw_cls_check_index_ret> >*/ {
+  std::map<int, rgw_cls_check_index_ret>& result;
 protected:
-  int issue_op(int shard_id, const string& oid) override;
+  int issue_op(int shard_id, const std::string& oid) override;
 public:
-  CLSRGWIssueBucketCheck(librados::IoCtx& ioc, map<int, string>& oids,
-			 map<int, rgw_cls_check_index_ret>& bucket_objs_ret,
+  CLSRGWIssueBucketCheck(librados::IoCtx& ioc, std::map<int, std::string>& oids,
+			 std::map<int, rgw_cls_check_index_ret>& bucket_objs_ret,
 			 uint32_t _max_aio) :
     CLSRGWConcurrentIO(ioc, oids, _max_aio), result(bucket_objs_ret) {}
 };
 
 class CLSRGWIssueBucketRebuild : public CLSRGWConcurrentIO {
 protected:
-  int issue_op(int shard_id, const string& oid) override;
+  int issue_op(int shard_id, const std::string& oid) override;
 public:
-  CLSRGWIssueBucketRebuild(librados::IoCtx& io_ctx, map<int, string>& bucket_objs,
+  CLSRGWIssueBucketRebuild(librados::IoCtx& io_ctx, std::map<int, std::string>& bucket_objs,
                            uint32_t max_aio) : CLSRGWConcurrentIO(io_ctx, bucket_objs, max_aio) {}
 };
 
 class CLSRGWIssueGetDirHeader : public CLSRGWConcurrentIO {
-  map<int, rgw_cls_list_ret>& result;
+  std::map<int, rgw_cls_list_ret>& result;
 protected:
-  int issue_op(int shard_id, const string& oid) override;
+  int issue_op(int shard_id, const std::string& oid) override;
 public:
-  CLSRGWIssueGetDirHeader(librados::IoCtx& io_ctx, map<int, string>& oids, map<int, rgw_cls_list_ret>& dir_headers,
+  CLSRGWIssueGetDirHeader(librados::IoCtx& io_ctx, std::map<int, std::string>& oids, std::map<int, rgw_cls_list_ret>& dir_headers,
                           uint32_t max_aio) :
     CLSRGWConcurrentIO(io_ctx, oids, max_aio), result(dir_headers) {}
 };
@@ -546,75 +545,75 @@ public:
 class CLSRGWIssueSetBucketResharding : public CLSRGWConcurrentIO {
   cls_rgw_bucket_instance_entry entry;
 protected:
-  int issue_op(int shard_id, const string& oid) override;
+  int issue_op(int shard_id, const std::string& oid) override;
 public:
-  CLSRGWIssueSetBucketResharding(librados::IoCtx& ioc, map<int, string>& _bucket_objs,
+  CLSRGWIssueSetBucketResharding(librados::IoCtx& ioc, std::map<int, std::string>& _bucket_objs,
                                  const cls_rgw_bucket_instance_entry& _entry,
                                  uint32_t _max_aio) : CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio), entry(_entry) {}
 };
 
 class CLSRGWIssueResyncBucketBILog : public CLSRGWConcurrentIO {
 protected:
-  int issue_op(int shard_id, const string& oid);
+  int issue_op(int shard_id, const std::string& oid);
 public:
-  CLSRGWIssueResyncBucketBILog(librados::IoCtx& io_ctx, map<int, string>& _bucket_objs, uint32_t max_aio) :
+  CLSRGWIssueResyncBucketBILog(librados::IoCtx& io_ctx, std::map<int, std::string>& _bucket_objs, uint32_t max_aio) :
     CLSRGWConcurrentIO(io_ctx, _bucket_objs, max_aio) {}
 };
 
 class CLSRGWIssueBucketBILogStop : public CLSRGWConcurrentIO {
 protected:
-  int issue_op(int shard_id, const string& oid);
+  int issue_op(int shard_id, const std::string& oid);
 public:
-  CLSRGWIssueBucketBILogStop(librados::IoCtx& io_ctx, map<int, string>& _bucket_objs, uint32_t max_aio) :
+  CLSRGWIssueBucketBILogStop(librados::IoCtx& io_ctx, std::map<int, std::string>& _bucket_objs, uint32_t max_aio) :
     CLSRGWConcurrentIO(io_ctx, _bucket_objs, max_aio) {}
 };
 
-int cls_rgw_get_dir_header_async(librados::IoCtx& io_ctx, string& oid, RGWGetDirHeader_CB *ctx);
+int cls_rgw_get_dir_header_async(librados::IoCtx& io_ctx, std::string& oid, RGWGetDirHeader_CB *ctx);
 
-void cls_rgw_encode_suggestion(char op, rgw_bucket_dir_entry& dirent, bufferlist& updates);
+void cls_rgw_encode_suggestion(char op, rgw_bucket_dir_entry& dirent, ceph::buffer::list& updates);
 
-void cls_rgw_suggest_changes(librados::ObjectWriteOperation& o, bufferlist& updates);
+void cls_rgw_suggest_changes(librados::ObjectWriteOperation& o, ceph::buffer::list& updates);
 
 /* usage logging */
 // these overloads which call io_ctx.operate() should not be called in the rgw.
 // rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
 #ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_rgw_usage_log_read(librados::IoCtx& io_ctx, const string& oid, const string& user, const string& bucket,
-                           uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries, string& read_iter,
-			   map<rgw_user_bucket, rgw_usage_log_entry>& usage, bool *is_truncated);
+int cls_rgw_usage_log_read(librados::IoCtx& io_ctx, const std::string& oid, const std::string& user, const std::string& bucket,
+                           uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries, std::string& read_iter,
+			   std::map<rgw_user_bucket, rgw_usage_log_entry>& usage, bool *is_truncated);
 #endif
 
-void cls_rgw_usage_log_trim(librados::ObjectWriteOperation& op, const string& user, const string& bucket, uint64_t start_epoch, uint64_t end_epoch);
+void cls_rgw_usage_log_trim(librados::ObjectWriteOperation& op, const std::string& user, const std::string& bucket, uint64_t start_epoch, uint64_t end_epoch);
 
 void cls_rgw_usage_log_clear(librados::ObjectWriteOperation& op);
 void cls_rgw_usage_log_add(librados::ObjectWriteOperation& op, rgw_usage_log_info& info);
 
 /* garbage collection */
 void cls_rgw_gc_set_entry(librados::ObjectWriteOperation& op, uint32_t expiration_secs, cls_rgw_gc_obj_info& info);
-void cls_rgw_gc_defer_entry(librados::ObjectWriteOperation& op, uint32_t expiration_secs, const string& tag);
-void cls_rgw_gc_remove(librados::ObjectWriteOperation& op, const vector<string>& tags);
+void cls_rgw_gc_defer_entry(librados::ObjectWriteOperation& op, uint32_t expiration_secs, const std::string& tag);
+void cls_rgw_gc_remove(librados::ObjectWriteOperation& op, const std::vector<std::string>& tags);
 
 // these overloads which call io_ctx.operate() should not be called in the rgw.
 // rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
 #ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_rgw_gc_list(librados::IoCtx& io_ctx, string& oid, string& marker, uint32_t max, bool expired_only,
-                    list<cls_rgw_gc_obj_info>& entries, bool *truncated, string& next_marker);
+int cls_rgw_gc_list(librados::IoCtx& io_ctx, std::string& oid, std::string& marker, uint32_t max, bool expired_only,
+                    std::list<cls_rgw_gc_obj_info>& entries, bool *truncated, std::string& next_marker);
 #endif
 
 /* lifecycle */
 // these overloads which call io_ctx.operate() should not be called in the rgw.
 // rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
 #ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_rgw_lc_get_head(librados::IoCtx& io_ctx, const string& oid, cls_rgw_lc_obj_head& head);
-int cls_rgw_lc_put_head(librados::IoCtx& io_ctx, const string& oid, cls_rgw_lc_obj_head& head);
-int cls_rgw_lc_get_next_entry(librados::IoCtx& io_ctx, const string& oid, string& marker, pair<string, int>& entry);
-int cls_rgw_lc_rm_entry(librados::IoCtx& io_ctx, const string& oid, const pair<string, int>& entry);
-int cls_rgw_lc_set_entry(librados::IoCtx& io_ctx, const string& oid, const pair<string, int>& entry);
-int cls_rgw_lc_get_entry(librados::IoCtx& io_ctx, const string& oid, const std::string& marker, rgw_lc_entry_t& entry);
-int cls_rgw_lc_list(librados::IoCtx& io_ctx, const string& oid,
-                    const string& marker,
+int cls_rgw_lc_get_head(librados::IoCtx& io_ctx, const std::string& oid, cls_rgw_lc_obj_head& head);
+int cls_rgw_lc_put_head(librados::IoCtx& io_ctx, const std::string& oid, cls_rgw_lc_obj_head& head);
+int cls_rgw_lc_get_next_entry(librados::IoCtx& io_ctx, const std::string& oid, std::string& marker, std::pair<std::string, int>& entry);
+int cls_rgw_lc_rm_entry(librados::IoCtx& io_ctx, const std::string& oid, const std::pair<std::string, int>& entry);
+int cls_rgw_lc_set_entry(librados::IoCtx& io_ctx, const std::string& oid, const std::pair<std::string, int>& entry);
+int cls_rgw_lc_get_entry(librados::IoCtx& io_ctx, const std::string& oid, const std::string& marker, rgw_lc_entry_t& entry);
+int cls_rgw_lc_list(librados::IoCtx& io_ctx, const std::string& oid,
+                    const std::string& marker,
                     uint32_t max_entries,
-                    map<string, int>& entries);
+                    std::map<std::string, int>& entries);
 #endif
 
 /* resharding */
@@ -623,9 +622,9 @@ void cls_rgw_reshard_remove(librados::ObjectWriteOperation& op, const cls_rgw_re
 // these overloads which call io_ctx.operate() should not be called in the rgw.
 // rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
 #ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_rgw_reshard_list(librados::IoCtx& io_ctx, const string& oid, string& marker, uint32_t max,
-                         list<cls_rgw_reshard_entry>& entries, bool* is_truncated);
-int cls_rgw_reshard_get(librados::IoCtx& io_ctx, const string& oid, cls_rgw_reshard_entry& entry);
+int cls_rgw_reshard_list(librados::IoCtx& io_ctx, const std::string& oid, std::string& marker, uint32_t max,
+                         std::list<cls_rgw_reshard_entry>& entries, bool* is_truncated);
+int cls_rgw_reshard_get(librados::IoCtx& io_ctx, const std::string& oid, cls_rgw_reshard_entry& entry);
 #endif
 
 /* resharding attribute on bucket index shard headers */
@@ -633,10 +632,10 @@ void cls_rgw_guard_bucket_resharding(librados::ObjectOperation& op, int ret_err)
 // these overloads which call io_ctx.operate() should not be called in the rgw.
 // rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
 #ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_rgw_set_bucket_resharding(librados::IoCtx& io_ctx, const string& oid,
+int cls_rgw_set_bucket_resharding(librados::IoCtx& io_ctx, const std::string& oid,
                                   const cls_rgw_bucket_instance_entry& entry);
-int cls_rgw_clear_bucket_resharding(librados::IoCtx& io_ctx, const string& oid);
-int cls_rgw_get_bucket_resharding(librados::IoCtx& io_ctx, const string& oid,
+int cls_rgw_clear_bucket_resharding(librados::IoCtx& io_ctx, const std::string& oid);
+int cls_rgw_get_bucket_resharding(librados::IoCtx& io_ctx, const std::string& oid,
                                   cls_rgw_bucket_instance_entry *entry);
 #endif
 

--- a/src/cls/rgw/cls_rgw_const.h
+++ b/src/cls/rgw/cls_rgw_const.h
@@ -1,4 +1,4 @@
-// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
 #ifndef CEPH_CLS_RGW_CONST_H

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -7,6 +7,11 @@
 #include "common/ceph_json.h"
 #include "include/utime.h"
 
+using std::list;
+using std::map;
+
+using ceph::Formatter;
+
 void rgw_cls_tag_timeout_op::dump(Formatter *f) const
 {
   f->dump_int("tag_timeout", tag_timeout);
@@ -111,7 +116,7 @@ void rgw_cls_obj_prepare_op::dump(Formatter *f) const
   f->dump_string("locator", locator);
   f->dump_bool("log_op", log_op);
   f->dump_int("bilog_flags", bilog_flags);
-  ::encode_json("zones_trace", zones_trace, f);
+  encode_json("zones_trace", zones_trace, f);
 }
 
 void rgw_cls_obj_complete_op::generate_test_instances(list<rgw_cls_obj_complete_op*>& o)
@@ -126,7 +131,7 @@ void rgw_cls_obj_complete_op::generate_test_instances(list<rgw_cls_obj_complete_
 
   list<rgw_bucket_dir_entry_meta *> l;
   rgw_bucket_dir_entry_meta::generate_test_instances(l);
-  list<rgw_bucket_dir_entry_meta *>::iterator iter = l.begin();
+  auto iter = l.begin();
   op->meta = *(*iter);
 
   o.push_back(op);
@@ -149,7 +154,7 @@ void rgw_cls_obj_complete_op::dump(Formatter *f) const
   f->dump_string("tag", tag);
   f->dump_bool("log_op", log_op);
   f->dump_int("bilog_flags", bilog_flags);
-  ::encode_json("zones_trace", zones_trace, f);
+  encode_json("zones_trace", zones_trace, f);
 }
 
 void rgw_cls_link_olh_op::generate_test_instances(list<rgw_cls_link_olh_op*>& o)
@@ -162,7 +167,7 @@ void rgw_cls_link_olh_op::generate_test_instances(list<rgw_cls_link_olh_op*>& o)
   op->olh_epoch = 123;
   list<rgw_bucket_dir_entry_meta *> l;
   rgw_bucket_dir_entry_meta::generate_test_instances(l);
-  list<rgw_bucket_dir_entry_meta *>::iterator iter = l.begin();
+  auto iter = l.begin();
   op->meta = *(*iter);
   op->log_op = true;
 
@@ -173,18 +178,18 @@ void rgw_cls_link_olh_op::generate_test_instances(list<rgw_cls_link_olh_op*>& o)
 
 void rgw_cls_link_olh_op::dump(Formatter *f) const
 {
-  ::encode_json("key", key, f);
-  ::encode_json("olh_tag", olh_tag, f);
-  ::encode_json("delete_marker", delete_marker, f);
-  ::encode_json("op_tag", op_tag, f);
-  ::encode_json("meta", meta, f);
-  ::encode_json("olh_epoch", olh_epoch, f);
-  ::encode_json("log_op", log_op, f);
-  ::encode_json("bilog_flags", (uint32_t)bilog_flags, f);
+  encode_json("key", key, f);
+  encode_json("olh_tag", olh_tag, f);
+  encode_json("delete_marker", delete_marker, f);
+  encode_json("op_tag", op_tag, f);
+  encode_json("meta", meta, f);
+  encode_json("olh_epoch", olh_epoch, f);
+  encode_json("log_op", log_op, f);
+  encode_json("bilog_flags", (uint32_t)bilog_flags, f);
   utime_t ut(unmod_since);
-  ::encode_json("unmod_since", ut, f);
-  ::encode_json("high_precision_time", high_precision_time, f);
-  ::encode_json("zones_trace", zones_trace, f);
+  encode_json("unmod_since", ut, f);
+  encode_json("high_precision_time", high_precision_time, f);
+  encode_json("zones_trace", zones_trace, f);
 }
 
 void rgw_cls_unlink_instance_op::generate_test_instances(list<rgw_cls_unlink_instance_op*>& o)
@@ -202,12 +207,12 @@ void rgw_cls_unlink_instance_op::generate_test_instances(list<rgw_cls_unlink_ins
 
 void rgw_cls_unlink_instance_op::dump(Formatter *f) const
 {
-  ::encode_json("key", key, f);
-  ::encode_json("op_tag", op_tag, f);
-  ::encode_json("olh_epoch", olh_epoch, f);
-  ::encode_json("log_op", log_op, f);
-  ::encode_json("bilog_flags", (uint32_t)bilog_flags, f);
-  ::encode_json("zones_trace", zones_trace, f);
+  encode_json("key", key, f);
+  encode_json("op_tag", op_tag, f);
+  encode_json("olh_epoch", olh_epoch, f);
+  encode_json("log_op", log_op, f);
+  encode_json("bilog_flags", (uint32_t)bilog_flags, f);
+  encode_json("zones_trace", zones_trace, f);
 }
 
 void rgw_cls_read_olh_log_op::generate_test_instances(list<rgw_cls_read_olh_log_op*>& o)
@@ -224,9 +229,9 @@ void rgw_cls_read_olh_log_op::generate_test_instances(list<rgw_cls_read_olh_log_
 
 void rgw_cls_read_olh_log_op::dump(Formatter *f) const
 {
-  ::encode_json("olh", olh, f);
-  ::encode_json("ver_marker", ver_marker, f);
-  ::encode_json("olh_tag", olh_tag, f);
+  encode_json("olh", olh, f);
+  encode_json("ver_marker", ver_marker, f);
+  encode_json("olh_tag", olh_tag, f);
 }
 
 void rgw_cls_read_olh_log_ret::generate_test_instances(list<rgw_cls_read_olh_log_ret*>& o)
@@ -235,7 +240,7 @@ void rgw_cls_read_olh_log_ret::generate_test_instances(list<rgw_cls_read_olh_log
   r->is_truncated = true;
   list<rgw_bucket_olh_log_entry *> l;
   rgw_bucket_olh_log_entry::generate_test_instances(l);
-  list<rgw_bucket_olh_log_entry *>::iterator iter = l.begin();
+  auto iter = l.begin();
   r->log[1].push_back(*(*iter));
 
   o.push_back(r);
@@ -245,8 +250,8 @@ void rgw_cls_read_olh_log_ret::generate_test_instances(list<rgw_cls_read_olh_log
 
 void rgw_cls_read_olh_log_ret::dump(Formatter *f) const
 {
-  ::encode_json("log", log, f);
-  ::encode_json("is_truncated", is_truncated, f);
+  encode_json("log", log, f);
+  encode_json("is_truncated", is_truncated, f);
 }
 
 void rgw_cls_trim_olh_log_op::generate_test_instances(list<rgw_cls_trim_olh_log_op*>& o)
@@ -263,9 +268,9 @@ void rgw_cls_trim_olh_log_op::generate_test_instances(list<rgw_cls_trim_olh_log_
 
 void rgw_cls_trim_olh_log_op::dump(Formatter *f) const
 {
-  ::encode_json("olh", olh, f);
-  ::encode_json("ver", ver, f);
-  ::encode_json("olh_tag", olh_tag, f);
+  encode_json("olh", olh, f);
+  encode_json("ver", ver, f);
+  encode_json("olh_tag", olh_tag, f);
 }
 
 void rgw_cls_bucket_clear_olh_op::generate_test_instances(list<rgw_cls_bucket_clear_olh_op *>& o)
@@ -281,8 +286,8 @@ void rgw_cls_bucket_clear_olh_op::generate_test_instances(list<rgw_cls_bucket_cl
 
 void rgw_cls_bucket_clear_olh_op::dump(Formatter *f) const
 {
-  ::encode_json("key", key, f);
-  ::encode_json("olh_tag", olh_tag, f);
+  encode_json("key", key, f);
+  encode_json("olh_tag", olh_tag, f);
 }
 
 void rgw_cls_list_op::generate_test_instances(list<rgw_cls_list_op*>& o)
@@ -305,8 +310,7 @@ void rgw_cls_list_ret::generate_test_instances(list<rgw_cls_list_ret*>& o)
 {
  list<rgw_bucket_dir *> l;
   rgw_bucket_dir::generate_test_instances(l);
-  list<rgw_bucket_dir *>::iterator iter;
-  for (iter = l.begin(); iter != l.end(); ++iter) {
+  for (auto iter = l.begin(); iter != l.end(); ++iter) {
     rgw_bucket_dir *d = *iter;
 
     rgw_cls_list_ret *ret = new rgw_cls_list_ret;
@@ -338,7 +342,7 @@ void rgw_cls_check_index_ret::generate_test_instances(list<rgw_cls_check_index_r
   r->calculated_header = *(h.front());
   o.push_back(r);
 
-  for (list<rgw_bucket_dir_header *>::iterator iter = h.begin(); iter != h.end(); ++iter) {
+  for (auto iter = h.begin(); iter != h.end(); ++iter) {
     delete *iter;
   }
   o.push_back(new rgw_cls_check_index_ret);
@@ -346,8 +350,8 @@ void rgw_cls_check_index_ret::generate_test_instances(list<rgw_cls_check_index_r
 
 void rgw_cls_check_index_ret::dump(Formatter *f) const
 {
-  ::encode_json("existing_header", existing_header, f);
-  ::encode_json("calculated_header", calculated_header, f);
+  encode_json("existing_header", existing_header, f);
+  encode_json("calculated_header", calculated_header, f);
 }
 
 void rgw_cls_bucket_update_stats_op::generate_test_instances(list<rgw_cls_bucket_update_stats_op*>& o)
@@ -365,12 +369,12 @@ void rgw_cls_bucket_update_stats_op::generate_test_instances(list<rgw_cls_bucket
 
 void rgw_cls_bucket_update_stats_op::dump(Formatter *f) const
 {
-  ::encode_json("absolute", absolute, f);
+  encode_json("absolute", absolute, f);
   map<int, rgw_bucket_category_stats> s;
   for (auto& entry : stats) {
     s[(int)entry.first] = entry.second;
   }
-  ::encode_json("stats", s, f);
+  encode_json("stats", s, f);
 }
 
 void cls_rgw_bi_log_list_op::dump(Formatter *f) const
@@ -421,13 +425,13 @@ void cls_rgw_reshard_add_op::generate_test_instances(list<cls_rgw_reshard_add_op
   ls.push_back(new cls_rgw_reshard_add_op);
   list<cls_rgw_reshard_entry *> l;
   cls_rgw_reshard_entry::generate_test_instances(l);
-  list<cls_rgw_reshard_entry *>::iterator iter = l.begin();
+  auto iter = l.begin();
   ls.back()->entry = *(*iter);
 }
 
 void cls_rgw_reshard_add_op::dump(Formatter *f) const
 {
-  ::encode_json("entry", entry, f);
+  encode_json("entry", entry, f);
 }
 
 void cls_rgw_reshard_list_op::generate_test_instances(list<cls_rgw_reshard_list_op*>& ls)
@@ -440,8 +444,8 @@ void cls_rgw_reshard_list_op::generate_test_instances(list<cls_rgw_reshard_list_
 
 void cls_rgw_reshard_list_op::dump(Formatter *f) const
 {
-  ::encode_json("max", max, f);
-  ::encode_json("marker", marker, f);
+  encode_json("max", max, f);
+  encode_json("marker", marker, f);
 }
 
 void cls_rgw_reshard_list_ret::generate_test_instances(list<cls_rgw_reshard_list_ret*>& ls)
@@ -454,8 +458,8 @@ void cls_rgw_reshard_list_ret::generate_test_instances(list<cls_rgw_reshard_list
 
 void cls_rgw_reshard_list_ret::dump(Formatter *f) const
 {
-  ::encode_json("entries", entries, f);
-  ::encode_json("is_truncated", is_truncated, f);
+  encode_json("entries", entries, f);
+  encode_json("is_truncated", is_truncated, f);
 }
 
 void cls_rgw_reshard_get_op::generate_test_instances(list<cls_rgw_reshard_get_op*>& ls)
@@ -466,7 +470,7 @@ void cls_rgw_reshard_get_op::generate_test_instances(list<cls_rgw_reshard_get_op
 
 void cls_rgw_reshard_get_op::dump(Formatter *f) const
 {
-  ::encode_json("entry", entry, f);
+  encode_json("entry", entry, f);
 }
 
 void cls_rgw_reshard_get_ret::generate_test_instances(list<cls_rgw_reshard_get_ret*>& ls)
@@ -477,7 +481,7 @@ void cls_rgw_reshard_get_ret::generate_test_instances(list<cls_rgw_reshard_get_r
 
 void cls_rgw_reshard_get_ret::dump(Formatter *f) const
 {
-  ::encode_json("entry", entry, f);
+  encode_json("entry", entry, f);
 }
 
 void cls_rgw_reshard_remove_op::generate_test_instances(list<cls_rgw_reshard_remove_op*>& ls)
@@ -490,8 +494,8 @@ void cls_rgw_reshard_remove_op::generate_test_instances(list<cls_rgw_reshard_rem
 
 void cls_rgw_reshard_remove_op::dump(Formatter *f) const
 {
-  ::encode_json("bucket_name", bucket_name, f);
-  ::encode_json("bucket_id", bucket_name, f);
+  encode_json("bucket_name", bucket_name, f);
+  encode_json("bucket_id", bucket_name, f);
 }
 
 
@@ -504,7 +508,7 @@ void cls_rgw_set_bucket_resharding_op::generate_test_instances(
 
 void cls_rgw_set_bucket_resharding_op::dump(Formatter *f) const
 {
-  ::encode_json("entry", entry, f);
+  encode_json("entry", entry, f);
 }
 
 void cls_rgw_clear_bucket_resharding_op::generate_test_instances(
@@ -527,7 +531,7 @@ void cls_rgw_guard_bucket_resharding_op::generate_test_instances(
 
 void cls_rgw_guard_bucket_resharding_op::dump(Formatter *f) const
 {
-  ::encode_json("ret_err", ret_err, f);
+  encode_json("ret_err", ret_err, f);
 }
 
 

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -12,18 +12,18 @@ struct rgw_cls_tag_timeout_op
 
   rgw_cls_tag_timeout_op() : tag_timeout(0) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(tag_timeout, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(tag_timeout, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<rgw_cls_tag_timeout_op*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_tag_timeout_op*>& ls);
 };
 WRITE_CLASS_ENCODER(rgw_cls_tag_timeout_op)
 
@@ -31,15 +31,15 @@ struct rgw_cls_obj_prepare_op
 {
   RGWModifyOp op;
   cls_rgw_obj_key key;
-  string tag;
-  string locator;
+  std::string tag;
+  std::string locator;
   bool log_op;
   uint16_t bilog_flags;
   rgw_zone_set zones_trace;
 
   rgw_cls_obj_prepare_op() : op(CLS_RGW_OP_UNKNOWN), log_op(false), bilog_flags(0) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(7, 5, bl);
     uint8_t c = (uint8_t)op;
     encode(c, bl);
@@ -51,7 +51,7 @@ struct rgw_cls_obj_prepare_op
     encode(zones_trace, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(7, 3, 3, bl);
     uint8_t c;
     decode(c, bl);
@@ -77,8 +77,8 @@ struct rgw_cls_obj_prepare_op
     }
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<rgw_cls_obj_prepare_op*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_obj_prepare_op*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_prepare_op)
 
@@ -86,19 +86,19 @@ struct rgw_cls_obj_complete_op
 {
   RGWModifyOp op;
   cls_rgw_obj_key key;
-  string locator;
+  std::string locator;
   rgw_bucket_entry_ver ver;
   rgw_bucket_dir_entry_meta meta;
-  string tag;
+  std::string tag;
   bool log_op;
   uint16_t bilog_flags;
 
-  list<cls_rgw_obj_key> remove_objs;
+  std::list<cls_rgw_obj_key> remove_objs;
   rgw_zone_set zones_trace;
 
   rgw_cls_obj_complete_op() : op(CLS_RGW_OP_ADD), log_op(false), bilog_flags(0) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(9, 7, bl);
     uint8_t c = (uint8_t)op;
     encode(c, bl);
@@ -114,7 +114,7 @@ struct rgw_cls_obj_complete_op
     encode(zones_trace, bl);
     ENCODE_FINISH(bl);
  }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(9, 3, 3, bl);
     uint8_t c;
     decode(c, bl);
@@ -129,10 +129,10 @@ struct rgw_cls_obj_complete_op
       decode(locator, bl);
     }
     if (struct_v >= 4 && struct_v < 7) {
-      list<string> old_remove_objs;
+      std::list<std::string> old_remove_objs;
       decode(old_remove_objs, bl);
 
-      for (list<string>::iterator iter = old_remove_objs.begin();
+      for (auto  iter = old_remove_objs.begin();
            iter != old_remove_objs.end(); ++iter) {
         cls_rgw_obj_key k;
         k.name = *iter;
@@ -160,27 +160,27 @@ struct rgw_cls_obj_complete_op
     }
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<rgw_cls_obj_complete_op*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_obj_complete_op*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_complete_op)
 
 struct rgw_cls_link_olh_op {
   cls_rgw_obj_key key;
-  string olh_tag;
+  std::string olh_tag;
   bool delete_marker;
-  string op_tag;
+  std::string op_tag;
   rgw_bucket_dir_entry_meta meta;
   uint64_t olh_epoch;
   bool log_op;
   uint16_t bilog_flags;
-  real_time unmod_since; /* only create delete marker if newer then this */
+  ceph::real_time unmod_since; /* only create delete marker if newer then this */
   bool high_precision_time;
   rgw_zone_set zones_trace;
 
   rgw_cls_link_olh_op() : delete_marker(false), olh_epoch(0), log_op(false), bilog_flags(0), high_precision_time(false) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(5, 1, bl);
     encode(key, bl);
     encode(olh_tag, bl);
@@ -198,7 +198,7 @@ struct rgw_cls_link_olh_op {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(5, bl);
     decode(key, bl);
     decode(olh_tag, bl);
@@ -227,23 +227,23 @@ struct rgw_cls_link_olh_op {
     DECODE_FINISH(bl);
   }
 
-  static void generate_test_instances(list<rgw_cls_link_olh_op *>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_link_olh_op *>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(rgw_cls_link_olh_op)
 
 struct rgw_cls_unlink_instance_op {
   cls_rgw_obj_key key;
-  string op_tag;
+  std::string op_tag;
   uint64_t olh_epoch;
   bool log_op;
   uint16_t bilog_flags;
-  string olh_tag;
+  std::string olh_tag;
   rgw_zone_set zones_trace;
 
   rgw_cls_unlink_instance_op() : olh_epoch(0), log_op(false), bilog_flags(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(3, 1, bl);
     encode(key, bl);
     encode(op_tag, bl);
@@ -255,7 +255,7 @@ struct rgw_cls_unlink_instance_op {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(3, bl);
     decode(key, bl);
     decode(op_tag, bl);
@@ -271,8 +271,8 @@ struct rgw_cls_unlink_instance_op {
     DECODE_FINISH(bl);
   }
 
-  static void generate_test_instances(list<rgw_cls_unlink_instance_op *>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_unlink_instance_op *>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(rgw_cls_unlink_instance_op)
 
@@ -280,51 +280,51 @@ struct rgw_cls_read_olh_log_op
 {
   cls_rgw_obj_key olh;
   uint64_t ver_marker;
-  string olh_tag;
+  std::string olh_tag;
 
   rgw_cls_read_olh_log_op() : ver_marker(0) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(olh, bl);
     encode(ver_marker, bl);
     encode(olh_tag, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(olh, bl);
     decode(ver_marker, bl);
     decode(olh_tag, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(list<rgw_cls_read_olh_log_op *>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_read_olh_log_op *>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(rgw_cls_read_olh_log_op)
 
 
 struct rgw_cls_read_olh_log_ret
 {
-  map<uint64_t, vector<rgw_bucket_olh_log_entry> > log;
+  std::map<uint64_t, std::vector<rgw_bucket_olh_log_entry> > log;
   bool is_truncated;
 
   rgw_cls_read_olh_log_ret() : is_truncated(false) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(log, bl);
     encode(is_truncated, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(log, bl);
     decode(is_truncated, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(list<rgw_cls_read_olh_log_ret *>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_read_olh_log_ret *>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(rgw_cls_read_olh_log_ret)
 
@@ -332,51 +332,51 @@ struct rgw_cls_trim_olh_log_op
 {
   cls_rgw_obj_key olh;
   uint64_t ver;
-  string olh_tag;
+  std::string olh_tag;
 
   rgw_cls_trim_olh_log_op() : ver(0) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(olh, bl);
     encode(ver, bl);
     encode(olh_tag, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(olh, bl);
     decode(ver, bl);
     decode(olh_tag, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(list<rgw_cls_trim_olh_log_op *>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_trim_olh_log_op *>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(rgw_cls_trim_olh_log_op)
 
 struct rgw_cls_bucket_clear_olh_op {
   cls_rgw_obj_key key;
-  string olh_tag;
+  std::string olh_tag;
 
   rgw_cls_bucket_clear_olh_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(key, bl);
     encode(olh_tag, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(key, bl);
     decode(olh_tag, bl);
     DECODE_FINISH(bl);
   }
 
-  static void generate_test_instances(list<rgw_cls_bucket_clear_olh_op *>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_bucket_clear_olh_op *>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(rgw_cls_bucket_clear_olh_op)
 
@@ -384,13 +384,13 @@ struct rgw_cls_list_op
 {
   cls_rgw_obj_key start_obj;
   uint32_t num_entries;
-  string filter_prefix;
+  std::string filter_prefix;
   bool list_versions;
-  string delimiter;
+  std::string delimiter;
 
   rgw_cls_list_op() : num_entries(0), list_versions(false) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(6, 4, bl);
     encode(num_entries, bl);
     encode(filter_prefix, bl);
@@ -399,7 +399,7 @@ struct rgw_cls_list_op
     encode(delimiter, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(6, 2, 2, bl);
     if (struct_v < 4) {
       decode(start_obj.name, bl);
@@ -419,8 +419,8 @@ struct rgw_cls_list_op
     }
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<rgw_cls_list_op*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_list_op*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_cls_list_op)
 
@@ -438,21 +438,21 @@ struct rgw_cls_list_ret {
     cls_filtered(true)
   {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(3, 2, bl);
     encode(dir, bl);
     encode(is_truncated, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(3, 2, 2, bl);
     decode(dir, bl);
     decode(is_truncated, bl);
     cls_filtered = struct_v >= 3;
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<rgw_cls_list_ret*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_list_ret*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_cls_list_ret)
 
@@ -463,57 +463,57 @@ struct rgw_cls_check_index_ret
 
   rgw_cls_check_index_ret() {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(existing_header, bl);
     encode(calculated_header, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(existing_header, bl);
     decode(calculated_header, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<rgw_cls_check_index_ret *>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_check_index_ret *>& o);
 };
 WRITE_CLASS_ENCODER(rgw_cls_check_index_ret)
 
 struct rgw_cls_bucket_update_stats_op
 {
   bool absolute{false};
-  map<RGWObjCategory, rgw_bucket_category_stats> stats;
+  std::map<RGWObjCategory, rgw_bucket_category_stats> stats;
 
   rgw_cls_bucket_update_stats_op() {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(absolute, bl);
     encode(stats, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(absolute, bl);
     decode(stats, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<rgw_cls_bucket_update_stats_op *>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_bucket_update_stats_op *>& o);
 };
 WRITE_CLASS_ENCODER(rgw_cls_bucket_update_stats_op)
 
 struct rgw_cls_obj_remove_op {
-  list<string> keep_attr_prefixes;
+  std::list<std::string> keep_attr_prefixes;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(keep_attr_prefixes, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(keep_attr_prefixes, bl);
     DECODE_FINISH(bl);
@@ -522,15 +522,15 @@ struct rgw_cls_obj_remove_op {
 WRITE_CLASS_ENCODER(rgw_cls_obj_remove_op)
 
 struct rgw_cls_obj_store_pg_ver_op {
-  string attr;
+  std::string attr;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(attr, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(attr, bl);
     DECODE_FINISH(bl);
@@ -539,19 +539,19 @@ struct rgw_cls_obj_store_pg_ver_op {
 WRITE_CLASS_ENCODER(rgw_cls_obj_store_pg_ver_op)
 
 struct rgw_cls_obj_check_attrs_prefix {
-  string check_prefix;
+  std::string check_prefix;
   bool fail_if_exist;
 
   rgw_cls_obj_check_attrs_prefix() : fail_if_exist(false) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(check_prefix, bl);
     encode(fail_if_exist, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(check_prefix, bl);
     decode(fail_if_exist, bl);
@@ -567,7 +567,7 @@ struct rgw_cls_obj_check_mtime {
 
   rgw_cls_obj_check_mtime() : type(CLS_RGW_CHECK_TIME_MTIME_EQ), high_precision_time(false) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
     encode(mtime, bl);
     encode((uint8_t)type, bl);
@@ -575,7 +575,7 @@ struct rgw_cls_obj_check_mtime {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
     decode(mtime, bl);
     uint8_t c;
@@ -593,18 +593,18 @@ struct rgw_cls_usage_log_add_op {
   rgw_usage_log_info info;
   rgw_user user;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
     encode(info, bl);
     encode(user.to_str(), bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
     decode(info, bl);
     if (struct_v >= 2) {
-      string s;
+      std::string s;
       decode(s, bl);
       user.from_str(s);
     }
@@ -619,14 +619,14 @@ struct rgw_cls_bi_get_op {
 
   rgw_cls_bi_get_op() : type(BIIndexType::Plain) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(key, bl);
     encode((uint8_t)type, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(key, bl);
     uint8_t c;
@@ -642,13 +642,13 @@ struct rgw_cls_bi_get_ret {
 
   rgw_cls_bi_get_ret() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entry, bl);
     DECODE_FINISH(bl);
@@ -661,13 +661,13 @@ struct rgw_cls_bi_put_op {
 
   rgw_cls_bi_put_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entry, bl);
     DECODE_FINISH(bl);
@@ -677,12 +677,12 @@ WRITE_CLASS_ENCODER(rgw_cls_bi_put_op)
 
 struct rgw_cls_bi_list_op {
   uint32_t max;
-  string name;
-  string marker;
+  std::string name;
+  std::string marker;
 
   rgw_cls_bi_list_op() : max(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(max, bl);
     encode(name, bl);
@@ -690,7 +690,7 @@ struct rgw_cls_bi_list_op {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(max, bl);
     decode(name, bl);
@@ -701,19 +701,19 @@ struct rgw_cls_bi_list_op {
 WRITE_CLASS_ENCODER(rgw_cls_bi_list_op)
 
 struct rgw_cls_bi_list_ret {
-  list<rgw_cls_bi_entry> entries;
+  std::list<rgw_cls_bi_entry> entries;
   bool is_truncated;
 
   rgw_cls_bi_list_ret() : is_truncated(false) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entries, bl);
     encode(is_truncated, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entries, bl);
     decode(is_truncated, bl);
@@ -725,13 +725,13 @@ WRITE_CLASS_ENCODER(rgw_cls_bi_list_ret)
 struct rgw_cls_usage_log_read_op {
   uint64_t start_epoch;
   uint64_t end_epoch;
-  string owner;
-  string bucket;
+  std::string owner;
+  std::string bucket;
 
-  string iter;  // should be empty for the first call, non empty for subsequent calls
+  std::string iter;  // should be empty for the first call, non empty for subsequent calls
   uint32_t max_entries;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
     encode(start_epoch, bl);
     encode(end_epoch, bl);
@@ -742,7 +742,7 @@ struct rgw_cls_usage_log_read_op {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
     decode(start_epoch, bl);
     decode(end_epoch, bl);
@@ -758,11 +758,11 @@ struct rgw_cls_usage_log_read_op {
 WRITE_CLASS_ENCODER(rgw_cls_usage_log_read_op)
 
 struct rgw_cls_usage_log_read_ret {
-  map<rgw_user_bucket, rgw_usage_log_entry> usage;
+  std::map<rgw_user_bucket, rgw_usage_log_entry> usage;
   bool truncated;
-  string next_iter;
+  std::string next_iter;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(usage, bl);
     encode(truncated, bl);
@@ -770,7 +770,7 @@ struct rgw_cls_usage_log_read_ret {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(usage, bl);
     decode(truncated, bl);
@@ -783,10 +783,10 @@ WRITE_CLASS_ENCODER(rgw_cls_usage_log_read_ret)
 struct rgw_cls_usage_log_trim_op {
   uint64_t start_epoch;
   uint64_t end_epoch;
-  string user;
-  string bucket;
+  std::string user;
+  std::string bucket;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(3, 2, bl);
     encode(start_epoch, bl);
     encode(end_epoch, bl);
@@ -795,7 +795,7 @@ struct rgw_cls_usage_log_trim_op {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(3, bl);
     decode(start_epoch, bl);
     decode(end_epoch, bl);
@@ -813,57 +813,57 @@ struct cls_rgw_gc_set_entry_op {
   cls_rgw_gc_obj_info info;
   cls_rgw_gc_set_entry_op() : expiration_secs(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(expiration_secs, bl);
     encode(info, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(expiration_secs, bl);
     decode(info, bl);
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_rgw_gc_set_entry_op*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_gc_set_entry_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_rgw_gc_set_entry_op)
 
 struct cls_rgw_gc_defer_entry_op {
   uint32_t expiration_secs;
-  string tag;
+  std::string tag;
   cls_rgw_gc_defer_entry_op() : expiration_secs(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(expiration_secs, bl);
     encode(tag, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(expiration_secs, bl);
     decode(tag, bl);
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_rgw_gc_defer_entry_op*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_gc_defer_entry_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_rgw_gc_defer_entry_op)
 
 struct cls_rgw_gc_list_op {
-  string marker;
+  std::string marker;
   uint32_t max;
   bool expired_only;
 
   cls_rgw_gc_list_op() : max(0), expired_only(true) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
     encode(marker, bl);
     encode(max, bl);
@@ -871,7 +871,7 @@ struct cls_rgw_gc_list_op {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
     decode(marker, bl);
     decode(max, bl);
@@ -881,19 +881,19 @@ struct cls_rgw_gc_list_op {
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_rgw_gc_list_op*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_gc_list_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_rgw_gc_list_op)
 
 struct cls_rgw_gc_list_ret {
-  list<cls_rgw_gc_obj_info> entries;
-  string next_marker;
+  std::list<cls_rgw_gc_obj_info> entries;
+  std::string next_marker;
   bool truncated;
 
   cls_rgw_gc_list_ret() : truncated(false) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
     encode(entries, bl);
     encode(next_marker, bl);
@@ -901,7 +901,7 @@ struct cls_rgw_gc_list_ret {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
     decode(entries, bl);
     if (struct_v >= 2)
@@ -910,119 +910,119 @@ struct cls_rgw_gc_list_ret {
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_rgw_gc_list_ret*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_gc_list_ret*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_rgw_gc_list_ret)
 
 struct cls_rgw_gc_remove_op {
-  vector<string> tags;
+  std::vector<std::string> tags;
 
   cls_rgw_gc_remove_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(tags, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(tags, bl);
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_rgw_gc_remove_op*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_gc_remove_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_rgw_gc_remove_op)
 
 struct cls_rgw_bi_log_list_op {
-  string marker;
+  std::string marker;
   uint32_t max;
 
   cls_rgw_bi_log_list_op() : max(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(marker, bl);
     encode(max, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(marker, bl);
     decode(max, bl);
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_rgw_bi_log_list_op*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_bi_log_list_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_rgw_bi_log_list_op)
 
 struct cls_rgw_bi_log_trim_op {
-  string start_marker;
-  string end_marker;
+  std::string start_marker;
+  std::string end_marker;
 
   cls_rgw_bi_log_trim_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(start_marker, bl);
     encode(end_marker, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(start_marker, bl);
     decode(end_marker, bl);
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_rgw_bi_log_trim_op*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_bi_log_trim_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_rgw_bi_log_trim_op)
 
 struct cls_rgw_bi_log_list_ret {
-  list<rgw_bi_log_entry> entries;
+  std::list<rgw_bi_log_entry> entries;
   bool truncated;
 
   cls_rgw_bi_log_list_ret() : truncated(false) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entries, bl);
     encode(truncated, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entries, bl);
     decode(truncated, bl);
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_rgw_bi_log_list_ret*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_bi_log_list_ret*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_rgw_bi_log_list_ret)
 
 struct cls_rgw_lc_get_next_entry_op {
-  string marker;
+  std::string marker;
   cls_rgw_lc_get_next_entry_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(marker, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(marker, bl);
     DECODE_FINISH(bl);
@@ -1036,13 +1036,13 @@ struct cls_rgw_lc_get_next_entry_ret {
   rgw_lc_entry_t entry;
   cls_rgw_lc_get_next_entry_ret() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entry, bl);
     DECODE_FINISH(bl);
@@ -1052,17 +1052,17 @@ struct cls_rgw_lc_get_next_entry_ret {
 WRITE_CLASS_ENCODER(cls_rgw_lc_get_next_entry_ret)
 
 struct cls_rgw_lc_get_entry_op {
-  string marker;
+  std::string marker;
   cls_rgw_lc_get_entry_op() {}
   cls_rgw_lc_get_entry_op(const std::string& _marker) : marker(_marker) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(marker, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(marker, bl);
     DECODE_FINISH(bl);
@@ -1075,13 +1075,13 @@ struct cls_rgw_lc_get_entry_ret {
   cls_rgw_lc_get_entry_ret() {}
   cls_rgw_lc_get_entry_ret(rgw_lc_entry_t&& _entry) : entry(std::move(_entry)) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entry, bl);
     DECODE_FINISH(bl);
@@ -1095,13 +1095,13 @@ struct cls_rgw_lc_rm_entry_op {
   rgw_lc_entry_t entry;
   cls_rgw_lc_rm_entry_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entry, bl);
     DECODE_FINISH(bl);
@@ -1113,13 +1113,13 @@ struct cls_rgw_lc_set_entry_op {
   rgw_lc_entry_t entry;
   cls_rgw_lc_set_entry_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entry, bl);
     DECODE_FINISH(bl);
@@ -1133,13 +1133,13 @@ struct cls_rgw_lc_put_head_op {
 
   cls_rgw_lc_put_head_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(head, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(head, bl);
     DECODE_FINISH(bl);
@@ -1153,13 +1153,13 @@ struct cls_rgw_lc_get_head_ret {
 
   cls_rgw_lc_get_head_ret() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(head, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(head, bl);
     DECODE_FINISH(bl);
@@ -1169,19 +1169,19 @@ struct cls_rgw_lc_get_head_ret {
 WRITE_CLASS_ENCODER(cls_rgw_lc_get_head_ret)
 
 struct cls_rgw_lc_list_entries_op {
-  string marker;
+  std::string marker;
   uint32_t max_entries = 0;
 
   cls_rgw_lc_list_entries_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(marker, bl);
     encode(max_entries, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(marker, bl);
     decode(max_entries, bl);
@@ -1192,19 +1192,19 @@ struct cls_rgw_lc_list_entries_op {
 WRITE_CLASS_ENCODER(cls_rgw_lc_list_entries_op)
 
 struct cls_rgw_lc_list_entries_ret {
-  map<string, int> entries;
+  std::map<std::string, int> entries;
   bool is_truncated{false};
 
   cls_rgw_lc_list_entries_ret() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
     encode(entries, bl);
     encode(is_truncated, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
     decode(entries, bl);
     if (struct_v >= 2) {
@@ -1221,68 +1221,68 @@ struct cls_rgw_reshard_add_op {
 
   cls_rgw_reshard_add_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entry, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(list<cls_rgw_reshard_add_op*>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_reshard_add_op*>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_add_op)
 
 struct cls_rgw_reshard_list_op {
   uint32_t max{0};
-  string marker;
+  std::string marker;
 
   cls_rgw_reshard_list_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(max, bl);
     encode(marker, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(max, bl);
     decode(marker, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(list<cls_rgw_reshard_list_op*>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_reshard_list_op*>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_list_op)
 
 
 struct cls_rgw_reshard_list_ret {
-  list<cls_rgw_reshard_entry> entries;
+  std::list<cls_rgw_reshard_entry> entries;
   bool is_truncated{false};
 
   cls_rgw_reshard_list_ret() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entries, bl);
     encode(is_truncated, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entries, bl);
     decode(is_truncated, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(list<cls_rgw_reshard_list_ret*>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_reshard_list_ret*>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_list_ret)
 
@@ -1291,19 +1291,19 @@ struct cls_rgw_reshard_get_op {
 
   cls_rgw_reshard_get_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entry, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(list<cls_rgw_reshard_get_op*>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_reshard_get_op*>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_get_op)
 
@@ -1312,30 +1312,30 @@ struct cls_rgw_reshard_get_ret {
 
   cls_rgw_reshard_get_ret() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entry, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(list<cls_rgw_reshard_get_ret*>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_reshard_get_ret*>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_get_ret)
 
 struct cls_rgw_reshard_remove_op {
-  string tenant;
-  string bucket_name;
-  string bucket_id;
+  std::string tenant;
+  std::string bucket_name;
+  std::string bucket_id;
 
   cls_rgw_reshard_remove_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(tenant, bl);
     encode(bucket_name, bl);
@@ -1343,106 +1343,106 @@ struct cls_rgw_reshard_remove_op {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(tenant, bl);
     decode(bucket_name, bl);
     decode(bucket_id, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(list<cls_rgw_reshard_remove_op*>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_reshard_remove_op*>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_remove_op)
 
 struct cls_rgw_set_bucket_resharding_op  {
   cls_rgw_bucket_instance_entry entry;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entry, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(list<cls_rgw_set_bucket_resharding_op*>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_set_bucket_resharding_op*>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_set_bucket_resharding_op)
 
 struct cls_rgw_clear_bucket_resharding_op {
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(list<cls_rgw_clear_bucket_resharding_op*>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_clear_bucket_resharding_op*>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_clear_bucket_resharding_op)
 
 struct cls_rgw_guard_bucket_resharding_op  {
   int ret_err{0};
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(ret_err, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(ret_err, bl);
     DECODE_FINISH(bl);
   }
 
-  static void generate_test_instances(list<cls_rgw_guard_bucket_resharding_op*>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_guard_bucket_resharding_op*>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_guard_bucket_resharding_op)
 
 struct cls_rgw_get_bucket_resharding_op  {
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     DECODE_FINISH(bl);
   }
 
-  static void generate_test_instances(list<cls_rgw_get_bucket_resharding_op*>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_get_bucket_resharding_op*>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_get_bucket_resharding_op)
 
 struct cls_rgw_get_bucket_resharding_ret  {
   cls_rgw_bucket_instance_entry new_instance;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(new_instance, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(new_instance, bl);
     DECODE_FINISH(bl);
   }
 
-  static void generate_test_instances(list<cls_rgw_get_bucket_resharding_ret*>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_get_bucket_resharding_ret*>& o);
+  void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_get_bucket_resharding_ret)
 

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -5,6 +5,11 @@
 #include "common/ceph_json.h"
 #include "include/utime.h"
 
+using std::list;
+using std::string;
+
+using ceph::bufferlist;
+using ceph::Formatter;
 
 void rgw_zone_set_entry::from_str(const string& s)
 {
@@ -30,7 +35,7 @@ string rgw_zone_set_entry::to_str() const
 void rgw_zone_set_entry::encode(bufferlist &bl) const
 {
   /* no ENCODE_START, ENCODE_END for backward compatibility */
-  ceph::encode(to_str(), bl);  
+  ceph::encode(to_str(), bl);
 }
 
 void rgw_zone_set_entry::decode(bufferlist::const_iterator &bl)
@@ -156,8 +161,7 @@ void rgw_bucket_dir_entry::generate_test_instances(list<rgw_bucket_dir_entry*>& 
   list<rgw_bucket_dir_entry_meta *> l;
   rgw_bucket_dir_entry_meta::generate_test_instances(l);
 
-  list<rgw_bucket_dir_entry_meta *>::iterator iter;
-  for (iter = l.begin(); iter != l.end(); ++iter) {
+  for (auto iter = l.begin(); iter != l.end(); ++iter) {
     rgw_bucket_dir_entry_meta *m = *iter;
     rgw_bucket_dir_entry *e = new rgw_bucket_dir_entry;
     e->key.name = "name";
@@ -576,11 +580,10 @@ void rgw_bucket_category_stats::dump(Formatter *f) const
 void rgw_bucket_dir_header::generate_test_instances(list<rgw_bucket_dir_header*>& o)
 {
   list<rgw_bucket_category_stats *> l;
-  list<rgw_bucket_category_stats *>::iterator iter;
   rgw_bucket_category_stats::generate_test_instances(l);
 
-  uint8_t i;
-  for (i = 0, iter = l.begin(); iter != l.end(); ++iter, ++i) {
+  uint8_t i = 0;
+  for (auto iter = l.begin(); iter != l.end(); ++iter, ++i) {
     RGWObjCategory c = static_cast<RGWObjCategory>(i);
     rgw_bucket_dir_header *h = new rgw_bucket_dir_header;
     rgw_bucket_category_stats *s = *iter;
@@ -612,18 +615,16 @@ void rgw_bucket_dir_header::dump(Formatter *f) const
 void rgw_bucket_dir::generate_test_instances(list<rgw_bucket_dir*>& o)
 {
   list<rgw_bucket_dir_header *> l;
-  list<rgw_bucket_dir_header *>::iterator iter;
   rgw_bucket_dir_header::generate_test_instances(l);
 
-  uint8_t i;
-  for (i = 0, iter = l.begin(); iter != l.end(); ++iter, ++i) {
+  uint8_t i = 0;
+  for (auto iter = l.begin(); iter != l.end(); ++iter, ++i) {
     rgw_bucket_dir *d = new rgw_bucket_dir;
     rgw_bucket_dir_header *h = *iter;
     d->header = *h;
 
     list<rgw_bucket_dir_entry *> el;
-    list<rgw_bucket_dir_entry *>::iterator eiter;
-    for (eiter = el.begin(); eiter != el.end(); ++eiter) {
+    for (auto eiter = el.begin(); eiter != el.end(); ++eiter) {
       rgw_bucket_dir_entry *e = *eiter;
       d->m[e->key.name] = *e;
 
@@ -670,8 +671,7 @@ void rgw_usage_log_entry::dump(Formatter *f) const
 
   f->open_array_section("categories");
   if (usage_map.size() > 0) {
-    map<string, rgw_usage_data>::const_iterator it;
-    for (it = usage_map.begin(); it != usage_map.end(); it++) {
+    for (auto it = usage_map.begin(); it != usage_map.end(); it++) {
       const rgw_usage_data& total_usage = it->second;
       f->open_object_section("entry");
       f->dump_string("category", it->first.c_str());

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -18,13 +18,10 @@
 
 class JSONObj;
 
-namespace ceph {
-  class Formatter;
-}
 using ceph::operator <<;
 
 struct rgw_zone_set_entry {
-  string zone;
+  std::string zone;
   std::optional<std::string> location_key;
 
   bool operator<(const rgw_zone_set_entry& e) const {
@@ -38,20 +35,20 @@ struct rgw_zone_set_entry {
   }
 
   rgw_zone_set_entry() {}
-  rgw_zone_set_entry(const string& _zone,
+  rgw_zone_set_entry(const std::string& _zone,
                      std::optional<std::string> _location_key) : zone(_zone),
                                                                 location_key(_location_key) {}
-  rgw_zone_set_entry(const string& s) {
+  rgw_zone_set_entry(const std::string& s) {
     from_str(s);
   }
 
-  void from_str(const string& s);
-  string to_str() const;
+  void from_str(const std::string& s);
+  std::string to_str() const;
 
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &bl);
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &bl);
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
 };
 WRITE_CLASS_ENCODER(rgw_zone_set_entry)
@@ -59,17 +56,17 @@ WRITE_CLASS_ENCODER(rgw_zone_set_entry)
 struct rgw_zone_set {
   std::set<rgw_zone_set_entry> entries;
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     /* no ENCODE_START, ENCODE_END for backward compatibility */
     ceph::encode(entries, bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     /* no DECODE_START, DECODE_END for backward compatibility */
     ceph::decode(entries, bl);
   }
 
-  void insert(const string& zone, std::optional<string> location_key);
-  bool exists(const string& zone, std::optional<string> location_key) const;
+  void insert(const std::string& zone, std::optional<std::string> location_key);
+  bool exists(const std::string& zone, std::optional<std::string> location_key) const;
 };
 WRITE_CLASS_ENCODER(rgw_zone_set)
 
@@ -110,19 +107,19 @@ enum RGWCheckMTimeType {
 
 #define ROUND_BLOCK_SIZE 4096
 
-static inline uint64_t cls_rgw_get_rounded_size(uint64_t size) {
+inline uint64_t cls_rgw_get_rounded_size(uint64_t size) {
   return (size + ROUND_BLOCK_SIZE - 1) & ~(ROUND_BLOCK_SIZE - 1);
 }
 
 /*
- * This takes a string that either wholly contains a delimiter or is a
+ * This takes a std::string that either wholly contains a delimiter or is a
  * path that ends with a delimiter and appends a new character to the
  * end such that when a we request bucket-index entries *after* this,
  * we'll get the next object after the "subdirectory". This works
  * because we append a '\xFF' charater, and no valid UTF-8 character
  * can contain that byte, so no valid entries can be skipped.
  */
-static inline std::string cls_rgw_after_delim(const std::string& path) {
+inline std::string cls_rgw_after_delim(const std::string& path) {
   // assert: ! path.empty()
   return path + '\xFF';
 }
@@ -134,7 +131,7 @@ struct rgw_bucket_pending_info {
 
   rgw_bucket_pending_info() : state(CLS_RGW_STATE_PENDING_MODIFY), op(0) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(2, 2, bl);
     uint8_t s = (uint8_t)state;
     encode(s, bl);
@@ -142,7 +139,7 @@ struct rgw_bucket_pending_info {
     encode(op, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(2, 2, 2, bl);
     uint8_t s;
     decode(s, bl);
@@ -151,9 +148,9 @@ struct rgw_bucket_pending_info {
     decode(op, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(list<rgw_bucket_pending_info*>& o);
+  static void generate_test_instances(std::list<rgw_bucket_pending_info*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_bucket_pending_info)
 
@@ -179,19 +176,19 @@ struct rgw_bucket_dir_entry_meta {
   RGWObjCategory category;
   uint64_t size;
   ceph::real_time mtime;
-  string etag;
-  string owner;
-  string owner_display_name;
-  string content_type;
+  std::string etag;
+  std::string owner;
+  std::string owner_display_name;
+  std::string content_type;
   uint64_t accounted_size;
-  string user_data;
-  string storage_class;
+  std::string user_data;
+  std::string storage_class;
   bool appendable;
 
   rgw_bucket_dir_entry_meta() :
     category(RGWObjCategory::None), size(0), accounted_size(0), appendable(false) { }
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(7, 3, bl);
     encode(category, bl);
     encode(size, bl);
@@ -207,7 +204,7 @@ struct rgw_bucket_dir_entry_meta {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(6, 3, 3, bl);
     decode(category, bl);
     decode(size, bl);
@@ -229,14 +226,14 @@ struct rgw_bucket_dir_entry_meta {
       decode(appendable, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(list<rgw_bucket_dir_entry_meta*>& o);
+  static void generate_test_instances(std::list<rgw_bucket_dir_entry_meta*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_bucket_dir_entry_meta)
 
 template<class T>
-void encode_packed_val(T val, bufferlist& bl)
+void encode_packed_val(T val, ceph::buffer::list& bl)
 {
   using ceph::encode;
   if ((uint64_t)val < 0x80) {
@@ -265,7 +262,7 @@ void encode_packed_val(T val, bufferlist& bl)
 }
 
 template<class T>
-void decode_packed_val(T& val, bufferlist::const_iterator& bl)
+void decode_packed_val(T& val, ceph::buffer::list::const_iterator& bl)
 {
   using ceph::decode;
   unsigned char c;
@@ -307,7 +304,7 @@ void decode_packed_val(T& val, bufferlist::const_iterator& bl)
       }
       break;
     default:
-      throw buffer::error();
+      throw ceph::buffer::error();
   }
 }
 
@@ -317,33 +314,33 @@ struct rgw_bucket_entry_ver {
 
   rgw_bucket_entry_ver() : pool(-1), epoch(0) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode_packed_val(pool, bl);
     encode_packed_val(epoch, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode_packed_val(pool, bl);
     decode_packed_val(epoch, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(list<rgw_bucket_entry_ver*>& o);
+  static void generate_test_instances(std::list<rgw_bucket_entry_ver*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_bucket_entry_ver)
 
 struct cls_rgw_obj_key {
-  string name;
-  string instance;
+  std::string name;
+  std::string instance;
 
   cls_rgw_obj_key() {}
-  cls_rgw_obj_key(const string &_name) : name(_name) {}
-  cls_rgw_obj_key(const string& n, const string& i) : name(n), instance(i) {}
+  cls_rgw_obj_key(const std::string &_name) : name(_name) {}
+  cls_rgw_obj_key(const std::string& n, const std::string& i) : name(n), instance(i) {}
 
-  void set(const string& _name) {
+  void set(const std::string& _name) {
     name = _name;
   }
 
@@ -364,24 +361,24 @@ struct cls_rgw_obj_key {
   bool empty() const {
     return name.empty();
   }
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(name, bl);
     encode(instance, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(name, bl);
     decode(instance, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->dump_string("name", name);
     f->dump_string("instance", instance);
   }
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(list<cls_rgw_obj_key*>& ls) {
+  static void generate_test_instances(std::list<cls_rgw_obj_key*>& ls) {
     ls.push_back(new cls_rgw_obj_key);
     ls.push_back(new cls_rgw_obj_key);
     ls.back()->name = "name";
@@ -412,16 +409,16 @@ struct rgw_bucket_dir_entry {
   std::string locator;
   bool exists;
   rgw_bucket_dir_entry_meta meta;
-  multimap<string, rgw_bucket_pending_info> pending_map;
+  std::multimap<std::string, rgw_bucket_pending_info> pending_map;
   uint64_t index_ver;
-  string tag;
+  std::string tag;
   uint16_t flags;
   uint64_t versioned_epoch;
 
   rgw_bucket_dir_entry() :
     exists(false), index_ver(0), flags(0), versioned_epoch(0) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(8, 3, bl);
     encode(key.name, bl);
     encode(ver.epoch, bl);
@@ -437,7 +434,7 @@ struct rgw_bucket_dir_entry {
     encode(versioned_epoch, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(8, 3, 3, bl);
     decode(key.name, bl);
     decode(ver.epoch, bl);
@@ -487,9 +484,9 @@ struct rgw_bucket_dir_entry {
     return flags & rgw_bucket_dir_entry::FLAG_COMMON_PREFIX;
   }
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(list<rgw_bucket_dir_entry*>& o);
+  static void generate_test_instances(std::list<rgw_bucket_dir_entry*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_bucket_dir_entry)
 
@@ -504,12 +501,12 @@ struct rgw_bucket_category_stats;
 
 struct rgw_cls_bi_entry {
   BIIndexType type;
-  string idx;
-  bufferlist data;
+  std::string idx;
+  ceph::buffer::list data;
 
   rgw_cls_bi_entry() : type(BIIndexType::Invalid) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(type, bl);
     encode(idx, bl);
@@ -517,7 +514,7 @@ struct rgw_cls_bi_entry {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     uint8_t c;
     decode(c, bl);
@@ -527,7 +524,7 @@ struct rgw_cls_bi_entry {
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj, cls_rgw_obj_key *effective_key = NULL);
 
   bool get_info(cls_rgw_obj_key *key, RGWObjCategory *category,
@@ -545,14 +542,14 @@ enum OLHLogOp {
 struct rgw_bucket_olh_log_entry {
   uint64_t epoch;
   OLHLogOp op;
-  string op_tag;
+  std::string op_tag;
   cls_rgw_obj_key key;
   bool delete_marker;
 
   rgw_bucket_olh_log_entry() : epoch(0), op(CLS_RGW_OLH_OP_UNKNOWN), delete_marker(false) {}
 
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(epoch, bl);
     encode((__u8)op, bl);
@@ -561,7 +558,7 @@ struct rgw_bucket_olh_log_entry {
     encode(delete_marker, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(epoch, bl);
     uint8_t c;
@@ -572,8 +569,8 @@ struct rgw_bucket_olh_log_entry {
     decode(delete_marker, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(list<rgw_bucket_olh_log_entry*>& o);
-  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_bucket_olh_log_entry*>& o);
+  void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
 };
 WRITE_CLASS_ENCODER(rgw_bucket_olh_log_entry)
@@ -582,14 +579,14 @@ struct rgw_bucket_olh_entry {
   cls_rgw_obj_key key;
   bool delete_marker;
   uint64_t epoch;
-  map<uint64_t, vector<struct rgw_bucket_olh_log_entry> > pending_log;
-  string tag;
+  std::map<uint64_t, std::vector<struct rgw_bucket_olh_log_entry> > pending_log;
+  std::string tag;
   bool exists;
   bool pending_removal;
 
   rgw_bucket_olh_entry() : delete_marker(false), epoch(0), exists(false), pending_removal(false) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(key, bl);
     encode(delete_marker, bl);
@@ -600,7 +597,7 @@ struct rgw_bucket_olh_entry {
     encode(pending_removal, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(1, bl);
     decode(key, bl);
     decode(delete_marker, bl);
@@ -611,29 +608,29 @@ struct rgw_bucket_olh_entry {
     decode(pending_removal, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
 };
 WRITE_CLASS_ENCODER(rgw_bucket_olh_entry)
 
 struct rgw_bi_log_entry {
-  string id;
-  string object;
-  string instance;
+  std::string id;
+  std::string object;
+  std::string instance;
   ceph::real_time timestamp;
   rgw_bucket_entry_ver ver;
   RGWModifyOp op;
   RGWPendingState state;
   uint64_t index_ver;
-  string tag;
+  std::string tag;
   uint16_t bilog_flags;
-  string owner; /* only being set if it's a delete marker */
-  string owner_display_name; /* only being set if it's a delete marker */
+  std::string owner; /* only being set if it's a delete marker */
+  std::string owner_display_name; /* only being set if it's a delete marker */
   rgw_zone_set zones_trace;
 
   rgw_bi_log_entry() : op(CLS_RGW_OP_UNKNOWN), state(CLS_RGW_STATE_PENDING_MODIFY), index_ver(0), bilog_flags(0) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(4, 1, bl);
     encode(id, bl);
     encode(object, bl);
@@ -652,7 +649,7 @@ struct rgw_bi_log_entry {
     encode(zones_trace, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START(4, bl);
     decode(id, bl);
     decode(object, bl);
@@ -678,9 +675,9 @@ struct rgw_bi_log_entry {
     }
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(list<rgw_bi_log_entry*>& o);
+  static void generate_test_instances(std::list<rgw_bi_log_entry*>& o);
 
   bool is_versioned() {
     return ((bilog_flags & RGW_BILOG_FLAG_VERSIONED_OP) != 0);
@@ -696,7 +693,7 @@ struct rgw_bucket_category_stats {
 
   rgw_bucket_category_stats() : total_size(0), total_size_rounded(0), num_entries(0) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(3, 2, bl);
     encode(total_size, bl);
     encode(total_size_rounded, bl);
@@ -704,7 +701,7 @@ struct rgw_bucket_category_stats {
     encode(actual_size, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(3, 2, 2, bl);
     decode(total_size, bl);
     decode(total_size_rounded, bl);
@@ -716,8 +713,8 @@ struct rgw_bucket_category_stats {
     }
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<rgw_bucket_category_stats*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_bucket_category_stats*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_bucket_category_stats)
 
@@ -727,7 +724,7 @@ enum class cls_rgw_reshard_status : uint8_t {
   DONE            = 2
 };
 
-static inline std::string to_string(const cls_rgw_reshard_status status)
+inline std::string to_string(const cls_rgw_reshard_status status)
 {
   switch (status) {
   case cls_rgw_reshard_status::NOT_RESHARDING:
@@ -747,10 +744,10 @@ struct cls_rgw_bucket_instance_entry {
   using RESHARD_STATUS = cls_rgw_reshard_status;
   
   cls_rgw_reshard_status reshard_status{RESHARD_STATUS::NOT_RESHARDING};
-  string new_bucket_instance_id;
+  std::string new_bucket_instance_id;
   int32_t num_shards{-1};
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode((uint8_t)reshard_status, bl);
     encode(new_bucket_instance_id, bl);
@@ -758,7 +755,7 @@ struct cls_rgw_bucket_instance_entry {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     uint8_t s;
     decode(s, bl);
@@ -768,15 +765,15 @@ struct cls_rgw_bucket_instance_entry {
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_rgw_bucket_instance_entry*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_bucket_instance_entry*>& o);
 
   void clear() {
     reshard_status = RESHARD_STATUS::NOT_RESHARDING;
     new_bucket_instance_id.clear();
   }
 
-  void set_status(const string& new_instance_id,
+  void set_status(const std::string& new_instance_id,
 		  int32_t new_num_shards,
 		  cls_rgw_reshard_status s) {
     reshard_status = s;
@@ -794,17 +791,17 @@ struct cls_rgw_bucket_instance_entry {
 WRITE_CLASS_ENCODER(cls_rgw_bucket_instance_entry)
 
 struct rgw_bucket_dir_header {
-  map<RGWObjCategory, rgw_bucket_category_stats> stats;
+  std::map<RGWObjCategory, rgw_bucket_category_stats> stats;
   uint64_t tag_timeout;
   uint64_t ver;
   uint64_t master_ver;
-  string max_marker;
+  std::string max_marker;
   cls_rgw_bucket_instance_entry new_instance;
   bool syncstopped;
 
   rgw_bucket_dir_header() : tag_timeout(0), ver(0), master_ver(0), syncstopped(false) {}
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(7, 2, bl);
     encode(stats, bl);
     encode(tag_timeout, bl);
@@ -815,7 +812,7 @@ struct rgw_bucket_dir_header {
     encode(syncstopped,bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(6, 2, 2, bl);
     decode(stats, bl);
     if (struct_v > 2) {
@@ -842,8 +839,8 @@ struct rgw_bucket_dir_header {
     }
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<rgw_bucket_dir_header*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_bucket_dir_header*>& o);
 
   bool resharding() const {
     return new_instance.resharding();
@@ -856,22 +853,22 @@ WRITE_CLASS_ENCODER(rgw_bucket_dir_header)
 
 struct rgw_bucket_dir {
   rgw_bucket_dir_header header;
-  boost::container::flat_map<string, rgw_bucket_dir_entry> m;
+  boost::container::flat_map<std::string, rgw_bucket_dir_entry> m;
 
-  void encode(bufferlist &bl) const {
+  void encode(ceph::buffer::list &bl) const {
     ENCODE_START(2, 2, bl);
     encode(header, bl);
     encode(m, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator &bl) {
+  void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(2, 2, 2, bl);
     decode(header, bl);
     decode(m, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<rgw_bucket_dir*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_bucket_dir*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_bucket_dir)
 
@@ -884,7 +881,7 @@ struct rgw_usage_data {
   rgw_usage_data() : bytes_sent(0), bytes_received(0), ops(0), successful_ops(0) {}
   rgw_usage_data(uint64_t sent, uint64_t received) : bytes_sent(sent), bytes_received(received), ops(0), successful_ops(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(bytes_sent, bl);
     encode(bytes_received, bl);
@@ -893,7 +890,7 @@ struct rgw_usage_data {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(bytes_sent, bl);
     decode(bytes_received, bl);
@@ -915,16 +912,16 @@ WRITE_CLASS_ENCODER(rgw_usage_data)
 struct rgw_usage_log_entry {
   rgw_user owner;
   rgw_user payer; /* if empty, same as owner */
-  string bucket;
+  std::string bucket;
   uint64_t epoch;
   rgw_usage_data total_usage; /* this one is kept for backwards compatibility */
-  map<string, rgw_usage_data> usage_map;
+  std::map<std::string, rgw_usage_data> usage_map;
 
   rgw_usage_log_entry() : epoch(0) {}
-  rgw_usage_log_entry(string& o, string& b) : owner(o), bucket(b), epoch(0) {}
-  rgw_usage_log_entry(string& o, string& p, string& b) : owner(o), payer(p), bucket(b), epoch(0) {}
+  rgw_usage_log_entry(std::string& o, std::string& b) : owner(o), bucket(b), epoch(0) {}
+  rgw_usage_log_entry(std::string& o, std::string& p, std::string& b) : owner(o), payer(p), bucket(b), epoch(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(3, 1, bl);
     encode(owner.to_str(), bl);
     encode(bucket, bl);
@@ -939,9 +936,9 @@ struct rgw_usage_log_entry {
   }
 
 
-   void decode(bufferlist::const_iterator& bl) {
+   void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(3, bl);
-    string s;
+    std::string s;
     decode(s, bl);
     owner.from_str(s);
     decode(bucket, bl);
@@ -956,14 +953,15 @@ struct rgw_usage_log_entry {
       decode(usage_map, bl);
     }
     if (struct_v >= 3) {
-      string p;
+      std::string p;
       decode(p, bl);
       payer.from_str(p);
     }
     DECODE_FINISH(bl);
   }
 
-  void aggregate(const rgw_usage_log_entry& e, map<string, bool> *categories = NULL) {
+  void aggregate(const rgw_usage_log_entry& e,
+		 std::map<std::string, bool> *categories = NULL) {
     if (owner.empty()) {
       owner = e.owner;
       bucket = e.bucket;
@@ -971,44 +969,44 @@ struct rgw_usage_log_entry {
       payer = e.payer;
     }
 
-    map<string, rgw_usage_data>::const_iterator iter;
-    for (iter = e.usage_map.begin(); iter != e.usage_map.end(); ++iter) {
+    for (auto iter = e.usage_map.begin(); iter != e.usage_map.end(); ++iter) {
       if (!categories || !categories->size() || categories->count(iter->first)) {
         add(iter->first, iter->second);
       }
     }
   }
 
-  void sum(rgw_usage_data& usage, map<string, bool>& categories) const {
+  void sum(rgw_usage_data& usage,
+	   std::map<std::string, bool>& categories) const {
     usage = rgw_usage_data();
-    for (map<string, rgw_usage_data>::const_iterator iter = usage_map.begin(); iter != usage_map.end(); ++iter) {
+    for (auto iter = usage_map.begin(); iter != usage_map.end(); ++iter) {
       if (!categories.size() || categories.count(iter->first)) {
         usage.aggregate(iter->second);
       }
     }
   }
 
-  void add(const string& category, const rgw_usage_data& data) {
+  void add(const std::string& category, const rgw_usage_data& data) {
     usage_map[category].aggregate(data);
     total_usage.aggregate(data);
   }
 
-  void dump(Formatter* f) const;
-  static void generate_test_instances(list<rgw_usage_log_entry*>& o);
+  void dump(ceph::Formatter* f) const;
+  static void generate_test_instances(std::list<rgw_usage_log_entry*>& o);
 
 };
 WRITE_CLASS_ENCODER(rgw_usage_log_entry)
 
 struct rgw_usage_log_info {
-  vector<rgw_usage_log_entry> entries;
+  std::vector<rgw_usage_log_entry> entries;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entries, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entries, bl);
     DECODE_FINISH(bl);
@@ -1019,20 +1017,20 @@ struct rgw_usage_log_info {
 WRITE_CLASS_ENCODER(rgw_usage_log_info)
 
 struct rgw_user_bucket {
-  string user;
-  string bucket;
+  std::string user;
+  std::string bucket;
 
   rgw_user_bucket() {}
-  rgw_user_bucket(const string& u, const string& b) : user(u), bucket(b) {}
+  rgw_user_bucket(const std::string& u, const std::string& b) : user(u), bucket(b) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(user, bl);
     encode(bucket, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(user, bl);
     decode(bucket, bl);
@@ -1057,14 +1055,14 @@ enum cls_rgw_gc_op {
 };
 
 struct cls_rgw_obj {
-  string pool;
+  std::string pool;
   cls_rgw_obj_key key;
-  string loc;
+  std::string loc;
 
   cls_rgw_obj() {}
-  cls_rgw_obj(string& _p, cls_rgw_obj_key& _k) : pool(_p), key(_k) {}
+  cls_rgw_obj(std::string& _p, cls_rgw_obj_key& _k) : pool(_p), key(_k) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
     encode(pool, bl);
     encode(key.name, bl);
@@ -1073,7 +1071,7 @@ struct cls_rgw_obj {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
     decode(pool, bl);
     decode(key.name, bl);
@@ -1084,13 +1082,13 @@ struct cls_rgw_obj {
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->dump_string("pool", pool);
     f->dump_string("oid", key.name);
     f->dump_string("key", loc);
     f->dump_string("instance", key.instance);
   }
-  static void generate_test_instances(list<cls_rgw_obj*>& ls) {
+  static void generate_test_instances(std::list<cls_rgw_obj*>& ls) {
     ls.push_back(new cls_rgw_obj);
     ls.push_back(new cls_rgw_obj);
     ls.back()->pool = "mypool";
@@ -1101,11 +1099,11 @@ struct cls_rgw_obj {
 WRITE_CLASS_ENCODER(cls_rgw_obj)
 
 struct cls_rgw_obj_chain {
-  list<cls_rgw_obj> objs;
+  std::list<cls_rgw_obj> objs;
 
   cls_rgw_obj_chain() {}
 
-  void push_obj(const string& pool, const cls_rgw_obj_key& key, const string& loc) {
+  void push_obj(const std::string& pool, const cls_rgw_obj_key& key, const std::string& loc) {
     cls_rgw_obj obj;
     obj.pool = pool;
     obj.key = key;
@@ -1113,28 +1111,28 @@ struct cls_rgw_obj_chain {
     objs.push_back(obj);
   }
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(objs, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(objs, bl);
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->open_array_section("objs");
-    for (list<cls_rgw_obj>::const_iterator p = objs.begin(); p != objs.end(); ++p) {
+    for (std::list<cls_rgw_obj>::const_iterator p = objs.begin(); p != objs.end(); ++p) {
       f->open_object_section("obj");
       p->dump(f);
       f->close_section();
     }
     f->close_section();
   }
-  static void generate_test_instances(list<cls_rgw_obj_chain*>& ls) {
+  static void generate_test_instances(std::list<cls_rgw_obj_chain*>& ls) {
     ls.push_back(new cls_rgw_obj_chain);
   }
 
@@ -1146,13 +1144,13 @@ WRITE_CLASS_ENCODER(cls_rgw_obj_chain)
 
 struct cls_rgw_gc_obj_info
 {
-  string tag;
+  std::string tag;
   cls_rgw_obj_chain chain;
   ceph::real_time time;
 
   cls_rgw_gc_obj_info() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(tag, bl);
     encode(chain, bl);
@@ -1160,7 +1158,7 @@ struct cls_rgw_gc_obj_info
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(tag, bl);
     decode(chain, bl);
@@ -1168,14 +1166,14 @@ struct cls_rgw_gc_obj_info
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->dump_string("tag", tag);
     f->open_object_section("chain");
     chain.dump(f);
     f->close_section();
     f->dump_stream("time") << time;
   }
-  static void generate_test_instances(list<cls_rgw_gc_obj_info*>& ls) {
+  static void generate_test_instances(std::list<cls_rgw_gc_obj_info*>& ls) {
     ls.push_back(new cls_rgw_gc_obj_info);
     ls.push_back(new cls_rgw_gc_obj_info);
     ls.back()->tag = "footag";
@@ -1188,11 +1186,11 @@ WRITE_CLASS_ENCODER(cls_rgw_gc_obj_info)
 struct cls_rgw_lc_obj_head
 {
   time_t start_date = 0;
-  string marker;
+  std::string marker;
 
   cls_rgw_lc_obj_head() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     uint64_t t = start_date;
     encode(t, bl);
@@ -1200,7 +1198,7 @@ struct cls_rgw_lc_obj_head
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     uint64_t t;
     decode(t, bl);
@@ -1209,24 +1207,24 @@ struct cls_rgw_lc_obj_head
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_rgw_lc_obj_head*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_lc_obj_head*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_obj_head)
 
 struct cls_rgw_reshard_entry
 {
   ceph::real_time time;
-  string tenant;
-  string bucket_name;
-  string bucket_id;
-  string new_instance_id;
+  std::string tenant;
+  std::string bucket_name;
+  std::string bucket_id;
+  std::string new_instance_id;
   uint32_t old_num_shards{0};
   uint32_t new_num_shards{0};
 
   cls_rgw_reshard_entry() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(time, bl);
     encode(tenant, bl);
@@ -1238,7 +1236,7 @@ struct cls_rgw_reshard_entry
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(time, bl);
     decode(tenant, bl);
@@ -1250,11 +1248,11 @@ struct cls_rgw_reshard_entry
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_rgw_reshard_entry*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_reshard_entry*>& o);
 
-  static void generate_key(const string& tenant, const string& bucket_name, string *key);
-  void get_key(string *key) const;
+  static void generate_key(const std::string& tenant, const std::string& bucket_name, std::string *key);
+  void get_key(std::string *key) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_entry)
 

--- a/src/cls/rgw_gc/cls_rgw_gc.cc
+++ b/src/cls/rgw_gc/cls_rgw_gc.cc
@@ -22,6 +22,14 @@
 
 #define GC_LIST_DEFAULT_MAX 128
 
+using std::string;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::make_timespan;
+using ceph::real_time;
+
 CLS_VER(1,0)
 CLS_NAME(rgw_gc)
 
@@ -32,7 +40,7 @@ static int cls_rgw_gc_queue_init(cls_method_context_t hctx, bufferlist *in, buff
   cls_rgw_gc_queue_init_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(5, "ERROR: cls_rgw_gc_queue_init: failed to decode entry\n");
     return -EINVAL;
   }
@@ -57,7 +65,7 @@ static int cls_rgw_gc_queue_enqueue(cls_method_context_t hctx, bufferlist *in, b
   cls_rgw_gc_set_entry_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_rgw_gc_queue_enqueue: failed to decode entry\n");
     return -EINVAL;
   }
@@ -94,7 +102,7 @@ static int cls_rgw_gc_queue_list_entries(cls_method_context_t hctx, bufferlist *
   cls_rgw_gc_list_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(5, "ERROR: cls_rgw_gc_queue_list_entries(): failed to decode input\n");
     return -EINVAL;
   }
@@ -110,7 +118,7 @@ static int cls_rgw_gc_queue_list_entries(cls_method_context_t hctx, bufferlist *
     auto iter_urgent_data = head.bl_urgent_data.cbegin();
     try {
       decode(urgent_data, iter_urgent_data);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       CLS_LOG(5, "ERROR: cls_rgw_gc_queue_list_entries(): failed to decode urgent data\n");
       return -EINVAL;
     }
@@ -143,7 +151,7 @@ static int cls_rgw_gc_queue_list_entries(cls_method_context_t hctx, bufferlist *
         cls_rgw_gc_obj_info info;
         try {
           decode(info, it.data);
-        } catch (buffer::error& err) {
+        } catch (ceph::buffer::error& err) {
           CLS_LOG(5, "ERROR: cls_rgw_gc_queue_list_entries(): failed to decode gc info\n");
           return -EINVAL;
         }
@@ -170,7 +178,7 @@ static int cls_rgw_gc_queue_list_entries(cls_method_context_t hctx, bufferlist *
             auto iter = bl_xattrs.cbegin();
             try {
               decode(xattr_urgent_data_map, iter);
-            } catch (buffer::error& err) {
+            } catch (ceph::buffer::error& err) {
               CLS_LOG(1, "ERROR: cls_rgw_gc_queue_list_entries(): failed to decode xattrs urgent data map\n");
               return -EINVAL;
             } //end - catch
@@ -225,7 +233,7 @@ static int cls_rgw_gc_queue_remove_entries(cls_method_context_t hctx, bufferlist
   cls_rgw_gc_queue_remove_entries_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(5, "ERROR: cls_rgw_gc_queue_remove_entries(): failed to decode input\n");
     return -EINVAL;
   }
@@ -241,7 +249,7 @@ static int cls_rgw_gc_queue_remove_entries(cls_method_context_t hctx, bufferlist
     auto iter_urgent_data = head.bl_urgent_data.cbegin();
     try {
       decode(urgent_data, iter_urgent_data);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       CLS_LOG(5, "ERROR: cls_rgw_gc_queue_remove_entries(): failed to decode urgent data\n");
       return -EINVAL;
     }
@@ -272,7 +280,7 @@ static int cls_rgw_gc_queue_remove_entries(cls_method_context_t hctx, bufferlist
         cls_rgw_gc_obj_info info;
         try {
           decode(info, it.data);
-        } catch (buffer::error& err) {
+        } catch (ceph::buffer::error& err) {
           CLS_LOG(5, "ERROR: cls_rgw_gc_queue_remove_entries(): failed to decode gc info\n");
           return -EINVAL;
         }
@@ -306,7 +314,7 @@ static int cls_rgw_gc_queue_remove_entries(cls_method_context_t hctx, bufferlist
             auto iter = bl_xattrs.cbegin();
             try {
               decode(xattr_urgent_data_map, iter);
-            } catch (buffer::error& err) {
+            } catch (ceph::buffer::error& err) {
               CLS_LOG(5, "ERROR: cls_rgw_gc_queue_remove_entries(): failed to decode xattrs urgent data map\n");
               return -EINVAL;
             } //end - catch
@@ -374,7 +382,7 @@ static int cls_rgw_gc_queue_update_entry(cls_method_context_t hctx, bufferlist *
   cls_rgw_gc_queue_defer_entry_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(5, "ERROR: cls_rgw_gc_queue_update_entry(): failed to decode input\n");
     return -EINVAL;
   }
@@ -393,7 +401,7 @@ static int cls_rgw_gc_queue_update_entry(cls_method_context_t hctx, bufferlist *
   cls_rgw_gc_urgent_data urgent_data;
   try {
     decode(urgent_data, bl_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(5, "ERROR: cls_rgw_gc_queue_update_entry(): failed to decode urgent data\n");
     return -EINVAL;
   }
@@ -418,7 +426,7 @@ static int cls_rgw_gc_queue_update_entry(cls_method_context_t hctx, bufferlist *
       auto iter = bl_xattrs.cbegin();
       try {
         decode(xattr_urgent_data_map, iter);
-      } catch (buffer::error& err) {
+      } catch (ceph::buffer::error& err) {
         CLS_LOG(1, "ERROR: cls_rgw_gc_queue_update_entry(): failed to decode xattrs urgent data map\n");
         return -EINVAL;
       } //end - catch
@@ -465,7 +473,7 @@ static int cls_rgw_gc_queue_update_entry(cls_method_context_t hctx, bufferlist *
         auto iter = bl_xattrs.cbegin();
         try {
           decode(xattr_urgent_data_map, iter);
-        } catch (buffer::error& err) {
+        } catch (ceph::buffer::error& err) {
           CLS_LOG(1, "ERROR: cls_rgw_gc_queue_remove_entries(): failed to decode xattrs urgent data map\n");
           return -EINVAL;
         } //end - catch

--- a/src/cls/rgw_gc/cls_rgw_gc_client.cc
+++ b/src/cls/rgw_gc/cls_rgw_gc_client.cc
@@ -9,6 +9,12 @@
 #include "cls/queue/cls_queue_const.h"
 #include "cls/rgw_gc/cls_rgw_gc_client.h"
 
+using std::list;
+using std::string;
+
+using ceph::decode;
+using ceph::encode;
+
 using namespace librados;
 
 void cls_rgw_gc_queue_init(ObjectWriteOperation& op, uint64_t size, uint64_t num_deferred_entries)
@@ -32,7 +38,7 @@ int cls_rgw_gc_queue_get_capacity(IoCtx& io_ctx, const string& oid, uint64_t& si
   auto iter = out.cbegin();
   try {
     decode(op_ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
 
@@ -69,7 +75,7 @@ int cls_rgw_gc_queue_list_entries(IoCtx& io_ctx, const string& oid, const string
   auto iter = out.cbegin();
   try {
     decode(ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
 

--- a/src/cls/rgw_gc/cls_rgw_gc_client.h
+++ b/src/cls/rgw_gc/cls_rgw_gc_client.h
@@ -1,16 +1,22 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_CLS_RGW_GC_CLIENT_H
 #define CEPH_CLS_RGW_GC_CLIENT_H
 
 #include "include/rados/librados.hpp"
-#include "cls/rgw_gc/cls_rgw_gc_types.h"
-#include "cls/queue/cls_queue_ops.h"
+
 #include "common/ceph_time.h"
 
+#include "cls/queue/cls_queue_ops.h"
+#include "cls/rgw/cls_rgw_types.h"
+#include "cls/rgw_gc/cls_rgw_gc_types.h"
+
 void cls_rgw_gc_queue_init(librados::ObjectWriteOperation& op, uint64_t size, uint64_t num_deferred_entries);
-int cls_rgw_gc_queue_get_capacity(librados::IoCtx& io_ctx, const string& oid, uint64_t& size);
+int cls_rgw_gc_queue_get_capacity(librados::IoCtx& io_ctx, const std::string& oid, uint64_t& size);
 void cls_rgw_gc_queue_enqueue(librados::ObjectWriteOperation& op, uint32_t expiration_secs, const cls_rgw_gc_obj_info& info);
-int cls_rgw_gc_queue_list_entries(librados::IoCtx& io_ctx, const string& oid, const string& marker, uint32_t max, bool expired_only,
-                    list<cls_rgw_gc_obj_info>& entries, bool *truncated, string& next_marker);
+int cls_rgw_gc_queue_list_entries(librados::IoCtx& io_ctx, const std::string& oid, const std::string& marker, uint32_t max, bool expired_only,
+				  std::list<cls_rgw_gc_obj_info>& entries, bool *truncated, std::string& next_marker);
 void cls_rgw_gc_queue_remove_entries(librados::ObjectWriteOperation& op, uint32_t num_entries);
 void cls_rgw_gc_queue_defer_entry(librados::ObjectWriteOperation& op, uint32_t expiration_secs, const cls_rgw_gc_obj_info& info);
 

--- a/src/cls/rgw_gc/cls_rgw_gc_ops.h
+++ b/src/cls/rgw_gc/cls_rgw_gc_ops.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_CLS_RGW_GC_OPS_H
 #define CEPH_CLS_RGW_GC_OPS_H
 
@@ -9,14 +12,14 @@ struct cls_rgw_gc_queue_init_op {
 
   cls_rgw_gc_queue_init_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(size, bl);
     encode(num_deferred_entries, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(size, bl);
     decode(num_deferred_entries, bl);
@@ -31,13 +34,13 @@ struct cls_rgw_gc_queue_remove_entries_op {
 
   cls_rgw_gc_queue_remove_entries_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(num_entries, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(num_entries, bl);
     DECODE_FINISH(bl);
@@ -50,14 +53,14 @@ struct cls_rgw_gc_queue_defer_entry_op {
   cls_rgw_gc_obj_info info;
   cls_rgw_gc_queue_defer_entry_op() : expiration_secs(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(expiration_secs, bl);
     encode(info, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(expiration_secs, bl);
     decode(info, bl);

--- a/src/cls/rgw_gc/cls_rgw_gc_types.h
+++ b/src/cls/rgw_gc/cls_rgw_gc_types.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_CLS_RGW_GC_TYPES_H
 #define CEPH_CLS_RGW_GC_TYPES_H
 
@@ -6,12 +9,12 @@
 
 struct cls_rgw_gc_urgent_data
 {
-  std::unordered_map<string,ceph::real_time> urgent_data_map;
+  std::unordered_map<std::string, ceph::real_time> urgent_data_map;
   uint32_t num_urgent_data_entries{0}; // requested by user
   uint32_t num_head_urgent_entries{0}; // actual number of entries in queue head
   uint32_t num_xattr_urgent_entries{0}; // actual number of entries in xattr in case of spill over
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(urgent_data_map, bl);
     encode(num_urgent_data_entries, bl);
@@ -20,7 +23,7 @@ struct cls_rgw_gc_urgent_data
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(urgent_data_map, bl);
     decode(num_urgent_data_entries, bl);

--- a/src/cls/timeindex/cls_timeindex.cc
+++ b/src/cls/timeindex/cls_timeindex.cc
@@ -1,4 +1,4 @@
-// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
 #include <errno.h>
@@ -8,6 +8,11 @@
 #include "cls_timeindex_ops.h"
 
 #include "include/compat.h"
+
+using std::map;
+using std::string;
+
+using ceph::bufferlist;
 
 CLS_VER(1,0)
 CLS_NAME(timeindex)
@@ -61,12 +66,12 @@ static int cls_timeindex_add(cls_method_context_t hctx,
   cls_timeindex_add_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_timeindex_add_op(): failed to decode op");
     return -EINVAL;
   }
 
-  for (list<cls_timeindex_entry>::iterator iter = op.entries.begin();
+  for (auto iter = op.entries.begin();
        iter != op.entries.end();
        ++iter) {
     cls_timeindex_entry& entry = *iter;
@@ -94,7 +99,7 @@ static int cls_timeindex_list(cls_method_context_t hctx,
   cls_timeindex_list_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_timeindex_list_op(): failed to decode op");
     return -EINVAL;
   }
@@ -128,8 +133,8 @@ static int cls_timeindex_list(cls_method_context_t hctx,
     return rc;
   }
 
-  list<cls_timeindex_entry>& entries = ret.entries;
-  map<string, bufferlist>::iterator iter = keys.begin();
+  auto& entries = ret.entries;
+  auto iter = keys.begin();
 
   string marker;
 
@@ -175,7 +180,7 @@ static int cls_timeindex_trim(cls_method_context_t hctx,
   cls_timeindex_trim_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_timeindex_trim: failed to decode entry");
     return -EINVAL;
   }
@@ -205,7 +210,7 @@ static int cls_timeindex_trim(cls_method_context_t hctx,
     return rc;
   }
 
-  map<string, bufferlist>::iterator iter = keys.begin();
+  auto iter = keys.begin();
 
   bool removed = false;
   for (; iter != keys.end(); ++iter) {

--- a/src/cls/timeindex/cls_timeindex_client.h
+++ b/src/cls/timeindex/cls_timeindex_client.h
@@ -27,7 +27,7 @@ public:
   ///* dtor
   ~TimeindexListCtx() {}
 
-  void handle_completion(int r, bufferlist& bl) override {
+  void handle_completion(int r, ceph::buffer::list& bl) override {
     if (r >= 0) {
       cls_timeindex_list_ret ret;
       try {
@@ -39,7 +39,7 @@ public:
           *truncated = ret.truncated;
         if (marker)
           *marker = ret.marker;
-      } catch (buffer::error& err) {
+      } catch (ceph::buffer::error& err) {
         // nothing we can do about it atm
       }
     }
@@ -50,7 +50,7 @@ void cls_timeindex_add_prepare_entry(
   cls_timeindex_entry& entry,
   const utime_t& key_timestamp,
   const std::string& key_ext,
-  bufferlist& bl);
+  ceph::buffer::list& bl);
 
 void cls_timeindex_add(
   librados::ObjectWriteOperation& op,
@@ -64,7 +64,7 @@ void cls_timeindex_add(
   librados::ObjectWriteOperation& op,
   const utime_t& timestamp,
   const std::string& name,
-  const bufferlist& bl);
+  const ceph::buffer::list& bl);
 
 void cls_timeindex_list(
   librados::ObjectReadOperation& op,

--- a/src/cls/timeindex/cls_timeindex_ops.h
+++ b/src/cls/timeindex/cls_timeindex_ops.h
@@ -7,17 +7,17 @@
 #include "cls_timeindex_types.h"
 
 struct cls_timeindex_add_op {
-  list<cls_timeindex_entry> entries;
+  std::list<cls_timeindex_entry> entries;
 
   cls_timeindex_add_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entries, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entries, bl);
     DECODE_FINISH(bl);
@@ -27,14 +27,14 @@ WRITE_CLASS_ENCODER(cls_timeindex_add_op)
 
 struct cls_timeindex_list_op {
   utime_t from_time;
-  string marker; /* if not empty, overrides from_time */
+  std::string marker; /* if not empty, overrides from_time */
   utime_t to_time; /* not inclusive */
   int max_entries; /* upperbound to returned num of entries
                       might return less than that and still be truncated */
 
   cls_timeindex_list_op() : max_entries(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(from_time, bl);
     encode(marker, bl);
@@ -43,7 +43,7 @@ struct cls_timeindex_list_op {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(from_time, bl);
     decode(marker, bl);
@@ -55,13 +55,13 @@ struct cls_timeindex_list_op {
 WRITE_CLASS_ENCODER(cls_timeindex_list_op)
 
 struct cls_timeindex_list_ret {
-  list<cls_timeindex_entry> entries;
-  string marker;
+  std::list<cls_timeindex_entry> entries;
+  std::string marker;
   bool truncated;
 
   cls_timeindex_list_ret() : truncated(false) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entries, bl);
     encode(marker, bl);
@@ -69,7 +69,7 @@ struct cls_timeindex_list_ret {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entries, bl);
     decode(marker, bl);
@@ -87,12 +87,12 @@ WRITE_CLASS_ENCODER(cls_timeindex_list_ret)
 struct cls_timeindex_trim_op {
   utime_t from_time;
   utime_t to_time; /* inclusive */
-  string from_marker;
-  string to_marker;
+  std::string from_marker;
+  std::string to_marker;
 
   cls_timeindex_trim_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(from_time, bl);
     encode(to_time, bl);
@@ -101,7 +101,7 @@ struct cls_timeindex_trim_op {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(from_time, bl);
     decode(to_time, bl);

--- a/src/cls/timeindex/cls_timeindex_types.h
+++ b/src/cls/timeindex/cls_timeindex_types.h
@@ -16,13 +16,13 @@ struct cls_timeindex_entry {
   utime_t key_ts;
   /* Not mandatory. The name_ext field, if not empty, will form second
    * part of the key. */
-  string key_ext;
+  std::string key_ext;
   /* Become value of OMAP-based mapping. */
-  bufferlist value;
+  ceph::buffer::list value;
 
   cls_timeindex_entry() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(key_ts, bl);
     encode(key_ext, bl);
@@ -30,7 +30,7 @@ struct cls_timeindex_entry {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(key_ts, bl);
     decode(key_ext, bl);
@@ -38,8 +38,8 @@ struct cls_timeindex_entry {
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_timeindex_entry*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_timeindex_entry*>& o);
 };
 WRITE_CLASS_ENCODER(cls_timeindex_entry)
 

--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -1,4 +1,4 @@
-// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
 #include <errno.h>
@@ -7,6 +7,13 @@
 #include "objclass/objclass.h"
 
 #include "cls_user_ops.h"
+
+using std::map;
+using std::string;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
 
 CLS_VER(1,0)
 CLS_NAME(user)
@@ -56,7 +63,7 @@ static int get_existing_bucket_entry(cls_method_context_t hctx, const string& bu
   try {
     auto iter = bl.cbegin();
     decode(entry, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: failed to decode entry %s", key.c_str());
     return -EIO;
   }
@@ -79,7 +86,7 @@ static int read_header(cls_method_context_t hctx, cls_user_header *header)
 
   try {
     decode(*header, bl);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: failed to decode user header");
     return -EIO;
   }
@@ -115,7 +122,7 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
   cls_user_set_buckets_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_user_add_op(): failed to decode op");
     return -EINVAL;
   }
@@ -127,8 +134,7 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     return ret;
   }
 
-  for (list<cls_user_bucket_entry>::iterator iter = op.entries.begin();
-       iter != op.entries.end(); ++iter) {
+  for (auto iter = op.entries.begin(); iter != op.entries.end(); ++iter) {
     cls_user_bucket_entry& update_entry = *iter;
 
     string key;
@@ -200,7 +206,7 @@ static int cls_user_complete_stats_sync(cls_method_context_t hctx, bufferlist *i
   cls_user_complete_stats_sync_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_user_add_op(): failed to decode op");
     return -EINVAL;
   }
@@ -233,7 +239,7 @@ static int cls_user_remove_bucket(cls_method_context_t hctx, bufferlist *in, buf
   cls_user_remove_bucket_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_user_add_op(): failed to decode op");
     return -EINVAL;
   }
@@ -285,7 +291,7 @@ static int cls_user_list_buckets(cls_method_context_t hctx, bufferlist *in, buff
   cls_user_list_buckets_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_user_list_op(): failed to decode op");
     return -EINVAL;
   }
@@ -313,8 +319,8 @@ static int cls_user_list_buckets(cls_method_context_t hctx, bufferlist *in, buff
           to_index.c_str(),
           match_prefix.c_str());
 
-  list<cls_user_bucket_entry>& entries = ret.entries;
-  map<string, bufferlist>::iterator iter = keys.begin();
+  auto& entries = ret.entries;
+  auto iter = keys.begin();
 
   string marker;
 
@@ -333,7 +339,7 @@ static int cls_user_list_buckets(cls_method_context_t hctx, bufferlist *in, buff
       cls_user_bucket_entry e;
       decode(e, biter);
       entries.push_back(e);
-    } catch (buffer::error& err) {
+    } catch (ceph::buffer::error& err) {
       CLS_LOG(0, "ERROR: cls_user_list: could not decode entry, index=%s", index.c_str());
     }
   }
@@ -354,7 +360,7 @@ static int cls_user_get_header(cls_method_context_t hctx, bufferlist *in, buffer
   cls_user_get_header_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_user_get_header_op(): failed to decode op");
     return -EINVAL;
   }
@@ -382,7 +388,7 @@ static int cls_user_reset_stats(cls_method_context_t hctx,
   try {
     auto bliter = in->cbegin();
     decode(op, bliter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: %s failed to decode op", __func__);
     return -EINVAL;
   }
@@ -407,7 +413,7 @@ static int cls_user_reset_stats(cls_method_context_t hctx,
 	auto bl = kv.second;
 	auto bliter = bl.cbegin();
 	decode(e, bliter);
-      } catch (buffer::error& err) {
+      } catch (ceph::buffer::error& err) {
 	CLS_LOG(0, "ERROR: %s failed to decode bucket entry for %s",
 		__func__, kv.first.c_str());
 	return -EIO;
@@ -449,4 +455,3 @@ CLS_INIT(user)
   cls_register_cxx_method(h_class, "reset_user_stats", CLS_METHOD_RD | CLS_METHOD_WR, cls_user_reset_stats, &h_user_reset_stats);
   return;
 }
-

--- a/src/cls/user/cls_user_client.cc
+++ b/src/cls/user/cls_user_client.cc
@@ -6,9 +6,15 @@
 #include "cls/user/cls_user_client.h"
 #include "include/rados/librados.hpp"
 
+using std::list;
+using std::string;
 
-using namespace librados;
+using ceph::bufferlist;
+using ceph::real_clock;
 
+using librados::IoCtx;
+using librados::ObjectOperationCompletion;
+using librados::ObjectReadOperation;
 
 void cls_user_set_buckets(librados::ObjectWriteOperation& op, list<cls_user_bucket_entry>& entries, bool add)
 {
@@ -59,7 +65,7 @@ public:
           *truncated = ret.truncated;
         if (marker)
           *marker = ret.marker;
-      } catch (buffer::error& err) {
+      } catch (ceph::buffer::error& err) {
         r = -EIO;
       }
     }
@@ -108,7 +114,7 @@ public:
         decode(ret, iter);
         if (header)
 	  *header = ret.header;
-      } catch (buffer::error& err) {
+      } catch (ceph::buffer::error& err) {
         r = -EIO;
       }
       if (ret_ctx) {
@@ -148,7 +154,7 @@ int cls_user_get_header_async(IoCtx& io_ctx, string& oid, RGWGetUserHeader_CB *c
   encode(call, in);
   ObjectReadOperation op;
   op.exec("user", "get_header", in, new ClsUserGetHeaderCtx(NULL, ctx, NULL)); /* no need to pass pret, as we'll call ctx->handle_response() with correct error */
-  AioCompletion *c = librados::Rados::aio_create_completion(nullptr, nullptr);
+  auto c = librados::Rados::aio_create_completion(nullptr, nullptr);
   int r = io_ctx.aio_operate(oid, c, &op, NULL);
   c->release();
   if (r < 0)

--- a/src/cls/user/cls_user_client.h
+++ b/src/cls/user/cls_user_client.h
@@ -1,4 +1,4 @@
-// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
 #ifndef CEPH_CLS_USER_CLIENT_H
@@ -18,19 +18,19 @@ public:
  * user objclass
  */
 
-void cls_user_set_buckets(librados::ObjectWriteOperation& op, list<cls_user_bucket_entry>& entries, bool add);
+void cls_user_set_buckets(librados::ObjectWriteOperation& op, std::list<cls_user_bucket_entry>& entries, bool add);
 void cls_user_complete_stats_sync(librados::ObjectWriteOperation& op);
 void cls_user_remove_bucket(librados::ObjectWriteOperation& op,  const cls_user_bucket& bucket);
 void cls_user_bucket_list(librados::ObjectReadOperation& op,
-                       const string& in_marker,
-                       const string& end_marker,
-                       int max_entries,
-                       list<cls_user_bucket_entry>& entries,
-                       string *out_marker,
-                       bool *truncated,
-                       int *pret);
+			  const std::string& in_marker,
+			  const std::string& end_marker,
+			  int max_entries,
+			  std::list<cls_user_bucket_entry>& entries,
+			  std::string *out_marker,
+			  bool *truncated,
+			  int *pret);
 void cls_user_get_header(librados::ObjectReadOperation& op, cls_user_header *header, int *pret);
-int cls_user_get_header_async(librados::IoCtx& io_ctx, string& oid, RGWGetUserHeader_CB *ctx);
+int cls_user_get_header_async(librados::IoCtx& io_ctx, std::string& oid, RGWGetUserHeader_CB *ctx);
 void cls_user_reset_stats(librados::ObjectWriteOperation& op);
 
 #endif

--- a/src/cls/user/cls_user_ops.cc
+++ b/src/cls/user/cls_user_ops.cc
@@ -1,9 +1,13 @@
-// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
 #include "cls/user/cls_user_ops.h"
 #include "common/Formatter.h"
 #include "common/ceph_json.h"
+
+using std::list;
+
+using ceph::Formatter;
 
 void cls_user_set_buckets_op::dump(Formatter *f) const
 {

--- a/src/cls/user/cls_user_ops.h
+++ b/src/cls/user/cls_user_ops.h
@@ -7,13 +7,13 @@
 #include "cls_user_types.h"
 
 struct cls_user_set_buckets_op {
-  list<cls_user_bucket_entry> entries;
+  std::list<cls_user_bucket_entry> entries;
   bool add;
-  real_time time; /* op time */
+  ceph::real_time time; /* op time */
 
   cls_user_set_buckets_op() : add(false) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entries, bl);
     encode(add, bl);
@@ -21,7 +21,7 @@ struct cls_user_set_buckets_op {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entries, bl);
     decode(add, bl);
@@ -29,8 +29,8 @@ struct cls_user_set_buckets_op {
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_user_set_buckets_op*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_user_set_buckets_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_user_set_buckets_op)
 
@@ -39,33 +39,33 @@ struct cls_user_remove_bucket_op {
 
   cls_user_remove_bucket_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(bucket, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(bucket, bl);
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_user_remove_bucket_op*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_user_remove_bucket_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_user_remove_bucket_op)
 
 struct cls_user_list_buckets_op {
-  string marker;
-  string end_marker;
+  std::string marker;
+  std::string end_marker;
   int max_entries; /* upperbound to returned num of entries
                       might return less than that and still be truncated */
 
   cls_user_list_buckets_op()
     : max_entries(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
     encode(marker, bl);
     encode(max_entries, bl);
@@ -73,7 +73,7 @@ struct cls_user_list_buckets_op {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
     decode(marker, bl);
     decode(max_entries, bl);
@@ -83,19 +83,19 @@ struct cls_user_list_buckets_op {
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_user_list_buckets_op*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_user_list_buckets_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_user_list_buckets_op)
 
 struct cls_user_list_buckets_ret {
-  list<cls_user_bucket_entry> entries;
-  string marker;
+  std::list<cls_user_bucket_entry> entries;
+  std::string marker;
   bool truncated;
 
   cls_user_list_buckets_ret() : truncated(false) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entries, bl);
     encode(marker, bl);
@@ -103,7 +103,7 @@ struct cls_user_list_buckets_ret {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(entries, bl);
     decode(marker, bl);
@@ -111,8 +111,8 @@ struct cls_user_list_buckets_ret {
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_user_list_buckets_ret*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_user_list_buckets_ret*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_user_list_buckets_ret)
 
@@ -120,39 +120,39 @@ WRITE_CLASS_ENCODER(cls_user_list_buckets_ret)
 struct cls_user_get_header_op {
   cls_user_get_header_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_user_get_header_op*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_user_get_header_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_user_get_header_op)
 
 struct cls_user_reset_stats_op {
-  real_time time;
+  ceph::real_time time;
   cls_user_reset_stats_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(time, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(time, bl);
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_user_reset_stats_op*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_user_reset_stats_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_user_reset_stats_op);
 
@@ -161,42 +161,42 @@ struct cls_user_get_header_ret {
 
   cls_user_get_header_ret() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(header, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(header, bl);
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_user_get_header_ret*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_user_get_header_ret*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_user_get_header_ret)
 
 struct cls_user_complete_stats_sync_op {
-  real_time time;
+  ceph::real_time time;
 
   cls_user_complete_stats_sync_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(time, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(time, bl);
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_user_complete_stats_sync_op*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_user_complete_stats_sync_op*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_user_complete_stats_sync_op)
 

--- a/src/cls/user/cls_user_types.cc
+++ b/src/cls/user/cls_user_types.cc
@@ -1,10 +1,17 @@
-// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
 #include "cls/user/cls_user_types.h"
 #include "common/Formatter.h"
 #include "common/ceph_json.h"
 #include "include/utime.h"
+
+using std::list;
+using std::string;
+
+using ceph::Formatter;
+using ceph::bufferlist;
+using ceph::real_clock;
 
 void cls_user_gen_test_bucket(cls_user_bucket *bucket, int i)
 {

--- a/src/cls/user/cls_user_types.h
+++ b/src/cls/user/cls_user_types.h
@@ -1,4 +1,4 @@
-// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
 #ifndef CEPH_CLS_USER_TYPES_H
@@ -23,7 +23,7 @@ struct cls_user_bucket {
     std::string data_extra_pool;
   } explicit_placement;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     /* since new version of this structure is not backward compatible,
      * we have older rgw running against newer osd if we encode it
      * in the new way. Only encode newer version if placement_id is
@@ -47,7 +47,7 @@ struct cls_user_bucket {
       ENCODE_FINISH(bl);
     }
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START_LEGACY_COMPAT_LEN(8, 3, 3, bl);
     decode(name, bl);
     if (struct_v < 8) {
@@ -89,8 +89,8 @@ struct cls_user_bucket {
     return name.compare(b.name) < 0;
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_user_bucket*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_user_bucket*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_user_bucket)
 
@@ -107,11 +107,11 @@ struct cls_user_bucket_entry {
 
   cls_user_bucket_entry() : size(0), size_rounded(0), count(0), user_stats_sync(false) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(9, 5, bl);
     uint64_t s = size;
     __u32 mt = ceph::real_clock::to_time_t(creation_time);
-    string empty_str;  // originally had the bucket name here, but we encode bucket later
+    std::string empty_str;  // originally had the bucket name here, but we encode bucket later
     encode(empty_str, bl);
     encode(s, bl);
     encode(mt, bl);
@@ -124,11 +124,11 @@ struct cls_user_bucket_entry {
     //::encode(placement_rule, bl); removed in v9
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START_LEGACY_COMPAT_LEN(9, 5, 5, bl);
     __u32 mt;
     uint64_t s;
-    string empty_str;  // backward compatibility
+    std::string empty_str;  // backward compatibility
     decode(empty_str, bl);
     decode(s, bl);
     decode(mt, bl);
@@ -153,8 +153,8 @@ struct cls_user_bucket_entry {
     }
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_user_bucket_entry*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_user_bucket_entry*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_user_bucket_entry)
 
@@ -168,14 +168,14 @@ struct cls_user_stats {
       total_bytes(0),
       total_bytes_rounded(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
      ENCODE_START(1, 1, bl);
     encode(total_entries, bl);
     encode(total_bytes, bl);
     encode(total_bytes_rounded, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(total_entries, bl);
     decode(total_bytes, bl);
@@ -183,8 +183,8 @@ struct cls_user_stats {
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_user_stats*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_user_stats*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_user_stats)
 
@@ -196,14 +196,14 @@ struct cls_user_header {
   ceph::real_time last_stats_sync;     /* last time a full stats sync completed */
   ceph::real_time last_stats_update;   /* last time a stats update was done */
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
      ENCODE_START(1, 1, bl);
     encode(stats, bl);
     encode(last_stats_sync, bl);
     encode(last_stats_update, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(stats, bl);
     decode(last_stats_sync, bl);
@@ -211,8 +211,8 @@ struct cls_user_header {
     DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<cls_user_header*>& ls);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_user_header*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_user_header)
 
@@ -222,5 +222,3 @@ void cls_user_gen_test_stats(cls_user_stats *stats);
 void cls_user_gen_test_header(cls_user_header *h);
 
 #endif
-
-

--- a/src/cls/version/cls_version.cc
+++ b/src/cls/version/cls_version.cc
@@ -9,6 +9,10 @@
 
 #include "include/compat.h"
 
+using std::list;
+
+using ceph::bufferlist;
+
 CLS_VER(1,0)
 CLS_NAME(version)
 
@@ -66,7 +70,7 @@ static int read_version(cls_method_context_t hctx, obj_version *objv, bool impli
   try {
     auto iter = bl.cbegin();
     decode(*objv, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(0, "ERROR: read_version(): failed to decode version entry\n");
     return -EIO;
   }
@@ -82,7 +86,7 @@ static int cls_version_set(cls_method_context_t hctx, bufferlist *in, bufferlist
   cls_version_set_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_version_get(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -148,7 +152,7 @@ static int cls_version_inc(cls_method_context_t hctx, bufferlist *in, bufferlist
   cls_version_inc_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_version_get(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -177,7 +181,7 @@ static int cls_version_check(cls_method_context_t hctx, bufferlist *in, bufferli
   cls_version_check_op op;
   try {
     decode(op, in_iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: cls_version_get(): failed to decode entry\n");
     return -EINVAL;
   }
@@ -186,7 +190,7 @@ static int cls_version_check(cls_method_context_t hctx, bufferlist *in, bufferli
   int ret = read_version(hctx, &objv, false);
   if (ret < 0)
     return ret;
-  
+
   if (!check_conds(op.conds, objv)) {
     CLS_LOG(20, "cls_version: failed condition check");
     return -ECANCELED;

--- a/src/cls/version/cls_version_client.cc
+++ b/src/cls/version/cls_version_client.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include <errno.h>
 
 #include "cls/version/cls_version_client.h"
@@ -29,7 +32,7 @@ void cls_version_inc(librados::ObjectWriteOperation& op, obj_version& objv, Vers
   bufferlist in;
   cls_version_inc_op call;
   call.objv = objv;
-  
+
   obj_version_cond c;
   c.cond = cond;
   c.ver = objv;
@@ -67,7 +70,7 @@ public:
         auto iter = outbl.cbegin();
         decode(ret, iter);
 	*objv = ret.objv;
-      } catch (buffer::error& err) {
+      } catch (ceph::buffer::error& err) {
         // nothing we can do about it atm
       }
     }
@@ -80,7 +83,7 @@ void cls_version_read(librados::ObjectReadOperation& op, obj_version *objv)
   op.exec("version", "read", inbl, new VersionReadCtx(objv));
 }
 
-int cls_version_read(librados::IoCtx& io_ctx, string& oid, obj_version *ver)
+int cls_version_read(librados::IoCtx& io_ctx, std::string& oid, obj_version *ver)
 {
   bufferlist in, out;
   int r = io_ctx.exec(oid, "version", "read", in, out);
@@ -91,7 +94,7 @@ int cls_version_read(librados::IoCtx& io_ctx, string& oid, obj_version *ver)
   try {
     auto iter = out.cbegin();
     decode(ret, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
 

--- a/src/cls/version/cls_version_client.h
+++ b/src/cls/version/cls_version_client.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_CLS_VERSION_CLIENT_H
 #define CEPH_CLS_VERSION_CLIENT_H
 
@@ -21,7 +24,7 @@ void cls_version_read(librados::ObjectReadOperation& op, obj_version *objv);
 // these overloads which call io_ctx.operate() or io_ctx.exec() should not be called in the rgw.
 // rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()/exec()
 #ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_version_read(librados::IoCtx& io_ctx, string& oid, obj_version *ver);
+int cls_version_read(librados::IoCtx& io_ctx, std::string& oid, obj_version *ver);
 #endif
 
 void cls_version_check(librados::ObjectOperation& op, obj_version& ver, VersionCond cond);

--- a/src/cls/version/cls_version_ops.h
+++ b/src/cls/version/cls_version_ops.h
@@ -11,13 +11,13 @@ struct cls_version_set_op {
 
   cls_version_set_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(objv, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(objv, bl);
     DECODE_FINISH(bl);
@@ -27,18 +27,18 @@ WRITE_CLASS_ENCODER(cls_version_set_op)
 
 struct cls_version_inc_op {
   obj_version objv;
-  list<obj_version_cond> conds;
+  std::list<obj_version_cond> conds;
 
   cls_version_inc_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(objv, bl);
     encode(conds, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(objv, bl);
     decode(conds, bl);
@@ -49,18 +49,18 @@ WRITE_CLASS_ENCODER(cls_version_inc_op)
 
 struct cls_version_check_op {
   obj_version objv;
-  list<obj_version_cond> conds;
+  std::list<obj_version_cond> conds;
 
   cls_version_check_op() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(objv, bl);
     encode(conds, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(objv, bl);
     decode(conds, bl);
@@ -74,13 +74,13 @@ struct cls_version_read_ret {
 
   cls_version_read_ret() {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(objv, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(objv, bl);
     DECODE_FINISH(bl);

--- a/src/cls/version/cls_version_types.cc
+++ b/src/cls/version/cls_version_types.cc
@@ -1,10 +1,12 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
 #include "cls/version/cls_version_types.h"
 #include "common/Formatter.h"
 #include "common/ceph_json.h"
 
 
-void obj_version::dump(Formatter *f) const
+void obj_version::dump(ceph::Formatter *f) const
 {
   f->dump_int("ver", ver);
   f->dump_string("tag", tag);
@@ -15,4 +17,3 @@ void obj_version::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("ver", ver, obj);
   JSONDecoder::decode_json("tag", tag, obj);
 }
-

--- a/src/cls/version/cls_version_types.h
+++ b/src/cls/version/cls_version_types.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_CLS_VERSION_TYPES_H
 #define CEPH_CLS_VERSION_TYPES_H
 
@@ -9,18 +12,18 @@ class JSONObj;
 
 struct obj_version {
   uint64_t ver;
-  string tag;
+  std::string tag;
 
   obj_version() : ver(0) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(ver, bl);
     encode(tag, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(ver, bl);
     decode(tag, bl);
@@ -50,9 +53,9 @@ struct obj_version {
             tag.compare(v.tag) == 0);
   }
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(list<obj_version*>& o);
+  static void generate_test_instances(std::list<obj_version*>& o);
 };
 WRITE_CLASS_ENCODER(obj_version)
 
@@ -71,7 +74,7 @@ struct obj_version_cond {
   struct obj_version ver;
   VersionCond cond;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(ver, bl);
     uint32_t c = (uint32_t)cond;
@@ -79,7 +82,7 @@ struct obj_version_cond {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(ver, bl);
     uint32_t c;

--- a/src/common/AsyncReserver.h
+++ b/src/common/AsyncReserver.h
@@ -43,21 +43,21 @@ class AsyncReserver {
     Reservation() {}
     Reservation(T i, unsigned pr, Context *g, Context *p = 0)
       : item(i), prio(pr), grant(g), preempt(p) {}
-    void dump(Formatter *f) const {
+    void dump(ceph::Formatter *f) const {
       f->dump_stream("item") << item;
       f->dump_unsigned("prio", prio);
       f->dump_bool("can_preempt", !!preempt);
     }
-    friend ostream& operator<<(ostream& out, const Reservation& r) {
+    friend std::ostream& operator<<(std::ostream& out, const Reservation& r) {
       return out << r.item << "(prio " << r.prio << " grant " << r.grant
 		 << " preempt " << r.preempt << ")";
     }
   };
 
-  map<unsigned, list<Reservation>> queues;
-  map<T, pair<unsigned, typename list<Reservation>::iterator>> queue_pointers;
-  map<T,Reservation> in_progress;
-  set<pair<unsigned,T>> preempt_by_prio;  ///< in_progress that can be preempted
+  std::map<unsigned, std::list<Reservation>> queues;
+  std::map<T, std::pair<unsigned, typename std::list<Reservation>::iterator>> queue_pointers;
+  std::map<T,Reservation> in_progress;
+  std::set<std::pair<unsigned,T>> preempt_by_prio;  ///< in_progress that can be preempted
 
   void preempt_one() {
     ceph_assert(!preempt_by_prio.empty());
@@ -73,7 +73,7 @@ class AsyncReserver {
 
   void do_queues() {
     rdout(20) << __func__ << ":\n";
-    JSONFormatter jf(true);
+    ceph::JSONFormatter jf(true);
     jf.open_object_section("queue");
     _dump(&jf);
     jf.close_section();
@@ -115,7 +115,7 @@ class AsyncReserver {
       p.grant = nullptr;
       in_progress[p.item] = p;
       if (p.preempt) {
-	preempt_by_prio.insert(make_pair(p.prio, p.item));
+	preempt_by_prio.insert(std::make_pair(p.prio, p.item));
       }
     }
   }
@@ -178,8 +178,8 @@ public:
 	   !in_progress.count(item));
       r.prio = newprio;
       queues[newprio].push_back(r);
-      queue_pointers.insert(make_pair(item,
-				    make_pair(newprio,--(queues[newprio]).end())));
+      queue_pointers.insert(std::make_pair(item,
+				    std::make_pair(newprio,--(queues[newprio]).end())));
     } else {
       auto p = in_progress.find(item);
       if (p != in_progress.end()) {
@@ -200,9 +200,9 @@ public:
 		        << " lowered priority let do_queues() preempt it" << dendl;
             }
           }
-	  preempt_by_prio.erase(make_pair(p->second.prio, p->second.item));
+	  preempt_by_prio.erase(std::make_pair(p->second.prio, p->second.item));
           p->second.prio = newprio;
-	  preempt_by_prio.insert(make_pair(p->second.prio, p->second.item));
+	  preempt_by_prio.insert(std::make_pair(p->second.prio, p->second.item));
 	} else {
           p->second.prio = newprio;
         }
@@ -214,11 +214,11 @@ public:
     return;
   }
 
-  void dump(Formatter *f) {
+  void dump(ceph::Formatter *f) {
     std::lock_guard l(lock);
     _dump(f);
   }
-  void _dump(Formatter *f) {
+  void _dump(ceph::Formatter *f) {
     f->dump_unsigned("max_allowed", max_allowed);
     f->dump_unsigned("min_priority", min_priority);
     f->open_array_section("queues");
@@ -260,8 +260,8 @@ public:
     ceph_assert(!queue_pointers.count(item) &&
 	   !in_progress.count(item));
     queues[prio].push_back(r);
-    queue_pointers.insert(make_pair(item,
-				    make_pair(prio,--(queues[prio]).end())));
+    queue_pointers.insert(std::make_pair(item,
+				    std::make_pair(prio,--(queues[prio]).end())));
     do_queues();
   }
 
@@ -294,7 +294,7 @@ public:
 	rdout(10) << __func__ << " cancel " << p->second
 		  << " (was in progress)" << dendl;
 	if (p->second.preempt) {
-	  preempt_by_prio.erase(make_pair(p->second.prio, p->second.item));
+	  preempt_by_prio.erase(std::make_pair(p->second.prio, p->second.item));
 	  delete p->second.preempt;
 	}
 	in_progress.erase(p);

--- a/src/common/ceph_releases.cc
+++ b/src/common/ceph_releases.cc
@@ -18,7 +18,7 @@ ceph_release_t ceph_release_from_name(std::string_view s)
 {
   ceph_release_t r = ceph_release_t::max;
   while (--r != ceph_release_t::unknown) {
-    if (s == ceph::to_string(r)) {
+    if (s == to_string(r)) {
       return r;
     }
   }
@@ -37,14 +37,14 @@ bool can_upgrade_from(ceph_release_t from_release,
   const auto to_release = ceph_release();
   if (cutoff < to_release) {
     err << "recorded " << from_release_name << " "
-        << ceph::to_integer<int>(from_release) << " (" << from_release << ") "
+        << to_integer<int>(from_release) << " (" << from_release << ") "
         << "is >2 releases older than installed "
-        << ceph::to_integer<int>(to_release) << " (" << to_release << "); "
+        << to_integer<int>(to_release) << " (" << to_release << "); "
         << "you can only upgrade 2 releases at a time\n"
         << "you should first upgrade to ";
     auto release = from_release;
     while (++release <= cutoff) {
-      err << ceph::to_integer<int>(release) << " (" << release << ")";
+      err << to_integer<int>(release) << " (" << release << ")";
       if (release < cutoff) {
         err << " or ";
       } else {

--- a/src/common/ceph_releases.h
+++ b/src/common/ceph_releases.h
@@ -32,22 +32,22 @@ enum class ceph_release_t : std::uint8_t {
 
 std::ostream& operator<<(std::ostream& os, const ceph_release_t r);
 
-static inline bool operator!(ceph_release_t& r) {
+inline bool operator!(ceph_release_t& r) {
   return (r < ceph_release_t::unknown ||
           r == ceph_release_t::unknown);
 }
 
-static inline ceph_release_t& operator--(ceph_release_t& r) {
+inline ceph_release_t& operator--(ceph_release_t& r) {
   r = static_cast<ceph_release_t>(static_cast<uint8_t>(r) - 1);
   return r;
 }
 
-static inline ceph_release_t& operator++(ceph_release_t& r) {
+inline ceph_release_t& operator++(ceph_release_t& r) {
   r = static_cast<ceph_release_t>(static_cast<uint8_t>(r) + 1);
   return r;
 }
 
-static inline bool operator<(ceph_release_t lhs, ceph_release_t rhs) {
+inline bool operator<(ceph_release_t lhs, ceph_release_t rhs) {
   // we used to use -1 for invalid release
   if (static_cast<int8_t>(lhs) < 0) {
     return true;
@@ -57,7 +57,7 @@ static inline bool operator<(ceph_release_t lhs, ceph_release_t rhs) {
   return static_cast<uint8_t>(lhs) < static_cast<uint8_t>(rhs);
 }
 
-static inline bool operator>(ceph_release_t lhs, ceph_release_t rhs) {
+inline bool operator>(ceph_release_t lhs, ceph_release_t rhs) {
   // we used to use -1 for invalid release
   if (static_cast<int8_t>(lhs) < 0) {
     return false;
@@ -67,7 +67,7 @@ static inline bool operator>(ceph_release_t lhs, ceph_release_t rhs) {
   return static_cast<uint8_t>(lhs) > static_cast<uint8_t>(rhs);
 }
 
-static inline bool operator>=(ceph_release_t lhs, ceph_release_t rhs) {
+inline bool operator>=(ceph_release_t lhs, ceph_release_t rhs) {
   return !(lhs < rhs);
 }
 
@@ -78,12 +78,9 @@ bool can_upgrade_from(ceph_release_t from_release,
 ceph_release_t ceph_release_from_name(std::string_view sv);
 ceph_release_t ceph_release();
 
-namespace ceph
-{
-  static inline std::string_view to_string(ceph_release_t r) {
-    return ceph_release_name(static_cast<int>(r));
-  }
-  template<typename IntType> IntType to_integer(ceph_release_t r) {
-    return static_cast<IntType>(r);
-  }
+inline std::string_view to_string(ceph_release_t r) {
+  return ceph_release_name(static_cast<int>(r));
+}
+template<typename IntType> IntType to_integer(ceph_release_t r) {
+  return static_cast<IntType>(r);
 }

--- a/src/common/map_cacher.hpp
+++ b/src/common/map_cacher.hpp
@@ -25,9 +25,9 @@ namespace MapCacher {
 template<typename K, typename V>
 class Transaction {
 public:
-  /// Set keys according to map
+  /// Std::set keys according to map
   virtual void set_keys(
-    const std::map<K, V> &keys ///< [in] keys/values to set
+    const std::map<K, V> &keys ///< [in] keys/values to std::set
     ) = 0;
 
   /// Remove keys
@@ -57,7 +57,7 @@ public:
   /// Returns next key
   virtual int get_next(
     const K &key,       ///< [in] key after which to get next
-    pair<K, V> *next    ///< [out] first key after key
+    std::pair<K, V> *next    ///< [out] first key after key
     ) = 0; ///< @return 0 on success, -ENOENT if there is no next
 
   virtual ~StoreDriver() {}
@@ -75,19 +75,19 @@ private:
 
   SharedPtrRegistry<K, boost::optional<V> > in_progress;
   typedef typename SharedPtrRegistry<K, boost::optional<V> >::VPtr VPtr;
-  typedef ContainerContext<set<VPtr> > TransHolder;
+  typedef ContainerContext<std::set<VPtr> > TransHolder;
 
 public:
   MapCacher(StoreDriver<K, V> *driver) : driver(driver) {}
 
-  /// Fetch first key/value pair after specified key
+  /// Fetch first key/value std::pair after specified key
   int get_next(
     K key,               ///< [in] key after which to get next
-    pair<K, V> *next     ///< [out] next key
+    std::pair<K, V> *next     ///< [out] next key
     ) {
     while (true) {
-      pair<K, boost::optional<V> > cached;
-      pair<K, V> store;
+      std::pair<K, boost::optional<V> > cached;
+      std::pair<K, V> store;
       bool got_cached = in_progress.get_next(key, &cached);
 
       bool got_store = false;
@@ -123,13 +123,11 @@ public:
 
   /// Adds operation setting keys to Transaction
   void set_keys(
-    const map<K, V> &keys,  ///< [in] keys/values to set
+    const std::map<K, V> &keys,  ///< [in] keys/values to std::set
     Transaction<K, V> *t    ///< [out] transaction to use
     ) {
     std::set<VPtr> vptrs;
-    for (typename map<K, V>::const_iterator i = keys.begin();
-	 i != keys.end();
-	 ++i) {
+    for (auto i = keys.begin(); i != keys.end(); ++i) {
       VPtr ip = in_progress.lookup_or_create(i->first, i->second);
       *ip = i->second;
       vptrs.insert(ip);
@@ -140,13 +138,11 @@ public:
 
   /// Adds operation removing keys to Transaction
   void remove_keys(
-    const set<K> &keys,  ///< [in]
+    const std::set<K> &keys,  ///< [in]
     Transaction<K, V> *t ///< [out] transaction to use
     ) {
     std::set<VPtr> vptrs;
-    for (typename set<K>::const_iterator i = keys.begin();
-	 i != keys.end();
-	 ++i) {
+    for (auto i = keys.begin(); i != keys.end(); ++i) {
       boost::optional<V> empty;
       VPtr ip = in_progress.lookup_or_create(*i, empty);
       *ip = empty;
@@ -158,12 +154,12 @@ public:
 
   /// Gets keys, uses cached values for unstable keys
   int get_keys(
-    const set<K> &keys_to_get, ///< [in] set of keys to fetch
-    map<K, V> *got             ///< [out] keys gotten
+    const std::set<K> &keys_to_get, ///< [in] std::set of keys to fetch
+    std::map<K, V> *got             ///< [out] keys gotten
     ) {
-    set<K> to_get;
-    map<K, V> _got;
-    for (typename set<K>::const_iterator i = keys_to_get.begin();
+    std::set<K> to_get;
+    std::map<K, V> _got;
+    for (auto i = keys_to_get.begin();
 	 i != keys_to_get.end();
 	 ++i) {
       VPtr val = in_progress.lookup(*i);
@@ -178,9 +174,7 @@ public:
     int r = driver->get_keys(to_get, &_got);
     if (r < 0)
       return r;
-    for (typename map<K, V>::iterator i = _got.begin();
-	 i != _got.end();
-	 ++i) {
+    for (auto i = _got.begin(); i != _got.end(); ++i) {
       got->insert(*i);
     }
     return 0;

--- a/src/include/ceph_assert.h
+++ b/src/include/ceph_assert.h
@@ -70,7 +70,7 @@ extern void __ceph_assert_warn(const char *assertion, const char *file, int line
 #define assert_warn(expr)							\
   ((expr)								\
    ? _CEPH_ASSERT_VOID_CAST (0)					\
-   : __ceph_assert_warn (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION))
+   : ::ceph::__ceph_assert_warn (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION))
 
 }
 

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -444,7 +444,7 @@ int librados::RadosClient::get_min_compatible_osd(int8_t* require_osd_release)
 
   objecter->with_osdmap(
     [require_osd_release](const OSDMap& o) {
-      *require_osd_release = ceph::to_integer<int8_t>(o.require_osd_release);
+      *require_osd_release = to_integer<int8_t>(o.require_osd_release);
     });
   return 0;
 }
@@ -459,10 +459,9 @@ int librados::RadosClient::get_min_compatible_client(int8_t* min_compat_client,
 
   objecter->with_osdmap(
     [min_compat_client, require_min_compat_client](const OSDMap& o) {
-      *min_compat_client =
-	ceph::to_integer<int8_t>(o.get_min_compat_client());
+      *min_compat_client = to_integer<int8_t>(o.get_min_compat_client());
       *require_min_compat_client =
-	ceph::to_integer<int8_t>(o.get_require_min_compat_client());
+	to_integer<int8_t>(o.get_require_min_compat_client());
     });
   return 0;
 }

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -150,7 +150,7 @@ void MDSMap::dump(Formatter *f) const
   f->dump_int("root", root);
   f->dump_int("session_timeout", session_timeout);
   f->dump_int("session_autoclose", session_autoclose);
-  f->dump_stream("min_compat_client") << ceph::to_integer<int>(min_compat_client) << " ("
+  f->dump_stream("min_compat_client") << to_integer<int>(min_compat_client) << " ("
 				      << min_compat_client << ")";
   f->dump_int("max_file_size", max_file_size);
   f->dump_int("last_failure", last_failure);
@@ -230,7 +230,7 @@ void MDSMap::print(ostream& out) const
   out << "session_timeout\t" << session_timeout << "\n"
       << "session_autoclose\t" << session_autoclose << "\n";
   out << "max_file_size\t" << max_file_size << "\n";
-  out << "min_compat_client\t" << ceph::to_integer<int>(min_compat_client) << " ("
+  out << "min_compat_client\t" << to_integer<int>(min_compat_client) << " ("
 			       << min_compat_client << ")\n";
   out << "last_failure\t" << last_failure << "\n"
       << "last_failure_osd_epoch\t" << last_failure_osd_epoch << "\n";

--- a/src/mgr/OSDPerfMetricTypes.cc
+++ b/src/mgr/OSDPerfMetricTypes.cc
@@ -5,6 +5,8 @@
 
 #include <ostream>
 
+using ceph::bufferlist;
+
 std::ostream& operator<<(std::ostream& os,
                          const OSDPerfMetricSubKeyDescriptor &d) {
   switch(d.type) {

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -352,7 +352,7 @@ public:
   }
 
   std::set<std::string> get_always_on_modules() const {
-    auto it = always_on_modules.find(ceph::to_integer<uint32_t>(ceph_release()));
+    auto it = always_on_modules.find(to_integer<uint32_t>(ceph_release()));
     if (it == always_on_modules.end())
       return {};
     return it->second;

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -328,7 +328,7 @@ void MonMap::print(ostream& out) const
   out << "fsid " << fsid << "\n";
   out << "last_changed " << last_changed << "\n";
   out << "created " << created << "\n";
-  out << "min_mon_release " << ceph::to_integer<unsigned>(min_mon_release)
+  out << "min_mon_release " << to_integer<unsigned>(min_mon_release)
       << " (" << min_mon_release << ")\n";
   unsigned i = 0;
   for (auto p = ranks.begin(); p != ranks.end(); ++p) {
@@ -342,8 +342,8 @@ void MonMap::dump(Formatter *f) const
   f->dump_stream("fsid") <<  fsid;
   last_changed.gmtime(f->dump_stream("modified"));
   created.gmtime(f->dump_stream("created"));
-  f->dump_unsigned("min_mon_release", ceph::to_integer<unsigned>(min_mon_release));
-  f->dump_string("min_mon_release_name", ceph::to_string(min_mon_release));
+  f->dump_unsigned("min_mon_release", to_integer<unsigned>(min_mon_release));
+  f->dump_string("min_mon_release_name", to_string(min_mon_release));
   f->open_object_section("features");
   persistent_features.dump(f, "persistent");
   optional_features.dump(f, "optional");
@@ -368,7 +368,7 @@ void MonMap::dump(Formatter *f) const
 void MonMap::dump_summary(Formatter *f) const
 {
   f->dump_unsigned("epoch", epoch);
-  f->dump_string("min_mon_release_name", ceph::to_string(min_mon_release));
+  f->dump_string("min_mon_release_name", to_string(min_mon_release));
   f->dump_unsigned("num_mons", ranks.size());
 }
 

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -208,7 +208,7 @@ void MonmapMonitor::apply_mon_features(const mon_feature_t& features,
   }
   if (min_mon_release > pending_map.min_mon_release) {
     dout(1) << __func__ << " increasing min_mon_release to "
-	    << ceph::to_integer<int>(min_mon_release) << " (" << min_mon_release
+	    << to_integer<int>(min_mon_release) << " (" << min_mon_release
 	    << ")" << dendl;
     pending_map.min_mon_release = min_mon_release;
   }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -11036,7 +11036,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     if (!sure) {
       FeatureMap m;
       mon->get_combined_feature_map(&m);
-      uint64_t features = ceph_release_features(ceph::to_integer<int>(vno));
+      uint64_t features = ceph_release_features(to_integer<int>(vno));
       bool first = true;
       bool ok = true;
       for (int type : {

--- a/src/objclass/class_api.cc
+++ b/src/objclass/class_api.cc
@@ -92,12 +92,14 @@ void cls_unregister_filter(cls_filter_handle_t handle)
   filter->unregister();
 }
 
-int cls_cxx_read(cls_method_context_t hctx, int ofs, int len, bufferlist *outbl)
+int cls_cxx_read(cls_method_context_t hctx, int ofs, int len,
+		 ceph::buffer::list *outbl)
 {
   return cls_cxx_read2(hctx, ofs, len, outbl, 0);
 }
 
-int cls_cxx_write(cls_method_context_t hctx, int ofs, int len, bufferlist *inbl)
+int cls_cxx_write(cls_method_context_t hctx, int ofs, int len,
+		  ceph::buffer::list *inbl)
 {
   return cls_cxx_write2(hctx, ofs, len, inbl, 0);
 }
@@ -133,7 +135,7 @@ int cls_gen_rand_base64(char *dest, int size) /* size should be the required str
   return 0;
 }
 
-void cls_cxx_subop_version(cls_method_context_t hctx, string *s)
+void cls_cxx_subop_version(cls_method_context_t hctx, std::string *s)
 {
   if (!s)
     return;

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -31,6 +31,25 @@
 #define DOUT_PREFIX_ARGS this
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)
+
+using std::dec;
+using std::hex;
+using std::list;
+using std::make_pair;
+using std::map;
+using std::pair;
+using std::ostream;
+using std::set;
+using std::string;
+using std::unique_ptr;
+using std::vector;
+
+using ceph::bufferhash;
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::ErasureCodeInterfaceRef;
+using ceph::Formatter;
+
 static ostream& _prefix(std::ostream *_dout, ECBackend *pgb) {
   return pgb->get_parent()->gen_dbg_prefix(*_dout);
 }

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -92,7 +92,7 @@ public:
   void on_change() override;
   void clear_recovery_state() override;
 
-  void dump_recovery_info(Formatter *f) const override;
+  void dump_recovery_info(ceph::Formatter *f) const override;
 
   void call_write_ordered(std::function<void(void)> &&cb) override;
 
@@ -103,7 +103,7 @@ public:
     PGTransactionUPtr &&t,
     const eversion_t &trim_to,
     const eversion_t &min_last_complete_ondisk,
-    vector<pg_log_entry_t>&& log_entries,
+    std::vector<pg_log_entry_t>&& log_entries,
     std::optional<pg_hit_set_history_t> &hset_history,
     Context *on_all_commit,
     ceph_tid_t tid,
@@ -116,7 +116,7 @@ public:
     uint64_t off,
     uint64_t len,
     uint32_t op_flags,
-    bufferlist *bl) override;
+    ceph::buffer::list *bl) override;
 
   /**
    * Async read mechanism
@@ -126,30 +126,30 @@ public:
    * buffer as well as for calling the callbacks.
    *
    * One tricky bit is that two reads may possibly not read from the same
-   * set of replicas.  This could result in two reads completing in the
+   * std::set of replicas.  This could result in two reads completing in the
    * wrong (from the interface user's point of view) order.  Thus, we
    * maintain a queue of in progress reads (@see in_progress_client_reads)
    * to ensure that we always call the completion callback in order.
    *
    * Another subtly is that while we may read a degraded object, we will
-   * still only perform a client read from shards in the acting set.  This
+   * still only perform a client read from shards in the acting std::set.  This
    * ensures that we won't ever have to restart a client initiated read in
    * check_recovery_sources.
    */
   void objects_read_and_reconstruct(
-    const map<hobject_t, std::list<boost::tuple<uint64_t, uint64_t, uint32_t> >
+    const std::map<hobject_t, std::list<boost::tuple<uint64_t, uint64_t, uint32_t> >
     > &reads,
     bool fast_read,
-    GenContextURef<map<hobject_t,pair<int, extent_map> > &&> &&func);
+    GenContextURef<std::map<hobject_t,std::pair<int, extent_map> > &&> &&func);
 
   friend struct CallClientContexts;
   struct ClientAsyncReadStatus {
     unsigned objects_to_read;
-    GenContextURef<map<hobject_t,pair<int, extent_map> > &&> func;
-    map<hobject_t,pair<int, extent_map> > results;
+    GenContextURef<std::map<hobject_t,std::pair<int, extent_map> > &&> func;
+    std::map<hobject_t,std::pair<int, extent_map> > results;
     explicit ClientAsyncReadStatus(
       unsigned objects_to_read,
-      GenContextURef<map<hobject_t,pair<int, extent_map> > &&> &&func)
+      GenContextURef<std::map<hobject_t,std::pair<int, extent_map> > &&> &&func)
       : objects_to_read(objects_to_read), func(std::move(func)) {}
     void complete_object(
       const hobject_t &hoid,
@@ -158,7 +158,7 @@ public:
       ceph_assert(objects_to_read);
       --objects_to_read;
       ceph_assert(!results.count(hoid));
-      results.emplace(hoid, make_pair(err, std::move(buffers)));
+      results.emplace(hoid, std::make_pair(err, std::move(buffers)));
     }
     bool is_complete() const {
       return objects_to_read == 0;
@@ -167,19 +167,19 @@ public:
       func.release()->complete(std::move(results));
     }
   };
-  list<ClientAsyncReadStatus> in_progress_client_reads;
+  std::list<ClientAsyncReadStatus> in_progress_client_reads;
   void objects_read_async(
     const hobject_t &hoid,
-    const list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
-		    pair<bufferlist*, Context*> > > &to_read,
+    const std::list<std::pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
+		    std::pair<ceph::buffer::list*, Context*> > > &to_read,
     Context *on_complete,
     bool fast_read = false) override;
 
   template <typename Func>
   void objects_read_async_no_cache(
-    const map<hobject_t,extent_set> &to_read,
+    const std::map<hobject_t,extent_set> &to_read,
     Func &&on_complete) {
-    map<hobject_t,std::list<boost::tuple<uint64_t, uint64_t, uint32_t> > > _to_read;
+    std::map<hobject_t,std::list<boost::tuple<uint64_t, uint64_t, uint32_t> > > _to_read;
     for (auto &&hpair: to_read) {
       auto &l = _to_read[hpair.first];
       for (auto extent: hpair.second) {
@@ -190,7 +190,7 @@ public:
       _to_read,
       false,
       make_gen_lambda_context<
-      map<hobject_t,pair<int, extent_map> > &&, Func>(
+      std::map<hobject_t,std::pair<int, extent_map> > &&, Func>(
 	  std::forward<Func>(on_complete)));
   }
   void kick_reads() {
@@ -208,8 +208,8 @@ private:
 			sinfo.get_stripe_width());
   }
 
-  void get_want_to_read_shards(set<int> *want_to_read) const {
-    const vector<int> &chunk_mapping = ec_impl->get_chunk_mapping();
+  void get_want_to_read_shards(std::set<int> *want_to_read) const {
+    const std::vector<int> &chunk_mapping = ec_impl->get_chunk_mapping();
     for (int i = 0; i < (int)ec_impl->get_data_chunk_count(); ++i) {
       int chunk = (int)chunk_mapping.size() > i ? chunk_mapping[i] : i;
       want_to_read->insert(chunk);
@@ -249,8 +249,8 @@ private:
   struct RecoveryOp {
     hobject_t hoid;
     eversion_t v;
-    set<pg_shard_t> missing_on;
-    set<shard_id_t> missing_on_shards;
+    std::set<pg_shard_t> missing_on;
+    std::set<shard_id_t> missing_on_shards;
 
     ObjectRecoveryInfo recovery_info;
     ObjectRecoveryProgress recovery_progress;
@@ -278,21 +278,21 @@ private:
     }
 
     // must be filled if state == WRITING
-    map<int, bufferlist> returned_data;
-    map<string, bufferlist> xattrs;
+    std::map<int, ceph::buffer::list> returned_data;
+    std::map<std::string, ceph::buffer::list> xattrs;
     ECUtil::HashInfoRef hinfo;
     ObjectContextRef obc;
-    set<pg_shard_t> waiting_on_pushes;
+    std::set<pg_shard_t> waiting_on_pushes;
 
     // valid in state READING
-    pair<uint64_t, uint64_t> extent_requested;
+    std::pair<uint64_t, uint64_t> extent_requested;
 
-    void dump(Formatter *f) const;
+    void dump(ceph::Formatter *f) const;
 
     RecoveryOp() : state(IDLE) {}
   };
   friend ostream &operator<<(ostream &lhs, const RecoveryOp &rhs);
-  map<hobject_t, RecoveryOp> recovery_ops;
+  std::map<hobject_t, RecoveryOp> recovery_ops;
 
   void continue_recovery_op(
     RecoveryOp &op,
@@ -301,8 +301,8 @@ private:
   friend struct OnRecoveryReadComplete;
   void handle_recovery_read_complete(
     const hobject_t &hoid,
-    boost::tuple<uint64_t, uint64_t, map<pg_shard_t, bufferlist> > &to_read,
-    std::optional<map<string, bufferlist> > attrs,
+    boost::tuple<uint64_t, uint64_t, std::map<pg_shard_t, ceph::buffer::list> > &to_read,
+    std::optional<std::map<std::string, ceph::buffer::list> > attrs,
     RecoveryMessages *m);
   void handle_recovery_push(
     const PushOp &op,
@@ -314,9 +314,9 @@ private:
     RecoveryMessages *m);
   void get_all_avail_shards(
     const hobject_t &hoid,
-    const set<pg_shard_t> &error_shards,
-    set<int> &have,
-    map<shard_id_t, pg_shard_t> &shards,
+    const std::set<pg_shard_t> &error_shards,
+    std::set<int> &have,
+    std::map<shard_id_t, pg_shard_t> &shards,
     bool for_recovery);
 
 public:
@@ -325,7 +325,7 @@ public:
    *
    * To avoid duplicating the logic for requesting and waiting for
    * multiple object shards, there is a common async read mechanism
-   * taking a map of hobject_t->read_request_t which defines callbacks
+   * taking a std::map of hobject_t->read_request_t which defines callbacks
    * taking read_result_ts as arguments.
    *
    * tid_to_read_map gives open read ops.  check_recovery_sources uses
@@ -343,23 +343,23 @@ public:
    */
   struct read_result_t {
     int r;
-    map<pg_shard_t, int> errors;
-    std::optional<map<string, bufferlist> > attrs;
-    list<
+    std::map<pg_shard_t, int> errors;
+    std::optional<std::map<std::string, ceph::buffer::list> > attrs;
+    std::list<
       boost::tuple<
-	uint64_t, uint64_t, map<pg_shard_t, bufferlist> > > returned;
+	uint64_t, uint64_t, std::map<pg_shard_t, ceph::buffer::list> > > returned;
     read_result_t() : r(0) {}
   };
   struct read_request_t {
-    const list<boost::tuple<uint64_t, uint64_t, uint32_t> > to_read;
-    const map<pg_shard_t, vector<pair<int, int>>> need;
+    const std::list<boost::tuple<uint64_t, uint64_t, uint32_t> > to_read;
+    const std::map<pg_shard_t, std::vector<std::pair<int, int>>> need;
     const bool want_attrs;
-    GenContext<pair<RecoveryMessages *, read_result_t& > &> *cb;
+    GenContext<std::pair<RecoveryMessages *, read_result_t& > &> *cb;
     read_request_t(
-      const list<boost::tuple<uint64_t, uint64_t, uint32_t> > &to_read,
-      const map<pg_shard_t, vector<pair<int, int>>> &need,
+      const std::list<boost::tuple<uint64_t, uint64_t, uint32_t> > &to_read,
+      const std::map<pg_shard_t, std::vector<std::pair<int, int>>> &need,
       bool want_attrs,
-      GenContext<pair<RecoveryMessages *, read_result_t& > &> *cb)
+      GenContext<std::pair<RecoveryMessages *, read_result_t& > &> *cb)
       : to_read(to_read), need(need), want_attrs(want_attrs),
 	cb(cb) {}
   };
@@ -379,16 +379,16 @@ public:
 
     ZTracer::Trace trace;
 
-    map<hobject_t, set<int>> want_to_read;
-    map<hobject_t, read_request_t> to_read;
-    map<hobject_t, read_result_t> complete;
+    std::map<hobject_t, std::set<int>> want_to_read;
+    std::map<hobject_t, read_request_t> to_read;
+    std::map<hobject_t, read_result_t> complete;
 
-    map<hobject_t, set<pg_shard_t>> obj_to_source;
-    map<pg_shard_t, set<hobject_t> > source_to_obj;
+    std::map<hobject_t, std::set<pg_shard_t>> obj_to_source;
+    std::map<pg_shard_t, std::set<hobject_t> > source_to_obj;
 
-    void dump(Formatter *f) const;
+    void dump(ceph::Formatter *f) const;
 
-    set<pg_shard_t> in_progress;
+    std::set<pg_shard_t> in_progress;
 
     ReadOp(
       int priority,
@@ -396,8 +396,8 @@ public:
       bool do_redundant_reads,
       bool for_recovery,
       OpRequestRef op,
-      map<hobject_t, set<int>> &&_want_to_read,
-      map<hobject_t, read_request_t> &&_to_read)
+      std::map<hobject_t, std::set<int>> &&_want_to_read,
+      std::map<hobject_t, read_request_t> &&_to_read)
       : priority(priority), tid(tid), op(op), do_redundant_reads(do_redundant_reads),
 	for_recovery(for_recovery), want_to_read(std::move(_want_to_read)),
 	to_read(std::move(_to_read)) {
@@ -408,7 +408,7 @@ public:
 	    boost::make_tuple(
 	      extent.get<0>(),
 	      extent.get<1>(),
-	      map<pg_shard_t, bufferlist>()));
+	      std::map<pg_shard_t, ceph::buffer::list>()));
 	}
       }
     }
@@ -422,12 +422,12 @@ public:
     ReadOp &op);
   void complete_read_op(ReadOp &rop, RecoveryMessages *m);
   friend ostream &operator<<(ostream &lhs, const ReadOp &rhs);
-  map<ceph_tid_t, ReadOp> tid_to_read_map;
-  map<pg_shard_t, set<ceph_tid_t> > shard_to_read_map;
+  std::map<ceph_tid_t, ReadOp> tid_to_read_map;
+  std::map<pg_shard_t, std::set<ceph_tid_t> > shard_to_read_map;
   void start_read_op(
     int priority,
-    map<hobject_t, set<int>> &want_to_read,
-    map<hobject_t, read_request_t> &to_read,
+    std::map<hobject_t, std::set<int>> &want_to_read,
+    std::map<hobject_t, read_request_t> &to_read,
     OpRequestRef op,
     bool do_redundant_reads, bool for_recovery);
 
@@ -448,7 +448,7 @@ public:
    *
    * As with client reads, there is a possibility of out-of-order
    * completions. Thus, callbacks and completion are called in order
-   * on the writing list.
+   * on the writing std::list.
    */
   struct Op : boost::intrusive::list_base_hook<> {
     /// From submit_transaction caller, describes operation
@@ -457,7 +457,7 @@ public:
     eversion_t version;
     eversion_t trim_to;
     std::optional<pg_hit_set_history_t> updated_hit_set_history;
-    vector<pg_log_entry_t> log_entries;
+    std::vector<pg_log_entry_t> log_entries;
     ceph_tid_t tid;
     osd_reqid_t reqid;
     ZTracer::Trace trace;
@@ -465,14 +465,14 @@ public:
     eversion_t roll_forward_to; /// Soon to be generated internally
 
     /// Ancillary also provided from submit_transaction caller
-    map<hobject_t, ObjectContextRef> obc_map;
+    std::map<hobject_t, ObjectContextRef> obc_map;
 
     /// see call_write_ordered
     std::list<std::function<void(void)> > on_write;
 
     /// Generated internally
-    set<hobject_t> temp_added;
-    set<hobject_t> temp_cleared;
+    std::set<hobject_t> temp_added;
+    std::set<hobject_t> temp_cleared;
 
     ECTransaction::WritePlan plan;
     bool requires_rmw() const { return !plan.to_read.empty(); }
@@ -482,19 +482,19 @@ public:
     bool using_cache = true;
 
     /// In progress read state;
-    map<hobject_t,extent_set> pending_read; // subset already being read
-    map<hobject_t,extent_set> remote_read;  // subset we must read
-    map<hobject_t,extent_map> remote_read_result;
+    std::map<hobject_t,extent_set> pending_read; // subset already being read
+    std::map<hobject_t,extent_set> remote_read;  // subset we must read
+    std::map<hobject_t,extent_map> remote_read_result;
     bool read_in_progress() const {
       return !remote_read.empty() && remote_read_result.empty();
     }
 
     /// In progress write state.
-    set<pg_shard_t> pending_commit;
+    std::set<pg_shard_t> pending_commit;
     // we need pending_apply for pre-mimic peers so that we don't issue a
     // read on a remote shard before it has applied a previous write.  We can
     // remove this after nautilus.
-    set<pg_shard_t> pending_apply;
+    std::set<pg_shard_t> pending_apply;
     bool write_in_progress() const {
       return !pending_commit.empty() || !pending_apply.empty();
     }
@@ -515,10 +515,10 @@ public:
   friend ostream &operator<<(ostream &lhs, const Op &rhs);
 
   ExtentCache cache;
-  map<ceph_tid_t, Op> tid_to_op_map; /// Owns Op structure
+  std::map<ceph_tid_t, Op> tid_to_op_map; /// Owns Op structure
 
   /**
-   * We model the possible rmw states as a set of waitlists.
+   * We model the possible rmw states as a std::set of waitlists.
    * All writes at this time complete in order, so a write blocked
    * at waiting_state blocks all writes behind it as well (same for
    * other states).
@@ -570,7 +570,7 @@ public:
   bool try_finish_rmw();
   void check_ops();
 
-  ErasureCodeInterfaceRef ec_impl;
+  ceph::ErasureCodeInterfaceRef ec_impl;
 
 
   /**
@@ -579,22 +579,22 @@ public:
    * Determines the whether _have is sufficient to recover an object
    */
   class ECRecPred : public IsPGRecoverablePredicate {
-    set<int> want;
-    ErasureCodeInterfaceRef ec_impl;
+    std::set<int> want;
+    ceph::ErasureCodeInterfaceRef ec_impl;
   public:
-    explicit ECRecPred(ErasureCodeInterfaceRef ec_impl) : ec_impl(ec_impl) {
+    explicit ECRecPred(ceph::ErasureCodeInterfaceRef ec_impl) : ec_impl(ec_impl) {
       for (unsigned i = 0; i < ec_impl->get_chunk_count(); ++i) {
 	want.insert(i);
       }
     }
-    bool operator()(const set<pg_shard_t> &_have) const override {
-      set<int> have;
-      for (set<pg_shard_t>::const_iterator i = _have.begin();
+    bool operator()(const std::set<pg_shard_t> &_have) const override {
+      std::set<int> have;
+      for (std::set<pg_shard_t>::const_iterator i = _have.begin();
 	   i != _have.end();
 	   ++i) {
 	have.insert(i->shard);
       }
-      map<int, vector<pair<int, int>>> min;
+      std::map<int, std::vector<std::pair<int, int>>> min;
       return ec_impl->minimum_to_decode(want, have, &min) == 0;
     }
   };
@@ -620,8 +620,8 @@ public:
   public:
     ECReadPred(
       pg_shard_t whoami,
-      ErasureCodeInterfaceRef ec_impl) : whoami(whoami), rec_pred(ec_impl) {}
-    bool operator()(const set<pg_shard_t> &_have) const override {
+      ceph::ErasureCodeInterfaceRef ec_impl) : whoami(whoami), rec_pred(ec_impl) {}
+    bool operator()(const std::set<pg_shard_t> &_have) const override {
       return _have.count(whoami) && rec_pred(_have);
     }
   };
@@ -634,7 +634,7 @@ public:
   /// If modified, ensure that the ref is held until the update is applied
   SharedPtrRegistry<hobject_t, ECUtil::HashInfo> unstable_hashinfo_registry;
   ECUtil::HashInfoRef get_hash_info(const hobject_t &hoid, bool checks = true,
-				    const map<string,bufferptr> *attr = NULL);
+				    const std::map<std::string, ceph::buffer::ptr> *attr = NULL);
 
 public:
   ECBackend(
@@ -643,29 +643,29 @@ public:
     ObjectStore::CollectionHandle &ch,
     ObjectStore *store,
     CephContext *cct,
-    ErasureCodeInterfaceRef ec_impl,
+    ceph::ErasureCodeInterfaceRef ec_impl,
     uint64_t stripe_width);
 
   /// Returns to_read replicas sufficient to reconstruct want
   int get_min_avail_to_read_shards(
     const hobject_t &hoid,     ///< [in] object
-    const set<int> &want,      ///< [in] desired shards
+    const std::set<int> &want,      ///< [in] desired shards
     bool for_recovery,         ///< [in] true if we may use non-acting replicas
     bool do_redundant_reads,   ///< [in] true if we want to issue redundant reads to reduce latency
-    map<pg_shard_t, vector<pair<int, int>>> *to_read   ///< [out] shards, corresponding subchunks to read
+    std::map<pg_shard_t, std::vector<std::pair<int, int>>> *to_read   ///< [out] shards, corresponding subchunks to read
     ); ///< @return error code, 0 on success
 
   int get_remaining_shards(
     const hobject_t &hoid,
-    const set<int> &avail,
-    const set<int> &want,
+    const std::set<int> &avail,
+    const std::set<int> &want,
     const read_result_t &result,
-    map<pg_shard_t, vector<pair<int, int>>> *to_read,
+    std::map<pg_shard_t, std::vector<std::pair<int, int>>> *to_read,
     bool for_recovery);
 
   int objects_get_attrs(
     const hobject_t &hoid,
-    map<string, bufferlist> *out) override;
+    std::map<std::string, ceph::buffer::list> *out) override;
 
   void rollback_append(
     const hobject_t &hoid,
@@ -683,7 +683,7 @@ public:
     return sinfo.logical_to_next_chunk_offset(logical_size);
   }
   void _failed_push(const hobject_t &hoid,
-    pair<RecoveryMessages *, ECBackend::read_result_t &> &in);
+    std::pair<RecoveryMessages *, ECBackend::read_result_t &> &in);
 };
 ostream &operator<<(ostream &lhs, const ECBackend::pipeline_state_t &rhs);
 

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -21,6 +21,17 @@
 #include "os/ObjectStore.h"
 #include "common/inline_variant.h"
 
+using std::make_pair;
+using std::map;
+using std::pair;
+using std::set;
+using std::string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::ErasureCodeInterfaceRef;
 
 void encode_and_write(
   pg_t pgid,
@@ -190,14 +201,14 @@ void ECTransaction::generate_transactions(
       bufferlist old_hinfo;
       encode(*hinfo, old_hinfo);
       xattr_rollback[ECUtil::get_hinfo_key()] = old_hinfo;
-      
+
       if (op.is_none() && op.truncate && op.truncate->first == 0) {
 	ceph_assert(op.truncate->first == 0);
 	ceph_assert(op.truncate->first ==
 	       op.truncate->second);
 	ceph_assert(entry);
 	ceph_assert(obc);
-	
+
 	if (op.truncate->first != op.truncate->second) {
 	  op.truncate->first = op.truncate->second;
 	} else {

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -26,10 +26,10 @@ namespace ECTransaction {
   struct WritePlan {
     PGTransactionUPtr t;
     bool invalidates_cache = false; // Yes, both are possible
-    map<hobject_t,extent_set> to_read;
-    map<hobject_t,extent_set> will_write; // superset of to_read
+    std::map<hobject_t,extent_set> to_read;
+    std::map<hobject_t,extent_set> will_write; // superset of to_read
 
-    map<hobject_t,ECUtil::HashInfoRef> hash_infos;
+    std::map<hobject_t,ECUtil::HashInfoRef> hash_infos;
   };
 
   bool requires_overwrite(
@@ -44,7 +44,7 @@ namespace ECTransaction {
     DoutPrefixProvider *dpp) {
     WritePlan plan;
     t->safe_create_traverse(
-      [&](pair<const hobject_t, PGTransaction::ObjectOperation> &i) {
+      [&](std::pair<const hobject_t, PGTransaction::ObjectOperation> &i) {
 	ECUtil::HashInfoRef hinfo = get_hinfo(i.first);
 	plan.hash_infos[i.first] = hinfo;
 
@@ -184,15 +184,15 @@ namespace ECTransaction {
 
   void generate_transactions(
     WritePlan &plan,
-    ErasureCodeInterfaceRef &ecimpl,
+    ceph::ErasureCodeInterfaceRef &ecimpl,
     pg_t pgid,
     const ECUtil::stripe_info_t &sinfo,
-    const map<hobject_t,extent_map> &partial_extents,
-    vector<pg_log_entry_t> &entries,
-    map<hobject_t,extent_map> *written,
-    map<shard_id_t, ObjectStore::Transaction> *transactions,
-    set<hobject_t> *temp_added,
-    set<hobject_t> *temp_removed,
+    const std::map<hobject_t,extent_map> &partial_extents,
+    std::vector<pg_log_entry_t> &entries,
+    std::map<hobject_t,extent_map> *written,
+    std::map<shard_id_t, ObjectStore::Transaction> *transactions,
+    std::set<hobject_t> *temp_added,
+    std::set<hobject_t> *temp_removed,
     DoutPrefixProvider *dpp,
     const ceph_release_t require_osd_release = ceph_release_t::unknown);
 };

--- a/src/osd/ECUtil.cc
+++ b/src/osd/ECUtil.cc
@@ -5,6 +5,9 @@
 #include "ECUtil.h"
 
 using namespace std;
+using ceph::bufferlist;
+using ceph::ErasureCodeInterfaceRef;
+using ceph::Formatter;
 
 int ECUtil::decode(
   const stripe_info_t &sinfo,

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -81,22 +81,22 @@ public:
 
 int decode(
   const stripe_info_t &sinfo,
-  ErasureCodeInterfaceRef &ec_impl,
-  std::map<int, bufferlist> &to_decode,
-  bufferlist *out);
+  ceph::ErasureCodeInterfaceRef &ec_impl,
+  std::map<int, ceph::buffer::list> &to_decode,
+  ceph::buffer::list *out);
 
 int decode(
   const stripe_info_t &sinfo,
-  ErasureCodeInterfaceRef &ec_impl,
-  std::map<int, bufferlist> &to_decode,
-  std::map<int, bufferlist*> &out);
+  ceph::ErasureCodeInterfaceRef &ec_impl,
+  std::map<int, ceph::buffer::list> &to_decode,
+  std::map<int, ceph::buffer::list*> &out);
 
 int encode(
   const stripe_info_t &sinfo,
-  ErasureCodeInterfaceRef &ec_impl,
-  bufferlist &in,
+  ceph::ErasureCodeInterfaceRef &ec_impl,
+  ceph::buffer::list &in,
   const std::set<int> &want,
-  std::map<int, bufferlist> *out);
+  std::map<int, ceph::buffer::list> *out);
 
 class HashInfo {
   uint64_t total_chunk_size = 0;
@@ -108,16 +108,16 @@ public:
   HashInfo() {}
   explicit HashInfo(unsigned num_chunks) :
     cumulative_shard_hashes(num_chunks, -1) {}
-  void append(uint64_t old_size, std::map<int, bufferlist> &to_append);
+  void append(uint64_t old_size, std::map<int, ceph::buffer::list> &to_append);
   void clear() {
     total_chunk_size = 0;
     cumulative_shard_hashes = std::vector<uint32_t>(
       cumulative_shard_hashes.size(),
       -1);
   }
-  void encode(bufferlist &bl) const;
-  void decode(bufferlist::const_iterator &bl);
-  void dump(Formatter *f) const;
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &bl);
+  void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<HashInfo*>& o);
   uint32_t get_chunk_hash(int shard) const {
     ceph_assert((unsigned)shard < cumulative_shard_hashes.size());

--- a/src/osd/ExtentCache.cc
+++ b/src/osd/ExtentCache.cc
@@ -14,6 +14,10 @@
 
 #include "ExtentCache.h"
 
+using std::ostream;
+
+using ceph::bufferlist;
+
 void ExtentCache::extent::_link_pin_state(pin_state &pin_state)
 {
   ceph_assert(parent_extent_set);

--- a/src/osd/ExtentCache.h
+++ b/src/osd/ExtentCache.h
@@ -96,27 +96,27 @@
 
 /// If someone wants these types, but not ExtentCache, move to another file
 struct bl_split_merge {
-  bufferlist split(
+  ceph::buffer::list split(
     uint64_t offset,
     uint64_t length,
-    bufferlist &bl) const {
-    bufferlist out;
+    ceph::buffer::list &bl) const {
+    ceph::buffer::list out;
     out.substr_of(bl, offset, length);
     return out;
   }
-  bool can_merge(const bufferlist &left, const bufferlist &right) const {
+  bool can_merge(const ceph::buffer::list &left, const ceph::buffer::list &right) const {
     return true;
   }
-  bufferlist merge(bufferlist &&left, bufferlist &&right) const {
-    bufferlist bl;
+  ceph::buffer::list merge(ceph::buffer::list &&left, ceph::buffer::list &&right) const {
+    ceph::buffer::list bl;
     bl.claim(left);
     bl.claim_append(right);
     return bl;
   }
-  uint64_t length(const bufferlist &b) const { return b.length(); }
+  uint64_t length(const ceph::buffer::list &b) const { return b.length(); }
 };
 using extent_set = interval_set<uint64_t>;
-using extent_map = interval_map<uint64_t, bufferlist, bl_split_merge>;
+using extent_map = interval_map<uint64_t, ceph::buffer::list, bl_split_merge>;
 
 class ExtentCache {
   struct object_extent_set;
@@ -131,7 +131,7 @@ private:
 
     uint64_t offset;
     uint64_t length;
-    std::optional<bufferlist> bl;
+    std::optional<ceph::buffer::list> bl;
 
     uint64_t get_length() const {
       return length;
@@ -151,7 +151,7 @@ private:
       return parent_pin_state->tid;
     }
 
-    extent(uint64_t offset, bufferlist _bl)
+    extent(uint64_t offset, ceph::buffer::list _bl)
       : offset(offset), length(_bl.length()), bl(_bl) {}
 
     extent(uint64_t offset, uint64_t length)
@@ -204,7 +204,7 @@ private:
 	UPDATE_PIN
       };
       type action = NONE;
-      std::optional<bufferlist> bl;
+      std::optional<ceph::buffer::list> bl;
     };
     template <typename F>
     void traverse_update(
@@ -253,7 +253,7 @@ private:
 	      (ext->offset + ext->get_length() > offset)) {
 	    extent *head = nullptr;
 	    if (ext->bl) {
-	      bufferlist bl;
+	      ceph::buffer::list bl;
 	      bl.substr_of(
 		*(ext->bl),
 		0,
@@ -271,7 +271,7 @@ private:
 	      (ext->offset + ext->get_length()) - (offset + length);
 	    extent *tail = nullptr;
 	    if (ext->bl) {
-	      bufferlist bl;
+	      ceph::buffer::list bl;
 	      bl.substr_of(
 		*(ext->bl),
 		ext->get_length() - nlen,
@@ -284,7 +284,7 @@ private:
 	  }
 	  if (action.action == update_action::UPDATE_PIN) {
 	    if (ext->bl) {
-	      bufferlist bl;
+	      ceph::buffer::list bl;
 	      bl.substr_of(
 		*(ext->bl),
 		extoff - ext->offset,
@@ -381,7 +381,7 @@ private:
 
   void release_pin(pin_state &p) {
     for (auto iter = p.pin_list.begin(); iter != p.pin_list.end(); ) {
-      unique_ptr<extent> extent(&*iter); // we now own this
+      std::unique_ptr<extent> extent(&*iter); // we now own this
       iter++; // unlink will invalidate
       ceph_assert(extent->parent_extent_set);
       auto &eset = *(extent->parent_extent_set);
@@ -482,10 +482,9 @@ public:
     release_pin(pin);
   }
 
-  ostream &print(
-    ostream &out) const;
+  std::ostream &print(std::ostream &out) const;
 };
 
-ostream &operator<<(ostream &lhs, const ExtentCache &cache);
+std::ostream &operator <<(std::ostream &lhs, const ExtentCache &cache);
 
 #endif

--- a/src/osd/MissingLoc.cc
+++ b/src/osd/MissingLoc.cc
@@ -8,6 +8,8 @@
 #define dout_prefix (gen_prefix(*_dout))
 #define dout_subsys ceph_subsys_osd
 
+using std::set;
+
 bool MissingLoc::readable_with_acting(
   const hobject_t &hoid,
   const set<pg_shard_t> &acting) const {
@@ -21,9 +23,7 @@ bool MissingLoc::readable_with_acting(
   const set<pg_shard_t> &locs = missing_loc_entry->second;
   ldout(cct, 10) << __func__ << ": locs:" << locs << dendl;
   set<pg_shard_t> have_acting;
-  for (set<pg_shard_t>::const_iterator i = locs.begin();
-       i != locs.end();
-       ++i) {
+  for (auto i = locs.begin(); i != locs.end(); ++i) {
     if (acting.count(*i))
       have_acting.insert(*i);
   }
@@ -38,7 +38,7 @@ void MissingLoc::add_batch_sources_info(
 		     << sources.size() << dendl;
   unsigned loop = 0;
   bool sources_updated = false;
-  for (map<hobject_t, pg_missing_item>::const_iterator i = needs_recovery_map.begin();
+  for (auto i = needs_recovery_map.begin();
       i != needs_recovery_map.end();
       ++i) {
     if (handle && ++loop >= cct->_conf->osd_loop_before_reset_tphandle) {
@@ -74,7 +74,7 @@ bool MissingLoc::add_source_info(
   unsigned loop = 0;
   bool sources_updated = false;
   // found items?
-  for (map<hobject_t,pg_missing_item>::const_iterator p = needs_recovery_map.begin();
+  for (auto p = needs_recovery_map.begin();
        p != needs_recovery_map.end();
        ++p) {
     const hobject_t &soid(p->first);
@@ -139,7 +139,7 @@ bool MissingLoc::add_source_info(
 void MissingLoc::check_recovery_sources(const OSDMapRef& osdmap)
 {
   set<pg_shard_t> now_down;
-  for (set<pg_shard_t>::iterator p = missing_loc_sources.begin();
+  for (auto p = missing_loc_sources.begin();
        p != missing_loc_sources.end();
        ) {
     if (osdmap->is_up(p->osd)) {
@@ -158,9 +158,9 @@ void MissingLoc::check_recovery_sources(const OSDMapRef& osdmap)
 		       << missing_loc_sources << dendl;
 
     // filter missing_loc
-    map<hobject_t, set<pg_shard_t>>::iterator p = missing_loc.begin();
+    auto p = missing_loc.begin();
     while (p != missing_loc.end()) {
-      set<pg_shard_t>::iterator q = p->second.begin();
+      auto q = p->second.begin();
       bool changed = false;
       while (q != p->second.end()) {
 	if (now_down.count(*q)) {
@@ -189,9 +189,9 @@ void MissingLoc::remove_stray_recovery_sources(pg_shard_t stray)
 {
   ldout(cct, 10) << __func__ << " remove osd " << stray << " from missing_loc" << dendl;
   // filter missing_loc
-  map<hobject_t, set<pg_shard_t>>::iterator p = missing_loc.begin();
+  auto p = missing_loc.begin();
   while (p != missing_loc.end()) {
-    set<pg_shard_t>::iterator q = p->second.begin();
+    auto q = p->second.begin();
     bool changed = false;
     while (q != p->second.end()) {
       if (*q == stray) {
@@ -214,9 +214,7 @@ void MissingLoc::remove_stray_recovery_sources(pg_shard_t stray)
     }
   }
   // filter missing_loc_sources
-  for (set<pg_shard_t>::iterator p = missing_loc_sources.begin();
-       p != missing_loc_sources.end();
-       ) {
+  for (auto p = missing_loc_sources.begin(); p != missing_loc_sources.end();) {
     if (*p != stray) {
       ++p;
       continue;

--- a/src/osd/MissingLoc.h
+++ b/src/osd/MissingLoc.h
@@ -17,7 +17,7 @@ class MissingLoc {
 
   class MappingInfo {
   public:
-    virtual const set<pg_shard_t> &get_upset() const = 0;
+    virtual const std::set<pg_shard_t> &get_upset() const = 0;
     virtual bool is_ec_pg() const = 0;
     virtual int get_pg_size() const = 0;
     virtual ~MappingInfo() {}
@@ -35,7 +35,7 @@ class MissingLoc {
 	      (l.up == r.up &&
 	       (l.other < r.other)));
     }
-    friend ostream& operator<<(ostream& out, const loc_count_t& l) {
+    friend std::ostream& operator<<(std::ostream& out, const loc_count_t& l) {
       ceph_assert(l.up >= 0);
       ceph_assert(l.other >= 0);
       return out << "(" << l.up << "+" << l.other << ")";
@@ -43,9 +43,9 @@ class MissingLoc {
   };
 
 
-  using missing_by_count_t = map < shard_id_t, map<loc_count_t,int> >;
+  using missing_by_count_t = std::map<shard_id_t, std::map<loc_count_t,int>>;
  private:
-  loc_count_t _get_count(const set<pg_shard_t> &shards) {
+  loc_count_t _get_count(const std::set<pg_shard_t> &shards) {
     loc_count_t r;
     for (auto s : shards) {
       if (mapping_info->get_upset().count(s)) {
@@ -57,21 +57,21 @@ class MissingLoc {
     return r;
   }
 
-  map<hobject_t, pg_missing_item> needs_recovery_map;
-  map<hobject_t, set<pg_shard_t> > missing_loc;
-  set<pg_shard_t> missing_loc_sources;
+  std::map<hobject_t, pg_missing_item> needs_recovery_map;
+  std::map<hobject_t, std::set<pg_shard_t> > missing_loc;
+  std::set<pg_shard_t> missing_loc_sources;
 
   // for every entry in missing_loc, we count how many of each type of shard we have,
-  // and maintain totals here.  The sum of the values for this map will always equal
+  // and maintain totals here.  The sum of the values for this std::map will always equal
   // missing_loc.size().
   missing_by_count_t missing_by_count;
 
   void pgs_by_shard_id(
-    const set<pg_shard_t>& s,
-    map< shard_id_t, set<pg_shard_t> >& pgsbs) {
+    const std::set<pg_shard_t>& s,
+    std::map<shard_id_t, std::set<pg_shard_t> >& pgsbs) {
     if (mapping_info->is_ec_pg()) {
       int num_shards = mapping_info->get_pg_size();
-      // For completely missing shards initialize with empty set<pg_shard_t>
+      // For completely missing shards initialize with empty std::set<pg_shard_t>
       for (int i = 0 ; i < num_shards ; ++i) {
 	shard_id_t shard(i);
 	pgsbs[shard];
@@ -83,14 +83,14 @@ class MissingLoc {
     }
   }
 
-  void _inc_count(const set<pg_shard_t>& s) {
-    map< shard_id_t, set<pg_shard_t> > pgsbs;
+  void _inc_count(const std::set<pg_shard_t>& s) {
+    std::map< shard_id_t, std::set<pg_shard_t> > pgsbs;
     pgs_by_shard_id(s, pgsbs);
     for (auto shard: pgsbs)
       ++missing_by_count[shard.first][_get_count(shard.second)];
   }
-  void _dec_count(const set<pg_shard_t>& s) {
-    map< shard_id_t, set<pg_shard_t> > pgsbs;
+  void _dec_count(const std::set<pg_shard_t>& s) {
+    std::map< shard_id_t, std::set<pg_shard_t> > pgsbs;
     pgs_by_shard_id(s, pgsbs);
     for (auto shard: pgsbs) {
       auto p = missing_by_count[shard.first].find(_get_count(shard.second));
@@ -105,7 +105,7 @@ class MissingLoc {
   MappingInfo *mapping_info;
   DoutPrefixProvider *dpp;
   CephContext *cct;
-  set<pg_shard_t> empty_set;
+  std::set<pg_shard_t> empty_set;
  public:
   boost::scoped_ptr<IsPGReadablePredicate> is_readable;
   boost::scoped_ptr<IsPGRecoverablePredicate> is_recoverable;
@@ -130,7 +130,7 @@ class MissingLoc {
   bool needs_recovery(
     const hobject_t &hoid,
     eversion_t *v = 0) const {
-    map<hobject_t, pg_missing_item>::const_iterator i =
+    std::map<hobject_t, pg_missing_item>::const_iterator i =
       needs_recovery_map.find(hoid);
     if (i == needs_recovery_map.end())
       return false;
@@ -157,10 +157,10 @@ class MissingLoc {
   }
   bool readable_with_acting(
     const hobject_t &hoid,
-    const set<pg_shard_t> &acting) const;
+    const std::set<pg_shard_t> &acting) const;
   uint64_t num_unfound() const {
     uint64_t ret = 0;
-    for (map<hobject_t, pg_missing_item>::const_iterator i =
+    for (std::map<hobject_t, pg_missing_item>::const_iterator i =
 	   needs_recovery_map.begin();
 	 i != needs_recovery_map.end();
 	 ++i) {
@@ -174,7 +174,7 @@ class MissingLoc {
   }
 
   bool have_unfound() const {
-    for (map<hobject_t, pg_missing_item>::const_iterator i =
+    for (std::map<hobject_t, pg_missing_item>::const_iterator i =
 	   needs_recovery_map.begin();
 	 i != needs_recovery_map.end();
 	 ++i) {
@@ -196,7 +196,7 @@ class MissingLoc {
   void add_location(const hobject_t &hoid, pg_shard_t location) {
     auto p = missing_loc.find(hoid);
     if (p == missing_loc.end()) {
-      p = missing_loc.emplace(hoid, set<pg_shard_t>()).first;
+      p = missing_loc.emplace(hoid, std::set<pg_shard_t>()).first;
     } else {
       _dec_count(p->second);
     }
@@ -225,11 +225,11 @@ class MissingLoc {
   }
 
   void add_active_missing(const pg_missing_t &missing) {
-    for (map<hobject_t, pg_missing_item>::const_iterator i =
+    for (std::map<hobject_t, pg_missing_item>::const_iterator i =
 	   missing.get_items().begin();
 	 i != missing.get_items().end();
 	 ++i) {
-      map<hobject_t, pg_missing_item>::const_iterator j =
+      std::map<hobject_t, pg_missing_item>::const_iterator j =
 	needs_recovery_map.find(i->first);
       if (j == needs_recovery_map.end()) {
 	needs_recovery_map.insert(*i);
@@ -263,7 +263,7 @@ class MissingLoc {
 
   /// Adds recovery sources in batch
   void add_batch_sources_info(
-    const set<pg_shard_t> &sources,  ///< [in] a set of resources which can be used for all objects
+    const std::set<pg_shard_t> &sources,  ///< [in] a std::set of resources which can be used for all objects
     HBHandle *handle  ///< [in] ThreadPool handle
     );
 
@@ -273,7 +273,7 @@ class MissingLoc {
   /// Remove stray from recovery sources
   void remove_stray_recovery_sources(pg_shard_t stray);
 
-  /// Call when hoid is no longer missing in acting set
+  /// Call when hoid is no longer missing in acting std::set
   void recovered(const hobject_t &hoid) {
     needs_recovery_map.erase(hoid);
     auto p = missing_loc.find(hoid);
@@ -287,11 +287,11 @@ class MissingLoc {
   void rebuild(
     const hobject_t &hoid,
     pg_shard_t self,
-    const set<pg_shard_t> &to_recover,
+    const std::set<pg_shard_t> &to_recover,
     const pg_info_t &info,
     const pg_missing_t &missing,
-    const map<pg_shard_t, pg_missing_t> &pmissing,
-    const map<pg_shard_t, pg_info_t> &pinfo) {
+    const std::map<pg_shard_t, pg_missing_t> &pmissing,
+    const std::map<pg_shard_t, pg_info_t> &pinfo) {
     recovered(hoid);
     std::optional<pg_missing_item> item;
     auto miter = missing.get_items().find(hoid);
@@ -317,7 +317,7 @@ class MissingLoc {
     if (item->is_delete())
       return;
     auto mliter =
-      missing_loc.emplace(hoid, set<pg_shard_t>()).first;
+      missing_loc.emplace(hoid, std::set<pg_shard_t>()).first;
     ceph_assert(info.last_backfill.is_max());
     ceph_assert(info.last_update >= item->need);
     if (!missing.is_missing(hoid))
@@ -335,14 +335,14 @@ class MissingLoc {
     _inc_count(mliter->second);
   }
 
-  const set<pg_shard_t> &get_locations(const hobject_t &hoid) const {
+  const std::set<pg_shard_t> &get_locations(const hobject_t &hoid) const {
     auto it = missing_loc.find(hoid);
     return it == missing_loc.end() ? empty_set : it->second;
   }
-  const map<hobject_t, set<pg_shard_t>> &get_missing_locs() const {
+  const std::map<hobject_t, std::set<pg_shard_t>> &get_missing_locs() const {
     return missing_loc;
   }
-  const map<hobject_t, pg_missing_item> &get_needs_recovery() const {
+  const std::map<hobject_t, pg_missing_item> &get_needs_recovery() const {
     return needs_recovery_map;
   }
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -7,9 +7,9 @@
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 #ifndef CEPH_OSD_H
@@ -30,8 +30,8 @@
 #include "mgr/MgrClient.h"
 
 #include "os/ObjectStore.h"
-#include "OSDCap.h" 
- 
+#include "OSDCap.h"
+
 #include "auth/KeyRing.h"
 
 #include "osd/ClassHandler.h"
@@ -175,11 +175,11 @@ public:
   }
 
   /*
-   * osdmap - current published map
-   * next_osdmap - pre_published map that is about to be published.
+   * osdmap - current published std::map
+   * next_osdmap - pre_published std::map that is about to be published.
    *
    * We use the next_osdmap to send messages and initiate connections,
-   * but only if the target is the same instance as the one in the map
+   * but only if the target is the same instance as the one in the std::map
    * epoch the current user is working from (i.e., the result is
    * equivalent to what is in next_osdmap).
    *
@@ -201,7 +201,7 @@ public:
 
   void activate_map();
   /// map epochs reserved below
-  map<epoch_t, unsigned> map_reservations;
+  std::map<epoch_t, unsigned> map_reservations;
 
   /// gets ref to next_osdmap and registers the epoch as reserved
   OSDMapRef get_nextmap_reserved() {
@@ -209,15 +209,15 @@ public:
     if (!next_osdmap)
       return OSDMapRef();
     epoch_t e = next_osdmap->get_epoch();
-    map<epoch_t, unsigned>::iterator i =
-      map_reservations.insert(make_pair(e, 0)).first;
+    std::map<epoch_t, unsigned>::iterator i =
+      map_reservations.insert(std::make_pair(e, 0)).first;
     i->second++;
     return next_osdmap;
   }
   /// releases reservation on map
   void release_map(OSDMapRef osdmap) {
     std::lock_guard l(pre_publish_lock);
-    map<epoch_t, unsigned>::iterator i =
+    std::map<epoch_t, unsigned>::iterator i =
       map_reservations.find(osdmap->get_epoch());
     ceph_assert(i != map_reservations.end());
     ceph_assert(i->second > 0);
@@ -258,7 +258,7 @@ public:
                                        OSDSuperblock& superblock);
 
   ConnectionRef get_con_osd_cluster(int peer, epoch_t from_epoch);
-  pair<ConnectionRef,ConnectionRef> get_con_osd_hb(int peer, epoch_t from_epoch);  // (back, front)
+  std::pair<ConnectionRef,ConnectionRef> get_con_osd_hb(int peer, epoch_t from_epoch);  // (back, front)
   void send_message_osd_cluster(int peer, Message *m, epoch_t from_epoch);
   void send_message_osd_cluster(std::vector<std::pair<int, Message*>>& messages, epoch_t from_epoch);
   void send_message_osd_cluster(Message *m, Connection *con) {
@@ -296,7 +296,7 @@ public:
     /// order the jobs by sched_time
     bool operator<(const ScrubJob& rhs) const;
   };
-  set<ScrubJob> sched_scrub_pg;
+  std::set<ScrubJob> sched_scrub_pg;
 
   /// @returns the scrub_reg_stamp used for unregister the scrub job
   utime_t reg_pg_scrub(spg_t pgid, utime_t t, double pool_scrub_min_interval,
@@ -316,7 +316,7 @@ public:
     std::lock_guard l(sched_scrub_lock);
     if (sched_scrub_pg.empty())
       return false;
-    set<ScrubJob>::iterator iter = sched_scrub_pg.begin();
+    std::set<ScrubJob>::iterator iter = sched_scrub_pg.begin();
     *out = *iter;
     return true;
   }
@@ -325,7 +325,7 @@ public:
     std::lock_guard l(sched_scrub_lock);
     if (sched_scrub_pg.empty())
       return false;
-    set<ScrubJob>::const_iterator iter = sched_scrub_pg.lower_bound(next);
+    std::set<ScrubJob>::const_iterator iter = sched_scrub_pg.lower_bound(next);
     if (iter == sched_scrub_pg.cend())
       return false;
     ++iter;
@@ -335,7 +335,7 @@ public:
     return true;
   }
 
-  void dumps_scrub(Formatter *f) {
+  void dumps_scrub(ceph::Formatter *f) {
     ceph_assert(f != nullptr);
     std::lock_guard l(sched_scrub_lock);
 
@@ -356,11 +356,11 @@ public:
   void dec_scrubs_local();
   bool inc_scrubs_remote();
   void dec_scrubs_remote();
-  void dump_scrub_reservations(Formatter *f);
+  void dump_scrub_reservations(ceph::Formatter *f);
 
   void reply_op_error(OpRequestRef op, int err);
   void reply_op_error(OpRequestRef op, int err, eversion_t v, version_t uv,
-		      vector<pg_log_op_return_item_t> op_returns);
+		      std::vector<pg_log_op_return_item_t> op_returns);
   void handle_misdirected_op(PG *pg, OpRequestRef op);
 
 
@@ -368,12 +368,12 @@ private:
   // -- agent shared state --
   ceph::mutex agent_lock = ceph::make_mutex("OSDService::agent_lock");
   ceph::condition_variable agent_cond;
-  map<uint64_t, set<PGRef> > agent_queue;
-  set<PGRef>::iterator agent_queue_pos;
+  std::map<uint64_t, std::set<PGRef> > agent_queue;
+  std::set<PGRef>::iterator agent_queue_pos;
   bool agent_valid_iterator;
   int agent_ops;
   int flush_mode_high_count; //once have one pg with FLUSH_MODE_HIGH then flush objects with high speed
-  set<hobject_t> agent_oids;
+  std::set<hobject_t> agent_oids;
   bool agent_active;
   struct AgentThread : public Thread {
     OSDService *osd;
@@ -395,15 +395,15 @@ public:
     if (!agent_queue.empty() &&
 	agent_queue.rbegin()->first < priority)
       agent_valid_iterator = false;  // inserting higher-priority queue
-    set<PGRef>& nq = agent_queue[priority];
+    std::set<PGRef>& nq = agent_queue[priority];
     if (nq.empty())
       agent_cond.notify_all();
     nq.insert(pg);
   }
 
   void _dequeue(PG *pg, uint64_t old_priority) {
-    set<PGRef>& oq = agent_queue[old_priority];
-    set<PGRef>::iterator p = oq.find(pg);
+    std::set<PGRef>& oq = agent_queue[old_priority];
+    std::set<PGRef>::iterator p = oq.find(pg);
     ceph_assert(p != oq.end());
     if (p == agent_queue_pos)
       ++agent_queue_pos;
@@ -561,11 +561,11 @@ public:
 
   // -- pg merge --
   ceph::mutex merge_lock = ceph::make_mutex("OSD::merge_lock");
-  map<pg_t,eversion_t> ready_to_merge_source;   // pg -> version
-  map<pg_t,std::tuple<eversion_t,epoch_t,epoch_t>> ready_to_merge_target;  // pg -> (version,les,lec)
-  set<pg_t> not_ready_to_merge_source;
-  map<pg_t,pg_t> not_ready_to_merge_target;
-  set<pg_t> sent_ready_to_merge_source;
+  std::map<pg_t,eversion_t> ready_to_merge_source;   // pg -> version
+  std::map<pg_t,std::tuple<eversion_t,epoch_t,epoch_t>> ready_to_merge_target;  // pg -> (version,les,lec)
+  std::set<pg_t> not_ready_to_merge_source;
+  std::map<pg_t,pg_t> not_ready_to_merge_target;
+  std::set<pg_t> sent_ready_to_merge_source;
 
   void set_ready_to_merge_source(PG *pg,
 				 eversion_t version);
@@ -585,22 +585,22 @@ public:
 private:
   ceph::mutex pg_temp_lock = ceph::make_mutex("OSDService::pg_temp_lock");
   struct pg_temp_t {
-    vector<int> acting;
+    std::vector<int> acting;
     bool forced = false;
   };
-  map<pg_t, pg_temp_t> pg_temp_wanted;
-  map<pg_t, pg_temp_t> pg_temp_pending;
+  std::map<pg_t, pg_temp_t> pg_temp_wanted;
+  std::map<pg_t, pg_temp_t> pg_temp_pending;
   void _sent_pg_temp();
   friend std::ostream& operator<<(std::ostream&, const pg_temp_t&);
 public:
-  void queue_want_pg_temp(pg_t pgid, const vector<int>& want,
+  void queue_want_pg_temp(pg_t pgid, const std::vector<int>& want,
 			  bool forced = false);
   void remove_want_pg_temp(pg_t pgid);
   void requeue_pg_temp();
   void send_pg_temp();
 
   ceph::mutex pg_created_lock = ceph::make_mutex("OSDService::pg_created_lock");
-  set<pg_t> pg_created;
+  std::set<pg_t> pg_created;
   void send_pg_created(pg_t pgid);
   void prune_pg_created();
   void send_pg_created();
@@ -615,19 +615,19 @@ public:
 private:
   // -- pg recovery and associated throttling --
   ceph::mutex recovery_lock = ceph::make_mutex("OSDService::recovery_lock");
-  list<pair<epoch_t, PGRef> > awaiting_throttle;
+  std::list<std::pair<epoch_t, PGRef> > awaiting_throttle;
 
   utime_t defer_recovery_until;
   uint64_t recovery_ops_active;
   uint64_t recovery_ops_reserved;
   bool recovery_paused;
 #ifdef DEBUG_RECOVERY_OIDS
-  map<spg_t, set<hobject_t> > recovery_oids;
+  std::map<spg_t, std::set<hobject_t> > recovery_oids;
 #endif
   bool _recover_now(uint64_t *available_pushes);
   void _maybe_queue_recovery();
   void _queue_for_recovery(
-    pair<epoch_t, PGRef> p, uint64_t reserved_pushes);
+    std::pair<epoch_t, PGRef> p, uint64_t reserved_pushes);
 public:
   void start_recovery_op(PG *pg, const hobject_t& soid);
   void finish_recovery_op(PG *pg, const hobject_t& soid, bool dequeue);
@@ -669,15 +669,15 @@ public:
     std::lock_guard l(recovery_lock);
 
     if (pg->is_forced_recovery_or_backfill()) {
-      awaiting_throttle.push_front(make_pair(pg->get_osdmap()->get_epoch(), pg));
+      awaiting_throttle.push_front(std::make_pair(pg->get_osdmap()->get_epoch(), pg));
     } else {
-      awaiting_throttle.push_back(make_pair(pg->get_osdmap()->get_epoch(), pg));
+      awaiting_throttle.push_back(std::make_pair(pg->get_osdmap()->get_epoch(), pg));
     }
     _maybe_queue_recovery();
   }
   void queue_recovery_after_sleep(PG *pg, epoch_t queued, uint64_t reserved_pushes) {
     std::lock_guard l(recovery_lock);
-    _queue_for_recovery(make_pair(queued, pg), reserved_pushes);
+    _queue_for_recovery(std::make_pair(queued, pg), reserved_pushes);
   }
 
   void queue_check_readable(spg_t spgid,
@@ -687,8 +687,8 @@ public:
   // osd map cache (past osd maps)
   ceph::mutex map_cache_lock = ceph::make_mutex("OSDService::map_cache_lock");
   SharedLRU<epoch_t, const OSDMap> map_cache;
-  SimpleLRU<epoch_t, bufferlist> map_bl_cache;
-  SimpleLRU<epoch_t, bufferlist> map_bl_inc_cache;
+  SimpleLRU<epoch_t, ceph::buffer::list> map_bl_cache;
+  SimpleLRU<epoch_t, ceph::buffer::list> map_bl_inc_cache;
 
   OSDMapRef try_get_map(epoch_t e);
   OSDMapRef get_map(epoch_t e) {
@@ -702,23 +702,23 @@ public:
   }
   OSDMapRef _add_map(OSDMap *o);
 
-  void _add_map_bl(epoch_t e, bufferlist& bl);
-  bool get_map_bl(epoch_t e, bufferlist& bl) {
+  void _add_map_bl(epoch_t e, ceph::buffer::list& bl);
+  bool get_map_bl(epoch_t e, ceph::buffer::list& bl) {
     std::lock_guard l(map_cache_lock);
     return _get_map_bl(e, bl);
   }
-  bool _get_map_bl(epoch_t e, bufferlist& bl);
+  bool _get_map_bl(epoch_t e, ceph::buffer::list& bl);
 
-  void _add_map_inc_bl(epoch_t e, bufferlist& bl);
-  bool get_inc_map_bl(epoch_t e, bufferlist& bl);
+  void _add_map_inc_bl(epoch_t e, ceph::buffer::list& bl);
+  bool get_inc_map_bl(epoch_t e, ceph::buffer::list& bl);
 
   /// identify split child pgids over a osdmap interval
   void identify_splits_and_merges(
     OSDMapRef old_map,
     OSDMapRef new_map,
     spg_t pgid,
-    set<pair<spg_t,epoch_t>> *new_children,
-    set<pair<spg_t,epoch_t>> *merge_pgs);
+    std::set<std::pair<spg_t,epoch_t>> *new_children,
+    std::set<std::pair<spg_t,epoch_t>> *merge_pgs);
 
   void need_heartbeat_peer_update();
 
@@ -735,7 +735,7 @@ public:
 
   void set_statfs(const struct store_statfs_t &stbuf,
     osd_alert_list_t& alerts);
-  osd_stat_t set_osd_stat(vector<int>& hb_peers, int num_pgs);
+  osd_stat_t set_osd_stat(std::vector<int>& hb_peers, int num_pgs);
   void inc_osd_stat_repaired(void);
   float compute_adjusted_ratio(osd_stat_t new_stat, float *pratio, uint64_t adjust_used = 0);
   osd_stat_t get_osd_stat() {
@@ -749,7 +749,7 @@ public:
     std::lock_guard l(stat_lock);
     return osd_stat.seq;
   }
-  void get_hb_pingtime(map<int, osd_stat_t::Interfaces> *pp)
+  void get_hb_pingtime(std::map<int, osd_stat_t::Interfaces> *pp)
   {
     std::lock_guard l(stat_lock);
     *pp = osd_stat.hb_pingtime;
@@ -771,7 +771,7 @@ private:
     default: return "???";
     }
   }
-  s_names get_full_state(string type) const {
+  s_names get_full_state(std::string type) const {
     if (type == "none")
       return NONE;
     else if (type == "failsafe")
@@ -793,7 +793,7 @@ private:
   bool _check_full(DoutPrefixProvider *dpp, s_names type) const;
 public:
   void check_full_status(float ratio, float pratio);
-  s_names recalc_full_state(float ratio, float pratio, string &inject);
+  s_names recalc_full_state(float ratio, float pratio, std::string &inject);
   bool _tentative_full(DoutPrefixProvider *dpp, s_names type, uint64_t adjust_used, osd_stat_t);
   bool check_failsafe_full(DoutPrefixProvider *dpp) const;
   bool check_full(DoutPrefixProvider *dpp) const;
@@ -817,13 +817,13 @@ private:
   epoch_t bind_epoch;  // epoch we last did a bind to new ip:ports
 public:
   /**
-   * Retrieve the boot_, up_, and bind_ epochs the OSD has set. The params
+   * Retrieve the boot_, up_, and bind_ epochs the OSD has std::set. The params
    * can be NULL if you don't care about them.
    */
   void retrieve_epochs(epoch_t *_boot_epoch, epoch_t *_up_epoch,
                        epoch_t *_bind_epoch) const;
   /**
-   * Set the boot, up, and bind epochs. Any NULL params will not be set.
+   * Std::set the boot, up, and bind epochs. Any NULL params will not be std::set.
    */
   void set_epochs(const epoch_t *_boot_epoch, const epoch_t *_up_epoch,
                   const epoch_t *_bind_epoch);
@@ -849,7 +849,7 @@ public:
   ceph::mutex hb_stamp_lock = ceph::make_mutex("OSDServce::hb_stamp_lock");
 
   /// osd -> heartbeat stamps
-  vector<HeartbeatStampsRef> hb_stamps;
+  std::vector<HeartbeatStampsRef> hb_stamps;
 
   /// get or create a ref for a peer's HeartbeatStamps
   HeartbeatStampsRef get_hb_stamps(unsigned osd);
@@ -886,8 +886,8 @@ public:
 
 #ifdef PG_DEBUG_REFS
   ceph::mutex pgid_lock = ceph::make_mutex("OSDService::pgid_lock");
-  map<spg_t, int> pgid_tracker;
-  map<spg_t, PG*> live_pgs;
+  std::map<spg_t, int> pgid_tracker;
+  std::map<spg_t, PG*> live_pgs;
   void add_pgid(spg_t pgid, PG *pg);
   void remove_pgid(spg_t pgid, PG *pg);
   void dump_live_pgids();
@@ -904,7 +904,7 @@ public:
 
   These are the constraints:
 
-  - client ops must remained ordered by client, regardless of map epoch
+  - client ops must remained ordered by client, regardless of std::map epoch
   - peering messages/events from peers must remain ordered by peer
   - peering messages and client ops need not be ordered relative to each other
 
@@ -943,27 +943,27 @@ public:
 
   - when we advance the osdmap on the OSDShard, we scan pg slots and
     discard any slots with no pg (and not waiting_for_split) that no
-    longer map to the current host.
+    longer std::map to the current host.
 
   */
 
 struct OSDShardPGSlot {
   using OpSchedulerItem = ceph::osd::scheduler::OpSchedulerItem;
   PGRef pg;                      ///< pg reference
-  deque<OpSchedulerItem> to_process; ///< order items for this slot
+  std::deque<OpSchedulerItem> to_process; ///< order items for this slot
   int num_running = 0;          ///< _process threads doing pg lookup/lock
 
-  deque<OpSchedulerItem> waiting;   ///< waiting for pg (or map + pg)
+  std::deque<OpSchedulerItem> waiting;   ///< waiting for pg (or map + pg)
 
   /// waiting for map (peering evt)
-  map<epoch_t,deque<OpSchedulerItem>> waiting_peering;
+  std::map<epoch_t,std::deque<OpSchedulerItem>> waiting_peering;
 
   /// incremented by wake_pg_waiters; indicates racing _process threads
   /// should bail out (their op has been requeued)
   uint64_t requeue_seq = 0;
 
   /// waiting for split child to materialize in these epoch(s)
-  set<epoch_t> waiting_for_split;
+  std::set<epoch_t> waiting_for_split;
 
   epoch_t epoch = 0;
   boost::intrusive::set_member_hook<> pg_epoch_item;
@@ -977,9 +977,9 @@ struct OSDShard {
   CephContext *cct;
   OSD *osd;
 
-  string shard_name;
+  std::string shard_name;
 
-  string sdata_wait_lock_name;
+  std::string sdata_wait_lock_name;
   ceph::mutex sdata_wait_lock;
   ceph::condition_variable sdata_cond;
 
@@ -991,13 +991,13 @@ struct OSDShard {
     return shard_osdmap;
   }
 
-  string shard_lock_name;
+  std::string shard_lock_name;
   ceph::mutex shard_lock;   ///< protects remaining members below
 
   /// map of slots for each spg_t.  maintains ordering of items dequeued
   /// from scheduler while _process thread drops shard lock to acquire the
   /// pg lock.  stale slots are removed by consume_map.
-  unordered_map<spg_t,unique_ptr<OSDShardPGSlot>> pg_slots;
+  std::unordered_map<spg_t,std::unique_ptr<OSDShardPGSlot>> pg_slots;
 
   struct pg_slot_compare_by_epoch {
     bool operator()(const OSDShardPGSlot& l, const OSDShardPGSlot& r) const {
@@ -1042,13 +1042,13 @@ struct OSDShard {
 
   void identify_splits_and_merges(
     const OSDMapRef& as_of_osdmap,
-    set<pair<spg_t,epoch_t>> *split_children,
-    set<pair<spg_t,epoch_t>> *merge_pgs);
-  void _prime_splits(set<pair<spg_t,epoch_t>> *pgids);
+    std::set<std::pair<spg_t,epoch_t>> *split_children,
+    std::set<std::pair<spg_t,epoch_t>> *merge_pgs);
+  void _prime_splits(std::set<std::pair<spg_t,epoch_t>> *pgids);
   void prime_splits(const OSDMapRef& as_of_osdmap,
-		    set<pair<spg_t,epoch_t>> *pgids);
+		    std::set<std::pair<spg_t,epoch_t>> *pgids);
   void prime_merges(const OSDMapRef& as_of_osdmap,
-		    set<pair<spg_t,epoch_t>> *merge_pgs);
+		    std::set<std::pair<spg_t,epoch_t>> *merge_pgs);
   void register_and_wake_split_child(PG *pg);
   void unprime_split_children(spg_t parent, unsigned old_pg_num);
 
@@ -1127,9 +1127,9 @@ protected:
   void asok_command(
     std::string_view prefix,
     const cmdmap_t& cmdmap,
-    Formatter *f,
-    const bufferlist& inbl,
-    std::function<void(int,const std::string&,bufferlist&)> on_finish);
+    ceph::Formatter *f,
+    const ceph::buffer::list& inbl,
+    std::function<void(int,const std::string&,ceph::buffer::list&)> on_finish);
 
 public:
   int get_nodeid() { return whoami; }
@@ -1159,17 +1159,17 @@ public:
   }
 
   static ghobject_t make_pg_log_oid(spg_t pg) {
-    stringstream ss;
+    std::stringstream ss;
     ss << "pglog_" << pg;
-    string s;
+    std::string s;
     getline(ss, s);
     return ghobject_t(hobject_t(sobject_t(object_t(s.c_str()), 0)));
   }
   
   static ghobject_t make_pg_biginfo_oid(spg_t pg) {
-    stringstream ss;
+    std::stringstream ss;
     ss << "pginfo_" << pg;
-    string s;
+    std::string s;
     getline(ss, s);
     return ghobject_t(hobject_t(sobject_t(object_t(s.c_str()), 0)));
   }
@@ -1182,7 +1182,7 @@ public:
     return ghobject_t(
       hobject_t(
 	sobject_t(
-	  object_t(string("final_pool_") + stringify(pool)),
+	  object_t(std::string("final_pool_") + stringify(pool)),
 	  CEPH_NOSNAP)));
   }
 
@@ -1198,7 +1198,7 @@ public:
   /**
    * get_osd_initial_compat_set()
    *
-   * Get the initial feature set for this OSD.  Features
+   * Get the initial feature std::set for this OSD.  Features
    * here are automatically upgraded.
    *
    * Return value: Initial osd CompatSet
@@ -1296,10 +1296,10 @@ private:
   void dispatch_session_waiting(const ceph::ref_t<Session>& session, OSDMapRef osdmap);
 
   ceph::mutex session_waiting_lock = ceph::make_mutex("OSD::session_waiting_lock");
-  set<ceph::ref_t<Session>> session_waiting_for_map;
+  std::set<ceph::ref_t<Session>> session_waiting_for_map;
 
   /// Caller assumes refs for included Sessions
-  void get_sessions_waiting_for_map(set<ceph::ref_t<Session>> *out) {
+  void get_sessions_waiting_for_map(std::set<ceph::ref_t<Session>> *out) {
     std::lock_guard l(session_waiting_lock);
     out->swap(session_waiting_for_map);
   }
@@ -1312,7 +1312,7 @@ private:
     session_waiting_for_map.erase(session);
   }
   void dispatch_sessions_waiting_on_map() {
-    set<ceph::ref_t<Session>> sessions_to_check;
+    std::set<ceph::ref_t<Session>> sessions_to_check;
     get_sessions_waiting_for_map(&sessions_to_check);
     for (auto i = sessions_to_check.begin();
 	 i != sessions_to_check.end();
@@ -1371,7 +1371,7 @@ private:
     static constexpr int HEARTBEAT_MAX_CONN = 2;
     /// history of inflight pings, arranging by timestamp we sent
     /// send time -> deadline -> remaining replies
-    map<utime_t, pair<utime_t, int>> ping_history;
+    std::map<utime_t, std::pair<utime_t, int>> ping_history;
 
     utime_t hb_interval_start;
     uint32_t hb_average_count = 0;
@@ -1380,16 +1380,16 @@ private:
     uint32_t hb_total_back = 0;
     uint32_t hb_min_back = UINT_MAX;
     uint32_t hb_max_back = 0;
-    vector<uint32_t> hb_back_pingtime;
-    vector<uint32_t> hb_back_min;
-    vector<uint32_t> hb_back_max;
+    std::vector<uint32_t> hb_back_pingtime;
+    std::vector<uint32_t> hb_back_min;
+    std::vector<uint32_t> hb_back_max;
 
     uint32_t hb_total_front = 0;
     uint32_t hb_min_front = UINT_MAX;
     uint32_t hb_max_front = 0;
-    vector<uint32_t> hb_front_pingtime;
-    vector<uint32_t> hb_front_min;
-    vector<uint32_t> hb_front_max;
+    std::vector<uint32_t> hb_front_pingtime;
+    std::vector<uint32_t> hb_front_min;
+    std::vector<uint32_t> hb_front_max;
 
     bool is_stale(utime_t stale) {
       if (ping_history.empty()) {
@@ -1434,11 +1434,11 @@ private:
   };
 
   ceph::mutex heartbeat_lock = ceph::make_mutex("OSD::heartbeat_lock");
-  map<int, int> debug_heartbeat_drops_remaining;
+  std::map<int, int> debug_heartbeat_drops_remaining;
   ceph::condition_variable heartbeat_cond;
   bool heartbeat_stop;
   std::atomic<bool> heartbeat_need_update;   
-  map<int,HeartbeatInfo> heartbeat_peers;  ///< map of osd id to HeartbeatInfo
+  std::map<int,HeartbeatInfo> heartbeat_peers;  ///< map of osd id to HeartbeatInfo
   utime_t last_mon_heartbeat;
   Messenger *hb_front_client_messenger;
   Messenger *hb_back_client_messenger;
@@ -1522,9 +1522,9 @@ public:
 
 private:
   // -- waiters --
-  list<OpRequestRef> finished;
+  std::list<OpRequestRef> finished;
   
-  void take_waiters(list<OpRequestRef>& ls) {
+  void take_waiters(std::list<OpRequestRef>& ls) {
     ceph_assert(ceph_mutex_is_locked(osd_lock));
     finished.splice(finished.end(), ls);
   }
@@ -1532,7 +1532,7 @@ private:
   
   // -- op tracking --
   OpTracker op_tracker;
-  void test_ops(std::string command, std::string args, ostream& ss);
+  void test_ops(std::string command, std::string args, std::ostream& ss);
   friend class TestOpsSocketHook;
   TestOpsSocketHook *test_ops_hook;
   friend struct C_FinishSplits;
@@ -1585,14 +1585,14 @@ protected:
       OpSchedulerItem&& qi);
 
     /// try to do some work
-    void _process(uint32_t thread_index, heartbeat_handle_d *hb) override;
+    void _process(uint32_t thread_index, ceph::heartbeat_handle_d *hb) override;
 
     /// enqueue a new item
     void _enqueue(OpSchedulerItem&& item) override;
 
     /// requeue an old item (at the front of the line)
     void _enqueue_front(OpSchedulerItem&& item) override;
-      
+
     void return_waiting_threads() override {
       for(uint32_t i = 0; i < osd->num_shards; i++) {
 	OSDShard* sdata = osd->shards[i];
@@ -1612,7 +1612,7 @@ protected:
       }
     }
 
-    void dump(Formatter *f) {
+    void dump(ceph::Formatter *f) {
       for(uint32_t i = 0; i < osd->num_shards; i++) {
 	auto &&sdata = osd->shards[i];
 
@@ -1639,7 +1639,7 @@ protected:
       }
     }
 
-    void handle_oncommits(list<Context*>& oncommits) {
+    void handle_oncommits(std::list<Context*>& oncommits) {
       for (auto p : oncommits) {
 	p->complete(0);
       }
@@ -1668,7 +1668,7 @@ protected:
     ThreadPool::TPHandle& handle);
 
   friend class PG;
-  friend class OSDShard;
+  friend struct OSDShard;
   friend class PrimaryLogPG;
 
 
@@ -1692,8 +1692,8 @@ protected:
   pool_pg_num_history_t pg_num_history;
 
   ceph::shared_mutex map_lock = ceph::make_shared_mutex("OSD::map_lock");
-  list<OpRequestRef>  waiting_for_osdmap;
-  deque<utime_t> osd_markdown_log;
+  std::list<OpRequestRef>  waiting_for_osdmap;
+  std::deque<utime_t> osd_markdown_log;
 
   friend struct send_map_on_destruct;
 
@@ -1703,7 +1703,7 @@ protected:
   void trim_maps(epoch_t oldest, int nreceived, bool skip_maps);
   void note_down_osd(int osd);
   void note_up_osd(int osd);
-  friend class C_OnMapCommit;
+  friend struct C_OnMapCommit;
 
   bool advance_pg(
     epoch_t advance_to,
@@ -1720,13 +1720,13 @@ protected:
   OSDMapRef add_map(OSDMap *o) {
     return service.add_map(o);
   }
-  bool get_map_bl(epoch_t e, bufferlist& bl) {
+  bool get_map_bl(epoch_t e, ceph::buffer::list& bl) {
     return service.get_map_bl(e, bl);
   }
 
 public:
   // -- shards --
-  vector<OSDShard*> shards;
+  std::vector<OSDShard*> shards;
   uint32_t num_shards = 0;
 
   void inc_num_pgs() {
@@ -1742,7 +1742,7 @@ public:
 protected:
   ceph::mutex merge_lock = ceph::make_mutex("OSD::merge_lock");
   /// merge epoch -> target pgid -> source pgid -> pg
-  map<epoch_t,map<spg_t,map<spg_t,PGRef>>> merge_waiters;
+  std::map<epoch_t,std::map<spg_t,std::map<spg_t,PGRef>>> merge_waiters;
 
   bool add_merge_waiter(OSDMapRef nextmap, spg_t target, PGRef source,
 			unsigned need);
@@ -1762,8 +1762,8 @@ protected:
   void register_pg(PGRef pg);
   bool try_finish_pg_delete(PG *pg, unsigned old_pg_num);
 
-  void _get_pgs(vector<PGRef> *v, bool clear_too=false);
-  void _get_pgids(vector<spg_t> *v);
+  void _get_pgs(std::vector<PGRef> *v, bool clear_too=false);
+  void _get_pgids(std::vector<spg_t> *v);
 
 public:
   PGRef lookup_lock_pg(spg_t pgid);
@@ -1793,11 +1793,11 @@ protected:
 
   void split_pgs(
     PG *parent,
-    const set<spg_t> &childpgids, set<PGRef> *out_pgs,
+    const std::set<spg_t> &childpgids, std::set<PGRef> *out_pgs,
     OSDMapRef curmap,
     OSDMapRef nextmap,
     PeeringCtx &rctx);
-  void _finish_splits(set<PGRef>& pgs);
+  void _finish_splits(std::set<PGRef>& pgs);
 
   // == monitor interaction ==
   ceph::mutex mon_report_lock = ceph::make_mutex("OSD::mon_report_lock");
@@ -1809,7 +1809,7 @@ protected:
   void _got_mon_epochs(epoch_t oldest, epoch_t newest);
   void _preboot(epoch_t oldest, epoch_t newest);
   void _send_boot();
-  void _collect_metadata(map<string,string> *pmeta);
+  void _collect_metadata(std::map<std::string,std::string> *pmeta);
   void _get_purged_snaps();
   void handle_get_purged_snaps_reply(MMonGetPurgedSnapsReply *r);
 
@@ -1840,8 +1840,8 @@ protected:
   void got_full_map(epoch_t e);
 
   // -- failures --
-  map<int,utime_t> failure_queue;
-  map<int,pair<utime_t,entity_addrvec_t> > failure_pending;
+  std::map<int,utime_t> failure_queue;
+  std::map<int,std::pair<utime_t,entity_addrvec_t> > failure_pending;
 
   void requeue_failures();
   void send_failures();
@@ -1876,7 +1876,7 @@ protected:
   bool require_self_aliveness(const Message *m, epoch_t alive_since);
   /**
    * Verifies that the OSD who sent the given op has the same
-   * address as in the given map.
+   * address as in the given std::map.
    * @pre op was sent by an OSD using the cluster messenger
    */
   bool require_same_peer_instance(const Message *m, const OSDMapRef& map,
@@ -1998,9 +1998,9 @@ private:
   // static bits
   static int mkfs(CephContext *cct, ObjectStore *store, uuid_d fsid, int whoami);
 
-  /* remove any non-user xattrs from a map of them */
-  void filter_xattrs(map<string, bufferptr>& attrs) {
-    for (map<string, bufferptr>::iterator iter = attrs.begin();
+  /* remove any non-user xattrs from a std::map of them */
+  void filter_xattrs(std::map<std::string, ceph::buffer::ptr>& attrs) {
+    for (std::map<std::string, ceph::buffer::ptr>::iterator iter = attrs.begin();
 	 iter != attrs.end();
 	 ) {
       if (('_' != iter->first.at(0)) || (iter->first.size() == 1))
@@ -2010,7 +2010,7 @@ private:
   }
 
 private:
-  int mon_cmd_maybe_osd_create(string &cmd);
+  int mon_cmd_maybe_osd_create(std::string &cmd);
   int update_crush_device_class();
   int update_crush_location();
 
@@ -2018,8 +2018,8 @@ private:
 			ObjectStore *store,
 			uuid_d& cluster_fsid, uuid_d& osd_fsid, int whoami);
 
-  void handle_scrub(struct MOSDScrub *m);
-  void handle_fast_scrub(struct MOSDScrub2 *m);
+  void handle_scrub(class MOSDScrub *m);
+  void handle_fast_scrub(class MOSDScrub2 *m);
   void handle_osd_ping(class MOSDPing *m);
 
   size_t get_num_cache_shards();
@@ -2033,11 +2033,11 @@ private:
   int get_recovery_max_active();
 
   void scrub_purged_snaps();
-  void probe_smart(const string& devid, ostream& ss);
+  void probe_smart(const std::string& devid, std::ostream& ss);
 
 public:
   static int peek_meta(ObjectStore *store,
-		       string *magic,
+		       std::string *magic,
 		       uuid_d *cluster_fsid,
 		       uuid_d *osd_fsid,
 		       int *whoami,

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1005,8 +1005,8 @@ void OSDMap::Incremental::dump(Formatter *f) const
   f->dump_float("new_full_ratio", new_full_ratio);
   f->dump_float("new_nearfull_ratio", new_nearfull_ratio);
   f->dump_float("new_backfillfull_ratio", new_backfillfull_ratio);
-  f->dump_int("new_require_min_compat_client", ceph::to_integer<int>(new_require_min_compat_client));
-  f->dump_int("new_require_osd_release", ceph::to_integer<int>(new_require_osd_release));
+  f->dump_int("new_require_min_compat_client", to_integer<int>(new_require_min_compat_client));
+  f->dump_int("new_require_osd_release", to_integer<int>(new_require_osd_release));
 
   if (fullmap.length()) {
     f->open_object_section("full_map");
@@ -3501,11 +3501,11 @@ void OSDMap::dump(Formatter *f) const
   f->dump_int("pool_max", get_pool_max());
   f->dump_int("max_osd", get_max_osd());
   f->dump_string("require_min_compat_client",
-		 ceph::to_string(require_min_compat_client));
+		 to_string(require_min_compat_client));
   f->dump_string("min_compat_client",
-		 ceph::to_string(get_min_compat_client()));
+		 to_string(get_min_compat_client()));
   f->dump_string("require_osd_release",
-		 ceph::to_string(require_osd_release));
+		 to_string(require_osd_release));
 
   f->open_array_section("pools");
   for (const auto &pool : pools) {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -76,6 +76,22 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)
 
+using std::list;
+using std::map;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::unique_ptr;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::decode;
+using ceph::encode;
+using ceph::Formatter;
+
 using namespace ceph::osd::scheduler;
 
 template <class T>
@@ -1262,9 +1278,7 @@ void PG::filter_snapc(vector<snapid_t> &snaps)
 
 void PG::requeue_object_waiters(map<hobject_t, list<OpRequestRef>>& m)
 {
-  for (map<hobject_t, list<OpRequestRef>>::iterator it = m.begin();
-       it != m.end();
-       ++it)
+  for (auto it = m.begin(); it != m.end(); ++it)
     requeue_ops(it->second);
   m.clear();
 }

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -55,7 +55,7 @@
 #include <string>
 #include <tuple>
 
-//#define DEBUG_RECOVERY_OIDS   // track set of recovering oids explicitly, to find counting bugs
+//#define DEBUG_RECOVERY_OIDS   // track std::set of recovering oids explicitly, to find counting bugs
 //#define PG_DEBUG_REFS    // track provenance of pg refs, helpful for finding leaks
 
 class OSD;
@@ -97,7 +97,7 @@ class PGRecoveryStats {
     // cppcheck-suppress unreachableCode
     per_state_info() : enter(0), exit(0), events(0) {}
   };
-  map<const char *,per_state_info> info;
+  std::map<const char *,per_state_info> info;
   ceph::mutex lock = ceph::make_mutex("PGRecoverStats::lock");
 
   public:
@@ -109,7 +109,7 @@ class PGRecoveryStats {
   }
   void dump(ostream& out) {
     std::lock_guard l(lock);
-    for (map<const char *,per_state_info>::iterator p = info.begin(); p != info.end(); ++p) {
+    for (std::map<const char *,per_state_info>::iterator p = info.begin(); p != info.end(); ++p) {
       per_state_info& i = p->second;
       out << i.enter << "\t" << i.exit << "\t"
 	  << i.events << "\t" << i.event_time << "\t"
@@ -119,10 +119,10 @@ class PGRecoveryStats {
     }
   }
 
-  void dump_formatted(Formatter *f) {
+  void dump_formatted(ceph::Formatter *f) {
     std::lock_guard l(lock);
     f->open_array_section("pg_recovery_stats");
-    for (map<const char *,per_state_info>::iterator p = info.begin();
+    for (std::map<const char *,per_state_info>::iterator p = info.begin();
 	 p != info.end(); ++p) {
       per_state_info& i = p->second;
       f->open_object_section("recovery_state");
@@ -133,10 +133,10 @@ class PGRecoveryStats {
       f->dump_stream("total_time") << i.total_time;
       f->dump_stream("min_time") << i.min_time;
       f->dump_stream("max_time") << i.max_time;
-      vector<string> states;
+      std::vector<std::string> states;
       get_str_vec(p->first, "/", states);
       f->open_array_section("nested_states");
-      for (vector<string>::iterator st = states.begin();
+      for (std::vector<std::string>::iterator st = states.begin();
 	   st != states.end(); ++st) {
 	f->dump_string("state", *st);
       }
@@ -169,7 +169,7 @@ class PGRecoveryStats {
  */
 
 class PG : public DoutPrefixProvider, public PeeringState::PeeringListener {
-  friend class NamedState;
+  friend struct NamedState;
   friend class PeeringState;
 
 public:
@@ -291,10 +291,10 @@ public:
   int get_role() const {
     return recovery_state.get_role();
   }
-  const vector<int> get_acting() const {
+  const std::vector<int> get_acting() const {
     return recovery_state.get_acting();
   }
-  const set<pg_shard_t> &get_actingset() const {
+  const std::set<pg_shard_t> &get_actingset() const {
     return recovery_state.get_actingset();
   }
   int get_acting_primary() const {
@@ -303,7 +303,7 @@ public:
   pg_shard_t get_primary() const {
     return recovery_state.get_primary();
   }
-  const vector<int> get_up() const {
+  const std::vector<int> get_up() const {
     return recovery_state.get_up();
   }
   int get_up_primary() const {
@@ -315,7 +315,7 @@ public:
   bool is_acting_recovery_backfill(pg_shard_t osd) const {
     return recovery_state.is_acting_recovery_backfill(osd);
   }
-  const set<pg_shard_t> &get_acting_recovery_backfill() const {
+  const std::set<pg_shard_t> &get_acting_recovery_backfill() const {
     return recovery_state.get_acting_recovery_backfill();
   }
   bool is_acting(pg_shard_t osd) const {
@@ -324,16 +324,16 @@ public:
   bool is_up(pg_shard_t osd) const {
     return recovery_state.is_up(osd);
   }
-  static bool has_shard(bool ec, const vector<int>& v, pg_shard_t osd) {
+  static bool has_shard(bool ec, const std::vector<int>& v, pg_shard_t osd) {
     return PeeringState::has_shard(ec, v, osd);
   }
 
   /// initialize created PG
   void init(
     int role,
-    const vector<int>& up,
+    const std::vector<int>& up,
     int up_primary,
-    const vector<int>& acting,
+    const std::vector<int>& acting,
     int acting_primary,
     const pg_history_t& history,
     const PastIntervals& pim,
@@ -361,7 +361,7 @@ public:
   void update_snap_mapper_bits(uint32_t bits) {
     snap_mapper.update_bits(bits);
   }
-  void start_split_stats(const set<spg_t>& childpgs, vector<object_stat_sum_t> *v);
+  void start_split_stats(const std::set<spg_t>& childpgs, std::vector<object_stat_sum_t> *v);
   virtual void split_colls(
     spg_t child,
     int split_bits,
@@ -369,7 +369,7 @@ public:
     const pg_pool_t *pool,
     ObjectStore::Transaction &t) = 0;
   void split_into(pg_t child_pgid, PG *child, unsigned split_bits);
-  void merge_from(map<spg_t,PGRef>& sources, PeeringCtx &rctx,
+  void merge_from(std::map<spg_t,PGRef>& sources, PeeringCtx &rctx,
 		  unsigned split_bits,
 		  const pg_merge_meta_t& last_pg_merge_meta);
   void finish_split_stats(const object_stat_sum_t& stats,
@@ -381,7 +381,7 @@ public:
   void reg_next_scrub();
   void unreg_next_scrub();
 
-  void queue_want_pg_temp(const vector<int> &wanted) override;
+  void queue_want_pg_temp(const std::vector<int> &wanted) override;
   void clear_want_pg_temp() override;
 
   void on_new_interval() override;
@@ -492,12 +492,12 @@ public:
   void queue_flushed(epoch_t started_at);
   void handle_advance_map(
     OSDMapRef osdmap, OSDMapRef lastmap,
-    vector<int>& newup, int up_primary,
-    vector<int>& newacting, int acting_primary,
+    std::vector<int>& newup, int up_primary,
+    std::vector<int>& newacting, int acting_primary,
     PeeringCtx &rctx);
   void handle_activate_map(PeeringCtx &rctx);
   void handle_initialize(PeeringCtx &rxcx);
-  void handle_query_state(Formatter *f);
+  void handle_query_state(ceph::Formatter *f);
 
   /**
    * @param ops_begun returns how many recovery ops the function started
@@ -513,8 +513,8 @@ public:
 
   virtual void get_watchers(std::list<obj_watch_item_t> *ls) = 0;
 
-  void dump_pgstate_history(Formatter *f);
-  void dump_missing(Formatter *f);
+  void dump_pgstate_history(ceph::Formatter *f);
+  void dump_missing(ceph::Formatter *f);
 
   void get_pg_stats(std::function<void(const pg_stat_t&, epoch_t lec)> f);
   void with_heartbeat_peers(std::function<void(int)> f);
@@ -536,10 +536,10 @@ public:
 
   virtual void snap_trimmer(epoch_t epoch_queued) = 0;
   virtual void do_command(
-    const string_view& prefix,
+    const std::string_view& prefix,
     const cmdmap_t& cmdmap,
-    const bufferlist& idata,
-    std::function<void(int,const std::string&,bufferlist&)> on_finish) = 0;
+    const ceph::buffer::list& idata,
+    std::function<void(int,const std::string&,ceph::buffer::list&)> on_finish) = 0;
 
   virtual bool agent_work(int max) = 0;
   virtual bool agent_work(int max, int agent_flush_quota) = 0;
@@ -613,8 +613,8 @@ protected:
 
 #ifdef PG_DEBUG_REFS
   ceph::mutex _ref_id_lock = ceph::make_mutex("PG::_ref_id_lock");
-  map<uint64_t, string> _live_ids;
-  map<string, uint64_t> _tag_counts;
+  std::map<uint64_t, std::string> _live_ids;
+  std::map<std::string, uint64_t> _tag_counts;
   uint64_t _ref_id = 0;
 
   friend uint64_t get_with_id(PG *pg) { return pg->get_with_id(); }
@@ -657,7 +657,7 @@ protected:
 
   // ------------------
   interval_set<snapid_t> snap_trimq;
-  set<snapid_t> snap_trimq_repeat;
+  std::set<snapid_t> snap_trimq_repeat;
 
   /* You should not use these items without taking their respective queue locks
    * (if they have one) */
@@ -666,7 +666,7 @@ protected:
   bool recovery_queued;
 
   int recovery_ops_active;
-  set<pg_shard_t> waiting_on_backfill;
+  std::set<pg_shard_t> waiting_on_backfill;
 #ifdef DEBUG_RECOVERY_OIDS
   multiset<hobject_t> recovering_oids;
 #endif
@@ -683,13 +683,13 @@ protected:
   }
 
   /* heartbeat peers */
-  void set_probe_targets(const set<pg_shard_t> &probe_set) override;
+  void set_probe_targets(const std::set<pg_shard_t> &probe_set) override;
   void clear_probe_targets() override;
 
   ceph::mutex heartbeat_peer_lock =
     ceph::make_mutex("PG::heartbeat_peer_lock");
-  set<int> heartbeat_peers;
-  set<int> probe_targets;
+  std::set<int> heartbeat_peers;
+  std::set<int> probe_targets;
 
 public:
   /**
@@ -704,7 +704,7 @@ public:
   struct BackfillInterval {
     // info about a backfill interval on a peer
     eversion_t version; /// version at which the scan occurred
-    map<hobject_t,eversion_t> objects;
+    std::map<hobject_t,eversion_t> objects;
     hobject_t begin;
     hobject_t end;
 
@@ -713,7 +713,7 @@ public:
       *this = BackfillInterval();
     }
 
-    /// clear objects list only
+    /// clear objects std::list only
     void clear_objects() {
       objects.clear();
     }
@@ -759,11 +759,11 @@ public:
     }
 
     /// dump
-    void dump(Formatter *f) const {
+    void dump(ceph::Formatter *f) const {
       f->dump_stream("begin") << begin;
       f->dump_stream("end") << end;
       f->open_array_section("objects");
-      for (map<hobject_t, eversion_t>::const_iterator i =
+      for (std::map<hobject_t, eversion_t>::const_iterator i =
 	     objects.begin();
 	   i != objects.end();
 	   ++i) {
@@ -778,7 +778,7 @@ public:
 
 protected:
   BackfillInterval backfill_info;
-  map<pg_shard_t, BackfillInterval> peer_backfill_info;
+  std::map<pg_shard_t, BackfillInterval> peer_backfill_info;
   bool backfill_reserving;
 
   // The primary's num_bytes and local num_bytes for this pg, only valid
@@ -934,7 +934,7 @@ protected:
    *     queues because we assume they cannot apply at that time (this is
    *     probably mostly true).
    *
-   *  3. The requeue_ops helper will push ops onto the waiting_for_map list if
+   *  3. The requeue_ops helper will push ops onto the waiting_for_map std::list if
    *     it is non-empty.
    *
    * These three behaviors are generally sufficient to maintain ordering, with
@@ -946,40 +946,40 @@ protected:
   // ops with newer maps than our (or blocked behind them)
   // track these by client, since inter-request ordering doesn't otherwise
   // matter.
-  unordered_map<entity_name_t,list<OpRequestRef>> waiting_for_map;
+  std::unordered_map<entity_name_t,std::list<OpRequestRef>> waiting_for_map;
 
   // ops waiting on peered
-  list<OpRequestRef>            waiting_for_peered;
+  std::list<OpRequestRef>            waiting_for_peered;
 
   /// ops waiting on readble
-  list<OpRequestRef>            waiting_for_readable;
+  std::list<OpRequestRef>            waiting_for_readable;
 
   // ops waiting on active (require peered as well)
-  list<OpRequestRef>            waiting_for_active;
-  list<OpRequestRef>            waiting_for_flush;
-  list<OpRequestRef>            waiting_for_scrub;
+  std::list<OpRequestRef>            waiting_for_active;
+  std::list<OpRequestRef>            waiting_for_flush;
+  std::list<OpRequestRef>            waiting_for_scrub;
 
-  list<OpRequestRef>            waiting_for_cache_not_full;
-  list<OpRequestRef>            waiting_for_clean_to_primary_repair;
-  map<hobject_t, list<OpRequestRef>> waiting_for_unreadable_object,
+  std::list<OpRequestRef>            waiting_for_cache_not_full;
+  std::list<OpRequestRef>            waiting_for_clean_to_primary_repair;
+  std::map<hobject_t, std::list<OpRequestRef>> waiting_for_unreadable_object,
 			     waiting_for_degraded_object,
 			     waiting_for_blocked_object;
 
-  set<hobject_t> objects_blocked_on_cache_full;
-  map<hobject_t,snapid_t> objects_blocked_on_degraded_snap;
-  map<hobject_t,ObjectContextRef> objects_blocked_on_snap_promotion;
+  std::set<hobject_t> objects_blocked_on_cache_full;
+  std::map<hobject_t,snapid_t> objects_blocked_on_degraded_snap;
+  std::map<hobject_t,ObjectContextRef> objects_blocked_on_snap_promotion;
 
   // Callbacks should assume pg (and nothing else) is locked
-  map<hobject_t, list<Context*>> callbacks_for_degraded_object;
+  std::map<hobject_t, std::list<Context*>> callbacks_for_degraded_object;
 
-  map<eversion_t,
-      list<
-	tuple<OpRequestRef, version_t, int,
-	      vector<pg_log_op_return_item_t>>>> waiting_for_ondisk;
+  std::map<eversion_t,
+      std::list<
+	std::tuple<OpRequestRef, version_t, int,
+		   std::vector<pg_log_op_return_item_t>>>> waiting_for_ondisk;
 
-  void requeue_object_waiters(map<hobject_t, list<OpRequestRef>>& m);
+  void requeue_object_waiters(std::map<hobject_t, std::list<OpRequestRef>>& m);
   void requeue_op(OpRequestRef op);
-  void requeue_ops(list<OpRequestRef> &l);
+  void requeue_ops(std::list<OpRequestRef> &l);
 
   // stats that persist lazily
   object_stat_collection_t unstable_stats;
@@ -1028,7 +1028,7 @@ protected:
   
   void update_object_snap_mapping(
     ObjectStore::Transaction *t, const hobject_t &soid,
-    const set<snapid_t> &snaps);
+    const std::set<snapid_t> &snaps);
   void clear_object_snap_mapping(
     ObjectStore::Transaction *t, const hobject_t &soid);
   void remove_snap_mapped_object(
@@ -1045,7 +1045,7 @@ protected:
 
   void purge_strays();
 
-  void update_heartbeat_peers(set<int> peers) override;
+  void update_heartbeat_peers(std::set<int> peers) override;
 
   Context *finish_sync_event;
 
@@ -1067,12 +1067,12 @@ protected:
   virtual void _split_into(pg_t child_pgid, PG *child, unsigned split_bits) = 0;
 
   friend class C_OSD_RepModify_Commit;
-  friend class C_DeleteMore;
+  friend struct C_DeleteMore;
 
   // -- backoff --
   ceph::mutex backoff_lock = // orders inside Backoff::lock
     ceph::make_mutex("PG::backoff_lock");
-  map<hobject_t,set<ceph::ref_t<Backoff>>> backoffs;
+  std::map<hobject_t,std::set<ceph::ref_t<Backoff>>> backoffs;
 
   void add_backoff(const ceph::ref_t<Session>& s, const hobject_t& begin, const hobject_t& end);
   void release_backoffs(const hobject_t& begin, const hobject_t& end);
@@ -1101,13 +1101,13 @@ public:
     ~Scrubber();
 
     // metadata
-    set<pg_shard_t> reserved_peers;
+    std::set<pg_shard_t> reserved_peers;
     bool local_reserved, remote_reserved, reserve_failed;
     epoch_t epoch_start;
 
     // common to both scrubs
     bool active;
-    set<pg_shard_t> waiting_on_whom;
+    std::set<pg_shard_t> waiting_on_whom;
     int shallow_errors;
     int deep_errors;
     int fixed;
@@ -1116,7 +1116,7 @@ public:
     epoch_t replica_scrub_start = 0;
     ScrubMap replica_scrubmap;
     ScrubMapBuilder replica_scrubmap_pos;
-    map<pg_shard_t, ScrubMap> received_maps;
+    std::map<pg_shard_t, ScrubMap> received_maps;
     OpRequestRef active_rep_scrub;
     utime_t scrub_reg_stamp;  // stamp we registered for
 
@@ -1145,13 +1145,13 @@ public:
     bool deep_scrub_on_error;
 
     // Maps from objects with errors to missing/inconsistent peers
-    map<hobject_t, set<pg_shard_t>> missing;
-    map<hobject_t, set<pg_shard_t>> inconsistent;
+    std::map<hobject_t, std::set<pg_shard_t>> missing;
+    std::map<hobject_t, std::set<pg_shard_t>> inconsistent;
 
-    // Map from object with errors to good peers
-    map<hobject_t, list<pair<ScrubMap::object, pg_shard_t> >> authoritative;
+    // Std::map from object with errors to good peers
+    std::map<hobject_t, std::list<std::pair<ScrubMap::object, pg_shard_t> >> authoritative;
 
-    // Cleaned map pending snap metadata scrub
+    // Cleaned std::map pending snap metadata scrub
     ScrubMap cleaned_meta_map;
 
     void clean_meta_map(ScrubMap &for_meta_scrub) {
@@ -1207,14 +1207,14 @@ public:
     int preempt_left;
     int preempt_divisor;
 
-    list<Context*> callbacks;
+    std::list<Context*> callbacks;
     void add_callback(Context *context) {
       callbacks.push_back(context);
     }
     void run_callbacks() {
-      list<Context*> to_run;
+      std::list<Context*> to_run;
       to_run.swap(callbacks);
-      for (list<Context*>::iterator i = to_run.begin();
+      for (std::list<Context*>::iterator i = to_run.begin();
 	   i != to_run.end();
 	   ++i) {
 	(*i)->complete(0);
@@ -1307,8 +1307,8 @@ protected:
 
   void repair_object(
     const hobject_t &soid,
-    const list<pair<ScrubMap::object, pg_shard_t> > &ok_peers,
-    const set<pg_shard_t> &bad_peers);
+    const std::list<std::pair<ScrubMap::object, pg_shard_t> > &ok_peers,
+    const std::set<pg_shard_t> &bad_peers);
 
   void chunky_scrub(ThreadPool::TPHandle &handle);
   void scrub_compare_maps();
@@ -1321,7 +1321,7 @@ protected:
   void scrub_clear_state(bool keep_repair = false);
   void _scan_snaps(ScrubMap &map);
   void _repair_oinfo_oid(ScrubMap &map);
-  void _scan_rollback_obs(const vector<ghobject_t> &rollback_obs);
+  void _scan_rollback_obs(const std::vector<ghobject_t> &rollback_obs);
   void _request_scrub_map(pg_shard_t replica, eversion_t version,
                           hobject_t start, hobject_t end, bool deep,
 			  bool allow_preemption);
@@ -1340,7 +1340,7 @@ protected:
   virtual void scrub_snapshot_metadata(
     ScrubMap &map,
     const std::map<hobject_t,
-                   pair<std::optional<uint32_t>,
+                   std::pair<std::optional<uint32_t>,
                         std::optional<uint32_t>>> &missing_digest) { }
   virtual void _scrub_clear_state() { }
   virtual void _scrub_finish() { }
@@ -1446,7 +1446,7 @@ protected:
     eversion_t *version,
     version_t *user_version,
     int *return_code,
-    vector<pg_log_op_return_item_t> *op_returns) const;
+    std::vector<pg_log_op_return_item_t> *op_returns) const;
   eversion_t projected_last_update;
   eversion_t get_next_version() const {
     eversion_t at_version(
@@ -1463,10 +1463,10 @@ protected:
   std::string get_corrupt_pg_log_name() const;
 
   void update_snap_map(
-    const vector<pg_log_entry_t> &log_entries,
+    const std::vector<pg_log_entry_t> &log_entries,
     ObjectStore::Transaction& t);
 
-  void filter_snapc(vector<snapid_t> &snaps);
+  void filter_snapc(std::vector<snapid_t> &snaps);
 
   virtual void kick_snap_trim() = 0;
   virtual void snap_trimmer_scrub_complete() = 0;
@@ -1503,7 +1503,7 @@ protected:
   bool op_has_sufficient_caps(OpRequestRef& op);
 
   // abstract bits
-  friend class FlushState;
+  friend struct FlushState;
 
   friend ostream& operator<<(ostream& out, const PG& pg);
 

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -30,6 +30,22 @@
 #include "messages/MOSDPGRecoveryDelete.h"
 #include "messages/MOSDPGRecoveryDeleteReply.h"
 
+using std::list;
+using std::make_pair;
+using std::map;
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::bufferptr;
+using ceph::ErasureCodeProfile;
+using ceph::ErasureCodeInterfaceRef;
+
 #define dout_context cct
 #define dout_subsys ceph_subsys_osd
 #define DOUT_PREFIX_ARGS this

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -57,7 +57,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
    ObjectStore *store;
    const coll_t coll;
    ObjectStore::CollectionHandle &ch;
- public:	
+ public:
    /**
     * Provides interfaces for PGBackend callbacks
     *
@@ -111,10 +111,10 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
        const object_stat_sum_t &delta_stats) = 0;
 
      /**
-      * Called when a read from a set of replicas/primary fails
+      * Called when a read from a std::set of replicas/primary fails
       */
      virtual void on_failed_pull(
-       const set<pg_shard_t> &from,
+       const std::set<pg_shard_t> &from,
        const hobject_t &soid,
        const eversion_t &v
        ) = 0;
@@ -152,31 +152,31 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
        OpRequestRef op = OpRequestRef()
        ) = 0;
      virtual void queue_transactions(
-       vector<ObjectStore::Transaction>& tls,
+       std::vector<ObjectStore::Transaction>& tls,
        OpRequestRef op = OpRequestRef()
        ) = 0;
      virtual epoch_t get_interval_start_epoch() const = 0;
      virtual epoch_t get_last_peering_reset_epoch() const = 0;
 
-     virtual const set<pg_shard_t> &get_acting_recovery_backfill_shards() const = 0;
-     virtual const set<pg_shard_t> &get_acting_shards() const = 0;
-     virtual const set<pg_shard_t> &get_backfill_shards() const = 0;
+     virtual const std::set<pg_shard_t> &get_acting_recovery_backfill_shards() const = 0;
+     virtual const std::set<pg_shard_t> &get_acting_shards() const = 0;
+     virtual const std::set<pg_shard_t> &get_backfill_shards() const = 0;
 
      virtual std::ostream& gen_dbg_prefix(std::ostream& out) const = 0;
 
-     virtual const map<hobject_t, set<pg_shard_t>> &get_missing_loc_shards()
+     virtual const std::map<hobject_t, std::set<pg_shard_t>> &get_missing_loc_shards()
        const = 0;
 
      virtual const pg_missing_tracker_t &get_local_missing() const = 0;
      virtual void add_local_next_event(const pg_log_entry_t& e) = 0;
-     virtual const map<pg_shard_t, pg_missing_t> &get_shard_missing()
+     virtual const std::map<pg_shard_t, pg_missing_t> &get_shard_missing()
        const = 0;
      virtual const pg_missing_const_i * maybe_get_shard_missing(
        pg_shard_t peer) const {
        if (peer == primary_shard()) {
 	 return &get_local_missing();
        } else {
-	 map<pg_shard_t, pg_missing_t>::const_iterator i =
+	 std::map<pg_shard_t, pg_missing_t>::const_iterator i =
 	   get_shard_missing().find(peer);
 	 if (i == get_shard_missing().end()) {
 	   return nullptr;
@@ -191,12 +191,12 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
        return *m;
      }
 
-     virtual const map<pg_shard_t, pg_info_t> &get_shard_info() const = 0;
+     virtual const std::map<pg_shard_t, pg_info_t> &get_shard_info() const = 0;
      virtual const pg_info_t &get_shard_info(pg_shard_t peer) const {
        if (peer == primary_shard()) {
 	 return get_info();
        } else {
-	 map<pg_shard_t, pg_info_t>::const_iterator i =
+	 std::map<pg_shard_t, pg_info_t>::const_iterator i =
 	   get_shard_info().find(peer);
 	 ceph_assert(i != get_shard_info().end());
 	 return i->second;
@@ -212,7 +212,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
 
      virtual ObjectContextRef get_obc(
        const hobject_t &hoid,
-       const map<string, bufferlist> &attrs) = 0;
+       const std::map<std::string, ceph::buffer::list> &attrs) = 0;
 
      virtual bool try_lock_for_read(
        const hobject_t &hoid,
@@ -231,7 +231,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
      virtual bool pg_is_repair() const = 0;
 
      virtual void log_operation(
-       vector<pg_log_entry_t>&& logv,
+       std::vector<pg_log_entry_t>&& logv,
        const std::optional<pg_hit_set_history_t> &hset_history,
        const eversion_t &trim_to,
        const eversion_t &roll_forward_to,
@@ -242,7 +242,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
 
      virtual void pgb_set_object_snap_mapping(
        const hobject_t &soid,
-       const set<snapid_t> &snaps,
+       const std::set<snapid_t> &snaps,
        ObjectStore::Transaction *t) = 0;
 
      virtual void pgb_clear_object_snap_mapping(
@@ -327,14 +327,14 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
    /**
     * RecoveryHandle
     *
-    * We may want to recover multiple objects in the same set of
+    * We may want to recover multiple objects in the same std::set of
     * messages.  RecoveryHandle is an interface for the opaque
     * object used by the implementation to store the details of
     * the pending recovery operations.
     */
    struct RecoveryHandle {
      bool cache_dont_need;
-     map<pg_shard_t, vector<pair<hobject_t, eversion_t> > > deletes;
+     std::map<pg_shard_t, std::vector<std::pair<hobject_t, eversion_t> > > deletes;
 
      RecoveryHandle(): cache_dont_need(false) {}
      virtual ~RecoveryHandle() {}
@@ -352,7 +352,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
    void recover_delete_object(const hobject_t &oid, eversion_t v,
 			      RecoveryHandle *h);
    void send_recovery_deletes(int prio,
-			      const map<pg_shard_t, vector<pair<hobject_t, eversion_t> > > &deletes);
+			      const std::map<pg_shard_t, std::vector<std::pair<hobject_t, eversion_t> > > &deletes);
 
    /**
     * recover_object
@@ -372,7 +372,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
     *
     * head may be NULL only if the head/snapdir is missing
     *
-    * @param missing [in] set of info, missing pairs for queried nodes
+    * @param missing [in] std::set of info, missing pairs for queried nodes
     * @param overlaps [in] mapping of object to file offset overlaps
     */
    virtual int recover_object(
@@ -417,23 +417,23 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
    virtual int get_ec_data_chunk_count() const { return 0; };
    virtual int get_ec_stripe_chunk_size() const { return 0; };
 
-   virtual void dump_recovery_info(Formatter *f) const = 0;
+   virtual void dump_recovery_info(ceph::Formatter *f) const = 0;
 
  private:
-   set<hobject_t> temp_contents;
+   std::set<hobject_t> temp_contents;
  public:
    // Track contents of temp collection, clear on reset
    void add_temp_obj(const hobject_t &oid) {
      temp_contents.insert(oid);
    }
-   void add_temp_objs(const set<hobject_t> &oids) {
+   void add_temp_objs(const std::set<hobject_t> &oids) {
      temp_contents.insert(oids.begin(), oids.end());
    }
    void clear_temp_obj(const hobject_t &oid) {
      temp_contents.erase(oid);
    }
-   void clear_temp_objs(const set<hobject_t> &oids) {
-     for (set<hobject_t>::const_iterator i = oids.begin();
+   void clear_temp_objs(const std::set<hobject_t> &oids) {
+     for (std::set<hobject_t>::const_iterator i = oids.begin();
 	  i != oids.end();
 	  ++i) {
        temp_contents.erase(*i);
@@ -451,7 +451,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
      const eversion_t &trim_to,           ///< [in] trim log to here
      const eversion_t &min_last_complete_ondisk, ///< [in] lower bound on
                                                  ///  committed version
-     vector<pg_log_entry_t>&& log_entries, ///< [in] log entries for t
+     std::vector<pg_log_entry_t>&& log_entries, ///< [in] log entries for t
      /// [in] hitset history (if updated with this transaction)
      std::optional<pg_hit_set_history_t> &hset_history,
      Context *on_all_commit,              ///< [in] called when all commit
@@ -493,7 +493,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
    /// Reapply old attributes
    void rollback_setattrs(
      const hobject_t &hoid,
-     map<string, std::optional<bufferlist> > &old_attrs,
+     std::map<std::string, std::optional<ceph::buffer::list> > &old_attrs,
      ObjectStore::Transaction *t);
 
    /// Truncate object to rollback append
@@ -524,7 +524,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
    /// Clone the extents back into place
    void rollback_extents(
      version_t gen,
-     const vector<pair<uint64_t, uint64_t> > &extents,
+     const std::vector<std::pair<uint64_t, uint64_t> > &extents,
      const hobject_t &hoid,
      ObjectStore::Transaction *t);
  public:
@@ -535,48 +535,48 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
      version_t gen,
      ObjectStore::Transaction *t);
 
-   /// List objects in collection
+   /// Std::list objects in collection
    int objects_list_partial(
      const hobject_t &begin,
      int min,
      int max,
-     vector<hobject_t> *ls,
+     std::vector<hobject_t> *ls,
      hobject_t *next);
 
    int objects_list_range(
      const hobject_t &start,
      const hobject_t &end,
-     vector<hobject_t> *ls,
-     vector<ghobject_t> *gen_obs=0);
+     std::vector<hobject_t> *ls,
+     std::vector<ghobject_t> *gen_obs=0);
 
    int objects_get_attr(
      const hobject_t &hoid,
-     const string &attr,
-     bufferlist *out);
+     const std::string &attr,
+     ceph::buffer::list *out);
 
    virtual int objects_get_attrs(
      const hobject_t &hoid,
-     map<string, bufferlist> *out);
+     std::map<std::string, ceph::buffer::list> *out);
 
    virtual int objects_read_sync(
      const hobject_t &hoid,
      uint64_t off,
      uint64_t len,
      uint32_t op_flags,
-     bufferlist *bl) = 0;
+     ceph::buffer::list *bl) = 0;
 
    virtual int objects_readv_sync(
      const hobject_t &hoid,
-     map<uint64_t, uint64_t>&& m,
+     std::map<uint64_t, uint64_t>&& m,
      uint32_t op_flags,
-     bufferlist *bl) {
+     ceph::buffer::list *bl) {
      return -EOPNOTSUPP;
    }
 
    virtual void objects_read_async(
      const hobject_t &hoid,
-     const list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
-		pair<bufferlist*, Context*> > > &to_read,
+     const std::list<std::pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
+		std::pair<ceph::buffer::list*, Context*> > > &to_read,
      Context *on_complete, bool fast_read = false) = 0;
 
    virtual bool auto_repair_supported() const = 0;
@@ -590,30 +590,30 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
      const ScrubMap::object &candidate,
      shard_info_wrapper& shard_error,
      inconsistent_obj_wrapper &result,
-     ostream &errorstream,
+     std::ostream &errorstream,
      bool has_snapset);
-   map<pg_shard_t, ScrubMap *>::const_iterator be_select_auth_object(
+   std::map<pg_shard_t, ScrubMap *>::const_iterator be_select_auth_object(
      const hobject_t &obj,
-     const map<pg_shard_t,ScrubMap*> &maps,
+     const std::map<pg_shard_t,ScrubMap*> &maps,
      object_info_t *auth_oi,
-     map<pg_shard_t, shard_info_wrapper> &shard_map,
+     std::map<pg_shard_t, shard_info_wrapper> &shard_map,
      bool &digest_match,
      spg_t pgid,
-     ostream &errorstream);
+     std::ostream &errorstream);
    void be_compare_scrubmaps(
-     const map<pg_shard_t,ScrubMap*> &maps,
-     const set<hobject_t> &master_set,
+     const std::map<pg_shard_t,ScrubMap*> &maps,
+     const std::set<hobject_t> &master_set,
      bool repair,
-     map<hobject_t, set<pg_shard_t>> &missing,
-     map<hobject_t, set<pg_shard_t>> &inconsistent,
-     map<hobject_t, list<pg_shard_t>> &authoritative,
-     map<hobject_t, pair<std::optional<uint32_t>,
+     std::map<hobject_t, std::set<pg_shard_t>> &missing,
+     std::map<hobject_t, std::set<pg_shard_t>> &inconsistent,
+     std::map<hobject_t, std::list<pg_shard_t>> &authoritative,
+     std::map<hobject_t, std::pair<std::optional<uint32_t>,
                          std::optional<uint32_t>>> &missing_digest,
      int &shallow_errors, int &deep_errors,
      Scrub::Store *store,
      const spg_t& pgid,
-     const vector<int> &acting,
-     ostream &errorstream);
+     const std::vector<int> &acting,
+     std::ostream &errorstream);
    virtual uint64_t be_get_ondisk_size(
      uint64_t logical_size) = 0;
    virtual int be_deep_scrub(
@@ -622,14 +622,14 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
      ScrubMapBuilder &pos,
      ScrubMap::object &o) = 0;
    void be_omap_checks(
-     const map<pg_shard_t,ScrubMap*> &maps,
-     const set<hobject_t> &master_set,
+     const std::map<pg_shard_t,ScrubMap*> &maps,
+     const std::set<hobject_t> &master_set,
      omap_stat_t& omap_stats,
-     ostream &warnstream) const;
+     std::ostream &warnstream) const;
 
    static PGBackend *build_pg_backend(
      const pg_pool_t &pool,
-     const map<string,string>& profile,
+     const std::map<std::string,std::string>& profile,
      Listener *l,
      coll_t coll,
      ObjectStore::CollectionHandle &ch,

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -19,6 +19,16 @@
 #include "include/unordered_map.h"
 #include "common/ceph_context.h"
 
+using std::make_pair;
+using std::map;
+using std::ostream;
+using std::set;
+using std::string;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+
 #define dout_context cct
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
@@ -140,18 +150,14 @@ void PGLog::IndexedLog::trim(
 ostream& PGLog::IndexedLog::print(ostream& out) const
 {
   out << *this << std::endl;
-  for (list<pg_log_entry_t>::const_iterator p = log.begin();
-       p != log.end();
-       ++p) {
+  for (auto p = log.begin(); p != log.end(); ++p) {
     out << *p << " " <<
       (logged_object(p->soid) ? "indexed" : "NOT INDEXED") <<
       std::endl;
     ceph_assert(!p->reqid_is_indexed() || logged_req(p->reqid));
   }
 
-  for (list<pg_log_dup_t>::const_iterator p = dups.begin();
-       p != dups.end();
-       ++p) {
+  for (auto p = dups.begin(); p != dups.end(); ++p) {
     out << *p << std::endl;
   }
 
@@ -232,15 +238,14 @@ void PGLog::proc_replica_log(
     we will send the peer enough log to arrive at the same state.
   */
 
-  for (map<hobject_t, pg_missing_item>::const_iterator i = omissing.get_items().begin();
+  for (auto i = omissing.get_items().begin();
        i != omissing.get_items().end();
        ++i) {
     dout(20) << " before missing " << i->first << " need " << i->second.need
 	     << " have " << i->second.have << dendl;
   }
 
-  list<pg_log_entry_t>::const_reverse_iterator first_non_divergent =
-    log.log.rbegin();
+  auto first_non_divergent = log.log.rbegin();
   while (1) {
     if (first_non_divergent == log.log.rend())
       break;
@@ -295,10 +300,7 @@ void PGLog::proc_replica_log(
     eversion_t first_missing =
       omissing.get_items().at(omissing.get_rmissing().begin()->second).need;
     oinfo.last_complete = eversion_t();
-    list<pg_log_entry_t>::const_iterator i = olog.log.begin();
-    for (;
-	 i != olog.log.end();
-	 ++i) {
+    for (auto i = olog.log.begin(); i != olog.log.end(); ++i) {
       if (i->version < first_missing)
 	oinfo.last_complete = i->version;
       else
@@ -368,7 +370,7 @@ void PGLog::merge_log(pg_info_t &oinfo, pg_log_t &olog, pg_shard_t fromosd,
   // The logs must overlap.
   ceph_assert(log.head >= olog.tail && olog.head >= log.tail);
 
-  for (map<hobject_t, pg_missing_item>::const_iterator i = missing.get_items().begin();
+  for (auto i = missing.get_items().begin();
        i != missing.get_items().end();
        ++i) {
     dout(20) << "pg_missing_t sobject: " << i->first << dendl;
@@ -383,12 +385,10 @@ void PGLog::merge_log(pg_info_t &oinfo, pg_log_t &olog, pg_shard_t fromosd,
   eversion_t orig_tail = log.tail;
   if (olog.tail < log.tail) {
     dout(10) << "merge_log extending tail to " << olog.tail << dendl;
-    list<pg_log_entry_t>::iterator from = olog.log.begin();
-    list<pg_log_entry_t>::iterator to;
+    auto from = olog.log.begin();
+    auto to = from;
     eversion_t last;
-    for (to = from;
-	 to != olog.log.end();
-	 ++to) {
+    for (; to != olog.log.end(); ++to) {
       if (to->version > log.tail)
 	break;
       log.index(*to);
@@ -425,8 +425,8 @@ void PGLog::merge_log(pg_info_t &oinfo, pg_log_t &olog, pg_shard_t fromosd,
     dout(10) << "merge_log extending head to " << olog.head << dendl;
 
     // find start point in olog
-    list<pg_log_entry_t>::iterator to = olog.log.end();
-    list<pg_log_entry_t>::iterator from = olog.log.end();
+    auto to = olog.log.end();
+    auto from = olog.log.end();
     eversion_t lower_bound = std::max(olog.tail, orig_tail);
     while (1) {
       if (from == olog.log.begin())
@@ -593,22 +593,18 @@ void PGLog::check() {
   if (log.log.size() != log_keys_debug.size()) {
     derr << "log.log.size() != log_keys_debug.size()" << dendl;
     derr << "actual log:" << dendl;
-    for (list<pg_log_entry_t>::iterator i = log.log.begin();
-	 i != log.log.end();
-	 ++i) {
+    for (auto i = log.log.begin(); i != log.log.end(); ++i) {
       derr << "    " << *i << dendl;
     }
     derr << "log_keys_debug:" << dendl;
-    for (set<string>::const_iterator i = log_keys_debug.begin();
+    for (auto i = log_keys_debug.begin();
 	 i != log_keys_debug.end();
 	 ++i) {
       derr << "    " << *i << dendl;
     }
   }
   ceph_assert(log.log.size() == log_keys_debug.size());
-  for (list<pg_log_entry_t>::iterator i = log.log.begin();
-       i != log.log.end();
-       ++i) {
+  for (auto i = log.log.begin(); i != log.log.end(); ++i) {
     ceph_assert(log_keys_debug.count(i->get_key_name()));
   }
 }
@@ -731,7 +727,7 @@ void PGLog::_write_log_and_missing_wo_missing(
     clear_after(log_keys_debug, dirty_from.get_key_name());
   }
 
-  for (list<pg_log_entry_t>::iterator p = log.log.begin();
+  for (auto p = log.log.begin();
        p != log.log.end() && p->version <= dirty_to;
        ++p) {
     bufferlist bl(sizeof(*p) * 2);
@@ -739,7 +735,7 @@ void PGLog::_write_log_and_missing_wo_missing(
     (*km)[p->get_key_name()].claim(bl);
   }
 
-  for (list<pg_log_entry_t>::reverse_iterator p = log.log.rbegin();
+  for (auto p = log.log.rbegin();
        p != log.log.rend() &&
 	 (p->version >= dirty_from || p->version >= writeout_from) &&
 	 p->version >= dirty_to;
@@ -750,7 +746,7 @@ void PGLog::_write_log_and_missing_wo_missing(
   }
 
   if (log_keys_debug) {
-    for (map<string, bufferlist>::iterator i = (*km).begin();
+    for (auto i = (*km).begin();
 	 i != (*km).end();
 	 ++i) {
       if (i->first[0] == '_')
@@ -786,7 +782,7 @@ void PGLog::_write_log_and_missing_wo_missing(
     (*km)[entry.get_key_name()].claim(bl);
   }
 
-  for (list<pg_log_dup_t>::reverse_iterator p = log.dups.rbegin();
+  for (auto p = log.dups.rbegin();
        p != log.dups.rend() &&
 	 (p->version >= dirty_from_dups || p->version >= write_from_dups) &&
 	 p->version >= dirty_to_dups;
@@ -860,7 +856,7 @@ void PGLog::_write_log_and_missing(
     clear_after(log_keys_debug, dirty_from.get_key_name());
   }
 
-  for (list<pg_log_entry_t>::iterator p = log.log.begin();
+  for (auto p = log.log.begin();
        p != log.log.end() && p->version <= dirty_to;
        ++p) {
     bufferlist bl(sizeof(*p) * 2);
@@ -868,7 +864,7 @@ void PGLog::_write_log_and_missing(
     (*km)[p->get_key_name()].claim(bl);
   }
 
-  for (list<pg_log_entry_t>::reverse_iterator p = log.log.rbegin();
+  for (auto p = log.log.rbegin();
        p != log.log.rend() &&
 	 (p->version >= dirty_from || p->version >= writeout_from) &&
 	 p->version >= dirty_to;
@@ -879,7 +875,7 @@ void PGLog::_write_log_and_missing(
   }
 
   if (log_keys_debug) {
-    for (map<string, bufferlist>::iterator i = (*km).begin();
+    for (auto i = (*km).begin();
 	 i != (*km).end();
 	 ++i) {
       if (i->first[0] == '_')
@@ -915,7 +911,7 @@ void PGLog::_write_log_and_missing(
     (*km)[entry.get_key_name()].claim(bl);
   }
 
-  for (list<pg_log_dup_t>::reverse_iterator p = log.dups.rbegin();
+  for (auto p = log.dups.rbegin();
        p != log.dups.rend() &&
 	 (p->version >= dirty_from_dups || p->version >= write_from_dups) &&
 	 p->version >= dirty_to_dups;
@@ -980,7 +976,7 @@ void PGLog::rebuild_missing_set_with_deletes(
   // versions on disk, just as if we were reading the log + metadata
   // off disk originally
   set<hobject_t> did;
-  for (list<pg_log_entry_t>::reverse_iterator i = log.log.rbegin();
+  for (auto i = log.log.rbegin();
        i != log.log.rend();
        ++i) {
     if (i->version <= info.last_complete)

--- a/src/osd/PGStateUtils.cc
+++ b/src/osd/PGStateUtils.cc
@@ -4,6 +4,8 @@
 #include "PGStateUtils.h"
 #include "common/Clock.h"
 
+using ceph::Formatter;
+
 /*------NamedState----*/
 NamedState::NamedState(PGStateHistory *pgsh, const char *state_name)
   : pgsh(pgsh), state_name(state_name), enter_time(ceph_clock_now()) {

--- a/src/osd/PGStateUtils.h
+++ b/src/osd/PGStateUtils.h
@@ -72,7 +72,7 @@ public:
     pi = nullptr;
   }
 
-  void dump(Formatter* f) const;
+  void dump(ceph::Formatter* f) const;
 
   const char *get_current_state() const {
     if (pi == nullptr) return "unknown";

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -24,6 +24,19 @@
 #define dout_context cct
 #define dout_subsys ceph_subsys_osd
 
+using std::dec;
+using std::hex;
+using std::make_pair;
+using std::map;
+using std::ostream;
+using std::pair;
+using std::set;
+using std::stringstream;
+using std::vector;
+
+using ceph::Formatter;
+using ceph::make_message;
+
 BufferedRecoveryMessages::BufferedRecoveryMessages(
   ceph_release_t r,
   PeeringCtx &ctx)
@@ -202,9 +215,7 @@ void PeeringState::check_recovery_sources(const OSDMapRef& osdmap)
   missing_loc.check_recovery_sources(osdmap);
   pl->check_recovery_sources(osdmap);
 
-  for (set<pg_shard_t>::iterator i = peer_log_requested.begin();
-       i != peer_log_requested.end();
-       ) {
+  for (auto i = peer_log_requested.begin(); i != peer_log_requested.end();) {
     if (!osdmap->is_up(i->osd)) {
       psdout(10) << "peer_log_requested removing " << *i << dendl;
       peer_log_requested.erase(i++);
@@ -213,9 +224,8 @@ void PeeringState::check_recovery_sources(const OSDMapRef& osdmap)
     }
   }
 
-  for (set<pg_shard_t>::iterator i = peer_missing_requested.begin();
-       i != peer_missing_requested.end();
-       ) {
+  for (auto i = peer_missing_requested.begin();
+       i != peer_missing_requested.end();) {
     if (!osdmap->is_up(i->osd)) {
       psdout(10) << "peer_missing_requested removing " << *i << dendl;
       peer_missing_requested.erase(i++);
@@ -261,9 +271,7 @@ void PeeringState::purge_strays()
   psdout(10) << "purge_strays " << stray_set << dendl;
 
   bool removed = false;
-  for (set<pg_shard_t>::iterator p = stray_set.begin();
-       p != stray_set.end();
-       ++p) {
+  for (auto p = stray_set.begin(); p != stray_set.end(); ++p) {
     ceph_assert(!is_acting_recovery_backfill(*p));
     if (get_osdmap()->is_up(p->osd)) {
       psdout(10) << "sending PGRemove to osd." << *p << dendl;
@@ -299,7 +307,7 @@ void PeeringState::purge_strays()
 bool PeeringState::proc_replica_info(
   pg_shard_t from, const pg_info_t &oinfo, epoch_t send_epoch)
 {
-  map<pg_shard_t, pg_info_t>::iterator p = peer_info.find(from);
+  auto p = peer_info.find(from);
   if (p != peer_info.end() && p->second.last_update == oinfo.last_update) {
     psdout(10) << " got dup osd." << from << " info "
 	       << oinfo << ", identical to ours" << dendl;
@@ -340,7 +348,7 @@ void PeeringState::remove_down_peer_info(const OSDMapRef &osdmap)
 {
   // Remove any downed osds from peer_info
   bool removed = false;
-  map<pg_shard_t, pg_info_t>::iterator p = peer_info.begin();
+  auto p = peer_info.begin();
   while (p != peer_info.end()) {
     if (!osdmap->is_up(p->first.osd)) {
       psdout(10) << " dropping down osd." << p->first << " info " << p->second << dendl;
@@ -375,9 +383,7 @@ void PeeringState::update_heartbeat_peers()
     if (up[i] != CRUSH_ITEM_NONE)
       new_peers.insert(up[i]);
   }
-  for (map<pg_shard_t,pg_info_t>::iterator p = peer_info.begin();
-       p != peer_info.end();
-       ++p) {
+  for (auto p = peer_info.begin(); p != peer_info.end(); ++p) {
     new_peers.insert(p->first.osd);
   }
   pl->update_heartbeat_peers(std::move(new_peers));
@@ -721,14 +727,14 @@ void PeeringState::on_new_interval()
   // initialize features
   acting_features = CEPH_FEATURES_SUPPORTED_DEFAULT;
   upacting_features = CEPH_FEATURES_SUPPORTED_DEFAULT;
-  for (vector<int>::iterator p = acting.begin(); p != acting.end(); ++p) {
+  for (auto p = acting.begin(); p != acting.end(); ++p) {
     if (*p == CRUSH_ITEM_NONE)
       continue;
     uint64_t f = osdmap->get_xinfo(*p).features;
     acting_features &= f;
     upacting_features &= f;
   }
-  for (vector<int>::iterator p = up.begin(); p != up.end(); ++p) {
+  for (auto p = up.begin(); p != up.end(); ++p) {
     if (*p == CRUSH_ITEM_NONE)
       continue;
     upacting_features &= osdmap->get_xinfo(*p).features;
@@ -1273,9 +1279,7 @@ PastIntervals::PriorSet PeeringState::build_prior()
 {
   if (1) {
     // sanity check
-    for (map<pg_shard_t,pg_info_t>::iterator it = peer_info.begin();
-	 it != peer_info.end();
-	 ++it) {
+    for (auto it = peer_info.begin(); it != peer_info.end(); ++it) {
       ceph_assert(info.history.last_epoch_started >=
 		  it->second.history.last_epoch_started);
     }
@@ -1341,12 +1345,12 @@ bool PeeringState::needs_recovery() const
   }
 
   ceph_assert(!acting_recovery_backfill.empty());
-  set<pg_shard_t>::const_iterator end = acting_recovery_backfill.end();
-  set<pg_shard_t>::const_iterator a = acting_recovery_backfill.begin();
+  auto end = acting_recovery_backfill.end();
+  auto a = acting_recovery_backfill.begin();
   for (; a != end; ++a) {
     if (*a == get_primary()) continue;
     pg_shard_t peer = *a;
-    map<pg_shard_t, pg_missing_t>::const_iterator pm = peer_missing.find(peer);
+    auto pm = peer_missing.find(peer);
     if (pm == peer_missing.end()) {
       psdout(10) << __func__ << " osd." << peer << " doesn't have missing set"
 		 << dendl;
@@ -1369,11 +1373,11 @@ bool PeeringState::needs_backfill() const
 
   // We can assume that only possible osds that need backfill
   // are on the backfill_targets vector nodes.
-  set<pg_shard_t>::const_iterator end = backfill_targets.end();
-  set<pg_shard_t>::const_iterator a = backfill_targets.begin();
+  auto end = backfill_targets.end();
+  auto a = backfill_targets.begin();
   for (; a != end; ++a) {
     pg_shard_t peer = *a;
-    map<pg_shard_t, pg_info_t>::const_iterator pi = peer_info.find(peer);
+    auto pi = peer_info.find(peer);
     if (!pi->second.last_backfill.is_max()) {
       psdout(10) << __func__ << " osd." << peer
 		 << " has last_backfill " << pi->second.last_backfill << dendl;
@@ -1393,12 +1397,12 @@ bool PeeringState::all_unfound_are_queried_or_lost(
 {
   ceph_assert(is_primary());
 
-  set<pg_shard_t>::const_iterator peer = might_have_unfound.begin();
-  set<pg_shard_t>::const_iterator mend = might_have_unfound.end();
+  auto peer = might_have_unfound.begin();
+  auto mend = might_have_unfound.end();
   for (; peer != mend; ++peer) {
     if (peer_missing.count(*peer))
       continue;
-    map<pg_shard_t, pg_info_t>::const_iterator iter = peer_info.find(*peer);
+    auto iter = peer_info.find(*peer);
     if (iter != peer_info.end() &&
         (iter->second.is_empty() || iter->second.dne()))
       continue;
@@ -1449,9 +1453,7 @@ map<pg_shard_t, pg_info_t>::const_iterator PeeringState::find_best_info(
    * when you find bugs! */
   eversion_t min_last_update_acceptable = eversion_t::max();
   epoch_t max_last_epoch_started_found = 0;
-  for (map<pg_shard_t, pg_info_t>::const_iterator i = infos.begin();
-       i != infos.end();
-       ++i) {
+  for (auto i = infos.begin(); i != infos.end(); ++i) {
     if (!cct->_conf->osd_find_best_info_ignore_history_les &&
 	max_last_epoch_started_found < i->second.history.last_epoch_started) {
       *history_les_bound = true;
@@ -1463,9 +1465,7 @@ map<pg_shard_t, pg_info_t>::const_iterator PeeringState::find_best_info(
       max_last_epoch_started_found = i->second.last_epoch_started;
     }
   }
-  for (map<pg_shard_t, pg_info_t>::const_iterator i = infos.begin();
-       i != infos.end();
-       ++i) {
+  for (auto i = infos.begin(); i != infos.end(); ++i) {
     if (max_last_epoch_started_found <= i->second.last_epoch_started) {
       if (min_last_update_acceptable > i->second.last_update)
 	min_last_update_acceptable = i->second.last_update;
@@ -1474,14 +1474,12 @@ map<pg_shard_t, pg_info_t>::const_iterator PeeringState::find_best_info(
   if (min_last_update_acceptable == eversion_t::max())
     return infos.end();
 
-  map<pg_shard_t, pg_info_t>::const_iterator best = infos.end();
+  auto best = infos.end();
   // find osd with newest last_update (oldest for ec_pool).
   // if there are multiples, prefer
   //  - a longer tail, if it brings another peer into log contiguity
   //  - the current primary
-  for (map<pg_shard_t, pg_info_t>::const_iterator p = infos.begin();
-       p != infos.end();
-       ++p) {
+  for (auto p = infos.begin(); p != infos.end(); ++p) {
     if (restrict_to_up_acting && !is_up(p->first) &&
 	!is_acting(p->first))
       continue;
@@ -1564,7 +1562,7 @@ void PeeringState::calc_ec_acting(
 {
   vector<int> want(size, CRUSH_ITEM_NONE);
   map<shard_id_t, set<pg_shard_t> > all_info_by_shard;
-  for (map<pg_shard_t, pg_info_t>::const_iterator i = all_info.begin();
+  for (auto i = all_info.begin();
        i != all_info.end();
        ++i) {
     all_info_by_shard[i->first.shard].insert(i->first);
@@ -1592,7 +1590,7 @@ void PeeringState::calc_ec_acting(
       ss << " selecting acting[i]: " << pg_shard_t(acting[i], shard_id_t(i)) << std::endl;
       want[i] = acting[i];
     } else if (!restrict_to_up_acting) {
-      for (set<pg_shard_t>::iterator j = all_info_by_shard[shard_id_t(i)].begin();
+      for (auto j = all_info_by_shard[shard_id_t(i)].begin();
 	   j != all_info_by_shard[shard_id_t(i)].end();
 	   ++j) {
 	ceph_assert(j->shard == i);
@@ -1729,7 +1727,7 @@ void PeeringState::calc_replicated_acting(
     // skip up osds we already considered above
     if (acting_cand == primary->first)
       continue;
-    vector<int>::const_iterator up_it = find(up.begin(), up.end(), i);
+    auto up_it = find(up.begin(), up.end(), i);
     if (up_it != up.end())
       continue;
 
@@ -1772,10 +1770,10 @@ void PeeringState::calc_replicated_acting(
     // skip up osds we already considered above
     if (i.first == primary->first)
       continue;
-    vector<int>::const_iterator up_it = find(up.begin(), up.end(), i.first.osd);
+    auto up_it = find(up.begin(), up.end(), i.first.osd);
     if (up_it != up.end())
       continue;
-    vector<int>::const_iterator acting_it = find(
+    auto acting_it = find(
       acting.begin(), acting.end(), i.first.osd);
     if (acting_it != acting.end())
       continue;
@@ -2012,16 +2010,14 @@ bool PeeringState::choose_acting(pg_shard_t &auth_log_shard_id,
   all_info[pg_whoami] = info;
 
   if (cct->_conf->subsys.should_gather<dout_subsys, 10>()) {
-    for (map<pg_shard_t, pg_info_t>::iterator p = all_info.begin();
-         p != all_info.end();
-         ++p) {
+    for (auto p = all_info.begin(); p != all_info.end(); ++p) {
       psdout(10) << __func__ << " all_info osd." << p->first << " "
 		 << p->second << dendl;
     }
   }
 
-  map<pg_shard_t, pg_info_t>::const_iterator auth_log_shard =
-    find_best_info(all_info, restrict_to_up_acting, history_les_bound);
+  auto auth_log_shard = find_best_info(all_info, restrict_to_up_acting,
+				       history_les_bound);
 
   if (auth_log_shard == all_info.end()) {
     if (up != acting) {
@@ -2138,9 +2134,7 @@ bool PeeringState::choose_acting(pg_shard_t &auth_log_shard_id,
   }
   // Will not change if already set because up would have had to change
   // Verify that nothing in backfill is in stray_set
-  for (set<pg_shard_t>::iterator i = want_backfill.begin();
-      i != want_backfill.end();
-      ++i) {
+  for (auto i = want_backfill.begin(); i != want_backfill.end(); ++i) {
     ceph_assert(stray_set.find(*i) == stray_set.end());
   }
   psdout(10) << "choose_acting want=" << want << " backfill_targets="
@@ -2227,8 +2221,8 @@ bool PeeringState::discover_all_missing(
 	     << unfound << " unfound"
 	     << dendl;
 
-  std::set<pg_shard_t>::const_iterator m = might_have_unfound.begin();
-  std::set<pg_shard_t>::const_iterator mend = might_have_unfound.end();
+  auto m = might_have_unfound.begin();
+  auto mend = might_have_unfound.end();
   for (; m != mend; ++m) {
     pg_shard_t peer(*m);
 
@@ -2242,7 +2236,7 @@ bool PeeringState::discover_all_missing(
       continue;
     }
 
-    map<pg_shard_t, pg_info_t>::const_iterator iter = peer_info.find(peer);
+    auto iter = peer_info.find(peer);
     if (iter != peer_info.end() &&
         (iter->second.is_empty() || iter->second.dne())) {
       // ignore empty peers
@@ -2306,9 +2300,7 @@ void PeeringState::build_might_have_unfound()
     pool.info.is_erasure());
 
   // include any (stray) peers
-  for (map<pg_shard_t, pg_info_t>::iterator p = peer_info.begin();
-       p != peer_info.end();
-       ++p)
+  for (auto p = peer_info.begin(); p != peer_info.end(); ++p)
     might_have_unfound.insert(p->first);
 
   psdout(15) << __func__ << ": built " << might_have_unfound << dendl;
@@ -2416,7 +2408,7 @@ void PeeringState::activate(
 						 prior_readable_until_ub);
 
     ceph_assert(!acting_recovery_backfill.empty());
-    for (set<pg_shard_t>::iterator i = acting_recovery_backfill.begin();
+    for (auto i = acting_recovery_backfill.begin();
 	 i != acting_recovery_backfill.end();
 	 ++i) {
       if (*i == pg_whoami) continue;
@@ -2521,9 +2513,7 @@ void PeeringState::activate(
 
       // update local version of peer's missing list!
       if (m && pi.last_backfill != hobject_t()) {
-        for (list<pg_log_entry_t>::iterator p = m->log.log.begin();
-             p != m->log.log.end();
-             ++p) {
+        for (auto p = m->log.log.begin(); p != m->log.log.end(); ++p) {
 	  if (p->soid <= pi.last_backfill &&
 	      !p->is_error()) {
 	    if (perform_deletes_during_peering() && p->is_delete()) {
@@ -2558,7 +2548,7 @@ void PeeringState::activate(
 
     // Set up missing_loc
     set<pg_shard_t> complete_shards;
-    for (set<pg_shard_t>::iterator i = acting_recovery_backfill.begin();
+    for (auto i = acting_recovery_backfill.begin();
 	 i != acting_recovery_backfill.end();
 	 ++i) {
       psdout(20) << __func__ << " setting up missing_loc from shard " << *i
@@ -2591,7 +2581,7 @@ void PeeringState::activate(
       } else {
         missing_loc.add_source_info(pg_whoami, info, pg_log.get_missing(),
 				    ctx.handle);
-        for (set<pg_shard_t>::iterator i = acting_recovery_backfill.begin();
+        for (auto i = acting_recovery_backfill.begin();
 	     i != acting_recovery_backfill.end();
 	     ++i) {
 	  if (*i == pg_whoami) continue;
@@ -2605,9 +2595,7 @@ void PeeringState::activate(
             ctx.handle);
         }
       }
-      for (map<pg_shard_t, pg_missing_t>::iterator i = peer_missing.begin();
-	   i != peer_missing.end();
-	   ++i) {
+      for (auto i = peer_missing.begin(); i != peer_missing.end(); ++i) {
 	if (is_acting_recovery_backfill(i->first))
 	  continue;
 	ceph_assert(peer_info.count(i->first));
@@ -2767,8 +2755,7 @@ void PeeringState::proc_replica_log(
 	     << oinfo << " " << omissing << dendl;
   might_have_unfound.insert(from);
 
-  for (map<hobject_t, pg_missing_item>::const_iterator i =
-	 omissing.get_items().begin();
+  for (auto i = omissing.get_items().begin();
        i != omissing.get_items().end();
        ++i) {
     psdout(20) << " after missing " << i->first
@@ -3152,9 +3139,7 @@ void PeeringState::update_blocked_by()
   info.stats.blocked_by.clear();
   info.stats.blocked_by.resize(keep);
   unsigned pos = 0;
-  for (set<int>::iterator p = blocked_by.begin();
-       p != blocked_by.end() && keep > 0;
-       ++p) {
+  for (auto p = blocked_by.begin(); p != blocked_by.end() && keep > 0; ++p) {
     if (skip > 0 && (rand() % (skip + keep) < skip)) {
       --skip;
     } else {
@@ -3620,24 +3605,22 @@ void PeeringState::dump_peering_state(Formatter *f)
   f->dump_string("state", get_pg_state_string());
   f->dump_unsigned("epoch", get_osdmap_epoch());
   f->open_array_section("up");
-  for (vector<int>::const_iterator p = up.begin(); p != up.end(); ++p)
+  for (auto p = up.begin(); p != up.end(); ++p)
     f->dump_unsigned("osd", *p);
   f->close_section();
   f->open_array_section("acting");
-  for (vector<int>::const_iterator p = acting.begin(); p != acting.end(); ++p)
+  for (auto p = acting.begin(); p != acting.end(); ++p)
     f->dump_unsigned("osd", *p);
   f->close_section();
   if (!backfill_targets.empty()) {
     f->open_array_section("backfill_targets");
-    for (set<pg_shard_t>::iterator p = backfill_targets.begin();
-	 p != backfill_targets.end();
-	 ++p)
+    for (auto p = backfill_targets.begin(); p != backfill_targets.end(); ++p)
       f->dump_stream("shard") << *p;
     f->close_section();
   }
   if (!async_recovery_targets.empty()) {
     f->open_array_section("async_recovery_targets");
-    for (set<pg_shard_t>::iterator p = async_recovery_targets.begin();
+    for (auto p = async_recovery_targets.begin();
 	 p != async_recovery_targets.end();
 	 ++p)
       f->dump_stream("shard") << *p;
@@ -3645,7 +3628,7 @@ void PeeringState::dump_peering_state(Formatter *f)
   }
   if (!acting_recovery_backfill.empty()) {
     f->open_array_section("acting_recovery_backfill");
-    for (set<pg_shard_t>::iterator p = acting_recovery_backfill.begin();
+    for (auto p = acting_recovery_backfill.begin();
 	 p != acting_recovery_backfill.end();
 	 ++p)
       f->dump_stream("shard") << *p;
@@ -3657,9 +3640,7 @@ void PeeringState::dump_peering_state(Formatter *f)
   f->close_section();
 
   f->open_array_section("peer_info");
-  for (map<pg_shard_t, pg_info_t>::const_iterator p = peer_info.begin();
-       p != peer_info.end();
-       ++p) {
+  for (auto p = peer_info.begin(); p != peer_info.end(); ++p) {
     f->open_object_section("info");
     f->dump_stream("peer") << p->first;
     p->second.dump(f);
@@ -3731,7 +3712,7 @@ void PeeringState::merge_new_log_entries(
   ceph_assert(is_primary());
 
   bool rebuild_missing = append_log_entries_update_missing(entries, t, trim_to, roll_forward_to);
-  for (set<pg_shard_t>::const_iterator i = acting_recovery_backfill.begin();
+  for (auto i = acting_recovery_backfill.begin();
        i != acting_recovery_backfill.end();
        ++i) {
     pg_shard_t peer(*i);
@@ -3828,9 +3809,7 @@ void PeeringState::append_log(
     pg_log.skip_rollforward();
   }
 
-  for (vector<pg_log_entry_t>::const_iterator p = logv.begin();
-       p != logv.end();
-       ++p) {
+  for (auto p = logv.begin(); p != logv.end(); ++p) {
     add_log_entry(*p, transaction_applied);
 
     /* We don't want to leave the rollforward artifacts around
@@ -4070,7 +4049,7 @@ void PeeringState::calc_trim_to()
         cct->_conf->osd_pg_log_trim_max >= cct->_conf->osd_pg_log_trim_min) {
       return;
     }
-    list<pg_log_entry_t>::const_iterator it = pg_log.get_log().log.begin();
+    auto it = pg_log.get_log().log.begin();
     eversion_t new_trim_to;
     for (size_t i = 0; i < num_to_trim; ++i) {
       new_trim_to = it->version;
@@ -4146,7 +4125,7 @@ void PeeringState::apply_op_stats(
   info.stats.stats.add(delta_stats);
   info.stats.stats.floor(0);
 
-  for (set<pg_shard_t>::const_iterator i = get_backfill_targets().begin();
+  for (auto i = get_backfill_targets().begin();
        i != get_backfill_targets().end();
        ++i) {
     pg_shard_t bt = *i;
@@ -4581,9 +4560,7 @@ boost::statechart::result PeeringState::Peering::react(const QueryState& q)
   q.f->close_section();
 
   q.f->open_array_section("probing_osds");
-  for (set<pg_shard_t>::iterator p = prior_set.probe.begin();
-       p != prior_set.probe.end();
-       ++p)
+  for (auto p = prior_set.probe.begin(); p != prior_set.probe.end(); ++p)
     q.f->dump_stream("osd") << *p;
   q.f->close_section();
 
@@ -4591,14 +4568,12 @@ boost::statechart::result PeeringState::Peering::react(const QueryState& q)
     q.f->dump_string("blocked", "peering is blocked due to down osds");
 
   q.f->open_array_section("down_osds_we_would_probe");
-  for (set<int>::iterator p = prior_set.down.begin();
-       p != prior_set.down.end();
-       ++p)
+  for (auto p = prior_set.down.begin(); p != prior_set.down.end(); ++p)
     q.f->dump_int("osd", *p);
   q.f->close_section();
 
   q.f->open_array_section("peering_blocked_by");
-  for (map<int,epoch_t>::iterator p = prior_set.blocked_by.begin();
+  for (auto p = prior_set.blocked_by.begin();
        p != prior_set.blocked_by.end();
        ++p) {
     q.f->open_object_section("osd");
@@ -4656,7 +4631,7 @@ void PeeringState::Backfilling::backfill_release_reservations()
 {
   DECLARE_LOCALS;
   pl->cancel_local_background_io_reservation();
-  for (set<pg_shard_t>::iterator it = ps->backfill_targets.begin();
+  for (auto it = ps->backfill_targets.begin();
        it != ps->backfill_targets.end();
        ++it) {
     ceph_assert(*it != ps->pg_whoami);
@@ -5329,10 +5304,9 @@ void PeeringState::Recovering::release_reservations(bool cancel)
   ceph_assert(cancel || !ps->pg_log.get_missing().have_missing());
 
   // release remote reservations
-  for (set<pg_shard_t>::const_iterator i =
-	 context< Active >().remote_shards_to_reserve_recovery.begin();
-        i != context< Active >().remote_shards_to_reserve_recovery.end();
-        ++i) {
+  for (auto i = context< Active >().remote_shards_to_reserve_recovery.begin();
+       i != context< Active >().remote_shards_to_reserve_recovery.end();
+       ++i) {
     if (*i == ps->pg_whoami) // skip myself
       continue;
     pl->send_cluster_message(
@@ -5498,9 +5472,7 @@ set<pg_shard_t> unique_osd_shard_set(const pg_shard_t & skip, const T &in)
 {
   set<int> osds_found;
   set<pg_shard_t> out;
-  for (typename T::const_iterator i = in.begin();
-       i != in.end();
-       ++i) {
+  for (auto i = in.begin(); i != in.end(); ++i) {
     if (*i != skip && !osds_found.count(i->osd)) {
       osds_found.insert(i->osd);
       out.insert(*i);
@@ -5538,7 +5510,7 @@ PeeringState::Active::Active(my_context ctx)
 
   // everyone has to commit/ack before we are truly active
   ps->blocked_by.clear();
-  for (set<pg_shard_t>::iterator p = ps->acting_recovery_backfill.begin();
+  for (auto p = ps->acting_recovery_backfill.begin();
        p != ps->acting_recovery_backfill.end();
        ++p) {
     if (p->shard != ps->pg_whoami.shard) {
@@ -5768,7 +5740,7 @@ boost::statechart::result PeeringState::Active::react(const QueryState& q)
 
   {
     q.f->open_array_section("might_have_unfound");
-    for (set<pg_shard_t>::iterator p = ps->might_have_unfound.begin();
+    for (auto p = ps->might_have_unfound.begin();
 	 p != ps->might_have_unfound.end();
 	 ++p) {
       q.f->open_object_section("osd");
@@ -5789,7 +5761,7 @@ boost::statechart::result PeeringState::Active::react(const QueryState& q)
   {
     q.f->open_object_section("recovery_progress");
     q.f->open_array_section("backfill_targets");
-    for (set<pg_shard_t>::const_iterator p = ps->backfill_targets.begin();
+    for (auto p = ps->backfill_targets.begin();
 	 p != ps->backfill_targets.end(); ++p)
       q.f->dump_stream("replica") << *p;
     q.f->close_section();
@@ -6360,9 +6332,7 @@ void PeeringState::GetInfo::get_infos()
   PastIntervals::PriorSet &prior_set = context< Peering >().prior_set;
 
   ps->blocked_by.clear();
-  for (set<pg_shard_t>::const_iterator it = prior_set.probe.begin();
-       it != prior_set.probe.end();
-       ++it) {
+  for (auto it = prior_set.probe.begin(); it != prior_set.probe.end(); ++it) {
     pg_shard_t peer = *it;
     if (peer == ps->pg_whoami) {
       continue;
@@ -6399,7 +6369,7 @@ boost::statechart::result PeeringState::GetInfo::react(const MNotifyRec& infoevt
 
   DECLARE_LOCALS;
 
-  set<pg_shard_t>::iterator p = peer_info_requested.find(infoevt.from);
+  auto p = peer_info_requested.find(infoevt.from);
   if (p != peer_info_requested.end()) {
     peer_info_requested.erase(p);
     ps->blocked_by.erase(infoevt.from.osd);
@@ -6418,7 +6388,7 @@ boost::statechart::result PeeringState::GetInfo::react(const MNotifyRec& infoevt
       // filter out any osds that got dropped from the probe set from
       // peer_info_requested.  this is less expensive than restarting
       // peering (which would re-probe everyone).
-      set<pg_shard_t>::iterator p = peer_info_requested.begin();
+      auto p = peer_info_requested.begin();
       while (p != peer_info_requested.end()) {
 	if (prior_set.probe.count(*p) == 0) {
 	  psdout(20) << " dropping osd." << *p << " from info_requested, no longer in probe set" << dendl;
@@ -6452,7 +6422,7 @@ boost::statechart::result PeeringState::GetInfo::react(const QueryState& q)
   q.f->dump_stream("enter_time") << enter_time;
 
   q.f->open_array_section("requested_info_from");
-  for (set<pg_shard_t>::iterator p = peer_info_requested.begin();
+  for (auto p = peer_info_requested.begin();
        p != peer_info_requested.end();
        ++p) {
     q.f->open_object_section("osd");
@@ -6523,7 +6493,7 @@ PeeringState::GetLog::GetLog(my_context ctx)
   // how much log to request?
   eversion_t request_log_from = ps->info.last_update;
   ceph_assert(!ps->acting_recovery_backfill.empty());
-  for (set<pg_shard_t>::iterator p = ps->acting_recovery_backfill.begin();
+  for (auto p = ps->acting_recovery_backfill.begin();
        p != ps->acting_recovery_backfill.end();
        ++p) {
     if (*p == ps->pg_whoami) continue;
@@ -6628,7 +6598,7 @@ boost::statechart::result PeeringState::WaitActingChange::react(const AdvMap& ad
   OSDMapRef osdmap = advmap.osdmap;
 
   psdout(10) << "verifying no want_acting " << ps->want_acting << " targets didn't go down" << dendl;
-  for (vector<int>::iterator p = ps->want_acting.begin(); p != ps->want_acting.end(); ++p) {
+  for (auto p = ps->want_acting.begin(); p != ps->want_acting.end(); ++p) {
     if (!osdmap->is_up(*p)) {
       psdout(10) << " want_acting target osd." << *p << " went down, resetting" << dendl;
       post_event(advmap);
@@ -6816,7 +6786,7 @@ PeeringState::GetMissing::GetMissing(my_context ctx)
   ps->log_weirdness();
   ceph_assert(!ps->acting_recovery_backfill.empty());
   eversion_t since;
-  for (set<pg_shard_t>::iterator i = ps->acting_recovery_backfill.begin();
+  for (auto i = ps->acting_recovery_backfill.begin();
        i != ps->acting_recovery_backfill.end();
        ++i) {
     if (*i == ps->get_primary()) continue;
@@ -6923,7 +6893,7 @@ boost::statechart::result PeeringState::GetMissing::react(const QueryState& q)
   q.f->dump_stream("enter_time") << enter_time;
 
   q.f->open_array_section("peer_missing_requested");
-  for (set<pg_shard_t>::iterator p = peer_missing_requested.begin();
+  for (auto p = peer_missing_requested.begin();
        p != peer_missing_requested.end();
        ++p) {
     q.f->open_object_section("osd");

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -30,13 +30,13 @@ struct PGPool {
   CephContext* cct;
   epoch_t cached_epoch;
   int64_t id;
-  string name;
+  std::string name;
 
   pg_pool_t info;
   SnapContext snapc;   // the default pool snapc, ready to go.
 
   PGPool(CephContext* cct, OSDMapRef map, int64_t i, const pg_pool_t& info,
-	 const string& name)
+	 const std::string& name)
     : cct(cct),
       cached_epoch(map->get_epoch()),
       id(i),
@@ -59,12 +59,12 @@ struct PGPool {
   }
 };
 
-class PeeringCtx;
+struct PeeringCtx;
 
 // [primary only] content recovery state
 struct BufferedRecoveryMessages {
   ceph_release_t require_osd_release;
-  map<int, vector<MessageRef>> message_map;
+  std::map<int, std::vector<MessageRef>> message_map;
 
   BufferedRecoveryMessages(ceph_release_t r)
     : require_osd_release(r) {
@@ -123,7 +123,7 @@ struct HeartbeatStamps : public RefCountedObject {
   /// highest up_from we've seen from this rank
   epoch_t up_from = 0;
 
-  void print(ostream& out) const {
+  void print(std::ostream& out) const {
     std::lock_guard l(lock);
     out << "hbstamp(osd." << osd << " up_from " << up_from
 	<< " peer_clock_delta [";
@@ -181,7 +181,7 @@ private:
 };
 using HeartbeatStampsRef = ceph::ref_t<HeartbeatStamps>;
 
-inline ostream& operator<<(ostream& out, const HeartbeatStamps& hb)
+inline std::ostream& operator<<(std::ostream& out, const HeartbeatStamps& hb)
 {
   hb.print(out);
   return out;
@@ -340,15 +340,15 @@ public:
 
     //============================ HB =============================
     /// Update hb set to peers
-    virtual void update_heartbeat_peers(set<int> peers) = 0;
+    virtual void update_heartbeat_peers(std::set<int> peers) = 0;
 
-    /// Set targets being probed in this interval
-    virtual void set_probe_targets(const set<pg_shard_t> &probe_set) = 0;
+    /// Std::set targets being probed in this interval
+    virtual void set_probe_targets(const std::set<pg_shard_t> &probe_set) = 0;
     /// Clear targets being probed in this interval
     virtual void clear_probe_targets() = 0;
 
     /// Queue for a pg_temp of wanted
-    virtual void queue_want_pg_temp(const vector<int> &wanted) = 0;
+    virtual void queue_want_pg_temp(const std::vector<int> &wanted) = 0;
     /// Clear queue for a pg_temp of wanted
     virtual void clear_want_pg_temp() = 0;
 
@@ -388,7 +388,7 @@ public:
     virtual void set_ready_to_merge_target(eversion_t lu, epoch_t les, epoch_t lec) = 0;
     virtual void set_ready_to_merge_source(eversion_t lu) = 0;
 
-    // ==================== Map notifications ===================
+    // ==================== Std::map notifications ===================
     virtual void on_active_actmap() = 0;
     virtual void on_active_advmap(const OSDMapRef &osdmap) = 0;
     virtual epoch_t oldest_stored_osdmap() = 0;
@@ -418,7 +418,7 @@ public:
     virtual void log_state_exit(
       const char *state_name, utime_t enter_time,
       uint64_t events, utime_t event_dur) = 0;
-    virtual void dump_recovery_info(Formatter *f) const = 0;
+    virtual void dump_recovery_info(ceph::Formatter *f) const = 0;
 
     virtual OstreamTemp get_clog_info() = 0;
     virtual OstreamTemp get_clog_error() = 0;
@@ -428,8 +428,8 @@ public:
   };
 
   struct QueryState : boost::statechart::event< QueryState > {
-    Formatter *f;
-    explicit QueryState(Formatter *f) : f(f) {}
+    ceph::Formatter *f;
+    explicit QueryState(ceph::Formatter *f) : f(f) {}
     void print(std::ostream *out) const {
       *out << "Query";
     }
@@ -438,12 +438,12 @@ public:
   struct AdvMap : boost::statechart::event< AdvMap > {
     OSDMapRef osdmap;
     OSDMapRef lastmap;
-    vector<int> newup, newacting;
+    std::vector<int> newup, newacting;
     int up_primary, acting_primary;
     AdvMap(
       OSDMapRef osdmap, OSDMapRef lastmap,
-      vector<int>& newup, int up_primary,
-      vector<int>& newacting, int acting_primary):
+      std::vector<int>& newup, int up_primary,
+      std::vector<int>& newacting, int acting_primary):
       osdmap(osdmap), lastmap(lastmap),
       newup(newup),
       newacting(newacting),
@@ -804,8 +804,8 @@ public:
     explicit Active(my_context ctx);
     void exit();
 
-    const set<pg_shard_t> remote_shards_to_reserve_recovery;
-    const set<pg_shard_t> remote_shards_to_reserve_backfill;
+    const std::set<pg_shard_t> remote_shards_to_reserve_recovery;
+    const std::set<pg_shard_t> remote_shards_to_reserve_backfill;
     bool all_replicas_activated;
 
     typedef boost::mpl::list <
@@ -928,7 +928,7 @@ public:
       boost::statechart::custom_reaction< RemoteReservationRevoked >,
       boost::statechart::transition< AllBackfillsReserved, Backfilling >
       > reactions;
-    set<pg_shard_t>::const_iterator backfill_osd_it;
+    std::set<pg_shard_t>::const_iterator backfill_osd_it;
     explicit WaitRemoteBackfillReserved(my_context ctx);
     void retry();
     void exit();
@@ -1134,7 +1134,7 @@ public:
       boost::statechart::custom_reaction< RemoteRecoveryReserved >,
       boost::statechart::transition< AllRemotesReserved, Recovering >
       > reactions;
-    set<pg_shard_t>::const_iterator remote_recovery_reservation_it;
+    std::set<pg_shard_t>::const_iterator remote_recovery_reservation_it;
     explicit WaitRemoteRecoveryReserved(my_context ctx);
     boost::statechart::result react(const RemoteRecoveryReserved &evt);
     void exit();
@@ -1228,7 +1228,7 @@ public:
   struct GetLog;
 
   struct GetInfo : boost::statechart::state< GetInfo, Peering >, NamedState {
-    set<pg_shard_t> peer_info_requested;
+    std::set<pg_shard_t> peer_info_requested;
 
     explicit GetInfo(my_context ctx);
     void exit();
@@ -1272,7 +1272,7 @@ public:
   struct WaitUpThru;
 
   struct GetMissing : boost::statechart::state< GetMissing, Peering >, NamedState {
-    set<pg_shard_t> peer_missing_requested;
+    std::set<pg_shard_t> peer_missing_requested;
 
     explicit GetMissing(my_context ctx);
     void exit();
@@ -1360,15 +1360,15 @@ public:
   pg_shard_t primary;        ///< id/shard of primary
   pg_shard_t pg_whoami;      ///< my id/shard
   pg_shard_t up_primary;     ///< id/shard of primary of up set
-  vector<int> up;            ///< crush mapping without temp pgs
-  set<pg_shard_t> upset;     ///< up in set form
-  vector<int> acting;        ///< actual acting set for the current interval
-  set<pg_shard_t> actingset; ///< acting in set form
+  std::vector<int> up;            ///< crush mapping without temp pgs
+  std::set<pg_shard_t> upset;     ///< up in set form
+  std::vector<int> acting;        ///< actual acting set for the current interval
+  std::set<pg_shard_t> actingset; ///< acting in set form
 
   /// union of acting, recovery, and backfill targets
-  set<pg_shard_t> acting_recovery_backfill;
+  std::set<pg_shard_t> acting_recovery_backfill;
 
-  vector<HeartbeatStampsRef> hb_stamps;
+  std::vector<HeartbeatStampsRef> hb_stamps;
 
   ceph::signedspan readable_interval = ceph::signedspan::zero();
 
@@ -1382,7 +1382,7 @@ public:
   ceph::signedspan prior_readable_until_ub = ceph::signedspan::zero();
 
   /// pg instances from prior interval(s) that may still be readable
-  set<int> prior_readable_down_osds;
+  std::set<int> prior_readable_down_osds;
 
   /// [replica] upper bound we got from the primary (primary's clock)
   ceph::signedspan readable_until_ub_from_primary = ceph::signedspan::zero();
@@ -1391,7 +1391,7 @@ public:
   ceph::signedspan readable_until_ub_sent = ceph::signedspan::zero();
 
   /// [primary] readable ub acked by acting set members
-  vector<ceph::signedspan> acting_readable_until_ub;
+  std::vector<ceph::signedspan> acting_readable_until_ub;
 
   bool send_notify = false; ///< True if a notify needs to be sent to the primary
 
@@ -1418,13 +1418,13 @@ public:
   /**
    * Primary state
    */
-  set<pg_shard_t>    stray_set; ///< non-acting osds that have PG data.
-  map<pg_shard_t, pg_info_t>    peer_info; ///< info from peers (stray or prior)
-  map<pg_shard_t, int64_t>    peer_bytes; ///< Peer's num_bytes from peer_info
-  set<pg_shard_t> peer_purged; ///< peers purged
-  map<pg_shard_t, pg_missing_t> peer_missing; ///< peer missing sets
-  set<pg_shard_t> peer_log_requested; ///< logs i've requested (and start stamps)
-  set<pg_shard_t> peer_missing_requested; ///< missing sets requested
+  std::set<pg_shard_t>    stray_set; ///< non-acting osds that have PG data.
+  std::map<pg_shard_t, pg_info_t>    peer_info; ///< info from peers (stray or prior)
+  std::map<pg_shard_t, int64_t>    peer_bytes; ///< Peer's num_bytes from peer_info
+  std::set<pg_shard_t> peer_purged; ///< peers purged
+  std::map<pg_shard_t, pg_missing_t> peer_missing; ///< peer missing sets
+  std::set<pg_shard_t> peer_log_requested; ///< logs i've requested (and start stamps)
+  std::set<pg_shard_t> peer_missing_requested; ///< missing sets requested
 
   /// features supported by all peers
   uint64_t peer_features = CEPH_FEATURES_SUPPORTED_DEFAULT;
@@ -1436,29 +1436,29 @@ public:
   /// most recently consumed osdmap's require_osd_version
   ceph_release_t last_require_osd_release = ceph_release_t::unknown;
 
-  vector<int> want_acting; ///< non-empty while peering needs a new acting set
+  std::vector<int> want_acting; ///< non-empty while peering needs a new acting set
 
   // acting_recovery_backfill contains shards that are acting,
   // async recovery targets, or backfill targets.
-  map<pg_shard_t,eversion_t> peer_last_complete_ondisk;
+  std::map<pg_shard_t,eversion_t> peer_last_complete_ondisk;
 
   /// up: min over last_complete_ondisk, peer_last_complete_ondisk
   eversion_t  min_last_complete_ondisk;
   /// point to which the log should be trimmed
   eversion_t  pg_trim_to;
 
-  set<int> blocked_by; ///< osds we are blocked by (for pg stats)
+  std::set<int> blocked_by; ///< osds we are blocked by (for pg stats)
 
   bool need_up_thru = false; ///< true if osdmap with updated up_thru needed
 
   /// I deleted these strays; ignore racing PGInfo from them
-  set<pg_shard_t> peer_activated;
+  std::set<pg_shard_t> peer_activated;
 
-  set<pg_shard_t> backfill_targets;       ///< osds to be backfilled
-  set<pg_shard_t> async_recovery_targets; ///< osds to be async recovered
+  std::set<pg_shard_t> backfill_targets;       ///< osds to be backfilled
+  std::set<pg_shard_t> async_recovery_targets; ///< osds to be async recovered
 
   /// osds which might have objects on them which are unfound on the primary
-  set<pg_shard_t> might_have_unfound;
+  std::set<pg_shard_t> might_have_unfound;
 
   bool deleting = false;  /// true while in removing or OSD is shutting down
   std::atomic<bool> deleted = {false}; /// true once deletion complete
@@ -1484,14 +1484,14 @@ public:
   bool should_restart_peering(
     int newupprimary,
     int newactingprimary,
-    const vector<int>& newup,
-    const vector<int>& newacting,
+    const std::vector<int>& newup,
+    const std::vector<int>& newacting,
     OSDMapRef lastmap,
     OSDMapRef osdmap);
   void start_peering_interval(
     const OSDMapRef lastmap,
-    const vector<int>& newup, int up_primary,
-    const vector<int>& newacting, int acting_primary,
+    const std::vector<int>& newup, int up_primary,
+    const std::vector<int>& newacting, int acting_primary,
     ObjectStore::Transaction &t);
   void on_new_interval();
   void clear_recovery_state();
@@ -1516,50 +1516,50 @@ public:
 
   void reject_reservation();
 
-  // acting set
-  map<pg_shard_t, pg_info_t>::const_iterator find_best_info(
-    const map<pg_shard_t, pg_info_t> &infos,
+  // acting std::set
+  std::map<pg_shard_t, pg_info_t>::const_iterator find_best_info(
+    const std::map<pg_shard_t, pg_info_t> &infos,
     bool restrict_to_up_acting,
     bool *history_les_bound) const;
   static void calc_ec_acting(
-    map<pg_shard_t, pg_info_t>::const_iterator auth_log_shard,
+    std::map<pg_shard_t, pg_info_t>::const_iterator auth_log_shard,
     unsigned size,
-    const vector<int> &acting,
-    const vector<int> &up,
-    const map<pg_shard_t, pg_info_t> &all_info,
+    const std::vector<int> &acting,
+    const std::vector<int> &up,
+    const std::map<pg_shard_t, pg_info_t> &all_info,
     bool restrict_to_up_acting,
-    vector<int> *want,
-    set<pg_shard_t> *backfill,
-    set<pg_shard_t> *acting_backfill,
-    ostream &ss);
+    std::vector<int> *want,
+    std::set<pg_shard_t> *backfill,
+    std::set<pg_shard_t> *acting_backfill,
+    std::ostream &ss);
   static void calc_replicated_acting(
-    map<pg_shard_t, pg_info_t>::const_iterator auth_log_shard,
+    std::map<pg_shard_t, pg_info_t>::const_iterator auth_log_shard,
     uint64_t force_auth_primary_missing_objects,
     unsigned size,
-    const vector<int> &acting,
-    const vector<int> &up,
+    const std::vector<int> &acting,
+    const std::vector<int> &up,
     pg_shard_t up_primary,
-    const map<pg_shard_t, pg_info_t> &all_info,
+    const std::map<pg_shard_t, pg_info_t> &all_info,
     bool restrict_to_up_acting,
-    vector<int> *want,
-    set<pg_shard_t> *backfill,
-    set<pg_shard_t> *acting_backfill,
+    std::vector<int> *want,
+    std::set<pg_shard_t> *backfill,
+    std::set<pg_shard_t> *acting_backfill,
     const OSDMapRef osdmap,
-    ostream &ss);
+    std::ostream &ss);
   void choose_async_recovery_ec(
-    const map<pg_shard_t, pg_info_t> &all_info,
+    const std::map<pg_shard_t, pg_info_t> &all_info,
     const pg_info_t &auth_info,
-    vector<int> *want,
-    set<pg_shard_t> *async_recovery,
+    std::vector<int> *want,
+    std::set<pg_shard_t> *async_recovery,
     const OSDMapRef osdmap) const;
   void choose_async_recovery_replicated(
-    const map<pg_shard_t, pg_info_t> &all_info,
+    const std::map<pg_shard_t, pg_info_t> &all_info,
     const pg_info_t &auth_info,
-    vector<int> *want,
-    set<pg_shard_t> *async_recovery,
+    std::vector<int> *want,
+    std::set<pg_shard_t> *async_recovery,
     const OSDMapRef osdmap) const;
 
-  bool recoverable(const vector<int> &want) const;
+  bool recoverable(const std::vector<int> &want) const;
   bool choose_acting(pg_shard_t &auth_log_shard,
 		     bool restrict_to_up_acting,
 		     bool *history_les_bound,
@@ -1591,7 +1591,7 @@ public:
   void calc_min_last_complete_ondisk() {
     eversion_t min = last_complete_ondisk;
     ceph_assert(!acting_recovery_backfill.empty());
-    for (set<pg_shard_t>::iterator i = acting_recovery_backfill.begin();
+    for (std::set<pg_shard_t>::iterator i = acting_recovery_backfill.begin();
 	 i != acting_recovery_backfill.end();
 	 ++i) {
       if (*i == get_primary()) continue;
@@ -1609,7 +1609,7 @@ public:
 
   void fulfill_info(
     pg_shard_t from, const pg_query_t &query,
-    pair<pg_shard_t, pg_info_t> &notify_info);
+    std::pair<pg_shard_t, pg_info_t> &notify_info);
   void fulfill_log(
     pg_shard_t from, const pg_query_t &query, epoch_t query_epoch);
   void fulfill_query(const MQuery& q, PeeringCtxWrapper &rctx);
@@ -1653,8 +1653,8 @@ public:
   /// Init fresh instance of PG
   void init(
     int role,
-    const vector<int>& newup, int new_up_primary,
-    const vector<int>& newacting, int new_acting_primary,
+    const std::vector<int>& newup, int new_up_primary,
+    const std::vector<int>& newacting, int new_acting_primary,
     const pg_history_t& history,
     const PastIntervals& pi,
     bool backfill,
@@ -1674,20 +1674,20 @@ public:
     return ret;
   }
 
-  /// Set initial primary/acting
+  /// Std::set initial primary/acting
   void init_primary_up_acting(
-    const vector<int> &newup,
-    const vector<int> &newacting,
+    const std::vector<int> &newup,
+    const std::vector<int> &newacting,
     int new_up_primary,
     int new_acting_primary);
   void init_hb_stamps();
 
-  /// Set initial role
+  /// Std::set initial role
   void set_role(int r) {
     role = r;
   }
 
-  /// Set predicates used for determining readable and recoverable
+  /// Std::set predicates used for determining readable and recoverable
   void set_backend_predicates(
     IsPGReadablePredicate *is_readable,
     IsPGRecoverablePredicate *is_recoverable) {
@@ -1699,7 +1699,7 @@ public:
 
   /// Get stats for child pgs
   void start_split_stats(
-    const set<spg_t>& childpgs, vector<object_stat_sum_t> *out);
+    const std::set<spg_t>& childpgs, std::vector<object_stat_sum_t> *out);
 
   /// Update new child with stats
   void finish_split_stats(
@@ -1711,7 +1711,7 @@ public:
 
   /// Merge state from sources
   void merge_from(
-    map<spg_t,PeeringState *>& sources,
+    std::map<spg_t,PeeringState *>& sources,
     PeeringCtx &rctx,
     unsigned split_bits,
     const pg_merge_meta_t& last_pg_merge_meta);
@@ -1787,7 +1787,7 @@ public:
    * Updates local log to reflect new write from primary.
    */
   void append_log(
-    vector<pg_log_entry_t>&& logv,
+    std::vector<pg_log_entry_t>&& logv,
     eversion_t trim_to,
     eversion_t roll_forward_to,
     eversion_t min_last_complete_ondisk,
@@ -1821,7 +1821,7 @@ public:
   /// Pre-process pending update on hoid represented by logv
   void pre_submit_op(
     const hobject_t &hoid,
-    const vector<pg_log_entry_t>& logv,
+    const std::vector<pg_log_entry_t>& logv,
     eversion_t at_version);
 
   /// Signal that oid has been locally recovered to version v
@@ -1880,16 +1880,16 @@ public:
    *
    * Force oid on peer to be missing at version.  If the object does not
    * currently need recovery, either candidates if provided or the remainder
-   * of the acting set will be deemed to have the object.
+   * of the acting std::set will be deemed to have the object.
    */
   void force_object_missing(
     const pg_shard_t &peer,
     const hobject_t &oid,
     eversion_t version) {
-    force_object_missing(set<pg_shard_t>{peer}, oid, version);
+    force_object_missing(std::set<pg_shard_t>{peer}, oid, version);
   }
   void force_object_missing(
-    const set<pg_shard_t> &peer,
+    const std::set<pg_shard_t> &peer,
     const hobject_t &oid,
     eversion_t version);
 
@@ -1897,12 +1897,12 @@ public:
   void prepare_backfill_for_missing(
     const hobject_t &soid,
     const eversion_t &version,
-    const vector<pg_shard_t> &targets);
+    const std::vector<pg_shard_t> &targets);
 
-  /// Set targets with the right version for revert (see recover_primary)
+  /// Std::set targets with the right version for revert (see recover_primary)
   void set_revert_with_targets(
     const hobject_t &soid,
-    const set<pg_shard_t> &good_peers);
+    const std::set<pg_shard_t> &good_peers);
 
   /// Update lcod for fromosd
   void update_peer_last_complete_ondisk(
@@ -1945,9 +1945,9 @@ public:
   void advance_map(
     OSDMapRef osdmap,       ///< [in] new osdmap
     OSDMapRef lastmap,      ///< [in] prev osdmap
-    vector<int>& newup,     ///< [in] new up set
+    std::vector<int>& newup,     ///< [in] new up set
     int up_primary,         ///< [in] new up primary
-    vector<int>& newacting, ///< [in] new acting
+    std::vector<int>& newacting, ///< [in] new acting
     int acting_primary,     ///< [in] new acting primary
     PeeringCtx &rctx        ///< [out] recovery context
     );
@@ -1992,7 +1992,7 @@ public:
   }
 
   /// Get prior intervals' readable_until down OSDs of note
-  const set<int>& get_prior_readable_down_osds() const {
+  const std::set<int>& get_prior_readable_down_osds() const {
     return prior_readable_down_osds;
   }
 
@@ -2064,7 +2064,7 @@ public:
   bool is_deleted() const {
     return deleted;
   }
-  const set<pg_shard_t> &get_upset() const override {
+  const std::set<pg_shard_t> &get_upset() const override {
     return upset;
   }
   bool is_acting_recovery_backfill(pg_shard_t osd) const {
@@ -2076,7 +2076,7 @@ public:
   bool is_up(pg_shard_t osd) const {
     return has_shard(pool.info.is_erasure(), up, osd);
   }
-  static bool has_shard(bool ec, const vector<int>& v, pg_shard_t osd) {
+  static bool has_shard(bool ec, const std::vector<int>& v, pg_shard_t osd) {
     if (ec) {
       return v.size() > (unsigned)osd.shard && v[osd.shard] == osd.osd;
     } else {
@@ -2101,10 +2101,10 @@ public:
   int get_role() const {
     return role;
   }
-  const vector<int> &get_acting() const {
+  const std::vector<int> &get_acting() const {
     return acting;
   }
-  const set<pg_shard_t> &get_actingset() const {
+  const std::set<pg_shard_t> &get_actingset() const {
     return actingset;
   }
   int get_acting_primary() const {
@@ -2113,7 +2113,7 @@ public:
   pg_shard_t get_primary() const {
     return primary;
   }
-  const vector<int> &get_up() const {
+  const std::vector<int> &get_up() const {
     return up;
   }
   int get_up_primary() const {
@@ -2123,16 +2123,16 @@ public:
   bool is_backfill_target(pg_shard_t osd) const {
     return backfill_targets.count(osd);
   }
-  const set<pg_shard_t> &get_backfill_targets() const {
+  const std::set<pg_shard_t> &get_backfill_targets() const {
     return backfill_targets;
   }
   bool is_async_recovery_target(pg_shard_t peer) const {
     return async_recovery_targets.count(peer);
   }
-  const set<pg_shard_t> &get_async_recovery_targets() const {
+  const std::set<pg_shard_t> &get_async_recovery_targets() const {
     return async_recovery_targets;
   }
-  const set<pg_shard_t> &get_acting_recovery_backfill() const {
+  const std::set<pg_shard_t> &get_acting_recovery_backfill() const {
     return acting_recovery_backfill;
   }
 
@@ -2297,17 +2297,17 @@ public:
   }
 
   /// Dump representation of past_intervals to out
-  void print_past_intervals(ostream &out) const {
+  void print_past_intervals(std::ostream &out) const {
     out << "[" << past_intervals.get_bounds()
 	<< ")/" << past_intervals.size();
   }
 
-  void dump_history(Formatter *f) const {
+  void dump_history(ceph::Formatter *f) const {
     state_history.dump(f);
   }
 
   /// Dump formatted peering status
-  void dump_peering_state(Formatter *f);
+  void dump_peering_state(ceph::Formatter *f);
 
 private:
   /// Mask feature vector with feature set from new peer
@@ -2347,7 +2347,7 @@ public:
   /// Must be called once per start_flush
   void complete_flush();
 
-  friend ostream &operator<<(ostream &out, const PeeringState &ps);
+  friend std::ostream &operator<<(std::ostream &out, const PeeringState &ps);
 };
 
-ostream &operator<<(ostream &out, const PeeringState &ps);
+std::ostream &operator<<(std::ostream &out, const PeeringState &ps);

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -88,7 +88,7 @@ public:
 
     version_t user_version; ///< The copy source's user version
     bool should_requeue;  ///< op should be requeued on cancel
-    vector<snapid_t> snaps;  ///< src's snaps (if clone)
+    std::vector<snapid_t> snaps;  ///< src's snaps (if clone)
     snapid_t snap_seq;       ///< src's snap_seq (if head)
     librados::snap_set_t snapset; ///< src snapset (if head)
     bool mirror_snapset;
@@ -96,9 +96,9 @@ public:
     uint32_t flags;    // object_copy_data_t::FLAG_*
     uint32_t source_data_digest, source_omap_digest;
     uint32_t data_digest, omap_digest;
-    mempool::osd_pglog::vector<pair<osd_reqid_t, version_t> > reqids; // [(reqid, user_version)]
-    mempool::osd_pglog::map<uint32_t, int> reqid_return_codes; // map reqids by index to error code
-    map<string, bufferlist> attrs; // xattrs
+    mempool::osd_pglog::vector<std::pair<osd_reqid_t, version_t> > reqids; // [(reqid, user_version)]
+    mempool::osd_pglog::map<uint32_t, int> reqid_return_codes; // std::map reqids by index to error code
+    std::map<std::string, ceph::buffer::list> attrs; // xattrs
     uint64_t truncate_seq;
     uint64_t truncate_size;
     bool is_data_digest() {
@@ -136,10 +136,10 @@ public:
     ceph_tid_t objecter_tid2;
 
     object_copy_cursor_t cursor;
-    map<string,bufferlist> attrs;
-    bufferlist data;
-    bufferlist omap_header;
-    bufferlist omap_data;
+    std::map<std::string,ceph::buffer::list> attrs;
+    ceph::buffer::list data;
+    ceph::buffer::list omap_header;
+    ceph::buffer::list omap_data;
     int rval;
 
     object_copy_cursor_t temp_cursor;
@@ -154,12 +154,12 @@ public:
     unsigned src_obj_fadvise_flags;
     unsigned dest_obj_fadvise_flags;
 
-    map<uint64_t, CopyOpRef> chunk_cops;
+    std::map<uint64_t, CopyOpRef> chunk_cops;
     int num_chunk;
     bool failed;
     uint64_t start_offset = 0;
     uint64_t last_offset = 0;
-    vector<OSDOp> chunk_ops;
+    std::vector<OSDOp> chunk_ops;
   
     CopyOp(CopyCallback *cb_, ObjectContextRef _obc, hobject_t s,
 	   object_locator_t l,
@@ -194,20 +194,20 @@ public:
   typedef boost::tuple<int, CopyResults*> CopyCallbackResults;
 
   friend class CopyFromCallback;
-  friend class CopyFromFinisher;
+  friend struct CopyFromFinisher;
   friend class PromoteCallback;
-  friend class PromoteFinisher;
+  friend struct PromoteFinisher;
 
   struct ProxyReadOp {
     OpRequestRef op;
     hobject_t soid;
     ceph_tid_t objecter_tid;
-    vector<OSDOp> &ops;
+    std::vector<OSDOp> &ops;
     version_t user_version;
     int data_offset;
     bool canceled;              ///< true if canceled
 
-    ProxyReadOp(OpRequestRef _op, hobject_t oid, vector<OSDOp>& _ops)
+    ProxyReadOp(OpRequestRef _op, hobject_t oid, std::vector<OSDOp>& _ops)
       : op(_op), soid(oid),
         objecter_tid(0), ops(_ops),
 	user_version(0), data_offset(0),
@@ -220,14 +220,14 @@ public:
     OpRequestRef op;
     hobject_t soid;
     ceph_tid_t objecter_tid;
-    vector<OSDOp> &ops;
+    std::vector<OSDOp> &ops;
     version_t user_version;
     bool sent_reply;
     utime_t mtime;
     bool canceled;
     osd_reqid_t reqid;
 
-    ProxyWriteOp(OpRequestRef _op, hobject_t oid, vector<OSDOp>& _ops, osd_reqid_t _reqid)
+    ProxyWriteOp(OpRequestRef _op, hobject_t oid, std::vector<OSDOp>& _ops, osd_reqid_t _reqid)
       : ctx(NULL), op(_op), soid(oid),
         objecter_tid(0), ops(_ops),
 	user_version(0), sent_reply(false),
@@ -239,7 +239,7 @@ public:
   struct FlushOp {
     ObjectContextRef obc;       ///< obc we are flushing
     OpRequestRef op;            ///< initiating op
-    list<OpRequestRef> dup_ops; ///< bandwagon jumpers
+    std::list<OpRequestRef> dup_ops; ///< bandwagon jumpers
     version_t flushed_version;  ///< user version we are flushing
     ceph_tid_t objecter_tid;    ///< copy-from request tid
     int rval;                   ///< copy-from result
@@ -247,8 +247,8 @@ public:
     bool removal;               ///< we are removing the backend object
     std::optional<std::function<void()>> on_flush; ///< callback, may be null
     // for chunked object
-    map<uint64_t, int> io_results; 
-    map<uint64_t, ceph_tid_t> io_tids; 
+    std::map<uint64_t, int> io_results; 
+    std::map<uint64_t, ceph_tid_t> io_tids; 
     uint64_t chunks;
 
     FlushOp()
@@ -267,7 +267,7 @@ public:
       : cb(cb), objecter_tid(tid) {}
   };
   typedef std::shared_ptr<ManifestOp> ManifestOpRef;
-  map<hobject_t, ManifestOpRef> manifest_ops;
+  std::map<hobject_t, ManifestOpRef> manifest_ops;
 
   boost::scoped_ptr<PGBackend> pgbackend;
   PGBackend *get_pgbackend() override {
@@ -307,7 +307,7 @@ public:
     const object_stat_sum_t &stat_diff,
     bool is_delete) override;
   void on_failed_pull(
-    const set<pg_shard_t> &from,
+    const std::set<pg_shard_t> &from,
     const hobject_t &soid,
     const eversion_t &version) override;
   void cancel_pull(const hobject_t &soid) override;
@@ -338,7 +338,7 @@ public:
 			 OpRequestRef op) override {
     osd->store->queue_transaction(ch, std::move(t), op);
   }
-  void queue_transactions(vector<ObjectStore::Transaction>& tls,
+  void queue_transactions(std::vector<ObjectStore::Transaction>& tls,
 			  OpRequestRef op) override {
     osd->store->queue_transactions(ch, tls, op, NULL);
   }
@@ -348,13 +348,13 @@ public:
   epoch_t get_last_peering_reset_epoch() const override {
     return get_last_peering_reset();
   }
-  const set<pg_shard_t> &get_acting_recovery_backfill_shards() const override {
+  const std::set<pg_shard_t> &get_acting_recovery_backfill_shards() const override {
     return get_acting_recovery_backfill();
   }
-  const set<pg_shard_t> &get_acting_shards() const override {
+  const std::set<pg_shard_t> &get_acting_shards() const override {
     return recovery_state.get_actingset();
   }
-  const set<pg_shard_t> &get_backfill_shards() const override {
+  const std::set<pg_shard_t> &get_backfill_shards() const override {
     return get_backfill_targets();
   }
 
@@ -362,15 +362,15 @@ public:
     return gen_prefix(out);
   }
 
-  const map<hobject_t, set<pg_shard_t>>
+  const std::map<hobject_t, std::set<pg_shard_t>>
     &get_missing_loc_shards() const override {
     return recovery_state.get_missing_loc().get_missing_locs();
   }
-  const map<pg_shard_t, pg_missing_t> &get_shard_missing() const override {
+  const std::map<pg_shard_t, pg_missing_t> &get_shard_missing() const override {
     return recovery_state.get_peer_missing();
   }
   using PGBackend::Listener::get_shard_missing;
-  const map<pg_shard_t, pg_info_t> &get_shard_info() const override {
+  const std::map<pg_shard_t, pg_info_t> &get_shard_info() const override {
     return recovery_state.get_peer_info();
   }
   using PGBackend::Listener::get_shard_info;  
@@ -401,7 +401,7 @@ public:
 
   ObjectContextRef get_obc(
     const hobject_t &hoid,
-    const map<string, bufferlist> &attrs) override {
+    const std::map<std::string, ceph::buffer::list> &attrs) override {
     return get_object_context(hoid, true, &attrs);
   }
 
@@ -444,7 +444,7 @@ public:
 
   void pgb_set_object_snap_mapping(
     const hobject_t &soid,
-    const set<snapid_t> &snaps,
+    const std::set<snapid_t> &snaps,
     ObjectStore::Transaction *t) override {
     return update_object_snap_mapping(t, soid, snaps);
   }
@@ -455,7 +455,7 @@ public:
   }
 
   void log_operation(
-    vector<pg_log_entry_t>&& logv,
+    std::vector<pg_log_entry_t>&& logv,
     const std::optional<pg_hit_set_history_t> &hset_history,
     const eversion_t &trim_to,
     const eversion_t &roll_forward_to,
@@ -486,7 +486,7 @@ public:
   }
 
   void replica_clear_repop_obc(
-    const vector<pg_log_entry_t> &logv,
+    const std::vector<pg_log_entry_t> &logv,
     ObjectStore::Transaction &t);
 
   void op_applied(const eversion_t &applied_version) override;
@@ -575,7 +575,7 @@ public:
   };
   void complete_disconnect_watches(
     ObjectContextRef obc,
-    const list<watch_disconnect_t> &to_disconnect);
+    const std::list<watch_disconnect_t> &to_disconnect);
 
   struct OpFinisher {
     virtual ~OpFinisher() {
@@ -590,7 +590,7 @@ public:
   struct OpContext {
     OpRequestRef op;
     osd_reqid_t reqid;
-    vector<OSDOp> *ops;
+    std::vector<OSDOp> *ops;
 
     const ObjectState *obs; // Old objectstate
     const SnapSet *snapset; // Old snapset
@@ -604,26 +604,26 @@ public:
     bool user_modify;     // user-visible modification
     bool undirty;         // user explicitly un-dirtying this object
     bool cache_evict;     ///< true if this is a cache eviction
-    bool ignore_cache;    ///< true if IGNORE_CACHE flag is set
+    bool ignore_cache;    ///< true if IGNORE_CACHE flag is std::set
     bool ignore_log_op_stats;  // don't log op stats
     bool update_log_only; ///< this is a write that returned an error - just record in pg log for dup detection
     ObjectCleanRegions clean_regions;
 
     // side effects
-    list<pair<watch_info_t,bool> > watch_connects; ///< new watch + will_ping flag
-    list<watch_disconnect_t> watch_disconnects; ///< old watch + send_discon
-    list<notify_info_t> notifies;
+    std::list<std::pair<watch_info_t,bool> > watch_connects; ///< new watch + will_ping flag
+    std::list<watch_disconnect_t> watch_disconnects; ///< old watch + send_discon
+    std::list<notify_info_t> notifies;
     struct NotifyAck {
       std::optional<uint64_t> watch_cookie;
       uint64_t notify_id;
-      bufferlist reply_bl;
+      ceph::buffer::list reply_bl;
       explicit NotifyAck(uint64_t notify_id) : notify_id(notify_id) {}
-      NotifyAck(uint64_t notify_id, uint64_t cookie, bufferlist& rbl)
+      NotifyAck(uint64_t notify_id, uint64_t cookie, ceph::buffer::list& rbl)
 	: watch_cookie(cookie), notify_id(notify_id) {
 	reply_bl.claim(rbl);
       }
     };
-    list<NotifyAck> notify_acks;
+    std::list<NotifyAck> notify_acks;
 
     uint64_t bytes_written, bytes_read;
 
@@ -638,7 +638,7 @@ public:
     int processed_subop_count = 0;
 
     PGTransactionUPtr op_t;
-    vector<pg_log_entry_t> log;
+    std::vector<pg_log_entry_t> log;
     std::optional<pg_hit_set_history_t> updated_hset_history;
 
     interval_set<uint64_t> modified_ranges;
@@ -656,15 +656,15 @@ public:
     int num_read;    ///< count read ops
     int num_write;   ///< count update ops
 
-    mempool::osd_pglog::vector<pair<osd_reqid_t, version_t> > extra_reqids;
+    mempool::osd_pglog::vector<std::pair<osd_reqid_t, version_t> > extra_reqids;
     mempool::osd_pglog::map<uint32_t, int> extra_reqid_return_codes;
 
     hobject_t new_temp_oid, discard_temp_oid;  ///< temp objects we should start/stop tracking
 
-    list<std::function<void()>> on_applied;
-    list<std::function<void()>> on_committed;
-    list<std::function<void()>> on_finish;
-    list<std::function<void()>> on_success;
+    std::list<std::function<void()>> on_applied;
+    std::list<std::function<void()>> on_committed;
+    std::list<std::function<void()>> on_finish;
+    std::list<std::function<void()>> on_success;
     template <typename F>
     void register_on_finish(F &&f) {
       on_finish.emplace_back(std::forward<F>(f));
@@ -685,8 +685,8 @@ public:
     bool sent_reply = false;
 
     // pending async reads <off, len, op_flags> -> <outbl, outr>
-    list<pair<boost::tuple<uint64_t, uint64_t, unsigned>,
-	      pair<bufferlist*, Context*> > > pending_async_reads;
+    std::list<std::pair<boost::tuple<uint64_t, uint64_t, unsigned>,
+	      std::pair<ceph::buffer::list*, Context*> > > pending_async_reads;
     int inflightreads;
     friend struct OnReadComplete;
     void start_async_reads(PrimaryLogPG *pg);
@@ -703,7 +703,7 @@ public:
     OpContext(const OpContext& other);
     const OpContext& operator=(const OpContext& other);
 
-    OpContext(OpRequestRef _op, osd_reqid_t _reqid, vector<OSDOp>* _ops,
+    OpContext(OpRequestRef _op, osd_reqid_t _reqid, std::vector<OSDOp>* _ops,
 	      ObjectContextRef& obc,
 	      PrimaryLogPG *_pg) :
       op(_op), reqid(_reqid), ops(_ops),
@@ -727,7 +727,7 @@ public:
       }
     }
     OpContext(OpRequestRef _op, osd_reqid_t _reqid,
-              vector<OSDOp>* _ops, PrimaryLogPG *_pg) :
+              std::vector<OSDOp>* _ops, PrimaryLogPG *_pg) :
       op(_op), reqid(_reqid), ops(_ops), obs(NULL), snapset(0),
       modify(false), user_modify(false), undirty(false), cache_evict(false),
       ignore_cache(false), ignore_log_op_stats(false), update_log_only(false),
@@ -749,8 +749,8 @@ public:
       ceph_assert(!op_t);
       if (reply)
 	reply->put();
-      for (list<pair<boost::tuple<uint64_t, uint64_t, unsigned>,
-		     pair<bufferlist*, Context*> > >::iterator i =
+      for (std::list<std::pair<boost::tuple<uint64_t, uint64_t, unsigned>,
+		     std::pair<ceph::buffer::list*, Context*> > >::iterator i =
 	     pending_async_reads.begin();
 	   i != pending_async_reads.end();
 	   pending_async_reads.erase(i++)) {
@@ -791,9 +791,9 @@ public:
 
     ObcLockManager lock_manager;
 
-    list<std::function<void()>> on_committed;
-    list<std::function<void()>> on_success;
-    list<std::function<void()>> on_finish;
+    std::list<std::function<void()>> on_committed;
+    std::list<std::function<void()>> on_success;
+    std::list<std::function<void()>> on_finish;
     
     RepGather(
       OpContext *c, ceph_tid_t rt,
@@ -907,7 +907,7 @@ protected:
    */
   void release_object_locks(
     ObcLockManager &lock_manager) {
-    list<pair<ObjectContextRef, list<OpRequestRef> > > to_req;
+    std::list<std::pair<ObjectContextRef, std::list<OpRequestRef> > > to_req;
     bool requeue_recovery = false;
     bool requeue_snaptrim = false;
     lock_manager.put_locks(
@@ -985,10 +985,10 @@ protected:
     int r = 0);
   struct LogUpdateCtx {
     boost::intrusive_ptr<RepGather> repop;
-    set<pg_shard_t> waiting_on;
+    std::set<pg_shard_t> waiting_on;
   };
   void cancel_log_updates();
-  map<ceph_tid_t, LogUpdateCtx> log_entry_update_waiting_on;
+  std::map<ceph_tid_t, LogUpdateCtx> log_entry_update_waiting_on;
 
 
   // hot/cold tracking
@@ -1046,19 +1046,19 @@ protected:
 
   // projected object info
   SharedLRU<hobject_t, ObjectContext> object_contexts;
-  // map from oid.snapdir() to SnapSetContext *
-  map<hobject_t, SnapSetContext*> snapset_contexts;
+  // std::map from oid.snapdir() to SnapSetContext *
+  std::map<hobject_t, SnapSetContext*> snapset_contexts;
   ceph::mutex snapset_contexts_lock =
     ceph::make_mutex("PrimaryLogPG::snapset_contexts_lock");
 
   // debug order that client ops are applied
-  map<hobject_t, map<client_t, ceph_tid_t>> debug_op_order;
+  std::map<hobject_t, std::map<client_t, ceph_tid_t>> debug_op_order;
 
   void populate_obc_watchers(ObjectContextRef obc);
   void check_blacklisted_obc_watchers(ObjectContextRef obc);
   void check_blacklisted_watchers() override;
-  void get_watchers(list<obj_watch_item_t> *ls) override;
-  void get_obc_watchers(ObjectContextRef obc, list<obj_watch_item_t> &pg_watchers);
+  void get_watchers(std::list<obj_watch_item_t> *ls) override;
+  void get_obc_watchers(ObjectContextRef obc, std::list<obj_watch_item_t> &pg_watchers);
 public:
   void handle_watch_timeout(WatchRef watch);
 protected:
@@ -1067,7 +1067,7 @@ protected:
   ObjectContextRef get_object_context(
     const hobject_t& soid,
     bool can_create,
-    const map<string, bufferlist> *attrs = 0
+    const std::map<std::string, ceph::buffer::list> *attrs = 0
     );
 
   void context_registry_on_change();
@@ -1087,7 +1087,7 @@ protected:
   SnapSetContext *get_snapset_context(
     const hobject_t& oid,
     bool can_create,
-    const map<string, bufferlist> *attrs = 0,
+    const std::map<std::string, ceph::buffer::list> *attrs = 0,
     bool oid_existed = true //indicate this oid whether exsited in backend
     );
   void register_snapset_context(SnapSetContext *ssc) {
@@ -1104,7 +1104,7 @@ protected:
   }
   void put_snapset_context(SnapSetContext *ssc);
 
-  map<hobject_t, ObjectContextRef> recovering;
+  std::map<hobject_t, ObjectContextRef> recovering;
 
   /*
    * Backfill
@@ -1120,12 +1120,12 @@ protected:
    *   - are not included in pg stats (yet)
    *   - have their stats in pending_backfill_updates on the primary
    */
-  set<hobject_t> backfills_in_flight;
-  map<hobject_t, pg_stat_t> pending_backfill_updates;
+  std::set<hobject_t> backfills_in_flight;
+  std::map<hobject_t, pg_stat_t> pending_backfill_updates;
 
-  void dump_recovery_info(Formatter *f) const override {
+  void dump_recovery_info(ceph::Formatter *f) const override {
     f->open_array_section("waiting_on_backfill");
-    for (set<pg_shard_t>::const_iterator p = waiting_on_backfill.begin();
+    for (std::set<pg_shard_t>::const_iterator p = waiting_on_backfill.begin();
         p != waiting_on_backfill.end(); ++p)
       f->dump_stream("osd") << *p;
     f->close_section();
@@ -1137,7 +1137,7 @@ protected:
     }
     {
       f->open_array_section("peer_backfill_info");
-      for (map<pg_shard_t, BackfillInterval>::const_iterator pbi =
+      for (std::map<pg_shard_t, BackfillInterval>::const_iterator pbi =
 	     peer_backfill_info.begin();
           pbi != peer_backfill_info.end(); ++pbi) {
         f->dump_stream("osd") << pbi->first;
@@ -1149,7 +1149,7 @@ protected:
     }
     {
       f->open_array_section("backfills_in_flight");
-      for (set<hobject_t>::const_iterator i = backfills_in_flight.begin();
+      for (std::set<hobject_t>::const_iterator i = backfills_in_flight.begin();
 	   i != backfills_in_flight.end();
 	   ++i) {
 	f->dump_stream("object") << *i;
@@ -1158,7 +1158,7 @@ protected:
     }
     {
       f->open_array_section("recovering");
-      for (map<hobject_t, ObjectContextRef>::const_iterator i = recovering.begin();
+      for (std::map<hobject_t, ObjectContextRef>::const_iterator i = recovering.begin();
 	   i != recovering.end();
 	   ++i) {
 	f->dump_stream("object") << i->first;
@@ -1281,7 +1281,7 @@ protected:
   void do_cache_redirect(OpRequestRef op);
   /**
    * This function attempts to start a promote.  Either it succeeds,
-   * or places op on a wait list.  If op is null, failure means that
+   * or places op on a wait std::list.  If op is null, failure means that
    * this is a noop.  If a future user wants to be able to distinguish
    * these cases, a return value should be added.
    */
@@ -1294,7 +1294,7 @@ protected:
     );
 
   int prepare_transaction(OpContext *ctx);
-  list<pair<OpRequestRef, OpContext*> > in_progress_async_reads;
+  std::list<std::pair<OpRequestRef, OpContext*> > in_progress_async_reads;
   void complete_read_ctx(int result, OpContext *ctx);
   
   // pg on-disk content
@@ -1312,7 +1312,7 @@ protected:
   hobject_t earliest_peer_backfill() const;
   bool all_peer_done() const;
   /**
-   * @param work_started will be set to true if recover_backfill got anywhere
+   * @param work_started will be std::set to true if recover_backfill got anywhere
    * @returns the number of operations started
    */
   uint64_t recover_backfill(uint64_t max, ThreadPool::TPHandle &handle,
@@ -1324,7 +1324,7 @@ protected:
    * @min return at least this many items, unless we are done
    * @max return no more than this many items
    * @bi.begin first item should be >= this value
-   * @bi [out] resulting map of objects to eversion_t's
+   * @bi [out] resulting std::map of objects to eversion_t's
    */
   void scan_range(
     int min, int max, BackfillInterval *bi,
@@ -1339,7 +1339,7 @@ protected:
 
   int prep_backfill_object_push(
     hobject_t oid, eversion_t v, ObjectContextRef obc,
-    vector<pg_shard_t> peers,
+    std::vector<pg_shard_t> peers,
     PGBackend::RecoveryHandle *h);
   void send_remove_op(const hobject_t& oid, eversion_t v, pg_shard_t peer);
 
@@ -1354,9 +1354,9 @@ protected:
   void recover_got(hobject_t oid, eversion_t v);
 
   // -- copyfrom --
-  map<hobject_t, CopyOpRef> copy_ops;
+  std::map<hobject_t, CopyOpRef> copy_ops;
 
-  int do_copy_get(OpContext *ctx, bufferlist::const_iterator& bp, OSDOp& op,
+  int do_copy_get(OpContext *ctx, ceph::buffer::list::const_iterator& bp, OSDOp& op,
 		  ObjectContextRef& obc);
   int finish_copy_get();
 
@@ -1391,13 +1391,13 @@ protected:
   void _copy_some(ObjectContextRef obc, CopyOpRef cop);
   void finish_copyfrom(CopyFromCallback *cb);
   void finish_promote(int r, CopyResults *results, ObjectContextRef obc);
-  void cancel_copy(CopyOpRef cop, bool requeue, vector<ceph_tid_t> *tids);
-  void cancel_copy_ops(bool requeue, vector<ceph_tid_t> *tids);
+  void cancel_copy(CopyOpRef cop, bool requeue, std::vector<ceph_tid_t> *tids);
+  void cancel_copy_ops(bool requeue, std::vector<ceph_tid_t> *tids);
 
   friend struct C_Copyfrom;
 
   // -- flush --
-  map<hobject_t, FlushOpRef> flush_ops;
+  std::map<hobject_t, FlushOpRef> flush_ops;
 
   /// start_flush takes ownership of on_flush iff ret == -EINPROGRESS
   int start_flush(
@@ -1406,8 +1406,8 @@ protected:
     std::optional<std::function<void()>> &&on_flush);
   void finish_flush(hobject_t oid, ceph_tid_t tid, int r);
   int try_flush_mark_clean(FlushOpRef fop);
-  void cancel_flush(FlushOpRef fop, bool requeue, vector<ceph_tid_t> *tids);
-  void cancel_flush_ops(bool requeue, vector<ceph_tid_t> *tids);
+  void cancel_flush(FlushOpRef fop, bool requeue, std::vector<ceph_tid_t> *tids);
+  void cancel_flush_ops(bool requeue, std::vector<ceph_tid_t> *tids);
 
   /// @return false if clone is has been evicted
   bool is_present_clone(hobject_t coid);
@@ -1420,7 +1420,7 @@ protected:
   void scrub_snapshot_metadata(
     ScrubMap &map,
     const std::map<hobject_t,
-                   pair<std::optional<uint32_t>,
+                   std::pair<std::optional<uint32_t>,
                         std::optional<uint32_t>>> &missing_digest) override;
   void _scrub_clear_state() override;
   void _scrub_finish() override;
@@ -1430,21 +1430,21 @@ protected:
                    unsigned split_bits) override;
   void apply_and_flush_repops(bool requeue);
 
-  int do_xattr_cmp_u64(int op, __u64 v1, bufferlist& xattr);
-  int do_xattr_cmp_str(int op, string& v1s, bufferlist& xattr);
+  int do_xattr_cmp_u64(int op, __u64 v1, ceph::buffer::list& xattr);
+  int do_xattr_cmp_str(int op, std::string& v1s, ceph::buffer::list& xattr);
 
   // -- checksum --
-  int do_checksum(OpContext *ctx, OSDOp& osd_op, bufferlist::const_iterator *bl_it);
+  int do_checksum(OpContext *ctx, OSDOp& osd_op, ceph::buffer::list::const_iterator *bl_it);
   int finish_checksum(OSDOp& osd_op, Checksummer::CSumType csum_type,
-                      bufferlist::const_iterator *init_value_bl_it,
-                      const bufferlist &read_bl);
+                      ceph::buffer::list::const_iterator *init_value_bl_it,
+                      const ceph::buffer::list &read_bl);
 
-  friend class C_ChecksumRead;
+  friend struct C_ChecksumRead;
 
   int do_extent_cmp(OpContext *ctx, OSDOp& osd_op);
-  int finish_extent_cmp(OSDOp& osd_op, const bufferlist &read_bl);
+  int finish_extent_cmp(OSDOp& osd_op, const ceph::buffer::list &read_bl);
 
-  friend class C_ExtentCmpRead;
+  friend struct C_ExtentCmpRead;
 
   int do_read(OpContext *ctx, OSDOp& osd_op);
   int do_sparse_read(OpContext *ctx, OSDOp& osd_op);
@@ -1453,27 +1453,27 @@ protected:
   bool pgls_filter(const PGLSFilter& filter, const hobject_t& sobj);
 
   std::pair<int, std::unique_ptr<const PGLSFilter>> get_pgls_filter(
-    bufferlist::const_iterator& iter);
+    ceph::buffer::list::const_iterator& iter);
 
-  map<hobject_t, list<OpRequestRef>> in_progress_proxy_ops;
+  std::map<hobject_t, std::list<OpRequestRef>> in_progress_proxy_ops;
   void kick_proxy_ops_blocked(hobject_t& soid);
-  void cancel_proxy_ops(bool requeue, vector<ceph_tid_t> *tids);
+  void cancel_proxy_ops(bool requeue, std::vector<ceph_tid_t> *tids);
 
   // -- proxyread --
-  map<ceph_tid_t, ProxyReadOpRef> proxyread_ops;
+  std::map<ceph_tid_t, ProxyReadOpRef> proxyread_ops;
 
   void do_proxy_read(OpRequestRef op, ObjectContextRef obc = NULL);
   void finish_proxy_read(hobject_t oid, ceph_tid_t tid, int r);
-  void cancel_proxy_read(ProxyReadOpRef prdop, vector<ceph_tid_t> *tids);
+  void cancel_proxy_read(ProxyReadOpRef prdop, std::vector<ceph_tid_t> *tids);
 
   friend struct C_ProxyRead;
 
   // -- proxywrite --
-  map<ceph_tid_t, ProxyWriteOpRef> proxywrite_ops;
+  std::map<ceph_tid_t, ProxyWriteOpRef> proxywrite_ops;
 
   void do_proxy_write(OpRequestRef op, ObjectContextRef obc = NULL);
   void finish_proxy_write(hobject_t oid, ceph_tid_t tid, int r);
-  void cancel_proxy_write(ProxyWriteOpRef pwop, vector<ceph_tid_t> *tids);
+  void cancel_proxy_write(ProxyWriteOpRef pwop, std::vector<ceph_tid_t> *tids);
 
   friend struct C_ProxyWrite_Commit;
 
@@ -1496,31 +1496,31 @@ protected:
 			     uint64_t last_offset);
   void handle_manifest_flush(hobject_t oid, ceph_tid_t tid, int r,
 			     uint64_t offset, uint64_t last_offset, epoch_t lpr);
-  void cancel_manifest_ops(bool requeue, vector<ceph_tid_t> *tids);
+  void cancel_manifest_ops(bool requeue, std::vector<ceph_tid_t> *tids);
   void refcount_manifest(ObjectContextRef obc, object_locator_t oloc, hobject_t soid,
                          SnapContext snapc, bool get, RefCountCallback *cb, uint64_t offset);
 
   friend struct C_ProxyChunkRead;
   friend class PromoteManifestCallback;
-  friend class C_CopyChunk;
+  friend struct C_CopyChunk;
   friend struct C_ManifestFlush;
   friend struct RefCountCallback;
 
 public:
   PrimaryLogPG(OSDService *o, OSDMapRef curmap,
 	       const PGPool &_pool,
-	       const map<string,string>& ec_profile,
+	       const std::map<std::string,std::string>& ec_profile,
 	       spg_t p);
   ~PrimaryLogPG() override {}
 
   void do_command(
-    const string_view& prefix,
+    const std::string_view& prefix,
     const cmdmap_t& cmdmap,
-    const bufferlist& idata,
-    std::function<void(int,const std::string&,bufferlist&)> on_finish) override;
+    const ceph::buffer::list& idata,
+    std::function<void(int,const std::string&,ceph::buffer::list&)> on_finish) override;
 
-  void clear_cache();
-  int get_cache_obj_count() {
+  void clear_cache() override;
+  int get_cache_obj_count() override {
     return object_contexts.get_count();
   }
   unsigned get_pg_shard() const {
@@ -1547,12 +1547,12 @@ public:
   void snap_trimmer(epoch_t e) override;
   void kick_snap_trim() override;
   void snap_trimmer_scrub_complete() override;
-  int do_osd_ops(OpContext *ctx, vector<OSDOp>& ops);
+  int do_osd_ops(OpContext *ctx, std::vector<OSDOp>& ops);
 
-  int _get_tmap(OpContext *ctx, bufferlist *header, bufferlist *vals);
+  int _get_tmap(OpContext *ctx, ceph::buffer::list *header, ceph::buffer::list *vals);
   int do_tmap2omap(OpContext *ctx, unsigned flags);
-  int do_tmapup(OpContext *ctx, bufferlist::const_iterator& bp, OSDOp& osd_op);
-  int do_tmapup_slow(OpContext *ctx, bufferlist::const_iterator& bp, OSDOp& osd_op, bufferlist& bl);
+  int do_tmapup(OpContext *ctx, ceph::buffer::list::const_iterator& bp, OSDOp& osd_op);
+  int do_tmapup_slow(OpContext *ctx, ceph::buffer::list::const_iterator& bp, OSDOp& osd_op, ceph::buffer::list& bl);
 
   void do_osd_op_effects(OpContext *ctx, const ConnectionRef& conn);
 private:
@@ -1585,7 +1585,7 @@ private:
     const char *mode,
     bool allow_incomplete_clones,
     std::optional<snapid_t> target,
-    vector<snapid_t>::reverse_iterator *curclone,
+    std::vector<snapid_t>::reverse_iterator *curclone,
     inconsistent_snapset_wrapper &snap_error);
 
 public:
@@ -1660,7 +1660,7 @@ private:
       boost::statechart::transition< Reset, NotTrimming >
       > reactions;
 
-    set<hobject_t> in_flight;
+    std::set<hobject_t> in_flight;
     snapid_t snap_to_trim;
 
     explicit Trimming(my_context ctx)
@@ -1901,13 +1901,13 @@ public:
   bool is_backfill_target(pg_shard_t osd) const {
     return recovery_state.is_backfill_target(osd);
   }
-  const set<pg_shard_t> &get_backfill_targets() const {
+  const std::set<pg_shard_t> &get_backfill_targets() const {
     return recovery_state.get_backfill_targets();
   }
   bool is_async_recovery_target(pg_shard_t peer) const {
     return recovery_state.is_async_recovery_target(peer);
   }
-  const set<pg_shard_t> &get_async_recovery_targets() const {
+  const std::set<pg_shard_t> &get_async_recovery_targets() const {
     return recovery_state.get_async_recovery_targets();
   }
   bool is_degraded_or_backfilling_object(const hobject_t& oid);
@@ -1930,7 +1930,7 @@ public:
 
   void mark_all_unfound_lost(
     int what,
-    std::function<void(int,const std::string&,bufferlist&)> on_finish);
+    std::function<void(int,const std::string&,ceph::buffer::list&)> on_finish);
   eversion_t pick_newest_available(const hobject_t& oid);
 
   void do_update_log_missing(
@@ -1957,23 +1957,23 @@ public:
   void setattr_maybe_cache(
     ObjectContextRef obc,
     PGTransaction *t,
-    const string &key,
-    bufferlist &val);
+    const std::string &key,
+    ceph::buffer::list &val);
   void setattrs_maybe_cache(
     ObjectContextRef obc,
     PGTransaction *t,
-    map<string, bufferlist> &attrs);
+    std::map<std::string, ceph::buffer::list> &attrs);
   void rmattr_maybe_cache(
     ObjectContextRef obc,
     PGTransaction *t,
-    const string &key);
+    const std::string &key);
   int getattr_maybe_cache(
     ObjectContextRef obc,
-    const string &key,
-    bufferlist *val);
+    const std::string &key,
+    ceph::buffer::list *val);
   int getattrs_maybe_cache(
     ObjectContextRef obc,
-    map<string, bufferlist> *out);
+    std::map<std::string, ceph::buffer::list> *out);
 
 public:
   void set_dynamic_perf_stats_queries(

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -33,6 +33,21 @@ static ostream& _prefix(std::ostream *_dout, ReplicatedBackend *pgb) {
   return pgb->get_parent()->gen_dbg_prefix(*_dout);
 }
 
+using std::list;
+using std::make_pair;
+using std::map;
+using std::ostringstream;
+using std::set;
+using std::pair;
+using std::string;
+using std::unique_ptr;
+using std::vector;
+
+using ceph::bufferhash;
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+
 namespace {
 class PG_SendMessageOnConn: public Context {
   PGBackend::Listener *pg;
@@ -1360,8 +1375,8 @@ void ReplicatedBackend::prepare_pull(
     // probably because user feed a wrong pullee
     p = q->second.begin();
     std::advance(p,
-                 util::generate_random_number<int>(0,
-                                                   q->second.size() - 1));
+                 ceph::util::generate_random_number<int>(0,
+							 q->second.size() - 1));
   }
   ceph_assert(get_osdmap()->is_up(p->osd));
   pg_shard_t fromshard = *p;

--- a/src/osd/ScrubStore.cc
+++ b/src/osd/ScrubStore.cc
@@ -6,6 +6,12 @@
 #include "common/scrub_types.h"
 #include "include/rados/rados_types.hpp"
 
+using std::ostringstream;
+using std::string;
+using std::vector;
+
+using ceph::bufferlist;
+
 namespace {
 ghobject_t make_scrub_object(const spg_t& pgid)
 {

--- a/src/osd/ScrubStore.h
+++ b/src/osd/ScrubStore.h
@@ -28,18 +28,18 @@ public:
   bool empty() const;
   void flush(ObjectStore::Transaction *);
   void cleanup(ObjectStore::Transaction *);
-  std::vector<bufferlist> get_snap_errors(ObjectStore* store,
+  std::vector<ceph::buffer::list> get_snap_errors(ObjectStore* store,
 					  int64_t pool,
 					  const librados::object_id_t& start,
 					  uint64_t max_return);
-  std::vector<bufferlist> get_object_errors(ObjectStore* store,
+  std::vector<ceph::buffer::list> get_object_errors(ObjectStore* store,
 					    int64_t pool,
 					    const librados::object_id_t& start,
 					    uint64_t max_return);
 private:
   Store(const coll_t& coll, const ghobject_t& oid, ObjectStore* store);
-  std::vector<bufferlist> get_errors(ObjectStore* store,
-				     const string& start, const string& end,
+  std::vector<ceph::buffer::list> get_errors(ObjectStore* store,
+				     const std::string& start, const std::string& end,
 				     uint64_t max_return);
 private:
   const coll_t coll;
@@ -47,8 +47,8 @@ private:
   // a temp object holding mappings from seq-id to inconsistencies found in
   // scrubbing
   OSDriver driver;
-  MapCacher::MapCacher<std::string, bufferlist> backend;
-  map<string, bufferlist> results;
+  MapCacher::MapCacher<std::string, ceph::buffer::list> backend;
+  std::map<std::string, ceph::buffer::list> results;
 };
 }
 

--- a/src/osd/Session.cc
+++ b/src/osd/Session.cc
@@ -9,6 +9,9 @@
 #define dout_context cct
 #define dout_subsys ceph_subsys_osd
 
+using std::map;
+using std::set;
+
 void Session::clear_backoffs()
 {
   map<spg_t,map<hobject_t,set<ceph::ref_t<Backoff>>>> ls;

--- a/src/osd/Session.h
+++ b/src/osd/Session.h
@@ -99,7 +99,7 @@ struct Backoff : public RefCountedObject {
   //   - both null (teardown), or
   //   - only session is set (and state == DELETING)
   PGRef pg;             ///< owning pg
-  ceph::ref_t<class Session> session;   ///< owning session
+  ceph::ref_t<struct Session> session;   ///< owning session
   hobject_t begin, end; ///< [) range to block, unless ==, then single obj
 
   friend ostream& operator<<(ostream& out, const Backoff& b) {
@@ -143,7 +143,7 @@ struct Session : public RefCountedObject {
   /// protects backoffs; orders inside Backoff::lock *and* PG::backoff_lock
   ceph::mutex backoff_lock = ceph::make_mutex("Session::backoff_lock");
   std::atomic<int> backoff_count= {0};  ///< simple count of backoffs
-  map<spg_t,map<hobject_t,set<ceph::ref_t<Backoff>>>> backoffs;
+  std::map<spg_t, std::map<hobject_t, std::set<ceph::ref_t<Backoff>>>> backoffs;
 
   std::atomic<uint64_t> backoff_seq = {0};
 

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -19,7 +19,17 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "snap_mapper."
 
+using std::make_pair;
+using std::map;
+using std::pair;
+using std::set;
 using std::string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::timespan_str;
 
 const string SnapMapper::LEGACY_MAPPING_PREFIX = "MAP_";
 const string SnapMapper::MAPPING_PREFIX = "SNA_";

--- a/src/osd/TierAgentState.h
+++ b/src/osd/TierAgentState.h
@@ -14,6 +14,17 @@
 #ifndef CEPH_OSD_TIERAGENT_H
 #define CEPH_OSD_TIERAGENT_H
 
+#include <ctime>
+#include <list>
+#include <map>
+#include <utility>
+
+#include "common/Formatter.h"
+#include "common/histogram.h"
+#include "common/hobject.h"
+
+#include "osd/HitSet.h"
+
 struct TierAgentState {
   /// current position iterating across pool
   hobject_t position;
@@ -27,10 +38,10 @@ struct TierAgentState {
   int hist_age;
 
   /// past HitSet(s) (not current)
-  map<time_t,HitSetRef> hit_set_map;
+  std::map<time_t,HitSetRef> hit_set_map;
 
   /// a few recent things we've seen that are clean
-  list<hobject_t> recent_clean;
+  std::list<hobject_t> recent_clean;
 
   enum flush_mode_t {
     FLUSH_MODE_IDLE,   // nothing to flush
@@ -89,7 +100,7 @@ struct TierAgentState {
 
   /// add archived HitSet
   void add_hit_set(time_t start, HitSetRef hs) {
-    hit_set_map.insert(make_pair(start, hs));
+    hit_set_map.insert(std::make_pair(start, hs));
   }
 
   /// remove old/trimmed HitSet
@@ -103,7 +114,7 @@ struct TierAgentState {
     hit_set_map.clear();
   }
 
-  void dump(Formatter *f) const {
+  void dump(ceph::Formatter *f) const {
     f->dump_string("flush_mode", get_flush_mode_name());
     f->dump_string("evict_mode", get_evict_mode_name());
     f->dump_unsigned("evict_effort", evict_effort);

--- a/src/osd/objclass.cc
+++ b/src/osd/objclass.cc
@@ -17,10 +17,19 @@
 
 #define dout_context ClassHandler::get_instance().cct
 
+using std::map;
+using std::set;
+using std::string;
+using std::vector;
+
+using ceph::bufferlist;
+using ceph::decode;
+using ceph::encode;
+using ceph::real_time;
+
 
 int cls_call(cls_method_context_t hctx, const char *cls, const char *method,
-                                 char *indata, int datalen,
-                                 char **outdata, int *outdatalen)
+	     char *indata, int datalen, char **outdata, int *outdatalen)
 {
   PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   bufferlist idata;
@@ -49,7 +58,7 @@ int cls_call(cls_method_context_t hctx, const char *cls, const char *method,
 }
 
 int cls_getxattr(cls_method_context_t hctx, const char *name,
-                                 char **outdata, int *outdatalen)
+		 char **outdata, int *outdatalen)
 {
   PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> nops(1);
@@ -73,7 +82,7 @@ int cls_getxattr(cls_method_context_t hctx, const char *name,
 }
 
 int cls_setxattr(cls_method_context_t hctx, const char *name,
-                                 const char *value, int val_len)
+		 const char *value, int val_len)
 {
   PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> nops(1);
@@ -91,7 +100,7 @@ int cls_setxattr(cls_method_context_t hctx, const char *name,
 }
 
 int cls_read(cls_method_context_t hctx, int ofs, int len,
-                                 char **outdata, int *outdatalen)
+	     char **outdata, int *outdatalen)
 {
   PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
@@ -150,7 +159,7 @@ int cls_cxx_stat(cls_method_context_t hctx, uint64_t *size, time_t *mtime)
   try {
     decode(s, iter);
     decode(ut, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
   if (size)
@@ -175,7 +184,7 @@ int cls_cxx_stat2(cls_method_context_t hctx, uint64_t *size, ceph::real_time *mt
   try {
     decode(s, iter);
     decode(ut, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
   if (size)
@@ -294,7 +303,7 @@ int cls_cxx_getxattrs(cls_method_context_t hctx, map<string, bufferlist> *attrse
   auto iter = op.outdata.cbegin();
   try {
     decode(*attrset, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
   return 0;
@@ -353,7 +362,7 @@ int cls_cxx_map_get_all_vals(cls_method_context_t hctx, map<string, bufferlist>*
   try {
     decode(*vals, iter);
     decode(*more, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
   return vals->size();
@@ -381,7 +390,7 @@ int cls_cxx_map_get_keys(cls_method_context_t hctx, const string &start_obj,
   try {
     decode(*keys, iter);
     decode(*more, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
   return keys->size();
@@ -410,7 +419,7 @@ int cls_cxx_map_get_vals(cls_method_context_t hctx, const string &start_obj,
   try {
     decode(*vals, iter);
     decode(*more, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
   return vals->size();
@@ -459,7 +468,7 @@ int cls_cxx_map_get_val(cls_method_context_t hctx, const string &key,
       return -ENOENT;
 
     *outbl = iter->second;
-  } catch (buffer::error& e) {
+  } catch (ceph::buffer::error& e) {
     return -EIO;
   }
   return 0;
@@ -567,7 +576,7 @@ int cls_cxx_list_watchers(cls_method_context_t hctx,
   auto iter = op.outdata.cbegin();
   try {
     decode(*watchers, iter);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     return -EIO;
   }
   return 0;
@@ -623,8 +632,8 @@ int cls_get_snapset_seq(cls_method_context_t hctx, uint64_t *snap_seq) {
 }
 
 int cls_cxx_chunk_write_and_set(cls_method_context_t hctx, int ofs, int len,
-                   bufferlist *write_inbl, uint32_t op_flags, bufferlist *set_inbl,
-		   int set_len)
+				bufferlist *write_inbl, uint32_t op_flags,
+				bufferlist *set_inbl, int set_len)
 {
   PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   char cname[] = "cas";

--- a/src/osd/object_state.h
+++ b/src/osd/object_state.h
@@ -181,7 +181,7 @@ struct RWState {
   }
 };
 
-inline ostream& operator<<(ostream& out, const RWState& rw)
+inline std::ostream& operator<<(std::ostream& out, const RWState& rw)
 {
   return out << "rwstate(" << rw.get_state_name()
 	     << " n=" << rw.count

--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -40,7 +40,7 @@ class OpSchedulerItem {
 public:
   class OrderLocker {
   public:
-    using Ref = unique_ptr<OrderLocker>;
+    using Ref = std::unique_ptr<OrderLocker>;
     virtual void lock() = 0;
     virtual void unlock() = 0;
     virtual ~OrderLocker() {}
@@ -85,13 +85,13 @@ public:
       return nullptr;
     }
 
-    virtual ostream &print(ostream &rhs) const = 0;
+    virtual std::ostream &print(std::ostream &rhs) const = 0;
 
     virtual void run(OSD *osd, OSDShard *sdata, PGRef& pg, ThreadPool::TPHandle &handle) = 0;
     virtual op_scheduler_class get_scheduler_class() const = 0;
 
     virtual ~OpQueueable() {}
-    friend ostream& operator<<(ostream& out, const OpQueueable& q) {
+    friend std::ostream& operator<<(std::ostream& out, const OpQueueable& q) {
       return q.print(out);
     }
 
@@ -169,7 +169,7 @@ public:
     return qitem->get_scheduler_class();
   }
 
-  friend ostream& operator<<(ostream& out, const OpSchedulerItem& item) {
+  friend std::ostream& operator<<(std::ostream& out, const OpSchedulerItem& item) {
      out << "OpSchedulerItem("
 	 << item.get_ordering_token() << " " << *item.qitem
 	 << " prio " << item.get_priority()
@@ -235,7 +235,7 @@ public:
     return op_type_t::client_op;
   }
 
-  ostream &print(ostream &rhs) const final {
+  std::ostream &print(std::ostream &rhs) const final {
     return rhs << "PGOpItem(op=" << *(op->get_req()) << ")";
   }
 
@@ -263,7 +263,7 @@ public:
   op_type_t get_op_type() const final {
     return op_type_t::peering_event;
   }
-  ostream &print(ostream &rhs) const final {
+  std::ostream &print(std::ostream &rhs) const final {
     return rhs << "PGPeeringEvent(" << evt->get_desc() << ")";
   }
   void run(OSD *osd, OSDShard *sdata, PGRef& pg, ThreadPool::TPHandle &handle) final;
@@ -291,7 +291,7 @@ public:
   op_type_t get_op_type() const final {
     return op_type_t::bg_snaptrim;
   }
-  ostream &print(ostream &rhs) const final {
+  std::ostream &print(std::ostream &rhs) const final {
     return rhs << "PGSnapTrim(pgid=" << get_pgid()
 	       << "epoch_queued=" << epoch_queued
 	       << ")";
@@ -313,7 +313,7 @@ public:
   op_type_t get_op_type() const final {
     return op_type_t::bg_scrub;
   }
-  ostream &print(ostream &rhs) const final {
+  std::ostream &print(std::ostream &rhs) const final {
     return rhs << "PGScrub(pgid=" << get_pgid()
 	       << "epoch_queued=" << epoch_queued
 	       << ")";
@@ -339,7 +339,7 @@ public:
   op_type_t get_op_type() const final {
     return op_type_t::bg_recovery;
   }
-  ostream &print(ostream &rhs) const final {
+  std::ostream &print(std::ostream &rhs) const final {
     return rhs << "PGRecovery(pgid=" << get_pgid()
 	       << "epoch_queued=" << epoch_queued
 	       << "reserved_pushes=" << reserved_pushes
@@ -356,7 +356,7 @@ public:
 };
 
 class PGRecoveryContext : public PGOpQueueable {
-  unique_ptr<GenContext<ThreadPool::TPHandle&>> c;
+  std::unique_ptr<GenContext<ThreadPool::TPHandle&>> c;
   epoch_t epoch;
 public:
   PGRecoveryContext(spg_t pgid,
@@ -366,7 +366,7 @@ public:
   op_type_t get_op_type() const final {
     return op_type_t::bg_recovery;
   }
-  ostream &print(ostream &rhs) const final {
+  std::ostream &print(std::ostream &rhs) const final {
     return rhs << "PGRecoveryContext(pgid=" << get_pgid()
 	       << " c=" << c.get() << " epoch=" << epoch
 	       << ")";
@@ -389,7 +389,7 @@ public:
   op_type_t get_op_type() const final {
     return op_type_t::bg_pg_delete;
   }
-  ostream &print(ostream &rhs) const final {
+  std::ostream &print(std::ostream &rhs) const final {
     return rhs << "PGDelete(" << get_pgid()
 	       << " e" << epoch_queued
 	       << ")";

--- a/src/perfglue/cpu_profiler.cc
+++ b/src/perfglue/cpu_profiler.cc
@@ -20,7 +20,7 @@
 #include "perfglue/cpu_profiler.h"
 
 void cpu_profiler_handle_command(const std::vector<std::string> &cmd,
-				 ostream& out)
+				 std::ostream& out)
 {
   if (cmd[1] == "status") {
     ProfilerState st;

--- a/src/perfglue/cpu_profiler.h
+++ b/src/perfglue/cpu_profiler.h
@@ -20,6 +20,6 @@
 #include <vector>
 
 void cpu_profiler_handle_command(const std::vector<std::string> &cmd,
-				 ostream& out);
+				 std::ostream& out);
 
 #endif

--- a/src/perfglue/disabled_stubs.cc
+++ b/src/perfglue/disabled_stubs.cc
@@ -19,7 +19,7 @@
 #include <string>
 
 void cpu_profiler_handle_command(const std::vector<std::string> &cmd,
-				 ostream& out)
+				 std::ostream& out)
 {
   out << "cpu_profiler support not linked in";
 }

--- a/src/perfglue/heap_profiler.cc
+++ b/src/perfglue/heap_profiler.cc
@@ -141,7 +141,7 @@ void ceph_heap_profiler_dump(const char *reason)
 #define HEAP_PROFILER_STATS_SIZE 2048
 
 void ceph_heap_profiler_handle_command(const std::vector<std::string>& cmd,
-                                       ostream& out)
+                                       std::ostream& out)
 {
 #ifdef HAVE_LIBTCMALLOC
   if (cmd.size() == 1 && cmd[0] == "dump") {

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -28,13 +28,13 @@ struct rgw_user {
       id(std::move(id)) {
   }
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(tenant, bl);
     encode(id, bl);
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(tenant, bl);
     decode(id, bl);
@@ -58,8 +58,8 @@ struct rgw_user {
     return id.empty();
   }
 
-  string to_str() const {
-    string s;
+  std::string to_str() const {
+    std::string s;
     to_str(s);
     return s;
   }
@@ -75,7 +75,7 @@ struct rgw_user {
     }
   }
 
-  rgw_user& operator=(const string& str) {
+  rgw_user& operator=(const std::string& str) {
     from_str(str);
     return *this;
   }
@@ -87,7 +87,7 @@ struct rgw_user {
 
     return id.compare(u.id);
   }
-  int compare(const string& str) const {
+  int compare(const std::string& str) const {
     rgw_user u(str);
     return compare(u);
   }
@@ -106,8 +106,8 @@ struct rgw_user {
     }
     return (id < rhs.id);
   }
-  void dump(Formatter *f) const;
-  static void generate_test_instances(list<rgw_user*>& o);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_user*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_user)
 
@@ -118,15 +118,15 @@ struct rgw_pool {
   rgw_pool() = default;
   rgw_pool(const rgw_pool& _p) : name(_p.name), ns(_p.ns) {}
   rgw_pool(rgw_pool&&) = default;
-  rgw_pool(const string& _s) {
+  rgw_pool(const std::string& _s) {
     from_str(_s);
   }
-  rgw_pool(const string& _name, const string& _ns) : name(_name), ns(_ns) {}
+  rgw_pool(const std::string& _name, const std::string& _ns) : name(_name), ns(_ns) {}
 
-  string to_str() const;
-  void from_str(const string& s);
+  std::string to_str() const;
+  void from_str(const std::string& s);
 
-  void init(const string& _s) {
+  void init(const std::string& _s) {
     from_str(_s);
   }
 
@@ -142,16 +142,16 @@ struct rgw_pool {
     return ns.compare(p.ns);
   }
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
      ENCODE_START(10, 10, bl);
     encode(name, bl);
     encode(ns, bl);
     ENCODE_FINISH(bl);
   }
 
-  void decode_from_bucket(bufferlist::const_iterator& bl);
+  void decode_from_bucket(ceph::buffer::list::const_iterator& bl);
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START_LEGACY_COMPAT_LEN(10, 3, 3, bl);
 
     decode(name, bl);
@@ -191,7 +191,7 @@ struct rgw_pool {
 };
 WRITE_CLASS_ENCODER(rgw_pool)
 
-inline ostream& operator<<(ostream& out, const rgw_pool& p) {
+inline std::ostream& operator<<(std::ostream& out, const rgw_pool& p) {
   out << p.to_str();
   return out;
 }
@@ -235,7 +235,7 @@ struct rgw_data_placement_target {
     return index_pool.compare(t.index_pool);
   };
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
 };
 
@@ -281,7 +281,7 @@ struct rgw_bucket {
 
   void convert(cls_user_bucket *b) const;
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
      ENCODE_START(10, 10, bl);
     encode(name, bl);
     encode(marker, bl);
@@ -296,7 +296,7 @@ struct rgw_bucket {
     }
     ENCODE_FINISH(bl);
   }
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START_LEGACY_COMPAT_LEN(10, 3, 3, bl);
     decode(name, bl);
     if (struct_v < 10) {
@@ -339,7 +339,7 @@ struct rgw_bucket {
     DECODE_FINISH(bl);
   }
 
-  void update_bucket_id(const string& new_bucket_id) {
+  void update_bucket_id(const std::string& new_bucket_id) {
     bucket_id = new_bucket_id;
   }
 
@@ -352,9 +352,9 @@ struct rgw_bucket {
     return explicit_placement.get_data_extra_pool();
   }
 
-  void dump(Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(list<rgw_bucket*>& o);
+  static void generate_test_instances(std::list<rgw_bucket*>& o);
 
   rgw_bucket& operator=(const rgw_bucket&) = default;
 
@@ -385,7 +385,7 @@ struct rgw_bucket {
 };
 WRITE_CLASS_ENCODER(rgw_bucket)
 
-inline ostream& operator<<(ostream& out, const rgw_bucket &b) {
+inline std::ostream& operator<<(std::ostream& out, const rgw_bucket &b) {
   out << b.tenant << ":" << b.name << "[" << b.bucket_id << "])";
   return out;
 }
@@ -416,7 +416,7 @@ struct rgw_bucket_shard {
   }
 };
 
-inline ostream& operator<<(ostream& out, const rgw_bucket_shard& bs) {
+inline std::ostream& operator<<(std::ostream& out, const rgw_bucket_shard& bs) {
   if (bs.shard_id <= 0) {
     return out << bs.bucket;
   }
@@ -426,18 +426,18 @@ inline ostream& operator<<(ostream& out, const rgw_bucket_shard& bs) {
 
 
 struct rgw_zone_id {
-  string id;
+  std::string id;
 
   rgw_zone_id() {}
-  rgw_zone_id(const string& _id) : id(_id) {}
-  rgw_zone_id(string&& _id) : id(std::move(_id)) {}
+  rgw_zone_id(const std::string& _id) : id(_id) {}
+  rgw_zone_id(std::string&& _id) : id(std::move(_id)) {}
 
-  void encode(bufferlist& bl) const {
+  void encode(ceph::buffer::list& bl) const {
     /* backward compatiblity, not using ENCODE_{START,END} macros */
     ceph::encode(id, bl);
   }
 
-  void decode(bufferlist::const_iterator& bl) {
+  void decode(ceph::buffer::list::const_iterator& bl) {
     /* backward compatiblity, not using DECODE_{START,END} macros */
     ceph::decode(id, bl);
   }
@@ -446,7 +446,7 @@ struct rgw_zone_id {
     id.clear();
   }
 
-  bool operator==(const string& _id) const {
+  bool operator==(const std::string& _id) const {
     return (id == _id);
   }
   bool operator==(const rgw_zone_id& zid) const {
@@ -468,12 +468,12 @@ struct rgw_zone_id {
 };
 WRITE_CLASS_ENCODER(rgw_zone_id)
 
-static inline ostream& operator<<(ostream& os, const rgw_zone_id& zid) {
+inline std::ostream& operator<<(std::ostream& os, const rgw_zone_id& zid) {
   os << zid.id;
   return os;
 }
 
-void encode_json_impl(const char *name, const rgw_zone_id& zid, Formatter *f);
+void encode_json_impl(const char *name, const rgw_zone_id& zid, ceph::Formatter *f);
 void decode_json_obj(rgw_zone_id& zid, JSONObj *obj);
 
 
@@ -489,7 +489,7 @@ class Principal {
   enum types { User, Role, Tenant, Wildcard, OidcProvider };
   types t;
   rgw_user u;
-  string idp_url;
+  std::string idp_url;
 
   explicit Principal(types t)
     : t(t) {}
@@ -497,7 +497,7 @@ class Principal {
   Principal(types t, std::string&& n, std::string i)
     : t(t), u(std::move(n), std::move(i)) {}
 
-  Principal(string&& idp_url)
+  Principal(std::string&& idp_url)
     : t(OidcProvider), idp_url(std::move(idp_url)) {}
 
 public:
@@ -518,7 +518,7 @@ public:
     return Principal(Tenant, std::move(t), {});
   }
 
-  static Principal oidc_provider(string&& idp_url) {
+  static Principal oidc_provider(std::string&& idp_url) {
     return Principal(std::move(idp_url));
   }
 
@@ -550,7 +550,7 @@ public:
     return u.id;
   }
 
-  const string& get_idp_url() const {
+  const std::string& get_idp_url() const {
     return idp_url;
   }
 
@@ -570,11 +570,11 @@ std::ostream& operator <<(std::ostream& m, const Principal& p);
 class JSONObj;
 
 void decode_json_obj(rgw_user& val, JSONObj *obj);
-void encode_json(const char *name, const rgw_user& val, Formatter *f);
-void encode_xml(const char *name, const rgw_user& val, Formatter *f);
+void encode_json(const char *name, const rgw_user& val, ceph::Formatter *f);
+void encode_xml(const char *name, const rgw_user& val, ceph::Formatter *f);
 
-inline ostream& operator<<(ostream& out, const rgw_user &u) {
-  string s;
+inline std::ostream& operator<<(std::ostream& out, const rgw_user &u) {
+  std::string s;
   u.to_str(s);
   return out << s;
 }


### PR DESCRIPTION
This is a part of a series of PRs to make Ceph build without `using namespace` declarations in header files.