### PR TITLE
octopus: ceph-object-corpus: update to octopus

### DIFF
--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -124,7 +124,7 @@ private:
     auto close_fd = make_scope_guard([fd] { ::close(fd); });
     if (auto bl_delta = appender.bl.length() - bl_offset; bl_delta > 0) {
       ceph::bufferlist dump_bl;
-      appender.bl.copy(bl_offset + space_offset, bl_delta - space_offset, dump_bl);
+      appender.bl.begin(bl_offset + space_offset).copy(bl_delta - space_offset, dump_bl);
       const size_t space_len = space_size();
       dump_bl.append(appender.get_pos() - space_len, space_len);
       dump_bl.write_fd(fd);


### PR DESCRIPTION
NOTE: the original PR has three commits, the last of which ("doc: add object corpus to release checklist") touches a file that is not present in octopus. For that reason, this backport cherry-picks only the first two commits.

backport tracker: https://tracker.ceph.com/issues/45207

---

backport of https://github.com/ceph/ceph/pull/34576
parent tracker: https://tracker.ceph.com/issues/45023

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh