### PR TITLE
octopus: monitoring: Fix pool capacity incorrect

### DIFF
--- a/monitoring/grafana/dashboards/pool-detail.json
+++ b/monitoring/grafana/dashboards/pool-detail.json
@@ -101,7 +101,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(ceph_pool_stored / ceph_pool_max_avail) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}",
+          "expr": "(ceph_pool_stored / (ceph_pool_stored + ceph_pool_max_avail)) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -182,7 +182,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "((ceph_pool_max_avail - ceph_pool_stored) / deriv(ceph_pool_stored[6h])) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"} > 0",
+          "expr": "(ceph_pool_max_avail / deriv(ceph_pool_stored[6h])) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"} > 0",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44979

---

backport of https://github.com/ceph/ceph/pull/32749
parent tracker: https://tracker.ceph.com/issues/44913

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh