### PR TITLE
rgw: use DEFER_DROP_PRIVILEGES flag unconditionally

### DIFF
--- a/qa/suites/rgw/crypt/3-rgw/rgw.yaml
+++ b/qa/suites/rgw/crypt/3-rgw/rgw.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     conf:
       client:
+        setuser: ceph
+        setgroup: ceph
         rgw crypt require ssl: false
         debug rgw: 20
 

--- a/qa/suites/rgw/hadoop-s3a/overrides.yaml
+++ b/qa/suites/rgw/hadoop-s3a/overrides.yaml
@@ -1,8 +1,6 @@
 overrides:
   ceph:
-    wait-for-scrub: false
     conf:
       client:
         setuser: ceph
         setgroup: ceph
-        debug rgw: 20

--- a/qa/suites/rgw/multifs/overrides.yaml
+++ b/qa/suites/rgw/multifs/overrides.yaml
@@ -3,6 +3,8 @@ overrides:
     wait-for-scrub: false
     conf:
       client:
+        setuser: ceph
+        setgroup: ceph
         debug rgw: 20
         rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=

--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -3,6 +3,8 @@ overrides:
     wait-for-scrub: false
     conf:
       client:
+        setuser: ceph
+        setgroup: ceph
         debug rgw: 20
         rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=

--- a/qa/suites/rgw/tempest/overrides.yaml
+++ b/qa/suites/rgw/tempest/overrides.yaml
@@ -1,8 +1,6 @@
 overrides:
   ceph:
-    wait-for-scrub: false
     conf:
       client:
         setuser: ceph
         setgroup: ceph
-        debug rgw: 20

--- a/qa/suites/rgw/thrash/civetweb.yaml
+++ b/qa/suites/rgw/thrash/civetweb.yaml
@@ -1,3 +1,8 @@
 overrides:
+  ceph:
+    conf:
+      client:
+        setuser: ceph
+        setgroup: ceph
   rgw:
     frontend: civetweb 

--- a/qa/suites/rgw/verify/overrides.yaml
+++ b/qa/suites/rgw/verify/overrides.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     conf:
       client:
+        setuser: ceph
+        setgroup: ceph
         debug rgw: 20
         rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=

--- a/qa/suites/rgw/website/overrides.yaml
+++ b/qa/suites/rgw/website/overrides.yaml
@@ -11,6 +11,8 @@ overrides:
         osd_min_pg_log_entries: 10
         osd_max_pg_log_entries: 10
       client:
+        setuser: ceph
+        setgroup: ceph
         debug rgw: 20
         rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=

--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -132,10 +132,11 @@ def start_rgw(ctx, config, clients):
                 raise ConfigError('vault: no "root_token" specified')
             # create token on file
             ctx.cluster.only(client).run(args=['echo', '-n', ctx.vault.root_token, run.Raw('>'), token_path])
-            log.info("Restrict access to token file")
-            ctx.cluster.only(client).run(args=['chmod', '600', token_path])
             log.info("Token file content")
             ctx.cluster.only(client).run(args=['cat', token_path])
+            log.info("Restrict access to token file")
+            ctx.cluster.only(client).run(args=['chmod', '600', token_path])
+            ctx.cluster.only(client).run(args=['sudo', 'chown', 'ceph', token_path])
 
             rgw_cmd.extend([
                 '--rgw_crypt_vault_addr', "{}:{}".format(*ctx.vault.endpoints[vault_role]),

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -203,17 +203,9 @@ int radosgw_Main(int argc, const char **argv)
   }
 
   int flags = CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS;
-  global_pre_init(
-    &defaults, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_DAEMON,
-    flags);
-
-  // Now that we've determined which frontend(s) to use, continue with global
-  // initialization. Passing false as the final argument ensures that
-  // global_pre_init() is not invoked twice.
-  // claim the reference and release it after subsequent destructors have fired
   auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_DAEMON,
-			 flags, "rgw_data", false);
+			 flags, "rgw_data");
 
   // First, let's determine which frontends are configured.
   list<string> frontends;

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -203,6 +203,10 @@ int radosgw_Main(int argc, const char **argv)
   }
 
   int flags = CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS;
+  // Prevent global_init() from dropping permissions until frontends can bind
+  // privileged ports
+  flags |= CINIT_FLAG_DEFER_DROP_PRIVILEGES;
+
   auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_DAEMON,
 			 flags, "rgw_data");
@@ -221,9 +225,6 @@ int radosgw_Main(int argc, const char **argv)
     string& f = *iter;
 
     if (f.find("civetweb") != string::npos || f.find("beast") != string::npos) {
-      // If civetweb or beast is configured as a frontend, prevent global_init() from
-      // dropping permissions by setting the appropriate flag.
-      flags |= CINIT_FLAG_DEFER_DROP_PRIVILEGES;
       if (f.find("port") != string::npos) {
         // check for the most common ws problems
         if ((f.find("port=") == string::npos) ||


### PR DESCRIPTION
fixes a regression from https://github.com/ceph/ceph/pull/33287 where `global_init()` was called before making the decision to add DEFER_DROP_PRIVILEGES

also adds the setuser/setgroup overrides so the rgw qa suite properly tests the binding of privileged ports

Fixes: https://tracker.ceph.com/issues/44661

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
