### PR TITLE
rbd-mirror: wait for events to replay before shut down journal replay

### DIFF
--- a/src/test/rbd_mirror/image_replayer/journal/test_mock_Replayer.cc
+++ b/src/test/rbd_mirror/image_replayer/journal/test_mock_Replayer.cc
@@ -1088,12 +1088,14 @@ TEST_F(TestMockImageReplayerJournalReplayer, Replay) {
   EXPECT_CALL(mock_local_journal_replay, decode(_, _)).WillOnce(Return(0));
   expect_preprocess(mock_event_preprocessor, false, 0);
   expect_process(mock_local_journal_replay, 0, 0);
+  EXPECT_CALL(mock_replay_status_formatter, handle_entry_processed(_));
 
   // the next event with preprocess
   expect_try_pop_front(mock_remote_journaler, tag.tid, true);
   EXPECT_CALL(mock_local_journal_replay, decode(_, _)).WillOnce(Return(0));
   expect_preprocess(mock_event_preprocessor, true, 0);
   expect_process(mock_local_journal_replay, 0, 0);
+  EXPECT_CALL(mock_replay_status_formatter, handle_entry_processed(_));
 
   // attempt to process the next event
   C_SaferCond replay_ctx;
@@ -1249,6 +1251,7 @@ TEST_F(TestMockImageReplayerJournalReplayer, DelayedReplay) {
             ReturnArg<1>()));
   expect_preprocess(mock_event_preprocessor, false, 0);
   expect_process(mock_local_journal_replay, 0, 0);
+  EXPECT_CALL(mock_replay_status_formatter, handle_entry_processed(_));
 
   // attempt to process the next event
   C_SaferCond replay_ctx;
@@ -1830,6 +1833,7 @@ TEST_F(TestMockImageReplayerJournalReplayer, AllocateTagDemotion) {
   EXPECT_CALL(mock_local_journal_replay, decode(_, _)).WillOnce(Return(0));
   expect_preprocess(mock_event_preprocessor, false, 0);
   expect_process(mock_local_journal_replay, 0, 0);
+  EXPECT_CALL(mock_replay_status_formatter, handle_entry_processed(_));
 
   remote_replay_handler->handle_entries_available();
   wait_for_notification();
@@ -2017,6 +2021,7 @@ TEST_F(TestMockImageReplayerJournalReplayer, ProcessError) {
   EXPECT_CALL(mock_local_journal_replay, decode(_, _)).WillOnce(Return(0));
   expect_preprocess(mock_event_preprocessor, false, 0);
   expect_process(mock_local_journal_replay, 0, -EINVAL);
+  EXPECT_CALL(mock_replay_status_formatter, handle_entry_processed(_));
 
   // attempt to process the next event
   C_SaferCond replay_ctx;
@@ -2089,6 +2094,7 @@ TEST_F(TestMockImageReplayerJournalReplayer, ImageNameUpdated) {
   EXPECT_CALL(mock_local_journal_replay, decode(_, _)).WillOnce(Return(0));
   expect_preprocess(mock_event_preprocessor, false, 0);
   expect_process(mock_local_journal_replay, 0, 0);
+  EXPECT_CALL(mock_replay_status_formatter, handle_entry_processed(_));
 
   // attempt to process the next event
   C_SaferCond replay_ctx;

--- a/src/tools/rbd_mirror/image_replayer/journal/Replayer.h
+++ b/src/tools/rbd_mirror/image_replayer/journal/Replayer.h
@@ -145,10 +145,10 @@ private:
    * REPLAY_COMPLETE  < * * * * * * * * * * * * * * * * * * *   *
    *    |                                                       *
    *    v                                                       *
-   * SHUT_DOWN_LOCAL_JOURNAL_REPLAY                             *
+   * WAIT_FOR_REPLAY                                            *
    *    |                                                       *
    *    v                                                       *
-   * WAIT_FOR_REPLAY                                            *
+   * SHUT_DOWN_LOCAL_JOURNAL_REPLAY                             *
    *    |                                                       *
    *    v                                                       *
    * CLOSE_LOCAL_IMAGE  < * * * * * * * * * * * * * * * * * * * *


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/45409
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
