### PR TITLE
octopus: librbd: avoid completing mirror:DisableRequest while holding its lock

### DIFF
--- a/src/librbd/mirror/DisableRequest.cc
+++ b/src/librbd/mirror/DisableRequest.cc
@@ -219,15 +219,14 @@ Context *DisableRequest<I>::handle_get_clients(int *result) {
   CephContext *cct = m_image_ctx->cct;
   ldout(cct, 10) << "r=" << *result << dendl;
 
+  std::unique_lock locker{m_lock};
+  ceph_assert(m_current_ops.empty());
+
   if (*result < 0) {
     lderr(cct) << "failed to get registered clients: " << cpp_strerror(*result)
                << dendl;
     return m_on_finish;
   }
-
-  std::lock_guard locker{m_lock};
-
-  ceph_assert(m_current_ops.empty());
 
   for (auto client : m_clients) {
     journal::ClientData client_data;
@@ -276,6 +275,7 @@ Context *DisableRequest<I>::handle_get_clients(int *result) {
     } else if (!m_remove) {
       return m_on_finish;
     }
+    locker.unlock();
 
     // no mirror clients to unregister
     send_remove_mirror_image();
@@ -342,7 +342,7 @@ Context *DisableRequest<I>::handle_remove_snap(int *result,
   CephContext *cct = m_image_ctx->cct;
   ldout(cct, 10) << "r=" << *result << dendl;
 
-  std::lock_guard locker{m_lock};
+  std::unique_lock locker{m_lock};
 
   ceph_assert(m_current_ops[client_id] > 0);
   m_current_ops[client_id]--;
@@ -360,6 +360,8 @@ Context *DisableRequest<I>::handle_remove_snap(int *result,
       if (m_ret[client_id] < 0) {
         return m_on_finish;
       }
+      locker.unlock();
+
       send_remove_mirror_image();
       return nullptr;
     }
@@ -404,7 +406,7 @@ Context *DisableRequest<I>::handle_unregister_client(
   CephContext *cct = m_image_ctx->cct;
   ldout(cct, 10) << "r=" << *result << dendl;
 
-  std::lock_guard locker{m_lock};
+  std::unique_lock locker{m_lock};
   ceph_assert(m_current_ops[client_id] == 0);
   m_current_ops.erase(client_id);
 
@@ -422,6 +424,7 @@ Context *DisableRequest<I>::handle_unregister_client(
     *result = m_error_result;
     return m_on_finish;
   }
+  locker.unlock();
 
   send_get_clients();
   return nullptr;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45598

---

backport of https://github.com/ceph/ceph/pull/35074
parent tracker: https://tracker.ceph.com/issues/45544

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh