### PR TITLE
rgw: Add bucket name to bucket stats error logging

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1378,7 +1378,7 @@ static int bucket_stats(rgw::sal::RGWRadosStore *store, const std::string& tenan
   string max_marker;
   int ret = store->getRados()->get_bucket_stats(bucket_info, RGW_NO_SHARD, &bucket_ver, &master_ver, stats, &max_marker);
   if (ret < 0) {
-    cerr << "error getting bucket stats ret=" << ret << std::endl;
+    cerr << "error getting bucket stats bucket=" << bucket.name << " ret=" << ret << std::endl;
     return ret;
   }
 


### PR DESCRIPTION
Add bucket name to bucket stats error logging to find out which bucket gets error in getting usage for all buckets from admin api.

Signed-off-by: Seena Fallah <seeenafallah@gmail.com>