### PR TITLE
mgr/dashboard: ECP modal enhancement

### DIFF
--- a/qa/tasks/mgr/dashboard/test_erasure_code_profile.py
+++ b/qa/tasks/mgr/dashboard/test_erasure_code_profile.py
@@ -102,9 +102,8 @@ class ECPTest(DashboardTestCase):
         self._get('/ui-api/erasure_code_profile/info')
         self.assertSchemaBody(JObj({
             'names': JList(six.string_types),
-            'failure_domains': JList(six.string_types),
             'plugins': JList(six.string_types),
-            'devices': JList(six.string_types),
             'directory': six.string_types,
+            'nodes': JList(JObj({}, allow_unknown=True))
         }))
 

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -414,4 +414,5 @@ class PoolTest(DashboardTestCase):
             'pg_autoscale_modes': JList(six.string_types),
             'erasure_code_profiles': JList(JObj({}, allow_unknown=True)),
             'used_rules': JObj({}, allow_unknown=True),
+            'used_profiles': JObj({}, allow_unknown=True),
         }))

--- a/src/pybind/mgr/dashboard/controllers/erasure_code_profile.py
+++ b/src/pybind/mgr/dashboard/controllers/erasure_code_profile.py
@@ -11,10 +11,10 @@ from .. import mgr
 
 @ApiController('/erasure_code_profile', Scope.POOL)
 class ErasureCodeProfile(RESTController):
-    '''
+    """
     create() supports additional key-value arguments that are passed to the
     ECP plugin.
-    '''
+    """
 
     def list(self):
         return CephService.get_erasure_code_profiles()
@@ -40,15 +40,15 @@ class ErasureCodeProfileUi(ErasureCodeProfile):
     @Endpoint()
     @ReadPermission
     def info(self):
-        '''Used for profile creation and editing'''
+        """
+        Used for profile creation and editing
+        """
         config = mgr.get('config')
-        osd_map_crush = mgr.get('osd_map_crush')
         return {
             # Because 'shec' is experimental it's not included
             'plugins': config['osd_erasure_code_plugins'].split() + ['shec'],
             'directory': config['erasure_code_dir'],
-            'devices': list({device['class'] for device in osd_map_crush['devices']}),
-            'failure_domains': [domain['name'] for domain in osd_map_crush['types']],
+            'nodes': mgr.get('osd_map_tree')['nodes'],
             'names': [name for name, _ in
                       mgr.get('osd_map').get('erasure_code_profiles', {}).items()]
         }

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -229,16 +229,23 @@ class PoolUi(Pool):
                     for o in options
                     if o['name'] == conf_name][0]
 
+        profiles = CephService.get_erasure_code_profiles()
         used_rules = {}
+        used_profiles = {}
         pool_names = []
         for p in self._pool_list():
             name = p['pool_name']
-            rule = p['crush_rule']
             pool_names.append(name)
+            rule = p['crush_rule']
             if rule in used_rules:
                 used_rules[rule].append(name)
             else:
                 used_rules[rule] = [name]
+            profile = p['erasure_code_profile']
+            if profile in used_profiles:
+                used_profiles[profile].append(name)
+            else:
+                used_profiles[profile] = [name]
 
         mgr_config = mgr.get('config')
         return {
@@ -252,6 +259,7 @@ class PoolUi(Pool):
             "compression_modes": get_config_option_enum('bluestore_compression_mode'),
             "pg_autoscale_default_mode": mgr_config['osd_pool_default_pg_autoscale_mode'],
             "pg_autoscale_modes": get_config_option_enum('osd_pool_default_pg_autoscale_mode'),
-            "erasure_code_profiles": CephService.get_erasure_code_profiles(),
-            "used_rules": used_rules
+            "erasure_code_profiles": profiles,
+            "used_rules": used_rules,
+            "used_profiles": used_profiles,
         }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.html
@@ -9,11 +9,11 @@
       <div class="modal-body">
         <div class="form-group row">
           <label for="name"
-                 class="col-form-label col-sm-3">
+                 class="cd-col-form-label">
             <ng-container i18n>Name</ng-container>
             <span class="required"></span>
           </label>
-          <div class="col-sm-9">
+          <div class="cd-col-form-input">
             <input type="text"
                    id="name"
                    name="name"
@@ -36,13 +36,13 @@
         <!-- Root -->
         <div class="form-group row">
           <label for="root"
-                 class="col-form-label col-sm-3">
+                 class="cd-col-form-label">
             <ng-container i18n>Root</ng-container>
             <cd-helper [html]="tooltips.root">
             </cd-helper>
             <span class="required"></span>
           </label>
-          <div class="col-sm-9">
+          <div class="cd-col-form-input">
             <select class="form-control custom-select"
                     id="root"
                     name="root"
@@ -64,13 +64,13 @@
         <!-- Failure Domain Type -->
         <div class="form-group row">
           <label for="failure_domain"
-                 class="col-form-label col-sm-3">
+                 class="cd-col-form-label">
             <ng-container i18n>Failure domain type</ng-container>
             <cd-helper [html]="tooltips.failure_domain">
             </cd-helper>
             <span class="required"></span>
           </label>
-          <div class="col-sm-9">
+          <div class="cd-col-form-input">
             <select class="form-control custom-select"
                     id="failure_domain"
                     name="failure_domain"
@@ -78,7 +78,7 @@
               <option *ngIf="!failureDomains"
                       ngValue=""
                       i18n>Loading...</option>
-              <option *ngFor="let domain of failureDomainKeys()"
+              <option *ngFor="let domain of failureDomainKeys"
                       [ngValue]="domain">
                 {{ domain }} ( {{failureDomains[domain].length}} )
               </option>
@@ -92,12 +92,12 @@
         <!-- Class -->
         <div class="form-group row">
           <label for="device_class"
-                 class="col-form-label col-sm-3">
+                 class="cd-col-form-label">
             <ng-container i18n>Device class</ng-container>
             <cd-helper [html]="tooltips.device_class">
             </cd-helper>
           </label>
-          <div class="col-sm-9">
+          <div class="cd-col-form-input">
             <select class="form-control custom-select"
                     id="device_class"
                     name="device_class"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.spec.ts
@@ -64,7 +64,7 @@ describe('CrushRuleFormComponent', () => {
     failureDomains: (nodes: CrushNode[], types: string[]) => {
       const expectation = {};
       types.forEach((type) => (expectation[type] = nodes.filter((node) => node.type === type)));
-      const keys = component.failureDomainKeys();
+      const keys = component.failureDomainKeys;
       expect(keys).toEqual(types);
       keys.forEach((key) => {
         expect(component.failureDomains[key].length).toBe(expectation[key].length);
@@ -156,7 +156,7 @@ describe('CrushRuleFormComponent', () => {
   it('calls listing to get rules on ngInit', () => {
     expect(crushRuleService.getInfo).toHaveBeenCalled();
     expect(component.names.length).toBe(2);
-    expect(component['nodes'].length).toBe(12);
+    expect(component.buckets.length).toBe(5);
   });
 
   describe('lists', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.ts
@@ -6,6 +6,7 @@ import * as _ from 'lodash';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
 import { CrushRuleService } from '../../../shared/api/crush-rule.service';
+import { CrushNodeSelectionClass } from '../../../shared/classes/crush.node.selection.class';
 import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { CdFormBuilder } from '../../../shared/forms/cd-form-builder';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
@@ -19,22 +20,16 @@ import { TaskWrapperService } from '../../../shared/services/task-wrapper.servic
   templateUrl: './crush-rule-form-modal.component.html',
   styleUrls: ['./crush-rule-form-modal.component.scss']
 })
-export class CrushRuleFormModalComponent implements OnInit {
+export class CrushRuleFormModalComponent extends CrushNodeSelectionClass implements OnInit {
   @Output()
   submitAction = new EventEmitter();
 
-  buckets: CrushNode[] = [];
-  failureDomains: { [type: string]: CrushNode[] } = {};
-  devices: string[] = [];
   tooltips = this.crushRuleService.formTooltips;
 
   form: CdFormGroup;
   names: string[];
   action: string;
   resource: string;
-
-  private nodes: CrushNode[] = [];
-  private easyNodes: { [id: number]: CrushNode } = {};
 
   constructor(
     private formBuilder: CdFormBuilder,
@@ -44,6 +39,7 @@ export class CrushRuleFormModalComponent implements OnInit {
     private i18n: I18n,
     public actionLabels: ActionLabelsI18n
   ) {
+    super();
     this.action = this.actionLabels.CREATE;
     this.resource = this.i18n('Crush Rule');
     this.createForm();
@@ -76,101 +72,14 @@ export class CrushRuleFormModalComponent implements OnInit {
     this.crushRuleService
       .getInfo()
       .subscribe(({ names, nodes }: { names: string[]; nodes: CrushNode[] }) => {
-        this.nodes = nodes;
-        nodes.forEach((node) => {
-          this.easyNodes[node.id] = node;
-        });
-        this.buckets = _.sortBy(
-          nodes.filter((n) => n.children),
-          'name'
+        this.initCrushNodeSelection(
+          nodes,
+          this.form.get('root'),
+          this.form.get('failure_domain'),
+          this.form.get('device_class')
         );
         this.names = names;
-        this.preSelectRoot();
       });
-    this.form.get('root').valueChanges.subscribe((root: CrushNode) => this.updateRoot(root));
-    this.form
-      .get('failure_domain')
-      .valueChanges.subscribe((domain: string) => this.updateDevices(domain));
-  }
-
-  private preSelectRoot() {
-    const rootNode = this.nodes.find((node) => node.type === 'root');
-    this.form.silentSet('root', rootNode);
-    this.updateRoot(rootNode);
-  }
-
-  private updateRoot(rootNode: CrushNode) {
-    const nodes = this.getSubNodes(rootNode);
-    const domains = {};
-    nodes.forEach((node) => {
-      if (!domains[node.type]) {
-        domains[node.type] = [];
-      }
-      domains[node.type].push(node);
-    });
-    Object.keys(domains).forEach((type) => {
-      if (domains[type].length <= 1) {
-        delete domains[type];
-      }
-    });
-    this.failureDomains = domains;
-    this.updateFailureDomain();
-  }
-
-  private getSubNodes(node: CrushNode): CrushNode[] {
-    let subNodes = [node]; // Includes parent node
-    if (!node.children) {
-      return subNodes;
-    }
-    node.children.forEach((id) => {
-      const childNode = this.easyNodes[id];
-      subNodes = subNodes.concat(this.getSubNodes(childNode));
-    });
-    return subNodes;
-  }
-
-  private updateFailureDomain() {
-    let failureDomain = this.getIncludedCustomValue(
-      'failure_domain',
-      Object.keys(this.failureDomains)
-    );
-    if (failureDomain === '') {
-      failureDomain = this.setMostCommonDomain();
-    }
-    this.updateDevices(failureDomain);
-  }
-
-  private getIncludedCustomValue(controlName: string, includedIn: string[]) {
-    const control = this.form.get(controlName);
-    return control.dirty && includedIn.includes(control.value) ? control.value : '';
-  }
-
-  private setMostCommonDomain(): string {
-    let winner = { n: 0, type: '' };
-    Object.keys(this.failureDomains).forEach((type) => {
-      const n = this.failureDomains[type].length;
-      if (winner.n < n) {
-        winner = { n, type };
-      }
-    });
-    this.form.silentSet('failure_domain', winner.type);
-    return winner.type;
-  }
-
-  updateDevices(failureDomain: string) {
-    const subNodes = _.flatten(
-      this.failureDomains[failureDomain].map((node) => this.getSubNodes(node))
-    );
-    this.devices = _.uniq(subNodes.filter((n) => n.device_class).map((n) => n.device_class)).sort();
-    const device =
-      this.devices.length === 1
-        ? this.devices[0]
-        : this.getIncludedCustomValue('device_class', this.devices);
-    this.form.get('device_class').setValue(device);
-  }
-
-  failureDomainKeys(): string[] {
-    return Object.keys(this.failureDomains).sort();
   }
 
   onSubmit() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.html
@@ -168,9 +168,9 @@
               <option *ngIf="!failureDomains"
                       ngValue=""
                       i18n>Loading...</option>
-              <option *ngFor="let domain of failureDomains"
+              <option *ngFor="let domain of failureDomainKeys"
                       [ngValue]="domain">
-                {{ domain }}
+                {{ domain }} ( {{failureDomains[domain].length}} )
               </option>
             </select>
           </div>
@@ -192,12 +192,12 @@
               <option *ngIf="!failureDomains"
                       ngValue=""
                       i18n>Loading...</option>
-              <option *ngIf="failureDomains && failureDomains.length > 0"
+              <option *ngIf="failureDomainKeys.length > 0"
                       ngValue=""
                       i18n>None</option>
-              <option *ngFor="let domain of failureDomains"
+              <option *ngFor="let domain of failureDomainKeys"
                       [ngValue]="domain">
-                {{ domain }}
+                {{ domain }} ( {{failureDomains[domain].length}} )
               </option>
             </select>
           </div>
@@ -253,12 +253,18 @@
             </cd-helper>
           </label>
           <div class="cd-col-form-input">
-            <input type="text"
-                   id="crushRoot"
-                   name="crushRoot"
-                   class="form-control"
-                   placeholder="root..."
-                   formControlName="crushRoot">
+            <select class="form-control custom-select"
+                    id="crushRoot"
+                    name="crushRoot"
+                    formControlName="crushRoot">
+              <option *ngIf="!buckets"
+                      ngValue=""
+                      i18n>Loading...</option>
+              <option *ngFor="let bucket of buckets"
+                      [ngValue]="bucket">
+                {{ bucket.name }}
+              </option>
+            </select>
           </div>
         </div>
 
@@ -275,12 +281,14 @@
                     name="crushDeviceClass"
                     formControlName="crushDeviceClass">
               <option ngValue=""
-                      i18n>any</option>
+                      i18n>Let Ceph decide</option>
               <option *ngFor="let deviceClass of devices"
                       [ngValue]="deviceClass">
                 {{ deviceClass }}
               </option>
             </select>
+            <span class="form-text text-muted"
+                  i18n>Available OSDs: {{deviceCount}}</span>
           </div>
         </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.html
@@ -61,7 +61,7 @@
         <div class="form-group row">
           <label for="k"
                  class="cd-col-form-label">
-            <span [ngClass]="{'required': requiredControls.includes('k')}"
+            <span class="required"
                   i18n>Data chunks (k)</span>
             <cd-helper [html]="tooltips.k">
             </cd-helper>
@@ -80,13 +80,25 @@
             <span class="invalid-feedback"
                   *ngIf="form.showError('k', frm, 'min')"
                   i18n>Must be equal to or greater than 2.</span>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('k', frm, 'max')"
+                  i18n>Chunks (k+m) have exceeded the available OSDs of {{deviceCount}}.</span>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('k', frm, 'unequal')"
+                  i18n>For an equal distribution k has to be a multiple of (k+m)/l.</span>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('k', frm, 'kLowerM')"
+                  i18n>K has to be equal to or greater than m in order to recover data correctly through c.</span>
+            <span *ngIf="plugin === 'lrc'"
+                  class="form-text text-muted"
+                  i18n>Distribution factor: {{lrcMultiK}}</span>
           </div>
         </div>
 
         <div class="form-group row">
           <label for="m"
                  class="cd-col-form-label">
-            <span [ngClass]="{'required': requiredControls.includes('m')}"
+            <span class="required"
                   i18n>Coding chunks (m)</span>
             <cd-helper [html]="tooltips.m">
             </cd-helper>
@@ -104,6 +116,9 @@
             <span class="invalid-feedback"
                   *ngIf="form.showError('m', frm, 'min')"
                   i18n>Must be equal to or greater than 1.</span>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('m', frm, 'max')"
+                  i18n>Chunks (k+m) have exceeded the available OSDs of {{deviceCount}}.</span>
           </div>
         </div>
 
@@ -111,7 +126,8 @@
              *ngIf="plugin === 'shec'">
           <label for="c"
                  class="cd-col-form-label">
-            <ng-container i18n>Durability estimator (c)</ng-container>
+            <span class="required"
+                  i18n>Durability estimator (c)</span>
             <cd-helper [html]="tooltips.plugins.shec.c">
             </cd-helper>
           </label>
@@ -125,6 +141,9 @@
             <span class="invalid-feedback"
                   *ngIf="form.showError('c', frm, 'min')"
                   i18n>Must be equal to or greater than 1.</span>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('c', frm, 'cGreaterM')"
+                  i18n>C has to be equal to or lower than m as m defines the amount of chunks that can be used.</span>
           </div>
         </div>
 
@@ -150,6 +169,11 @@
             <span class="invalid-feedback"
                   *ngIf="form.showError('l', frm, 'min')"
                   i18n>Must be equal to or greater than 1.</span>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('l', frm, 'unequal')"
+                  i18n>Can't split up chunks (k+m) correctly with the current locality.</span>
+            <span class="form-text text-muted"
+                  i18n>Locality groups: {{lrcGroups}}</span>
           </div>
         </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -236,6 +236,10 @@
                   <button class="btn btn-light"
                           type="button"
                           *ngIf="!editing"
+                          tooltip="This profile can't be deleted as it is in use."
+                          i18n-tooltip
+                          triggers=""
+                          #ecpDeletionBtn="bs-tooltip"
                           (click)="deleteErasureCodeProfile()">
                     <i [ngClass]="[icons.trash]"
                        aria-hidden="true"></i>
@@ -245,10 +249,28 @@
               <span class="form-text text-muted"
                     id="ecp-info-block"
                     *ngIf="data.erasureInfo && form.getValue('erasureProfile')">
-                <cd-table-key-value [renderObjects]="true"
-                                    [data]="form.getValue('erasureProfile')"
-                                    [autoReload]="false">
-                </cd-table-key-value>
+                <tabset #ecpInfoTabs>
+                  <tab i18n-heading
+                       heading="Profile"
+                       class="ecp-info">
+                    <cd-table-key-value [renderObjects]="true"
+                                        [data]="form.getValue('erasureProfile')"
+                                        [autoReload]="false">
+                    </cd-table-key-value>
+                  </tab>
+                  <tab i18n-heading
+                       heading="Used by pools"
+                       class="used-by-pools">
+                    <ng-template #ecpIsNotUsed>
+                      <span i18n>Profile is not in use.</span>
+                    </ng-template>
+                    <ul *ngIf="ecpUsage; else ecpIsNotUsed">
+                      <li *ngFor="let pool of ecpUsage">
+                        {{ pool }}
+                      </li>
+                    </ul>
+                  </tab>
+                </tabset>
               </span>
             </div>
           </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -7,16 +7,18 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import * as _ from 'lodash';
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
-import { BsModalService } from 'ngx-bootstrap/modal';
+import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { TabsetComponent, TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import {
   configureTestBed,
   FixtureHelper,
   FormHelper,
-  i18nProviders
+  i18nProviders,
+  modalServiceShow
 } from '../../../../testing/unit-test-helper';
 import { NotFoundComponent } from '../../../core/not-found/not-found.component';
 import { CrushRuleService } from '../../../shared/api/crush-rule.service';
@@ -146,6 +148,9 @@ describe('PoolFormComponent', () => {
       pg_autoscale_modes: ['off', 'warn', 'on'],
       used_rules: {
         used_rule: ['some.pool.uses.it']
+      },
+      used_profiles: {
+        ecp1: ['some.other.pool.uses.it']
       }
     };
   };
@@ -165,6 +170,7 @@ describe('PoolFormComponent', () => {
   configureTestBed({
     declarations: [NotFoundComponent],
     imports: [
+      BrowserAnimationsModule,
       HttpClientTestingModule,
       RouterTestingModule.withRoutes(routes),
       ToastrModule.forRoot(),
@@ -174,6 +180,7 @@ describe('PoolFormComponent', () => {
     ],
     providers: [
       ErasureCodeProfileService,
+      BsModalRef,
       SelectBadgesComponent,
       { provide: ActivatedRoute, useValue: { params: of({ name: 'somePoolName' }) } },
       i18nProviders
@@ -973,45 +980,145 @@ describe('PoolFormComponent', () => {
       fixtureHelper.expectIdElementsVisible(['erasureProfile', 'ecp-info-block'], true);
     });
 
+    it('should select the newly created profile', () => {
+      spyOn(ecpService, 'list').and.callFake(() => of(infoReturn.erasure_code_profiles));
+      expect(form.getValue('erasureProfile').name).toBe('ecp1');
+      const name = 'awesomeProfile';
+      spyOn(TestBed.get(BsModalService), 'show').and.callFake(() => {
+        return {
+          content: {
+            submitAction: of({ name })
+          }
+        };
+      });
+      const ecp2 = new ErasureCodeProfile();
+      ecp2.name = name;
+      infoReturn.erasure_code_profiles.push(ecp2);
+      component.addErasureCodeProfile();
+      expect(form.getValue('erasureProfile').name).toBe(name);
+    });
+
     describe('ecp deletion', () => {
       let taskWrapper: TaskWrapperService;
       let deletion: CriticalConfirmationModalComponent;
+      let deleteSpy: jasmine.Spy;
+      let modalSpy: jasmine.Spy;
+      let modal: any;
 
-      const callDeletion = () => {
+      const callEcpDeletion = () => {
         component.deleteErasureCodeProfile();
-        deletion.submitActionObservable();
+        modal.ref.content.callSubmitAction();
       };
 
-      const testPoolDeletion = (name: string) => {
+      const expectSuccessfulEcpDeletion = (name: string) => {
         setSelectedEcp(name);
-        callDeletion();
+        callEcpDeletion();
         expect(ecpService.delete).toHaveBeenCalledWith(name);
-        expect(taskWrapper.wrapTaskAroundCall).toHaveBeenCalledWith({
-          task: {
-            name: 'ecp/delete',
-            metadata: {
-              name: name
+        expect(taskWrapper.wrapTaskAroundCall).toHaveBeenCalledWith(
+          expect.objectContaining({
+            task: {
+              name: 'ecp/delete',
+              metadata: {
+                name: name
+              }
             }
-          },
-          call: undefined // because of stub
-        });
+          })
+        );
       };
 
       beforeEach(() => {
-        spyOn(TestBed.get(BsModalService), 'show').and.callFake((deletionClass, config) => {
-          deletion = Object.assign(new deletionClass(), config.initialState);
-          return {
-            content: deletion
-          };
+        deletion = undefined;
+        modalSpy = spyOn(TestBed.get(BsModalService), 'show').and.callFake(
+          (comp: any, init: any) => {
+            modal = modalServiceShow(comp, init);
+            return modal.ref;
+          }
+        );
+        deleteSpy = spyOn(ecpService, 'delete').and.callFake((name: string) => {
+          const profiles = infoReturn.erasure_code_profiles;
+          const index = _.findIndex(profiles, (profile) => profile.name === name);
+          profiles.splice(index, 1);
+          return of({ status: 202 });
         });
-        spyOn(ecpService, 'delete').and.stub();
         taskWrapper = TestBed.get(TaskWrapperService);
         spyOn(taskWrapper, 'wrapTaskAroundCall').and.callThrough();
+
+        const ecp2 = new ErasureCodeProfile();
+        ecp2.name = 'someEcpName';
+        infoReturn.erasure_code_profiles.push(ecp2);
+
+        const ecp3 = new ErasureCodeProfile();
+        ecp3.name = 'aDifferentEcpName';
+        infoReturn.erasure_code_profiles.push(ecp3);
       });
 
       it('should delete two different erasure code profiles', () => {
-        testPoolDeletion('someEcpName');
-        testPoolDeletion('aDifferentEcpName');
+        expectSuccessfulEcpDeletion('someEcpName');
+        expectSuccessfulEcpDeletion('aDifferentEcpName');
+      });
+
+      describe('with unused profile', () => {
+        beforeEach(() => {
+          expectSuccessfulEcpDeletion('someEcpName');
+        });
+
+        it('should not open the tooltip nor the crush info', () => {
+          expect(component.ecpDeletionBtn.isOpen).toBe(false);
+          expect(component.data.erasureInfo).toBe(false);
+        });
+
+        it('should reload the rules after deletion', () => {
+          const expected = infoReturn.erasure_code_profiles;
+          const currentProfiles = component.info.erasure_code_profiles;
+          expect(currentProfiles.length).toBe(expected.length);
+          expect(currentProfiles).toEqual(expected);
+        });
+      });
+
+      describe('rule in use', () => {
+        beforeEach(() => {
+          spyOn(global, 'setTimeout').and.callFake((fn: Function) => fn());
+          component.ecpInfoTabs = { tabs: [{}, {}] } as TabsetComponent; // Mock it
+          deleteSpy.calls.reset();
+          setSelectedEcp('ecp1');
+          component.deleteErasureCodeProfile();
+        });
+
+        it('should not open the modal', () => {
+          expect(deletion).toBe(undefined);
+        });
+
+        it('should not have called delete and opened the tooltip', () => {
+          expect(ecpService.delete).not.toHaveBeenCalled();
+          expect(component.ecpDeletionBtn.isOpen).toBe(true);
+          expect(component.data.erasureInfo).toBe(true);
+        });
+
+        it('should open the third crush info tab', () => {
+          expect(component.ecpInfoTabs).toEqual({
+            tabs: [{}, { active: true }]
+          } as TabsetComponent);
+        });
+
+        it('should hide the tooltip when clicking on delete again', () => {
+          component.deleteErasureCodeProfile();
+          expect(component.ecpDeletionBtn.isOpen).toBe(false);
+        });
+
+        it('should hide the tooltip when clicking on add', () => {
+          modalSpy.and.callFake((): any => ({
+            content: {
+              submitAction: of('someProfile')
+            }
+          }));
+          component.addErasureCodeProfile();
+          expect(component.ecpDeletionBtn.isOpen).toBe(false);
+        });
+
+        it('should hide the tooltip when changing the crush rule', () => {
+          setSelectedEcp('someEcpName');
+          expect(component.ecpDeletionBtn.isOpen).toBe(false);
+        });
       });
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -799,6 +799,21 @@ describe('PoolFormComponent', () => {
       fixture.detectChanges();
     });
 
+    it('should select the newly created rule', () => {
+      expect(form.getValue('crushRule').rule_name).toBe('rep1');
+      const name = 'awesomeRule';
+      spyOn(TestBed.get(BsModalService), 'show').and.callFake(() => {
+        return {
+          content: {
+            submitAction: of({ name })
+          }
+        };
+      });
+      infoReturn.crush_rules_replicated.push(createCrushRule({ id: 8, name }));
+      component.addCrushRule();
+      expect(form.getValue('crushRule').rule_name).toBe(name);
+    });
+
     it('should not show info per default', () => {
       fixtureHelper.expectElementVisible('#crushRule', true);
       fixtureHelper.expectElementVisible('#crush-info-block', false);
@@ -837,30 +852,32 @@ describe('PoolFormComponent', () => {
 
       const expectSuccessfulDeletion = (name: string) => {
         expect(crushRuleService.delete).toHaveBeenCalledWith(name);
-        expect(taskWrapper.wrapTaskAroundCall).toHaveBeenCalledWith({
-          task: {
-            name: 'crushRule/delete',
-            metadata: {
-              name: name
+        expect(taskWrapper.wrapTaskAroundCall).toHaveBeenCalledWith(
+          expect.objectContaining({
+            task: {
+              name: 'crushRule/delete',
+              metadata: {
+                name: name
+              }
             }
-          },
-          call: undefined // because of stub
-        });
+          })
+        );
       };
 
       beforeEach(() => {
         modalSpy = spyOn(TestBed.get(BsModalService), 'show').and.callFake(
-          (deletionClass, config) => {
+          (deletionClass: any, config: any) => {
             deletion = Object.assign(new deletionClass(), config.initialState);
             return {
               content: deletion
             };
           }
         );
-        deleteSpy = spyOn(crushRuleService, 'delete').and.callFake((name) => {
+        deleteSpy = spyOn(crushRuleService, 'delete').and.callFake((name: string) => {
           const rules = infoReturn.crush_rules_replicated;
           const index = _.findIndex(rules, (rule) => rule.rule_name === name);
           rules.splice(index, 1);
+          return of(undefined);
         });
         taskWrapper = TestBed.get(TaskWrapperService);
         spyOn(taskWrapper, 'wrapTaskAroundCall').and.callThrough();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.spec.ts
@@ -1,0 +1,207 @@
+import { FormControl } from '@angular/forms';
+
+import { configureTestBed } from '../../../testing/unit-test-helper';
+import { CrushNode } from '../models/crush-node';
+import { CrushRuleConfig } from '../models/crush-rule';
+import { CrushNodeSelectionClass } from './crush.node.selection.class';
+
+describe('CrushNodeSelectionService', () => {
+  let service: CrushNodeSelectionClass;
+
+  let controls: {
+    root: FormControl;
+    failure: FormControl;
+    device: FormControl;
+  };
+
+  // Object contains mock functions
+  const mock = {
+    node: (
+      name: string,
+      id: number,
+      type: string,
+      type_id: number,
+      children?: number[],
+      device_class?: string
+    ): CrushNode => {
+      return { name, type, type_id, id, children, device_class };
+    },
+    rule: (
+      name: string,
+      root: string,
+      failure_domain: string,
+      device_class?: string
+    ): CrushRuleConfig => ({
+      name,
+      root,
+      failure_domain,
+      device_class
+    }),
+    nodes: [] as CrushNode[]
+  };
+
+  /**
+   * Create the following test crush map:
+   * > default
+   * --> ssd-host
+   * ----> 3x osd with ssd
+   * --> mix-host
+   * ----> hdd-rack
+   * ------> 2x osd-rack with hdd
+   * ----> ssd-rack
+   * ------> 2x osd-rack with ssd
+   */
+  mock.nodes = [
+    // Root node
+    mock.node('default', -1, 'root', 11, [-2, -3]),
+    // SSD host
+    mock.node('ssd-host', -2, 'host', 1, [1, 0, 2]),
+    mock.node('osd.0', 0, 'osd', 0, undefined, 'ssd'),
+    mock.node('osd.1', 1, 'osd', 0, undefined, 'ssd'),
+    mock.node('osd.2', 2, 'osd', 0, undefined, 'ssd'),
+    // SSD and HDD mixed devices host
+    mock.node('mix-host', -3, 'host', 1, [-4, -5]),
+    // HDD rack
+    mock.node('hdd-rack', -4, 'rack', 3, [3, 4]),
+    mock.node('osd2.0', 3, 'osd-rack', 0, undefined, 'hdd'),
+    mock.node('osd2.1', 4, 'osd-rack', 0, undefined, 'hdd'),
+    // SSD rack
+    mock.node('ssd-rack', -5, 'rack', 3, [5, 6]),
+    mock.node('osd2.0', 5, 'osd-rack', 0, undefined, 'ssd'),
+    mock.node('osd2.1', 6, 'osd-rack', 0, undefined, 'ssd')
+  ];
+
+  // Object contains functions to get something
+  const get = {
+    nodeByName: (name: string): CrushNode => mock.nodes.find((node) => node.name === name),
+    nodesByNames: (names: string[]): CrushNode[] => names.map(get.nodeByName)
+  };
+
+  // Expects that are used frequently
+  const assert = {
+    failureDomains: (nodes: CrushNode[], types: string[]) => {
+      const expectation = {};
+      types.forEach((type) => (expectation[type] = nodes.filter((node) => node.type === type)));
+      const keys = service.failureDomainKeys;
+      expect(keys).toEqual(types);
+      keys.forEach((key) => {
+        expect(service.failureDomains[key].length).toBe(expectation[key].length);
+      });
+    },
+    formFieldValues: (root: CrushNode, failureDomain: string, device: string) => {
+      expect(controls.root.value).toEqual(root);
+      expect(controls.failure.value).toBe(failureDomain);
+      expect(controls.device.value).toBe(device);
+    },
+    valuesOnRootChange: (
+      rootName: string,
+      expectedFailureDomain: string,
+      expectedDevice: string
+    ) => {
+      const node = get.nodeByName(rootName);
+      controls.root.setValue(node);
+      assert.formFieldValues(node, expectedFailureDomain, expectedDevice);
+    }
+  };
+
+  configureTestBed({
+    providers: [CrushNodeSelectionClass]
+  });
+
+  beforeEach(() => {
+    controls = {
+      root: new FormControl(null),
+      failure: new FormControl(''),
+      device: new FormControl('')
+    };
+    // Normally this should be extended by the class using it
+    service = new CrushNodeSelectionClass();
+    // Therefore to get it working correctly use "this" instead of "service"
+    service.initCrushNodeSelection(mock.nodes, controls.root, controls.failure, controls.device);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+    expect(mock.nodes.length).toBe(12);
+  });
+
+  describe('lists', () => {
+    afterEach(() => {
+      // The available buckets should not change
+      expect(service.buckets).toEqual(
+        get.nodesByNames(['default', 'hdd-rack', 'mix-host', 'ssd-host', 'ssd-rack'])
+      );
+    });
+
+    it('has the following lists after init', () => {
+      assert.failureDomains(mock.nodes, ['host', 'osd', 'osd-rack', 'rack']); // Not root as root only exist once
+      expect(service.devices).toEqual(['hdd', 'ssd']);
+    });
+
+    it('has the following lists after selection of ssd-host', () => {
+      controls.root.setValue(get.nodeByName('ssd-host'));
+      assert.failureDomains(get.nodesByNames(['osd.0', 'osd.1', 'osd.2']), ['osd']); // Not host as it only exist once
+      expect(service.devices).toEqual(['ssd']);
+    });
+
+    it('has the following lists after selection of mix-host', () => {
+      controls.root.setValue(get.nodeByName('mix-host'));
+      expect(service.devices).toEqual(['hdd', 'ssd']);
+      assert.failureDomains(
+        get.nodesByNames(['hdd-rack', 'ssd-rack', 'osd2.0', 'osd2.1', 'osd2.0', 'osd2.1']),
+        ['osd-rack', 'rack']
+      );
+    });
+  });
+
+  describe('selection', () => {
+    it('selects the first root after init automatically', () => {
+      assert.formFieldValues(get.nodeByName('default'), 'osd-rack', '');
+    });
+
+    it('should select all values automatically by selecting "ssd-host" as root', () => {
+      assert.valuesOnRootChange('ssd-host', 'osd', 'ssd');
+    });
+
+    it('selects automatically the most common failure domain', () => {
+      // Select mix-host as mix-host has multiple failure domains (osd-rack and rack)
+      assert.valuesOnRootChange('mix-host', 'osd-rack', '');
+    });
+
+    it('should override automatic selections', () => {
+      assert.formFieldValues(get.nodeByName('default'), 'osd-rack', '');
+      assert.valuesOnRootChange('ssd-host', 'osd', 'ssd');
+      assert.valuesOnRootChange('mix-host', 'osd-rack', '');
+    });
+
+    it('should not override manual selections if possible', () => {
+      controls.failure.setValue('rack');
+      controls.failure.markAsDirty();
+      controls.device.setValue('ssd');
+      controls.device.markAsDirty();
+      assert.valuesOnRootChange('mix-host', 'rack', 'ssd');
+    });
+
+    it('should preselect device by domain selection', () => {
+      controls.failure.setValue('osd');
+      assert.formFieldValues(get.nodeByName('default'), 'osd', 'ssd');
+    });
+  });
+
+  describe('get available OSDs count', () => {
+    it('should have 4 available OSDs with the default selection', () => {
+      expect(service.deviceCount).toBe(4);
+    });
+
+    it('should reduce available OSDs to 2 if a device type is set', () => {
+      controls.device.setValue('ssd');
+      controls.device.markAsDirty();
+      expect(service.deviceCount).toBe(2);
+    });
+
+    it('should show 3 OSDs when selecting "ssd-host"', () => {
+      assert.valuesOnRootChange('ssd-host', 'osd', 'ssd');
+      expect(service.deviceCount).toBe(3);
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.ts
@@ -1,0 +1,140 @@
+import { AbstractControl } from '@angular/forms';
+
+import * as _ from 'lodash';
+
+import { CrushNode } from '../models/crush-node';
+
+export class CrushNodeSelectionClass {
+  private nodes: CrushNode[] = [];
+  private easyNodes: { [id: number]: CrushNode } = {};
+  private allDevices: string[] = [];
+  private controls: {
+    root: AbstractControl;
+    failure: AbstractControl;
+    device: AbstractControl;
+  };
+
+  buckets: CrushNode[] = [];
+  failureDomains: { [type: string]: CrushNode[] } = {};
+  failureDomainKeys: string[] = [];
+  devices: string[] = [];
+  deviceCount = 0;
+
+  initCrushNodeSelection(
+    nodes: CrushNode[],
+    rootControl: AbstractControl,
+    failureControl: AbstractControl,
+    deviceControl: AbstractControl
+  ) {
+    this.nodes = nodes;
+    nodes.forEach((node) => {
+      this.easyNodes[node.id] = node;
+    });
+    this.buckets = _.sortBy(
+      nodes.filter((n) => n.children),
+      'name'
+    );
+    this.controls = {
+      root: rootControl,
+      failure: failureControl,
+      device: deviceControl
+    };
+    this.preSelectRoot();
+    this.controls.root.valueChanges.subscribe(() => this.onRootChange());
+    this.controls.failure.valueChanges.subscribe(() => this.onFailureDomainChange());
+    this.controls.device.valueChanges.subscribe(() => this.onDeviceChange());
+  }
+
+  private preSelectRoot() {
+    const rootNode = this.nodes.find((node) => node.type === 'root');
+    this.silentSet(this.controls.root, rootNode);
+    this.onRootChange();
+  }
+
+  private silentSet(control: AbstractControl, value: any) {
+    control.setValue(value, { emitEvent: false });
+  }
+
+  private onRootChange() {
+    const nodes = this.getSubNodes(this.controls.root.value);
+    const domains = {};
+    nodes.forEach((node) => {
+      if (!domains[node.type]) {
+        domains[node.type] = [];
+      }
+      domains[node.type].push(node);
+    });
+    Object.keys(domains).forEach((type) => {
+      if (domains[type].length <= 1) {
+        delete domains[type];
+      }
+    });
+    this.failureDomains = domains;
+    this.failureDomainKeys = Object.keys(domains).sort();
+    this.updateFailureDomain();
+  }
+
+  private getSubNodes(node: CrushNode): CrushNode[] {
+    let subNodes = [node]; // Includes parent node
+    if (!node.children) {
+      return subNodes;
+    }
+    node.children.forEach((id) => {
+      const childNode = this.easyNodes[id];
+      subNodes = subNodes.concat(this.getSubNodes(childNode));
+    });
+    return subNodes;
+  }
+
+  private updateFailureDomain() {
+    let failureDomain = this.getIncludedCustomValue(
+      this.controls.failure,
+      Object.keys(this.failureDomains)
+    );
+    if (failureDomain === '') {
+      failureDomain = this.setMostCommonDomain(this.controls.failure);
+    }
+    this.updateDevices(failureDomain);
+  }
+
+  private getIncludedCustomValue(control: AbstractControl, includedIn: string[]) {
+    return control.dirty && includedIn.includes(control.value) ? control.value : '';
+  }
+
+  private setMostCommonDomain(failureControl: AbstractControl): string {
+    let winner = { n: 0, type: '' };
+    Object.keys(this.failureDomains).forEach((type) => {
+      const n = this.failureDomains[type].length;
+      if (winner.n < n) {
+        winner = { n, type };
+      }
+    });
+    this.silentSet(failureControl, winner.type);
+    return winner.type;
+  }
+
+  private onFailureDomainChange() {
+    this.updateDevices();
+  }
+
+  private updateDevices(failureDomain: string = this.controls.failure.value) {
+    const subNodes = _.flatten(
+      this.failureDomains[failureDomain].map((node) => this.getSubNodes(node))
+    );
+    this.allDevices = subNodes.filter((n) => n.device_class).map((n) => n.device_class);
+    this.devices = _.uniq(this.allDevices).sort();
+    const device =
+      this.devices.length === 1
+        ? this.devices[0]
+        : this.getIncludedCustomValue(this.controls.device, this.devices);
+    this.silentSet(this.controls.device, device);
+    this.onDeviceChange(device);
+  }
+
+  private onDeviceChange(deviceType: string = this.controls.device.value) {
+    this.deviceCount =
+      deviceType === ''
+        ? this.allDevices.length
+        : this.allDevices.filter((type) => type === deviceType).length;
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/pool-form-info.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/pool-form-info.ts
@@ -14,4 +14,5 @@ export class PoolFormInfo {
   pg_autoscale_modes: string[];
   erasure_code_profiles: ErasureCodeProfile[];
   used_rules: { [rule_name: string]: string[] };
+  used_profiles: { [profile_name: string]: string[] };
 }


### PR DESCRIPTION
Now root, failure domain and device class will be preselected in the erasure code profile modal.

Like for crush rule, now also if you try to delete an used ECP you can't
and the info box will show you, what pool is using the profile.

New validations with meaningful error messages:
* For all plugins
  * k + m <= OSDs that are available
  * k > 1
* For LRC
  * Display calculation factor for k (always)
  * Show error calculation for k is not met (also shows calculation)
  * Display number of groups for l (always)
  * Show error if calculation for l is not met (also shows calculation)
* For SHEC
  * m <= k
  * c <= m

Fixes: https://tracker.ceph.com/issues/44621
Signed-off-by: Stephan Müller <smueller@suse.com>---

---

![ecp-validations](https://user-images.githubusercontent.com/16167865/78765107-d0de5900-7987-11ea-8a9d-03cfd9e0ade7.gif)

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
