### PR TITLE
mgr/dashboard: Fix I18N errors

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -147,9 +147,11 @@ export class TelemetryComponent implements OnInit {
     this.mgrModuleService.updateConfig('telemetry', config).subscribe(
       () => {
         this.disableModule(
-          'Your settings have been applied successfully. ' +
-            'Due to privacy/legal reasons the Telemetry module is now disabled until you ' +
-            'complete the next step and accept the license.',
+          this.i18n(
+            `Your settings have been applied successfully. \
+Due to privacy/legal reasons the Telemetry module is now disabled until you \
+complete the next step and accept the license.`
+          ),
           () => {
             this.getReport();
           }
@@ -169,7 +171,7 @@ export class TelemetryComponent implements OnInit {
   disableModule(message: string = null, followUpFunc: Function = null) {
     this.telemetryService.enable(false).subscribe(() => {
       if (message) {
-        this.notificationService.show(NotificationType.success, this.i18n(message));
+        this.notificationService.show(NotificationType.success, message);
       }
       if (followUpFunc) {
         followUpFunc();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.ts
@@ -58,10 +58,9 @@ export class SmartListComponent implements OnInit, OnChanges {
         let userMessage = '';
         if (smartData.smartctl_error_code === -22) {
           userMessage = this.i18n(
-            'Smartctl has received an unknown argument (error code ' +
-              '{{code}}). You may be using an ' +
-              'incompatible version of smartmontools. Version >= 7.0 of ' +
-              'smartmontools is required to successfully retrieve data.',
+            `Smartctl has received an unknown argument (error code {{code}}). \
+You may be using an incompatible version of smartmontools. Version >= 7.0 of \
+smartmontools is required to successfully retrieve data.`,
             { code: smartData.smartctl_error_code }
           );
         } else {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -155,8 +155,7 @@
         <li routerLinkActive="active"
             class="tc_submenuitem tc_submenuitem_monitoring"
             *ngIf="permissions.prometheus.read">
-          <a i18n
-             routerLink="/monitoring">
+          <a routerLink="/monitoring">
             <ng-container i18n>Monitoring</ng-container>
             <small *ngIf="prometheusAlertService.alerts.length > 0"
                    class="badge badge-danger">{{ prometheusAlertService.alerts.length }}</small>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/password-policy.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/password-policy.service.ts
@@ -35,11 +35,11 @@ export class PasswordPolicyService {
               'Cannot contain any sequential characters e.g. "abc"'
             ),
             pwdPolicyCheckComplexityEnabled: this.i18n(
-              'Must consist of characters from the following groups:\n' +
-                '  * Alphabetic a-z, A-Z\n' +
-                '  * Numbers 0-9\n' +
-                '  * Special chars: !"#$%& \'()*+,-./:;<=>?@[\\]^_`{{|}}~\n' +
-                '  * Any other characters (signs)'
+              `Must consist of characters from the following groups:
+  * Alphabetic a-z, A-Z
+  * Numbers 0-9
+  * Special chars: !"#$%& '()*+,-./:;<=>?@[\\]^_\`{{|}}~
+  * Any other characters (signs)`
             )
           };
           helpText = helpText.concat(

--- a/src/pybind/mgr/dashboard/run-frontend-unittests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-unittests.sh
@@ -37,12 +37,17 @@ fi
 
 # I18N
 npm run i18n:extract
-i18n_lint=`awk '/<source> |<source>$| <\/source>/,/<\/context-group>/ {printf "%-4s ", NR; print}' src/locale/messages.xlf`
-if [ "$i18n_lint" ]; then
-  echo -e "The following source translations in 'messages.xlf' need to be \
-fixed, please check the I18N suggestions in 'HACKING.rst':\n"
-  echo "${i18n_lint}"
+if [ $? -gt 0 ]; then
   failed=true
+  echo -e "\nTranslations extraction has failed."
+else
+  i18n_lint=`awk '/<source> |<source>$| <\/source>/,/<\/context-group>/ {printf "%-4s ", NR; print}' src/locale/messages.xlf`
+  if [ "$i18n_lint" ]; then
+    echo -e "\nThe following source translations in 'messages.xlf' need to be \
+  fixed, please check the I18N suggestions in 'HACKING.rst':\n"
+    echo "${i18n_lint}"
+    failed=true
+  fi
 fi
 
 # npm resolutions


### PR DESCRIPTION
We were just checking if the translation sources were correct and ignore if the
extraction simply failed.

Fixes: https://tracker.ceph.com/issues/45428

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
