### PR TITLE
crimson/osd: avoid using variadic future

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -564,11 +564,13 @@ static seastar::future<ceph::bufferlist> do_pgnls_common(
           // the sole purpose of this chaining is to pass `next` to 2nd
           // stage altogether with items
           logger().debug("do_pgnls_common: 1st done");
-          return seastar::make_ready_future<decltype(items), decltype(next)>(
-            std::move(items), std::move(next));
+          return seastar::make_ready_future<
+            std::tuple<std::vector<hobject_t>, hobject_t>>(
+              std::make_tuple(std::move(items), std::move(next)));
       });
   }).then(
-    [pg_end, filter] (const std::vector<hobject_t>& items, auto next) {
+    [pg_end, filter] (auto&& ret) {
+      auto& [items, next] = ret;
       auto is_matched = [] (const auto& obj) {
         return !obj.is_min();
       };


### PR DESCRIPTION
it is deprecated by seastar. let's use future<tuple<...>> instead

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
