### PR TITLE
qa/workunits/rbd: retry the addition of a mirror pool peer

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -248,9 +248,11 @@ peer_add()
     local peer_uuid
 
     for s in 1 2 4 8 16 32; do
+        set +e
         peer_uuid=$(rbd --cluster ${cluster} mirror pool peer add \
             ${pool} ${client_cluster} $@)
         error_code=$?
+        set -e
 
         if [ $error_code -eq 17 ]; then
             # raced with a remote heartbeat ping -- remove and retry

--- a/qa/workunits/rbd/rbd_mirror_journal.sh
+++ b/qa/workunits/rbd/rbd_mirror_journal.sh
@@ -349,8 +349,8 @@ for cluster in ${CLUSTER1} ${CLUSTER2}; do
     CEPH_ARGS='' rbd --cluster ${cluster} pool init ${pool}
     rbd --cluster ${cluster} mirror pool enable ${pool} pool
 done
-rbd --cluster ${CLUSTER1} mirror pool peer add ${pool} ${CLUSTER2}
-rbd --cluster ${CLUSTER2} mirror pool peer add ${pool} ${CLUSTER1}
+peer_add ${CLUSTER1} ${pool} ${CLUSTER2}
+peer_add ${CLUSTER2} ${pool} ${CLUSTER1}
 rdp_image=test_remove_data_pool
 create_image ${CLUSTER2} ${pool} ${image} 128
 create_image ${CLUSTER2} ${POOL} ${rdp_image} 128 --data-pool ${pool}


### PR DESCRIPTION
fb4311f5 has fixed this for setup, but "remove mirroring pool"
test needs fixing too.

Fixes: https://tracker.ceph.com/issues/44938
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
