### PR TITLE
selinux: additional targeted policy for rgw multisite

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -85,6 +85,7 @@ corenet_tcp_bind_cyphesis_port(ceph_t)
 corenet_tcp_sendrecv_cyphesis_port(ceph_t)
 
 allow ceph_t commplex_main_port_t:tcp_socket name_connect;
+allow ceph_t http_cache_port_t:tcp_socket name_connect;
 
 corecmd_exec_bin(ceph_t)
 corecmd_exec_shell(ceph_t)


### PR DESCRIPTION
selinux: additional targeted policy for rgw multisite

fix AVC seen in teuthology run

Fixes: https://tracker.ceph.com/issues/45022
Signed-off-by: [Your Name] <[your email]>

-->
## Checklist
- [X] References tracker ticket
- [X] Updates documentation if necessary
- [X] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
