### PR TITLE
ceph-volume: handle idempotency with batch and explicit scenarios

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import json
 from textwrap import dedent
 from ceph_volume import terminal, decorators
 from ceph_volume.util import disk, prompt_bool
@@ -376,6 +377,11 @@ class Batch(object):
                 # filtered
                 if self.args.yes and dev_list and self.usable and devs != usable:
                     err = '{} devices were filtered in non-interactive mode, bailing out'
+                    if self.args.format == "json" and self.args.report:
+                        # if a json report is requested, report unchanged so idempotency checks
+                        # in ceph-ansible will work
+                        print(json.dumps({"changed": False, "osds": [], "vgs": []}))
+                        raise SystemExit(0)
                     raise RuntimeError(err.format(len(devs) - len(usable)))
 
 


### PR DESCRIPTION
If you used --wal-devices or --db-devices with batch and too
many devices are filtered out then a RuntimeError was raised.

However, if --report and --format=json is used then we
should return valid json indicating that no OSDS will be created
so that ceph-ansible and other systems can use that for idempotency checks.

Resolves: rhbz#1827349

https://bugzilla.redhat.com/show_bug.cgi?id=1827349

Signed-off-by: Andrew Schoen <aschoen@redhat.com>

