### PR TITLE
crimson: add support for backfill, part 0

### DIFF
--- a/src/common/intrusive_lru.h
+++ b/src/common/intrusive_lru.h
@@ -148,6 +148,19 @@ public:
     }
   }
 
+  /**
+   * Returns the TRef corresponding to k if it exists or
+   * nullptr otherwise.
+   */
+  TRef get(const K &k) {
+    if (auto iter = lru_set.find(k); iter != std::end(lru_set)) {
+      access(*iter);
+      return TRef(static_cast<T*>(&*iter));
+    } else {
+      return nullptr;
+    }
+  }
+
   void set_target_size(size_t target_size) {
     lru_target_size = target_size;
     evict();

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(crimson-osd
+  backfill_state.cc
   ec_backend.cc
   heartbeat.cc
   main.cc

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(crimson-osd
   ${PROJECT_SOURCE_DIR}/src/osd/PGStateUtils.cc
   ${PROJECT_SOURCE_DIR}/src/osd/MissingLoc.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PGLog.cc
+  ${PROJECT_SOURCE_DIR}/src/osd/recovery_types.cc
   ${PROJECT_SOURCE_DIR}/src/osd/osd_perf_counters.cc
   watch.cc
   )

--- a/src/crimson/osd/backfill_facades.h
+++ b/src/crimson/osd/backfill_facades.h
@@ -41,6 +41,10 @@ struct BackfillState::PeeringFacade {
                                              const pg_stat_t &stats) {
     return peering_state.update_complete_backfill_object_stats(hoid, stats);
   }
+
+  PeeringFacade(PeeringState& peering_state)
+    : peering_state(peering_state) {
+  }
 };
 
 // PGFacade -- a facade (in the GoF-defined meaning) simplifying the huge
@@ -52,6 +56,8 @@ struct BackfillState::PGFacade {
   decltype(auto) get_projected_last_update() const {
     return pg.projected_last_update;
   }
+
+  PGFacade(PG& pg) : pg(pg) {}
 };
 
 } // namespace crimson::osd

--- a/src/crimson/osd/backfill_facades.h
+++ b/src/crimson/osd/backfill_facades.h
@@ -42,6 +42,10 @@ struct BackfillState::PeeringFacade {
     return peering_state.update_complete_backfill_object_stats(hoid, stats);
   }
 
+  bool is_backfilling() const {
+    return peering_state.is_backfilling();
+  }
+
   PeeringFacade(PeeringState& peering_state)
     : peering_state(peering_state) {
   }

--- a/src/crimson/osd/backfill_facades.h
+++ b/src/crimson/osd/backfill_facades.h
@@ -1,0 +1,57 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "crimson/osd/backfill_state.h"
+#include "crimson/osd/pg.h"
+#include "osd/PeeringState.h"
+
+namespace crimson::osd {
+
+// PeeringFacade -- a facade (in the GoF-defined meaning) simplifying
+// the interface of PeeringState. The motivation is to have an inventory
+// of behaviour that must be provided by a unit test's mock.
+struct BackfillState::PeeringFacade {
+  PeeringState& peering_state;
+
+  decltype(auto) earliest_backfill() const {
+    return peering_state.earliest_backfill();
+  }
+
+  decltype(auto) get_backfill_targets() const {
+    return peering_state.get_backfill_targets();
+  }
+
+  decltype(auto) get_peer_info(pg_shard_t peer) const {
+    return peering_state.get_peer_info(peer);
+  }
+
+  decltype(auto) get_info() const {
+    return peering_state.get_info();
+  }
+
+  decltype(auto) get_pg_log() const {
+    return peering_state.get_pg_log();
+  }
+  bool is_backfill_target(pg_shard_t peer) const {
+    return peering_state.is_backfill_target(peer);
+  }
+  void update_complete_backfill_object_stats(const hobject_t &hoid,
+                                             const pg_stat_t &stats) {
+    return peering_state.update_complete_backfill_object_stats(hoid, stats);
+  }
+};
+
+// PGFacade -- a facade (in the GoF-defined meaning) simplifying the huge
+// interface of crimson's PG class. The motivation is to have an inventory
+// of behaviour that must be provided by a unit test's mock.
+struct BackfillState::PGFacade {
+  PG& pg;
+
+  decltype(auto) get_projected_last_update() const {
+    return pg.projected_last_update;
+  }
+};
+
+} // namespace crimson::osd

--- a/src/crimson/osd/backfill_state.cc
+++ b/src/crimson/osd/backfill_state.cc
@@ -67,6 +67,7 @@ BackfillState::Initial::react(const BackfillState::Triggered& evt)
   logger().debug("{}: backfill triggered", __func__);
   ceph_assert(backfill_state().last_backfill_started == \
               peering_state().earliest_backfill());
+  ceph_assert(peering_state().is_backfilling());
   // initialize BackfillIntervals
   for (const auto& bt : peering_state().get_backfill_targets()) {
     backfill_state().peer_backfill_info[bt].reset(

--- a/src/crimson/osd/backfill_state.cc
+++ b/src/crimson/osd/backfill_state.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include <algorithm>
+#include <boost/type_index.hpp>
 
 #include "crimson/osd/backfill_state.h"
 #include "crimson/osd/backfill_facades.h"
@@ -29,6 +30,20 @@ BackfillState::BackfillState(
 {
   logger().debug("{}:{}", __func__, __LINE__);
   backfill_machine.initiate();
+}
+
+template <class S>
+BackfillState::StateHelper<S>::StateHelper()
+{
+  logger().debug("enter {}",
+		 boost::typeindex::type_id<S>().pretty_name());
+}
+
+template <class S>
+BackfillState::StateHelper<S>::~StateHelper()
+{
+  logger().debug("exit {}",
+		 boost::typeindex::type_id<S>().pretty_name());
 }
 
 BackfillState::~BackfillState() = default;
@@ -265,7 +280,6 @@ BackfillState::Enqueuing::update_on_peers(const hobject_t& check)
 BackfillState::Enqueuing::Enqueuing(my_context ctx)
   : my_base(ctx)
 {
-  logger().debug("{}", __func__);
   auto& primary_bi = backfill_state().backfill_info;
 
   // update our local interval to cope with recent changes
@@ -336,7 +350,6 @@ BackfillState::Enqueuing::Enqueuing(my_context ctx)
 BackfillState::PrimaryScanning::PrimaryScanning(my_context ctx)
   : my_base(ctx)
 {
-  logger().debug("{}", __func__);
   backfill_state().backfill_info.version = \
     peering_state().get_info().last_update;
   backfill_listener().request_primary_scan(
@@ -373,7 +386,6 @@ bool BackfillState::ReplicasScanning::replica_needs_scan(
 BackfillState::ReplicasScanning::ReplicasScanning(my_context ctx)
   : my_base(ctx)
 {
-  logger().debug("{}", __func__);
   for (const auto& bt : peering_state().get_backfill_targets()) {
     if (const auto& pbi = backfill_state().peer_backfill_info.at(bt);
         replica_needs_scan(pbi, backfill_state().backfill_info)) {
@@ -434,7 +446,6 @@ BackfillState::ReplicasScanning::react(ObjectPushed evt)
 BackfillState::Waiting::Waiting(my_context ctx)
   : my_base(ctx)
 {
-  logger().debug("{}: entered Waiting", __func__);
 }
 
 boost::statechart::result

--- a/src/crimson/osd/backfill_state.cc
+++ b/src/crimson/osd/backfill_state.cc
@@ -1,0 +1,533 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <algorithm>
+
+#include "crimson/osd/backfill_state.h"
+#include "crimson/osd/backfill_facades.h"
+#include "crimson/osd/pg.h"
+#include "osd/PeeringState.h"
+
+namespace {
+  seastar::logger& logger() {
+    return crimson::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace crimson::osd {
+
+BackfillState::BackfillState(
+  BackfillState::BackfillListener& backfill_listener,
+  std::unique_ptr<BackfillState::PeeringFacade> peering_state,
+  std::unique_ptr<BackfillState::PGFacade> pg)
+  : backfill_machine(*this,
+                     backfill_listener,
+                     std::move(peering_state),
+                     std::move(pg)),
+    progress_tracker(
+      std::make_unique<BackfillState::ProgressTracker>(backfill_machine))
+{
+  logger().debug("{}:{}", __func__, __LINE__);
+  backfill_machine.initiate();
+}
+
+BackfillState::~BackfillState() = default;
+
+BackfillState::BackfillMachine::BackfillMachine(
+  BackfillState& backfill_state,
+  BackfillState::BackfillListener& backfill_listener,
+  std::unique_ptr<BackfillState::PeeringFacade> peering_state,
+  std::unique_ptr<BackfillState::PGFacade> pg)
+  : backfill_state(backfill_state),
+    backfill_listener(backfill_listener),
+    peering_state(std::move(peering_state)),
+    pg(std::move(pg))
+{}
+
+BackfillState::BackfillMachine::~BackfillMachine() = default;
+
+BackfillState::Initial::Initial(my_context ctx)
+  : my_base(ctx)
+{
+  backfill_state().last_backfill_started = peering_state().earliest_backfill();
+  logger().debug("{}: bft={} from {}",
+                 __func__, peering_state().get_backfill_targets(),
+                 backfill_state().last_backfill_started);
+  for (const auto& bt : peering_state().get_backfill_targets()) {
+    logger().debug("{}: target shard {} from {}",
+                   __func__, bt, peering_state().get_peer_info(bt).last_backfill);
+  }
+  ceph_assert(peering_state().get_backfill_targets().size());
+  ceph_assert(!backfill_state().last_backfill_started.is_max());
+}
+
+boost::statechart::result
+BackfillState::Initial::react(const BackfillState::Triggered& evt)
+{
+  logger().debug("{}: backfill triggered", __func__);
+  ceph_assert(backfill_state().last_backfill_started == \
+              peering_state().earliest_backfill());
+  // initialize BackfillIntervals
+  for (const auto& bt : peering_state().get_backfill_targets()) {
+    backfill_state().peer_backfill_info[bt].reset(
+      peering_state().get_peer_info(bt).last_backfill);
+  }
+  backfill_state().backfill_info.reset(backfill_state().last_backfill_started);
+  if (Enqueuing::all_enqueued(peering_state(),
+                              backfill_state().backfill_info,
+                              backfill_state().peer_backfill_info)) {
+    logger().debug("{}: switching to Done state", __func__);
+    return transit<BackfillState::Done>();
+  } else {
+    logger().debug("{}: switching to Enqueuing state", __func__);
+    return transit<BackfillState::Enqueuing>();
+  }
+}
+
+
+// -- Enqueuing
+void BackfillState::Enqueuing::maybe_update_range()
+{
+  if (auto& primary_bi = backfill_state().backfill_info;
+      primary_bi.version >= pg().get_projected_last_update()) {
+    logger().info("{}: bi is current", __func__);
+    ceph_assert(primary_bi.version == pg().get_projected_last_update());
+  } else if (primary_bi.version >= peering_state().get_info().log_tail) {
+#if 0
+    if (peering_state().get_pg_log().get_log().empty() &&
+        pg().get_projected_log().empty()) {
+      /* Because we don't move log_tail on split, the log might be
+       * empty even if log_tail != last_update.  However, the only
+       * way to get here with an empty log is if log_tail is actually
+       * eversion_t(), because otherwise the entry which changed
+       * last_update since the last scan would have to be present.
+       */
+      ceph_assert(primary_bi.version == eversion_t());
+      return;
+    }
+#endif
+    logger().debug("{}: bi is old, ({}) can be updated with log to {}",
+                   __func__,
+                   primary_bi.version,
+                   pg().get_projected_last_update());
+    logger().debug("{}: scanning pg log first", __func__);
+    peering_state().get_pg_log().get_log().scan_log_after(primary_bi.version,
+      [&, this](const pg_log_entry_t& e) {
+        logger().debug("maybe_update_range(lambda): updating from version {}",
+                       e.version);
+        if (e.soid >= primary_bi.begin && e.soid <  primary_bi.end) {
+	  if (e.is_update()) {
+	    logger().debug("maybe_update_range(lambda): {} updated to ver {}",
+                           e.soid, e.version);
+            primary_bi.objects.erase(e.soid);
+            primary_bi.objects.insert(std::make_pair(e.soid,
+                                                             e.version));
+	  } else if (e.is_delete()) {
+            logger().debug("maybe_update_range(lambda): {} removed",
+                           e.soid);
+            primary_bi.objects.erase(e.soid);
+          }
+        }
+      });
+    primary_bi.version = pg().get_projected_last_update();
+  } else {
+    ceph_abort_msg(
+      "scan_range should have raised primary_bi.version past log_tail");
+  }
+}
+
+void BackfillState::Enqueuing::trim_backfill_infos()
+{
+  for (const auto& bt : peering_state().get_backfill_targets()) {
+    backfill_state().peer_backfill_info[bt].trim_to(
+      std::max(peering_state().get_peer_info(bt).last_backfill,
+               backfill_state().last_backfill_started));
+  }
+  backfill_state().backfill_info.trim_to(
+    backfill_state().last_backfill_started);
+}
+
+/* static */ bool BackfillState::Enqueuing::all_enqueued(
+  const PeeringFacade& peering_state,
+  const BackfillInterval& backfill_info,
+  const std::map<pg_shard_t, BackfillInterval>& peer_backfill_info)
+{
+  const bool all_local_enqueued = \
+    backfill_info.extends_to_end() && backfill_info.empty();
+  const bool all_peer_enqueued = std::all_of(
+    std::begin(peer_backfill_info),
+    std::end(peer_backfill_info),
+    [] (const auto& kv) {
+      [[maybe_unused]] const auto& [ shard, peer_backfill_info ] = kv;
+      return peer_backfill_info.extends_to_end() && peer_backfill_info.empty();
+    });
+  return all_local_enqueued && all_peer_enqueued;
+}
+
+hobject_t BackfillState::Enqueuing::earliest_peer_backfill(
+  const std::map<pg_shard_t, BackfillInterval>& peer_backfill_info) const
+{
+  hobject_t e = hobject_t::get_max();
+  for (const pg_shard_t& bt : peering_state().get_backfill_targets()) {
+    const auto iter = peer_backfill_info.find(bt);
+    ceph_assert(iter != peer_backfill_info.end());
+    e = std::min(e, iter->second.begin);
+  }
+  return e;
+}
+
+bool BackfillState::Enqueuing::should_rescan_replicas(
+  const std::map<pg_shard_t, BackfillInterval>& peer_backfill_info,
+  const BackfillInterval& backfill_info) const
+{
+  const auto& targets = peering_state().get_backfill_targets();
+  return std::any_of(std::begin(targets), std::end(targets),
+    [&, this] (const auto& bt) {
+      return ReplicasScanning::replica_needs_scan(peer_backfill_info.at(bt),
+                                                  backfill_info);
+    });
+}
+
+bool BackfillState::Enqueuing::should_rescan_primary(
+  const std::map<pg_shard_t, BackfillInterval>& peer_backfill_info,
+  const BackfillInterval& backfill_info) const
+{
+  return backfill_info.begin <= earliest_peer_backfill(peer_backfill_info) &&
+	 !backfill_info.extends_to_end();
+}
+
+void BackfillState::Enqueuing::trim_backfilled_object_from_intervals(
+  BackfillState::Enqueuing::result_t&& result,
+  hobject_t& last_backfill_started,
+  std::map<pg_shard_t, BackfillInterval>& peer_backfill_info)
+{
+  std::for_each(std::begin(result.pbi_targets), std::end(result.pbi_targets),
+    [this, &peer_backfill_info] (const auto& bt) {
+      peer_backfill_info.at(bt).pop_front();
+    });
+  last_backfill_started = std::move(result.new_last_backfill_started);
+}
+
+BackfillState::Enqueuing::result_t
+BackfillState::Enqueuing::remove_on_peers(const hobject_t& check)
+{
+  // set `new_last_backfill_started` to `check`
+  result_t result { {}, check };
+  for (const auto& bt : peering_state().get_backfill_targets()) {
+    const auto& pbi = backfill_state().peer_backfill_info.at(bt);
+    if (pbi.begin == check) {
+      result.pbi_targets.insert(bt);
+      const auto& version = pbi.objects.begin()->second;
+      backfill_state().progress_tracker->enqueue_drop(pbi.begin);
+      backfill_listener().enqueue_drop(bt, pbi.begin, version);
+    }
+  }
+  logger().debug("{}: BACKFILL removing {} from peers {}",
+                 __func__, check, result.pbi_targets);
+  ceph_assert(!result.pbi_targets.empty());
+  return result;
+}
+
+BackfillState::Enqueuing::result_t
+BackfillState::Enqueuing::update_on_peers(const hobject_t& check)
+{
+  const auto& primary_bi = backfill_state().backfill_info;
+  result_t result { {}, primary_bi.begin };
+
+  for (const auto& bt : peering_state().get_backfill_targets()) {
+    const auto& peer_bi = backfill_state().peer_backfill_info.at(bt);
+
+    // Find all check peers that have the wrong version
+    if (const eversion_t& obj_v = primary_bi.objects.begin()->second;
+        check == primary_bi.begin && check == peer_bi.begin) {
+      if(peer_bi.objects.begin()->second != obj_v) {
+        backfill_state().progress_tracker->enqueue_push(primary_bi.begin);
+        backfill_listener().enqueue_push(bt, primary_bi.begin, obj_v);
+      } else {
+        // it's fine, keep it!
+      }
+      result.pbi_targets.insert(bt);
+    } else {
+      const pg_info_t& pinfo = peering_state().get_peer_info(bt);
+      // Only include peers that we've caught up to their backfill line
+      // otherwise, they only appear to be missing this object
+      // because their peer_bi.begin > backfill_info.begin.
+      if (primary_bi.begin > pinfo.last_backfill) {
+        backfill_state().progress_tracker->enqueue_push(primary_bi.begin);
+        backfill_listener().enqueue_push(bt, primary_bi.begin, obj_v);
+      }
+    }
+  }
+  return result;
+}
+
+BackfillState::Enqueuing::Enqueuing(my_context ctx)
+  : my_base(ctx)
+{
+  logger().debug("{}", __func__);
+  auto& primary_bi = backfill_state().backfill_info;
+
+  // update our local interval to cope with recent changes
+  primary_bi.begin = backfill_state().last_backfill_started;
+  if (primary_bi.version < peering_state().get_info().log_tail) {
+    // it might be that the OSD is so flooded with modifying operations
+    // that backfill will be spinning here over and over. For the sake
+    // of performance and complexity we don't synchronize with entire PG.
+    // similar can happen in classical OSD.
+    logger().warn("{}: bi is old, rescanning of local backfill_info",
+                  __func__);
+    post_event(RequestPrimaryScanning{});
+    return;
+  } else {
+    maybe_update_range();
+  }
+  trim_backfill_infos();
+
+  while (!primary_bi.empty()) {
+    if (!backfill_listener().budget_available()) {
+      post_event(RequestWaiting{});
+      return;
+    } else if (should_rescan_replicas(backfill_state().peer_backfill_info,
+                                      primary_bi)) {
+      // Count simultaneous scans as a single op and let those complete
+      post_event(RequestReplicasScanning{});
+      return;
+    }
+    // Get object within set of peers to operate on and the set of targets
+    // for which that object applies.
+    if (const hobject_t check = \
+          earliest_peer_backfill(backfill_state().peer_backfill_info);
+        check < primary_bi.begin) {
+      // Don't increment ops here because deletions
+      // are cheap and not replied to unlike real recovery_ops,
+      // and we can't increment ops without requeueing ourself
+      // for recovery.
+      auto result = remove_on_peers(check);
+      trim_backfilled_object_from_intervals(std::move(result),
+					    backfill_state().last_backfill_started,
+					    backfill_state().peer_backfill_info);
+    } else {
+      auto result = update_on_peers(check);
+      trim_backfilled_object_from_intervals(std::move(result),
+					    backfill_state().last_backfill_started,
+					    backfill_state().peer_backfill_info);
+      backfill_state().backfill_info.pop_front();
+    }
+  }
+
+  if (should_rescan_primary(backfill_state().peer_backfill_info,
+                            primary_bi)) {
+    // need to grab one another chunk of the object namespace and restart
+    // the queueing.
+    logger().debug("{}: reached end for current local chunk",
+                   __func__);
+    post_event(RequestPrimaryScanning{});
+  } else if (backfill_state().progress_tracker->tracked_objects_completed()) {
+    post_event(RequestDone{});
+  } else {
+    logger().debug("{}: reached end for both local and all peers ",
+                   "but still has in-flight operations", __func__);
+    post_event(RequestWaiting{});
+  }
+}
+
+// -- PrimaryScanning
+BackfillState::PrimaryScanning::PrimaryScanning(my_context ctx)
+  : my_base(ctx)
+{
+  logger().debug("{}", __func__);
+  backfill_state().backfill_info.version = \
+    peering_state().get_info().last_update;
+  backfill_listener().request_primary_scan(
+    backfill_state().backfill_info.begin);
+}
+
+boost::statechart::result
+BackfillState::PrimaryScanning::react(PrimaryScanned evt)
+{
+  logger().debug("{}", __func__);
+  backfill_state().backfill_info = std::move(evt.result);
+  return transit<Enqueuing>();
+}
+
+boost::statechart::result
+BackfillState::PrimaryScanning::react(ObjectPushed evt)
+{
+  logger().debug("PrimaryScanning::react() on ObjectPushed; evt.object={}",
+                 evt.object);
+  backfill_state().progress_tracker->complete_to(evt.object, evt.stat);
+  return discard_event();
+}
+
+// -- ReplicasScanning
+bool BackfillState::ReplicasScanning::replica_needs_scan(
+  const BackfillInterval& replica_backfill_info,
+  const BackfillInterval& local_backfill_info)
+{
+  return replica_backfill_info.empty() && \
+         replica_backfill_info.begin <= local_backfill_info.begin && \
+         !replica_backfill_info.extends_to_end();
+}
+
+BackfillState::ReplicasScanning::ReplicasScanning(my_context ctx)
+  : my_base(ctx)
+{
+  logger().debug("{}", __func__);
+  for (const auto& bt : peering_state().get_backfill_targets()) {
+    if (const auto& pbi = backfill_state().peer_backfill_info.at(bt);
+        replica_needs_scan(pbi, backfill_state().backfill_info)) {
+      logger().debug("{}: scanning peer osd.{} from {}",
+                     __func__, bt, pbi.end);
+      backfill_listener().request_replica_scan(bt, pbi.end, hobject_t{});
+
+      ceph_assert(waiting_on_backfill.find(bt) == \
+                  waiting_on_backfill.end());
+      waiting_on_backfill.insert(bt);
+    }
+  }
+  ceph_assert(!waiting_on_backfill.empty());
+  // TODO: start_recovery_op(hobject_t::get_max()); // XXX: was pbi.end
+}
+
+#if 0
+BackfillState::ReplicasScanning::~ReplicasScanning()
+{
+  // TODO: finish_recovery_op(hobject_t::get_max());
+}
+#endif
+
+boost::statechart::result
+BackfillState::ReplicasScanning::react(ReplicaScanned evt)
+{
+  logger().debug("{}: got scan result from osd={}, result={}",
+                 __func__, evt.from, evt.result);
+  // TODO: maybe we'll be able to move waiting_on_backfill from
+  // the machine to the state.
+  ceph_assert(peering_state().is_backfill_target(evt.from));
+  if (waiting_on_backfill.erase(evt.from)) {
+    backfill_state().peer_backfill_info[evt.from] = std::move(evt.result);
+    if (waiting_on_backfill.empty()) {
+      ceph_assert(backfill_state().peer_backfill_info.size() == \
+                  peering_state().get_backfill_targets().size());
+      return transit<Enqueuing>();
+    }
+  } else {
+    // we canceled backfill for a while due to a too full, and this
+    // is an extra response from a non-too-full peer
+    logger().debug("{}: canceled backfill (too full?)", __func__);
+  }
+  return discard_event();
+}
+
+boost::statechart::result
+BackfillState::ReplicasScanning::react(ObjectPushed evt)
+{
+  logger().debug("ReplicasScanning::react() on ObjectPushed; evt.object={}",
+                 evt.object);
+  backfill_state().progress_tracker->complete_to(evt.object, evt.stat);
+  return discard_event();
+}
+
+
+// -- Waiting
+BackfillState::Waiting::Waiting(my_context ctx)
+  : my_base(ctx)
+{
+  logger().debug("{}: entered Waiting", __func__);
+}
+
+boost::statechart::result
+BackfillState::Waiting::react(ObjectPushed evt)
+{
+  logger().debug("Waiting::react() on ObjectPushed; evt.object={}",
+                 evt.object);
+  backfill_state().progress_tracker->complete_to(evt.object, evt.stat);
+  if (!Enqueuing::all_enqueued(peering_state(),
+                               backfill_state().backfill_info,
+                               backfill_state().peer_backfill_info)) {
+    return transit<Enqueuing>();
+  } else if (backfill_state().progress_tracker->tracked_objects_completed()) {
+    return transit<Done>();
+  } else {
+    // we still have something to wait on
+    logger().debug("Waiting::react() on ObjectPushed; still waiting");
+    return discard_event();
+  }
+}
+
+// -- Done
+BackfillState::Done::Done(my_context ctx)
+  : my_base(ctx)
+{
+  logger().info("{}: backfill is done", __func__);
+  backfill_listener().backfilled();
+}
+
+// -- Crashed
+BackfillState::Crashed::Crashed()
+{
+  ceph_abort_msg("{}: this should not happen");
+}
+
+// ProgressTracker is an intermediary between the BackfillListener and
+// BackfillMachine + its states. All requests to push or drop an object
+// are directed through it. The same happens with notifications about
+// completing given operations which are generated by BackfillListener
+// and dispatched as i.e. ObjectPushed events.
+// This allows ProgressTacker to track the list of in-flight operations
+// which is essential to make the decision whether the entire machine
+// should switch from Waiting to Done keep in Waiting.
+// ProgressTracker also coordinates .last_backfill_started and stats
+// updates.
+bool BackfillState::ProgressTracker::tracked_objects_completed() const
+{
+  return registry.empty();
+}
+
+void BackfillState::ProgressTracker::enqueue_push(const hobject_t& obj)
+{
+  ceph_assert(registry.count(obj) == 0);
+  registry[obj] = registry_item_t{ op_stage_t::enqueued_push, std::nullopt };
+}
+
+void BackfillState::ProgressTracker::enqueue_drop(const hobject_t& obj)
+{
+  ceph_assert(registry.count(obj) == 0);
+  registry[obj] = registry_item_t{ op_stage_t::enqueued_drop, pg_stat_t{} };
+}
+
+void BackfillState::ProgressTracker::complete_to(
+  const hobject_t& obj,
+  const pg_stat_t& stats)
+{
+  logger().debug("{}: obj={}",
+                 __func__, obj);
+  if (auto completion_iter = registry.find(obj);
+      completion_iter != std::end(registry)) {
+    completion_iter->second = \
+      registry_item_t{ op_stage_t::completed_push, stats };
+  } else {
+    ceph_abort_msg("completing untracked object shall not happen");
+  }
+  for (auto it = std::begin(registry);
+       it != std::end(registry) &&
+         it->second.stage != op_stage_t::enqueued_push;
+       it = registry.erase(it)) {
+    auto& [soid, item] = *it;
+    assert(item.stats);
+    peering_state().update_complete_backfill_object_stats(
+      soid,
+      *item.stats);
+  }
+  if (Enqueuing::all_enqueued(peering_state(),
+                              backfill_state().backfill_info,
+                              backfill_state().peer_backfill_info) &&
+      tracked_objects_completed()) {
+    backfill_state().last_backfill_started = hobject_t::get_max();
+    backfill_listener().update_peers_last_backfill(hobject_t::get_max());
+  } else {
+    backfill_listener().update_peers_last_backfill(obj);
+  }
+}
+
+} // namespace crimson::osd

--- a/src/crimson/osd/backfill_state.h
+++ b/src/crimson/osd/backfill_state.h
@@ -36,6 +36,10 @@ struct BackfillState {
   struct ReplicaScanned : sc::event<ReplicaScanned> {
     pg_shard_t from;
     BackfillInterval result;
+    ReplicaScanned(pg_shard_t from, BackfillInterval&& result)
+      : from(std::move(from)),
+        result(std::move(result)) {
+    }
   };
 
   struct ObjectPushed : sc::event<ObjectPushed> {

--- a/src/crimson/osd/backfill_state.h
+++ b/src/crimson/osd/backfill_state.h
@@ -48,6 +48,9 @@ struct BackfillState {
     // for tracking replicas.
     hobject_t object;
     pg_stat_t stat;
+    ObjectPushed(hobject_t object)
+      : object(std::move(object)) {
+    }
   };
 
   struct Triggered : sc::event<Triggered> {

--- a/src/crimson/osd/backfill_state.h
+++ b/src/crimson/osd/backfill_state.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <boost/statechart/custom_reaction.hpp>
 #include <boost/statechart/event.hpp>
 #include <boost/statechart/event_base.hpp>
@@ -11,6 +13,7 @@
 #include <boost/statechart/state_machine.hpp>
 #include <boost/statechart/transition.hpp>
 
+#include "osd/PeeringState.h"
 #include "osd/recovery_types.h"
 
 namespace crimson::osd {
@@ -19,6 +22,8 @@ namespace sc = boost::statechart;
 
 struct BackfillState {
   struct BackfillListener;
+  struct PeeringFacade;
+  struct PGFacade;
 
   // events comes first
   struct PrimaryScanned : sc::event<PrimaryScanned> {
@@ -30,63 +35,228 @@ struct BackfillState {
     BackfillInterval result;
   };
 
-  struct Flushed : sc::event<Flushed> {
+  struct ObjectPushed : sc::event<ObjectPushed> {
+    // TODO: implement replica management; I don't want to follow
+    // current convention where the backend layer is responsible
+    // for tracking replicas.
+    hobject_t object;
+    pg_stat_t stat;
   };
 
   struct Triggered : sc::event<Triggered> {
   };
 
+private:
+  // internal events
+  struct RequestPrimaryScanning : sc::event<RequestPrimaryScanning> {
+  };
+
+  struct RequestReplicasScanning : sc::event<RequestReplicasScanning> {
+  };
+
+  struct RequestWaiting : sc::event<RequestWaiting> {
+  };
+
+  struct RequestDone : sc::event<RequestDone> {
+  };
+
+  class ProgressTracker;
+
+public:
+
   struct Initial;
   struct Enqueuing;
+  struct PrimaryScanning;
+  struct ReplicasScanning;
+  struct Waiting;
+  struct Done;
 
-  class BackfillMachine : public sc::state_machine<BackfillMachine, Initial> {
+  struct BackfillMachine : sc::state_machine<BackfillMachine, Initial> {
+    BackfillMachine(BackfillState& backfill_state,
+                    BackfillListener& backfill_listener,
+                    std::unique_ptr<PeeringFacade> peering_state,
+                    std::unique_ptr<PGFacade> pg);
+    ~BackfillMachine();
+    BackfillState& backfill_state;
+    BackfillListener& backfill_listener;
+    std::unique_ptr<PeeringFacade> peering_state;
+    std::unique_ptr<PGFacade> pg;
   };
+
+private:
+  template <class S>
+  struct StateHelper {
+    BackfillState& backfill_state() {
+      return static_cast<S*>(this) \
+        ->template context<BackfillMachine>().backfill_state;
+    }
+    BackfillListener& backfill_listener() {
+      return static_cast<S*>(this) \
+        ->template context<BackfillMachine>().backfill_listener;
+    }
+    PeeringFacade& peering_state() {
+      return *static_cast<S*>(this) \
+        ->template context<BackfillMachine>().peering_state;
+    }
+    PGFacade& pg() {
+      return *static_cast<S*>(this)->template context<BackfillMachine>().pg;
+    }
+
+    const PeeringFacade& peering_state() const {
+      return *static_cast<const S*>(this) \
+        ->template context<BackfillMachine>().peering_state;
+    }
+    const BackfillState& backfill_state() const {
+      return static_cast<const S*>(this) \
+        ->template context<BackfillMachine>().backfill_state;
+    }
+  };
+
+public:
 
   // states
-  struct Crashed : sc::state<Crashed, BackfillMachine>, NamedState {
+  struct Crashed : sc::simple_state<Crashed, BackfillMachine>,
+                   StateHelper<Crashed> {
+    explicit Crashed();
   };
 
-  struct Initial : sc::state<Initial, BackfillMachine>, NamedState {
+  struct Initial : sc::state<Initial, BackfillMachine>,
+                   StateHelper<Initial> {
     using reactions = boost::mpl::list<
       sc::custom_reaction<Triggered>,
       sc::transition<sc::event_base, Crashed>>;
+    explicit Initial(my_context);
     // initialize after triggering backfill by on_activate_complete().
     // transit to Enqueuing.
     sc::result react(const Triggered&);
   };
 
-  struct Enqueuing : sc::state<Enqueuing, BackfillMachine>, NamedState {
+  struct Enqueuing : sc::state<Enqueuing, BackfillMachine>,
+                     StateHelper<Enqueuing> {
     using reactions = boost::mpl::list<
+      sc::transition<RequestPrimaryScanning, PrimaryScanning>,
+      sc::transition<RequestReplicasScanning, ReplicasScanning>,
+      sc::transition<RequestWaiting, Waiting>,
+      sc::transition<RequestDone, Done>,
       sc::transition<sc::event_base, Crashed>>;
+    explicit Enqueuing(my_context);
+
+    // indicate whether there is any remaining work to do when it comes
+    // to comparing the hobject_t namespace between primary and replicas.
+    // true doesn't necessarily mean backfill is done -- there could be
+    // in-flight pushes or drops which had been enqueued but aren't
+    // completed yet.
+    static bool all_enqueued(
+      const PeeringFacade& peering_state,
+      const BackfillInterval& backfill_info,
+      const std::map<pg_shard_t, BackfillInterval>& peer_backfill_info);
+
+  private:
+    void maybe_update_range();
+    void trim_backfill_infos();
+
+    // these methods take BackfillIntervals instead of extracting them from
+    // the state to emphasize the relationships across the main loop.
+    hobject_t earliest_peer_backfill(
+      const std::map<pg_shard_t, BackfillInterval>& peer_backfill_info) const;
+    bool should_rescan_replicas(
+      const std::map<pg_shard_t, BackfillInterval>& peer_backfill_info,
+      const BackfillInterval& backfill_info) const;
+    // indicate whether a particular acting primary needs to scanned again
+    // to process next piece of the hobject_t's namespace.
+    // the logic is per analogy to replica_needs_scan(). See comments there.
+    bool should_rescan_primary(
+      const std::map<pg_shard_t, BackfillInterval>& peer_backfill_info,
+      const BackfillInterval& backfill_info) const;
+
+    // the result_t is intermediary between {remove,update}_on_peers() and
+    // updating BackfillIntervals in trim_backfilled_object_from_intervals.
+    // This step is important because it affects the main loop's condition,
+    // and thus deserves to be exposed instead of being called deeply from
+    // {remove,update}_on_peers().
+    struct [[nodiscard]] result_t {
+      std::set<pg_shard_t> pbi_targets;
+      hobject_t new_last_backfill_started;
+    };
+    void trim_backfilled_object_from_intervals(
+      result_t&&,
+      hobject_t& last_backfill_started,
+      std::map<pg_shard_t, BackfillInterval>& peer_backfill_info);
+    result_t remove_on_peers(const hobject_t& check);
+    result_t update_on_peers(const hobject_t& check);
   };
 
   struct PrimaryScanning : sc::state<PrimaryScanning, BackfillMachine>,
-                           NamedState {
+                           StateHelper<PrimaryScanning> {
     using reactions = boost::mpl::list<
+      sc::custom_reaction<ObjectPushed>,
       sc::custom_reaction<PrimaryScanned>,
       sc::transition<sc::event_base, Crashed>>;
+    explicit PrimaryScanning(my_context);
+    sc::result react(ObjectPushed);
     // collect scanning result and transit to Enqueuing.
-    sc::result react(const PrimaryScanned&);
+    sc::result react(PrimaryScanned);
   };
 
   struct ReplicasScanning : sc::state<ReplicasScanning, BackfillMachine>,
-                            NamedState {
+                            StateHelper<ReplicasScanning> {
     using reactions = boost::mpl::list<
+      sc::custom_reaction<ObjectPushed>,
       sc::custom_reaction<ReplicaScanned>,
       sc::transition<sc::event_base, Crashed>>;
+    explicit ReplicasScanning(my_context);
     // collect scanning result; if all results are collected, transition
     // to Enqueuing will happen.
-    sc::result react(const ReplicaScanned&);
+    sc::result react(ObjectPushed);
+    sc::result react(ReplicaScanned);
+
+    // indicate whether a particular peer should be scanned to retrieve
+    // BackfillInterval for new range of hobject_t namespace.
+    // true when bi.objects is exhausted, replica bi's end is not MAX,
+    // and primary bi'begin is further than the replica's one.
+    static bool replica_needs_scan(
+      const BackfillInterval& replica_backfill_info,
+      const BackfillInterval& local_backfill_info);
+
+  private:
+    std::set<pg_shard_t> waiting_on_backfill;
   };
 
-  struct Flushing : sc::simple_state<Flushing, BackfillMachine>,
-                    NamedState {
+  struct Waiting : sc::state<Waiting, BackfillMachine>,
+                   StateHelper<Waiting> {
     using reactions = boost::mpl::list<
-      sc::transition<Flushed, Enqueuing>,
+      sc::custom_reaction<ObjectPushed>,
       sc::transition<sc::event_base, Crashed>>;
+    explicit Waiting(my_context);
+    sc::result react(ObjectPushed);
   };
+
+  struct Done : sc::state<Done, BackfillMachine>,
+                StateHelper<Done> {
+    using reactions = boost::mpl::list<
+      sc::transition<sc::event_base, Crashed>>;
+    explicit Done(my_context);
+  };
+
+  BackfillState(BackfillListener& backfill_listener,
+                std::unique_ptr<PeeringFacade> peering_state,
+                std::unique_ptr<PGFacade> pg);
+  ~BackfillState();
+
+private:
+  hobject_t last_backfill_started;
+  BackfillInterval backfill_info;
+  std::map<pg_shard_t, BackfillInterval> peer_backfill_info;
+  BackfillMachine backfill_machine;
+  std::unique_ptr<ProgressTracker> progress_tracker;
 };
 
+// BackfillListener -- an interface used by the backfill FSM to request
+// low-level services like issueing `MOSDPGPush` or `MOSDPGBackfillRemove`.
+// The goals behind the interface are: 1) unittestability; 2) possibility
+// to retrofit classical OSD with BackfillState. For the second reason we
+// never use `seastar::future` -- instead responses to the requests are
+// conveyed as events; see ObjectPushed as an example.
 struct BackfillState::BackfillListener {
   virtual void request_replica_scan(
     const pg_shard_t& target,
@@ -114,6 +284,44 @@ struct BackfillState::BackfillListener {
   virtual void backfilled() = 0;
 
   virtual ~BackfillListener() = default;
+};
+
+class BackfillState::ProgressTracker {
+  // TODO: apply_stat,
+  enum class op_stage_t {
+    enqueued_push,
+    enqueued_drop,
+    completed_push,
+  };
+
+  struct registry_item_t {
+    op_stage_t stage;
+    std::optional<pg_stat_t> stats;
+  };
+
+  BackfillMachine& backfill_machine;
+  std::map<hobject_t, registry_item_t> registry;
+
+  BackfillState& backfill_state() {
+    return backfill_machine.backfill_state;
+  }
+  PeeringFacade& peering_state() {
+    return *backfill_machine.peering_state;
+  }
+  BackfillListener& backfill_listener() {
+    return backfill_machine.backfill_listener;
+  }
+
+public:
+  ProgressTracker(BackfillMachine& backfill_machine)
+    : backfill_machine(backfill_machine) {
+  }
+
+  bool tracked_objects_completed() const;
+
+  void enqueue_push(const hobject_t&);
+  void enqueue_drop(const hobject_t&);
+  void complete_to(const hobject_t&, const pg_stat_t&);
 };
 
 } // namespace crimson::osd

--- a/src/crimson/osd/backfill_state.h
+++ b/src/crimson/osd/backfill_state.h
@@ -1,0 +1,119 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <boost/statechart/custom_reaction.hpp>
+#include <boost/statechart/event.hpp>
+#include <boost/statechart/event_base.hpp>
+#include <boost/statechart/simple_state.hpp>
+#include <boost/statechart/state.hpp>
+#include <boost/statechart/state_machine.hpp>
+#include <boost/statechart/transition.hpp>
+
+#include "osd/recovery_types.h"
+
+namespace crimson::osd {
+
+namespace sc = boost::statechart;
+
+struct BackfillState {
+  struct BackfillListener;
+
+  // events comes first
+  struct PrimaryScanned : sc::event<PrimaryScanned> {
+    BackfillInterval result;
+  };
+
+  struct ReplicaScanned : sc::event<ReplicaScanned> {
+    pg_shard_t from;
+    BackfillInterval result;
+  };
+
+  struct Flushed : sc::event<Flushed> {
+  };
+
+  struct Triggered : sc::event<Triggered> {
+  };
+
+  struct Initial;
+  struct Enqueuing;
+
+  class BackfillMachine : public sc::state_machine<BackfillMachine, Initial> {
+  };
+
+  // states
+  struct Crashed : sc::state<Crashed, BackfillMachine>, NamedState {
+  };
+
+  struct Initial : sc::state<Initial, BackfillMachine>, NamedState {
+    using reactions = boost::mpl::list<
+      sc::custom_reaction<Triggered>,
+      sc::transition<sc::event_base, Crashed>>;
+    // initialize after triggering backfill by on_activate_complete().
+    // transit to Enqueuing.
+    sc::result react(const Triggered&);
+  };
+
+  struct Enqueuing : sc::state<Enqueuing, BackfillMachine>, NamedState {
+    using reactions = boost::mpl::list<
+      sc::transition<sc::event_base, Crashed>>;
+  };
+
+  struct PrimaryScanning : sc::state<PrimaryScanning, BackfillMachine>,
+                           NamedState {
+    using reactions = boost::mpl::list<
+      sc::custom_reaction<PrimaryScanned>,
+      sc::transition<sc::event_base, Crashed>>;
+    // collect scanning result and transit to Enqueuing.
+    sc::result react(const PrimaryScanned&);
+  };
+
+  struct ReplicasScanning : sc::state<ReplicasScanning, BackfillMachine>,
+                            NamedState {
+    using reactions = boost::mpl::list<
+      sc::custom_reaction<ReplicaScanned>,
+      sc::transition<sc::event_base, Crashed>>;
+    // collect scanning result; if all results are collected, transition
+    // to Enqueuing will happen.
+    sc::result react(const ReplicaScanned&);
+  };
+
+  struct Flushing : sc::simple_state<Flushing, BackfillMachine>,
+                    NamedState {
+    using reactions = boost::mpl::list<
+      sc::transition<Flushed, Enqueuing>,
+      sc::transition<sc::event_base, Crashed>>;
+  };
+};
+
+struct BackfillState::BackfillListener {
+  virtual void request_replica_scan(
+    const pg_shard_t& target,
+    const hobject_t& begin,
+    const hobject_t& end) = 0;
+
+  virtual void request_primary_scan(
+    const hobject_t& begin) = 0;
+
+  virtual void enqueue_push(
+    const pg_shard_t& target,
+    const hobject_t& obj,
+    const eversion_t& v) = 0;
+
+  virtual void enqueue_drop(
+    const pg_shard_t& target,
+    const hobject_t& obj,
+    const eversion_t& v) = 0;
+
+  virtual void update_peers_last_backfill(
+    const hobject_t& new_last_backfill) = 0;
+
+  virtual bool budget_available() const = 0;
+
+  virtual void backfilled() = 0;
+
+  virtual ~BackfillListener() = default;
+};
+
+} // namespace crimson::osd

--- a/src/crimson/osd/backfill_state.h
+++ b/src/crimson/osd/backfill_state.h
@@ -28,6 +28,9 @@ struct BackfillState {
   // events comes first
   struct PrimaryScanned : sc::event<PrimaryScanned> {
     BackfillInterval result;
+    PrimaryScanned(BackfillInterval&& result)
+      : result(std::move(result)) {
+    }
   };
 
   struct ReplicaScanned : sc::event<ReplicaScanned> {

--- a/src/crimson/osd/backfill_state.h
+++ b/src/crimson/osd/backfill_state.h
@@ -243,6 +243,11 @@ public:
                 std::unique_ptr<PGFacade> pg);
   ~BackfillState();
 
+  void process_event(
+    boost::intrusive_ptr<const sc::event_base> evt) {
+    backfill_machine.process_event(*std::move(evt));
+  }
+
 private:
   hobject_t last_backfill_started;
   BackfillInterval backfill_info;

--- a/src/crimson/osd/backfill_state.h
+++ b/src/crimson/osd/backfill_state.h
@@ -96,6 +96,9 @@ public:
 private:
   template <class S>
   struct StateHelper {
+    StateHelper();
+    ~StateHelper();
+
     BackfillState& backfill_state() {
       return static_cast<S*>(this) \
         ->template context<BackfillMachine>().backfill_state;

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -235,6 +235,9 @@ public:
   std::pair<ObjectContextRef, bool> get_cached_obc(const hobject_t &hoid) {
     return obc_lru.get_or_create(hoid);
   }
+  ObjectContextRef maybe_get_cached_obc(const hobject_t &hoid) {
+    return obc_lru.get(hoid);
+  }
 
   const char** get_tracked_conf_keys() const final;
   void handle_conf_change(const crimson::common::ConfigProxy& conf,

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -620,6 +620,8 @@ seastar::future<> OSD::ms_dispatch(crimson::net::Connection* conn, MessageRef m)
     case MSG_OSD_PG_RECOVERY_DELETE_REPLY:
       [[fallthrough]];
     case MSG_OSD_PG_SCAN:
+      [[fallthrough]];
+    case MSG_OSD_PG_BACKFILL:
       return handle_recovery_subreq(conn, boost::static_pointer_cast<MOSDFastDispatchOp>(m));
     case MSG_OSD_PG_LEASE:
       [[fallthrough]];

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -640,6 +640,8 @@ seastar::future<> OSD::ms_dispatch(crimson::net::Connection* conn, MessageRef m)
     case MSG_OSD_PG_RECOVERY_DELETE:
       [[fallthrough]];
     case MSG_OSD_PG_RECOVERY_DELETE_REPLY:
+      [[fallthrough]];
+    case MSG_OSD_PG_SCAN:
       return handle_recovery_subreq(conn, boost::static_pointer_cast<MOSDFastDispatchOp>(m));
     case MSG_OSD_PG_LEASE:
       [[fallthrough]];

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -155,9 +155,6 @@ private:
   seastar::future<Ref<PG>> load_pg(spg_t pgid);
   seastar::future<> load_pgs();
 
-  epoch_t up_thru_wanted = 0;
-  seastar::future<> _send_alive();
-
   // OSDMapService methods
   epoch_t get_up_epoch() const final {
     return up_epoch;

--- a/src/crimson/osd/osd_operations/background_recovery.cc
+++ b/src/crimson/osd/osd_operations/background_recovery.cc
@@ -108,4 +108,13 @@ seastar::future<bool> PglogBasedRecovery::do_recovery()
       crimson::common::local_conf()->osd_recovery_max_single_start));
 }
 
+seastar::future<bool> BackfillRecovery::do_recovery()
+{
+  if (pg->has_reset_since(epoch_started))
+    return seastar::make_ready_future<bool>(false);
+  // FIXME: blocking future, limits
+  pg->get_recovery_handler()->dispatch_backfill_event(std::move(evt));
+  return seastar::make_ready_future<bool>(false);
 }
+
+} // namespace crimson::osd

--- a/src/crimson/osd/osd_operations/background_recovery.h
+++ b/src/crimson/osd/osd_operations/background_recovery.h
@@ -74,9 +74,17 @@ public:
 
 class BackfillRecovery final : public BackgroundRecovery {
   boost::intrusive_ptr<const boost::statechart::event_base> evt;
+  OrderedPipelinePhase::Handle handle;
   seastar::future<bool> do_recovery() override;
 
 public:
+  class BackfillRecoveryPipeline {
+    OrderedPipelinePhase process = {
+      "BackfillRecovery::PGPipeline::process"
+    };
+    friend class BackfillRecovery;
+  };
+
   template <class EventT>
   BackfillRecovery(
     Ref<PG> pg,

--- a/src/crimson/osd/osd_operations/background_recovery.h
+++ b/src/crimson/osd/osd_operations/background_recovery.h
@@ -83,6 +83,7 @@ public:
       "BackfillRecovery::PGPipeline::process"
     };
     friend class BackfillRecovery;
+    friend class PeeringEvent;
   };
 
   template <class EventT>
@@ -91,6 +92,8 @@ public:
     ShardServices &ss,
     epoch_t epoch_started,
     const EventT& evt);
+
+  static BackfillRecoveryPipeline &bp(PG &pg);
 };
 
 template <class EventT>

--- a/src/crimson/osd/osd_operations/background_recovery.h
+++ b/src/crimson/osd/osd_operations/background_recovery.h
@@ -72,4 +72,32 @@ public:
     epoch_t epoch_started);
 };
 
+class BackfillRecovery final : public BackgroundRecovery {
+  boost::intrusive_ptr<const boost::statechart::event_base> evt;
+  seastar::future<bool> do_recovery() override;
+
+public:
+  template <class EventT>
+  BackfillRecovery(
+    Ref<PG> pg,
+    ShardServices &ss,
+    epoch_t epoch_started,
+    const EventT& evt);
+};
+
+template <class EventT>
+BackfillRecovery::BackfillRecovery(
+  Ref<PG> pg,
+  ShardServices &ss,
+  const epoch_t epoch_started,
+  const EventT& evt)
+  : BackgroundRecovery(
+      std::move(pg),
+      ss,
+      epoch_started,
+      crimson::osd::scheduler::scheduler_class_t::background_best_effort),
+    evt(evt.intrusive_from_this())
+{}
+
+
 }

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -131,8 +131,7 @@ seastar::future<> ClientRequest::process_op(
     const hobject_t& soid = m->get_hobj();
     if (pg.is_unreadable_object(soid, &ver)) {
       auto [op, fut] = osd.get_shard_services().start_operation<UrgentRecovery>(
-			  soid, ver, pgref, osd.get_shard_services(), m->get_min_epoch(),
-			  crimson::osd::scheduler::scheduler_class_t::immediate);
+			  soid, ver, pgref, osd.get_shard_services(), m->get_min_epoch());
       return std::move(fut);
     }
     return seastar::now();

--- a/src/crimson/osd/osd_operations/peering_event.cc
+++ b/src/crimson/osd/osd_operations/peering_event.cc
@@ -77,6 +77,11 @@ seastar::future<> PeeringEvent::start()
       }).then([this, pg](auto) {
 	return with_blocking_future(handle.enter(pp(*pg).process));
       }).then([this, pg] {
+        // TODO: likely we should synchronize also with the pg log-based
+        // recovery.
+	return with_blocking_future(
+          handle.enter(BackfillRecovery::bp(*pg).process));
+      }).then([this, pg] {
 	pg->do_peering_event(evt, ctx);
 	handle.exit();
 	return complete_rctx(pg);

--- a/src/crimson/osd/osd_operations/peering_event.cc
+++ b/src/crimson/osd/osd_operations/peering_event.cc
@@ -80,6 +80,9 @@ seastar::future<> PeeringEvent::start()
 	pg->do_peering_event(evt, ctx);
 	handle.exit();
 	return complete_rctx(pg);
+      }).then([this, pg] {
+	return pg->get_need_up_thru() ? shard_services.send_alive(pg->get_same_interval_since())
+                               : seastar::now();
       });
     }
   }).then([this, ref=std::move(ref)] {

--- a/src/crimson/osd/osd_operations/peering_event.cc
+++ b/src/crimson/osd/osd_operations/peering_event.cc
@@ -85,6 +85,8 @@ seastar::future<> PeeringEvent::start()
                                : seastar::now();
       });
     }
+  }).then([this] {
+    return shard_services.send_pg_temp();
   }).then([this, ref=std::move(ref)] {
     logger().debug("{}: complete", *this);
   });

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -86,7 +86,9 @@ seastar::future<> PGAdvanceMap::start()
 	    osd.shard_services.dispatch_context(
 	      pg->get_collection_ref(),
 	      std::move(rctx)));
-	});
+	}).then([this] {
+          return osd.shard_services.send_pg_temp();
+        });
     }).then([this, ref=std::move(ref)] {
       logger().debug("{}: complete", *this);
     });

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -80,7 +80,9 @@ seastar::future<> PGAdvanceMap::start()
 	    logger().info("PGAdvanceMap::start new pg {}", *pg);
 	  }
 	  return seastar::when_all_succeed(
-	    pg->get_need_up_thru() ? osd._send_alive() : seastar::now(),
+	    pg->get_need_up_thru() \
+              ? osd.shard_services.send_alive(pg->get_same_interval_since())
+              : seastar::now(),
 	    osd.shard_services.dispatch_context(
 	      pg->get_collection_ref(),
 	      std::move(rctx)));

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -238,6 +238,8 @@ void PG::on_activate_complete()
   wait_for_active_blocker.on_active();
 
   if (peering_state.needs_recovery()) {
+    logger().info("{}: requesting recovery",
+                  __func__);
     (void) shard_services.start_operation<LocalPeeringEvent>(
       this,
       shard_services,
@@ -247,6 +249,8 @@ void PG::on_activate_complete()
       get_osdmap_epoch(),
       PeeringState::DoRecovery{});
   } else if (peering_state.needs_backfill()) {
+    logger().info("{}: requesting backfill",
+                  __func__);
     (void) shard_services.start_operation<LocalPeeringEvent>(
       this,
       shard_services,

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -453,6 +453,9 @@ public:
   const auto& get_pool() const {
     return peering_state.get_pool();
   }
+  pg_shard_t get_primary() const {
+    return peering_state.get_primary();
+  }
 
   /// initialize created PG
   void init(

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -592,7 +592,7 @@ public:
   const pg_missing_tracker_t& get_local_missing() const {
     return peering_state.get_pg_log().get_missing();
   }
-  epoch_t get_last_peering_reset() const {
+  epoch_t get_last_peering_reset() const final {
     return peering_state.get_last_peering_reset();
   }
   const set<pg_shard_t> &get_acting_recovery_backfill() const {

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -344,7 +344,7 @@ public:
   }
 
   void on_backfill_reserved() final {
-    ceph_assert(0 == "Not implemented");
+    recovery_handler->on_backfill_reserved();
   }
   void on_backfill_canceled() final {
     ceph_assert(0 == "Not implemented");

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -350,8 +350,7 @@ public:
     ceph_assert(0 == "Not implemented");
   }
   void on_recovery_reserved() final {
-    recovery_handler->start_background_recovery(
-      crimson::osd::scheduler::scheduler_class_t::background_recovery);
+    recovery_handler->start_pglogbased_recovery();
   }
 
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -116,7 +116,7 @@ public:
     return peering_state.get_min_last_complete_ondisk();
   }
 
-  const pg_info_t& get_info() const {
+  const pg_info_t& get_info() const final {
     return peering_state.get_info();
   }
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -349,6 +349,7 @@ public:
   void on_backfill_canceled() final {
     ceph_assert(0 == "Not implemented");
   }
+
   void on_recovery_reserved() final {
     recovery_handler->start_pglogbased_recovery();
   }

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -449,6 +449,9 @@ public:
   bool get_need_up_thru() const {
     return peering_state.get_need_up_thru();
   }
+  epoch_t get_same_interval_since() const {
+    return get_info().history.same_interval_since;
+  }
 
   const auto& get_pool() const {
     return peering_state.get_pool();

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -344,8 +344,7 @@ public:
   }
 
   void on_backfill_reserved() final {
-    recovery_handler->start_background_recovery(
-      crimson::osd::scheduler::scheduler_class_t::background_best_effort);
+    ceph_assert(0 == "Not implemented");
   }
   void on_backfill_canceled() final {
     ceph_assert(0 == "Not implemented");

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -657,6 +657,7 @@ private:
   friend class PGAdvanceMap;
   friend class PeeringEvent;
   friend class RepRequest;
+  friend class BackfillRecovery;
   friend struct BackfillState::PGFacade;
 private:
   seastar::future<bool> find_unfound() {
@@ -675,6 +676,9 @@ private:
   const set<pg_shard_t> &get_actingset() const {
     return peering_state.get_actingset();
   }
+
+private:
+  BackfillRecovery::BackfillRecoveryPipeline backfill_pipeline;
 };
 
 std::ostream& operator<<(std::ostream&, const PG& pg);

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -202,8 +202,8 @@ public:
   }
   void request_local_background_io_reservation(
     unsigned priority,
-    PGPeeringEventRef on_grant,
-    PGPeeringEventRef on_preempt) final {
+    PGPeeringEventURef on_grant,
+    PGPeeringEventURef on_preempt) final {
     shard_services.local_reserver.request_reservation(
       pgid,
       on_grant ? make_lambda_context([this, on_grant=std::move(on_grant)] (int) {

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -23,6 +23,7 @@
 
 #include "crimson/common/type_helpers.h"
 #include "crimson/os/futurized_collection.h"
+#include "crimson/osd/backfill_state.h"
 #include "crimson/osd/osd_operations/client_request.h"
 #include "crimson/osd/osd_operations/peering_event.h"
 #include "crimson/osd/osd_operations/replicated_request.h"
@@ -657,6 +658,7 @@ private:
   friend class PGAdvanceMap;
   friend class PeeringEvent;
   friend class RepRequest;
+  friend struct BackfillState::PGFacade;
 private:
   seastar::future<bool> find_unfound() {
     return seastar::make_ready_future<bool>(true);

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -230,8 +230,8 @@ public:
 
   void request_remote_recovery_reservation(
     unsigned priority,
-    PGPeeringEventRef on_grant,
-    PGPeeringEventRef on_preempt) final {
+    PGPeeringEventURef on_grant,
+    PGPeeringEventURef on_preempt) final {
     shard_services.remote_reserver.request_reservation(
       pgid,
       on_grant ? make_lambda_context([this, on_grant=std::move(on_grant)] (int) {

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -453,7 +453,17 @@ void PGRecovery::enqueue_push(
   const hobject_t& obj,
   const eversion_t& v)
 {
-  ceph_abort_msg("Not implemented");
+  logger().debug("{}: target={} obj={} v={}",
+                 __func__, target, obj, v);
+  std::ignore = pg->get_recovery_backend()->recover_object(obj, v).\
+  handle_exception([] (auto) {
+    ceph_abort_msg("got exception on backfill's push");
+    return seastar::make_ready_future<>();
+  }).then([this, obj] {
+    logger().debug("enqueue_push:{}", __func__);
+    using BackfillState = crimson::osd::BackfillState;
+    start_backfill_recovery(BackfillState::ObjectPushed(std::move(obj)));
+  });
 }
 
 void PGRecovery::enqueue_drop(

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -472,7 +472,8 @@ void PGRecovery::update_peers_last_backfill(
 
 bool PGRecovery::budget_available() const
 {
-  ceph_abort_msg("Not implemented");
+  // TODO: the limits!
+  return true;
 }
 
 void PGRecovery::backfilled()

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -26,15 +26,13 @@ namespace {
   }
 }
 
-void PGRecovery::start_background_recovery(
-  crimson::osd::scheduler::scheduler_class_t klass)
+void PGRecovery::start_pglogbased_recovery()
 {
-  using BackgroundRecovery = crimson::osd::BackgroundRecovery;
-  (void) pg->get_shard_services().start_operation<BackgroundRecovery>(
+  using PglogBasedRecovery = crimson::osd::PglogBasedRecovery;
+  (void) pg->get_shard_services().start_operation<PglogBasedRecovery>(
     static_cast<crimson::osd::PG*>(pg),
     pg->get_shard_services(),
-    pg->get_osdmap_epoch(),
-    klass);
+    pg->get_osdmap_epoch());
 }
 
 crimson::osd::blocking_future<bool>

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -417,7 +417,19 @@ void PGRecovery::request_replica_scan(
   const hobject_t& begin,
   const hobject_t& end)
 {
-  ceph_abort_msg("Not implemented");
+  logger().debug("{}: target.osd={}", __func__, target.osd);
+  auto msg = make_message<MOSDPGScan>(
+    MOSDPGScan::OP_SCAN_GET_DIGEST,
+    pg->get_pg_whoami(),
+    pg->get_osdmap_epoch(),
+    pg->get_last_peering_reset(),
+    spg_t(pg->get_pgid().pgid, target.shard),
+    begin,
+    end);
+  std::ignore = pg->get_shard_services().send_to_osd(
+    target.osd,
+    std::move(msg),
+    pg->get_osdmap_epoch());
 }
 
 void PGRecovery::request_primary_scan(

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -344,7 +344,7 @@ void PGRecovery::on_local_recover(
       obc->obs.oi = recovery_info.oi;
       // obc is loaded the excl lock
       obc->put_lock_type(RWState::RWEXCL);
-      assert(obc->get_recovery_read().get0());
+      ceph_assert_always(obc->get_recovery_read().get0());
     }
     if (!pg->is_unreadable_object(soid)) {
       pg->get_recovery_backend()->get_recovering(soid).set_readable();

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -545,5 +545,12 @@ void PGRecovery::on_backfill_reserved()
     std::make_unique<BackfillState::PeeringFacade>(pg->get_peering_state()),
     std::make_unique<BackfillState::PGFacade>(
       *static_cast<crimson::osd::PG*>(pg)));
+  // yes, it's **not** backfilling yet. The PG_STATE_BACKFILLING
+  // will be set after on_backfill_reserved() returns.
+  // Backfill needs to take this into consideration when scheduling
+  // events -- they must be mutually exclusive with PeeringEvent
+  // instances. Otherwise the execution might begin without having
+  // the state updated.
+  ceph_assert(!pg->get_peering_state().is_backfilling());
   start_backfill_recovery(BackfillState::Triggered{});
 }

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -488,7 +488,14 @@ bool PGRecovery::budget_available() const
 
 void PGRecovery::backfilled()
 {
-  ceph_abort_msg("Not implemented");
+  shard_services.start_operation<LocalPeeringEvent>(
+    this,
+    shard_services,
+    pg_whoami,
+    pgid,
+    get_osdmap_epoch(),
+    get_osdmap_epoch(),
+    PeeringState::Backfilled{});
 }
 
 void PGRecovery::dispatch_backfill_event(

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -399,3 +399,49 @@ void PGRecovery::_committed_pushed_object(epoch_t epoch,
 	__func__);
   }
 }
+
+void PGRecovery::request_replica_scan(
+  const pg_shard_t& target,
+  const hobject_t& begin,
+  const hobject_t& end)
+{
+  ceph_abort_msg("Not implemented");
+}
+
+void PGRecovery::request_primary_scan(
+  const hobject_t& begin)
+{
+  ceph_abort_msg("Not implemented");
+}
+
+void PGRecovery::enqueue_push(
+  const pg_shard_t& target,
+  const hobject_t& obj,
+  const eversion_t& v)
+{
+  ceph_abort_msg("Not implemented");
+}
+
+void PGRecovery::enqueue_drop(
+  const pg_shard_t& target,
+  const hobject_t& obj,
+  const eversion_t& v)
+{
+  ceph_abort_msg("Not implemented");
+}
+
+void PGRecovery::update_peers_last_backfill(
+  const hobject_t& new_last_backfill)
+{
+  ceph_abort_msg("Not implemented");
+}
+
+bool PGRecovery::budget_available() const
+{
+  ceph_abort_msg("Not implemented");
+}
+
+void PGRecovery::backfilled()
+{
+  ceph_abort_msg("Not implemented");
+}

--- a/src/crimson/osd/pg_recovery.h
+++ b/src/crimson/osd/pg_recovery.h
@@ -31,9 +31,6 @@ private:
   size_t start_replica_recovery_ops(
     size_t max_to_start,
     std::vector<crimson::osd::blocking_future<>> *out);
-  size_t start_backfill_ops(
-    size_t max_to_start,
-    std::vector<crimson::osd::blocking_future<>> *out);
 
   std::vector<pg_shard_t> get_replica_recovery_order() const {
     return pg->get_replica_recovery_order();

--- a/src/crimson/osd/pg_recovery.h
+++ b/src/crimson/osd/pg_recovery.h
@@ -77,4 +77,5 @@ private:
   seastar::future<> handle_recovery_delete_reply(
       Ref<MOSDPGRecoveryDeleteReply> m);
   seastar::future<> handle_pull_response(Ref<MOSDPGPush> m);
+  seastar::future<> handle_scan(MOSDPGScan& m);
 };

--- a/src/crimson/osd/pg_recovery.h
+++ b/src/crimson/osd/pg_recovery.h
@@ -18,8 +18,7 @@ class PGRecovery {
 public:
   PGRecovery(PGRecoveryListener* pg) : pg(pg) {}
   virtual ~PGRecovery() {}
-  void start_background_recovery(
-    crimson::osd::scheduler::scheduler_class_t klass);
+  void start_pglogbased_recovery();
 
   crimson::osd::blocking_future<bool> start_recovery_ops(size_t max_to_start);
   seastar::future<> stop() { return seastar::now(); }

--- a/src/crimson/osd/pg_recovery.h
+++ b/src/crimson/osd/pg_recovery.h
@@ -83,6 +83,9 @@ private:
   // backfill begin
   std::unique_ptr<crimson::osd::BackfillState> backfill_state;
 
+  template <class EventT>
+  void start_backfill_recovery(
+    const EventT& evt);
   void request_replica_scan(
     const pg_shard_t& target,
     const hobject_t& begin,

--- a/src/crimson/osd/pg_recovery.h
+++ b/src/crimson/osd/pg_recovery.h
@@ -22,6 +22,10 @@ public:
   void start_pglogbased_recovery();
 
   crimson::osd::blocking_future<bool> start_recovery_ops(size_t max_to_start);
+  void on_backfill_reserved();
+  void dispatch_backfill_event(
+    boost::intrusive_ptr<const boost::statechart::event_base> evt);
+
   seastar::future<> stop() { return seastar::now(); }
 private:
   PGRecoveryListener* pg;
@@ -77,6 +81,8 @@ private:
   seastar::future<> handle_scan(MOSDPGScan& m);
 
   // backfill begin
+  std::unique_ptr<crimson::osd::BackfillState> backfill_state;
+
   void request_replica_scan(
     const pg_shard_t& target,
     const hobject_t& begin,

--- a/src/crimson/osd/pg_recovery_listener.h
+++ b/src/crimson/osd/pg_recovery_listener.h
@@ -32,5 +32,6 @@ public:
   virtual bool is_unreadable_object(const hobject_t&, eversion_t* v = 0) const = 0;
   virtual bool has_reset_since(epoch_t) const = 0;
   virtual std::vector<pg_shard_t> get_replica_recovery_order() const = 0;
+  virtual epoch_t get_last_peering_reset() const = 0;
   virtual seastar::future<> stop() = 0;
 };

--- a/src/crimson/osd/pg_recovery_listener.h
+++ b/src/crimson/osd/pg_recovery_listener.h
@@ -33,5 +33,6 @@ public:
   virtual bool has_reset_since(epoch_t) const = 0;
   virtual std::vector<pg_shard_t> get_replica_recovery_order() const = 0;
   virtual epoch_t get_last_peering_reset() const = 0;
+  virtual const pg_info_t& get_info() const= 0;
   virtual seastar::future<> stop() = 0;
 };

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -1,10 +1,13 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <fmt/format.h>
+
 #include "crimson/common/exception.h"
 #include "crimson/osd/recovery_backend.h"
 #include "crimson/osd/pg.h"
 
+#include "messages/MOSDFastDispatchOp.h"
 #include "osd/osd_types.h"
 
 namespace {
@@ -53,5 +56,16 @@ void RecoveryBackend::WaitForObjectRecovery::stop() {
   for (auto& [pg_shard, pr] : pushes) {
     pr.set_exception(
 	crimson::common::system_shutdown_exception());
+  }
+}
+
+seastar::future<> RecoveryBackend::handle_recovery_op(
+  Ref<MOSDFastDispatchOp> m)
+{
+  switch (m->get_header().type) {
+  default:
+    return seastar::make_exception_future<>(
+	std::invalid_argument(fmt::format("invalid request type: {}",
+					  m->get_header().type)));
   }
 }

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -47,7 +47,7 @@ public:
   }
 
   virtual seastar::future<> handle_recovery_op(
-    Ref<MOSDFastDispatchOp> m) = 0;
+    Ref<MOSDFastDispatchOp> m);
 
   virtual seastar::future<> recover_object(
     const hobject_t& soid,

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -11,6 +11,8 @@
 #include "crimson/osd/object_context.h"
 #include "crimson/osd/shard_services.h"
 
+#include "messages/MOSDPGScan.h"
+#include "osd/recovery_types.h"
 #include "osd/osd_types.h"
 
 namespace crimson::osd{
@@ -20,6 +22,12 @@ namespace crimson::osd{
 class PGBackend;
 
 class RecoveryBackend {
+  seastar::future<> handle_scan_get_digest(
+    MOSDPGScan& m);
+  seastar::future<> handle_scan_digest(
+    MOSDPGScan& m);
+  seastar::future<> handle_scan(
+    MOSDPGScan& m);
 protected:
   class WaitForObjectRecovery;
 public:
@@ -58,6 +66,11 @@ public:
   virtual seastar::future<> push_delete(
     const hobject_t& soid,
     eversion_t need) = 0;
+
+  seastar::future<BackfillInterval> scan_for_backfill(
+    const hobject_t& from,
+    std::int64_t min,
+    std::int64_t max);
 
   void on_peering_interval_change(ceph::os::Transaction& t) {
     clean_up(t, "new peering interval");

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -11,6 +11,7 @@
 #include "crimson/osd/object_context.h"
 #include "crimson/osd/shard_services.h"
 
+#include "messages/MOSDPGBackfill.h"
 #include "messages/MOSDPGScan.h"
 #include "osd/recovery_types.h"
 #include "osd/osd_types.h"
@@ -22,6 +23,14 @@ namespace crimson::osd{
 class PGBackend;
 
 class RecoveryBackend {
+  void handle_backfill_finish(
+    MOSDPGBackfill& m);
+  seastar::future<> handle_backfill_progress(
+    MOSDPGBackfill& m);
+  seastar::future<> handle_backfill_finish_ack(
+    MOSDPGBackfill& m);
+  seastar::future<> handle_backfill(MOSDPGBackfill& m);
+
   seastar::future<> handle_scan_get_digest(
     MOSDPGScan& m);
   seastar::future<> handle_scan_digest(

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -65,7 +65,7 @@ seastar::future<> ReplicatedRecoveryBackend::recover_object(
 	      recovery_waiter.obc->put_lock_type(RWState::RWEXCL);
 	    }
 	    bool got = recovery_waiter.obc->get_recovery_read().get0();
-	    assert(pulled ? got : 1);
+	    ceph_assert_always(pulled ? got : 1);
 	    if (!got) {
 	      return recovery_waiter.obc->get_recovery_read(true)
 	      .then([](bool) { return seastar::now(); });
@@ -80,7 +80,7 @@ seastar::future<> ReplicatedRecoveryBackend::recover_object(
 	      recovery_waiter.obc = obc;
 	      // obc is loaded with excl lock
 	      recovery_waiter.obc->put_lock_type(RWState::RWEXCL);
-	      assert(recovery_waiter.obc->get_recovery_read().get0());
+	      ceph_assert_always(recovery_waiter.obc->get_recovery_read().get0());
 	      return seastar::make_ready_future<>();
 	    })
 	  );

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -84,6 +84,8 @@ seastar::future<> ReplicatedRecoveryBackend::recover_object(
 	      return seastar::make_ready_future<>();
 	    })
 	  );
+	} else {
+	  logger().debug("recover_object: already has obc!");
 	}
 	return seastar::now();
       }().then([this, soid, need, &pops, &shards] {

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -1082,9 +1082,8 @@ seastar::future<> ReplicatedRecoveryBackend::handle_recovery_op(Ref<MOSDFastDisp
     return handle_recovery_delete_reply(
 	boost::static_pointer_cast<MOSDPGRecoveryDeleteReply>(m));
   default:
-    return seastar::make_exception_future<>(
-	std::invalid_argument(fmt::format("invalid request type: {}",
-					  m->get_header().type)));
+    // delegate to parent class for handling backend-agnostic recovery ops.
+    return RecoveryBackend::handle_recovery_op(std::move(m));
   }
 }
 

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -44,6 +44,7 @@ namespace crimson::osd {
 class ShardServices : public md_config_obs_t {
   using cached_map_t = boost::local_shared_ptr<const OSDMap>;
   OSDMapService &osdmap_service;
+  const int whoami;
   crimson::net::Messenger &cluster_msgr;
   crimson::net::Messenger &public_msgr;
   crimson::mon::Client &monc;
@@ -61,6 +62,7 @@ class ShardServices : public md_config_obs_t {
 public:
   ShardServices(
     OSDMapService &osdmap_service,
+    const int whoami,
     crimson::net::Messenger &cluster_msgr,
     crimson::net::Messenger &public_msgr,
     crimson::mon::Client &monc,
@@ -204,6 +206,11 @@ private:
 public:
   AsyncReserver<spg_t, DirectFinisher> local_reserver;
   AsyncReserver<spg_t, DirectFinisher> remote_reserver;
+
+private:
+  epoch_t up_thru_wanted = 0;
+public:
+  seastar::future<> send_alive(epoch_t want);
 };
 
 }

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -33,6 +33,7 @@ set(osd_srcs
   scheduler/mClockScheduler.cc
   PeeringState.cc
   PGStateUtils.cc
+  recovery_types.cc
   MissingLoc.cc
   osd_perf_counters.cc
   ${CMAKE_SOURCE_DIR}/src/common/TrackedOp.cc

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -98,7 +98,6 @@
 #include "messages/MOSDPGInfo2.h"
 #include "messages/MOSDPGCreate.h"
 #include "messages/MOSDPGCreate2.h"
-#include "messages/MOSDPGScan.h"
 #include "messages/MBackfillReserve.h"
 #include "messages/MRecoveryReserve.h"
 #include "messages/MOSDForceRecovery.h"

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1620,15 +1620,15 @@ void PG::schedule_event_after(
 
 void PG::request_local_background_io_reservation(
   unsigned priority,
-  PGPeeringEventRef on_grant,
-  PGPeeringEventRef on_preempt) {
+  PGPeeringEventURef on_grant,
+  PGPeeringEventURef on_preempt) {
   osd->local_reserver.request_reservation(
     pg_id,
     on_grant ? new QueuePeeringEvt(
-      this, on_grant) : nullptr,
+      this, std::move(on_grant)) : nullptr,
     priority,
     on_preempt ? new QueuePeeringEvt(
-      this, on_preempt) : nullptr);
+      this, std::move(on_preempt)) : nullptr);
 }
 
 void PG::update_local_background_io_priority(

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1645,15 +1645,15 @@ void PG::cancel_local_background_io_reservation() {
 
 void PG::request_remote_recovery_reservation(
   unsigned priority,
-  PGPeeringEventRef on_grant,
-  PGPeeringEventRef on_preempt) {
+  PGPeeringEventURef on_grant,
+  PGPeeringEventURef on_preempt) {
   osd->remote_reserver.request_reservation(
     pg_id,
     on_grant ? new QueuePeeringEvt(
-      this, on_grant) : nullptr,
+      this, std::move(on_grant)) : nullptr,
     priority,
     on_preempt ? new QueuePeeringEvt(
-      this, on_preempt) : nullptr);
+      this, std::move(on_preempt)) : nullptr);
 }
 
 void PG::cancel_remote_recovery_reservation() {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3926,16 +3926,6 @@ int PG::pg_stat_adjust(osd_stat_t *ns)
   return 0;
 }
 
-ostream& operator<<(ostream& out, const PG::BackfillInterval& bi)
-{
-  out << "BackfillInfo(" << bi.begin << "-" << bi.end
-      << " " << bi.objects.size() << " objects";
-  if (!bi.objects.empty())
-    out << " " << bi.objects;
-  out << ")";
-  return out;
-}
-
 void PG::dump_pgstate_history(Formatter *f)
 {
   std::scoped_lock l{*this};

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -407,8 +407,8 @@ public:
     float delay) override;
   void request_local_background_io_reservation(
     unsigned priority,
-    PGPeeringEventRef on_grant,
-    PGPeeringEventRef on_preempt) override;
+    PGPeeringEventURef on_grant,
+    PGPeeringEventURef on_preempt) override;
   void update_local_background_io_priority(
     unsigned priority) override;
   void cancel_local_background_io_reservation() override;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -415,8 +415,8 @@ public:
 
   void request_remote_recovery_reservation(
     unsigned priority,
-    PGPeeringEventRef on_grant,
-    PGPeeringEventRef on_preempt) override;
+    PGPeeringEventURef on_grant,
+    PGPeeringEventURef on_preempt) override;
   void cancel_remote_recovery_reservation() override;
 
   void schedule_event_on_commit(

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -38,6 +38,7 @@
 #include "PGBackend.h"
 #include "PGPeeringEvent.h"
 #include "PeeringState.h"
+#include "recovery_types.h"
 #include "MissingLoc.h"
 
 #include "mgr/OSDPerfMetricTypes.h"
@@ -682,91 +683,6 @@ protected:
     ceph::make_mutex("PG::heartbeat_peer_lock");
   std::set<int> heartbeat_peers;
   std::set<int> probe_targets;
-
-public:
-  /**
-   * BackfillInterval
-   *
-   * Represents the objects in a range [begin, end)
-   *
-   * Possible states:
-   * 1) begin == end == hobject_t() indicates the the interval is unpopulated
-   * 2) Else, objects contains all objects in [begin, end)
-   */
-  struct BackfillInterval {
-    // info about a backfill interval on a peer
-    eversion_t version; /// version at which the scan occurred
-    std::map<hobject_t,eversion_t> objects;
-    hobject_t begin;
-    hobject_t end;
-
-    /// clear content
-    void clear() {
-      *this = BackfillInterval();
-    }
-
-    /// clear objects std::list only
-    void clear_objects() {
-      objects.clear();
-    }
-
-    /// reinstantiate with a new start+end position and sort order
-    void reset(hobject_t start) {
-      clear();
-      begin = end = start;
-    }
-
-    /// true if there are no objects in this interval
-    bool empty() const {
-      return objects.empty();
-    }
-
-    /// true if interval extends to the end of the range
-    bool extends_to_end() const {
-      return end.is_max();
-    }
-
-    /// removes items <= soid and adjusts begin to the first object
-    void trim_to(const hobject_t &soid) {
-      trim();
-      while (!objects.empty() &&
-	     objects.begin()->first <= soid) {
-	pop_front();
-      }
-    }
-
-    /// Adjusts begin to the first object
-    void trim() {
-      if (!objects.empty())
-	begin = objects.begin()->first;
-      else
-	begin = end;
-    }
-
-    /// drop first entry, and adjust @begin accordingly
-    void pop_front() {
-      ceph_assert(!objects.empty());
-      objects.erase(objects.begin());
-      trim();
-    }
-
-    /// dump
-    void dump(ceph::Formatter *f) const {
-      f->dump_stream("begin") << begin;
-      f->dump_stream("end") << end;
-      f->open_array_section("objects");
-      for (std::map<hobject_t, eversion_t>::const_iterator i =
-	     objects.begin();
-	   i != objects.end();
-	   ++i) {
-	f->open_object_section("object");
-	f->dump_stream("object") << i->first;
-	f->dump_stream("version") << i->second;
-	f->close_section();
-      }
-      f->close_section();
-    }
-  };
 
 protected:
   BackfillInterval backfill_info;
@@ -1508,8 +1424,5 @@ protected:
   // ref to recovery_state.info
   const pg_info_t &info;
 };
-
-
-ostream& operator<<(ostream& out, const PG::BackfillInterval& bi);
 
 #endif

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1461,7 +1461,6 @@ map<pg_shard_t, pg_info_t>::const_iterator PeeringState::find_best_info(
   /* See doc/dev/osd_internals/last_epoch_started.rst before attempting
    * to make changes to this process.  Also, make sure to update it
    * when you find bugs! */
-  eversion_t min_last_update_acceptable = eversion_t::max();
   epoch_t max_last_epoch_started_found = 0;
   for (auto i = infos.begin(); i != infos.end(); ++i) {
     if (!cct->_conf->osd_find_best_info_ignore_history_les &&
@@ -1475,6 +1474,7 @@ map<pg_shard_t, pg_info_t>::const_iterator PeeringState::find_best_info(
       max_last_epoch_started_found = i->second.last_epoch_started;
     }
   }
+  eversion_t min_last_update_acceptable = eversion_t::max();
   for (auto i = infos.begin(); i != infos.end(); ++i) {
     if (max_last_epoch_started_found <= i->second.last_epoch_started) {
       if (min_last_update_acceptable > i->second.last_update)

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -4870,11 +4870,11 @@ PeeringState::WaitLocalBackfillReserved::WaitLocalBackfillReserved(my_context ct
   ps->state_set(PG_STATE_BACKFILL_WAIT);
   pl->request_local_background_io_reservation(
     ps->get_backfill_priority(),
-    std::make_shared<PGPeeringEvent>(
+    std::make_unique<PGPeeringEvent>(
       ps->get_osdmap_epoch(),
       ps->get_osdmap_epoch(),
       LocalBackfillReserved()),
-    std::make_shared<PGPeeringEvent>(
+    std::make_unique<PGPeeringEvent>(
       ps->get_osdmap_epoch(),
       ps->get_osdmap_epoch(),
       DeferBackfill(0.0)));
@@ -5234,11 +5234,11 @@ PeeringState::WaitLocalRecoveryReserved::WaitLocalRecoveryReserved(my_context ct
   ps->state_set(PG_STATE_RECOVERY_WAIT);
   pl->request_local_background_io_reservation(
     ps->get_recovery_priority(),
-    std::make_shared<PGPeeringEvent>(
+    std::make_unique<PGPeeringEvent>(
       ps->get_osdmap_epoch(),
       ps->get_osdmap_epoch(),
       LocalRecoveryReserved()),
-    std::make_shared<PGPeeringEvent>(
+    std::make_unique<PGPeeringEvent>(
       ps->get_osdmap_epoch(),
       ps->get_osdmap_epoch(),
       DeferRecovery(0.0)));
@@ -6253,11 +6253,11 @@ PeeringState::WaitDeleteReserved::WaitDeleteReserved(my_context ctx)
   pl->cancel_local_background_io_reservation();
   pl->request_local_background_io_reservation(
     context<ToDelete>().priority,
-    std::make_shared<PGPeeringEvent>(
+    std::make_unique<PGPeeringEvent>(
       ps->get_osdmap_epoch(),
       ps->get_osdmap_epoch(),
       DeleteReserved()),
-    std::make_shared<PGPeeringEvent>(
+    std::make_unique<PGPeeringEvent>(
       ps->get_osdmap_epoch(),
       ps->get_osdmap_epoch(),
       DeleteInterrupted()));

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -5027,21 +5027,21 @@ PeeringState::RepNotRecovering::react(const RequestBackfillPrio &evt)
 	evt.primary_num_bytes, evt.local_num_bytes)) {
     post_event(RejectTooFullRemoteReservation());
   } else {
-    PGPeeringEventRef preempt;
+    PGPeeringEventURef preempt;
     if (HAVE_FEATURE(ps->upacting_features, RECOVERY_RESERVATION_2)) {
       // older peers will interpret preemption as TOOFULL
-      preempt = std::make_shared<PGPeeringEvent>(
+      preempt = std::make_unique<PGPeeringEvent>(
 	pl->get_osdmap_epoch(),
 	pl->get_osdmap_epoch(),
 	RemoteBackfillPreempted());
     }
     pl->request_remote_recovery_reservation(
       evt.priority,
-      std::make_shared<PGPeeringEvent>(
+      std::make_unique<PGPeeringEvent>(
 	pl->get_osdmap_epoch(),
 	pl->get_osdmap_epoch(),
         RemoteBackfillReserved()),
-      preempt);
+      std::move(preempt));
   }
   return transit<RepWaitBackfillReserved>();
 }
@@ -5055,10 +5055,10 @@ PeeringState::RepNotRecovering::react(const RequestRecoveryPrio &evt)
   // (pre-mimic compat)
   int prio = evt.priority ? evt.priority : ps->get_recovery_priority();
 
-  PGPeeringEventRef preempt;
+  PGPeeringEventURef preempt;
   if (HAVE_FEATURE(ps->upacting_features, RECOVERY_RESERVATION_2)) {
     // older peers can't handle this
-    preempt = std::make_shared<PGPeeringEvent>(
+    preempt = std::make_unique<PGPeeringEvent>(
       ps->get_osdmap_epoch(),
       ps->get_osdmap_epoch(),
       RemoteRecoveryPreempted());
@@ -5066,11 +5066,11 @@ PeeringState::RepNotRecovering::react(const RequestRecoveryPrio &evt)
 
   pl->request_remote_recovery_reservation(
     prio,
-    std::make_shared<PGPeeringEvent>(
+    std::make_unique<PGPeeringEvent>(
       ps->get_osdmap_epoch(),
       ps->get_osdmap_epoch(),
       RemoteRecoveryReserved()),
-    preempt);
+    std::move(preempt));
   return transit<RepWaitRecoveryReserved>();
 }
 

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1355,11 +1355,10 @@ bool PeeringState::needs_recovery() const
   }
 
   ceph_assert(!acting_recovery_backfill.empty());
-  auto end = acting_recovery_backfill.end();
-  auto a = acting_recovery_backfill.begin();
-  for (; a != end; ++a) {
-    if (*a == get_primary()) continue;
-    pg_shard_t peer = *a;
+  for (const pg_shard_t& peer : acting_recovery_backfill) {
+    if (peer == get_primary()) {
+      continue;
+    }
     auto pm = peer_missing.find(peer);
     if (pm == peer_missing.end()) {
       psdout(10) << __func__ << " osd." << peer << " doesn't have missing set"
@@ -1383,11 +1382,9 @@ bool PeeringState::needs_backfill() const
 
   // We can assume that only possible osds that need backfill
   // are on the backfill_targets vector nodes.
-  auto end = backfill_targets.end();
-  auto a = backfill_targets.begin();
-  for (; a != end; ++a) {
-    pg_shard_t peer = *a;
+  for (const pg_shard_t& peer : backfill_targets) {
     auto pi = peer_info.find(peer);
+    ceph_assert(pi != peer_info.end());
     if (!pi->second.last_backfill.is_max()) {
       psdout(10) << __func__ << " osd." << peer
 		 << " has last_backfill " << pi->second.last_backfill << dendl;

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -326,8 +326,8 @@ public:
      */
     virtual void request_remote_recovery_reservation(
       unsigned priority,
-      PGPeeringEventRef on_grant,
-      PGPeeringEventRef on_preempt) = 0;
+      PGPeeringEventURef on_grant,
+      PGPeeringEventURef on_preempt) = 0;
     /// Cancel pending remote background reservation request
     virtual void cancel_remote_recovery_reservation() = 0;
 

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -245,7 +245,7 @@ struct PeeringCtxWrapper {
   }
 };
 
-  /* Encapsulates PG recovery process */
+/* Encapsulates PG recovery process */
 class PeeringState : public MissingLoc::MappingInfo {
 public:
   struct PeeringListener : public EpochSource {

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -310,8 +310,8 @@ public:
      */
     virtual void request_local_background_io_reservation(
       unsigned priority,
-      PGPeeringEventRef on_grant,
-      PGPeeringEventRef on_preempt) = 0;
+      PGPeeringEventURef on_grant,
+      PGPeeringEventURef on_preempt) = 0;
     /// Modify pending local background reservation request priority
     virtual void update_local_background_io_priority(
       unsigned priority) = 0;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4197,6 +4197,8 @@ void PrimaryLogPG::do_scan(
       // take care to preserve ordering!
       bi.clear_objects();
       decode_noclear(bi.objects, p);
+      dout(10) << __func__ << " bi.begin=" << bi.begin << " bi.end=" << bi.end
+               << " bi.objects.size()=" << bi.objects.size() << dendl;
 
       if (waiting_on_backfill.erase(from)) {
 	if (waiting_on_backfill.empty()) {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2639,6 +2639,7 @@ struct pg_history_t {
 			       // (note: may be pg creation epoch for
 			       // pre-luminous clusters)
   epoch_t last_epoch_started = 0;;  // lower bound on last epoch started (anywhere, not necessarily locally)
+                                    // https://docs.ceph.com/docs/master/dev/osd_internals/last_epoch_started/
   epoch_t last_interval_started = 0;; // first epoch of last_epoch_started interval
   epoch_t last_epoch_clean = 0;;    // lower bound on last epoch the PG was completely clean.
   epoch_t last_interval_clean = 0;; // first epoch of last_epoch_clean interval

--- a/src/osd/recovery_types.cc
+++ b/src/osd/recovery_types.cc
@@ -1,0 +1,16 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "recovery_types.h"
+
+ostream& operator<<(ostream& out, const BackfillInterval& bi)
+{
+  out << "BackfillInfo(" << bi.begin << "-" << bi.end
+      << " " << bi.objects.size() << " objects";
+  if (!bi.objects.empty())
+    out << " " << bi.objects;
+  out << ")";
+  return out;
+}
+
+

--- a/src/osd/recovery_types.h
+++ b/src/osd/recovery_types.h
@@ -1,0 +1,95 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <map>
+
+#include "osd_types.h"
+
+/**
+ * BackfillInterval
+ *
+ * Represents the objects in a range [begin, end)
+ *
+ * Possible states:
+ * 1) begin == end == hobject_t() indicates the the interval is unpopulated
+ * 2) Else, objects contains all objects in [begin, end)
+ */
+struct BackfillInterval {
+  // info about a backfill interval on a peer
+  eversion_t version; /// version at which the scan occurred
+  std::map<hobject_t,eversion_t> objects;
+  hobject_t begin;
+  hobject_t end;
+
+  /// clear content
+  void clear() {
+    *this = BackfillInterval();
+  }
+
+  /// clear objects std::list only
+  void clear_objects() {
+    objects.clear();
+  }
+
+  /// reinstantiate with a new start+end position and sort order
+  void reset(hobject_t start) {
+    clear();
+    begin = end = start;
+  }
+
+  /// true if there are no objects in this interval
+  bool empty() const {
+    return objects.empty();
+  }
+
+  /// true if interval extends to the end of the range
+  bool extends_to_end() const {
+    return end.is_max();
+  }
+
+  /// removes items <= soid and adjusts begin to the first object
+  void trim_to(const hobject_t &soid) {
+    trim();
+    while (!objects.empty() &&
+           objects.begin()->first <= soid) {
+      pop_front();
+    }
+  }
+
+  /// Adjusts begin to the first object
+  void trim() {
+    if (!objects.empty())
+      begin = objects.begin()->first;
+    else
+      begin = end;
+  }
+
+  /// drop first entry, and adjust @begin accordingly
+  void pop_front() {
+    ceph_assert(!objects.empty());
+    objects.erase(objects.begin());
+    trim();
+  }
+
+  /// dump
+  void dump(ceph::Formatter *f) const {
+    f->dump_stream("begin") << begin;
+    f->dump_stream("end") << end;
+    f->open_array_section("objects");
+    for (std::map<hobject_t, eversion_t>::const_iterator i =
+           objects.begin();
+         i != objects.end();
+         ++i) {
+      f->open_object_section("object");
+      f->dump_stream("object") << i->first;
+      f->dump_stream("version") << i->second;
+      f->close_section();
+    }
+    f->close_section();
+  }
+};
+
+std::ostream &operator<<(std::ostream &out, const BackfillInterval &bi);
+


### PR DESCRIPTION
This is initial PR of the backfill-for-crimson effort. Part no. 1 part will bring unit tests for the backfill FSM introduced here.

## TODO
- [x] move `BackfillState` from `PG` to `PGRecovery`,
- [x] drop the DNM commit for `PeeringState`,
- [ ] glue with regular IO blocking when it's ready,
- [ ] `BackfillListener::enqueue_drop` with the corresponding flush,
- [ ] `BackfillListener::budget_available()`.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
