### PR TITLE
rgw: remove noexcept from function definition

### DIFF
--- a/src/rgw/rgw_bucket_sync_cache.h
+++ b/src/rgw/rgw_bucket_sync_cache.h
@@ -84,8 +84,8 @@ class Handle {
   Handle(boost::intrusive_ptr<Cache> cache,
          boost::intrusive_ptr<Entry> entry) noexcept
     : cache(std::move(cache)), entry(std::move(entry)) {}
-  Handle(Handle&&) noexcept = default;
-  Handle(const Handle&) noexcept = default;
+  Handle(Handle&&) = default;
+  Handle(const Handle&) = default;
   Handle& operator=(Handle&& o) noexcept {
     // move the entry first so that its cache stays referenced over destruction
     entry = std::move(o.entry);


### PR DESCRIPTION
Clang complains:
src/rgw/rgw_bucket_sync_cache.h:88:3: error: exception specification of explicitly defaulted copy co
nstructor does not match the calculated one
  Handle(const Handle&) noexcept = default;
  ^
1 error generated.

And a reference that I found for this:
    https://github.com/mapnik/mapnik/issues/3274
Suggesting that the noexcept is inherited from the first definition.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>