### PR TITLE
octopus: rgw: fix rgw tries to fetch anonymous user

### DIFF
--- a/src/rgw/services/svc_user_rados.cc
+++ b/src/rgw/services/svc_user_rados.cc
@@ -115,6 +115,10 @@ int RGWSI_User_RADOS::read_user_info(RGWSI_MetaBackend::Context *ctx,
                                map<string, bufferlist> * const pattrs,
                                optional_yield y)
 {
+  if(user.id == RGW_USER_ANON_ID) {
+    ldout(svc.meta_be->ctx(), 20) << "RGWSI_User_RADOS::read_user_info(): anonymous user" << dendl;
+    return -ENOENT;
+  }
   bufferlist bl;
   RGWUID user_id;
 
@@ -738,7 +742,11 @@ int RGWSI_User_RADOS::list_buckets(RGWSI_MetaBackend::Context *ctx,
   int ret;
 
   buckets->clear();
-  
+   if (user.id == RGW_USER_ANON_ID) {
+    ldout(cct, 20) << "RGWSI_User_RADOS::list_buckets(): anonymous user" << dendl;
+    *is_truncated = false;
+    return 0;
+  } 
   rgw_raw_obj obj = get_buckets_obj(user);
 
   bool truncated = false;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45484

---

backport of https://github.com/ceph/ceph/pull/34287
parent tracker: https://tracker.ceph.com/issues/44772

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh