### PR TITLE
qa: fix test_exports bytes/string comparison mismatch

### DIFF
--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -133,10 +133,10 @@ class TestExports(CephFSTestCase):
             log.debug("mount.getfattr('1','ceph.dir.pin'): %s " % dir_pin)
             if str(p) < "5" and not(dir_pin):
                 self.skipTest("Kernel does not support getting the extended attribute ceph.dir.pin")
-        self.assertEqual(self.mount_a.getfattr("1", "ceph.dir.pin"), b'1')
-        self.assertEqual(self.mount_a.getfattr("1/2", "ceph.dir.pin"), b'0')
+        self.assertEqual(self.mount_a.getfattr("1", "ceph.dir.pin"), '1')
+        self.assertEqual(self.mount_a.getfattr("1/2", "ceph.dir.pin"), '0')
         if (len(self.fs.get_active_names()) > 2):
-            self.assertEqual(self.mount_a.getfattr("1/2/3", "ceph.dir.pin"), b'2')
+            self.assertEqual(self.mount_a.getfattr("1/2/3", "ceph.dir.pin"), '2')
 
     def test_session_race(self):
         """


### PR DESCRIPTION
mount.getfattr() returns string rather than bytes after https://github.com/ceph/ceph/pull/34941. This PR fixes the comparison mismatch.

Fixes: https://tracker.ceph.com/issues/45538
Signed-off-by: Sidharth Anupkrishnan <sanupkri@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
