### PR TITLE
mgr/dashboard: Use TestBed.inject instead of TestBed.get

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.spec.ts
@@ -45,7 +45,7 @@ describe('IscsiTargetDiscoveryModalComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(IscsiTargetDiscoveryModalComponent);
     component = fixture.componentInstance;
-    httpTesting = TestBed.get(HttpTestingController);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   describe('with update permissions', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.spec.ts
@@ -162,8 +162,8 @@ describe('IscsiTargetFormComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(IscsiTargetFormComponent);
     component = fixture.componentInstance;
-    httpTesting = TestBed.get(HttpTestingController);
-    activatedRoute = TestBed.get(ActivatedRoute);
+    httpTesting = TestBed.inject(HttpTestingController);
+    activatedRoute = <ActivatedRouteStub>TestBed.inject(ActivatedRoute);
     fixture.detectChanges();
 
     httpTesting.expectOne('ui-api/iscsi/settings').flush(SETTINGS);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.spec.ts
@@ -51,8 +51,8 @@ describe('IscsiTargetListComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(IscsiTargetListComponent);
     component = fixture.componentInstance;
-    summaryService = TestBed.get(SummaryService);
-    iscsiService = TestBed.get(IscsiService);
+    summaryService = TestBed.inject(SummaryService);
+    iscsiService = TestBed.inject(IscsiService);
 
     // this is needed because summaryService isn't being reset after each test.
     summaryService['summaryDataSource'] = new BehaviorSubject(null);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
@@ -46,7 +46,7 @@ describe('IscsiComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(IscsiComponent);
     component = fixture.componentInstance;
-    iscsiService = TestBed.get(IscsiService);
+    iscsiService = TestBed.inject(IscsiService);
     fixture.detectChanges();
     tcmuiscsiData = {
       images: []

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-create-modal/bootstrap-create-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-create-modal/bootstrap-create-modal.component.spec.ts
@@ -41,10 +41,10 @@ describe('BootstrapCreateModalComponent', () => {
     component = fixture.componentInstance;
     component.siteName = 'site-A';
 
-    notificationService = TestBed.get(NotificationService);
+    notificationService = TestBed.inject(NotificationService);
     spyOn(notificationService, 'show').and.stub();
 
-    rbdMirroringService = TestBed.get(RbdMirroringService);
+    rbdMirroringService = TestBed.inject(RbdMirroringService);
 
     formHelper = new FormHelper(component.createBootstrapForm);
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-import-modal/bootstrap-import-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-import-modal/bootstrap-import-modal.component.spec.ts
@@ -41,10 +41,10 @@ describe('BootstrapImportModalComponent', () => {
     component = fixture.componentInstance;
     component.siteName = 'site-A';
 
-    notificationService = TestBed.get(NotificationService);
+    notificationService = TestBed.inject(NotificationService);
     spyOn(notificationService, 'show').and.stub();
 
-    rbdMirroringService = TestBed.get(RbdMirroringService);
+    rbdMirroringService = TestBed.inject(RbdMirroringService);
 
     formHelper = new FormHelper(component.importBootstrapForm);
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/edit-site-name-modal/edit-site-name-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/edit-site-name-modal/edit-site-name-modal.component.spec.ts
@@ -36,10 +36,10 @@ describe('EditSiteNameModalComponent', () => {
     component = fixture.componentInstance;
     component.siteName = 'site-A';
 
-    notificationService = TestBed.get(NotificationService);
+    notificationService = TestBed.inject(NotificationService);
     spyOn(notificationService, 'show').and.stub();
 
-    rbdMirroringService = TestBed.get(RbdMirroringService);
+    rbdMirroringService = TestBed.inject(RbdMirroringService);
   });
 
   it('should create', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.spec.ts
@@ -41,10 +41,10 @@ describe('PoolEditModeModalComponent', () => {
     component = fixture.componentInstance;
     component.poolName = 'somePool';
 
-    notificationService = TestBed.get(NotificationService);
+    notificationService = TestBed.inject(NotificationService);
     spyOn(notificationService, 'show').and.stub();
 
-    rbdMirroringService = TestBed.get(RbdMirroringService);
+    rbdMirroringService = TestBed.inject(RbdMirroringService);
 
     formHelper = new FormHelper(component.editModeForm);
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.spec.ts
@@ -43,10 +43,10 @@ describe('PoolEditPeerModalComponent', () => {
     component.mode = 'add';
     component.poolName = 'somePool';
 
-    notificationService = TestBed.get(NotificationService);
+    notificationService = TestBed.inject(NotificationService);
     spyOn(notificationService, 'show').and.stub();
 
-    rbdMirroringService = TestBed.get(RbdMirroringService);
+    rbdMirroringService = TestBed.inject(RbdMirroringService);
 
     formHelper = new FormHelper(component.editPeerForm);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-configuration-form/rbd-configuration-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-configuration-form/rbd-configuration-form.component.spec.ts
@@ -43,7 +43,7 @@ describe('RbdConfigurationFormComponent', () => {
     component.form = new CdFormGroup({}, null);
     fh = new FormHelper(component.form);
     fixture.detectChanges();
-    sections = TestBed.get(RbdConfigurationService).sections;
+    sections = TestBed.inject(RbdConfigurationService).sections;
   });
 
   it('should create', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
@@ -52,7 +52,7 @@ describe('RbdFormComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(RbdFormComponent);
     component = fixture.componentInstance;
-    activatedRoute = TestBed.get(ActivatedRoute);
+    activatedRoute = <ActivatedRouteStub>TestBed.inject(ActivatedRoute);
 
     component.loadingReady();
   });
@@ -78,8 +78,8 @@ describe('RbdFormComponent', () => {
       cloneAction = spyOn(component, 'cloneAction').and.returnValue(of(null));
       copyAction = spyOn(component, 'copyAction').and.returnValue(of(null));
       spyOn(component, 'setResponse').and.stub();
-      routerNavigate = spyOn(TestBed.get(Router), 'navigate').and.stub();
-      rbdServiceGetSpy = spyOn(TestBed.get(RbdService), 'get');
+      routerNavigate = spyOn(TestBed.inject(Router), 'navigate').and.stub();
+      rbdServiceGetSpy = spyOn(TestBed.inject(RbdService), 'get');
       rbdServiceGetSpy.and.returnValue(of({ pool_name: 'foo', pool_image: 'bar' }));
       component.mode = undefined;
     });
@@ -202,7 +202,7 @@ describe('RbdFormComponent', () => {
     let rbdService: RbdService;
 
     beforeEach(() => {
-      rbdService = TestBed.get(RbdService);
+      rbdService = TestBed.inject(RbdService);
       component.mode = RbdFormMode.editing;
       fixture.detectChanges();
       spyOn(rbdService, 'get').and.callThrough();
@@ -284,7 +284,7 @@ describe('RbdFormComponent', () => {
 
     describe('test edit form flags', () => {
       const prepare = (pool: string, image: string, enabledFeatures: string[]): void => {
-        const rbdService = TestBed.get(RbdService);
+        const rbdService = TestBed.inject(RbdService);
         spyOn(rbdService, 'get').and.returnValue(
           of({
             name: image,
@@ -341,7 +341,7 @@ describe('RbdFormComponent', () => {
 
     describe('test create form flags', () => {
       beforeEach(() => {
-        const rbdService = TestBed.get(RbdService);
+        const rbdService = TestBed.inject(RbdService);
         spyOn(rbdService, 'defaultFeatures').and.returnValue(of(defaultFeatures));
         component.router = { url: '/block/rbd/create' } as Router;
         fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
@@ -67,8 +67,8 @@ describe('RbdListComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(RbdListComponent);
     component = fixture.componentInstance;
-    summaryService = TestBed.get(SummaryService);
-    rbdService = TestBed.get(RbdService);
+    summaryService = TestBed.inject(SummaryService);
+    rbdService = TestBed.inject(RbdService);
 
     // this is needed because summaryService isn't being reset after each test.
     summaryService['summaryDataSource'] = new BehaviorSubject(null);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -71,7 +71,7 @@ describe('RbdSnapshotListComponent', () => {
     fixture = TestBed.createComponent(RbdSnapshotListComponent);
     component = fixture.componentInstance;
     component.ngOnChanges();
-    summaryService = TestBed.get(SummaryService);
+    summaryService = TestBed.inject(SummaryService);
   });
 
   it('should create', () => {
@@ -87,8 +87,8 @@ describe('RbdSnapshotListComponent', () => {
 
     beforeEach(() => {
       fixture.detectChanges();
-      const i18n = TestBed.get(I18n);
-      const actionLabelsI18n = TestBed.get(ActionLabelsI18n);
+      const i18n = TestBed.inject(I18n);
+      const actionLabelsI18n = TestBed.inject(ActionLabelsI18n);
       called = false;
       rbdService = new RbdService(null, null);
       notificationService = new NotificationService(null, null, null);
@@ -190,15 +190,15 @@ describe('RbdSnapshotListComponent', () => {
     beforeEach(() => {
       component.poolName = 'pool01';
       component.rbdName = 'image01';
-      spyOn(TestBed.get(BsModalService), 'show').and.callFake(() => {
+      spyOn(TestBed.inject(BsModalService), 'show').and.callFake(() => {
         const ref = new BsModalRef();
         ref.content = new RbdSnapshotFormModalComponent(
           null,
           null,
           null,
           null,
-          TestBed.get(I18n),
-          TestBed.get(ActionLabelsI18n)
+          TestBed.inject(I18n),
+          TestBed.inject(ActionLabelsI18n)
         );
         ref.content.onSubmit = new Subject();
         return ref;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.spec.ts
@@ -46,8 +46,8 @@ describe('RbdTrashListComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(RbdTrashListComponent);
     component = fixture.componentInstance;
-    summaryService = TestBed.get(SummaryService);
-    rbdService = TestBed.get(RbdService);
+    summaryService = TestBed.inject(SummaryService);
+    rbdService = TestBed.inject(RbdService);
     fixture.detectChanges();
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.spec.ts
@@ -34,7 +34,7 @@ describe('RbdTrashMoveModalComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(RbdTrashMoveModalComponent);
     component = fixture.componentInstance;
-    httpTesting = TestBed.get(HttpTestingController);
+    httpTesting = TestBed.inject(HttpTestingController);
 
     component.poolName = 'foo';
     component.imageName = 'bar';
@@ -55,7 +55,7 @@ describe('RbdTrashMoveModalComponent', () => {
     let notificationService: NotificationService;
 
     beforeEach(() => {
-      notificationService = TestBed.get(NotificationService);
+      notificationService = TestBed.inject(NotificationService);
       spyOn(notificationService, 'show').and.stub();
       spyOn(component.modalRef, 'hide').and.callThrough();
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-purge-modal/rbd-trash-purge-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-purge-modal/rbd-trash-purge-modal.component.spec.ts
@@ -35,7 +35,7 @@ describe('RbdTrashPurgeModalComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RbdTrashPurgeModalComponent);
-    httpTesting = TestBed.get(HttpTestingController);
+    httpTesting = TestBed.inject(HttpTestingController);
     component = fixture.componentInstance;
   });
 
@@ -76,8 +76,8 @@ describe('RbdTrashPurgeModalComponent', () => {
 
     beforeEach(() => {
       fixture.detectChanges();
-      notificationService = TestBed.get(NotificationService);
-      modalRef = TestBed.get(BsModalRef);
+      notificationService = TestBed.inject(NotificationService);
+      modalRef = TestBed.inject(BsModalRef);
 
       component.purgeForm.patchValue({ poolName: 'foo' });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-restore-modal/rbd-trash-restore-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-restore-modal/rbd-trash-restore-modal.component.spec.ts
@@ -48,9 +48,9 @@ describe('RbdTrashRestoreModalComponent', () => {
     let req: TestRequest;
 
     beforeEach(() => {
-      httpTesting = TestBed.get(HttpTestingController);
-      notificationService = TestBed.get(NotificationService);
-      modalRef = TestBed.get(BsModalRef);
+      httpTesting = TestBed.inject(HttpTestingController);
+      notificationService = TestBed.inject(NotificationService);
+      modalRef = TestBed.inject(BsModalRef);
 
       component.poolName = 'foo';
       component.imageName = 'bar';

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
@@ -383,14 +383,14 @@ describe('CephfsDirectoriesComponent', () => {
       updatedQuotas: {}
     };
 
-    cephfsService = TestBed.get(CephfsService);
+    cephfsService = TestBed.inject(CephfsService);
     lsDirSpy = spyOn(cephfsService, 'lsDir').and.callFake(mockLib.lsDir);
     spyOn(cephfsService, 'mkSnapshot').and.callFake(mockLib.mkSnapshot);
     spyOn(cephfsService, 'rmSnapshot').and.callFake(mockLib.rmSnapshot);
     spyOn(cephfsService, 'updateQuota').and.callFake(mockLib.updateQuota);
 
-    modalShowSpy = spyOn(TestBed.get(BsModalService), 'show').and.callFake(mockLib.modalShow);
-    notificationShowSpy = spyOn(TestBed.get(NotificationService), 'show').and.stub();
+    modalShowSpy = spyOn(TestBed.inject(BsModalService), 'show').and.callFake(mockLib.modalShow);
+    notificationShowSpy = spyOn(TestBed.inject(NotificationService), 'show').and.stub();
 
     fixture = TestBed.createComponent(CephfsDirectoriesComponent);
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.spec.ts
@@ -110,7 +110,7 @@ describe('CephfsTabsComponent', () => {
         data: [{}, {}, {}, {}]
       }
     };
-    service = TestBed.get(CephfsService);
+    service = TestBed.inject(CephfsService);
     spyOn(service, 'getTabs').and.callFake(() => of(data));
 
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -49,7 +49,7 @@ describe('HostsComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(HostsComponent);
     component = fixture.componentInstance;
-    hostListSpy = spyOn(TestBed.get(HostService), 'list');
+    hostListSpy = spyOn(TestBed.inject(HostService), 'list');
     fixture.detectChanges();
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.spec.ts
@@ -34,7 +34,7 @@ describe('InventoryComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(InventoryComponent);
     component = fixture.componentInstance;
-    orchService = TestBed.get(OrchestratorService);
+    orchService = TestBed.inject(OrchestratorService);
     spyOn(orchService, 'status').and.returnValue(of({ available: true }));
     spyOn(orchService, 'inventoryDeviceList').and.callThrough();
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.spec.ts
@@ -42,8 +42,8 @@ describe('MgrModuleListComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(MgrModuleListComponent);
     component = fixture.componentInstance;
-    mgrModuleService = TestBed.get(MgrModuleService);
-    notificationService = TestBed.get(NotificationService);
+    mgrModuleService = TestBed.inject(MgrModuleService);
+    notificationService = TestBed.inject(NotificationService);
   });
 
   it('should create', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.spec.ts
@@ -59,7 +59,7 @@ describe('MonitorComponent', () => {
       mon_status: null,
       out_quorum: []
     };
-    getMonitorSpy = spyOn(TestBed.get(MonitorService), 'getMonitor').and.returnValue(
+    getMonitorSpy = spyOn(TestBed.inject(MonitorService), 'getMonitor').and.returnValue(
       of(getMonitorPayload)
     );
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.spec.ts
@@ -39,7 +39,7 @@ describe('OsdFlagsModalComponent', () => {
   });
 
   beforeEach(() => {
-    httpTesting = TestBed.get(HttpTestingController);
+    httpTesting = TestBed.inject(HttpTestingController);
     fixture = TestBed.createComponent(OsdFlagsModalComponent);
     component = fixture.componentInstance;
   });
@@ -66,12 +66,12 @@ describe('OsdFlagsModalComponent', () => {
     let bsModalRef: BsModalRef;
 
     beforeEach(() => {
-      notificationService = TestBed.get(NotificationService);
+      notificationService = TestBed.inject(NotificationService);
       spyOn(notificationService, 'show').and.callFake((type) => {
         notificationType = type;
       });
 
-      bsModalRef = TestBed.get(BsModalRef);
+      bsModalRef = TestBed.inject(BsModalRef);
       spyOn(bsModalRef, 'hide').and.callThrough();
       component.unknownFlags = ['foo'];
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.spec.ts
@@ -114,8 +114,8 @@ describe('OsdFormComponent', () => {
     component = fixture.componentInstance;
     form = component.form;
     formHelper = new FormHelper(form);
-    orchService = TestBed.get(OrchestratorService);
-    summaryService = TestBed.get(SummaryService);
+    orchService = TestBed.inject(OrchestratorService);
+    summaryService = TestBed.inject(SummaryService);
     summaryService['summaryDataSource'] = new BehaviorSubject(null);
     summaryService['summaryData$'] = summaryService['summaryDataSource'].asObservable();
     summaryService['summaryDataSource'].next({ version: 'master' });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -73,19 +73,21 @@ describe('OsdListComponent', () => {
    * we will have to fake its request to be able to open those modals.
    */
   const mockSafeToDestroy = () => {
-    spyOn(TestBed.get(OsdService), 'safeToDestroy').and.callFake(() =>
+    spyOn(TestBed.inject(OsdService), 'safeToDestroy').and.callFake(() =>
       of({ is_safe_to_destroy: true })
     );
   };
 
   const mockSafeToDelete = () => {
-    spyOn(TestBed.get(OsdService), 'safeToDelete').and.callFake(() =>
+    spyOn(TestBed.inject(OsdService), 'safeToDelete').and.callFake(() =>
       of({ is_safe_to_delete: true })
     );
   };
 
   const mockOrchestratorStatus = () => {
-    spyOn(TestBed.get(OrchestratorService), 'status').and.callFake(() => of({ available: true }));
+    spyOn(TestBed.inject(OrchestratorService), 'status').and.callFake(() =>
+      of({ available: true })
+    );
   };
 
   configureTestBed({
@@ -113,8 +115,8 @@ describe('OsdListComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(OsdListComponent);
     component = fixture.componentInstance;
-    osdService = TestBed.get(OsdService);
-    modalServiceShowSpy = spyOn(TestBed.get(BsModalService), 'show').and.stub();
+    osdService = TestBed.inject(OsdService);
+    modalServiceShowSpy = spyOn(TestBed.inject(BsModalService), 'show').and.stub();
   });
 
   it('should create', () => {
@@ -358,7 +360,7 @@ describe('OsdListComponent', () => {
 
     it('has all menu entries disabled except create', () => {
       const tableActionElement = fixture.debugElement.query(By.directive(TableActionsComponent));
-      const toClassName = TestBed.get(TableActionsComponent).toClassName;
+      const toClassName = TestBed.inject(TableActionsComponent).toClassName;
       const getActionClasses = (action: CdTableAction) =>
         tableActionElement.query(By.css(`.${toClassName(action.name)} .dropdown-item`)).classes;
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-pg-scrub-modal/osd-pg-scrub-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-pg-scrub-modal/osd-pg-scrub-modal.component.spec.ts
@@ -37,7 +37,7 @@ describe('OsdPgScrubModalComponent', () => {
     fixture = TestBed.createComponent(OsdPgScrubModalComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-    configurationService = TestBed.get(ConfigurationService);
+    configurationService = TestBed.inject(ConfigurationService);
   });
 
   it('should create', () => {
@@ -48,8 +48,8 @@ describe('OsdPgScrubModalComponent', () => {
     let notificationService: NotificationService;
 
     beforeEach(() => {
-      spyOn(TestBed.get(Router), 'navigate').and.stub();
-      notificationService = TestBed.get(NotificationService);
+      spyOn(TestBed.inject(Router), 'navigate').and.stub();
+      notificationService = TestBed.inject(NotificationService);
       spyOn(notificationService, 'show');
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.spec.ts
@@ -37,7 +37,7 @@ describe('OsdRecvSpeedModalComponent', () => {
     fixture = TestBed.createComponent(OsdRecvSpeedModalComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-    configurationService = TestBed.get(ConfigurationService);
+    configurationService = TestBed.inject(ConfigurationService);
     configOptions = [
       {
         name: 'osd_max_backfills',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-reweight-modal/osd-reweight-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-reweight-modal/osd-reweight-modal.component.spec.ts
@@ -43,7 +43,9 @@ describe('OsdReweightModalComponent', () => {
     component.osdId = 1;
     component.reweightForm.get('weight').setValue(0.5);
 
-    const osdServiceSpy = spyOn(TestBed.get(OsdService), 'reweight').and.callFake(() => of(true));
+    const osdServiceSpy = spyOn(TestBed.inject(OsdService), 'reweight').and.callFake(() =>
+      of(true)
+    );
     component.reweight();
 
     expect(osdServiceSpy.calls.count()).toBe(1);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-form/silence-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-form/silence-form.component.spec.ts
@@ -102,7 +102,7 @@ describe('SilenceFormComponent', () => {
     spyOn(global, 'Date').and.callFake((arg) => (arg ? new originalDate(arg) : beginningDate));
 
     prometheus = new PrometheusHelper();
-    prometheusService = TestBed.get(PrometheusService);
+    prometheusService = TestBed.inject(PrometheusService);
     spyOn(prometheusService, 'getAlerts').and.callFake(() =>
       of([prometheus.createAlert('alert0')])
     );
@@ -126,12 +126,12 @@ describe('SilenceFormComponent', () => {
       })
     );
 
-    router = TestBed.get(Router);
+    router = TestBed.inject(Router);
 
-    notificationService = TestBed.get(NotificationService);
+    notificationService = TestBed.inject(NotificationService);
     spyOn(notificationService, 'show').and.stub();
 
-    authStorageService = TestBed.get(AuthStorageService);
+    authStorageService = TestBed.inject(AuthStorageService);
     spyOn(authStorageService, 'getUsername').and.returnValue('someUser');
 
     fixture = TestBed.createComponent(SilenceFormComponent);
@@ -460,7 +460,7 @@ describe('SilenceFormComponent', () => {
       addMatcher('alertname', 'alert.*', true);
       expectMatch(null);
 
-      const modalService = TestBed.get(BsModalService);
+      const modalService = TestBed.inject(BsModalService);
       spyOn(modalService, 'show').and.callFake(() => {
         return {
           content: {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-list/silence-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-list/silence-list.component.spec.ts
@@ -45,7 +45,7 @@ describe('SilenceListComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(SilenceListComponent);
     component = fixture.componentInstance;
-    prometheusService = TestBed.get(PrometheusService);
+    prometheusService = TestBed.inject(PrometheusService);
   });
 
   it('should create', () => {
@@ -117,7 +117,7 @@ describe('SilenceListComponent', () => {
       const mockObservable = () => of([]);
       spyOn(component, 'refresh').and.callFake(mockObservable);
       spyOn(prometheusService, 'expireSilence').and.callFake(mockObservable);
-      spyOn(TestBed.get(BsModalService), 'show').and.callFake((deletionClass, config) => {
+      spyOn(TestBed.inject(BsModalService), 'show').and.callFake((deletionClass, config) => {
         return {
           content: Object.assign(new deletionClass(), config.initialState)
         };
@@ -125,7 +125,7 @@ describe('SilenceListComponent', () => {
     });
 
     it('should expire a silence', () => {
-      const notificationService = TestBed.get(NotificationService);
+      const notificationService = TestBed.inject(NotificationService);
       spyOn(notificationService, 'show').and.stub();
       expectSilenceToExpire('someSilenceId');
       expect(notificationService.show).toHaveBeenCalledWith(

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.spec.ts
@@ -85,8 +85,8 @@ describe('ServiceDaemonListComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ServiceDaemonListComponent);
     component = fixture.componentInstance;
-    const hostService = TestBed.get(HostService);
-    const cephServiceService = TestBed.get(CephServiceService);
+    const hostService = TestBed.inject(HostService);
+    const cephServiceService = TestBed.inject(CephServiceService);
     spyOn(hostService, 'getDaemons').and.callFake(() =>
       of(getDaemonsByHostname(component.hostname))
     );

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.spec.ts
@@ -67,8 +67,8 @@ describe('ServicesComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ServicesComponent);
     component = fixture.componentInstance;
-    const orchService = TestBed.get(OrchestratorService);
-    const cephServiceService = TestBed.get(CephServiceService);
+    const orchService = TestBed.inject(OrchestratorService);
+    const cephServiceService = TestBed.inject(CephServiceService);
     spyOn(orchService, 'status').and.returnValue(of({ available: true }));
     spyOn(cephServiceService, 'list').and.returnValue(of(services));
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
@@ -63,7 +63,7 @@ describe('TelemetryComponent', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(TelemetryComponent);
       component = fixture.componentInstance;
-      mgrModuleService = TestBed.get(MgrModuleService);
+      mgrModuleService = TestBed.inject(MgrModuleService);
       options = {};
       configs = {};
       optionsNames.forEach((name) => (options[name] = { name }));
@@ -71,8 +71,8 @@ describe('TelemetryComponent', () => {
       spyOn(mgrModuleService, 'getOptions').and.callFake(() => observableOf(options));
       spyOn(mgrModuleService, 'getConfig').and.callFake(() => observableOf(configs));
       fixture.detectChanges();
-      httpTesting = TestBed.get(HttpTestingController);
-      router = TestBed.get(Router);
+      httpTesting = TestBed.inject(HttpTestingController);
+      router = TestBed.inject(Router);
       spyOn(router, 'navigate');
     });
 
@@ -142,9 +142,9 @@ describe('TelemetryComponent', () => {
       fixture = TestBed.createComponent(TelemetryComponent);
       component = fixture.componentInstance;
       fixture.detectChanges();
-      telemetryService = TestBed.get(TelemetryService);
-      httpTesting = TestBed.get(HttpTestingController);
-      router = TestBed.get(Router);
+      telemetryService = TestBed.inject(TelemetryService);
+      httpTesting = TestBed.inject(HttpTestingController);
+      router = TestBed.inject(Router);
       spyOn(router, 'navigate');
     });
 
@@ -156,7 +156,7 @@ describe('TelemetryComponent', () => {
       spyOn(telemetryService, 'getReport').and.returnValue(observableOf(reportText));
       component.ngOnInit();
 
-      const downloadSpy = spyOn(TestBed.get(TextToDownloadService), 'download');
+      const downloadSpy = spyOn(TestBed.inject(TextToDownloadService), 'download');
       const filename = 'reportText.json';
       component.download(reportText, filename);
       expect(downloadSpy).toHaveBeenCalledWith(JSON.stringify(reportText, null, 2), filename);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
@@ -68,7 +68,7 @@ describe('HealthComponent', () => {
   });
 
   beforeEach(() => {
-    fakeFeatureTogglesService = spyOn(TestBed.get(FeatureTogglesService), 'get').and.returnValue(
+    fakeFeatureTogglesService = spyOn(TestBed.inject(FeatureTogglesService), 'get').and.returnValue(
       of({
         rbd: true,
         mirroring: true,
@@ -79,7 +79,7 @@ describe('HealthComponent', () => {
     );
     fixture = TestBed.createComponent(HealthComponent);
     component = fixture.componentInstance;
-    getHealthSpy = spyOn(TestBed.get(HealthService), 'getMinimalHealth');
+    getHealthSpy = spyOn(TestBed.inject(HealthService), 'getMinimalHealth');
     getHealthSpy.and.returnValue(of(healthPayload));
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mds-summary.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mds-summary.pipe.spec.ts
@@ -11,7 +11,7 @@ describe('MdsSummaryPipe', () => {
   });
 
   beforeEach(() => {
-    pipe = TestBed.get(MdsSummaryPipe);
+    pipe = TestBed.inject(MdsSummaryPipe);
   });
 
   it('create an instance', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mgr-summary.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mgr-summary.pipe.spec.ts
@@ -12,7 +12,7 @@ describe('MgrSummaryPipe', () => {
   });
 
   beforeEach(() => {
-    pipe = TestBed.get(MgrSummaryPipe);
+    pipe = TestBed.inject(MgrSummaryPipe);
   });
 
   it('create an instance', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mon-summary.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/mon-summary.pipe.spec.ts
@@ -11,7 +11,7 @@ describe('MonSummaryPipe', () => {
   });
 
   beforeEach(() => {
-    pipe = TestBed.get(MonSummaryPipe);
+    pipe = TestBed.inject(MonSummaryPipe);
   });
 
   it('create an instance', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/osd-summary.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/osd-summary.pipe.spec.ts
@@ -10,7 +10,7 @@ describe('OsdSummaryPipe', () => {
   });
 
   beforeEach(() => {
-    pipe = TestBed.get(OsdSummaryPipe);
+    pipe = TestBed.inject(OsdSummaryPipe);
   });
 
   it('create an instance', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.spec.ts
@@ -20,7 +20,7 @@ describe('NfsFormClientComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NfsFormClientComponent);
-    const formBuilder = TestBed.get(CdFormBuilder);
+    const formBuilder = TestBed.inject(CdFormBuilder);
     component = fixture.componentInstance;
 
     component.form = new CdFormGroup({

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -44,7 +44,7 @@ describe('NfsFormComponent', () => {
   });
 
   beforeEach(() => {
-    const summaryService = TestBed.get(SummaryService);
+    const summaryService = TestBed.inject(SummaryService);
     spyOn(summaryService, 'refresh').and.callFake(() => true);
     spyOn(summaryService, 'subscribeOnce').and.callFake(() =>
       of({
@@ -54,8 +54,8 @@ describe('NfsFormComponent', () => {
 
     fixture = TestBed.createComponent(NfsFormComponent);
     component = fixture.componentInstance;
-    httpTesting = TestBed.get(HttpTestingController);
-    activatedRoute = TestBed.get(ActivatedRoute);
+    httpTesting = TestBed.inject(HttpTestingController);
+    activatedRoute = <ActivatedRouteStub>TestBed.inject(ActivatedRoute);
     fixture.detectChanges();
 
     httpTesting.expectOne('api/nfs-ganesha/daemon').flush([

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.spec.ts
@@ -50,9 +50,9 @@ describe('NfsListComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(NfsListComponent);
     component = fixture.componentInstance;
-    summaryService = TestBed.get(SummaryService);
-    nfsService = TestBed.get(NfsService);
-    httpTesting = TestBed.get(HttpTestingController);
+    summaryService = TestBed.inject(SummaryService);
+    nfsService = TestBed.inject(NfsService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   it('should create', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.spec.ts
@@ -19,7 +19,7 @@ describe('TablePerformanceCounterComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TablePerformanceCounterComponent);
     component = fixture.componentInstance;
-    httpTesting = TestBed.get(HttpTestingController);
+    httpTesting = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.spec.ts
@@ -111,7 +111,7 @@ describe('CrushRuleFormComponent', () => {
     fixtureHelper = new FixtureHelper(fixture);
     component = fixture.componentInstance;
     formHelper = new FormHelper(component.form);
-    crushRuleService = TestBed.get(CrushRuleService);
+    crushRuleService = TestBed.inject(CrushRuleService);
     data = {
       names: ['rule1', 'rule2'],
       /**
@@ -248,7 +248,7 @@ describe('CrushRuleFormComponent', () => {
 
   describe('submission', () => {
     beforeEach(() => {
-      const taskWrapper = TestBed.get(TaskWrapperService);
+      const taskWrapper = TestBed.inject(TaskWrapperService);
       spyOn(taskWrapper, 'wrapTaskAroundCall').and.callThrough();
       spyOn(crushRuleService, 'create').and.stub();
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.spec.ts
@@ -59,7 +59,7 @@ describe('ErasureCodeProfileFormModalComponent', () => {
     fixtureHelper = new FixtureHelper(fixture);
     component = fixture.componentInstance;
     formHelper = new FormHelper(component.form);
-    ecpService = TestBed.get(ErasureCodeProfileService);
+    ecpService = TestBed.inject(ErasureCodeProfileService);
     data = {
       plugins: ['isa', 'jerasure', 'shec', 'lrc'],
       names: ['ecp1', 'ecp2'],
@@ -400,7 +400,7 @@ describe('ErasureCodeProfileFormModalComponent', () => {
       submittedEcp['packetsize'] = 2048;
       submittedEcp['technique'] = 'reed_sol_van';
 
-      const taskWrapper = TestBed.get(TaskWrapperService);
+      const taskWrapper = TestBed.inject(TaskWrapperService);
       spyOn(taskWrapper, 'wrapTaskAroundCall').and.callThrough();
       spyOn(ecpService, 'create').and.stub();
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -109,7 +109,7 @@ describe('PoolFormComponent', () => {
     poolServiceMethod: 'create' | 'update' = 'create'
   ) => {
     spyOn(poolService, poolServiceMethod).and.stub();
-    const taskWrapper = TestBed.get(TaskWrapperService);
+    const taskWrapper = TestBed.inject(TaskWrapperService);
     spyOn(taskWrapper, 'wrapTaskAroundCall').and.callThrough();
     component.submit();
     expect(poolService[poolServiceMethod]).toHaveBeenCalledWith(pool);
@@ -190,14 +190,14 @@ describe('PoolFormComponent', () => {
   let navigationSpy: jasmine.Spy;
 
   beforeEach(() => {
-    poolService = TestBed.get(PoolService);
+    poolService = TestBed.inject(PoolService);
     setInfo();
     spyOn(poolService, 'getInfo').and.callFake(() => of(infoReturn));
 
-    ecpService = TestBed.get(ErasureCodeProfileService);
-    crushRuleService = TestBed.get(CrushRuleService);
+    ecpService = TestBed.inject(ErasureCodeProfileService);
+    crushRuleService = TestBed.inject(CrushRuleService);
 
-    router = TestBed.get(Router);
+    router = TestBed.inject(Router);
     navigationSpy = spyOn(router, 'navigate').and.stub();
 
     setUpPoolComponent();
@@ -226,7 +226,7 @@ describe('PoolFormComponent', () => {
         read: false,
         delete: false
       };
-      authStorageService = TestBed.get(AuthStorageService);
+      authStorageService = TestBed.inject(AuthStorageService);
       spyOn(authStorageService, 'getPermissions').and.callFake(() => ({
         pool: poolPermissions
       }));
@@ -811,7 +811,7 @@ describe('PoolFormComponent', () => {
     it('should select the newly created rule', () => {
       expect(form.getValue('crushRule').rule_name).toBe('rep1');
       const name = 'awesomeRule';
-      spyOn(TestBed.get(BsModalService), 'show').and.callFake(() => {
+      spyOn(TestBed.inject(BsModalService), 'show').and.callFake(() => {
         return {
           content: {
             submitAction: of({ name })
@@ -874,7 +874,7 @@ describe('PoolFormComponent', () => {
       };
 
       beforeEach(() => {
-        modalSpy = spyOn(TestBed.get(BsModalService), 'show').and.callFake(
+        modalSpy = spyOn(TestBed.inject(BsModalService), 'show').and.callFake(
           (deletionClass: any, config: any) => {
             deletion = Object.assign(new deletionClass(), config.initialState);
             return {
@@ -888,7 +888,7 @@ describe('PoolFormComponent', () => {
           rules.splice(index, 1);
           return of(undefined);
         });
-        taskWrapper = TestBed.get(TaskWrapperService);
+        taskWrapper = TestBed.inject(TaskWrapperService);
         spyOn(taskWrapper, 'wrapTaskAroundCall').and.callThrough();
       });
 
@@ -986,7 +986,7 @@ describe('PoolFormComponent', () => {
       spyOn(ecpService, 'list').and.callFake(() => of(infoReturn.erasure_code_profiles));
       expect(form.getValue('erasureProfile').name).toBe('ecp1');
       const name = 'awesomeProfile';
-      spyOn(TestBed.get(BsModalService), 'show').and.callFake(() => {
+      spyOn(TestBed.inject(BsModalService), 'show').and.callFake(() => {
         return {
           content: {
             submitAction: of({ name })
@@ -1030,7 +1030,7 @@ describe('PoolFormComponent', () => {
 
       beforeEach(() => {
         deletion = undefined;
-        modalSpy = spyOn(TestBed.get(BsModalService), 'show').and.callFake(
+        modalSpy = spyOn(TestBed.inject(BsModalService), 'show').and.callFake(
           (comp: any, init: any) => {
             modal = modalServiceShow(comp, init);
             return modal.ref;
@@ -1042,7 +1042,7 @@ describe('PoolFormComponent', () => {
           profiles.splice(index, 1);
           return of({ status: 202 });
         });
-        taskWrapper = TestBed.get(TaskWrapperService);
+        taskWrapper = TestBed.inject(TaskWrapperService);
         spyOn(taskWrapper, 'wrapTaskAroundCall').and.callThrough();
 
         const ecp2 = new ErasureCodeProfile();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -64,7 +64,7 @@ describe('PoolListComponent', () => {
     fixture = TestBed.createComponent(PoolListComponent);
     component = fixture.componentInstance;
     component.permissions.pool.read = true;
-    poolService = TestBed.get(PoolService);
+    poolService = TestBed.inject(PoolService);
     spyOn(poolService, 'getList').and.callFake(() => of(getPoolList()));
     fixture.detectChanges();
   });
@@ -87,10 +87,10 @@ describe('PoolListComponent', () => {
 
     beforeEach(() => {
       configOptRead = true;
-      spyOn(TestBed.get(AuthStorageService), 'getPermissions').and.callFake(() => ({
+      spyOn(TestBed.inject(AuthStorageService), 'getPermissions').and.callFake(() => ({
         configOpt: { read: configOptRead }
       }));
-      configurationService = TestBed.get(ConfigurationService);
+      configurationService = TestBed.inject(ConfigurationService);
     });
 
     it('should set value correctly if mon_allow_pool_delete flag is set to true', () => {
@@ -171,13 +171,13 @@ describe('PoolListComponent', () => {
     };
 
     beforeEach(() => {
-      spyOn(TestBed.get(BsModalService), 'show').and.callFake((deletionClass, config) => {
+      spyOn(TestBed.inject(BsModalService), 'show').and.callFake((deletionClass, config) => {
         return {
           content: Object.assign(new deletionClass(), config.initialState)
         };
       });
       spyOn(poolService, 'delete').and.stub();
-      taskWrapper = TestBed.get(TaskWrapperService);
+      taskWrapper = TestBed.inject(TaskWrapperService);
       spyOn(taskWrapper, 'wrapTaskAroundCall').and.callThrough();
     });
 
@@ -198,7 +198,7 @@ describe('PoolListComponent', () => {
     };
 
     beforeEach(() => {
-      summaryService = TestBed.get(SummaryService);
+      summaryService = TestBed.inject(SummaryService);
       summaryService['summaryDataSource'].next({
         executing_tasks: [],
         finished_tasks: []

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
@@ -43,10 +43,10 @@ describe('RgwBucketFormComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(RgwBucketFormComponent);
     component = fixture.componentInstance;
-    rgwBucketService = TestBed.get(RgwBucketService);
+    rgwBucketService = TestBed.inject(RgwBucketService);
     rgwBucketServiceGetSpy = spyOn(rgwBucketService, 'get');
-    getPlacementTargetsSpy = spyOn(TestBed.get(RgwSiteService), 'get');
-    enumerateSpy = spyOn(TestBed.get(RgwUserService), 'enumerate');
+    getPlacementTargetsSpy = spyOn(TestBed.inject(RgwSiteService), 'get');
+    enumerateSpy = spyOn(TestBed.inject(RgwUserService), 'enumerate');
     formHelper = new FormHelper(component.bucketForm);
   });
 
@@ -178,8 +178,8 @@ describe('RgwBucketFormComponent', () => {
     let notificationService: NotificationService;
 
     beforeEach(() => {
-      spyOn(TestBed.get(Router), 'navigate').and.stub();
-      notificationService = TestBed.get(NotificationService);
+      spyOn(TestBed.inject(Router), 'navigate').and.stub();
+      notificationService = TestBed.inject(NotificationService);
       spyOn(notificationService, 'show');
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.spec.ts
@@ -42,9 +42,9 @@ describe('RgwDaemonListComponent', () => {
   });
 
   beforeEach(() => {
-    getPermissionsSpy = spyOn(TestBed.get(AuthStorageService), 'getPermissions');
+    getPermissionsSpy = spyOn(TestBed.inject(AuthStorageService), 'getPermissions');
     getPermissionsSpy.and.returnValue(new Permissions({}));
-    getRealmsSpy = spyOn(TestBed.get(RgwSiteService), 'get');
+    getRealmsSpy = spyOn(TestBed.inject(RgwSiteService), 'get');
     getRealmsSpy.and.returnValue(of([]));
     fixture = TestBed.createComponent(RgwDaemonListComponent);
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
@@ -42,7 +42,7 @@ describe('RgwUserFormComponent', () => {
     fixture = TestBed.createComponent(RgwUserFormComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-    rgwUserService = TestBed.get(RgwUserService);
+    rgwUserService = TestBed.inject(RgwUserService);
     formHelper = new FormHelper(component.userForm);
   });
 
@@ -271,8 +271,8 @@ describe('RgwUserFormComponent', () => {
     let notificationService: NotificationService;
 
     beforeEach(() => {
-      spyOn(TestBed.get(Router), 'navigate').and.stub();
-      notificationService = TestBed.get(NotificationService);
+      spyOn(TestBed.inject(Router), 'navigate').and.stub();
+      notificationService = TestBed.inject(NotificationService);
       spyOn(notificationService, 'show');
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/pg-category.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/pg-category.service.spec.ts
@@ -12,7 +12,7 @@ describe('PgCategoryService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(PgCategoryService);
+    service = TestBed.inject(PgCategoryService);
   });
 
   it('should be created', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.spec.ts
@@ -90,7 +90,7 @@ describe('OsdSmartListComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
 
-    osdService = TestBed.get(OsdService);
+    osdService = TestBed.inject(OsdService);
   });
 
   it('should create', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login-password-form/login-password-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login-password-form/login-password-form.component.spec.ts
@@ -40,10 +40,10 @@ describe('LoginPasswordFormComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(LoginPasswordFormComponent);
     component = fixture.componentInstance;
-    httpTesting = TestBed.get(HttpTestingController);
-    router = TestBed.get(Router);
-    authStorageService = TestBed.get(AuthStorageService);
-    authService = TestBed.get(AuthService);
+    httpTesting = TestBed.inject(HttpTestingController);
+    router = TestBed.inject(Router);
+    authStorageService = TestBed.inject(AuthStorageService);
+    authService = TestBed.inject(AuthService);
     spyOn(router, 'navigate');
     fixture.detectChanges();
     form = component.userForm;

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.spec.ts
@@ -47,12 +47,12 @@ describe('RoleFormComponent', () => {
     fixture = TestBed.createComponent(RoleFormComponent);
     component = fixture.componentInstance;
     form = component.roleForm;
-    httpTesting = TestBed.get(HttpTestingController);
-    roleService = TestBed.get(RoleService);
-    router = TestBed.get(Router);
+    httpTesting = TestBed.inject(HttpTestingController);
+    roleService = TestBed.inject(RoleService);
+    router = TestBed.inject(Router);
     spyOn(router, 'navigate');
     fixture.detectChanges();
-    const notify = TestBed.get(NotificationService);
+    const notify = TestBed.inject(NotificationService);
     spyOn(notify, 'show');
   });
 
@@ -172,7 +172,7 @@ describe('RoleFormComponent', () => {
     const scopes = ['osd', 'user'];
     beforeEach(() => {
       spyOn(roleService, 'get').and.callFake(() => of(role));
-      spyOn(TestBed.get(ScopeService), 'list').and.callFake(() => of(scopes));
+      spyOn(TestBed.inject(ScopeService), 'list').and.callFake(() => of(scopes));
       setUrl('/user-management/roles/edit/role1');
       component.ngOnInit();
       const reqScopes = httpTesting.expectOne('ui-api/scope');

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
@@ -60,17 +60,17 @@ describe('UserFormComponent', () => {
   });
 
   beforeEach(() => {
-    spyOn(TestBed.get(PasswordPolicyService), 'getHelpText').and.callFake(() => of(''));
+    spyOn(TestBed.inject(PasswordPolicyService), 'getHelpText').and.callFake(() => of(''));
     fixture = TestBed.createComponent(UserFormComponent);
     component = fixture.componentInstance;
     form = component.userForm;
-    httpTesting = TestBed.get(HttpTestingController);
-    userService = TestBed.get(UserService);
-    modalService = TestBed.get(BsModalService);
-    router = TestBed.get(Router);
+    httpTesting = TestBed.inject(HttpTestingController);
+    userService = TestBed.inject(UserService);
+    modalService = TestBed.inject(BsModalService);
+    router = TestBed.inject(Router);
     spyOn(router, 'navigate');
     fixture.detectChanges();
-    const notify = TestBed.get(NotificationService);
+    const notify = TestBed.inject(NotificationService);
     spyOn(notify, 'show');
     formHelper = new FormHelper(form);
   });
@@ -176,9 +176,9 @@ describe('UserFormComponent', () => {
 
     beforeEach(() => {
       spyOn(userService, 'get').and.callFake(() => of(user));
-      spyOn(TestBed.get(RoleService), 'list').and.callFake(() => of(roles));
+      spyOn(TestBed.inject(RoleService), 'list').and.callFake(() => of(roles));
       setUrl('/user-management/users/edit/user1');
-      spyOn(TestBed.get(SettingsService), 'getStandardSettings').and.callFake(() =>
+      spyOn(TestBed.inject(SettingsService), 'getStandardSettings').and.callFake(() =>
         of({
           user_pwd_expiration_warning_1: 10,
           user_pwd_expiration_warning_2: 5,
@@ -215,7 +215,7 @@ describe('UserFormComponent', () => {
     });
 
     it('should alert if user is removing needed role permission', () => {
-      spyOn(TestBed.get(AuthStorageService), 'getUsername').and.callFake(() => user.username);
+      spyOn(TestBed.inject(AuthStorageService), 'getUsername').and.callFake(() => user.username);
       let modalBodyTpl = null;
       spyOn(modalService, 'show').and.callFake((_content, config) => {
         modalBodyTpl = config.initialState.bodyTpl;
@@ -226,7 +226,7 @@ describe('UserFormComponent', () => {
     });
 
     it('should logout if current user roles have been changed', () => {
-      spyOn(TestBed.get(AuthStorageService), 'getUsername').and.callFake(() => user.username);
+      spyOn(TestBed.inject(AuthStorageService), 'getUsername').and.callFake(() => user.username);
       formHelper.setValue('roles', ['user-manager']);
       component.submit();
       const userReq = httpTesting.expectOne(`api/user/${user.username}`);
@@ -237,7 +237,7 @@ describe('UserFormComponent', () => {
     });
 
     it('should submit', () => {
-      spyOn(TestBed.get(AuthStorageService), 'getUsername').and.callFake(() => user.username);
+      spyOn(TestBed.inject(AuthStorageService), 'getUsername').and.callFake(() => user.username);
       component.submit();
       const userReq = httpTesting.expectOne(`api/user/${user.username}`);
       expect(userReq.request.method).toBe('PUT');

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.spec.ts
@@ -39,9 +39,9 @@ describe('UserPasswordFormComponent', () => {
     fixture = TestBed.createComponent(UserPasswordFormComponent);
     component = fixture.componentInstance;
     form = component.userForm;
-    httpTesting = TestBed.get(HttpTestingController);
-    router = TestBed.get(Router);
-    authStorageService = TestBed.get(AuthStorageService);
+    httpTesting = TestBed.inject(HttpTestingController);
+    router = TestBed.inject(Router);
+    authStorageService = TestBed.inject(AuthStorageService);
     spyOn(router, 'navigate');
     fixture.detectChanges();
     formHelper = new FormHelper(form);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/breadcrumbs/breadcrumbs.component.spec.ts
@@ -53,7 +53,7 @@ describe('BreadcrumbsComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(BreadcrumbsComponent);
-    router = TestBed.get(Router);
+    router = TestBed.inject(Router);
     component = fixture.componentInstance;
     fixture.detectChanges();
     expect(component.crumbs).toEqual([]);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.spec.ts
@@ -24,7 +24,7 @@ describe('NotificationsComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(NotificationsComponent);
     component = fixture.componentInstance;
-    summaryService = TestBed.get(SummaryService);
+    summaryService = TestBed.inject(SummaryService);
 
     fixture.detectChanges();
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.spec.ts
@@ -19,8 +19,8 @@ describe('AuthService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(AuthService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(AuthService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {
@@ -45,7 +45,7 @@ describe('AuthService', () => {
   }));
 
   it('should logout and remove the user', () => {
-    const router = TestBed.get(Router);
+    const router = TestBed.inject(Router);
     spyOn(router, 'navigate').and.stub();
 
     service.logout();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
@@ -14,8 +14,8 @@ describe('CephfsService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(CephfsService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(CephfsService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.spec.ts
@@ -15,8 +15,8 @@ describe('ConfigurationService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(ConfigurationService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(ConfigurationService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/crush-rule.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/crush-rule.service.spec.ts
@@ -15,8 +15,8 @@ describe('CrushRuleService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(CrushRuleService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(CrushRuleService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/erasure-code-profile.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/erasure-code-profile.service.spec.ts
@@ -17,8 +17,8 @@ describe('ErasureCodeProfileService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(ErasureCodeProfileService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(ErasureCodeProfileService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/health.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/health.service.spec.ts
@@ -14,8 +14,8 @@ describe('HealthService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(HealthService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(HealthService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.spec.ts
@@ -14,8 +14,8 @@ describe('HostService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(HostService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(HostService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/iscsi.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/iscsi.service.spec.ts
@@ -14,8 +14,8 @@ describe('IscsiService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(IscsiService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(IscsiService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/logging.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/logging.service.spec.ts
@@ -14,8 +14,8 @@ describe('LoggingService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(LoggingService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(LoggingService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/logs.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/logs.service.spec.ts
@@ -14,8 +14,8 @@ describe('LogsService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(LogsService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(LogsService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.spec.ts
@@ -14,8 +14,8 @@ describe('MgrModuleService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(MgrModuleService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(MgrModuleService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/monitor.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/monitor.service.spec.ts
@@ -14,8 +14,8 @@ describe('MonitorService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(MonitorService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(MonitorService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nfs.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nfs.service.spec.ts
@@ -14,8 +14,8 @@ describe('NfsService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(NfsService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(NfsService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/orchestrator.service.spec.ts
@@ -15,8 +15,8 @@ describe('OrchestratorService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(OrchestratorService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(OrchestratorService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
@@ -14,8 +14,8 @@ describe('OsdService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(OsdService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(OsdService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-counter.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-counter.service.spec.ts
@@ -14,8 +14,8 @@ describe('PerformanceCounterService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(PerformanceCounterService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(PerformanceCounterService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.spec.ts
@@ -17,8 +17,8 @@ describe('PoolService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(PoolService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(PoolService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/prometheus.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/prometheus.service.spec.ts
@@ -16,8 +16,8 @@ describe('PrometheusService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(PrometheusService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(PrometheusService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {
@@ -175,7 +175,7 @@ describe('PrometheusService', () => {
 
     beforeEach(() => {
       x = false;
-      TestBed.get(SettingsService)['settings'] = {};
+      TestBed.inject(SettingsService)['settings'] = {};
       service.ifAlertmanagerConfigured(
         (v) => (x = v),
         () => (x = [])
@@ -216,7 +216,7 @@ describe('PrometheusService', () => {
 
     beforeEach(() => {
       x = false;
-      TestBed.get(SettingsService)['settings'] = {};
+      TestBed.inject(SettingsService)['settings'] = {};
       service.ifPrometheusConfigured(
         (v) => (x = v),
         () => (x = [])

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd-mirroring.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd-mirroring.service.spec.ts
@@ -33,8 +33,8 @@ describe('RbdMirroringService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(RbdMirroringService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(RbdMirroringService);
+    httpTesting = TestBed.inject(HttpTestingController);
     getMirroringSummaryCalls = () => {
       return httpTesting.match((request: HttpRequest<any>) => {
         return request.url.match(/api\/block\/mirroring\/summary/) && request.method === 'GET';

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.spec.ts
@@ -16,8 +16,8 @@ describe('RbdService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(RbdService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(RbdService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
@@ -14,8 +14,8 @@ describe('RgwBucketService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(RgwBucketService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(RgwBucketService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.spec.ts
@@ -14,8 +14,8 @@ describe('RgwDaemonService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(RgwDaemonService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(RgwDaemonService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-site.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-site.service.spec.ts
@@ -14,8 +14,8 @@ describe('RgwSiteService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(RgwSiteService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(RgwSiteService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.spec.ts
@@ -16,8 +16,8 @@ describe('RgwUserService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(RgwUserService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(RgwUserService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/role.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/role.service.spec.ts
@@ -14,8 +14,8 @@ describe('RoleService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(RoleService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(RoleService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/scope.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/scope.service.spec.ts
@@ -14,8 +14,8 @@ describe('ScopeService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(ScopeService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(ScopeService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/settings.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/settings.service.spec.ts
@@ -17,8 +17,8 @@ describe('SettingsService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(SettingsService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(SettingsService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/telemetry.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/telemetry.service.spec.ts
@@ -14,8 +14,8 @@ describe('TelemetryService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(TelemetryService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(TelemetryService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/user.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/user.service.spec.ts
@@ -15,8 +15,8 @@ describe('UserService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(UserService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(UserService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/config-option/config-option.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/config-option/config-option.component.spec.ts
@@ -28,7 +28,7 @@ describe('ConfigOptionComponent', () => {
     fixture = TestBed.createComponent(ConfigOptionComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-    configurationService = TestBed.get(ConfigurationService);
+    configurationService = TestBed.inject(ConfigurationService);
 
     const configOptions: Record<string, any> = [
       {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.spec.ts
@@ -103,7 +103,7 @@ describe('ConfirmationModalComponent', () => {
     mockFixture = TestBed.createComponent(MockComponent);
     mockComponent = mockFixture.componentInstance;
     mockFixture.detectChanges();
-    modalService = TestBed.get(BsModalService);
+    modalService = TestBed.inject(BsModalService);
     spyOn(modalService, 'show').and.callFake((_modalComp, config) => {
       const data = modalServiceShow(ConfirmationModalComponent, config);
       fixture = data.fixture;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.spec.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { AlertModule } from 'ngx-bootstrap/alert';
+import { of } from 'rxjs';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
 import { SummaryService } from '../../../shared/services/summary.service';
@@ -45,7 +46,7 @@ describe('GrafanaComponent', () => {
 
   describe('with grafana initialized', () => {
     beforeEach(() => {
-      TestBed.get(SettingsService).settings = { 'api/grafana/url': 'http:localhost:3000' };
+      TestBed.inject(SettingsService)['settings'] = { 'api/grafana/url': 'http:localhost:3000' };
       fixture.detectChanges();
     });
 
@@ -76,7 +77,7 @@ describe('GrafanaComponent', () => {
     });
 
     it('should have Dashboard', () => {
-      TestBed.get(SettingsService).validateGrafanaDashboardUrl = { uid: 200 };
+      TestBed.inject(SettingsService).validateGrafanaDashboardUrl = () => of({ uid: 200 });
       expect(component.dashboardExist).toBe(true);
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.spec.ts
@@ -75,7 +75,7 @@ describe('NotificationsSidebarComponent', () => {
     beforeEach(() => {
       prometheusReadPermission = 'read';
       configOptReadPermission = 'read';
-      spyOn(TestBed.get(AuthStorageService), 'getPermissions').and.callFake(
+      spyOn(TestBed.inject(AuthStorageService), 'getPermissions').and.callFake(
         () =>
           new Permissions({
             prometheus: [prometheusReadPermission],
@@ -83,12 +83,14 @@ describe('NotificationsSidebarComponent', () => {
           })
       );
 
-      spyOn(TestBed.get(PrometheusService), 'ifAlertmanagerConfigured').and.callFake((fn) => fn());
+      spyOn(TestBed.inject(PrometheusService), 'ifAlertmanagerConfigured').and.callFake((fn) =>
+        fn()
+      );
 
-      prometheusAlertService = TestBed.get(PrometheusAlertService);
+      prometheusAlertService = TestBed.inject(PrometheusAlertService);
       spyOn(prometheusAlertService, 'refresh').and.stub();
 
-      prometheusNotificationService = TestBed.get(PrometheusNotificationService);
+      prometheusNotificationService = TestBed.inject(PrometheusNotificationService);
       spyOn(prometheusNotificationService, 'refresh').and.stub();
     });
 
@@ -130,7 +132,7 @@ describe('NotificationsSidebarComponent', () => {
 
     beforeEach(() => {
       fixture.detectChanges();
-      summaryService = TestBed.get(SummaryService);
+      summaryService = TestBed.inject(SummaryService);
 
       spyOn(component, '_handleTasks').and.callThrough();
     });
@@ -150,7 +152,7 @@ describe('NotificationsSidebarComponent', () => {
 
   describe('Notifications', () => {
     it('should fetch latest notifications', fakeAsync(() => {
-      const notificationService: NotificationService = TestBed.get(NotificationService);
+      const notificationService: NotificationService = TestBed.inject(NotificationService);
       fixture.detectChanges();
 
       expect(component.notifications.length).toBe(0);
@@ -166,7 +168,7 @@ describe('NotificationsSidebarComponent', () => {
     let notificationService: NotificationService;
 
     beforeEach(() => {
-      notificationService = TestBed.get(NotificationService);
+      notificationService = TestBed.inject(NotificationService);
       fixture.detectChanges();
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.spec.ts
@@ -37,8 +37,8 @@ describe('PwdExpirationNotificationComponent', () => {
 
   describe('password expiration date has been set', () => {
     beforeEach(() => {
-      authStorageService = TestBed.get(AuthStorageService);
-      settingsService = TestBed.get(SettingsService);
+      authStorageService = TestBed.inject(AuthStorageService);
+      settingsService = TestBed.inject(SettingsService);
       spyOn(authStorageService, 'getPwdExpirationDate').and.returnValue(1645488000);
       spyOn(settingsService, 'getStandardSettings').and.returnValue(
         observableOf({
@@ -105,7 +105,7 @@ describe('PwdExpirationNotificationComponent', () => {
 
   describe('password expiration date has not been set', () => {
     beforeEach(() => {
-      authStorageService = TestBed.get(AuthStorageService);
+      authStorageService = TestBed.inject(AuthStorageService);
       spyOn(authStorageService, 'getPwdExpirationDate').and.returnValue(null);
       fixture = TestBed.createComponent(PwdExpirationNotificationComponent);
       component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/select-badges/select-badges.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/select-badges/select-badges.component.spec.ts
@@ -36,7 +36,7 @@ describe('SelectBadgesComponent', () => {
       { name: 'option1', description: '', selected: false, enabled: true },
       { name: 'option2', description: '', selected: false, enabled: true }
     ];
-    const i18n = TestBed.get(I18n);
+    const i18n = TestBed.inject(I18n);
     const messages = new SelectMessages({ empty: 'foo bar' }, i18n);
     const selectionLimit = 2;
     const customBadges = true;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.spec.ts
@@ -166,7 +166,7 @@ describe('TableKeyValueComponent', () => {
     let datePipe: CdDatePipe;
 
     beforeEach(() => {
-      datePipe = TestBed.get(CdDatePipe);
+      datePipe = TestBed.inject(CdDatePipe);
       spyOn(datePipe, 'transform').and.callThrough();
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/copy2clipboard-button.directive.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/copy2clipboard-button.directive.spec.ts
@@ -11,7 +11,7 @@ describe('Copy2clipboardButtonDirective', () => {
   });
 
   it('should create an instance', () => {
-    const i18n = TestBed.get(I18n);
+    const i18n = TestBed.inject(I18n);
     const directive = new Copy2ClipboardButtonDirective(null, null, null, i18n);
     expect(directive).toBeTruthy();
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/boolean-text.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/boolean-text.pipe.spec.ts
@@ -13,7 +13,7 @@ describe('BooleanTextPipe', () => {
   });
 
   beforeEach(() => {
-    const i18n = TestBed.get(I18n);
+    const i18n = TestBed.inject(I18n);
     pipe = new BooleanTextPipe(i18n);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/not-available.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/not-available.pipe.spec.ts
@@ -13,7 +13,7 @@ describe('NotAvailablePipe', () => {
   });
 
   beforeEach(() => {
-    const i18n = TestBed.get(I18n);
+    const i18n = TestBed.inject(I18n);
     pipe = new NotAvailablePipe(i18n);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.spec.ts
@@ -76,19 +76,19 @@ describe('ApiInterceptorService', () => {
     const baseTime = new Date('2022-02-22');
     spyOn(global, 'Date').and.returnValue(baseTime);
 
-    httpClient = TestBed.get(HttpClient);
-    httpTesting = TestBed.get(HttpTestingController);
+    httpClient = TestBed.inject(HttpClient);
+    httpTesting = TestBed.inject(HttpTestingController);
 
-    notificationService = TestBed.get(NotificationService);
+    notificationService = TestBed.inject(NotificationService);
     spyOn(notificationService, 'show').and.callThrough();
     spyOn(notificationService, 'save');
 
-    router = TestBed.get(Router);
+    router = TestBed.inject(Router);
     spyOn(router, 'navigate');
   });
 
   it('should be created', () => {
-    const service = TestBed.get(ApiInterceptorService);
+    const service = TestBed.inject(ApiInterceptorService);
     expect(service).toBeTruthy();
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.spec.ts
@@ -24,9 +24,9 @@ describe('AuthGuardService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(AuthGuardService);
-    authStorageService = TestBed.get(AuthStorageService);
-    ngZone = TestBed.get(NgZone);
+    service = TestBed.inject(AuthGuardService);
+    authStorageService = TestBed.inject(AuthStorageService);
+    ngZone = TestBed.inject(NgZone);
   });
 
   it('should be created', () => {
@@ -39,7 +39,7 @@ describe('AuthGuardService', () => {
   });
 
   it('should prevent user if not loggedIn and redirect to login page', fakeAsync(() => {
-    const router = TestBed.get(Router);
+    const router = TestBed.inject(Router);
     ngZone.run(() => {
       expect(service.canActivate()).toBe(false);
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/change-password-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/change-password-guard.service.spec.ts
@@ -24,9 +24,9 @@ describe('ChangePasswordGuardService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(ChangePasswordGuardService);
-    authStorageService = TestBed.get(AuthStorageService);
-    ngZone = TestBed.get(NgZone);
+    service = TestBed.inject(ChangePasswordGuardService);
+    authStorageService = TestBed.inject(AuthStorageService);
+    ngZone = TestBed.inject(NgZone);
   });
 
   it('should be created', () => {
@@ -54,7 +54,7 @@ describe('ChangePasswordGuardService', () => {
     spyOn(authStorageService, 'isLoggedIn').and.returnValue(true);
     spyOn(authStorageService, 'isSSO').and.returnValue(false);
     spyOn(authStorageService, 'getPwdUpdateRequired').and.returnValue(true);
-    const router = TestBed.get(Router);
+    const router = TestBed.inject(Router);
     ngZone.run(() => {
       expect(service.canActivate()).toBeFalsy();
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/dep-checker.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/dep-checker.service.spec.ts
@@ -14,7 +14,7 @@ describe('DepCheckerService', () => {
   });
 
   it('should be created', () => {
-    const service: DepCheckerService = TestBed.get(DepCheckerService);
+    const service: DepCheckerService = TestBed.inject(DepCheckerService);
     expect(service).toBeTruthy();
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/device.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/device.service.spec.ts
@@ -10,7 +10,7 @@ describe('DeviceService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.get(DeviceService);
+    service = TestBed.inject(DeviceService);
   });
 
   it('should be created', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/feature-toggles-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/feature-toggles-guard.service.spec.ts
@@ -36,10 +36,10 @@ describe('FeatureTogglesGuardService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(FeatureTogglesGuardService);
-    fakeFeatureTogglesService = TestBed.get(FeatureTogglesService);
-    ngZone = TestBed.get(NgZone);
-    router = TestBed.get(Router);
+    service = TestBed.inject(FeatureTogglesGuardService);
+    fakeFeatureTogglesService = TestBed.inject(FeatureTogglesService);
+    ngZone = TestBed.inject(NgZone);
+    router = TestBed.inject(Router);
   });
 
   it('should be created', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/feature-toggles.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/feature-toggles.service.spec.ts
@@ -14,8 +14,8 @@ describe('FeatureTogglesService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(FeatureTogglesService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(FeatureTogglesService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/language.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/language.service.spec.ts
@@ -14,8 +14,8 @@ describe('LanguageService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(LanguageService);
-    httpTesting = TestBed.get(HttpTestingController);
+    service = TestBed.inject(LanguageService);
+    httpTesting = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
@@ -46,9 +46,9 @@ describe('ModuleStatusGuardService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(ModuleStatusGuardService);
-    httpClient = TestBed.get(HttpClient);
-    router = TestBed.get(Router);
+    service = TestBed.inject(ModuleStatusGuardService);
+    httpClient = TestBed.inject(HttpClient);
+    router = TestBed.inject(Router);
     route = new ActivatedRouteSnapshot();
     route.url = [];
     route.data = {
@@ -57,7 +57,7 @@ describe('ModuleStatusGuardService', () => {
         redirectTo: '/foo'
       }
     };
-    ngZone = TestBed.get(NgZone);
+    ngZone = TestBed.inject(NgZone);
   });
 
   it('should be created', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/no-sso-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/no-sso-guard.service.spec.ts
@@ -25,10 +25,10 @@ describe('NoSsoGuardService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(NoSsoGuardService);
-    authStorageService = TestBed.get(AuthStorageService);
-    ngZone = TestBed.get(NgZone);
-    router = TestBed.get(Router);
+    service = TestBed.inject(NoSsoGuardService);
+    authStorageService = TestBed.inject(AuthStorageService);
+    ngZone = TestBed.inject(NgZone);
+    router = TestBed.inject(Router);
   });
 
   it('should be created', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
@@ -34,7 +34,7 @@ describe('NotificationService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(NotificationService);
+    service = TestBed.inject(NotificationService);
     service.removeAll();
   });
 
@@ -233,7 +233,7 @@ describe('NotificationService', () => {
       spyOn(global, 'Date').and.returnValue(baseTime);
       spyOn(window, 'setTimeout').and.callFake((fn) => fn());
 
-      toastr = TestBed.get(ToastrService);
+      toastr = TestBed.inject(ToastrService);
       // spyOn needs to know the methods before spying and can't read the array for clarification
       ['error', 'info', 'success'].forEach((method: 'error' | 'info' | 'success') =>
         spyOn(toastr, method).and.stub()

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/password-policy.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/password-policy.service.spec.ts
@@ -38,8 +38,8 @@ describe('PasswordPolicyService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(PasswordPolicyService);
-    settingsService = TestBed.get(SettingsService);
+    service = TestBed.inject(PasswordPolicyService);
+    settingsService = TestBed.inject(SettingsService);
     settingsService['settings'] = {};
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert-formatter.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert-formatter.spec.ts
@@ -27,8 +27,8 @@ describe('PrometheusAlertFormatter', () => {
 
   beforeEach(() => {
     prometheus = new PrometheusHelper();
-    service = TestBed.get(PrometheusAlertFormatter);
-    notificationService = TestBed.get(NotificationService);
+    service = TestBed.inject(PrometheusAlertFormatter);
+    notificationService = TestBed.inject(NotificationService);
     spyOn(notificationService, 'show').and.stub();
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.spec.ts
@@ -35,13 +35,13 @@ describe('PrometheusAlertService', () => {
   });
 
   it('should create', () => {
-    expect(TestBed.get(PrometheusAlertService)).toBeTruthy();
+    expect(TestBed.inject(PrometheusAlertService)).toBeTruthy();
   });
 
   describe('test failing status codes and verify disabling of the alertmanager', () => {
     const isDisabledByStatusCode = (statusCode: number, expectedStatus: boolean, done: any) => {
-      service = TestBed.get(PrometheusAlertService);
-      prometheusService = TestBed.get(PrometheusService);
+      service = TestBed.inject(PrometheusAlertService);
+      prometheusService = TestBed.inject(PrometheusService);
       spyOn(prometheusService, 'ifAlertmanagerConfigured').and.callFake((fn) => fn());
       spyOn(prometheusService, 'getAlerts').and.returnValue(
         Observable.create((observer: any) => observer.error({ status: statusCode, error: {} }))
@@ -73,8 +73,8 @@ describe('PrometheusAlertService', () => {
   });
 
   it('should flatten the response of getRules()', () => {
-    service = TestBed.get(PrometheusAlertService);
-    prometheusService = TestBed.get(PrometheusService);
+    service = TestBed.inject(PrometheusAlertService);
+    prometheusService = TestBed.inject(PrometheusService);
 
     spyOn(service['prometheusService'], 'ifPrometheusConfigured').and.callFake((fn) => fn());
     spyOn(prometheusService, 'getRules').and.returnValue(
@@ -108,16 +108,16 @@ describe('PrometheusAlertService', () => {
 
   describe('refresh', () => {
     beforeEach(() => {
-      service = TestBed.get(PrometheusAlertService);
+      service = TestBed.inject(PrometheusAlertService);
       service['alerts'] = [];
       service['canAlertsBeNotified'] = false;
 
       spyOn(window, 'setTimeout').and.callFake((fn: Function) => fn());
 
-      notificationService = TestBed.get(NotificationService);
+      notificationService = TestBed.inject(NotificationService);
       spyOn(notificationService, 'show').and.stub();
 
-      prometheusService = TestBed.get(PrometheusService);
+      prometheusService = TestBed.inject(PrometheusService);
       spyOn(prometheusService, 'ifAlertmanagerConfigured').and.callFake((fn) => fn());
       spyOn(prometheusService, 'getAlerts').and.callFake(() => of(alerts));
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-notification.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-notification.service.spec.ts
@@ -46,17 +46,17 @@ describe('PrometheusNotificationService', () => {
   beforeEach(() => {
     prometheus = new PrometheusHelper();
 
-    service = TestBed.get(PrometheusNotificationService);
+    service = TestBed.inject(PrometheusNotificationService);
     service['notifications'] = [];
 
-    notificationService = TestBed.get(NotificationService);
+    notificationService = TestBed.inject(NotificationService);
     shown = [];
     spyOn(notificationService, 'show').and.callThrough();
     spyOn(notificationService, 'save').and.callFake((n) => shown.push(n));
 
     spyOn(window, 'setTimeout').and.callFake((fn: Function) => fn());
 
-    prometheusService = TestBed.get(PrometheusService);
+    prometheusService = TestBed.inject(PrometheusService);
     getNotificationSinceMock = () => of(notifications);
     spyOn(prometheusService, 'getNotifications').and.callFake(() => getNotificationSinceMock());
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-silence-matcher.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-silence-matcher.service.spec.ts
@@ -27,7 +27,7 @@ describe('PrometheusSilenceMatcherService', () => {
 
   beforeEach(() => {
     prometheus = new PrometheusHelper();
-    service = TestBed.get(PrometheusSilenceMatcherService);
+    service = TestBed.inject(PrometheusSilenceMatcherService);
     rules = [
       prometheus.createRule('alert0', 'someSeverity', [prometheus.createAlert('alert0')]),
       prometheus.createRule('alert1', 'someSeverity', []),

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/rbd-configuration.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/rbd-configuration.service.spec.ts
@@ -12,7 +12,7 @@ describe('RbdConfigurationService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(RbdConfigurationService);
+    service = TestBed.inject(RbdConfigurationService);
   });
 
   it('should be created', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/refresh-interval.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/refresh-interval.service.spec.ts
@@ -13,7 +13,7 @@ describe('RefreshIntervalService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(RefreshIntervalService);
+    service = TestBed.inject(RefreshIntervalService);
   });
 
   it('should be created', () => {
@@ -22,7 +22,7 @@ describe('RefreshIntervalService', () => {
 
   it('should initial private interval time right', () => {
     sessionStorage.setItem('dashboard_interval', '10000');
-    const ngZone = TestBed.get(NgZone);
+    const ngZone = TestBed.inject(NgZone);
     service = new RefreshIntervalService(ngZone);
     expect(service.getRefreshInterval()).toBe(10000);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
@@ -42,8 +42,8 @@ describe('SummaryService', () => {
   });
 
   beforeEach(() => {
-    summaryService = TestBed.get(SummaryService);
-    authStorageService = TestBed.get(AuthStorageService);
+    summaryService = TestBed.inject(SummaryService);
+    authStorageService = TestBed.inject(AuthStorageService);
   });
 
   it('should be created', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.spec.ts
@@ -34,9 +34,9 @@ describe('TaskListService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(TaskListService);
-    summaryService = TestBed.get(SummaryService);
-    taskMessageService = TestBed.get(TaskMessageService);
+    service = TestBed.inject(TaskListService);
+    summaryService = TestBed.inject(SummaryService);
+    taskMessageService = TestBed.inject(TaskMessageService);
     summaryService['summaryDataSource'].next({ executing_tasks: [] });
 
     taskMessageService.messages['test/create'] = taskMessageService.messages['rbd/create'];

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager.service.spec.ts
@@ -40,8 +40,8 @@ describe('TaskManagerService', () => {
   });
 
   beforeEach(() => {
-    taskManagerService = TestBed.get(TaskManagerService);
-    summaryService = TestBed.get(SummaryService);
+    taskManagerService = TestBed.inject(TaskManagerService);
+    summaryService = TestBed.inject(SummaryService);
     called = false;
     taskManagerService.subscribe('foo', {}, () => (called = true));
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.spec.ts
@@ -19,7 +19,7 @@ describe('TaskManagerMessageService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(TaskMessageService);
+    service = TestBed.inject(TaskMessageService);
     finishedTask = new FinishedTask();
     finishedTask.duration = 30;
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.spec.ts
@@ -52,8 +52,8 @@ describe('TaskWrapperService', () => {
 
     beforeEach(() => {
       passed = false;
-      notify = TestBed.get(NotificationService);
-      summaryService = TestBed.get(SummaryService);
+      notify = TestBed.inject(NotificationService);
+      summaryService = TestBed.inject(SummaryService);
       spyOn(notify, 'show');
       spyOn(notify, 'notifyTask').and.stub();
       spyOn(service, '_handleExecutingTasks').and.callThrough();
@@ -75,7 +75,7 @@ describe('TaskWrapperService', () => {
     });
 
     it('should call notifyTask if asynchronous task would have been finished', () => {
-      const taskManager = TestBed.get(TaskManagerService);
+      const taskManager = TestBed.inject(TaskManagerService);
       spyOn(taskManager, 'subscribe').and.callFake((_name, _metadata, onTaskFinished) => {
         onTaskFinished();
       });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/text-to-download.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/text-to-download.service.spec.ts
@@ -11,7 +11,7 @@ describe('TextToDownloadService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(TextToDownloadService);
+    service = TestBed.inject(TextToDownloadService);
   });
 
   it('should be created', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/time-diff.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/time-diff.service.spec.ts
@@ -12,7 +12,7 @@ describe('TimeDiffService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(TimeDiffService);
+    service = TestBed.inject(TimeDiffService);
   });
 
   it('should be created', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/timer.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/timer.service.spec.ts
@@ -19,7 +19,7 @@ describe('TimerService', () => {
   });
 
   beforeEach(() => {
-    service = TestBed.get(TimerService);
+    service = TestBed.inject(TimerService);
     receivedData = [];
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/testing/activated-route-stub.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/testing/activated-route-stub.ts
@@ -1,15 +1,18 @@
+import { ActivatedRoute } from '@angular/router';
+
 import { ReplaySubject } from 'rxjs';
 
 /**
  * An ActivateRoute test double with a `params` observable.
  * Use the `setParams()` method to add the next `params` value.
  */
-export class ActivatedRouteStub {
+export class ActivatedRouteStub extends ActivatedRoute {
   // Use a ReplaySubject to share previous values with subscribers
   // and pump new values into the `params` observable
   private subject = new ReplaySubject<object>();
 
   constructor(initialParams?: object) {
+    super();
     this.setParams(initialParams);
   }
 


### PR DESCRIPTION
This new method has the same behavior, but is type safe.

Fixes: https://tracker.ceph.com/issues/45326

Signed-off-by: Tiago Melo <tmelo@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
- [ ] After #33121
---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
