### PR TITLE
For the list object function, we modified the type of objects' size

### DIFF
--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -837,6 +837,7 @@ protected:
   int max;
   vector<rgw_bucket_dir_entry> objs;
   map<string, bool> common_prefixes;
+  int size_around;
 
   int default_max;
   bool is_truncated;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -838,7 +838,6 @@ protected:
   vector<rgw_bucket_dir_entry> objs;
   map<string, bool> common_prefixes;
   int size_around;
-
   int default_max;
   bool is_truncated;
   bool allow_unordered;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1511,6 +1511,12 @@ void RGWListBucket_ObjStore_S3::send_versioned_response()
       if (!iter->is_delete_marker()) {
         s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
         s->formatter->dump_int("Size", iter->meta.accounted_size);
+        if((iter->meta.accounted_size) % 4096 != 0){
+          size_around = (((iter->meta.accounted_size)/4096)+1) * 4096;
+        }else{
+          size_around = iter->meta.accounted_size;
+        }
+        s->formatter->dump_int("Size_Around", size_around);
         auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
         s->formatter->dump_string("StorageClass", storage_class.c_str());
       }
@@ -1600,6 +1606,12 @@ void RGWListBucket_ObjStore_S3::send_response()
         dump_time(s, "LastModified", &iter->meta.mtime);
         s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
         s->formatter->dump_int("Size", iter->meta.accounted_size);
+        if((iter->meta.accounted_size) % 4096 != 0){
+          size_around = (((iter->meta.accounted_size)/4096)+1) * 4096;
+        }else{
+          size_around = iter->meta.accounted_size;
+        }
+        s->formatter->dump_int("Size_Around", size_around);
         auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
         s->formatter->dump_string("StorageClass", storage_class.c_str());
         dump_owner(s, rgw_user(iter->meta.owner), iter->meta.owner_display_name);
@@ -1678,6 +1690,12 @@ void RGWListBucket_ObjStore_S3v2::send_versioned_response()
       if (!iter->is_delete_marker()) {
         s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
         s->formatter->dump_int("Size", iter->meta.accounted_size);
+        if((iter->meta.accounted_size) % 4096 != 0){
+          size_around = (((iter->meta.accounted_size)/4096)+1) * 4096;
+        }else{
+          size_around = iter->meta.accounted_size;
+        }
+        s->formatter->dump_int("Size_Around", size_around);
         auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
         s->formatter->dump_string("StorageClass", storage_class.c_str());
       }
@@ -1758,6 +1776,12 @@ void RGWListBucket_ObjStore_S3v2::send_response()
       dump_time(s, "LastModified", &iter->meta.mtime);
       s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
       s->formatter->dump_int("Size", iter->meta.accounted_size);
+      if((iter->meta.accounted_size) % 4096 != 0){
+          size_around = (((iter->meta.accounted_size)/4096)+1) * 4096;
+        }else{
+          size_around = iter->meta.accounted_size;
+        }
+        s->formatter->dump_int("Size_Around", size_around);
       auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
       s->formatter->dump_string("StorageClass", storage_class.c_str());
       if (fetchOwner == true) {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1777,11 +1777,11 @@ void RGWListBucket_ObjStore_S3v2::send_response()
       s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
       s->formatter->dump_int("Size", iter->meta.accounted_size);
       if((iter->meta.accounted_size) % 4096 != 0){
-          size_around = (((iter->meta.accounted_size)/4096)+1) * 4096;
-        }else{
-          size_around = iter->meta.accounted_size;
-        }
-        s->formatter->dump_int("Size_Around", size_around);
+        size_around = (((iter->meta.accounted_size)/4096)+1) * 4096;
+      }else{
+        size_around = iter->meta.accounted_size;
+      }
+      s->formatter->dump_int("Size_Around", size_around);
       auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
       s->formatter->dump_string("StorageClass", storage_class.c_str());
       if (fetchOwner == true) {


### PR DESCRIPTION
Signed-off-by: 王迎彬 <wangyingbin@inspur.com>
After getting object size using list object function, we calculated the sum size of some objects (not all objects in the bucket). But after downloading, we found that there is a big discrepancy between the calculation result and the size displayed on the local computer, which caused many download failures. After research, it is found that the listed results is the size after alignment. So we add the Size_Around to show the size computer memory. Overall, adding Size_Around is very necessary.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
