### PR TITLE
nautilus: mgr/dashboard: use FQDN for failover redirection

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -179,7 +179,7 @@ class CherryPyConfig(object):
 
         uri = "{0}://{1}:{2}{3}/".format(
             'https' if ssl else 'http',
-            socket.getfqdn() if server_addr in ['::', '0.0.0.0'] else server_addr,
+            socket.getfqdn(server_addr if server_addr != '::' else ''),
             server_port,
             self.url_prefix
         )


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45019

---

backport of https://github.com/ceph/ceph/pull/34452
parent tracker: https://tracker.ceph.com/issues/44923

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh