### PR TITLE
cephadm: Add shell '--mount' option to mount host file or directory

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -110,7 +110,7 @@ Enable Ceph CLI
 ===============
 
 Cephadm does not require any Ceph packages to be installed on the
-host.  However, we recommend enabling easy access to the the ``ceph``
+host.  However, we recommend enabling easy access to the ``ceph``
 command.  There are several ways to do this:
 
 * The ``cephadm shell`` command launches a bash shell in a container
@@ -119,7 +119,9 @@ command.  There are several ways to do this:
   host, they are passed into the container environment so that the
   shell is fully functional. Note that when executed on a MON host,
   ``cephadm shell`` will infer the ``config`` from the MON container
-  instead of using the default configuration::
+  instead of using the default configuration. If ``--mount <path>``
+  is given, then the host ``<path>`` (file or directory) will appear
+  under ``/mnt`` inside the container::
 
     # cephadm shell
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2778,6 +2778,12 @@ def command_shell():
         mounts[pathify(args.config)] = '/etc/ceph/ceph.conf:z'
     if args.keyring:
         mounts[pathify(args.keyring)] = '/etc/ceph/ceph.keyring:z'
+    if args.mount:
+        mount = pathify(args.mount)
+        filename = ''
+        if os.path.isfile(mount):
+            _, filename = os.path.split(mount)
+        mounts[mount] = '/mnt/{}:z'.format(filename)
     if args.command:
         command = args.command
     else:
@@ -4301,6 +4307,9 @@ def _get_parser():
     parser_shell.add_argument(
         '--keyring', '-k',
         help='ceph.keyring to pass through to the container')
+    parser_shell.add_argument(
+        '--mount', '-m',
+        help='file or directory path that will be mounted in container /mnt')
     parser_shell.add_argument(
         '--env', '-e',
         action='append',


### PR DESCRIPTION
The Problem:
---
I have a file on my host, that I would like to use to set a "config-key":
```
master:/etc/ceph # head -1 /tmp/ceph-salt-ssh-id_rsa
-----BEGIN RSA PRIVATE KEY-----
```
But when I try to use that file, I get an error because the file is not accessible inside the container:
```
master:/etc/ceph # cephadm shell -- ceph config-key set mgr/cephadm/ssh_identity_key -i /tmp/ceph-salt-ssh-id_rsa
...
Can't open input file /tmp/ceph-salt-ssh-id_rsa: [Errno 2] No such file or directory: '/tmp/c
```

Proposed Solution
---

Add a new `--mount` option to `cephadm shell`, that allows to mount a host file or directory:

```
master:~ # cephadm shell --help
...
  --mount MOUNT, -m MOUNT
                        file or directory path that will be mounted in
                        container /mnt
...
```
```
master:~ # cephadm shell --mount /tmp/ceph-salt-ssh-id_rsa -- ceph config-key set mgr/cephadm/ssh_identity_key -i /mnt/tmp/ceph-salt-ssh-id_rsa
...
set mgr/cephadm/ssh_identity_key
```




Fixes: https://tracker.ceph.com/issues/45284

Signed-off-by: Ricardo Marques <rimarques@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
