### PR TITLE
nautilus: qa/suites/upgrade: disable more min pg per osd warnings

### DIFF
--- a/qa/suites/upgrade/luminous-x/parallel/1-ceph-install/luminous.yaml
+++ b/qa/suites/upgrade/luminous-x/parallel/1-ceph-install/luminous.yaml
@@ -34,6 +34,7 @@ tasks:
       global:
         mon warn on pool no app: false
         bluestore_warn_on_legacy_statfs: false
+        mon pg warn min per osd: 0
 - exec:
     osd.0:
       - ceph osd require-osd-release luminous

--- a/qa/suites/upgrade/luminous-x/stress-split/1-ceph-install/luminous.yaml
+++ b/qa/suites/upgrade/luminous-x/stress-split/1-ceph-install/luminous.yaml
@@ -16,6 +16,7 @@ tasks:
     conf:
       global:
         bluestore_warn_on_legacy_statfs: false
+        mon pg warn min per osd: 0
 - exec:
     osd.0:
       - ceph osd require-osd-release luminous

--- a/qa/suites/upgrade/mimic-x-singleton/1-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x-singleton/1-install/mimic.yaml
@@ -19,4 +19,7 @@ tasks:
     extra_packages: ['librados2']
 - print: "**** done install mimic"
 - ceph:
+    conf:
+      global:
+        mon pg warn min per osd: 0
 - print: "**** done ceph"


### PR DESCRIPTION
This follows 58eb3edc8478c993c5446475df58d659d3f6d356.

This change is not cherry-picked from master since it already has
1ac34a5ea3d1aca299b02e574b295dd4bf6167f4.

Signed-off-by: Neha Ojha <nojha@redhat.com>

Fixes failures like:

http://pulpito.ceph.com/yuriw-2020-05-13_22:56:37-rados-wip-yuri6-testing-2020-05-13-1919-nautilus-distro-basic-smithi/5052973/
http://pulpito.ceph.com/teuthology-2020-05-11_02:25:02-upgrade:luminous-x-nautilus-distro-basic-smithi/5043370/
