### PR TITLE
rgw/http: add timeout to http client

### DIFF
--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -53,6 +53,8 @@ protected:
 
   param_vec_t headers;
 
+  long  req_timeout{0L};
+
   RGWHTTPManager *get_manager();
 
   int init_request(rgw_http_req_data *req_data);
@@ -134,6 +136,12 @@ public:
 
   void set_verify_ssl(bool flag) {
     verify_ssl = flag;
+  }
+
+  // set request timeout in seconds
+  // zero (default) mean that request will never timeout
+  void set_req_timeout(long timeout) {
+    req_timeout = timeout;
   }
 
   int process(optional_yield y);


### PR DESCRIPTION
some more http client related fixes:
* prevent "Expect: 100-continue" from being sent when not needed
* fixed a small issue with the wait on the condition, where the `done` value was not checked. This is needed to fix "spurious wakeups"
* `CURLOPT_INFILESIZE` was set with a pointer value and not the actual size

Following Issues are not blockers for notification testing (e.g. https://github.com/ceph/ceph/pull/34293), and could be addressed later:
- According to [this](https://curl.haxx.se/libcurl/c/CURLOPT_POSTFIELDS.html) setting the post field should be sufficient to prevent from the `Expect: 100-continue` to be sent. However, tests showed the the field is sent regardless. So, to prevent it it was removed explicitly from the header
- If a server respect that field, and actually answer with `100 Continue` result code, the RGW treat that as an `-EIO` error.If the server ignore that, there is no issue
- if uploaded file size is more than 2GB, different option should be used

Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>