### PR TITLE
nautilus: test: Add flush_pg_stats to avoid race with getting num_shards_repaired

### DIFF
--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -607,6 +607,7 @@ function TEST_repair_stats() {
     repair $pgid
     wait_for_clean || return 1
     ceph pg dump pgs
+    flush_pg_stats
 
     # This should have caused 1 object to be repaired
     ceph pg $pgid query | jq '.info.stats.stat_sum'
@@ -680,6 +681,7 @@ function TEST_repair_stats_ec() {
     repair $pgid
     wait_for_clean || return 1
     ceph pg dump pgs
+    flush_pg_stats
 
     # This should have caused 1 object to be repaired
     ceph pg $pgid query | jq '.info.stats.stat_sum'


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44689

---

backport of https://github.com/ceph/ceph/pull/33776
parent tracker: https://tracker.ceph.com/issues/44439

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh