### PR TITLE
test/rgw: allow the rgw teuthology task to capture/set dns names

### DIFF
--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -104,9 +104,9 @@ def start_rgw(ctx, config, clients):
                 ])
 
 
-        if client_config.get('dns-name'):
+        if client_config.get('dns-name') is not None:
             rgw_cmd.extend(['--rgw-dns-name', endpoint.dns_name])
-        if client_config.get('dns-s3website-name'):
+        if client_config.get('dns-s3website-name') is not None:
             rgw_cmd.extend(['--rgw-dns-s3website-name', endpoint.website_dns_name])
 
 
@@ -222,9 +222,8 @@ def assign_endpoints(ctx, config, default_cert):
             dns_name += remote.hostname
 
         website_dns_name = client_config.get('dns-s3website-name')
-        if website_dns_name:
-            if len(website_dns_name) == 0 or website_dns_name.endswith('.'):
-                website_dns_name += remote.hostname
+        if website_dns_name is not None and (len(website_dns_name) == 0 or website_dns_name.endswith('.')):
+            website_dns_name += remote.hostname
 
         role_endpoints[role] = RGWEndpoint(remote.hostname, port, ssl_certificate, dns_name, website_dns_name)
 


### PR DESCRIPTION
A teuthology workunit might want to use the rgw task, setting the rgw-dns-name and/or rgw-dns-s3website-name configuration options to the fully-qualified default name. Existing code implies that by setting these configuration options to the empty string will result in that. However the current logic does not support that given it has Python conditionals that treat the empty string as false. This fixes that code.

Tracker: https://tracker.ceph.com/issues/45166