### PR TITLE
cephadm: fix shell mount for special files

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -386,6 +386,7 @@ $CEPHADM shell --fsid $FSID -- true
 $CEPHADM shell --fsid $FSID -- test -d /var/log/ceph
 expect_false $CEPHADM --timeout 10 shell --fsid $FSID -- sleep 60
 $CEPHADM --timeout 60 shell --fsid $FSID -- sleep 10
+$CEPHADM shell --fsid $FSID --mount $TMPDIR -- stat /mnt/$(basename $TMPDIR)
 
 ## enter
 expect_false $CEPHADM enter

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2790,9 +2790,7 @@ def command_shell():
         mounts[pathify(args.keyring)] = '/etc/ceph/ceph.keyring:z'
     if args.mount:
         mount = pathify(args.mount)
-        filename = ''
-        if os.path.isfile(mount):
-            _, filename = os.path.split(mount)
+        filename = os.path.basename(mount)
         mounts[mount] = '/mnt/{}:z'.format(filename)
     if args.command:
         command = args.command

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -930,9 +930,8 @@ def read_config(fn):
 
 def pathify(p):
     # type: (str) -> str
-    if not p.startswith('/'):
-        return os.path.join(os.getcwd(), p)
-    return p
+    p = os.path.expanduser(p)
+    return os.path.abspath(p)
 
 def get_file_timestamp(fn):
     try:


### PR DESCRIPTION
Allows the mount of special files (block devs, char devs, named pipes, sockets, etc.)


```
$ mknod /tmp/pipe p
$ cephadm -v shell --mount /tmp/pipe
...
DEBUG:cephadm:Running command (timeout=None): /usr/bin/podman run --rm --net=host --ipc=host -it -e LANG=C -e PS1=[ceph: \u@\h \W]\$  --privileged --group-add=disk -e CONTAINER_IMAGE=docker.io/ceph/daemon-base:latest-master-devel -e NODE_NAME=host1 -v /var/run/ceph/32feca97-5d28-4694-8018-a8b829781a20:/var/run/ceph:z -v /var/log/ceph/32feca97-5d28-4694-8018-a8b829781a20:/var/log/ceph:z -v /var/lib/ceph/32feca97-5d28-4694-8018-a8b829781a20/crash:/var/lib/ceph/crash:z -v /dev:/dev -v /run/udev:/run/udev -v /sys:/sys -v /run/lvm:/run/lvm -v /run/lock/lvm:/run/lock/lvm -v /tmp/pipe:/mnt/:z -v /var/lib/ceph/32feca97-5d28-4694-8018-a8b829781a20/home:/root --entrypoint bash docker.io/ceph/daemon-base:latest-master-devel
Error: container_linux.go:349: starting container process caused "process_linux.go:449: container init caused \"rootfs_linux.go:58: mounting \\\"/tmp/pipe\\\" to rootfs \\\"/var/lib/containers/storage/btrfs/subvolumes/ed7887dd847a6233bf7098f31d7b5538d78f1b286aa75a3c3b2d01ae1588aca7\\\" at \\\"/var/lib/containers/storage/btrfs/subvolumes/ed7887dd847a6233bf7098f31d7b5538d78f1b286aa75a3c3b2d01ae1588aca7/mnt\\\" caused \\\"not a directory\\\"\"": OCI runtime error
```


Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
