### PR TITLE
qa/workunits/cephadm/test_cephadm.sh: add fsid to ceph-volume cmds

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -288,16 +288,17 @@ done
 
 for id in `seq 0 $((--OSD_TO_CREATE))`; do
     device_name=/dev/$OSD_VG_NAME/$OSD_LV_NAME.$id
+    CEPH_VOLUME="$CEPHADM ceph-volume \
+                       --fsid $FSID \
+                       --config $CONFIG \
+                       --keyring $TMPDIR/keyring.bootstrap.osd --"
 
     # prepare the osd
-    $CEPHADM ceph-volume --config $CONFIG --keyring $TMPDIR/keyring.bootstrap.osd -- \
-            lvm prepare --bluestore --data $device_name --no-systemd
-    $CEPHADM ceph-volume --config $CONFIG --keyring $TMPDIR/keyring.bootstrap.osd -- \
-            lvm batch --no-auto $device_name --yes --no-systemd
+    $CEPH_VOLUME lvm prepare --bluestore --data $device_name --no-systemd
+    $CEPH_VOLUME lvm batch --no-auto $device_name --yes --no-systemd
 
     # osd id and osd fsid
-    $CEPHADM ceph-volume --config $CONFIG --keyring $TMPDIR/keyring.bootstrap.osd -- \
-            lvm list --format json $device_name > $TMPDIR/osd.map
+    $CEPH_VOLUME lvm list --format json $device_name > $TMPDIR/osd.map
     osd_id=$($SUDO cat $TMPDIR/osd.map | jq -cr '.. | ."ceph.osd_id"? | select(.)')
     osd_fsid=$($SUDO cat $TMPDIR/osd.map | jq -cr '.. | ."ceph.osd_fsid"? | select(.)')
 

--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -14,7 +14,7 @@ TMPDIR=$(mktemp -d)
 
 function cleanup()
 {
-    dump_all_logs
+    dump_all_logs $FSID
     rm -rf $TMPDIR
 }
 trap cleanup EXIT
@@ -114,8 +114,9 @@ function is_available()
 
 function dump_log()
 {
-    local name="$1"
-    local num_lines="$2"
+    local fsid="$1"
+    local name="$2"
+    local num_lines="$3"
 
     if [ -z $num_lines ]; then
         num_lines=100
@@ -125,16 +126,17 @@ function dump_log()
     echo 'dump daemon log:' $name
     echo '-------------------------'
 
-    $CEPHADM logs --name $name -- --no-pager -n $num_lines
+    $CEPHADM logs --fsid $fsid --name $name -- --no-pager -n $num_lines
 }
 
 function dump_all_logs()
 {
-    names=$($CEPHADM ls | jq -r '.[].name')
+    local fsid="$1"
+    local names=$($CEPHADM ls | jq -r '.[] | select(.fsid == "'$fsid'").name')
 
     echo 'dumping logs for daemons: ' $names
     for name in $names; do
-        dump_log $name
+        dump_log $fsid $name
     done
 }
 


### PR DESCRIPTION
needed when testing with a multi-cluster setup

```
+ sudo /tmp/tmp.wm7pCT7NXu/cephadm --image docker.io/ceph/daemon-base:latest-master-devel ceph-volume --config test_cephadm.sh.3vQh5w/tmp.78NxJtNUMV --keyring test_cephadm.sh.3vQh5w/keyring.bootstrap.osd -- lvm prepare --bluestore --data /dev/test_cephadm/test_cephadm.0 --no-systemd
ERROR: Cannot infer an fsid, one must be specified: ['fa8ed3c0-6947-4866-9249-ab62057886e7', '00000000-0000-0000-0000-0000deadbeef']
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
