### PR TITLE
nautilus: qa/suites/rados: use default objectsize for upgrade tests

### DIFF
--- a/qa/suites/rados/thrash-old-clients/workloads/radosbench.yaml
+++ b/qa/suites/rados/thrash-old-clients/workloads/radosbench.yaml
@@ -8,26 +8,34 @@ overrides:
 tasks:
 - full_sequential:
   - radosbench:
+      objectsize: 0
       clients: [client.2]
       time: 90
   - radosbench:
+      objectsize: 0
       clients: [client.2]
       time: 90
   - radosbench:
+      objectsize: 0
       clients: [client.2]
       time: 90
   - radosbench:
+      objectsize: 0
       clients: [client.2]
       time: 90
   - radosbench:
+      objectsize: 0
       clients: [client.2]
       time: 90
   - radosbench:
+      objectsize: 0
       clients: [client.2]
       time: 90
   - radosbench:
+      objectsize: 0
       clients: [client.2]
       time: 90
   - radosbench:
+      objectsize: 0
       clients: [client.2]
       time: 90


### PR DESCRIPTION
in pre-nautilus release, rados cli does not accept `-O` option, so we
should not pass `-O` to this tool. otherwise we will have following
failure:
```
2020-05-01T05:47:04.863 INFO:tasks.radosbench.radosbench.2.smithi183.stderr:unrecognized command -O; -h or --help for usage
2020-05-01T05:47:04.865 DEBUG:teuthology.orchestra.run:got remote process result: 1
```

this change is not cherry-picked from master. as we don't perfor
upgrade tests from pre-nautilus releases

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
