### PR TITLE
mgr/orch: fix `orch apply iscsi`

### DIFF
--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -568,7 +568,7 @@ This is an overview of the current implementation status of the orchestrators.
 =================================== ====== =========
  Command                             Rook   Cephadm
 =================================== ====== =========
- apply iscsi                         ⚪      ⚪
+ apply iscsi                         ⚪     ✔
  apply mds                           ✔      ✔
  apply mgr                           ⚪      ✔
  apply mon                           ✔      ✔
@@ -583,7 +583,7 @@ This is an overview of the current implementation status of the orchestrators.
  daemon {stop,start,...}             ⚪      ✔
  device {ident,fault}-(on,off}       ⚪      ✔
  device ls                           ✔      ✔
- iscsi add                           ⚪      ⚪
+ iscsi add                           ⚪     ✔
  mds add                             ✔      ✔
  nfs add                             ✔      ✔
  rbd-mirror add                      ⚪      ✔

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2068,7 +2068,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         try:
             tree = json.loads(out)
         except json.decoder.JSONDecodeError:
-            self.log.error(f"Could not decode json -> {out}")
+            self.log.exception(f"Could not decode json -> {out}")
             return osd_host_map
 
         nodes = tree.get('nodes', {})
@@ -2479,10 +2479,10 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                     daemon_type, daemon_id, host))
                 if daemon_type == 'mon':
                     create_func(daemon_id, host, network)  # type: ignore
-                elif daemon_type == 'nfs':
+                elif daemon_type in ['nfs', 'iscsi']:
                     create_func(daemon_id, host, spec)  # type: ignore
                 else:
-                    create_func(daemon_id, host)           # type: ignore
+                    create_func(daemon_id, host)  # type: ignore
 
                 # add to daemon list so next name(s) will also be unique
                 sd = orchestrator.DaemonDescription(
@@ -2514,7 +2514,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 if self._apply_service(spec):
                     r = True
             except Exception as e:
-                self.log.warning('Failed to apply %s spec %s: %s' % (
+                self.log.exception('Failed to apply %s spec %s: %s' % (
                     spec.service_name(), spec, e))
         return r
 
@@ -2625,9 +2625,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 daemon_type, daemon_id, host))
             if daemon_type == 'mon':
                 args.append((daemon_id, host, network))  # type: ignore
-            elif daemon_type == 'nfs':
-                args.append((daemon_id, host, spec)) # type: ignore
-            elif daemon_type == 'iscsi':
+            elif daemon_type in ['nfs', 'iscsi']:
                 args.append((daemon_id, host, spec))  # type: ignore
             else:
                 args.append((daemon_id, host))  # type: ignore

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -927,6 +927,26 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command(
+        'orch apply iscsi',
+        'name=pool,type=CephString '
+        'name=trusted_ip_list,type=CephString,req=false '
+        'name=placement,type=CephString,req=false '
+        'name=unmanaged,type=CephBool,req=false',
+        'Scale an iSCSI service')
+    def _apply_iscsi(self, pool, trusted_ip_list=None, placement=None, unmanaged=False, inbuf=None):
+        spec = IscsiServiceSpec(
+            service_id='iscsi',
+            pool=pool,
+            trusted_ip_list=trusted_ip_list,
+            placement=PlacementSpec.from_string(placement),
+            unmanaged=unmanaged,
+        )
+        completion = self.apply_iscsi(spec)
+        self._orchestrator_wait([completion])
+        raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
+    @_cli_write_command(
         'orch set backend',
         "name=module_name,type=CephString,req=true",
         'Select orchestrator module backend')


### PR DESCRIPTION
Adds missing orch cli:
`$ ceph orch apply iscsi --pool <pool>`

Also fixes invocation error during apply:
```
Error ENOENT: ServiceSpec: __init__() missing 1 required positional argument: 'service_id
```

Fixes: https://tracker.ceph.com/issues/45249
Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
