### PR TITLE
docs/cephadm: <encrypted> is a global flag

### DIFF
--- a/doc/cephadm/drivegroups.rst
+++ b/doc/cephadm/drivegroups.rst
@@ -173,7 +173,7 @@ This example would deploy all OSDs with encryption enabled.
       host_pattern: '*'
     data_devices:
       all: true
-      encrypted: true
+    encrypted: true
 
 See a full list in the DriveGroupSpecs
 


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
