### PR TITLE
mgr/dashboard: replace hard coded telemetry URLs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -25,7 +25,8 @@
               The data being reported does <b>not</b> contain any sensitive data like pool names, object names, object contents,
               hostnames, or device serial numbers. It contains counters and statistics on how the cluster has been
               deployed, the version of Ceph, the distribution of the hosts and other parameters which help the project
-              to gain a better understanding of the way Ceph is used. The data is sent secured to https://telemetry.ceph.com.</p>
+              to gain a better understanding of the way Ceph is used. The data is sent secured to {{ sendToUrl }} and
+              {{ sendToDeviceUrl }} (device report).</p>
             <div *ngIf="moduleEnabled">
               The plugin is already <b>enabled</b>. Click <b>Deactivate</b> to disable it.&nbsp;
               <button type="button"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -44,6 +44,8 @@ export class TelemetryComponent implements OnInit {
   ];
   report: object = undefined;
   reportId: number = undefined;
+  sendToUrl = '';
+  sendToDeviceUrl = '';
   step = 1;
 
   constructor(
@@ -64,9 +66,12 @@ export class TelemetryComponent implements OnInit {
     ];
     observableForkJoin(observables).subscribe(
       (resp: object) => {
-        this.moduleEnabled = resp[1]['enabled'];
+        const configResp = resp[1];
+        this.moduleEnabled = configResp['enabled'];
+        this.sendToUrl = configResp['url'];
+        this.sendToDeviceUrl = configResp['device_url'];
         this.options = _.pick(resp[0], this.requiredFields);
-        const configs = _.pick(resp[1], this.requiredFields);
+        const configs = _.pick(configResp, this.requiredFields);
         this.createConfigForm();
         this.configForm.setValue(configs);
         this.loading = false;


### PR DESCRIPTION
Replace the hard coded telemetry URLs by the actual config option values given by the cluster.

Fixes: https://tracker.ceph.com/issues/45319
Signed-off-by: Tatjana Dehler <tdehler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
