### PR TITLE
nautilus: mgr/dashboard: fixing RBD purge error in backend

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rbd.py
+++ b/qa/tasks/mgr/dashboard/test_rbd.py
@@ -784,7 +784,7 @@ class RbdTest(DashboardTestCase):
         time.sleep(1)
 
         self._task_post('/api/block/image/trash/purge?pool_name={}'.format('rbd'))
-        self.assertStatus(200)
+        self.assertStatus([200, 201])
 
         time.sleep(1)
 
@@ -792,4 +792,4 @@ class RbdTest(DashboardTestCase):
         self.assertIsNotNone(trash_not_expired)
 
         trash_expired = self.get_trash('rbd', id_expired)
-        self.assertIsNone(trash_expired)
+        self.wait_until_equal(lambda: self.get_trash('rbd', id_expired), None, 60)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45273

---

backport of https://github.com/ceph/ceph/pull/34705
parent tracker: https://tracker.ceph.com/issues/45149

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh