### PR TITLE
mgr/orch: Clean-up ServiceSpec handling during add/remove (mds, rgw, iscsi, nfs)

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -684,7 +684,7 @@ Usage:
         'name=fs_name,type=CephString '
         'name=placement,type=CephString,req=false',
         'Start MDS daemon(s)')
-    def _mds_add(self, fs_name, placement=None):
+    def _mds_add(self, fs_name, placement=None, inbuf=None):
         spec = ServiceSpec(
             'mds', fs_name,
             placement=PlacementSpec.from_string(placement),
@@ -763,7 +763,7 @@ Usage:
         "name=namespace,type=CephString,req=false "
         'name=placement,type=CephString,req=false',
         'Start NFS daemon(s)')
-    def _nfs_add(self, svc_arg, pool, namespace=None, placement=None):
+    def _nfs_add(self, svc_arg, pool, namespace=None, placement=None, inbuf=None):
         spec = NFSServiceSpec(
             svc_arg,
             pool=pool,
@@ -864,7 +864,10 @@ Usage:
         'name=placement,type=CephString,req=false '
         'name=unmanaged,type=CephBool,req=false',
         'Update the number of MDS instances for the given fs_name')
-    def _apply_mds(self, fs_name, placement=None, unmanaged=False):
+    def _apply_mds(self, fs_name,
+                   placement=None,
+                   unmanaged=False,
+                   inbuf=None):
         placement = PlacementSpec.from_string(placement)
         placement.validate()
         spec = ServiceSpec(
@@ -891,7 +894,8 @@ Usage:
                    port=None,
                    ssl=False,
                    placement=None,
-                   unmanaged=False):
+                   unmanaged=False,
+                   inbuf=None):
         spec = RGWSpec(
             rgw_realm=realm_name,
             rgw_zone=zone_name,
@@ -914,7 +918,10 @@ Usage:
         'name=placement,type=CephString,req=false '
         'name=unmanaged,type=CephBool,req=false',
         'Scale an NFS service')
-    def _apply_nfs(self, svc_id, pool, namespace=None, placement=None, unmanaged=False):
+    def _apply_nfs(self, svc_id, pool, namespace=None,
+                   placement=None,
+                   unmanaged=False,
+                   inbuf=None):
         spec = NFSServiceSpec(
             svc_id,
             pool=pool,

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -652,8 +652,9 @@ Usage:
                 raise OrchestratorValidationError(usage)
             spec = ServiceSpec.from_json(yaml.safe_load(inbuf))
         else:
-            placement = PlacementSpec.from_string(placement)  # type: ignore
-            spec = ServiceSpec(daemon_type, placement=placement)  # type: ignore
+            spec = PlacementSpec.from_string(placement)
+            assert daemon_type
+            spec = ServiceSpec(daemon_type, placement=spec)
 
         daemon_type = spec.service_type
 
@@ -875,8 +876,9 @@ Usage:
             content: Iterator = yaml.load_all(inbuf)
             specs = [ServiceSpec.from_json(s) for s in content]
         else:
-            placement = PlacementSpec.from_string(placement)  # type: ignore
-            specs = [ServiceSpec(service_type, placement=placement, unmanaged=unmanaged)]  # type: ignore
+            spec = PlacementSpec.from_string(placement)
+            assert service_type
+            specs = [ServiceSpec(service_type, placement=spec, unmanaged=unmanaged)]
 
         completion = self.apply(specs)
         self._orchestrator_wait([completion])

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -484,7 +484,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
                    all_available_devices: bool = False,
                    preview: bool = False,
                    service_name: Optional[str] = None,
-                   unmanaged: Optional[bool] = None,
+                   unmanaged: bool = False,
                    format: Optional[str] = 'plain',
                    inbuf: Optional[str] = None) -> HandleCommandResult:
         """Apply DriveGroupSpecs to create OSDs"""
@@ -640,7 +640,10 @@ Usage:
         'name=daemon_type,type=CephChoices,strings=mon|mgr|rbd-mirror|crash|alertmanager|grafana|node-exporter|prometheus,req=false '
         'name=placement,type=CephString,req=false',
         'Add daemon(s)')
-    def _daemon_add_misc(self, daemon_type=None, placement=None, inbuf=None):
+    def _daemon_add_misc(self,
+                         daemon_type: Optional[str] = None,
+                         placement: Optional[str] = None,
+                         inbuf: Optional[str] = None) -> HandleCommandResult:
         usage = f"""Usage:
     ceph orch daemon add -i <json_file>
     ceph orch daemon add {daemon_type or '<daemon_type>'} <placement>"""
@@ -649,8 +652,8 @@ Usage:
                 raise OrchestratorValidationError(usage)
             spec = ServiceSpec.from_json(yaml.safe_load(inbuf))
         else:
-            placement = PlacementSpec.from_string(placement)
-            spec = ServiceSpec(daemon_type, placement=placement)
+            placement = PlacementSpec.from_string(placement)  # type: ignore
+            spec = ServiceSpec(daemon_type, placement=placement)  # type: ignore
 
         daemon_type = spec.service_type
 
@@ -690,7 +693,10 @@ Usage:
         'name=fs_name,type=CephString '
         'name=placement,type=CephString,req=false',
         'Start MDS daemon(s)')
-    def _mds_add(self, fs_name, placement=None, inbuf=None):
+    def _mds_add(self,
+                 fs_name: str,
+                 placement: Optional[str] = None,
+                 inbuf: Optional[str] = None) -> HandleCommandResult:
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -710,7 +716,11 @@ Usage:
         'name=zone_name,type=CephString '
         'name=placement,type=CephString,req=false',
         'Start RGW daemon(s)')
-    def _rgw_add(self, realm_name, zone_name, placement=None, inbuf=None):
+    def _rgw_add(self,
+                 realm_name: str,
+                 zone_name: str,
+                 placement: Optional[str] = None,
+                 inbuf: Optional[str] = None) -> HandleCommandResult:
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -727,17 +737,22 @@ Usage:
 
     @_cli_write_command(
         'orch daemon add nfs',
-        "name=svc_arg,type=CephString "
+        "name=svc_id,type=CephString "
         "name=pool,type=CephString "
         "name=namespace,type=CephString,req=false "
         'name=placement,type=CephString,req=false',
         'Start NFS daemon(s)')
-    def _nfs_add(self, svc_arg, pool, namespace=None, placement=None, inbuf=None):
+    def _nfs_add(self,
+                 svc_id: str,
+                 pool: str,
+                 namespace: Optional[str] = None,
+                 placement: Optional[str] = None,
+                 inbuf: Optional[str] = None) -> HandleCommandResult:
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
         spec = NFSServiceSpec(
-            svc_arg,
+            svc_id,
             pool=pool,
             namespace=namespace,
             placement=PlacementSpec.from_string(placement),
@@ -754,7 +769,11 @@ Usage:
         'name=trusted_ip_list,type=CephString,req=false '
         'name=placement,type=CephString,req=false',
         'Start iscsi daemon(s)')
-    def _iscsi_add(self, pool, trusted_ip_list=None, placement=None, inbuf=None):
+    def _iscsi_add(self,
+                   pool: str,
+                   trusted_ip_list: Optional[str] = None,
+                   placement: Optional[str] = None,
+                   inbuf: Optional[str] = None) -> HandleCommandResult:
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -831,7 +850,11 @@ Usage:
         'name=placement,type=CephString,req=false '
         'name=unmanaged,type=CephBool,req=false',
         'Update the size or placement for a service or apply a large yaml spec')
-    def _apply_misc(self, service_type=None, placement=None, unmanaged=False, inbuf=None):
+    def _apply_misc(self,
+                    service_type: Optional[str] = None,
+                    placement: Optional[str] = None,
+                    unmanaged: bool = False,
+                    inbuf: Optional[str] = None) -> HandleCommandResult:
         usage = """Usage:
   ceph orch apply -i <yaml spec>
   ceph orch apply <service_type> <placement> [--unmanaged]
@@ -842,8 +865,8 @@ Usage:
             content: Iterator = yaml.load_all(inbuf)
             specs = [ServiceSpec.from_json(s) for s in content]
         else:
-            placement = PlacementSpec.from_string(placement)
-            specs = [ServiceSpec(service_type, placement=placement, unmanaged=unmanaged)]
+            placement = PlacementSpec.from_string(placement)  # type: ignore
+            specs = [ServiceSpec(service_type, placement=placement, unmanaged=unmanaged)]  # type: ignore
 
         completion = self.apply(specs)
         self._orchestrator_wait([completion])
@@ -856,10 +879,11 @@ Usage:
         'name=placement,type=CephString,req=false '
         'name=unmanaged,type=CephBool,req=false',
         'Update the number of MDS instances for the given fs_name')
-    def _apply_mds(self, fs_name,
-                   placement=None,
-                   unmanaged=False,
-                   inbuf=None):
+    def _apply_mds(self,
+                   fs_name: str,
+                   placement: Optional[str] = None,
+                   unmanaged: bool = False,
+                   inbuf: Optional[str] = None) -> HandleCommandResult:
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -882,13 +906,15 @@ Usage:
         'name=placement,type=CephString,req=false '
         'name=unmanaged,type=CephBool,req=false',
         'Update the number of RGW instances for the given zone')
-    def _apply_rgw(self, zone_name, realm_name,
-                   subcluster=None,
-                   port=None,
-                   ssl=False,
-                   placement=None,
-                   unmanaged=False,
-                   inbuf=None):
+    def _apply_rgw(self,
+                   realm_name: str,
+                   zone_name: str,
+                   subcluster: Optional[str] = None,
+                   port: Optional[int] = None,
+                   ssl: bool = False,
+                   placement: Optional[str] = None,
+                   unmanaged: bool = False,
+                   inbuf: Optional[str] = None) -> HandleCommandResult:
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -914,10 +940,13 @@ Usage:
         'name=placement,type=CephString,req=false '
         'name=unmanaged,type=CephBool,req=false',
         'Scale an NFS service')
-    def _apply_nfs(self, svc_id, pool, namespace=None,
-                   placement=None,
-                   unmanaged=False,
-                   inbuf=None):
+    def _apply_nfs(self,
+                   svc_id: str,
+                   pool: str,
+                   namespace: Optional[str] = None,
+                   placement: Optional[str] = None,
+                   unmanaged: bool = False,
+                   inbuf: Optional[str] = None) -> HandleCommandResult:
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -940,7 +969,12 @@ Usage:
         'name=placement,type=CephString,req=false '
         'name=unmanaged,type=CephBool,req=false',
         'Scale an iSCSI service')
-    def _apply_iscsi(self, pool, trusted_ip_list=None, placement=None, unmanaged=False, inbuf=None):
+    def _apply_iscsi(self,
+                     pool: str,
+                     trusted_ip_list: Optional[str] = None,
+                     placement: Optional[str] = None,
+                     unmanaged: bool = False,
+                     inbuf: Optional[str] = None) -> HandleCommandResult:
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -951,6 +985,7 @@ Usage:
             placement=PlacementSpec.from_string(placement),
             unmanaged=unmanaged,
         )
+
         completion = self.apply_iscsi(spec)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -695,6 +695,7 @@ Usage:
             'mds', fs_name,
             placement=PlacementSpec.from_string(placement),
         )
+
         completion = self.add_mds(spec)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
@@ -702,62 +703,18 @@ Usage:
 
     @_cli_write_command(
         'orch daemon add rgw',
-        'name=realm_name,type=CephString,req=false '
-        'name=zone_name,type=CephString,req=false '
+        'name=realm_name,type=CephString '
+        'name=zone_name,type=CephString '
         'name=placement,type=CephString,req=false',
         'Start RGW daemon(s)')
-    def _rgw_add(self, realm_name=None, zone_name=None, placement=None, inbuf=None):
-        usage = """
-Usage:
-  ceph orch daemon rgw add -i <json_file>
-  ceph orch daemon rgw add <realm_name> <zone_name>
-        """
-        if inbuf:
-            try:
-                rgw_spec = RGWSpec.from_json(json.loads(inbuf))
-            except ValueError as e:
-                msg = 'Failed to read JSON input: {}'.format(str(e)) + usage
-                return HandleCommandResult(-errno.EINVAL, stderr=msg)
-        elif realm_name and zone_name:
-            rgw_spec = RGWSpec(
-                rgw_realm=realm_name,
-                rgw_zone=zone_name,
-                placement=PlacementSpec.from_string(placement))
-        else:
-            return HandleCommandResult(-errno.EINVAL, stderr=usage)
+    def _rgw_add(self, realm_name, zone_name, placement=None, inbuf=None):
+        spec = RGWSpec(
+            rgw_realm=realm_name,
+            rgw_zone=zone_name,
+            placement=PlacementSpec.from_string(placement),
+        )
 
-        completion = self.add_rgw(rgw_spec)
-        self._orchestrator_wait([completion])
-        raise_if_exception(completion)
-        return HandleCommandResult(stdout=completion.result_str())
-
-    @_cli_write_command(
-        'orch daemon add iscsi',
-        'name=pool,type=CephString '
-        'name=trusted_ip_list,type=CephString,req=false '
-        'name=placement,type=CephString,req=false',
-        'Start iscsi daemon(s)')
-    def _iscsi_add(self, pool, trusted_ip_list=None, placement=None, inbuf=None):
-        usage = """
-        Usage:
-          ceph orch daemon add iscsi -i <json_file>
-          ceph orch daemon add iscsi <pool>
-                """
-        if inbuf:
-            try:
-                iscsi_spec = IscsiServiceSpec.from_json(json.loads(inbuf))
-            except ValueError as e:
-                msg = 'Failed to read JSON input: {}'.format(str(e)) + usage
-                return HandleCommandResult(-errno.EINVAL, stderr=msg)
-        else:
-            iscsi_spec = IscsiServiceSpec(
-                service_id='iscsi',
-                pool=pool,
-                trusted_ip_list=trusted_ip_list,
-                placement=PlacementSpec.from_string(placement),
-            )
-
-        completion = self.add_iscsi(iscsi_spec)
+        completion = self.add_rgw(spec)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
@@ -778,6 +735,25 @@ Usage:
         )
         spec.validate_add()
         completion = self.add_nfs(spec)
+        self._orchestrator_wait([completion])
+        raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
+    @_cli_write_command(
+        'orch daemon add iscsi',
+        'name=pool,type=CephString '
+        'name=trusted_ip_list,type=CephString,req=false '
+        'name=placement,type=CephString,req=false',
+        'Start iscsi daemon(s)')
+    def _iscsi_add(self, pool, trusted_ip_list=None, placement=None, inbuf=None):
+        spec = IscsiServiceSpec(
+            service_id='iscsi',
+            pool=pool,
+            trusted_ip_list=trusted_ip_list,
+            placement=PlacementSpec.from_string(placement),
+        )
+
+        completion = self.add_iscsi(spec)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -714,11 +714,17 @@ Usage:
         'orch daemon add rgw',
         'name=realm_name,type=CephString '
         'name=zone_name,type=CephString '
+        'name=subcluster,type=CephString,req=false '
+        'name=port,type=CephInt,req=false '
+        'name=ssl,type=CephBool,req=false '
         'name=placement,type=CephString,req=false',
         'Start RGW daemon(s)')
     def _rgw_add(self,
                  realm_name: str,
                  zone_name: str,
+                 subcluster: Optional[str] = None,
+                 port: Optional[int] = None,
+                 ssl: bool = False,
                  placement: Optional[str] = None,
                  inbuf: Optional[str] = None) -> HandleCommandResult:
         if inbuf:
@@ -727,6 +733,9 @@ Usage:
         spec = RGWSpec(
             rgw_realm=realm_name,
             rgw_zone=zone_name,
+            subcluster=subcluster,
+            rgw_frontend_port=port,
+            ssl=ssl,
             placement=PlacementSpec.from_string(placement),
         )
 
@@ -757,6 +766,7 @@ Usage:
             namespace=namespace,
             placement=PlacementSpec.from_string(placement),
         )
+
         spec.validate_add()
         completion = self.add_nfs(spec)
         self._orchestrator_wait([completion])
@@ -891,6 +901,7 @@ Usage:
             'mds', fs_name,
             placement=PlacementSpec.from_string(placement),
             unmanaged=unmanaged)
+
         completion = self.apply_mds(spec)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
@@ -922,11 +933,12 @@ Usage:
             rgw_realm=realm_name,
             rgw_zone=zone_name,
             subcluster=subcluster,
-            placement=PlacementSpec.from_string(placement),
-            unmanaged=unmanaged,
             rgw_frontend_port=port,
             ssl=ssl,
+            placement=PlacementSpec.from_string(placement),
+            unmanaged=unmanaged,
         )
+
         completion = self.apply_rgw(spec)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
@@ -957,6 +969,7 @@ Usage:
             placement=PlacementSpec.from_string(placement),
             unmanaged=unmanaged,
         )
+
         completion = self.apply_nfs(spec)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -924,6 +924,7 @@ Usage:
         )
         completion = self.apply_nfs(spec)
         self._orchestrator_wait([completion])
+        raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command(

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -672,6 +672,12 @@ Usage:
             completion = self.add_node_exporter(spec)
         elif daemon_type == 'prometheus':
             completion = self.add_prometheus(spec)
+        elif daemon_type == 'mds':
+            completion = self.add_mds(spec)
+        elif daemon_type == 'rgw':
+            completion = self.add_rgw(spec)
+        elif daemon_type == 'nfs':
+            completion = self.add_nfs(spec)
         elif daemon_type == 'iscsi':
             completion = self.add_iscsi(spec)
         else:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -654,6 +654,8 @@ Usage:
 
             spec = ServiceSpec(daemon_type, placement=placement)
 
+        daemon_type = spec.service_type
+
         if daemon_type == 'mon':
             completion = self.add_mon(spec)
         elif daemon_type == 'mgr':

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -691,6 +691,9 @@ Usage:
         'name=placement,type=CephString,req=false',
         'Start MDS daemon(s)')
     def _mds_add(self, fs_name, placement=None, inbuf=None):
+        if inbuf:
+            raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
+
         spec = ServiceSpec(
             'mds', fs_name,
             placement=PlacementSpec.from_string(placement),
@@ -708,6 +711,9 @@ Usage:
         'name=placement,type=CephString,req=false',
         'Start RGW daemon(s)')
     def _rgw_add(self, realm_name, zone_name, placement=None, inbuf=None):
+        if inbuf:
+            raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
+
         spec = RGWSpec(
             rgw_realm=realm_name,
             rgw_zone=zone_name,
@@ -727,6 +733,9 @@ Usage:
         'name=placement,type=CephString,req=false',
         'Start NFS daemon(s)')
     def _nfs_add(self, svc_arg, pool, namespace=None, placement=None, inbuf=None):
+        if inbuf:
+            raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
+
         spec = NFSServiceSpec(
             svc_arg,
             pool=pool,
@@ -746,6 +755,9 @@ Usage:
         'name=placement,type=CephString,req=false',
         'Start iscsi daemon(s)')
     def _iscsi_add(self, pool, trusted_ip_list=None, placement=None, inbuf=None):
+        if inbuf:
+            raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
+
         spec = IscsiServiceSpec(
             service_id='iscsi',
             pool=pool,
@@ -848,6 +860,9 @@ Usage:
                    placement=None,
                    unmanaged=False,
                    inbuf=None):
+        if inbuf:
+            raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
+
         spec = ServiceSpec(
             'mds', fs_name,
             placement=PlacementSpec.from_string(placement),
@@ -874,6 +889,9 @@ Usage:
                    placement=None,
                    unmanaged=False,
                    inbuf=None):
+        if inbuf:
+            raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
+
         spec = RGWSpec(
             rgw_realm=realm_name,
             rgw_zone=zone_name,
@@ -900,6 +918,9 @@ Usage:
                    placement=None,
                    unmanaged=False,
                    inbuf=None):
+        if inbuf:
+            raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
+
         spec = NFSServiceSpec(
             svc_id,
             pool=pool,
@@ -920,6 +941,9 @@ Usage:
         'name=unmanaged,type=CephBool,req=false',
         'Scale an iSCSI service')
     def _apply_iscsi(self, pool, trusted_ip_list=None, placement=None, unmanaged=False, inbuf=None):
+        if inbuf:
+            raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
+
         spec = IscsiServiceSpec(
             service_id='iscsi',
             pool=pool,

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -650,8 +650,6 @@ Usage:
             spec = ServiceSpec.from_json(yaml.safe_load(inbuf))
         else:
             placement = PlacementSpec.from_string(placement)
-            placement.validate()
-
             spec = ServiceSpec(daemon_type, placement=placement)
 
         daemon_type = spec.service_type
@@ -857,8 +855,6 @@ Usage:
             specs = [ServiceSpec.from_json(s) for s in content]
         else:
             placement = PlacementSpec.from_string(placement)
-            placement.validate()
-
             specs = [ServiceSpec(service_type, placement=placement, unmanaged=unmanaged)]
 
         completion = self.apply(specs)
@@ -876,11 +872,9 @@ Usage:
                    placement=None,
                    unmanaged=False,
                    inbuf=None):
-        placement = PlacementSpec.from_string(placement)
-        placement.validate()
         spec = ServiceSpec(
             'mds', fs_name,
-            placement=placement,
+            placement=PlacementSpec.from_string(placement),
             unmanaged=unmanaged)
         completion = self.apply_mds(spec)
         self._orchestrator_wait([completion])


### PR DESCRIPTION
Simplify and bug fix the various ServiceSpec add/apply implementations: mds, rgw, iscsi, nfs

Allows for a ServiceSpec during add/apply:
```
$ cat iscsi.yaml
service_type: iscsi
service_id: foo
pool: cephfs.a.data
placement:
   hosts:
      - host1
   count: 1
$ ceph orch daemon add -i iscsi.yaml
--or--
$ ceph orch apply -i iscsi.yaml
```

But, drops support for a ServiceSpec when a service_type is specified on the cli:
```
$ ceph orch daemon add iscsi cephfs.a.data -i iscsi.yaml
--or--
$ ceph orch apply iscsi cephfs.a.data -i iscsi.yaml
```


Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
