### PR TITLE
nautilus: bash_completion: Do not auto complete obsolete and hidden cmds 

### DIFF
--- a/src/bash_completion/ceph
+++ b/src/bash_completion/ceph
@@ -27,7 +27,7 @@ _ceph()
 	COMPREPLY=( $(compgen -W "${options_noarg} ${options_arg}" -- $cur) )
 	return 0
     fi
-    declare -A hint_args
+    declare -a hint_args
     for (( i=1 ; i<cnt ; i++ ))
     do
 	#skip this word if it is option

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -680,6 +680,9 @@ def complete(sigdict, args, target):
     match_count = 0
     comps = []
     for cmdtag, cmd in sigdict.items():
+        flags = cmd.get('flags', 0)
+        if flags & (Flag.OBSOLETE | Flag.HIDDEN):
+            continue
         sig = cmd['sig']
         j = 0
         # iterate over all arguments, except last one


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45474

---

backport of https://github.com/ceph/ceph/pull/34632
parent tracker: https://tracker.ceph.com/issues/45141

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh