### PR TITLE
[DNM] luminous backport of radosgw-admin radoslist and orphan list

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -257,3 +257,8 @@ target_link_libraries(rgw LINK_PRIVATE
 set_target_properties(rgw PROPERTIES OUTPUT_NAME rgw VERSION 2.0.0
   SOVERSION 2)
 install(TARGETS rgw DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+configure_file(${CMAKE_SOURCE_DIR}/src/rgw/rgw-orphan-list.in
+  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rgw-orphan-list @ONLY)
+install(PROGRAMS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rgw-orphan-list
+  DESTINATION bin)

--- a/src/rgw/rgw-orphan-list.in
+++ b/src/rgw/rgw-orphan-list.in
@@ -28,9 +28,9 @@ error_out() {
 }
 
 echo "Available pools:"
-rados lspools >$temp_file 2>$lspools_err
+rados lspools >"$temp_file" 2>"$lspools_err"
 if [ "$?" -ne 0 ] ;then
-    error_out "rados lspools" $lspools_err
+    error_out "rados lspools" "$lspools_err"
 fi
 sed 's/^/    /' $temp_file # list pools and indent
 printf "Which pool do you want to search for orphans? "
@@ -39,17 +39,17 @@ read pool
 echo "Note: files produced will be tagged with the current timestamp -- ${timestamp}."
 
 echo "running 'rados ls' at $(date)"
-rados ls --pool="$pool" >$rados_out 2>$rados_err
+rados ls --pool="$pool" >"$rados_out" 2>"$rados_err"
 if [ "$?" -ne 0 ] ;then
-    error_out "rados ls" $rados_err
+    error_out "rados ls" "$rados_err"
 fi
 sort -u "$rados_out" >"$temp_file"
 mv -f "$temp_file" "$rados_out"
 
 echo "running 'radosgw-admin bucket radoslist' at $(date)"
-radosgw-admin bucket radoslist >$rgwadmin_out 2>$rgwadmin_err
+radosgw-admin bucket radoslist >"$rgwadmin_out" 2>"$rgwadmin_err"
 if [ "$?" -ne 0 ] ;then
-    error_out "radosgw-admin radoslist" $rgwadmin_err
+    error_out "radosgw-admin radoslist" "$rgwadmin_err"
 fi
 sort -u "$rgwadmin_out" >"$temp_file"
 mv -f "$temp_file" "$rgwadmin_out"

--- a/src/rgw/rgw-orphan-list.in
+++ b/src/rgw/rgw-orphan-list.in
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# version 1
+
+# IMPORTANT: affects order produced by 'sort' and 'ceph-diff-sorted'
+# relies on this ordering
+export LANG=C
+
+out_dir="."
+temp_file=/tmp/temp.$$
+timestamp=$(date -u +%Y%m%d%k%M)
+lspools_err="${out_dir}/lspools-${timestamp}.error"
+rados_out="${out_dir}/rados-${timestamp}.intermediate"
+rados_err="${out_dir}/rados-${timestamp}.error"
+rgwadmin_out="${out_dir}/radosgw-admin-${timestamp}.intermediate"
+rgwadmin_err="${out_dir}/radosgw-admin-${timestamp}.error"
+delta_out="${out_dir}/orphan-list-${timestamp}.out"
+
+error_out() {
+    echo "An error was encountered while running '$1'. Aborting."
+    if [ $# -gt 1 ] ;then
+	echo "Review file '$2' for details."
+    fi
+    echo "***"
+    echo "*** WARNING: The results are incomplete. Do not use! ***"
+    echo "***"
+    exit 1
+}
+
+echo "Available pools:"
+rados lspools >$temp_file 2>$lspools_err
+if [ "$?" -ne 0 ] ;then
+    error_out "rados lspools" $lspools_err
+fi
+sed 's/^/    /' $temp_file # list pools and indent
+printf "Which pool do you want to search for orphans? "
+read pool
+
+echo "Note: files produced will be tagged with the current timestamp -- ${timestamp}."
+
+echo "running 'rados ls' at $(date)"
+rados ls --pool="$pool" >$rados_out 2>$rados_err
+if [ "$?" -ne 0 ] ;then
+    error_out "rados ls" $rados_err
+fi
+sort -u "$rados_out" >"$temp_file"
+mv -f "$temp_file" "$rados_out"
+
+echo "running 'radosgw-admin bucket radoslist' at $(date)"
+radosgw-admin bucket radoslist >$rgwadmin_out 2>$rgwadmin_err
+if [ "$?" -ne 0 ] ;then
+    error_out "radosgw-admin radoslist" $rgwadmin_err
+fi
+sort -u "$rgwadmin_out" >"$temp_file"
+mv -f "$temp_file" "$rgwadmin_out"
+
+echo "computing delta at $(date)"
+ceph-diff-sorted "$rados_out" "$rgwadmin_out" | grep "^<" | sed 's/^< *//' >"$delta_out"
+# use PIPESTATUS to get at exit status of first process in above pipe;
+# 0 means same, 1 means different, >1 means error
+if [ "${PIPESTATUS[0]}" -gt 1 ] ;then
+    error_out "ceph-diff-sorted"
+fi
+
+found="$(wc -l <$delta_out)"
+possible="$(wc -l <$rados_out)"
+percentage=$(expr 100 \* $found / $possible)
+
+echo "$found potential orphans found out of a possible $possible (${percentage}%)."
+echo "The results can be found in ${delta_out}."
+echo "    Intermediate files: ${rados_out} and ${rgwadmin_out}"
+echo "***"
+echo "*** WARNING: This is EXPERIMENTAL code and the results should be used"
+echo "***          only with CAUTION!"
+echo "***"
+echo "Done at $(date)."

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5320,21 +5320,18 @@ int main(int argc, const char **argv)
   if (opt_cmd == OPT_BUCKET_RADOS_LIST) {
     if (bucket_name.empty()) {
       cerr << "ERROR: bucket not specified" << std::endl;
-      return -EINVAL;
+      return EINVAL;
     }
 
-    RGWBucketInfo bucket_info;
-    int ret = init_bucket(tenant, bucket_name, bucket_id, bucket_info, bucket);
+    RGWRadosList lister(store,
+			max_concurrent_ios, orphan_stale_secs, tenant);
+    ret = lister.run(bucket_name);
     if (ret < 0) {
-      cerr << "ERROR: could not init bucket: " << cpp_strerror(-ret) << std::endl;
-      return -ret;
-    }
-
-    RGWRadosList lister(store, max_concurrent_ios, orphan_stale_secs, cout);
-    ret = lister.run(bucket.get_key());
-    if (ret < 0) {
-      cerr << "bucket radoslist failed to finish before encountering error: " <<
-	cpp_strerror(-ret) << std::endl;
+      cerr <<
+	"ERROR: bucket radoslist failed to finish before " <<
+	"encountering error: " << cpp_strerror(-ret) << std::endl;
+      cerr << "WARNING: THE RESULTS ARE NOT RELIABLE AND SHOULD NOT " <<
+	"BE USED TO MANUALLY DELETE ORPHANS" << std::endl;
       return -ret;
     }
   }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5318,20 +5318,24 @@ int main(int argc, const char **argv)
   } /* OPT_BUCKETS_LIST */
 
   if (opt_cmd == OPT_BUCKET_RADOS_LIST) {
-    if (bucket_name.empty()) {
-      cerr << "ERROR: bucket not specified" << std::endl;
-      return EINVAL;
-    }
-
     RGWRadosList lister(store,
 			max_concurrent_ios, orphan_stale_secs, tenant);
-    ret = lister.run(bucket_name);
+    if (bucket_name.empty()) {
+      ret = lister.run();
+    } else {
+      ret = lister.run(bucket_name);
+    }
+
     if (ret < 0) {
-      cerr <<
+      std::cerr <<
 	"ERROR: bucket radoslist failed to finish before " <<
 	"encountering error: " << cpp_strerror(-ret) << std::endl;
-      cerr << "WARNING: THE RESULTS ARE NOT RELIABLE AND SHOULD NOT " <<
-	"BE USED TO MANUALLY DELETE ORPHANS" << std::endl;
+      std::cerr << "************************************"
+	"************************************" << std::endl;
+      std::cerr << "WARNING: THE RESULTS ARE NOT RELIABLE AND SHOULD NOT " <<
+	"BE USED IN DELETING ORPHANS" << std::endl;
+      std::cerr << "************************************"
+	"************************************" << std::endl;
       return -ret;
     }
   }

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1540,6 +1540,14 @@ struct rgw_obj_key {
     return instance;
   }
 
+  void set_ns(const std::string& _ns) {
+    ns = _ns;
+  }
+
+  const std::string& get_ns() const {
+    return ns;
+  }
+
   string get_index_key_name() const {
     if (ns.empty()) {
       if (name.size() < 1 || name[0] != '_') {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1695,6 +1695,13 @@ public:
 struct RGWMultipartUploadEntry {
   rgw_bucket_dir_entry obj;
   RGWMPObj mp;
+
+  friend std::ostream& operator<<(std::ostream& out,
+				  const RGWMultipartUploadEntry& e) {
+    return out << "RGWMultipartUploadEntry{ obj.key=\"" << e.obj.key <<
+      "\" mp=" << e.mp <<
+      " }";
+  }
 };
 
 class RGWListBucketMultiparts : public RGWOp {

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -1512,8 +1512,8 @@ int RGWRadosList::do_incomplete_multipart(
       do {
 	map<uint32_t, RGWUploadPartInfo> parts;
 
-	for (const auto& upload : uploads) {
-	  const RGWMPObj& mp = upload.mp;
+	for (auto& upload : uploads) {
+	  RGWMPObj& mp = upload.mp;
 	  ret = list_multipart_parts(store, bucket_info, store->ctx(),
 				     mp.get_upload_id(), mp.get_meta(),
 				     max_parts,

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -396,7 +396,7 @@ int RGWOrphanSearch::build_buckets_instance_index()
   int ret = store->meta_mgr->list_keys_init(section, &handle);
   if (ret < 0) {
     lderr(store->ctx()) << "ERROR: can't get key: " << cpp_strerror(-ret) << dendl;
-    return -ret;
+    return ret;
   }
 
   map<int, list<string> > instances;
@@ -413,7 +413,7 @@ int RGWOrphanSearch::build_buckets_instance_index()
     ret = store->meta_mgr->list_keys_next(handle, max, keys, &truncated);
     if (ret < 0) {
       lderr(store->ctx()) << "ERROR: lists_keys_next(): " << cpp_strerror(-ret) << dendl;
-      return -ret;
+      return ret;
     }
 
     for (list<string>::iterator iter = keys.begin(); iter != keys.end(); ++iter) {
@@ -576,7 +576,7 @@ int RGWOrphanSearch::build_linked_oids_for_bucket(const string& bucket_instance_
                                &result, nullptr, &truncated);
     if (ret < 0) {
       cerr << "ERROR: store->list_objects(): " << cpp_strerror(-ret) << std::endl;
-      return -ret;
+      return ret;
     }
 
     for (vector<rgw_bucket_dir_entry>::iterator iter = result.begin(); iter != result.end(); ++iter) {

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -957,8 +957,13 @@ int RGWRadosList::handle_stat_result(RGWRados::Object::Stat::Result& result,
   // iterator to store result of dlo/slo attribute find
   decltype(result.attrs)::iterator attr_it = result.attrs.end();
   const std::string oid = bucket.marker + "_" + result.obj.get_object();
+  ldout(store->ctx(), 20) << "radoslist processing object=\"" <<
+      oid << "\"" << dendl;
   if (visited_oids.find(oid) != visited_oids.end()) {
     // apparently we hit a loop; don't continue with this oid
+    ldout(store->ctx(), 15) <<
+      "radoslist stopped loop at already visited object=\"" <<
+      oid << "\"" << dendl;
     return 0;
   }
 
@@ -987,6 +992,8 @@ int RGWRadosList::handle_stat_result(RGWRados::Object::Stat::Result& result,
 
     obj_oids.insert(oid);
     visited_oids.insert(oid); // prevent dlo loops
+    ldout(store->ctx(), 15) << "radoslist added to visited list DLO=\"" <<
+      oid << "\"" << dendl;
 
     char* prefix_path_c = attr_it->second.c_str();
     const std::string& prefix_path = prefix_path_c;
@@ -1000,12 +1007,17 @@ int RGWRadosList::handle_stat_result(RGWRados::Object::Stat::Result& result,
     const std::string prefix = prefix_path.substr(sep_pos + 1);
 
     add_bucket_prefix(bucket_name, prefix);
+    ldout(store->ctx(), 25) << "radoslist DLO oid=\"" << oid <<
+      "\" added bucket=\"" << bucket_name << "\" prefix=\"" <<
+      prefix << "\" to process list" << dendl;
   } else if ((attr_it = result.attrs.find(RGW_ATTR_SLO_MANIFEST)) !=
 	     result.attrs.end()) {
     // *** handle SLO object
 
     obj_oids.insert(oid);
     visited_oids.insert(oid); // prevent slo loops
+    ldout(store->ctx(), 15) << "radoslist added to visited list SLO=\"" <<
+      oid << "\"" << dendl;
 
     RGWSLOInfo slo_info;
     bufferlist::iterator bliter = attr_it->second.begin();
@@ -1033,6 +1045,9 @@ int RGWRadosList::handle_stat_result(RGWRados::Object::Stat::Result& result,
 
       const rgw_obj_key obj_key(obj_name);
       add_bucket_filter(bucket_name, obj_key);
+      ldout(store->ctx(), 25) << "radoslist SLO oid=\"" << oid <<
+	"\" added bucket=\"" << bucket_name << "\" obj_key=\"" <<
+	obj_key << "\" to process list" << dendl;
     }
   } else {
     RGWObjManifest& manifest = result.manifest;

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -950,17 +950,21 @@ int RGWRadosList::handle_stat_result(RGWRados::Object::Stat::Result& result,
 
   rgw_bucket& bucket = result.obj.bucket;
 
-  ldout(store->ctx(), 20) << "RRGWRadosList::" << __func__ <<
+  ldout(store->ctx(), 20) << "RGWRadosList::" << __func__ <<
       " bucket=" << bucket << ", has_manifest=" << result.has_manifest <<
       dendl;
 
   // iterator to store result of dlo/slo attribute find
   decltype(result.attrs)::iterator attr_it = result.attrs.end();
+  const std::string oid = bucket.marker + "_" + result.obj.get_object();
+  if (visited_oids.find(oid) != visited_oids.end()) {
+    // apparently we hit a loop; don't continue with this oid
+    return 0;
+  }
 
   if (!result.has_manifest) {
     /* a very very old object, or part of a multipart upload during upload */
-    const string loc = bucket.marker + "_" + result.obj.get_object();
-    obj_oids.insert(loc);
+    obj_oids.insert(oid);
 
     /*
      * multipart parts don't have manifest on them, it's in the meta
@@ -976,13 +980,13 @@ int RGWRadosList::handle_stat_result(RGWRados::Object::Stat::Result& result,
      * impact. Perhaps a future version can consult the meta object
      * and produce an absolutely correct output. */
 
-    obj_oids.insert(obj_force_ns(loc, "shadow"));
+    obj_oids.insert(obj_force_ns(oid, "shadow"));
   } else if ((attr_it = result.attrs.find(RGW_ATTR_USER_MANIFEST)) !=
 	     result.attrs.end()) {
     // *** handle DLO object
 
-    const std::string s = bucket.marker + "_" + result.obj.get_object();
-    obj_oids.insert(s);
+    obj_oids.insert(oid);
+    visited_oids.insert(oid); // prevent dlo loops
 
     char* prefix_path_c = attr_it->second.c_str();
     const std::string& prefix_path = prefix_path_c;
@@ -1000,8 +1004,8 @@ int RGWRadosList::handle_stat_result(RGWRados::Object::Stat::Result& result,
 	     result.attrs.end()) {
     // *** handle SLO object
 
-    const std::string s = bucket.marker + "_" + result.obj.get_object();
-    obj_oids.insert(s);
+    obj_oids.insert(oid);
+    visited_oids.insert(oid); // prevent slo loops
 
     RGWSLOInfo slo_info;
     bufferlist::iterator bliter = attr_it->second.begin();
@@ -1009,7 +1013,7 @@ int RGWRadosList::handle_stat_result(RGWRados::Object::Stat::Result& result,
       ::decode(slo_info, bliter);
     } catch (buffer::error& err) {
       ldout(store->ctx(), 0) <<
-	"ERROR: failed to decode slo manifest for " << s << dendl;
+	"ERROR: failed to decode slo manifest for " << oid << dendl;
       return -EIO;
     }
 
@@ -1040,8 +1044,7 @@ int RGWRadosList::handle_stat_result(RGWRados::Object::Stat::Result& result,
     if (0 == manifest.get_max_head_size()) {
       // in multipart, the head object contains no data and just has
       // the manifest
-      const std::string s = bucket.marker + "_" + result.obj.get_object();
-      obj_oids.insert(s);
+      obj_oids.insert(oid);
       first_insert = true;
     }
 

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -1056,9 +1056,11 @@ int RGWRadosList::handle_stat_result(RGWRados::Object::Stat::Result& result,
     // tail bucket, if it exists
     bool first_insert = false;
 
-    if (0 == manifest.get_max_head_size()) {
-      // in multipart, the head object contains no data and just has
-      // the manifest
+    // in multipart, the head object contains no data and just has the
+    // manifest AND empty objects have no manifest, but they're
+    // realized as empty rados objects
+    if (0 == manifest.get_max_head_size() ||
+	manifest.obj_begin() == manifest.obj_end()) {
       obj_oids.insert(oid);
       first_insert = true;
     }

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -210,6 +210,14 @@ public:
 
 
 class RGWRadosList {
+
+  /*
+   * process_t describes how to process a irectory, we will either
+   * process the whole thing (entire_container == true) or a portion
+   * of it (entire_container == false). When we only process a
+   * portion, we will list the specific keys and/or specific lexical
+   * prefixes.
+   */
   struct process_t {
     bool entire_container;
     std::set<rgw_obj_key> filter_keys;
@@ -252,7 +260,6 @@ class RGWRadosList {
   int handle_stat_result(RGWRados::Object::Stat::Result& result,
 			 std::set<string>& obj_oids);
   int pop_and_handle_stat_op(RGWObjectCtx& obj_ctx,
-			     map<int, list<string> >& oids,
 			     std::deque<RGWRados::Object::Stat>& ops);
 
 public:
@@ -267,19 +274,16 @@ public:
     tenant_name(_tenant_name)
   {}
 
-#if 0
-  // possible future expansion -- have it find all bucket....
-  int RGWRadosList::build_buckets_instance_index();
-#endif
+  int process_bucket(const std::string& bucket_instance_id,
+		     const std::string& prefix,
+		     const std::set<rgw_obj_key>& entries_filter);
 
-  int build_linked_oids_for_bucket(const std::string& bucket_instance_id,
-				   const std::string& prefix,
-				   const std::set<rgw_obj_key>& entries_filter,
-				   std::map<int, list<string>>& oids);
+  int do_incomplete_multipart(RGWRados* store, RGWBucketInfo& bucket_info);
 
   int build_linked_oids_index();
 
   int run(const std::string& bucket_id);
+  int run();
 }; // class RGWRadosList
 
 #endif

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -209,5 +209,42 @@ public:
 };
 
 
+class RGWRadosList {
+  RGWRados *store;
+
+  std::ostream& out;
+
+  uint16_t max_concurrent_ios;
+  uint64_t stale_secs;
+
+  int handle_stat_result(RGWRados::Object::Stat::Result& result,
+			 std::set<string>& obj_oids);
+  int pop_and_handle_stat_op(map<int, list<string> >& oids,
+			     std::deque<RGWRados::Object::Stat>& ops);
+
+public:
+
+  RGWRadosList(RGWRados *_store,
+	    int _max_ios,
+	    uint64_t _stale_secs,
+	    std::ostream& _out = std::cout) :
+    store(_store),
+    out(_out),
+    max_concurrent_ios(_max_ios),
+    stale_secs(_stale_secs)
+  {}
+
+#if 0
+  // possible future expansion -- have it find all bucket....
+  int RGWRadosList::build_buckets_instance_index()
+#endif
+
+  int build_linked_oids_for_bucket(const string& bucket_instance_id,
+				   map<int, list<string>>& oids);
+
+  int build_linked_oids_index();
+
+  int run(const std::string& bucket_id);
+}; // class RGWRadosList
 
 #endif

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -221,6 +221,7 @@ class RGWRadosList {
   };
 
   std::map<std::string,process_t> bucket_process_map;
+  std::set<std::string> visited_oids;
 
   void add_bucket_entire(const std::string& bucket_name) {
     auto p = bucket_process_map.emplace(std::make_pair(bucket_name,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -4117,7 +4117,7 @@ public:
   string& get_key() {
     return oid;
   }
-  bool from_meta(string& meta) {
+  bool from_meta(const string& meta) {
     int end_pos = meta.rfind('.'); // search for ".meta"
     if (end_pos < 0)
       return false;
@@ -4135,7 +4135,11 @@ public:
     meta = "";
     upload_id = "";
   }
-};
+  friend std::ostream& operator<<(std::ostream& out, const RGWMPObj& obj) {
+    return out << "RGWMPObj:{ prefix=\"" << obj.prefix <<
+      "\", meta=\"" << obj.meta << "\" }";
+  }
+}; // class RGWMPObj
 
 class RGWPutObjProcessor_Multipart : public RGWPutObjProcessor_Atomic
 {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -742,18 +742,18 @@ public:
     void seek(uint64_t ofs);
 
     void operator++();
-    bool operator==(const obj_iterator& rhs) {
+    bool operator==(const obj_iterator& rhs) const {
       return (ofs == rhs.ofs);
     }
-    bool operator!=(const obj_iterator& rhs) {
+    bool operator!=(const obj_iterator& rhs) const {
       return (ofs != rhs.ofs);
     }
-    const rgw_obj_select& get_location() {
+    const rgw_obj_select& get_location() const {
       return location;
     }
 
     /* start of current stripe */
-    uint64_t get_stripe_ofs() {
+    uint64_t get_stripe_ofs() const {
       if (manifest->explicit_objs) {
         return explicit_iter->first;
       }
@@ -771,7 +771,7 @@ public:
     }
 
     /* current stripe size */
-    uint64_t get_stripe_size() {
+    uint64_t get_stripe_size() const {
       if (manifest->explicit_objs) {
         return explicit_iter->second.size;
       }
@@ -779,7 +779,7 @@ public:
     }
 
     /* offset where data starts within current stripe */
-    uint64_t location_ofs() {
+    uint64_t location_ofs() const {
       if (manifest->explicit_objs) {
         return explicit_iter->second.loc_ofs;
       }

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -79,6 +79,10 @@ add_executable(osdmaptool ${osdomaptool_srcs})
 target_link_libraries(osdmaptool global)
 install(TARGETS osdmaptool DESTINATION bin)
 
+set(ceph-diff-sorted_srcs ceph-diff-sorted.cc)
+add_executable(ceph-diff-sorted ${ceph-diff-sorted_srcs})
+install(TARGETS ceph-diff-sorted DESTINATION bin)
+
 if(WITH_TESTS)
 set(ceph_psim_srcs psim.cc)
 add_executable(ceph_psim ${ceph_psim_srcs})

--- a/src/tools/ceph-diff-sorted.cc
+++ b/src/tools/ceph-diff-sorted.cc
@@ -1,0 +1,173 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/*
+ * diffsorted -- a utility to compute a line-by-line diff on two
+ * sorted input files
+ *
+ * Copyright © 2019 Red Hat
+ *
+ * Author: J. Eric Ivancich
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.
+ */
+
+
+/*
+ * SUMMARY
+ *
+ * The `diffsorted` utility does a line-by-line diff on two sorted text
+ * files and indicating lines that are in one file but not the other
+ * using diff-style notation (although line numbers are not indicated).
+ *
+ * USAGE
+ *
+ *     rgw-diff-sorted file1.txt file2.txt
+ *
+ * NOTES
+ *
+ * Each files should have its lines in sorted order and should have no
+ * empty lines.
+ *
+ * A potential input file can be sorted using the `sort` utility provided
+ * that LANG=C to insure byte lexical order. For example:
+ *
+ *     LANG=C sort unsorted.txt >sorted.txt
+ *
+ * or:
+ *
+ *     export LANG=C
+ *     sort unsorted.txt >sorted.txt
+ *
+ * EXIT STATUS
+ *
+ *     0 : files same
+ *     1 : files different
+ *     2 : usage problem (e.g., wrong number of command-line arguments)
+ *     3 : problem opening input file
+ *     4 : bad file content (e.g., unsorted order or empty lines)
+ */
+
+
+#include <iostream>
+#include <fstream>
+
+
+struct FileOfLines {
+  const char* filename;
+  std::ifstream input;
+  std::string this_line, prev_line;
+  bool next_eof;
+  bool is_eof;
+
+  FileOfLines(const char* _filename) :
+    filename(_filename),
+    input(filename),
+    next_eof(false),
+    is_eof(false)
+  { }
+
+  void dump(const std::string& prefix) {
+    do {
+      std::cout << prefix << this_line << std::endl;
+      advance();
+    } while (!eof());
+  }
+
+  bool eof() const {
+    return is_eof;
+  }
+
+  bool good() const {
+    return input.good();
+  }
+
+  void advance() {
+    if (next_eof) {
+      is_eof = true;
+      return;
+    }
+
+    prev_line = this_line;
+    std::getline(input, this_line);
+    if (this_line.empty()) {
+      if (!input.eof()) {
+	std::cerr << "Error: " << filename << " has an empty line." <<
+	  std::endl;
+	exit(4);
+      }
+      is_eof = true;
+      return;
+    } else if (input.eof()) {
+      next_eof = true;
+    }
+
+    if (this_line < prev_line) {
+      std::cerr << "Error: " << filename << " is not in sorted order; \"" <<
+	this_line << "\" follows \"" << prev_line << "\"." << std::endl;
+      exit(4);
+    }
+  }
+
+  const std::string line() const {
+    return this_line;
+  }
+};
+
+int main(int argc, const char* argv[]) {
+  if (argc != 3) {
+    std::cerr << "Usage: " << argv[0] << " <file1> <file2>" << std::endl;
+    exit(2);
+  }
+
+  FileOfLines input1(argv[1]);
+  if (!input1.good()) {
+    std::cerr << "Error opening " << argv[1] <<
+      "." << std::endl;
+    exit(3);
+  }
+
+  FileOfLines input2(argv[2]);
+  if (!input2.good()) {
+    std::cerr << "Error opening " << argv[2] <<
+      "." << std::endl;
+    exit(3);
+  }
+
+  bool files_same = true;
+
+  input1.advance();
+  input2.advance();
+
+  while (!input1.eof() && !input2.eof()) {
+    if (input1.line() == input2.line()) {
+      input1.advance();
+      input2.advance();
+    } else if (input1.line() < input2.line()) {
+      files_same = false;
+      std::cout << "< " << input1.line() << std::endl;
+      input1.advance();
+    } else {
+      files_same = false;
+      std::cout << "> " << input2.line() << std::endl;
+      input2.advance();
+    }
+  }
+
+  if (!input1.eof()) {
+    files_same = false;
+    input1.dump("< ");
+  } else if (!input2.eof()) {
+    files_same = false;
+    input2.dump("> ");
+  }
+
+  if (files_same) {
+    exit(0);
+  } else {
+    exit(1);
+  }
+}


### PR DESCRIPTION
This is a backport of new space-leak detection logic to Luminous, for the benefit of upstream users unable to upgrade to Nautilus.

These changes were taken from curated branches that received downstream testing, but have not been verified in their current form.

As Luminous is past end-of-life, it's not expected that these changes will be part of an upstream release.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
