### PR TITLE
mgr/cephadm: node-exporter is not a ceph service

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1798,10 +1798,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         # type: (str, str, Optional[str], Optional[str]) -> Dict[str, Any]
         # keyring
         if not keyring:
-            if daemon_type == 'mon':
-                ename = 'mon.'
-            else:
-                ename = utils.name_to_config_section(daemon_type + '.' + daemon_id)
+            ename = utils.name_to_auth_entity(daemon_type + '.' + daemon_id)
             ret, keyring, err = self.check_mon_command({
                 'prefix': 'auth get',
                 'entity': ename,

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1846,6 +1846,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         elif daemon_type == 'alertmanager':
             cephadm_config, deps = self.alertmanager_service.generate_config()
             extra_args.extend(['--config-json', '-'])
+        elif daemon_type == 'node-exporter':
+            cephadm_config, deps = self.node_exporter_service.generate_config()
+            extra_args.extend(['--config-json', '-'])
         else:
             # Ceph.daemons (mon, mgr, mds, osd, etc)
             cephadm_config = self._get_config_and_keyring(

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -193,7 +193,7 @@ class IscsiService(CephadmService):
     def create(self, igw_id, host, spec) -> str:
         ret, keyring, err = self.mgr.check_mon_command({
             'prefix': 'auth get-or-create',
-            'entity': utils.name_to_config_section('iscsi') + '.' + igw_id,
+            'entity': utils.name_to_auth_entity('iscsi') + '.' + igw_id,
             'caps': ['mon', 'profile rbd, '
                             'allow command "osd blacklist", '
                             'allow command "config-key get" with "key" prefix "iscsi/"',

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -273,3 +273,6 @@ scrape_configs:
 class NodeExporterService(CephadmService):
     def create(self, daemon_id, host) -> str:
         return self.mgr._create_daemon('node-exporter', daemon_id, host)
+
+    def generate_config(self) -> Tuple[Dict[str, Any], List[str]]:
+        return {}, []

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -13,3 +13,18 @@ def name_to_config_section(name):
         return name
     else:
         return 'mon'
+
+
+def name_to_auth_entity(name) -> str:
+    """
+    Map from daemon names to ceph entity names (as seen in config)
+    """
+    daemon_type = name.split('.', 1)[0]
+    if daemon_type in ['rgw', 'rbd-mirror', 'nfs', 'crash', 'iscsi']:
+        return 'client.' + name
+    elif daemon_type == 'mon':
+        return 'mon.'
+    elif daemon_type in ['osd', 'mds', 'mgr', 'client']:
+        return name
+    else:
+        raise OrchestratorError("unknown auth entity name")


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/45427

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
