### PR TITLE
nautilus: qa/suites/rados/rest: don't pass empty dict as data arg

### DIFF
--- a/qa/workunits/rest/test_mgr_rest_api.py
+++ b/qa/workunits/rest/test_mgr_rest_api.py
@@ -85,7 +85,7 @@ for method, endpoint, args in screenplay:
     print("URL = " + url)
     request = getattr(requests, method)(
         url,
-        data=json.dumps(args),
+        data=json.dumps(args) if args else None,
         headers=headers,
         verify=False,
         auth=auth)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45060

**NOTE: the master PR has two commits, but the second one (which reverted a change that was made post-nautilus) is not needed on nautilus.**

---

backport of https://github.com/ceph/ceph/pull/34310
parent tracker: https://tracker.ceph.com/issues/43720

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh