### PR TITLE
mgr/dashboard: Improve run-frontend-e2e-tests.sh

### DIFF
--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -30,7 +30,6 @@ stop() {
 }
 
 check_device_available() {
-    : ${DEVICE:="chrome"}
     failed=false
 
     if [ "$DEVICE" == "docker" ]; then
@@ -56,13 +55,13 @@ check_device_available() {
     fi
 }
 
-CYPRESS_BASE_URL=''
-DEVICE=''
-CYPRESS_LOGIN_PWD=''
-CYPRESS_LOGIN_USER=''
-NO_COLOR=1
-RECORD=''
-REMOTE='false'
+: ${CYPRESS_BASE_URL:=''}
+: ${CYPRESS_LOGIN_PWD:=''}
+: ${CYPRESS_LOGIN_USER:=''}
+: ${DEVICE:="chrome"}
+: ${NO_COLOR:=1}
+: ${CYPRESS_ARGS:=''}
+: ${REMOTE:='false'}
 
 while getopts 'd:p:r:u:' flag; do
   case "${flag}" in
@@ -93,20 +92,7 @@ fi
 
 cd $DASH_DIR/frontend
 
-if [ -n "$CYPRESS_RECORD_KEY" ]; then
-    RECORD="--record --key $CYPRESS_RECORD_KEY"
-fi
-
 case "$DEVICE" in
-    electron)
-        npx cypress run $RECORD || stop 1
-        ;;
-    chrome)
-        npx cypress run $RECORD --browser chrome --headless || stop 1
-        ;;
-    chromium)
-        npx cypress run $RECORD --browser chromium --headless || stop 1
-        ;;
     docker)
         failed=0
         docker run \
@@ -119,6 +105,9 @@ case "$DEVICE" in
             --network=host \
             cypress/included:4.4.0 || failed=1
         stop $failed
+        ;;
+    *)
+        npx cypress run $CYPRESS_ARGS --browser $DEVICE --headless || stop 1
         ;;
 esac
 


### PR DESCRIPTION
Allow to configure settings with env variables.
Improve message sent to cypress dashboard.

Fixes: https://tracker.ceph.com/issues/45408

Add Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
