### PR TITLE
octopus: rgw: reshard: skip stale bucket id entries from reshard queue

### DIFF
--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -641,7 +641,6 @@ int RGWBucketReshard::do_reshard(int num_shards,
 	    return ret;
 	  }
 	}
-
 	if (verbose_json_out) {
 	  formatter->close_section();
 	  formatter->flush(*out);
@@ -1021,19 +1020,25 @@ int RGWReshard::process_single_logshard(int logshard_num)
 						 entry.tenant, entry.bucket_name,
 						 bucket_info, nullptr,
 						 null_yield, &attrs);
-	if (ret < 0) {
-	  ldout(cct, 0) <<  __func__ <<
-	    ": Error in get_bucket_info for bucket " << entry.bucket_name <<
-	    ": " << cpp_strerror(-ret) << dendl;
-	  if (ret != -ENOENT) {
-	    // any error other than ENOENT will abort
-	    return ret;
+	if (ret < 0 || bucket_info.bucket.bucket_id != entry.bucket_id) {
+	  if (ret < 0) {
+	    ldout(cct, 0) <<  __func__ <<
+	      ": Error in get_bucket_info for bucket " << entry.bucket_name <<
+	      ": " << cpp_strerror(-ret) << dendl;
+	    if (ret != -ENOENT) {
+	      // any error other than ENOENT will abort
+	      return ret;
+	    }
+	  } else {
+	    ldout(cct,0) << __func__ <<
+	      ": Bucket: " << entry.bucket_name <<
+	      " already resharded by someone, skipping " << dendl;
 	  }
 
 	  // we've encountered a reshard queue entry for an apparently
 	  // non-existent bucket; let's try to recover by cleaning up
 	  ldout(cct, 0) <<  __func__ <<
-	    ": removing reshard queue entry for non-existent bucket " <<
+	    ": removing reshard queue entry for a resharded or non-existent bucket" <<
 	    entry.bucket_name << dendl;
 
 	  ret = remove(entry);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45259

---

backport of https://github.com/ceph/ceph/pull/34614
parent tracker: https://tracker.ceph.com/issues/45134

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh