### PR TITLE
nautilus: mgr/telegraf: catch FileNotFoundError exception

### DIFF
--- a/qa/suites/rados/mgr/tasks/module_selftest.yaml
+++ b/qa/suites/rados/mgr/tasks/module_selftest.yaml
@@ -18,7 +18,7 @@ tasks:
         - influxdb python module not found
         - \(MGR_ZABBIX_
         - foo bar
-        - evicting unresponsive client
+        - Failed to open Telegraf
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_module_selftest

--- a/src/pybind/mgr/telegraf/module.py
+++ b/src/pybind/mgr/telegraf/module.py
@@ -240,8 +240,8 @@ class Module(MgrModule):
         sock = BaseSocket(url)
         self.log.debug('Sending data to Telegraf at %s', sock.address)
         now = self.now()
-        with sock as s:
-            try:
+        try:
+            with sock as s:
                 for measurement in self.gather_measurements():
                     self.log.debug(measurement)
                     line = Line(measurement['measurement'],
@@ -249,8 +249,10 @@ class Module(MgrModule):
                                 measurement['tags'], now)
                     self.log.debug(line.to_line_protocol())
                     s.send(line.to_line_protocol())
-            except (socket.error, RuntimeError, IOError, OSError):
-                self.log.exception('Failed to send statistics to Telegraf:')
+        except (socket.error, RuntimeError, IOError, OSError):
+            self.log.exception('Failed to send statistics to Telegraf:')
+        except FileNotFoundError:
+            self.log.exception('Failed to open Telegraf at: %s', url.geturl())
 
     def shutdown(self):
         self.log.info('Stopping Telegraf module')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45070

---

backport of https://github.com/ceph/ceph/pull/34468
parent tracker: https://tracker.ceph.com/issues/43551

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh