### PR TITLE
os/bluestore/BlueFS: Make log_dump possible without opening bluefs

### DIFF
--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -192,7 +192,10 @@ void log_dump(
   const string& path,
   const vector<string>& devs)
 {
-  BlueFS* fs = open_bluefs(cct, path, devs);
+  validate_path(cct, path, true);
+  BlueFS *fs = new BlueFS(cct);
+
+  add_devices(fs, cct, devs);
   int r = fs->log_dump();
   if (r < 0) {
     cerr << "log_dump failed" << ": "


### PR DESCRIPTION
This allows 'ceph-bluestore-tool bluefs-log-dump' to print bluefs log
without mount(), which allows to print even if its content is corrupted.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>