### PR TITLE
octopus: spec: address some warnings raised by RPM 4.15.1

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2325,8 +2325,7 @@ if [ $1 -eq 0 ]; then
     fi
 fi
 exit 0
-
-%endif # with selinux
+%endif
 
 %files grafana-dashboards
 %if 0%{?suse_version}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -936,7 +936,7 @@ Summary:	Ceph distributed file system client library
 %if 0%{?suse_version}
 Group:		System/Libraries
 %endif
-Obsoletes:	libcephfs1
+Obsoletes:	libcephfs1 < %{_epoch_prefix}%{version}-%{release}
 %if 0%{?rhel} || 0%{?fedora}
 Obsoletes:	ceph-libs < %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	ceph-libcephfs


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45034

---

backport of https://github.com/ceph/ceph/pull/34427
parent tracker: https://tracker.ceph.com/issues/44964

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh