### PR TITLE
librbd: avoid completing mirror:DisableRequest while holding its lock

### DIFF
--- a/src/librbd/mirror/DisableRequest.cc
+++ b/src/librbd/mirror/DisableRequest.cc
@@ -219,15 +219,14 @@ Context *DisableRequest<I>::handle_get_clients(int *result) {
   CephContext *cct = m_image_ctx->cct;
   ldout(cct, 10) << "r=" << *result << dendl;
 
+  std::unique_lock locker{m_lock};
+  ceph_assert(m_current_ops.empty());
+
   if (*result < 0) {
     lderr(cct) << "failed to get registered clients: " << cpp_strerror(*result)
                << dendl;
     return m_on_finish;
   }
-
-  std::lock_guard locker{m_lock};
-
-  ceph_assert(m_current_ops.empty());
 
   for (auto client : m_clients) {
     journal::ClientData client_data;
@@ -276,6 +275,7 @@ Context *DisableRequest<I>::handle_get_clients(int *result) {
     } else if (!m_remove) {
       return m_on_finish;
     }
+    locker.unlock();
 
     // no mirror clients to unregister
     send_remove_mirror_image();
@@ -342,7 +342,7 @@ Context *DisableRequest<I>::handle_remove_snap(int *result,
   CephContext *cct = m_image_ctx->cct;
   ldout(cct, 10) << "r=" << *result << dendl;
 
-  std::lock_guard locker{m_lock};
+  std::unique_lock locker{m_lock};
 
   ceph_assert(m_current_ops[client_id] > 0);
   m_current_ops[client_id]--;
@@ -360,6 +360,8 @@ Context *DisableRequest<I>::handle_remove_snap(int *result,
       if (m_ret[client_id] < 0) {
         return m_on_finish;
       }
+      locker.unlock();
+
       send_remove_mirror_image();
       return nullptr;
     }
@@ -404,7 +406,7 @@ Context *DisableRequest<I>::handle_unregister_client(
   CephContext *cct = m_image_ctx->cct;
   ldout(cct, 10) << "r=" << *result << dendl;
 
-  std::lock_guard locker{m_lock};
+  std::unique_lock locker{m_lock};
   ceph_assert(m_current_ops[client_id] == 0);
   m_current_ops.erase(client_id);
 
@@ -422,6 +424,7 @@ Context *DisableRequest<I>::handle_unregister_client(
     *result = m_error_result;
     return m_on_finish;
   }
+  locker.unlock();
 
   send_get_clients();
   return nullptr;


### PR DESCRIPTION
Ensure that the lock is released before another thread has the chance
to complete the state machine and attempt to destruct the in-use lock.

Fixes: https://tracker.ceph.com/issues/45544
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
