### PR TITLE
rbd/cache: Replicated Write Log core codes - aio_writesame

### DIFF
--- a/src/librbd/cache/ReplicatedWriteLog.h
+++ b/src/librbd/cache/ReplicatedWriteLog.h
@@ -97,6 +97,7 @@ public:
   using C_BlockIORequestT = rwl::C_BlockIORequest<This>;
   using C_FlushRequestT = rwl::C_FlushRequest<This>;
   using C_DiscardRequestT = rwl::C_DiscardRequest<This>;
+  using C_WriteSameRequestT = rwl::C_WriteSameRequest<This>;
 
   CephContext * get_context();
   void release_guarded_request(BlockGuardCell *cell);

--- a/src/librbd/cache/rwl/LogOperation.cc
+++ b/src/librbd/cache/rwl/LogOperation.cc
@@ -211,7 +211,7 @@ void WriteLogOperation::complete(int result) {
   utime_t buf_lat = buf_persist_comp_time - buf_persist_time;
   m_perfcounter->tinc(l_librbd_rwl_log_op_buf_to_bufc_t, buf_lat);
   m_perfcounter->hinc(l_librbd_rwl_log_op_buf_to_bufc_t_hist, buf_lat.to_nsec(),
-                    log_entry->ram_entry.write_bytes);
+                      log_entry->ram_entry.write_bytes);
   m_perfcounter->tinc(l_librbd_rwl_log_op_buf_to_app_t, log_append_time - buf_persist_time);
 }
 
@@ -306,6 +306,30 @@ std::ostream &DiscardLogOperation::format(std::ostream &os) const {
 
 std::ostream &operator<<(std::ostream &os,
                          const DiscardLogOperation &op) {
+  return op.format(os);
+}
+
+WriteSameLogOperation::WriteSameLogOperation(WriteLogOperationSet &set,
+                                             uint64_t image_offset_bytes,
+                                             uint64_t write_bytes,
+                                             uint32_t data_len,
+                                             CephContext *cct)
+  : WriteLogOperation(set, image_offset_bytes, write_bytes, cct) {
+  log_entry =
+    std::make_shared<WriteSameLogEntry>(set.sync_point->log_entry, image_offset_bytes, write_bytes, data_len);
+  ldout(m_cct, 20) << __func__ << " " << this << dendl;
+}
+
+WriteSameLogOperation::~WriteSameLogOperation() { }
+
+std::ostream &WriteSameLogOperation::format(std::ostream &os) const {
+  os << "(Write Same) ";
+  WriteLogOperation::format(os);
+  return os;
+};
+
+std::ostream &operator<<(std::ostream &os,
+                         const WriteSameLogOperation &op) {
   return op.format(os);
 }
 

--- a/src/librbd/cache/rwl/LogOperation.h
+++ b/src/librbd/cache/rwl/LogOperation.h
@@ -202,6 +202,28 @@ public:
                                   const DiscardLogOperation &op);
 };
 
+class WriteSameLogOperation : public WriteLogOperation {
+public:
+  using GenericWriteLogOperation::m_lock;
+  using GenericWriteLogOperation::sync_point;
+  using GenericWriteLogOperation::on_write_append;
+  using GenericWriteLogOperation::on_write_persist;
+  using WriteLogOperation::log_entry;
+  using WriteLogOperation::bl;
+  using WriteLogOperation::buffer_alloc;
+  WriteSameLogOperation(WriteLogOperationSet &set,
+                        const uint64_t image_offset_bytes,
+                        const uint64_t write_bytes,
+                        const uint32_t data_len,
+                        CephContext *cct);
+  ~WriteSameLogOperation();
+  WriteSameLogOperation(const WriteSameLogOperation&) = delete;
+  WriteSameLogOperation &operator=(const WriteSameLogOperation&) = delete;
+  std::ostream &format(std::ostream &os) const;
+  friend std::ostream &operator<<(std::ostream &os,
+                                  const WriteSameLogOperation &op);
+};
+
 } // namespace rwl
 } // namespace cache
 } // namespace librbd

--- a/src/librbd/cache/rwl/Request.h
+++ b/src/librbd/cache/rwl/Request.h
@@ -153,6 +153,8 @@ public:
 
   void dispatch() override;
 
+  virtual std::shared_ptr<WriteLogOperation> create_operation(uint64_t offset, uint64_t len);
+
   virtual void setup_log_operations(DeferredContexts &on_exit);
 
   bool append_write_request(std::shared_ptr<SyncPoint> sync_point);
@@ -165,6 +167,7 @@ public:
 
 protected:
   using C_BlockIORequest<T>::m_resources;
+  PerfCounters *m_perfcounter = nullptr;
   /* Plain writes will allocate one buffer per request extent */
   void setup_buffer_resources(
       uint64_t &bytes_cached, uint64_t &bytes_dirtied, uint64_t &bytes_allocated,
@@ -176,7 +179,6 @@ private:
   std::atomic<int> m_appended = {0};
   bool m_queued = false;
   ceph::mutex &m_lock;
-  PerfCounters *m_perfcounter = nullptr;
   template <typename U>
   friend std::ostream &operator<<(std::ostream &os,
                                   const C_WriteRequest<U> &req);
@@ -298,6 +300,40 @@ private:
   template <typename U>
   friend std::ostream &operator<<(std::ostream &os,
                                   const C_DiscardRequest<U> &req);
+};
+
+/**
+ * This is the custodian of the BlockGuard cell for this write same.
+ *
+ * A writesame allocates and persists a data buffer like a write, but the
+ * data buffer is usually much shorter than the write same.
+ */
+template <typename T>
+class C_WriteSameRequest : public C_WriteRequest<T> {
+public:
+  using C_BlockIORequest<T>::rwl;
+  C_WriteSameRequest(T &rwl, const utime_t arrived, io::Extents &&image_extents,
+                     bufferlist&& bl, const int fadvise_flags, ceph::mutex &lock,
+                     PerfCounters *perfcounter, Context *user_req);
+
+  ~C_WriteSameRequest() override;
+
+  void update_req_stats(utime_t &now) override;
+
+  void setup_buffer_resources(
+      uint64_t &bytes_cached, uint64_t &bytes_dirtied, uint64_t &bytes_allocated,
+      uint64_t &number_lanes, uint64_t &number_log_entries,
+      uint64_t &number_unpublished_reserves) override;
+
+  std::shared_ptr<WriteLogOperation> create_operation(uint64_t offset, uint64_t len) override;
+
+  const char *get_name() const override {
+    return "C_WriteSameRequest";
+  }
+
+  template<typename U>
+  friend std::ostream &operator<<(std::ostream &os,
+                                  const C_WriteSameRequest<U> &req);
 };
 
 struct BlockGuardReqState {

--- a/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc
+++ b/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc
@@ -529,5 +529,43 @@ TEST_F(TestMockCacheReplicatedWriteLog, aio_discard) {
   ASSERT_EQ(0, finish_ctx3.wait());
 }
 
+TEST_F(TestMockCacheReplicatedWriteLog, aio_writesame) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockReplicatedWriteLog rwl(mock_image_ctx, get_cache_state(mock_image_ctx));
+  expect_op_work_queue(mock_image_ctx);
+  expect_metadata_set(mock_image_ctx);
+
+  MockContextRWL finish_ctx1;
+  expect_context_complete(finish_ctx1, 0);
+  rwl.init(&finish_ctx1);
+  ASSERT_EQ(0, finish_ctx1.wait());
+
+  MockContextRWL finish_ctx2;
+  expect_context_complete(finish_ctx2, 0);
+  bufferlist bl, test_bl;
+  bl.append(std::string(512, '1'));
+  test_bl.append(std::string(4096, '1'));
+  int fadvise_flags = 0;
+  rwl.aio_writesame(0, 4096, std::move(bl), fadvise_flags, &finish_ctx2);
+  ASSERT_EQ(0, finish_ctx2.wait());
+
+  MockContextRWL finish_ctx_read;
+  bufferlist read_bl;
+  expect_context_complete(finish_ctx_read, 0);
+  rwl.aio_read({{0, 4096}}, &read_bl, fadvise_flags, &finish_ctx_read);
+  ASSERT_EQ(0, finish_ctx_read.wait());
+  ASSERT_EQ(4096, read_bl.length());
+  ASSERT_TRUE(test_bl.contents_equal(read_bl));
+
+  MockContextRWL finish_ctx3;
+  expect_context_complete(finish_ctx3, 0);
+  rwl.shut_down(&finish_ctx3);
+
+  ASSERT_EQ(0, finish_ctx3.wait());
+}
+
 } // namespace cache
 } // namespace librbd


### PR DESCRIPTION
Adds Replicated Write Log, a persistent, write back cache for Ceph RBD.
Implements: http://tracker.ceph.com/projects/ceph/wiki/Rbd_-_ordered_crash-consistent_write-back_caching_extension

Trello: https://trello.com/c/QnsQaGTn

[Obsoletes https://github.com//pull/29087]

The PR 29087 is split into smaller PRs to make review easier.
The first PR: #31279
The second PR: #31963
The 3rd PR: #33502
The 4th PR: #34430
The 5th PR: #34699 

This is the 6th PR (aio_writesame) which defines the following parts:
librbd: add WriteSameLogEntry
librbd: add WriteSameLogOperation 
librbd: add WriteSameRequest
librbd: add aio_writesame 
librbd: add aio_writesame test case 

Signed-off-by: Scott Peterson scott.d.peterson@intel.com
Signed-off-by: Lisa Li xiaoyan.li@intel.com
Signed-off-by: Yuan Lu yuan.y.lu@intel.com
Signed-off-by: Mahati Chamarthy mahati.chamarthy@intel.com

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
