### PR TITLE
[wip] mgr/cephadm: Add host draining

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -40,7 +40,7 @@ from .services.nfs import NFSService
 from .services.osd import RemoveUtil, OSDRemoval, OSDService
 from .services.monitoring import GrafanaService, AlertmanagerService, PrometheusService, \
     NodeExporterService
-from .schedule import HostAssignment
+from .schedule import HostAssignment, DRAIN_LABEL
 from .inventory import Inventory, SpecStore, HostCache
 from .upgrade import CEPH_UPGRADE_ORDER, CephadmUpgrade
 from .template import TemplateMgr
@@ -1106,6 +1106,16 @@ you may want to run:
         self.inventory.rm_label(host, label)
         self.log.info('Removed label %s to host %s' % (label, host))
         return 'Removed label %s from host %s' % (label, host)
+
+    @trivial_completion
+    def drain_host(self, host):
+        self.inventory.add_label(host, DRAIN_LABEL)
+        self.event.set()
+
+    @trivial_completion
+    def abort_drain_host(self, host):
+        self.inventory.rm_label(host, DRAIN_LABEL)
+        self.event.set()
 
     def update_osdspec_previews(self, search_host: str = ''):
         # Set global 'pending' flag for host

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -86,6 +86,24 @@ class HostAssignment(object):
                     f'Cannot place {self.spec.one_line_str()}: No matching '
                     f'hosts for label {self.spec.placement.label}')
 
+    def respect_drain(self, candidates: List[HostPlacementSpec]) -> List[HostPlacementSpec]:
+        num_existing = len(self.get_daemons_func(self.service_name))
+
+        to_be_drained = self._labeled(DRAIN_LABEL)
+        ret = [
+            h for h in candidates if h.hostname not in to_be_drained
+        ]
+
+        if len(ret) < 1 and num_existing >= 1:
+            raise OrchestratorValidationError(
+                f'Cannot drain {to_be_drained}: cannot scale service {self.service_name} to 0')
+
+
+
+        return ret
+
+
+
     def place(self):
         # type: () -> List[HostPlacementSpec]
         """

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -779,12 +779,10 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def remove_host(self, host):
-        # type: (str) -> Completion
+    def remove_host(self, host, force=False):
+        # type: (str, bool) -> Completion
         """
         Remove a host from the orchestrator inventory.
-
-        :param host: hostname
         """
         raise NotImplementedError()
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -819,6 +819,20 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def drain_host(self, host):
+        # type: (str) -> Completion
+        """
+        Drains a host. something similar to `kubectl drain`
+        """
+        raise NotImplementedError()
+
+    def abort_drain_host(self, host):
+        # type: (str) -> Completion
+        """
+        Replenish the host.
+        """
+        raise NotImplementedError()
+
     def get_inventory(self, host_filter=None, refresh=False):
         # type: (Optional[InventoryFilter], bool) -> Completion
         """

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -254,6 +254,26 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
+    @_cli_write_command(
+        'orch host drain',
+        'name=hostname,type=CephString',
+        'Drains a host')
+    def _host_drain(self, hostname):
+        completion = self.drain_host(hostname)
+        self._orchestrator_wait([completion])
+        raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
+    @_cli_write_command(
+        'orch host abort-drain',
+        'name=hostname,type=CephString',
+        'Replenish a host')
+    def _host_abort_drain(self, hostname):
+        completion = self.abort_drain_host(hostname)
+        self._orchestrator_wait([completion])
+        raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
     @_cli_read_command(
         'orch device ls',
         "name=hostname,type=CephString,n=N,req=false "

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -188,10 +188,11 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
 
     @_cli_write_command(
         'orch host rm',
-        "name=hostname,type=CephString,req=true",
+        "name=hostname,type=CephString,req=true "
+        'name=force,type=CephBool,req=false',
         'Remove a host')
-    def _remove_host(self, hostname):
-        completion = self.remove_host(hostname)
+    def _remove_host(self, hostname, force=False):
+        completion = self.remove_host(hostname, force)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -348,7 +348,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         assert isinstance(host, six.string_types)
 
     @deferred_write("remove_host")
-    def remove_host(self, host):
+    def remove_host(self, host, force=False):
         assert isinstance(host, six.string_types)
 
     @deferred_write("apply_mgr")


### PR DESCRIPTION
**Blocked by:**

- [x] #34633

---

Workflow is something like:

```bash
ceph orch host rm myhost # fails with daemons still running
ceph orch drain myhost # removes crash and node-exporter
ceph orch rm daemon osd.7
ceph orch rm daemon mon.a
ceph orch host rm myhost # succeeds
```

Also:

* `host rm`: Assert host is empty (+tests + cleanup of the tests)
* Added Inventory class. Later discovered that I can simply use a label for this.
* Moved `HostAssignment` to a new module

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
