### PR TITLE
cephadm: Make ceph-iscsi SSL aware

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2868,9 +2868,33 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         ret, keyring, err = self.mon_command({
             'prefix': 'auth get-or-create',
             'entity': utils.name_to_config_section('iscsi') + '.' + igw_id,
-            'caps': ['mon', 'allow rw',
+            'caps': ['mon', 'profile rbd, '
+                            'allow command "osd blacklist", '
+                            'allow command "config-key get" with "key" prefix "iscsi/"',
                      'osd', f'allow rwx pool={spec.pool}'],
         })
+
+        if spec.ssl_cert:
+            if isinstance(spec.ssl_cert, list):
+                cert_data = '\n'.join(spec.ssl_cert)
+            else:
+                cert_data = spec.ssl_cert
+            ret, out, err = self.mon_command({
+                'prefix': 'config-key set',
+                'key': f'iscsi/{utils.name_to_config_section("iscsi")}.{igw_id}/iscsi-gateway.crt',
+                'val': cert_data,
+            })
+
+        if spec.ssl_key:
+            if isinstance(spec.ssl_key, list):
+                key_data = '\n'.join(spec.ssl_key)
+            else:
+                key_data = spec.ssl_key
+            ret, out, err = self.mon_command({
+                'prefix': 'config-key set',
+                'key': f'iscsi/{utils.name_to_config_section("iscsi")}.{igw_id}/iscsi-gateway.key',
+                'val': key_data,
+            })
 
         api_secure = 'false' if spec.api_secure is None else spec.api_secure
         igw_conf = f"""

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -599,6 +599,9 @@ class IscsiServiceSpec(ServiceSpec):
         self.ssl_cert = ssl_cert
         self.ssl_key = ssl_key
 
+        if not self.api_secure and self.ssl_cert and self.ssl_key:
+            self.api_secure = True
+
     def validate_add(self):
         servicespec_validate_add(self)
 


### PR DESCRIPTION
Ceph-iscsi's `rbd-target-api.py` supports listening over SSL if you
provide an SSL cert and key. Originally the script is opinionated and
requires these files to be named `/etc/ceph/iscsi-gateway.{crt,key}`.

When dealing with containers, having to place files inside a container to
enable SSL isn't very clean. To make things easier, like RGW, you can
now place the SSL cert and key data in the mon config-key store.
Well, we will be able once this PR[0] lands.

This will mean there are 2 ways to enable SSL in ceph-iscsi via orch/cephadm.

1. Push the SSL key and cert into the mon config-key under the keys, below, and
   then make sure api_secure is enabled (requires json):

  iscsi/{clientname}/iscsi-gateway.crt
  iscsi/{clientname}/iscsi-gateway.key

2. Provide the SSL key and cert in the json you pass the orchestrator and
   it'll push them up for you.

NOTE: This patch cannot merge until the ceph-iscsi pr[0] lands.

[0] - https://github.com/ceph/ceph-iscsi/pull/173

Signed-off-by: Matthew Oliver <moliver@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
