### PR TITLE
nautilus: qa/suites/upgrade: disable min pg per osd warning

### DIFF
--- a/qa/suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
@@ -34,6 +34,7 @@ tasks:
       global:
         mon warn on pool no app: false
         bluestore_warn_on_legacy_statfs: false
+        mon pg warn min per osd: 0
 - exec:
     osd.0:
       - ceph osd require-osd-release mimic

--- a/qa/suites/upgrade/mimic-x/stress-split/1-ceph-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/1-ceph-install/mimic.yaml
@@ -16,6 +16,7 @@ tasks:
     conf:
       global:
         bluestore_warn_on_legacy_statfs: false
+        mon pg warn min per osd: 0
 - exec:
     osd.0:
       - ceph osd require-osd-release mimic


### PR DESCRIPTION
disable the TOO_FEW_PGS warning, as
1ac34a5ea3d1aca299b02e574b295dd4bf6167f4 is not backported to mimic, we
will have TOO_FEW_PGS warnings when a healthy cluster is expected when
upgrading from mimic.

this change disables this warning by setting "mon_pg_warn_min_per_osd" to
"0".

this change is not cherry-picked from master. as
1ac34a5ea3d1aca299b02e574b295dd4bf6167f4 is already included by master,
and we don't perform upgrade from mimic on master branch.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
