### PR TITLE
octopus: monitoring: fix decimal precision in Grafana %percentages

### DIFF
--- a/monitoring/grafana/dashboards/ceph-cluster.json
+++ b/monitoring/grafana/dashboards/ceph-cluster.json
@@ -260,6 +260,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
+      "decimals": 2,
       "format": "percentunit",
       "gauge": {
         "maxValue": 100,

--- a/monitoring/grafana/dashboards/hosts-overview.json
+++ b/monitoring/grafana/dashboards/hosts-overview.json
@@ -133,6 +133,7 @@
       "datasource": "$datasource",
       "decimals": 0,
       "description": "Average CPU busy across all hosts (OSD, RGW, MON etc) within the cluster",
+      "decimals": 2,
       "format": "percentunit",
       "gauge": {
         "maxValue": 100,
@@ -216,6 +217,7 @@
       "datasource": "$datasource",
       "decimals": 0,
       "description": "Average Memory Usage across all hosts in the cluster (excludes buffer/cache usage)",
+      "decimals": 2,
       "format": "percentunit",
       "gauge": {
         "maxValue": 100,

--- a/monitoring/grafana/dashboards/pool-detail.json
+++ b/monitoring/grafana/dashboards/pool-detail.json
@@ -50,6 +50,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
+      "decimals": 2,
       "format": "percentunit",
       "gauge": {
         "maxValue": 1,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45328

---

backport of https://github.com/ceph/ceph/pull/34682
parent tracker: https://tracker.ceph.com/issues/45183

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh