### PR TITLE
nautilus: selinux: Allow ceph to setsched

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -142,6 +142,7 @@ allow ceph_t configfs_t:lnk_file { create getattr read unlink };
 allow ceph_t random_device_t:chr_file getattr;
 allow ceph_t urandom_device_t:chr_file getattr;
 allow ceph_t self:process setpgid;
+allow ceph_t self:process setsched;
 allow ceph_t var_run_t:dir { write create add_name };
 allow ceph_t var_run_t:file { read write create open getattr };
 allow ceph_t init_var_run_t:file getattr;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44260

---

backport of https://github.com/ceph/ceph/pull/33404
parent tracker: https://tracker.ceph.com/issues/44196

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh