### PR TITLE
nautilus: qa: fix various py3 cephfs qa bugs x2

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -193,20 +193,20 @@ class CephFSMount(object):
             pyscript = dedent("""
                 import time
 
-                f = open("{path}", 'w')
-                f.write('content')
-                f.flush()
-                f.write('content2')
-                while True:
-                    time.sleep(1)
+                with open("{path}", 'w') as f:
+                    f.write('content')
+                    f.flush()
+                    f.write('content2')
+                    while True:
+                        time.sleep(1)
                 """).format(path=path)
         else:
             pyscript = dedent("""
                 import time
 
-                f = open("{path}", 'r')
-                while True:
-                    time.sleep(1)
+                with open("{path}", 'r') as f:
+                    while True:
+                        time.sleep(1)
                 """).format(path=path)
 
         rproc = self._run_python(pyscript)
@@ -317,7 +317,7 @@ class CephFSMount(object):
             f1 = open("{path}-1", 'r')
             try:
                 fcntl.flock(f1, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except IOError, e:
+            except IOError as e:
                 if e.errno == errno.EAGAIN:
                     pass
             else:
@@ -327,7 +327,7 @@ class CephFSMount(object):
             try:
                 lockdata = struct.pack('hhllhh', fcntl.F_WRLCK, 0, 0, 0, 0, 0)
                 fcntl.fcntl(f2, fcntl.F_SETLK, lockdata)
-            except IOError, e:
+            except IOError as e:
                 if e.errno == errno.EAGAIN:
                     pass
             else:
@@ -361,7 +361,7 @@ class CephFSMount(object):
                     time.sleep(1)
                     if not {loop}:
                         break
-            except IOError, e:
+            except IOError as e:
                 pass
             os.close(fd)
             """).format(path=path, loop=str(loop))
@@ -387,11 +387,10 @@ class CephFSMount(object):
         return self.run_python(dedent("""
             import zlib
             path = "{path}"
-            f = open(path, 'w')
-            for i in range(0, {size}):
-                val = zlib.crc32("%s" % i) & 7
-                f.write(chr(val))
-            f.close()
+            with open(path, 'w') as f:
+                for i in range(0, {size}):
+                    val = zlib.crc32(str(i).encode('utf-8')) & 7
+                    f.write(chr(val))
         """.format(
             path=os.path.join(self.mountpoint, filename),
             size=size
@@ -402,15 +401,14 @@ class CephFSMount(object):
         return self.run_python(dedent("""
             import zlib
             path = "{path}"
-            f = open(path, 'r')
-            bytes = f.read()
-            f.close()
+            with open(path, 'r') as f:
+                bytes = f.read()
             if len(bytes) != {size}:
                 raise RuntimeError("Bad length {{0}} vs. expected {{1}}".format(
                     len(bytes), {size}
                 ))
             for i, b in enumerate(bytes):
-                val = zlib.crc32("%s" % i) & 7
+                val = zlib.crc32(str(i).encode('utf-8')) & 7
                 if b != chr(val):
                     raise RuntimeError("Bad data at offset {{0}}".format(i))
         """.format(
@@ -471,12 +469,11 @@ class CephFSMount(object):
 
             for i in range(0, n):
                 fname = "{{0}}_{{1}}".format(abs_path, i)
-                h = open(fname, 'w')
-                h.write('content')
-                if {sync}:
-                    h.flush()
-                    os.fsync(h.fileno())
-                h.close()
+                with open(fname, 'w') as f:
+                    f.write('content')
+                    if {sync}:
+                        f.flush()
+                        os.fsync(f.fileno())
             """).format(abs_path=abs_path, count=count, sync=str(sync))
 
         self.run_python(pyscript)

--- a/qa/tasks/cephfs/test_cap_flush.py
+++ b/qa/tasks/cephfs/test_cap_flush.py
@@ -43,7 +43,7 @@ class TestCapFlush(CephFSTestCase):
             os.chdir("{0}")
             os.setgid(65534)
             os.setuid(65534)
-            fd = os.open("{1}", os.O_CREAT | os.O_RDWR, 0644)
+            fd = os.open("{1}", os.O_CREAT | os.O_RDWR, 0o644)
             os.fchmod(fd, 0o640)
             """).format(dir_path, file_name)
         self.mount_a.run_python(py_script)

--- a/qa/tasks/cephfs/test_cap_flush.py
+++ b/qa/tasks/cephfs/test_cap_flush.py
@@ -24,7 +24,7 @@ class TestCapFlush(CephFSTestCase):
             import os
             os.mkdir("{0}")
             fd = os.open("{0}", os.O_RDONLY)
-            os.fchmod(fd, 0777)
+            os.fchmod(fd, 0o777)
             os.fsync(fd)
             """).format(dir_path)
         self.mount_a.run_python(py_script)
@@ -44,7 +44,7 @@ class TestCapFlush(CephFSTestCase):
             os.setgid(65534)
             os.setuid(65534)
             fd = os.open("{1}", os.O_CREAT | os.O_RDWR, 0644)
-            os.fchmod(fd, 0640)
+            os.fchmod(fd, 0o640)
             """).format(dir_path, file_name)
         self.mount_a.run_python(py_script)
 

--- a/qa/tasks/cephfs/test_journal_migration.py
+++ b/qa/tasks/cephfs/test_journal_migration.py
@@ -78,9 +78,9 @@ class TestJournalMigration(CephFSTestCase):
                               "--path", "/tmp/journal.json"], 0)
         p = self.fs.tool_remote.run(
             args=[
-                "python",
+                "python3",
                 "-c",
-                "import json; print len(json.load(open('/tmp/journal.json')))"
+                "import json; print(len(json.load(open('/tmp/journal.json'))))"
             ],
             stdout=StringIO())
         event_count = int(p.stdout.getvalue().strip())

--- a/qa/tasks/cephfs/test_pool_perm.py
+++ b/qa/tasks/cephfs/test_pool_perm.py
@@ -19,8 +19,8 @@ class TestPoolPerm(CephFSTestCase):
                 if {check_read}:
                     ret = os.read(fd, 1024)
                 else:
-                    os.write(fd, 'content')
-            except OSError, e:
+                    os.write(fd, b'content')
+            except OSError as e:
                 if e.errno != errno.EPERM:
                     raise
             else:

--- a/qa/tasks/cephfs/test_strays.py
+++ b/qa/tasks/cephfs/test_strays.py
@@ -45,11 +45,10 @@ class TestStrays(CephFSTestCase):
             size = {size}
             file_count = {file_count}
             os.mkdir(os.path.join(mount_path, subdir))
-            for i in xrange(0, file_count):
+            for i in range(0, file_count):
                 filename = "{{0}}_{{1}}.bin".format(i, size)
-                f = open(os.path.join(mount_path, subdir, filename), 'w')
-                f.write(size * 'x')
-                f.close()
+                with open(os.path.join(mount_path, subdir, filename), 'w') as f:
+                    f.write(size * 'x')
         """.format(
             mount_path=self.mount_a.mountpoint,
             size=1024,
@@ -152,12 +151,11 @@ class TestStrays(CephFSTestCase):
             size_unit = {size_unit}
             file_multiplier = {file_multiplier}
             os.mkdir(os.path.join(mount_path, subdir))
-            for i in xrange(0, file_multiplier):
-                for size in xrange(0, {size_range}*size_unit, size_unit):
+            for i in range(0, file_multiplier):
+                for size in range(0, {size_range}*size_unit, size_unit):
                     filename = "{{0}}_{{1}}.bin".format(i, size / size_unit)
-                    f = open(os.path.join(mount_path, subdir, filename), 'w')
-                    f.write(size * 'x')
-                    f.close()
+                    with open(os.path.join(mount_path, subdir, filename), 'w') as f:
+                        f.write(size * 'x')
         """.format(
             mount_path=self.mount_a.mountpoint,
             size_unit=size_unit,
@@ -842,7 +840,8 @@ class TestStrays(CephFSTestCase):
                 path = os.path.join("{path}", "subdir")
                 os.mkdir(path)
                 for n in range(0, {file_count}):
-                    open(os.path.join(path, "%s" % n), 'w').write("%s" % n)
+                    with open(os.path.join(path, "%s" % n), 'w') as f:
+                        f.write(str(n))
                 """.format(
             path=self.mount_a.mountpoint,
             file_count=LOW_LIMIT+1
@@ -859,7 +858,8 @@ class TestStrays(CephFSTestCase):
             path = os.path.join("{path}", "subdir2")
             os.mkdir(path)
             for n in range(0, {file_count}):
-                open(os.path.join(path, "%s" % n), 'w').write("%s" % n)
+                with open(os.path.join(path, "%s" % n), 'w') as f:
+                    f.write(str(n))
             dfd = os.open(path, os.O_DIRECTORY)
             os.fsync(dfd)
             """.format(
@@ -882,7 +882,8 @@ class TestStrays(CephFSTestCase):
             import os
             path = os.path.join("{path}", "subdir2")
             for n in range({file_count}, ({file_count}*3)//2):
-                open(os.path.join(path, "%s" % n), 'w').write("%s" % n)
+                with open(os.path.join(path, "%s" % n), 'w') as f:
+                    f.write(str(n))
             """.format(
         path=self.mount_a.mountpoint,
         file_count=LOW_LIMIT
@@ -897,9 +898,8 @@ class TestStrays(CephFSTestCase):
                 os.mkdir(path)
                 for n in range({file_count}):
                     fpath = os.path.join(path, "%s" % n)
-                    f = open(fpath, 'w')
-                    f.write("%s" % n)
-                    f.close()
+                    with open(fpath, 'w') as f:
+                        f.write(str(n))
                     os.unlink(fpath)
                 """.format(
             path=self.mount_a.mountpoint,
@@ -922,9 +922,8 @@ class TestStrays(CephFSTestCase):
             os.mkdir(path)
             for n in range({file_count}):
                 fpath = os.path.join(path, "%s" % n)
-                f = open(fpath, 'w')
-                f.write("%s" % n)
-                f.close()
+                with open(fpath, 'w') as f:
+                    f.write(str(n))
                 os.unlink(fpath)
             """.format(
         path=self.mount_a.mountpoint,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44655

---

backport of https://github.com/ceph/ceph/pull/32533
parent tracker: https://tracker.ceph.com/issues/43515

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh