### PR TITLE
octopus: cephfs: Client: fix Finisher assert failure

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -303,9 +303,6 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
 				  cct->_conf->client_oc_target_dirty,
 				  cct->_conf->client_oc_max_dirty_age,
 				  true));
-  objecter_finisher.start();
-  filer.reset(new Filer(objecter, &objecter_finisher));
-  objecter->enable_blacklist_events();
 }
 
 
@@ -473,10 +470,20 @@ void Client::dump_status(Formatter *f)
   }
 }
 
-int Client::init()
+void Client::_pre_init()
 {
   timer.init();
+
+  objecter_finisher.start();
+  filer.reset(new Filer(objecter, &objecter_finisher));
+  objecter->enable_blacklist_events();
+
   objectcacher->start();
+}
+
+int Client::init()
+{
+  _pre_init();
   {
     std::lock_guard l{client_lock};
     ceph_assert(!initialized);
@@ -14623,8 +14630,7 @@ StandaloneClient::~StandaloneClient()
 
 int StandaloneClient::init()
 {
-  timer.init();
-  objectcacher->start();
+  _pre_init();
   objecter->init();
 
   client_lock.lock();

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -953,6 +953,8 @@ protected:
 
   void _close_sessions();
 
+  void _pre_init();
+
   /**
    * The basic housekeeping parts of init (perf counters, admin socket)
    * that is independent of how objecters/monclient/messengers are


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45495

---

backport of https://github.com/ceph/ceph/pull/33915
parent tracker: https://tracker.ceph.com/issues/44389

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh