### PR TITLE
rbd/cache: Replicated Write Log core codes - aio_read

### DIFF
--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -168,6 +168,7 @@ if(WITH_RBD_RWL)
     ${librbd_internal_srcs}
     cache/rwl/ImageCacheState.cc
     cache/rwl/LogEntry.cc
+    cache/rwl/LogMap.cc
     cache/rwl/LogOperation.cc
     cache/rwl/Request.cc
     cache/rwl/SyncPoint.cc

--- a/src/librbd/cache/ReplicatedWriteLog.h
+++ b/src/librbd/cache/ReplicatedWriteLog.h
@@ -14,6 +14,7 @@
 #include "librbd/cache/Types.h"
 #include "librbd/cache/rwl/LogOperation.h"
 #include "librbd/cache/rwl/Request.h"
+#include "librbd/cache/rwl/LogMap.h"
 #include <functional>
 #include <list>
 
@@ -36,6 +37,8 @@ class GenericLogEntry;
 typedef std::list<std::shared_ptr<WriteLogEntry>> WriteLogEntries;
 typedef std::list<std::shared_ptr<GenericLogEntry>> GenericLogEntries;
 typedef std::list<std::shared_ptr<GenericWriteLogEntry>> GenericWriteLogEntries;
+typedef LogMapEntries<GenericWriteLogEntry> WriteLogMapEntries;
+typedef LogMap<GenericWriteLogEntry> WriteLogMap;
 
 /**** Write log entries end ****/
 
@@ -125,6 +128,7 @@ public:
   uint32_t get_free_log_entries() {
     return m_free_log_entries;
   }
+  void add_into_log_map(rwl::GenericWriteLogEntries &log_entries);
 private:
   typedef std::list<rwl::C_WriteRequest<This> *> C_WriteRequests;
   typedef std::list<rwl::C_BlockIORequest<This> *> C_BlockIORequests;
@@ -219,6 +223,8 @@ private:
 
   rwl::GenericLogOperations m_ops_to_flush; /* Write ops needing flush in local log */
   rwl::GenericLogOperations m_ops_to_append; /* Write ops needing event append in local log */
+
+  rwl::WriteLogMap m_blocks_to_log_entries;
 
   /* New entries are at the back. Oldest at the front */
   rwl::GenericLogEntries m_log_entries;

--- a/src/librbd/cache/rwl/LogEntry.h
+++ b/src/librbd/cache/rwl/LogEntry.h
@@ -19,6 +19,8 @@ class SyncPointLogEntry;
 class GenericWriteLogEntry;
 class WriteLogEntry;
 
+typedef std::list<std::shared_ptr<GenericWriteLogEntry>> GenericWriteLogEntries;
+
 class GenericLogEntry {
 public:
   WriteLogPmemEntry ram_entry;
@@ -106,6 +108,7 @@ public:
   std::shared_ptr<SyncPointLogEntry> get_sync_point_entry() override {
     return sync_point_entry;
   }
+  virtual void copy_pmem_bl(bufferlist *out_bl) = 0;
   std::ostream &format(std::ostream &os) const;
   friend std::ostream &operator<<(std::ostream &os,
                                   const GenericWriteLogEntry &entry);
@@ -151,7 +154,7 @@ public:
   /* Returns a ref to a bl containing bufferptrs to the entry pmem buffer */
   buffer::list &get_pmem_bl();
   /* Constructs a new bl containing copies of pmem_bp */
-  void copy_pmem_bl(bufferlist *out_bl);
+  void copy_pmem_bl(bufferlist *out_bl) override;
   void writeback(librbd::cache::ImageWritebackInterface &image_writeback,
                  Context *ctx) override;
   std::ostream &format(std::ostream &os) const;

--- a/src/librbd/cache/rwl/LogMap.cc
+++ b/src/librbd/cache/rwl/LogMap.cc
@@ -1,0 +1,275 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "LogMap.h"
+#include "include/ceph_assert.h"
+#include "librbd/Utils.h"
+
+namespace librbd {
+namespace cache {
+namespace rwl {
+
+#define dout_subsys ceph_subsys_rbd_rwl
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::cache::rwl::LogMap: " << this << " " \
+                           <<  __func__ << ": "
+template <typename T>
+std::ostream &operator<<(std::ostream &os,
+                         LogMapEntry<T> &e) {
+  os << "block_extent=" << e.block_extent << ", "
+     << "log_entry=[" << e.log_entry << "]";
+  return os;
+};
+
+template <typename T>
+LogMapEntry<T>::LogMapEntry(const BlockExtent block_extent,
+                            std::shared_ptr<T> log_entry)
+  : block_extent(block_extent) , log_entry(log_entry) {
+}
+
+template <typename T>
+LogMapEntry<T>::LogMapEntry(std::shared_ptr<T> log_entry)
+  : block_extent(log_entry->block_extent()) , log_entry(log_entry) {
+}
+
+template <typename T>
+LogMap<T>::LogMap(CephContext *cct)
+  : m_cct(cct),
+    m_lock(ceph::make_mutex(util::unique_lock_name(
+           "librbd::cache::rwl::LogMap::m_lock", this))) {
+}
+
+/**
+ * Add a write log entry to the map. Subsequent queries for blocks
+ * within this log entry's extent will find this log entry. Portions
+ * of prior write log entries overlapping with this log entry will
+ * be replaced in the map by this log entry.
+ *
+ * The map_entries field of the log entry object will be updated to
+ * contain this map entry.
+ *
+ * The map_entries fields of all log entries overlapping with this
+ * entry will be updated to remove the regions that overlap with
+ * this.
+ */
+template <typename T>
+void LogMap<T>::add_log_entry(std::shared_ptr<T> log_entry) {
+  std::lock_guard locker(m_lock);
+  add_log_entry_locked(log_entry);
+}
+
+template <typename T>
+void LogMap<T>::add_log_entries(std::list<std::shared_ptr<T>> &log_entries) {
+  std::lock_guard locker(m_lock);
+  ldout(m_cct, 20) << dendl;
+  for (auto &log_entry : log_entries) {
+    add_log_entry_locked(log_entry);
+  }
+}
+
+/**
+ * Remove any map entries that refer to the supplied write log
+ * entry.
+ */
+template <typename T>
+void LogMap<T>::remove_log_entry(std::shared_ptr<T> log_entry) {
+  std::lock_guard locker(m_lock);
+  remove_log_entry_locked(log_entry);
+}
+
+template <typename T>
+void LogMap<T>::remove_log_entries(std::list<std::shared_ptr<T>> &log_entries) {
+  std::lock_guard locker(m_lock);
+  ldout(m_cct, 20) << dendl;
+  for (auto &log_entry : log_entries) {
+    remove_log_entry_locked(log_entry);
+  }
+}
+
+/**
+ * Returns the list of all write log entries that overlap the specified block
+ * extent. This doesn't tell you which portions of these entries overlap the
+ * extent, or each other. For that, use find_map_entries(). A log entry may
+ * appear in the list more than once, if multiple map entries refer to it
+ * (e.g. the middle of that write log entry has been overwritten).
+ */
+template <typename T>
+std::list<std::shared_ptr<T>> LogMap<T>::find_log_entries(BlockExtent block_extent) {
+  std::lock_guard locker(m_lock);
+  ldout(m_cct, 20) << dendl;
+  return find_log_entries_locked(block_extent);
+}
+
+/**
+ * Returns the list of all write log map entries that overlap the
+ * specified block extent.
+ */
+template <typename T>
+LogMapEntries<T> LogMap<T>::find_map_entries(BlockExtent block_extent) {
+  std::lock_guard locker(m_lock);
+  ldout(m_cct, 20) << dendl;
+  return find_map_entries_locked(block_extent);
+}
+
+template <typename T>
+void LogMap<T>::add_log_entry_locked(std::shared_ptr<T> log_entry) {
+  LogMapEntry<T> map_entry(log_entry);
+  ldout(m_cct, 20) << "block_extent=" << map_entry.block_extent
+                   << dendl;
+  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+  LogMapEntries<T> overlap_entries = find_map_entries_locked(map_entry.block_extent);
+  for (auto &entry : overlap_entries) {
+    ldout(m_cct, 20) << entry << dendl;
+    if (map_entry.block_extent.block_start <= entry.block_extent.block_start) {
+      if (map_entry.block_extent.block_end >= entry.block_extent.block_end) {
+        ldout(m_cct, 20) << "map entry completely occluded by new log entry" << dendl;
+        remove_map_entry_locked(entry);
+      } else {
+        ceph_assert(map_entry.block_extent.block_end < entry.block_extent.block_end);
+        /* The new entry occludes the beginning of the old entry */
+        BlockExtent adjusted_extent(map_entry.block_extent.block_end,
+                                    entry.block_extent.block_end);
+        adjust_map_entry_locked(entry, adjusted_extent);
+      }
+    } else {
+      if (map_entry.block_extent.block_end >= entry.block_extent.block_end) {
+        /* The new entry occludes the end of the old entry */
+        BlockExtent adjusted_extent(entry.block_extent.block_start,
+                                    map_entry.block_extent.block_start);
+        adjust_map_entry_locked(entry, adjusted_extent);
+      } else {
+        /* The new entry splits the old entry */
+        split_map_entry_locked(entry, map_entry.block_extent);
+      }
+    }
+  }
+  add_map_entry_locked(map_entry);
+}
+
+template <typename T>
+void LogMap<T>::remove_log_entry_locked(std::shared_ptr<T> log_entry) {
+  ldout(m_cct, 20) << "*log_entry=" << *log_entry << dendl;
+  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+
+  LogMapEntries<T> possible_hits = find_map_entries_locked(log_entry->block_extent());
+  for (auto &possible_hit : possible_hits) {
+    if (possible_hit.log_entry == log_entry) {
+      /* This map entry refers to the specified log entry */
+      remove_map_entry_locked(possible_hit);
+    }
+  }
+}
+
+template <typename T>
+void LogMap<T>::add_map_entry_locked(LogMapEntry<T> &map_entry) {
+  ceph_assert(map_entry.log_entry);
+  m_block_to_log_entry_map.insert(map_entry);
+  map_entry.log_entry->inc_map_ref();
+}
+
+template <typename T>
+void LogMap<T>::remove_map_entry_locked(LogMapEntry<T> &map_entry) {
+  auto it = m_block_to_log_entry_map.find(map_entry);
+  ceph_assert(it != m_block_to_log_entry_map.end());
+
+  LogMapEntry<T> erased = *it;
+  m_block_to_log_entry_map.erase(it);
+  erased.log_entry->dec_map_ref();
+  if (0 == erased.log_entry->get_map_ref()) {
+    ldout(m_cct, 20) << "log entry has zero map entries: " << erased.log_entry << dendl;
+  }
+}
+
+template <typename T>
+void LogMap<T>::adjust_map_entry_locked(LogMapEntry<T> &map_entry, BlockExtent &new_extent) {
+  auto it = m_block_to_log_entry_map.find(map_entry);
+  ceph_assert(it != m_block_to_log_entry_map.end());
+
+  LogMapEntry<T> adjusted = *it;
+  m_block_to_log_entry_map.erase(it);
+
+  m_block_to_log_entry_map.insert(LogMapEntry<T>(new_extent, adjusted.log_entry));
+}
+
+template <typename T>
+void LogMap<T>::split_map_entry_locked(LogMapEntry<T> &map_entry, BlockExtent &removed_extent) {
+  auto it = m_block_to_log_entry_map.find(map_entry);
+  ceph_assert(it != m_block_to_log_entry_map.end());
+
+  LogMapEntry<T> split = *it;
+  m_block_to_log_entry_map.erase(it);
+
+  BlockExtent left_extent(split.block_extent.block_start,
+                          removed_extent.block_start);
+  m_block_to_log_entry_map.insert(LogMapEntry<T>(left_extent, split.log_entry));
+
+  BlockExtent right_extent(removed_extent.block_end,
+                           split.block_extent.block_end);
+  m_block_to_log_entry_map.insert(LogMapEntry<T>(right_extent, split.log_entry));
+
+  split.log_entry->inc_map_ref();
+}
+
+template <typename T>
+std::list<std::shared_ptr<T>> LogMap<T>::find_log_entries_locked(const BlockExtent &block_extent) {
+  std::list<std::shared_ptr<T>> overlaps;
+  ldout(m_cct, 20) << "block_extent=" << block_extent << dendl;
+
+  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+  LogMapEntries<T> map_entries = find_map_entries_locked(block_extent);
+  for (auto &map_entry : map_entries) {
+    overlaps.emplace_back(map_entry.log_entry);
+  }
+  return overlaps;
+}
+
+/**
+ * TODO: Generalize this to do some arbitrary thing to each map
+ * extent, instead of returning a list.
+ */
+template <typename T>
+LogMapEntries<T> LogMap<T>::find_map_entries_locked(const BlockExtent &block_extent) {
+  LogMapEntries<T> overlaps;
+
+  ldout(m_cct, 20) << "block_extent=" << block_extent << dendl;
+  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+  auto p = m_block_to_log_entry_map.equal_range(LogMapEntry<T>(block_extent));
+  ldout(m_cct, 20) << "count=" << std::distance(p.first, p.second) << dendl;
+  for ( auto i = p.first; i != p.second; ++i ) {
+    LogMapEntry<T> entry = *i;
+    overlaps.emplace_back(entry);
+    ldout(m_cct, 20) << entry << dendl;
+  }
+  return overlaps;
+}
+
+/* We map block extents to write log entries, or portions of write log
+ * entries. These are both represented by a WriteLogMapEntry. When a
+ * GenericWriteLogEntry is added to this map, a WriteLogMapEntry is created to
+ * represent the entire block extent of the GenericWriteLogEntry, and the
+ * WriteLogMapEntry is added to the set.
+ *
+ * The set must not contain overlapping WriteLogMapEntrys. WriteLogMapEntrys
+ * in the set that overlap with one being added are adjusted (shrunk, split,
+ * or removed) before the new entry is added.
+ *
+ * This comparison works despite the ambiguity because we ensure the set
+ * contains no overlapping entries. This comparison works to find entries
+ * that overlap with a given block extent because equal_range() returns the
+ * first entry in which the extent doesn't end before the given extent
+ * starts, and the last entry for which the extent starts before the given
+ * extent ends (the first entry that the key is less than, and the last entry
+ * that is less than the key).
+ */
+template <typename T>
+bool LogMap<T>::LogMapEntryCompare::operator()(const LogMapEntry<T> &lhs,
+                                               const LogMapEntry<T> &rhs) const {
+  if (lhs.block_extent.block_end <= rhs.block_extent.block_start) {
+    return true;
+  }
+  return false;
+}
+
+} //namespace rwl
+} //namespace cache
+} //namespace librbd

--- a/src/librbd/cache/rwl/LogMap.h
+++ b/src/librbd/cache/rwl/LogMap.h
@@ -1,0 +1,81 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_CACHE_RWL_LOG_MAP_H
+#define CEPH_LIBRBD_CACHE_RWL_LOG_MAP_H
+
+#include "librbd/BlockGuard.h"
+#include <list>
+
+namespace librbd {
+namespace cache {
+namespace rwl {
+
+/**
+ * WriteLogMap: maps block extents to GenericWriteLogEntries
+ *
+ * A WriteLogMapEntry (based on LogMapEntry) refers to a portion of a GenericWriteLogEntry
+ */
+template <typename T>
+class LogMapEntry {
+public:
+  BlockExtent block_extent;
+  std::shared_ptr<T> log_entry;
+
+  LogMapEntry(BlockExtent block_extent,
+              std::shared_ptr<T> log_entry = nullptr);
+  LogMapEntry(std::shared_ptr<T> log_entry);
+
+  template <typename U>
+  friend std::ostream &operator<<(std::ostream &os,
+                                  LogMapEntry<U> &e);
+};
+
+template <typename T>
+using LogMapEntries = std::list<LogMapEntry<T>>;
+
+template <typename T>
+class LogMap {
+public:
+  LogMap(CephContext *cct);
+  LogMap(const LogMap&) = delete;
+  LogMap &operator=(const LogMap&) = delete;
+
+  void add_log_entry(std::shared_ptr<T> log_entry);
+  void add_log_entries(std::list<std::shared_ptr<T>> &log_entries);
+  void remove_log_entry(std::shared_ptr<T> log_entry);
+  void remove_log_entries(std::list<std::shared_ptr<T>> &log_entries);
+  std::list<std::shared_ptr<T>> find_log_entries(BlockExtent block_extent);
+  LogMapEntries<T> find_map_entries(BlockExtent block_extent);
+
+private:
+  void add_log_entry_locked(std::shared_ptr<T> log_entry);
+  void remove_log_entry_locked(std::shared_ptr<T> log_entry);
+  void add_map_entry_locked(LogMapEntry<T> &map_entry);
+  void remove_map_entry_locked(LogMapEntry<T> &map_entry);
+  void adjust_map_entry_locked(LogMapEntry<T> &map_entry, BlockExtent &new_extent);
+  void split_map_entry_locked(LogMapEntry<T> &map_entry, BlockExtent &removed_extent);
+  std::list<std::shared_ptr<T>> find_log_entries_locked(const BlockExtent &block_extent);
+  LogMapEntries<T> find_map_entries_locked(const BlockExtent &block_extent);
+
+  using LogMapEntryT = LogMapEntry<T>;
+
+  class LogMapEntryCompare {
+  public:
+    bool operator()(const LogMapEntryT &lhs,
+                    const LogMapEntryT &rhs) const;
+  };
+
+  using BlockExtentToLogMapEntries = std::set<LogMapEntryT,
+                                              LogMapEntryCompare>;
+
+  CephContext *m_cct;
+  ceph::mutex m_lock;
+  BlockExtentToLogMapEntries m_block_to_log_entry_map;
+};
+
+} //namespace rwl
+} //namespace cache
+} //namespace librbd
+
+#endif //CEPH_LIBRBD_CACHE_RWL_LOG_MAP_H

--- a/src/librbd/cache/rwl/Request.cc
+++ b/src/librbd/cache/rwl/Request.cc
@@ -403,6 +403,57 @@ std::ostream &operator<<(std::ostream &os,
   return os;
 };
 
+void C_ReadRequest::finish(int r) {
+  ldout(m_cct, 20) << "(" << get_name() << "): r=" << r << dendl;
+  int hits = 0;
+  int misses = 0;
+  int hit_bytes = 0;
+  int miss_bytes = 0;
+  if (r >= 0) {
+    /*
+     * At this point the miss read has completed. We'll iterate through
+     * read_extents and produce *m_out_bl by assembling pieces of miss_bl
+     * and the individual hit extent bufs in the read extents that represent
+     * hits.
+     */
+    uint64_t miss_bl_offset = 0;
+    for (auto &extent : read_extents) {
+      if (extent.m_bl.length()) {
+        /* This was a hit */
+        ceph_assert(extent.second == extent.m_bl.length());
+        ++hits;
+        hit_bytes += extent.second;
+        m_out_bl->claim_append(extent.m_bl);
+      } else {
+        /* This was a miss. */
+        ++misses;
+        miss_bytes += extent.second;
+        bufferlist miss_extent_bl;
+        miss_extent_bl.substr_of(miss_bl, miss_bl_offset, extent.second);
+        /* Add this read miss bufferlist to the output bufferlist */
+        m_out_bl->claim_append(miss_extent_bl);
+        /* Consume these bytes in the read miss bufferlist */
+        miss_bl_offset += extent.second;
+      }
+    }
+  }
+  ldout(m_cct, 20) << "(" << get_name() << "): r=" << r << " bl=" << *m_out_bl << dendl;
+  utime_t now = ceph_clock_now();
+  ceph_assert((int)m_out_bl->length() == hit_bytes + miss_bytes);
+  m_on_finish->complete(r);
+  m_perfcounter->inc(l_librbd_rwl_rd_bytes, hit_bytes + miss_bytes);
+  m_perfcounter->inc(l_librbd_rwl_rd_hit_bytes, hit_bytes);
+  m_perfcounter->tinc(l_librbd_rwl_rd_latency, now - m_arrived_time);
+  if (!misses) {
+    m_perfcounter->inc(l_librbd_rwl_rd_hit_req, 1);
+    m_perfcounter->tinc(l_librbd_rwl_rd_hit_latency, now - m_arrived_time);
+  } else {
+    if (hits) {
+      m_perfcounter->inc(l_librbd_rwl_rd_part_hit_req, 1);
+    }
+  }
+}
+
 std::ostream &operator<<(std::ostream &os,
                          const BlockGuardReqState &r) {
   os << "barrier=" << r.barrier << ", "

--- a/src/librbd/cache/rwl/Request.h
+++ b/src/librbd/cache/rwl/Request.h
@@ -231,6 +231,31 @@ private:
                                   const C_FlushRequest<U> &req);
 };
 
+class C_ReadRequest : public Context {
+public:
+  io::Extents miss_extents; // move back to caller
+  ImageExtentBufs read_extents;
+  bufferlist miss_bl;
+
+  C_ReadRequest(CephContext *cct, utime_t arrived, PerfCounters *perfcounter, bufferlist *out_bl, Context *on_finish)
+    : m_cct(cct), m_on_finish(on_finish), m_out_bl(out_bl),
+      m_arrived_time(arrived), m_perfcounter(perfcounter) {}
+  ~C_ReadRequest() {}
+
+  void finish(int r) override;
+
+  const char *get_name() const {
+    return "C_ReadRequest";
+  }
+
+private:
+  CephContext *m_cct;
+  Context *m_on_finish;
+  bufferlist *m_out_bl;
+  utime_t m_arrived_time;
+  PerfCounters *m_perfcounter;
+};
+
 struct BlockGuardReqState {
   bool barrier = false; /* This is a barrier request */
   bool current_barrier = false; /* This is the currently active barrier */

--- a/src/librbd/cache/rwl/Types.h
+++ b/src/librbd/cache/rwl/Types.h
@@ -141,6 +141,9 @@ namespace librbd {
 namespace cache {
 namespace rwl {
 
+class ImageExtentBuf;
+typedef std::vector<ImageExtentBuf> ImageExtentBufs;
+
 const int IN_FLIGHT_FLUSH_WRITE_LIMIT = 64;
 const int IN_FLIGHT_FLUSH_BYTES_LIMIT = (1 * 1024 * 1024);
 
@@ -264,6 +267,15 @@ io::Extent whole_volume_extent();
 BlockExtent block_extent(const io::Extent& image_extent);
 
 Context * override_ctx(int r, Context *ctx);
+
+class ImageExtentBuf : public io::Extent {
+public:
+  bufferlist m_bl;
+  ImageExtentBuf(io::Extent extent)
+    : io::Extent(extent) { }
+  ImageExtentBuf(io::Extent extent, bufferlist bl)
+    : io::Extent(extent), m_bl(bl) { }
+};
 
 } // namespace rwl
 } // namespace cache

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -119,7 +119,8 @@ set(unittest_librbd_srcs
 if(WITH_RBD_RWL)
    set(unittest_librbd_srcs
      ${unittest_librbd_srcs}
-     cache/test_mock_ReplicatedWriteLog.cc)
+     cache/test_mock_ReplicatedWriteLog.cc
+     cache/rwl/test_WriteLogMap.cc)
 endif(WITH_RBD_RWL)
 
 add_executable(unittest_librbd

--- a/src/test/librbd/cache/rwl/test_WriteLogMap.cc
+++ b/src/test/librbd/cache/rwl/test_WriteLogMap.cc
@@ -1,0 +1,336 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_fixture.h"
+#include "test/librbd/test_support.h"
+
+#include "librbd/cache/rwl/LogMap.cc"
+
+void register_test_write_log_map() {
+}
+
+namespace librbd {
+namespace cache {
+namespace rwl {
+
+struct TestLogEntry {
+  uint64_t image_offset_bytes;
+  uint64_t write_bytes;
+  uint32_t referring_map_entries = 0;
+  TestLogEntry(const uint64_t image_offset_bytes, const uint64_t write_bytes)
+    : image_offset_bytes(image_offset_bytes), write_bytes(write_bytes) {
+  }
+  uint64_t get_offset_bytes() {
+    return image_offset_bytes;
+  }
+  uint64_t get_write_bytes() {
+    return write_bytes;
+  }
+  BlockExtent block_extent() {
+    return BlockExtent(image_offset_bytes, image_offset_bytes + write_bytes);
+  }
+  uint32_t get_map_ref() {
+    return referring_map_entries;
+  }
+  void inc_map_ref() {
+    referring_map_entries++;
+  }
+  void dec_map_ref() {
+    referring_map_entries--;
+  }
+  friend std::ostream &operator<<(std::ostream &os,
+                                  const TestLogEntry &entry) {
+    os << "referring_map_entries=" << entry.referring_map_entries << ", "
+       << "image_offset_bytes=" << entry.image_offset_bytes << ", "
+       << "write_bytes=" << entry.write_bytes;
+    return os;
+  };
+};
+
+typedef std::list<std::shared_ptr<TestLogEntry>> TestLogEntries;
+typedef LogMapEntry<TestLogEntry> TestMapEntry;
+typedef LogMapEntries<TestLogEntry> TestLogMapEntries;
+typedef LogMap<TestLogEntry> TestLogMap;
+
+class TestWriteLogMap : public TestFixture {
+public:
+  void SetUp() override {
+    TestFixture::SetUp();
+    m_cct = reinterpret_cast<CephContext*>(m_ioctx.cct());
+  }
+
+  CephContext *m_cct;
+};
+
+TEST_F(TestWriteLogMap, Simple) {
+  TestLogEntries es;
+  TestLogMapEntries lme;
+  TestLogMap  map(m_cct);
+
+  /* LogEntry takes offset, length, in bytes */
+  auto e1 = make_shared<TestLogEntry>(4, 8);
+  TestLogEntry *e1_ptr = e1.get();
+  ASSERT_EQ(4, e1_ptr->get_offset_bytes());
+  ASSERT_EQ(8, e1_ptr->get_write_bytes());
+  map.add_log_entry(e1);
+
+  /* BlockExtent takes first, last, in blocks */
+  TestLogMapEntries found0 = map.find_map_entries(BlockExtent(0, 100));
+  int numfound = found0.size();
+  /* Written range includes the single write above */
+  ASSERT_EQ(1, numfound);
+  ASSERT_EQ(e1, found0.front().log_entry);
+
+  /* Nothing before that */
+  found0 = map.find_map_entries(BlockExtent(0, 3));
+  numfound = found0.size();
+  ASSERT_EQ(0, numfound);
+
+  /* Nothing after that */
+  found0 = map.find_map_entries(BlockExtent(12, 99));
+  numfound = found0.size();
+  ASSERT_EQ(0, numfound);
+
+  /* 4-11 will be e1 */
+  for (int i=4; i<12; i++) {
+    TestLogMapEntries found0 = map.find_map_entries(BlockExtent(i, i + 1));
+    int numfound = found0.size();
+    ASSERT_EQ(1, numfound);
+    ASSERT_EQ(e1, found0.front().log_entry);
+  }
+
+  map.remove_log_entry(e1);
+  /* Nothing should be found */
+  for (int i=4; i<12; i++) {
+    TestLogMapEntries found0 = map.find_map_entries(BlockExtent(i, i + 1));
+    int numfound = found0.size();
+    ASSERT_EQ(0, numfound);
+  }
+}
+
+TEST_F(TestWriteLogMap, OverlapFront) {
+  TestLogMap map(m_cct);
+
+  auto e0 = make_shared<TestLogEntry>(4, 8);
+  map.add_log_entry(e0);
+  /* replaces block 4-7 of e0 */
+  auto e1 = make_shared<TestLogEntry>(0, 8);
+  map.add_log_entry(e1);
+
+  /* Written range includes the two writes above */
+  TestLogMapEntries found0 = map.find_map_entries(BlockExtent(0, 100));
+  int numfound = found0.size();
+  ASSERT_EQ(2, numfound);
+  ASSERT_EQ(e1, found0.front().log_entry);
+  ASSERT_EQ(0, found0.front().block_extent.block_start);
+  ASSERT_EQ(8, found0.front().block_extent.block_end);
+  found0.pop_front();
+  ASSERT_EQ(e0, found0.front().log_entry);
+  ASSERT_EQ(8, found0.front().block_extent.block_start);
+  ASSERT_EQ(12, found0.front().block_extent.block_end);
+
+  /* 0-7 will be e1 */
+  for (int i=0; i<8; i++) {
+    TestLogMapEntries found0 = map.find_map_entries(BlockExtent(i, i + 1));
+    int numfound = found0.size();
+    ASSERT_EQ(1, numfound);
+    ASSERT_EQ(e1, found0.front().log_entry);
+  }
+
+  /* 8-11 will be e0 */
+  for (int i=8; i<12; i++) {
+    TestLogMapEntries found0 = map.find_map_entries(BlockExtent(i, i + 1));
+    int numfound = found0.size();
+    ASSERT_EQ(1, numfound);
+    ASSERT_EQ(e0, found0.front().log_entry);
+  }
+}
+
+TEST_F(TestWriteLogMap, OverlapBack) {
+  TestLogMap map(m_cct);
+
+  auto e0 = make_shared<TestLogEntry>(0, 8);
+  map.add_log_entry(e0);
+  /* replaces block 4-7 of e0 */
+  auto e1 = make_shared<TestLogEntry>(4, 8);
+  map.add_log_entry(e1);
+
+  /* Written range includes the two writes above */
+  TestLogMapEntries found0 = map.find_map_entries(BlockExtent(0, 100));
+  int numfound = found0.size();
+  ASSERT_EQ(2, numfound);
+  ASSERT_EQ(e0, found0.front().log_entry);
+  ASSERT_EQ(0, found0.front().block_extent.block_start);
+  ASSERT_EQ(4, found0.front().block_extent.block_end);
+  found0.pop_front();
+  ASSERT_EQ(e1, found0.front().log_entry);
+  ASSERT_EQ(4, found0.front().block_extent.block_start);
+  ASSERT_EQ(12, found0.front().block_extent.block_end);
+
+  /* 0-3 will be e0 */
+  for (int i=0; i<4; i++) {
+    TestLogMapEntries found0 = map.find_map_entries(BlockExtent(i, i + 1));
+    int numfound = found0.size();
+    ASSERT_EQ(1, numfound);
+    ASSERT_EQ(e0, found0.front().log_entry);
+  }
+
+  /* 4-11 will be e1 */
+  for (int i=4; i<12; i++) {
+    TestLogMapEntries found0 = map.find_map_entries(BlockExtent(i, i + 1));
+    int numfound = found0.size();
+    ASSERT_EQ(1, numfound);
+    ASSERT_EQ(e1, found0.front().log_entry);
+  }
+
+  map.remove_log_entry(e0);
+
+  /* 0-3 will find nothing */
+  for (int i=0; i<4; i++) {
+    TestLogMapEntries found0 = map.find_map_entries(BlockExtent(i, i + 1));
+    int numfound = found0.size();
+    ASSERT_EQ(0, numfound);
+  }
+
+  /* 4-11 will still be e1 */
+  for (int i=4; i<12; i++) {
+    TestLogMapEntries found0 = map.find_map_entries(BlockExtent(i, i + 1));
+    int numfound = found0.size();
+    ASSERT_EQ(1, numfound);
+    ASSERT_EQ(e1, found0.front().log_entry);
+  }
+
+}
+
+TEST_F(TestWriteLogMap, OverlapMiddle) {
+  TestLogMap map(m_cct);
+
+  auto e0 = make_shared<TestLogEntry>(0, 1);
+  map.add_log_entry(e0);
+
+  TestLogMapEntries found0 = map.find_map_entries(BlockExtent(0, 1));
+  int numfound = found0.size();
+  ASSERT_EQ(1, numfound);
+  ASSERT_EQ(e0, found0.front().log_entry);
+  TestLogEntries entries = map.find_log_entries(BlockExtent(0, 1));
+  int entriesfound = entries.size();
+  ASSERT_EQ(1, entriesfound);
+  ASSERT_EQ(e0, entries.front());
+
+  auto e1 = make_shared<TestLogEntry>(1, 1);
+  map.add_log_entry(e1);
+
+  found0 = map.find_map_entries(BlockExtent(1, 2));
+  numfound = found0.size();
+  ASSERT_EQ(1, numfound);
+  ASSERT_EQ(e1, found0.front().log_entry);
+  entries = map.find_log_entries(BlockExtent(1, 2));
+  entriesfound = entries.size();
+  ASSERT_EQ(1, entriesfound);
+  ASSERT_EQ(e1, entries.front());
+
+  auto e2 = make_shared<TestLogEntry>(2, 1);
+  map.add_log_entry(e2);
+
+  found0 = map.find_map_entries(BlockExtent(2, 3));
+  numfound = found0.size();
+  ASSERT_EQ(1, numfound);
+  ASSERT_EQ(e2, found0.front().log_entry);
+  entries = map.find_log_entries(BlockExtent(2, 3));
+  entriesfound = entries.size();
+  ASSERT_EQ(1, entriesfound);
+  ASSERT_EQ(e2, entries.front());
+
+  /* replaces e1 */
+  auto e3 = make_shared<TestLogEntry>(1, 1);
+  map.add_log_entry(e3);
+
+  found0 = map.find_map_entries(BlockExtent(1, 2));
+  numfound = found0.size();
+  ASSERT_EQ(1, numfound);
+  ASSERT_EQ(e3, found0.front().log_entry);
+  entries = map.find_log_entries(BlockExtent(1, 2));
+  entriesfound = entries.size();
+  ASSERT_EQ(1, entriesfound);
+  ASSERT_EQ(e3, entries.front());
+
+  found0 = map.find_map_entries(BlockExtent(0, 100));
+  numfound = found0.size();
+  ASSERT_EQ(3, numfound);
+  ASSERT_EQ(e0, found0.front().log_entry);
+  found0.pop_front();
+  ASSERT_EQ(e3, found0.front().log_entry);
+  found0.pop_front();
+  ASSERT_EQ(e2, found0.front().log_entry);
+  entries = map.find_log_entries(BlockExtent(0, 100));
+  entriesfound = entries.size();
+  ASSERT_EQ(3, entriesfound);
+  ASSERT_EQ(e0, entries.front());
+  entries.pop_front();
+  ASSERT_EQ(e3, entries.front());
+  entries.pop_front();
+  ASSERT_EQ(e2, entries.front());
+
+  entries.clear();
+  entries.emplace_back(e0);
+  entries.emplace_back(e1);
+  map.remove_log_entries(entries);
+
+  found0 = map.find_map_entries(BlockExtent(0, 100));
+  numfound = found0.size();
+  ASSERT_EQ(2, numfound);
+  ASSERT_EQ(e3, found0.front().log_entry);
+  found0.pop_front();
+  ASSERT_EQ(e2, found0.front().log_entry);
+}
+
+TEST_F(TestWriteLogMap, OverlapSplit) {
+  TestLogMap map(m_cct);
+
+  auto e0 = make_shared<TestLogEntry>(0, 8);
+  map.add_log_entry(e0);
+
+  /* Splits e0 at 1 */
+  auto e1 = make_shared<TestLogEntry>(1, 1);
+  map.add_log_entry(e1);
+
+  /* Splits e0 again at 4 */
+  auto e2 = make_shared<TestLogEntry>(4, 2);
+  map.add_log_entry(e2);
+
+  /* Replaces one block of e2, and one of e0 */
+  auto e3 = make_shared<TestLogEntry>(5, 2);
+  map.add_log_entry(e3);
+
+  /* Expecting: 0:e0, 1:e1, 2..3:e0, 4:e2, 5..6:e3, 7:e0 */
+  TestLogMapEntries found0 = map.find_map_entries(BlockExtent(0, 100));
+  int numfound = found0.size();
+  ASSERT_EQ(6, numfound);
+  ASSERT_EQ(e0, found0.front().log_entry);
+  ASSERT_EQ(0, found0.front().block_extent.block_start);
+  ASSERT_EQ(1, found0.front().block_extent.block_end);
+  found0.pop_front();
+  ASSERT_EQ(e1, found0.front().log_entry);
+  ASSERT_EQ(1, found0.front().block_extent.block_start);
+  ASSERT_EQ(2, found0.front().block_extent.block_end);
+  found0.pop_front();
+  ASSERT_EQ(e0, found0.front().log_entry);
+  ASSERT_EQ(2, found0.front().block_extent.block_start);
+  ASSERT_EQ(4, found0.front().block_extent.block_end);
+  found0.pop_front();
+  ASSERT_EQ(e2, found0.front().log_entry);
+  ASSERT_EQ(4, found0.front().block_extent.block_start);
+  ASSERT_EQ(5, found0.front().block_extent.block_end);
+  found0.pop_front();
+  ASSERT_EQ(e3, found0.front().log_entry);
+  ASSERT_EQ(5, found0.front().block_extent.block_start);
+  ASSERT_EQ(7, found0.front().block_extent.block_end);
+  found0.pop_front();
+  ASSERT_EQ(e0, found0.front().log_entry);
+  ASSERT_EQ(7, found0.front().block_extent.block_start);
+  ASSERT_EQ(8, found0.front().block_extent.block_end);
+}
+
+} // namespace rwl
+} // namespace cache
+} // namespace librbd

--- a/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc
+++ b/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc
@@ -365,5 +365,125 @@ TEST_F(TestMockCacheReplicatedWriteLog, aio_flush_source_user) {
   ASSERT_EQ(0, finish_ctx3.wait());
 }
 
+TEST_F(TestMockCacheReplicatedWriteLog, aio_read_hit_rwl_cache) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockReplicatedWriteLog rwl(mock_image_ctx, get_cache_state(mock_image_ctx));
+  expect_op_work_queue(mock_image_ctx);
+  expect_metadata_set(mock_image_ctx);
+
+  MockContextRWL finish_ctx1;
+  expect_context_complete(finish_ctx1, 0);
+  rwl.init(&finish_ctx1);
+  ASSERT_EQ(0, finish_ctx1.wait());
+
+  MockContextRWL finish_ctx2;
+  expect_context_complete(finish_ctx2, 0);
+  Extents image_extents{{0, 4096}};
+  bufferlist bl;
+  bl.append(std::string(4096, '1'));
+  bufferlist bl_copy = bl;
+  int fadvise_flags = 0;
+  rwl.aio_write(std::move(image_extents), std::move(bl), fadvise_flags, &finish_ctx2);
+  ASSERT_EQ(0, finish_ctx2.wait());
+
+  MockContextRWL finish_ctx_read;
+  expect_context_complete(finish_ctx_read, 0);
+  Extents image_extents_read{{0, 4096}};
+  bufferlist read_bl;
+  rwl.aio_read(std::move(image_extents_read), &read_bl, fadvise_flags, &finish_ctx_read);
+  ASSERT_EQ(0, finish_ctx_read.wait());
+  ASSERT_EQ(4096, read_bl.length());
+  ASSERT_TRUE(bl_copy.contents_equal(read_bl));
+
+  MockContextRWL finish_ctx3;
+  expect_context_complete(finish_ctx3, 0);
+  rwl.shut_down(&finish_ctx3);
+  ASSERT_EQ(0, finish_ctx3.wait());
+}
+
+TEST_F(TestMockCacheReplicatedWriteLog, aio_read_hit_part_rwl_cache) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockReplicatedWriteLog rwl(mock_image_ctx, get_cache_state(mock_image_ctx));
+  expect_op_work_queue(mock_image_ctx);
+  expect_metadata_set(mock_image_ctx);
+
+  MockContextRWL finish_ctx1;
+  expect_context_complete(finish_ctx1, 0);
+  rwl.init(&finish_ctx1);
+  ASSERT_EQ(0, finish_ctx1.wait());
+
+  MockContextRWL finish_ctx2;
+  expect_context_complete(finish_ctx2, 0);
+  Extents image_extents{{0, 4096}};
+  bufferlist bl;
+  bl.append(std::string(4096, '1'));
+  bufferlist bl_copy = bl;
+  int fadvise_flags = 0;
+  rwl.aio_write(std::move(image_extents), std::move(bl), fadvise_flags, &finish_ctx2);
+  ASSERT_EQ(0, finish_ctx2.wait());
+
+  MockContextRWL finish_ctx_read;
+  Extents image_extents_read{{512, 4096}};
+  bufferlist hit_bl;
+  bl_copy.begin(511).copy(4096-512, hit_bl);
+  expect_context_complete(finish_ctx_read, 512);
+  bufferlist read_bl;
+  rwl.aio_read(std::move(image_extents_read), &read_bl, fadvise_flags, &finish_ctx_read);
+  ASSERT_EQ(512, finish_ctx_read.wait());
+  ASSERT_EQ(4096, read_bl.length());
+  bufferlist read_bl_hit;
+  read_bl.begin(0).copy(4096-512, read_bl_hit);
+  ASSERT_TRUE(hit_bl.contents_equal(read_bl_hit));
+
+  MockContextRWL finish_ctx3;
+  expect_context_complete(finish_ctx3, 0);
+  rwl.shut_down(&finish_ctx3);
+  ASSERT_EQ(0, finish_ctx3.wait());
+}
+
+TEST_F(TestMockCacheReplicatedWriteLog, aio_read_miss_rwl_cache) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockReplicatedWriteLog rwl(mock_image_ctx, get_cache_state(mock_image_ctx));
+  expect_op_work_queue(mock_image_ctx);
+  expect_metadata_set(mock_image_ctx);
+
+  MockContextRWL finish_ctx1;
+  expect_context_complete(finish_ctx1, 0);
+  rwl.init(&finish_ctx1);
+  ASSERT_EQ(0, finish_ctx1.wait());
+
+  MockContextRWL finish_ctx2;
+  expect_context_complete(finish_ctx2, 0);
+  Extents image_extents{{0, 4096}};
+  bufferlist bl;
+  bl.append(std::string(4096, '1'));
+  int fadvise_flags = 0;
+  rwl.aio_write(std::move(image_extents), std::move(bl), fadvise_flags, &finish_ctx2);
+  ASSERT_EQ(0, finish_ctx2.wait());
+
+  MockContextRWL finish_ctx_read;
+  Extents image_extents_read{{4096, 4096}};
+  expect_context_complete(finish_ctx_read, 4096);
+  bufferlist read_bl;
+  ASSERT_EQ(0, read_bl.length());
+  rwl.aio_read(std::move(image_extents_read), &read_bl, fadvise_flags, &finish_ctx_read);
+  ASSERT_EQ(4096, finish_ctx_read.wait());
+  ASSERT_EQ(4096, read_bl.length());
+
+  MockContextRWL finish_ctx3;
+  expect_context_complete(finish_ctx3, 0);
+  rwl.shut_down(&finish_ctx3);
+  ASSERT_EQ(0, finish_ctx3.wait());
+}
+
 } // namespace cache
 } // namespace librbd

--- a/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc
+++ b/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc
@@ -45,6 +45,7 @@ inline ImageCtx *get_image_ctx(MockImageCtx *image_ctx) {
 #include "librbd/cache/rwl/Request.cc"
 #include "librbd/cache/rwl/Types.cc"
 #include "librbd/cache/rwl/LogOperation.cc"
+#include "librbd/cache/rwl/LogMap.cc"
 
 template class librbd::cache::ImageWriteback<librbd::MockImageCtx>;
 template class librbd::cache::rwl::ImageCacheState<librbd::MockImageCtx>;


### PR DESCRIPTION
Adds Replicated Write Log, a persistent, write back cache for Ceph RBD.
Implements: http://tracker.ceph.com/projects/ceph/wiki/Rbd_-_ordered_crash-consistent_write-back_caching_extension

Trello: https://trello.com/c/QnsQaGTn

[Obsoletes https://github.com//pull/29087]

The PR 29087 is split into smaller PRs to make review easier.
The first PR: #31279
The second PR: #31963
The 3rd PR: #33502
The 4th PR: #34430 

This is the 5th PR (aio read) which defines the following parts:
librbd: add ReadRequest to handle read
librbd: add LogMap class
librbd: add WriteLogMap test cases
librbd: add aio_read
librbd: add aio_read test cases

Signed-off-by: Scott Peterson scott.d.peterson@intel.com
Signed-off-by: Lisa Li xiaoyan.li@intel.com
Signed-off-by: Yuan Lu yuan.y.lu@intel.com
Signed-off-by: Mahati Chamarthy mahati.chamarthy@intel.com

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
