### PR TITLE
doc/config: osd_scrub_during_recovery is disabled by default

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -258,7 +258,7 @@ scrubbing operations.
               Already running scrubs will be continued. This might be useful to reduce
               load on busy clusters.
 :Type: Boolean
-:Default: ``true``
+:Default: ``false``
 
 
 ``osd scrub thread timeout``


### PR DESCRIPTION
The documentation wasn't correct on this part as the default is false as per https://github.com/ceph/ceph/blob/master/src/common/options.cc#L3161
