### PR TITLE
qa/tasks/cephfs/mount: switch to StringIO to fix TypeErrors

### DIFF
--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -11,7 +11,7 @@ import random
 import traceback
 
 from io import BytesIO
-from six import StringIO
+from io import StringIO
 
 from teuthology.exceptions import CommandFailedError
 from teuthology import misc
@@ -1094,7 +1094,7 @@ class Filesystem(MDSCluster):
             os.path.join(self._prefix, "rados"), "-p", pool, "getxattr", obj_name, xattr_name
         ]
         try:
-            proc = remote.run(args=args, stdout=BytesIO())
+            proc = remote.run(args=args, stdout=StringIO())
         except CommandFailedError as e:
             log.error(e.__str__())
             raise ObjectNotFound(obj_name)
@@ -1105,7 +1105,8 @@ class Filesystem(MDSCluster):
                                             "type", type,
                                             "import", "-",
                                             "decode", "dump_json"],
-            stdin=data
+            stdin=data,
+            stdout=StringIO()
         )
 
         return json.loads(dump.strip())

--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -1,4 +1,3 @@
-from io import BytesIO
 from io import StringIO
 import json
 import time
@@ -196,15 +195,15 @@ class FuseMount(CephFSMount):
                 self.mountpoint,
             ],
             cwd=self.test_dir,
-            stdout=BytesIO(),
-            stderr=BytesIO(),
+            stdout=StringIO(),
+            stderr=StringIO(),
             wait=False,
             timeout=(15*60)
         )
         try:
             proc.wait()
         except CommandFailedError:
-            error = six.ensure_str(proc.stderr.getvalue())
+            error = proc.stderr.getvalue()
             if ("endpoint is not connected" in error
             or "Software caused connection abort" in error):
                 # This happens is fuse is killed without unmount
@@ -242,11 +241,11 @@ class FuseMount(CephFSMount):
         # Now that we're mounted, set permissions so that the rest of the test will have
         # unrestricted access to the filesystem mount.
         try:
-            stderr = BytesIO()
+            stderr = StringIO()
             self.client_remote.run(args=['sudo', 'chmod', '1777', self.mountpoint], timeout=(15*60), cwd=self.test_dir, stderr=stderr)
         except run.CommandFailedError:
             stderr = stderr.getvalue()
-            if b"Read-only file system".lower() in stderr.lower():
+            if "Read-only file system".lower() in stderr.lower():
                 pass
             else:
                 raise
@@ -260,7 +259,7 @@ class FuseMount(CephFSMount):
 
         try:
             log.info('Running fusermount -u on {name}...'.format(name=self.client_remote.name))
-            stderr = BytesIO()
+            stderr = StringIO()
             self.client_remote.run(
                 args = [
                     'sudo',
@@ -301,7 +300,7 @@ class FuseMount(CephFSMount):
                     """).format(self._fuse_conn))
                     self._fuse_conn = None
 
-                stderr = BytesIO()
+                stderr = StringIO()
                 # make sure its unmounted
                 try:
                     self.client_remote.run(

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -50,8 +50,8 @@ class CephFSMount(object):
         # and there is no workaround, will continue to use the 'brctl'
         args = ["bash", "-c",
                 "cat /etc/os-release"]
-        p = self.client_remote.run(args=args, stderr=BytesIO(),
-                                   stdout=BytesIO(), timeout=(5*60))
+        p = self.client_remote.run(args=args, stderr=StringIO(),
+                                   stdout=StringIO(), timeout=(5*60))
         distro = re.findall(r'NAME="Ubuntu"', p.stdout.getvalue())
         version = re.findall(r'VERSION_ID="18.04"', p.stdout.getvalue())
         self.use_brctl = len(distro) is not 0 and len(version) is not 0
@@ -109,8 +109,8 @@ class CephFSMount(object):
         mask = self.ceph_brx_net.split('/')[1]
         brd = IP(self.ceph_brx_net).broadcast()
 
-        brx = self.client_remote.run(args=['ip', 'addr'], stderr=BytesIO(),
-                                     stdout=BytesIO(), timeout=(5*60))
+        brx = self.client_remote.run(args=['ip', 'addr'], stderr=StringIO(),
+                                     stdout=StringIO(), timeout=(5*60))
         brx = re.findall(r'inet .* ceph-brx', brx.stdout.getvalue())
         if brx:
             # If the 'ceph-brx' already exists, then check whether
@@ -146,7 +146,7 @@ class CephFSMount(object):
         self.client_remote.run(args=['touch', '/tmp/python-ceph-brx'],
                                timeout=(5*60))
         p = self.client_remote.run(args=['cat', '/proc/sys/net/ipv4/ip_forward'],
-                                   stderr=BytesIO(), stdout=BytesIO(),
+                                   stderr=StringIO(), stdout=StringIO(),
                                    timeout=(5*60))
         val = p.stdout.getvalue().strip()
         args = ["sudo", "bash", "-c",
@@ -157,8 +157,8 @@ class CephFSMount(object):
         self.client_remote.run(args=args, timeout=(5*60))
         
         # Setup the NAT
-        p = self.client_remote.run(args=['route'], stderr=BytesIO(),
-                                   stdout=BytesIO(), timeout=(5*60))
+        p = self.client_remote.run(args=['route'], stderr=StringIO(),
+                                   stdout=StringIO(), timeout=(5*60))
         p = re.findall(r'default .*', p.stdout.getvalue())
         if p == False:
             raise RuntimeError("No default gw found")
@@ -175,7 +175,7 @@ class CephFSMount(object):
 
     def _setup_netns(self):
         p = self.client_remote.run(args=['ip', 'netns', 'list'],
-                                   stderr=BytesIO(), stdout=BytesIO(),
+                                   stderr=StringIO(), stdout=StringIO(),
                                    timeout=(5*60))
         p = p.stdout.getvalue().strip()
         if re.match(self.netns_name, p) is not None:
@@ -188,7 +188,7 @@ class CephFSMount(object):
         nsid = 0
         while True:
             p = self.client_remote.run(args=['ip', 'netns', 'list-id'],
-                                       stderr=BytesIO(), stdout=BytesIO(),
+                                       stderr=StringIO(), stdout=StringIO(),
                                        timeout=(5*60))
             p = re.search(r"nsid {} ".format(nsid), p.stdout.getvalue())
             if p is None:
@@ -219,8 +219,8 @@ class CephFSMount(object):
                 ns_name = ns.split()[0]
                 args = ["sudo", "bash", "-c",
                         "ip netns exec {0} ip addr".format(ns_name)]
-                p = self.client_remote.run(args=args, stderr=BytesIO(),
-                                           stdout=BytesIO(), timeout=(5*60))
+                p = self.client_remote.run(args=args, stderr=StringIO(),
+                                           stdout=StringIO(), timeout=(5*60))
                 q = re.search("{0}".format(ip), p.stdout.getvalue())
                 if q is not None:
                     found = True
@@ -302,8 +302,8 @@ class CephFSMount(object):
         self.nsid = -1
 
     def _cleanup_brx_and_nat(self):
-        brx = self.client_remote.run(args=['ip', 'addr'], stderr=BytesIO(),
-                                     stdout=BytesIO(), timeout=(5*60))
+        brx = self.client_remote.run(args=['ip', 'addr'], stderr=StringIO(),
+                                     stdout=StringIO(), timeout=(5*60))
         brx = re.findall(r'inet .* ceph-brx', brx.stdout.getvalue())
         if not brx:
             return
@@ -311,12 +311,12 @@ class CephFSMount(object):
         # If we are the last netns, will delete the ceph-brx
         if self.use_brctl == True:
             p = self.client_remote.run(args=['brctl', 'show', 'ceph-brx'],
-                                       stderr=BytesIO(), stdout=BytesIO(),
+                                       stderr=StringIO(), stdout=StringIO(),
                                        timeout=(5*60))
         else:
             self._bringup_network_manager_service()
             p = self.client_remote.run(args=['nmcli', 'connection', 'show'],
-                                       stderr=BytesIO(), stdout=BytesIO(),
+                                       stderr=StringIO(), stdout=StringIO(),
                                        timeout=(5*60))
         _list = re.findall(r'brx\.', p.stdout.getvalue().strip())
         if len(_list) != 0:
@@ -343,8 +343,8 @@ class CephFSMount(object):
         ip = IP(self.ceph_brx_net)[-2]
         mask = self.ceph_brx_net.split('/')[1]
 
-        p = self.client_remote.run(args=['route'], stderr=BytesIO(),
-                                   stdout=BytesIO(), timeout=(5*60))
+        p = self.client_remote.run(args=['route'], stderr=StringIO(),
+                                   stdout=StringIO(), timeout=(5*60))
         p = re.findall(r'default .*', p.stdout.getvalue())
         if p == False:
             raise RuntimeError("No default gw found")
@@ -361,7 +361,7 @@ class CephFSMount(object):
 
         # Restore the ip_forward
         p = self.client_remote.run(args=['cat', '/tmp/python-ceph-brx'],
-                                   stderr=BytesIO(), stdout=BytesIO(),
+                                   stderr=StringIO(), stdout=StringIO(),
                                    timeout=(5*60))
         val = p.stdout.getvalue().strip()
         args = ["sudo", "bash", "-c",
@@ -457,7 +457,7 @@ class CephFSMount(object):
 
         Prerequisite: the client is not mounted.
         """
-        stderr = BytesIO()
+        stderr = StringIO()
         try:
             self.client_remote.run(
                 args=[

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1190,7 +1190,6 @@ class InteractiveFailureResult(unittest.TextTestResult):
 def enumerate_methods(s):
     log.info("e: {0}".format(s))
     for t in s._tests:
-	print("t {0}, s._tests {1}".format(t, s._tests))
         if isinstance(t, suite.BaseTestSuite):
             for sub in enumerate_methods(t):
                 yield sub
@@ -1222,10 +1221,7 @@ def scan_tests(modules):
     max_required_mgr = 0
     require_memstore = False
 
-    print("module = {}".format(overall_suite))
     for suite_, case in enumerate_methods(overall_suite):
-	print("suite {0}".format(suite_))
-	print("case {0}".format(case))
         max_required_mds = max(max_required_mds,
                                getattr(case, "MDSS_REQUIRED", 0))
         max_required_clients = max(max_required_clients,


### PR DESCRIPTION
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
