### PR TITLE
mgr/cephadm: implement cached osdspec previews

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -163,12 +163,15 @@ class HostCache():
         self.daemons = {}   # type: Dict[str, Dict[str, orchestrator.DaemonDescription]]
         self.last_daemon_update = {}   # type: Dict[str, datetime.datetime]
         self.devices = {}              # type: Dict[str, List[inventory.Device]]
+        self.osdspec_previews = {}     # type: Dict[str, List[Dict[str, Any]]]
         self.networks = {}             # type: Dict[str, Dict[str, List[str]]]
         self.last_device_update = {}   # type: Dict[str, datetime.datetime]
         self.daemon_refresh_queue = [] # type: List[str]
         self.device_refresh_queue = [] # type: List[str]
+        self.osdspec_previews_refresh_queue = [] # type: List[str]
         self.daemon_config_deps = {}   # type: Dict[str, Dict[str, Dict[str,Any]]]
         self.last_host_check = {}      # type: Dict[str, datetime.datetime]
+        self.loading_osdspec_preview = {}  # type: Dict[str, bool]
 
     def load(self):
         # type: () -> None
@@ -189,6 +192,8 @@ class HostCache():
                 # and always trigger a new scrape on mgr restart.
                 self.daemon_refresh_queue.append(host)
                 self.daemons[host] = {}
+                self.osdspec_previews[host] = []
+                self.loading_osdspec_preview[host] = False
                 self.devices[host] = []
                 self.networks[host] = {}
                 self.daemon_config_deps[host] = {}
@@ -198,6 +203,8 @@ class HostCache():
                 for d in j.get('devices', []):
                     self.devices[host].append(inventory.Device.from_json(d))
                 self.networks[host] = j.get('networks', {})
+                self.osdspec_previews[host] = j.get('osdspec_previews', [])
+
                 for name, d in j.get('daemon_config_deps', {}).items():
                     self.daemon_config_deps[host][name] = {
                         'deps': d.get('deps', []),
@@ -216,6 +223,19 @@ class HostCache():
                 self.mgr.log.warning('unable to load cached state for %s: %s' % (
                     host, e))
                 pass
+
+    def update_osdspec_previews(self, search_host: str = ''):
+        # Set global 'pending' flag for host
+        self.loading_osdspec_preview[search_host] = True
+        previews = []
+        # query OSDSpecs for host <search host> and generate/get the preview
+        for preview in self.mgr.osd_service.get_previews(search_host):
+            # There can be multiple previews for one host due to multiple OSDSpecs.
+            previews.append(preview)
+        self.mgr.log.debug(f"Loading OSDSpec previews to HostCache")
+        self.osdspec_previews[search_host] = previews
+        # Unset global 'pending' flag for host
+        self.loading_osdspec_preview[search_host] = False
 
     def update_host_daemons(self, host, dm):
         # type: (str, Dict[str, orchestrator.DaemonDescription]) -> None
@@ -246,9 +266,11 @@ class HostCache():
         self.daemons[host] = {}
         self.devices[host] = []
         self.networks[host] = {}
+        self.osdspec_previews[host] = []
         self.daemon_config_deps[host] = {}
         self.daemon_refresh_queue.append(host)
         self.device_refresh_queue.append(host)
+        self.osdspec_previews_refresh_queue.append(host)
 
     def invalidate_host_daemons(self, host):
         # type: (str) -> None
@@ -269,6 +291,7 @@ class HostCache():
         j = {   # type: ignore
             'daemons': {},
             'devices': [],
+            'osdspec_previews': [],
             'daemon_config_deps': {},
         }
         if host in self.last_daemon_update:
@@ -285,8 +308,11 @@ class HostCache():
                 'deps': depi.get('deps', []),
                 'last_config': depi['last_config'].strftime(DATEFMT),
             }
+        if self.osdspec_previews[host]:
+            j['osdspec_previews'] = self.osdspec_previews[host]
+
         if host in self.last_host_check:
-            j['last_host_check']= self.last_host_check[host].strftime(DATEFMT)
+            j['last_host_check'] = self.last_host_check[host].strftime(DATEFMT)
         self.mgr.set_store(HOST_CACHE_PREFIX + host, json.dumps(j))
 
     def rm_host(self, host):
@@ -295,6 +321,10 @@ class HostCache():
             del self.daemons[host]
         if host in self.devices:
             del self.devices[host]
+        if host in self.osdspec_previews:
+            del self.osdspec_previews[host]
+        if host in self.loading_osdspec_preview:
+            del self.loading_osdspec_preview[host]
         if host in self.networks:
             del self.networks[host]
         if host in self.last_daemon_update:
@@ -382,6 +412,17 @@ class HostCache():
             seconds=self.mgr.device_cache_timeout)
         if host not in self.last_device_update or self.last_device_update[host] < cutoff:
             return True
+        return False
+
+    def host_needs_osdspec_preview_refresh(self, host):
+        if host in self.mgr.offline_hosts:
+            logger.debug(f'Host "{host}" marked as offline. Skipping osdspec preview refresh')
+            return False
+        if host in self.osdspec_previews_refresh_queue:
+            self.osdspec_previews_refresh_queue.remove(host)
+            return True
+        #  Since this is dependent on other factors (device and spec) this does not  need
+        #  to be updated periodically.
         return False
 
     def host_needs_check(self, host):

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -313,22 +313,6 @@ class TestCephadm(object):
             out = cephadm_module.osd_service.driveselection_to_ceph_volume(dg, ds, [], preview)
             assert out in exp_command
 
-    @mock.patch("cephadm.module.SpecStore.find")
-    @mock.patch("cephadm.services.osd.OSDService.prepare_drivegroup")
-    @mock.patch("cephadm.services.osd.OSDService.driveselection_to_ceph_volume")
-    @mock.patch("cephadm.services.osd.OSDService._run_ceph_volume_command")
-    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
-    def test_preview_drivegroups_str(self, _run_c_v_command, _ds_to_cv, _prepare_dg, _find_store, cephadm_module):
-        with self._with_host(cephadm_module, 'test'):
-            dg = DriveGroupSpec(placement=PlacementSpec(host_pattern='test'), data_devices=DeviceSelection(paths=['']))
-            _find_store.return_value = [dg]
-            _prepare_dg.return_value = [('host1', 'ds_dummy')]
-            _run_c_v_command.return_value = ("{}", '', 0)
-            cephadm_module.osd_service.preview_drivegroups(drive_group_name='foo')
-            _find_store.assert_called_once_with(service_name='foo')
-            _prepare_dg.assert_called_once_with(dg)
-            _run_c_v_command.assert_called_once()
-
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm(
         json.dumps([
             dict(

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -949,11 +949,17 @@ class Orchestrator(object):
         """ Update OSD cluster """
         raise NotImplementedError()
 
-    def set_unmanaged_flag(self, service_name: str, unmanaged_flag: bool) -> HandleCommandResult:
+    def set_unmanaged_flag(self,
+                           unmanaged_flag: bool,
+                           service_type: str = 'osd',
+                           service_name=None
+                           ) -> HandleCommandResult:
         raise NotImplementedError()
 
-    def preview_drivegroups(self, drive_group_name: Optional[str] = 'osd',
-                            dg_specs: Optional[List[DriveGroupSpec]] = None) -> List[Dict[str, Dict[Any, Any]]]:
+    def preview_osdspecs(self,
+                         osdspec_name: Optional[str] = 'osd',
+                         osdspecs: Optional[List[DriveGroupSpec]] = None
+                         ) -> Completion:
         """ Get a preview for OSD deployments """
         raise NotImplementedError()
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -3,6 +3,7 @@ import errno
 import json
 from typing import List, Set, Optional, Iterator
 import re
+import ast
 
 import yaml
 import six
@@ -452,9 +453,13 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
 
             return HandleCommandResult(stdout=table.get_string())
 
-    def set_unmanaged_flag(self, service_name: str, unmanaged_flag: bool) -> HandleCommandResult:
+    def set_unmanaged_flag(self,
+                           unmanaged_flag: bool,
+                           service_type: str = 'osd',
+                           service_name=None
+                           ) -> HandleCommandResult:
         # setting unmanaged for $service_name
-        completion = self.describe_service(service_name=service_name)
+        completion = self.describe_service(service_name=service_name, service_type=service_type)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         services: List[ServiceDescription] = completion.result
@@ -473,32 +478,65 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
             return HandleCommandResult(stdout=f"No specs found with the <service_name> -> {service_name}")
 
     @_cli_write_command(
-        'orch apply osd',
-        'name=all_available_devices,type=CephBool,req=false '
-        'name=preview,type=CephBool,req=false '
+        'orch osd spec',
         'name=service_name,type=CephString,req=false '
+        'name=preview,type=CephBool,req=false '
         'name=unmanaged,type=CephBool,req=false '
         "name=format,type=CephChoices,strings=plain|json|json-pretty|yaml,req=false",
-        'Create OSD daemon(s) using a drive group spec')
-    def _apply_osd(self,
-                   all_available_devices: bool = False,
-                   preview: bool = False,
-                   service_name: Optional[str] = None,
-                   unmanaged: bool = False,
-                   format: Optional[str] = 'plain',
-                   inbuf: Optional[str] = None) -> HandleCommandResult:
-        """Apply DriveGroupSpecs to create OSDs"""
+        'Common operations on an OSDSpec. Allows previewing and changing the unmanaged flag.')
+    def _misc_osd(self,
+                  preview: bool = False,
+                  service_name: Optional[str] = None,
+                  unmanaged=None,
+                  format: Optional[str] = 'plain',
+                  ) -> HandleCommandResult:
         usage = """
-Usage:
-  ceph orch apply osd -i <json_file/yaml_file>
-  ceph orch apply osd --all-available-devices
-  ceph orch apply osd --service-name <service_name> --preview
-  ceph orch apply osd --service-name <service_name> --unmanaged=True|False
+usage:
+  ceph orch osd spec --preview
+  ceph orch osd spec --unmanaged=true|false 
+  ceph orch osd spec --service-name <service_name> --preview
+  ceph orch osd spec --service-name <service_name> --unmanaged=true|false (defaults to false)
+  
+Restrictions:
+
+    Mutexes:
+    * --preview ,--unmanaged 
+
+    Although it it's possible to set these at the same time, we will lack a proper response to each
+    action, possibly shadowing any failures.
+
+Description:
+
+    * --service-name
+        If flag is omitted, assume to target all existing OSDSpecs.
+        Needs either --unamanged or --preview.
+
+    * --unmanaged
+        Applies <unamanged> flag to targeted --service-name.
+        If --service-name is omitted, target all OSDSpecs
+        
+Examples:
+
+    # ceph orch osd spec --preview
+    
+    Queries all available OSDSpecs for previews
+    
+    # ceph orch osd spec --service-name my-osdspec-name --preview
+    
+    Queries only the specified <my-osdspec-name> for previews
+    
+    # ceph orch osd spec --unmanaged=true
+    
+    # Changes flags of all available OSDSpecs to true
+    
+    # ceph orch osd spec --service-name my-osdspec-name --unmanaged=true
+    
+    Changes the unmanaged flag of <my-osdspec-name> to true
 """
 
-        def print_preview(prev, format):
+        def print_preview(previews, format_to):
             if format != 'plain':
-                return to_format(prev, format)
+                return to_format(previews, format_to)
             else:
                 table = PrettyTable(
                     ['NAME', 'HOST', 'DATA', 'DB', 'WAL'],
@@ -506,70 +544,148 @@ Usage:
                 table.align = 'l'
                 table.left_padding_width = 0
                 table.right_padding_width = 1
-                for data in prev:
-                    dg_name = data.get('drivegroup')
-                    hostname = data.get('host')
-                    for osd in data.get('data', {}).get('osds', []):
-                        db_path = '-'
-                        wal_path = '-'
-                        block_db = osd.get('block.db', {}).get('path')
-                        block_wal = osd.get('block.wal', {}).get('path')
-                        block_data = osd.get('data', {}).get('path', '')
-                        if not block_data:
-                            continue
-                        if block_db:
-                            db_path = data.get('data', {}).get('vg', {}).get('devices', [])
-                        if block_wal:
-                            wal_path = data.get('data', {}).get('wal_vg', {}).get('devices', [])
-                        table.add_row((dg_name, hostname, block_data, db_path, wal_path))
-                out = table.get_string()
-                if not out:
-                    out = "No pending deployments."
-                return out
+                for host, data in previews.items():
+                    for spec in data:
+                        if spec.get('error'):
+                            return spec.get('message')
+                        dg_name = spec.get('osdspec')
+                        for osd in spec.get('data', {}).get('osds', []):
+                            db_path = '-'
+                            wal_path = '-'
+                            block_db = osd.get('block.db', {}).get('path')
+                            block_wal = osd.get('block.wal', {}).get('path')
+                            block_data = osd.get('data', {}).get('path', '')
+                            if not block_data:
+                                continue
+                            if block_db:
+                                db_path = spec.get('data', {}).get('vg', {}).get('devices', [])
+                            if block_wal:
+                                wal_path = spec.get('data', {}).get('wal_vg', {}).get('devices', [])
+                            table.add_row((dg_name, host, block_data, db_path, wal_path))
+                ret = table.get_string()
+                if not ret:
+                    ret = "Couldn't draw any conclusion.. This is likely a bug and should be reported"
+                return ret
 
-        if (inbuf or all_available_devices) and service_name:
+        if preview and (unmanaged is not None):
+            return HandleCommandResult(-errno.EINVAL, stderr=usage)
+
+        if service_name:
+            if preview:
+                completion = self.preview_osdspecs(osdspec_name=service_name)
+                self._orchestrator_wait([completion])
+                raise_if_exception(completion)
+                out = completion.result_str()
+                return HandleCommandResult(stdout=print_preview(ast.literal_eval(out), format))
+            if unmanaged is not None:
+                return self.set_unmanaged_flag(service_name=service_name, unmanaged_flag=unmanaged)
+
+            return HandleCommandResult(-errno.EINVAL, stderr=usage)
+
+        if preview:
+            completion = self.preview_osdspecs()
+            self._orchestrator_wait([completion])
+            raise_if_exception(completion)
+            out = completion.result_str()
+            return HandleCommandResult(stdout=print_preview(ast.literal_eval(out), format))
+
+        if unmanaged is not None:
+            return self.set_unmanaged_flag(unmanaged_flag=unmanaged)
+
+        return HandleCommandResult(-errno.EINVAL, stderr=usage)
+
+    @_cli_write_command(
+        'orch apply osd',
+        'name=all_available_devices,type=CephBool,req=false '
+        'name=unmanaged,type=CephBool,req=false '
+        "name=format,type=CephChoices,strings=plain|json|json-pretty|yaml,req=false",
+        'Create OSD daemon(s) using a drive group spec')
+    def _apply_osd(self,
+                   all_available_devices: bool = False,
+                   format: Optional[str] = 'plain',
+                   unmanaged=None,
+                   inbuf: Optional[str] = None) -> HandleCommandResult:
+        """Apply DriveGroupSpecs to create OSDs"""
+        usage = """
+usage:
+  ceph orch apply osd -i <json_file/yaml_file>
+  ceph orch apply osd --all-available-devices
+  ceph orch apply osd --all-available-devices --unmanaged=true|false 
+  
+Restrictions:
+  
+  Mutexes:
+  * -i, --all-available-devices
+  * -i, --unmanaged (this would overwrite the osdspec loaded from a file)
+  
+  Parameters:
+  
+  * --unmanaged
+     Only works with --all-available-devices.
+  
+Description:
+  
+  * -i
+    An inbuf object like a file or a json/yaml blob containing a valid OSDSpec
+    
+  * --all-available-devices
+    The most simple OSDSpec there is. Takes all as 'available' marked devices
+    and creates standalone OSDs on them.
+    
+  * --unmanaged
+    Set a the unmanaged flag for all--available-devices (default is False)
+    
+Examples:
+
+   # ceph orch apply osd -i <file.yml|json>
+   
+   Applies one or more OSDSpecs found in <file>
+   
+   # ceph orch osd apply --all-available-devices --unmanaged=true
+   
+   Creates and applies simple OSDSpec with the unmanaged flag set to <true>
+"""
+
+        if inbuf and all_available_devices:
             # mutually exclusive
             return HandleCommandResult(-errno.EINVAL, stderr=usage)
 
-        if preview and not (service_name or all_available_devices or inbuf):
-            # get all stored drivegroups and print
-            prev = self.preview_drivegroups()
-            return HandleCommandResult(stdout=print_preview(prev, format))
-
-        if service_name and preview:
-            # get specified drivegroup and print
-            prev = self.preview_drivegroups(service_name)
-            return HandleCommandResult(stdout=print_preview(prev, format))
-
-        if service_name and unmanaged is not None:
-            return self.set_unmanaged_flag(service_name, unmanaged)
-
         if not inbuf and not all_available_devices:
+            # one parameter must be present
             return HandleCommandResult(-errno.EINVAL, stderr=usage)
+
         if inbuf:
-            if all_available_devices:
-                raise OrchestratorError('--all-available-devices cannot be combined with an osd spec')
+            if unmanaged is not None:
+                return HandleCommandResult(-errno.EINVAL, stderr=usage)
             try:
                 drivegroups = yaml.load_all(inbuf)
                 dg_specs = [DriveGroupSpec.from_json(dg) for dg in drivegroups]
+                # This acts weird when abstracted to a function
+                completion = self.apply_drivegroups(dg_specs)
+                self._orchestrator_wait([completion])
+                raise_if_exception(completion)
+                return HandleCommandResult(stdout=completion.result_str())
             except ValueError as e:
                 msg = 'Failed to read JSON/YAML input: {}'.format(str(e)) + usage
                 return HandleCommandResult(-errno.EINVAL, stderr=msg)
-        else:
+        if all_available_devices:
+            if unmanaged is None:
+                unmanaged = False
             dg_specs = [
                 DriveGroupSpec(
                     service_id='all-available-devices',
                     placement=PlacementSpec(host_pattern='*'),
                     data_devices=DeviceSelection(all=True),
+                    unmanaged=unmanaged
                 )
             ]
-
-        if not preview:
+            # This acts weird when abstracted to a function
             completion = self.apply_drivegroups(dg_specs)
             self._orchestrator_wait([completion])
             raise_if_exception(completion)
-        ret = self.preview_drivegroups(dg_specs=dg_specs)
-        return HandleCommandResult(stdout=print_preview(ret, format))
+            return HandleCommandResult(stdout=completion.result_str())
+
+        return HandleCommandResult(-errno.EINVAL, stderr=usage)
 
     @_cli_write_command(
         'orch daemon add osd',


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Fixes: https://tracker.ceph.com/issues/45407
Unblocks: https://github.com/ceph/ceph/pull/34665


* No longer blocks mgr when applying OSDSpecs.
  * Previews are not being displayed anymore. Previews are not generated in the background. `ceph apply osd ...` again abides the default `Scheduled ... update` theme.  

* orch CLI has slightly changed
  * `--preview` has moved to it's own sub command `ceph orch osd ..`
  * `--unmanaged` is now mainly managed in `ceph orch osd`
    * `--all-available-devices` still accepts the `--unmanaged` flag so that it can be applied without doing anything

* Added `ceph orch osd` to CLI
  * accepts `--preview` and `--unmanaged` for all or provided OSDSpecs
  * This makes the `ceph orch apply osd` method a bit more lean.

* Added more text to the `usage` of `apply osd` and `osd`
  * Added example usages

* Caching
  * OSDSpec previews are similarly to how Devices and Daemons are cached.
    * Host based
    * Reactive, meaning that only certain events trigger a refresh.

Refresh Events:
  * when Devices have changed (devices get a refresh event, per host basis)
  * when Hosts are being added/removed
  * when OSDSpecs are being added/removed/changed

------------------------

When previews are not fully generated yet, you'll see a warning:

`Preview data is being generated.. Please try again in a bit.`

this is also available in json/xml/yaml output.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
