### PR TITLE
cephadm: Add `chown` to unit.run for adoped simple OSDs

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1786,6 +1786,11 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
         if daemon_type == 'osd':
             # osds have a pre-start step
             assert osd_fsid
+            f.write('# Simple OSDs need chown on startup:\n')
+            for n in ['block', 'block.db', 'block.wal']:
+                p = os.path.join(data_dir, n)
+                f.write('[ ! -L {p} ] || chown {uid}:{gid} {p}\n'.format(p=p, uid=uid, gid=gid))
+            f.write('# LVM OSDs use ceph-volume lvm activate:\n')
             prestart = CephContainer(
                 image=args.image,
                 entrypoint='/usr/sbin/ceph-volume',

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3127,13 +3127,13 @@ class AdoptOsd(object):
             with open(path, 'r') as f:
                 osd_fsid = f.read().strip()
             logger.info("Found online OSD at %s" % path)
-            if os.path.exists(os.path.join(self.osd_data_dir, 'type')):
-                with open(os.path.join(self.osd_data_dir, 'type')) as f:
-                    osd_type = f.read().strip()
-            else:
-                logger.info('"type" file missing for OSD data dir')
         except IOError:
             logger.info('Unable to read OSD fsid from %s' % path)
+        if os.path.exists(os.path.join(self.osd_data_dir, 'type')):
+            with open(os.path.join(self.osd_data_dir, 'type')) as f:
+                osd_type = f.read().strip()
+        else:
+            logger.info('"type" file missing for OSD data dir')
 
         return osd_fsid, osd_type
 
@@ -3215,6 +3215,7 @@ def command_adopt_ceph(daemon_type, daemon_id, fsid):
         if not osd_fsid:
             raise Error('Unable to find OSD {}'.format(daemon_id))
         logger.info('objectstore_type is %s' % osd_type)
+        assert osd_type
         if osd_type == 'filestore':
             raise Error('FileStore is not supported by cephadm')
 


### PR DESCRIPTION
We're not using `ceph-volume simple activate` anymore, so need to add `chown ceph:ceph` for each of block, block.db and block.wal to ensure old-style simple OSDs are able to start.

This PR also addresses a couple of the comments in https://github.com/ceph/ceph/pull/34565, but I didn't change it to loop over all devices when looking at ceph.type in check_offline_lvm_osd() - based on the ceph-volume lvm prepare code, there may be several different types, but finding one that's 'block' indicates bluestore, and finding one that's 'data' indicates filestore.
    
Fixes: https://tracker.ceph.com/issues/45129
Signed-off-by: Tim Serong <tserong@suse.com>