### PR TITLE
mgr/dashboard: Fix random E2E error in mgr-modules

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/mgr-modules.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/mgr-modules.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { ManagerModulesPageHelper } from './mgr-modules.po';
+import { Input, ManagerModulesPageHelper } from './mgr-modules.po';
 
 describe('Manager modules page', () => {
   const mgrmodules = new ManagerModulesPageHelper();
@@ -15,29 +15,84 @@ describe('Manager modules page', () => {
   });
 
   describe('verifies editing functionality for manager modules', () => {
-    it('should test editing on diskprediction_local module', () => {
-      const diskpredLocalArr = [
-        ['11', 'predict_interval'],
-        ['0122', 'sleep_interval']
+    it('should test editing on diskprediction_cloud module', () => {
+      const diskpredCloudArr: Input[] = [
+        {
+          id: 'diskprediction_cert_context',
+          newValue: 'Foo',
+          oldValue: ''
+        },
+        {
+          id: 'sleep_interval',
+          newValue: '456',
+          oldValue: '60'
+        }
       ];
-      mgrmodules.editMgrModule('diskprediction_local', diskpredLocalArr);
+      mgrmodules.editMgrModule('diskprediction_cloud', diskpredCloudArr);
     });
 
     it('should test editing on balancer module', () => {
-      const balancerArr = [['rq', 'pool_ids']];
+      const balancerArr: Input[] = [
+        {
+          id: 'crush_compat_max_iterations',
+          newValue: '123',
+          oldValue: '25'
+        }
+      ];
       mgrmodules.editMgrModule('balancer', balancerArr);
     });
 
     it('should test editing on dashboard module', () => {
-      const dashboardArr = [
-        ['rq', 'RGW_API_USER_ID'],
-        ['rafa', 'GRAFANA_API_PASSWORD']
+      const dashboardArr: Input[] = [
+        {
+          id: 'RGW_API_USER_ID',
+          newValue: 'rq',
+          oldValue: ''
+        },
+        {
+          id: 'GRAFANA_API_PASSWORD',
+          newValue: 'rafa',
+          oldValue: ''
+        }
       ];
       mgrmodules.editMgrModule('dashboard', dashboardArr);
     });
 
     it('should test editing on devicehealth module', () => {
-      mgrmodules.editDevicehealth('1987', 'sox', '1999', '2020', '456', '567');
+      const devHealthArray: Input[] = [
+        {
+          id: 'mark_out_threshold',
+          newValue: '1987',
+          oldValue: '2419200'
+        },
+        {
+          id: 'pool_name',
+          newValue: 'sox',
+          oldValue: 'device_health_metrics'
+        },
+        {
+          id: 'retention_period',
+          newValue: '1999',
+          oldValue: '15552000'
+        },
+        {
+          id: 'scrape_frequency',
+          newValue: '2020',
+          oldValue: '86400'
+        },
+        {
+          id: 'sleep_interval',
+          newValue: '456',
+          oldValue: '600'
+        },
+        {
+          id: 'warn_threshold',
+          newValue: '567',
+          oldValue: '7257600'
+        }
+      ];
+
+      mgrmodules.editMgrModule('devicehealth', devHealthArray);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/mgr-modules.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/mgr-modules.po.ts
@@ -1,117 +1,53 @@
 import { PageHelper } from '../page-helper.po';
 
+export class Input {
+  id: string;
+  oldValue: string;
+  newValue: string;
+}
+
 export class ManagerModulesPageHelper extends PageHelper {
   pages = { index: { url: '#/mgr-modules', id: 'cd-mgr-module-list' } };
 
   /**
    * Selects the Manager Module and then fills in the desired fields.
-   * Doesn't check/uncheck boxes because it is not reflected in the details table.
-   * DOES NOT WORK FOR ALL MGR MODULES, for example, Device health
    */
-  editMgrModule(name: string, tuple: string[][]) {
+  editMgrModule(name: string, inputs: Input[]) {
     this.navigateEdit(name);
 
-    for (const entry of tuple) {
+    for (const input of inputs) {
       // Clears fields and adds edits
-      cy.get(`#${entry[1]}`).clear().type(entry[0]);
+      cy.get(`#${input.id}`).clear().type(input.newValue);
     }
 
     cy.contains('button', 'Update').click();
     // Checks if edits appear
     this.getExpandCollapseElement(name).should('be.visible').click();
-    for (const entry of tuple) {
-      cy.get('.datatable-body').last().contains(entry[0]);
+
+    for (const input of inputs) {
+      cy.get('.datatable-body').last().contains(input.newValue);
     }
 
     // Clear mgr module of all edits made to it
     this.navigateEdit(name);
 
     // Clears the editable fields
-    for (const entry of tuple) {
-      cy.get(`#${entry[1]}`).clear();
+    for (const input of inputs) {
+      const id = `#${input.id}`;
+      cy.get(id).clear();
+      if (input.oldValue) {
+        cy.get(id).type(input.oldValue);
+      }
     }
 
     // Checks that clearing represents in details tab of module
     cy.contains('button', 'Update').click();
     this.getExpandCollapseElement(name).should('be.visible').click();
-    for (const entry of tuple) {
-      cy.get('.datatable-body').eq(1).should('contain', entry[1]).and('not.contain', entry[0]);
-    }
-  }
-
-  /**
-   * Selects the Devicehealth manager module, then fills in the desired fields,
-   * including all fields except checkboxes.
-   * Then checks if these edits appear in the details table.
-   */
-  editDevicehealth(
-    threshhold?: string,
-    pooln?: string,
-    retention?: string,
-    scrape?: string,
-    sleep?: string,
-    warn?: string
-  ) {
-    let devHealthArray: [string, string][];
-    devHealthArray = [
-      [threshhold, 'mark_out_threshold'],
-      [pooln, 'pool_name'],
-      [retention, 'retention_period'],
-      [scrape, 'scrape_frequency'],
-      [sleep, 'sleep_interval'],
-      [warn, 'warn_threshold']
-    ];
-
-    this.navigateEdit('devicehealth');
-    for (let i = 0, devHealthTuple; (devHealthTuple = devHealthArray[i]); i++) {
-      if (devHealthTuple[0] !== undefined) {
-        // Clears and inputs edits
-        cy.get(`#${devHealthTuple[1]}`).type(devHealthTuple[0]);
-      }
-    }
-
-    cy.contains('button', 'Update').click();
-    this.getFirstTableCell('devicehealth').should('be.visible');
-    // Checks for visibility of devicehealth in table
-    this.getExpandCollapseElement('devicehealth').click();
-    for (let i = 0, devHealthTuple: [string, string]; (devHealthTuple = devHealthArray[i]); i++) {
-      if (devHealthTuple[0] !== undefined) {
-        // Repeatedly reclicks the module to check if edits has been done
-        cy.contains('.datatable-body-cell-label', 'devicehealth').click();
-        cy.get('.datatable-body').last().contains(devHealthTuple[0]).should('be.visible');
-      }
-    }
-
-    // Inputs old values into devicehealth fields. This manager module doesn't allow for updates
-    // to be made when the values are cleared. Therefore, I restored them to their original values
-    // (on my local run of ceph-dev, this is subject to change i would assume).
-    // I'd imagine there is a better way of doing this.
-    this.navigateEdit('devicehealth');
-
-    cy.get('#mark_out_threshold').clear().type('2419200');
-
-    cy.get('#pool_name').clear().type('device_health_metrics');
-
-    cy.get('#retention_period').clear().type('15552000');
-
-    cy.get('#scrape_frequency').clear().type('86400');
-
-    cy.get('#sleep_interval').clear().type('600');
-
-    cy.get('#warn_threshold').clear().type('7257600');
-
-    // Checks that clearing represents in details tab
-    cy.contains('button', 'Update').click();
-    this.getExpandCollapseElement('devicehealth').should('be.visible').click();
-    for (let i = 0, devHealthTuple: [string, string]; (devHealthTuple = devHealthArray[i]); i++) {
-      if (devHealthTuple[0] !== undefined) {
-        // Repeatedly reclicks the module to check if clearing has been done
-        cy.contains('.datatable-body-cell-label', 'devicehealth').click();
-        cy.get('.datatable-body')
-          .eq(1)
-          .should('contain', devHealthTuple[1])
-          .and('not.contain', devHealthTuple[0]);
-      }
+    for (const input of inputs) {
+      cy.get('.datatable-body')
+        .eq(1)
+        .should('contain', input.id)
+        .and('not.contain', input.newValue);
     }
   }
 }


### PR DESCRIPTION
This test failed at random times when it tried to find the new value of pool_ids
in the balancer module.
This happened because the value of pool_ids is automatically reverted by ceph,
so in some situations when we tried to read the new value,
it was already reverted and failed.

Enhanced the tests to be able to use any text input, not only the ones with
empty default values.

Fixes: https://tracker.ceph.com/issues/45445

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
