### PR TITLE
octopus: mgr/dashboard: lint error on plugins/debug.py

### DIFF
--- a/src/pybind/mgr/dashboard/plugins/debug.py
+++ b/src/pybind/mgr/dashboard/plugins/debug.py
@@ -21,7 +21,7 @@ class Actions(Enum):
 
 
 @PM.add_plugin  # pylint: disable=too-many-ancestors
-class Debug(SP, I.CanCherrypy, I.ConfiguresCherryPy):
+class Debug(SP, I.CanCherrypy, I.ConfiguresCherryPy):  # pylint: disable=too-many-ancestors
     NAME = 'debug'
 
     OPTIONS = [


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45051

---

backport of https://github.com/ceph/ceph/pull/34411
parent tracker: https://tracker.ceph.com/issues/44589

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh