### PR TITLE
[DNM][RFC] mds/Server: Add new expected files directory xattr

### DIFF
--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -598,6 +598,14 @@ public:
   void dump(ceph::Formatter *f, int flags = DUMP_DEFAULT) const;
   void dump_load(ceph::Formatter *f);
 
+  mds_rank_t bucket_hash(mds_rank_t max) const {
+    return ((mds_rank_t) ceph_frag_value(frag)) % max;
+  }
+  bool is_hot_exportable(mds_rank_t dest, mds_rank_t max) const {
+    mds_rank_t rank = bucket_hash(max);
+    return (rank == dest);
+  }
+
   // context
   MDCache *cache;
 

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -5553,39 +5553,15 @@ bool CInode::is_exportable(mds_rank_t dest) const
   }
 }
 
-void CInode::set_expected_files(uint64_t files)
+void CInode::set_expected_file_bits(uint8_t bits)
 {
   ceph_assert(is_dir());
   ceph_assert(is_projected());
 
-  // Convert file count into directory fragment split bits
-  uint32_t bits = 0;
-  if (files > 0) {
-    auto fragments = files / g_conf().get_val<int64_t>("mds_bal_split_size") + 1;
-    while (fragments > 0) {
-      bits++;
-      fragments >>= 1;
-    }
-  }
-
-  get_projected_inode()->expected_files = files;
   get_projected_inode()->expected_file_bits = bits;
 }
 
-uint64_t CInode::get_expected_files() const
-{
-  const CInode *in = this;
-  if (in->is_system()) {
-    return 0;
-  }
-  // No expected files for unlinked directory
-  if (in->get_inode().nlink == 0) {
-    return 0;
-  }
-  return in->get_inode().expected_files;
-}
-
-uint32_t CInode::get_expected_file_bits() const
+uint8_t CInode::get_expected_file_bits() const
 {
   const CInode *in = this;
   if (in->is_system()) {

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -927,7 +927,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
   mds_rank_t get_export_pin(bool inherit=true, bool ephemeral=true) const;
   void set_export_pin(mds_rank_t rank);
-  void queue_export_pin(mds_rank_t target);
+  void queue_export_pin(mds_rank_t export_pin);
   void maybe_export_pin(bool update=false);
 
   void check_pin_policy();
@@ -963,8 +963,12 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     maybe_ephemeral_dist();
     maybe_ephemeral_rand();
   }
+  void maybe_fragment();
   void set_expected_file_bits(uint8_t bits);
   uint8_t get_expected_file_bits() const;
+
+  void set_hot_flag(bool flag);
+  bool get_hot_flag(bool inherit=true) const;
 
   void print(std::ostream& out) override;
   void dump(ceph::Formatter *f, int flags = DUMP_DEFAULT) const;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -963,9 +963,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     maybe_ephemeral_dist();
     maybe_ephemeral_rand();
   }
-  void set_expected_files(uint64_t files);
-  uint64_t get_expected_files() const;
-  uint32_t get_expected_file_bits() const;
+  void set_expected_file_bits(uint8_t bits);
+  uint8_t get_expected_file_bits() const;
 
   void print(std::ostream& out) override;
   void dump(ceph::Formatter *f, int flags = DUMP_DEFAULT) const;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -963,6 +963,9 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     maybe_ephemeral_dist();
     maybe_ephemeral_rand();
   }
+  void set_expected_files(uint64_t files);
+  uint64_t get_expected_files() const;
+  uint32_t get_expected_file_bits() const;
 
   void print(std::ostream& out) override;
   void dump(ceph::Formatter *f, int flags = DUMP_DEFAULT) const;

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -58,7 +58,7 @@ public:
   void hit_inode(CInode *in, int type, int who=-1);
   void hit_dir(CDir *dir, int type, int who=-1, double amount=1.0);
 
-  void queue_split(const CDir *dir, bool fast);
+  void queue_split(const CDir *dir, bool fast, int bits=-1);
   void queue_merge(CDir *dir);
   bool is_fragment_pending(dirfrag_t df) {
     return split_pending.count(df) || merge_pending.count(df);
@@ -87,6 +87,8 @@ private:
   //MDSMap is up to date
   void prep_rebalance(int beat);
   int mantle_prep_rebalance();
+
+  void handle_hot_flags(void);
 
   mds_load_t get_load();
   int localize_balancer();

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -595,6 +595,8 @@ struct inode_t {
   quota_info_t quota;
 
   mds_rank_t export_pin = MDS_RANK_NONE;
+  uint64_t expected_files = 0;
+  uint32_t expected_file_bits = 0;
 
   double export_ephemeral_random_pin = 0;
   bool export_ephemeral_distributed_pin = false;
@@ -621,7 +623,7 @@ private:
 template<template<typename> class Allocator>
 void inode_t<Allocator>::encode(ceph::buffer::list &bl, uint64_t features) const
 {
-  ENCODE_START(16, 6, bl);
+  ENCODE_START(17, 6, bl);
 
   encode(ino, bl);
   encode(rdev, bl);
@@ -676,13 +678,15 @@ void inode_t<Allocator>::encode(ceph::buffer::list &bl, uint64_t features) const
   encode(export_ephemeral_random_pin, bl);
   encode(export_ephemeral_distributed_pin, bl);
 
+  encode(expected_files, bl);
+  encode(expected_file_bits, bl);
   ENCODE_FINISH(bl);
 }
 
 template<template<typename> class Allocator>
 void inode_t<Allocator>::decode(ceph::buffer::list::const_iterator &p)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(16, 6, 6, p);
+  DECODE_START_LEGACY_COMPAT_LEN(17, 6, 6, p);
 
   decode(ino, p);
   decode(rdev, p);
@@ -780,6 +784,13 @@ void inode_t<Allocator>::decode(ceph::buffer::list::const_iterator &p)
     export_ephemeral_distributed_pin = false;
   }
 
+  if (struct_v >= 17) {
+    decode(expected_files, p);
+    decode(expected_file_bits, p);
+  } else {
+    expected_files = 0;
+    expected_file_bits = 0;
+  }
   DECODE_FINISH(p);
 }
 

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -595,8 +595,7 @@ struct inode_t {
   quota_info_t quota;
 
   mds_rank_t export_pin = MDS_RANK_NONE;
-  uint64_t expected_files = 0;
-  uint32_t expected_file_bits = 0;
+  uint8_t expected_file_bits = 0;
 
   double export_ephemeral_random_pin = 0;
   bool export_ephemeral_distributed_pin = false;
@@ -678,7 +677,6 @@ void inode_t<Allocator>::encode(ceph::buffer::list &bl, uint64_t features) const
   encode(export_ephemeral_random_pin, bl);
   encode(export_ephemeral_distributed_pin, bl);
 
-  encode(expected_files, bl);
   encode(expected_file_bits, bl);
   ENCODE_FINISH(bl);
 }
@@ -785,10 +783,8 @@ void inode_t<Allocator>::decode(ceph::buffer::list::const_iterator &p)
   }
 
   if (struct_v >= 17) {
-    decode(expected_files, p);
     decode(expected_file_bits, p);
   } else {
-    expected_files = 0;
     expected_file_bits = 0;
   }
   DECODE_FINISH(p);

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -594,8 +594,10 @@ struct inode_t {
 
   quota_info_t quota;
 
+  // manual pinning and directory optimization
   mds_rank_t export_pin = MDS_RANK_NONE;
   uint8_t expected_file_bits = 0;
+  bool hot_flag = false;
 
   double export_ephemeral_random_pin = 0;
   bool export_ephemeral_distributed_pin = false;
@@ -678,6 +680,7 @@ void inode_t<Allocator>::encode(ceph::buffer::list &bl, uint64_t features) const
   encode(export_ephemeral_distributed_pin, bl);
 
   encode(expected_file_bits, bl);
+  encode(hot_flag, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -784,8 +787,10 @@ void inode_t<Allocator>::decode(ceph::buffer::list::const_iterator &p)
 
   if (struct_v >= 17) {
     decode(expected_file_bits, p);
+    decode(hot_flag, p);
   } else {
     expected_file_bits = 0;
+    hot_flag = false;
   }
   DECODE_FINISH(p);
 }

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -700,7 +700,7 @@ int JournalTool::recover_dentries(
 
   // Replay fullbits (dentry+inode)
   for (const auto& frag : metablob.lump_order) {
-    EMetaBlob::dirlump const &lump = metablob.lump_map.find(frag)->second;
+    EMetaBlob::dirlump const &lump = metablob.lm_get(frag);
     lump._decode_bits();
     object_t frag_oid = InodeStore::get_object_name(frag.ino, frag.frag, "");
 


### PR DESCRIPTION
This PR is a first pass-attempt at providing a mechanism for pre-fragmenting directories via a user-supplied estimate of the directory file count via a ceph.dir.expected_files xattrs.  During testing of the io500 benchmark it was observed that with many clients all writing small files to a single directory and when utilizing many MDS servers, performance was cyclically slower and at times exports would fail due to lock contention.  It was hypothesized that these issues may be related to the creation of new directory fragments during the write process.  Unfortunately the current directory pinning and planned ephemeral pinning don't help in this case as there is only a single directory being written to (though this PR may in the future include a similar scheme for directory fragments).

The following table showcases io500 test results for this PR run on a fast 10 node cluster with NVMe drives running 80 OSDs, 61 MDS instances, and 300 co-located client processes.  round-robin pinning was used for the mdtest_easy work directories (one per client), while the single mdtest_hard work directory either had expected_files set to 0 (same behavior as master) or set to 30,000,000 which is enough to avoid fragmentation during writes.

Test | default | mdtest_hard expected_files = 30,000,000
-- | -- | --
ior_easy_write | 63.933 GB/s | 64.520 GB/s
mdtest_easy_write | 297.736 kiops | 298.683 kiops
ior_hard_write | 9.953 GB/s | 10.943 GB/s
mdtest_hard_write | 25.383 kiops | **47.303 kiops**
find | **520.900 kiops** | 343.320 kiops
ior_easy_read | 79.702 GB/s | 79.815 GB/s
mdtest_easy_stat | 827.990 kiops | 782.929 kiops
ior_hard_read | 14.901 GB/s | 15.039 GB/s
mdtest_hard_stat | 111.982 kiops | **219.834 kiops**
mdtest_easy_delete | 101.965 kiops | **155.380 kiops**
mdtest_hard_read | 30.498 kiops | **100.534 kiops**
mdtest_hard_delete | 8.932 kiops | **13.168 kiops**
overall score | 54.347 | **65.7956**

One curious note is that "find" throughput went down, but there is an easy explanation for this.  It's slower to run many parallel copies of find against files in one big directory than it is to run against files in many directories pinned to different MDS instances.  With the expected_files set to 30M, we nearly double the write throughput during the mdtest_hard write test, meaning that there is a much higher ratio of files in the big single directory vs files in the pinned round-robin directory hierarchy from mdtest_easy_write.

Future work on this PR will investigate pinning pre-fragmented directory fragments to specific MDS instances either using a hashing or round-robin scheme to avoid rebalancing decisions during workload exection for directories where the user is both expecting a large number of files and a heavy even distribution of workload across those files.

Signed-off-by: Mark Nelson <mnelson@redhat.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
