### PR TITLE
nautilus: osd/PeeringState.h: ignore RemoteBackfillReserved in WaitLocalBackfillReserved

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2471,9 +2471,14 @@ protected:
 
     struct WaitLocalBackfillReserved : boost::statechart::state< WaitLocalBackfillReserved, Active >, NamedState {
       typedef boost::mpl::list<
-	boost::statechart::transition< LocalBackfillReserved, WaitRemoteBackfillReserved >
+	boost::statechart::transition< LocalBackfillReserved, WaitRemoteBackfillReserved >,
+	boost::statechart::custom_reaction< RemoteBackfillReserved >
 	> reactions;
       explicit WaitLocalBackfillReserved(my_context ctx);
+      boost::statechart::result react(const RemoteBackfillReserved& evt) {
+	/* no-op */
+	return discard_event();
+      }
       void exit();
     };
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44324

---

backport of https://github.com/ceph/ceph/pull/33525
parent tracker: https://tracker.ceph.com/issues/44248

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh