### PR TITLE
mgr: logger.warn() -> logger.warning()

### DIFF
--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -157,7 +157,7 @@ class Alerts(MgrModule):
                 for code, alert in r.items():
                     checks[code] = alert
         else:
-            self.log.warn('Alert is not sent because smtp_host is not configured')
+            self.log.warning('Alert is not sent because smtp_host is not configured')
         self.set_health_checks(checks)
 
     def serve(self):

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -429,7 +429,7 @@ class Module(MgrModule):
         self.event = Event()
 
     def handle_command(self, inbuf, command):
-        self.log.warn("Handling command: '%s'" % str(command))
+        self.log.warning("Handling command: '%s'" % str(command))
         if command['prefix'] == 'balancer status':
             s = {
                 'plans': list(self.plans.keys()),
@@ -1098,7 +1098,7 @@ class Module(MgrModule):
         metrics = self.get_module_option('crush_compat_metrics').split(',')
         key = metrics[0] # balancing using the first score metric
         if key not in ['pgs', 'bytes', 'objects']:
-            self.log.warn("Invalid crush_compat balancing key %s. Using 'pgs'." % key)
+            self.log.warning("Invalid crush_compat balancing key %s. Using 'pgs'." % key)
             key = 'pgs'
 
         # go

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -595,7 +595,7 @@ class Module(MgrModule):
         }), '')
         r, outb, outs = result.wait()
         if r != 0:
-            self.log.warn('Could not mark OSD %s out. r: [%s], outb: [%s], outs: [%s]' % (osd_ids, r, outb, outs))
+            self.log.warning('Could not mark OSD %s out. r: [%s], outb: [%s], outs: [%s]' % (osd_ids, r, outb, outs))
         for osd_id in osd_ids:
             result = CommandResult('')
             self.send_command(result, 'mon', '', json.dumps({
@@ -606,7 +606,7 @@ class Module(MgrModule):
             }), '')
             r, outb, outs = result.wait()
             if r != 0:
-                self.log.warn('Could not set osd.%s primary-affinity, r: [%s], outs: [%s]' % (osd_id, r, outb, outs))
+                self.log.warning('Could not set osd.%s primary-affinity, r: [%s], outs: [%s]' % (osd_id, r, outb, outs))
 
     def extract_smart_features(self, raw):
         # FIXME: extract and normalize raw smartctl --json output and

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1404,7 +1404,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
 
                 schema = self.get_perf_schema(service['type'], service['id'])
                 if not schema:
-                    self.log.warn("No perf counter schema for {0}.{1}".format(
+                    self.log.warning("No perf counter schema for {0}.{1}".format(
                         service['type'], service['id']
                     ))
                     continue

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -464,10 +464,10 @@ class Module(MgrModule):
         # In the case that we ignored some PGs, log the reason why (we may
         # not end up creating a progress event)
         if len(unmoved_pgs):
-            self.log.warn("{0} PGs were on osd.{1}, but didn't get new locations".format(
+            self.log.warning("{0} PGs were on osd.{1}, but didn't get new locations".format(
                 len(unmoved_pgs), osd_id))
 
-        self.log.warn("{0} PGs affected by osd.{1} being marked {2}".format(
+        self.log.warning("{0} PGs affected by osd.{1} being marked {2}".format(
             len(affected_pgs), osd_id, marked))
 
 
@@ -507,13 +507,13 @@ class Module(MgrModule):
                 old_weight = old_osds[osd_id]['in']
 
                 if new_weight == 0.0 and old_weight > new_weight:
-                    self.log.warn("osd.{0} marked out".format(osd_id))
+                    self.log.warning("osd.{0} marked out".format(osd_id))
                     self._osd_in_out(old_osdmap, old_dump, new_osdmap, osd_id, "out")
                 elif new_weight >= 1.0 and old_weight == 0.0:
                     # Only consider weight>=1.0 as "in" to avoid spawning
                     # individual recovery events on every adjustment
                     # in a gradual weight-in
-                    self.log.warn("osd.{0} marked in".format(osd_id))
+                    self.log.warning("osd.{0} marked in".format(osd_id))
                     self._osd_in_out(old_osdmap, old_dump, new_osdmap, osd_id, "in")
 
     def notify(self, notify_type, notify_data):
@@ -666,7 +666,7 @@ class Module(MgrModule):
                                                                    ev.message))
             self._complete(ev)
         except KeyError:
-            self.log.warn("complete: ev {0} does not exist".format(ev_id))
+            self.log.warning("complete: ev {0} does not exist".format(ev_id))
             pass
 
     def fail(self, ev_id, message):
@@ -683,7 +683,7 @@ class Module(MgrModule):
                                                                     message))
             self._complete(ev)
         except KeyError:
-            self.log.warn("fail: ev {0} does not exist".format(ev_id))
+            self.log.warning("fail: ev {0} does not exist".format(ev_id))
 
     def _handle_ls(self):
         if len(self._events) or len(self._completed_events):

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -528,7 +528,7 @@ class Module(MgrModule):
                 try:
                     self.metrics["pg_{}".format(state)].set(num, (pool,))
                 except KeyError:
-                    self.log.warn("skipping pg in unknown state {}".format(state))
+                    self.log.warning("skipping pg in unknown state {}".format(state))
 
     def get_osd_stats(self):
         osd_stats = self.get('osd_stats')

--- a/src/pybind/mgr/restful/api/config.py
+++ b/src/pybind/mgr/restful/api/config.py
@@ -33,7 +33,7 @@ class ConfigOsd(RestController):
         valid_flags = set(args.keys()) & set(common.OSD_FLAGS)
         invalid_flags = list(set(args.keys()) - valid_flags)
         if invalid_flags:
-            context.instance.log.warn("%s not valid to set/unset", invalid_flags)
+            context.instance.log.warning("%s not valid to set/unset", invalid_flags)
 
         for flag in list(valid_flags):
             if args[flag]:

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -251,7 +251,7 @@ class Module(MgrModule):
                 self._serve()
                 self.server.socket.close()
             except CannotServe as cs:
-                self.log.warn("server not running: %s", cs)
+                self.log.warning("server not running: %s", cs)
             except:
                 self.log.error(str(traceback.format_exc()))
 
@@ -409,7 +409,7 @@ class Module(MgrModule):
 
 
     def handle_command(self, inbuf, command):
-        self.log.warn("Handling command: '%s'" % str(command))
+        self.log.warning("Handling command: '%s'" % str(command))
         if command['prefix'] == "restful create-key":
             if command['key_name'] in self.keys:
                 return 0, self.keys[command['key_name']], ""

--- a/src/pybind/mgr/volumes/fs/async_cloner.py
+++ b/src/pybind/mgr/volumes/fs/async_cloner.py
@@ -80,7 +80,7 @@ def sync_attrs(fs_handle, target_path, source_statx):
         fs_handle.lutimes(target_path, (time.mktime(source_statx["atime"].timetuple()),
                                         time.mktime(source_statx["mtime"].timetuple())))
     except cephfs.Error as e:
-        log.warn("error synchronizing attrs for {0} ({1})".format(target_path, e))
+        log.warning("error synchronizing attrs for {0} ({1})".format(target_path, e))
         raise e
 
 def bulk_copy(fs_handle, source_path, dst_path, should_cancel):
@@ -129,7 +129,7 @@ def bulk_copy(fs_handle, source_path, dst_path, should_cancel):
                             copy_file(fs_handle, d_full_src, d_full_dst, mo, cancel_check=should_cancel)
                         else:
                             handled = False
-                            log.warn("cptree: (IGNORE) {0}".format(d_full_src))
+                            log.warning("cptree: (IGNORE) {0}".format(d_full_src))
                         if handled:
                             sync_attrs(fs_handle, d_full_dst, stx)
                     d = fs_handle.readdir(dir_handle)
@@ -281,7 +281,7 @@ class Cloner(AsyncJobs):
                             raise VolumeException(-errno.EINVAL, "cannot cancel -- clone finished (check clone status)")
                         track_idx = self.get_clone_tracking_index(fs_handle, clone_subvolume)
                         if not track_idx:
-                            log.warn("cannot lookup clone tracking index for {0}".format(clone_subvolume.base_path))
+                            log.warning("cannot lookup clone tracking index for {0}".format(clone_subvolume.base_path))
                             raise VolumeException(-errno.EINVAL, "error canceling clone")
                         if OpSm.is_init_state("clone", clone_state):
                             # clone has not started yet -- cancel right away.

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
@@ -203,7 +203,7 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
             if me.errno == -errno.ENOENT:
                 return False
             else:
-                log.warn("error checking protected snap {0} ({1})".format(snapname, me))
+                log.warning("error checking protected snap {0} ({1})".format(snapname, me))
                 raise VolumeException(-errno.EINVAL, "snapshot protection check failed")
         else:
             return True
@@ -238,7 +238,7 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
             self.metadata_mgr.update_section("protected snaps", snapname, "1")
             self.metadata_mgr.flush()
         except MetadataMgrException as me:
-            log.warn("error updating protected snap list ({0})".format(me))
+            log.warning("error updating protected snap list ({0})".format(me))
             raise VolumeException(-errno.EINVAL, "error protecting snapshot")
 
     def _unprotect_snapshot(self, snapname):
@@ -246,7 +246,7 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
             self.metadata_mgr.remove_option("protected snaps", snapname)
             self.metadata_mgr.flush()
         except MetadataMgrException as me:
-            log.warn("error updating protected snap list ({0})".format(me))
+            log.warning("error updating protected snap list ({0})".format(me))
             raise VolumeException(-errno.EINVAL, "error unprotecting snapshot")
 
     def protect_snapshot(self, snapname):
@@ -285,7 +285,7 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
                 track_idx = index.track(tgt_subvolume.base_path)
                 self._add_snap_clone(track_idx, snapname)
         except (IndexException, MetadataMgrException) as e:
-            log.warn("error creating clone index: {0}".format(e))
+            log.warning("error creating clone index: {0}".format(e))
             raise VolumeException(-errno.EINVAL, "error cloning subvolume")
 
     def detach_snapshot(self, snapname, track_id):
@@ -296,5 +296,5 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
                 index.untrack(track_id)
                 self._remove_snap_clone(track_id)
         except (IndexException, MetadataMgrException) as e:
-            log.warn("error delining snapshot from clone: {0}".format(e))
+            log.warning("error delining snapshot from clone: {0}".format(e))
             raise VolumeException(-errno.EINVAL, "error delinking snapshot from clone")

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -343,7 +343,7 @@ class VolumeClient(CephfsClient):
                     target_subvolume.remove()
                     self.purge_queue.queue_job(volname)
                 except Exception as e:
-                    log.warn("failed to cleanup clone subvolume '{0}' ({1})".format(target_subvolname, e))
+                    log.warning("failed to cleanup clone subvolume '{0}' ({1})".format(target_subvolname, e))
                 raise ve
 
     def _clone_subvolume_snapshot(self, fs_handle, volname, subvolume, **kwargs):


### PR DESCRIPTION
logger.warn() is the same as logger.warning(), but was removed in py3.3

fixes tox warnings -

```
progress/test_progress.py::TestModule::test_osd_in_out
progress/test_progress.py::TestModule::test_osd_in_out
  /home/ceph/src/pybind/mgr/progress/module.py:470: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    self.log.warn("{0} PGs affected by osd.{1} being marked {2}".format(
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
