### PR TITLE
nautilus: qa/tasks/ceph.py: do not use option mimic does not understand

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1680,6 +1680,25 @@ def validate_config(ctx, config):
             last_role = role
 
 
+def stop_logging_health(remote, cluster, retry):
+    # try this several times, since tell to mons is lossy.
+    args = 'sudo ceph --cluster {cluster} {retry_opts} tell mon.* injectargs -- --no-mon-health-to-clog'
+    try:
+        retry_opts = '--mon-client-directed-command-retry {}'.format(retry)
+        remote.run(
+            args=args.format(cluster=cluster,
+                             retry_opts=retry_opts))
+    except run.CommandFailedError:
+        for i in range(retry):
+            try:
+                remote.run(
+                    args=args.format(cluster=cluster,
+                                     retry_opts=''))
+                return
+            except run.CommandFailedError:
+                pass
+
+
 @contextlib.contextmanager
 def task(ctx, config):
     """
@@ -1886,17 +1905,4 @@ def task(ctx, config):
             # a bunch of scary messages unrelated to our actual run.
             firstmon = teuthology.get_first_mon(ctx, config, config['cluster'])
             (mon0_remote,) = ctx.cluster.only(firstmon).remotes.keys()
-            # try this several times, since tell to mons is lossy.
-            mon0_remote.run(
-                args=[
-                    'sudo',
-                    'ceph',
-                    '--cluster', config['cluster'],
-                    '--mon-client-directed-command-retry', '5',
-                    'tell',
-                    'mon.*',
-                    'injectargs',
-                    '--',
-                    '--no-mon-health-to-clog',
-                ]
-            )
+            stop_logging_health(mon0_remote, config['cluster'], 5)


### PR DESCRIPTION
mimic does not have `mon-client-directed-command-retry` option, so we
should not pass this option to a mimic ceph client.

in this change, we fall back to plain retry, if command fails. this
change is not cherry-picked from master. as we don't run upgrade test
from mimic to master.

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit d7c62d365ad1bc9571d9ffe4835d5e4a7836bc4f)

Fixes: https://tracker.ceph.com/issues/45356


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
