### PR TITLE
nautilus: mgr: force purge normal ceph entities from service map

### DIFF
--- a/qa/suites/fs/basic_functional/tasks/cephfs_scrub_tests.yaml
+++ b/qa/suites/fs/basic_functional/tasks/cephfs_scrub_tests.yaml
@@ -1,6 +1,7 @@
 overrides:
   ceph:
     log-whitelist:
+      - Replacing daemon mds
       - Scrub error on inode
       - Behind on trimming
       - Metadata damage detected


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45050

---

backport of https://github.com/ceph/ceph/pull/34281
parent tracker: https://tracker.ceph.com/issues/44677

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh