### PR TITLE
qa/workunits/cephadm/test_cephadm.sh: wait longer for monitoring stack

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -334,21 +334,21 @@ done
 ${CEPHADM//--image $IMAGE_MASTER/} deploy \
     --name node-exporter.a --fsid $FSID
 cond="curl 'http://localhost:9100' | grep -q 'Node Exporter'"
-is_available "node-exporter" "$cond" 5
+is_available "node-exporter" "$cond" 10
 
 # add prometheus
 cat ${CEPHADM_SAMPLES_DIR}/prometheus.json | \
         ${CEPHADM//--image $IMAGE_MASTER/} deploy \
 	    --name prometheus.a --fsid $FSID --config-json -
 cond="curl 'localhost:9095/api/v1/query?query=up'"
-is_available "prometheus" "$cond" 5
+is_available "prometheus" "$cond" 10
 
 # add grafana
 cat ${CEPHADM_SAMPLES_DIR}/grafana.json | \
         ${CEPHADM//--image $IMAGE_MASTER/} deploy \
             --name grafana.a --fsid $FSID --config-json -
 cond="curl --insecure 'https://localhost:3000' | grep -q 'grafana'"
-is_available "grafana" "$cond" 30
+is_available "grafana" "$cond" 50
 
 # add nfs-ganesha
 nfs_stop


### PR DESCRIPTION
Give the monitoring stack (node-exporter, prom, grafana) a few more
retries to become available before giving up

```
curl: (7) Failed to connect to localhost port 9100: Connection refused
+ num=10
+ '[' 10 -ge 10 ']'
+ echo 'node-exporter is not available'
node-exporter is not available
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
