### PR TITLE
qa/rgw: fix issue error in tests_ps.py

### DIFF
--- a/src/test/rgw/rgw_multi/tests_ps.py
+++ b/src/test/rgw/rgw_multi/tests_ps.py
@@ -2744,7 +2744,7 @@ def test_ps_s3_multipart_on_master():
     assert_equal(len(events), 1)
     assert_equal(events[0]['Records'][0]['eventName'], 's3:ObjectCreated:CompleteMultipartUpload')
     assert_equal(events[0]['Records'][0]['s3']['configurationId'], notification_name+'_3')
-    print events[0]['Records'][0]['s3']['object']['size']
+    print(events[0]['Records'][0]['s3']['object']['size'])
 
     # cleanup
     stop_amqp_receiver(receiver1, task1)


### PR DESCRIPTION
The Python interpreter on teuthology complains about the lack of parens in a print statement.

Tracker: https://tracker.ceph.com/issues/45380