### PR TITLE
mgr/dashboard: improve logs

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/logs.py
+++ b/src/pybind/mgr/dashboard/controllers/logs.py
@@ -49,7 +49,7 @@ class Logs(BaseController):
 
     def load_buffer(self, buf, channel_name):
         lines = CephService.send_command(
-            'mon', 'log last', channel=channel_name, num=LOG_BUFFER_SIZE)
+            'mon', 'log last', channel=channel_name, num=LOG_BUFFER_SIZE, level='debug')
         for l in lines:
             buf.appendleft(l)
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
@@ -18,8 +18,7 @@
               <span class="message">{{ line.message }}</span>
             </p>
 
-            <span *ngIf="contentData.clog.length === 0"
-                  i18n>No entries found</span>
+            <ng-container *ngIf="clog.length != 0 else noEntriesTpl"></ng-container>
           </div>
         </div>
       </ng-template>
@@ -37,8 +36,7 @@
               <span class="message">{{ line.message }}</span>
             </p>
 
-            <span *ngIf="contentData.audit_log.length === 0"
-                  i18n>No entries found</span>
+            <ng-container *ngIf="audit_log.length != 0 else noEntriesTpl"></ng-container>
           </div>
         </div>
       </ng-template>
@@ -96,6 +94,7 @@
                id="logs-date"
                placeholder="YYYY-MM-DD"
                ngbDatepicker
+               [maxDate]="maxDate"
                #d="ngbDatepicker"
                (click)="d.open()"
                [(ngModel)]="selectedDate"
@@ -123,4 +122,12 @@
                       (ngModelChange)="filterLogs()"></ngb-timepicker>
     </div>
   </div>
+</ng-template>
+
+<ng-template #noEntriesTpl>
+  <span i18n>No log entries found. Please try to select different filter options.</span>
+  <span>&nbsp;</span>
+  <a href="#"
+     (click)="resetFilter()"
+     i18n>Reset filter.</a>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.scss
@@ -37,6 +37,10 @@ p {
   .info {
     color: bd.$info;
   }
+
+  .debug {
+    color: bd.$gray-700;
+  }
 }
 
 ::ng-deep cd-logs ngb-timepicker input.ngb-tp-input {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.ts
@@ -19,6 +19,7 @@ export class LogsComponent implements OnInit, OnDestroy {
 
   interval: number;
   priorities: Array<{ name: string; value: string }> = [
+    { name: 'Debug', value: '[DBG]' },
     { name: 'Info', value: '[INF]' },
     { name: 'Warning', value: '[WRN]' },
     { name: 'Error', value: '[ERR]' },
@@ -29,6 +30,11 @@ export class LogsComponent implements OnInit, OnDestroy {
   selectedDate: NgbDateStruct;
   startTime = { hour: 0, minute: 0 };
   endTime = { hour: 23, minute: 59 };
+  maxDate = {
+    year: new Date().getFullYear(),
+    month: new Date().getMonth() + 1,
+    day: new Date().getDate()
+  };
 
   constructor(
     private logsService: LogsService,
@@ -119,5 +125,15 @@ export class LogsComponent implements OnInit, OnDestroy {
   clearDate() {
     this.selectedDate = null;
     this.filterLogs();
+  }
+  resetFilter() {
+    this.priority = 'All';
+    this.search = '';
+    this.selectedDate = null;
+    this.startTime = { hour: 0, minute: 0 };
+    this.endTime = { hour: 23, minute: 59 };
+    this.filterLogs();
+
+    return false;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/log-priority.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/log-priority.pipe.ts
@@ -5,7 +5,9 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class LogPriorityPipe implements PipeTransform {
   transform(value: any): any {
-    if (value === '[INF]') {
+    if (value === '[DBG]') {
+      return 'debug';
+    } else if (value === '[INF]') {
       return 'info';
     } else if (value === '[WRN]') {
       return 'warn';


### PR DESCRIPTION
Changes the text that is being displayed when no log entry was found.
Also changes the log level to debug.
User can no longer select a date in the future to filter log entries.

![Screenshot_20200427_121700](https://user-images.githubusercontent.com/7863239/80363902-36d24800-8885-11ea-8467-a712d7a42f28.png)

In the standup meeting we discussed if we want to add a parameter to the log resource, to set the log level that will be returned by the backend.
Currently the backend only returns 30 log entries and if a lot of debug messages are being written to the log files, the user might miss an important entry. 
However, we came to no conclusion. That's why I want to raise the topic here again.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
