### PR TITLE
mimic: ceph-volume/batch: return success when all devices are filtered

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -366,7 +366,12 @@ class Batch(object):
                 self.filtered_devices.update({d: used_reason for d in
                                               getattr(self.args, dev_list_prop)
                                               if d.used_by_ceph})
-                if self.args.yes and dev_list and devs != usable:
+                # only fail if non-interactive, this iteration concerns
+                # non-data devices, there are usable data devices (or not all
+                # data devices were filtered) and non-data devices were filtered
+                # so in short this branch is not taken if all data devices are
+                # filtered
+                if self.args.yes and dev_list and self.usable and devs != usable:
                     err = '{} devices were filtered in non-interactive mode, bailing out'
                     raise RuntimeError(err.format(len(devs) - len(usable)))
 

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/playbooks/test_explicit.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/playbooks/test_explicit.yml
@@ -9,7 +9,6 @@
         state: stopped
       with_items: "{{ osd_ids }}"
 
-
 - hosts: mons
   become: yes
   tasks:
@@ -17,7 +16,6 @@
     - name: purge osds
       command: "ceph --cluster {{ cluster }} osd purge osd.{{ item }} --yes-i-really-mean-it"
       with_items: "{{ osd_ids }}"
-
 
 - hosts: osds
   become: yes
@@ -34,7 +32,7 @@
       environment:
         CEPH_VOLUME_DEBUG: 1
 
-    - name: ensure batch create is idempotent
+    - name: ensure batch create is idempotent when all data devices are filtered
       command: "ceph-volume --cluster {{ cluster }} lvm batch --yes --{{ osd_objectstore|default('bluestore') }} {{ '--dmcrypt' if dmcrypt|default(false) else '' }} {{ devices[:2] | join(' ') }} --db-devices {{ devices[2:] | join(' ') }}"
       register: batch_cmd
       failed_when: false
@@ -46,7 +44,6 @@
         msg: "lvm batch failed idempotency check"
       when:
          - batch_cmd.rc != 0
-         - "'strategy changed' not in batch_cmd.stderr"
 
     - name: run batch --report to see if devices get filtered
       command: "ceph-volume --cluster {{ cluster }} lvm batch --report --format=json --{{ osd_objectstore|default('bluestore') }} {{ '--dmcrypt' if dmcrypt|default(false) else '' }} {{ devices[:2] | join(' ') }} --db-devices {{ devices[2:] | join(' ') }}"
@@ -60,4 +57,3 @@
         msg: "lvm batch --report failed idempotency check"
       when:
          - report_cmd.rc != 0
-         - "'strategy changed' not in report_cmd.stderr"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45000

---

backport of https://github.com/ceph/ceph/pull/34472
parent tracker: https://tracker.ceph.com/issues/44994

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh