### PR TITLE
nautilus: rgw: increase log level for same or older period pull msg

### DIFF
--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -1097,7 +1097,7 @@ int RGWPeriod::update_latest_epoch(epoch_t epoch)
       return r;
     } else if (epoch <= info.epoch) {
       r = -EEXIST; // fail with EEXIST if epoch is not newer
-      ldout(cct, 1) << "found existing latest_epoch " << info.epoch
+      ldout(cct, 10) << "found existing latest_epoch " << info.epoch
           << " >= given epoch " << epoch << ", returning r=" << r << dendl;
       return r;
     } else {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44653

---

backport of https://github.com/ceph/ceph/pull/33527
parent tracker: https://tracker.ceph.com/issues/44338

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh