### PR TITLE
cls/2pc_queue: remove the dependency of cls_2pc_queue with cls_queue

### DIFF
--- a/src/cls/2pc_queue/cls_2pc_queue_client.cc
+++ b/src/cls/2pc_queue/cls_2pc_queue_client.cc
@@ -19,7 +19,7 @@ void cls_2pc_queue_init(ObjectWriteOperation& op, const std::string& queue_name,
 
 int cls_2pc_queue_get_capacity(IoCtx& io_ctx, const string& queue_name, uint64_t& size) {
   bufferlist in, out;
-  const auto r = io_ctx.exec(queue_name, QUEUE_CLASS, QUEUE_GET_CAPACITY, in, out);
+  const auto r = io_ctx.exec(queue_name, TPC_QUEUE_CLASS, TPC_QUEUE_GET_CAPACITY, in, out);
   if (r < 0 ) {
     return r;
   }
@@ -91,7 +91,7 @@ int cls_2pc_queue_list_entries(IoCtx& io_ctx, const string& queue_name, const st
   op.max = max;
   encode(op, in);
 
-  const auto r = io_ctx.exec(queue_name, QUEUE_CLASS, QUEUE_LIST_ENTRIES, in, out);
+  const auto r = io_ctx.exec(queue_name, TPC_QUEUE_CLASS, TPC_QUEUE_LIST_ENTRIES, in, out);
   if (r < 0) {
     return r;
   }
@@ -138,6 +138,6 @@ void cls_2pc_queue_remove_entries(ObjectWriteOperation& op, const std::string& e
   cls_queue_remove_op rem_op;
   rem_op.end_marker = end_marker;
   encode(rem_op, in);
-  op.exec(QUEUE_CLASS, QUEUE_REMOVE_ENTRIES, in);
+  op.exec(TPC_QUEUE_CLASS, TPC_QUEUE_REMOVE_ENTRIES, in);
 }
 

--- a/src/cls/2pc_queue/cls_2pc_queue_const.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_const.h
@@ -3,8 +3,11 @@
 #define TPC_QUEUE_CLASS "2pc_queue"
 
 #define TPC_QUEUE_INIT "2pc_queue_init"
+#define TPC_QUEUE_GET_CAPACITY "2pc_queue_get_capacity"
 #define TPC_QUEUE_RESERVE "2pc_queue_reserve"
 #define TPC_QUEUE_COMMIT "2pc_queue_commit"
 #define TPC_QUEUE_ABORT "2pc_queue_abort"
 #define TPC_QUEUE_LIST_RESERVATIONS "2pc_queue_list_reservations"
+#define TPC_QUEUE_LIST_ENTRIES "2pc_queue_list_entries"
+#define TPC_QUEUE_REMOVE_ENTRIES "2pc_queue_remove_entries"
 


### PR DESCRIPTION
both queues share the same code base, however, cls_2pc_queue should work
even if cls_queue objectclass is not loaded into the osd

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>