### PR TITLE
cephadm: enable logging to stderr in ceph-iscsi

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -234,6 +234,9 @@ class IscsiService(CephadmService):
         api_user = {spec.api_user or ''}
         api_password = {spec.api_password or ''}
         api_secure = {api_secure}
+        log_to_stderr = True
+        log_to_stderr_prefix = debug
+        log_to_file = False
         """
         extra_config = {'iscsi-gateway.cfg': igw_conf}
         return self.mgr._create_daemon('iscsi', igw_id, host, keyring=keyring,


### PR DESCRIPTION
All the other ceph servies when deployed are deployed with:

  --default-log-to-stderr=true --default-log-stderr-prefix=debug
  --default-log-to-file=false

Ceph-iscsi doesn't have these as commandline params but once
https://github.com/ceph/ceph-iscsi/pull/186 lands it'll have something
similar as config options. This patch sets these options

Signed-off-by: Matthew Oliver <moliver@suse.com>

Fixes: https://tracker.ceph.com/issues/45245


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
