### PR TITLE
librbd: track per syncpoint's logentry number with perf counter

### DIFF
--- a/src/librbd/cache/ReplicatedWriteLog.cc
+++ b/src/librbd/cache/ReplicatedWriteLog.cc
@@ -99,6 +99,24 @@ void ReplicatedWriteLog<I>::perf_start(std::string name) {
     16,                              ///< Ranges into the mS
   };
 
+  // Syncpoint logentry number x-axis configuration for op histograms
+  PerfHistogramCommon::axis_config_d sp_logentry_number_config{
+    "logentry number",
+    PerfHistogramCommon::SCALE_LINEAR, // log entry number in linear scale
+    0,                                 // Start at 0
+    1,                                 // Quantization unit is 1
+    260,                               // Up to 260 > (MAX_WRITES_PER_SYNC_POINT)
+  };
+
+  // Syncpoint bytes number y-axis configuration for op histogram
+  PerfHistogramCommon::axis_config_d sp_bytes_number_config{
+    "Number of SyncPoint",
+    PerfHistogramCommon::SCALE_LOG2,   // Request size in logarithmic scale
+    0,                                 // Start at 0
+    512,                               // Quantization unit is 512
+    17,                                // Writes up to 8M >= MAX_BYTES_PER_SYNC_POINT
+  };
+
   // Op size axis configuration for op histogram y axis, values are in bytes
   PerfHistogramCommon::axis_config_d op_hist_y_axis_config{
     "Request size (bytes)",
@@ -126,6 +144,11 @@ void ReplicatedWriteLog<I>::perf_start(std::string name) {
   plb.add_time_avg(l_librbd_rwl_rd_hit_latency, "hit_rd_latency", "Latency of read hits");
 
   plb.add_u64_counter(l_librbd_rwl_rd_part_hit_req, "part_hit_rd", "reads partially hitting RWL");
+
+  plb.add_u64_counter_histogram(
+    l_librbd_rwl_syncpoint_hist, "syncpoint_logentry_bytes_histogram",
+    sp_logentry_number_config, sp_bytes_number_config,
+    "Histogram of syncpoint's logentry numbers vs bytes number");
 
   plb.add_u64_counter(l_librbd_rwl_wr_req, "wr", "Writes");
   plb.add_u64_counter(l_librbd_rwl_wr_req_def, "wr_def", "Writes deferred for resources");

--- a/src/librbd/cache/ReplicatedWriteLog.cc
+++ b/src/librbd/cache/ReplicatedWriteLog.cc
@@ -113,7 +113,7 @@ void ReplicatedWriteLog<I>::perf_start(std::string name) {
     "Number of items",
     PerfHistogramCommon::SCALE_LINEAR, ///< Request size in linear scale
     0,                                 ///< Start at 0
-    1,                                 ///< Quantization unit is 512 bytes
+    1,                                 ///< Quantization unit is 1
     32,                                ///< Writes up to >32k
   };
 

--- a/src/librbd/cache/rwl/SyncPoint.cc
+++ b/src/librbd/cache/rwl/SyncPoint.cc
@@ -93,6 +93,8 @@ void SyncPoint::add_in_on_appending_ctxs(Context* ctx) {
 
 void SyncPoint::setup_earlier_sync_point(std::shared_ptr<SyncPoint> sync_point,
                                          uint64_t last_op_sequence_num) {
+    m_perfcounter->inc(l_librbd_rwl_syncpoint_hist,
+                       sync_point->log_entry->writes, sync_point->log_entry->bytes);
     earlier_sync_point = sync_point;
     log_entry->prior_sync_point_flushed = false;
     earlier_sync_point->log_entry->next_sync_point_entry = log_entry;

--- a/src/librbd/cache/rwl/Types.h
+++ b/src/librbd/cache/rwl/Types.h
@@ -27,6 +27,9 @@ enum {
   // Reed requests with hit and miss extents
   l_librbd_rwl_rd_part_hit_req,  // read ops
 
+  // Per SyncPoint's LogEntry number and write bytes distribution
+  l_librbd_rwl_syncpoint_hist,
+
   // All write requests
   l_librbd_rwl_wr_req,             // write requests
   l_librbd_rwl_wr_req_def,         // write requests deferred for resources


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
