### PR TITLE
[RFC]msg: add new func support_reencode.

### DIFF
--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -203,7 +203,7 @@ void LogEntry::log_to_syslog(string level, string facility)
 
 void LogEntry::encode(bufferlist& bl, uint64_t features) const
 {
-  assert(HAVE_FEATURE(features, SERVER_NAUTILUS));
+  assert((features == 0) || HAVE_FEATURE(features, SERVER_NAUTILUS));
   ENCODE_START(5, 5, bl);
   __u16 t = prio;
   encode(name, bl);

--- a/src/messages/MOSDMap.h
+++ b/src/messages/MOSDMap.h
@@ -158,6 +158,10 @@ public:
       out << " src has " << oldest_map << ".." << newest_map;
     out << ")";
   }
+
+  bool support_reencode() const override {
+    return false;
+  }
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -513,6 +513,10 @@ public:
   virtual void dump(ceph::Formatter *f) const;
 
   void encode(uint64_t features, int crcflags, bool skip_header_crc = false);
+
+  virtual bool support_reencode() const {
+    return true;
+  }
 };
 
 extern Message *decode_message(CephContext *cct,

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -214,9 +214,7 @@ void ProtocolV1::send_message(Message *m) {
   ceph::buffer::list bl;
   uint64_t f = connection->get_features();
 
-  // TODO: Currently not all messages supports reencode like MOSDMap, so here
-  // only let fast dispatch support messages prepare message
-  bool can_fast_prepare = messenger->ms_can_fast_dispatch(m);
+  bool can_fast_prepare = m->support_reencode();
   if (can_fast_prepare) {
     prepare_send_message(f, m, bl);
   }

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -422,9 +422,7 @@ void ProtocolV2::prepare_send_message(uint64_t features,
 void ProtocolV2::send_message(Message *m) {
   uint64_t f = connection->get_features();
 
-  // TODO: Currently not all messages supports reencode like MOSDMap, so here
-  // only let fast dispatch support messages prepare message
-  const bool can_fast_prepare = messenger->ms_can_fast_dispatch(m);
+  const bool can_fast_prepare = m->support_reencode();
   if (can_fast_prepare) {
     prepare_send_message(f, m);
   }


### PR DESCRIPTION
Currently, we use Messenger::ms_can_fast_dispatch to verfiy Message
whether support reencode. Now we add a new api of Message to support

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
