### PR TITLE
mimic: BlueFS: prevent BlueFS::dirty_files from being leaked when syncing metadata

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2076,7 +2076,7 @@ int BlueFS::_preallocate(FileRef f, uint64_t off, uint64_t len)
 void BlueFS::sync_metadata()
 {
   std::unique_lock<std::mutex> l(lock);
-  if (log_t.empty()) {
+  if (log_t.empty() && dirty_files.empty()) {
     dout(10) << __func__ << " - no pending log events" << dendl;
   } else {
     dout(10) << __func__ << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43086

---

backport of https://github.com/ceph/ceph/pull/30631
parent tracker: https://tracker.ceph.com/issues/42091

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh