### PR TITLE
cephadm: Aquire lock, if fsid != None

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2810,8 +2810,8 @@ def command_ceph_volume():
     if args.fsid:
         make_log_dir(args.fsid)
 
-    l = FileLock(args.fsid)
-    l.acquire()
+        l = FileLock(args.fsid)
+        l.acquire()
 
     (uid, gid) = (0, 0) # ceph-volume runs as root
     mounts = get_container_mounts(args.fsid, 'osd', None)


### PR DESCRIPTION
Fixes:

```
Traceback (most recent call last):
  File "./cephadm", line 4494, in <module>
    r = args.func()
  File "./cephadm", line 1077, in _infer_fsid
    return func()
  File "./cephadm", line 1103, in _infer_image
    return func()
  File "./cephadm", line 2813, in command_ceph_volume
    l = FileLock(args.fsid)
  File "./cephadm", line 560, in __init__
    self._lock_file = os.path.join(LOCK_DIR, name + '.lock')
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
