### PR TITLE
cephadm: `ls`: also return systemd_unit

### DIFF
--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -46,6 +46,8 @@ Synopsis
                               [--config CONFIG] [--keyring KEYRING]
                               command [command ...]
 
+| **cephadm** **unit**  [-h] [--fsid FSID] --name NAME command
+
 | **cephadm** **logs** [-h] [--fsid FSID] --name NAME [command [command ...]]
 
 | **cephadm** **bootstrap** [-h] [--config CONFIG] [--mon-id MON_ID]

--- a/doc/man_index.rst
+++ b/doc/man_index.rst
@@ -23,6 +23,7 @@
    man/8/ceph-run
    man/8/ceph-syn
    man/8/ceph
+   man/8/cephadm
    man/8/crushtool
    man/8/librados-config
    man/8/monmaptool

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2993,14 +2993,15 @@ def list_daemons(detail=True, legacy_dir=None):
                     fsid = get_legacy_daemon_fsid(
                             cluster, daemon_type, daemon_id,
                             legacy_dir=legacy_dir)
+                    legacy_unit_name = 'ceph-%s@%s' % (daemon_type, daemon_id)
                     i = {
                         'style': 'legacy',
                         'name': '%s.%s' % (daemon_type, daemon_id),
                         'fsid': fsid if fsid is not None else 'unknown',
+                        'systemd_unit': legacy_unit_name,
                     }
                     if detail:
-                        (i['enabled'], i['state'], _) = check_unit(
-                            'ceph-%s@%s' % (daemon_type, daemon_id))
+                        (i['enabled'], i['state'], _) = check_unit(legacy_unit_name)
                         if not host_version:
                             try:
                                 out, err, code = call(['ceph', '-v'])
@@ -3108,6 +3109,7 @@ def list_daemons(detail=True, legacy_dir=None):
                             os.path.join(data_dir, fsid, j, 'unit.image'))
                         i['configured'] = get_file_timestamp(
                             os.path.join(data_dir, fsid, j, 'unit.configured'))
+                        i['systemd_unit'] = unit_name
 
                     ls.append(i)
 


### PR DESCRIPTION
Let users directly know the systemd unit name.

Enable things like

```
cephadm ls | jq -r '.[].systemd_unit' | xargs -n 1 systemctl status | cat
```

(Also add missing `cephadm unit ...` to `man cephadm`)

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
