### PR TITLE
nautilus: mon: disable min pg per osd warning

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1597,7 +1597,7 @@ std::vector<Option> get_global_options() {
     .add_service("mgr"),
 
     Option("mon_pg_warn_min_per_osd", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(30)
+    .set_default(0)
     .add_service("mgr")
     .set_description("minimal number PGs per (in) osd before we warn the admin"),
 


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/30352

Fixes: https://tracker.ceph.com/issues/45135