### PR TITLE
systemd: lock down more privileges

### DIFF
--- a/systemd/ceph-fuse@.service.in
+++ b/systemd/ceph-fuse@.service.in
@@ -6,21 +6,25 @@ Conflicts=umount.target
 PartOf=ceph-fuse.target
 
 [Service]
-EnvironmentFile=-@SYSTEMD_ENV_FILE@
 Environment=CLUSTER=ceph
+EnvironmentFile=-@SYSTEMD_ENV_FILE@
 ExecStart=/usr/bin/ceph-fuse -f --cluster ${CLUSTER} %I
 LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 # ceph-fuse requires access to /dev fuse device
 PrivateDevices=no
+ProtectClock=true
 ProtectControlGroups=true
+ProtectHostname=true
+ProtectKernelLogs=true
 ProtectKernelModules=true
 ProtectKernelTunables=true
-TasksMax=infinity
 Restart=on-failure
-StartLimitInterval=30min
+RestrictSUIDSGID=true
 StartLimitBurst=3
+StartLimitInterval=30min
+TasksMax=infinity
 
 [Install]
 WantedBy=ceph-fuse.target

--- a/systemd/ceph-immutable-object-cache@.service.in
+++ b/systemd/ceph-immutable-object-cache@.service.in
@@ -5,20 +5,26 @@ Wants=network-online.target local-fs.target
 PartOf=ceph-immutable-object-cache.target
 
 [Service]
-LimitNOFILE=1048576
-LimitNPROC=1048576
-EnvironmentFile=-@SYSTEMD_ENV_FILE@
 Environment=CLUSTER=ceph
-ExecStart=/usr/bin/ceph-immutable-object-cache -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+EnvironmentFile=-@SYSTEMD_ENV_FILE@
 ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/usr/bin/ceph-immutable-object-cache -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
 PrivateDevices=yes
-ProtectHome=true
-ProtectSystem=full
 PrivateTmp=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=full
 Restart=on-failure
-StartLimitInterval=30min
+RestrictSUIDSGID=true
 StartLimitBurst=3
-TasksMax=infinity
 
 [Install]
 WantedBy=ceph-immutable-object-cache.target

--- a/systemd/ceph-mds@.service.in
+++ b/systemd/ceph-mds@.service.in
@@ -5,26 +5,30 @@ Wants=network-online.target local-fs.target time-sync.target
 PartOf=ceph-mds.target
 
 [Service]
+Environment=CLUSTER=ceph
+EnvironmentFile=-@SYSTEMD_ENV_FILE@
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
-EnvironmentFile=-@SYSTEMD_ENV_FILE@
-Environment=CLUSTER=ceph
-ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
-ExecReload=/bin/kill -HUP $MAINPID
 LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 PrivateDevices=yes
+PrivateTmp=true
+ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
 ProtectKernelModules=true
 ProtectKernelTunables=true
 ProtectSystem=full
-PrivateTmp=true
-TasksMax=infinity
 Restart=on-failure
-StartLimitInterval=30min
+RestrictSUIDSGID=true
 StartLimitBurst=3
+StartLimitInterval=30min
+TasksMax=infinity
 
 [Install]
 WantedBy=ceph-mds.target

--- a/systemd/ceph-mgr@.service.in
+++ b/systemd/ceph-mgr@.service.in
@@ -5,30 +5,34 @@ Wants=network-online.target local-fs.target time-sync.target
 PartOf=ceph-mgr.target
 
 [Service]
+Environment=CLUSTER=ceph
+EnvironmentFile=-@SYSTEMD_ENV_FILE@
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/usr/bin/ceph-mgr -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
-EnvironmentFile=-@SYSTEMD_ENV_FILE@
-Environment=CLUSTER=ceph
-ExecStart=/usr/bin/ceph-mgr -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
-ExecReload=/bin/kill -HUP $MAINPID
 LockPersonality=true
+NoNewPrivileges=true
+PrivateDevices=yes
+PrivateTmp=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=full
+Restart=on-failure
+RestartSec=10
+RestrictSUIDSGID=true
+StartLimitBurst=3
+StartLimitInterval=30min
 
 # We need to disable this protection as some python libraries generate
 # dynamic code, like python-cffi, and require mmap calls to succeed
 MemoryDenyWriteExecute=false
 
-NoNewPrivileges=true
-PrivateDevices=yes
-ProtectControlGroups=true
-ProtectHome=true
-ProtectKernelModules=true
-ProtectKernelTunables=true
-ProtectSystem=full
-PrivateTmp=true
-Restart=on-failure
-RestartSec=10
-StartLimitInterval=30min
-StartLimitBurst=3
 
 [Install]
 WantedBy=ceph-mgr.target

--- a/systemd/ceph-mon@.service.in
+++ b/systemd/ceph-mon@.service.in
@@ -7,32 +7,35 @@ Description=Ceph cluster monitor daemon
 # configuration.
 After=network-online.target local-fs.target time-sync.target
 Wants=network-online.target local-fs.target time-sync.target
-
 PartOf=ceph-mon.target
 
 [Service]
+Environment=CLUSTER=ceph
+EnvironmentFile=-@SYSTEMD_ENV_FILE@
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
-EnvironmentFile=-@SYSTEMD_ENV_FILE@
-Environment=CLUSTER=ceph
-ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
-ExecReload=/bin/kill -HUP $MAINPID
 LockPersonality=true
 MemoryDenyWriteExecute=true
 # Need NewPrivileges via `sudo smartctl`
 NoNewPrivileges=false
 PrivateDevices=yes
+PrivateTmp=true
+ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
 ProtectKernelModules=true
 ProtectKernelTunables=true
 ProtectSystem=full
-PrivateTmp=true
-TasksMax=infinity
 Restart=on-failure
-StartLimitInterval=30min
-StartLimitBurst=5
 RestartSec=10
+RestrictSUIDSGID=true
+StartLimitBurst=5
+StartLimitInterval=30min
+TasksMax=infinity
 
 [Install]
 WantedBy=ceph-mon.target

--- a/systemd/ceph-osd@.service.in
+++ b/systemd/ceph-osd@.service.in
@@ -5,29 +5,33 @@ Wants=network-online.target local-fs.target time-sync.target
 PartOf=ceph-osd.target
 
 [Service]
-LimitNOFILE=1048576
-LimitNPROC=1048576
-EnvironmentFile=-@SYSTEMD_ENV_FILE@
 Environment=CLUSTER=ceph
+EnvironmentFile=-@SYSTEMD_ENV_FILE@
+ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecStartPre=/usr/lib/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i
-ExecReload=/bin/kill -HUP $MAINPID
+LimitNOFILE=1048576
+LimitNPROC=1048576
 LockPersonality=true
 MemoryDenyWriteExecute=true
 # Need NewPrivileges via `sudo smartctl`
 NoNewPrivileges=false
+PrivateTmp=true
+ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
 ProtectKernelModules=true
 # flushing filestore requires access to /proc/sys/vm/drop_caches
 ProtectKernelTunables=false
 ProtectSystem=full
-PrivateTmp=true
-TasksMax=infinity
 Restart=on-failure
-StartLimitInterval=30min
-StartLimitBurst=3
 RestartSec=10
+RestrictSUIDSGID=true
+StartLimitBurst=3
+StartLimitInterval=30min
+TasksMax=infinity
 
 [Install]
 WantedBy=ceph-osd.target

--- a/systemd/ceph-radosgw@.service.in
+++ b/systemd/ceph-radosgw@.service.in
@@ -5,25 +5,29 @@ Wants=network-online.target local-fs.target time-sync.target
 PartOf=ceph-radosgw.target
 
 [Service]
+Environment=CLUSTER=ceph
+EnvironmentFile=-@SYSTEMD_ENV_FILE@
+ExecStart=/usr/bin/radosgw -f --cluster ${CLUSTER} --name client.%i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
-EnvironmentFile=-@SYSTEMD_ENV_FILE@
-Environment=CLUSTER=ceph
-ExecStart=/usr/bin/radosgw -f --cluster ${CLUSTER} --name client.%i --setuser ceph --setgroup ceph
 LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 PrivateDevices=yes
+PrivateTmp=true
+ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
 ProtectKernelModules=true
 ProtectKernelTunables=true
 ProtectSystem=full
-PrivateTmp=true
-TasksMax=infinity
 Restart=on-failure
-StartLimitInterval=30s
+RestrictSUIDSGID=true
 StartLimitBurst=5
+StartLimitInterval=30s
+TasksMax=infinity
 
 [Install]
 WantedBy=ceph-radosgw.target

--- a/systemd/ceph-rbd-mirror@.service.in
+++ b/systemd/ceph-rbd-mirror@.service.in
@@ -5,25 +5,29 @@ Wants=network-online.target local-fs.target
 PartOf=ceph-rbd-mirror.target
 
 [Service]
+Environment=CLUSTER=ceph
+EnvironmentFile=-@SYSTEMD_ENV_FILE@
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/usr/bin/rbd-mirror -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
-EnvironmentFile=-@SYSTEMD_ENV_FILE@
-Environment=CLUSTER=ceph
-ExecStart=/usr/bin/rbd-mirror -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
-ExecReload=/bin/kill -HUP $MAINPID
 LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 PrivateDevices=yes
+PrivateTmp=true
+ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
 ProtectKernelModules=true
 ProtectKernelTunables=true
 ProtectSystem=full
-PrivateTmp=true
 Restart=on-failure
-StartLimitInterval=30min
+RestrictSUIDSGID=true
 StartLimitBurst=3
+StartLimitInterval=30min
 TasksMax=infinity
 
 [Install]


### PR DESCRIPTION
Including:

        ProtectClock=true
        ProtectHostname=true
        ProtectKernelLogs=true
        RestrictSUIDSGID=true

Also, alphabetize [service] settings.

Finally, add some protections for
systemd/ceph-immutable-object-cache@.service.in present in our other
service files but not this one.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
