### PR TITLE
qa/cephfs: run() cleanup whether FS was mounted or not

### DIFF
--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -71,6 +71,7 @@ class KernelMount(CephFSMount):
 
     def umount(self, force=False):
         if not self.is_mounted():
+            self.cleanup()
             return
 
         log.debug('Unmounting client client.{id}...'.format(id=self.client_id))
@@ -92,7 +93,6 @@ class KernelMount(CephFSMount):
             raise e
 
         self.mounted = False
-        self.cleanup_netns()
         self.cleanup()
 
     def umount_wait(self, force=False, require_clean=False, timeout=900):
@@ -100,6 +100,7 @@ class KernelMount(CephFSMount):
         Unlike the fuse client, the kernel client's umount is immediate
         """
         if not self.is_mounted():
+            self.cleanup()
             return
 
         try:
@@ -109,7 +110,6 @@ class KernelMount(CephFSMount):
                 raise
 
             # force delete the netns and umount
-            self.cleanup_netns()
             self.client_remote.run(
                 args=['sudo',
                       'umount',
@@ -120,7 +120,6 @@ class KernelMount(CephFSMount):
                 timeout=(15*60))
 
             self.mounted = False
-            self.cleanup_netns()
             self.cleanup()
 
     def wait_until_mounted(self):

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -449,7 +449,6 @@ class CephFSMount(object):
         """
         log.info('Cleaning up killed connection on {0}'.format(self.client_remote.name))
         self.umount_wait(force=True)
-        self.cleanup()
 
     def cleanup(self):
         """
@@ -475,6 +474,8 @@ class CephFSMount(object):
                 pass
             else:
                 raise
+
+        self.cleanup_netns()
 
     def wait_until_mounted(self):
         raise NotImplementedError()


### PR DESCRIPTION
In case the mount command in mount() fails, it would still have created
the mountpoint and network namespace for the FS's mount. Therefore, run
cleanup() and cleanup_netns() in umount() and umount_wait() even when
self.mounted is set to False.

Also, move the call to cleanup_netns() in cleanup().

Fixes: https://tracker.ceph.com/issues/45430



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>