### PR TITLE
nautilus: mon: calculate min_size on osd pool set size

### DIFF
--- a/qa/workunits/mon/pool_ops.sh
+++ b/qa/workunits/mon/pool_ops.sh
@@ -8,6 +8,41 @@ function expect_false()
 	if "$@"; then return 1; else return 0; fi
 }
 
+function get_config_value_or_die()
+{
+  local pool_name config_opt raw val
+
+  pool_name=$1
+  config_opt=$2
+
+  raw="`$SUDO ceph osd pool get $pool_name $config_opt 2>/dev/null`"
+  if [[ $? -ne 0 ]]; then
+    echo "error obtaining config opt '$config_opt' from '$pool_name': $raw"
+    exit 1
+  fi
+
+  raw=`echo $raw | sed -e 's/[{} "]//g'`
+  val=`echo $raw | cut -f2 -d:`
+
+  echo "$val"
+  return 0
+}
+
+function expect_config_value()
+{
+  local pool_name config_opt expected_val val
+  pool_name=$1
+  config_opt=$2
+  expected_val=$3
+
+  val=$(get_config_value_or_die $pool_name $config_opt)
+
+  if [[ "$val" != "$expected_val" ]]; then
+    echo "expected '$expected_val', got '$val'"
+    exit 1
+  fi
+}
+
 # note: we need to pass the other args or ceph_argparse.py will take
 # 'invalid' that is not replicated|erasure and assume it is the next
 # argument, which is a string.
@@ -20,8 +55,11 @@ ceph osd pool create foooo 123
 ceph osd pool create foo 123 # idempotent
 
 ceph osd pool set foo size 1
+expect_config_value "foo" "min_size" 1
 ceph osd pool set foo size 4
+expect_config_value "foo" "min_size" 2
 ceph osd pool set foo size 10
+expect_config_value "foo" "min_size" 5
 expect_false ceph osd pool set foo size 0
 expect_false ceph osd pool set foo size 20
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7565,8 +7565,7 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
       return r;
     }
     p.size = n;
-    if (n < p.min_size)
-      p.min_size = n;
+    p.min_size = g_conf().get_osd_pool_default_min_size(p.size);
   } else if (var == "min_size") {
     if (p.has_flag(pg_pool_t::FLAG_NOSIZECHANGE)) {
       ss << "pool min size change is disabled; you must unset nosizechange flag for the pool first";


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45040

---

backport of https://github.com/ceph/ceph/pull/34342
parent tracker: https://tracker.ceph.com/issues/44862

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh