### PR TITLE
ceph_volume_client.py: python 3.8 compatibility

### DIFF
--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -378,7 +378,7 @@ class CephFSVolumeClient(object):
                 if vol_meta['auths'][auth_id] == want_auth:
                     continue
 
-                readonly = access_level == 'r'
+                readonly = True if access_level == 'r' else False
                 self._authorize_volume(volume_path, auth_id, readonly)
 
             # Recovered from partial auth updates for the auth ID's access


### PR DESCRIPTION
Installing 15.2.1 on Ubuntu 20.04 yields this warning:
```
Setting up python3-cephfs (15.2.1-0ubuntu1) ...
/usr/lib/python3/dist-packages/ceph_volume_client.py:358: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  group_id = group_id if group_id is not 'None' else None
/usr/lib/python3/dist-packages/ceph_volume_client.py:381: SyntaxWarning: "is" with a literal. Did you mean "=="?
  readonly = True if access_level is 'r' else False
/usr/lib/python3/dist-packages/ceph_volume_client.py:1102: SyntaxWarning: "is" with a literal. Did you mean "=="?
  unwanted_access_level = 'r' if want_access_level is 'rw' else 'rw'
```
Make the suggested changes.

Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
