### PR TITLE
nautilus: qa/workunits/rbd: fix list-mapped filter in unmap_device

### DIFF
--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -109,7 +109,7 @@ unmap_device()
 
     for s in 0.5 1 2 4 8 16 32; do
 	sleep ${s}
-        rbd-nbd list-mapped | expect_false grep "${list_dev} $" && return 0
+        rbd-nbd list-mapped | expect_false grep "${list_dev} *$" && return 0
     done
     return 1
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45365

---

backport of https://github.com/ceph/ceph/pull/34787
parent tracker: https://tracker.ceph.com/issues/45305

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh