### PR TITLE
rgw: belong the anonymous object to the bucket owner

### DIFF
--- a/src/rgw/rgw_acl_s3.h
+++ b/src/rgw/rgw_acl_s3.h
@@ -89,8 +89,12 @@ public:
 
   virtual int create_canned(ACLOwner& _owner, ACLOwner& bucket_owner, const string& canned_acl) {
     RGWAccessControlList_S3& _acl = static_cast<RGWAccessControlList_S3 &>(acl);
-    int ret = _acl.create_canned(_owner, bucket_owner, canned_acl);
-    owner = _owner;
+    if (_owner.get_id() == rgw_user("anonymous")) {
+      owner = bucket_owner;
+    } else {
+      owner = _owner;
+    }
+    int ret = _acl.create_canned(owner, bucket_owner, canned_acl);
     return ret;
   }
   int create_from_headers(RGWUserCtl *user_ctl, const RGWEnv *env, ACLOwner& _owner);


### PR DESCRIPTION
fixbug: https://tracker.ceph.com/issues/44987

After set one bucket full_control to anyone, we can put a object without signature.
However, after putting a object without signature, I can not set the acl of it using s3cmd with the 403 error.Comparing with the s3 public write bucket, I found out that the anonymous object belong to the bucket owner in s3,while it belong to anonymous user in rgw, which made the 403 error.

Signed-off-by: wangyunqing <wangyunqing@inspur.com>