### PR TITLE
octopus: rgw: fix some list buckets handle leak

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1655,6 +1655,7 @@ int RGWBucketAdminOp::info(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState
           formatter->dump_string("bucket", bucket_name);
       }
     }
+    store->ctl()->meta.mgr->list_keys_complete(handle);
 
     formatter->close_section();
   }
@@ -1811,6 +1812,11 @@ static int process_stale_instances(rgw::sal::RGWRadosStore *store, RGWBucketAdmi
   bool truncated;
 
   formatter->open_array_section("keys");
+  auto g = make_scope_guard([&store, &handle, &formatter]() {
+                              store->ctl()->meta.mgr->list_keys_complete(handle);
+                              formatter->close_section(); // keys
+                              formatter->flush(cout);
+                            });
 
   do {
     list<std::string> keys;
@@ -1836,8 +1842,6 @@ static int process_stale_instances(rgw::sal::RGWRadosStore *store, RGWBucketAdmi
     }
   } while (truncated);
 
-  formatter->close_section(); // keys
-  formatter->flush(cout);
   return 0;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45498

---

backport of https://github.com/ceph/ceph/pull/29886
parent tracker: https://tracker.ceph.com/issues/44283

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh