### PR TITLE
cls/journal: use EC pool stripe width for padding appends

### DIFF
--- a/src/cls/journal/cls_journal.cc
+++ b/src/cls/journal/cls_journal.cc
@@ -1183,6 +1183,11 @@ int journal_object_append(cls_method_context_t hctx, bufferlist *in,
     min_alloc_size = 8;
   }
 
+  auto stripe_width = cls_get_pool_stripe_width(hctx);
+  if (stripe_width > 0) {
+    min_alloc_size = round_up_to(min_alloc_size, stripe_width);
+  }
+
   CLS_LOG(20, "pad to %" PRIu64, min_alloc_size);
 
   auto end = offset + data.length();

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -160,6 +160,7 @@ int cls_cxx_chunk_write_and_set(cls_method_context_t hctx, int ofs, int len,
 bool cls_has_chunk(cls_method_context_t hctx, std::string fp_oid);
 
 extern uint64_t cls_get_osd_min_alloc_size(cls_method_context_t hctx);
+extern uint64_t cls_get_pool_stripe_width(cls_method_context_t hctx);
 
 #endif
 

--- a/src/osd/objclass.cc
+++ b/src/osd/objclass.cc
@@ -703,3 +703,10 @@ uint64_t cls_get_osd_min_alloc_size(cls_method_context_t hctx) {
 
   return ctx->pg->get_min_alloc_size();
 }
+
+uint64_t cls_get_pool_stripe_width(cls_method_context_t hctx)
+{
+  PrimaryLogPG::OpContext *ctx = *(PrimaryLogPG::OpContext **)hctx;
+
+  return ctx->pg->get_pool().stripe_width;
+}

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -1534,3 +1534,7 @@ int cls_cxx_map_read_header(cls_method_handle_t, bufferlist *) {
 uint64_t cls_get_osd_min_alloc_size(cls_method_context_t hctx) {
   return 0;
 }
+
+uint64_t cls_get_pool_stripe_width(cls_method_context_t hctx) {
+  return 0;
+}


### PR DESCRIPTION
to avoid ECSubRead ops to reencode a partially updated stripe.

Signed-off-by: Mykola Golub <mgolub@suse.com>