### PR TITLE
qa/suites/*/rados_cls_all.yaml: load all classes

### DIFF
--- a/qa/suites/rados/basic/tasks/rados_cls_all.yaml
+++ b/qa/suites/rados/basic/tasks/rados_cls_all.yaml
@@ -2,10 +2,8 @@ overrides:
   ceph:
     conf:
       osd:
-        osd_class_load_list: "cephfs hello journal lock log numops rbd refcount 
-                              rgw sdk timeindex user version"
-        osd_class_default_list: "cephfs hello journal lock log numops rbd refcount 
-                                 rgw sdk timeindex user version"
+        osd_class_load_list: "*"
+        osd_class_default_list: "*"
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rados/verify/tasks/rados_cls_all.yaml
+++ b/qa/suites/rados/verify/tasks/rados_cls_all.yaml
@@ -2,10 +2,8 @@ overrides:
   ceph:
     conf:
       osd:
-        osd_class_load_list: "cephfs hello journal lock log numops rbd refcount 
-                              rgw sdk timeindex user version"
-        osd_class_default_list: "cephfs hello journal lock log numops rbd refcount 
-                                 rgw sdk timeindex user version"
+        osd_class_load_list: "*"
+        osd_class_default_list: "*"
 tasks:
 - workunit:
     clients:

--- a/qa/suites/smoke/basic/tasks/rados_cls_all.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_cls_all.yaml
@@ -2,10 +2,8 @@ overrides:
   ceph:
     conf:
       osd:
-        osd_class_load_list: "cephfs hello journal lock log numops rbd refcount
-                              rgw sdk timeindex user version"
-        osd_class_default_list: "cephfs hello journal lock log numops rbd refcount
-                                 rgw sdk timeindex user version"
+        osd_class_load_list: "*"
+        osd_class_default_list: "*"
 tasks:
 - install:
 - ceph:


### PR DESCRIPTION
the intention to add the whitelist was to test "sdk" class, but if we
add new classes to the list, and add tests exercising them, the tests
fail if we fail to update these `rados_cls_all.yaml` accordingly.

so in this change, the list is now '*' which allows OSD to load all
classes found in the specified directory

Fixes: https://tracker.ceph.com/issues/45113
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
