### PR TITLE
octopus: cephadm: create /var/run/ceph dir via unit.run, not unit file

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1811,6 +1811,10 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
             install_path = find_program('install')
             f.write('{install_path} -d -m0770 -o {uid} -g {gid} /var/run/ceph/{fsid}\n'.format(install_path=install_path, fsid=fsid, uid=uid, gid=gid))
 
+        if daemon_type in Ceph.daemons:
+            install_path = find_program('install')
+            f.write('{install_path} -d -m0770 -o {uid} -g {gid} /var/run/ceph/{fsid}\n'.format(install_path=install_path, fsid=fsid, uid=uid, gid=gid))
+
         # container run command
         f.write(' '.join(c.run_cmd()) + '\n')
         os.fchmod(f.fileno(), 0o600)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45037

---

backport of https://github.com/ceph/ceph/pull/34384
parent tracker: https://tracker.ceph.com/issues/44894

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh