### PR TITLE
rbd/cache: Replicated Write Log core codes part 4

### DIFF
--- a/src/librbd/cache/ImageCache.h
+++ b/src/librbd/cache/ImageCache.h
@@ -36,7 +36,7 @@ public:
   virtual void aio_discard(uint64_t offset, uint64_t length,
                            uint32_t discard_granularity_bytes,
                            Context *on_finish) = 0;
-  virtual void aio_flush(Context *on_finish) = 0;
+  virtual void aio_flush(io::FlushSource flush_source, Context *on_finish) = 0;
   virtual void aio_writesame(uint64_t offset, uint64_t length,
                              ceph::bufferlist&& bl,
                              int fadvise_flags, Context *on_finish) = 0;

--- a/src/librbd/cache/ImageWriteback.cc
+++ b/src/librbd/cache/ImageWriteback.cc
@@ -74,14 +74,15 @@ void ImageWriteback<I>::aio_discard(uint64_t offset, uint64_t length,
 }
 
 template <typename I>
-void ImageWriteback<I>::aio_flush(Context *on_finish) {
+void ImageWriteback<I>::aio_flush(io::FlushSource flush_source, Context *on_finish) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "on_finish=" << on_finish << dendl;
 
   ImageCtx *image_ctx = util::get_image_ctx(&m_image_ctx);
   auto aio_comp = io::AioCompletion::create_and_start(
       on_finish, image_ctx, io::AIO_TYPE_FLUSH);
-  io::ImageFlushRequest<> req(*image_ctx, aio_comp, io::FLUSH_SOURCE_INTERNAL, {});
+  io::ImageFlushRequest<> req(*image_ctx, aio_comp, flush_source,
+                              {});
   req.set_bypass_image_cache();
   req.send();
 }

--- a/src/librbd/cache/ImageWriteback.h
+++ b/src/librbd/cache/ImageWriteback.h
@@ -6,6 +6,7 @@
 
 #include "include/buffer_fwd.h"
 #include "include/int_types.h"
+#include "librbd/io/Types.h"
 #include <vector>
 
 class Context;
@@ -27,7 +28,7 @@ public:
                          int fadvise_flags, Context *on_finish) = 0;
   virtual void aio_discard(uint64_t offset, uint64_t length,
                            uint32_t discard_granularity_bytes, Context *on_finish) = 0;
-  virtual void aio_flush(Context *on_finish) = 0 ;
+  virtual void aio_flush(io::FlushSource flush_source, Context *on_finish) = 0 ;
   virtual void aio_writesame(uint64_t offset, uint64_t length,
                              ceph::bufferlist&& bl,
                              int fadvise_flags, Context *on_finish) = 0;
@@ -54,7 +55,7 @@ public:
                  int fadvise_flags, Context *on_finish);
   void aio_discard(uint64_t offset, uint64_t length,
                    uint32_t discard_granularity_bytes, Context *on_finish);
-  void aio_flush(Context *on_finish);
+  void aio_flush(io::FlushSource flush_source, Context *on_finish);
   void aio_writesame(uint64_t offset, uint64_t length,
                      ceph::bufferlist&& bl,
                      int fadvise_flags, Context *on_finish);

--- a/src/librbd/cache/PassthroughImageCache.cc
+++ b/src/librbd/cache/PassthroughImageCache.cc
@@ -57,11 +57,11 @@ void PassthroughImageCache<I>::aio_discard(uint64_t offset, uint64_t length,
 }
 
 template <typename I>
-void PassthroughImageCache<I>::aio_flush(Context *on_finish) {
+void PassthroughImageCache<I>::aio_flush(librbd::io::FlushSource flush_source, Context *on_finish) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "on_finish=" << on_finish << dendl;
 
-  m_image_writeback.aio_flush(on_finish);
+  m_image_writeback.aio_flush(flush_source, on_finish);
 }
 
 template <typename I>
@@ -126,7 +126,7 @@ void PassthroughImageCache<I>::flush(Context *on_finish) {
 
   // internal flush -- nothing to writeback but make sure
   // in-flight IO is flushed
-  aio_flush(on_finish);
+  aio_flush(librbd::io::FLUSH_SOURCE_INTERNAL, on_finish);
 }
 
 } // namespace cache

--- a/src/librbd/cache/PassthroughImageCache.h
+++ b/src/librbd/cache/PassthroughImageCache.h
@@ -30,7 +30,7 @@ public:
   void aio_discard(uint64_t offset, uint64_t length,
                    uint32_t discard_granularity_bytes,
                    Context *on_finish) override;
-  void aio_flush(Context *on_finish) override;
+  void aio_flush(librbd::io::FlushSource flush_source, Context *on_finish) override;
   void aio_writesame(uint64_t offset, uint64_t length,
                      ceph::bufferlist&& bl,
                      int fadvise_flags, Context *on_finish) override;

--- a/src/librbd/cache/ReplicatedWriteLog.h
+++ b/src/librbd/cache/ReplicatedWriteLog.h
@@ -74,7 +74,7 @@ public:
   void aio_discard(uint64_t offset, uint64_t length,
                    uint32_t discard_granularity_bytes,
                    Context *on_finish) override;
-  void aio_flush(Context *on_finish) override;
+  void aio_flush(io::FlushSource flush_source, Context *on_finish) override;
   void aio_writesame(uint64_t offset, uint64_t length,
                      ceph::bufferlist&& bl,
                      int fadvise_flags, Context *on_finish) override;
@@ -131,7 +131,9 @@ private:
 
   BlockGuardCell* detain_guarded_request_helper(rwl::GuardedRequest &req);
   BlockGuardCell* detain_guarded_request_barrier_helper(rwl::GuardedRequest &req);
-  void detain_guarded_request(C_BlockIORequestT *request, rwl::GuardedRequestFunctionContext *guarded_ctx);
+  void detain_guarded_request(C_BlockIORequestT *request,
+                              rwl::GuardedRequestFunctionContext *guarded_ctx,
+                              bool is_barrier);
 
   librbd::cache::rwl::ImageCacheState<ImageCtxT>* m_cache_state = nullptr;
 
@@ -177,7 +179,6 @@ private:
   uint64_t m_flushed_sync_gen = 0;
 
   bool m_persist_on_write_until_flush = true;
-  bool m_flush_seen = false;
 
   AsyncOpTracker m_async_op_tracker;
   /* Debug counters for the places m_async_op_tracker is used */

--- a/src/librbd/cache/rwl/Types.cc
+++ b/src/librbd/cache/rwl/Types.cc
@@ -111,6 +111,18 @@ BlockExtent block_extent(const io::Extent& image_extent) {
   return convert_to_block_extent(image_extent.first, image_extent.second);
 }
 
+Context * override_ctx(int r, Context *ctx) {
+  if (r < 0) {
+    /* Override next_ctx status with this error */
+    return new LambdaContext(
+      [r, ctx](int _r) {
+        ctx->complete(r);
+      });
+  } else {
+    return ctx;
+  }
+}
+
 } // namespace rwl
 } // namespace cache
 } // namespace librbd

--- a/src/librbd/cache/rwl/Types.h
+++ b/src/librbd/cache/rwl/Types.h
@@ -263,6 +263,8 @@ io::Extent whole_volume_extent();
 
 BlockExtent block_extent(const io::Extent& image_extent);
 
+Context * override_ctx(int r, Context *ctx);
+
 } // namespace rwl
 } // namespace cache
 } // namespace librbd

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -717,7 +717,11 @@ void ImageFlushRequest<I>::send_request() {
     });
 
   // ensure all in-flight IOs are settled if non-user flush request
-  aio_comp->async_op.flush(ctx);
+  if (m_flush_source == FLUSH_SOURCE_WRITEBACK) {
+    ctx->complete(0);
+  } else {
+    aio_comp->async_op.flush(ctx);
+  }
 
   // might be flushing during image shutdown
   if (image_ctx.perfcounter != nullptr) {
@@ -733,7 +737,7 @@ void ImageFlushRequest<I>::send_image_cache_request() {
   AioCompletion *aio_comp = this->m_aio_comp;
   aio_comp->set_request_count(1);
   C_AioRequest *req_comp = new C_AioRequest(aio_comp);
-  image_ctx.image_cache->aio_flush(req_comp);
+  image_ctx.image_cache->aio_flush(librbd::io::FLUSH_SOURCE_USER, req_comp);
 }
 
 template <typename I>

--- a/src/librbd/io/Types.h
+++ b/src/librbd/io/Types.h
@@ -42,7 +42,8 @@ typedef enum {
 enum FlushSource {
   FLUSH_SOURCE_USER,
   FLUSH_SOURCE_INTERNAL,
-  FLUSH_SOURCE_SHUTDOWN
+  FLUSH_SOURCE_SHUTDOWN,
+  FLUSH_SOURCE_WRITEBACK
 };
 
 enum Direction {

--- a/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc
+++ b/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc
@@ -261,5 +261,108 @@ TEST_F(TestMockCacheReplicatedWriteLog, flush) {
   ASSERT_EQ(0, finish_ctx3.wait());
 }
 
+TEST_F(TestMockCacheReplicatedWriteLog, aio_flush_source_shutdown) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockReplicatedWriteLog rwl(mock_image_ctx, get_cache_state(mock_image_ctx));
+  expect_op_work_queue(mock_image_ctx);
+  expect_metadata_set(mock_image_ctx);
+
+  MockContextRWL finish_ctx1;
+  expect_context_complete(finish_ctx1, 0);
+  rwl.init(&finish_ctx1);
+  ASSERT_EQ(0, finish_ctx1.wait());
+
+  MockContextRWL finish_ctx2;
+  expect_context_complete(finish_ctx2, 0);
+  Extents image_extents{{0, 4096}};
+  bufferlist bl;
+  bl.append(std::string(4096, '1'));
+  int fadvise_flags = 0;
+  rwl.aio_write(std::move(image_extents), std::move(bl), fadvise_flags, &finish_ctx2);
+  ASSERT_EQ(0, finish_ctx2.wait());
+
+  MockContextRWL finish_ctx_flush;
+  expect_context_complete(finish_ctx_flush, 0);
+  rwl.aio_flush(io::FLUSH_SOURCE_SHUTDOWN, &finish_ctx_flush);
+  ASSERT_EQ(0, finish_ctx_flush.wait());
+
+  MockContextRWL finish_ctx3;
+  expect_context_complete(finish_ctx3, 0);
+  rwl.shut_down(&finish_ctx3);
+  ASSERT_EQ(0, finish_ctx3.wait());
+}
+
+TEST_F(TestMockCacheReplicatedWriteLog, aio_flush_source_internal) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockReplicatedWriteLog rwl(mock_image_ctx, get_cache_state(mock_image_ctx));
+  expect_op_work_queue(mock_image_ctx);
+  expect_metadata_set(mock_image_ctx);
+
+  MockContextRWL finish_ctx1;
+  expect_context_complete(finish_ctx1, 0);
+  rwl.init(&finish_ctx1);
+  ASSERT_EQ(0, finish_ctx1.wait());
+
+  MockContextRWL finish_ctx2;
+  expect_context_complete(finish_ctx2, 0);
+  Extents image_extents{{0, 4096}};
+  bufferlist bl;
+  bl.append(std::string(4096, '1'));
+  int fadvise_flags = 0;
+  rwl.aio_write(std::move(image_extents), std::move(bl), fadvise_flags, &finish_ctx2);
+  ASSERT_EQ(0, finish_ctx2.wait());
+
+  MockContextRWL finish_ctx_flush;
+  expect_context_complete(finish_ctx_flush, 0);
+  rwl.aio_flush(io::FLUSH_SOURCE_INTERNAL, &finish_ctx_flush);
+  ASSERT_EQ(0, finish_ctx_flush.wait());
+
+  MockContextRWL finish_ctx3;
+  expect_context_complete(finish_ctx3, 0);
+  rwl.shut_down(&finish_ctx3);
+  ASSERT_EQ(0, finish_ctx3.wait());
+}
+
+TEST_F(TestMockCacheReplicatedWriteLog, aio_flush_source_user) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockReplicatedWriteLog rwl(mock_image_ctx, get_cache_state(mock_image_ctx));
+  expect_op_work_queue(mock_image_ctx);
+  expect_metadata_set(mock_image_ctx);
+
+  MockContextRWL finish_ctx1;
+  expect_context_complete(finish_ctx1, 0);
+  rwl.init(&finish_ctx1);
+  ASSERT_EQ(0, finish_ctx1.wait());
+
+  MockContextRWL finish_ctx2;
+  expect_context_complete(finish_ctx2, 0);
+  Extents image_extents{{0, 4096}};
+  bufferlist bl;
+  bl.append(std::string(4096, '1'));
+  int fadvise_flags = 0;
+  rwl.aio_write(std::move(image_extents), std::move(bl), fadvise_flags, &finish_ctx2);
+  ASSERT_EQ(0, finish_ctx2.wait());
+
+  usleep(10000);
+  MockContextRWL finish_ctx_flush;
+  expect_context_complete(finish_ctx_flush, 0);
+  rwl.aio_flush(io::FLUSH_SOURCE_USER, &finish_ctx_flush);
+  ASSERT_EQ(0, finish_ctx_flush.wait());
+
+  MockContextRWL finish_ctx3;
+  expect_context_complete(finish_ctx3, 0);
+  rwl.shut_down(&finish_ctx3);
+  ASSERT_EQ(0, finish_ctx3.wait());
+}
+
 } // namespace cache
 } // namespace librbd

--- a/src/test/librbd/mock/cache/MockImageCache.h
+++ b/src/test/librbd/mock/cache/MockImageCache.h
@@ -5,6 +5,7 @@
 #define CEPH_TEST_LIBRBD_CACHE_MOCK_IMAGE_CACHE_H
 
 #include "gmock/gmock.h"
+#include "librbd/io/Types.h"
 #include <vector>
 
 namespace librbd {
@@ -30,6 +31,7 @@ struct MockImageCache {
 
   MOCK_METHOD4(aio_discard, void(uint64_t, uint64_t, uint32_t, Context *));
   MOCK_METHOD1(aio_flush, void(Context *));
+  MOCK_METHOD2(aio_flush, void(librbd::io::FlushSource, Context *));
   MOCK_METHOD5(aio_writesame_mock, void(uint64_t, uint64_t, ceph::bufferlist& bl,
                                         int, Context *));
   void aio_writesame(uint64_t off, uint64_t len, ceph::bufferlist&& bl,


### PR DESCRIPTION
Adds Replicated Write Log, a persistent, write back cache for Ceph RBD.
Implements: http://tracker.ceph.com/projects/ceph/wiki/Rbd_-_ordered_crash-consistent_write-back_caching_extension

Trello: https://trello.com/c/QnsQaGTn

[Obsoletes https://github.com//pull/29087]

The PR 29087 is split into smaller PRs to make review easier.
The first PR: #31279
The second PR: #31963
The 3rd PR: #33502 

This is the 4th PR (aio flush) which defines the following parts:
librbd: add aio_flush
librbd: add aio_flush test case

Signed-off-by: Scott Peterson scott.d.peterson@intel.com
Signed-off-by: Lisa Li xiaoyan.li@intel.com
Signed-off-by: Yuan Lu yuan.y.lu@intel.com
Signed-off-by: Mahati Chamarthy mahati.chamarthy@intel.com

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
