### PR TITLE
cephfs: allow pool names with hyphen and period

### DIFF
--- a/doc/cephfs/administration.rst
+++ b/doc/cephfs/administration.rst
@@ -6,6 +6,9 @@ CephFS Administrative commands
 File Systems
 ------------
 
+.. note:: The names of the file systems, metadata pools, and data pools can
+          only have characters in the set [a-zA-Z0-9\_-.].
+
 These commands operate on the CephFS file systems in your Ceph cluster.
 Note that by default only one file system is permitted: to enable
 creation of multiple file systems use ``ceph fs flag set enable_multiple true``.

--- a/doc/cephfs/createfs.rst
+++ b/doc/cephfs/createfs.rst
@@ -35,6 +35,8 @@ Generally, the metadata pool will have at most a few gigabytes of data. For
 this reason, a smaller PG count is usually recommended. 64 or 128 is commonly
 used in practice for large clusters.
 
+.. note:: The names of the file systems, metadata pools, and data pools can
+          only have characters in the set [a-zA-Z0-9\_-.].
 
 Creating a file system
 ======================

--- a/doc/cephfs/file-layouts.rst
+++ b/doc/cephfs/file-layouts.rst
@@ -20,10 +20,10 @@ Layout fields
 -------------
 
 pool
-    String, giving ID or name.  Which RADOS pool a file's data objects will be stored in.
+    String, giving ID or name. String can only have characters in the set [a-zA-Z0-9\_-.]. Which RADOS pool a file's data objects will be stored in.
 
 pool_namespace
-    String.  Within the data pool, which RADOS namespace the objects will
+    String with only characters in the set [a-zA-Z0-9\_-.].  Within the data pool, which RADOS namespace the objects will
     be written to.  Empty by default (i.e. default namespace).
 
 stripe_unit

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -74,6 +74,14 @@ class TestAdminCommands(CephFSTestCase):
         self.mount_a.run_shell("mkdir subdir")
         self.fs.set_dir_layout(self.mount_a, "subdir", FileLayout(pool=p))
 
+    def test_add_data_pool_non_alphamueric_name_as_subdir(self):
+        """
+        That a new data pool with non-alphanumeric name can be added and used for a sub-directory.
+        """
+        p = self.fs.add_data_pool("I-am-data_pool00.")
+        self.mount_a.run_shell("mkdir subdir")
+        self.fs.set_dir_layout(self.mount_a, "subdir", FileLayout(pool=p))
+
     def test_add_data_pool_ec(self):
         """
         That a new EC data pool can be added.

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -1856,7 +1856,7 @@ struct keys_and_values
       query =  pair >> *(qi::lit(' ') >> pair);
       pair  =  key >> '=' >> value;
       key   =  qi::char_("a-zA-Z_") >> *qi::char_("a-zA-Z_0-9");
-      value = +qi::char_("a-zA-Z_0-9");
+      value = +qi::char_("a-zA-Z0-9-_.");
     }
   qi::rule<Iterator, std::map<std::string, std::string>()> query;
   qi::rule<Iterator, std::pair<std::string, std::string>()> pair;


### PR DESCRIPTION
... to be set as pool layouts for files and directories.

Fixes: https://tracker.ceph.com/issues/45521


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
