### PR TITLE
mgr/dashboard: Fix RGW Bucket checkbox

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
@@ -131,8 +131,7 @@
                        id="versioning"
                        name="versioning"
                        formControlName="versioning"
-                       [checked]="isVersioningEnabled"
-                       (change)="updateVersioning()">
+                       (change)="setMfaDeleteValidators()">
                 <label class="custom-control-label"
                        for="versioning"
                        i18n>Enabled</label>
@@ -158,8 +157,7 @@
                        id="mfa-delete"
                        name="mfa-delete"
                        formControlName="mfa-delete"
-                       [checked]="isMfaDeleteEnabled"
-                       (change)="updateMfaDelete()">
+                       (change)="setMfaDeleteValidators()">
                 <label class="custom-control-label"
                        for="mfa-delete"
                        i18n>Delete enabled</label>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
@@ -227,8 +227,10 @@ describe('RgwBucketFormComponent', () => {
       component.editing = true;
       rgwBucketServiceGetSpy.and.returnValue(observableOf(fakeResponse));
       component.ngOnInit();
-      component.isVersioningEnabled = versioningChecked;
-      component.isMfaDeleteEnabled = mfaDeleteChecked;
+      component.bucketForm.patchValue({
+        versioning: versioningChecked,
+        'mfa-delete': mfaDeleteChecked
+      });
       fixture.detectChanges();
 
       const mfaTokenSerial = fixture.debugElement.nativeElement.querySelector('#mfa-token-serial');


### PR DESCRIPTION
Using reactive forms mixed with [checked] stopped working in Angular 9.

Fixes: https://tracker.ceph.com/issues/44970

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
