### PR TITLE
octopus: qa/standalone/scrub/osd-scrub-repair.sh: fix race in TEST_auto_repair_bluestore_failed

### DIFF
--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -494,6 +494,7 @@ function TEST_auto_repair_bluestore_failed() {
     repair $pgid
     sleep 2
 
+    flush_pg_stats
     ceph pg dump pgs
     ceph pg dump pgs | grep -q "^$(pgid).* active+clean " || return 1
     grep scrub_finish $dir/osd.${primary}.log

--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -496,7 +496,7 @@ function TEST_auto_repair_bluestore_failed() {
 
     flush_pg_stats
     ceph pg dump pgs
-    ceph pg dump pgs | grep -q "^$(pgid).* active+clean " || return 1
+    ceph pg dump pgs | grep -q -e "^${pgid}.* active+clean " -e "^${pgid}.* active+clean+wait " || return 1
     grep scrub_finish $dir/osd.${primary}.log
 
     # Tear down


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45314

---

backport of https://github.com/ceph/ceph/pull/34602
parent tracker: https://tracker.ceph.com/issues/45075

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh