### PR TITLE
octopus: mgr/dashboard: Fix ServiceDetails and PoolDetails unit tests

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-details/service-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-details/service-details.component.spec.ts
@@ -1,11 +1,14 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
-import { CoreModule } from '../../../../core/core.module';
 import { CdTableSelection } from '../../../../shared/models/cd-table-selection';
+import { SummaryService } from '../../../../shared/services/summary.service';
 import { SharedModule } from '../../../../shared/shared.module';
-import { CephModule } from '../../../ceph.module';
+import { ServiceDaemonListComponent } from '../service-daemon-list/service-daemon-list.component';
 import { ServiceDetailsComponent } from './service-details.component';
 
 describe('ServiceDetailsComponent', () => {
@@ -13,19 +16,19 @@ describe('ServiceDetailsComponent', () => {
   let fixture: ComponentFixture<ServiceDetailsComponent>;
 
   configureTestBed({
-    imports: [HttpClientTestingModule, CephModule, CoreModule, SharedModule],
-    declarations: [],
-    providers: [i18nProviders]
+    imports: [HttpClientTestingModule, RouterTestingModule, TabsModule.forRoot(), SharedModule],
+    declarations: [ServiceDetailsComponent, ServiceDaemonListComponent],
+    providers: [i18nProviders, { provide: SummaryService, useValue: { subscribe: jest.fn() } }]
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ServiceDetailsComponent);
     component = fixture.componentInstance;
     component.selection = new CdTableSelection();
-    fixture.detectChanges();
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.spec.ts
@@ -1,11 +1,14 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { TabsetComponent, TabsModule } from 'ngx-bootstrap/tabs';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
-import { AppModule } from '../../../app.module';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { Permissions } from '../../../shared/models/permissions';
+import { SharedModule } from '../../../shared/shared.module';
 import { RbdConfigurationListComponent } from '../../block/rbd-configuration-list/rbd-configuration-list.component';
 import { PoolDetailsComponent } from './pool-details.component';
 
@@ -14,7 +17,13 @@ describe('PoolDetailsComponent', () => {
   let fixture: ComponentFixture<PoolDetailsComponent>;
 
   configureTestBed({
-    imports: [TabsModule.forRoot(), AppModule],
+    imports: [
+      BrowserAnimationsModule,
+      TabsModule.forRoot(),
+      SharedModule,
+      HttpClientTestingModule,
+      RouterTestingModule
+    ],
     declarations: [PoolDetailsComponent, RbdConfigurationListComponent],
     providers: [i18nProviders]
   });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45281

---

backport of https://github.com/ceph/ceph/pull/34312
parent tracker: https://tracker.ceph.com/issues/42929

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh