### PR TITLE
mgr/cephadm: replace async_map_completion with a simple wrapper (again)

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1371,7 +1371,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         # type: (Optional[str]) -> List[str]
         return list(self.inventory.filter_by_label(label))
 
-    @async_completion
+    @trivial_completion
     def add_host(self, spec):
         # type: (HostSpec) -> str
         """
@@ -1395,7 +1395,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         self.log.info('Added host %s' % spec.hostname)
         return "Added host '{}'".format(spec.hostname)
 
-    @async_completion
+    @trivial_completion
     def remove_host(self, host):
         # type: (str) -> str
         """
@@ -1410,7 +1410,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         self.log.info('Removed host %s' % host)
         return "Removed host '{}'".format(host)
 
-    @async_completion
+    @trivial_completion
     def update_host_addr(self, host, addr):
         self.inventory.set_addr(host, addr)
         self._reset_con(host)
@@ -1429,13 +1429,13 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         """
         return list(self.inventory.all_specs())
 
-    @async_completion
+    @trivial_completion
     def add_host_label(self, host, label):
         self.inventory.add_label(host, label)
         self.log.info('Added label %s to host %s' % (label, host))
         return 'Added label %s to host %s' % (label, host)
 
-    @async_completion
+    @trivial_completion
     def remove_host_label(self, host, label):
         self.inventory.rm_label(host, label)
         self.log.info('Removed label %s to host %s' % (label, host))
@@ -1681,6 +1681,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         self.cache.invalidate_host_daemons(host)
         return "{} {} from host '{}'".format(action, name, host)
 
+    @trivial_completion
     def daemon_action(self, action, daemon_type, daemon_id):
         args = []
         for host, dm in self.cache.daemons.items():
@@ -2290,6 +2291,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
     def apply_rgw(self, spec):
         return self._apply(spec)
 
+    @trivial_completion
     def add_iscsi(self, spec):
         # type: (ServiceSpec) -> orchestrator.Completion
         return self._add_daemon('iscsi', spec, self.iscsi_servcie.create, self.iscsi_servcie.config)
@@ -2298,6 +2300,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
     def apply_iscsi(self, spec):
         return self._apply(spec)
 
+    @trivial_completion
     def add_rbd_mirror(self, spec):
         return self._add_daemon('rbd-mirror', spec, self.rbd_mirror_service.create)
 
@@ -2305,6 +2308,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
     def apply_rbd_mirror(self, spec):
         return self._apply(spec)
 
+    @trivial_completion
     def add_nfs(self, spec):
         return self._add_daemon('nfs', spec, self.nfs_service.create, self.nfs_service.config)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -103,12 +103,10 @@ class AsyncCompletion(orchestrator.Completion):
                  value=orchestrator._Promise.NO_RESULT,  # type: Any
                  on_complete=None,  # type: Optional[Callable]
                  name=None,  # type: Optional[str]
-                 many=False, # type: bool
                  update_progress=False,  # type: bool
                  ):
 
         assert CephadmOrchestrator.instance is not None
-        self.many = many
         self.update_progress = update_progress
         if name is None and on_complete is not None:
             name = getattr(on_complete, '__name__', None)
@@ -150,33 +148,14 @@ class AsyncCompletion(orchestrator.Completion):
                 assert self._on_complete_ is not None
                 try:
                     res = self._on_complete_(*args, **kwargs)
-                    if self.update_progress and self.many:
-                        assert self.progress_reference
-                        self.progress_reference.progress += 1.0 / len(value)
                     return res
                 except Exception as e:
                     self.fail(e)
                     raise
 
             assert CephadmOrchestrator.instance
-            if self.many:
-                if not value:
-                    logger.info('calling map_async without values')
-                    callback([])
-                if six.PY3:
-                    CephadmOrchestrator.instance._worker_pool.map_async(do_work, value,
-                                                                    callback=callback,
-                                                                    error_callback=error_callback)
-                else:
-                    CephadmOrchestrator.instance._worker_pool.map_async(do_work, value,
-                                                                    callback=callback)
-            else:
-                if six.PY3:
-                    CephadmOrchestrator.instance._worker_pool.apply_async(do_work, (value,),
-                                                                      callback=callback, error_callback=error_callback)
-                else:
-                    CephadmOrchestrator.instance._worker_pool.apply_async(do_work, (value,),
-                                                                      callback=callback)
+            CephadmOrchestrator.instance._worker_pool.apply_async(do_work, (value,),
+                                                              callback=callback, error_callback=error_callback)
             return self.ASYNC_RESULT
 
         return run
@@ -186,41 +165,6 @@ class AsyncCompletion(orchestrator.Completion):
         # type: (Callable) -> None
         self._on_complete_ = inner
 
-
-def ssh_completion(cls=AsyncCompletion, **c_kwargs):
-    # type: (Type[orchestrator.Completion], Any) -> Callable
-    """
-    See ./HACKING.rst for a how-to
-    """
-    def decorator(f):
-        @wraps(f)
-        def wrapper(*args):
-
-            name = f.__name__
-            many = c_kwargs.get('many', False)
-
-            # Some weired logic to make calling functions with multiple arguments work.
-            if len(args) == 1:
-                [value] = args
-                if many and value and isinstance(value[0], tuple):
-                    return cls(on_complete=lambda x: f(*x), value=value, name=name, **c_kwargs)
-                else:
-                    return cls(on_complete=f, value=value, name=name, **c_kwargs)
-            else:
-                if many:
-                    self, value = args
-
-                    def call_self(inner_args):
-                        if not isinstance(inner_args, tuple):
-                            inner_args = (inner_args, )
-                        return f(self, *inner_args)
-
-                    return cls(on_complete=call_self, value=value, name=name, **c_kwargs)
-                else:
-                    return cls(on_complete=lambda x: f(*x), value=args, name=name, **c_kwargs)
-
-        return wrapper
-    return decorator
 
 def forall_hosts(f):
     @wraps(f)
@@ -251,32 +195,6 @@ def forall_hosts(f):
 
 
     return forall_hosts_wrapper
-
-
-def async_completion(f):
-    # type: (Callable) -> Callable[..., AsyncCompletion]
-    """
-    See ./HACKING.rst for a how-to
-
-    :param f: wrapped function
-    """
-    return ssh_completion()(f)
-
-
-def async_map_completion(f):
-    # type: (Callable) -> Callable[..., AsyncCompletion]
-    """
-    See ./HACKING.rst for a how-to
-
-    :param f: wrapped function
-
-    kind of similar to
-
-    >>> def sync_map(f):
-    ...     return lambda x: map(f, x)
-
-    """
-    return ssh_completion(many=True)(f)
 
 
 def trivial_completion(f):

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -6,13 +6,8 @@ from threading import Event
 from functools import wraps
 
 import string
-try:
-    from typing import List, Dict, Optional, Callable, Tuple, TypeVar, Type, \
-        Any, NamedTuple, Iterator, Set, Sequence
-    from typing import TYPE_CHECKING, cast
-except ImportError:
-    TYPE_CHECKING = False  # just for type checking
-
+from typing import List, Dict, Optional, Callable, Tuple, TypeVar, Type, \
+    Any, NamedTuple, Iterator, Set, Sequence, TYPE_CHECKING, cast, Union
 
 import datetime
 import six
@@ -58,6 +53,8 @@ except ImportError:
     pass
 
 logger = logging.getLogger(__name__)
+
+T = TypeVar('T')
 
 DEFAULT_SSH_CONFIG = """
 Host *
@@ -166,9 +163,9 @@ class AsyncCompletion(orchestrator.Completion):
         self._on_complete_ = inner
 
 
-def forall_hosts(f):
+def forall_hosts(f: Callable[..., T]) -> Callable[..., List[T]]:
     @wraps(f)
-    def forall_hosts_wrapper(*args) -> list:
+    def forall_hosts_wrapper(*args) -> List[T]:
 
         # Some weired logic to make calling functions with multiple arguments work.
         if len(args) == 1:
@@ -1618,7 +1615,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     @trivial_completion
     def remove_daemons(self, names):
-        # type: (List[str]) -> orchestrator.Completion
+        # type: (List[str]) -> List[str]
         args = []
         for host, dm in self.cache.daemons.items():
             for name in names:
@@ -1849,10 +1846,10 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             'Reconfigured' if reconfig else 'Deployed', name, host)
 
     @forall_hosts
-    def _remove_daemons(self, name, host):
+    def _remove_daemons(self, name, host) -> str:
         return self._remove_daemon(name, host)
 
-    def _remove_daemon(self, name, host):
+    def _remove_daemon(self, name, host) -> str:
         """
         Remove a daemon
         """
@@ -2083,7 +2080,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                            e)
 
     def _add_daemon(self, daemon_type, spec,
-                    create_func, config_func=None):
+                    create_func: Callable[..., T], config_func=None) -> List[T]:
         """
         Add (and place) a daemon. Require explicit host placement.  Do not
         schedule, and do not apply the related scheduling limitations.
@@ -2099,7 +2096,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     def _create_daemons(self, daemon_type, spec, daemons,
                         hosts, count,
-                        create_func, config_func=None):
+                        create_func: Callable[..., T], config_func=None) -> List[T]:
         if count > len(hosts):
             raise OrchestratorError('too few hosts: want %d, have %s' % (
                 count, hosts))
@@ -2141,12 +2138,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     @trivial_completion
     def add_mon(self, spec):
-        # type: (ServiceSpec) -> orchestrator.Completion
+        # type: (ServiceSpec) -> List[str]
         return self._add_daemon('mon', spec, self.mon_service.create)
 
     @trivial_completion
     def add_mgr(self, spec):
-        # type: (ServiceSpec) -> orchestrator.Completion
+        # type: (ServiceSpec) -> List[str]
         return self._add_daemon('mgr', spec, self.mgr_service.create)
 
     def _apply(self, spec: ServiceSpec) -> str:
@@ -2211,7 +2208,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     @trivial_completion
     def add_iscsi(self, spec):
-        # type: (ServiceSpec) -> orchestrator.Completion
+        # type: (ServiceSpec) -> List[str]
         return self._add_daemon('iscsi', spec, self.iscsi_servcie.create, self.iscsi_servcie.config)
 
     @trivial_completion
@@ -2248,7 +2245,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     @trivial_completion
     def add_node_exporter(self, spec):
-        # type: (ServiceSpec) -> AsyncCompletion
+        # type: (ServiceSpec) -> List[str]
         return self._add_daemon('node-exporter', spec,
                                 self.node_exporter_service.create)
 
@@ -2258,7 +2255,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     @trivial_completion
     def add_crash(self, spec):
-        # type: (ServiceSpec) -> AsyncCompletion
+        # type: (ServiceSpec) -> List[str]
         return self._add_daemon('crash', spec,
                                 self.crash_service.create)
 
@@ -2268,7 +2265,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     @trivial_completion
     def add_grafana(self, spec):
-        # type: (ServiceSpec) -> AsyncCompletion
+        # type: (ServiceSpec) -> List[str]
         return self._add_daemon('grafana', spec, self.grafana_service.create)
 
     @trivial_completion
@@ -2277,7 +2274,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     @trivial_completion
     def add_alertmanager(self, spec):
-        # type: (ServiceSpec) -> AsyncCompletion
+        # type: (ServiceSpec) -> List[str]
         return self._add_daemon('alertmanager', spec, self.alertmanager_service.create)
 
     @trivial_completion

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -222,6 +222,36 @@ def ssh_completion(cls=AsyncCompletion, **c_kwargs):
         return wrapper
     return decorator
 
+def forall_hosts(f):
+    @wraps(f)
+    def forall_hosts_wrapper(*args) -> list:
+
+        # Some weired logic to make calling functions with multiple arguments work.
+        if len(args) == 1:
+            vals = args[0]
+            self = None
+        elif len(args) == 2:
+            self, vals = args
+        else:
+            assert 'either f([...]) or self.f([...])'
+
+        def do_work(arg):
+            if not isinstance(arg, tuple):
+                arg = (arg, )
+            try:
+                if self:
+                    return f(self, *arg)
+                return f(*arg)
+            except Exception as e:
+                logger.exception(f'executing {f.__name__}({args}) failed.')
+                raise
+
+        assert CephadmOrchestrator.instance is not None
+        return CephadmOrchestrator.instance._worker_pool.map(do_work, vals)
+
+
+    return forall_hosts_wrapper
+
 
 def async_completion(f):
     # type: (Callable) -> Callable[..., AsyncCompletion]
@@ -1614,6 +1644,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
                 result.append(dd)
         return result
 
+    @trivial_completion
     def service_action(self, action, service_name):
         args = []
         for host, dm in self.cache.daemons.items():
@@ -1624,7 +1655,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         self.log.info('%s service %s' % (action.capitalize(), service_name))
         return self._daemon_actions(args)
 
-    @async_map_completion
+    @forall_hosts
     def _daemon_actions(self, daemon_type, daemon_id, host, action):
         return self._daemon_action(daemon_type, daemon_id, host, action)
 
@@ -1666,6 +1697,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             ','.join(['%s.%s' % (a[0], a[1]) for a in args])))
         return self._daemon_actions(args)
 
+    @trivial_completion
     def remove_daemons(self, names):
         # type: (List[str]) -> orchestrator.Completion
         args = []
@@ -1728,8 +1760,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             raise OrchestratorError('Zap failed: %s' % '\n'.join(out + err))
         return '\n'.join(out + err)
 
+    @trivial_completion
     def blink_device_light(self, ident_fault, on, locs):
-        @async_map_completion
+        @forall_hosts
         def blink(host, dev, path):
             cmd = [
                 'lsmcli',
@@ -1896,7 +1929,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         return "{} {} on host '{}'".format(
             'Reconfigured' if reconfig else 'Deployed', name, host)
 
-    @async_map_completion
+    @forall_hosts
     def _remove_daemons(self, name, host):
         return self._remove_daemon(name, host)
 
@@ -2177,7 +2210,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             )
             daemons.append(sd)
 
-        @async_map_completion
+        @forall_hosts
         def create_func_map(*args):
             return create_func(*args)
 
@@ -2187,10 +2220,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
     def apply_mon(self, spec):
         return self._apply(spec)
 
+    @trivial_completion
     def add_mon(self, spec):
         # type: (ServiceSpec) -> orchestrator.Completion
         return self._add_daemon('mon', spec, self.mon_service.create)
 
+    @trivial_completion
     def add_mgr(self, spec):
         # type: (ServiceSpec) -> orchestrator.Completion
         return self._add_daemon('mgr', spec, self.mgr_service.create)
@@ -2239,6 +2274,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
     def apply_mgr(self, spec):
         return self._apply(spec)
 
+    @trivial_completion
     def add_mds(self, spec: ServiceSpec):
         return self._add_daemon('mds', spec, self.mds_service.create, self.mds_service.config)
 
@@ -2246,6 +2282,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
     def apply_mds(self, spec: ServiceSpec):
         return self._apply(spec)
 
+    @trivial_completion
     def add_rgw(self, spec):
         return self._add_daemon('rgw', spec, self.rgw_service.create, self.rgw_service.config)
 
@@ -2279,6 +2316,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         # type: () -> str
         return self.get('mgr_map').get('services', {}).get('dashboard', '')
 
+    @trivial_completion
     def add_prometheus(self, spec):
         return self._add_daemon('prometheus', spec, self.prometheus_service.create)
 
@@ -2286,6 +2324,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
     def apply_prometheus(self, spec):
         return self._apply(spec)
 
+    @trivial_completion
     def add_node_exporter(self, spec):
         # type: (ServiceSpec) -> AsyncCompletion
         return self._add_daemon('node-exporter', spec,
@@ -2295,6 +2334,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
     def apply_node_exporter(self, spec):
         return self._apply(spec)
 
+    @trivial_completion
     def add_crash(self, spec):
         # type: (ServiceSpec) -> AsyncCompletion
         return self._add_daemon('crash', spec,
@@ -2304,6 +2344,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
     def apply_crash(self, spec):
         return self._apply(spec)
 
+    @trivial_completion
     def add_grafana(self, spec):
         # type: (ServiceSpec) -> AsyncCompletion
         return self._add_daemon('grafana', spec, self.grafana_service.create)
@@ -2312,6 +2353,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
     def apply_grafana(self, spec: ServiceSpec):
         return self._apply(spec)
 
+    @trivial_completion
     def add_alertmanager(self, spec):
         # type: (ServiceSpec) -> AsyncCompletion
         return self._add_daemon('alertmanager', spec, self.alertmanager_service.create)

--- a/src/pybind/mgr/cephadm/tests/test_completion.py
+++ b/src/pybind/mgr/cephadm/tests/test_completion.py
@@ -12,7 +12,7 @@ import pytest
 
 from tests import mock
 from .fixtures import cephadm_module, wait
-from ..module import trivial_completion, async_completion, async_map_completion, forall_hosts
+from ..module import trivial_completion, forall_hosts
 
 
 class TestCompletion(object):
@@ -23,19 +23,6 @@ class TestCompletion(object):
             return x+1
         assert wait(cephadm_module, run(1)) == 2
 
-    @pytest.mark.parametrize("input", [
-        ((1, ), ),
-        ((1, 2), ),
-        (("hallo", ), ),
-        (("hallo", "foo"), ),
-    ])
-    def test_async(self, input, cephadm_module):
-        @async_completion
-        def run(*args):
-            return str(args)
-
-        assert wait(cephadm_module, run(*input)) == str(input)
-
     @pytest.mark.parametrize("input,expected", [
         ([], []),
         ([1], ["(1,)"]),
@@ -45,30 +32,11 @@ class TestCompletion(object):
         ([(1, 2), (3, 4)], ["(1, 2)", "(3, 4)"]),
     ])
     def test_async_map(self, input, expected, cephadm_module):
-        @async_map_completion
-        def run(*args):
-            return str(args)
-
-        c = run(input)
-        wait(cephadm_module, c)
-        assert c.result == expected
-
         @forall_hosts
         def run_forall(*args):
             return str(args)
         assert run_forall(input) == expected
 
-    def test_async_self(self, cephadm_module):
-        class Run(object):
-            def __init__(self):
-                self.attr = 1
-
-            @async_completion
-            def run(self, x):
-                assert self.attr == 1
-                return x + 1
-
-        assert wait(cephadm_module, Run().run(1)) == 2
 
     @pytest.mark.parametrize("input,expected", [
         ([], []),
@@ -83,108 +51,9 @@ class TestCompletion(object):
             def __init__(self):
                 self.attr = 1
 
-            @async_map_completion
-            def run(self, *args):
-                assert self.attr == 1
-                return str(args)
-
             @forall_hosts
             def run_forall(self, *args):
                 assert self.attr == 1
                 return str(args)
 
-        c = Run().run(input)
-        wait(cephadm_module, c)
-        assert c.result == expected
-
         assert Run().run_forall(input) == expected
-
-    def test_then1(self, cephadm_module):
-        @async_map_completion
-        def run(x):
-            return x+1
-
-        assert wait(cephadm_module, run([1,2]).then(str)) == '[2, 3]'
-
-    def test_then2(self, cephadm_module):
-        @async_map_completion
-        def run(x):
-            time.sleep(0.1)
-            return x+1
-
-        @async_completion
-        def async_str(results):
-            return str(results)
-
-        c = run([1,2]).then(async_str)
-
-        wait(cephadm_module, c)
-        assert c.result == '[2, 3]'
-
-    def test_then3(self, cephadm_module):
-        @async_map_completion
-        def run(x):
-            time.sleep(0.1)
-            return x+1
-
-        def async_str(results):
-            return async_completion(str)(results)
-
-        c = run([1,2]).then(async_str)
-
-        wait(cephadm_module, c)
-        assert c.result == '[2, 3]'
-
-    def test_then4(self, cephadm_module):
-        @async_map_completion
-        def run(x):
-            time.sleep(0.1)
-            return x+1
-
-        def async_str(results):
-            return async_completion(str)(results).then(lambda x: x + "hello")
-
-        c = run([1,2]).then(async_str)
-
-        wait(cephadm_module, c)
-        assert c.result == '[2, 3]hello'
-
-    @pytest.mark.skip(reason="see limitation of async_map_completion")
-    def test_then5(self, cephadm_module):
-        @async_map_completion
-        def run(x):
-            time.sleep(0.1)
-            return async_completion(str)(x+1)
-
-        c = run([1,2])
-
-        wait(cephadm_module, c)
-        assert c.result == "['2', '3']"
-
-    def test_raise(self, cephadm_module):
-        @async_completion
-        def run(x):
-            raise ZeroDivisionError()
-
-        with pytest.raises(ZeroDivisionError):
-            wait(cephadm_module, run(1))
-
-    def test_progress(self, cephadm_module):
-        @async_map_completion
-        def run(*args):
-            return str(args)
-
-        c = run(list(range(2)))
-        c.update_progress = True
-        c.add_progress(
-            mgr=cephadm_module,
-            message="my progress"
-        )
-        wait(cephadm_module, c)
-        assert c.result == [str((x,)) for x in range(2)]
-        assert cephadm_module.remote.mock_calls == [
-            mock.call('progress', 'update', mock.ANY, 'my progress', float(i) / 2, [('origin', 'orchestrator')])
-            for i in range(2+1)] + [
-            mock.call('progress', 'update', mock.ANY, 'my progress', 1.0, [('origin', 'orchestrator')]),
-            mock.call('progress', 'complete', mock.ANY),
-        ]

--- a/src/pybind/mgr/cephadm/tests/test_completion.py
+++ b/src/pybind/mgr/cephadm/tests/test_completion.py
@@ -12,7 +12,7 @@ import pytest
 
 from tests import mock
 from .fixtures import cephadm_module, wait
-from ..module import trivial_completion, async_completion, async_map_completion
+from ..module import trivial_completion, async_completion, async_map_completion, forall_hosts
 
 
 class TestCompletion(object):
@@ -53,6 +53,11 @@ class TestCompletion(object):
         wait(cephadm_module, c)
         assert c.result == expected
 
+        @forall_hosts
+        def run_forall(*args):
+            return str(args)
+        assert run_forall(input) == expected
+
     def test_async_self(self, cephadm_module):
         class Run(object):
             def __init__(self):
@@ -83,9 +88,16 @@ class TestCompletion(object):
                 assert self.attr == 1
                 return str(args)
 
+            @forall_hosts
+            def run_forall(self, *args):
+                assert self.attr == 1
+                return str(args)
+
         c = Run().run(input)
         wait(cephadm_module, c)
         assert c.result == expected
+
+        assert Run().run_forall(input) == expected
 
     def test_then1(self, cephadm_module):
         @async_map_completion


### PR DESCRIPTION
Resurrect #34091

Let's see, if we see https://tracker.ceph.com/issues/44990 in the qa run

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
