### PR TITLE
nautilus: bluestore/bdev: initialize size when creating object

### DIFF
--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -33,7 +33,7 @@ namespace ceph {
 /// label for block device
 struct bluestore_bdev_label_t {
   uuid_d osd_uuid;     ///< osd uuid
-  uint64_t size;       ///< device size
+  uint64_t size = 0;   ///< device size
   utime_t btime;       ///< birth time
   string description;  ///< device description
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45330

---

backport of https://github.com/ceph/ceph/pull/29968
parent tracker: https://tracker.ceph.com/issues/45250

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh