### PR TITLE
qa/workunits/erasure-code:fix the problem of obtaining coding technical errors in the script

### DIFF
--- a/qa/workunits/erasure-code/bench.sh
+++ b/qa/workunits/erasure-code/bench.sh
@@ -111,6 +111,10 @@ function bench_run() {
     k2ms[4]="2 3"
     k2ms[6]="2 3 4"
     k2ms[10]="3 4"
+	local isa2technique_vandermonde='reed_sol_van'
+    local isa2technique_cauchy='cauchy'
+    local jerasure2technique_vandermonde='reed_sol_van'
+    local jerasure2technique_cauchy='cauchy_good'
     for technique in ${TECHNIQUES} ; do
         for plugin in ${PLUGINS} ; do
             eval technique_parameter=\$${plugin}2technique_${technique}


### PR DESCRIPTION
qa/workunits/erasure-code:fix the problem of obtaining coding technical errors in the script

isa / jerasure codec ‘technique’, obtained by character calculation,
 but the calculated character has no corresponding preset value,
 which will cause the test to report an error and exit

Signed-off-by:  lijiaxu <lijiaxu@cmss.chinamobile.com>