### PR TITLE
octopus: mgr/test_orchestrator: fix _get_ceph_daemons()

### DIFF
--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -165,11 +165,10 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         types = ("mds", "osd", "mon", "rgw", "mgr")
         out = map(str, check_output(['ps', 'aux']).splitlines())
         processes = [p for p in out if any(
-            [('ceph-' + t in p) for t in types])]
+            [('ceph-{} '.format(t) in p) for t in types])]
 
         daemons = []
         for p in processes:
-            daemon = orchestrator.DaemonDescription()
             # parse daemon type
             m = re.search('ceph-([^ ]+)', p)
             if m:
@@ -179,7 +178,6 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
 
             # parse daemon ID. Possible options: `-i <id>`, `--id=<id>`, `--id <id>`
             patterns = [r'-i\s(\w+)', r'--id[\s=](\w+)']
-            daemon_id = None
             for pattern in patterns:
                 m = re.search(pattern, p)
                 if m:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45460

---

backport of https://github.com/ceph/ceph/pull/34689
parent tracker: https://tracker.ceph.com/issues/45186

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh