### PR TITLE
cephfs-shell: Fix multiple flake8 errors

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -112,7 +112,7 @@ def to_bytes(param):
     elif isinstance(param, str):
         return bytes(param, encoding='utf-8')
     elif isinstance(param, list):
-        return [i.encode('utf-8') if isinstance(i, str) else to_bytes(i) for \
+        return [i.encode('utf-8') if isinstance(i, str) else to_bytes(i) for
                 i in param]
     elif isinstance(param, int) or isinstance(param, float):
         return str(param).encode('utf-8')

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1357,7 +1357,7 @@ class CephFSShell(Cmd):
         else:
             self.perror("snapshot can only be created or deleted; check - "
                         "help snap")
-            self.exit_code = e.get_error_code()
+            self.exit_code = 1
 
     def do_help(self, line):
         """

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1223,7 +1223,7 @@ class CephFSShell(Cmd):
                     if f[0] is ord('/'):
                         f = b'.' + f
                     poutput('{:10s} {}'.format(humansize(dusage),
-                        f.decode('utf-8')))
+                            f.decode('utf-8')))
                 except libcephfs.Error as e:
                     perror(e)
                     self.exit_code = e.get_error_code()
@@ -1402,12 +1402,15 @@ class CephFSShell(Cmd):
 
                 poutput("File: {}\nSize: {:d}\nBlocks: {:d}\nIO Block: {:d}\n"
                         "Device: {:d}\tInode: {:d}\tLinks: {:d}\nPermission: "
-                        "{:o}/{}\tUid: {:d}\tGid: {:d}\n\Access: {}\nModify: "
+                        "{:o}/{}\tUid: {:d}\tGid: {:d}\nAccess: {}\nModify: "
                         "{}\nChange: {}".format(path.decode('utf-8'),
-                        stat.st_size, stat.st_blocks, stat.st_blksize,
-                        stat.st_dev, stat.st_ino, stat.st_nlink, stat.st_mode,
-                        mode_notation(stat.st_mode), stat.st_uid, stat.st_gid,
-                        atime, mtime, ctime))
+                                                stat.st_size, stat.st_blocks,
+                                                stat.st_blksize, stat.st_dev,
+                                                stat.st_ino, stat.st_nlink,
+                                                stat.st_mode,
+                                                mode_notation(stat.st_mode),
+                                                stat.st_uid, stat.st_gid, atime,
+                                                mtime, ctime))
             except libcephfs.Error as e:
                 perror(e)
                 self.exit_code = e.get_error_code()

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -64,6 +64,7 @@ shell = None    # holds instance of class CephFSShell
 #
 #######################################################################
 
+
 def poutput(s, end='\n'):
     shell.poutput(s, end=end)
 
@@ -118,6 +119,7 @@ def to_bytes(param):
     elif param is None:
         return None
 
+
 def ls(path, opts=''):
     # opts tries to be like /bin/ls opts
     almost_all = 'A' in opts
@@ -133,6 +135,7 @@ def ls(path, opts=''):
     except libcephfs.ObjectNotFound as e:
         perror(e)
         shell.exit_code = e.get_error_code()
+
 
 def glob(path, pattern):
     paths = []

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1135,12 +1135,12 @@ class CephFSShell(Cmd):
             try:
                 statfs = cephfs.statfs(file)
                 stat = cephfs.stat(file)
-                block_size = statfs['f_blocks']*statfs['f_bsize'] // 1024
+                block_size = (statfs['f_blocks'] * statfs['f_bsize']) // 1024
                 available = block_size - stat.st_size
                 use = 0
 
                 if block_size > 0:
-                    use = (stat.st_size*100 // block_size)
+                    use = (stat.st_size * 100) // block_size
 
                 if header:
                     header = False


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->
This patch series fixes E302, E502, E226, E128, E122 and F821 flake8 errors.

Fixes: https://tracker.ceph.com/issues/44645
Signed-off-by: Varsha Rao <varao@redhat.com>
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
