### PR TITLE
octopus: mgr/status: Fix "ceph fs status" json format writing to stderr

### DIFF
--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1,9 +1,12 @@
+import json
+
 from teuthology.orchestra.run import CommandFailedError
 
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from tasks.cephfs.fuse_mount import FuseMount
 
 from tasks.cephfs.filesystem import FileLayout
+
 
 class TestAdminCommands(CephFSTestCase):
     """
@@ -20,6 +23,12 @@ class TestAdminCommands(CephFSTestCase):
 
         s = self.fs.mon_manager.raw_cluster_cmd("fs", "status")
         self.assertTrue("active" in s)
+
+        mdsmap = json.loads(self.fs.mon_manager.raw_cluster_cmd("fs", "status", "--format=json-pretty"))["mdsmap"]
+        self.assertEqual(mdsmap[0]["state"], "active")
+
+        mdsmap = json.loads(self.fs.mon_manager.raw_cluster_cmd("fs", "status", "--format=json"))["mdsmap"]
+        self.assertEqual(mdsmap[0]["state"], "active")
 
     def _setup_ec_pools(self, n, metadata=True, overwrites=True):
         if metadata:

--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -12,7 +12,7 @@ import prettytable
 import six
 import json
 
-from mgr_module import MgrModule
+from mgr_module import MgrModule, HandleCommandResult
 
 
 class Module(MgrModule):
@@ -260,11 +260,11 @@ class Module(MgrModule):
                 output += version_table.get_string() + "\n"
 
         if output_format == "json":
-            return 0, "", json.dumps(json_output, sort_keys=True)
+            return HandleCommandResult(stdout=json.dumps(json_output, sort_keys=True))
         elif output_format == "json-pretty":
-            return 0, "", json.dumps(json_output, sort_keys=True, indent=4, separators=(',', ': '))
+            return HandleCommandResult(stdout=json.dumps(json_output, sort_keys=True, indent=4, separators=(',', ': ')))
         else:
-            return 0, output, ""
+            return HandleCommandResult(stdout=output)
 
     def handle_osd_status(self, cmd):
         osd_table = PrettyTable(['ID', 'HOST', 'USED', 'AVAIL', 'WR OPS',


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45251
possibly a backport of https://github.com/ceph/ceph/pull/34561
parent tracker: https://tracker.ceph.com/issues/44962

---

original PR body:

"ceph fs status" json format outputs to stderr instead of
stdout. This patch fixes the same.

Fixes: https://tracker.ceph.com/issues/44962
Signed-off-by: Kotresh HR <khiremat@redhat.com>
(cherry picked from commit 138117f2f48c4cca014334b4547b229c1f05807e)





---

updated using ceph-backport.sh version 15.1.1.389
