### PR TITLE
nautilus: common/bl: fix memory corruption in bufferlist::claim_append()

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1344,7 +1344,8 @@ static ceph::spinlock debug_lock;
 	if (unlikely(raw && !raw->is_shareable())) {
 	  auto* clone = ptr_node::copy_hypercombined(*curbuf);
 	  curbuf = bl._buffers.erase_after_and_dispose(curbuf_prev);
-	  bl._buffers.insert_after(curbuf_prev++, *clone);
+	  bl._buffers.insert_after(curbuf_prev, *clone);
+	  ++curbuf_prev;
 	} else {
 	  curbuf_prev = curbuf++;
 	}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43920

---

backport of https://github.com/ceph/ceph/pull/32823
parent tracker: https://tracker.ceph.com/issues/43814

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh