### PR TITLE
octopus: qa/test_config_session_timeout: fix options conflicting

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -333,7 +333,7 @@ class LocalRemote(object):
 
         # Filter out helper tools that don't exist in a vstart environment
         args = [a for a in args if a not in {
-            'adjust-ulimits', 'ceph-coverage', 'timeout'}]
+            'adjust-ulimits', 'ceph-coverage'}]
 
         # Adjust binary path prefix if given a bare program name
         if "/" not in args[0]:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44844

---

backport of https://github.com/ceph/ceph/pull/33740
parent tracker: https://tracker.ceph.com/issues/44437

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh