### PR TITLE
nautilus: common/ceph_time: tolerate mono time going backwards

### DIFF
--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -482,7 +482,19 @@ inline timespan abs(signedspan z) {
     timespan(-z.count());
 }
 inline timespan to_timespan(signedspan z) {
-  ceph_assert(z >= signedspan::zero());
+  if (z < signedspan::zero()) {
+    //ceph_assert(z >= signedspan::zero());
+    // There is a kernel bug that seems to be triggering this assert.  We've
+    // seen it in:
+    //   centos 8.1: 4.18.0-147.el8.x86_64
+    //   debian 10.3: 4.19.0-8-amd64
+    //   debian 10.1: 4.19.67-2+deb10u1
+    //   ubuntu 18.04
+    // see bugs:
+    //   https://tracker.ceph.com/issues/43365
+    //   https://tracker.ceph.com/issues/44078
+    z = signedspan::zero();
+  }
   return std::chrono::duration_cast<timespan>(z);
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44486

---

backport of https://github.com/ceph/ceph/pull/33699
parent tracker: https://tracker.ceph.com/issues/43365

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh