### PR TITLE
kv/RocksDBStore: Reduced verification on sharding

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4417,11 +4417,11 @@ std::vector<Option> get_global_options() {
     .set_description("Rocksdb options"),
 
     Option("bluestore_rocksdb_cf", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
+    .set_default(true)
     .set_description("Enable use of rocksdb column families for bluestore metadata"),
 
     Option("bluestore_rocksdb_cfs", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("m(5) O(7,0-13) L")
+    .set_default("m(3) O(3,0-13) L")
     .set_description("Definition of column families and their sharding")
     .set_long_description("Space separated list of elements: column_def [ '=' rocksdb_options ]. "
 			  "column_def := column_name [ '(' shard_count [ ',' hash_begin '-' [ hash_end ] ] ')' ]. "

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -146,7 +146,6 @@ private:
   int apply_sharding(const rocksdb::Options& opt,
 		     const std::string& sharding_text);
   int verify_sharding(const rocksdb::Options& opt,
-		      const std::string& sharding_text,
 		      std::vector<rocksdb::ColumnFamilyDescriptor>& existing_cfs,
 		      std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> >& existing_cfs_shard,
 		      std::vector<rocksdb::ColumnFamilyDescriptor>& missing_cfs,


### PR DESCRIPTION
Now sharding is not checked against stored definition.
Only check of columns remain. Stored definitons are always applied.

Fixes: https://tracker.ceph.com/issues/45335

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>