### PR TITLE
nautilus: mgr/PyModule: fix missing tracebacks in handle_pyerror()

### DIFF
--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -42,6 +42,7 @@ std::string handle_pyerror()
     PyObject *exc, *val, *tb;
     object formatted_list, formatted;
     PyErr_Fetch(&exc, &val, &tb);
+    PyErr_NormalizeException(&exc, &val, &tb);
     handle<> hexc(exc), hval(allow_null(val)), htb(allow_null(tb));
     object traceback(import("traceback"));
     if (!tb) {
@@ -55,6 +56,7 @@ std::string handle_pyerror()
           std::stringstream ss;
           ss << PyString_AsString(name_attr) << ": " << PyString_AsString(val);
           Py_XDECREF(name_attr);
+          ss << "\nError processing exception object: " << peek_pyerror();
           return ss.str();
         }
     } else {
@@ -68,6 +70,7 @@ std::string handle_pyerror()
           std::stringstream ss;
           ss << PyString_AsString(name_attr) << ": " << PyString_AsString(val);
           Py_XDECREF(name_attr);
+          ss << "\nError processing exception object: " << peek_pyerror();
           return ss.str();
         }
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45043

---

backport of https://github.com/ceph/ceph/pull/34366
parent tracker: https://tracker.ceph.com/issues/44799

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh