### PR TITLE
cephadm: Fix error parsing shell command arguments

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4327,7 +4327,7 @@ def _get_parser():
         default=[],
         help='set environment variable')
     parser_shell.add_argument(
-        'command', nargs='*',
+        'command', nargs=argparse.REMAINDER,
         help='command (optional)')
 
     parser_enter = subparsers.add_parser(
@@ -4341,7 +4341,7 @@ def _get_parser():
         required=True,
         help='daemon name (type.id)')
     parser_enter.add_argument(
-        'command', nargs='*',
+        'command', nargs=argparse.REMAINDER,
         help='command')
 
     parser_ceph_volume = subparsers.add_parser(
@@ -4360,7 +4360,7 @@ def _get_parser():
         '--keyring', '-k',
         help='ceph.keyring to pass through to the container')
     parser_ceph_volume.add_argument(
-        'command', nargs='+',
+        'command', nargs=argparse.REMAINDER,
         help='command')
 
     parser_unit = subparsers.add_parser(
@@ -4589,7 +4589,10 @@ def _get_parser():
 
 def _parse_args(av):
     parser = _get_parser()
-    return parser.parse_args(av)
+    args = parser.parse_args(av)
+    if 'command' in args and args.command and args.command[0] == "--":
+        args.command.pop(0)
+    return args
 
 if __name__ == "__main__":
     # allow argv to be injected


### PR DESCRIPTION
Optional arguments in the _command_ parameter used in _cephadm shell_ are not
parsed properly. This fixes this problem.

Example:
Before the fix:
```
[root@ceph-node-00 /]# ./cephadm shell --fsid 82ab3202-8dec-11ea-a4bb-525400a7519d -c /etc/ceph/ceph.conf -k /etc/ceph/ceph.client.admin.keyring ceph orch apply osd --all-available-devices
usage: cephadm [-h] [--image IMAGE] [--docker] [--data-dir DATA_DIR]
               [--log-dir LOG_DIR] [--logrotate-dir LOGROTATE_DIR]
               [--unit-dir UNIT_DIR] [--verbose] [--timeout TIMEOUT]
               [--retry RETRY]
               {version,pull,inspect-image,ls,list-networks,adopt,rm-daemon,rm-cluster,run,shell,enter,ceph-volume,unit,logs,bootstrap,deploy,check-host,prepare-host,add-repo,rm-repo,install}
               ...
cephadm: error: unrecognized arguments: --all-available-devices

```
after the fix:

```
root@ceph-node-00 /]# ./cephadm shell --fsid 82ab3202-8dec-11ea-a4bb-525400a7519d -c /etc/ceph/ceph.conf -k /etc/ceph/ceph.client.admin.keyring ceph orch apply osd --all-available-devices
INFO:cephadm:Using recent ceph image docker.io/ceph/daemon-base:latest-master-devel
NAME                  HOST                     DATA     DB WAL 
all-available-devices ceph-node-00.cephlab.com /dev/vdb -  -   
all-available-devices ceph-node-01.cephlab.com /dev/vdb -  -   
all-available-devices ceph-node-02.cephlab.com /dev/vdb -  -   
```




Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
