### PR TITLE
rgw: adding a tip to the documentation about topic-name being used as AMQP routing-key

### DIFF
--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -98,6 +98,8 @@ Request parameters:
   - "none": message is considered "delivered" if sent to broker
   - "broker": message is considered "delivered" if acked by broker (default)
 
+.. tip:: The topic-name (see :ref:`radosgw-create-a-topic`) is used for the AMQP "routing key"
+
 - Kafka endpoint 
 
  - URI: ``kafka://[<user>:<password>@]<fqdn>[:<port]``

--- a/doc/radosgw/pubsub-module.rst
+++ b/doc/radosgw/pubsub-module.rst
@@ -137,6 +137,8 @@ PubSub REST API
 Topics
 ~~~~~~
  
+.. _radosgw-create-a-topic:
+
 Create a Topic
 ``````````````
 
@@ -177,6 +179,8 @@ The endpoint URI may include parameters depending with the type of endpoint:
 
   - "none": message is considered "delivered" if sent to broker
   - "broker": message is considered "delivered" if acked by broker (default)
+
+.. tip:: The topic-name (see :ref:`radosgw-create-a-topic`) is used for the AMQP "routing key"
 
 - Kafka endpoint 
 


### PR DESCRIPTION
I would like to suggest adding a tip, that the pubsub-topic-name is used as the AMQP routing-key.

It could also be, that this is clear for everyone else - but I had to search through the [source-code](https://github.com/ceph/ceph/blob/036c40e9432deafb4379cedb5c119109376cc5b9/src/rgw/rgw_amqp.cc#L565) to find out that the topic-name is passed as the fourth argument to `amqp_basic_publish()` :smile: .