### PR TITLE
qa/cephfs: install iptables package and remove network-manager

### DIFF
--- a/qa/cephfs/begin.yaml
+++ b/qa/cephfs/begin.yaml
@@ -13,7 +13,8 @@ tasks:
         - flex
         - libelf-dev
         - libssl-dev
-        - network-manager
+        - iptables
+        - nftables
         - iproute2
         - util-linux
         # for xfstests-dev
@@ -29,7 +30,8 @@ tasks:
         - flex
         - elfutils-libelf-devel
         - openssl-devel
-        - NetworkManager
+        - iptables
+        - nftables
         - iproute
         - util-linux
         # for xfstests-dev

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -86,11 +86,6 @@ class CephFSMount(object):
         self.fs.wait_for_daemons()
         log.info('Ready to start {}...'.format(type(self).__name__))
 
-    def _bringup_network_manager_service(self):
-        args = ["sudo", "bash", "-c",
-                "systemctl start NetworkManager"]
-        self.client_remote.run(args=args, timeout=(5*60))
-
     def _setup_brx_and_nat(self):
         # The ip for ceph-brx should be
         ip = IP(self.ceph_brx_net)[-2]


### PR DESCRIPTION
Since will use ip command to setup the bridge, there will be no
dependency to network manager package.

Fixes: https://tracker.ceph.com/issues/45531
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
