### PR TITLE
nautilus: rgw: fix multipart upload's error response

### DIFF
--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -485,7 +485,7 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
       .set_must_exist(true)
       .set(p, bl);
   if (r < 0) {
-    return r;
+    return r == -ENOENT ? -ERR_NO_SUCH_UPLOAD : r;
   }
 
   if (!obj_op.meta.canceled) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45517

---

backport of https://github.com/ceph/ceph/pull/32771
parent tracker: https://tracker.ceph.com/issues/43751

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh