### PR TITLE
python-common: Fix wrong type annotation

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -5,9 +5,7 @@ try:
 except ImportError:
     pass
 
-from ceph.deployment.inventory import Device
-
-from ..inventory import Devices
+from ..inventory import Device
 from ..drive_group import DriveGroupSpec, DeviceSelection
 
 from .filter import FilterGenerator
@@ -18,7 +16,7 @@ logger = logging.getLogger(__name__)
 class DriveSelection(object):
     def __init__(self,
                  spec,  # type: DriveGroupSpec
-                 disks,  # type: Devices
+                 disks,  # type: List[Device]
                  ):
         self.disks = disks.copy()
         self.spec = spec

--- a/src/python-common/ceph/deployment/inventory.py
+++ b/src/python-common/ceph/deployment/inventory.py
@@ -28,6 +28,7 @@ class Devices(object):
         return cls([Device.from_json(i) for i in input])
 
     def copy(self):
+        # type: () -> Devices
         return Devices(devices=list(self.devices))
 
 

--- a/src/python-common/ceph/tests/utils.py
+++ b/src/python-common/ceph/tests/utils.py
@@ -1,5 +1,10 @@
 from ceph.deployment.inventory import Devices, Device
 
+try:
+    from typing import Any, List
+except ImportError:
+    pass  # for type checking
+
 
 def _mk_device(rotational=True,
                locked=False,
@@ -29,6 +34,7 @@ def _mk_device(rotational=True,
 
 
 def _mk_inventory(devices):
+    # type: (Any) -> List[Device]
     devs = []
     for dev_, name in zip(devices, map(chr, range(ord('a'), ord('z')))):
         dev = Device.from_json(dev_.to_json())


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
