### PR TITLE
mimic: rados: prevent ShardedOpWQ suicide_grace drop when waiting for work.

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10113,8 +10113,9 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
 	sdata->shard_lock.Unlock();
 	return;
       }
+      // found a work item; reapply default wq timeouts
       osd->cct->get_heartbeat_map()->reset_timeout(hb,
-	  osd->cct->_conf->threadpool_default_timeout, 0);
+        timeout_interval, suicide_interval);
     } else {
       dout(0) << __func__ << " need return immediately" << dendl;
       sdata->sdata_wait_lock.Unlock();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45358

---

backport of https://github.com/ceph/ceph/pull/34575
parent tracker: https://tracker.ceph.com/issues/45076

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh