### PR TITLE
rgw: increase civetweb request timeout to 65 seconds

### DIFF
--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -96,6 +96,7 @@ int RGWCivetWebFrontend::run()
   set_conf_default(conf_map, "canonicalize_url_path", "no");
   set_conf_default(conf_map, "enable_auth_domain_check", "no");
   set_conf_default(conf_map, "allow_unicode_in_urls", "yes");
+  set_conf_default(conf_map, "request_timeout_ms", "65000");
 
   std::string listening_ports;
   // support multiple port= entries


### PR DESCRIPTION
Increase civetweb request timeout to 65 seconds as the default is too low (30s) and most of the S3 SDKs have higher timeouts.

Fixes: https://tracker.ceph.com/issues/45239

Signed-off-by: Or Friedmann <ofriedma@redhat.com>