### PR TITLE
mgr/dashboard: customize CherryPy Server Header

### DIFF
--- a/qa/tasks/mgr/dashboard/test_requests.py
+++ b/qa/tasks/mgr/dashboard/test_requests.py
@@ -21,3 +21,9 @@ class RequestsTest(DashboardTestCase):
         self.assertHeaders({
             'Content-Type': 'application/json',
         })
+
+    def test_server(self):
+        self._get('/api/summary')
+        self.assertHeaders({
+            'server': 'Ceph-Dashboard'
+        })

--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -15,6 +15,10 @@ import jwt
 from .access_control import LocalAuthenticator, UserDoesNotExist
 from .. import mgr
 
+cherrypy.config.update({
+    'response.headers.server': 'Ceph-Dashboard'
+    })
+
 
 class JwtManager(object):
     JWT_TOKEN_BLACKLIST_KEY = "jwt_token_black_list"


### PR DESCRIPTION
This commit is intended to hide CherryPy name and version, from HTTP requests CherryPy 'Server' header. 

Fixes: <https://tracker.ceph.com/issues/44935>
Signed-off-by: Anurag Bandhu <abandhu@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
