### PR TITLE
qa/tasks/cephfs/mount.py: skip saving/restoring the previous value for ip_forward

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -119,18 +119,6 @@ class CephFSMount(object):
                     "ip addr add {0}/{1} brd {2} dev ceph-brx".format(ip, mask, brd)]
             self.client_remote.run(args=args, timeout=(5*60))
         
-        # Save the ip_forward's old value
-        save_path = "/tmp/python-ceph-brx"
-        if not os.path.exists(save_path):
-            self.client_remote.run(args=['touch', save_path], timeout=(5*60))
-            p = self.client_remote.run(args=['cat', '/proc/sys/net/ipv4/ip_forward'],
-                                       stderr=StringIO(), stdout=StringIO(),
-                                       timeout=(5*60))
-            val = p.stdout.getvalue().strip()
-            args = ["sudo", "bash", "-c",
-                    "echo {0} > {1}".format(val, save_path)]
-            self.client_remote.run(args=args, timeout=(5*60))
-
         args = ["sudo", "bash", "-c",
                 "echo 1 > /proc/sys/net/ipv4/ip_forward"]
         self.client_remote.run(args=args, timeout=(5*60))
@@ -302,18 +290,6 @@ class CephFSMount(object):
         args = ["sudo", "bash", "-c",
                 "iptables -t nat -D POSTROUTING -s {0}/{1} -o {2} -j MASQUERADE".format(ip, mask, gw)]
         self.client_remote.run(args=args, timeout=(5*60))
-
-        # Restore the ip_forward
-        save_path = "/tmp/python-ceph-brx"
-        p = self.client_remote.run(args=['cat', save_path],
-                                   stderr=StringIO(), stdout=StringIO(),
-                                   timeout=(5*60))
-        val = p.stdout.getvalue().strip()
-        args = ["sudo", "bash", "-c",
-                "echo {} > /proc/sys/net/ipv4/ip_forward".format(val)]
-        self.client_remote.run(args=args, timeout=(5*60))
-        self.client_remote.run(args=['rm', '-f', save_path],
-                               timeout=(5*60))
 
     def setup_netns(self):
         """


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/45525
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
