### PR TITLE
octopus: monitoring: alert for pool fill up broken

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -232,7 +232,7 @@ groups:
           (
             predict_linear(ceph_pool_stored[2d], 3600 * 24 * 5) >=
             ceph_pool_max_avail
-          ) * on(pool_id) group_right(name) ceph_pool_metadata
+          ) * on(pool_id) group_left(name) ceph_pool_metadata
         labels:
           severity: warning
           type: ceph_default


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45209

---

backport of https://github.com/ceph/ceph/pull/34469
parent tracker: https://tracker.ceph.com/issues/44991

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh