### PR TITLE
nautilus: osd: dispatch_context and queue split finish on early bail-out

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8962,6 +8962,11 @@ bool OSD::advance_pg(
 		  << " is merge source, target is " << parent
 		   << dendl;
 	  pg->write_if_dirty(rctx);
+	  if (!new_pgs.empty()) {
+	    rctx->transaction->register_on_applied(new C_FinishSplits(this,
+								      new_pgs));
+	    new_pgs.clear();
+	  }
 	  dispatch_context_transaction(*rctx, pg, &handle);
 	  pg->ch->flush();
 	  // release backoffs explicitly, since the on_shutdown path
@@ -9034,6 +9039,12 @@ bool OSD::advance_pg(
 	  } else {
 	    dout(20) << __func__ << " not ready to merge yet" << dendl;
 	    pg->write_if_dirty(rctx);
+	    if (!new_pgs.empty()) {
+	      rctx->transaction->register_on_applied(new C_FinishSplits(this,
+								        new_pgs));
+	      new_pgs.clear();
+	    }
+	    dispatch_context_transaction(*rctx, pg, &handle);
 	    pg->unlock();
 	    // kick source(s) to get them ready
 	    for (auto& i : children) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43919

---

backport of https://github.com/ceph/ceph/pull/32942
parent tracker: https://tracker.ceph.com/issues/43825

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh