### PR TITLE
octopus: mgr/dashboard: fix API tests to be py3 compatible

### DIFF
--- a/qa/tasks/mgr/dashboard/test_perf_counters.py
+++ b/qa/tasks/mgr/dashboard/test_perf_counters.py
@@ -39,7 +39,7 @@ class PerfCountersControllerTest(DashboardTestCase):
         self._validate_perf(mon, 'mon', data, allow_empty=False)
 
     def test_perf_counters_mgr_get(self):
-        mgr = self.mgr_cluster.mgr_ids[0]
+        mgr = list(self.mgr_cluster.mgr_ids)[0]
         data = self._get('/api/perf_counters/mgr/{}'.format(mgr))
         self.assertStatus(200)
         self._validate_perf(mgr, 'mgr', data, allow_empty=False)

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -30,6 +30,7 @@ Alternative usage:
 
 """
 
+from six import StringIO
 from io import BytesIO
 from collections import defaultdict
 import getpass
@@ -935,7 +936,7 @@ class LocalCephManager(CephManager):
         if watch_channel is not None:
             args.append("--watch-channel")
             args.append(watch_channel)
-        proc = self.controller.run(args=args, wait=False, stdout=BytesIO())
+        proc = self.controller.run(args=args, wait=False, stdout=StringIO())
         return proc
 
     def raw_cluster_cmd(self, *args, **kwargs):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45280

---

backport of https://github.com/ceph/ceph/pull/34752
parent tracker: https://tracker.ceph.com/issues/45246

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh