### PR TITLE
nautilus: rgw: dmclock: wait until the request is handled

### DIFF
--- a/src/rgw/rgw_dmclock_sync_scheduler.cc
+++ b/src/rgw/rgw_dmclock_sync_scheduler.cc
@@ -24,8 +24,9 @@ int SyncScheduler::add_request(const client_id& client, const ReqParams& params,
     }
     queue.request_completed();
     // Perform a blocking wait until the request callback is called
-    if (std::unique_lock<std::mutex> lk(req_mtx); rstate != ReqState::Wait) {
-      req_cv.wait(lk, [&rstate] {return rstate != ReqState::Wait;});
+    {
+      std::unique_lock lock{req_mtx};
+      req_cv.wait(lock, [&rstate] {return rstate != ReqState::Wait;});
     }
     if (rstate == ReqState::Cancelled) {
       //FIXME: decide on error code for cancelled request


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45436

---

backport of https://github.com/ceph/ceph/pull/30777
parent tracker: https://tracker.ceph.com/issues/42217

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh