### PR TITLE
nautilus: doc/releases/nautilus: restart OSDs to make them bind to v2 addr

### DIFF
--- a/doc/releases/nautilus.rst
+++ b/doc/releases/nautilus.rst
@@ -360,7 +360,10 @@ Instructions
    and verify that each monitor has both a ``v2:`` and ``v1:`` address
    listed.
 
-#. For each host that has been upgrade, you should update your
+   Running nautilus OSDs will not bind to their v2 address automatically.
+   They must be restarted for that to happen.
+
+#. For each host that has been upgraded, you should update your
    ``ceph.conf`` file so that it references both the v2 and v1
    addresses.  Things will still work if only the v1 IP and port are
    listed, but each CLI instantiation or daemon will need to reconnect


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45054

---

backport of https://github.com/ceph/ceph/pull/34371
parent tracker: https://tracker.ceph.com/issues/43896

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh