### PR TITLE
pybind/mgr: properly mock the mon store for pytest

### DIFF
--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -11,23 +11,6 @@ from orchestrator import raise_if_exception, Completion
 from tests import mock
 
 
-def set_store(self, k, v):
-    if v is None:
-        del self._store[k]
-    else:
-        self._store[k] = v
-
-
-def get_store(self, k):
-    return self._store.get(k, None)
-
-
-def get_store_prefix(self, prefix):
-    return {
-        k: v for k, v in self._store.items()
-        if k.startswith(prefix)
-    }
-
 
 def get_ceph_option(_, key):
     return __file__
@@ -52,30 +35,13 @@ def mon_command(*args, **kwargs):
 @pytest.yield_fixture()
 def cephadm_module():
     with mock.patch("cephadm.module.CephadmOrchestrator.get_ceph_option", get_ceph_option),\
-            mock.patch("cephadm.module.CephadmOrchestrator._configure_logging", lambda *args: None),\
             mock.patch("cephadm.module.CephadmOrchestrator.remote"),\
-            mock.patch("cephadm.module.CephadmOrchestrator.set_store", set_store), \
-            mock.patch("cephadm.module.CephadmOrchestrator.get_store", get_store),\
-            mock.patch("cephadm.inventory.HostCache.save_host"), \
-            mock.patch("cephadm.inventory.HostCache.rm_host"), \
             mock.patch("cephadm.module.CephadmOrchestrator.send_command"), \
-            mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command), \
-            mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix", get_store_prefix):
+            mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command):
 
-        CephadmOrchestrator._register_commands('')
-        CephadmOrchestrator._register_options('')
         m = CephadmOrchestrator.__new__ (CephadmOrchestrator)
-        m._root_logger = mock.MagicMock()
-        m._store = {
-            'ssh_config': '',
-            'ssh_identity_key': '',
-            'ssh_identity_pub': '',
-            'inventory': {},
-            'upgrade_state': None,
-        }
         m.__init__('cephadm', 0, 0)
         m._cluster_fsid = "fsid"
-        m.mode = "root"
         yield m
 
 

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -16,19 +16,47 @@ if 'UNITTEST' in os.environ:
     except ImportError:
         import mock
 
+    M_classes = set()
+
     class M(object):
+        def _ceph_get_store(self, k):
+            return self._store.get(k, None)
+
+        def _ceph_set_store(self, k, v):
+            if v is None:
+                if k in self._store:
+                    del self._store[k]
+            else:
+                self._store[k] = v
+
+        def _ceph_get_store_prefix(self, prefix):
+            return {
+                k: v for k, v in self._store.items()
+                if k.startswith(prefix)
+            }
+
+        def _ceph_get_module_option(self, module, key, localized_prefix: None):
+            return self._ceph_get_store(f'{module}/{key}')
+
+        def _ceph_set_module_option(self, module, key, val):
+            return self._ceph_set_store(f'{module}/{key}', val)
+
         def __init__(self, *args):
+            self._store = {}
+
+            if self.__class__.__name__ not in M_classes:
+                # call those only once. 
+                self._register_commands('')
+                self._register_options('')
+                M_classes.add(self.__class__.__name__)
+
             super(M, self).__init__()
             self._ceph_get_version = mock.Mock()
             self._ceph_get = mock.MagicMock()
-            self._ceph_get_module_option = mock.MagicMock()
             self._ceph_get_option = mock.MagicMock()
-            self._validate_module_option = lambda _: True
             self._configure_logging = lambda *_: None
             self._unconfigure_logging = mock.MagicMock()
             self._ceph_log = mock.MagicMock()
-            self._ceph_get_store = lambda _: ''
-            self._ceph_get_store_prefix = lambda _: {}
             self._ceph_dispatch_remote = lambda *_: None
 
 


### PR DESCRIPTION
Might make

https://github.com/ceph/ceph/blob/a43859541b9df46f57fde99e9c18cd7b322c1cc9/src/pybind/mgr/dashboard/tests/__init__.py#L62

obsolete in the future.

This is a spin-off from #34633

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
