### PR TITLE
qa/standalone/scrub/osd-scrub-repair.sh: fix race in TEST_auto_repair_bluestore_failed

### DIFF
--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -496,7 +496,7 @@ function TEST_auto_repair_bluestore_failed() {
 
     flush_pg_stats
     ceph pg dump pgs
-    ceph pg dump pgs | grep -q "^${pgid}.* active+clean " || return 1
+    ceph pg dump pgs | grep -q -e "^${pgid}.* active+clean " -e "^${pgid}.* active+clean+wait " || return 1
     grep scrub_finish $dir/osd.${primary}.log
 
     # Tear down

--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -494,6 +494,7 @@ function TEST_auto_repair_bluestore_failed() {
     repair $pgid
     sleep 2
 
+    flush_pg_stats
     ceph pg dump pgs
     ceph pg dump pgs | grep -q "^${pgid}.* active+clean " || return 1
     grep scrub_finish $dir/osd.${primary}.log


### PR DESCRIPTION
We need to flush_pg_stats before checking for active+clean.

Fixed: https://tracker.ceph.com/issues/45075
Signed-off-by: Neha Ojha <nojha@redhat.com>