### PR TITLE
octopus: monitoring: root volume full alert fires false positives

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -166,6 +166,7 @@ groups:
     rules:
       - alert: root volume full
         expr: node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} * 100 < 5
+        for: 5m
         labels:
           severity: critical
           type: ceph_default


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44955

---

backport of https://github.com/ceph/ceph/pull/34239
parent tracker: https://tracker.ceph.com/issues/44780

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh