### PR TITLE
nautilus: doc/rgw: document 'rgw gc max concurrent io'

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -218,6 +218,14 @@ instances or all radosgw-admin commands can be put into the ``[global]`` or the
 :Default: ``3600``
 
 
+``rgw gc max concurrent io``
+
+:Description: The maximum number of concurrent IO operations that the RGW garbage
+              collection thread will use when purging old data.
+:Type: Integer
+:Default: ``10``
+
+
 ``rgw s3 success create obj status``
 
 :Description: The alternate success status response for ``create-obj``.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45480

---

backport of https://github.com/ceph/ceph/pull/34952
parent tracker: https://tracker.ceph.com/issues/44958

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh