### PR TITLE
tests: update unmap.t for table spacing changes

### DIFF
--- a/src/test/cli-integration/rbd/unmap.t
+++ b/src/test/cli-integration/rbd/unmap.t
@@ -30,8 +30,8 @@ Unmap by device
 Unmap by device (img is already mapped):
 
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   -    /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    -     /dev/rbd? (glob)
   $ sudo rbd device unmap $DEV
   $ rbd device list
 
@@ -39,15 +39,15 @@ Unmap by device partition:
 
   $ DEV=$(sudo rbd device map img)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   -    /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    -     /dev/rbd? (glob)
   $ sudo rbd device unmap ${DEV}p1
   $ rbd device list
 
   $ DEV=$(sudo rbd device map img)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   -    /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    -     /dev/rbd? (glob)
   $ sudo rbd device unmap ${DEV}p5
   $ rbd device list
 
@@ -84,16 +84,16 @@ img:
   $ sudo rbd device map img
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   -    /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    -     /dev/rbd? (glob)
   $ sudo rbd device unmap img
   $ rbd device list
 
   $ sudo rbd device map img
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   -    /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    -     /dev/rbd? (glob)
   $ sudo rbd --image img device unmap
   $ rbd device list
 
@@ -102,24 +102,24 @@ img@snap:
   $ sudo rbd device map img@snap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap img@snap
   $ rbd device list
 
   $ sudo rbd device map img@snap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd --snap snap device unmap img
   $ rbd device list
 
   $ sudo rbd device map img@snap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd --image img --snap snap device unmap
   $ rbd device list
 
@@ -128,32 +128,32 @@ pool/img@snap, default pool:
   $ sudo rbd device map rbd/img@snap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap rbd/img@snap
   $ rbd device list
 
   $ sudo rbd device map rbd/img@snap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd --pool rbd device unmap img@snap
   $ rbd device list
 
   $ sudo rbd device map rbd/img@snap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd --pool rbd --snap snap device unmap img
   $ rbd device list
 
   $ sudo rbd device map rbd/img@snap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd --pool rbd --image img --snap snap device unmap
   $ rbd device list
 
@@ -162,32 +162,32 @@ pool/img@snap, custom pool:
   $ sudo rbd device map custom/img@snap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool   namespace image snap device    
-  ?  custom           img   snap /dev/rbd?  (glob)
+  id  pool    namespace  image  snap  device   
+  ?   custom             img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap custom/img@snap
   $ rbd device list
 
   $ sudo rbd device map custom/img@snap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool   namespace image snap device    
-  ?  custom           img   snap /dev/rbd?  (glob)
+  id  pool    namespace  image  snap  device   
+  ?   custom             img    snap  /dev/rbd? (glob)
   $ sudo rbd --pool custom device unmap img@snap
   $ rbd device list
 
   $ sudo rbd device map custom/img@snap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool   namespace image snap device    
-  ?  custom           img   snap /dev/rbd?  (glob)
+  id  pool    namespace  image  snap  device   
+  ?   custom             img    snap  /dev/rbd? (glob)
   $ sudo rbd --pool custom --snap snap device unmap img
   $ rbd device list
 
   $ sudo rbd device map custom/img@snap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool   namespace image snap device    
-  ?  custom           img   snap /dev/rbd?  (glob)
+  id  pool    namespace  image  snap  device   
+  ?   custom             img    snap  /dev/rbd? (glob)
   $ sudo rbd --pool custom --image img --snap snap device unmap
   $ rbd device list
 
@@ -238,13 +238,13 @@ Unmap img first:
   $ sudo rbd device map anotherimg
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image      snap device    
-  ?  rbd            img        -    /dev/rbd?  (glob)
-  ?  rbd            anotherimg -    /dev/rbd?  (glob)
+  id  pool  namespace  image       snap  device   
+  ?   rbd              img         -     /dev/rbd? (glob)
+  ?   rbd              anotherimg  -     /dev/rbd? (glob)
   $ sudo rbd device unmap img
   $ rbd device list
-  id pool namespace image      snap device    
-  ?  rbd            anotherimg -    /dev/rbd?  (glob)
+  id  pool  namespace  image       snap  device   
+  ?   rbd              anotherimg  -     /dev/rbd? (glob)
   $ sudo rbd device unmap anotherimg
   $ rbd device list
 
@@ -255,13 +255,13 @@ Unmap anotherimg first:
   $ sudo rbd device map anotherimg
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image      snap device    
-  ?  rbd            img        -    /dev/rbd?  (glob)
-  ?  rbd            anotherimg -    /dev/rbd?  (glob)
+  id  pool  namespace  image       snap  device   
+  ?   rbd              img         -     /dev/rbd? (glob)
+  ?   rbd              anotherimg  -     /dev/rbd? (glob)
   $ sudo rbd device unmap anotherimg
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   -    /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    -     /dev/rbd? (glob)
   $ sudo rbd device unmap img
   $ rbd device list
 
@@ -276,13 +276,13 @@ Unmap the image first:
   $ sudo rbd device map img@snap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   -    /dev/rbd?  (glob)
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    -     /dev/rbd? (glob)
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap img
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap img@snap
   $ rbd device list
 
@@ -293,13 +293,13 @@ Unmap the snap first:
   $ sudo rbd device map img@snap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   -    /dev/rbd?  (glob)
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    -     /dev/rbd? (glob)
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap img@snap
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   -    /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    -     /dev/rbd? (glob)
   $ sudo rbd device unmap img
   $ rbd device list
 
@@ -314,13 +314,13 @@ Unmap snap first:
   $ sudo rbd device map custom/img@anothersnap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool   namespace image snap        device    
-  ?  custom           img   snap        /dev/rbd?  (glob)
-  ?  custom           img   anothersnap /dev/rbd?  (glob)
+  id  pool    namespace  image  snap         device   
+  ?   custom             img    snap         /dev/rbd? (glob)
+  ?   custom             img    anothersnap  /dev/rbd? (glob)
   $ sudo rbd device unmap custom/img@snap
   $ rbd device list
-  id pool   namespace image snap        device    
-  ?  custom           img   anothersnap /dev/rbd?  (glob)
+  id  pool    namespace  image  snap         device   
+  ?   custom             img    anothersnap  /dev/rbd? (glob)
   $ sudo rbd device unmap custom/img@anothersnap
   $ rbd device list
 
@@ -331,13 +331,13 @@ Unmap anothersnap first:
   $ sudo rbd device map custom/img@anothersnap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool   namespace image snap        device    
-  ?  custom           img   snap        /dev/rbd?  (glob)
-  ?  custom           img   anothersnap /dev/rbd?  (glob)
+  id  pool    namespace  image  snap         device   
+  ?   custom             img    snap         /dev/rbd? (glob)
+  ?   custom             img    anothersnap  /dev/rbd? (glob)
   $ sudo rbd device unmap custom/img@anothersnap
   $ rbd device list
-  id pool   namespace image snap device    
-  ?  custom           img   snap /dev/rbd?  (glob)
+  id  pool    namespace  image  snap  device   
+  ?   custom             img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap custom/img@snap
   $ rbd device list
 
@@ -352,13 +352,13 @@ img:
   $ sudo rbd device map custom/img
   /dev/rbd? (glob)
   $ rbd device list
-  id pool   namespace image snap device    
-  ?  rbd              img   -    /dev/rbd?  (glob)
-  ?  custom           img   -    /dev/rbd?  (glob)
+  id  pool    namespace  image  snap  device   
+  ?   rbd                img    -     /dev/rbd? (glob)
+  ?   custom             img    -     /dev/rbd? (glob)
   $ sudo rbd device unmap img
   $ rbd device list
-  id pool   namespace image snap device    
-  ?  custom           img   -    /dev/rbd?  (glob)
+  id  pool    namespace  image  snap  device   
+  ?   custom             img    -     /dev/rbd? (glob)
   $ sudo rbd device unmap custom/img
   $ rbd device list
 
@@ -369,13 +369,13 @@ img@snap:
   $ sudo rbd device map custom/img@snap
   /dev/rbd? (glob)
   $ rbd device list
-  id pool   namespace image snap device    
-  ?  rbd              img   snap /dev/rbd?  (glob)
-  ?  custom           img   snap /dev/rbd?  (glob)
+  id  pool    namespace  image  snap  device   
+  ?   rbd                img    snap  /dev/rbd? (glob)
+  ?   custom             img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap custom/img@snap
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap img@snap
   $ rbd device list
 
@@ -391,14 +391,14 @@ img:
   rbd: warning: image already mapped as /dev/rbd? (glob)
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   -    /dev/rbd?  (glob)
-  ?  rbd            img   -    /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    -     /dev/rbd? (glob)
+  ?   rbd              img    -     /dev/rbd? (glob)
   $ sudo rbd device unmap img
   rbd: rbd/img: mapped more than once, unmapping /dev/rbd? only (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   -    /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    -     /dev/rbd? (glob)
   $ sudo rbd device unmap img
   $ rbd device list
 
@@ -410,14 +410,14 @@ img@snap:
   rbd: warning: image already mapped as /dev/rbd? (glob)
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   snap /dev/rbd?  (glob)
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    snap  /dev/rbd? (glob)
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap img@snap
   rbd: rbd/img@snap: mapped more than once, unmapping /dev/rbd? only (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap img@snap
   $ rbd device list
 
@@ -429,14 +429,14 @@ pool/img@snap, default pool:
   rbd: warning: image already mapped as /dev/rbd? (glob)
   /dev/rbd? (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   snap /dev/rbd?  (glob)
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    snap  /dev/rbd? (glob)
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap rbd/img@snap
   rbd: rbd/img@snap: mapped more than once, unmapping /dev/rbd? only (glob)
   $ rbd device list
-  id pool namespace image snap device    
-  ?  rbd            img   snap /dev/rbd?  (glob)
+  id  pool  namespace  image  snap  device   
+  ?   rbd              img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap rbd/img@snap
   $ rbd device list
 
@@ -448,14 +448,14 @@ pool/img@snap, custom pool:
   rbd: warning: image already mapped as /dev/rbd? (glob)
   /dev/rbd? (glob)
   $ rbd device list
-  id pool   namespace image snap device    
-  ?  custom           img   snap /dev/rbd?  (glob)
-  ?  custom           img   snap /dev/rbd?  (glob)
+  id  pool    namespace  image  snap  device   
+  ?   custom             img    snap  /dev/rbd? (glob)
+  ?   custom             img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap custom/img@snap
   rbd: custom/img@snap: mapped more than once, unmapping /dev/rbd? only (glob)
   $ rbd device list
-  id pool   namespace image snap device    
-  ?  custom           img   snap /dev/rbd?  (glob)
+  id  pool    namespace  image  snap  device   
+  ?   custom             img    snap  /dev/rbd? (glob)
   $ sudo rbd device unmap custom/img@snap
   $ rbd device list
 


### PR DESCRIPTION
Introduced in 4d42b4c5a0ed ("common/TextTable: default to 2 spaces
separating columns") and 41f003518a07 ("common/TextTable: only pad
between columns").

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>