### PR TITLE
octopus: mgr/dashboard: Prevent iSCSI target recreation when editing controls 

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -306,6 +306,7 @@ class IscsiTarget(RESTController):
             raise DashboardException(msg='Target IQN already in use',
                                      code='target_iqn_already_in_use',
                                      component='iscsi')
+
         settings = IscsiClient.instance(gateway_name=gateway).get_settings()
         new_portal_names = {p['host'] for p in portals}
         old_portal_names = set(config['targets'][target_iqn]['portals'].keys())
@@ -485,9 +486,12 @@ class IscsiTarget(RESTController):
 
     @staticmethod
     def _target_deletion_required(target, new_target_iqn, new_target_controls):
+        gateway = get_available_gateway()
+        settings = IscsiClient.instance(gateway_name=gateway).get_settings()
+
         if target['target_iqn'] != new_target_iqn:
             return True
-        if target['target_controls'] != new_target_controls:
+        if settings['api_version'] < 2 and target['target_controls'] != new_target_controls:
             return True
         return False
 
@@ -627,6 +631,13 @@ class IscsiTarget(RESTController):
                                                                              targetauth_action)
 
     @staticmethod
+    def _is_auth_equal(target_auth, auth):
+        return auth['user'] == target_auth['username'] and \
+               auth['password'] == target_auth['password'] and \
+               auth['mutual_user'] == target_auth['mutual_username'] and \
+               auth['mutual_password'] == target_auth['mutual_password']
+
+    @staticmethod
     def _create(target_iqn, target_controls, acl_enabled,
                 auth, portals, disks, clients, groups,
                 task_progress_begin, task_progress_end, config, settings):
@@ -653,13 +664,17 @@ class IscsiTarget(RESTController):
                                                                                    ip_list)
                 TaskManager.current_task().inc_progress(task_progress_inc)
 
-            if acl_enabled:
-                IscsiTarget._update_targetauth(config, target_iqn, auth, gateway_name)
-                IscsiTarget._update_targetacl(target_config, target_iqn, acl_enabled, gateway_name)
-
-            else:
-                IscsiTarget._update_targetacl(target_config, target_iqn, acl_enabled, gateway_name)
-                IscsiTarget._update_targetauth(config, target_iqn, auth, gateway_name)
+            if not target_config or \
+               acl_enabled != target_config['acl_enabled'] or \
+               not IscsiTarget._is_auth_equal(target_config['auth'], auth):
+                if acl_enabled:
+                    IscsiTarget._update_targetauth(config, target_iqn, auth, gateway_name)
+                    IscsiTarget._update_targetacl(target_config, target_iqn, acl_enabled,
+                                                  gateway_name)
+                else:
+                    IscsiTarget._update_targetacl(target_config, target_iqn, acl_enabled,
+                                                  gateway_name)
+                    IscsiTarget._update_targetauth(config, target_iqn, auth, gateway_name)
 
             for disk in disks:
                 pool = disk['pool']

--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -255,10 +255,6 @@ class IscsiTarget(RESTController):
             raise DashboardException(msg='Target does not exist',
                                      code='target_does_not_exist',
                                      component='iscsi')
-        if target_iqn not in config['targets']:
-            raise DashboardException(msg='Target does not exist',
-                                     code='target_does_not_exist',
-                                     component='iscsi')
         portal_names = list(config['targets'][target_iqn]['portals'].keys())
         validate_rest_api(portal_names)
         if portal_names:

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -553,6 +553,7 @@ class IscsiClientMock(object):
 
     def get_settings(self):
         return {
+            "api_version": 2,
             "backstores": [
                 "user:rbd"
             ],


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45084

---

backport of https://github.com/ceph/ceph/pull/34065
parent tracker: https://tracker.ceph.com/issues/44659

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh