### PR TITLE
pybind/ceph_volume_client: Fix PEP-8 SyntaxWarning

### DIFF
--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -355,7 +355,7 @@ class CephFSVolumeClient(object):
                 continue
 
             (group_id, volume_id) = volume.split('/')
-            group_id = group_id if group_id is not 'None' else None
+            group_id = group_id if group_id != 'None' else None
             volume_path = VolumePath(group_id, volume_id)
             access_level = volume_data['access_level']
 
@@ -378,7 +378,7 @@ class CephFSVolumeClient(object):
                 if vol_meta['auths'][auth_id] == want_auth:
                     continue
 
-                readonly = True if access_level is 'r' else False
+                readonly = access_level == 'r'
                 self._authorize_volume(volume_path, auth_id, readonly)
 
             # Recovered from partial auth updates for the auth ID's access
@@ -1099,7 +1099,7 @@ class CephFSVolumeClient(object):
 
             # Construct auth caps that if present might conflict with the desired
             # auth caps.
-            unwanted_access_level = 'r' if want_access_level is 'rw' else 'rw'
+            unwanted_access_level = 'r' if want_access_level == 'rw' else 'rw'
             unwanted_mds_cap = 'allow {0} path={1}'.format(unwanted_access_level, path)
             if namespace:
                 unwanted_osd_cap = 'allow {0} pool={1} namespace={2}'.format(


### PR DESCRIPTION
When `ceph_volume_client.py` run in `python 3.8`, I got the following warning:
```console
/usr/lib/python3/dist-packages/ceph_volume_client.py:358: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  group_id = group_id if group_id is not 'None' else None
/usr/lib/python3/dist-packages/ceph_volume_client.py:381: SyntaxWarning: "is" with a literal. Did you mean "=="?
  readonly = True if access_level is 'r' else False
/usr/lib/python3/dist-packages/ceph_volume_client.py:1102: SyntaxWarning: "is" with a literal. Did you mean "=="?
  unwanted_access_level = 'r' if want_access_level is 'rw' else 'rw'
```
The Python spec say that:
* `is` checks for **identity** - if the two variables point to the exact same object.
* `==` checks for **equality** - if the two variables point at values are equal. That is, if they will act the same way in the same situations.

Signed-off-by: Dũng Đặng Minh dungdm93@live.com