### PR TITLE
octopus: test/libcephfs: retry and wait for caps when setting the RD deleg

### DIFF
--- a/src/test/libcephfs/deleg.cc
+++ b/src/test/libcephfs/deleg.cc
@@ -42,6 +42,20 @@ static void wait_for_atomic_bool(std::atomic_bool &recalled)
   }
 }
 
+static int ceph_ll_delegation_wait(struct ceph_mount_info *cmount, Fh *fh,
+				   unsigned cmd, ceph_deleg_cb_t cb, void *priv)
+{
+  int ret, retry = 0;
+
+  /* Wait 10s at most */
+  do {
+    ret = ceph_ll_delegation(cmount, fh, cmd, cb, priv);
+    usleep(10000);
+  } while (ret == -EAGAIN && retry++ < 1000);
+
+  return ret;
+}
+
 static int set_default_deleg_timeout(struct ceph_mount_info *cmount)
 {
   uint32_t session_timeout = ceph_get_cap_return_timeout(cmount);
@@ -166,7 +180,7 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
   sprintf(filename, "deleg.rwrw.%x", getpid());
   ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0666,
 		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
-  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
+  ASSERT_EQ(ceph_ll_delegation_wait(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
   std::thread breaker1(open_breaker_func, tcmount, filename, O_RDWR, &opened);
 
   wait_for_atomic_bool(recalled);
@@ -182,7 +196,7 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
   sprintf(filename, "deleg.rorw.%x", getpid());
   ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0666,
 		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
-  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
+  ASSERT_EQ(ceph_ll_delegation_wait(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
   std::thread breaker2(open_breaker_func, tcmount, filename, O_RDONLY, &opened);
   wait_for_atomic_bool(recalled);
   ASSERT_EQ(opened.load(), false);
@@ -196,7 +210,7 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
   ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0666,
 		    O_RDONLY|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
   recalled.store(false);
-  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_RD, dummy_deleg_cb, &recalled), 0);
+  ASSERT_EQ(ceph_ll_delegation_wait(cmount, fh, CEPH_DELEGATION_RD, dummy_deleg_cb, &recalled), 0);
   std::thread breaker3(open_breaker_func, tcmount, filename, O_RDONLY, &opened);
   breaker3.join();
   ASSERT_EQ(recalled.load(), false);
@@ -219,7 +233,7 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
   sprintf(newname, "deleg.new.%x", getpid());
   ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0666,
 		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
-  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
+  ASSERT_EQ(ceph_ll_delegation_wait(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
   std::thread breaker5(namespace_breaker_func, tcmount, DelegTestLink, filename, newname);
   wait_for_atomic_bool(recalled);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
@@ -232,7 +246,7 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
   recalled.store(false);
   ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0666,
 		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
-  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
+  ASSERT_EQ(ceph_ll_delegation_wait(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
   std::thread breaker6(namespace_breaker_func, tcmount, DelegTestRename, filename, newname);
   wait_for_atomic_bool(recalled);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
@@ -244,7 +258,7 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
   recalled.store(false);
   ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0666,
 		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
-  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
+  ASSERT_EQ(ceph_ll_delegation_wait(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
   std::thread breaker7(namespace_breaker_func, tcmount, DelegTestUnlink, filename, nullptr);
   wait_for_atomic_bool(recalled);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
@@ -307,7 +321,7 @@ TEST(LibCephFS, DelegTimeout) {
   ASSERT_EQ(ceph_ll_open(cmount, file, O_RDONLY, &fh, perms), 0);
 
   std::atomic_bool recalled(false);
-  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_RD, dummy_deleg_cb, &recalled), 0);
+  ASSERT_EQ(ceph_ll_delegation_wait(cmount, fh, CEPH_DELEGATION_RD, dummy_deleg_cb, &recalled), 0);
   std::atomic_bool opened(false);
   std::thread breaker1(open_breaker_func, nullptr, filename, O_RDWR, &opened);
   breaker1.join();
@@ -361,7 +375,7 @@ TEST(LibCephFS, RecalledGetattr) {
 
   /* Break delegation */
   std::atomic_bool recalled(false);
-  ASSERT_EQ(ceph_ll_delegation(cmount2, fh, CEPH_DELEGATION_RD, dummy_deleg_cb, &recalled), 0);
+  ASSERT_EQ(ceph_ll_delegation_wait(cmount2, fh, CEPH_DELEGATION_RD, dummy_deleg_cb, &recalled), 0);
   ASSERT_EQ(ceph_ll_read(cmount2, fh, 0, sizeof(filename), filename),
 	    static_cast<int>(sizeof(filename)));
   ASSERT_EQ(ceph_ll_getattr(cmount2, file, &stx, CEPH_STATX_ALL_STATS, 0, perms), 0);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44843

---

backport of https://github.com/ceph/ceph/pull/34021
parent tracker: https://tracker.ceph.com/issues/44525

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh