### PR TITLE
nautilus: client: only set MClientCaps::FLAG_SYNC when flushing dirty auth caps

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3610,15 +3610,17 @@ void Client::check_caps(Inode *in, unsigned flags)
     }
 
     int flushing;
+    int msg_flags = 0;
     ceph_tid_t flush_tid;
     if (in->auth_cap == &cap && in->dirty_caps) {
       flushing = mark_caps_flushing(in, &flush_tid);
+      if (flags & CHECK_CAPS_SYNCHRONOUS)
+	msg_flags |= MClientCaps::FLAG_SYNC;
     } else {
       flushing = 0;
       flush_tid = 0;
     }
 
-    int msg_flags = (flags & CHECK_CAPS_SYNCHRONOUS) ? MClientCaps::FLAG_SYNC : 0;
     send_cap(in, session, &cap, msg_flags, cap_used, wanted, retain,
 	     flushing, flush_tid);
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45478

---

backport of https://github.com/ceph/ceph/pull/34455
parent tracker: https://tracker.ceph.com/issues/44963

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh