### PR TITLE
qa/cephfs: use StringIO instead of BytesIO

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -1,5 +1,4 @@
 from contextlib import contextmanager
-from io import BytesIO
 import json
 import logging
 import datetime
@@ -593,7 +592,7 @@ class CephFSMount(object):
             cwd = self.mountpoint
 
         return self.client_remote.run(args=args, stdin=stdin, wait=wait,
-                                      stdout=BytesIO(), stderr=BytesIO(),
+                                      stdout=StringIO(), stderr=StringIO(),
                                       cwd=cwd, check_status=check_status)
 
     def run_as_user(self, args, user, wait=True, stdin=None,
@@ -611,7 +610,7 @@ class CephFSMount(object):
             cwd = self.mountpoint
 
         return self.client_remote.run(args=args, wait=wait, stdin=stdin,
-                                      stdout=BytesIO(), stderr=BytesIO(),
+                                      stdout=StringIO(), stderr=StringIO(),
                                       check_status=check_status, cwd=cwd)
 
     def run_as_root(self, args, wait=True, stdin=None, check_status=True,
@@ -624,7 +623,7 @@ class CephFSMount(object):
             cwd = self.mountpoint
 
         return self.client_remote.run(args=args, wait=wait, stdin=stdin,
-                                      stdout=BytesIO(), stderr=BytesIO(),
+                                      stdout=StringIO(), stderr=StringIO(),
                                       check_status=check_status, cwd=cwd)
 
     def _verify(self, proc, retval=None, errmsg=None):


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/45425



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>