### PR TITLE
qa/cephfs: move run_shell to mount.py and add methods for negative testing

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -194,15 +194,49 @@ class CephFSMount(object):
         return six.ensure_str(p.stdout.getvalue().strip())
 
     def run_shell(self, args, wait=True, stdin=None, check_status=True,
-                  omit_sudo=True):
-        if isinstance(args, str):
-            args = args.split()
+                  cwd=None, omit_sudo=True):
+        args = args.split() if isinstance(args, str) else args
+        # XXX: all commands ran with CephFS mount as CWD must be executed with
+        #  superuser privileges when tests are being run using teuthology.
+        if args[0] != 'sudo':
+            args.insert(0, 'sudo')
+        if not cwd:
+            cwd = self.mountpoint
 
-        args = ["cd", self.mountpoint, run.Raw('&&'), "sudo"] + args
-        return self.client_remote.run(args=args, stdout=StringIO(),
-                                      stderr=StringIO(), wait=wait,
-                                      stdin=stdin, check_status=check_status,
-                                      omit_sudo=omit_sudo)
+        return self.client_remote.run(args=args, stdin=stdin, wait=wait,
+                                      stdout=BytesIO(), stderr=BytesIO(),
+                                      cwd=cwd, check_status=check_status)
+
+    def run_as_user(self, args, user, wait=True, stdin=None,
+                    check_status=True, cwd=None):
+        if isinstance(args, str):
+            args = 'sudo -u %s -s /bin/bash -c %s' % (user, args)
+        elif isinstance(args, list):
+            cmdlist = args
+            cmd = ''
+            for i in cmdlist:
+                cmd = cmd + i + ' '
+            args = ['sudo', '-u', user, '-s', '/bin/bash', '-c']
+            args.append(cmd)
+        if not cwd:
+            cwd = self.mountpoint
+
+        return self.client_remote.run(args=args, wait=wait, stdin=stdin,
+                                      stdout=BytesIO(), stderr=BytesIO(),
+                                      check_status=check_status, cwd=cwd)
+
+    def run_as_root(self, args, wait=True, stdin=None, check_status=True,
+                    cwd=None):
+        if isinstance(args, str):
+            args = 'sudo ' + args
+        if isinstance(args, list):
+            args.insert(0, 'sudo')
+        if not cwd:
+            cwd = self.mountpoint
+
+        return self.client_remote.run(args=args, wait=wait, stdin=stdin,
+                                      stdout=BytesIO(), stderr=BytesIO(),
+                                      check_status=check_status, cwd=cwd)
 
     def open_no_data(self, basename):
         """

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -238,6 +238,46 @@ class CephFSMount(object):
                                       stdout=BytesIO(), stderr=BytesIO(),
                                       check_status=check_status, cwd=cwd)
 
+    def _verify(self, proc, retval=None, errmsg=None):
+        if retval:
+            msg = ('expected return value: {}\nreceived return value: '
+                   '{}\n'.format(retval, proc.returncode))
+            assert proc.returncode == retval, msg
+
+        if errmsg:
+            stderr = proc.stderr.getvalue().lower()
+            msg = ('didn\'t find given string in stderr -\nexpected string: '
+                   '{}\nreceived error message: {}\nnote: received error '
+                   'message is converted to lowercase'.format(errmsg, stderr))
+            assert errmsg in stderr, msg
+
+    def negtestcmd(self, args, retval=None, errmsg=None, stdin=None,
+                   cwd=None, wait=True):
+        """
+        Conduct a negative test for the given command.
+
+        retval and errmsg are parameters to confirm the cause of command
+        failure.
+        """
+        proc = self.run_shell(args=args, wait=wait, stdin=stdin, cwd=cwd,
+                              check_status=False)
+        self._verify(proc, retval, errmsg)
+        return proc
+
+    def negtestcmd_as_user(self, args, user, retval=None, errmsg=None,
+                           stdin=None, cwd=None, wait=True):
+        proc = self.run_as_user(args=args, user=user, wait=wait, stdin=stdin,
+                                cwd=cwd, check_status=False)
+        self._verify(proc, retval, errmsg)
+        return proc
+
+    def negtestcmd_as_root(self, args, retval=None, errmsg=None, stdin=None,
+                           cwd=None, wait=True):
+        proc = self.run_as_root(args=args, wait=wait, stdin=stdin, cwd=cwd,
+                                check_status=False)
+        self._verify(proc, retval, errmsg)
+        return proc
+
     def open_no_data(self, basename):
         """
         A pure metadata operation

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -512,7 +512,6 @@ def safe_kill(pid):
         else:
             raise
 
-
 class LocalKernelMount(KernelMount):
     def __init__(self, ctx, test_dir, client_id):
         super(LocalKernelMount, self).__init__(ctx, test_dir, client_id, LocalRemote(), None, None, None)
@@ -531,67 +530,6 @@ class LocalKernelMount(KernelMount):
             return os.path.join(os.getcwd(), 'keyring')
         else:
             return keyring_path
-
-    def run_shell(self, args, wait=True, stdin=None, check_status=True,
-                  omit_sudo=False):
-        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
-        # the "cd foo && bar" shenanigans isn't needed to begin with and
-        # then we wouldn't have to special case this
-        return self.client_remote.run(args=args, wait=wait, cwd=self.mountpoint,
-                                      stdin=stdin, check_status=check_status,
-                                      omit_sudo=omit_sudo)
-
-    def run_as_user(self, args, user, wait=True, stdin=None, check_status=True):
-        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
-        # the "cd foo && bar" shenanigans isn't needed to begin with and
-        # then we wouldn't have to special case this
-        if isinstance(args, str):
-            args = 'sudo -u %s -s /bin/bash -c %s' % (user, args)
-        elif isinstance(args, list):
-            cmdlist = args
-            cmd = ''
-            for i in cmdlist:
-                cmd = cmd + i + ' '
-            args = ['sudo', '-u', user, '-s', '/bin/bash', '-c']
-            args.append(cmd)
-
-        return self.client_remote.run(args=args, wait=wait, cwd=self.mountpoint,
-                                      check_status=check_status, stdin=stdin,
-                                      omit_sudo=False)
-
-    def run_as_root(self, args, wait=True, stdin=None, check_status=True):
-        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
-        # the "cd foo && bar" shenanigans isn't needed to begin with and
-        # then we wouldn't have to special case this
-        if isinstance(args, str):
-            args = 'sudo ' + args
-        if isinstance(args, list):
-            args.insert(0, 'sudo')
-
-        return self.client_remote.run(args=args, wait=wait, cwd=self.mountpoint,
-                                      check_status=check_status,
-                                      omit_sudo=False)
-
-    def testcmd(self, args, wait=True, stdin=None, omit_sudo=False):
-        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
-        # the "cd foo && bar" shenanigans isn't needed to begin with and
-        # then we wouldn't have to special case this
-        return self.run_shell(args, wait=wait, stdin=stdin, check_status=False,
-                              omit_sudo=omit_sudo)
-
-    def testcmd_as_user(self, args, user, wait=True, stdin=None):
-        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
-        # the "cd foo && bar" shenanigans isn't needed to begin with and
-        # then we wouldn't have to special case this
-        return self.run_as_user(args, user=user, wait=wait, stdin=stdin,
-                                check_status=False)
-
-    def testcmd_as_root(self, args, wait=True, stdin=None):
-        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
-        # the "cd foo && bar" shenanigans isn't needed to begin with and
-        # then we wouldn't have to special case this
-        return self.run_as_root(args, wait=wait, stdin=stdin,
-                                check_status=False)
 
     def setupfs(self, name=None):
         if name is None and self.fs is not None:
@@ -720,66 +658,6 @@ class LocalFuseMount(FuseMount):
         # This is going to end up in a config file, so use an absolute path
         # to avoid assumptions about daemons' pwd
         return os.path.abspath("./client.{0}.keyring".format(self.client_id))
-
-    def run_shell(self, args, wait=True, stdin=None, check_status=True, omit_sudo=True):
-        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
-        # the "cd foo && bar" shenanigans isn't needed to begin with and
-        # then we wouldn't have to special case this
-        return self.client_remote.run(args=args, wait=wait, cwd=self.mountpoint,
-                                      stdin=stdin, check_status=check_status,
-                                      omit_sudo=omit_sudo)
-
-    def run_as_user(self, args, user, wait=True, stdin=None, check_status=True):
-        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
-        # the "cd foo && bar" shenanigans isn't needed to begin with and
-        # then we wouldn't have to special case this
-        if isinstance(args, str):
-            args = 'sudo -u %s -s /bin/bash -c %s' % (user, args)
-        elif isinstance(args, list):
-            cmdlist = args
-            cmd = ''
-            for i in cmdlist:
-                cmd = cmd + i + ' '
-            args = ['sudo', '-u', user, '-s', '/bin/bash', '-c']
-            args.append(cmd)
-
-        return self.client_remote.run(args=args, wait=wait, cwd=self.mountpoint,
-                                      check_status=check_status, stdin=stdin,
-                                      omit_sudo=False)
-
-    def run_as_root(self, args, wait=True, stdin=None, check_status=True):
-        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
-        # the "cd foo && bar" shenanigans isn't needed to begin with and
-        # then we wouldn't have to special case this
-        if isinstance(args, str):
-            args = 'sudo ' + args
-        if isinstance(args, list):
-            args.insert(0, 'sudo')
-
-        return self.client_remote.run(args=args, wait=wait, cwd=self.mountpoint,
-                                      check_status=check_status,
-                                      omit_sudo=False)
-
-    def testcmd(self, args, wait=True, stdin=None, omit_sudo=True):
-        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
-        # the "cd foo && bar" shenanigans isn't needed to begin with and
-        # then we wouldn't have to special case this
-        return self.run_shell(args, wait=wait, stdin=stdin, check_status=False,
-                              omit_sudo=omit_sudo)
-
-    def testcmd_as_user(self, args, user, wait=True, stdin=None):
-        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
-        # the "cd foo && bar" shenanigans isn't needed to begin with and
-        # then we wouldn't have to special case this
-        return self.run_as_user(args, user=user, wait=wait, stdin=stdin,
-                                check_status=False)
-
-    def testcmd_as_root(self, args, wait=True, stdin=None):
-        # FIXME maybe should add a pwd arg to teuthology.orchestra so that
-        # the "cd foo && bar" shenanigans isn't needed to begin with and
-        # then we wouldn't have to special case this
-        return self.run_as_root(args, wait=wait, stdin=stdin,
-                                check_status=False)
 
     def setupfs(self, name=None):
         if name is None and self.fs is not None:


### PR DESCRIPTION
Same as https://github.com/ceph/ceph/pull/33279, except for improvements. https://github.com/ceph/ceph/pull/33279 was reverted because it got merged even though tests for didn't pass.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>