### PR TITLE
rgw: URL encode bucket name in metadata sync

### DIFF
--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1049,10 +1049,12 @@ public:
     RGWRESTConn *conn = sync_env->conn;
     reenter(this) {
       yield {
+        string key_encode;
+        url_encode(key, key_encode);
         rgw_http_param_pair pairs[] = { { "key" , key.c_str()},
 	                                { NULL, NULL } };
 
-        string p = string("/admin/metadata/") + section + "/" + key;
+        string p = string("/admin/metadata/") + section + "/" + key_encode;
 
         http_op = new RGWRESTReadResource(conn, p, pairs, NULL, sync_env->http_manager);
 


### PR DESCRIPTION
I found a bug in metadata sync: some special swift buckets jammed the sync, the scene where I found this bug is:
Bucket names created via swift are allowed to contain symbols, such as "?". I created a bucket named "test???" in master zonegroup, and rgw return me "201 Created", but i found this bucket was not in the list returned by executing "radosgw-admin bucket list" in the slave zonegroup, and corresponding bucket_entrypoint and  bucket_instance object were not in metadata pool. More seriously, the buckets created later were not synchronized to slave zonegroup, the metadata sync was jammed in the shard where "test???" is located. In slave zonegroup, sync status like this: ![image](https://user-images.githubusercontent.com/59043755/82299139-bb793780-99e7-11ea-8f18-d190e3ab738c.png), rgw log like this: 
![image](https://user-images.githubusercontent.com/59043755/82300030-ddbf8500-99e8-11ea-9a38-ef199c64ea43.png)
Then, i find metadata sync coroutine does not URL encode the bucket name, resulting in a "403 Signature doesn't match" error in the request to master zonegroup. So i added this part of code.


Signed-off-by: caolei <halei15848934852@163.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
