### PR TITLE
cephfs-shell: Remove get_error_code() call on OSError type exception …

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -714,7 +714,7 @@ class CephFSShell(Cmd):
                     else:
                         perror('{}: already exists! use --force to overwrite'.format(
                                root_src_dir.decode('utf-8')))
-                        self.exit_code = e.get_error_code()
+                        self.exit_code = e.errno
                         return
 
             for file_ in files:
@@ -1065,7 +1065,7 @@ class CephFSShell(Cmd):
             os.chdir(os.path.expanduser(args.path))
         except OSError as e:
             perror("Cannot change to {}: {}".format(e.filename, e.strerror))
-            self.exit_code = e.get_error_code()
+            self.exit_code = e.errno
 
     def complete_lls(self, text, line, begidx, endidx):
         """
@@ -1094,7 +1094,7 @@ class CephFSShell(Cmd):
                     print_list(items)
                 except OSError as e:
                     perror("'{}': {}".format(e.filename, e.strerror))
-                    self.exit_code = e.get_error_code()
+                    self.exit_code = e.errno
         # Arguments to the with_argpaser decorator function are sticky.
         # The items in args.path do not get overwritten in subsequent calls.
         # The arguments remain in args.paths after the function exits and we
@@ -1530,7 +1530,10 @@ def read_ceph_conf(shell, config_file):
         shell.prompt = get_bool_vals_for_boolopts(cephfs.conf_get('prompt'))
         shell.quiet = get_bool_vals_for_boolopts(cephfs.conf_get('quiet'))
         shell.timing = get_bool_vals_for_boolopts(cephfs.conf_get('timing'))
-    except (OSError, libcephfs.Error) as e:
+    except OSError as e:
+        perror(e)
+        shell.exit_code = e.errno
+    except libcephfs.Error as e:
         perror(e)
         shell.exit_code = e.get_error_code()
 


### PR DESCRIPTION
…objects

OSError type exception has no attribute 'get_error_code'. Insead use errno to
fetch error code.

Fixes: https://tracker.ceph.com/issues/45373
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
