### PR TITLE
mgr/dashboard: Use right size in pool form

### DIFF
--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -416,4 +416,5 @@ class PoolTest(DashboardTestCase):
             'erasure_code_profiles': JList(JObj({}, allow_unknown=True)),
             'used_rules': JObj({}, allow_unknown=True),
             'used_profiles': JObj({}, allow_unknown=True),
+            'nodes': JList(JObj({}, allow_unknown=True)),
         }))

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -262,4 +262,5 @@ class PoolUi(Pool):
             "erasure_code_profiles": profiles,
             "used_rules": used_rules,
             "used_profiles": used_profiles,
+            'nodes': mgr.get('osd_map_tree')['nodes']
         }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.spec.ts
@@ -11,7 +11,8 @@ import {
   configureTestBed,
   FixtureHelper,
   FormHelper,
-  i18nProviders
+  i18nProviders,
+  Mocks
 } from '../../../../testing/unit-test-helper';
 import { CrushRuleService } from '../../../shared/api/crush-rule.service';
 import { CrushNode } from '../../../shared/models/crush-node';
@@ -27,31 +28,6 @@ describe('CrushRuleFormComponent', () => {
   let formHelper: FormHelper;
   let fixtureHelper: FixtureHelper;
   let data: { names: string[]; nodes: CrushNode[] };
-
-  // Object contains mock functions
-  const mock = {
-    node: (
-      name: string,
-      id: number,
-      type: string,
-      type_id: number,
-      children?: number[],
-      device_class?: string
-    ): CrushNode => {
-      return { name, type, type_id, id, children, device_class };
-    },
-    rule: (
-      name: string,
-      root: string,
-      failure_domain: string,
-      device_class?: string
-    ): CrushRuleConfig => ({
-      name,
-      root,
-      failure_domain,
-      device_class
-    })
-  };
 
   // Object contains functions to get something
   const get = {
@@ -125,25 +101,7 @@ describe('CrushRuleFormComponent', () => {
        * ----> ssd-rack
        * ------> 2x osd-rack with ssd
        */
-      nodes: [
-        // Root node
-        mock.node('default', -1, 'root', 11, [-2, -3]),
-        // SSD host
-        mock.node('ssd-host', -2, 'host', 1, [1, 0, 2]),
-        mock.node('osd.0', 0, 'osd', 0, undefined, 'ssd'),
-        mock.node('osd.1', 1, 'osd', 0, undefined, 'ssd'),
-        mock.node('osd.2', 2, 'osd', 0, undefined, 'ssd'),
-        // SSD and HDD mixed devices host
-        mock.node('mix-host', -3, 'host', 1, [-4, -5]),
-        // HDD rack
-        mock.node('hdd-rack', -4, 'rack', 3, [3, 4]),
-        mock.node('osd2.0', 3, 'osd-rack', 0, undefined, 'hdd'),
-        mock.node('osd2.1', 4, 'osd-rack', 0, undefined, 'hdd'),
-        // SSD rack
-        mock.node('ssd-rack', -5, 'rack', 3, [5, 6]),
-        mock.node('osd2.0', 5, 'osd-rack', 0, undefined, 'ssd'),
-        mock.node('osd2.1', 6, 'osd-rack', 0, undefined, 'ssd')
-      ]
+      nodes: Mocks.getCrushMap()
     };
     spyOn(crushRuleService, 'getInfo').and.callFake(() => of(data));
     fixture.detectChanges();
@@ -254,12 +212,12 @@ describe('CrushRuleFormComponent', () => {
     });
 
     it('creates a rule with only required fields', () => {
-      assert.creation(mock.rule('default-rule', 'default', 'osd-rack'));
+      assert.creation(Mocks.getCrushRuleConfig('default-rule', 'default', 'osd-rack'));
     });
 
     it('creates a rule with all fields', () => {
       assert.valuesOnRootChange('ssd-host', 'osd', 'ssd');
-      assert.creation(mock.rule('ssd-host-rule', 'ssd-host', 'osd', 'ssd'));
+      assert.creation(Mocks.getCrushRuleConfig('ssd-host-rule', 'ssd-host', 'osd', 'ssd'));
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.spec.ts
@@ -12,10 +12,10 @@ import {
   configureTestBed,
   FixtureHelper,
   FormHelper,
-  i18nProviders
+  i18nProviders,
+  Mocks
 } from '../../../../testing/unit-test-helper';
 import { ErasureCodeProfileService } from '../../../shared/api/erasure-code-profile.service';
-import { CrushNode } from '../../../shared/models/crush-node';
 import { ErasureCodeProfile } from '../../../shared/models/erasure-code-profile';
 import { TaskWrapperService } from '../../../shared/services/task-wrapper.service';
 import { PoolModule } from '../pool.module';
@@ -28,20 +28,6 @@ describe('ErasureCodeProfileFormModalComponent', () => {
   let formHelper: FormHelper;
   let fixtureHelper: FixtureHelper;
   let data: {};
-
-  // Object contains mock functions
-  const mock = {
-    node: (
-      name: string,
-      id: number,
-      type: string,
-      type_id: number,
-      children?: number[],
-      device_class?: string
-    ): CrushNode => {
-      return { name, type, type_id, id, children, device_class };
-    }
-  };
 
   configureTestBed({
     imports: [
@@ -70,34 +56,34 @@ describe('ErasureCodeProfileFormModalComponent', () => {
        * ----> 3x osd with ssd
        * --> mix-host
        * ----> hdd-rack
-       * ------> 2x osd-rack with hdd
+       * ------> 5x osd-rack with hdd
        * ----> ssd-rack
-       * ------> 2x osd-rack with ssd
+       * ------> 5x osd-rack with ssd
        */
       nodes: [
         // Root node
-        mock.node('default', -1, 'root', 11, [-2, -3]),
+        Mocks.getCrushNode('default', -1, 'root', 11, [-2, -3]),
         // SSD host
-        mock.node('ssd-host', -2, 'host', 1, [1, 0, 2]),
-        mock.node('osd.0', 0, 'osd', 0, undefined, 'ssd'),
-        mock.node('osd.1', 1, 'osd', 0, undefined, 'ssd'),
-        mock.node('osd.2', 2, 'osd', 0, undefined, 'ssd'),
+        Mocks.getCrushNode('ssd-host', -2, 'host', 1, [1, 0, 2]),
+        Mocks.getCrushNode('osd.0', 0, 'osd', 0, undefined, 'ssd'),
+        Mocks.getCrushNode('osd.1', 1, 'osd', 0, undefined, 'ssd'),
+        Mocks.getCrushNode('osd.2', 2, 'osd', 0, undefined, 'ssd'),
         // SSD and HDD mixed devices host
-        mock.node('mix-host', -3, 'host', 1, [-4, -5]),
+        Mocks.getCrushNode('mix-host', -3, 'host', 1, [-4, -5]),
         // HDD rack
-        mock.node('hdd-rack', -4, 'rack', 3, [3, 4, 5, 6, 7]),
-        mock.node('osd2.0', 3, 'osd-rack', 0, undefined, 'hdd'),
-        mock.node('osd2.1', 4, 'osd-rack', 0, undefined, 'hdd'),
-        mock.node('osd2.2', 5, 'osd-rack', 0, undefined, 'hdd'),
-        mock.node('osd2.3', 6, 'osd-rack', 0, undefined, 'hdd'),
-        mock.node('osd2.4', 7, 'osd-rack', 0, undefined, 'hdd'),
+        Mocks.getCrushNode('hdd-rack', -4, 'rack', 3, [3, 4, 5, 6, 7]),
+        Mocks.getCrushNode('osd2.0', 3, 'osd-rack', 0, undefined, 'hdd'),
+        Mocks.getCrushNode('osd2.1', 4, 'osd-rack', 0, undefined, 'hdd'),
+        Mocks.getCrushNode('osd2.2', 5, 'osd-rack', 0, undefined, 'hdd'),
+        Mocks.getCrushNode('osd2.3', 6, 'osd-rack', 0, undefined, 'hdd'),
+        Mocks.getCrushNode('osd2.4', 7, 'osd-rack', 0, undefined, 'hdd'),
         // SSD rack
-        mock.node('ssd-rack', -5, 'rack', 3, [8, 9, 10, 11, 12]),
-        mock.node('osd3.0', 8, 'osd-rack', 0, undefined, 'ssd'),
-        mock.node('osd3.1', 9, 'osd-rack', 0, undefined, 'ssd'),
-        mock.node('osd3.2', 10, 'osd-rack', 0, undefined, 'ssd'),
-        mock.node('osd3.3', 11, 'osd-rack', 0, undefined, 'ssd'),
-        mock.node('osd3.4', 12, 'osd-rack', 0, undefined, 'ssd')
+        Mocks.getCrushNode('ssd-rack', -5, 'rack', 3, [8, 9, 10, 11, 12]),
+        Mocks.getCrushNode('osd3.0', 8, 'osd-rack', 0, undefined, 'ssd'),
+        Mocks.getCrushNode('osd3.1', 9, 'osd-rack', 0, undefined, 'ssd'),
+        Mocks.getCrushNode('osd3.2', 10, 'osd-rack', 0, undefined, 'ssd'),
+        Mocks.getCrushNode('osd3.3', 11, 'osd-rack', 0, undefined, 'ssd'),
+        Mocks.getCrushNode('osd3.4', 12, 'osd-rack', 0, undefined, 'ssd')
       ]
     };
     spyOn(ecpService, 'getInfo').and.callFake(() => of(data));

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -142,7 +142,7 @@
               <span class="invalid-feedback"
                     *ngIf="form.showError('size', formDir)"
                     i18n>The size specified is out of range. A value from
-                {{ getMinSize() }} to {{ getMaxSize() }} is valid.</span>
+                {{ getMinSize() }} to {{ getMaxSize() }} is usable.</span>
             </div>
           </div>
 
@@ -343,7 +343,8 @@
                     <tab i18n-heading
                          heading="Crush rule"
                          class="crush-rule-info">
-                      <cd-table-key-value [renderObjects]="true"
+                      <cd-table-key-value [renderObjects]="false"
+                                          [hideKeys]="['steps', 'ruleset', 'type', 'rule_name']"
                                           [data]="form.getValue('crushRule')"
                                           [autoReload]="false">
                       </cd-table-key-value>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -251,6 +251,7 @@
                        heading="Profile"
                        class="ecp-info">
                     <cd-table-key-value [renderObjects]="true"
+                                        [hideKeys]="['name']"
                                         [data]="form.getValue('erasureProfile')"
                                         [autoReload]="false">
                     </cd-table-key-value>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.spec.ts
@@ -1,11 +1,13 @@
 import { FormControl } from '@angular/forms';
 
+import * as _ from 'lodash';
+
 import { configureTestBed, Mocks } from '../../../testing/unit-test-helper';
 import { CrushNode } from '../models/crush-node';
 import { CrushNodeSelectionClass } from './crush.node.selection.class';
 
 describe('CrushNodeSelectionService', () => {
-  const nodes = Mocks.getCrushNodes()
+  const nodes = Mocks.getCrushMap();
 
   let service: CrushNodeSelectionClass;
   let controls: {
@@ -22,15 +24,6 @@ describe('CrushNodeSelectionService', () => {
 
   // Expects that are used frequently
   const assert = {
-    failureDomains: (nodes: CrushNode[], types: string[]) => {
-      const expectation = {};
-      types.forEach((type) => (expectation[type] = nodes.filter((node) => node.type === type)));
-      const keys = service.failureDomainKeys;
-      expect(keys).toEqual(types);
-      keys.forEach((key) => {
-        expect(service.failureDomains[key].length).toBe(expectation[key].length);
-      });
-    },
     formFieldValues: (root: CrushNode, failureDomain: string, device: string) => {
       expect(controls.root.value).toEqual(root);
       expect(controls.failure.value).toBe(failureDomain);
@@ -44,6 +37,19 @@ describe('CrushNodeSelectionService', () => {
       const node = get.nodeByName(rootName);
       controls.root.setValue(node);
       assert.formFieldValues(node, expectedFailureDomain, expectedDevice);
+    },
+    failureDomainNodes: (
+      failureDomains: { [failureDomain: string]: CrushNode[] },
+      expected: { [failureDomains: string]: string[] | CrushNode[] }
+    ) => {
+      expect(Object.keys(failureDomains)).toEqual(Object.keys(expected));
+      Object.keys(failureDomains).forEach((key) => {
+        if (_.isString(expected[key][0])) {
+          expect(failureDomains[key]).toEqual(get.nodesByNames(expected[key] as string[]));
+        } else {
+          expect(failureDomains[key]).toEqual(expected[key]);
+        }
+      });
     }
   };
 
@@ -77,23 +83,31 @@ describe('CrushNodeSelectionService', () => {
     });
 
     it('has the following lists after init', () => {
-      assert.failureDomains(nodes, ['host', 'osd', 'osd-rack', 'rack']); // Not root as root only exist once
+      assert.failureDomainNodes(service.failureDomains, {
+        host: ['ssd-host', 'mix-host'],
+        osd: ['osd.1', 'osd.0', 'osd.2'],
+        rack: ['hdd-rack', 'ssd-rack'],
+        'osd-rack': ['osd2.0', 'osd2.1', 'osd3.0', 'osd3.1']
+      });
       expect(service.devices).toEqual(['hdd', 'ssd']);
     });
 
     it('has the following lists after selection of ssd-host', () => {
       controls.root.setValue(get.nodeByName('ssd-host'));
-      assert.failureDomains(get.nodesByNames(['osd.0', 'osd.1', 'osd.2']), ['osd']); // Not host as it only exist once
+      assert.failureDomainNodes(service.failureDomains, {
+        // Not host as it only exist once
+        osd: ['osd.1', 'osd.0', 'osd.2']
+      });
       expect(service.devices).toEqual(['ssd']);
     });
 
     it('has the following lists after selection of mix-host', () => {
       controls.root.setValue(get.nodeByName('mix-host'));
       expect(service.devices).toEqual(['hdd', 'ssd']);
-      assert.failureDomains(
-        get.nodesByNames(['hdd-rack', 'ssd-rack', 'osd2.0', 'osd2.1', 'osd3.0', 'osd3.1']),
-        ['osd-rack', 'rack']
-      );
+      assert.failureDomainNodes(service.failureDomains, {
+        rack: ['hdd-rack', 'ssd-rack'],
+        'osd-rack': ['osd2.0', 'osd2.1', 'osd3.0', 'osd3.1']
+      });
     });
   });
 
@@ -145,6 +159,62 @@ describe('CrushNodeSelectionService', () => {
     it('should show 3 OSDs when selecting "ssd-host"', () => {
       assert.valuesOnRootChange('ssd-host', 'osd', 'ssd');
       expect(service.deviceCount).toBe(3);
+    });
+  });
+
+  describe('search tree', () => {
+    it('returns the following list after searching for mix-host', () => {
+      const subNodes = CrushNodeSelectionClass.search(nodes, 'mix-host');
+      expect(subNodes).toEqual(
+        get.nodesByNames([
+          'mix-host',
+          'hdd-rack',
+          'osd2.0',
+          'osd2.1',
+          'ssd-rack',
+          'osd3.0',
+          'osd3.1'
+        ])
+      );
+    });
+
+    it('returns the following list after searching for mix-host with SSDs', () => {
+      const subNodes = CrushNodeSelectionClass.search(nodes, 'mix-host~ssd');
+      expect(subNodes.map((n) => n.name)).toEqual(['mix-host', 'ssd-rack', 'osd3.0', 'osd3.1']);
+    });
+
+    it('returns an empty array if node can not be found', () => {
+      expect(CrushNodeSelectionClass.search(nodes, 'not-there')).toEqual([]);
+    });
+
+    it('returns the following list after searching for mix-host failure domains', () => {
+      const subNodes = CrushNodeSelectionClass.search(nodes, 'mix-host');
+      assert.failureDomainNodes(CrushNodeSelectionClass.getFailureDomains(subNodes), {
+        host: ['mix-host'],
+        rack: ['hdd-rack', 'ssd-rack'],
+        'osd-rack': ['osd2.0', 'osd2.1', 'osd3.0', 'osd3.1']
+      });
+    });
+
+    it('returns the following list after searching for mix-host failure domains for a specific type', () => {
+      const subNodes = CrushNodeSelectionClass.search(nodes, 'mix-host~hdd');
+      const hddHost = _.cloneDeep(get.nodesByNames(['mix-host'])[0]);
+      hddHost.children = [-4];
+      assert.failureDomainNodes(CrushNodeSelectionClass.getFailureDomains(subNodes), {
+        host: [hddHost],
+        rack: ['hdd-rack'],
+        'osd-rack': ['osd2.0', 'osd2.1']
+      });
+      const ssdHost = _.cloneDeep(get.nodesByNames(['mix-host'])[0]);
+      ssdHost.children = [-5];
+      assert.failureDomainNodes(
+        CrushNodeSelectionClass.searchFailureDomains(nodes, 'mix-host~ssd'),
+        {
+          host: [ssdHost],
+          rack: ['ssd-rack'],
+          'osd-rack': ['osd3.0', 'osd3.1']
+        }
+      );
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.spec.ts
@@ -1,79 +1,22 @@
 import { FormControl } from '@angular/forms';
 
-import { configureTestBed } from '../../../testing/unit-test-helper';
+import { configureTestBed, Mocks } from '../../../testing/unit-test-helper';
 import { CrushNode } from '../models/crush-node';
-import { CrushRuleConfig } from '../models/crush-rule';
 import { CrushNodeSelectionClass } from './crush.node.selection.class';
 
 describe('CrushNodeSelectionService', () => {
-  let service: CrushNodeSelectionClass;
+  const nodes = Mocks.getCrushNodes()
 
+  let service: CrushNodeSelectionClass;
   let controls: {
     root: FormControl;
     failure: FormControl;
     device: FormControl;
   };
 
-  // Object contains mock functions
-  const mock = {
-    node: (
-      name: string,
-      id: number,
-      type: string,
-      type_id: number,
-      children?: number[],
-      device_class?: string
-    ): CrushNode => {
-      return { name, type, type_id, id, children, device_class };
-    },
-    rule: (
-      name: string,
-      root: string,
-      failure_domain: string,
-      device_class?: string
-    ): CrushRuleConfig => ({
-      name,
-      root,
-      failure_domain,
-      device_class
-    }),
-    nodes: [] as CrushNode[]
-  };
-
-  /**
-   * Create the following test crush map:
-   * > default
-   * --> ssd-host
-   * ----> 3x osd with ssd
-   * --> mix-host
-   * ----> hdd-rack
-   * ------> 2x osd-rack with hdd
-   * ----> ssd-rack
-   * ------> 2x osd-rack with ssd
-   */
-  mock.nodes = [
-    // Root node
-    mock.node('default', -1, 'root', 11, [-2, -3]),
-    // SSD host
-    mock.node('ssd-host', -2, 'host', 1, [1, 0, 2]),
-    mock.node('osd.0', 0, 'osd', 0, undefined, 'ssd'),
-    mock.node('osd.1', 1, 'osd', 0, undefined, 'ssd'),
-    mock.node('osd.2', 2, 'osd', 0, undefined, 'ssd'),
-    // SSD and HDD mixed devices host
-    mock.node('mix-host', -3, 'host', 1, [-4, -5]),
-    // HDD rack
-    mock.node('hdd-rack', -4, 'rack', 3, [3, 4]),
-    mock.node('osd2.0', 3, 'osd-rack', 0, undefined, 'hdd'),
-    mock.node('osd2.1', 4, 'osd-rack', 0, undefined, 'hdd'),
-    // SSD rack
-    mock.node('ssd-rack', -5, 'rack', 3, [5, 6]),
-    mock.node('osd2.0', 5, 'osd-rack', 0, undefined, 'ssd'),
-    mock.node('osd2.1', 6, 'osd-rack', 0, undefined, 'ssd')
-  ];
-
   // Object contains functions to get something
   const get = {
-    nodeByName: (name: string): CrushNode => mock.nodes.find((node) => node.name === name),
+    nodeByName: (name: string): CrushNode => nodes.find((node) => node.name === name),
     nodesByNames: (names: string[]): CrushNode[] => names.map(get.nodeByName)
   };
 
@@ -117,12 +60,12 @@ describe('CrushNodeSelectionService', () => {
     // Normally this should be extended by the class using it
     service = new CrushNodeSelectionClass();
     // Therefore to get it working correctly use "this" instead of "service"
-    service.initCrushNodeSelection(mock.nodes, controls.root, controls.failure, controls.device);
+    service.initCrushNodeSelection(nodes, controls.root, controls.failure, controls.device);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
-    expect(mock.nodes.length).toBe(12);
+    expect(nodes.length).toBe(12);
   });
 
   describe('lists', () => {
@@ -134,7 +77,7 @@ describe('CrushNodeSelectionService', () => {
     });
 
     it('has the following lists after init', () => {
-      assert.failureDomains(mock.nodes, ['host', 'osd', 'osd-rack', 'rack']); // Not root as root only exist once
+      assert.failureDomains(nodes, ['host', 'osd', 'osd-rack', 'rack']); // Not root as root only exist once
       expect(service.devices).toEqual(['hdd', 'ssd']);
     });
 
@@ -148,7 +91,7 @@ describe('CrushNodeSelectionService', () => {
       controls.root.setValue(get.nodeByName('mix-host'));
       expect(service.devices).toEqual(['hdd', 'ssd']);
       assert.failureDomains(
-        get.nodesByNames(['hdd-rack', 'ssd-rack', 'osd2.0', 'osd2.1', 'osd2.0', 'osd2.1']),
+        get.nodesByNames(['hdd-rack', 'ssd-rack', 'osd2.0', 'osd2.1', 'osd3.0', 'osd3.1']),
         ['osd-rack', 'rack']
       );
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/crush-rule.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/crush-rule.ts
@@ -2,6 +2,7 @@ import { CrushStep } from './crush-step';
 
 export class CrushRule {
   max_size: number;
+  usable_size?: number;
   min_size: number;
   rule_id: number;
   rule_name: string;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/pool-form-info.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/pool-form-info.ts
@@ -1,3 +1,4 @@
+import { CrushNode } from './crush-node';
 import { CrushRule } from './crush-rule';
 import { ErasureCodeProfile } from './erasure-code-profile';
 
@@ -15,4 +16,5 @@ export class PoolFormInfo {
   erasure_code_profiles: ErasureCodeProfile[];
   used_rules: { [rule_name: string]: string[] };
   used_profiles: { [profile_name: string]: string[] };
+  nodes: CrushNode[];
 }

--- a/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
@@ -12,6 +12,8 @@ import { Icons } from '../app/shared/enum/icons.enum';
 import { CdFormGroup } from '../app/shared/forms/cd-form-group';
 import { CdTableAction } from '../app/shared/models/cd-table-action';
 import { CdTableSelection } from '../app/shared/models/cd-table-selection';
+import { CrushNode } from '../app/shared/models/crush-node';
+import { CrushRule, CrushRuleConfig } from '../app/shared/models/crush-rule';
 import { Permission } from '../app/shared/models/permissions';
 import {
   AlertmanagerAlert,
@@ -373,5 +375,170 @@ export class IscsiHelper {
     formHelper.expectValidChange(fieldName, 'thisIsCorrect');
     formHelper.expectErrorChange(fieldName, '##?badChars?##', 'pattern');
     formHelper.expectErrorChange(fieldName, 'thisPasswordIsWayTooBig', 'pattern');
+  }
+}
+
+export class Mocks {
+  static getCrushNode(
+    name: string,
+    id: number,
+    type: string,
+    type_id: number,
+    children?: number[],
+    device_class?: string
+  ): CrushNode {
+    return { name, type, type_id, id, children, device_class };
+  }
+
+  /**
+   * Create the following test crush map:
+   * > default
+   * --> ssd-host
+   * ----> 3x osd with ssd
+   * --> mix-host
+   * ----> hdd-rack
+   * ------> 2x osd-rack with hdd
+   * ----> ssd-rack
+   * ------> 2x osd-rack with ssd
+   */
+  static getCrushMap(): CrushNode[] {
+    return [
+      // Root node
+      this.getCrushNode('default', -1, 'root', 11, [-2, -3]),
+      // SSD host
+      this.getCrushNode('ssd-host', -2, 'host', 1, [1, 0, 2]),
+      this.getCrushNode('osd.0', 0, 'osd', 0, undefined, 'ssd'),
+      this.getCrushNode('osd.1', 1, 'osd', 0, undefined, 'ssd'),
+      this.getCrushNode('osd.2', 2, 'osd', 0, undefined, 'ssd'),
+      // SSD and HDD mixed devices host
+      this.getCrushNode('mix-host', -3, 'host', 1, [-4, -5]),
+      // HDD rack
+      this.getCrushNode('hdd-rack', -4, 'rack', 3, [3, 4]),
+      this.getCrushNode('osd2.0', 3, 'osd-rack', 0, undefined, 'hdd'),
+      this.getCrushNode('osd2.1', 4, 'osd-rack', 0, undefined, 'hdd'),
+      // SSD rack
+      this.getCrushNode('ssd-rack', -5, 'rack', 3, [5, 6]),
+      this.getCrushNode('osd3.0', 5, 'osd-rack', 0, undefined, 'ssd'),
+      this.getCrushNode('osd3.1', 6, 'osd-rack', 0, undefined, 'ssd')
+    ];
+  }
+
+  /**
+   * Generates an simple crush map with multiple hosts that have OSDs with either ssd or hdd OSDs.
+   * Hosts with zero or even numbers at the end have SSD OSDs the other hosts have hdd OSDs.
+   *
+   * Host names follow the following naming convention:
+   * host.$index
+   * $index represents a number count started at 0 (like an index within an array) (same for OSDs)
+   *
+   * OSD names follow the following naming convention:
+   * osd.$hostIndex.$osdIndex
+   *
+   * The following crush map will be generated with the set defaults:
+   * > default
+   * --> host.0 (has only ssd OSDs)
+   * ----> osd.0.0
+   * ----> osd.0.1
+   * ----> osd.0.2
+   * ----> osd.0.3
+   * --> host.1 (has only hdd OSDs)
+   * ----> osd.1.0
+   * ----> osd.1.1
+   * ----> osd.1.2
+   * ----> osd.1.3
+   */
+  static generateSimpleCrushMap(hosts: number = 2, osds: number = 4): CrushNode[] {
+    const nodes = [];
+    const createOsdLeafs = (hostSuffix: number): number[] => {
+      let osdId = 0;
+      const osdIds = [];
+      const osdsInUse = hostSuffix * osds;
+      for (let o = 0; o < osds; o++) {
+        osdIds.push(osdId);
+        nodes.push(
+          this.getCrushNode(
+            `osd.${hostSuffix}.${osdId}`,
+            osdId + osdsInUse,
+            'osd',
+            0,
+            undefined,
+            hostSuffix % 2 === 0 ? 'ssd' : 'hdd'
+          )
+        );
+        osdId++;
+      }
+      return osdIds;
+    };
+    const createHostBuckets = (): number[] => {
+      let hostId = -2;
+      const hostIds = [];
+      for (let h = 0; h < hosts; h++) {
+        const hostSuffix = hostId * -1 - 2;
+        hostIds.push(hostId);
+        nodes.push(
+          this.getCrushNode(`host.${hostSuffix}`, hostId, 'host', 1, createOsdLeafs(hostSuffix))
+        );
+        hostId--;
+      }
+      return hostIds;
+    };
+    nodes.push(this.getCrushNode('default', -1, 'root', 11, createHostBuckets()));
+    return nodes;
+  }
+
+  static getCrushRuleConfig(
+    name: string,
+    root: string,
+    failure_domain: string,
+    device_class?: string
+  ): CrushRuleConfig {
+    return {
+      name,
+      root,
+      failure_domain,
+      device_class
+    };
+  }
+
+  static getCrushRule({
+    id = 0,
+    name = 'somePoolName',
+    min = 1,
+    max = 10,
+    type = 'replicated',
+    failureDomain = 'osd',
+    itemName = 'default' // This string also sets the device type - "default~ssd" <- ssd usage only
+  }: {
+    max?: number;
+    min?: number;
+    id?: number;
+    name?: string;
+    type?: string;
+    failureDomain?: string;
+    itemName?: string;
+  }): CrushRule {
+    const typeNumber = type === 'erasure' ? 3 : 1;
+    const rule = new CrushRule();
+    rule.max_size = max;
+    rule.min_size = min;
+    rule.rule_id = id;
+    rule.ruleset = typeNumber;
+    rule.rule_name = name;
+    rule.steps = [
+      {
+        item_name: itemName,
+        item: -1,
+        op: 'take'
+      },
+      {
+        num: 0,
+        type: failureDomain,
+        op: 'choose_firstn'
+      },
+      {
+        op: 'emit'
+      }
+    ];
+    return rule;
   }
 }


### PR DESCRIPTION
Currently the max size is determined by the number of OSDs, which is
compared with the maximum of the current crush rule.

The problem with that is, that this is wrong for every crush rule that
doesn't have OSDs as failure domain and that don't have the root of the
cluster set as root of the crush rule.

Now the crush map will be used to determine how many failure domains are
really available in the cluster and how many can really be used in the
end. This number now defines the maximum size you can enter.

The crush detail view will now the new attribute usable_size and hide
the redundant information steps, ruleset, type and rule_name.

Fixes: https://tracker.ceph.com/issues/44620
Signed-off-by: Stephan Müller <smueller@suse.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
