### PR TITLE
rgw: src/rgw/rgw_url.cc, also cope with a vhost appended to a AMQP-URL

### DIFF
--- a/src/rgw/rgw_url.cc
+++ b/src/rgw/rgw_url.cc
@@ -14,32 +14,33 @@ namespace {
   const std::string schema_re = "([[:alpha:]]+:\\/\\/)";
   const std::string user_pass_re = "(([^:\\s]+):([^@\\s]+)@)?";
   const std::string host_port_re = "([[:alnum:].:-]+)";
+  const std::string vhost_re = "(/[[:print:]]+)?";
 }
 
 bool parse_url_authority(const std::string& url, std::string& host, std::string& user, std::string& password) {
-  const std::string re = schema_re + user_pass_re + host_port_re;
+  const std::string re = schema_re + user_pass_re + host_port_re + vhost_re;
   const std::regex url_regex(re, std::regex::icase);
   std::smatch url_match_result;
 
   if (std::regex_match(url, url_match_result, url_regex)) {
     host = url_match_result[HOST_GROUP_IDX];
-    user = url_match_result[USER_GROUP_IDX];  
+    user = url_match_result[USER_GROUP_IDX];
     password = url_match_result[PASSWORD_GROUP_IDX];
-	return true; 
+    return true;
   }
 
   return false;
 }
 
 bool parse_url_userinfo(const std::string& url, std::string& user, std::string& password) {
-  const std::string re = schema_re + user_pass_re + host_port_re;
+  const std::string re = schema_re + user_pass_re + host_port_re + vhost_re;
   const std::regex url_regex(re);
   std::smatch url_match_result;
 
   if (std::regex_match(url, url_match_result, url_regex)) {
-    user = url_match_result[USER_GROUP_IDX];  
+    user = url_match_result[USER_GROUP_IDX];
     password = url_match_result[PASSWORD_GROUP_IDX];
-	return true; 
+    return true;
   }
 
   return false;


### PR DESCRIPTION
On trying to setup a pubsub-topic by using an AMQP-based push-endpoint, the topic-creation gets rejected with an error-message `malformed endpoint URL`.

```
2020-04-23T21:43:12.366+0200 7fc529fe0700  1 endpoint validation error: malformed endpoint URL:amqp://user:pass@amqphost:5672/amqp-vhost
```

If I get the code right, there is currently no handling for a vhost-information in *rgw_url.cc*.

I've tried to fix that in *rgw_url.cc* by adding an additional regex-pattern to match on.