### PR TITLE
ceph-fuse: switch to fuse_reply_iov and add splice read/write support to reduce the memory copy

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -58,7 +58,15 @@ static void fuse_usage()
   struct fuse_args args = FUSE_ARGS_INIT(2, (char**)argv);
 #if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
   struct fuse_cmdline_opts opts = {};
-  if (fuse_parse_cmdline(&args, &opts) == -1) {
+  if (fuse_parse_cmdline(&args, &opts) != -1) {
+    if (opts.show_help) {
+      cout << "usage: " << argv[0] << " [options] <mountpoint>\n\n";
+      cout << "FUSE options:\n";
+      fuse_cmdline_help();
+      fuse_lowlevel_help();
+      cout << "\n";
+    }
+  } else {
 #else
   if (fuse_parse_cmdline(&args, nullptr, nullptr, nullptr) == -1) {
 #endif

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -612,9 +612,12 @@ static void fuse_ll_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
   Fh *fh = reinterpret_cast<Fh*>(fi->fh);
   bufferlist bl;
   int r = cfuse->client->ll_read(fh, off, size, &bl);
-  if (r >= 0)
-    fuse_reply_buf(req, bl.c_str(), bl.length());
-  else
+  if (r >= 0) {
+    vector<iovec> iov;
+    bl.prepare_iov(&iov);
+    iov.insert(iov.begin(), {0}); // the first one is reserved for fuse_out_header
+    fuse_reply_iov(req, &iov[0], iov.size());
+  } else
     fuse_reply_err(req, -r);
 }
 

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -88,6 +88,7 @@ public:
   struct fuse_session *se;
 #if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
   struct fuse_cmdline_opts opts;
+  struct fuse_conn_info_opts *conn_opts;
 #else
   struct fuse_chan *ch;
   char *mountpoint;
@@ -989,6 +990,10 @@ static void do_init(void *data, fuse_conn_info *conn)
   CephFuse::Handle *cfuse = (CephFuse::Handle *)data;
   Client *client = cfuse->client;
 
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  fuse_apply_conn_info_opts(cfuse->conn_opts, conn);
+#endif
+
 #if !defined(__APPLE__)
   if (!client->fuse_default_permissions && client->ll_handle_umask()) {
     // apply umask in userspace if posix acl is enabled
@@ -1105,6 +1110,8 @@ void CephFuse::Handle::finalize()
     fuse_session_unmount(se);
     fuse_session_destroy(se);
   }
+  if (conn_opts)
+    free(conn_opts);
   if (opts.mountpoint)
     free(opts.mountpoint);
 #else
@@ -1132,7 +1139,7 @@ int CephFuse::Handle::init(int argc, const char *argv[])
 
   // set up fuse argc/argv
   int newargc = 0;
-  const char **newargv = (const char **) malloc((argc + 10) * sizeof(char *));
+  const char **newargv = (const char **) malloc((argc + 11) * sizeof(char *));
   if(!newargv)
     return ENOMEM;
 
@@ -1146,11 +1153,11 @@ int CephFuse::Handle::init(int argc, const char *argv[])
 #if FUSE_VERSION < FUSE_MAKE_VERSION(3, 0)
   auto fuse_big_writes = client->cct->_conf.get_val<bool>(
     "fuse_big_writes");
+#endif
   auto fuse_max_write = client->cct->_conf.get_val<Option::size_t>(
     "fuse_max_write");
   auto fuse_atomic_o_trunc = client->cct->_conf.get_val<bool>(
     "fuse_atomic_o_trunc");
-#endif
   auto fuse_debug = client->cct->_conf.get_val<bool>(
     "fuse_debug");
 
@@ -1168,6 +1175,7 @@ int CephFuse::Handle::init(int argc, const char *argv[])
     newargv[newargc++] = "-o";
     newargv[newargc++] = "big_writes";
   }
+#endif
   if (fuse_max_write > 0) {
     char strsplice[65];
     newargv[newargc++] = "-o";
@@ -1178,7 +1186,6 @@ int CephFuse::Handle::init(int argc, const char *argv[])
     newargv[newargc++] = "-o";
     newargv[newargc++] = "atomic_o_trunc";
   }
-#endif
 #endif
   if (fuse_debug)
     newargv[newargc++] = "-d";
@@ -1201,6 +1208,17 @@ int CephFuse::Handle::init(int argc, const char *argv[])
     return EINVAL;
   }
 
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  derr << "init, args.argv = " << args.argv << " args.argc=" << args.argc << dendl;
+  conn_opts = fuse_parse_conn_info_opts(&args);
+  if (!conn_opts) {
+    derr << "fuse_parse_conn_info_opts failed" << dendl;
+    fuse_opt_free_args(&args);
+    free(newargv);
+    return EINVAL;
+  }
+#endif
+
   ceph_assert(args.allocated);  // Checking fuse has realloc'd args so we can free newargv
   free(newargv);
   return 0;
@@ -1210,6 +1228,10 @@ int CephFuse::Handle::start()
 {
 #if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
   se = fuse_session_new(&args, &fuse_ll_oper, sizeof(fuse_ll_oper), this);
+  if (!se) {
+    derr << "fuse_session_new failed" << dendl;
+    return EDOM;
+  }
 #else
   ch = fuse_mount(mountpoint, &args);
   if (!ch) {
@@ -1218,11 +1240,11 @@ int CephFuse::Handle::start()
   }
 
   se = fuse_lowlevel_new(&args, &fuse_ll_oper, sizeof(fuse_ll_oper), this);
-#endif
   if (!se) {
     derr << "fuse_lowlevel_new failed" << dendl;
     return EDOM;
   }
+#endif
 
   signal(SIGTERM, SIG_DFL);
   signal(SIGINT, SIG_DFL);

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8555,6 +8555,18 @@ std::vector<Option> get_mds_client_options() {
     .set_description("pass default_permisions to FUSE on mount")
     .set_flag(Option::FLAG_STARTUP),
 
+    Option("fuse_splice_read", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description("enable splice read to reduce the memory copies"),
+
+    Option("fuse_splice_write", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description("enable splice write to reduce the memory copies"),
+
+    Option("fuse_splice_move", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description("enable splice move to reduce the memory copies"),
+
     Option("fuse_big_writes", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description("big_writes is deprecated in libfuse 3.0.0"),


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/45267
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
