### PR TITLE
octopus: qa/tasks/cephfs: umount the mountpoints when tearDown

### DIFF
--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -244,6 +244,9 @@ class FuseMount(CephFSMount):
         return self.client_remote.run(args=["ls", "-d", self.mountpoint], check_status=False, cwd=self.test_dir, timeout=(15*60)).exitstatus == 0
 
     def umount(self):
+        if not self.is_mounted():
+            return
+
         try:
             log.info('Running fusermount -u on {name}...'.format(name=self.client_remote.name))
             self.client_remote.run(

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -74,6 +74,9 @@ class KernelMount(CephFSMount):
         self.mounted = True
 
     def umount(self, force=False):
+        if not self.is_mounted():
+            return
+
         log.debug('Unmounting client client.{id}...'.format(id=self.client_id))
 
         cmd=['sudo', 'umount', self.mountpoint]

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class XFSTestsDev(CephFSTestCase):
 
     def setUp(self):
-        CephFSTestCase.setUp(self)
+        super(XFSTestsDev, self).setUp()
         self.prepare_xfstests_dev()
 
     def prepare_xfstests_dev(self):
@@ -172,3 +172,5 @@ class XFSTestsDev(CephFSTestCase):
         self.mount_a.client_remote.run(args=['sudo', 'rm', '-rf',
                                              self.repo_path],
                                        omit_sudo=False, check_status=False)
+
+        super(XFSTestsDev, self).tearDown()

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -615,33 +615,6 @@ class LocalKernelMount(KernelMount):
         log.info("I think my launching pid was {0}".format(self.fuse_daemon.subproc.pid))
         return path
 
-    def umount(self, force=False):
-        log.debug('Unmounting client client.{id}...'.format(id=self.client_id))
-
-        cmd=['sudo', 'umount', self.mountpoint]
-        if force:
-            cmd.append('-f')
-
-        try:
-            self.client_remote.run(args=cmd, timeout=(15*60), omit_sudo=False)
-        except Exception as e:
-            self.client_remote.run(args=[
-                'sudo',
-                Raw('PATH=/usr/sbin:$PATH'),
-                'lsof',
-                Raw(';'),
-                'ps', 'auxf',
-            ], timeout=(15*60), omit_sudo=False)
-            raise e
-
-        rproc = self.client_remote.run(args=[
-                'rmdir',
-                '--',
-                self.mountpoint,
-            ])
-        rproc.wait()
-        self.mounted = False
-
     def mount(self, mount_path=None, mount_fs_name=None, mount_options=[]):
         self.setupfs(name=mount_fs_name)
 
@@ -802,10 +775,6 @@ class LocalFuseMount(FuseMount):
         path = "{0}/client.{1}.{2}.asok".format(d, self.client_id, self.fuse_daemon.subproc.pid)
         log.info("I think my launching pid was {0}".format(self.fuse_daemon.subproc.pid))
         return path
-
-    def umount(self):
-        if self.is_mounted():
-            super(LocalFuseMount, self).umount()
 
     def mount(self, mount_path=None, mount_fs_name=None, mountpoint=None, mount_options=[]):
         if mountpoint is not None:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45216

---

backport of https://github.com/ceph/ceph/pull/33711
parent tracker: https://tracker.ceph.com/issues/44408

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh