### PR TITLE
nautilus: build/ops: address SElinux denials observed in rgw/multisite test run

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -4,6 +4,7 @@ require {
 	type sysfs_t;
 	type configfs_t;
 	type commplex_main_port_t;
+	type http_cache_port_t;
 	type rpm_exec_t;
 	type rpm_var_lib_t;
 	type kernel_t;

--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -86,6 +86,7 @@ corenet_tcp_bind_cyphesis_port(ceph_t)
 corenet_tcp_sendrecv_cyphesis_port(ceph_t)
 
 allow ceph_t commplex_main_port_t:tcp_socket name_connect;
+allow ceph_t http_cache_port_t:tcp_socket name_connect;
 
 corecmd_exec_bin(ceph_t)
 corecmd_exec_shell(ceph_t)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45073

---

parent tracker: https://tracker.ceph.com/issues/45022

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh