### PR TITLE
cephadm: fix ceph-iscsi deploy with json

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -727,12 +727,12 @@ Usage:
 
     @_cli_write_command(
         'orch daemon add iscsi',
-        'name=pool,type=CephString '
+        'name=pool,type=CephString,req=false '
         'name=fqdn_enabled,type=CephString,req=false '
         'name=trusted_ip_list,type=CephString,req=false '
         'name=placement,type=CephString,req=false',
         'Start iscsi daemon(s)')
-    def _iscsi_add(self, pool, fqdn_enabled=None, trusted_ip_list=None, placement=None, inbuf=None):
+    def _iscsi_add(self, pool=None, fqdn_enabled=None, trusted_ip_list=None, placement=None, inbuf=None):
         usage = """
         Usage:
           ceph orch daemon add iscsi -i <json_file>
@@ -744,7 +744,7 @@ Usage:
             except ValueError as e:
                 msg = 'Failed to read JSON input: {}'.format(str(e)) + usage
                 return HandleCommandResult(-errno.EINVAL, stderr=msg)
-        else:
+        elif pool:
             iscsi_spec = IscsiServiceSpec(
                 service_id='iscsi',
                 pool=pool,
@@ -752,6 +752,8 @@ Usage:
                 trusted_ip_list=trusted_ip_list,
                 placement=PlacementSpec.from_string(placement),
             )
+        else:
+            return HandleCommandResult(-errno.EINVAL, stderr=usage)
 
         completion = self.add_iscsi(iscsi_spec)
         self._orchestrator_wait([completion])


### PR DESCRIPTION
We were making pool a requirement, even though we say we can use a json
file with `-i` to deploy ceph-iscsi.

This patch fixes this. If your not using `-i <json>` then pool is still
required. But this means tools can deploy with json.

Fixes: https://tracker.ceph.com/issues/45198
Signed-off-by: Matthew Oliver <moliver@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
