### PR TITLE
mimic: devices/simple/scan: Fix string in log statement

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/simple/scan.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/scan.py
@@ -103,8 +103,9 @@ class Scan(object):
             file_json_key = file_
             if file_.endswith('_dmcrypt'):
                 file_json_key = file_.rstrip('_dmcrypt')
-                logger.info(('reading file {}, stripping _dmcrypt',
-                             'suffix').format(file_))
+                logger.info(
+                    'reading file {}, stripping _dmcrypt suffix'.format(file_)
+                )
             if os.path.islink(file_path):
                 if os.path.exists(file_path):
                     osd_metadata[file_json_key] = self.scan_device(file_path)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44973

---

backport of https://github.com/ceph/ceph/pull/34412
parent tracker: https://tracker.ceph.com/issues/44949

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh