### PR TITLE
octopus: doc/rgw: document 'rgw gc max concurrent io'

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -447,6 +447,15 @@ configuration parameters.
 :Type: Integer
 :Default: ``3600``
 
+
+``rgw gc max concurrent io``
+
+:Description: The maximum number of concurrent IO operations that the RGW garbage
+              collection thread will use when purging old data.
+:Type: Integer
+:Default: ``10``
+
+
 Multisite Settings
 ==================
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45479

---

backport of https://github.com/ceph/ceph/pull/34952
parent tracker: https://tracker.ceph.com/issues/44958

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh