### PR TITLE
doc/rados: Remove obsolete placement group note from EC pool creation

### DIFF
--- a/doc/rados/operations/erasure-code.rst
+++ b/doc/rados/operations/erasure-code.rst
@@ -24,9 +24,6 @@ requires at least three hosts::
     $ rados --pool ecpool get NYAN -
     ABCDEFGHI
 
-.. note:: the 12 in *pool create* stands for 
-          `the number of placement groups <../pools>`_.
-
 Erasure code profiles
 ---------------------
 


### PR DESCRIPTION
Signed-off-by: Danny Abukalam <danny@softiron.co.uk>