### PR TITLE
nautilus: osd/PeeringState: do not trim pg log past last_update_ondisk

### DIFF
--- a/qa/overrides/short_pg_log.yaml
+++ b/qa/overrides/short_pg_log.yaml
@@ -4,3 +4,4 @@ overrides:
       global:
         osd_min_pg_log_entries: 1
         osd_max_pg_log_entries: 2
+        osd_pg_log_trim_min: 0

--- a/qa/suites/rados/singleton/all/osd-recovery.yaml
+++ b/qa/suites/rados/singleton/all/osd-recovery.yaml
@@ -25,5 +25,6 @@ tasks:
     conf:
       osd:
         osd min pg log entries: 5
+        osd pg log trim min: 0
         osd_fast_fail_on_connection_refused: false
 - osd_recovery:

--- a/qa/suites/rados/thrash/workloads/radosbench-high-concurrency.yaml
+++ b/qa/suites/rados/thrash/workloads/radosbench-high-concurrency.yaml
@@ -1,0 +1,49 @@
+overrides:
+  ceph:
+    conf:
+      client.0:
+        debug ms: 1
+        debug objecter: 20
+        debug rados: 20
+tasks:
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      concurrency: 128
+      size: 8192
+      time: 90

--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -21,6 +21,7 @@ def task(ctx, config):
         time: <seconds to run>
         pool: <pool to use>
         size: write size to use
+        concurrency: max number of outstanding writes (16)
         objectsize: object size to use
         unique_pool: use a unique pool, defaults to False
         ec_pool: create an ec pool, defaults to False
@@ -76,6 +77,7 @@ def task(ctx, config):
             else:
                 pool = manager.create_pool_with_unique_name(erasure_code_profile_name=profile_name)
 
+        concurrency = config.get('concurrency', 16)
         osize = config.get('objectsize', 65536)
         if osize is 0:
             objectsize = []
@@ -94,6 +96,7 @@ def task(ctx, config):
                               '--no-log-to-stderr',
                               '--name', role]
                               + size + objectsize +
+                              ['-t', str(concurrency)] +
                               ['-p' , pool,
                           'bench', str(60), "write", "--no-cleanup"
                           ]).format(tdir=testdir),

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1663,9 +1663,10 @@ void PrimaryLogPG::calc_trim_to_aggressive()
     target = cct->_conf->osd_max_pg_log_entries;
   }
   // limit pg log trimming up to the can_rollback_to value
-  eversion_t limit = std::min(
+  eversion_t limit = std::min({
     pg_log.get_head(),
-    pg_log.get_can_rollback_to());
+    pg_log.get_can_rollback_to(),
+    last_update_ondisk});
   dout(10) << __func__ << " limit = " << limit << dendl;
 
   if (limit != eversion_t() &&

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -446,6 +446,9 @@ public:
     bool transaction_applied,
     ObjectStore::Transaction &t,
     bool async = false) override {
+    if (is_primary()) {
+      ceph_assert(trim_to <= last_update_ondisk);
+    }
     if (hset_history) {
       info.hit_set = *hset_history;
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44841

---

backport of https://github.com/ceph/ceph/pull/33910
parent tracker: https://tracker.ceph.com/issues/44532

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh