### PR TITLE
mgr/dashboard: Improve Summary's subscribe methods

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
@@ -146,10 +146,11 @@ export class IscsiTargetListComponent extends ListWithDetails implements OnInit,
           this.settings = settings;
         });
       } else {
-        const summary = this.summaryservice.getCurrentSummary();
-        const releaseName = this.cephReleaseNamePipe.transform(summary.version);
-        this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/dashboard/#enabling-iscsi-management`;
-        this.status = result.message;
+        this.summaryservice.subscribeOnce((summary) => {
+          const releaseName = this.cephReleaseNamePipe.transform(summary.version);
+          this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/dashboard/#enabling-iscsi-management`;
+          this.status = result.message;
+        });
       }
     });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-create-modal/bootstrap-create-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-create-modal/bootstrap-create-modal.component.ts
@@ -55,11 +55,7 @@ export class BootstrapCreateModalComponent implements OnDestroy, OnInit {
       this.createBootstrapForm.get('siteName').setValue(response.site_name);
     });
 
-    this.subs = this.rbdMirroringService.subscribeSummary((data: any) => {
-      if (!data) {
-        return;
-      }
-
+    this.subs = this.rbdMirroringService.subscribeSummary((data) => {
       const pools = data.content_data.pools;
       this.pools = pools.reduce((acc: any[], pool: Pool) => {
         acc.push({

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-import-modal/bootstrap-import-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-import-modal/bootstrap-import-modal.component.ts
@@ -62,11 +62,7 @@ export class BootstrapImportModalComponent implements OnInit, OnDestroy {
       this.importBootstrapForm.get('siteName').setValue(response.site_name);
     });
 
-    this.subs = this.rbdMirroringService.subscribeSummary((data: any) => {
-      if (!data) {
-        return;
-      }
-
+    this.subs = this.rbdMirroringService.subscribeSummary((data) => {
       const pools = data.content_data.pools;
       this.pools = pools.reduce((acc: any[], pool: Pool) => {
         acc.push({

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/daemon-list/daemon-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/daemon-list/daemon-list.component.ts
@@ -45,10 +45,7 @@ export class DaemonListComponent implements OnInit, OnDestroy {
       }
     ];
 
-    this.subs = this.rbdMirroringService.subscribeSummary((data: any) => {
-      if (!data) {
-        return;
-      }
+    this.subs = this.rbdMirroringService.subscribeSummary((data) => {
       this.data = data.content_data.daemons;
     });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.ts
@@ -77,10 +77,7 @@ export class ImageListComponent implements OnInit, OnDestroy {
       }
     ];
 
-    this.subs = this.rbdMirroringService.subscribeSummary((data: any) => {
-      if (!data) {
-        return;
-      }
+    this.subs = this.rbdMirroringService.subscribeSummary((data) => {
       this.image_error.data = data.content_data.image_error;
       this.image_syncing.data = data.content_data.image_syncing;
       this.image_ready.data = data.content_data.image_ready;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.ts
@@ -67,10 +67,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.subs.add(this.rbdMirroringService.startPolling());
     this.subs.add(
-      this.rbdMirroringService.subscribeSummary((data: any) => {
-        if (!data) {
-          return;
-        }
+      this.rbdMirroringService.subscribeSummary((data) => {
         this.status = data.content_data.status;
         this.siteName = data.site_name;
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.ts
@@ -59,12 +59,8 @@ export class PoolEditModeModalComponent implements OnInit, OnDestroy {
       this.setResponse(resp);
     });
 
-    this.subs = this.rbdMirroringService.subscribeSummary((data: any) => {
+    this.subs = this.rbdMirroringService.subscribeSummary((data) => {
       this.peerExists = false;
-      if (!data) {
-        return;
-      }
-
       const poolData = data.content_data.pools;
       const pool = poolData.find((o: any) => this.poolName === o['name']);
       this.peerExists = pool && pool['peer_uuids'].length;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-list/pool-list.component.ts
@@ -94,10 +94,7 @@ export class PoolListComponent implements OnInit, OnDestroy {
       }
     ];
 
-    this.subs = this.rbdMirroringService.subscribeSummary((data: any) => {
-      if (!data) {
-        return;
-      }
+    this.subs = this.rbdMirroringService.subscribeSummary((data) => {
       this.data = data.content_data.pools;
     });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.spec.ts
@@ -17,6 +17,7 @@ import {
 import { RbdService } from '../../../shared/api/rbd.service';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { ExecutingTask } from '../../../shared/models/executing-task';
+import { Summary } from '../../../shared/models/summary.model';
 import { SummaryService } from '../../../shared/services/summary.service';
 import { TaskListService } from '../../../shared/services/task-list.service';
 import { SharedModule } from '../../../shared/shared.module';
@@ -57,7 +58,7 @@ describe('RbdTrashListComponent', () => {
   it('should load trash images when summary is trigged', () => {
     spyOn(rbdService, 'listTrash').and.callThrough();
 
-    summaryService['summaryDataSource'].next({ executingTasks: null });
+    summaryService['summaryDataSource'].next(new Summary());
     expect(rbdService.listTrash).toHaveBeenCalled();
   });
 
@@ -91,7 +92,7 @@ describe('RbdTrashListComponent', () => {
       addImage('1');
       addImage('2');
       component.images = images;
-      summaryService['summaryDataSource'].next({ executingTasks: [] });
+      summaryService['summaryDataSource'].next(new Summary());
       spyOn(rbdService, 'listTrash').and.callFake(() =>
         of([{ pool_name: 'rbd', status: 1, value: images }])
       );
@@ -125,7 +126,7 @@ describe('RbdTrashListComponent', () => {
     };
 
     beforeEach(() => {
-      summaryService['summaryDataSource'].next({ executingTasks: [] });
+      summaryService['summaryDataSource'].next(new Summary());
       spyOn(rbdService, 'listTrash').and.callFake(() => {
         of([{ pool_name: 'rbd', status: 1, value: images }]);
       });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/monitoring-list/monitoring-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/monitoring-list/monitoring-list.component.ts
@@ -38,17 +38,9 @@ export class MonitoringListComponent implements OnInit {
       this.isPrometheusConfigured = true;
     });
 
-    const subs = this.summaryService.subscribe((summary: any) => {
-      if (!summary) {
-        return;
-      }
-
+    this.summaryService.subscribeOnce((summary) => {
       const releaseName = this.cephReleaseNamePipe.transform(summary.version);
       this.docsUrl = `https://docs.ceph.com/docs/${releaseName}/mgr/dashboard/#enabling-prometheus-alerting`;
-
-      setTimeout(() => {
-        subs.unsubscribe();
-      }, 0);
     });
 
     // Activate tab according to given fragment

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-details/service-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-details/service-details.component.spec.ts
@@ -18,7 +18,15 @@ describe('ServiceDetailsComponent', () => {
   configureTestBed({
     imports: [HttpClientTestingModule, RouterTestingModule, TabsModule.forRoot(), SharedModule],
     declarations: [ServiceDetailsComponent, ServiceDaemonListComponent],
-    providers: [i18nProviders, { provide: SummaryService, useValue: { subscribe: jest.fn() } }]
+    providers: [
+      i18nProviders,
+      {
+        provide: SummaryService,
+        useValue: {
+          subscribeOnce: jest.fn()
+        }
+      }
+    ]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-501/nfs-501.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-501/nfs-501.component.ts
@@ -24,19 +24,11 @@ export class Nfs501Component implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    const subs = this.summaryService.subscribe((summary: any) => {
-      if (!summary) {
-        return;
-      }
-
+    this.summaryService.subscribeOnce((summary) => {
       const releaseName = this.cephReleaseNamePipe.transform(summary.version);
       this.docsUrl =
         `http://docs.ceph.com/docs/${releaseName}/mgr/dashboard/` +
         `#configuring-nfs-ganesha-in-the-dashboard`;
-
-      setTimeout(() => {
-        subs.unsubscribe();
-      }, 0);
     });
 
     this.routeParamsSubscribe = this.route.params.subscribe((params: { message: string }) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -6,6 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
 import { ToastrModule } from 'ngx-toastr';
+import { of } from 'rxjs';
 
 import { ActivatedRouteStub } from '../../../../testing/activated-route-stub';
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
@@ -45,11 +46,11 @@ describe('NfsFormComponent', () => {
   beforeEach(() => {
     const summaryService = TestBed.get(SummaryService);
     spyOn(summaryService, 'refresh').and.callFake(() => true);
-    spyOn(summaryService, 'getCurrentSummary').and.callFake(() => {
-      return {
+    spyOn(summaryService, 'subscribeOnce').and.callFake(() =>
+      of({
         version: 'master'
-      };
-    });
+      })
+    );
 
     fixture = TestBed.createComponent(NfsFormComponent);
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -125,9 +125,10 @@ export class NfsFormComponent extends CdForm implements OnInit {
       this.getData(promises);
     }
 
-    const summary = this.summaryservice.getCurrentSummary();
-    const releaseName = this.cephReleaseNamePipe.transform(summary.version);
-    this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/radosgw/nfs/`;
+    this.summaryservice.subscribeOnce((summary) => {
+      const releaseName = this.cephReleaseNamePipe.transform(summary.version);
+      this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/radosgw/nfs/`;
+    });
   }
 
   getData(promises: Observable<any>[]) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.spec.ts
@@ -16,6 +16,7 @@ import {
 import { NfsService } from '../../../shared/api/nfs.service';
 import { TableActionsComponent } from '../../../shared/datatable/table-actions/table-actions.component';
 import { ExecutingTask } from '../../../shared/models/executing-task';
+import { Summary } from '../../../shared/models/summary.model';
 import { SummaryService } from '../../../shared/services/summary.service';
 import { TaskListService } from '../../../shared/services/task-list.service';
 import { SharedModule } from '../../../shared/shared.module';
@@ -29,7 +30,7 @@ describe('NfsListComponent', () => {
   let nfsService: NfsService;
   let httpTesting: HttpTestingController;
 
-  const refresh = (data: object) => {
+  const refresh = (data: Summary) => {
     summaryService['summaryDataSource'].next(data);
   };
 
@@ -70,7 +71,7 @@ describe('NfsListComponent', () => {
     });
 
     it('should load exports on init', () => {
-      refresh({});
+      refresh(new Summary());
       httpTesting.expectOne('api/nfs-ganesha/export');
       expect(nfsService.list).toHaveBeenCalled();
     });
@@ -127,7 +128,7 @@ describe('NfsListComponent', () => {
       addExport('b');
       addExport('c');
       component.exports = exports;
-      refresh({ executing_tasks: [], finished_tasks: [] });
+      refresh(new Summary());
       spyOn(nfsService, 'list').and.callFake(() => of(exports));
       fixture.detectChanges();
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -199,7 +199,10 @@ describe('PoolListComponent', () => {
 
     beforeEach(() => {
       summaryService = TestBed.get(SummaryService);
-      summaryService['summaryDataSource'].next({ executing_tasks: [], finished_tasks: [] });
+      summaryService['summaryDataSource'].next({
+        executing_tasks: [],
+        finished_tasks: []
+      });
     });
 
     it('gets all pools without executing pools', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-501/rgw-501.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-501/rgw-501.component.ts
@@ -21,19 +21,11 @@ export class Rgw501Component implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    const subs = this.summaryService.subscribe((summary: any) => {
-      if (!summary) {
-        return;
-      }
-
+    this.summaryService.subscribeOnce((summary) => {
       const releaseName = this.cephReleaseNamePipe.transform(summary.version);
       this.docsUrl =
         `http://docs.ceph.com/docs/${releaseName}/mgr/dashboard/` +
         `#enabling-the-object-gateway-management-frontend`;
-
-      setTimeout(() => {
-        subs.unsubscribe();
-      }, 0);
     });
 
     this.routeParamsSubscribe = this.route.params.subscribe((params: { message: string }) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/about/about.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/about/about.component.ts
@@ -40,10 +40,7 @@ export class AboutComponent implements OnInit, OnDestroy {
     this.projectConstants = AppConstants;
     this.hostAddr = window.location.hostname;
     this.modalVariables = this.setVariables();
-    this.subs = this.summaryService.subscribe((summary: any) => {
-      if (!summary) {
-        return;
-      }
+    this.subs = this.summaryService.subscribe((summary) => {
       const version = summary.version.replace('ceph version ', '').split(' ');
       this.hostAddr = summary.mgr_host.replace(/(^\w+:|^)\/\//, '').replace(/\/$/, '');
       this.versionNumber = version[0];

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.ts
@@ -28,17 +28,9 @@ export class DashboardHelpComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    const subs = this.summaryService.subscribe((summary: any) => {
-      if (!summary) {
-        return;
-      }
-
+    this.summaryService.subscribeOnce((summary) => {
       const releaseName = this.cephReleaseNamePipe.transform(summary.version);
       this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/dashboard/`;
-
-      setTimeout(() => {
-        subs.unsubscribe();
-      }, 0);
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
@@ -46,11 +46,8 @@ export class NavigationComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.subs.add(
-      this.summaryService.subscribe((data: any) => {
-        if (!data) {
-          return;
-        }
-        this.summaryData = data;
+      this.summaryService.subscribe((summary) => {
+        this.summaryData = summary;
       })
     );
     this.subs.add(

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.ts
@@ -23,11 +23,8 @@ export class NotificationsComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.subs.add(
-      this.summaryService.subscribe((data: any) => {
-        if (!data) {
-          return;
-        }
-        this.hasRunningTasks = data.executing_tasks.length > 0;
+      this.summaryService.subscribe((summary) => {
+        this.hasRunningTasks = summary.executing_tasks.length > 0;
       })
     );
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd-mirroring.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd-mirroring.service.spec.ts
@@ -59,7 +59,7 @@ describe('RbdMirroringService', () => {
     const subs = service.startPolling();
     tick();
     const calledWith: any[] = [];
-    service.subscribeSummary((data: any) => {
+    service.subscribeSummary((data) => {
       calledWith.push(data);
     });
     tick(service.REFRESH_INTERVAL * 2);
@@ -67,22 +67,10 @@ describe('RbdMirroringService', () => {
 
     expect(calls.length).toEqual(3);
     calls.forEach((call: TestRequest) => flushCalls(call));
-    expect(calledWith).toEqual([null, summary]);
+    expect(calledWith).toEqual([summary]);
 
     subs.unsubscribe();
   }));
-
-  it('should get current summary', () => {
-    service.refresh();
-    const calledWith: any[] = [];
-    service.subscribeSummary((data: any) => {
-      calledWith.push(data);
-    });
-    const calls = getMirroringSummaryCalls();
-    calls.forEach((call: TestRequest) => flushCalls(call));
-
-    expect(service.getCurrentSummary()).toEqual(summary);
-  });
 
   it('should get pool config', () => {
     service.getPool('poolName').subscribe();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
@@ -179,20 +179,13 @@ export class GrafanaComponent implements OnInit, OnChanges {
       three: 'grafana_three'
     };
 
-    const subs = this.summaryService.subscribe((summary: any) => {
-      if (!summary) {
-        return;
-      }
-
+    this.summaryService.subscribeOnce((summary) => {
       const releaseName = this.cephReleaseNamePipe.transform(summary.version);
       this.docsUrl =
         `http://docs.ceph.com/docs/${releaseName}/mgr/dashboard/` +
         `#enabling-the-embedding-of-grafana-dashboards`;
-
-      setTimeout(() => {
-        subs.unsubscribe();
-      }, 0);
     });
+
     this.settingsService.ifSettingConfigured('api/grafana/url', (url) => {
       this.grafanaExist = true;
       this.loading = false;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.ts
@@ -108,15 +108,12 @@ export class NotificationsSidebarComponent implements OnInit, OnDestroy {
     );
 
     this.subs.add(
-      this.summaryService.subscribe((data: any) => {
-        if (!data) {
-          return;
-        }
-        this._handleTasks(data.executing_tasks);
+      this.summaryService.subscribe((summary) => {
+        this._handleTasks(summary.executing_tasks);
 
         this.mutex.acquire().then((release) => {
           _.filter(
-            data.finished_tasks,
+            summary.finished_tasks,
             (task: FinishedTask) => !this.last_task || moment(task.end_time).isAfter(this.last_task)
           ).forEach((task) => {
             const config = this.notificationService.finishedTaskToNotification(task, task.success);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-panel/orchestrator-doc-panel.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/orchestrator-doc-panel/orchestrator-doc-panel.component.ts
@@ -17,17 +17,9 @@ export class OrchestratorDocPanelComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    const subs = this.summaryService.subscribe((summary: any) => {
-      if (!summary) {
-        return;
-      }
-
+    this.summaryService.subscribeOnce((summary) => {
       const releaseName = this.cephReleaseNamePipe.transform(summary.version);
       this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/orchestrator/`;
-
-      setTimeout(() => {
-        subs.unsubscribe();
-      }, 0);
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/finished-task.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/finished-task.ts
@@ -2,8 +2,8 @@ import { Task } from './task';
 import { TaskException } from './task-exception';
 
 export class FinishedTask extends Task {
-  begin_time: number;
-  end_time: number;
+  begin_time: string;
+  end_time: string;
   exception: TaskException;
   latency: number;
   progress: number;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/mirroring-summary.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/mirroring-summary.ts
@@ -1,0 +1,4 @@
+export interface MirroringSummary {
+  content_data?: any;
+  site_name?: any;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/summary.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/summary.model.ts
@@ -1,0 +1,15 @@
+import { ExecutingTask } from './executing-task';
+import { FinishedTask } from './finished-task';
+
+export class Summary {
+  executing_tasks?: ExecutingTask[];
+  filesystems?: any[];
+  finished_tasks?: FinishedTask[];
+  have_mon_connection?: boolean;
+  health_status?: string;
+  mgr_host?: string;
+  mgr_id?: string;
+  rbd_mirroring?: any;
+  rbd_pools?: any[];
+  version?: string;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
@@ -6,6 +6,7 @@ import { of as observableOf, Subscriber, Subscription } from 'rxjs';
 
 import { configureTestBed } from '../../../testing/unit-test-helper';
 import { ExecutingTask } from '../models/executing-task';
+import { Summary } from '../models/summary.model';
 import { AuthStorageService } from './auth-storage.service';
 import { SummaryService } from './summary.service';
 
@@ -14,7 +15,7 @@ describe('SummaryService', () => {
   let authStorageService: AuthStorageService;
   let subs: Subscription;
 
-  const summary: Record<string, any> = {
+  const summary: Summary = {
     executing_tasks: [],
     health_status: 'HEALTH_OK',
     mgr_id: 'x',
@@ -28,6 +29,8 @@ describe('SummaryService', () => {
   const httpClientSpy = {
     get: () => observableOf(summary)
   };
+
+  const nextSummary = (newData: any) => summaryService['summaryDataSource'].next(newData);
 
   configureTestBed({
     imports: [RouterTestingModule],
@@ -66,23 +69,71 @@ describe('SummaryService', () => {
     subs.unsubscribe();
   }));
 
+  describe('Should test subscribe without initial value', () => {
+    let result: Summary;
+    let i: number;
+
+    const callback = (response: Summary) => {
+      i++;
+      result = response;
+    };
+
+    beforeEach(() => {
+      i = 0;
+      result = undefined;
+      nextSummary(undefined);
+    });
+
+    it('should call subscribeOnce', () => {
+      const subscriber = summaryService.subscribeOnce(callback);
+
+      expect(subscriber).toEqual(jasmine.any(Subscriber));
+      expect(i).toBe(0);
+      expect(result).toEqual(undefined);
+
+      nextSummary(undefined);
+      expect(i).toBe(0);
+      expect(result).toEqual(undefined);
+      expect(subscriber.closed).toBe(false);
+
+      nextSummary(summary);
+      expect(result).toEqual(summary);
+      expect(i).toBe(1);
+      expect(subscriber.closed).toBe(true);
+
+      nextSummary(summary);
+      expect(result).toEqual(summary);
+      expect(i).toBe(1);
+    });
+
+    it('should call subscribe', () => {
+      const subscriber = summaryService.subscribe(callback);
+
+      expect(subscriber).toEqual(jasmine.any(Subscriber));
+      expect(i).toBe(0);
+      expect(result).toEqual(undefined);
+
+      nextSummary(undefined);
+      expect(i).toBe(0);
+      expect(result).toEqual(undefined);
+      expect(subscriber.closed).toBe(false);
+
+      nextSummary(summary);
+      expect(result).toEqual(summary);
+      expect(i).toBe(1);
+      expect(subscriber.closed).toBe(false);
+
+      nextSummary(summary);
+      expect(result).toEqual(summary);
+      expect(i).toBe(2);
+      expect(subscriber.closed).toBe(false);
+    });
+  });
+
   describe('Should test methods after first refresh', () => {
     beforeEach(() => {
       authStorageService.set('foobar', undefined, undefined);
       summaryService.refresh();
-    });
-
-    it('should call getCurrentSummary', () => {
-      expect(summaryService.getCurrentSummary()).toEqual(summary);
-    });
-
-    it('should call subscribe', () => {
-      let result;
-      const subscriber = summaryService.subscribe((data) => {
-        result = data;
-      });
-      expect(subscriber).toEqual(jasmine.any(Subscriber));
-      expect(result).toEqual(summary);
     });
 
     it('should call addRunningTask', () => {
@@ -92,7 +143,11 @@ describe('SummaryService', () => {
           image_name: 'someImage'
         })
       );
-      const result = summaryService.getCurrentSummary();
+      let result: any;
+      summaryService.subscribeOnce((response) => {
+        result = response;
+      });
+
       expect(result.executing_tasks.length).toBe(1);
       expect(result.executing_tasks[0]).toEqual({
         metadata: { image_name: 'someImage', pool_name: 'somePool' },
@@ -101,19 +156,23 @@ describe('SummaryService', () => {
     });
 
     it('should call addRunningTask with duplicate task', () => {
-      let result = summaryService.getCurrentSummary();
+      let result: any;
+      summaryService.subscribe((response) => {
+        result = response;
+      });
+
       const exec_task = new ExecutingTask('rbd/delete', {
         pool_name: 'somePool',
         image_name: 'someImage'
       });
 
       result.executing_tasks = [exec_task];
-      summaryService['summaryDataSource'].next(result);
-      result = summaryService.getCurrentSummary();
+      nextSummary(result);
+
       expect(result.executing_tasks.length).toBe(1);
 
       summaryService.addRunningTask(exec_task);
-      result = summaryService.getCurrentSummary();
+
       expect(result.executing_tasks.length).toBe(1);
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
@@ -3,8 +3,10 @@ import { Injectable } from '@angular/core';
 
 import * as _ from 'lodash';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { filter, first } from 'rxjs/operators';
 
 import { ExecutingTask } from '../models/executing-task';
+import { Summary } from '../models/summary.model';
 import { TimerService } from './timer.service';
 
 @Injectable({
@@ -13,7 +15,7 @@ import { TimerService } from './timer.service';
 export class SummaryService {
   readonly REFRESH_INTERVAL = 5000;
   // Observable sources
-  private summaryDataSource = new BehaviorSubject(null);
+  private summaryDataSource = new BehaviorSubject<Summary>(null);
   // Observable streams
   summaryData$ = this.summaryDataSource.asObservable();
 
@@ -29,29 +31,35 @@ export class SummaryService {
     return this.retrieveSummaryObservable().subscribe(this.retrieveSummaryObserver());
   }
 
-  private retrieveSummaryObservable(): Observable<Object> {
-    return this.http.get('api/summary');
+  private retrieveSummaryObservable(): Observable<Summary> {
+    return this.http.get<Summary>('api/summary');
   }
 
-  private retrieveSummaryObserver(): (data: any) => void {
-    return (data: Object) => {
+  private retrieveSummaryObserver(): (data: Summary) => void {
+    return (data: Summary) => {
       this.summaryDataSource.next(data);
     };
   }
 
   /**
-   * Returns the current value of summaryData
+   * Subscribes to the summaryData and receive only the first, non undefined, value.
    */
-  getCurrentSummary(): { [key: string]: any; executing_tasks: object[] } {
-    return this.summaryDataSource.getValue();
+  subscribeOnce(next: (summary: Summary) => void, error?: (error: any) => void): Subscription {
+    return this.summaryData$
+      .pipe(
+        filter((value) => !!value),
+        first()
+      )
+      .subscribe(next, error);
   }
 
   /**
    * Subscribes to the summaryData,
    * which is updated periodically or when a new task is created.
+   * Will receive only non undefined values.
    */
-  subscribe(next: (summary: any) => void, error?: (error: any) => void): Subscription {
-    return this.summaryData$.subscribe(next, error);
+  subscribe(next: (summary: Summary) => void, error?: (error: any) => void): Subscription {
+    return this.summaryData$.pipe(filter((value) => !!value)).subscribe(next, error);
   }
 
   /**

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.ts
@@ -56,12 +56,10 @@ export class TaskListService implements OnDestroy {
     this.itemFilter = itemFilter;
     this.builders = builders || {};
 
-    this.summaryDataSubscription = this.summaryService.subscribe((tasks: any) => {
-      if (tasks) {
-        this.getUpdate().subscribe((resp: any) => {
-          this.updateData(resp, tasks.executing_tasks.filter(this.taskFilter));
-        }, this.onFetchError);
-      }
+    this.summaryDataSubscription = this.summaryService.subscribe((summary) => {
+      this.getUpdate().subscribe((resp: any) => {
+        this.updateData(resp, summary['executing_tasks'].filter(this.taskFilter));
+      }, this.onFetchError);
     }, this.onFetchError);
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager.service.ts
@@ -26,12 +26,9 @@ export class TaskManagerService {
   subscriptions: Array<TaskSubscription> = [];
 
   init(summaryService: SummaryService) {
-    return summaryService.subscribe((data: any) => {
-      if (!data) {
-        return;
-      }
-      const executingTasks = data.executing_tasks;
-      const finishedTasks = data.finished_tasks;
+    return summaryService.subscribe((summary) => {
+      const executingTasks = summary.executing_tasks;
+      const finishedTasks = summary.finished_tasks;
       const newSubscriptions: Array<TaskSubscription> = [];
       for (const subscription of this.subscriptions) {
         const finishedTask = <FinishedTask>this._getTask(subscription, finishedTasks);


### PR DESCRIPTION
Now subscribe only emits if the value is not undefined,
removing the need to do the validation after each subscribe.

Add a new subscribeOnce method, which replaces getCurrentSummary.
Like the previous one, this will only emit when there is a non undefined value,
and will only emit once.
After it emits, the subscription is closed automatically.

Fixes: https://tracker.ceph.com/issues/36563

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
