### PR TITLE
osd: Make the _day operator"" internals big-endian.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -337,7 +337,7 @@ constexpr unsigned long long operator"" _hr (unsigned long long hr) {
   return hr * 60 * 60;
 }
 constexpr unsigned long long operator"" _day (unsigned long long day) {
-  return day * 60 * 60 * 24;
+  return day * 24 * 60 * 60;
 }
 constexpr unsigned long long operator"" _K (unsigned long long n) {
   return n << 10;


### PR DESCRIPTION
A rather trivial change inspired by PR #34702, where an instance of
`7*60*60*24` (used to describe the number of seconds in a week) was fixed,
decided to have a look at the code and cleaned a similar case of weird-endian-ness.

Signed-off-by: Jasper Spaans <jasper@startmail.com>
