### PR TITLE
ceph-object-corpus: update to octopus

### DIFF
--- a/doc/dev/release-checklists.rst
+++ b/doc/dev/release-checklists.rst
@@ -104,3 +104,4 @@ First stable release
 ====================
 
 - [ ] src/ceph_release: change type `stable`
+- [ ] generate new object corpus for encoding/decoding tests - see :doc:`corpus`

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -124,7 +124,7 @@ private:
     auto close_fd = make_scope_guard([fd] { ::close(fd); });
     if (auto bl_delta = appender.bl.length() - bl_offset; bl_delta > 0) {
       ceph::bufferlist dump_bl;
-      appender.bl.copy(bl_offset + space_offset, bl_delta - space_offset, dump_bl);
+      appender.bl.begin(bl_offset + space_offset).copy(bl_delta - space_offset, dump_bl);
       const size_t space_len = space_size();
       dump_bl.append(appender.get_pos() - space_len, space_len);
       dump_bl.write_fd(fd);


### PR DESCRIPTION
The object corpus page in the docs already describes the script that does this, src/script/gen-corpus.sh. The only thing missing was a bufferlist interface change to get it running.

Depends on https://github.com/ceph/ceph-object-corpus/pull/11