### PR TITLE
doc/dev/corpus.rst: tweak formatting

### DIFF
--- a/doc/dev/corpus.rst
+++ b/doc/dev/corpus.rst
@@ -12,11 +12,13 @@ You can also mark known or deliberate incompatibilities between versions with::
  archive/$version/forward_incompat/$type
 
 The presence of a file indicates that new versions of code cannot
-decode old objects across that $version (this is normally the case).
+decode old objects across that ``$version`` (this is normally the case).
 
 
 How to generate an object corpus
 --------------------------------
+
+.. highlight:: shell
 
 We can generate an object corpus for a particular version of ceph using the
 script of ``script/gen-corpus.sh``, or by following the instructions below:
@@ -51,7 +53,7 @@ script of ``script/gen-corpus.sh``, or by following the instructions below:
 	bin/ceph_test_librbd
 	bin/ceph_test_libcephfs
 	bin/init-ceph restart mds.a
-    ../qa/workunits/rgw/run-s3tests.sh
+	../qa/workunits/rgw/run-s3tests.sh
 
 #. Stop::
 


### PR DESCRIPTION
* use `shell` lexer, otherwise the Python one is used, and the rendered
  result does not look right
* be consistent when indenting -- either use tab or spaces, otherwise
  the indent in code block would be wrong.
* double quote the variables in text

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
