### PR TITLE
nautilus: rgw: fix some list buckets handle leak

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1658,6 +1658,7 @@ int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
           formatter->dump_string("bucket", bucket_name);
       }
     }
+    store->meta_mgr->list_keys_complete(handle);
 
     formatter->close_section();
   }
@@ -1814,6 +1815,11 @@ static int process_stale_instances(RGWRados *store, RGWBucketAdminOpState& op_st
   bool truncated;
 
   formatter->open_array_section("keys");
+  auto g = make_scope_guard([&store, &handle, &formatter]() {
+                              store->meta_mgr->list_keys_complete(handle);
+                              formatter->close_section(); // keys
+                              formatter->flush(cout);
+                            });
 
   do {
     list<std::string> keys;
@@ -1839,8 +1845,6 @@ static int process_stale_instances(RGWRados *store, RGWBucketAdminOpState& op_st
     }
   } while (truncated);
 
-  formatter->close_section(); // keys
-  formatter->flush(cout);
   return 0;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45499

---

backport of https://github.com/ceph/ceph/pull/29886
parent tracker: https://tracker.ceph.com/issues/44283

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh