### PR TITLE
mgr/dashboard: Remove entryComponents

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -41,18 +41,6 @@ import { RbdTrashPurgeModalComponent } from './rbd-trash-purge-modal/rbd-trash-p
 import { RbdTrashRestoreModalComponent } from './rbd-trash-restore-modal/rbd-trash-restore-modal.component';
 
 @NgModule({
-  entryComponents: [
-    RbdDetailsComponent,
-    RbdNamespaceFormModalComponent,
-    RbdSnapshotFormModalComponent,
-    RbdTrashMoveModalComponent,
-    RbdTrashRestoreModalComponent,
-    RbdTrashPurgeModalComponent,
-    IscsiTargetDetailsComponent,
-    IscsiTargetImageSettingsModalComponent,
-    IscsiTargetIqnSettingsModalComponent,
-    IscsiTargetDiscoveryModalComponent
-  ],
   imports: [
     CommonModule,
     MirroringModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.spec.ts
@@ -13,6 +13,7 @@ import {
   i18nProviders,
   IscsiHelper
 } from '../../../../testing/unit-test-helper';
+import { LoadingPanelComponent } from '../../../shared/components/loading-panel/loading-panel.component';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { SharedModule } from '../../../shared/shared.module';
 import { IscsiTargetFormComponent } from './iscsi-target-form.component';
@@ -141,23 +142,26 @@ describe('IscsiTargetFormComponent', () => {
     }
   ];
 
-  configureTestBed({
-    declarations: [IscsiTargetFormComponent],
-    imports: [
-      SharedModule,
-      ReactiveFormsModule,
-      HttpClientTestingModule,
-      RouterTestingModule,
-      ToastrModule.forRoot()
-    ],
-    providers: [
-      i18nProviders,
-      {
-        provide: ActivatedRoute,
-        useValue: new ActivatedRouteStub({ target_iqn: undefined })
-      }
-    ]
-  });
+  configureTestBed(
+    {
+      declarations: [IscsiTargetFormComponent],
+      imports: [
+        SharedModule,
+        ReactiveFormsModule,
+        HttpClientTestingModule,
+        RouterTestingModule,
+        ToastrModule.forRoot()
+      ],
+      providers: [
+        i18nProviders,
+        {
+          provide: ActivatedRoute,
+          useValue: new ActivatedRouteStub({ target_iqn: undefined })
+        }
+      ]
+    },
+    [LoadingPanelComponent]
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(IscsiTargetFormComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/mirroring.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/mirroring.module.ts
@@ -22,14 +22,6 @@ import { PoolEditPeerModalComponent } from './pool-edit-peer-modal/pool-edit-pee
 import { PoolListComponent } from './pool-list/pool-list.component';
 
 @NgModule({
-  entryComponents: [
-    BootstrapCreateModalComponent,
-    BootstrapImportModalComponent,
-    EditSiteNameModalComponent,
-    OverviewComponent,
-    PoolEditModeModalComponent,
-    PoolEditPeerModalComponent
-  ],
   imports: [
     CommonModule,
     SharedModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -11,7 +11,6 @@ import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { TimepickerModule } from 'ngx-bootstrap/timepicker';
 
-import { OrchestratorDocModalComponent } from '../../shared/components/orchestrator-doc-modal/orchestrator-doc-modal.component';
 import { SharedModule } from '../../shared/shared.module';
 import { PerformanceCounterModule } from '../performance-counter/performance-counter.module';
 import { CephSharedModule } from '../shared/ceph-shared.module';
@@ -51,19 +50,6 @@ import { ServicesComponent } from './services/services.component';
 import { TelemetryComponent } from './telemetry/telemetry.component';
 
 @NgModule({
-  entryComponents: [
-    OsdDetailsComponent,
-    OsdScrubModalComponent,
-    OsdFlagsModalComponent,
-    OsdRecvSpeedModalComponent,
-    OsdReweightModalComponent,
-    OsdPgScrubModalComponent,
-    OsdReweightModalComponent,
-    SilenceMatcherModalComponent,
-    OsdDevicesSelectionModalComponent,
-    OsdCreationPreviewModalComponent,
-    OrchestratorDocModalComponent
-  ],
   imports: [
     CommonModule,
     PerformanceCounterModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.spec.ts
@@ -6,6 +6,7 @@ import { ToastrModule } from 'ngx-toastr';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
+import { LoadingPanelComponent } from '../../../../shared/components/loading-panel/loading-panel.component';
 import { SharedModule } from '../../../../shared/shared.module';
 import { HostFormComponent } from './host-form.component';
 
@@ -13,17 +14,20 @@ describe('HostFormComponent', () => {
   let component: HostFormComponent;
   let fixture: ComponentFixture<HostFormComponent>;
 
-  configureTestBed({
-    imports: [
-      SharedModule,
-      HttpClientTestingModule,
-      RouterTestingModule,
-      ReactiveFormsModule,
-      ToastrModule.forRoot()
-    ],
-    providers: [i18nProviders],
-    declarations: [HostFormComponent]
-  });
+  configureTestBed(
+    {
+      imports: [
+        SharedModule,
+        HttpClientTestingModule,
+        RouterTestingModule,
+        ReactiveFormsModule,
+        ToastrModule.forRoot()
+      ],
+      providers: [i18nProviders],
+      declarations: [HostFormComponent]
+    },
+    [LoadingPanelComponent]
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HostFormComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.spec.ts
@@ -6,6 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ToastrModule } from 'ngx-toastr';
 
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
+import { LoadingPanelComponent } from '../../../../shared/components/loading-panel/loading-panel.component';
 import { SharedModule } from '../../../../shared/shared.module';
 import { MgrModuleFormComponent } from './mgr-module-form.component';
 
@@ -13,17 +14,20 @@ describe('MgrModuleFormComponent', () => {
   let component: MgrModuleFormComponent;
   let fixture: ComponentFixture<MgrModuleFormComponent>;
 
-  configureTestBed({
-    declarations: [MgrModuleFormComponent],
-    imports: [
-      HttpClientTestingModule,
-      ReactiveFormsModule,
-      RouterTestingModule,
-      SharedModule,
-      ToastrModule.forRoot()
-    ],
-    providers: i18nProviders
-  });
+  configureTestBed(
+    {
+      declarations: [MgrModuleFormComponent],
+      imports: [
+        HttpClientTestingModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        SharedModule,
+        ToastrModule.forRoot()
+      ],
+      providers: i18nProviders
+    },
+    [LoadingPanelComponent]
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MgrModuleFormComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
@@ -12,6 +12,7 @@ import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-h
 import { MgrModuleService } from '../../../shared/api/mgr-module.service';
 import { TelemetryService } from '../../../shared/api/telemetry.service';
 
+import { LoadingPanelComponent } from '../../../shared/components/loading-panel/loading-panel.component';
 import { TextToDownloadService } from '../../../shared/services/text-to-download.service';
 import { SharedModule } from '../../../shared/shared.module';
 import { TelemetryComponent } from './telemetry.component';
@@ -47,17 +48,20 @@ describe('TelemetryComponent', () => {
     'url'
   ];
 
-  configureTestBed({
-    declarations: [TelemetryComponent],
-    imports: [
-      HttpClientTestingModule,
-      ReactiveFormsModule,
-      RouterTestingModule,
-      SharedModule,
-      ToastrModule.forRoot()
-    ],
-    providers: i18nProviders
-  });
+  configureTestBed(
+    {
+      declarations: [TelemetryComponent],
+      imports: [
+        HttpClientTestingModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        SharedModule,
+        ToastrModule.forRoot()
+      ],
+      providers: i18nProviders
+    },
+    [LoadingPanelComponent]
+  );
 
   describe('configForm', () => {
     beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -10,6 +10,7 @@ import { of } from 'rxjs';
 
 import { ActivatedRouteStub } from '../../../../testing/activated-route-stub';
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
+import { LoadingPanelComponent } from '../../../shared/components/loading-panel/loading-panel.component';
 import { CephReleaseNamePipe } from '../../../shared/pipes/ceph-release-name.pipe';
 import { SummaryService } from '../../../shared/services/summary.service';
 import { SharedModule } from '../../../shared/shared.module';
@@ -22,26 +23,29 @@ describe('NfsFormComponent', () => {
   let httpTesting: HttpTestingController;
   let activatedRoute: ActivatedRouteStub;
 
-  configureTestBed({
-    declarations: [NfsFormComponent, NfsFormClientComponent],
-    imports: [
-      HttpClientTestingModule,
-      ReactiveFormsModule,
-      RouterTestingModule,
-      SharedModule,
-      ToastrModule.forRoot(),
-      NgbTypeaheadModule
-    ],
-    providers: [
-      {
-        provide: ActivatedRoute,
-        useValue: new ActivatedRouteStub({ cluster_id: undefined, export_id: undefined })
-      },
-      i18nProviders,
-      SummaryService,
-      CephReleaseNamePipe
-    ]
-  });
+  configureTestBed(
+    {
+      declarations: [NfsFormComponent, NfsFormClientComponent],
+      imports: [
+        HttpClientTestingModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        SharedModule,
+        ToastrModule.forRoot(),
+        NgbTypeaheadModule
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: new ActivatedRouteStub({ cluster_id: undefined, export_id: undefined })
+        },
+        i18nProviders,
+        SummaryService,
+        CephReleaseNamePipe
+      ]
+    },
+    [LoadingPanelComponent]
+  );
 
   beforeEach(() => {
     const summaryService = TestBed.inject(SummaryService);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
@@ -37,8 +37,7 @@ import { PoolListComponent } from './pool-list/pool-list.component';
     ErasureCodeProfileFormModalComponent,
     CrushRuleFormModalComponent,
     PoolDetailsComponent
-  ],
-  entryComponents: [CrushRuleFormModalComponent, ErasureCodeProfileFormModalComponent]
+  ]
 })
 export class PoolModule {}
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -27,15 +27,6 @@ import { RgwUserSubuserModalComponent } from './rgw-user-subuser-modal/rgw-user-
 import { RgwUserSwiftKeyModalComponent } from './rgw-user-swift-key-modal/rgw-user-swift-key-modal.component';
 
 @NgModule({
-  entryComponents: [
-    RgwDaemonDetailsComponent,
-    RgwBucketDetailsComponent,
-    RgwUserDetailsComponent,
-    RgwUserSwiftKeyModalComponent,
-    RgwUserS3KeyModalComponent,
-    RgwUserCapabilityModalComponent,
-    RgwUserSubuserModalComponent
-  ],
   imports: [
     CommonModule,
     SharedModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.spec.ts
@@ -11,6 +11,7 @@ import { of } from 'rxjs';
 import { configureTestBed, FormHelper, i18nProviders } from '../../../../testing/unit-test-helper';
 import { RoleService } from '../../../shared/api/role.service';
 import { ScopeService } from '../../../shared/api/scope.service';
+import { LoadingPanelComponent } from '../../../shared/components/loading-panel/loading-panel.component';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { SharedModule } from '../../../shared/shared.module';
@@ -31,17 +32,20 @@ describe('RoleFormComponent', () => {
 
   const routes: Routes = [{ path: 'roles', component: FakeComponent }];
 
-  configureTestBed({
-    imports: [
-      RouterTestingModule.withRoutes(routes),
-      HttpClientTestingModule,
-      ReactiveFormsModule,
-      ToastrModule.forRoot(),
-      SharedModule
-    ],
-    declarations: [RoleFormComponent, FakeComponent],
-    providers: i18nProviders
-  });
+  configureTestBed(
+    {
+      imports: [
+        RouterTestingModule.withRoutes(routes),
+        HttpClientTestingModule,
+        ReactiveFormsModule,
+        ToastrModule.forRoot(),
+        SharedModule
+      ],
+      declarations: [RoleFormComponent, FakeComponent],
+      providers: i18nProviders
+    },
+    [LoadingPanelComponent]
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RoleFormComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
@@ -16,6 +16,7 @@ import { RoleService } from '../../../shared/api/role.service';
 import { SettingsService } from '../../../shared/api/settings.service';
 import { UserService } from '../../../shared/api/user.service';
 import { ComponentsModule } from '../../../shared/components/components.module';
+import { LoadingPanelComponent } from '../../../shared/components/loading-panel/loading-panel.component';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { NotificationService } from '../../../shared/services/notification.service';
@@ -44,20 +45,23 @@ describe('UserFormComponent', () => {
     { path: 'users', component: FakeComponent }
   ];
 
-  configureTestBed({
-    imports: [
-      RouterTestingModule.withRoutes(routes),
-      HttpClientTestingModule,
-      ReactiveFormsModule,
-      ComponentsModule,
-      ToastrModule.forRoot(),
-      SharedModule,
-      ButtonsModule.forRoot(),
-      BsDatepickerModule.forRoot()
-    ],
-    declarations: [UserFormComponent, FakeComponent],
-    providers: i18nProviders
-  });
+  configureTestBed(
+    {
+      imports: [
+        RouterTestingModule.withRoutes(routes),
+        HttpClientTestingModule,
+        ReactiveFormsModule,
+        ComponentsModule,
+        ToastrModule.forRoot(),
+        SharedModule,
+        ButtonsModule.forRoot(),
+        BsDatepickerModule.forRoot()
+      ],
+      declarations: [UserFormComponent, FakeComponent],
+      providers: i18nProviders
+    },
+    [LoadingPanelComponent]
+  );
 
   beforeEach(() => {
     spyOn(TestBed.inject(PasswordPolicyService), 'getHelpText').and.callFake(() => of(''));

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation.module.ts
@@ -18,7 +18,6 @@ import { NavigationComponent } from './navigation/navigation.component';
 import { NotificationsComponent } from './notifications/notifications.component';
 
 @NgModule({
-  entryComponents: [AboutComponent],
   imports: [
     CommonModule,
     AuthModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -105,12 +105,6 @@ import { ViewCacheComponent } from './view-cache/view-cache.component';
     AlertPanelComponent,
     PwdExpirationNotificationComponent,
     OrchestratorDocPanelComponent
-  ],
-  entryComponents: [
-    ModalComponent,
-    CriticalConfirmationModalComponent,
-    ConfirmationModalComponent,
-    FormModalComponent
   ]
 })
 export class ComponentsModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.spec.ts
@@ -17,9 +17,7 @@ import { ModalComponent } from '../modal/modal.component';
 import { SubmitButtonComponent } from '../submit-button/submit-button.component';
 import { ConfirmationModalComponent } from './confirmation-modal.component';
 
-@NgModule({
-  entryComponents: [ConfirmationModalComponent]
-})
+@NgModule({})
 export class MockModule {}
 
 @Component({

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.spec.ts
@@ -12,9 +12,7 @@ import { AlertPanelComponent } from '../alert-panel/alert-panel.component';
 import { LoadingPanelComponent } from '../loading-panel/loading-panel.component';
 import { CriticalConfirmationModalComponent } from './critical-confirmation-modal.component';
 
-@NgModule({
-  entryComponents: [CriticalConfirmationModalComponent]
-})
+@NgModule({})
 export class MockModule {}
 
 @Component({

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/directives.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/directives.module.ts
@@ -1,7 +1,5 @@
 import { NgModule } from '@angular/core';
 
-import { AlertPanelComponent } from '../components/alert-panel/alert-panel.component';
-import { LoadingPanelComponent } from '../components/loading-panel/loading-panel.component';
 import { AutofocusDirective } from './autofocus.directive';
 import { Copy2ClipboardButtonDirective } from './copy2clipboard-button.directive';
 import { DimlessBinaryPerSecondDirective } from './dimless-binary-per-second.directive';
@@ -35,8 +33,6 @@ import { TrimDirective } from './trim.directive';
     MillisecondsDirective,
     IopsDirective,
     FormLoadingDirective
-  ],
-  providers: [],
-  entryComponents: [LoadingPanelComponent, AlertPanelComponent]
+  ]
 })
 export class DirectivesModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/form-loading.directive.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/form-loading.directive.spec.ts
@@ -5,6 +5,8 @@ import { By } from '@angular/platform-browser';
 import { NgbAlertModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { configureTestBed, i18nProviders } from '../../../testing/unit-test-helper';
+import { AlertPanelComponent } from '../components/alert-panel/alert-panel.component';
+import { LoadingPanelComponent } from '../components/loading-panel/loading-panel.component';
 import { CdForm } from '../forms/cd-form';
 import { SharedModule } from '../shared.module';
 import { FormLoadingDirective } from './form-loading.directive';
@@ -26,11 +28,14 @@ describe('FormLoadingDirective', () => {
     expect(fixture.debugElement.queryAll(By.css('cd-loading-panel')).length).toEqual(loading);
   };
 
-  configureTestBed({
-    declarations: [TestComponent],
-    imports: [SharedModule, NgbAlertModule],
-    providers: [i18nProviders]
-  });
+  configureTestBed(
+    {
+      declarations: [TestComponent],
+      imports: [SharedModule, NgbAlertModule],
+      providers: [i18nProviders]
+    },
+    [LoadingPanelComponent, AlertPanelComponent]
+  );
 
   afterEach(() => {
     fixture = null;

--- a/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
@@ -2,6 +2,7 @@ import { DebugElement, LOCALE_ID, TRANSLATIONS, TRANSLATIONS_FORMAT, Type } from
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
 import { configureTestSuite } from 'ng-bullet';
@@ -23,8 +24,18 @@ import {
   PrometheusRule
 } from '../app/shared/models/prometheus-alerts';
 
-export function configureTestBed(configuration: any) {
-  configureTestSuite(() => TestBed.configureTestingModule(configuration));
+export function configureTestBed(configuration: any, entryComponents?: any) {
+  configureTestSuite(() => {
+    if (entryComponents) {
+      // Declare entryComponents without having to add them to a module
+      // This is needed since Jest doesn't yet support not declaring entryComponents
+      TestBed.configureTestingModule(configuration).overrideModule(BrowserDynamicTestingModule, {
+        set: { entryComponents: entryComponents }
+      });
+    } else {
+      TestBed.configureTestingModule(configuration);
+    }
+  });
 }
 
 export class PermissionHelper {


### PR DESCRIPTION
entryComponents is no longer required in Angular 9.

Fixes: https://tracker.ceph.com/issues/45325

Signed-off-by: Tiago Melo <tmelo@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug
- [x] After #33121 

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
