### PR TITLE
bash_completion: Do not auto complete obsolete and hidden cmds 

### DIFF
--- a/src/bash_completion/ceph
+++ b/src/bash_completion/ceph
@@ -27,7 +27,7 @@ _ceph()
 	COMPREPLY=( $(compgen -W "${options_noarg} ${options_arg}" -- $cur) )
 	return 0
     fi
-    declare -A hint_args
+    declare -a hint_args
     for (( i=1 ; i<cnt ; i++ ))
     do
 	#skip this word if it is option

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -679,6 +679,9 @@ def complete(sigdict, args, target):
     match_count = 0
     comps = []
     for cmdtag, cmd in sigdict.items():
+        flags = cmd.get('flags', 0)
+        if flags & (Flag.OBSOLETE | Flag.HIDDEN):
+            continue
         sig = cmd['sig']
         j = 0
         # iterate over all arguments, except last one


### PR DESCRIPTION
This patch fixes two things.

1. Do not auto complete obsolete and hidden commands
2. sub command completions often failed due to the
   use of associative arrays which does not keep the
   order. Hence used non-associative arrays.

Fixes: https://tracker.ceph.com/issues/45141
Signed-off-by: Kotresh HR <khiremat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
