### PR TITLE
Revert "qa/tests: replaced ubuntu_latest.yaml with ubuntu 20.04"

### DIFF
--- a/qa/distros/all/ubuntu_20.04.yaml
+++ b/qa/distros/all/ubuntu_20.04.yaml
@@ -1,2 +1,0 @@
-os_type: ubuntu
-os_version: "20.04"

--- a/qa/distros/supported-all-distro/ubuntu_latest.yaml
+++ b/qa/distros/supported-all-distro/ubuntu_latest.yaml
@@ -1,1 +1,1 @@
-../all/ubuntu_20.04.yaml
+../all/ubuntu_18.04.yaml

--- a/qa/distros/supported-random-distro$/ubuntu_latest.yaml
+++ b/qa/distros/supported-random-distro$/ubuntu_latest.yaml
@@ -1,1 +1,1 @@
-../all/ubuntu_20.04.yaml
+../all/ubuntu_18.04.yaml

--- a/qa/distros/supported/ubuntu_latest.yaml
+++ b/qa/distros/supported/ubuntu_latest.yaml
@@ -1,1 +1,1 @@
-../all/ubuntu_20.04.yaml
+../all/ubuntu_18.04.yaml


### PR DESCRIPTION
This reverts commit 835f2f5f511e7363f4056e5137382982aac1bfbf.

Reverting this to narrow down recent failures seen in rados and upgrade suites.

Signed-off-by: Neha Ojha <nojha@redhat.com>
