### PR TITLE
qa/cephadm: make test_adoption checkout a specific commit

### DIFF
--- a/qa/workunits/cephadm/test_adoption.sh
+++ b/qa/workunits/cephadm/test_adoption.sh
@@ -3,6 +3,7 @@
 SCRIPT_NAME=$(basename ${BASH_SOURCE[0]})
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CEPHADM_SRC_DIR=${SCRIPT_DIR}/../../../src/cephadm
+CORPUS_COMMIT=50c5dd734638939facd1ed32295ce59c9a5986b4
 
 [ -z "$SUDO" ] && SUDO=sudo
 if [ -z "$CEPHADM" ]; then
@@ -54,8 +55,10 @@ CEPHADM="$SUDO $CEPHADM_BIN"
 CORPUS_GIT_SUBMOD="cephadm-adoption-corpus"
 TMPDIR=$(mktemp -d)
 git clone https://github.com/ceph/$CORPUS_GIT_SUBMOD $TMPDIR
-CORPUS_DIR=${TMPDIR}/archive
 trap "$SUDO rm -rf $TMPDIR" EXIT
+
+git -C $TMPDIR checkout $CORPUS_COMMIT
+CORPUS_DIR=${TMPDIR}/archive
 
 for subdir in `ls ${CORPUS_DIR}`; do
     for tarfile in `ls ${CORPUS_DIR}/${subdir} | grep .tgz`; do


### PR DESCRIPTION
Reason is, I want to have a test run of test_adoption, *before* master is affected.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
