### PR TITLE
rbd/cache: Replicated Write Log core codes - load existing cache

### DIFF
--- a/src/librbd/cache/ReplicatedWriteLog.h
+++ b/src/librbd/cache/ReplicatedWriteLog.h
@@ -262,6 +262,8 @@ private:
   ThreadPool m_thread_pool;
   ContextWQ m_work_queue;
 
+  uint32_t m_discard_granularity_bytes;
+
   void perf_start(const std::string name);
   void perf_stop();
   void log_perf();
@@ -270,6 +272,7 @@ private:
 
   void rwl_init(Context *on_finish, rwl::DeferredContexts &later);
   void update_image_cache_state(Context *on_finish);
+  void load_existing_entries(rwl::DeferredContexts &later);
   void wake_up();
   void process_work();
 

--- a/src/librbd/cache/rwl/LogEntry.h
+++ b/src/librbd/cache/rwl/LogEntry.h
@@ -36,7 +36,6 @@ public:
   virtual bool can_writeback() const {
     return false;
   }
-  // TODO: discard need to override this
   virtual bool can_retire() const {
     return false;
   }
@@ -210,6 +209,9 @@ public:
     /* The bytes in the image this op makes dirty. */
     return ram_entry.write_bytes;
   };
+  bool can_retire() const override {
+    return this->completed;
+  }
   void copy_pmem_bl(bufferlist *out_bl) override {
     ceph_assert(false);
   }

--- a/src/librbd/cache/rwl/Request.cc
+++ b/src/librbd/cache/rwl/Request.cc
@@ -606,6 +606,7 @@ void C_WriteSameRequest<T>::setup_buffer_resources(
   if (pattern_length > buffer.allocation_size) {
     buffer.allocation_size = pattern_length;
   }
+  bytes_allocated += buffer.allocation_size;
 }
 
 template <typename T>

--- a/src/librbd/cache/rwl/Types.h
+++ b/src/librbd/cache/rwl/Types.h
@@ -212,6 +212,23 @@ struct WriteLogPmemEntry {
   BlockExtent block_extent();
   uint64_t get_offset_bytes();
   uint64_t get_write_bytes();
+  bool is_sync_point() {
+    return sync_point;
+  }
+  bool is_discard() {
+    return discard;
+  }
+  bool is_writesame() {
+    return writesame;
+  }
+  bool is_write() {
+    /* Log entry is a basic write */
+    return !is_sync_point() && !is_discard() && !is_writesame();
+  }
+  bool is_writer() {
+    /* Log entry is any type that writes data */
+    return is_write() || is_discard() || is_writesame();
+  }
   friend std::ostream& operator<<(std::ostream& os,
                                   const WriteLogPmemEntry &entry);
 };


### PR DESCRIPTION
Adds Replicated Write Log, a persistent, write back cache for Ceph RBD.
Implements: http://tracker.ceph.com/projects/ceph/wiki/Rbd_-_ordered_crash-consistent_write-back_caching_extension

Trello: https://trello.com/c/QnsQaGTn

[Obsoletes https://github.com//pull/29078]

The PR 29078 is split into smaller PRs to make review easier.
The first PR: #31279
The second PR: #31963
The 3rd PR: #33502
The 4th PR: #34430
The 5th PR: #34699
The 6th PR: #34706
The 7th PR: #34756
The 8th PR: #34851
The 9th PR: #34853 

This is the 10th PR (load existing cache) which defines the following parts:
librbd: load existing cache

Signed-off-by: Scott Peterson scott.d.peterson@intel.com
Signed-off-by: Lisa Li xiaoyan.li@intel.com
Signed-off-by: Yuan Lu yuan.y.lu@intel.com
Signed-off-by: Mahati Chamarthy mahati.chamarthy@intel.com

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
