### PR TITLE
mgr/orch: service_id can contain a '.' char (mds, nfs, iscsi)

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2467,7 +2467,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                     config_func(spec)
                     did_config = True
                 daemon_id = self.get_unique_name(daemon_type, host, daemons,
-                                                 spec.service_id, name)
+                                                 prefix=spec.service_id,
+                                                 forcename=name)
                 self.log.debug('Placing %s.%s on host %s' % (
                     daemon_type, daemon_id, host))
                 if daemon_type == 'mon':
@@ -2613,7 +2614,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         args = []  # type: List[tuple]
         for host, network, name in hosts:
             daemon_id = self.get_unique_name(daemon_type, host, daemons,
-                                             spec.service_id, name)
+                                             prefix=spec.service_id,
+                                             forcename=name)
             self.log.debug('Placing %s.%s on host %s' % (
                 daemon_type, daemon_id, host))
             if daemon_type == 'mon':

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -282,6 +282,21 @@ def test_spec_octopus():
         ),
         False
     ),
+    (
+        # zone contains hostname
+        # https://tracker.ceph.com/issues/45294
+        RGWSpec(
+            rgw_realm="default.rgw.realm",
+            rgw_zone="ceph.001",
+            subcluster='1',
+        ),
+        DaemonDescription(
+            daemon_type='rgw',
+            daemon_id="default.rgw.realm.ceph.001.1.ceph.001.ytywjo",
+            hostname="ceph.001",
+        ),
+        True
+    ),
 
     # https://tracker.ceph.com/issues/45293
     (

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -2,7 +2,9 @@ import json
 
 import pytest
 
-from ceph.deployment.service_spec import ServiceSpec, RGWSpec, PlacementSpec
+from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec, \
+    ServiceSpecValidationError, IscsiServiceSpec, PlacementSpec
+
 from orchestrator import DaemonDescription, OrchestratorError
 
 
@@ -224,8 +226,8 @@ def test_spec_octopus():
 
 @pytest.mark.parametrize("spec,dd,valid",
 [
+    # https://tracker.ceph.com/issues/44934
     (
-        # https://tracker.ceph.com/issues/44934
         RGWSpec(
             rgw_realm="default-rgw-realm",
             rgw_zone="eu-central-1",
@@ -280,8 +282,125 @@ def test_spec_octopus():
         ),
         False
     ),
+
+    # https://tracker.ceph.com/issues/45293
+    (
+        ServiceSpec(
+            service_type='mds',
+            service_id="a",
+        ),
+        DaemonDescription(
+            daemon_type='mds',
+            daemon_id="a.host1.abc123",
+            hostname="host1",
+        ),
+        True
+    ),
+    (
+        # '.' char in service_id
+        ServiceSpec(
+            service_type='mds',
+            service_id="a.b.c",
+        ),
+        DaemonDescription(
+            daemon_type='mds',
+            daemon_id="a.b.c.host1.abc123",
+            hostname="host1",
+        ),
+        True
+    ),
+
+    # https://tracker.ceph.com/issues/45293
+    (
+        NFSServiceSpec(
+            service_id="a",
+        ),
+        DaemonDescription(
+            daemon_type='nfs',
+            daemon_id="a.host1",
+            hostname="host1",
+        ),
+        True
+    ),
+    (
+        # service_id contains a '.' char
+        NFSServiceSpec(
+            service_id="a.b.c",
+        ),
+        DaemonDescription(
+            daemon_type='nfs',
+            daemon_id="a.b.c.host1",
+            hostname="host1",
+        ),
+        True
+    ),
+    (
+        # trailing chars after hostname
+        NFSServiceSpec(
+            service_id="a.b.c",
+        ),
+        DaemonDescription(
+            daemon_type='nfs',
+            daemon_id="a.b.c.host1.abc123",
+            hostname="host1",
+        ),
+        True
+    ),
+    (
+        # chars after hostname without '.'
+        NFSServiceSpec(
+            service_id="a",
+        ),
+        DaemonDescription(
+            daemon_type='nfs',
+            daemon_id="a.host1abc123",
+            hostname="host1",
+        ),
+        False
+    ),
+    (
+        # chars before hostname without '.'
+        NFSServiceSpec(
+            service_id="a",
+        ),
+        DaemonDescription(
+            daemon_type='nfs',
+            daemon_id="a.abc123",
+            hostname="host1",
+        ),
+        False
+    ),
+
+    # https://tracker.ceph.com/issues/45293
+    (
+        IscsiServiceSpec(
+            service_type='iscsi',
+            service_id="a",
+        ),
+        DaemonDescription(
+            daemon_type='iscsi',
+            daemon_id="a.host1.abc123",
+            hostname="host1",
+        ),
+        True
+    ),
+    (
+        # '.' char in service_id
+        IscsiServiceSpec(
+            service_type='iscsi',
+            service_id="a.b.c",
+        ),
+        DaemonDescription(
+            daemon_type='iscsi',
+            daemon_id="a.b.c.host1.abc123",
+            hostname="host1",
+        ),
+        True
+    ),
 ])
-def test_rgw_service_name(spec: RGWSpec, dd: DaemonDescription, valid):
+def test_daemon_description_service_name(spec: ServiceSpec,
+                                         dd: DaemonDescription,
+                                         valid: bool):
     if valid:
         assert spec.service_name() == dd.service_name()
     else:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1304,24 +1304,11 @@ class DaemonDescription(object):
                 if m:
                     return m.group(1)
 
-        if self.daemon_type == 'rgw':
-            if self.hostname and self.hostname in self.daemon_id:
-                pre, post_ = self.daemon_id.split(self.hostname)
-                return pre[:-1]
-            else:
-                # daemon_id == "realm.zone.host.random"
-                v = self.daemon_id.split('.')
-                if len(v) == 4:
-                    return '.'.join(v[0:2])
-                # subcluster or fqdn? undecidable.
-                raise OrchestratorError(f"DaemonDescription: Cannot calculate service_id: {v}")
-
-        if self.daemon_type in ['mds', 'nfs', 'iscsi']:
-            service_id = _match()
-            if service_id:
-                return service_id
             raise OrchestratorError("DaemonDescription: Cannot calculate service_id: " \
                     f"daemon_id='{self.daemon_id}' hostname='{self.hostname}'")
+
+        if self.daemon_type in ['mds', 'nfs', 'iscsi', 'rgw']:
+            return _match()
 
         return self.daemon_id
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -4,15 +4,18 @@ ceph-mgr orchestrator interface
 
 Please see the ceph-mgr module developer's guide for more information.
 """
+
+import copy
+import datetime
+import errno
 import logging
 import pickle
+import re
 import time
+import uuid
+
 from collections import namedtuple
 from functools import wraps
-import uuid
-import datetime
-import copy
-import errno
 
 from ceph.deployment import inventory
 from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec, \
@@ -1292,6 +1295,15 @@ class DaemonDescription(object):
         return False
 
     def service_id(self):
+        def _match():
+            if self.hostname:
+                # daemon_id == "service_id.hostname"
+                # daemon_id == "service_id.hostname.random"
+                p = re.compile(r'(.*)\.%s(\.{1}\w+)?$' % (self.hostname))
+                m = p.match(self.daemon_id)
+                if m:
+                    return m.group(1)
+
         if self.daemon_type == 'rgw':
             if self.hostname and self.hostname in self.daemon_id:
                 pre, post_ = self.daemon_id.split(self.hostname)
@@ -1303,9 +1315,15 @@ class DaemonDescription(object):
                     return '.'.join(v[0:2])
                 # subcluster or fqdn? undecidable.
                 raise OrchestratorError(f"DaemonDescription: Cannot calculate service_id: {v}")
+
         if self.daemon_type in ['mds', 'nfs', 'iscsi']:
-            return self.daemon_id.split('.')[0]
-        return self.daemon_type
+            service_id = _match()
+            if service_id:
+                return service_id
+            raise OrchestratorError("DaemonDescription: Cannot calculate service_id: " \
+                    f"daemon_id='{self.daemon_id}' hostname='{self.hostname}'")
+
+        return self.daemon_id
 
     def service_name(self):
         if self.daemon_type in ['rgw', 'mds', 'nfs', 'iscsi']:


### PR DESCRIPTION
Match last occurrence of the hostname substr when parsing the daemon_id

* The service_id can contain a '.' char (mds, nfs, iscsi)
* rgw realm/zone could contain 'hostname'

Fixes: https://tracker.ceph.com/issues/45293
Fixes: https://tracker.ceph.com/issues/45294
Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
