### PR TITLE
octopus: mgr/dashboard: Fix HomeTest setup 

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_home.py
+++ b/src/pybind/mgr/dashboard/tests/test_home.py
@@ -31,7 +31,7 @@ class HomeTest(ControllerTestCase, FakeFsMixin):
             cls.fs.create_file(
                 os.path.join(lang.DEFAULT_LANGUAGE_PATH, 'index.html'),
                 contents='<!doctype html><html lang="en"><body></body></html>')
-        cls.setup_controllers([HomeController])
+            cls.setup_controllers([HomeController])
 
     @mock.patch(FakeFsMixin.builtins_open, new=FakeFsMixin.f_open)
     @mock.patch('os.stat', new=FakeFsMixin.f_os.stat)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45539

---

backport of https://github.com/ceph/ceph/pull/35017
parent tracker: https://tracker.ceph.com/issues/45516

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh