### PR TITLE
cephadm: remove fqdn_enabled from ceph-iscsi

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2919,7 +2919,6 @@ cluster_client_name = {utils.name_to_config_section('iscsi')}.{igw_id}
 pool = {spec.pool}
 trusted_ip_list = {spec.trusted_ip_list or ''}
 minimum_gateways = 1
-fqdn_enabled = {spec.fqdn_enabled or ''}
 api_port = {spec.api_port or ''}
 api_user = {spec.api_user or ''}
 api_password = {spec.api_password or ''}

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -728,11 +728,10 @@ Usage:
     @_cli_write_command(
         'orch daemon add iscsi',
         'name=pool,type=CephString '
-        'name=fqdn_enabled,type=CephString,req=false '
         'name=trusted_ip_list,type=CephString,req=false '
         'name=placement,type=CephString,req=false',
         'Start iscsi daemon(s)')
-    def _iscsi_add(self, pool, fqdn_enabled=None, trusted_ip_list=None, placement=None, inbuf=None):
+    def _iscsi_add(self, pool, trusted_ip_list=None, placement=None, inbuf=None):
         usage = """
         Usage:
           ceph orch daemon add iscsi -i <json_file>
@@ -748,7 +747,6 @@ Usage:
             iscsi_spec = IscsiServiceSpec(
                 service_id='iscsi',
                 pool=pool,
-                fqdn_enabled=fqdn_enabled,
                 trusted_ip_list=trusted_ip_list,
                 placement=PlacementSpec.from_string(placement),
             )

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -575,7 +575,6 @@ class IscsiServiceSpec(ServiceSpec):
     def __init__(self, service_id, pool=None,
                  placement=None,
                  trusted_ip_list=None,
-                 fqdn_enabled=None,
                  api_port=None,
                  api_user=None,
                  api_password=None,
@@ -591,7 +590,6 @@ class IscsiServiceSpec(ServiceSpec):
         #: RADOS pool where ceph-iscsi config data is stored.
         self.pool = pool
         self.trusted_ip_list = trusted_ip_list
-        self.fqdn_enabled = fqdn_enabled
         self.api_port = api_port
         self.api_user = api_user
         self.api_password = api_password


### PR DESCRIPTION
The fqdn_enabled option never actually landed in the ceph-iscsi master
branch. So this patch removes it from the cephadm ceph-iscsi spec.

Fixes: https://tracker.ceph.com/issues/45196
Signed-off-by: Matthew Oliver <moliver@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
