### PR TITLE
octopus: docs/cephadm: <encrypted> is a global flag

### DIFF
--- a/doc/cephadm/drivegroups.rst
+++ b/doc/cephadm/drivegroups.rst
@@ -173,7 +173,7 @@ This example would deploy all OSDs with encryption enabled.
       host_pattern: '*'
     data_devices:
       all: true
-      encrypted: true
+    encrypted: true
 
 See a full list in the DriveGroupSpecs
 


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/34439