### PR TITLE
cephadm: Make ceph-iscsi api user and password mandatory

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -442,7 +442,8 @@ class TestCephadm(object):
     def test_iscsi(self, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            spec = IscsiServiceSpec('name', pool='pool', placement=ps)
+            spec = IscsiServiceSpec('name', pool='pool', api_user='user',
+                                    api_password='password', placement=ps)
             c = cephadm_module.add_iscsi(spec)
             [out] = wait(cephadm_module, c)
             match_glob(out, "Deployed iscsi.name.* on host 'test'")
@@ -473,7 +474,8 @@ class TestCephadm(object):
             (ServiceSpec('mds', service_id='fsname'), CephadmOrchestrator.apply_mds),
             (RGWSpec(rgw_realm='realm', rgw_zone='zone'), CephadmOrchestrator.apply_rgw),
             (NFSServiceSpec('name', pool='pool', namespace='namespace'), CephadmOrchestrator.apply_nfs),
-            (IscsiServiceSpec('name', pool='pool'), CephadmOrchestrator.apply_iscsi),
+            (IscsiServiceSpec('name', pool='pool', api_user='user', api_password='password'),
+             CephadmOrchestrator.apply_iscsi),
         ]
     )
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -777,11 +777,15 @@ Usage:
     @_cli_write_command(
         'orch daemon add iscsi',
         'name=pool,type=CephString '
+        'name=api_user,type=CephString '
+        'name=api_password,type=CephString '
         'name=trusted_ip_list,type=CephString,req=false '
         'name=placement,type=CephString,req=false',
         'Start iscsi daemon(s)')
     def _iscsi_add(self,
                    pool: str,
+                   api_user: str,
+                   api_password: str,
                    trusted_ip_list: Optional[str] = None,
                    placement: Optional[str] = None,
                    inbuf: Optional[str] = None) -> HandleCommandResult:
@@ -791,6 +795,8 @@ Usage:
         spec = IscsiServiceSpec(
             service_id='iscsi',
             pool=pool,
+            api_user=api_user,
+            api_password=api_password,
             trusted_ip_list=trusted_ip_list,
             placement=PlacementSpec.from_string(placement),
         )
@@ -980,12 +986,16 @@ Usage:
     @_cli_write_command(
         'orch apply iscsi',
         'name=pool,type=CephString '
+        'name=api_user,type=CephString '
+        'name=api_password,type=CephString '
         'name=trusted_ip_list,type=CephString,req=false '
         'name=placement,type=CephString,req=false '
         'name=unmanaged,type=CephBool,req=false',
         'Scale an iSCSI service')
     def _apply_iscsi(self,
                      pool: str,
+                     api_user: str,
+                     api_password: str,
                      trusted_ip_list: Optional[str] = None,
                      placement: Optional[str] = None,
                      unmanaged: bool = False,
@@ -996,6 +1006,8 @@ Usage:
         spec = IscsiServiceSpec(
             service_id='iscsi',
             pool=pool,
+            api_user=api_user,
+            api_password=api_password,
             trusted_ip_list=trusted_ip_list,
             placement=PlacementSpec.from_string(placement),
             unmanaged=unmanaged,

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -600,9 +600,15 @@ class IscsiServiceSpec(ServiceSpec):
         if not self.api_secure and self.ssl_cert and self.ssl_key:
             self.api_secure = True
 
-    def validate_add(self):
-        servicespec_validate_add(self)
+    def validate(self):
+        super(IscsiServiceSpec, self).validate()
 
         if not self.pool:
             raise ServiceSpecValidationError(
                 'Cannot add ISCSI: No Pool specified')
+        if not self.api_user:
+            raise ServiceSpecValidationError(
+                'Cannot add ISCSI: No Api user specified')
+        if not self.api_password:
+            raise ServiceSpecValidationError(
+                'Cannot add ISCSI: No Api password specified')


### PR DESCRIPTION
The api user and password is required in order to use the API so let's
make these mandatory. The `ceph orch daemon add iscsi` now has them
mandatory:

  ceph orch daemon add iscsi <pool> <api_user> <api_password>

If your using apply with a yaml file, the validate in the spec now
checks for these too.

Signed-off-by: Matthew Oliver <moliver@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
