### PR TITLE
mgr/dashboard: get fresh inventory data from orchestrator

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/orchestrator.py
+++ b/src/pybind/mgr/dashboard/controllers/orchestrator.py
@@ -11,7 +11,7 @@ from ..exceptions import DashboardException
 from ..security import Scope
 from ..services.exception import handle_orchestrator_error
 from ..services.orchestrator import OrchClient
-from ..tools import TaskManager, wraps
+from ..tools import TaskManager, wraps, str_to_bool
 
 
 def get_device_osd_map():
@@ -102,10 +102,13 @@ class Orchestrator(RESTController):
 class OrchestratorInventory(RESTController):
 
     @raise_if_no_orchestrator
-    def list(self, hostname=None):
+    def list(self, hostname=None, refresh=None):
         orch = OrchClient.instance()
         hosts = [hostname] if hostname else None
-        inventory_hosts = [host.to_json() for host in orch.inventory.list(hosts)]
+        do_refresh = False
+        if refresh is not None:
+            do_refresh = str_to_bool(refresh)
+        inventory_hosts = [host.to_json() for host in orch.inventory.list(hosts, do_refresh)]
         device_osd_map = get_device_osd_map()
         for inventory_host in inventory_hosts:
             host_osds = device_osd_map.get(inventory_host['name'])

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.spec.ts
@@ -46,13 +46,13 @@ describe('InventoryComponent', () => {
   describe('after ngOnInit', () => {
     it('should load devices', () => {
       fixture.detectChanges();
-      expect(orchService.inventoryDeviceList).toHaveBeenCalledWith(undefined);
+      expect(orchService.inventoryDeviceList).toHaveBeenCalledWith(undefined, true);
     });
 
     it('should load devices for a host', () => {
       component.hostname = 'host0';
       fixture.detectChanges();
-      expect(orchService.inventoryDeviceList).toHaveBeenCalledWith('host0');
+      expect(orchService.inventoryDeviceList).toHaveBeenCalledWith('host0', true);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.ts
@@ -16,8 +16,6 @@ export class InventoryComponent implements OnChanges, OnInit {
   icons = Icons;
 
   hasOrchestrator = false;
-  docsUrl: string;
-
   devices: Array<InventoryDevice> = [];
 
   constructor(private orchService: OrchestratorService) {}
@@ -25,9 +23,6 @@ export class InventoryComponent implements OnChanges, OnInit {
   ngOnInit() {
     this.orchService.status().subscribe((status) => {
       this.hasOrchestrator = status.available;
-      if (status.available) {
-        this.getInventory();
-      }
     });
   }
 
@@ -42,7 +37,7 @@ export class InventoryComponent implements OnChanges, OnInit {
     if (this.hostname === '') {
       return;
     }
-    this.orchService.inventoryDeviceList(this.hostname).subscribe(
+    this.orchService.inventoryDeviceList(this.hostname, true).subscribe(
       (devices: InventoryDevice[]) => {
         this.devices = devices;
       },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.html
@@ -22,6 +22,8 @@
               [disabled]="availDevices.length === 0 || !canSelect">
         <i [ngClass]="[icons.add]"></i>
         <ng-container i18n>Add</ng-container>
+        <i *ngIf="loading"
+           [ngClass]="[icons.spinner, icons.spin]"></i>
       </button>
     </ng-container>
     <ng-template #blockClearDevices>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.ts
@@ -29,6 +29,8 @@ export class OsdDevicesSelectionGroupsComponent implements OnInit, OnChanges {
 
   @Input() canSelect: boolean;
 
+  @Input() loading = false;
+
   @Output()
   selected = new EventEmitter<DevicesSelectionChangeEvent>();
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
@@ -1,6 +1,6 @@
 <cd-orchestrator-doc-panel *ngIf="!hasOrchestrator"></cd-orchestrator-doc-panel>
 <div class="cd-col-form"
-     *ngIf="!loading && hasOrchestrator">
+     *ngIf="hasOrchestrator">
   <form name="form"
         #formDir="ngForm"
         [formGroup]="form"
@@ -15,6 +15,7 @@
                                            type="data"
                                            [availDevices]="availDevices"
                                            [canSelect]="availDevices.length !== 0"
+                                           [loading]="loading"
                                            (selected)="onDevicesSelected($event)"
                                            (cleared)="onDevicesCleared($event)">
           </cd-osd-devices-selection-groups>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
@@ -126,7 +126,7 @@ export class OsdFormComponent implements OnInit {
       return;
     }
     this.loading = true;
-    this.orchService.inventoryDeviceList().subscribe(
+    this.orchService.inventoryDeviceList(undefined, true).subscribe(
       (devices: InventoryDevice[]) => {
         this.allDevices = _.filter(devices, 'available');
         this.availDevices = [...this.allDevices];

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.ts
@@ -29,13 +29,19 @@ export class OrchestratorService {
     });
   }
 
-  inventoryList(hostname?: string): Observable<InventoryHost[]> {
-    const options = hostname ? { params: new HttpParams().set('hostname', hostname) } : {};
-    return this.http.get<InventoryHost[]>(`${this.url}/inventory`, options);
+  inventoryList(hostname?: string, refresh?: boolean): Observable<InventoryHost[]> {
+    let params = new HttpParams();
+    if (hostname) {
+      params = params.append('hostname', hostname);
+    }
+    if (refresh) {
+      params = params.append('refresh', _.toString(refresh));
+    }
+    return this.http.get<InventoryHost[]>(`${this.url}/inventory`, { params: params });
   }
 
-  inventoryDeviceList(hostname?: string): Observable<InventoryDevice[]> {
-    return this.inventoryList(hostname).pipe(
+  inventoryDeviceList(hostname?: string, refresh?: boolean): Observable<InventoryDevice[]> {
+    return this.inventoryList(hostname, refresh).pipe(
       mergeMap((hosts: InventoryHost[]) => {
         const devices = _.flatMap(hosts, (host) => {
           return host.devices.map((device) => {


### PR DESCRIPTION
Getting inventory data with `refresh` flag on. This is a
time-consuming call, but it's acceptable since auto-reload is not
enabled on inventory tables.

Changes:
- Inventory page/tab: fresh data are returned on initial loading and
  every manual refresh.
- OSD create form: get fresh inventory before creating OSDs.

Fixes: https://tracker.ceph.com/issues/44803
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

## Screenshot
In OSD creation form, a spin is displayed when loading inventory:
![osd-create-form](https://user-images.githubusercontent.com/1691518/80353818-82e2b400-88a8-11ea-89ed-bff76d22e20f.gif)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst



-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
