### PR TITLE
octopus: os/bluestore: fix extent leak after main device expand.

### DIFF
--- a/src/os/bluestore/BitmapFreelistManager.cc
+++ b/src/os/bluestore/BitmapFreelistManager.cc
@@ -117,7 +117,7 @@ int BitmapFreelistManager::_expand(uint64_t old_size, KeyValueDB* db)
     dout(10) << __func__ << " rounding1 blocks up from 0x" << std::hex
              << old_size << " to 0x" << (blocks0 * bytes_per_block)
 	     << " (0x" << blocks0 << " blocks)" << std::dec << dendl;
-    // reset past-eof blocks to unallocated
+    // reset previous past-eof blocks to unallocated
     _xor(old_size, blocks0 * bytes_per_block - old_size, txn);
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45127

---

backport of https://github.com/ceph/ceph/pull/34022
parent tracker: https://tracker.ceph.com/issues/45110

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh