### PR TITLE
qa/tasks/mgr/dashboard: set last_opt_revision when setting enabled

### DIFF
--- a/qa/tasks/mgr/dashboard/test_mgr_module.py
+++ b/qa/tasks/mgr/dashboard/test_mgr_module.py
@@ -127,18 +127,20 @@ class MgrModuleTelemetryTest(MgrModuleTestCase):
     def test_put(self):
         self.set_config_key('config/mgr/mgr/telemetry/contact', '')
         self.set_config_key('config/mgr/mgr/telemetry/description', '')
-        self.set_config_key('config/mgr/mgr/telemetry/enabled', 'True')
         self.set_config_key('config/mgr/mgr/telemetry/interval', '72')
         self.set_config_key('config/mgr/mgr/telemetry/leaderboard', 'False')
         self.set_config_key('config/mgr/mgr/telemetry/organization', '')
         self.set_config_key('config/mgr/mgr/telemetry/proxy', '')
         self.set_config_key('config/mgr/mgr/telemetry/url', '')
+        self.set_config_key('config/mgr/mgr/telemetry/last_opt_revision', '2')
+        self.set_config_key('config/mgr/mgr/telemetry/enabled', 'True')
         self._put(
             '/api/mgr/module/telemetry',
             data={
                 'config': {
                     'contact': 'tux@suse.com',
                     'description': 'test',
+                    'last_opt_revision': 1,
                     'enabled': False,
                     'interval': 4711,
                     'leaderboard': True,


### PR DESCRIPTION
telemetry requires user to re opt-in when opt_revision is bumped up

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
