### PR TITLE
cephadm: Infer config on "cephadm shell"

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -114,10 +114,12 @@ host.  However, we recommend enabling easy access to the the ``ceph``
 command.  There are several ways to do this:
 
 * The ``cephadm shell`` command launches a bash shell in a container
-  with all of the Ceph packages installed.  By default, if
+  with all of the Ceph packages installed. By default, if
   configuration and keyring files are found in ``/etc/ceph`` on the
   host, they are passed into the container environment so that the
-  shell is fully functional::
+  shell is fully functional. Note that when executed on a MON host,
+  ``cephadm shell`` will infer the ``config`` from the MON container
+  instead of using the default configuration::
 
     # cephadm shell
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1078,6 +1078,36 @@ def infer_fsid(func):
 
     return _infer_fsid
 
+def infer_config(func):
+    """
+    If we find a MON daemon, use the config from that container
+    """
+    @wraps(func)
+    def _infer_config():
+        if args.config:
+            logger.debug('Using specified config: %s' % args.config)
+            return func()
+        config = None
+        if args.fsid:
+            name = args.name
+            if not name:
+                daemon_list = list_daemons(detail=False)
+                for daemon in daemon_list:
+                    if daemon['name'].startswith('mon.'):
+                        name = daemon['name']
+                        break
+            if name:
+                config = '/var/lib/ceph/{}/{}/config'.format(args.fsid, name)
+        if config:
+            logger.info('Inferring config %s' % config)
+            args.config = config
+        elif os.path.exists(SHELL_DEFAULT_CONF):
+            logger.debug('Using default config: %s' % SHELL_DEFAULT_CONF)
+            args.config = SHELL_DEFAULT_CONF
+        return func()
+
+    return _infer_config
+
 def _get_default_image():
     if DEFAULT_IMAGE_IS_MASTER:
         yellow = '\033[93m'
@@ -2708,6 +2738,7 @@ def command_run():
 ##################################
 
 @infer_fsid
+@infer_config
 @infer_image
 def command_shell():
     # type: () -> int
@@ -2729,8 +2760,6 @@ def command_shell():
     # use /etc/ceph files by default, if present.  we do this instead of
     # making these defaults in the arg parser because we don't want an error
     # if they don't exist.
-    if not args.config and os.path.exists(SHELL_DEFAULT_CONF):
-        args.config = SHELL_DEFAULT_CONF
     if not args.keyring and os.path.exists(SHELL_DEFAULT_KEYRING):
         args.keyring = SHELL_DEFAULT_KEYRING
 


### PR DESCRIPTION
This PR simplifies the usage of `cephadm shell` on **MON** nodes by inferring the **config**:

```
node2:~ # cephadm shell
INFO:cephadm:Inferring fsid 3637a7ea-8593-11ea-a951-5254005a2e6a
INFO:cephadm:Inferring config /var/lib/ceph/3637a7ea-8593-11ea-a951-5254005a2e6a/mon.node2/config
INFO:cephadm:Using recent ceph image registry.opensuse.org/filesystems/ceph/octopus/upstream/images/ceph/ceph:latest
[ceph: root@node2 /]# ceph -s
  cluster:
    id:     3637a7ea-8593-11ea-a951-5254005a2e6a
...
```

The main motivation of this PR, is that the `/etc/ceph/ceph.conf` generated by the  `bootstrap` command will became outdated when new MONs are added.

Fixes: https://tracker.ceph.com/issues/44792

Signed-off-by: Ricardo Marques <rimarques@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
