### PR TITLE
cephadm: fix the hang-up of cryptsetup on creating encrypted OSD

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2090,6 +2090,7 @@ class CephContainer:
             'run',
             '--rm',
             '--net=host',
+            '--ipc=host',
         ] + self.container_args + priv + \
         cname + envs + \
         vols + entrypoint + \
@@ -2123,6 +2124,7 @@ class CephContainer:
             'run',
             '--rm',
             '--net=host',
+            '--ipc=host',
         ] + self.container_args + priv + envs + vols + [
             '--entrypoint', cmd[0],
             self.image


### PR DESCRIPTION
Creating encrypted OSD fails due to the container's dedicated ipc
namespace. Sharing the ipc namespace with host resolve this problem.

## Checklist
- [o] References tracker ticket
- [o] Updates documentation if necessary
- [o] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
