### PR TITLE
nautilus: mgr/dashboard: fix backport #33764

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.html
@@ -1,31 +1,27 @@
 <div class="row">
   <div class="col-sm-12 col-lg-12">
-    <div class="card">
-      <div class="card-header"
-           i18n>CRUSH map viewer</div>
-      <div class="card-body">
-        <div class="row">
-          <div class="col-sm-6 col-lg-6">
-            <tree [tree]="tree"
-                  [settings]="{rootIsVisible: false}"
-                  (nodeSelected)="onNodeSelected($event)">
-              <ng-template let-node>
-                <span class="badge"
-                      [ngClass]="{'badge-success': ['in', 'up'].includes(node.status), 'badge-danger': ['down', 'out', 'destroyed'].includes(node.status)}">
-                  {{ node.status }}
-                </span>
-                <span>&nbsp;</span>
-                <span class="node-name"
-                      [ngClass]="{'type-osd': node.type === 'osd'}"
-                      [innerHTML]="node.value"></span>
-              </ng-template>
-            </tree>
-          </div>
-          <div class="col-sm-6 col-lg-6 metadata"
-               *ngIf="metadata">
-            <legend>{{ metadataTitle }}</legend>
-            <cd-table-key-value [data]="metadata"></cd-table-key-value>
-          </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">
+          <span i18n>CRUSH map viewer</span>
+        </h3>
+      </div>
+      <div class="panel-body">
+        <div class="col-sm-6 col-lg-6">
+          <tree [tree]="tree"
+                [settings]="{rootIsVisible: false}"
+                (nodeSelected)="onNodeSelected($event)">
+            <ng-template let-node>
+              <span class="label"
+                    [ngClass]="{'label-success': ['in', 'up'].includes(node.status), 'label-danger': ['down', 'out', 'destroyed'].includes(node.status)}">{{ node.status }}</span>
+              <span>&nbsp;</span>
+              <span class="node-name" [innerHTML]="node.value"></span>
+            </ng-template>
+          </tree>
+        </div>
+        <div class="col-sm-6 col-lg-6 metadata" *ngIf="metadata">
+          <legend>{{ metadataTitle }}</legend>
+          <cd-table-key-value [data]="metadata"></cd-table-key-value>
         </div>
       </div>
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.spec.ts
@@ -33,8 +33,8 @@ describe('CrushmapComponent', () => {
 
   it('should display right title', () => {
     fixture.detectChanges();
-    const card = debugElement.nativeElement.querySelector('.card-header');
-    expect(card.textContent).toBe('CRUSH map viewer');
+    const span = debugElement.nativeElement.querySelector('span');
+    expect(span.textContent).toBe('CRUSH map viewer');
   });
 
   describe('test tree', () => {


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/33764/ resulted in the mixing
of Bootstrap 4 classes into Nautilus dashboard, which is Bootstrap 3
based.

This fix reverts most of those unintended changes (see cbb4c62b9b918823594f506488fc6c0ab4ee2300
for understanding the original extent of changes).

Fixes: https://tracker.ceph.com/issues/44198
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
