### PR TITLE
mgr: drop python2 support

### DIFF
--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -121,7 +121,6 @@ namespace {
     {nullptr, nullptr, 0, nullptr}
   };
 
-#if PY_MAJOR_VERSION >= 3
   static PyModuleDef ceph_logger_module = {
     PyModuleDef_HEAD_INIT,
     "ceph_logger",
@@ -129,7 +128,6 @@ namespace {
     -1,
     log_methods,
   };
-#endif
 }
 
 PyModuleConfig::PyModuleConfig() = default;  
@@ -252,7 +250,6 @@ std::string PyModule::get_site_packages()
   return site_packages.str();
 }
 
-#if PY_MAJOR_VERSION >= 3
 PyObject* PyModule::init_ceph_logger()
 {
   auto py_logger = PyModule_Create(&ceph_logger_module);
@@ -260,25 +257,12 @@ PyObject* PyModule::init_ceph_logger()
   PySys_SetObject("stdout", py_logger);
   return py_logger;
 }
-#else
-void PyModule::init_ceph_logger()
-{
-  auto py_logger = Py_InitModule("ceph_logger", log_methods);
-  PySys_SetObject(const_cast<char*>("stderr"), py_logger);
-  PySys_SetObject(const_cast<char*>("stdout"), py_logger);
-}
-#endif
 
-#if PY_MAJOR_VERSION >= 3
 PyObject* PyModule::init_ceph_module()
-#else
-void PyModule::init_ceph_module()
-#endif
 {
   static PyMethodDef module_methods[] = {
     {nullptr, nullptr, 0, nullptr}
   };
-#if PY_MAJOR_VERSION >= 3
   static PyModuleDef ceph_module_def = {
     PyModuleDef_HEAD_INIT,
     "ceph_module",
@@ -291,9 +275,6 @@ void PyModule::init_ceph_module()
     nullptr
   };
   PyObject *ceph_module = PyModule_Create(&ceph_module_def);
-#else
-  PyObject *ceph_module = Py_InitModule("ceph_module", module_methods);
-#endif
   ceph_assert(ceph_module != nullptr);
   std::map<const char*, PyTypeObject*> classes{
     {{"BaseMgrModule", &BaseMgrModuleType},
@@ -311,9 +292,7 @@ void PyModule::init_ceph_module()
 
     PyModule_AddObject(ceph_module, name, (PyObject *)type);
   }
-#if PY_MAJOR_VERSION >= 3
   return ceph_module;
-#endif
 }
 
 int PyModule::load(PyThreadState *pMainThreadState)
@@ -333,26 +312,15 @@ int PyModule::load(PyThreadState *pMainThreadState)
       pMyThreadState.set(thread_state);
       // Some python modules do not cope with an unpopulated argv, so lets
       // fake one.  This step also picks up site-packages into sys.path.
-#if PY_MAJOR_VERSION >= 3
       const wchar_t *argv[] = {L"ceph-mgr"};
       PySys_SetArgv(1, (wchar_t**)argv);
-#else
-      const char *argv[] = {"ceph-mgr"};
-      PySys_SetArgv(1, (char**)argv);
-#endif
       // Configure sys.path to include mgr_module_path
       string paths = (":" + g_conf().get_val<std::string>("mgr_module_path") +
 		      ":" + get_site_packages());
-#if PY_MAJOR_VERSION >= 3
       wstring sys_path(Py_GetPath() + wstring(begin(paths), end(paths)));
       PySys_SetPath(const_cast<wchar_t*>(sys_path.c_str()));
       dout(10) << "Computed sys.path '"
 	       << string(begin(sys_path), end(sys_path)) << "'" << dendl;
-#else
-      string sys_path(Py_GetPath() + paths);
-      PySys_SetPath(const_cast<char*>(sys_path.c_str()));
-      dout(10) << "Computed sys.path '" << sys_path << "'" << dendl;
-#endif
     }
   }
   // Environment is all good, import the external module

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -109,13 +109,8 @@ public:
     const std::string& value);
 
   int load(PyThreadState *pMainThreadState);
-#if PY_MAJOR_VERSION >= 3
   static PyObject* init_ceph_logger();
   static PyObject* init_ceph_module();
-#else
-  static void init_ceph_logger();
-  static void init_ceph_module();
-#endif
 
   void set_enabled(const bool enabled_)
   {

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -41,13 +41,9 @@ void PyModuleRegistry::init()
   std::lock_guard locker(lock);
 
   // Set up global python interpreter
-#if PY_MAJOR_VERSION >= 3
 #define WCHAR(s) L ## #s
   Py_SetProgramName(const_cast<wchar_t*>(WCHAR(MGR_PYTHON_EXECUTABLE)));
 #undef WCHAR
-#else
-  Py_SetProgramName(const_cast<char*>(MGR_PYTHON_EXECUTABLE));
-#endif
   // Add more modules
   if (g_conf().get_val<bool>("daemonize")) {
     PyImport_AppendInittab("ceph_logger", PyModule::init_ceph_logger);


### PR DESCRIPTION
just stop checking for `PY_MAJOR_VERSION`, since we've moved to python3.
no need to be python2 compatible.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
