### PR TITLE
octopus: ceph-fuse: link to libfuse3 and pass `-o big_writes` to libfuse if libfuse < 3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ endif()
 
 option(WITH_FUSE "Fuse is here" ON)
 if(WITH_FUSE)
-  find_package(fuse)
+  find_package(FUSE)
   set(HAVE_LIBFUSE ${FUSE_FOUND})
 endif()
 

--- a/cmake/modules/FindFUSE.cmake
+++ b/cmake/modules/FindFUSE.cmake
@@ -6,8 +6,13 @@
 # - FUSE_LIBRARIES : FUSE library
 # - FUSE_VERSION : the version of the FUSE library found
 
-set(fuse_names fuse)
-set(fuse_suffixes fuse)
+if(PACKAGE_FIND_VERSION AND PACKAGE_FIND_VERSION VERSION_LESS "3.0")
+  set(fuse_names fuse)
+  set(fuse_suffixes fuse)
+else()
+  set(fuse_names fuse3 fuse)
+  set(fuse_suffixes fuse3 fuse)
+endif()
 
 if(APPLE)
   list(APPEND fuse_names libosxfuse.dylib)

--- a/cmake/modules/FindFUSE.cmake
+++ b/cmake/modules/FindFUSE.cmake
@@ -21,7 +21,7 @@ find_library(FUSE_LIBRARIES
   PATHS /usr/local/lib64 /usr/local/lib)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(fuse DEFAULT_MSG
+find_package_handle_standard_args(FUSE DEFAULT_MSG
   FUSE_INCLUDE_DIRS FUSE_LIBRARIES)
 
 mark_as_advanced(

--- a/cmake/modules/FindFUSE.cmake
+++ b/cmake/modules/FindFUSE.cmake
@@ -26,3 +26,14 @@ find_package_handle_standard_args(FUSE DEFAULT_MSG
 
 mark_as_advanced(
   FUSE_INCLUDE_DIRS FUSE_LIBRARIES)
+
+if(FUSE_FOUND)
+  if(NOT TARGET FUSE::FUSE)
+    add_library(FUSE::FUSE UNKNOWN IMPORTED)
+    set_target_properties(FUSE::FUSE PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${FUSE_INCLUDE_DIRS}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${FUSE_LIBRARIES}"
+      VERSION "${FUSE_VERSION}")
+  endif()
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -552,7 +552,7 @@ add_dependencies(ceph-osd erasure_code_plugins)
 target_link_libraries(ceph-osd osd os global-static common
   ${BLKID_LIBRARIES})
 if(WITH_FUSE)
-  target_link_libraries(ceph-osd ${FUSE_LIBRARIES})
+  target_link_libraries(ceph-osd FUSE::FUSE)
 endif()
 set_target_properties(ceph-osd PROPERTIES
   POSITION_INDEPENDENT_CODE ${EXE_LINKER_USE_PIE}
@@ -705,10 +705,9 @@ if(WITH_FUSE)
     ceph_fuse.cc
     client/fuse_ll.cc)
   add_executable(ceph-fuse ${ceph_fuse_srcs})
-  target_link_libraries(ceph-fuse ${FUSE_LIBRARIES}
+  target_link_libraries(ceph-fuse FUSE::FUSE
     ${GSSAPI_LIBRARIES} client ceph-common global-static ${EXTRALIBS})
   set_target_properties(ceph-fuse PROPERTIES
-    COMPILE_FLAGS "-I${FUSE_INCLUDE_DIRS}"
     POSITION_INDEPENDENT_CODE ${EXE_LINKER_USE_PIE})
   install(TARGETS ceph-fuse DESTINATION bin)
   install(PROGRAMS mount.fuse.ceph DESTINATION ${CMAKE_INSTALL_SBINDIR})

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -41,6 +41,7 @@
 #include <fcntl.h>
 
 #include <fuse.h>
+#include <fuse_lowlevel.h>
 
 #define dout_context g_ceph_context
 
@@ -51,7 +52,12 @@ static void fuse_usage()
     "-h",
   };
   struct fuse_args args = FUSE_ARGS_INIT(2, (char**)argv);
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  struct fuse_cmdline_opts opts = {};
+  if (fuse_parse_cmdline(&args, &opts) == -1) {
+#else
   if (fuse_parse_cmdline(&args, nullptr, nullptr, nullptr) == -1) {
+#endif
     derr << "fuse_parse_cmdline failed." << dendl;
   }
   ceph_assert(args.allocated);
@@ -105,7 +111,12 @@ int main(int argc, const char **argv, const char *envp[]) {
       };
 
       struct fuse_args fargs = FUSE_ARGS_INIT(2, (char**)tmpargv);
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+      struct fuse_cmdline_opts opts = {};
+      if (fuse_parse_cmdline(&fargs, &opts) == -1) {
+#else
       if (fuse_parse_cmdline(&fargs, nullptr, nullptr, nullptr) == -1) {
+#endif
        derr << "fuse_parse_cmdline failed." << dendl;
       }
       ceph_assert(fargs.allocated);

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -941,7 +941,7 @@ static int remount_cb(void *handle)
   // trims all unused dentries in the file system
   char cmd[128+PATH_MAX];
   CephFuse::Handle *cfuse = (CephFuse::Handle *)handle;
-  snprintf(cmd, sizeof(cmd), "mount -i -o remount %s", cfuse->mountpoint);
+  snprintf(cmd, sizeof(cmd), "LIBMOUNT_FSTAB=/dev/null mount -i -o remount %s", cfuse->mountpoint);
   int r = system(cmd);
   if (r != 0 && r != -1) {
     r = WEXITSTATUS(r);

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -85,9 +85,13 @@ public:
   int fd_on_success;
   Client *client;
 
-  struct fuse_chan *ch;
   struct fuse_session *se;
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  struct fuse_cmdline_opts opts;
+#else
+  struct fuse_chan *ch;
   char *mountpoint;
+#endif
 
   ceph::mutex stag_lock = ceph::make_mutex("fuse_ll.cc stag_lock");
   int last_stag;
@@ -418,7 +422,11 @@ static void fuse_ll_mkdir(fuse_req_t req, fuse_ino_t parent, const char *name,
   if (cfuse->fino_snap(parent) == CEPH_SNAPDIR &&
       fuse_multithreaded && fuse_syncfs_on_mksnap) {
     int err = 0;
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+    int fd = ::open(cfuse->opts.mountpoint, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+#else
     int fd = ::open(cfuse->mountpoint, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+#endif
     if (fd < 0) {
       err = errno;
     } else {
@@ -504,7 +512,11 @@ static void fuse_ll_symlink(fuse_req_t req, const char *existing,
 }
 
 static void fuse_ll_rename(fuse_req_t req, fuse_ino_t parent, const char *name,
-			   fuse_ino_t newparent, const char *newname)
+			   fuse_ino_t newparent, const char *newname
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+                           , unsigned int flags
+#endif
+                           )
 {
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
@@ -916,7 +928,11 @@ static void ino_invalidate_cb(void *handle, vinodeno_t vino, int64_t off,
 #if FUSE_VERSION >= FUSE_MAKE_VERSION(2, 8)
   CephFuse::Handle *cfuse = (CephFuse::Handle *)handle;
   fuse_ino_t fino = cfuse->make_fake_ino(vino.ino, vino.snapid);
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  fuse_lowlevel_notify_inval_inode(cfuse->se, fino, off, len);
+#else
   fuse_lowlevel_notify_inval_inode(cfuse->ch, fino, off, len);
+#endif
 #endif
 }
 
@@ -929,7 +945,11 @@ static void dentry_invalidate_cb(void *handle, vinodeno_t dirino,
   fuse_ino_t fino = 0;
   if (ino.ino != inodeno_t())
     fino = cfuse->make_fake_ino(ino.ino, ino.snapid);
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  fuse_lowlevel_notify_delete(cfuse->se, fdirino, fino, name.c_str(), name.length());
+#else
   fuse_lowlevel_notify_delete(cfuse->ch, fdirino, fino, name.c_str(), name.length());
+#endif
 #elif FUSE_VERSION >= FUSE_MAKE_VERSION(2, 8)
   fuse_lowlevel_notify_inval_entry(cfuse->ch, fdirino, name.c_str(), name.length());
 #endif
@@ -941,7 +961,12 @@ static int remount_cb(void *handle)
   // trims all unused dentries in the file system
   char cmd[128+PATH_MAX];
   CephFuse::Handle *cfuse = (CephFuse::Handle *)handle;
-  snprintf(cmd, sizeof(cmd), "LIBMOUNT_FSTAB=/dev/null mount -i -o remount %s", cfuse->mountpoint);
+  snprintf(cmd, sizeof(cmd), "LIBMOUNT_FSTAB=/dev/null mount -i -o remount %s",
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+                  cfuse->opts.mountpoint);
+#else
+                  cfuse->mountpoint);
+#endif
   int r = system(cmd);
   if (r != 0 && r != -1) {
     r = WEXITSTATUS(r);
@@ -1043,14 +1068,19 @@ const static struct fuse_lowlevel_ops fuse_ll_oper = {
 CephFuse::Handle::Handle(Client *c, int fd) :
   fd_on_success(fd),
   client(c),
-  ch(NULL),
   se(NULL),
+#if FUSE_VERSION < FUSE_MAKE_VERSION(3, 0)
+  ch(NULL),
   mountpoint(NULL),
+#endif
   last_stag(0)
 {
   snap_stag_map[CEPH_NOSNAP] = 0;
   stag_snap_map[0] = CEPH_NOSNAP;
   memset(&args, 0, sizeof(args));
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  memset(&opts, 0, sizeof(opts));
+#endif
 }
 
 CephFuse::Handle::~Handle()
@@ -1060,6 +1090,15 @@ CephFuse::Handle::~Handle()
 
 void CephFuse::Handle::finalize()
 {
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  if (se) {
+    fuse_remove_signal_handlers(se);
+    fuse_session_unmount(se);
+    fuse_session_destroy(se);
+  }
+  if (opts.mountpoint)
+    free(opts.mountpoint);
+#else
   if (se)
     fuse_remove_signal_handlers(se);
   if (ch)
@@ -1068,6 +1107,7 @@ void CephFuse::Handle::finalize()
     fuse_session_destroy(se);
   if (ch)
     fuse_unmount(mountpoint, ch);
+#endif
 
   pthread_key_delete(fuse_req_key);
 }
@@ -1094,14 +1134,16 @@ int CephFuse::Handle::init(int argc, const char *argv[])
     "fuse_allow_other");
   auto fuse_default_permissions = client->cct->_conf.get_val<bool>(
     "fuse_default_permissions");
+#if FUSE_VERSION < FUSE_MAKE_VERSION(3, 0)
   auto fuse_big_writes = client->cct->_conf.get_val<bool>(
     "fuse_big_writes");
-  auto fuse_atomic_o_trunc = client->cct->_conf.get_val<bool>(
-    "fuse_atomic_o_trunc");
-  auto fuse_debug = client->cct->_conf.get_val<bool>(
-    "fuse_debug");
   auto fuse_max_write = client->cct->_conf.get_val<Option::size_t>(
     "fuse_max_write");
+  auto fuse_atomic_o_trunc = client->cct->_conf.get_val<bool>(
+    "fuse_atomic_o_trunc");
+#endif
+  auto fuse_debug = client->cct->_conf.get_val<bool>(
+    "fuse_debug");
 
   if (fuse_allow_other) {
     newargv[newargc++] = "-o";
@@ -1112,6 +1154,7 @@ int CephFuse::Handle::init(int argc, const char *argv[])
     newargv[newargc++] = "default_permissions";
   }
 #if defined(__linux__)
+#if FUSE_VERSION < FUSE_MAKE_VERSION(3, 0)
   if (fuse_big_writes) {
     newargv[newargc++] = "-o";
     newargv[newargc++] = "big_writes";
@@ -1128,6 +1171,7 @@ int CephFuse::Handle::init(int argc, const char *argv[])
     newargv[newargc++] = "atomic_o_trunc";
   }
 #endif
+#endif
   if (fuse_debug)
     newargv[newargc++] = "-d";
 
@@ -1138,7 +1182,11 @@ int CephFuse::Handle::init(int argc, const char *argv[])
   struct fuse_args a = FUSE_ARGS_INIT(newargc, (char**)newargv);
   args = a;  // Roundabout construction b/c FUSE_ARGS_INIT is for initialization not assignment
 
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  if (fuse_parse_cmdline(&args, &opts) == -1) {
+#else
   if (fuse_parse_cmdline(&args, &mountpoint, NULL, NULL) == -1) {
+#endif
     derr << "fuse_parse_cmdline failed." << dendl;
     fuse_opt_free_args(&args);
     free(newargv);
@@ -1152,6 +1200,9 @@ int CephFuse::Handle::init(int argc, const char *argv[])
 
 int CephFuse::Handle::start()
 {
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  se = fuse_session_new(&args, &fuse_ll_oper, sizeof(fuse_ll_oper), this);
+#else
   ch = fuse_mount(mountpoint, &args);
   if (!ch) {
     derr << "fuse_mount(mountpoint=" << mountpoint << ") failed." << dendl;
@@ -1159,6 +1210,7 @@ int CephFuse::Handle::start()
   }
 
   se = fuse_lowlevel_new(&args, &fuse_ll_oper, sizeof(fuse_ll_oper), this);
+#endif
   if (!se) {
     derr << "fuse_lowlevel_new failed" << dendl;
     return EDOM;
@@ -1171,7 +1223,14 @@ int CephFuse::Handle::start()
     return ENOSYS;
   }
 
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  if (fuse_session_mount(se, opts.mountpoint) != 0) {
+    derr << "fuse_session_mount failed" << dendl;
+    return ENOSYS;
+  }
+#else
   fuse_session_add_chan(se, ch);
+#endif
 
 
   struct client_callback_args args = {
@@ -1197,7 +1256,11 @@ int CephFuse::Handle::loop()
   auto fuse_multithreaded = client->cct->_conf.get_val<bool>(
     "fuse_multithreaded");
   if (fuse_multithreaded) {
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+    return fuse_session_loop_mt(se, opts.clone_fd);
+#else
     return fuse_session_loop_mt(se);
+#endif
   } else {
     return fuse_session_loop(se);
   }
@@ -1327,8 +1390,13 @@ void CephFuse::finalize()
 
 std::string CephFuse::get_mount_point() const
 {
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  if (_handle->opts.mountpoint) {
+    return _handle->opts.mountpoint;
+#else
   if (_handle->mountpoint) {
     return _handle->mountpoint;
+#endif
   } else {
     return "";
   }

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8323,7 +8323,7 @@ std::vector<Option> get_mds_client_options() {
     .set_flag(Option::FLAG_STARTUP),
 
     Option("fuse_big_writes", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
+    .set_default(true)
     .set_description("big_writes is deprecated in libfuse 3.0.0"),
 
     Option("fuse_max_write", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)

--- a/src/include/ceph_fuse.h
+++ b/src/include/ceph_fuse.h
@@ -1,0 +1,32 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2012 Inktank Storage, Inc.
+ * Copyright (C) 2014 Red Hat <contact@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ */
+#ifndef CEPH_FUSE_H
+#define CEPH_FUSE_H
+
+#define FUSE_USE_VERSION 30
+#include "acconfig.h"
+#include <fuse.h>
+
+static inline int filler_compat(fuse_fill_dir_t filler,
+                                void *buf, const char *name,
+                                const struct stat *stbuf,
+                                off_t off)
+{
+  return filler(buf, name, stbuf, off
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+                , static_cast<enum fuse_fill_dir_flags>(0)
+#endif
+        );
+}
+#endif /* CEPH_FUSE_H */

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -92,8 +92,7 @@ if(HAVE_LIBAIO)
 endif(HAVE_LIBAIO)
 
 if(WITH_FUSE)
-  target_include_directories(os SYSTEM PRIVATE ${FUSE_INCLUDE_DIRS})
-  target_link_libraries(os ${FUSE_LIBRARIES})
+  target_link_libraries(os FUSE::FUSE)
 endif()
 
 if(HAVE_LIBZFS)

--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -9,6 +9,8 @@
 
 #define FUSE_USE_VERSION 30
 #include <fuse.h>
+#include <fuse_lowlevel.h>
+#include "include/ceph_fuse.h"
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -31,7 +33,9 @@
 struct fs_info {
   struct fuse_args args;
   struct fuse *f;
+#if FUSE_VERSION < FUSE_MAKE_VERSION(3, 0)
   struct fuse_chan *ch;
+#endif
   char *mountpoint;
 };
 
@@ -229,7 +233,11 @@ static int parse_fn(CephContext* cct, const char *path, coll_t *cid,
 }
 
 
-static int os_getattr(const char *path, struct stat *stbuf)
+static int os_getattr(const char *path, struct stat *stbuf
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+                      , struct fuse_file_info *fi
+#endif
+                      )
 {
   fuse_context *fc = fuse_get_context();
   FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
@@ -386,7 +394,11 @@ static int os_readdir(const char *path,
 		      void *buf,
 		      fuse_fill_dir_t filler,
 		      off_t offset,
-		      struct fuse_file_info *fi)
+		      struct fuse_file_info *fi
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+                      , enum fuse_readdir_flags
+#endif
+                      )
 {
   fuse_context *fc = fuse_get_context();
   FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
@@ -411,11 +423,11 @@ static int os_readdir(const char *path,
   switch (t) {
   case FN_ROOT:
     {
-      filler(buf, "type", NULL, 0);
+      filler_compat(filler, buf, "type", NULL, 0);
       vector<coll_t> cls;
       fs->store->list_collections(cls);
       for (auto c : cls) {
-	int r = filler(buf, stringify(c).c_str(), NULL, 0);
+	int r = filler_compat(filler, buf, stringify(c).c_str(), NULL, 0);
 	if (r > 0)
 	  break;
       }
@@ -427,28 +439,28 @@ static int os_readdir(const char *path,
       if (!ch) {
 	return -ENOENT;
       }
-      filler(buf, "bitwise_hash_start", NULL, 0);
+      filler_compat(filler, buf, "bitwise_hash_start", NULL, 0);
       if (fs->store->collection_bits(ch) >= 0) {
-	filler(buf, "bitwise_hash_end", NULL, 0);
-	filler(buf, "bitwise_hash_bits", NULL, 0);
+	filler_compat(filler, buf, "bitwise_hash_end", NULL, 0);
+	filler_compat(filler, buf, "bitwise_hash_bits", NULL, 0);
       }
-      filler(buf, "all", NULL, 0);
-      filler(buf, "by_bitwise_hash", NULL, 0);
+      filler_compat(filler, buf, "all", NULL, 0);
+      filler_compat(filler, buf, "by_bitwise_hash", NULL, 0);
       spg_t pgid;
       if (cid.is_pg(&pgid) &&
 	  fs->store->exists(ch, pgid.make_pgmeta_oid())) {
-	filler(buf, "pgmeta", NULL, 0);
+	filler_compat(filler, buf, "pgmeta", NULL, 0);
       }
     }
     break;
 
   case FN_OBJECT:
     {
-      filler(buf, "bitwise_hash", NULL, 0);
-      filler(buf, "data", NULL, 0);
-      filler(buf, "omap", NULL, 0);
-      filler(buf, "attr", NULL, 0);
-      filler(buf, "omap_header", NULL, 0);
+      filler_compat(filler, buf, "bitwise_hash", NULL, 0);
+      filler_compat(filler, buf, "data", NULL, 0);
+      filler_compat(filler, buf, "omap", NULL, 0);
+      filler_compat(filler, buf, "attr", NULL, 0);
+      filler_compat(filler, buf, "omap_header", NULL, 0);
     }
     break;
 
@@ -503,7 +515,7 @@ static int os_readdir(const char *path,
 	  uint64_t cur_off = ((uint64_t)bitwise_hash << hash_shift) |
 	    (uint64_t)hashoff;
 	  string s = stringify(p);
-	  r = filler(buf, s.c_str(), NULL, cur_off);
+	  r = filler_compat(filler, buf, s.c_str(), NULL, cur_off);
 	  if (r)
 	    break;
 	}
@@ -526,7 +538,7 @@ static int os_readdir(const char *path,
 	  continue;
 	}
 	++offset;
-	int r = filler(buf, k.c_str(), NULL, offset);
+	int r = filler_compat(filler, buf, k.c_str(), NULL, offset);
 	if (r)
 	  break;
       }
@@ -544,7 +556,7 @@ static int os_readdir(const char *path,
 	  continue;
 	}
 	++offset;
-	int r = filler(buf, a.first.c_str(), NULL, offset);
+	int r = filler_compat(filler, buf, a.first.c_str(), NULL, offset);
 	if (r)
 	  break;
       }
@@ -781,7 +793,11 @@ static int os_mkdir(const char *path, mode_t mode)
   return 0;
 }
 
-static int os_chmod(const char *path, mode_t mode)
+static int os_chmod(const char *path, mode_t mode
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+                    , struct fuse_file_info *fi
+#endif
+                    )
 {
   fuse_context *fc = fuse_get_context();
   FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
@@ -1052,7 +1068,11 @@ static int os_unlink(const char *path)
   return 0;
 }
 
-static int os_truncate(const char *path, off_t size)
+static int os_truncate(const char *path, off_t size
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+                       , struct fuse_file_info *fi
+#endif
+                       )
 {
   fuse_context *fc = fuse_get_context();
   FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
@@ -1118,7 +1138,9 @@ static int os_statfs(const char *path, struct statvfs *stbuf)
 static struct fuse_operations fs_oper = {
   getattr: os_getattr,
   readlink: 0,
+#if FUSE_VERSION < FUSE_MAKE_VERSION(3, 0)
   getdir: 0,
+#endif
   mknod: 0,
   mkdir: os_mkdir,
   unlink: os_unlink,
@@ -1129,7 +1151,9 @@ static struct fuse_operations fs_oper = {
   chmod: os_chmod,
   chown: 0,
   truncate: os_truncate,
+#if FUSE_VERSION < FUSE_MAKE_VERSION(3, 0)
   utime: 0,
+#endif
   open: os_open,
   read: os_read,
   write: os_write,
@@ -1178,16 +1202,38 @@ int FuseStore::start()
     "-d", // debug
   };
   int c = 3;
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  int rc;
+  struct fuse_cmdline_opts opts = {};
+#endif
   auto fuse_debug = store->cct->_conf.get_val<bool>("fuse_debug");
   if (fuse_debug)
     ++c;
   fuse_args a = FUSE_ARGS_INIT(c, (char**)v);
   info->args = a;
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  if (fuse_parse_cmdline(&info->args, &opts) == -1) {
+#else
   if (fuse_parse_cmdline(&info->args, &info->mountpoint, NULL, NULL) == -1) {
+#endif
     derr << __func__ << " failed to parse args" << dendl;
     return -EINVAL;
   }
 
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  info->mountpoint = opts.mountpoint;
+  info->f = fuse_new(&info->args, &fs_oper, sizeof(fs_oper), (void*)this);
+  if (!info->f) {
+    derr << __func__ << " fuse_new failed" << dendl;
+    return -EIO;
+  }
+
+  rc = fuse_mount(info->f, info->mountpoint);
+  if (rc != 0) {
+    derr << __func__ << " fuse_mount failed" << dendl;
+    return -EIO;
+  }
+#else
   info->ch = fuse_mount(info->mountpoint, &info->args);
   if (!info->ch) {
     derr << __func__ << " fuse_mount failed" << dendl;
@@ -1201,6 +1247,7 @@ int FuseStore::start()
     derr << __func__ << " fuse_new failed" << dendl;
     return -EIO;
   }
+#endif
 
   fuse_thread.create("fusestore");
   dout(10) << __func__ << " done" << dendl;
@@ -1220,7 +1267,11 @@ int FuseStore::loop()
 int FuseStore::stop()
 {
   dout(10) << __func__ << " enter" << dendl;
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  fuse_unmount(info->f);
+#else
   fuse_unmount(info->mountpoint, info->ch);
+#endif
   fuse_thread.join();
   fuse_destroy(info->f);
   dout(10) << __func__ << " exit" << dendl;

--- a/src/rbd_fuse/CMakeLists.txt
+++ b/src/rbd_fuse/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(rbd-fuse
   rbd-fuse.cc)
 target_link_libraries(rbd-fuse
-  ceph-common librbd librados global ${FUSE_LIBRARIES})
+  ceph-common librbd librados global FUSE::FUSE)
 install(TARGETS rbd-fuse DESTINATION bin)

--- a/src/rbd_fuse/rbd-fuse.cc
+++ b/src/rbd_fuse/rbd-fuse.cc
@@ -505,7 +505,7 @@ rbdfs_init(struct fuse_conn_info *conn)
 	ret = rados_ioctx_create(cluster, pool_name, &ioctx);
 	if (ret < 0)
 		exit(91);
-#if FUSE_VERSION >= FUSE_MAKE_VERSION(2, 8)
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(2, 8) && FUSE_VERSION < FUSE_MAKE_VERSION(3, 0)
 	conn->want |= FUSE_CAP_BIG_WRITES;
 #endif
 	rados_ioctx_set_namespace(ioctx, nspace_name);

--- a/src/rbd_fuse/rbd-fuse.cc
+++ b/src/rbd_fuse/rbd-fuse.cc
@@ -587,7 +587,7 @@ rbdfs_rename(const char *path, const char *destname)
 }
 
 int
-rbdfs_utime(const char *path, struct utimbuf *utime)
+rbdfs_utimens(const char *path, const struct timespec tv[2])
 {
 	// called on create; not relevant
 	return 0;
@@ -735,7 +735,9 @@ const static struct fuse_operations rbdfs_oper = {
   chmod:      0,
   chown:      0,
   truncate:   rbdfs_truncate,
-  utime:      rbdfs_utime,
+#if FUSE_VERSION < FUSE_MAKE_VERSION(3, 0)
+  utime:      0,
+#endif
   open:	      rbdfs_open,
   read:	      rbdfs_read,
   write:      rbdfs_write,
@@ -755,6 +757,10 @@ const static struct fuse_operations rbdfs_oper = {
   destroy:    rbdfs_destroy,
   access:     0,
   create:     rbdfs_create,
+  ftruncate:  0,
+  fgetattr:   0,
+  lock:       0,
+  utimens:    rbdfs_utimens,
   /* skip unimplemented */
 };
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -50,7 +50,7 @@ add_executable(ceph-objectstore-tool
   RadosDump.cc)
 target_link_libraries(ceph-objectstore-tool osd os global Boost::program_options ${CMAKE_DL_LIBS})
 if(WITH_FUSE)
-  target_link_libraries(ceph-objectstore-tool ${FUSE_LIBRARIES})
+  target_link_libraries(ceph-objectstore-tool FUSE::FUSE)
 endif(WITH_FUSE)
 install(TARGETS ceph-objectstore-tool DESTINATION bin)
 


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/45046
* https://tracker.ceph.com/issues/45211

---

backport of

* https://github.com/ceph/ceph/pull/34306
* https://github.com/ceph/ceph/pull/34531
* https://github.com/ceph/ceph/pull/34604

parent trackers:

* https://tracker.ceph.com/issues/44771
* https://tracker.ceph.com/issues/44885

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh