### PR TITLE
rgw: Add support subuser for bucket acl S3

### DIFF
--- a/src/rgw/rgw_acl.cc
+++ b/src/rgw/rgw_acl.cc
@@ -39,7 +39,12 @@ void RGWAccessControlList::_add_grant(ACLGrant *grant)
       if (!grant->get_id(id)) {
         ldout(cct, 0) << "ERROR: grant->get_id() failed" << dendl;
       }
-      acl_user_map[id.to_str()] |= perm.get_permissions();
+      string id_str = id.to_str();
+      string subuser = grant->get_subuser();
+      if (!subuser.empty()) {
+        id_str += ":" + subuser;
+      }
+      acl_user_map[id_str] |= perm.get_permissions();
     }
   }
 }
@@ -48,7 +53,12 @@ void RGWAccessControlList::add_grant(ACLGrant *grant)
 {
   rgw_user id;
   grant->get_id(id); // not that this will return false for groups, but that's ok, we won't search groups
-  grant_map.insert(pair<string, ACLGrant>(id.to_str(), *grant));
+  string id_str = id.to_str();
+  string subuser = grant->get_subuser();
+  if (!subuser.empty()) {
+    id_str += ":" + subuser;
+  }
+  grant_map.insert(pair<string, ACLGrant>(id_str, *grant));
   _add_grant(grant);
 }
 

--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -109,6 +109,7 @@ class ACLGrant
 protected:
   ACLGranteeType type;
   rgw_user id;
+  string subuser;
   string email;
   ACLPermission permission;
   string name;
@@ -134,6 +135,7 @@ public:
       return true;
     }
   }
+  string& get_subuser() { return subuser; }
   ACLGranteeType& get_type() { return type; }
   const ACLGranteeType& get_type() const { return type; }
   ACLPermission& get_permission() { return permission; }
@@ -147,6 +149,7 @@ public:
     string s;
     id.to_str(s);
     encode(s, bl);
+    encode(subuser, bl);
     string uri;
     encode(uri, bl);
     encode(email, bl);
@@ -163,6 +166,7 @@ public:
     string s;
     decode(s, bl);
     id.from_str(s);
+    decode(subuser, bl);
     string uri;
     decode(uri, bl);
     decode(email, bl);
@@ -187,9 +191,10 @@ public:
 
   ACLGroupTypeEnum uri_to_group(string& uri);
   
-  void set_canon(const rgw_user& _id, const string& _name, const uint32_t perm) {
+  void set_canon(const rgw_user& _id, const string& _subuser, const string& _name, const uint32_t perm) {
     type.set(ACL_TYPE_CANON_USER);
     id = _id;
+    subuser = _subuser;
     name = _name;
     permission.set_permissions(perm);
   }
@@ -355,7 +360,7 @@ public:
     referer_list.clear();
 
     ACLGrant grant;
-    grant.set_canon(id, name, RGW_PERM_FULL_CONTROL);
+    grant.set_canon(id, std::string(), name, RGW_PERM_FULL_CONTROL);
     add_grant(&grant);
   }
 };

--- a/src/rgw/rgw_acl_swift.cc
+++ b/src/rgw/rgw_acl_swift.cc
@@ -123,9 +123,9 @@ static ACLGrant user_to_grant(CephContext* const cct,
   if (user_ctl->get_info_by_uid(user, &grant_user, null_yield) < 0) {
     ldout(cct, 10) << "grant user does not exist: " << uid << dendl;
     /* skipping silently */
-    grant.set_canon(user, std::string(), perm);
+    grant.set_canon(user, std::string(), std::string(), perm);
   } else {
-    grant.set_canon(user, grant_user.display_name, perm);
+    grant.set_canon(user, std::string(), grant_user.display_name, perm);
   }
 
   return grant;
@@ -314,10 +314,10 @@ void RGWAccessControlPolicy_SWIFTAcct::add_grants(RGWUserCtl * const user_ctl,
       if (user_ctl->get_info_by_uid(user, &grant_user, null_yield) < 0) {
         ldout(cct, 10) << "grant user does not exist:" << uid << dendl;
         /* skipping silently */
-        grant.set_canon(user, std::string(), perm);
+        grant.set_canon(user, std::string(), std::string(), perm);
         acl.add_grant(&grant);
       } else {
-        grant.set_canon(user, grant_user.display_name, perm);
+        grant.set_canon(user, std::string(), grant_user.display_name, perm);
         acl.add_grant(&grant);
       }
     }

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -688,6 +688,7 @@ protected:
 
 uint32_t rgw_perms_from_aclspec_default_strategy(
   const rgw_user& uid,
+  const string& subuser,
   const rgw::auth::Identity::aclspec_t& aclspec);
 
 #endif /* CEPH_RGW_AUTH_H */

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -3632,7 +3632,7 @@ int RGWBucketCtl::chown(rgw::sal::RGWRadosStore *store, RGWBucketInfo& bucket_in
 
         //Create a grant and add grant
         ACLGrant grant;
-        grant.set_canon(user_id, display_name, RGW_PERM_FULL_CONTROL);
+        grant.set_canon(user_id, std::string(), display_name, RGW_PERM_FULL_CONTROL);
         acl.add_grant(&grant);
 
         //Update the ACL owner to the new user

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1143,10 +1143,10 @@ bool verify_requester_payer_permission(struct perm_state_base *s)
 
 bool verify_bucket_permission(const DoutPrefixProvider* dpp,
                               struct perm_state_base * const s,
-			      const rgw_bucket& bucket,
+                              const rgw_bucket& bucket,
                               RGWAccessControlPolicy * const user_acl,
                               RGWAccessControlPolicy * const bucket_acl,
-			      const boost::optional<Policy>& bucket_policy,
+                              const boost::optional<Policy>& bucket_policy,
                               const vector<Policy>& user_policies,
                               const uint64_t op)
 {

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -292,7 +292,7 @@ void ACLGrant::generate_test_instances(list<ACLGrant*>& o)
   email = "r@gw";
 
   ACLGrant *g1 = new ACLGrant;
-  g1->set_canon(id, name, RGW_PERM_READ);
+  g1->set_canon(id, std::string(), name, RGW_PERM_READ);
   g1->email = email;
   o.push_back(g1);
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -837,7 +837,6 @@ static int rgw_iam_add_existing_objtags(rgw::sal::RGWRadosStore* store, struct r
 }
 
 static void rgw_add_grant_to_iam_environment(rgw::IAM::Environment& e, struct req_state *s){
-
   using header_pair_t = std::pair <const char*, const char*>;
   static const std::initializer_list <header_pair_t> acl_header_conditionals {
     {"HTTP_X_AMZ_GRANT_READ", "s3:x-amz-grant-read"},
@@ -851,7 +850,7 @@ static void rgw_add_grant_to_iam_environment(rgw::IAM::Environment& e, struct re
     for (const auto& c: acl_header_conditionals){
       auto hdr = s->info.env->get(c.first);
       if(hdr) {
-	e[c.second] = hdr;
+	      e[c.second] = hdr;
       }
     }
   }


### PR DESCRIPTION
This can help to support bucket acl for subusers in a pattern of `user:subuser`

Fixes: https://tracker.ceph.com/issues/45007
Signed-off-by: Seena Fallah <seenafallah@gmail.com>