### PR TITLE
osd/tier: make flushing cache pool faster by cut down list_objects frequency, flush cache pool PGs in same priority queue cyclic

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -527,6 +527,7 @@ OPTION(osd_recovery_retry_interval, OPT_DOUBLE)
 // max agent flush ops
 OPTION(osd_agent_max_ops, OPT_INT)
 OPTION(osd_agent_max_low_ops, OPT_INT)
+OPTION(osd_agent_flush_quota, OPT_INT)
 OPTION(osd_agent_min_evict_effort, OPT_FLOAT)
 OPTION(osd_agent_quantize_effort, OPT_FLOAT)
 OPTION(osd_agent_delay_time, OPT_FLOAT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2434,6 +2434,10 @@ std::vector<Option> get_global_options() {
     .set_default(2)
     .set_description("maximum concurrent low-priority tiering operations for tiering agent"),
 
+    Option("osd_agent_flush_quota", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("osd_agent_flush_quota should be less than osd_agent_max_low_ops, otherwise will block agent_entry"),
+
     Option("osd_agent_min_evict_effort", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(.1)
     .set_min_max(0.0, .99)


### PR DESCRIPTION
Listing 100 objects costs 3 milliseconds approximately using ssd. In order to cut down list_objects frequency, we add a configuration osd_agent_flush_quota to control the min objects for one flush operation, so as to decrease the list_objects operations.

Also, we handle PGs in the same priority level cyclic instead of handling all objects of a PG  before another.

Fixes: https://tracker.ceph.com/issues/45140
Signed-off-by: Mingyuan Liang <liangmingyuan@baidu.com>