### PR TITLE
mgr/cephadm: cephadm bootstrap add --apply-spec <cluster.yaml>

### DIFF
--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -70,6 +70,8 @@ Synopsis
 |                           [--skip-pull] [--skip-firewalld] [--allow-overwrite]
 |                           [--allow-fqdn-hostname] [--skip-prepare-host]
 |                           [--orphan-initial-daemons] [--skip-monitoring-stack]
+|                           [--apply-spec APPLY_SPEC]
+
 
 
 | **cephadm** **deploy** [-h] --name NAME --fsid FSID [--config CONFIG]
@@ -216,7 +218,7 @@ Arguments:
 * [--skip-prepare-host]           Do not prepare host
 * [--orphan-initial-daemons]      Do not create initial mon, mgr, and crash service specs
 * [--skip-monitoring-stack]       Do not automatically provision monitoring stack] (prometheus, grafana, alertmanager, node-exporter)
-
+* [--apply-spec APPLY_SPEC]       Apply cluster spec after bootstrap (copy ssh key, add hosts and apply services)
 
 ceph-volume
 -----------

--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -73,6 +73,32 @@ Add and remove hosts::
     ceph orch host add <hostname> [<addr>] [<labels>...]
     ceph orch host rm <hostname>
 
+Host Specification
+------------------
+
+Many hosts can be added at once using
+``ceph orch apply -i`` by submitting a multi-document YAML file::
+
+    ---
+    service_type: host
+    addr: node-00
+    hostname: node-00
+    labels:
+    - example1
+    - example2
+    ---
+    service_type: host
+    addr: node-01
+    hostname: node-01
+    labels:
+    - grafana
+    ---
+    service_type: host
+    addr: node-02
+    hostname: node-02
+
+This can be combined with service specifications (below) to create a cluster spec file to deploy a whole cluster in one command.  see ``cephadm bootstrap --apply-spec`` also to do this during bootstrap. Cluster SSH Keys must be copied to hosts prior.
+
 OSD Management
 ==============
 
@@ -548,8 +574,7 @@ Or with hosts:
       hosts: 
         - host1
         - host2
-        - host3
-
+        - host3 
 
 Configuring the Orchestrator CLI
 ================================

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2655,6 +2655,28 @@ def command_bootstrap():
                         get_fqdn(), port,
                         args.initial_dashboard_user,
                         password))
+    
+    if args.apply_spec:
+        logger.info('Applying %s to cluster' % args.apply_spec)
+
+        with open(args.apply_spec) as f:
+            for line in f:
+                if 'hostname:' in line:
+                    line = line.replace('\n', '')
+                    split = line.split(': ')
+                    if split[1] != host:
+                        logger.info('Adding ssh key to %s' % split[1])
+
+                        ssh_key = '/etc/ceph/ceph.pub'
+                        if args.ssh_public_key:
+                            ssh_key = args.ssh_public_key.name
+                        out, err, code = call_throws(['ssh-copy-id', '-f', '-i', ssh_key, 'root@%s' % split[1]])
+
+        mounts = {}
+        mounts[pathify(args.apply_spec)] = '/tmp/spec.yml:z'
+
+        out = cli(['orch', 'apply', '-i', '/tmp/spec.yml'], extra_mounts=mounts)
+        logger.info(out)
 
     logger.info('You can access the Ceph CLI with:\n\n'
                 '\tsudo %s shell --fsid %s -c %s -k %s\n' % (
@@ -4541,6 +4563,10 @@ def _get_parser():
         '--skip-monitoring-stack',
         action='store_true',
         help='Do not automatically provision monitoring stack (prometheus, grafana, alertmanager, node-exporter)')
+    parser_bootstrap.add_argument(
+        '--apply-spec',
+        help='Apply cluster spec after bootstrap (copy ssh key, add hosts and apply services)')
+
 
     parser_deploy = subparsers.add_parser(
         'deploy', help='deploy a daemon')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -27,6 +27,7 @@ from mgr_module import MgrModule, HandleCommandResult
 import orchestrator
 from orchestrator import OrchestratorError, OrchestratorValidationError, HostSpec, \
     CLICommandMeta
+from orchestrator._interface import GenericSpec
 
 from . import remotes
 from . import utils
@@ -1055,8 +1056,7 @@ you may want to run:
         # type: (Optional[str]) -> List[str]
         return list(self.inventory.filter_by_label(label))
 
-    @trivial_completion
-    def add_host(self, spec):
+    def _add_host(self, spec):
         # type: (HostSpec) -> str
         """
         Add a host to be managed by the orchestrator.
@@ -1078,6 +1078,10 @@ you may want to run:
         self.event.set()  # refresh stray health check
         self.log.info('Added host %s' % spec.hostname)
         return "Added host '{}'".format(spec.hostname)
+
+    @trivial_completion
+    def add_host(self, spec: HostSpec) -> str:
+        return self._add_host(spec)
 
     @trivial_completion
     def remove_host(self, host):
@@ -1992,7 +1996,13 @@ you may want to run:
         # type: (ServiceSpec) -> List[str]
         return self._add_daemon('mgr', spec, self.mgr_service.create)
 
-    def _apply(self, spec: ServiceSpec) -> str:
+    def _apply(self, spec: GenericSpec) -> str:
+        if spec.service_type == 'host':
+            return self._add_host(cast(HostSpec, spec))
+
+        return self._apply_service_spec(cast(ServiceSpec, spec))
+
+    def _apply_service_spec(self, spec: ServiceSpec) -> str:
         if spec.placement.is_empty():
             # fill in default placement
             defaults = {
@@ -2029,8 +2039,11 @@ you may want to run:
         return "Scheduled %s update..." % spec.service_name()
 
     @trivial_completion
-    def apply(self, specs: List[ServiceSpec]):
-        return [self._apply(spec) for spec in specs]
+    def apply(self, specs: List[GenericSpec]):
+        results = []
+        for spec in specs:
+            results.append(self._apply(spec))
+        return results
 
     @trivial_completion
     def apply_mgr(self, spec):

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1,7 +1,7 @@
 import datetime
 import errno
 import json
-from typing import List, Set, Optional, Iterator
+from typing import List, Set, Optional, Iterator, cast
 import re
 import ast
 
@@ -20,7 +20,7 @@ from ._interface import OrchestratorClientMixin, DeviceLightLoc, _cli_read_comma
     raise_if_exception, _cli_write_command, TrivialReadCompletion, OrchestratorError, \
     NoOrchestrator, OrchestratorValidationError, NFSServiceSpec, \
     RGWSpec, InventoryFilter, InventoryHost, HostSpec, CLICommandMeta, \
-    ServiceDescription, DaemonDescription, IscsiServiceSpec
+    ServiceDescription, DaemonDescription, IscsiServiceSpec, json_to_generic_spec, GenericSpec
 
 
 def nice_delta(now, t, suffix=''):
@@ -468,7 +468,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
             spec = service.spec
             spec.unmanaged = unmanaged_flag
             specs.append(spec)
-        completion = self.apply(specs)
+        completion = self.apply(cast(List[GenericSpec], specs))
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         if specs:
@@ -996,12 +996,13 @@ Usage:
             if service_type or placement or unmanaged:
                 raise OrchestratorValidationError(usage)
             content: Iterator = yaml.load_all(inbuf)
-            specs = [ServiceSpec.from_json(s) for s in content]
-        else:
-            spec = PlacementSpec.from_string(placement)
-            assert service_type
-            specs = [ServiceSpec(service_type, placement=spec, unmanaged=unmanaged)]
+            specs: List[GenericSpec] = [json_to_generic_spec(s) for s in content]
 
+        else:
+            placmentspec = PlacementSpec.from_string(placement)
+            assert service_type
+            specs = [ServiceSpec(service_type, placement=placmentspec, unmanaged=unmanaged)]
+ 
         completion = self.apply(specs)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)


### PR DESCRIPTION
Have a single command when setting up a cluster for Day 1

example spec

```
---
service_type: host
addr: jmo-node-00
hostname: jmo-node-00
---
service_type: host
addr: jmo-node-01
hostname: jmo-node-01
labels:
  - grafana
---
service_type: host
addr: jmo-node-02
hostname: jmo-node-02
---
service_type: grafana
placement:
  label: "grafana"
---
service_type: osd
placement:
  host_pattern: '*'
data_devices:
  all: true

```
Fixes: [https://tracker.ceph.com/issues/44873]

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>


