### PR TITLE
mgr/dashboard: Add new 'cdi' npm script

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -220,7 +220,7 @@ Angular CLI:
 Package installation
 ~~~~~~~~~~~~~~~~~~~~
 
-Run ``npm ci`` in directory ``src/pybind/mgr/dashboard/frontend`` to
+Run ``npm run cdi`` in directory ``src/pybind/mgr/dashboard/frontend`` to
 install the required packages locally.
 
 Adding or updating packages
@@ -230,7 +230,7 @@ Run the following commands to add/update a package::
 
   npm install <PACKAGE_NAME>
   npm run fix:audit
-  npm ci
+  npm run cdi
 
 ``fix:audit`` is required because we have some packages that need to be fixed
 to a specific version and npm install tends to overwrite this.

--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -34,7 +34,9 @@
     "fix:audit": "npx npm-force-resolutions",
     "compodoc": "compodoc",
     "doc-build": "compodoc -p src/tsconfig.app.json",
-    "doc-serve": "compodoc --port 8444 -s src/tsconfig.app.json"
+    "doc-serve": "compodoc --port 8444 -s src/tsconfig.app.json",
+    "cdi": "node cd --preci && npm ci && node cd --postci || exit 0"
+
   },
   "private": true,
   "jest": {


### PR DESCRIPTION
This is a wrapper of 'npm ci'.
It prevents 'npm ci' to be called if
there are no changes in 'packages-lock.json'.

Fixes: https://tracker.ceph.com/issues/45350

Signed-off-by: Tiago Melo <tmelo@suse.com>

-->
## Checklist
- [x] After #33121 

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
