### PR TITLE
octopus: os/bluestore: fix 'unused' calculation

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -13575,12 +13575,14 @@ int BlueStore::_do_alloc_write(
     }
 
     if (wi.mark_unused) {
+      ceph_assert(!dblob.is_compressed());
       auto b_end = b_off + wi.bl.length();
       if (b_off) {
         dblob.add_unused(0, b_off);
       }
-      if (b_end < wi.blob_length) {
-        dblob.add_unused(b_end, wi.blob_length - b_end);
+      uint64_t llen = dblob.get_logical_length();
+      if (b_end < llen) {
+        dblob.add_unused(b_end, llen - b_end);
       }
     }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -13235,7 +13235,10 @@ void BlueStore::_do_write_small(
   uint64_t b_off0 = b_off;
   _pad_zeros(&bl, &b_off0, block_size);
   o->extent_map.punch_hole(c, offset, length, &wctx->old_extents);
-  wctx->write(offset, b, alloc_len, b_off0, bl, b_off, length, true, true);
+  wctx->write(offset, b, alloc_len, b_off0, bl, b_off, length,
+    min_alloc_size != block_size, // use 'unused' bitmap when alloc granularity
+                                  // doesn't match disk one only
+    true);
 
   return;
 }

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -633,6 +633,7 @@ public:
     if (!has_unused()) {
       return false;
     }
+    ceph_assert(!is_compressed());
     uint64_t blob_len = get_logical_length();
     ceph_assert((blob_len % (sizeof(unused)*8)) == 0);
     ceph_assert(offset + length <= blob_len);
@@ -648,6 +649,7 @@ public:
 
   /// mark a range that has never been used
   void add_unused(uint64_t offset, uint64_t length) {
+    ceph_assert(!is_compressed());
     uint64_t blob_len = get_logical_length();
     ceph_assert((blob_len % (sizeof(unused)*8)) == 0);
     ceph_assert(offset + length <= blob_len);
@@ -665,6 +667,7 @@ public:
   /// indicate that a range has (now) been used.
   void mark_used(uint64_t offset, uint64_t length) {
     if (has_unused()) {
+      ceph_assert(!is_compressed());
       uint64_t blob_len = get_logical_length();
       ceph_assert((blob_len % (sizeof(unused)*8)) == 0);
       ceph_assert(offset + length <= blob_len);

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1596,6 +1596,98 @@ TEST(BlueStoreRepairer, StoreSpaceTracker)
   ASSERT_TRUE(bmap2.is_used(hoid, 0x3223b19ffff));
 }
 
+TEST(bluestore_blob_t, unused)
+{
+  {
+    bluestore_blob_t b;
+    uint64_t min_alloc_size = 64 << 10; // 64 kB
+
+    // _do_write_small 0x0~1000
+    uint64_t offset = 0x0;
+    uint64_t length = 0x1000; // 4kB
+    uint64_t suggested_boff = 0;
+    PExtentVector extents;
+    extents.emplace_back(0x1a560000, min_alloc_size);
+    b.allocated(p2align(suggested_boff, min_alloc_size), 0 /*no matter*/, extents);
+    b.mark_used(offset, length);
+    ASSERT_FALSE(b.is_unused(offset, length));
+
+    // _do_write_small 0x2000~1000
+    offset = 0x2000;
+    length = 0x1000;
+    b.add_unused(0, 0x10000);
+    ASSERT_TRUE(b.is_unused(offset, length));
+    b.mark_used(offset, length);
+    ASSERT_FALSE(b.is_unused(offset, length));
+
+    // _do_write_small 0xc000~2000
+    offset = 0xc000;
+    length = 0x2000;
+    ASSERT_TRUE(b.is_unused(offset, length));
+    b.mark_used(offset, length);
+    ASSERT_FALSE(b.is_unused(offset, length));
+  }
+
+  {
+    bluestore_blob_t b;
+    uint64_t min_alloc_size = 64 << 10; // 64 kB
+
+    // _do_write_small 0x11000~1000
+    uint64_t offset = 0x11000;
+    uint64_t length = 0x1000; // 4kB
+    uint64_t suggested_boff = 0x11000;
+    PExtentVector extents;
+    extents.emplace_back(0x1a560000, min_alloc_size);
+    b.allocated(p2align(suggested_boff, min_alloc_size), 0 /*no matter*/, extents);
+    b.add_unused(0, offset);
+    b.add_unused(offset + length, min_alloc_size * 2 - offset - length);
+    b.mark_used(offset, length);
+    ASSERT_FALSE(b.is_unused(offset, length));
+
+    // _do_write_small 0x15000~3000
+    offset = 0x15000;
+    length = 0x3000;
+    ASSERT_TRUE(b.is_unused(offset, length));
+    b.mark_used(offset, length);
+    ASSERT_FALSE(b.is_unused(offset, length));
+  }
+
+  {
+    // reuse blob
+    bluestore_blob_t b;
+    uint64_t min_alloc_size = 64 << 10; // 64 kB
+
+    // _do_write_small 0x2a000~1000
+    // and 0x1d000~1000
+    uint64_t unused_granularity = 0x3000;
+    // offsets and lenght below are selected to
+    // be aligned with unused_granularity
+    uint64_t offset0 = 0x2a000;
+    uint64_t offset = 0x1d000;
+    uint64_t length = 0x1000; // 4kB
+    PExtentVector extents;
+    extents.emplace_back(0x410000, min_alloc_size);
+    b.allocated(p2align(offset0, min_alloc_size), min_alloc_size, extents);
+    b.add_unused(0, min_alloc_size * 3);
+    b.mark_used(offset0, length);
+    ASSERT_FALSE(b.is_unused(offset0, length));
+    ASSERT_TRUE(b.is_unused(offset, length));
+
+    extents.clear();
+    extents.emplace_back(0x430000, min_alloc_size);
+    b.allocated(p2align(offset, min_alloc_size), min_alloc_size, extents);
+    b.mark_used(offset, length);
+    ASSERT_FALSE(b.is_unused(offset0, length));
+    ASSERT_FALSE(b.is_unused(offset, length));
+    ASSERT_FALSE(b.is_unused(offset, unused_granularity));
+
+    ASSERT_TRUE(b.is_unused(0, offset / unused_granularity * unused_granularity));
+    ASSERT_TRUE(b.is_unused(offset + length, offset0 - offset - length));
+    auto end0_aligned = round_up_to(offset0 + length, unused_granularity);
+    ASSERT_TRUE(b.is_unused(end0_aligned, min_alloc_size * 3 - end0_aligned));
+  }
+}
+
 int main(int argc, char **argv) {
   vector<const char*> args;
   argv_to_vec(argc, (const char **)argv, args);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45063

---

backport of https://github.com/ceph/ceph/pull/33052
parent tracker: https://tracker.ceph.com/issues/41901

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh