### PR TITLE
Port tests to Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,7 +578,7 @@ option(WITH_SYSTEM_BOOST "require and build with system Boost" OFF)
 # Boost::thread depends on Boost::atomic, so list it explicitly.
 set(BOOST_COMPONENTS
   atomic chrono thread system regex random program_options date_time
-  iostreams context coroutine)
+  iostreams context coroutine filesystem)
 set(BOOST_HEADER_COMPONENTS container)
 
 if(WITH_MGR)
@@ -586,7 +586,7 @@ if(WITH_MGR)
     python${MGR_PYTHON_VERSION_MAJOR}${MGR_PYTHON_VERSION_MINOR})
 endif()
 if(WITH_SEASTAR)
-  list(APPEND BOOST_COMPONENTS filesystem timer)
+  list(APPEND BOOST_COMPONENTS timer)
 endif()
 
 if(WITH_RADOSGW AND WITH_RADOSGW_LUA_PACKAGES)

--- a/src/log/test.cc
+++ b/src/log/test.cc
@@ -362,7 +362,7 @@ TEST(Log, GarbleRecovery)
   log.flush();
   log.stop();
   struct stat file_status;
-  ASSERT_EQ(lstat(test_file, &file_status), 0);
+  ASSERT_EQ(stat(test_file, &file_status), 0);
   ASSERT_GT(file_status.st_size, 2000);
 }
 

--- a/src/osdc/CMakeLists.txt
+++ b/src/osdc/CMakeLists.txt
@@ -5,6 +5,7 @@ set(osdc_files
   error_code.cc
   Striper.cc)
 add_library(osdc STATIC ${osdc_files})
+target_link_libraries(osdc ceph-common)
 if(WITH_EVENTTRACE)
   add_dependencies(osdc eventtrace_tp)
 endif()

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -3,61 +3,76 @@ include(AddCephTest)
 set(UNITTEST_LIBS GMock::Main GMock::GMock GTest::GTest ${CMAKE_THREAD_LIBS_INIT} 
     ${GSSAPI_LIBRARIES} ${OPENLDAP_LIBRARIES} ${CMAKE_DL_LIBS})
 
+if(WIN32)
+  # Needed by Boost.
+  list(APPEND UNITTEST_LIBS ws2_32)
+endif()
+
 add_library(unit-main OBJECT unit.cc)
 target_include_directories(unit-main PRIVATE
   $<TARGET_PROPERTY:GTest::GTest,INTERFACE_INCLUDE_DIRECTORIES>)
 
-add_subdirectory(cls_hello)
-add_subdirectory(cls_fifo)
-add_subdirectory(cls_lock)
-add_subdirectory(cls_cas)
-add_subdirectory(cls_log)
-add_subdirectory(cls_numops)
-add_subdirectory(cls_sdk)
-if(WITH_RBD)
-  add_subdirectory(cls_journal)
-  add_subdirectory(cls_rbd)
-endif(WITH_RBD)
-add_subdirectory(cls_refcount)
-add_subdirectory(cls_rgw)
-add_subdirectory(cls_version)
-add_subdirectory(cls_lua)
-add_subdirectory(cls_rgw_gc)
-add_subdirectory(cls_queue)
-add_subdirectory(cls_2pc_queue)
-add_subdirectory(cls_cmpomap)
 add_subdirectory(common)
 add_subdirectory(compressor)
 add_subdirectory(crush)
 add_subdirectory(direct_messenger)
 add_subdirectory(encoding)
-add_subdirectory(erasure-code)
-add_subdirectory(filestore)
-add_subdirectory(fs)
-add_subdirectory(journal)
-add_subdirectory(libcephfs)
 add_subdirectory(librados)
-add_subdirectory(neorados)
 add_subdirectory(librados_test_stub)
 if(WITH_LIBRADOSSTRIPER)
   add_subdirectory(libradosstriper)
 endif()
-if(WITH_RBD)
+if(WITH_RBD AND NOT WIN32)
+  # librbd tests require libcls*, which in turn require libos and libosd, which
+  # haven't been ported to Windows yet.
   add_subdirectory(librbd)
-endif(WITH_RBD)
+endif(WITH_RBD AND NOT WIN32)
 if (WITH_CEPHFS)
   add_subdirectory(mds)
 endif()
-add_subdirectory(mon)
-add_subdirectory(mgr)
-add_subdirectory(msgr)
-add_subdirectory(ObjectMap)
-add_subdirectory(objectstore)
-add_subdirectory(os)
-add_subdirectory(osd)
-add_subdirectory(osdc)
 add_subdirectory(pybind)
-add_subdirectory(immutable_object_cache)
+
+# Not available on Windows for the time being.
+if(NOT WIN32)
+  # libcls_* dependencies cascade to osd, kv and other libs that are not
+  # available on Windows yet.
+  add_subdirectory(cls_hello)
+  add_subdirectory(cls_fifo)
+  add_subdirectory(cls_cas)
+  add_subdirectory(cls_lock)
+  add_subdirectory(cls_log)
+  add_subdirectory(cls_numops)
+  add_subdirectory(cls_sdk)
+  if(WITH_RBD)
+    add_subdirectory(cls_journal)
+    add_subdirectory(cls_rbd)
+  endif(WITH_RBD)
+  add_subdirectory(cls_refcount)
+  add_subdirectory(cls_rgw)
+  add_subdirectory(cls_version)
+  add_subdirectory(cls_lua)
+  add_subdirectory(cls_rgw_gc)
+  add_subdirectory(cls_queue)
+  add_subdirectory(cls_2pc_queue)
+  add_subdirectory(cls_cmpomap)
+  add_subdirectory(journal)
+
+  add_subdirectory(erasure-code)
+  add_subdirectory(filestore)
+  add_subdirectory(fs)
+  add_subdirectory(libcephfs)
+  add_subdirectory(mon)
+  add_subdirectory(mgr)
+  add_subdirectory(msgr)
+  add_subdirectory(neorados)
+  add_subdirectory(objectstore)
+  add_subdirectory(ObjectMap)
+  add_subdirectory(os)
+  add_subdirectory(osd)
+  add_subdirectory(osdc)
+  add_subdirectory(immutable_object_cache)
+endif()
+
 if(WITH_RADOSGW)
   set(rgw_libs rgw_a)
   if(WITH_RADOSGW_AMQP_ENDPOINT)
@@ -68,9 +83,9 @@ if(WITH_RADOSGW)
   endif()
   add_subdirectory(rgw)
 endif(WITH_RADOSGW)
-if(WITH_RBD)
-  add_subdirectory(rbd_mirror)
-endif(WITH_RBD)
+if(WITH_RBD AND NOT WIN32)
+add_subdirectory(rbd_mirror)
+endif(WITH_RBD AND NOT WIN32)
 if(WITH_SEASTAR)
   add_subdirectory(crimson)
 endif()
@@ -119,7 +134,10 @@ if(WITH_LIBCEPHFS)
 endif(WITH_LIBCEPHFS)
 
 add_executable(test_build_librados buildtest_skeleton.cc)
-target_link_libraries(test_build_librados librados pthread ${CRYPTO_LIBS} ${EXTRALIBS} osdc osd os ceph-common cls_lock_client ${BLKID_LIBRARIES})
+target_link_libraries(test_build_librados librados pthread ${CRYPTO_LIBS} ${EXTRALIBS} ceph-common ${BLKID_LIBRARIES})
+if(NOT WIN32)
+  target_link_libraries(test_build_librados os osdc osd cls_lock_client)
+endif()
 
 # bench_log
 set(bench_log_srcs
@@ -128,7 +146,10 @@ set(bench_log_srcs
 add_executable(ceph_bench_log
   ${bench_log_srcs}
   )
-target_link_libraries(ceph_bench_log global pthread rt ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
+target_link_libraries(ceph_bench_log global pthread ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
+if(NOT WIN32)
+  target_link_libraries(ceph_bench_log rt)
+endif()
 
 # ceph_test_mutate
 add_executable(ceph_test_mutate
@@ -137,11 +158,13 @@ add_executable(ceph_test_mutate
 target_link_libraries(ceph_test_mutate global librados ${BLKID_LIBRARIES} 
   ${CMAKE_DL_LIBS})
 
+if(NOT WIN32)
 # test_trans
 add_executable(test_trans
   test_trans.cc
   )
 target_link_libraries(test_trans os global ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
+endif()
 
 ## Benchmarks
 
@@ -169,9 +192,11 @@ if(WITH_KVS)
   install(TARGETS ceph_kvstorebench DESTINATION bin)
 endif(WITH_KVS)
 
-# ceph_objectstore_bench
-add_executable(ceph_objectstore_bench objectstore_bench.cc)
-target_link_libraries(ceph_objectstore_bench os global ${BLKID_LIBRARIES})
+if(NOT WIN32)
+  # ceph_objectstore_bench
+  add_executable(ceph_objectstore_bench objectstore_bench.cc)
+  target_link_libraries(ceph_objectstore_bench os global ${BLKID_LIBRARIES})
+endif()
 
 if(${WITH_RADOSGW})
   # test_cors
@@ -364,6 +389,13 @@ add_executable(ceph_multi_stress_watch
   )
 target_link_libraries(ceph_multi_stress_watch librados global radostest-cxx)
 
+install(TARGETS
+  ceph_bench_log
+  ceph_multi_stress_watch
+  ceph_omapbench
+  DESTINATION bin)
+
+if(NOT WIN32)
 #ceph_perf_local
 add_executable(ceph_perf_local
   perf_local.cc
@@ -381,10 +413,7 @@ endif()
 target_link_libraries(ceph_perf_local global ${UNITTEST_LIBS})
 
 install(TARGETS
-  ceph_bench_log
-  ceph_multi_stress_watch
   ceph_objectstore_bench
-  ceph_omapbench
   ceph_perf_local
   DESTINATION bin)
 
@@ -418,6 +447,7 @@ add_executable(ceph_test_snap_mapper
   $<TARGET_OBJECTS:unit-main>
   )
 target_link_libraries(ceph_test_snap_mapper osd global ${BLKID_LIBRARIES} ${UNITTEST_LIBS})
+endif(NOT WIN32)
 
 add_executable(ceph_test_stress_watch
   test_stress_watch.cc
@@ -483,25 +513,30 @@ endif()
 
 #following dependencies are run inside make check unit tests
 add_dependencies(tests
-  ceph-mon
   ceph-authtool
-  get_command_descriptions
-  crushtool
   ceph-conf
   rados
-  monmaptool
-  ceph-osd
+  ceph_snappy)
+if(NOT WIN32)
+  # Not currently supported on Windows
+  add_dependencies(tests
+  ceph-mon
+  get_command_descriptions
   ceph-dencoder
   ceph-objectstore-tool
   ceph-kvstore-tool
   ceph-monstore-tool
+  ceph-osd
   osdmaptool
   ceph_example
   ceph_snappy
   cls_lock
   ceph_test_objectstore
   ceph_erasure_code_non_regression
-  cython_modules)
+  cython_modules
+  crushtool
+  monmaptool)
+
 if (WITH_CEPHFS)
   add_dependencies(tests ceph-mds)
 endif()
@@ -535,6 +570,9 @@ if(WITH_RBD)
     add_ceph_test(rbd-ggate.sh ${CMAKE_CURRENT_SOURCE_DIR}/rbd-ggate.sh)
   endif(FREEBSD)
 endif(WITH_RBD)
+
+endif(NOT WIN32)
+
 add_ceph_test(run-cli-tests ${CMAKE_CURRENT_SOURCE_DIR}/run-cli-tests)
 
 # flaky, see https://tracker.ceph.com/issues/44243
@@ -604,12 +642,16 @@ add_executable(unittest_str_list
 add_ceph_unittest(unittest_str_list)
 target_link_libraries(unittest_str_list global)
 
+# This test's usage of templates generates more sections than a PE file can
+# contain.
+if(NOT MINGW)
 # unittest_log
 add_executable(unittest_log
   ${CMAKE_SOURCE_DIR}/src/log/test.cc
   )
 add_ceph_unittest(unittest_log)
 target_link_libraries(unittest_log global)
+endif(NOT MINGW)
 
 # unittest_base64
 add_executable(unittest_base64
@@ -647,6 +689,7 @@ add_executable(unittest_run_cmd
 add_ceph_unittest(unittest_run_cmd)
 target_link_libraries(unittest_run_cmd global)
 
+if(NOT WIN32)
 # signals
 add_executable(unittest_signals
   signals.cc
@@ -654,6 +697,7 @@ add_executable(unittest_signals
   )
 add_ceph_unittest(unittest_signals)
 target_link_libraries(unittest_signals global)
+endif()
 
 # unittest_simple_spin
 add_executable(unittest_simple_spin
@@ -835,6 +879,7 @@ target_link_libraries(unittest_rbd_replay
   librbd
   librados
   global
+  ceph-common
   rbd_replay
   rbd_replay_ios
   ${BLKID_LIBRARIES}
@@ -860,11 +905,13 @@ add_executable(unittest_texttable
 add_ceph_unittest(unittest_texttable)
 target_link_libraries(unittest_texttable ceph-common)
 
+if(NOT WIN32)
 # unittest_on_exit
 add_executable(unittest_on_exit
   on_exit.cc)
 add_ceph_unittest(unittest_on_exit)
 target_link_libraries(unittest_on_exit ceph-common)
+endif()
 
 # unittest_subprocess
 add_executable(unittest_subprocess

--- a/src/test/TestTimers.cc
+++ b/src/test/TestTimers.cc
@@ -255,6 +255,7 @@ int main(int argc, const char **argv)
   int ret;
   ceph::mutex safe_timer_lock = ceph::make_mutex("safe_timer_lock");
   SafeTimer safe_timer(g_ceph_context, safe_timer_lock);
+  safe_timer.init();
 
   ret = basic_timer_test <SafeTimer>(safe_timer, &safe_timer_lock);
   if (ret)
@@ -273,6 +274,7 @@ int main(int argc, const char **argv)
     goto done;
 
 done:
+  safe_timer.shutdown();
   print_status(argv[0], ret);
   return ret;
 }

--- a/src/test/admin_socket.cc
+++ b/src/test/admin_socket.cc
@@ -225,20 +225,29 @@ TEST(AdminSocketClient, Ping) {
   {
     bool ok;
     std::string result = client.ping(&ok);
+#ifndef _WIN32
+// TODO: convert WSA errors.
     EXPECT_NE(std::string::npos, result.find("No such file or directory"));
+#endif
     ASSERT_FALSE(ok);
   }
   // file exists but does not allow connections (no process, wrong type...)
-  ASSERT_TRUE(::creat(path.c_str(), 0777));
+  int fd = ::creat(path.c_str(), 0777);
+  ASSERT_TRUE(fd);
+  // On Windows, we won't be able to remove the file unless we close it
+  // first.
+  ASSERT_FALSE(::close(fd));
   {
     bool ok;
     std::string result = client.ping(&ok);
+#ifndef _WIN32
 #if defined(__APPLE__) || defined(__FreeBSD__)
     const char* errmsg = "Socket operation on non-socket";
 #else
     const char* errmsg = "Connection refused";
 #endif
     EXPECT_NE(std::string::npos, result.find(errmsg));
+#endif /* _WIN32 */
     ASSERT_FALSE(ok);
   }
   // a daemon is connected to the socket
@@ -259,7 +268,9 @@ TEST(AdminSocketClient, Ping) {
     ASSERT_TRUE(asoct.init(path));
     bool ok;
     std::string result = client.ping(&ok);
+    #ifndef _WIN32
     EXPECT_NE(std::string::npos, result.find("Resource temporarily unavailable"));
+    #endif
     ASSERT_FALSE(ok);
     {
       std::lock_guard l{blocking->_lock};
@@ -282,18 +293,22 @@ TEST(AdminSocket, bind_and_listen) {
     message = asoct.bind_and_listen(path, &fd);
     ASSERT_NE(0, fd);
     ASSERT_EQ("", message);
-    ASSERT_EQ(0, ::close(fd));
+    ASSERT_EQ(0, ::compat_closesocket(fd));
     ASSERT_EQ(0, ::unlink(path.c_str()));
   }
   // silently discard an existing file
   {
     int fd = 0;
     string message;
-    ASSERT_TRUE(::creat(path.c_str(), 0777));
+    int fd2 = ::creat(path.c_str(), 0777);
+    ASSERT_TRUE(fd2);
+    // On Windows, we won't be able to remove the file unless we close it
+    // first.
+    ASSERT_FALSE(::close(fd2));
     message = asoct.bind_and_listen(path, &fd);
     ASSERT_NE(0, fd);
     ASSERT_EQ("", message);
-    ASSERT_EQ(0, ::close(fd));
+    ASSERT_EQ(0, ::compat_closesocket(fd));
     ASSERT_EQ(0, ::unlink(path.c_str()));
   }
   // do not take over a live socket

--- a/src/test/admin_socket_output_tests.cc
+++ b/src/test/admin_socket_output_tests.cc
@@ -42,7 +42,7 @@ bool test_dump_pgstate_history(std::string &output) {
     return false;
   }
 
-  uint total = 0;
+  unsigned int total = 0;
   if ((*iterone)->get_name() == "pgs") {
     JSONObjIter iter = (*(*iterone)->find_first())->find_first();
     for (; !iter.end(); ++iter) {

--- a/src/test/ceph_crypto.cc
+++ b/src/test/ceph_crypto.cc
@@ -268,11 +268,11 @@ void do_simple_crypto() {
   exit(0);
 }
 
-#if GTEST_HAS_DEATH_TEST
+#if GTEST_HAS_DEATH_TEST && !defined(_WIN32)
 TEST_F(ForkDeathTest, MD5) {
   ASSERT_EXIT(do_simple_crypto(), ::testing::ExitedWithCode(0), "^$");
 }
-#endif //GTEST_HAS_DEATH_TEST
+#endif // GTEST_HAS_DEATH_TEST && !defined(_WIN32)
 
 int main(int argc, char **argv) {
   std::vector<const char*> args(argv, argv + argc);

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -1,4 +1,6 @@
+if(NOT WIN32)
 # get_command_descriptions
+# libmon not currently available on Windows.
 add_executable(get_command_descriptions
   get_command_descriptions.cc
   $<TARGET_OBJECTS:common_texttable_obj>
@@ -11,6 +13,7 @@ target_link_libraries(get_command_descriptions
   ${BLKID_LIBRARIES}
   ${CMAKE_DL_LIBS}
   )
+endif(NOT WIN32)
 
 # Though FreeBSD has blkdev support, the unittests' mocks only work in Linux
 if(HAVE_BLKID AND LINUX)
@@ -64,6 +67,7 @@ add_executable(unittest_prioritized_queue
 target_link_libraries(unittest_prioritized_queue ceph-common)
 add_ceph_unittest(unittest_prioritized_queue)
 
+if(NOT WIN32)
 # unittest_mclock_priority_queue
 add_executable(unittest_mclock_priority_queue
   test_mclock_priority_queue.cc
@@ -72,6 +76,7 @@ add_ceph_unittest(unittest_mclock_priority_queue)
 target_link_libraries(unittest_mclock_priority_queue
   ceph-common
   dmclock::dmclock)
+endif(NOT WIN32)
 
 # unittest_str_map
 add_executable(unittest_str_map
@@ -285,28 +290,30 @@ if(WITH_CEPHFS)
   target_link_libraries(unittest_global_doublefree cephfs librados)
 endif(WITH_CEPHFS)
 
+if(NOT WIN32)
 add_executable(unittest_dns_resolve
   dns_resolve.cc
   $<TARGET_OBJECTS:unit-main>)
 target_link_libraries(unittest_dns_resolve global)
 add_ceph_unittest(unittest_dns_resolve)
+endif()
 
 add_executable(unittest_back_trace
   test_back_trace.cc)
 set_source_files_properties(test_back_trace.cc PROPERTIES
   COMPILE_FLAGS -fno-inline)
-target_link_libraries(unittest_back_trace ceph-common)
 add_ceph_unittest(unittest_back_trace)
+target_link_libraries(unittest_back_trace ceph-common)
 
 add_executable(unittest_hostname
     test_hostname.cc)
-target_link_libraries(unittest_hostname ceph-common)
 add_ceph_unittest(unittest_hostname)
+target_link_libraries(unittest_hostname ceph-common)
 
 add_executable(unittest_iso_8601
     test_iso_8601.cc)
-target_link_libraries(unittest_iso_8601 ceph-common)
 add_ceph_unittest(unittest_iso_8601)
+target_link_libraries(unittest_iso_8601 ceph-common)
 
 add_executable(unittest_convenience test_convenience.cc)
 add_ceph_unittest(unittest_convenience)
@@ -330,7 +337,7 @@ add_ceph_unittest(unittest_hobject)
 
 add_executable(unittest_async_completion test_async_completion.cc)
 add_ceph_unittest(unittest_async_completion)
-target_link_libraries(unittest_async_completion Boost::system)
+target_link_libraries(unittest_async_completion ceph-common Boost::system)
 
 add_executable(unittest_async_shared_mutex test_async_shared_mutex.cc)
 add_ceph_unittest(unittest_async_shared_mutex)

--- a/src/test/common/test_hostname.cc
+++ b/src/test/common/test_hostname.cc
@@ -62,6 +62,10 @@ TEST(Hostname, short) {
 	 << ", skipping test because env var may or may not be short form"
 	      << std::endl;
   } else {
-    ASSERT_EQ(shn, exec("hostname -s")) ;
+    #ifdef _WIN32
+    ASSERT_EQ(shn, exec("hostname"));
+    #else
+    ASSERT_EQ(shn, exec("hostname -s"));
+    #endif
   }
 }

--- a/src/test/compressor/CMakeLists.txt
+++ b/src/test/compressor/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(ceph_example SHARED compressor_plugin_example.cc)
+target_link_libraries(ceph_example ceph-common)
 
 # unittest_compression
 add_executable(unittest_compression

--- a/src/test/lazy-omap-stats/CMakeLists.txt
+++ b/src/test/lazy-omap-stats/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(ceph_test_lazy_omap_stats
   main.cc
   lazy_omap_stats_test.cc)
 target_link_libraries(ceph_test_lazy_omap_stats
-  librados ${UNITTEST_LIBS} Boost::system)
+  librados Boost::system Boost::filesystem ${UNITTEST_LIBS})
 install(TARGETS
   ceph_test_lazy_omap_stats
   DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/lazy-omap-stats/lazy_omap_stats_test.cc
+++ b/src/test/lazy-omap-stats/lazy_omap_stats_test.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "lazy_omap_stats_test.h"
+#include "include/compat.h"
 
 using namespace std;
 namespace bp = boost::process;

--- a/src/test/lazy-omap-stats/lazy_omap_stats_test.h
+++ b/src/test/lazy-omap-stats/lazy_omap_stats_test.h
@@ -19,6 +19,7 @@
 #include <regex>
 #include <string>
 
+#include "include/compat.h"
 #include "include/rados/librados.hpp"
 
 struct index_t {

--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -17,7 +17,9 @@
 #include "test/librados/TestCase.h"
 #include "gtest/gtest.h"
 #include <sys/time.h>
+#ifndef _WIN32
 #include <sys/resource.h>
+#endif
 
 #include <errno.h>
 #include <map>
@@ -328,6 +330,7 @@ static void shutdown_racer_func()
   }
 }
 
+#ifndef _WIN32
 // See trackers #20988 and #42026
 TEST_F(LibRadosMisc, ShutdownRace)
 {
@@ -348,3 +351,4 @@ TEST_F(LibRadosMisc, ShutdownRace)
     threads[i].join();
   ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &rold), 0);
 }
+#endif /* _WIN32 */

--- a/src/test/librados/test_shared.h
+++ b/src/test/librados/test_shared.h
@@ -19,12 +19,21 @@ void assert_eq_sparse(ceph::bufferlist& expected,
 class TestAlarm
 {
 public:
+  #ifndef _WIN32
   TestAlarm() {
     alarm(1200);
   }
   ~TestAlarm() {
     alarm(0);
   }
+  #else
+  // TODO: add a timeout mechanism for Windows as well, possibly by using
+  // CreateTimerQueueTimer.
+  TestAlarm() {
+  }
+  ~TestAlarm() {
+  }
+  #endif
 };
 
 template<class Rep, class Period, typename Func, typename... Args,

--- a/src/test/librados/watch_notify.cc
+++ b/src/test/librados/watch_notify.cc
@@ -16,12 +16,12 @@ typedef RadosTestEC LibRadosWatchNotifyEC;
 int notify_sleep = 0;
 
 // notify
-static sem_t *sem;
+static sem_t sem;
 
 static void watch_notify_test_cb(uint8_t opcode, uint64_t ver, void *arg)
 {
   std::cout << __func__ << std::endl;
-  sem_post(sem);
+  sem_post(&sem);
 }
 
 class LibRadosWatchNotify : public RadosTest
@@ -85,7 +85,7 @@ class WatchNotifyTestCtx2;
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 TEST_F(LibRadosWatchNotify, WatchNotify) {
-  ASSERT_NE(SEM_FAILED, (sem = sem_open("/test_watch_notify_sem", O_CREAT, 0644, 0)));
+  ASSERT_EQ(0, sem_init(&sem, 0, 0));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
@@ -102,18 +102,18 @@ TEST_F(LibRadosWatchNotify, WatchNotify) {
     }
   }
   TestAlarm alarm;
-  sem_wait(sem);
+  sem_wait(&sem);
   rados_unwatch(ioctx, "foo", handle);
 
   // when dne ...
   ASSERT_EQ(-ENOENT,
       rados_watch(ioctx, "dne", 0, &handle, watch_notify_test_cb, NULL));
 
-  sem_close(sem);
+  sem_destroy(&sem);
 }
 
 TEST_F(LibRadosWatchNotifyEC, WatchNotify) {
-  ASSERT_NE(SEM_FAILED, (sem = sem_open("/test_watch_notify_sem", O_CREAT, 0644, 0)));
+  ASSERT_EQ(0, sem_init(&sem, 0, 0));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   ASSERT_EQ(0, rados_write(ioctx, "foo", buf, sizeof(buf), 0));
@@ -130,9 +130,9 @@ TEST_F(LibRadosWatchNotifyEC, WatchNotify) {
     }
   }
   TestAlarm alarm;
-  sem_wait(sem);
+  sem_wait(&sem);
   rados_unwatch(ioctx, "foo", handle);
-  sem_close(sem);
+  sem_destroy(&sem);
 }
 
 #pragma GCC diagnostic pop

--- a/src/test/librados/watch_notify_cxx.cc
+++ b/src/test/librados/watch_notify_cxx.cc
@@ -68,7 +68,7 @@ public:
 };
 
 // notify
-static sem_t *sem;
+static sem_t sem;
 
 class WatchNotifyTestCtx : public WatchCtx
 {
@@ -76,12 +76,12 @@ public:
   void notify(uint8_t opcode, uint64_t ver, bufferlist& bl) override
   {
     std::cout << __func__ << std::endl;
-    sem_post(sem);
+    sem_post(&sem);
   }
 };
 
 TEST_P(LibRadosWatchNotifyPP, WatchNotify) {
-  ASSERT_NE(SEM_FAILED, (sem = sem_open("/test_watch_notify_sem", O_CREAT, 0644, 0)));
+  ASSERT_EQ(0, sem_init(&sem, 0, 0));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
@@ -104,13 +104,13 @@ TEST_P(LibRadosWatchNotifyPP, WatchNotify) {
     }
   }
   TestAlarm alarm;
-  sem_wait(sem);
+  sem_wait(&sem);
   ioctx.unwatch("foo", handle);
-  sem_close(sem);
+  sem_destroy(&sem);
 }
 
 TEST_F(LibRadosWatchNotifyECPP, WatchNotify) {
-  ASSERT_NE(SEM_FAILED, (sem = sem_open("/test_watch_notify_sem", O_CREAT, 0644, 0)));
+  ASSERT_EQ(0, sem_init(&sem, 0, 0));
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl1;
@@ -133,15 +133,15 @@ TEST_F(LibRadosWatchNotifyECPP, WatchNotify) {
     }
   }
   TestAlarm alarm;
-  sem_wait(sem);
+  sem_wait(&sem);
   ioctx.unwatch("foo", handle);
-  sem_close(sem);
+  sem_destroy(&sem);
 }
 
 // --
 
 TEST_P(LibRadosWatchNotifyPP, WatchNotifyTimeout) {
-  ASSERT_NE(SEM_FAILED, (sem = sem_open("/test_watch_notify_sem", O_CREAT, 0644, 0)));
+  ASSERT_EQ(0, sem_init(&sem, 0, 0));
   ioctx.set_notify_timeout(1);
   uint64_t handle;
   WatchNotifyTestCtx ctx;
@@ -153,12 +153,12 @@ TEST_P(LibRadosWatchNotifyPP, WatchNotifyTimeout) {
   ASSERT_EQ(0, ioctx.write("foo", bl1, sizeof(buf), 0));
 
   ASSERT_EQ(0, ioctx.watch("foo", 0, &handle, &ctx));
-  sem_close(sem);
+  sem_destroy(&sem);
   ASSERT_EQ(0, ioctx.unwatch("foo", handle));
 }
 
 TEST_F(LibRadosWatchNotifyECPP, WatchNotifyTimeout) {
-  ASSERT_NE(SEM_FAILED, (sem = sem_open("/test_watch_notify_sem", O_CREAT, 0644, 0)));
+  ASSERT_EQ(0, sem_init(&sem, 0, 0));
   ioctx.set_notify_timeout(1);
   uint64_t handle;
   WatchNotifyTestCtx ctx;
@@ -170,7 +170,7 @@ TEST_F(LibRadosWatchNotifyECPP, WatchNotifyTimeout) {
   ASSERT_EQ(0, ioctx.write("foo", bl1, sizeof(buf), 0));
 
   ASSERT_EQ(0, ioctx.watch("foo", 0, &handle, &ctx));
-  sem_close(sem);
+  sem_destroy(&sem);
   ASSERT_EQ(0, ioctx.unwatch("foo", handle));
 }
 

--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -25,11 +25,13 @@
 #endif
 #include <sys/file.h>
 #include <sys/stat.h>
+#ifndef _WIN32
 #include <sys/mman.h>
+#include <sys/ioctl.h>
+#endif
 #if defined(__linux__)
 #include <linux/fs.h>
 #endif
-#include <sys/ioctl.h>
 #ifdef HAVE_ERR_H
 #include <err.h>
 #endif
@@ -132,7 +134,7 @@ int			logcount = 0;	/* total ops */
 #define OP_SKIPPED	101
 
 #undef PAGE_SIZE
-#define PAGE_SIZE       getpagesize()
+#define PAGE_SIZE       get_page_size()
 #undef PAGE_MASK
 #define PAGE_MASK       (PAGE_SIZE - 1)
 
@@ -3070,7 +3072,7 @@ main(int argc, char **argv)
 	goodfile[0] = 0;
 	logfile[0] = 0;
 
-	page_size = getpagesize();
+	page_size = PAGE_SIZE;
 	page_mask = page_size - 1;
 	mmap_mask = page_mask;
 
@@ -3271,7 +3273,9 @@ main(int argc, char **argv)
 				fprintf(stdout, "mapped writes DISABLED\n");
 			break;
 		case 'Z':
+            #ifdef O_DIRECT
 			o_direct = O_DIRECT;
+            #endif
 			break;
 		default:
 			usage();
@@ -3285,6 +3289,7 @@ main(int argc, char **argv)
 	pool = argv[0];
 	iname = argv[1];
 
+    #ifndef _WIN32
 	signal(SIGHUP,	cleanup);
 	signal(SIGINT,	cleanup);
 	signal(SIGPIPE,	cleanup);
@@ -3295,6 +3300,7 @@ main(int argc, char **argv)
 	signal(SIGVTALRM,	cleanup);
 	signal(SIGUSR1,	cleanup);
 	signal(SIGUSR2,	cleanup);
+    #endif
 
 	random_generator.seed(seed);
 

--- a/src/test/system/CMakeLists.txt
+++ b/src/test/system/CMakeLists.txt
@@ -9,12 +9,16 @@ set(libsystest_srcs
   st_rados_list_objects.cc)
 add_library(systest STATIC ${libsystest_srcs})
 
+if(NOT WIN32)
+  set(RT_LIB rt)
+endif()
+
 # test_rados_list_parallel
 add_executable(ceph_test_rados_list_parallel
   rados_list_parallel.cc
   )
 target_link_libraries(ceph_test_rados_list_parallel librados systest global pthread
-  rt ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS}) 
+  ${RT_LIB} ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
 
 # test_rados_open_pools_parallel
 set(test_rados_open_pools_parallel_srcs 
@@ -24,7 +28,7 @@ add_executable(ceph_test_rados_open_pools_parallel
   )
 target_link_libraries(ceph_test_rados_open_pools_parallel
   librados systest global
-  pthread rt ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS}) 
+  pthread ${RT_LIB} ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
 
 # test_rados_delete_pools_parallel
 set(test_rados_delete_pools_parallel_srcs
@@ -37,7 +41,7 @@ add_executable(ceph_test_rados_delete_pools_parallel
   ${test_rados_delete_pools_parallel_srcs}
   )
 target_link_libraries(ceph_test_rados_delete_pools_parallel librados systest global
-  pthread rt ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS}) 
+  pthread ${RT_LIB} ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
 
 install(TARGETS
   ceph_test_rados_delete_pools_parallel

--- a/src/test/system/cross_process_sem.cc
+++ b/src/test/system/cross_process_sem.cc
@@ -17,7 +17,9 @@
 #include <errno.h>
 #include <semaphore.h>
 #include <stdlib.h>
+#ifndef _WIN32
 #include <sys/mman.h>
+#endif
 
 #include "include/ceph_assert.h"
 
@@ -36,6 +38,7 @@ struct cross_process_sem_data_t
 int CrossProcessSem::
 create(int initial_val, CrossProcessSem** res)
 {
+  #ifndef _WIN32
   struct cross_process_sem_data_t *data = static_cast < cross_process_sem_data_t*> (
     mmap(NULL, sizeof(struct cross_process_sem_data_t),
        PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, -1, 0));
@@ -43,6 +46,11 @@ create(int initial_val, CrossProcessSem** res)
     int err = errno;
     return err;
   }
+  #else
+  // We can't use multiple processes on Windows for the time being.
+  struct cross_process_sem_data_t *data = (cross_process_sem_data_t*)malloc(
+    sizeof(cross_process_sem_data_t));
+  #endif /* _WIN32 */
   int ret = sem_init(&data->sem, 1, initial_val);
   if (ret) {
     return ret;
@@ -54,7 +62,11 @@ create(int initial_val, CrossProcessSem** res)
 CrossProcessSem::
 ~CrossProcessSem()
 {
+  #ifndef _WIN32
   munmap(m_data, sizeof(struct cross_process_sem_data_t));
+  #else
+  free(m_data);
+  #endif
   m_data = NULL;
 }
 

--- a/src/test/system/cross_process_sem.cc
+++ b/src/test/system/cross_process_sem.cc
@@ -46,12 +46,13 @@ create(int initial_val, CrossProcessSem** res)
     int err = errno;
     return err;
   }
+  int ret = sem_init(&data->sem, 1, initial_val);
   #else
   // We can't use multiple processes on Windows for the time being.
   struct cross_process_sem_data_t *data = (cross_process_sem_data_t*)malloc(
     sizeof(cross_process_sem_data_t));
+  int ret = sem_init(&data->sem, 0, initial_val);
   #endif /* _WIN32 */
-  int ret = sem_init(&data->sem, 1, initial_val);
   if (ret) {
     return ret;
   }

--- a/src/test/system/st_rados_create_pool.cc
+++ b/src/test/system/st_rados_create_pool.cc
@@ -13,6 +13,7 @@
 */
 
 #include "cross_process_sem.h"
+#include "include/ceph_assert.h"
 #include "include/rados/librados.h"
 #include "st_rados_create_pool.h"
 #include "systest_runnable.h"

--- a/src/test/system/systest_runnable.cc
+++ b/src/test/system/systest_runnable.cc
@@ -25,9 +25,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <string>
+#ifndef _WIN32
 #include <sys/syscall.h>
-#include <sys/types.h>
 #include <sys/wait.h>
+#endif
+#include <sys/types.h>
 #include <unistd.h>
 #include <atomic>
 #include <limits>
@@ -40,6 +42,8 @@ static pid_t do_gettid(void)
 {
 #if defined(__linux__)
   return static_cast < pid_t >(syscall(SYS_gettid));
+#elif defined(_WIN32)
+  return static_cast < pid_t >(GetCurrentThreadId());
 #else
   return static_cast < pid_t >(pthread_getthreadid_np());
 #endif
@@ -87,6 +91,10 @@ start()
       return ret;
     m_started = true;
   } else {
+    #ifdef _WIN32
+    printf("Using separate processes is not supported on Windows.\n");
+    return -1;
+    #else
     std::string err_msg;
     ret = preforker.prefork(err_msg);
     if (ret < 0)
@@ -99,6 +107,7 @@ start()
     } else {
       m_started = true;
     }
+    #endif
   }
   return 0;
 }
@@ -127,9 +136,13 @@ join()
     }
     return "";
   } else {
+    #ifdef _WIN32
+    return "Using separate processes is not supported on Windows.\n";
+    #else
     std::string err_msg;
     ret = preforker.parent_wait(err_msg);
     return err_msg;
+    #endif
   }
 }
 

--- a/src/test/system/systest_runnable.h
+++ b/src/test/system/systest_runnable.h
@@ -20,7 +20,9 @@
 #include <string>
 #include <vector>
 
+#ifndef _WIN32
 #include "common/Preforker.h"
+#endif
 
 #define RETURN1_IF_NOT_VAL(expected, expr) \
   do {\
@@ -79,7 +81,9 @@ private:
 
   friend void* systest_runnable_pthread_helper(void *arg);
 
+  #ifndef _WIN32
   Preforker preforker;
+  #endif
   const char **m_argv_orig;
   bool m_started;
   int m_id;

--- a/src/test/system/systest_settings.cc
+++ b/src/test/system/systest_settings.cc
@@ -33,7 +33,14 @@ inst()
 bool SysTestSettings::
 use_threads() const
 {
+  #ifdef _WIN32
+  // We can't use multiple processes on Windows for the time being.
+  // We'd need a mechanism for spawning those procecesses and also handle
+  // the inter-process communication.
+  return true;
+  #else
   return m_use_threads;
+  #endif
 }
 
 std::string SysTestSettings::

--- a/src/test/test_stress_watch.cc
+++ b/src/test/test_stress_watch.cc
@@ -22,7 +22,7 @@ using std::map;
 using std::ostringstream;
 using std::string;
 
-static sem_t *sem;
+static sem_t sem;
 static std::atomic<bool> stop_flag = { false };
 
 class WatchNotifyTestCtx : public WatchCtx
@@ -30,7 +30,7 @@ class WatchNotifyTestCtx : public WatchCtx
 public:
     void notify(uint8_t opcode, uint64_t ver, bufferlist& bl) override
     {
-      sem_post(sem);
+      sem_post(&sem);
     }
 };
 
@@ -66,7 +66,7 @@ INSTANTIATE_TEST_SUITE_P(WatchStressTests, WatchStress,
 			::testing::Values("", "cache"));
 
 TEST_P(WatchStress, Stress1) {
-  ASSERT_NE(SEM_FAILED, (sem = sem_open("test_stress_watch", O_CREAT, 0644, 0)));
+  ASSERT_EQ(0, sem_init(&sem, 0, 0));
   Rados ncluster;
   std::string pool_name = get_temp_pool_name();
   ASSERT_EQ("", create_one_pool_pp(pool_name, ncluster));
@@ -102,7 +102,7 @@ TEST_P(WatchStress, Stress1) {
       sleep(1); // Give a change to see an incorrect notify
     } else {
       TestAlarm alarm;
-      sem_wait(sem);
+      sem_wait(&sem);
     }
 
     if (do_blocklist) {
@@ -116,7 +116,7 @@ TEST_P(WatchStress, Stress1) {
   thr->join();
   nioctx.close();
   ASSERT_EQ(0, destroy_one_pool_pp(pool_name, ncluster));
-  sem_close(sem);
+  sem_destroy(&sem);
 }
 
 #pragma GCC diagnostic pop

--- a/src/test/test_subprocess.cc
+++ b/src/test/test_subprocess.cc
@@ -23,6 +23,14 @@
 #include "gtest/gtest.h"
 #include "common/fork_function.h"
 
+#ifdef _WIN32
+// Some of the tests expect GNU binaries to be available. We'll just rely on
+// the ones provided by Msys (which also comes with Git for Windows).
+#define SHELL "bash.exe"
+#else
+#define SHELL "/bin/sh"
+#endif
+
 bool read_from_fd(int fd, std::string &out) {
   out.clear();
   char buf[1024];
@@ -53,6 +61,10 @@ TEST(SubProcess, False)
 TEST(SubProcess, NotFound)
 {
   SubProcess p("NOTEXISTENTBINARY", SubProcess::CLOSE, SubProcess::CLOSE, SubProcess::PIPE);
+  #ifdef _WIN32
+  // Windows will error out early.
+  ASSERT_EQ(p.spawn(), -1);
+  #else
   ASSERT_EQ(p.spawn(), 0);
   std::string buf;
   ASSERT_TRUE(read_from_fd(p.get_stderr(), buf));
@@ -60,6 +72,7 @@ TEST(SubProcess, NotFound)
   ASSERT_EQ(p.join(), 1);
   std::cerr << "err: " << p.err() << std::endl;
   ASSERT_FALSE(p.err().c_str()[0] == '\0');
+  #endif
 }
 
 TEST(SubProcess, Echo)
@@ -121,6 +134,7 @@ TEST(SubProcess, Killed)
   ASSERT_FALSE(cat.err().c_str()[0] == '\0');
 }
 
+#ifndef _WIN32
 TEST(SubProcess, CatWithArgs)
 {
   SubProcess cat("cat", SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE);
@@ -142,15 +156,16 @@ TEST(SubProcess, CatWithArgs)
   std::cerr << "err: " << cat.err() << std::endl;
   ASSERT_FALSE(cat.err().c_str()[0] == '\0');
 }
+#endif
 
 TEST(SubProcess, Subshell)
 {
-  SubProcess sh("/bin/sh", SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE);
+  SubProcess sh(SHELL, SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE);
   sh.add_cmd_args("-c",
       "sleep 0; "
       "cat; "
       "echo 'error from subshell' >&2; "
-      "/bin/sh -c 'exit 13'", NULL);
+      SHELL " -c 'exit 13'", NULL);
   ASSERT_EQ(sh.spawn(), 0);
   std::string msg("hello via subshell");
   int n = write(sh.get_stdin(), msg.c_str(), msg.size());
@@ -210,8 +225,10 @@ TEST(SubProcessTimed, SleepTimedout)
   ASSERT_EQ(sleep.spawn(), 0);
   std::string buf;
   ASSERT_TRUE(read_from_fd(sleep.get_stderr(), buf));
+  #ifndef _WIN32
   std::cerr << "stderr: " << buf;
   ASSERT_FALSE(buf.empty());
+  #endif
   ASSERT_EQ(sleep.join(), 128 + SIGKILL);
   std::cerr << "err: " << sleep.err() << std::endl;
   ASSERT_FALSE(sleep.err().c_str()[0] == '\0');
@@ -219,7 +236,7 @@ TEST(SubProcessTimed, SleepTimedout)
 
 TEST(SubProcessTimed, SubshellNoTimeout)
 {
-  SubProcessTimed sh("/bin/sh", SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE, 0);
+  SubProcessTimed sh(SHELL, SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE, 0);
   sh.add_cmd_args("-c", "cat >&2", NULL);
   ASSERT_EQ(sh.spawn(), 0);
   std::string msg("the quick brown fox jumps over the lazy dog");
@@ -239,8 +256,8 @@ TEST(SubProcessTimed, SubshellNoTimeout)
 
 TEST(SubProcessTimed, SubshellKilled)
 {
-  SubProcessTimed sh("/bin/sh", SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE, 10);
-  sh.add_cmd_args("-c", "sh -c cat", NULL);
+  SubProcessTimed sh(SHELL, SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE, 10);
+  sh.add_cmd_args("-c", SHELL "-c cat", NULL);
   ASSERT_EQ(sh.spawn(), 0);
   std::string msg("etaoin shrdlu");
   int n = write(sh.get_stdin(), msg.c_str(), msg.size());
@@ -256,18 +273,21 @@ TEST(SubProcessTimed, SubshellKilled)
 
 TEST(SubProcessTimed, SubshellTimedout)
 {
-  SubProcessTimed sh("/bin/sh", SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE, 1, SIGTERM);
+  SubProcessTimed sh(SHELL, SubProcess::PIPE, SubProcess::PIPE, SubProcess::PIPE, 1, SIGTERM);
   sh.add_cmd_args("-c", "sleep 1000& cat; NEVER REACHED", NULL);
   ASSERT_EQ(sh.spawn(), 0);
   std::string buf;
+  #ifndef _WIN32
   ASSERT_TRUE(read_from_fd(sh.get_stderr(), buf));
   std::cerr << "stderr: " << buf;
   ASSERT_FALSE(buf.empty());
+  #endif
   ASSERT_EQ(sh.join(), 128 + SIGTERM);
   std::cerr << "err: " << sh.err() << std::endl;
   ASSERT_FALSE(sh.err().c_str()[0] == '\0');
 }
 
+#ifndef _WIN32
 TEST(fork_function, normal)
 {
   ASSERT_EQ(0, fork_function(10, std::cerr, [&]() { return 0; }));
@@ -291,3 +311,4 @@ TEST(fork_function, timeout)
 	sleep(60);
 	return -111; }));
 }
+#endif

--- a/win32_build.sh
+++ b/win32_build.sh
@@ -119,8 +119,10 @@ if [[ -n $DEV_BUILD ]]; then
   echo "Dev build enabled."
   echo "Git versioning will be disabled."
   ENABLE_GIT_VERSION="OFF"
+  WITH_CEPH_DEBUG_MUTEX="ON"
 else
   ENABLE_GIT_VERSION="ON"
+  WITH_CEPH_DEBUG_MUTEX="OFF"
 fi
 
 # As opposed to Linux, Windows shared libraries can't have unresolved
@@ -132,11 +134,11 @@ cmake -D CMAKE_PREFIX_PATH=$depsDirs \
       -D WITH_GSSAPI=OFF -D WITH_FUSE=OFF -D WITH_XFS=OFF \
       -D WITH_BLUESTORE=OFF -D WITH_LEVELDB=OFF \
       -D WITH_LTTNG=OFF -D WITH_BABELTRACE=OFF \
-      -D WITH_SYSTEM_BOOST=ON -D WITH_MGR=OFF \
+      -D WITH_SYSTEM_BOOST=ON -D WITH_MGR=OFF -D WITH_KVS=OFF \
       -D WITH_LIBCEPHFS=OFF -D WITH_KRBD=OFF -D WITH_RADOSGW=OFF \
-      -D ENABLE_SHARED=OFF -D WITH_RBD=ON -D BUILD_GMOCK=OFF \
+      -D ENABLE_SHARED=OFF -D WITH_RBD=ON -D BUILD_GMOCK=ON \
       -D WITH_CEPHFS=OFF -D WITH_MANPAGE=OFF \
-      -D WITH_MGR_DASHBOARD_FRONTEND=OFF -D WITH_SYSTEMD=OFF -D WITH_TESTS=OFF \
+      -D WITH_MGR_DASHBOARD_FRONTEND=OFF -D WITH_SYSTEMD=OFF -D WITH_TESTS=ON \
       -D LZ4_INCLUDE_DIR=$lz4Include -D LZ4_LIBRARY=$lz4Lib \
       -D Backtrace_INCLUDE_DIR="$backtraceDir/include" \
       -D Backtrace_LIBRARY="$backtraceDir/lib/libbacktrace.a" \
@@ -144,6 +146,7 @@ cmake -D CMAKE_PREFIX_PATH=$depsDirs \
       -D ALLOCATOR="$ALLOCATOR" -D CMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE \
       -D WNBD_INCLUDE_DIRS="$wnbdSrcDir/include" \
       -D WNBD_LIBRARIES="$wnbdLibDir/libwnbd.a" \
+      -D WITH_CEPH_DEBUG_MUTEX=$WITH_CEPH_DEBUG_MUTEX \
       -G "$generatorUsed" \
       $CEPH_DIR  2>&1 | tee "${BUILD_DIR}/cmake.log"
 fi # [[ -z $SKIP_CMAKE ]]
@@ -160,6 +163,7 @@ if [[ -z $SKIP_BUILD ]]; then
     make_targets["src/tools/rbd"]="all"
     make_targets["src/tools/rbd_wnbd"]="all"
     make_targets["src/compressor"]="all"
+    make_targets["src/test"]="all"
 
     for target_subdir in "${!make_targets[@]}"; do
       echo "Building $target_subdir: ${make_targets[$target_subdir]}" | tee -a "${BUILD_DIR}/build.log"


### PR DESCRIPTION
Port tests to Windows

This PR ports some of the Ceph tests to Windows, providing significant test coverage for the client libraries.

Here are some [test_results.zip](https://github.com/ceph/ceph/files/4077517/test_results.zip).

For more details about the build process and current status, please check the
README.windows.rst file.

Other Windows related PRs:

~~Part 1: #31981~~
~~Part 2: #32704~~
~~Part 3: #32705~~
~~Part 4: #32707~~
~~Part 5: #32780~~
~~Part 6: #32779~~
~~Part 7: #32778~~
~~Part 8: #32777~~

~~ceph/fmt#2~~
~~ceph/rocksdb#42~~
#32027 librados: avoid symbol versioning on Windows
#32776 Update Windows build scripts
#34858 Add Windows CephFS support
~~#33750 Add Windows RBD support~~