### PR TITLE
doc: fix TCMalloc spelling

### DIFF
--- a/doc/rados/configuration/bluestore-config-ref.rst
+++ b/doc/rados/configuration/bluestore-config-ref.rst
@@ -141,7 +141,7 @@ automatically manage these within the space of ``block``.
 Automatic Cache Sizing
 ======================
 
-Bluestore can be configured to automatically resize it's caches when tc_malloc
+Bluestore can be configured to automatically resize it's caches when TCMalloc
 is configured as the memory allocator and the ``bluestore_cache_autotune``
 setting is enabled.  This option is currently enabled by default.  Bluestore
 will attempt to keep OSD heap memory usage under a designated target size via


### PR DESCRIPTION
The google/tcmalloc page on GitHub refers to "TCMalloc", not
"tc_malloc".

Signed-off-by: Nathan Cutler <ncutler@suse.com>