### PR TITLE
qa/cephfs: run nsenter commands with superuser privileges

### DIFF
--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -415,16 +415,17 @@ class FuseMount(CephFSMount):
     def _prefix(self):
         return ""
 
-    def admin_socket(self, args):
+    def find_admin_socket(self):
         pyscript = """
 import glob
 import re
 import os
 import subprocess
 
-def find_socket(client_name):
+def _find_admin_socket(client_name):
         asok_path = "{asok_path}"
         files = glob.glob(asok_path)
+        mountpoint = "{mountpoint}"
 
         # Given a non-glob path, it better be there
         if "*" not in asok_path:
@@ -434,20 +435,24 @@ def find_socket(client_name):
         for f in files:
                 pid = re.match(".*\.(\d+)\.asok$", f).group(1)
                 if os.path.exists("/proc/{{0}}".format(pid)):
-                        return f
+                    with open("/proc/{{0}}/cmdline".format(pid), 'r') as proc_f:
+                        contents = proc_f.read()
+                        if mountpoint in contents:
+                            return f
         raise RuntimeError("Client socket {{0}} not found".format(client_name))
 
-print(find_socket("{client_name}"))
+print(_find_admin_socket("{client_name}"))
 """.format(
             asok_path=self._asok_path(),
-            client_name="client.{0}".format(self.client_id))
+            client_name="client.{0}".format(self.client_id),
+            mountpoint=self.mountpoint)
 
-        # Find the admin socket
-        asok_path = self.client_remote.sh(
-            ['sudo', 'python3', '-c', pyscript],
-            stdout=StringIO(),
-            timeout=(15*60)).strip()
+        asok_path = self.run_python(pyscript)
         log.info("Found client admin socket at {0}".format(asok_path))
+        return asok_path
+
+    def admin_socket(self, args):
+        asok_path = self.find_admin_socket()
 
         # Query client ID from admin socket, wait 2 seconds
         # and retry 10 times if it is not ready

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -53,6 +53,7 @@ from teuthology.orchestra.run import Raw, quote
 from teuthology.orchestra.daemon import DaemonGroup
 from teuthology.orchestra.remote import Remote
 from teuthology.config import config as teuth_config
+from teuthology.contextutil import safe_while
 import six
 import logging
 
@@ -164,6 +165,11 @@ class LocalRemoteProcess(object):
         self.subproc = subproc
         self.stdout = stdout or BytesIO()
         self.stderr = stderr or BytesIO()
+        # this variable is meant for instance of this class named fuse_daemon.
+        # child process of the command launched with sudo must be killed,
+        # since killing parent process alone has no impact on the child
+        # process.
+        self.fuse_pid = -1
 
         self.check_status = check_status
         self.exitstatus = self.returncode = None
@@ -222,7 +228,10 @@ class LocalRemoteProcess(object):
         if self.subproc.pid and not self.finished:
             log.info("kill: killing pid {0} ({1})".format(
                 self.subproc.pid, self.args))
-            safe_kill(self.subproc.pid)
+            if self.fuse_pid != -1:
+                safe_kill(self.fuse_pid)
+            else:
+                safe_kill(self.subproc.pid)
         else:
             log.info("kill: already terminated ({0})".format(self.args))
 
@@ -585,8 +594,7 @@ class LocalKernelMount(KernelMount):
                 if asok_conf:
                     d = asok_conf.groups(1)[0]
                     break
-        path = "{0}/client.{1}.{2}.asok".format(d, self.client_id, self.fuse_daemon.subproc.pid)
-        log.info("I think my launching pid was {0}".format(self.fuse_daemon.subproc.pid))
+        path = "{0}/client.{1}.*.asok".format(d, self.client_id)
         return path
 
     def mount(self, mount_path=None, mount_fs_name=None, mount_options=[]):
@@ -689,8 +697,7 @@ class LocalFuseMount(FuseMount):
                 if asok_conf:
                     d = asok_conf.groups(1)[0]
                     break
-        path = "{0}/client.{1}.{2}.asok".format(d, self.client_id, self.fuse_daemon.subproc.pid)
-        log.info("I think my launching pid was {0}".format(self.fuse_daemon.subproc.pid))
+        path = "{0}/client.{1}.*.asok".format(d, self.client_id)
         return path
 
     def mount(self, mount_path=None, mount_fs_name=None, mountpoint=None, mount_options=[]):
@@ -725,29 +732,26 @@ class LocalFuseMount(FuseMount):
         pre_mount_conns = list_connections()
         log.info("Pre-mount connections: {0}".format(pre_mount_conns))
 
-        prefix = [os.path.join(BIN_PREFIX, "ceph-fuse")]
+        prefix = ['sudo', 'nsenter',
+                  '--net=/var/run/netns/{0}'.format(self.netns_name),
+                  '--setuid', str(os.getuid()),
+                  os.path.join(BIN_PREFIX, "ceph-fuse")]
         if os.getuid() != 0:
             prefix += ["--client_die_on_failed_dentry_invalidate=false"]
-
         if mount_path is not None:
             prefix += ["--client_mountpoint={0}".format(mount_path)]
-
         if mount_fs_name is not None:
             prefix += ["--client_fs={0}".format(mount_fs_name)]
-
         prefix += mount_options;
+        fuse_cmd_args = prefix + ["-f", "--name",
+                                  "client.{0}".format(self.client_id),
+                                  self.mountpoint]
 
-        self.fuse_daemon = self.client_remote.run(args=
-                                            ['nsenter',
-                                             '--net=/var/run/netns/{0}'.format(self.netns_name),
-                                            ] + prefix + [
-                                                "-f",
-                                                "--name",
-                                                "client.{0}".format(self.client_id),
-                                                self.mountpoint
-                                            ], wait=False)
-
-        log.info("Mounting client.{0} with pid {1}".format(self.client_id, self.fuse_daemon.subproc.pid))
+        self.fuse_daemon = self.client_remote.run(args=fuse_cmd_args,
+                                                  wait=False)
+        self._set_fuse_daemon_pid()
+        log.info("Mounting client.{0} with pid "
+                 "{1}".format(self.client_id, self.fuse_daemon.subproc.pid))
 
         # Wait for the connection reference to appear in /sys
         waited = 0
@@ -780,6 +784,20 @@ class LocalFuseMount(FuseMount):
         self.gather_mount_info()
 
         self.mounted = True
+    def _set_fuse_daemon_pid(self):
+        # NOTE: When a command <args> is launched with sudo, two processes are
+        # launched, one with sudo in <args> and other without. Make sure we
+        # get the PID of latter one.
+        with safe_while(sleep=1, tries=15) as proceed:
+            while proceed():
+                try:
+                    sock = self.find_admin_socket()
+                except (RuntimeError, CommandFailedError):
+                    continue
+
+                self.fuse_daemon.fuse_pid = int(re.match(".*\.(\d+)\.asok$",
+                                                         sock).group(1))
+                break
 
     def _run_python(self, pyscript, py_version='python'):
         """

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -599,7 +599,11 @@ class LocalKernelMount(KernelMount):
 
     def mount(self, mount_path=None, mount_fs_name=None, mount_options=[]):
         self.setupfs(name=mount_fs_name)
-        self.setup_netns()
+        if opt_use_ns:
+            self.using_namespace = True
+            self.setup_netns()
+        else:
+            self.using_namespace = False
 
         log.info('Mounting kclient client.{id} at {remote} {mnt}...'.format(
             id=self.client_id, remote=self.client_remote, mnt=self.mountpoint))
@@ -625,26 +629,24 @@ class LocalKernelMount(KernelMount):
         for mount_opt in mount_options:
             opts += ",{0}".format(mount_opt)
 
-        self.client_remote.run(
-            args=[
-                'sudo',
-                'nsenter',
-                '--net=/var/run/netns/{0}'.format(self.netns_name),
-                './bin/mount.ceph',
-                ':{mount_path}'.format(mount_path=mount_path),
-                self.mountpoint,
-                '-v',
-                '-o',
-                opts
-            ],
-            timeout=(30*60),
-            omit_sudo=False,
-        )
+        mount_cmd_args = ['sudo']
+        if self.using_namespace:
+            mount_cmd_args += ['nsenter',
+                               '--net=/var/run/netns/{0}'.format(self.netns_name)]
+        mount_cmd_args += ['./bin/mount.ceph',
+                           ':{mount_path}'.format(mount_path=mount_path),
+                           self.mountpoint, '-v', '-o', opts]
+        self.client_remote.run(args=mount_cmd_args, timeout=(30*60),
+                               omit_sudo=False)
 
         self.client_remote.run(
             args=['sudo', 'chmod', '1777', self.mountpoint], timeout=(5*60))
 
         self.mounted = True
+
+    def cleanup_netns(self):
+        if self.using_namespace:
+            super(type(self), self).cleanup_netns()
 
     def _run_python(self, pyscript, py_version='python'):
         """
@@ -704,7 +706,11 @@ class LocalFuseMount(FuseMount):
         if mountpoint is not None:
             self.mountpoint = mountpoint
         self.setupfs(name=mount_fs_name)
-        self.setup_netns()
+        if opt_use_ns:
+            self.using_namespace = True
+            self.setup_netns()
+        else:
+            self.using_namespace = False
 
         self.client_remote.run(args=['mkdir', '-p', self.mountpoint])
 
@@ -732,10 +738,12 @@ class LocalFuseMount(FuseMount):
         pre_mount_conns = list_connections()
         log.info("Pre-mount connections: {0}".format(pre_mount_conns))
 
-        prefix = ['sudo', 'nsenter',
-                  '--net=/var/run/netns/{0}'.format(self.netns_name),
-                  '--setuid', str(os.getuid()),
-                  os.path.join(BIN_PREFIX, "ceph-fuse")]
+        prefix = []
+        if self.using_namespace:
+            prefix += ['sudo', 'nsenter',
+                       '--net=/var/run/netns/{0}'.format(self.netns_name),
+                       '--setuid', str(os.getuid())]
+        prefix += [os.path.join(BIN_PREFIX, "ceph-fuse")]
         if os.getuid() != 0:
             prefix += ["--client_die_on_failed_dentry_invalidate=false"]
         if mount_path is not None:
@@ -798,6 +806,10 @@ class LocalFuseMount(FuseMount):
                 self.fuse_daemon.fuse_pid = int(re.match(".*\.(\d+)\.asok$",
                                                          sock).group(1))
                 break
+
+    def cleanup_netns(self):
+        if self.using_namespace:
+            super(type(self), self).cleanup_netns()
 
     def _run_python(self, pyscript, py_version='python'):
         """
@@ -1207,6 +1219,8 @@ def exec_test():
     global opt_log_ps_output
     opt_log_ps_output = False
     use_kernel_client = False
+    global opt_use_ns
+    opt_use_ns = False
     opt_brxnet= None
 
     args = sys.argv[1:]
@@ -1229,6 +1243,8 @@ def exec_test():
             clear_old_log()
         elif f == "--kclient":
             use_kernel_client = True
+        elif f == '--usens':
+            opt_use_ns = True
         elif '--brxnet' in f:
             if re.search(r'=[0-9./]+', f) is None:
                 log.error("--brxnet=<ip/mask> option needs one argument: '{0}'".format(f))


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/45339



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>