### PR TITLE
spec: address some warnings raised by RPM 4.15.1

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2333,8 +2333,7 @@ if [ $1 -eq 0 ]; then
     fi
 fi
 exit 0
-
-%endif # with selinux
+%endif
 
 %files grafana-dashboards
 %if 0%{?suse_version}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -947,7 +947,7 @@ Summary:	Ceph distributed file system client library
 %if 0%{?suse_version}
 Group:		System/Libraries
 %endif
-Obsoletes:	libcephfs1
+Obsoletes:	libcephfs1 < %{_epoch_prefix}%{version}-%{release}
 %if 0%{?rhel} || 0%{?fedora}
 Obsoletes:	ceph-libs < %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	ceph-libcephfs


### PR DESCRIPTION
RPM 4.15.1 warns:

* It's not recommended to have unversioned Obsoletes.
* extra tokens at the end of `%endif` directive

Heed the warnings.

Fixes: https://tracker.ceph.com/issues/44964
