### PR TITLE
ceph-fuse: link to libfuse3 and pass `-o big_writes` to libfuse if libfuse < 3.0.0

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -41,6 +41,7 @@
 #include <fcntl.h>
 
 #include <fuse.h>
+#include <fuse_lowlevel.h>
 
 #define dout_context g_ceph_context
 
@@ -51,7 +52,12 @@ static void fuse_usage()
     "-h",
   };
   struct fuse_args args = FUSE_ARGS_INIT(2, (char**)argv);
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  struct fuse_cmdline_opts opts = {};
+  if (fuse_parse_cmdline(&args, &opts) == -1) {
+#else
   if (fuse_parse_cmdline(&args, nullptr, nullptr, nullptr) == -1) {
+#endif
     derr << "fuse_parse_cmdline failed." << dendl;
   }
   ceph_assert(args.allocated);
@@ -105,7 +111,12 @@ int main(int argc, const char **argv, const char *envp[]) {
       };
 
       struct fuse_args fargs = FUSE_ARGS_INIT(2, (char**)tmpargv);
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+      struct fuse_cmdline_opts opts = {};
+      if (fuse_parse_cmdline(&fargs, &opts) == -1) {
+#else
       if (fuse_parse_cmdline(&fargs, nullptr, nullptr, nullptr) == -1) {
+#endif
        derr << "fuse_parse_cmdline failed." << dendl;
       }
       ceph_assert(fargs.allocated);

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -85,9 +85,13 @@ public:
   int fd_on_success;
   Client *client;
 
-  struct fuse_chan *ch;
   struct fuse_session *se;
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  struct fuse_cmdline_opts opts;
+#else
+  struct fuse_chan *ch;
   char *mountpoint;
+#endif
 
   ceph::mutex stag_lock = ceph::make_mutex("fuse_ll.cc stag_lock");
   int last_stag;
@@ -418,7 +422,11 @@ static void fuse_ll_mkdir(fuse_req_t req, fuse_ino_t parent, const char *name,
   if (cfuse->fino_snap(parent) == CEPH_SNAPDIR &&
       fuse_multithreaded && fuse_syncfs_on_mksnap) {
     int err = 0;
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+    int fd = ::open(cfuse->opts.mountpoint, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+#else
     int fd = ::open(cfuse->mountpoint, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+#endif
     if (fd < 0) {
       err = errno;
     } else {
@@ -504,7 +512,11 @@ static void fuse_ll_symlink(fuse_req_t req, const char *existing,
 }
 
 static void fuse_ll_rename(fuse_req_t req, fuse_ino_t parent, const char *name,
-			   fuse_ino_t newparent, const char *newname)
+			   fuse_ino_t newparent, const char *newname
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+                           , unsigned int flags
+#endif
+                           )
 {
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
@@ -916,7 +928,11 @@ static void ino_invalidate_cb(void *handle, vinodeno_t vino, int64_t off,
 #if FUSE_VERSION >= FUSE_MAKE_VERSION(2, 8)
   CephFuse::Handle *cfuse = (CephFuse::Handle *)handle;
   fuse_ino_t fino = cfuse->make_fake_ino(vino.ino, vino.snapid);
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  fuse_lowlevel_notify_inval_inode(cfuse->se, fino, off, len);
+#else
   fuse_lowlevel_notify_inval_inode(cfuse->ch, fino, off, len);
+#endif
 #endif
 }
 
@@ -929,7 +945,11 @@ static void dentry_invalidate_cb(void *handle, vinodeno_t dirino,
   fuse_ino_t fino = 0;
   if (ino.ino != inodeno_t())
     fino = cfuse->make_fake_ino(ino.ino, ino.snapid);
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  fuse_lowlevel_notify_delete(cfuse->se, fdirino, fino, name.c_str(), name.length());
+#else
   fuse_lowlevel_notify_delete(cfuse->ch, fdirino, fino, name.c_str(), name.length());
+#endif
 #elif FUSE_VERSION >= FUSE_MAKE_VERSION(2, 8)
   fuse_lowlevel_notify_inval_entry(cfuse->ch, fdirino, name.c_str(), name.length());
 #endif
@@ -941,7 +961,12 @@ static int remount_cb(void *handle)
   // trims all unused dentries in the file system
   char cmd[128+PATH_MAX];
   CephFuse::Handle *cfuse = (CephFuse::Handle *)handle;
-  snprintf(cmd, sizeof(cmd), "LIBMOUNT_FSTAB=/dev/null mount -i -o remount %s", cfuse->mountpoint);
+  snprintf(cmd, sizeof(cmd), "LIBMOUNT_FSTAB=/dev/null mount -i -o remount %s",
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+                  cfuse->opts.mountpoint);
+#else
+                  cfuse->mountpoint);
+#endif
   int r = system(cmd);
   if (r != 0 && r != -1) {
     r = WEXITSTATUS(r);
@@ -1043,14 +1068,19 @@ const static struct fuse_lowlevel_ops fuse_ll_oper = {
 CephFuse::Handle::Handle(Client *c, int fd) :
   fd_on_success(fd),
   client(c),
-  ch(NULL),
   se(NULL),
+#if FUSE_VERSION < FUSE_MAKE_VERSION(3, 0)
+  ch(NULL),
   mountpoint(NULL),
+#endif
   last_stag(0)
 {
   snap_stag_map[CEPH_NOSNAP] = 0;
   stag_snap_map[0] = CEPH_NOSNAP;
   memset(&args, 0, sizeof(args));
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  memset(&opts, 0, sizeof(opts));
+#endif
 }
 
 CephFuse::Handle::~Handle()
@@ -1060,6 +1090,15 @@ CephFuse::Handle::~Handle()
 
 void CephFuse::Handle::finalize()
 {
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  if (se) {
+    fuse_remove_signal_handlers(se);
+    fuse_session_unmount(se);
+    fuse_session_destroy(se);
+  }
+  if (opts.mountpoint)
+    free(opts.mountpoint);
+#else
   if (se)
     fuse_remove_signal_handlers(se);
   if (ch)
@@ -1068,6 +1107,7 @@ void CephFuse::Handle::finalize()
     fuse_session_destroy(se);
   if (ch)
     fuse_unmount(mountpoint, ch);
+#endif
 
   pthread_key_delete(fuse_req_key);
 }
@@ -1094,14 +1134,16 @@ int CephFuse::Handle::init(int argc, const char *argv[])
     "fuse_allow_other");
   auto fuse_default_permissions = client->cct->_conf.get_val<bool>(
     "fuse_default_permissions");
+#if FUSE_VERSION < FUSE_MAKE_VERSION(3, 0)
   auto fuse_big_writes = client->cct->_conf.get_val<bool>(
     "fuse_big_writes");
-  auto fuse_atomic_o_trunc = client->cct->_conf.get_val<bool>(
-    "fuse_atomic_o_trunc");
-  auto fuse_debug = client->cct->_conf.get_val<bool>(
-    "fuse_debug");
   auto fuse_max_write = client->cct->_conf.get_val<Option::size_t>(
     "fuse_max_write");
+  auto fuse_atomic_o_trunc = client->cct->_conf.get_val<bool>(
+    "fuse_atomic_o_trunc");
+#endif
+  auto fuse_debug = client->cct->_conf.get_val<bool>(
+    "fuse_debug");
 
   if (fuse_allow_other) {
     newargv[newargc++] = "-o";
@@ -1112,6 +1154,7 @@ int CephFuse::Handle::init(int argc, const char *argv[])
     newargv[newargc++] = "default_permissions";
   }
 #if defined(__linux__)
+#if FUSE_VERSION < FUSE_MAKE_VERSION(3, 0)
   if (fuse_big_writes) {
     newargv[newargc++] = "-o";
     newargv[newargc++] = "big_writes";
@@ -1127,6 +1170,7 @@ int CephFuse::Handle::init(int argc, const char *argv[])
     newargv[newargc++] = "atomic_o_trunc";
   }
 #endif
+#endif
   if (fuse_debug)
     newargv[newargc++] = "-d";
 
@@ -1137,7 +1181,11 @@ int CephFuse::Handle::init(int argc, const char *argv[])
   struct fuse_args a = FUSE_ARGS_INIT(newargc, (char**)newargv);
   args = a;  // Roundabout construction b/c FUSE_ARGS_INIT is for initialization not assignment
 
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  if (fuse_parse_cmdline(&args, &opts) == -1) {
+#else
   if (fuse_parse_cmdline(&args, &mountpoint, NULL, NULL) == -1) {
+#endif
     derr << "fuse_parse_cmdline failed." << dendl;
     fuse_opt_free_args(&args);
     free(newargv);
@@ -1151,6 +1199,9 @@ int CephFuse::Handle::init(int argc, const char *argv[])
 
 int CephFuse::Handle::start()
 {
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  se = fuse_session_new(&args, &fuse_ll_oper, sizeof(fuse_ll_oper), this);
+#else
   ch = fuse_mount(mountpoint, &args);
   if (!ch) {
     derr << "fuse_mount(mountpoint=" << mountpoint << ") failed." << dendl;
@@ -1158,6 +1209,7 @@ int CephFuse::Handle::start()
   }
 
   se = fuse_lowlevel_new(&args, &fuse_ll_oper, sizeof(fuse_ll_oper), this);
+#endif
   if (!se) {
     derr << "fuse_lowlevel_new failed" << dendl;
     return EDOM;
@@ -1170,7 +1222,14 @@ int CephFuse::Handle::start()
     return ENOSYS;
   }
 
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  if (fuse_session_mount(se, opts.mountpoint) != 0) {
+    derr << "fuse_session_mount failed" << dendl;
+    return ENOSYS;
+  }
+#else
   fuse_session_add_chan(se, ch);
+#endif
 
 
   struct client_callback_args args = {
@@ -1196,7 +1255,11 @@ int CephFuse::Handle::loop()
   auto fuse_multithreaded = client->cct->_conf.get_val<bool>(
     "fuse_multithreaded");
   if (fuse_multithreaded) {
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+    return fuse_session_loop_mt(se, opts.clone_fd);
+#else
     return fuse_session_loop_mt(se);
+#endif
   } else {
     return fuse_session_loop(se);
   }
@@ -1326,8 +1389,13 @@ void CephFuse::finalize()
 
 std::string CephFuse::get_mount_point() const
 {
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  if (_handle->opts.mountpoint) {
+    return _handle->opts.mountpoint;
+#else
   if (_handle->mountpoint) {
     return _handle->mountpoint;
+#endif
   } else {
     return "";
   }

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8345,7 +8345,7 @@ std::vector<Option> get_mds_client_options() {
     .set_flag(Option::FLAG_STARTUP),
 
     Option("fuse_big_writes", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
+    .set_default(true)
     .set_description("big_writes is deprecated in libfuse 3.0.0"),
 
     Option("fuse_max_write", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)

--- a/src/include/ceph_fuse.h
+++ b/src/include/ceph_fuse.h
@@ -1,0 +1,32 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2012 Inktank Storage, Inc.
+ * Copyright (C) 2014 Red Hat <contact@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ */
+#ifndef CEPH_FUSE_H
+#define CEPH_FUSE_H
+
+#define FUSE_USE_VERSION 30
+#include "acconfig.h"
+#include <fuse.h>
+
+static inline int filler_compat(fuse_fill_dir_t filler,
+                                void *buf, const char *name,
+                                const struct stat *stbuf,
+                                off_t off)
+{
+  return filler(buf, name, stbuf, off
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+                , static_cast<enum fuse_fill_dir_flags>(0)
+#endif
+        );
+}
+#endif /* CEPH_FUSE_H */

--- a/src/rbd_fuse/rbd-fuse.cc
+++ b/src/rbd_fuse/rbd-fuse.cc
@@ -505,7 +505,7 @@ rbdfs_init(struct fuse_conn_info *conn)
 	ret = rados_ioctx_create(cluster, pool_name, &ioctx);
 	if (ret < 0)
 		exit(91);
-#if FUSE_VERSION >= FUSE_MAKE_VERSION(2, 8)
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(2, 8) && FUSE_VERSION < FUSE_MAKE_VERSION(3, 0)
 	conn->want |= FUSE_CAP_BIG_WRITES;
 #endif
 	rados_ioctx_set_namespace(ioctx, nspace_name);

--- a/src/rbd_fuse/rbd-fuse.cc
+++ b/src/rbd_fuse/rbd-fuse.cc
@@ -587,7 +587,7 @@ rbdfs_rename(const char *path, const char *destname)
 }
 
 int
-rbdfs_utime(const char *path, struct utimbuf *utime)
+rbdfs_utimens(const char *path, const struct timespec tv[2])
 {
 	// called on create; not relevant
 	return 0;
@@ -735,7 +735,9 @@ const static struct fuse_operations rbdfs_oper = {
   chmod:      0,
   chown:      0,
   truncate:   rbdfs_truncate,
-  utime:      rbdfs_utime,
+#if FUSE_VERSION < FUSE_MAKE_VERSION(3, 0)
+  utime:      0,
+#endif
   open:	      rbdfs_open,
   read:	      rbdfs_read,
   write:      rbdfs_write,
@@ -755,6 +757,10 @@ const static struct fuse_operations rbdfs_oper = {
   destroy:    rbdfs_destroy,
   access:     0,
   create:     rbdfs_create,
+  ftruncate:  0,
+  fgetattr:   0,
+  lock:       0,
+  utimens:    rbdfs_utimens,
   /* skip unimplemented */
 };
 


### PR DESCRIPTION
The big_writes is deprecated since libfuse 3.0. But if ceph-fuse is
linked to libfuse < 3.0, without big_writes option enabled, the write
performance is very poor.

Fixes: https://tracker.ceph.com/issues/44885
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
