### PR TITLE
rbd/cache: Replicated Write Log core codes - aio_discard

### DIFF
--- a/src/librbd/cache/ReplicatedWriteLog.h
+++ b/src/librbd/cache/ReplicatedWriteLog.h
@@ -96,6 +96,8 @@ public:
   using C_WriteRequestT = rwl::C_WriteRequest<This>;
   using C_BlockIORequestT = rwl::C_BlockIORequest<This>;
   using C_FlushRequestT = rwl::C_FlushRequest<This>;
+  using C_DiscardRequestT = rwl::C_DiscardRequest<This>;
+
   CephContext * get_context();
   void release_guarded_request(BlockGuardCell *cell);
   void release_write_lanes(C_BlockIORequestT *req);

--- a/src/librbd/cache/rwl/LogOperation.cc
+++ b/src/librbd/cache/rwl/LogOperation.cc
@@ -266,6 +266,49 @@ std::ostream &operator<<(std::ostream &os,
   return os;
 };
 
+DiscardLogOperation::DiscardLogOperation(std::shared_ptr<SyncPoint> sync_point,
+                                         const uint64_t image_offset_bytes,
+                                         const uint64_t write_bytes,
+                                         uint32_t discard_granularity_bytes,
+                                         const utime_t dispatch_time,
+                                         PerfCounters *perfcounter,
+                                         CephContext *cct)
+  : GenericWriteLogOperation(sync_point, dispatch_time, perfcounter, cct),
+    log_entry(std::make_shared<DiscardLogEntry>(sync_point->log_entry,
+                                                image_offset_bytes,
+                                                write_bytes,
+                                                discard_granularity_bytes)) {
+  on_write_append = sync_point->prior_persisted_gather_new_sub();
+  on_write_persist = nullptr;
+  log_entry->sync_point_entry->writes++;
+  log_entry->sync_point_entry->bytes += write_bytes;
+}
+
+DiscardLogOperation::~DiscardLogOperation() { }
+
+void DiscardLogOperation::init(uint64_t current_sync_gen, bool persist_on_flush,
+                               uint64_t last_op_sequence_num, Context *write_persist) {
+  log_entry->init(current_sync_gen, persist_on_flush, last_op_sequence_num);
+  this->on_write_persist = write_persist;
+}
+
+std::ostream &DiscardLogOperation::format(std::ostream &os) const {
+  os << "(Discard) ";
+  GenericWriteLogOperation::format(os);
+  os << ", ";
+  if (log_entry) {
+    os << "log_entry=[" << *log_entry << "], ";
+  } else {
+    os << "log_entry=nullptr, ";
+  }
+  return os;
+};
+
+std::ostream &operator<<(std::ostream &os,
+                         const DiscardLogOperation &op) {
+  return op.format(os);
+}
+
 } // namespace rwl
 } // namespace cache
 } // namespace librbd

--- a/src/librbd/cache/rwl/LogOperation.h
+++ b/src/librbd/cache/rwl/LogOperation.h
@@ -47,7 +47,10 @@ public:
   virtual void appending() = 0;
   virtual void complete(int r) = 0;
   virtual void mark_log_entry_completed() {};
-  virtual bool reserved_allocated() {
+  virtual bool reserved_allocated() const {
+    return false;
+  }
+  virtual bool is_writing_op() const {
     return false;
   }
   virtual void copy_bl_to_pmem_buffer() {};
@@ -105,7 +108,10 @@ public:
   void mark_log_entry_completed() override{
     sync_point->log_entry->writes_completed++;
   }
-  bool reserved_allocated() override {
+  bool reserved_allocated() const override {
+    return true;
+  }
+  bool is_writing_op() const override {
     return true;
   }
   void appending() override;
@@ -164,6 +170,36 @@ public:
   WriteLogOperationSet &operator=(const WriteLogOperationSet&) = delete;
   friend std::ostream &operator<<(std::ostream &os,
                                   const WriteLogOperationSet &s);
+};
+
+class DiscardLogOperation : public GenericWriteLogOperation {
+public:
+  using GenericWriteLogOperation::m_lock;
+  using GenericWriteLogOperation::sync_point;
+  using GenericWriteLogOperation::on_write_append;
+  using GenericWriteLogOperation::on_write_persist;
+  std::shared_ptr<DiscardLogEntry> log_entry;
+  DiscardLogOperation(std::shared_ptr<SyncPoint> sync_point,
+                      const uint64_t image_offset_bytes,
+                      const uint64_t write_bytes,
+                      uint32_t discard_granularity_bytes,
+                      const utime_t dispatch_time,
+                      PerfCounters *perfcounter,
+                      CephContext *cct);
+  ~DiscardLogOperation() override;
+  DiscardLogOperation(const DiscardLogOperation&) = delete;
+  DiscardLogOperation &operator=(const DiscardLogOperation&) = delete;
+  const std::shared_ptr<GenericLogEntry> get_log_entry() override {
+    return log_entry;
+  }
+  bool reserved_allocated() const override {
+    return false;
+  }
+  void init(uint64_t current_sync_gen, bool persist_on_flush,
+            uint64_t last_op_sequence_num, Context *write_persist);
+  std::ostream &format(std::ostream &os) const;
+  friend std::ostream &operator<<(std::ostream &os,
+                                  const DiscardLogOperation &op);
 };
 
 } // namespace rwl

--- a/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc
+++ b/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc
@@ -485,5 +485,49 @@ TEST_F(TestMockCacheReplicatedWriteLog, aio_read_miss_rwl_cache) {
   ASSERT_EQ(0, finish_ctx3.wait());
 }
 
+TEST_F(TestMockCacheReplicatedWriteLog, aio_discard) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockImageCtx mock_image_ctx(*ictx);
+  MockReplicatedWriteLog rwl(mock_image_ctx, get_cache_state(mock_image_ctx));
+  expect_op_work_queue(mock_image_ctx);
+  expect_metadata_set(mock_image_ctx);
+
+  MockContextRWL finish_ctx1;
+  expect_context_complete(finish_ctx1, 0);
+  rwl.init(&finish_ctx1);
+  ASSERT_EQ(0, finish_ctx1.wait());
+
+  MockContextRWL finish_ctx2;
+  expect_context_complete(finish_ctx2, 0);
+  Extents image_extents{{0, 4096}};
+  bufferlist bl;
+  bl.append(std::string(4096, '1'));
+  bufferlist bl_copy = bl;
+  int fadvise_flags = 0;
+  rwl.aio_write(std::move(image_extents), std::move(bl), fadvise_flags, &finish_ctx2);
+  ASSERT_EQ(0, finish_ctx2.wait());
+
+  MockContextRWL finish_ctx_discard;
+  expect_context_complete(finish_ctx_discard, 0);
+  rwl.aio_discard(0, 4096, 1, &finish_ctx_discard);
+  ASSERT_EQ(0, finish_ctx_discard.wait());
+
+  MockContextRWL finish_ctx_read;
+  bufferlist read_bl;
+  expect_context_complete(finish_ctx_read, 0);
+  rwl.aio_read({{0, 4096}}, &read_bl, fadvise_flags, &finish_ctx_read);
+  ASSERT_EQ(0, finish_ctx_read.wait());
+  ASSERT_EQ(4096, read_bl.length());
+  ASSERT_TRUE(read_bl.is_zero());
+
+  MockContextRWL finish_ctx3;
+  expect_context_complete(finish_ctx3, 0);
+  rwl.shut_down(&finish_ctx3);
+
+  ASSERT_EQ(0, finish_ctx3.wait());
+}
+
 } // namespace cache
 } // namespace librbd


### PR DESCRIPTION
Adds Replicated Write Log, a persistent, write back cache for Ceph RBD.
Implements: http://tracker.ceph.com/projects/ceph/wiki/Rbd_-_ordered_crash-consistent_write-back_caching_extension

Trello: https://trello.com/c/QnsQaGTn

[Obsoletes https://github.com//pull/29087]

The PR 29087 is split into smaller PRs to make review easier.
The first PR: #31279
The second PR: #31963
The 3rd PR: #33502
The 4th PR: #34430
The 5th PR: #34699
The 6th PR: #34706 

This is the 7th PR (aio_discard) which defines the following parts:
librbd: add DiscardLogEntry
librbd: add DiscardLogOperation
librbd: add DiscardRequest
librbd: add aio_discard
librbd: add aio_discard test case

Signed-off-by: Scott Peterson scott.d.peterson@intel.com
Signed-off-by: Lisa Li xiaoyan.li@intel.com
Signed-off-by: Yuan Lu yuan.y.lu@intel.com
Signed-off-by: Mahati Chamarthy mahati.chamarthy@intel.com

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
