### PR TITLE
mgr/dashboard: fix tasks.mgr.dashboard.test_rgw.RgwBucketTest.test_all

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rgw.py
+++ b/qa/tasks/mgr/dashboard/test_rgw.py
@@ -116,7 +116,7 @@ class RgwBucketTest(RgwTestCase):
 
     _mfa_token_serial = '1'
     _mfa_token_seed = '23456723'
-    _mfa_token_time_step = 3
+    _mfa_token_time_step = 2
 
     AUTH_ROLES = ['rgw-manager']
 
@@ -152,7 +152,7 @@ class RgwBucketTest(RgwTestCase):
         totp_key = base64.b32decode(self._mfa_token_seed)
         totp = TOTP(totp_key, 6, SHA1(), self._mfa_token_time_step, backend=default_backend(),
                     enforce_key_length=False)
-        time_value = time.time()
+        time_value = int(time.time())
         return totp.generate(time_value)
 
     def test_all(self):
@@ -241,7 +241,7 @@ class RgwBucketTest(RgwTestCase):
         self.assertEqual(data['mfa_delete'], 'Enabled')
 
         # Update bucket: disable versioning & MFA Delete.
-        time.sleep(self._mfa_token_time_step + 2)  # Required to get new TOTP pin.
+        time.sleep(self._mfa_token_time_step * 3)  # Required to get new TOTP pin.
         self._put(
             '/api/rgw/bucket/teuth-test-bucket',
             params={


### PR DESCRIPTION
Increased the time for getting 2nd TOTP.

Fixes: https://tracker.ceph.com/issues/44405
Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
