### PR TITLE
octopus: ceph-volume/batch: check lvs list before access

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -106,9 +106,12 @@ def filter_devices(args):
     if len(unused_devices) == 1:
         last_device = unused_devices[0]
         if not last_device.rotational and last_device.is_lvm_member:
-            reason = "Used by ceph as a %s already and there are no devices left for data/block" % (
-                last_device.lvs[0].tags.get("ceph.type"),
-            )
+            if last_device.lvs:
+                reason = "Used by ceph as a %s already and there are no devices left for data/block" % (
+                    last_device.lvs[0].tags.get("ceph.type"),
+                )
+            else:
+                reason = "Disk is an LVM member already, skipping"
             filtered_devices[last_device.abspath] = {"reasons": [reason]}
             logger.info(reason + ": %s" % last_device.abspath)
             unused_devices = []


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45003

---

backport of https://github.com/ceph/ceph/pull/34463
parent tracker: https://tracker.ceph.com/issues/44989

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh