### PR TITLE
cephadm: warn when no valid version arguments are supplied to add-repo

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3975,6 +3975,8 @@ def create_packager(stable=None, version=None, branch=None, commit=None):
 def command_add_repo():
     if args.version and args.release:
         raise Error('you can specify either --release or --version but not both')
+    if not args.version and not args.release and not args.dev and not args.dev_commit:
+        raise Error('please supply a --release, --version, --dev or --dev-commit argument')
     if args.version:
         try:
             (x, y, z) = args.version.split('.')


### PR DESCRIPTION
Currently add-repo will add a broken repository by default, this commit gives a pretty error to instruct the user to use one of the version arguments.

Fixes #45029

Signed-off-by: Maran Hidskes <maran@protonmail.com>
