### PR TITLE
mgr/dashboard: increase Grafana iframe height to avoid scroll bar

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.html
@@ -34,7 +34,7 @@
       <ng-template ngbNavContent>
         <cd-grafana [grafanaPath]="'host-details?var-ceph_hosts=' + selectedHostname"
                     uid="rtOg0AiWz"
-                    grafanaStyle="three">
+                    grafanaStyle="four">
         </cd-grafana>
       </ng-template>
     </li>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
@@ -80,7 +80,7 @@
       <ng-template ngbNavContent>
         <cd-grafana [grafanaPath]="'osd-device-details?var-osd=osd.' + osd['id']"
                     uid="CrAHE0iZz"
-                    grafanaStyle="GrafanaStyles.two">
+                    grafanaStyle="three">
         </cd-grafana>
       </ng-template>
     </li>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -45,7 +45,7 @@
     <ng-template ngbNavContent>
       <cd-grafana [grafanaPath]="'osd-overview?'"
                   uid="lo02I1Aiz"
-                  grafanaStyle="three">
+                  grafanaStyle="four">
       </cd-grafana>
     </ng-template>
   </li>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
@@ -21,7 +21,7 @@
       <ng-template ngbNavContent>
         <cd-grafana [grafanaPath]="'ceph-pool-detail?var-pool_name='+ selection['pool_name']"
                     uid="-xyV8KCiz"
-                    grafanaStyle="one">
+                    grafanaStyle="three">
         </cd-grafana>
       </ng-template>
     </li>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.scss
@@ -16,6 +16,10 @@
   height: 900px;
 }
 
+.grafana_four {
+  height: 1160px;
+}
+
 .timepicker {
   label {
     font-weight: 700;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
@@ -164,7 +164,8 @@ export class GrafanaComponent implements OnInit, OnChanges {
     this.styles = {
       one: 'grafana_one',
       two: 'grafana_two',
-      three: 'grafana_three'
+      three: 'grafana_three',
+      four: 'grafana_four'
     };
 
     this.settingsService.ifSettingConfigured('api/grafana/url', (url) => {


### PR DESCRIPTION
Add Grafana component style four with height 1160px
Fixes : https://tracker.ceph.com/issues/44966
Signed-off-by: Ngwa Sedrick Meh <nsedrick101@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
