### PR TITLE
mgr/apicli: add new API CLI module

### DIFF
--- a/src/pybind/mgr/cli/__init__.py
+++ b/src/pybind/mgr/cli/__init__.py
@@ -1,0 +1,1 @@
+from .module import CLI

--- a/src/pybind/mgr/cli/module.py
+++ b/src/pybind/mgr/cli/module.py
@@ -1,0 +1,121 @@
+"""
+CLI Module - expose Ceph-Mgr Python API via CLI
+"""
+import functools
+import inspect
+import json
+import logging
+import re
+from threading import Event
+from typing import Callable, Any
+
+from mgr_module import MgrModule, HandleCommandResult, CLICommand, API
+
+
+logger = logging.getLogger()
+
+class CephCommander:
+    """
+    Utility class to inspect Python functions and generate corresponding
+    CephCommand signatures (see src/mon/MonCommand.h for details)
+    """
+
+    def __init__(self, func: Callable):
+        self.func = func
+        self.signature = inspect.signature(func)
+        self.params = self.signature.parameters
+
+    def to_ceph_signature(self):
+        """
+        Generate CephCommand signature (dict-like)
+        """
+        return {
+            'prefix': f'mgr cli {self.func.__name__}',
+            'args': self.format_args(),
+            'desc': self.format_desc(),
+            'perm': API.perm.get(self.func),
+        }
+
+    def format_args(self):
+        params = iter(self.params.values())
+        # Skip first param ('self')
+        next(params)
+        return ' '.join(self.format_param(param) for param in params)
+
+    def format_desc(self):
+        # Remove all whitespace
+        # TODO: try to parse docstring (first line, params, etc.)
+        return ' '.join(self.func.__doc__.split()) if self.func.__doc__ else ''
+
+    @classmethod
+    def format_param(cls, param: inspect.Parameter):
+        return f'name={param.name},type={cls.python_type_to_ceph_type(param.annotation)},req={cls.is_required(param.default)}'
+
+    @staticmethod
+    def is_required(default: Any):
+        return (default == inspect.Parameter.empty)
+
+    @staticmethod
+    def python_type_to_ceph_type(_type: type):
+        PY_TO_CEPH = {
+            str: 'CephString',
+            int: 'CephInt'
+        }
+        return PY_TO_CEPH.get(_type, 'CephArgtype')
+
+
+class MgrAPIReflector(type):
+    """
+    Metaclass to register COMMANDS and Command Handlers via CLICommand
+    decorator
+    """
+
+    def __new__(cls, name, bases, dct):
+        klass = super().__new__(cls, name, bases, dct)
+        for base in bases:
+            for name, func in inspect.getmembers(base, cls.is_public):
+                # However not necessary (CLICommand uses a registry)
+                # save functions to klass._cli_{name}() methods. This
+                # can help on unit testing
+                setattr(
+                    klass,
+                    f'_cli_{name}',
+                    CLICommand(**CephCommander(func).to_ceph_signature())(
+                        functools.partial(cls.func_wrapper, func))
+                )
+        return klass
+
+    @staticmethod
+    def is_public(func: Callable):
+        return (
+            inspect.isfunction(func) and
+            not func.__name__.startswith('_') and
+            not API.hook.get(func) and
+            not API.internal.get(func)
+        )
+
+    @staticmethod
+    def func_wrapper(func, self, *args, **kwargs):
+        return HandleCommandResult(
+            0,
+            json.dumps(func(self, *args, **kwargs), sort_keys=True, indent=4)
+        )
+
+
+class CLI(MgrModule, metaclass=MgrAPIReflector):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.stop = Event()
+
+    def serve(self):
+        logger.info("Starting")
+        while not self.stop.wait(self.get_ceph_option('mgr_tick_period')):
+            pass
+
+    def shutdown(self):
+        """
+        This method is called by the mgr when the module needs to shut
+        down (i.e., when the serve() function needs to exit).
+        """
+        logger.info('Stopping')
+        self.stop.set()


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/45264

Sample output:

```bash
# ceph cli -h
 Monitor commands: 
 =================
cli cluster_log <channel> <priority:int> <message>   Send message to the cluster log. :param channel: The 
                                                      log channel. This can be 'cluster', 'audit', ... :
                                                      type channel: str :param priority: The log message 
                                                      priority. This can be CLUSTER_LOG_PRIO_DEBUG, 
                                                      CLUSTER_LOG_PRIO_INFO, CLUSTER_LOG_PRIO_SEC, 
                                                      CLUSTER_LOG_PRIO_WARN or CLUSTER_LOG_PRIO_ERROR. :
                                                      type priority: int :param message: The message to 
                                                      log. :type message: str
cli get <data_name>                                  Called by the plugin to fetch named cluster-wide 
                                                      objects from ceph-mgr. :param str data_name: Valid 
                                                      things to fetch are osd_crush_map_text, osd_map, 
                                                      osd_map_tree, osd_map_crush, config, mon_map, fs_
                                                      map, osd_metadata, pg_summary, io_rate, pg_dump, df,
                                                      osd_stats, health, mon_status, devices, device 
                                                      <devid>, pg_stats, pool_stats, pg_ready, osd_ping_
                                                      times. Note: All these structures have their own 
                                                      JSON representations: experiment or look at the C++ 
                                                      ``dump()`` methods to learn about them.
cli get_all_perf_counters [<prio_limit:int>]         Return the perf counters currently known to this 
 [<services>]                                         ceph-mgr instance, filtered by priority equal to or 
                                                      greater than `prio_limit`. The result is a map of 
                                                      string to dict, associating services (like "osd.123"
                                                      ) with their counters. The counter dict for each 
                                                      service maps counter paths to a counter info 
                                                      structure, which is the information from the schema,
                                                      plus an additional "value" member with the latest 
                                                      value.
```

Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
