### PR TITLE
rgw: unable to compile fcgi frontend

### DIFF
--- a/src/rgw/rgw_fcgi_process.cc
+++ b/src/rgw/rgw_fcgi_process.cc
@@ -89,7 +89,7 @@ void RGWFCGXProcess::run()
   }
 
   for (;;) {
-    RGWFCGXRequest* req = new RGWFCGXRequest(store->get_new_req_id(), &qr);
+    RGWFCGXRequest* req = new RGWFCGXRequest(store->getRados()->get_new_req_id(), &qr);
     dout(10) << "allocated request req=" << hex << req << dec << dendl;
     req_throttle.get(1);
     int ret = FCGX_Accept_r(req->fcgx);


### PR DESCRIPTION
Although we are not supporting this frontend it is still possible to compile it

This fix is intend to be able to compile fcgi

Signed-off-by: Or Friedmann <ofriedma@redhat.com>
