### PR TITLE
octopus: rgw: pubsub sync module ignores ERR_USER_EXIST

### DIFF
--- a/src/rgw/rgw_sync_module_pubsub.cc
+++ b/src/rgw/rgw_sync_module_pubsub.cc
@@ -1055,7 +1055,7 @@ public:
       create_user.display_name = "pubsub";
       create_user.generate_key = false;
       yield call(new RGWUserCreateCR(sync_env->async_rados, sync_env->store, create_user, sync_env->dpp));
-      if (retcode < 0) {
+      if (retcode < 0 && retcode != -ERR_USER_EXIST) {
         ldpp_dout(sync_env->dpp, 1) << "ERROR: failed to create rgw user: ret=" << retcode << dendl;
         return set_cr_error(retcode);
       }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44895

---

backport of https://github.com/ceph/ceph/pull/34322
parent tracker: https://tracker.ceph.com/issues/44857

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh