### PR TITLE
mgr/dashboard: Forms now wait for all data to load until displayed

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
@@ -1,9 +1,9 @@
-<div class="cd-col-form">
+<div class="cd-col-form"
+     *cdFormLoading="loading">
   <form name="targetForm"
         #formDir="ngForm"
         [formGroup]="targetForm"
-        novalidate
-        *ngIf="targetForm">
+        novalidate>
     <div class="card">
       <div i18n="form title|Example: Create Pool@@formTitle"
            class="card-header">{{ action | titlecase }} {{ resource | upperFirst }}</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
@@ -13,6 +13,7 @@ import { SelectMessages } from '../../../shared/components/select/select-message
 import { SelectOption } from '../../../shared/components/select/select-option.model';
 import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { Icons } from '../../../shared/enum/icons.enum';
+import { CdForm } from '../../../shared/forms/cd-form';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
 import { FinishedTask } from '../../../shared/models/finished-task';
@@ -25,7 +26,7 @@ import { IscsiTargetIqnSettingsModalComponent } from '../iscsi-target-iqn-settin
   templateUrl: './iscsi-target-form.component.html',
   styleUrls: ['./iscsi-target-form.component.scss']
 })
-export class IscsiTargetFormComponent implements OnInit {
+export class IscsiTargetFormComponent extends CdForm implements OnInit {
   cephIscsiConfigVersion: number;
   targetForm: CdFormGroup;
   modalRef: BsModalRef;
@@ -97,6 +98,7 @@ export class IscsiTargetFormComponent implements OnInit {
     private taskWrapper: TaskWrapperService,
     public actionLabels: ActionLabelsI18n
   ) {
+    super();
     this.resource = this.i18n('target');
   }
 
@@ -182,6 +184,8 @@ export class IscsiTargetFormComponent implements OnInit {
       if (data[5]) {
         this.resolveModel(data[5]);
       }
+
+      this.loadingReady();
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -1,4 +1,5 @@
-<div class="cd-col-form">
+<div class="cd-col-form"
+     *cdFormLoading="loading">
   <form name="rbdForm"
         #formDir="ngForm"
         [formGroup]="rbdForm"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
@@ -53,6 +53,8 @@ describe('RbdFormComponent', () => {
     fixture = TestBed.createComponent(RbdFormComponent);
     component = fixture.componentInstance;
     activatedRoute = TestBed.get(ActivatedRoute);
+
+    component.loadingReady();
   });
 
   it('should create', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -12,6 +12,7 @@ import { PoolService } from '../../../shared/api/pool.service';
 import { RbdService } from '../../../shared/api/rbd.service';
 import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { Icons } from '../../../shared/enum/icons.enum';
+import { CdForm } from '../../../shared/forms/cd-form';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import {
   RbdConfigurationEntry,
@@ -38,7 +39,7 @@ import { RbdFormResponseModel } from './rbd-form-response.model';
   templateUrl: './rbd-form.component.html',
   styleUrls: ['./rbd-form.component.scss']
 })
-export class RbdFormComponent implements OnInit {
+export class RbdFormComponent extends CdForm implements OnInit {
   poolPermission: Permission;
   rbdForm: CdFormGroup;
   getDirtyConfigurationValues: (
@@ -105,6 +106,7 @@ export class RbdFormComponent implements OnInit {
     public actionLabels: ActionLabelsI18n,
     public router: Router
   ) {
+    super();
     this.poolPermission = this.authStorageService.getPermissions().pool;
     this.resource = this.i18n('RBD');
     this.features = {
@@ -293,6 +295,8 @@ export class RbdFormComponent implements OnInit {
         this.setResponse(resp, this.snapName);
         this.rbdImage.next(resp);
       }
+
+      this.loadingReady();
     });
 
     _.each(this.features, (feature) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
@@ -1,4 +1,5 @@
-<div class="cd-col-form">
+<div class="cd-col-form"
+     *cdFormLoading="loading">
   <form name="configForm"
         #formDir="ngForm"
         [formGroup]="configForm"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
@@ -9,6 +9,7 @@ import { ConfigurationService } from '../../../../shared/api/configuration.servi
 import { ConfigFormModel } from '../../../../shared/components/config-option/config-option.model';
 import { ConfigOptionTypes } from '../../../../shared/components/config-option/config-option.types';
 import { NotificationType } from '../../../../shared/enum/notification-type.enum';
+import { CdForm } from '../../../../shared/forms/cd-form';
 import { CdFormGroup } from '../../../../shared/forms/cd-form-group';
 import { NotificationService } from '../../../../shared/services/notification.service';
 import { ConfigFormCreateRequestModel } from './configuration-form-create-request.model';
@@ -18,7 +19,7 @@ import { ConfigFormCreateRequestModel } from './configuration-form-create-reques
   templateUrl: './configuration-form.component.html',
   styleUrls: ['./configuration-form.component.scss']
 })
-export class ConfigurationFormComponent implements OnInit {
+export class ConfigurationFormComponent extends CdForm implements OnInit {
   configForm: CdFormGroup;
   response: ConfigFormModel;
   type: string;
@@ -36,6 +37,7 @@ export class ConfigurationFormComponent implements OnInit {
     private notificationService: NotificationService,
     private i18n: I18n
   ) {
+    super();
     this.createForm();
   }
 
@@ -62,6 +64,7 @@ export class ConfigurationFormComponent implements OnInit {
       const configName = params.name;
       this.configService.get(configName).subscribe((resp: ConfigFormModel) => {
         this.setResponse(resp);
+        this.loadingReady();
       });
     });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
@@ -1,9 +1,6 @@
-<cd-loading-panel *ngIf="loading"
-                  i18n>Loading...</cd-loading-panel>
-
-<div class="cd-col-form">
+<div class="cd-col-form"
+     *cdFormLoading="loading">
   <form name="hostForm"
-        *ngIf="!loading"
         #formDir="ngForm"
         [formGroup]="hostForm"
         novalidate>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
@@ -4,6 +4,7 @@ import { Router } from '@angular/router';
 import { I18n } from '@ngx-translate/i18n-polyfill';
 import { HostService } from '../../../../shared/api/host.service';
 import { ActionLabelsI18n, URLVerbs } from '../../../../shared/constants/app.constants';
+import { CdForm } from '../../../../shared/forms/cd-form';
 import { CdFormGroup } from '../../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../../shared/forms/cd-validators';
 import { FinishedTask } from '../../../../shared/models/finished-task';
@@ -14,11 +15,10 @@ import { TaskWrapperService } from '../../../../shared/services/task-wrapper.ser
   templateUrl: './host-form.component.html',
   styleUrls: ['./host-form.component.scss']
 })
-export class HostFormComponent implements OnInit {
+export class HostFormComponent extends CdForm implements OnInit {
   hostForm: CdFormGroup;
   action: string;
   resource: string;
-  loading = true;
   hostnames: string[];
 
   constructor(
@@ -28,6 +28,7 @@ export class HostFormComponent implements OnInit {
     private hostService: HostService,
     private taskWrapper: TaskWrapperService
   ) {
+    super();
     this.resource = this.i18n('host');
     this.action = this.actionLabels.CREATE;
     this.createForm();
@@ -38,7 +39,7 @@ export class HostFormComponent implements OnInit {
       this.hostnames = resp.map((host) => {
         return host['hostname'];
       });
-      this.loading = false;
+      this.loadingReady();
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.html
@@ -1,11 +1,5 @@
-<cd-loading-panel *ngIf="loading && !error"
-                  i18n>Loading configuration...</cd-loading-panel>
-<cd-alert-panel type="error"
-                *ngIf="loading && error"
-                i18n>The configuration could not be loaded.</cd-alert-panel>
-
 <div class="cd-col-form"
-     *ngIf="!loading && !error">
+     *cdFormLoading="loading">
   <form name="mgrModuleForm"
         #frm="ngForm"
         [formGroup]="mgrModuleForm"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.ts
@@ -8,6 +8,7 @@ import { forkJoin as observableForkJoin } from 'rxjs';
 
 import { MgrModuleService } from '../../../../shared/api/mgr-module.service';
 import { NotificationType } from '../../../../shared/enum/notification-type.enum';
+import { CdForm } from '../../../../shared/forms/cd-form';
 import { CdFormBuilder } from '../../../../shared/forms/cd-form-builder';
 import { CdFormGroup } from '../../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../../shared/forms/cd-validators';
@@ -18,10 +19,8 @@ import { NotificationService } from '../../../../shared/services/notification.se
   templateUrl: './mgr-module-form.component.html',
   styleUrls: ['./mgr-module-form.component.scss']
 })
-export class MgrModuleFormComponent implements OnInit {
+export class MgrModuleFormComponent extends CdForm implements OnInit {
   mgrModuleForm: CdFormGroup;
-  error = false;
-  loading = false;
   moduleName = '';
   moduleOptions: any[] = [];
 
@@ -32,27 +31,28 @@ export class MgrModuleFormComponent implements OnInit {
     private mgrModuleService: MgrModuleService,
     private notificationService: NotificationService,
     private i18n: I18n
-  ) {}
+  ) {
+    super();
+  }
 
   ngOnInit() {
     this.route.params.subscribe((params: { name: string }) => {
       this.moduleName = decodeURIComponent(params.name);
-      this.loading = true;
       const observables = [
         this.mgrModuleService.getOptions(this.moduleName),
         this.mgrModuleService.getConfig(this.moduleName)
       ];
       observableForkJoin(observables).subscribe(
         (resp: object) => {
-          this.loading = false;
           this.moduleOptions = resp[0];
           // Create the form dynamically.
           this.createForm();
           // Set the form field values.
           this.mgrModuleForm.setValue(resp[1]);
+          this.loadingReady();
         },
         (_error) => {
-          this.error = true;
+          this.loadingError();
         }
       );
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
@@ -1,6 +1,7 @@
 <cd-orchestrator-doc-panel *ngIf="!hasOrchestrator"></cd-orchestrator-doc-panel>
+
 <div class="cd-col-form"
-     *ngIf="!loading && hasOrchestrator">
+     *cdFormLoading="loading">
   <form name="form"
         #formDir="ngForm"
         [formGroup]="form"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
@@ -10,6 +10,7 @@ import { OrchestratorService } from '../../../../shared/api/orchestrator.service
 import { SubmitButtonComponent } from '../../../../shared/components/submit-button/submit-button.component';
 import { ActionLabelsI18n } from '../../../../shared/constants/app.constants';
 import { Icons } from '../../../../shared/enum/icons.enum';
+import { CdForm } from '../../../../shared/forms/cd-form';
 import { CdFormGroup } from '../../../../shared/forms/cd-form-group';
 import { CdTableColumn } from '../../../../shared/models/cd-table-column';
 import { AuthStorageService } from '../../../../shared/services/auth-storage.service';
@@ -26,7 +27,7 @@ import { OsdFeature } from './osd-feature.interface';
   templateUrl: './osd-form.component.html',
   styleUrls: ['./osd-form.component.scss']
 })
-export class OsdFormComponent implements OnInit {
+export class OsdFormComponent extends CdForm implements OnInit {
   @ViewChild('dataDeviceSelectionGroups', { static: false })
   dataDeviceSelectionGroups: OsdDevicesSelectionGroupsComponent;
 
@@ -44,7 +45,6 @@ export class OsdFormComponent implements OnInit {
   form: CdFormGroup;
   columns: Array<CdTableColumn> = [];
 
-  loading = false;
   allDevices: InventoryDevice[] = [];
 
   availDevices: InventoryDevice[] = [];
@@ -60,7 +60,7 @@ export class OsdFormComponent implements OnInit {
   features: { [key: string]: OsdFeature };
   featureList: OsdFeature[] = [];
 
-  hasOrchestrator = false;
+  hasOrchestrator = true;
   docsUrl: string;
 
   constructor(
@@ -71,6 +71,7 @@ export class OsdFormComponent implements OnInit {
     private router: Router,
     private bsModalService: BsModalService
   ) {
+    super();
     this.resource = this.i18n('OSDs');
     this.action = this.actionLabels.CREATE;
     this.features = {
@@ -86,8 +87,10 @@ export class OsdFormComponent implements OnInit {
   ngOnInit() {
     this.orchService.status().subscribe((status) => {
       this.hasOrchestrator = status.available;
-      if (this.hasOrchestrator) {
+      if (status.available) {
         this.getDataDevices();
+      } else {
+        this.loadingNone();
       }
     });
 
@@ -122,20 +125,16 @@ export class OsdFormComponent implements OnInit {
   }
 
   getDataDevices() {
-    if (this.loading) {
-      return;
-    }
-    this.loading = true;
     this.orchService.inventoryDeviceList().subscribe(
       (devices: InventoryDevice[]) => {
         this.allDevices = _.filter(devices, 'available');
         this.availDevices = [...this.allDevices];
-        this.loading = false;
+        this.loadingReady();
       },
       () => {
         this.allDevices = [];
         this.availDevices = [];
-        this.loading = false;
+        this.loadingError();
       }
     );
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -1,11 +1,5 @@
-<cd-loading-panel *ngIf="loading && !error"
-                  i18n>Loading configuration...</cd-loading-panel>
-<cd-alert-panel type="error"
-                *ngIf="loading && error"
-                i18n>The configuration could not be loaded.</cd-alert-panel>
-
 <div class="cd-col-form"
-     *ngIf="!loading && !error">
+     *cdFormLoading="loading">
   <ng-container [ngSwitch]="step">
     <!-- Configuration step -->
     <div *ngSwitchCase="1">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -4,12 +4,12 @@ import { Router } from '@angular/router';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
 import * as _ from 'lodash';
-import { BlockUI, NgBlockUI } from 'ng-block-ui';
 import { forkJoin as observableForkJoin } from 'rxjs';
 
 import { MgrModuleService } from '../../../shared/api/mgr-module.service';
 import { TelemetryService } from '../../../shared/api/telemetry.service';
 import { NotificationType } from '../../../shared/enum/notification-type.enum';
+import { CdForm } from '../../../shared/forms/cd-form';
 import { CdFormBuilder } from '../../../shared/forms/cd-form-builder';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
@@ -21,14 +21,9 @@ import { TextToDownloadService } from '../../../shared/services/text-to-download
   templateUrl: './telemetry.component.html',
   styleUrls: ['./telemetry.component.scss']
 })
-export class TelemetryComponent implements OnInit {
-  @BlockUI()
-  blockUI: NgBlockUI;
-
-  error = false;
+export class TelemetryComponent extends CdForm implements OnInit {
   configForm: CdFormGroup;
   licenseAgrmt = false;
-  loading = false;
   moduleEnabled: boolean;
   options: Object = {};
   previewForm: CdFormGroup;
@@ -54,10 +49,11 @@ export class TelemetryComponent implements OnInit {
     private telemetryService: TelemetryService,
     private i18n: I18n,
     private textToDownloadService: TextToDownloadService
-  ) {}
+  ) {
+    super();
+  }
 
   ngOnInit() {
-    this.loading = true;
     const observables = [
       this.mgrModuleService.getOptions('telemetry'),
       this.mgrModuleService.getConfig('telemetry')
@@ -69,10 +65,10 @@ export class TelemetryComponent implements OnInit {
         const configs = _.pick(resp[1], this.requiredFields);
         this.createConfigForm();
         this.configForm.setValue(configs);
-        this.loading = false;
+        this.loadingReady();
       },
       (_error) => {
-        this.error = true;
+        this.loadingError();
       }
     );
   }
@@ -120,17 +116,18 @@ export class TelemetryComponent implements OnInit {
   }
 
   private getReport() {
-    this.loading = true;
+    this.loadingStart();
+
     this.telemetryService.getReport().subscribe(
       (resp: object) => {
         this.report = resp;
         this.reportId = resp['report']['report_id'];
         this.createPreviewForm();
-        this.loading = false;
+        this.loadingReady();
         this.step++;
       },
       (_error) => {
-        this.error = true;
+        this.loadingError();
       }
     );
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -1,4 +1,5 @@
-<div class="cd-col-form">
+<div class="cd-col-form"
+     *cdFormLoading="loading">
   <form name="nfsForm"
         #formDir="ngForm"
         [formGroup]="nfsForm"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -13,6 +13,7 @@ import { SelectMessages } from '../../../shared/components/select/select-message
 import { SelectOption } from '../../../shared/components/select/select-option.model';
 import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { Icons } from '../../../shared/enum/icons.enum';
+import { CdForm } from '../../../shared/forms/cd-form';
 import { CdFormBuilder } from '../../../shared/forms/cd-form-builder';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
@@ -29,7 +30,7 @@ import { NfsFormClientComponent } from '../nfs-form-client/nfs-form-client.compo
   templateUrl: './nfs-form.component.html',
   styleUrls: ['./nfs-form.component.scss']
 })
-export class NfsFormComponent implements OnInit {
+export class NfsFormComponent extends CdForm implements OnInit {
   @ViewChild('nfsClients', { static: true })
   nfsClients: NfsFormClientComponent;
 
@@ -92,6 +93,7 @@ export class NfsFormComponent implements OnInit {
     private i18n: I18n,
     public actionLabels: ActionLabelsI18n
   ) {
+    super();
     this.permission = this.authStorageService.getPermissions().pool;
     this.resource = this.i18n('NFS export');
     this.createForm();
@@ -137,6 +139,8 @@ export class NfsFormComponent implements OnInit {
       if (data[4]) {
         this.resolveModel(data[4]);
       }
+
+      this.loadingReady();
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -1,9 +1,6 @@
-<cd-loading-panel *ngIf="!(info && ecProfiles)"
-                  i18n>Loading...</cd-loading-panel>
-
-<div class="cd-col-form">
+<div class="cd-col-form"
+     *cdFormLoading="loading">
   <form name="form"
-        *ngIf="info && ecProfiles"
         #formDir="ngForm"
         [formGroup]="form"
         novalidate>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -201,6 +201,8 @@ describe('PoolFormComponent', () => {
     navigationSpy = spyOn(router, 'navigate').and.stub();
 
     setUpPoolComponent();
+
+    component.loadingReady();
   });
 
   it('should create', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -16,6 +16,7 @@ import { CriticalConfirmationModalComponent } from '../../../shared/components/c
 import { SelectOption } from '../../../shared/components/select/select-option.model';
 import { ActionLabelsI18n, URLVerbs } from '../../../shared/constants/app.constants';
 import { Icons } from '../../../shared/enum/icons.enum';
+import { CdForm } from '../../../shared/forms/cd-form';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
 import {
@@ -51,7 +52,7 @@ interface FormFieldDescription {
   templateUrl: './pool-form.component.html',
   styleUrls: ['./pool-form.component.scss']
 })
-export class PoolFormComponent implements OnInit {
+export class PoolFormComponent extends CdForm implements OnInit {
   @ViewChild('crushInfoTabs', { static: false }) crushInfoTabs: TabsetComponent;
   @ViewChild('crushDeletionBtn', { static: false }) crushDeletionBtn: TooltipDirective;
   @ViewChild('ecpInfoTabs', { static: false }) ecpInfoTabs: TabsetComponent;
@@ -99,6 +100,7 @@ export class PoolFormComponent implements OnInit {
     private i18n: I18n,
     public actionLabels: ActionLabelsI18n
   ) {
+    super();
     this.editing = this.router.url.startsWith(`/pool/${URLVerbs.EDIT}`);
     this.action = this.editing ? this.actionLabels.EDIT : this.actionLabels.CREATE;
     this.resource = this.i18n('pool');
@@ -190,6 +192,7 @@ export class PoolFormComponent implements OnInit {
         this.initEditMode();
       } else {
         this.setAvailableApps();
+        this.loadingReady();
       }
       this.listenToChanges();
       this.setComplexValidators();
@@ -240,6 +243,7 @@ export class PoolFormComponent implements OnInit {
       this.poolService.get(param.name).subscribe((pool: Pool) => {
         this.data.pool = pool;
         this.initEditFormData(pool);
+        this.loadingReady();
       })
     );
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
@@ -1,8 +1,5 @@
-<cd-loading-panel *ngIf="editing && loading && !error"
-                  i18n>Loading bucket data...</cd-loading-panel>
-
 <div class="cd-col-form"
-     *ngIf="!loading && !error">
+     *cdFormLoading="loading">
   <form name="bucketForm"
         #frm="ngForm"
         [formGroup]="bucketForm"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
@@ -11,6 +11,7 @@ import { of as observableOf } from 'rxjs';
 import { configureTestBed, FormHelper, i18nProviders } from '../../../../testing/unit-test-helper';
 import { RgwBucketService } from '../../../shared/api/rgw-bucket.service';
 import { RgwSiteService } from '../../../shared/api/rgw-site.service';
+import { RgwUserService } from '../../../shared/api/rgw-user.service';
 import { NotificationType } from '../../../shared/enum/notification-type.enum';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { SharedModule } from '../../../shared/shared.module';
@@ -24,6 +25,7 @@ describe('RgwBucketFormComponent', () => {
   let rgwBucketService: RgwBucketService;
   let getPlacementTargetsSpy: jasmine.Spy;
   let rgwBucketServiceGetSpy: jasmine.Spy;
+  let enumerateSpy: jasmine.Spy;
   let formHelper: FormHelper;
 
   configureTestBed({
@@ -44,6 +46,7 @@ describe('RgwBucketFormComponent', () => {
     rgwBucketService = TestBed.get(RgwBucketService);
     rgwBucketServiceGetSpy = spyOn(rgwBucketService, 'get');
     getPlacementTargetsSpy = spyOn(TestBed.get(RgwSiteService), 'getPlacementTargets');
+    enumerateSpy = spyOn(TestBed.get(RgwUserService), 'enumerate');
     formHelper = new FormHelper(component.bucketForm);
   });
 
@@ -156,6 +159,7 @@ describe('RgwBucketFormComponent', () => {
         ]
       };
       getPlacementTargetsSpy.and.returnValue(observableOf(payload));
+      enumerateSpy.and.returnValue(observableOf([]));
       fixture.detectChanges();
 
       expect(component.zonegroup).toBe(payload.zonegroup);
@@ -226,6 +230,7 @@ describe('RgwBucketFormComponent', () => {
       component['route'].params = observableOf({ bid: 'bid' });
       component.editing = true;
       rgwBucketServiceGetSpy.and.returnValue(observableOf(fakeResponse));
+      enumerateSpy.and.returnValue(observableOf([]));
       component.ngOnInit();
       component.bucketForm.patchValue({
         versioning: versioningChecked,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
@@ -1,12 +1,5 @@
-<cd-loading-panel *ngIf="editing && loading && !error"
-                  i18n>Loading user data...</cd-loading-panel>
-<cd-alert-panel type="error"
-                *ngIf="editing && error"
-                (backAction)="goToListView()"
-                i18n>The user data could not be loaded.</cd-alert-panel>
-
 <div class="cd-col-form"
-     *ngIf="!loading && !error">
+     *cdFormLoading="loading">
   <form #frm="ngForm"
         [formGroup]="userForm"
         novalidate>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.html
@@ -1,4 +1,5 @@
-<div class="cd-col-form">
+<div class="cd-col-form"
+     *cdFormLoading="loading">
   <form name="roleForm"
         #formDir="ngForm"
         [formGroup]="roleForm"

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.ts
@@ -11,6 +11,7 @@ import { RoleService } from '../../../shared/api/role.service';
 import { ScopeService } from '../../../shared/api/scope.service';
 import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { NotificationType } from '../../../shared/enum/notification-type.enum';
+import { CdForm } from '../../../shared/forms/cd-form';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
@@ -23,7 +24,7 @@ import { RoleFormModel } from './role-form.model';
   templateUrl: './role-form.component.html',
   styleUrls: ['./role-form.component.scss']
 })
-export class RoleFormComponent implements OnInit {
+export class RoleFormComponent extends CdForm implements OnInit {
   @ViewChild('headerPermissionCheckboxTpl', { static: true })
   headerPermissionCheckboxTpl: TemplateRef<any>;
   @ViewChild('cellScopeCheckboxTpl', { static: true })
@@ -55,6 +56,7 @@ export class RoleFormComponent implements OnInit {
     private i18n: I18n,
     public actionLabels: ActionLabelsI18n
   ) {
+    super();
     this.resource = this.i18n('role');
     this.createForm();
     this.listenToChanges();
@@ -131,6 +133,8 @@ export class RoleFormComponent implements OnInit {
     this.scopeService.list().subscribe((scopes: Array<string>) => {
       this.scopes = scopes;
       this.roleForm.get('scopes_permissions').setValue({});
+
+      this.loadingReady();
     });
   }
 
@@ -147,6 +151,8 @@ export class RoleFormComponent implements OnInit {
         ['name', 'description', 'scopes_permissions'].forEach((key) =>
           this.roleForm.get(key).setValue(resp[1][key])
         );
+
+        this.loadingReady();
       });
     });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
@@ -1,11 +1,8 @@
-<cd-loading-panel *ngIf="!pwdExpirationSettings"
-                  i18n>Loading...</cd-loading-panel>
-
-<div class="cd-col-form">
+<div class="cd-col-form"
+     *cdFormLoading="loading">
   <form name="userForm"
         #formDir="ngForm"
         [formGroup]="userForm"
-        *ngIf="pwdExpirationSettings"
         novalidate>
     <div class="card">
       <div i18n="form title|Example: Create Pool@@formTitle"

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
@@ -16,6 +16,7 @@ import { SelectMessages } from '../../../shared/components/select/select-message
 import { ActionLabelsI18n } from '../../../shared/constants/app.constants';
 import { Icons } from '../../../shared/enum/icons.enum';
 import { NotificationType } from '../../../shared/enum/notification-type.enum';
+import { CdForm } from '../../../shared/forms/cd-form';
 import { CdFormBuilder } from '../../../shared/forms/cd-form-builder';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
@@ -32,7 +33,7 @@ import { UserFormModel } from './user-form.model';
   templateUrl: './user-form.component.html',
   styleUrls: ['./user-form.component.scss']
 })
-export class UserFormComponent implements OnInit {
+export class UserFormComponent extends CdForm implements OnInit {
   @ViewChild('removeSelfUserReadUpdatePermissionTpl', { static: true })
   removeSelfUserReadUpdatePermissionTpl: TemplateRef<any>;
 
@@ -73,6 +74,7 @@ export class UserFormComponent implements OnInit {
     private formBuilder: CdFormBuilder,
     private settingsService: SettingsService
   ) {
+    super();
     this.resource = this.i18n('user');
     this.createForm();
     this.messages = new SelectMessages({ empty: this.i18n('There are no roles.') }, this.i18n);
@@ -149,6 +151,8 @@ export class UserFormComponent implements OnInit {
             pwdExpirationDateField.setValue(expirationDate);
             pwdExpirationDateField.setValidators([Validators.required]);
           }
+
+          this.loadingReady();
         }
       }
     );
@@ -161,6 +165,8 @@ export class UserFormComponent implements OnInit {
       this.userService.get(username).subscribe((userFormModel: UserFormModel) => {
         this.response = _.cloneDeep(userFormModel);
         this.setResponse(userFormModel);
+
+        this.loadingReady();
       });
     });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/alert-panel/alert-panel.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/alert-panel/alert-panel.component.html
@@ -38,12 +38,3 @@
 <ng-template #content>
   <ng-content></ng-content>
 </ng-template>
-
-<div class="text-right"
-     *ngIf="backAction.observers.length > 0">
-  <button class="btn btn-light tc_backButton"
-          type="button"
-          (click)="backAction.emit()"
-          autofocus
-          i18n>Back</button>
-</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/alert-panel/alert-panel.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/alert-panel/alert-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { I18n } from '@ngx-translate/i18n-polyfill';
 import { Icons } from '../../enum/icons.enum';
 
@@ -12,8 +12,6 @@ export class AlertPanelComponent implements OnInit {
   title = '';
   @Input()
   bootstrapClass = '';
-  @Output()
-  backAction = new EventEmitter();
   @Input()
   type: 'warning' | 'error' | 'info' | 'success';
   @Input()

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.spec.ts
@@ -8,6 +8,8 @@ import { Observable, Subscriber, timer as observableTimer } from 'rxjs';
 
 import { configureTestBed, modalServiceShow } from '../../../../testing/unit-test-helper';
 import { DirectivesModule } from '../../directives/directives.module';
+import { AlertPanelComponent } from '../alert-panel/alert-panel.component';
+import { LoadingPanelComponent } from '../loading-panel/loading-panel.component';
 import { CriticalConfirmationModalComponent } from './critical-confirmation-modal.component';
 
 @NgModule({
@@ -94,7 +96,12 @@ describe('CriticalConfirmationModalComponent', () => {
   let fixture: ComponentFixture<CriticalConfirmationModalComponent>;
 
   configureTestBed({
-    declarations: [MockComponent, CriticalConfirmationModalComponent],
+    declarations: [
+      MockComponent,
+      CriticalConfirmationModalComponent,
+      LoadingPanelComponent,
+      AlertPanelComponent
+    ],
     schemas: [NO_ERRORS_SCHEMA],
     imports: [ModalModule.forRoot(), ReactiveFormsModule, MockModule, DirectivesModule],
     providers: [BsModalRef]

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/loading-panel/loading-panel.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/loading-panel/loading-panel.component.html
@@ -1,7 +1,8 @@
 <alert type="info">
   <strong>
     <i [ngClass]="[icons.spinner, icons.spin]"
-       aria-hidden="true"></i>
+       aria-hidden="true"
+       class="mr-2"></i>
   </strong>
   <ng-content></ng-content>
 </alert>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/directives.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/directives.module.ts
@@ -1,9 +1,12 @@
 import { NgModule } from '@angular/core';
 
+import { AlertPanelComponent } from '../components/alert-panel/alert-panel.component';
+import { LoadingPanelComponent } from '../components/loading-panel/loading-panel.component';
 import { AutofocusDirective } from './autofocus.directive';
 import { Copy2ClipboardButtonDirective } from './copy2clipboard-button.directive';
 import { DimlessBinaryPerSecondDirective } from './dimless-binary-per-second.directive';
 import { DimlessBinaryDirective } from './dimless-binary.directive';
+import { FormLoadingDirective } from './form-loading.directive';
 import { IopsDirective } from './iops.directive';
 import { MillisecondsDirective } from './milliseconds.directive';
 import { PasswordButtonDirective } from './password-button.directive';
@@ -19,7 +22,8 @@ import { TrimDirective } from './trim.directive';
     PasswordButtonDirective,
     TrimDirective,
     MillisecondsDirective,
-    IopsDirective
+    IopsDirective,
+    FormLoadingDirective
   ],
   exports: [
     AutofocusDirective,
@@ -29,8 +33,10 @@ import { TrimDirective } from './trim.directive';
     PasswordButtonDirective,
     TrimDirective,
     MillisecondsDirective,
-    IopsDirective
+    IopsDirective,
+    FormLoadingDirective
   ],
-  providers: []
+  providers: [],
+  entryComponents: [LoadingPanelComponent, AlertPanelComponent]
 })
 export class DirectivesModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/form-loading.directive.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/form-loading.directive.spec.ts
@@ -1,0 +1,85 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { AlertModule } from 'ngx-bootstrap/alert';
+
+import { configureTestBed, i18nProviders } from '../../../testing/unit-test-helper';
+import { CdForm } from '../forms/cd-form';
+import { SharedModule } from '../shared.module';
+import { FormLoadingDirective } from './form-loading.directive';
+
+@Component({ selector: 'cd-test-cmp', template: '<span *cdFormLoading="loading">foo</span>' })
+class TestComponent extends CdForm {
+  constructor() {
+    super();
+  }
+}
+
+describe('FormLoadingDirective', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<any>;
+
+  const expectShown = (elem: number, error: number, loading: number) => {
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(elem);
+    expect(fixture.debugElement.queryAll(By.css('cd-alert-panel')).length).toEqual(error);
+    expect(fixture.debugElement.queryAll(By.css('cd-loading-panel')).length).toEqual(loading);
+  };
+
+  configureTestBed({
+    declarations: [TestComponent],
+    imports: [AlertModule.forRoot(), SharedModule],
+    providers: [i18nProviders]
+  });
+
+  afterEach(() => {
+    fixture = null;
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create an instance', () => {
+    const directive = new FormLoadingDirective(null, null, null, null);
+    expect(directive).toBeTruthy();
+  });
+
+  it('should show loading component by default', () => {
+    expectShown(0, 0, 1);
+
+    const alert = fixture.debugElement.nativeElement.querySelector('cd-loading-panel alert');
+    expect(alert.textContent).toBe('Loading form data...');
+  });
+
+  it('should show error component when calling loadingError()', () => {
+    component.loadingError();
+    fixture.detectChanges();
+
+    expectShown(0, 1, 0);
+
+    const alert = fixture.debugElement.nativeElement.querySelector(
+      'cd-alert-panel .alert-panel-text'
+    );
+    expect(alert.textContent).toBe('Form data could not be loaded.');
+  });
+
+  it('should show original component when calling loadingReady()', () => {
+    component.loadingReady();
+    fixture.detectChanges();
+
+    expectShown(1, 0, 0);
+
+    const alert = fixture.debugElement.nativeElement.querySelector('span');
+    expect(alert.textContent).toBe('foo');
+  });
+
+  it('should show nothing when calling loadingNone()', () => {
+    component.loadingNone();
+    fixture.detectChanges();
+
+    expectShown(0, 0, 0);
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/form-loading.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/form-loading.directive.ts
@@ -1,0 +1,54 @@
+import {
+  ComponentFactoryResolver,
+  Directive,
+  Input,
+  TemplateRef,
+  ViewContainerRef
+} from '@angular/core';
+
+import { I18n } from '@ngx-translate/i18n-polyfill';
+
+import { AlertPanelComponent } from '../components/alert-panel/alert-panel.component';
+import { LoadingPanelComponent } from '../components/loading-panel/loading-panel.component';
+import { LoadingStatus } from '../forms/cd-form';
+
+@Directive({
+  selector: '[cdFormLoading]'
+})
+export class FormLoadingDirective {
+  constructor(
+    private templateRef: TemplateRef<any>,
+    private viewContainer: ViewContainerRef,
+    private componentFactoryResolver: ComponentFactoryResolver,
+    private i18n: I18n
+  ) {}
+
+  @Input('cdFormLoading') set cdFormLoading(condition: LoadingStatus) {
+    let factory: any;
+    let content: any;
+
+    this.viewContainer.clear();
+
+    switch (condition) {
+      case LoadingStatus.Loading:
+        factory = this.componentFactoryResolver.resolveComponentFactory(LoadingPanelComponent);
+        content = this.resolveNgContent(this.i18n(`Loading form data...`));
+        this.viewContainer.createComponent(factory, null, null, content);
+        break;
+      case LoadingStatus.Ready:
+        this.viewContainer.createEmbeddedView(this.templateRef);
+        break;
+      case LoadingStatus.Error:
+        factory = this.componentFactoryResolver.resolveComponentFactory(AlertPanelComponent);
+        content = this.resolveNgContent(this.i18n(`Form data could not be loaded.`));
+        const componentRef = this.viewContainer.createComponent(factory, null, null, content);
+        (<AlertPanelComponent>componentRef.instance).type = 'error';
+        break;
+    }
+  }
+
+  resolveNgContent(content: string) {
+    const element = document.createTextNode(content);
+    return [[element]];
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form.spec.ts
@@ -1,0 +1,32 @@
+import { CdForm, LoadingStatus } from './cd-form';
+
+describe('CdForm', () => {
+  let form: CdForm;
+
+  beforeEach(() => {
+    form = new CdForm();
+  });
+
+  describe('loading', () => {
+    it('should start in loading state', () => {
+      expect(form.loading).toBe(LoadingStatus.Loading);
+    });
+
+    it('should change to ready when calling loadingReady', () => {
+      form.loadingReady();
+      expect(form.loading).toBe(LoadingStatus.Ready);
+    });
+
+    it('should change to error state calling loadingError', () => {
+      form.loadingError();
+      expect(form.loading).toBe(LoadingStatus.Error);
+    });
+
+    it('should change to loading state calling loadingStart', () => {
+      form.loadingError();
+      expect(form.loading).toBe(LoadingStatus.Error);
+      form.loadingStart();
+      expect(form.loading).toBe(LoadingStatus.Loading);
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form.ts
@@ -1,0 +1,26 @@
+export enum LoadingStatus {
+  Loading,
+  Ready,
+  Error,
+  None
+}
+
+export class CdForm {
+  loading = LoadingStatus.Loading;
+
+  loadingStart() {
+    this.loading = LoadingStatus.Loading;
+  }
+
+  loadingReady() {
+    this.loading = LoadingStatus.Ready;
+  }
+
+  loadingError() {
+    this.loading = LoadingStatus.Error;
+  }
+
+  loadingNone() {
+    this.loading = LoadingStatus.None;
+  }
+}


### PR DESCRIPTION
Add directive to handle the display of the form.
It will display the form only when loading is finished.
Otherwise it will show a loading message or error message.

Add a new class that should be extended by all form components.
For now it only has methods for dealing with loading,
but this could be improved later.

Fixes: https://tracker.ceph.com/issues/44912

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
