### PR TITLE
test/cli-integration/balancer/misplaced.t: start with balancer off

### DIFF
--- a/src/test/cli-integration/balancer/misplaced.t
+++ b/src/test/cli-integration/balancer/misplaced.t
@@ -1,3 +1,5 @@
+  $ ceph balancer off
+  $ ceph balancer mode none
   $ ceph osd pool create balancer_opt 128
   pool 'balancer_opt' created
   $ ceph osd pool application enable balancer_opt rados


### PR DESCRIPTION
Also set mode to none else the sequence of commands makes the balancer
start in upmap mode instead of crush-compat.

Fixes: https://tracker.ceph.com/issues/45298
Signed-off-by: Neha Ojha <nojha@redhat.com>