### PR TITLE
mgr/cephadm: refresh osd config when mons change

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2554,7 +2554,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 self._remove_daemon(dd.name(), dd.hostname)
 
             # ignore unmanaged services
-            if not spec or spec.unmanaged:
+            if spec and spec.unmanaged:
                 continue
 
             # dependencies?


### PR DESCRIPTION
OSDs don't have a service spec, so the previous implementation was not reconfiguring them when the list of mons changed.

Fixes: https://tracker.ceph.com/issues/45393
Signed-off-by: Tim Serong <tserong@suse.com>