### PR TITLE
octopus: rbd: ignore tx-only mirror peers when adding new peers

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -233,6 +233,41 @@ EOF
     done
 }
 
+peer_add()
+{
+    local cluster=$1 ; shift
+    local pool=$1 ; shift
+    local client_cluster=$1 ; shift
+
+    local uuid_var_name
+    if [ -n "$1" ]; then
+        uuid_var_name=$1 ; shift
+    fi
+
+    local error_code
+    local peer_uuid
+
+    for s in 1 2 4 8 16 32; do
+        peer_uuid=$(rbd --cluster ${cluster} mirror pool peer add \
+            ${pool} ${client_cluster} $@)
+        error_code=$?
+
+        if [ $error_code -eq 17 ]; then
+            # raced with a remote heartbeat ping -- remove and retry
+            sleep $s
+            rbd --cluster ${cluster} --pool ${pool} mirror pool peer remove ${peer_uuid}
+        else
+            test $error_code -eq 0
+            if [ -n "$uuid_var_name" ]; then
+                eval ${uuid_var_name}=${peer_uuid}
+            fi
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 setup_pools()
 {
     local cluster=$1
@@ -264,8 +299,8 @@ setup_pools()
 
     if [ -z ${RBD_MIRROR_MANUAL_PEERS} ]; then
       if [ -z ${RBD_MIRROR_CONFIG_KEY} ]; then
-        rbd --cluster ${cluster} mirror pool peer add ${POOL} ${remote_cluster}
-        rbd --cluster ${cluster} mirror pool peer add ${PARENT_POOL} ${remote_cluster}
+        peer_add ${cluster} ${POOL} ${remote_cluster}
+        peer_add ${cluster} ${PARENT_POOL} ${remote_cluster}
       else
         mon_map_file=${TEMPDIR}/${remote_cluster}.monmap
         CEPH_ARGS='' ceph --cluster ${remote_cluster} mon getmap > ${mon_map_file}
@@ -275,12 +310,11 @@ setup_pools()
         admin_key_file=${TEMPDIR}/${remote_cluster}.client.${CEPH_ID}.key
         CEPH_ARGS='' ceph --cluster ${remote_cluster} auth get-key client.${CEPH_ID} > ${admin_key_file}
 
-        CEPH_ARGS='' rbd --cluster ${cluster} mirror pool peer add ${POOL} \
-            client.${CEPH_ID}@${remote_cluster}${PEER_CLUSTER_SUFFIX} \
+        CEPH_ARGS='' peer_add ${cluster} ${POOL} \
+            client.${CEPH_ID}@${remote_cluster}${PEER_CLUSTER_SUFFIX} '' \
             --remote-mon-host "${mon_addr}" --remote-key-file ${admin_key_file}
 
-        uuid=$(rbd --cluster ${cluster} mirror pool peer add ${PARENT_POOL} \
-            client.${CEPH_ID}@${remote_cluster}${PEER_CLUSTER_SUFFIX})
+        peer_add ${cluster} ${PARENT_POOL} client.${CEPH_ID}@${remote_cluster}${PEER_CLUSTER_SUFFIX} uuid
         CEPH_ARGS='' rbd --cluster ${cluster} mirror pool peer set ${PARENT_POOL} ${uuid} mon-host ${mon_addr}
         CEPH_ARGS='' rbd --cluster ${cluster} mirror pool peer set ${PARENT_POOL} ${uuid} key-file ${admin_key_file}
       fi

--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -1474,7 +1474,7 @@ int Mirror<I>::peer_site_add(librados::IoCtx& io_ctx, std::string *uuid,
     if (r == -ESTALE) {
       ldout(cct, 5) << "duplicate UUID detected, retrying" << dendl;
     } else if (r < 0) {
-      lderr(cct) << "failed to add mirror peer '" << uuid << "': "
+      lderr(cct) << "failed to add mirror peer '" << site_name << "': "
                  << cpp_strerror(r) << dendl;
       return r;
     }

--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -1017,8 +1017,19 @@ int execute_peer_add(const po::variables_map &vm,
     std::cerr << "rbd: failed to list mirror peers" << std::endl;
     return r;
   }
+
+  // ignore tx-only peers since the restriction is for rx
+  mirror_peers.erase(
+    std::remove_if(
+      mirror_peers.begin(), mirror_peers.end(),
+      [](const librbd::mirror_peer_site_t& peer) {
+        return (peer.direction == RBD_MIRROR_PEER_DIRECTION_TX);
+      }),
+    mirror_peers.end());
+
   if (!mirror_peers.empty()) {
-    std::cerr << "rbd: multiple peers are not currently supported" << std::endl;
+    std::cerr << "rbd: multiple RX peers are not currently supported"
+              << std::endl;
     return -EINVAL;
   }
 
@@ -1173,8 +1184,37 @@ int execute_peer_set(const po::variables_map &vm,
       return -EINVAL;
     }
 
-    r = rbd.mirror_peer_site_set_direction(
-      io_ctx, uuid, boost::any_cast<rbd_mirror_peer_direction_t>(direction));
+    auto peer_direction = boost::any_cast<rbd_mirror_peer_direction_t>(
+      direction);
+    if (peer_direction != RBD_MIRROR_PEER_DIRECTION_TX) {
+      // TODO: temporary restriction to prevent adding multiple peers
+      // until rbd-mirror daemon can properly handle the scenario
+      std::vector<librbd::mirror_peer_site_t> mirror_peers;
+      r = rbd.mirror_peer_site_list(io_ctx, &mirror_peers);
+      if (r < 0) {
+        std::cerr << "rbd: failed to list mirror peers" << std::endl;
+        return r;
+      }
+
+      // ignore peer to be updated and tx-only peers since the restriction is
+      // for rx
+      mirror_peers.erase(
+        std::remove_if(
+          mirror_peers.begin(), mirror_peers.end(),
+          [uuid](const librbd::mirror_peer_site_t& peer) {
+            return (peer.uuid == uuid ||
+                    peer.direction == RBD_MIRROR_PEER_DIRECTION_TX);
+          }),
+        mirror_peers.end());
+
+      if (!mirror_peers.empty()) {
+        std::cerr << "rbd: multiple RX peers are not currently supported"
+                  << std::endl;
+        return -EINVAL;
+      }
+    }
+
+    r = rbd.mirror_peer_site_set_direction(io_ctx, uuid, peer_direction);
   } else {
     r = update_peer_config_key(io_ctx, uuid, key, value);
   }

--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -1042,7 +1042,10 @@ int execute_peer_add(const po::variables_map &vm,
   std::string uuid;
   r = rbd.mirror_peer_site_add(
     io_ctx, &uuid, mirror_peer_direction, remote_cluster, remote_client_name);
-  if (r < 0) {
+  if (r == -EEXIST) {
+    std::cerr << "rbd: mirror peer already exists" << std::endl;
+    return r;
+  } else if (r < 0) {
     std::cerr << "rbd: error adding mirror peer" << std::endl;
     return r;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45036

---

backport of

* https://github.com/ceph/ceph/pull/34422
* https://github.com/ceph/ceph/pull/34573

parent tracker: https://tracker.ceph.com/issues/44938

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh