### PR TITLE
mgr: turn on balancer in upmap mode by default

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -324,3 +324,11 @@
 
 * librbd now inherits the stripe unit and count from its parent image upon creation.
   This can be overridden by specifying different stripe settings during clone creation.
+
+* The balancer is now on by default in upmap mode. Since upmap mode requires
+  ``require_min_compat_client`` luminous, new clusters will only support luminous
+  and newer clients by default. Existing clusters can enable upmap support by running
+  ``ceph osd set-require-min-compat-client luminous``. It is still possible to turn
+  the balancer off using the ``ceph balancer off`` command. In earlier versions,
+  the balancer was included in the ``always_on_modules`` list, but needed to be
+  turned on explicitly using the ``ceph balancer on`` command.

--- a/doc/rados/operations/balancer.rst
+++ b/doc/rados/operations/balancer.rst
@@ -19,17 +19,15 @@ The current status of the balancer can be checked at any time with::
 Automatic balancing
 -------------------
 
-The automatic balancing can be enabled, using the default settings, with::
-
-  ceph balancer on
-
-The balancer can be turned back off again with::
+The automatic balancing feature is enabled by default in ``upmap``
+mode. Please refer to :ref:`upmap` for more details. The balancer can be
+turned off with::
 
   ceph balancer off
 
-This will use the ``crush-compat`` mode, which is backward compatible
-with older clients, and will make small changes to the data
-distribution over time to ensure that OSDs are equally utilized.
+The balancer mode can be changed to ``crush-compat`` mode, which is
+backward compatible with older clients, and will make small changes to
+the data distribution over time to ensure that OSDs are equally utilized.
 
 
 Throttling
@@ -86,11 +84,7 @@ There are currently two supported balancer modes:
 
    Note that using upmap requires that all clients be Luminous or newer.
 
-The default mode is ``crush-compat``.  The mode can be adjusted with::
-
-  ceph balancer mode upmap
-
-or::
+The default mode is ``upmap``.  The mode can be adjusted with::
 
   ceph balancer mode crush-compat
 

--- a/doc/rados/operations/upmap.rst
+++ b/doc/rados/operations/upmap.rst
@@ -1,3 +1,5 @@
+.. _upmap:
+
 Using the pg-upmap
 ==================
 
@@ -12,8 +14,13 @@ clients understand the new *pg-upmap* structure in the OSDMap.
 Enabling
 --------
 
-To allow use of the feature, you must tell the cluster that it only
-needs to support luminous (and newer) clients with::
+New clusters will have this module on by default. The cluster must only
+have luminous (and newer) clients. You can the turn the balancer off with::
+
+  ceph balancer off
+
+To allow use of the feature on existing clusters, you must tell the
+cluster that it only needs to support luminous (and newer) clients with::
 
   ceph osd set-require-min-compat-client luminous
 
@@ -26,7 +33,7 @@ use with::
 Balancer module
 -----------------
 
-The new `balancer` module for ceph-mgr will automatically balance
+The `balancer` module for ceph-mgr will automatically balance
 the number of PGs per OSD.  See ``Balancer``
 
 

--- a/qa/standalone/mgr/balancer.sh
+++ b/qa/standalone/mgr/balancer.sh
@@ -49,12 +49,11 @@ function TEST_balancer() {
     wait_for_clean || return 1
 
     ceph pg dump pgs
-    ceph osd set-require-min-compat-client luminous
     ceph balancer status || return 1
     eval MODE=$(ceph balancer status | jq '.mode')
-    test $MODE = "none" || return 1
+    test $MODE = "upmap" || return 1
     ACTIVE=$(ceph balancer status | jq '.active')
-    test $ACTIVE = "false" || return 1
+    test $ACTIVE = "true" || return 1
 
     ceph balancer ls || return 1
     PLANS=$(ceph balancer ls)
@@ -80,6 +79,7 @@ function TEST_balancer() {
     ceph balancer status || return 1
     eval MODE=$(ceph balancer status | jq '.mode')
     test $MODE = "crush-compat" || return 1
+    ceph balancer off || return 1
     ! ceph balancer optimize plan_crush $TEST_POOL1 || return 1
     ceph balancer status || return 1
     eval RESULT=$(ceph balancer status | jq '.optimize_result')

--- a/qa/standalone/mon/osd-pool-df.sh
+++ b/qa/standalone/mon/osd-pool-df.sh
@@ -58,10 +58,11 @@ function TEST_ceph_df() {
     local ec_poolname=testcephdf_erasurecode
     create_pool $rep_poolname 6 6 replicated
     create_pool $ec_poolname 6 6 erasure ec42profile
+    sleep 2
 
     local global_avail=`ceph df -f json | jq '.stats.total_avail_bytes'`
-    local rep_avail=`ceph df -f json | jq '.pools | map(select(.name == "$rep_poolname"))[0].stats.max_avail'`
-    local ec_avail=`ceph df -f json | jq '.pools | map(select(.name == "$ec_poolname"))[0].stats.max_avail'`
+    local rep_avail=`ceph df -f json | jq '.pools | map(select(.name == "'$rep_poolname'"))[0].stats.max_avail'`
+    local ec_avail=`ceph df -f json | jq '.pools | map(select(.name == "'$ec_poolname'"))[0].stats.max_avail'`
 
     echo "${global_avail} >= ${rep_avail}*3" | bc || return 1
     echo "${global_avail} >= ${ec_avail}*1.5" | bc || return 1

--- a/qa/standalone/mon/osd-pool-df.sh
+++ b/qa/standalone/mon/osd-pool-df.sh
@@ -58,7 +58,7 @@ function TEST_ceph_df() {
     local ec_poolname=testcephdf_erasurecode
     create_pool $rep_poolname 6 6 replicated
     create_pool $ec_poolname 6 6 erasure ec42profile
-    sleep 2
+    flush_pg_stats
 
     local global_avail=`ceph df -f json | jq '.stats.total_avail_bytes'`
     local rep_avail=`ceph df -f json | jq '.pools | map(select(.name == "'$rep_poolname'"))[0].stats.max_avail'`

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1435,7 +1435,6 @@ function test_mon_osd()
   #
   # require-min-compat-client
   expect_false ceph osd set-require-min-compat-client dumpling  # firefly tunables
-  ceph osd set-require-min-compat-client luminous
   ceph osd get-require-min-compat-client | grep luminous
   ceph osd dump | grep 'require_min_compat_client luminous'
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1664,7 +1664,7 @@ std::vector<Option> get_global_options() {
     .set_description("nearfull ratio for OSDs to be set during initial creation of cluster"),
 
     Option("mon_osd_initial_require_min_compat_client", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("jewel")
+    .set_default("luminous")
     .set_flag(Option::FLAG_NO_MON_UPDATE)
     .set_flag(Option::FLAG_CLUSTER_CREATE)
     .set_description(""),

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -216,7 +216,7 @@ class Module(MgrModule):
         {
             'name': 'active',
             'type': 'bool',
-            'default': False,
+            'default': True,
             'desc': 'automatically balance PGs across cluster',
             'runtime': True,
         },
@@ -293,7 +293,7 @@ class Module(MgrModule):
         {
             'name': 'mode',
             'desc': 'Balancer mode',
-            'default': 'none',
+            'default': 'upmap',
             'enum_allowed': ['none', 'crush-compat', 'upmap'],
             'runtime': True,
         },


### PR DESCRIPTION
This PR turns the balancer on by default in the upmap mode. Since the upmap mode requires require_min_compat_client luminous, we are also changing the default value of `mon_osd_initial_require_min_compat_client` from jewel to luminous. It is still possible to turn the balancer off.

In earlier versions, the balancer was included in the always_on_modules list, but needed to be turned on explicitly using the `ceph balancer on` command. 

Signed-off-by: Neha Ojha <nojha@redhat.com>