### PR TITLE
src/client/fuse_ll: compatible with libfuse3.5 or higher

### DIFF
--- a/cmake/modules/FindFUSE.cmake
+++ b/cmake/modules/FindFUSE.cmake
@@ -19,15 +19,6 @@ if(APPLE)
   list(APPEND fuse_suffixes osxfuse)
 endif()
 
-find_path(
-  FUSE_INCLUDE_DIR
-  NAMES fuse_common.h fuse_lowlevel.h fuse.h
-  PATH_SUFFIXES ${fuse_suffixes})
-
-find_library(FUSE_LIBRARIES
-  NAMES ${fuse_names}
-  PATHS /usr/local/lib64 /usr/local/lib)
-
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
   pkg_search_module(PKG_FUSE QUIET ${fuse_names})
@@ -36,7 +27,28 @@ if(PKG_CONFIG_FOUND)
     "\\1" FUSE_MAJOR_VERSION "${PKG_FUSE_VERSION}")
   string(REGEX REPLACE "([0-9]+)\.([0-9]+)\.([0-9]+)"
     "\\2" FUSE_MINOR_VERSION "${PKG_FUSE_VERSION}")
+
+  find_path(
+    FUSE_INCLUDE_DIR
+    NAMES fuse_common.h fuse_lowlevel.h fuse.h
+    HINTS ${PKG_FUSE_INCLUDE_DIRS}
+    PATH_SUFFIXES ${fuse_suffixes}
+    NO_DEFAULT_PATH)
+
+  find_library(FUSE_LIBRARIES
+    NAMES ${fuse_names}
+    HINTS ${PKG_FUSE_LIBDIR}
+    NO_DEFAULT_PATH)
 else()
+  find_path(
+    FUSE_INCLUDE_DIR
+    NAMES fuse_common.h fuse_lowlevel.h fuse.h
+    PATH_SUFFIXES ${fuse_suffixes})
+
+  find_library(FUSE_LIBRARIES
+    NAMES ${fuse_names}
+    PATHS /usr/local/lib64 /usr/local/lib)
+
   foreach(ver "MAJOR" "MINOR")
     file(STRINGS "${FUSE_INCLUDE_DIR}/fuse_common.h" fuse_ver_${ver}_line
       REGEX "^#define[\t ]+FUSE_${ver}_VERSION[\t ]+[0-9]+$")

--- a/cmake/modules/FindFUSE.cmake
+++ b/cmake/modules/FindFUSE.cmake
@@ -28,14 +28,25 @@ find_library(FUSE_LIBRARIES
   NAMES ${fuse_names}
   PATHS /usr/local/lib64 /usr/local/lib)
 
-foreach(ver "MAJOR" "MINOR")
-  file(STRINGS "${FUSE_INCLUDE_DIR}/fuse_common.h" fuse_ver_${ver}_line
-    REGEX "^#define[\t ]+FUSE_${ver}_VERSION[\t ]+[0-9]+$")
-  string(REGEX REPLACE ".*#define[\t ]+FUSE_${ver}_VERSION[\t ]+([0-9]+)$"
-    "\\1" FUSE_VERSION_${ver} "${fuse_ver_${ver}_line}")
-endforeach()
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_search_module(PKG_FUSE QUIET ${fuse_names})
+
+  string(REGEX REPLACE "([0-9]+)\.([0-9]+)\.([0-9]+)"
+    "\\1" FUSE_MAJOR_VERSION "${PKG_FUSE_VERSION}")
+  string(REGEX REPLACE "([0-9]+)\.([0-9]+)\.([0-9]+)"
+    "\\2" FUSE_MINOR_VERSION "${PKG_FUSE_VERSION}")
+else()
+  foreach(ver "MAJOR" "MINOR")
+    file(STRINGS "${FUSE_INCLUDE_DIR}/fuse_common.h" fuse_ver_${ver}_line
+      REGEX "^#define[\t ]+FUSE_${ver}_VERSION[\t ]+[0-9]+$")
+    string(REGEX REPLACE ".*#define[\t ]+FUSE_${ver}_VERSION[\t ]+([0-9]+)$"
+      "\\1" FUSE_${ver}_VERSION "${fuse_ver_${ver}_line}")
+  endforeach()
+endif()
+
 set(FUSE_VERSION
-  "${FUSE_VERSION_MAJOR}.${FUSE_VERSION_MINOR}")
+  "${FUSE_MAJOR_VERSION}.${FUSE_MINOR_VERSION}")
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(FUSE

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -44,6 +44,7 @@
 
 #include <fuse.h>
 #include <fuse_lowlevel.h>
+#include "include/ceph_fuse.h"
 
 #define dout_context g_ceph_context
 

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -641,7 +641,13 @@ static void fuse_ll_flush(fuse_req_t req, fuse_ino_t ino,
 }
 
 #ifdef FUSE_IOCTL_COMPAT
-static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino, int cmd, void *arg, struct fuse_file_info *fi,
+static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 5)
+                          unsigned int cmd,
+#else
+                          int cmd,
+#endif
+                          void *arg, struct fuse_file_info *fi,
 			  unsigned flags, const void *in_buf, size_t in_bufsz, size_t out_bufsz)
 {
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -34,6 +34,7 @@
 #include "common/config.h"
 #include "include/ceph_assert.h"
 #include "include/cephfs/ceph_ll_client.h"
+#include "include/ceph_fuse.h"
 
 #include "fuse_ll.h"
 #include <fuse.h>

--- a/src/include/ceph_fuse.h
+++ b/src/include/ceph_fuse.h
@@ -15,8 +15,19 @@
 #define CEPH_FUSE_H
 
 #define FUSE_USE_VERSION 30
-#include "acconfig.h"
 #include <fuse.h>
+#include "acconfig.h"
+
+/*
+ * Redefine the FUSE_VERSION macro defined in "fuse_common.h"
+ * header file, because the MINOR numner has been forgotten to
+ * update since libfuse 3.2 to 3.8. We need to fetch the MINOR
+ * number from pkgconfig file.
+ */
+#ifdef FUSE_VERSION
+#undef FUSE_VERSION
+#define FUSE_VERSION FUSE_MAKE_VERSION(CEPH_FUSE_MAJOR_VERSION, CEPH_FUSE_MINOR_VERSION)
+#endif
 
 static inline int filler_compat(fuse_fill_dir_t filler,
                                 void *buf, const char *name,

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -87,6 +87,12 @@
 /* Define if you have fuse */
 #cmakedefine HAVE_LIBFUSE
 
+/* Define version major */
+#define CEPH_FUSE_MAJOR_VERSION @FUSE_MAJOR_VERSION@
+
+/* Define version minor */
+#define CEPH_FUSE_MINOR_VERSION @FUSE_MINOR_VERSION@
+
 /* Define to 1 if you have libxfs */
 #cmakedefine HAVE_LIBXFS 1
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/45396
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
