### PR TITLE
mgr/telegraf: catch FileNotFoundError exception

### DIFF
--- a/qa/suites/rados/mgr/tasks/module_selftest.yaml
+++ b/qa/suites/rados/mgr/tasks/module_selftest.yaml
@@ -18,6 +18,7 @@ tasks:
         - influxdb python module not found
         - \(MGR_ZABBIX_
         - foo bar
+        - Failed to open Telegraf
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_module_selftest

--- a/src/pybind/mgr/telegraf/module.py
+++ b/src/pybind/mgr/telegraf/module.py
@@ -240,8 +240,8 @@ class Module(MgrModule):
         sock = BaseSocket(url)
         self.log.debug('Sending data to Telegraf at %s', sock.address)
         now = self.now()
-        with sock as s:
-            try:
+        try:
+            with sock as s:
                 for measurement in self.gather_measurements():
                     self.log.debug(measurement)
                     line = Line(measurement['measurement'],
@@ -249,8 +249,10 @@ class Module(MgrModule):
                                 measurement['tags'], now)
                     self.log.debug(line.to_line_protocol())
                     s.send(line.to_line_protocol())
-            except (socket.error, RuntimeError, IOError, OSError):
-                self.log.exception('Failed to send statistics to Telegraf:')
+        except (socket.error, RuntimeError, IOError, OSError):
+            self.log.exception('Failed to send statistics to Telegraf:')
+        except FileNotFoundError:
+            self.log.exception('Failed to open Telegraf at: %s', url.geturl())
 
     def shutdown(self):
         self.log.info('Stopping Telegraf module')


### PR DESCRIPTION
in tasks/module_selftest.yaml, `TestModuleSelftest.test_telegraf()` is
called. but we fail to prepare a unix domain socket to which the telegraf
module can send stats. and telegraf module does not catch
FileNotFoundError exception, so the exception is populated to ceph-mgr
and is found by the test, hence the test is marked a failure whenever
telegraf is tested.

in this change,

* catch this exception, so it won't be caught by ceph-mgr
* whitelist the error message, so the test can pass

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
