### PR TITLE
ceph-volume: add mode specific available fields in inventory subcommand

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/test_inventory.py
+++ b/src/ceph-volume/ceph_volume/tests/test_inventory.py
@@ -113,8 +113,12 @@ class TestInventory(object):
     expected_keys = [
         'path',
         'rejected_reasons',
+        'rejected_reasons_lvm',
+        'rejected_reasons_raw',
         'sys_api',
         'available',
+        'available_lvm',
+        'available_raw',
         'lvs',
         'device_id',
         'lsm_data',

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -211,11 +211,40 @@ class TestDevice(object):
         assert disk.available
 
     def test_reject_not_acceptable_device(self, device_info):
-        data = {"/dev/dm-0": {"foo": "bar"}}
+        data = {"/dev/sdb": {"removable": 0, "size": 5368709120}}
+        lsblk = {"TYPE": "INVALID"}
+        device_info(devices=data, lsblk=lsblk)
+        disk = device.Device("/dev/sdb")
+        assert not disk.available
+        assert not disk.available_lvm
+        assert not disk.available_raw
+
+    def test_judge_device_type_device(self, device_info):
+        data = {"/dev/sdb": {"removable": 0, "size": 5368709120}}
+        lsblk = {"TYPE": "device"}
+        device_info(devices=data, lsblk=lsblk)
+        disk = device.Device("/dev/sdb")
+        assert disk.available
+        assert disk.available_lvm
+        assert disk.available_raw
+
+    def test_judge_mpath_type_device(self, device_info):
+        data = {"/dev/dm-0": {"removable": 0, "size": 5368709120}}
         lsblk = {"TYPE": "mpath"}
         device_info(devices=data, lsblk=lsblk)
         disk = device.Device("/dev/dm-0")
         assert not disk.available
+        assert disk.available_lvm
+        assert disk.available_raw
+
+    def test_judge_crypt_type_device(self, device_info):
+        data = {"/dev/dm-0": {"removable": 0, "size": 5368709120}}
+        lsblk = {"TYPE": "crypt"}
+        device_info(devices=data, lsblk=lsblk)
+        disk = device.Device("/dev/dm-0")
+        assert not disk.available
+        assert not disk.available_lvm
+        assert disk.available_raw
 
     def test_reject_readonly_device(self, device_info):
         data = {"/dev/cdrom": {"ro": 1}}

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -9,7 +9,7 @@ from ceph_volume.util.lsmdisk import LSMDisk
 from ceph_volume.util.constants import ceph_disk_guids
 
 report_template = """
-{dev:<25} {size:<12} {rot!s:<7} {available!s:<9} {model}"""
+{dev:<25} {size:<12} {rot!s:<7} {available!s:<9} {model:<20} {available_lvm!s:<13} {available_raw!s:<13}"""
 
 
 def encryption_status(abspath):
@@ -43,6 +43,8 @@ class Devices(object):
                 rot='rotates',
                 model='Model name',
                 available='available',
+                available_lvm='available_lvm',
+                available_raw='available_raw',
             )]
         for device in sorted(self.devices):
             output.append(device.report())
@@ -62,7 +64,11 @@ class Device(object):
 
     report_fields = [
         'rejected_reasons',
+        'rejected_reasons_lvm',
+        'rejected_reasons_raw',
         'available',
+        'available_lvm',
+        'available_raw',
         'path',
         'sys_api',
         'device_id',
@@ -223,6 +229,8 @@ class Device(object):
             size=self.size_human,
             rot=self.rotational,
             available=self.available,
+            available_lvm=self.available_lvm,
+            available_raw=self.available_raw,
             model=self.model,
         )
 
@@ -478,6 +486,7 @@ class Device(object):
             rejected.append("Used by ceph-disk")
         if self.has_bluestore_label:
             rejected.append('Has BlueStore device label')
+
         return rejected
 
     def _check_lvm_reject_reasons(self):


### PR DESCRIPTION
Add the available fields dedicated to both lvm mode and raw mode.

Although LVM mode can only be created on top of raw disk or its partition, there is no such limitation in raw mode. However, the "available" field of `ceph-volume inventory` don't distinguish the availability of the two modes properly. For example, crypt type device is regarded as unavailable even though `ceph-volume raw prepare` can create an OSD in this device. 

The related discussion:
https://github.com/ceph/ceph/pull/34375#issuecomment-623301127

Fixes: https://tracker.ceph.com/issues/45443

## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug