### PR TITLE
nautilus: mon: Get session_map_lock before remove_session

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4355,6 +4355,7 @@ void Monitor::_ms_dispatch(Message *m)
       if (s->item.is_on_list()) {
         // forwarded messages' sessions are not in the sessions map and
         // exist only while the op is being handled.
+        std::lock_guard l(session_map_lock);
         remove_session(s);
       }
       s = nullptr;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44468

---

backport of https://github.com/ceph/ceph/pull/33682
parent tracker: https://tracker.ceph.com/issues/44407

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh