### PR TITLE
cephadm: Manually remove containers

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1853,6 +1853,9 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
             install_path = find_program('install')
             f.write('{install_path} -d -m0770 -o {uid} -g {gid} /var/run/ceph/{fsid}\n'.format(install_path=install_path, fsid=fsid, uid=uid, gid=gid))
 
+        # Sometimes, adding `--rm` to a run_cmd doesn't work. Let's remove the container manually
+        f.write(' '.join(c.rm_cmd()) + '\n')
+
         # container run command
         f.write(' '.join(c.run_cmd()) + '\n')
         os.fchmod(f.fileno(), 0o600)
@@ -2176,6 +2179,14 @@ class CephContainer:
         ] + self.container_args + [
             self.cname,
         ] + cmd
+
+    def rm_cmd(self):
+        # type: () -> List[str]
+        return [
+            str(container_path),
+            'rm', '-f',
+            self.cname
+        ]
 
     def run(self, timeout=DEFAULT_TIMEOUT):
         # type: (Optional[int]) -> str


### PR DESCRIPTION
This fixes:
```
Error: error creating container storage: the container name "ceph-<fsid>-mon.b" is already in use by "<container-id>". You have to remove that container to be able to reuse that name.: that name is already in use
```

Relates to https://tracker.ceph.com/issues/44990

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
