### PR TITLE
rgw: Fix bug on subuser create for user_id with colon

### DIFF
--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -100,6 +100,12 @@ For example::
   radosgw-admin subuser create --uid=johndoe --subuser=johndoe:swift --access=full
 
 
+It is preferred to be explicit when creating subusers, specifying users with a ``--uid``.
+If a ``--uid`` is not supplied, we parse the uid until the last colon ::
+
+  radosgw-admin subuser create --subuser={user_uid}:{subuser_uid} --access=[ read | write | readwrite | full ]
+
+
 .. note:: ``full`` is not ``readwrite``, as it also includes the access control policy.
 
 .. code-block:: javascript

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -282,7 +282,8 @@ struct RGWUserAdminOpState {
     if (_subuser.empty())
       return;
 
-    size_t pos = _subuser.find(":");
+    // user_id can have ":" in it so we should find the last ":" for user_id:subuser pattern
+    size_t pos = _subuser.find_last_of(":");
     if (pos != string::npos) {
       rgw_user tmp_id;
       tmp_id.from_str(_subuser.substr(0, pos));


### PR DESCRIPTION
user_id with colon like foo:bar can't create subuser with radosgw-admin subuser create without uid given
```
radosgw-admin subuser create --subuser foo:bar:subuser
```

Fixes: https://tracker.ceph.com/issues/45236
Signed-off-by: Seena Fallah seeenafallah@gmail.com