### PR TITLE
nautilus: qa: log warning on scrub error

### DIFF
--- a/qa/tasks/mon_thrash.py
+++ b/qa/tasks/mon_thrash.py
@@ -299,8 +299,8 @@ class MonitorThrasher:
                 self.log('triggering scrub')
                 try:
                     self.manager.raw_cluster_cmd('scrub')
-                except Exception:
-                    log.exception("Saw exception while triggering scrub")
+                except Exception as e:
+                    log.warning("Ignoring exception while triggering scrub: %s", e)
 
             if self.thrash_delay > 0.0:
                 self.log('waiting for {delay} secs before continuing thrashing'.format(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43773

---

backport of https://github.com/ceph/ceph/pull/32739
parent tracker: https://tracker.ceph.com/issues/43718

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh