### PR TITLE
octopus: cephadm: ceph-volume: disallow concurrent execution

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2635,6 +2635,9 @@ def command_ceph_volume():
     if args.fsid:
         make_log_dir(args.fsid)
 
+    l = FileLock(args.fsid)
+    l.acquire()
+
     (uid, gid) = (0, 0) # ceph-volume runs as root
     mounts = get_container_mounts(args.fsid, 'osd', None)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44893

---

backport of https://github.com/ceph/ceph/pull/34320
parent tracker: https://tracker.ceph.com/issues/44820

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh