### PR TITLE
objclass: limit range of no c++ var name mangling

### DIFF
--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -4,8 +4,6 @@
 #ifndef CEPH_OBJCLASS_H
 #define CEPH_OBJCLASS_H
 
-#ifdef __cplusplus
-
 #include "../include/types.h"
 #include "msg/msg_types.h"
 #include "common/hobject.h"
@@ -16,6 +14,7 @@
 struct obj_list_watch_response_t;
 class PGLSFilter;
 
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -75,6 +74,7 @@ extern void class_fini(void);
 
 #ifdef __cplusplus
 }
+#endif
 // Classes expose a filter constructor that returns a subclass of PGLSFilter
 typedef PGLSFilter* (*cls_cxx_filter_factory_t)();
 
@@ -162,6 +162,4 @@ bool cls_has_chunk(cls_method_context_t hctx, std::string fp_oid);
 extern uint64_t cls_get_osd_min_alloc_size(cls_method_context_t hctx);
 extern uint64_t cls_get_pool_stripe_width(cls_method_context_t hctx);
 
-#endif
-
-#endif
+#endif // CEPH_OBJCLASS_H


### PR DESCRIPTION
Signed-off-by: Changcheng Liu <changcheng.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
