### PR TITLE
mgr/cephadm: Use mon command to set grafana url in the dashboard

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2569,19 +2569,20 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
         # make sure the dashboard [does not] references grafana
         try:
-            current_url = self.get_module_option_ex('dashboard',
-                                                    'GRAFANA_API_URL')
+
+            ret, current_url, err = self.check_mon_command({"prefix": "get-grafana-api-url"})
             if grafanas:
                 host = grafanas[0].hostname
                 url = f'https://{self.inventory.get_addr(host)}:3000'
                 if current_url != url:
                     self.log.info('Setting dashboard grafana config to %s' % url)
-                    self.set_module_option_ex('dashboard', 'GRAFANA_API_URL',
-                                              url)
+                    ret, outs, err = self.check_mon_command({
+                        "prefix": "set-grafana-api-url",
+                        "value": url,
+                    })
                     # FIXME: is it a signed cert??
         except Exception as e:
-            self.log.debug('got exception fetching dashboard grafana state: %s',
-                           e)
+            self.log.exception('unable to set dashboard grafana setting')
 
     def _add_daemon(self, daemon_type, spec,
                     create_func, config_func=None):

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1046,8 +1046,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             host_num_daemons = 0
             daemon_detail = []  # type: List[str]
             for item in ls:
-                host = item.get('hostname')
-                daemons = item.get('services')  # misnomer!
+                host = item.get('hostname', '')
+                daemons = item.get('services', [])  # misnomer!
                 missing_names = []
                 for s in daemons:
                     name = '%s.%s' % (s.get('type'), s.get('id'))

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -60,7 +60,8 @@ def cephadm_module():
             mock.patch("cephadm.module.HostCache.rm_host"), \
             mock.patch("cephadm.module.CephadmOrchestrator.send_command"), \
             mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command), \
-            mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix", get_store_prefix):
+            mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix", get_store_prefix), \
+            mock.patch("cephadm.module.CephadmOrchestrator.list_servers", lambda _: []):
 
         CephadmOrchestrator._register_commands('')
         CephadmOrchestrator._register_options('')

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -87,6 +87,32 @@ class TestCephadm(object):
         assert wait(cephadm_module, cephadm_module.get_hosts()) == []
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
+    def test_host_fqdn(self, cephadm_module):
+        with self._with_host(cephadm_module, 'first.fqdn'):
+            with pytest.raises(OrchestratorError):
+                with self._with_host(cephadm_module, 'second'):
+                    assert False
+
+        with self._with_host(cephadm_module, 'first'):
+            with pytest.raises(OrchestratorError):
+                with self._with_host(cephadm_module, 'second.fqdn'):
+                    assert False
+
+        with self._with_host(cephadm_module, 'first.fqdn'):
+            with self._with_host(cephadm_module, 'second.fqdn'):
+                pass
+
+        with mock.patch("cephadm.module.CephadmOrchestrator.list_servers", lambda _: [{'hostname': 'host.fqdn'}]):
+            with pytest.raises(OrchestratorError):
+                with self._with_host(cephadm_module, 'host'):
+                    pass
+
+        with mock.patch("cephadm.module.CephadmOrchestrator.list_servers", lambda _: [{'hostname': 'host'}]):
+            with pytest.raises(OrchestratorError):
+                with self._with_host(cephadm_module, 'host.fqdn'):
+                    pass
+
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
     def test_service_ls(self, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             c = cephadm_module.list_daemons(refresh=True)

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1047,7 +1047,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         """
         return self._ceph_get_latest_counter(svc_type, svc_name, path)
 
-    def list_servers(self):
+    def list_servers(self) -> List[dict]:
         """
         Like ``get_server``, but gives information about all servers (i.e. all
         unique hostnames that have been mentioned in daemon metadata)

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -770,8 +770,8 @@ class Orchestrator(object):
         # type: () -> None
         raise NotImplementedError()
 
-    def add_host(self, host_spec):
-        # type: (HostSpec) -> Completion
+    def add_host(self, host_spec, force=False):
+        # type: (HostSpec, bool) -> Completion
         """
         Add a host to the orchestrator inventory.
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -176,11 +176,13 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
         'orch host add',
         'name=hostname,type=CephString,req=true '
         'name=addr,type=CephString,req=false '
-        'name=labels,type=CephString,n=N,req=false',
+        'name=labels,type=CephString,n=N,req=false '
+        'name=force,type=CephBool,req=false',
         'Add a host')
-    def _add_host(self, hostname:str, addr: Optional[str]=None, labels: Optional[List[str]]=None):
+    def _add_host(self, hostname:str, addr: Optional[str]=None,
+                  labels: Optional[List[str]]=None, force=False):
         s = HostSpec(hostname=hostname, addr=addr, labels=labels)
-        completion = self.add_host(s)
+        completion = self.add_host(s, force)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -332,8 +332,8 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         return [orchestrator.HostSpec('localhost')]
 
     @deferred_write("add_host")
-    def add_host(self, spec):
-        # type: (orchestrator.HostSpec) -> None
+    def add_host(self, spec, force=False):
+        # type: (orchestrator.HostSpec, bool) -> None
         host = spec.hostname
         if host == 'raise_no_support':
             raise orchestrator.OrchestratorValidationError("MON count must be either 1, 3 or 5")

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -18,6 +18,9 @@ class ServiceSpecValidationError(Exception):
 
 
 def assert_valid_host(name):
+    if not name:
+        raise ServiceSpecValidationError("Empty hostname provided.")
+
     p = re.compile('^[a-zA-Z0-9-]+$')
     try:
         assert len(name) <= 250, 'name is too long (max 250 chars)'


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/44877
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
