### PR TITLE
rgw/rgw_bucket: clear tenant string for non tenanted buckets in rgw_bucket_parse_bucket_key function.

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -207,6 +207,8 @@ int rgw_bucket_parse_bucket_key(CephContext *cct, const string& key,
     auto tenant = name.substr(0, pos);
     bucket->tenant.assign(tenant.begin(), tenant.end());
     name = name.substr(pos + 1);
+  } else {
+    bucket->tenant.clear();
   }
 
   // split name:instance


### PR DESCRIPTION
rgw/rgw_bucket: clear tenant string for non tenanted buckets in rgw_bucket_parse_bucket_key function.

Fixes: https://tracker.ceph.com/issues/45355
Signed-off-by: Vikhyat Umrao <vikhyat@redhat.com>
