### PR TITLE
luminous: rgw: bug fix in put_obj_tags and post_obj interface

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1720,6 +1720,9 @@ int RGWPostObj_ObjStore_S3::get_tags()
     RGWObjTagging_S3 *tagging;
 
     tagging = static_cast<RGWObjTagging_S3 *>(parser.find_first("Tagging"));
+    if (!tagging) {
+      return -ERR_MALFORMED_XML;
+    }
     obj_tags_s3 = static_cast<RGWObjTagSet_S3 *>(tagging->find_first("TagSet"));
     if(!obj_tags_s3){
       return -ERR_MALFORMED_XML;


### PR DESCRIPTION
fixbug: https://tracker.ceph.com/issues/44967
    
When I call put object tagging or post object with tagging interface with wrong XML parameter name, like lowercase "tagging", rgw crash. Because where will be a NALL pointer in  get_params() function if XML body has Incorrect starttag and endtag name, the null pointer is then used to call the find_first() function.


Signed-off-by: caolei <halei15848934852@163.com>


