### PR TITLE
cephadm: skip port in use check during reconfig/redeploy

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1461,8 +1461,8 @@ def get_daemon_args(fsid, daemon_type, daemon_id):
     return r
 
 def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
-                       config=None, keyring=None, reconfig=False):
-    # type: (str, str, Union[int, str], int, int, Optional[str], Optional[str], Optional[bool]) ->  None
+                       config=None, keyring=None):
+    # type: (str, str, Union[int, str], int, int, Optional[str], Optional[str]) ->  None
     data_dir = make_data_dir(fsid, daemon_type, daemon_id, uid=uid, gid=gid)
     make_log_dir(fsid, uid=uid, gid=gid)
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2687,7 +2687,12 @@ def command_deploy():
     if state == 'running':
         redeploy = True
 
-    logger.info('Deploying daemon %s.%s ...' % (daemon_type, daemon_id))
+    if args.reconfig:
+        logger.info('%s daemon %s ...' % ('Reconfig', args.name))
+    elif redeploy:
+        logger.info('%s daemon %s ...' % ('Redeploy', args.name))
+    else:
+        logger.info('%s daemon %s ...' % ('Deploy', args.name))
 
     if daemon_type in Ceph.daemons:
         (config, keyring) = get_config_and_keyring()

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2681,6 +2681,12 @@ def command_deploy():
     if daemon_type not in get_supported_daemons():
         raise Error('daemon type %s not recognized' % daemon_type)
 
+    redeploy = False
+    unit_name = get_unit_name(args.fsid, daemon_type, daemon_id)
+    (_, state, _) = check_unit(unit_name)
+    if state == 'running':
+        redeploy = True
+
     logger.info('Deploying daemon %s.%s ...' % (daemon_type, daemon_id))
 
     if daemon_type in Ceph.daemons:
@@ -2699,7 +2705,7 @@ def command_deploy():
         monitoring_args = []  # type: List[str]
 
         # Default Checks
-        if not args.reconfig:
+        if not args.reconfig and not redeploy:
             daemon_ports = Monitoring.port_map[daemon_type]  # type: List[int]
             if any([port_in_use(port) for port in daemon_ports]):
                 raise Error("TCP Port(s) '{}' required for {} is already in use".format(",".join(map(str, daemon_ports)), daemon_type))
@@ -2724,7 +2730,7 @@ def command_deploy():
                       reconfig=args.reconfig)
 
     elif daemon_type == NFSGanesha.daemon_type:
-        if not args.reconfig:
+        if not args.reconfig and not redeploy:
             NFSGanesha.port_in_use()
         (config, keyring) = get_config_and_keyring()
         # TODO: extract ganesha uid/gid (997, 994) ?

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2724,7 +2724,8 @@ def command_deploy():
                       reconfig=args.reconfig)
 
     elif daemon_type == NFSGanesha.daemon_type:
-        NFSGanesha.port_in_use()
+        if not args.reconfig:
+            NFSGanesha.port_in_use()
         (config, keyring) = get_config_and_keyring()
         # TODO: extract ganesha uid/gid (997, 994) ?
         (uid, gid) = extract_uid_gid()
@@ -2732,6 +2733,7 @@ def command_deploy():
         deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid,
                       config=config, keyring=keyring,
                       reconfig=args.reconfig)
+
     elif daemon_type == CephIscsi.daemon_type:
         (config, keyring) = get_config_and_keyring()
         (uid, gid) = extract_uid_gid()


### PR DESCRIPTION
The `port_in_use` check prevents a reconfig/redeploy of the monitoring components (node-exporter, grafana, etc.) as well as nfs-ganesha.

Workaround is to stop the service before issuing a reconfig/redeploy.

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
