### PR TITLE
octopus: qa/suites/rados/cephadm/upgrade: start from v15.2.0

### DIFF
--- a/qa/suites/rados/cephadm/upgrade/1-start.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start.yaml
@@ -1,4 +1,4 @@
 tasks:
 - cephadm:
-    image: quay.io/ceph-ci/ceph:wip-sage4-testing-2020-03-19-1456
-    cephadm_branch: wip-sage4-testing-2020-03-19-1456
+    image: docker.io/ceph/ceph:v15.2.0
+    cephadm_branch: v15.2.0


### PR DESCRIPTION
Backport of #34406