### PR TITLE
nautilus: spec: address some warnings raised by RPM 4.15.1

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2252,8 +2252,7 @@ if [ $1 -eq 0 ]; then
     fi
 fi
 exit 0
-
-%endif # with selinux
+%endif
 
 %if 0%{with python2}
 %files -n python-ceph-compat

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -883,7 +883,7 @@ Summary:	Ceph distributed file system client library
 %if 0%{?suse_version}
 Group:		System/Libraries
 %endif
-Obsoletes:	libcephfs1
+Obsoletes:	libcephfs1 < %{_epoch_prefix}%{version}-%{release}
 %if 0%{?rhel} || 0%{?fedora}
 Obsoletes:	ceph-libs < %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	ceph-libcephfs


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45035

---

backport of https://github.com/ceph/ceph/pull/34427
parent tracker: https://tracker.ceph.com/issues/44964

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh