### PR TITLE
octopus: doc/releases/nautilus: restart OSDs to make them bind to v2 addr

### DIFF
--- a/doc/releases/nautilus.rst
+++ b/doc/releases/nautilus.rst
@@ -1667,6 +1667,9 @@ Instructions
    and verify that each monitor has both a ``v2:`` and ``v1:`` address
    listed.
 
+   Running nautilus OSDs will not bind to their v2 address automatically.
+   They must be restarted for that to happen.
+
    .. important:: 
       Before this step is run, the following command must already have been run:
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45053

---

backport of https://github.com/ceph/ceph/pull/34371
parent tracker: https://tracker.ceph.com/issues/43896

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh