### PR TITLE
mgr/cephadm: fix env_var passing to cephadm

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2887,6 +2887,7 @@ def command_ceph_volume():
     c = CephContainer(
         image=args.image,
         entrypoint='/usr/sbin/ceph-volume',
+        envs=args.env,
         args=args.command,
         privileged=True,
         volume_mounts=mounts,
@@ -4192,6 +4193,11 @@ def _get_parser():
         type=int,
         default=DEFAULT_RETRY,
         help='max number of retries')
+    parser.add_argument(
+        '--env', '-e',
+        action='append',
+        default=[],
+        help='set environment variable')
 
     subparsers = parser.add_subparsers(help='sub-command')
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -911,10 +911,13 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                      stdin=None,
                      no_fsid=False,
                      error_ok=False,
-                     image=None):
-        # type: (str, Optional[str], str, List[str], Optional[str], Optional[str], bool, bool, Optional[str]) -> Tuple[List[str], List[str], int]
+                     image=None,
+                     env_vars=None):
+        # type: (str, Optional[str], str, List[str], Optional[str], Optional[str], bool, bool, Optional[str], Optional[List[str]]) -> Tuple[List[str], List[str], int]
         """
         Run cephadm on the remote host with the given command + args
+
+        :env_vars: in format -> [KEY=VALUE, ..]
         """
         if not addr and host in self.inventory:
             addr = self.inventory.get_addr(host)
@@ -946,6 +949,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.log.debug('%s container image %s' % (entity, image))
 
             final_args = []
+
+            if env_vars:
+                for env_var_pair in env_vars:
+                    final_args.extend(['--env', env_var_pair])
+
             if image:
                 final_args.extend(['--image', image])
             final_args.append(command)

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -30,7 +30,9 @@ class OSDService(CephadmService):
             if not cmd:
                 logger.debug("No data_devices, skipping DriveGroup: {}".format(drive_group.service_id))
                 continue
-            env_vars = [f"CEPH_VOLUME_OSDSPEC_AFFINITY={drive_group.service_id}"]
+            # env_vars = [f"CEPH_VOLUME_OSDSPEC_AFFINITY={drive_group.service_id}"]
+            # disable this until https://github.com/ceph/ceph/pull/34835 is merged
+            env_vars: List[str] = []
             ret_msg = self.create(host, cmd, replace_osd_ids=drive_group.osd_id_claims.get(host, []), env_vars=env_vars)
             ret.append(ret_msg)
         return ", ".join(ret)

--- a/src/python-common/ceph/deployment/translate.py
+++ b/src/python-common/ceph/deployment/translate.py
@@ -101,7 +101,4 @@ class to_ceph_volume(object):
             cmd += " --report"
             cmd += " --format json"
 
-        if self.spec.service_id is not None:
-            cmd = f"CEPH_VOLUME_OSDSPEC_AFFINITY={self.spec.service_id} " + cmd
-
         return cmd


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

This needs to be merged together with: https://github.com/ceph/ceph/pull/34835

Fixes: https://tracker.ceph.com/issues/45394

Revert commit 8f275834ff4a5adcda165ea39e263840e5dd139a when https://github.com/ceph/ceph/pull/34835 is merged

* moves the `bin/cephadm shell`'s --env flag to the global parser
* changes the way we pass environment variables to bin/cephadm from mgr/cephadm

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
