### PR TITLE
cephadm: Update images used

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 FSID='00000000-0000-0000-0000-0000deadbeef'
 
 # images that are used
-IMAGE_MASTER=${IMAGE_MASTER:-'quay.io/ceph-ci/ceph:octopus'} # octopus for octopus branch
+IMAGE_MASTER=${IMAGE_MASTER:-'docker.io/ceph/daemon-base:latest-master-devel'}
 IMAGE_NAUTILUS=${IMAGE_NAUTILUS:-'docker.io/ceph/daemon-base:latest-nautilus'}
 IMAGE_MIMIC=${IMAGE_MIMIC:-'docker.io/ceph/daemon-base:latest-mimic'}
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1,6 +1,8 @@
 #!/usr/bin/python3
 
-DEFAULT_IMAGE='docker.io/ceph/ceph:v15'
+DEFAULT_IMAGE='docker.io/ceph/daemon-base:latest-master-devel'
+DEFAULT_IMAGE_IS_MASTER=True
+LATEST_STABLE_RELEASE='octopus'
 DATA_DIR='/var/lib/ceph'
 LOG_DIR='/var/log/ceph'
 LOCK_DIR='/run/cephadm'
@@ -1076,6 +1078,16 @@ def infer_fsid(func):
 
     return _infer_fsid
 
+def _get_default_image():
+    if DEFAULT_IMAGE_IS_MASTER:
+        yellow = '\033[93m'
+        end = '\033[0m'
+        s = '{}Warning: This is a development version of cephadm. Please refer to https://docs.ceph.com/docs/{}/cephadm/install{}'.format(
+            yellow, LATEST_STABLE_RELEASE, end
+        )
+        print(s)
+    return DEFAULT_IMAGE
+
 def infer_image(func):
     """
     Use the most recent ceph image
@@ -1087,7 +1099,7 @@ def infer_image(func):
         if not args.image:
             args.image = get_last_local_ceph_image()
         if not args.image:
-            args.image = DEFAULT_IMAGE
+            args.image = _get_default_image()
         return func()
 
     return _infer_image
@@ -1103,7 +1115,8 @@ def default_image(func):
             if not args.image:
                 args.image = os.environ.get('CEPHADM_IMAGE')
             if not args.image:
-                args.image = DEFAULT_IMAGE
+                args.image = _get_default_image()
+
         return func()
 
     return _default_image
@@ -4395,7 +4408,7 @@ def _get_parser():
     parser_add_repo.set_defaults(func=command_add_repo)
     parser_add_repo.add_argument(
         '--release',
-        help='use latest version of a named release (e.g., octopus)')
+        help='use latest version of a named release (e.g., {})'.format(LATEST_STABLE_RELEASE))
     parser_add_repo.add_argument(
         '--version',
         help='use specific upstream version (x.y.z)')

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -445,7 +445,7 @@ std::vector<Option> get_global_options() {
     Option("container_image", Option::TYPE_STR, Option::LEVEL_BASIC)
     .set_description("container image (used by cephadm orchestrator)")
     .set_flag(Option::FLAG_STARTUP)
-    .set_default("docker.io/ceph/ceph:v15"),
+    .set_default("docker.io/ceph/daemon-base:latest-master-devel"),
 
     Option("no_config_file", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)

--- a/test_cephadm.sh
+++ b/test_cephadm.sh
@@ -3,7 +3,7 @@
 SCRIPT_NAME=$(basename ${BASH_SOURCE[0]})
 
 fsid='00000000-0000-0000-0000-0000deadbeef'
-image='quay.io/ceph-ci/ceph:octopus'
+image='docker.io/ceph/daemon-base:latest-master-devel'
 [ -z "$ip" ] && ip=127.0.0.1
 
 OSD_IMAGE_NAME="${SCRIPT_NAME%.*}_osd.img"


### PR DESCRIPTION
Follow-up on #34406

Fixes:

```
2020-04-06T22:16:28.891 INFO:tasks.workunit.client.0.smithi040.stderr:Traceback (most recent call last):
2020-04-06T22:16:28.891 INFO:tasks.workunit.client.0.smithi040.stderr:  File "/tmp/tmp.oGFFRSjAZr/cephadm", line 4322, in <module>
2020-04-06T22:16:28.891 INFO:tasks.workunit.client.0.smithi040.stderr:    r = args.func()
2020-04-06T22:16:28.891 INFO:tasks.workunit.client.0.smithi040.stderr:  File "/tmp/tmp.oGFFRSjAZr/cephadm", line 964, in _infer_image
2020-04-06T22:16:28.891 INFO:tasks.workunit.client.0.smithi040.stderr:    return func()
2020-04-06T22:16:28.891 INFO:tasks.workunit.client.0.smithi040.stderr:  File "/tmp/tmp.oGFFRSjAZr/cephadm", line 1992, in command_version
2020-04-06T22:16:28.891 INFO:tasks.workunit.client.0.smithi040.stderr:    out = CephContainer(args.image, 'ceph', ['--version']).run()
2020-04-06T22:16:28.892 INFO:tasks.workunit.client.0.smithi040.stderr:  File "/tmp/tmp.oGFFRSjAZr/cephadm", line 1984, in run
2020-04-06T22:16:28.892 INFO:tasks.workunit.client.0.smithi040.stderr:    self.run_cmd(), desc=self.entrypoint, timeout=timeout)
2020-04-06T22:16:28.892 INFO:tasks.workunit.client.0.smithi040.stderr:  File "/tmp/tmp.oGFFRSjAZr/cephadm", line 708, in call_throws
2020-04-06T22:16:28.892 INFO:tasks.workunit.client.0.smithi040.stderr:    raise RuntimeError('Failed command: %s' % ' '.join(command))
2020-04-06T22:16:28.892 INFO:tasks.workunit.client.0.smithi040.stderr:RuntimeError: Failed command: /bin/podman run --rm --net=host -e CONTAINER_IMAGE=quay.io/ceph-ci/ceph:octopus -e NODE_NAME=smithi040 --entrypoint ceph quay.io/ceph-ci/ceph:octopus --version
```



See also "use quay octopus tip until 15.2 tag is available"
* a9b15c7e1a0c14376cd66f166370694294398494.

See also  "update default container images"
* 1f05f7578794380f969a7e93db07345626b3e4df.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
