### PR TITLE
mgr/volumes: Integrate cephadm with volume nfs interface

### DIFF
--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -17,18 +17,15 @@ Create NFS Ganesha Cluster
 
 .. code:: bash
 
-    $ ceph nfs cluster create <type=cephfs> [--size=1] <clusterid>
+    $ ceph nfs cluster create <type=cephfs> <clusterid> [<placement>]
 
 This creates a common recovery pool for all Ganesha daemons, new user based on
 cluster_id and common ganesha config rados object.
 
-Here size denotes the number of ganesha daemons within a cluster and type is
-export type. Currently only CephFS is supported.
-
-.. note:: This does not setup ganesha recovery database and start the daemons.
-          It needs to be done manually if not using vstart for creating
-          clusters. Please refer `ganesha-rados-grace doc
-          <https://github.com/nfs-ganesha/nfs-ganesha/blob/next/src/doc/man/ganesha-rados-grace.rst>`_
+Here type is export type and placement specifies the size of cluster and hosts.
+For more details on placement specification refer the `orchestrator doc
+<https://docs.ceph.com/docs/master/mgr/orchestrator/#placement-specification>`_.
+Currently only CephFS export type is supported.
 
 Create CephFS Export
 ====================

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -56,6 +56,15 @@ It creates export rados objects containing the export block. Here binding is
 the pseudo root name and type is export type. Currently only CephFS is
 supported.
 
+Delete CephFS Export
+====================
+
+.. code:: bash
+
+    $ ceph nfs export delete <binding> <clusterid>
+
+It deletes an export in cluster based on pseudo root name (binding).
+
 Configuring NFS-Ganesha to export CephFS with vstart
 ====================================================
 

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -50,7 +50,7 @@ Create CephFS Export
 
 .. code:: bash
 
-    $ ceph nfs export create <type=cephfs> <fsname> <binding> <clusterid> [--readonly] [--path=/path/in/cephfs]
+    $ ceph nfs export create <type=cephfs> <fsname> <clusterid> <binding> [--readonly] [--path=/path/in/cephfs]
 
 It creates export rados objects containing the export block. Here binding is
 the pseudo root name and type is export type. Currently only CephFS is
@@ -61,7 +61,7 @@ Delete CephFS Export
 
 .. code:: bash
 
-    $ ceph nfs export delete <binding> <clusterid>
+    $ ceph nfs export delete <clusterid> <binding>
 
 It deletes an export in cluster based on pseudo root name (binding).
 

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -50,11 +50,10 @@ Create CephFS Export
 
 .. code:: bash
 
-    $ ceph nfs export create <type=cephfs> <fsname> <clusterid> <binding> [--readonly] [--path=/path/in/cephfs]
+    $ ceph nfs export create cephfs <fsname> <clusterid> <binding> [--readonly] [--path=/path/in/cephfs]
 
 It creates export rados objects containing the export block. Here binding is
-the pseudo root name and type is export type. Currently only CephFS is
-supported.
+the pseudo root name and type is export type.
 
 Delete CephFS Export
 ====================

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -27,6 +27,15 @@ For more details on placement specification refer the `orchestrator doc
 <https://docs.ceph.com/docs/master/mgr/orchestrator/#placement-specification>`_.
 Currently only CephFS export type is supported.
 
+Update NFS Ganesha Cluster
+==========================
+
+.. code:: bash
+
+    $ ceph nfs cluster update <clusterid> <placement>
+
+This updates the deployed cluster according to the placement value.
+
 Create CephFS Export
 ====================
 

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -36,6 +36,15 @@ Update NFS Ganesha Cluster
 
 This updates the deployed cluster according to the placement value.
 
+Delete NFS Ganesha Cluster
+==========================
+
+.. code:: bash
+
+    $ ceph nfs cluster delete <clusterid>
+
+This deletes the deployed cluster.
+
 Create CephFS Export
 ====================
 

--- a/qa/suites/rados/cephadm/workunits/task/test_orch_cli.yaml
+++ b/qa/suites/rados/cephadm/workunits/task/test_orch_cli.yaml
@@ -1,0 +1,17 @@
+roles:
+- - host.a
+  - osd.0
+  - osd.1
+  - osd.2
+  - mon.a
+  - mgr.a
+  - client.0
+tasks:
+- install:
+- cephadm:
+- cephadm.shell:
+    host.a:
+      - ceph orch apply mds 1
+- cephfs_test_runner:
+    modules:
+      - tasks.cephfs.test_nfs

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -105,14 +105,16 @@ class TestNFS(MgrTestCase):
         self._check_export_obj_deleted()
         self._test_delete_cluster()
 
-    def _test_create_multiple_exports(self):
+    def test_create_multiple_exports(self):
         #Export-1 with default values
         self._create_default_export()
         #Export-2 with r only
-        self._create_export(export_id='2', extra_cmd=[self.pseudo_path, '--readonly'])
+        self._create_export(export_id='2', extra_cmd=[self.pseudo_path+'1', '--readonly'])
         #Export-3 for subvolume with r only
         self._cmd('fs', 'subvolume', 'create', self.fs_name, 'sub_vol')
         fs_path = self._cmd('fs', 'subvolume', 'getpath', self.fs_name, 'sub_vol')
-        self._create_export(export_id='3', extra_cmd=[self.pseudo_path, '--readonly', fs_path.strip()])
+        self._create_export(export_id='3', extra_cmd=[self.pseudo_path+'2', '--readonly', fs_path.strip()])
+        #Export-4 for subvolume
+        self._create_export(export_id='4', extra_cmd=[self.pseudo_path+'3', fs_path.strip()])
         self._test_delete_cluster()
         self._check_export_obj_deleted(conf_obj=True)

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -1,0 +1,83 @@
+import os
+import json
+import time
+import errno
+import logging
+from io import BytesIO
+
+from tasks.mgr.mgr_test_case import MgrTestCase
+from teuthology.exceptions import CommandFailedError
+
+log = logging.getLogger(__name__)
+
+
+class TestNFS(MgrTestCase):
+    def _nfs_cmd(self, *args):
+        return self.mgr_cluster.mon_manager.raw_cluster_cmd("nfs", *args)
+
+    def _orch_cmd(self, *args):
+        return self.mgr_cluster.mon_manager.raw_cluster_cmd("orch", *args)
+
+    def _sys_cmd(self, cmd):
+        cmd[0:0] = ['sudo']
+        ret = self.ctx.cluster.run(args=cmd, check_status=False, stdout=BytesIO(), stderr=BytesIO())
+        stdout = ret[0].stdout
+        if stdout:
+            # It's RemoteProcess defined in teuthology/orchestra/run.py
+            return stdout.getvalue()
+
+    def setUp(self):
+        super(TestNFS, self).setUp()
+        self._load_module("cephadm")
+        self._orch_cmd("set", "backend", "cephadm")
+
+        self.cluster_id = "test"
+        self.export_type = "cephfs"
+        self.pseudo_path = "/cephfs"
+        self.expected_name = 'nfs.ganesha-test'
+
+    def _check_port_status(self):
+        log.info("NETSTAT")
+        self._sys_cmd(['netstat', '-tnlp'])
+
+    def _check_nfs_server_status(self):
+        res = self._sys_cmd(['systemctl', 'status', 'nfs-server'])
+        if isinstance(res, bytes) and b'Active: active' in res:
+            self._disable_nfs()
+
+    def _disable_nfs(self):
+        log.info("Disabling NFS")
+        self._sys_cmd(['systemctl', 'disable', 'nfs-server', '--now'])
+
+    def _check_nfs_status(self):
+        return self._orch_cmd('ls', 'nfs')
+
+    def _check_idempotency(self, *args):
+        for _ in range(2):
+            self._nfs_cmd(*args)
+
+    def test_create_cluster(self):
+        self._check_nfs_server_status()
+        self._nfs_cmd("cluster", "create", self.export_type, self.cluster_id)
+        time.sleep(8)
+        orch_output = self._check_nfs_status()
+        expected_status = '1/1'
+        try:
+            if self.expected_name not in orch_output or expected_status not in orch_output:
+                raise CommandFailedError("NFS Ganesha cluster could not be deployed")
+        except (TypeError, CommandFailedError):
+            raise
+
+    def test_create_cluster_idempotent(self):
+        self._check_nfs_server_status()
+        self._check_idempotency("cluster", "create", self.export_type, self.cluster_id)
+
+    def test_delete_cluster(self):
+        self.test_create_cluster()
+        self._nfs_cmd("cluster", "delete", self.cluster_id)
+        time.sleep(8)
+        orch_output = self._check_nfs_status()
+        self.assertEqual("No services reported\n", orch_output)
+
+    def test_delete_cluster_idempotent(self):
+        self._check_idempotency("cluster", "delete", self.cluster_id)

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -12,18 +12,20 @@ log = logging.getLogger(__name__)
 
 
 class TestNFS(MgrTestCase):
+    def _cmd(self, *args):
+        return self.mgr_cluster.mon_manager.raw_cluster_cmd(*args)
+
     def _nfs_cmd(self, *args):
-        return self.mgr_cluster.mon_manager.raw_cluster_cmd("nfs", *args)
+        return self._cmd("nfs", *args)
 
     def _orch_cmd(self, *args):
-        return self.mgr_cluster.mon_manager.raw_cluster_cmd("orch", *args)
+        return self._cmd("orch", *args)
 
     def _sys_cmd(self, cmd):
         cmd[0:0] = ['sudo']
         ret = self.ctx.cluster.run(args=cmd, check_status=False, stdout=BytesIO(), stderr=BytesIO())
         stdout = ret[0].stdout
         if stdout:
-            # It's RemoteProcess defined in teuthology/orchestra/run.py
             return stdout.getvalue()
 
     def setUp(self):
@@ -34,7 +36,9 @@ class TestNFS(MgrTestCase):
         self.cluster_id = "test"
         self.export_type = "cephfs"
         self.pseudo_path = "/cephfs"
-        self.expected_name = 'nfs.ganesha-test'
+        self.path = "/"
+        self.fs_name = "nfs-cephfs"
+        self.expected_name = "nfs.ganesha-test"
 
     def _check_port_status(self):
         log.info("NETSTAT")
@@ -52,32 +56,66 @@ class TestNFS(MgrTestCase):
     def _check_nfs_status(self):
         return self._orch_cmd('ls', 'nfs')
 
-    def _check_idempotency(self, *args):
-        for _ in range(2):
-            self._nfs_cmd(*args)
-
-    def test_create_cluster(self):
+    def _test_create_cluster(self):
         self._check_nfs_server_status()
-        self._nfs_cmd("cluster", "create", self.export_type, self.cluster_id)
+        self._nfs_cmd('cluster', 'create', self.export_type, self.cluster_id)
         time.sleep(8)
         orch_output = self._check_nfs_status()
         expected_status = '1/1'
-        try:
-            if self.expected_name not in orch_output or expected_status not in orch_output:
-                raise CommandFailedError("NFS Ganesha cluster could not be deployed")
-        except (TypeError, CommandFailedError):
-            raise
+        if self.expected_name not in orch_output or expected_status not in orch_output:
+            raise RuntimeError("NFS Ganesha cluster could not be deployed")
 
-    def test_create_cluster_idempotent(self):
-        self._check_nfs_server_status()
-        self._check_idempotency("cluster", "create", self.export_type, self.cluster_id)
-
-    def test_delete_cluster(self):
-        self.test_create_cluster()
-        self._nfs_cmd("cluster", "delete", self.cluster_id)
+    def _test_delete_cluster(self):
+        self._nfs_cmd('cluster', 'delete', self.cluster_id)
         time.sleep(8)
         orch_output = self._check_nfs_status()
         self.assertEqual("No services reported\n", orch_output)
 
-    def test_delete_cluster_idempotent(self):
-        self._check_idempotency("cluster", "delete", self.cluster_id)
+    def _create_export(self, export_id, create_fs=False, extra_cmd=None):
+        if create_fs:
+            self._cmd('fs', 'volume', 'create', self.fs_name)
+        export_cmd = ['nfs', 'export', 'create', 'cephfs', self.fs_name, self.cluster_id]
+        if isinstance(extra_cmd, list):
+            export_cmd.extend(extra_cmd)
+        else:
+            export_cmd.append(self.pseudo_path)
+
+        self._cmd(*export_cmd)
+        res = self._sys_cmd(['rados', '-p', 'nfs-ganesha', '-N', self.cluster_id, 'get', f'export-{export_id}', '-'])
+        if res == b'':
+            raise RuntimeError("Export cannot be created")
+
+    def _create_default_export(self):
+            self._test_create_cluster()
+            self._create_export(export_id='1', create_fs=True)
+
+    def _delete_export(self):
+        self._nfs_cmd('export', 'delete', self.cluster_id, self.pseudo_path)
+
+    def _check_export_obj_deleted(self, conf_obj=False):
+        rados_obj_ls = self._sys_cmd(['rados', '-p', 'nfs-ganesha', '-N', self.cluster_id, 'ls'])
+
+        if b'export-' in rados_obj_ls or (conf_obj and b'conf-nfs' in rados_obj_ls):
+            raise RuntimeError("Delete export failed")
+
+    def test_create_and_delete_cluster(self):
+        self._test_create_cluster()
+        self._test_delete_cluster()
+
+    def test_export_create_and_delete(self):
+        self._create_default_export()
+        self._delete_export()
+        self._check_export_obj_deleted()
+        self._test_delete_cluster()
+
+    def _test_create_multiple_exports(self):
+        #Export-1 with default values
+        self._create_default_export()
+        #Export-2 with r only
+        self._create_export(export_id='2', extra_cmd=[self.pseudo_path, '--readonly'])
+        #Export-3 for subvolume with r only
+        self._cmd('fs', 'subvolume', 'create', self.fs_name, 'sub_vol')
+        fs_path = self._cmd('fs', 'subvolume', 'getpath', self.fs_name, 'sub_vol')
+        self._create_export(export_id='3', extra_cmd=[self.pseudo_path, '--readonly', fs_path.strip()])
+        self._test_delete_cluster()
+        self._check_export_obj_deleted(conf_obj=True)

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -30,9 +30,6 @@ class TestNFS(MgrTestCase):
 
     def setUp(self):
         super(TestNFS, self).setUp()
-        self._load_module("cephadm")
-        self._orch_cmd("set", "backend", "cephadm")
-
         self.cluster_id = "test"
         self.export_type = "cephfs"
         self.pseudo_path = "/cephfs"

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -388,8 +388,12 @@ class NFSCluster:
 
         return 0, "", "NFS Cluster Created Successfully"
 
-    def update_nfs_cluster(self, size):
-        raise NotImplementedError()
+    def update_nfs_cluster(self, placement):
+        if not self.check_cluster_exists():
+            return -errno.EINVAL, "", "Cluster does not exist"
+
+        self._call_orch_apply_nfs(placement)
+        return 0, "", "NFS Cluster Updated Successfully"
 
     def delete_nfs_cluster(self):
         raise NotImplementedError()

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -250,6 +250,7 @@ class FSExport(object):
                 ioctx.set_namespace(self.rados_namespace)
             if append:
                 ioctx.append(obj, raw_config.encode('utf-8'))
+                ioctx.notify(obj)
             else:
                 ioctx.write_full(obj, raw_config.encode('utf-8'))
             log.debug(

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -224,7 +224,7 @@ class FSExport(object):
 
     def _delete_user(self, entity):
         self.mgr.check_mon_command({
-            'prefix': 'auth del',
+            'prefix': 'auth rm',
             'entity': 'client.{}'.format(entity),
             })
         log.info(f"Export user deleted is {entity}")

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -302,7 +302,7 @@ class FSExport(object):
         self.rados_namespace = cluster_id
         access_type = "RW"
         if read_only:
-            access_type = "R"
+            access_type = "RO"
 
         if not self._fetch_export(pseudo_path):
             ex_id = self._gen_export_id()

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -349,10 +349,10 @@ class NFSCluster:
             log.exception(str(e))
             return True
 
-    def _call_orch_apply_nfs(self, size):
+    def _call_orch_apply_nfs(self, placement):
         spec = NFSServiceSpec(service_type='nfs', service_id=self.cluster_id,
                               pool=self.pool_name, namespace=self.pool_ns,
-                              placement=PlacementSpec.from_string(str(size)))
+                              placement=PlacementSpec.from_string(placement))
         try:
             completion = self.mgr.apply_nfs(spec)
             self.mgr._orchestrator_wait([completion])
@@ -360,7 +360,7 @@ class NFSCluster:
         except Exception as e:
             log.exception("Failed to create NFS daemons:{}".format(e))
 
-    def create_nfs_cluster(self, export_type, size):
+    def create_nfs_cluster(self, export_type, placement):
         if export_type != 'cephfs':
             return -errno.EINVAL,"", f"Invalid export type: {export_type}"
 
@@ -384,7 +384,7 @@ class NFSCluster:
         if self.check_cluster_exists():
             log.info(f"{self.cluster_id} cluster already exists")
         else:
-            self._call_orch_apply_nfs(size)
+            self._call_orch_apply_nfs(placement)
 
         return 0, "", "NFS Cluster Created Successfully"
 

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -294,7 +294,7 @@ class FSExport(object):
         self._write_raw_config(conf_block, "export-{}".format(export.export_id))
         self._update_common_conf(export.cluster_id, export.export_id)
 
-    def create_export(self, export_type, fs_name, pseudo_path, read_only, path, cluster_id):
+    def create_export(self, export_type, fs_name, cluster_id, pseudo_path, read_only, path):
         if export_type != 'cephfs':
             return -errno.EINVAL,"", f"Invalid export type: {export_type}"
 
@@ -344,7 +344,7 @@ class FSExport(object):
 
         return (0, json.dumps(result, indent=4), '')
 
-    def delete_export(self, pseudo_path, cluster_id, export_obj=None):
+    def delete_export(self, cluster_id, pseudo_path, export_obj=None):
         try:
             self.rados_namespace = cluster_id
             if export_obj:
@@ -368,7 +368,7 @@ class FSExport(object):
         try:
             export_list = list(self.exports[cluster_id])
             for export in export_list:
-                self.delete_export(None, cluster_id, export)
+                self.delete_export(cluster_id, None, export)
             log.info(f"All exports successfully deleted for cluster id: {cluster_id}")
         except KeyError:
             log.info("No exports to delete")

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -225,6 +225,15 @@ class FSExport(object):
 
         return json_res[0]['entity'], json_res[0]['key']
 
+    def _delete_user(self, entity):
+        ret, out, err = self.mgr.mon_command({
+            'prefix': 'auth del',
+            'entity': 'client.{}'.format(entity),
+            })
+
+        if ret!= 0:
+            log.error(f"User could not be deleted: {err}")
+
     def format_path(self, path):
         if path is not None:
             path = path.strip()
@@ -337,6 +346,7 @@ class FSExport(object):
                 common_conf = 'conf-nfs.ganesha-{}'.format(cluster_id)
                 self._delete_export_url(common_conf, export.export_id)
                 self.exports[cluster_id].remove(export)
+                self._delete_user(export.fsal.user_id)
             else:
                 log.warn("Export does not exist")
         except KeyError:

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -396,4 +396,15 @@ class NFSCluster:
         return 0, "", "NFS Cluster Updated Successfully"
 
     def delete_nfs_cluster(self):
-        raise NotImplementedError()
+        if self.check_cluster_exists():
+            try:
+                completion = self.mgr.remove_service('nfs.' + self.cluster_id)
+                self.mgr._orchestrator_wait([completion])
+                orchestrator.raise_if_exception(completion)
+            except Exception as e:
+                log.exception("Failed to delete NFS Cluster")
+                return -errno.EINVAL, "", str(e)
+        else:
+            log.warn("Cluster does not exist")
+
+        return 0, "", "NFS Cluster Deleted Successfully"

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -294,10 +294,7 @@ class FSExport(object):
         self._write_raw_config(conf_block, "export-{}".format(export.export_id))
         self._update_common_conf(export.cluster_id, export.export_id)
 
-    def create_export(self, export_type, fs_name, cluster_id, pseudo_path, read_only, path):
-        if export_type != 'cephfs':
-            return -errno.EINVAL,"", f"Invalid export type: {export_type}"
-
+    def create_export(self, fs_name, cluster_id, pseudo_path, read_only, path):
         if not self.check_fs(fs_name):
             return -errno.EINVAL,"", "Invalid CephFS name"
 

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -247,6 +247,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'desc': "Create an NFS Cluster",
             'perm': 'rw'
         },
+        {
+            'cmd': 'nfs cluster update '
+                   'name=clusterid,type=CephString '
+                   'name=placement,type=CephString ',
+            'desc': "Updates an NFS Cluster",
+            'perm': 'rw'
+        },
         # volume ls [recursive]
         # subvolume ls <volume>
         # volume authorize/deauthorize
@@ -430,3 +437,6 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         nfs_cluster_obj = NFSCluster(self, cmd['clusterid'])
         return nfs_cluster_obj.create_nfs_cluster(export_type=cmd['type'],
                                                   placement=cmd.get('placement', None))
+    def _cmd_nfs_cluster_update(self, inbuf, cmd):
+        nfs_cluster_obj = NFSCluster(self, cmd['clusterid'])
+        return nfs_cluster_obj.update_nfs_cluster(placement=cmd['placement'])

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -234,8 +234,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'perm': 'rw'
         },
         {
-            'cmd': 'fs nfs export delete '
-                   'name=export_id,type=CephInt,req=true ',
+            'cmd': 'nfs export delete '
+                   'name=binding,type=CephString '
+                   'name=attach,type=CephString ',
             'desc': "Delete a cephfs export",
             'perm': 'rw'
         },
@@ -437,8 +438,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                 pseudo_path=cmd['binding'], read_only=cmd.get('readonly', False),
                 path=cmd.get('path', '/'), cluster_id=cmd.get('attach'))
 
-    def _cmd_fs_nfs_export_delete(self, inbuf, cmd):
-        return self.fs_export.delete_export(cmd['export_id'])
+    def _cmd_nfs_export_delete(self, inbuf, cmd):
+        return self.fs_export.delete_export(pseudo_path=cmd['binding'], cluster_id=cmd.get('attach'))
 
     def _cmd_nfs_cluster_create(self, inbuf, cmd):
         return self.nfs.create_nfs_cluster(cluster_id=cmd['clusterid'], export_type=cmd['type'],

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -281,6 +281,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         super(Module, self).__init__(*args, **kwargs)
         self.vc = VolumeClient(self)
         self.fs_export = FSExport(self)
+        self.nfs = NFSCluster(self)
 
     def __del__(self):
         self.vc.shutdown()
@@ -440,14 +441,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.fs_export.delete_export(cmd['export_id'])
 
     def _cmd_nfs_cluster_create(self, inbuf, cmd):
-        nfs_cluster_obj = NFSCluster(self, cmd['clusterid'])
-        return nfs_cluster_obj.create_nfs_cluster(export_type=cmd['type'],
-                                                  placement=cmd.get('placement', None))
+        return self.nfs.create_nfs_cluster(cluster_id=cmd['clusterid'], export_type=cmd['type'],
+                                           placement=cmd.get('placement', None))
 
     def _cmd_nfs_cluster_update(self, inbuf, cmd):
-        nfs_cluster_obj = NFSCluster(self, cmd['clusterid'])
-        return nfs_cluster_obj.update_nfs_cluster(placement=cmd['placement'])
+        return self.nfs.update_nfs_cluster(cluster_id=cmd['clusterid'], placement=cmd['placement'])
 
     def _cmd_nfs_cluster_delete(self, inbuf, cmd):
-        nfs_cluster_obj = NFSCluster(self, cmd['clusterid'])
-        return nfs_cluster_obj.delete_nfs_cluster()
+        return self.nfs.delete_nfs_cluster(cluster_id=cmd['clusterid'])

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -223,8 +223,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'perm': 'r'
         },
         {
-            'cmd': 'nfs export create '
-            'name=type,type=CephString '
+            'cmd': 'nfs export create cephfs '
             'name=fsname,type=CephString '
             'name=attach,type=CephString '
             'name=binding,type=CephString '
@@ -432,14 +431,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.vc.clone_cancel(
             vol_name=cmd['vol_name'], clone_name=cmd['clone_name'],  group_name=cmd.get('group_name', None))
 
-    def _cmd_nfs_export_create(self, inbuf, cmd):
+    def _cmd_nfs_export_create_cephfs(self, inbuf, cmd):
         #TODO Extend export creation for rgw.
-        return self.fs_export.create_export(export_type=cmd['type'], fs_name=cmd['fsname'],
-                cluster_id=cmd.get('attach'), pseudo_path=cmd.get('binding'),
-                read_only=cmd.get('readonly', False), path=cmd.get('path', '/'))
+        return self.fs_export.create_export(fs_name=cmd['fsname'], cluster_id=cmd['attach'],
+                pseudo_path=cmd['binding'], read_only=cmd.get('readonly', False), path=cmd.get('path', '/'))
 
     def _cmd_nfs_export_delete(self, inbuf, cmd):
-        return self.fs_export.delete_export(cluster_id=cmd.get('attach'), pseudo_path=cmd.get('binding'))
+        return self.fs_export.delete_export(cluster_id=cmd['attach'], pseudo_path=cmd['binding'])
 
     def _cmd_nfs_cluster_create(self, inbuf, cmd):
         return self.nfs.create_nfs_cluster(cluster_id=cmd['clusterid'], export_type=cmd['type'],

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -254,6 +254,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'desc': "Updates an NFS Cluster",
             'perm': 'rw'
         },
+        {
+            'cmd': 'nfs cluster delete '
+                   'name=clusterid,type=CephString ',
+            'desc': "Deletes an NFS Cluster",
+            'perm': 'rw'
+        },
         # volume ls [recursive]
         # subvolume ls <volume>
         # volume authorize/deauthorize
@@ -437,6 +443,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         nfs_cluster_obj = NFSCluster(self, cmd['clusterid'])
         return nfs_cluster_obj.create_nfs_cluster(export_type=cmd['type'],
                                                   placement=cmd.get('placement', None))
+
     def _cmd_nfs_cluster_update(self, inbuf, cmd):
         nfs_cluster_obj = NFSCluster(self, cmd['clusterid'])
         return nfs_cluster_obj.update_nfs_cluster(placement=cmd['placement'])
+
+    def _cmd_nfs_cluster_delete(self, inbuf, cmd):
+        nfs_cluster_obj = NFSCluster(self, cmd['clusterid'])
+        return nfs_cluster_obj.delete_nfs_cluster()

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -243,7 +243,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'cmd': 'nfs cluster create '
                    'name=type,type=CephString '
                    'name=clusterid,type=CephString '
-                   'name=size,type=CephInt,req=false ',
+                   'name=placement,type=CephString,req=false ',
             'desc': "Create an NFS Cluster",
             'perm': 'rw'
         },
@@ -427,6 +427,6 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.fs_export.delete_export(cmd['export_id'])
 
     def _cmd_nfs_cluster_create(self, inbuf, cmd):
-        #TODO add placement option
         nfs_cluster_obj = NFSCluster(self, cmd['clusterid'])
-        return nfs_cluster_obj.create_nfs_cluster(export_type=cmd['type'], size=cmd.get('size', 1))
+        return nfs_cluster_obj.create_nfs_cluster(export_type=cmd['type'],
+                                                  placement=cmd.get('placement', None))

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -226,8 +226,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'cmd': 'nfs export create '
             'name=type,type=CephString '
             'name=fsname,type=CephString '
-            'name=binding,type=CephString '
             'name=attach,type=CephString '
+            'name=binding,type=CephString '
             'name=readonly,type=CephBool,req=false '
             'name=path,type=CephString,req=false ',
             'desc': "Create a cephfs export",
@@ -235,8 +235,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'nfs export delete '
-                   'name=binding,type=CephString '
-                   'name=attach,type=CephString ',
+                   'name=attach,type=CephString '
+                   'name=binding,type=CephString ',
             'desc': "Delete a cephfs export",
             'perm': 'rw'
         },
@@ -435,11 +435,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def _cmd_nfs_export_create(self, inbuf, cmd):
         #TODO Extend export creation for rgw.
         return self.fs_export.create_export(export_type=cmd['type'], fs_name=cmd['fsname'],
-                pseudo_path=cmd['binding'], read_only=cmd.get('readonly', False),
-                path=cmd.get('path', '/'), cluster_id=cmd.get('attach'))
+                cluster_id=cmd.get('attach'), pseudo_path=cmd.get('binding'),
+                read_only=cmd.get('readonly', False), path=cmd.get('path', '/'))
 
     def _cmd_nfs_export_delete(self, inbuf, cmd):
-        return self.fs_export.delete_export(pseudo_path=cmd['binding'], cluster_id=cmd.get('attach'))
+        return self.fs_export.delete_export(cluster_id=cmd.get('attach'), pseudo_path=cmd.get('binding'))
 
     def _cmd_nfs_cluster_create(self, inbuf, cmd):
         return self.nfs.create_nfs_cluster(cluster_id=cmd['clusterid'], export_type=cmd['type'],

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1092,6 +1092,9 @@ start_ganesha() {
             osd "allow rw pool=$pool_name namespace=$namespace, allow rw tag cephfs data=a" \
             mds "allow rw path=/" \
             >> "$keyring_fn"
+
+        ceph_adm mgr module enable test_orchestrator
+        ceph_adm orch set backend test_orchestrator
         prun ceph_adm nfs cluster create cephfs $name
 
         echo "NFS_CORE_PARAM {
@@ -1112,7 +1115,7 @@ start_ganesha() {
            Minor_Versions = 1, 2;
         }
 
-        %url rados://$pool_name/$namespace/conf-nfs
+        %url rados://$pool_name/$namespace/conf-nfs.$test_user
 
         RADOS_KV {
            pool = $pool_name;

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1106,7 +1106,7 @@ start_ganesha() {
             NFS_Port = $port;
         }
 
-        CACHEINODE {
+        MDCACHE {
            Dir_Chunk = 0;
            NParts = 1;
            Cache_Size = 1;

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1064,11 +1064,12 @@ EOF
 }
 
 # Ganesha Daemons requires nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rados-grace
-# (version 2.7.6-2 and above) packages installed. On Fedora>=30 these packages
-# can be installed directly with 'dnf'. For CentOS>=8 the packages need to be
-# downloaded first from  https://download.nfs-ganesha.org/2.7/2.7.6/CentOS/ and
-# then install it. Similarly for Ubuntu 16.04 follow the instructions on
-# https://launchpad.net/~nfs-ganesha/+archive/ubuntu/nfs-ganesha-2.7
+# nfs-ganesha-rados-urls (version 2.8.3 and above) packages installed. On
+# Fedora>=31 these packages can be installed directly with 'dnf'. For CentOS>=8
+# the packages need to be downloaded first from
+# https://download.nfs-ganesha.org/2.8/2.8.3/CentOS and then installed.
+# Similarly for Ubuntu 16.04 follow the instructions on
+# https://launchpad.net/~nfs-ganesha/+archive/ubuntu/nfs-ganesha-2.8
 
 start_ganesha() {
     GANESHA_PORT=$(($CEPH_PORT + 4000))

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1367,7 +1367,7 @@ EOF
 fi
 
 # Ganesha Daemons
-if [ $GANESHA_DAEMON_NUM -gt 0 ]; then
+if [ $GANESHA_DAEMON_NUM -gt 0 ] && [ "$cephadm" -eq 0 ]; then
     start_ganesha
 fi
 

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1085,6 +1085,7 @@ start_ganesha() {
         test_user="ganesha-$name"
         pool_name="nfs-ganesha"
         namespace=$name
+        url="rados://$pool_name/$namespace/conf-nfs.$test_user"
 
         prun rm -rf $ganesha_dir
         prun mkdir -p $ganesha_dir
@@ -1116,7 +1117,7 @@ start_ganesha() {
            Minor_Versions = 1, 2;
         }
 
-        %url rados://$pool_name/$namespace/conf-nfs.$test_user
+        %url $url
 
         RADOS_KV {
            pool = $pool_name;
@@ -1127,6 +1128,7 @@ start_ganesha() {
 
         RADOS_URLS {
 	   Userid = $test_user;
+	   watch_url = \"$url\";
         }" > "$ganesha_dir/ganesha.conf"
 	wconf <<EOF
 [ganesha.$name]

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1139,7 +1139,7 @@ start_ganesha() {
         pid file = $ganesha_dir/ganesha.pid
 EOF
 
-        prun ceph_adm nfs export create cephfs "a" "/cephfs" $name
+        prun ceph_adm nfs export create cephfs "a" $name "/cephfs"
         prun ganesha-rados-grace -p $pool_name -n $namespace add $name
         prun ganesha-rados-grace -p $pool_name -n $namespace
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->
Major changes are:
* Add placement option to cluster create interface
`
 $ ceph nfs cluster create <type=cephfs> <clusterid> [<placement>]
`

* Add cluster delete and update interface
```
$ ceph nfs cluster update <clusterid> <placement>
$ ceph nfs cluster delete <clusterid>
```
* Rearrangement of binding and cluster id in export create interface
* Remove type option in export create interface
```
 $ ceph nfs export create cephfs <fsname> <clusterid> <binding> [--readonly] [--path=/path/in/cephfs]
```
* Add export delete interface
```
$ ceph nfs export delete <clusterid> <binding>
```
* Update Ganesha package details
* Add `watch_url` in vstart
* Add tests
* Call orch nfs interface

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
