### PR TITLE
octopus: qa/standalone/osd/osd-backfill-stats.sh: get_latest_osdmap to propagate map change

### DIFF
--- a/qa/standalone/osd/osd-backfill-stats.sh
+++ b/qa/standalone/osd/osd-backfill-stats.sh
@@ -353,6 +353,7 @@ function TEST_backfill_out2() {
     sleep 2
     primary=$(get_primary $poolname obj1)
     ceph osd unset nobackfill
+    ceph tell osd.$primary get_latest_osdmap
     ceph tell osd.$primary debug kick_recovery_wq 0
     sleep 2
 
@@ -410,6 +411,7 @@ function TEST_backfill_sizeup4_allout() {
     sleep 2
     primary=$(get_primary $poolname obj1)
     ceph osd unset nobackfill
+    ceph tell osd.$primary get_latest_osdmap
     ceph tell osd.$primary debug kick_recovery_wq 0
     sleep 2
 
@@ -474,6 +476,7 @@ function TEST_backfill_remapped() {
     primary=$(get_primary $poolname obj1)
 
     ceph osd unset nobackfill
+    ceph tell osd.$primary get_latest_osdmap
     ceph tell osd.$primary debug kick_recovery_wq 0
 
     sleep 2
@@ -534,6 +537,7 @@ function TEST_backfill_ec_all_out() {
     sleep 2
     primary=$(get_primary $poolname obj1)
     ceph osd unset nobackfill
+    ceph tell osd.$primary get_latest_osdmap
     ceph tell osd.$primary debug kick_recovery_wq 0
     sleep 2
 
@@ -584,6 +588,7 @@ function TEST_backfill_ec_prim_out() {
     sleep 2
     primary=$(get_primary $poolname obj1)
     ceph osd unset nobackfill
+    ceph tell osd.$primary get_latest_osdmap
     ceph tell osd.$primary debug kick_recovery_wq 0
     sleep 2
 
@@ -642,6 +647,7 @@ function TEST_backfill_ec_down_all_out() {
     sleep 2
     primary=$(get_primary $poolname obj1)
     ceph osd unset nobackfill
+    ceph tell osd.$primary get_latest_osdmap
     ceph tell osd.$primary debug kick_recovery_wq 0
     sleep 2
     flush_pg_stats
@@ -726,6 +732,7 @@ function TEST_backfill_ec_down_out() {
     sleep 2
     primary=$(get_primary $poolname obj1)
     ceph osd unset nobackfill
+    ceph tell osd.$primary get_latest_osdmap
     ceph tell osd.$primary debug kick_recovery_wq 0
     sleep 2
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44685

---

backport of https://github.com/ceph/ceph/pull/34047
parent tracker: https://tracker.ceph.com/issues/44518

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh