### PR TITLE
ceph-volume: add ceph.osdspec_affinity tag

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -946,6 +946,7 @@ class Volume(object):
                 'type': type_,
                 'osd_fsid': self.tags['ceph.osd_fsid'],
                 'cluster_fsid': self.tags['ceph.cluster_fsid'],
+                'osdspec_affinity': self.tags.get('ceph.osdspec_affinity', ''),
             }
             type_uuid = '{}_uuid'.format(type_)
             report[type_uuid] = self.tags['ceph.{}'.format(type_uuid)]

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -294,6 +294,7 @@ class Prepare(object):
             'ceph.cluster_fsid': cluster_fsid,
             'ceph.cluster_name': conf.cluster,
             'ceph.crush_device_class': crush_device_class,
+            'ceph.osdspec_affinity': prepare_utils.get_osdspec_affinity()
         }
         if self.args.filestore:
             #TODO: allow auto creation of journal on passed device, only works

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -399,6 +399,10 @@ def get_monmap(osd_id):
     ])
 
 
+def get_osdspec_affinity():
+    return os.environ.get('CEPH_VOLUME_OSDSPEC_AFFINITY', '')
+
+
 def osd_mkfs_bluestore(osd_id, fsid, keyring=None, wal=False, db=False):
     """
     Create the files for the OSD to function. A normal call will look like:
@@ -449,15 +453,14 @@ def osd_mkfs_bluestore(osd_id, fsid, keyring=None, wal=False, db=False):
         )
         system.chown(db)
 
+    if get_osdspec_affinity():
+        base_command.extend(['--osdspec-affinity', get_osdspec_affinity()])
+
     command = base_command + supplementary_command
 
     _, _, returncode = process.call(command, stdin=keyring, show_command=True)
     if returncode != 0:
         raise RuntimeError('Command failed with exit code %s: %s' % (returncode, ' '.join(command)))
-
-
-def get_osdspec_affinity():
-    return os.environ.get('CEPH_VOLUME_OSDSPEC_AFFINITY', '')
 
 
 def osd_mkfs_filestore(osd_id, fsid, keyring):
@@ -488,6 +491,9 @@ def osd_mkfs_filestore(osd_id, fsid, keyring):
         '-i', osd_id,
         '--monmap', monmap,
     ]
+
+    if get_osdspec_affinity():
+        command.extend(['--osdspec-affinity', get_osdspec_affinity()])
 
     if __release__ != 'luminous':
         # goes through stdin

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -456,6 +456,10 @@ def osd_mkfs_bluestore(osd_id, fsid, keyring=None, wal=False, db=False):
         raise RuntimeError('Command failed with exit code %s: %s' % (returncode, ' '.join(command)))
 
 
+def get_osdspec_affinity():
+    return os.environ.get('CEPH_VOLUME_OSDSPEC_AFFINITY', '')
+
+
 def osd_mkfs_filestore(osd_id, fsid, keyring):
     """
     Create the files for the OSD to function. A normal call will look like:


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Part 1) of https://tracker.ceph.com/issues/44755
Resolves: https://tracker.ceph.com/issues/44929   (only the DG_AFFINITY part)


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
