### PR TITLE
nautilus: mon/FSCommands: Fix 'add_data_pool' command and 'fs new' command 

### DIFF
--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1,3 +1,5 @@
+import json
+
 from teuthology.orchestra.run import CommandFailedError
 
 from unittest import case
@@ -31,6 +33,11 @@ class TestAdminCommands(CephFSTestCase):
         if overwrites:
             self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'set', n+"-data", 'allow_ec_overwrites', 'true')
 
+    def _check_pool_application_metadata_key_value(self, pool, app, key, value):
+        output = self.fs.mon_manager.raw_cluster_cmd(
+            'osd', 'pool', 'application', 'get', pool, app, key)
+        self.assertEqual(str(output.strip()), value)
+
     def test_add_data_pool_root(self):
         """
         That a new data pool can be added and used for the root directory.
@@ -38,6 +45,19 @@ class TestAdminCommands(CephFSTestCase):
 
         p = self.fs.add_data_pool("foo")
         self.fs.set_dir_layout(self.mount_a, ".", FileLayout(pool=p))
+
+    def test_add_data_pool_application_metadata(self):
+        """
+        That the application metadata set on a newly added data pool is as expected.
+        """
+        pool_name = "foo"
+        mon_cmd = self.fs.mon_manager.raw_cluster_cmd
+        mon_cmd('osd', 'pool', 'create', pool_name, str(self.fs.pgs_per_fs_pool))
+        # Check whether https://tracker.ceph.com/issues/43061 is fixed
+        mon_cmd('osd', 'pool', 'application', 'enable', pool_name, 'cephfs')
+        self.fs.add_data_pool(pool_name, create=False)
+        self._check_pool_application_metadata_key_value(
+            pool_name, 'cephfs', 'data', self.fs.name)
 
     def test_add_data_pool_subdir(self):
         """

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -255,10 +255,10 @@ class FsNewHandler : public FileSystemCommandHandler
     }
     mon->osdmon()->do_application_enable(data,
 					 pg_pool_t::APPLICATION_NAME_CEPHFS,
-					 "data", fs_name);
+					 "data", fs_name, true);
     mon->osdmon()->do_application_enable(metadata,
 					 pg_pool_t::APPLICATION_NAME_CEPHFS,
-					 "metadata", fs_name);
+					 "metadata", fs_name, true);
     mon->osdmon()->do_set_pool_opt(metadata,
 				   pool_opts_t::RECOVERY_PRIORITY,
 				   static_cast<int64_t>(5));

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -697,7 +697,7 @@ class AddDataPoolHandler : public FileSystemCommandHandler
     }
     mon->osdmon()->do_application_enable(poolid,
 					 pg_pool_t::APPLICATION_NAME_CEPHFS,
-					 "data", fs_name);
+					 "data", fs_name, true);
     mon->osdmon()->propose_pending();
 
     fsmap.modify_filesystem(

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4467,7 +4467,8 @@ void OSDMonitor::check_pg_creates_sub(Subscription *sub)
 void OSDMonitor::do_application_enable(int64_t pool_id,
                                        const std::string &app_name,
 				       const std::string &app_key,
-				       const std::string &app_value)
+				       const std::string &app_value,
+				       bool force)
 {
   ceph_assert(paxos->is_plugged() && is_writeable());
 
@@ -4487,7 +4488,11 @@ void OSDMonitor::do_application_enable(int64_t pool_id,
   if (app_key.empty()) {
     p.application_metadata.insert({app_name, {}});
   } else {
-    p.application_metadata.insert({app_name, {{app_key, app_value}}});
+    if (force) {
+      p.application_metadata[app_name][app_key] = app_value;
+    } else {
+      p.application_metadata.insert({app_name, {{app_key, app_value}}});
+    }
   }
   p.last_change = pending_inc.epoch;
   pending_inc.new_pools[pool_id] = p;

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -746,7 +746,8 @@ public:
 
   void do_application_enable(int64_t pool_id, const std::string &app_name,
 			     const std::string &app_key="",
-			     const std::string &app_value="");
+			     const std::string &app_value="",
+			     bool force=false);
   void do_set_pool_opt(int64_t pool_id, pool_opts_t::key_t opt,
 		       pool_opts_t::value_t);
 


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/45225
* https://tracker.ceph.com/issues/45229

backport of:

* https://github.com/ceph/ceph/pull/34534

parent trackers:

* https://tracker.ceph.com/issues/43061
* https://tracker.ceph.com/issues/43761

---

Fixes: https://tracker.ceph.com/issues/45225
Fixes: https://tracker.ceph.com/issues/45229