### PR TITLE
librgw: fix error handling in rgw_mount

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1766,7 +1766,7 @@ void rgwfile_version(int *major, int *minor, int *extra)
   rc = new_fs->authorize(rgwlib.get_store());
   if (rc != 0) {
     delete new_fs;
-    return -EINVAL;
+    return rc;
   }
 
   /* register fs for shared gc */
@@ -1797,7 +1797,7 @@ int rgw_mount2(librgw_t rgw, const char *uid, const char *acc_key,
   rc = new_fs->authorize(rgwlib.get_store());
   if (rc != 0) {
     delete new_fs;
-    return -EINVAL;
+    return rc;
   }
 
   /* register fs for shared gc */


### PR DESCRIPTION
RGWLibFS::authorize() returns EINVAL, ERR_USER_SUSPENDED or errors generated by rgw::sal::RGWRadosStore
If in rgw_mount the authorize function returns an error code not equal to 0, client always get -EINVAL instead of other codes.

Signed-off-by: Rafal Wadolowski <rwadolowski@cloudferro.com>
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
