### PR TITLE
nautilus: mds: handle ceph_assert on blacklisting

### DIFF
--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -417,6 +417,13 @@ void Journaler::_finish_reread_head_and_probe(int r, C_OnFinisher *onfinish)
     return;
   }
 
+  // Let the caller know that the operation has failed or was intentionally
+  // failed since the caller has been blacklisted.
+  if (r == -EBLACKLISTED) {
+    onfinish->complete(r);
+    return;
+  }
+
   ceph_assert(!r); //if we get an error, we're boned
   _reprobe(onfinish);
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44483

---

backport of https://github.com/ceph/ceph/pull/33662
parent tracker: https://tracker.ceph.com/issues/44132

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh