### PR TITLE
mimic: selinux: Allow ceph-mgr access to httpd dir

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -7,6 +7,7 @@ require {
 	type urandom_device_t;
 	type setfiles_t;
 	type nvme_device_t;
+	type httpd_config_t;
 	class sock_file unlink;
 	class lnk_file read;
 	class dir read;
@@ -118,6 +119,8 @@ allow ceph_t urandom_device_t:chr_file getattr;
 allow ceph_t self:process setpgid;
 allow ceph_t var_run_t:dir { write create add_name };
 allow ceph_t var_run_t:file { read write create open getattr };
+
+allow ceph_t httpd_config_t:dir search;
 
 fsadm_manage_pid(ceph_t)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44983

---

backport of https://github.com/ceph/ceph/pull/34434
parent tracker: https://tracker.ceph.com/issues/44216

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh