### PR TITLE
mgr/dashboard: Fix HomeTest setup

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_home.py
+++ b/src/pybind/mgr/dashboard/tests/test_home.py
@@ -31,7 +31,7 @@ class HomeTest(ControllerTestCase, FakeFsMixin):
             cls.fs.create_file(
                 os.path.join(lang.DEFAULT_LANGUAGE_PATH, 'index.html'),
                 contents='<!doctype html><html lang="en"><body></body></html>')
-        cls.setup_controllers([HomeController])
+            cls.setup_controllers([HomeController])
 
     @mock.patch(FakeFsMixin.builtins_open, new=FakeFsMixin.f_open)
     @mock.patch('os.stat', new=FakeFsMixin.f_os.stat)


### PR DESCRIPTION
'setup_controllers' was being called outside of the fake fs mock,
so the tests would fail if there was no real dist folder.

Fixes: https://tracker.ceph.com/issues/45516

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
