### PR TITLE
qa/tasks/rbd_fio: unbreak after the conversion from StringIO

### DIFF
--- a/qa/tasks/rbd_fio.py
+++ b/qa/tasks/rbd_fio.py
@@ -77,7 +77,7 @@ def get_ioengine_package_name(ioengine, remote):
 def run_rbd_map(remote, image, iodepth):
     iodepth = max(iodepth, 128)  # RBD_QUEUE_DEPTH_DEFAULT
     dev = remote.sh(['sudo', 'rbd', 'device', 'map', '-o',
-                     'queue_depth={}'.format(iodepth), image]).rstripg('\n')
+                     'queue_depth={}'.format(iodepth), image]).rstrip('\n')
     teuthology.sudo_write_file(
         remote,
         '/sys/block/{}/queue/nr_requests'.format(os.path.basename(dev)),


### PR DESCRIPTION
Fix a bad typo in commit db7ae8eff60a ("qa/tasks/rbd_fio: get rid of
StringIO for py3").

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>
