### PR TITLE
Add Windows CephFS support

### DIFF
--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -6,6 +6,7 @@
 
 #include <numeric>
 
+#include "include/compat.h"
 #include "include/ceph_assert.h"
 #include "include/types.h"
 #include "include/xlist.h"

--- a/src/common/compat.cc
+++ b/src/common/compat.cc
@@ -529,6 +529,26 @@ ssize_t get_self_exe_path(char* path, int buff_length) {
   return GetModuleFileName(NULL, path, buff_length - 1);
 }
 
+int geteuid()
+{
+  return 0;
+}
+
+int getegid()
+{
+  return 0;
+}
+
+int getuid()
+{
+  return 0;
+}
+
+int getgid()
+{
+  return 0;
+}
+
 #else
 
 unsigned get_page_size() {

--- a/src/include/cephfs/ceph_ll_client.h
+++ b/src/include/cephfs/ceph_ll_client.h
@@ -15,6 +15,10 @@
 #define CEPH_CEPH_LL_CLIENT_H
 #include <stdint.h>
 
+#ifdef _WIN32
+#include "include/win32/fs_compat.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -150,6 +150,9 @@ int sched_setaffinity(pid_t pid, size_t cpusetsize,
 #define LOG_AUTHPRIV    (10<<3)
 #define LOG_FTP         (11<<3)
 #define __STRING(x)     "x"
+#endif
+
+#if defined(__sun) || defined(_AIX) || defined(_WIN32)
 #define IFTODT(mode)   (((mode) & 0170000) >> 12)
 #endif
 
@@ -220,6 +223,7 @@ int ceph_memzero_s(void *dest, size_t destsz, size_t count);
 #include <time.h>
 
 #include "include/win32/win32_errno.h"
+#include "include/win32/fs_compat.h"
 
 // There are a few name collisions between Windows headers and Ceph.
 // Updating Ceph definitions would be the prefferable fix in order to avoid
@@ -237,12 +241,12 @@ typedef unsigned int uint;
 
 typedef _sigset_t sigset_t;
 
-typedef int uid_t;
-typedef int gid_t;
+typedef unsigned int uid_t;
+typedef unsigned int gid_t;
 
-typedef long blksize_t;
-typedef long blkcnt_t;
-typedef long nlink_t;
+typedef unsigned int blksize_t;
+typedef unsigned __int64 blkcnt_t;
+typedef unsigned short nlink_t;
 
 typedef long long loff_t;
 
@@ -297,6 +301,12 @@ int chown(const char *path, uid_t owner, gid_t group);
 int fchown(int fd, uid_t owner, gid_t group);
 int lchown(const char *path, uid_t owner, gid_t group);
 int setenv(const char *name, const char *value, int overwrite);
+
+int geteuid();
+int getegid();
+int getuid();
+int getgid();
+
 #define unsetenv(name) _putenv_s(name, "")
 
 int win_socketpair(int socks[2]);

--- a/src/include/win32/fs_compat.h
+++ b/src/include/win32/fs_compat.h
@@ -1,0 +1,35 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2021 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+// Those definitions allow handling information coming from Ceph and should
+// not be passed to Windows functions.
+
+#define S_IFLNK   0120000
+
+#define S_ISTYPE(m, TYPE) ((m & S_IFMT) == TYPE)
+#define S_ISLNK(m)  S_ISTYPE(m, S_IFLNK)
+#define S_ISUID     04000
+#define S_ISGID     02000
+#define S_ISVTX     01000
+
+#define LOCK_SH    1
+#define LOCK_EX    2
+#define LOCK_NB    4
+#define LOCK_UN    8
+#define LOCK_MAND  32
+#define LOCK_READ  64
+#define LOCK_WRITE 128
+#define LOCK_RW    192
+
+#define AT_SYMLINK_NOFOLLOW 0x100
+
+#define MAXSYMLINKS  65000

--- a/src/include/win32/sys/statvfs.h
+++ b/src/include/win32/sys/statvfs.h
@@ -1,0 +1,36 @@
+#ifndef _SYS_STATVFS_H
+#define _SYS_STATVFS_H  1
+
+typedef unsigned __int64 fsfilcnt64_t;
+typedef unsigned __int64 fsblkcnt64_t;
+typedef unsigned __int64 fsblkcnt_t;
+
+struct statvfs
+{
+    unsigned long int f_bsize;
+    unsigned long int f_frsize;
+    fsblkcnt64_t f_blocks;
+    fsblkcnt64_t f_bfree;
+    fsblkcnt64_t f_bavail;
+    fsfilcnt64_t f_files;
+    fsfilcnt64_t f_ffree;
+    fsfilcnt64_t f_favail;
+    unsigned long int f_fsid;
+    unsigned long int f_flag;
+    unsigned long int f_namemax;
+    int __f_spare[6];
+};
+struct flock {
+    short l_type;
+    short l_whence;
+    off_t l_start;
+    off_t l_len;
+    pid_t l_pid;
+};
+
+#define F_RDLCK 0
+#define F_WRLCK 1
+#define F_UNLCK 2
+#define F_SETLK 6
+
+#endif /* _SYS_STATVFS_H */

--- a/src/include/win32/win32_errno.h
+++ b/src/include/win32/win32_errno.h
@@ -21,6 +21,8 @@
 
 #include <errno.h>
 
+#include "include/int_types.h"
+
 #ifndef EBADMSG
 #define EBADMSG 104
 #endif

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -22,6 +22,7 @@
 
 #include "common/config.h"
 #include "common/RefCountedObj.h"
+#include "include/compat.h"
 #include "include/counter.h"
 #include "include/elist.h"
 #include "include/types.h"

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -462,6 +462,16 @@ void MDSDaemon::clean_up_admin_socket()
 
 int MDSDaemon::init()
 {
+#ifdef _WIN32
+  // Some file related flags and types are stubbed on Windows. In order to avoid
+  // incorrect behavior, we're going to prevent the MDS from running on Windows
+  // until those limitations are addressed. MDS clients, however, are allowed
+  // to run on Windows.
+  derr << "The Ceph MDS does not support running on Windows at the moment."
+       << dendl;
+  return -ENOSYS;
+#endif // _WIN32
+
   dout(10) << "Dumping misc struct sizes:" << dendl;
   dout(10) << sizeof(MDSCacheObject) << "\tMDSCacheObject" << dendl;
   dout(10) << sizeof(CInode) << "\tCInode" << dendl;

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -17,6 +17,7 @@
 #include "common/StackStringStream.h"
 #include "common/entity_name.h"
 
+#include "include/compat.h"
 #include "include/Context.h"
 #include "include/frag.h"
 #include "include/xlist.h"

--- a/win32_build.sh
+++ b/win32_build.sh
@@ -155,11 +155,16 @@ if [[ -z $SKIP_BUILD ]]; then
     # We're going to use an associative array having subdirectories as keys
     # and targets as values.
     declare -A make_targets
-    make_targets["src/tools"]="ceph-conf ceph_radosacl ceph_scratchtool rados"
+    make_targets["src/tools"]="ceph-conf rados"
     make_targets["src/tools/immutable_object_cache"]="all"
     make_targets["src/tools/rbd"]="all"
     make_targets["src/tools/rbd_wnbd"]="all"
     make_targets["src/compressor"]="all"
+
+    if [[ -z $SKIP_TESTS ]]; then
+      make_targets["src/tools"]+=" ceph_radosacl ceph_scratchtool"
+      make_targets["src/test"]="all"
+    fi
 
     for target_subdir in "${!make_targets[@]}"; do
       echo "Building $target_subdir: ${make_targets[$target_subdir]}" | tee -a "${BUILD_DIR}/build.log"


### PR DESCRIPTION
Add Windows CephFS support

This PR provides a few changes required in order to use the
CephFS client on Windows.

A subsequent patch will make use of it along with Dokan, an
interface similar to Fuse.

For more details about the build process and current status, please check the
README.windows.rst file.

Other Windows related PRs:

~~Part 1: #31981~~
~~Part 2: #32704~~
~~Part 3: #32705~~
~~Part 4: #32707~~
~~Part 5: #32780~~
~~Part 6: #32779~~
~~Part 7: #32778~~
~~Part 8: #32777~~

~~ceph/fmt#2~~
~~ceph/rocksdb#42~~
#32027 librados: avoid symbol versioning on Windows
~~#32776 Update Windows build scripts~~
~~#33750 Add Windows RBD support~~
~~#34859 Port tests to Windows~~
#34858 ceph-dokan
