### PR TITLE
rbd/cache: Replicated Write Log core codes - retire entries and invalidate

### DIFF
--- a/src/librbd/cache/ReplicatedWriteLog.h
+++ b/src/librbd/cache/ReplicatedWriteLog.h
@@ -91,7 +91,7 @@ public:
   /// internal state methods
   void init(Context *on_finish) override;
   void shut_down(Context *on_finish) override;
-  void invalidate(Context *on_finish);
+  void invalidate(Context *on_finish) override;
   void flush(Context *on_finish) override;
 
   using This = ReplicatedWriteLog<ImageCtxT>;
@@ -148,6 +148,7 @@ private:
 
   std::atomic<bool> m_initialized = {false};
   std::atomic<bool> m_shutting_down = {false};
+  std::atomic<bool> m_invalidating = {false};
   PMEMobjpool *m_log_pool = nullptr;
   const char* m_rwl_pool_layout_name;
 
@@ -298,7 +299,7 @@ private:
   int append_op_log_entries(rwl::GenericLogOperations &ops);
   void complete_op_log_entries(rwl::GenericLogOperations &&ops, const int r);
   void schedule_complete_op_log_entries(rwl::GenericLogOperations &&ops, const int r);
-  void internal_flush(Context *on_finish);
+  void internal_flush(bool invalidate, Context *on_finish);
 };
 
 } // namespace cache

--- a/src/librbd/cache/ReplicatedWriteLog.h
+++ b/src/librbd/cache/ReplicatedWriteLog.h
@@ -37,6 +37,8 @@ class GenericLogEntry;
 typedef std::list<std::shared_ptr<WriteLogEntry>> WriteLogEntries;
 typedef std::list<std::shared_ptr<GenericLogEntry>> GenericLogEntries;
 typedef std::list<std::shared_ptr<GenericWriteLogEntry>> GenericWriteLogEntries;
+typedef std::vector<std::shared_ptr<GenericLogEntry>> GenericLogEntriesVector;
+
 typedef LogMapEntries<GenericWriteLogEntry> WriteLogMapEntries;
 typedef LogMap<GenericWriteLogEntry> WriteLogMap;
 
@@ -197,6 +199,7 @@ private:
 
   /* Acquire locks in order declared here */
 
+  mutable ceph::mutex m_log_retire_lock;
   /* Hold a read lock on m_entry_reader_lock to add readers to log entry
    * bufs. Hold a write lock to prevent readers from being added (e.g. when
    * removing log entrys from the map). No lock required to remove readers. */
@@ -275,6 +278,8 @@ private:
   bool handle_flushed_sync_point(std::shared_ptr<rwl::SyncPointLogEntry> log_entry);
   void sync_point_writer_flushed(std::shared_ptr<rwl::SyncPointLogEntry> log_entry);
   void process_writeback_dirty_entries();
+  bool can_retire_entry(const std::shared_ptr<rwl::GenericLogEntry> log_entry);
+  bool retire_entries(const unsigned long int frees_per_tx);
 
   void init_flush_new_sync_point(rwl::DeferredContexts &later);
   void new_sync_point(rwl::DeferredContexts &later);

--- a/src/librbd/cache/rwl/LogEntry.cc
+++ b/src/librbd/cache/rwl/LogEntry.cc
@@ -107,7 +107,7 @@ void WriteLogEntry::init_pmem_bl() {
   bl_refs = after_bl - before_bl;
 }
 
-unsigned int WriteLogEntry::reader_count() {
+unsigned int WriteLogEntry::reader_count() const {
   if (pmem_bp.have_raw()) {
     return (pmem_bp.raw_nref() - bl_refs - 1);
   } else {

--- a/src/librbd/cache/rwl/Types.h
+++ b/src/librbd/cache/rwl/Types.h
@@ -165,6 +165,10 @@ constexpr double USABLE_SIZE = (7.0 / 10);
 const uint64_t BLOCK_ALLOC_OVERHEAD_BYTES = 16;
 const uint8_t RWL_POOL_VERSION = 1;
 const uint64_t MAX_LOG_ENTRIES = (1024 * 1024);
+const double AGGRESSIVE_RETIRE_HIGH_WATER = 0.75;
+const double RETIRE_HIGH_WATER = 0.50;
+const double RETIRE_LOW_WATER = 0.40;
+const int RETIRE_BATCH_TIME_LIMIT_MS = 250;
 
 /* Defer a set of Contexts until destruct/exit. Used for deferring
  * work on a given thread until a required lock is dropped. */


### PR DESCRIPTION
Adds Replicated Write Log, a persistent, write back cache for Ceph RBD.
Implements: http://tracker.ceph.com/projects/ceph/wiki/Rbd_-_ordered_crash-consistent_write-back_caching_extension

Trello: https://trello.com/c/QnsQaGTn

[Obsoletes https://github.com//pull/29087]

The PR 29087 is split into smaller PRs to make review easier.
The first PR: #31279
The second PR: #31963
The 3rd PR: #33502
The 4th PR: #34430
The 5th PR: #34699
The 6th PR: #34706
The 7th PR: #34756 

This is the 8th PR (retire entries + invalidate ) which defines the following parts:
librbd: retire entries
librbd: add invalidate
librbd: add invalidate test case

Signed-off-by: Scott Peterson scott.d.peterson@intel.com
Signed-off-by: Lisa Li xiaoyan.li@intel.com
Signed-off-by: Yuan Lu yuan.y.lu@intel.com
Signed-off-by: Mahati Chamarthy mahati.chamarthy@intel.com

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
