### PR TITLE
librbd: support duration controllable continuous burst

### DIFF
--- a/doc/rbd/rbd-config-ref.rst
+++ b/doc/rbd/rbd-config-ref.rst
@@ -375,6 +375,54 @@ settings.
 :Default: ``0``
 
 
+``rbd qos iops burst seconds``
+
+:Description: The desired burst duration in seconds of IO operations.
+:Type: Unsigned Integer
+:Required: No
+:Default: ``1``
+
+
+``rbd qos bps burst seconds``
+
+:Description: The desired burst duration in seconds of IO bytes.
+:Type: Unsigned Integer
+:Required: No
+:Default: ``1``
+
+
+``rbd qos read iops burst seconds``
+
+:Description: The desired burst duration in seconds of read operations.
+:Type: Unsigned Integer
+:Required: No
+:Default: ``1``
+
+
+``rbd qos write iops burst seconds``
+
+:Description: The desired burst duration in seconds of write operations.
+:Type: Unsigned Integer
+:Required: No
+:Default: ``1``
+
+
+``rbd qos read bps burst seconds``
+
+:Description: The desired burst duration in seconds of read bytes.
+:Type: Unsigned Integer
+:Required: No
+:Default: ``1``
+
+
+``rbd qos write bps burst seconds``
+
+:Description: The desired burst duration in seconds of write bytes.
+:Type: Unsigned Integer
+:Required: No
+:Default: ``1``
+
+
 ``rbd qos schedule tick min``
 
 :Description: The minimum schedule tick (in milliseconds) for QoS.

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7463,6 +7463,36 @@ static std::vector<Option> get_rbd_options() {
     .set_default(0)
     .set_description("the desired burst limit of write bytes"),
 
+    Option("rbd_qos_iops_burst_seconds", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(1)
+    .set_min(1)
+    .set_description("the desired burst duration in seconds of IO operations"),
+
+    Option("rbd_qos_bps_burst_seconds", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(1)
+    .set_min(1)
+    .set_description("the desired burst duration in seconds of IO bytes"),
+
+    Option("rbd_qos_read_iops_burst_seconds", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(1)
+    .set_min(1)
+    .set_description("the desired burst duration in seconds of read operations"),
+
+    Option("rbd_qos_write_iops_burst_seconds", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(1)
+    .set_min(1)
+    .set_description("the desired burst duration in seconds of write operations"),
+
+    Option("rbd_qos_read_bps_burst_seconds", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(1)
+    .set_min(1)
+    .set_description("the desired burst duration in seconds of read bytes"),
+
+    Option("rbd_qos_write_bps_burst_seconds", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(1)
+    .set_min(1)
+    .set_description("the desired burst duration in seconds of write bytes"),
+
     Option("rbd_qos_schedule_tick_min", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(50)
     .set_min(1)

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -816,27 +816,33 @@ public:
     io_image_dispatcher->apply_qos_limit(
       io::IMAGE_DISPATCH_FLAG_QOS_IOPS_THROTTLE,
       config.get_val<uint64_t>("rbd_qos_iops_limit"),
-      config.get_val<uint64_t>("rbd_qos_iops_burst"));
+      config.get_val<uint64_t>("rbd_qos_iops_burst"),
+      config.get_val<uint64_t>("rbd_qos_iops_burst_seconds"));
     io_image_dispatcher->apply_qos_limit(
       io::IMAGE_DISPATCH_FLAG_QOS_BPS_THROTTLE,
       config.get_val<uint64_t>("rbd_qos_bps_limit"),
-      config.get_val<uint64_t>("rbd_qos_bps_burst"));
+      config.get_val<uint64_t>("rbd_qos_bps_burst"),
+      config.get_val<uint64_t>("rbd_qos_bps_burst_seconds"));
     io_image_dispatcher->apply_qos_limit(
       io::IMAGE_DISPATCH_FLAG_QOS_READ_IOPS_THROTTLE,
       config.get_val<uint64_t>("rbd_qos_read_iops_limit"),
-      config.get_val<uint64_t>("rbd_qos_read_iops_burst"));
+      config.get_val<uint64_t>("rbd_qos_read_iops_burst"),
+      config.get_val<uint64_t>("rbd_qos_read_iops_burst_seconds"));
     io_image_dispatcher->apply_qos_limit(
       io::IMAGE_DISPATCH_FLAG_QOS_WRITE_IOPS_THROTTLE,
       config.get_val<uint64_t>("rbd_qos_write_iops_limit"),
-      config.get_val<uint64_t>("rbd_qos_write_iops_burst"));
+      config.get_val<uint64_t>("rbd_qos_write_iops_burst"),
+      config.get_val<uint64_t>("rbd_qos_write_iops_burst_seconds"));
     io_image_dispatcher->apply_qos_limit(
       io::IMAGE_DISPATCH_FLAG_QOS_READ_BPS_THROTTLE,
       config.get_val<uint64_t>("rbd_qos_read_bps_limit"),
-      config.get_val<uint64_t>("rbd_qos_read_bps_burst"));
+      config.get_val<uint64_t>("rbd_qos_read_bps_burst"),
+      config.get_val<uint64_t>("rbd_qos_read_bps_burst_seconds"));
     io_image_dispatcher->apply_qos_limit(
       io::IMAGE_DISPATCH_FLAG_QOS_WRITE_BPS_THROTTLE,
       config.get_val<uint64_t>("rbd_qos_write_bps_limit"),
-      config.get_val<uint64_t>("rbd_qos_write_bps_burst"));
+      config.get_val<uint64_t>("rbd_qos_write_bps_burst"),
+      config.get_val<uint64_t>("rbd_qos_write_bps_burst_seconds"));
 
     if (!disable_zero_copy &&
         config.get_val<bool>("rbd_disable_zero_copy_writes")) {

--- a/src/librbd/io/ImageDispatcher.cc
+++ b/src/librbd/io/ImageDispatcher.cc
@@ -144,8 +144,8 @@ void ImageDispatcher<I>::apply_qos_schedule_tick_min(uint64_t tick) {
 
 template <typename I>
 void ImageDispatcher<I>::apply_qos_limit(uint64_t flag, uint64_t limit,
-                                         uint64_t burst) {
-  m_qos_image_dispatch->apply_qos_limit(flag, limit, burst);
+                                         uint64_t burst, uint64_t burst_seconds) {
+  m_qos_image_dispatch->apply_qos_limit(flag, limit, burst, burst_seconds);
 }
 
 template <typename I>

--- a/src/librbd/io/ImageDispatcher.h
+++ b/src/librbd/io/ImageDispatcher.h
@@ -33,7 +33,8 @@ public:
   void shut_down(Context* on_finish) override;
 
   void apply_qos_schedule_tick_min(uint64_t tick) override;
-  void apply_qos_limit(uint64_t flag, uint64_t limit, uint64_t burst) override;
+  void apply_qos_limit(uint64_t flag, uint64_t limit, uint64_t burst,
+                       uint64_t burst_seconds) override;
 
   bool writes_blocked() const override;
   int block_writes() override;

--- a/src/librbd/io/ImageDispatcherInterface.h
+++ b/src/librbd/io/ImageDispatcherInterface.h
@@ -19,7 +19,7 @@ struct ImageDispatcherInterface
 public:
   virtual void apply_qos_schedule_tick_min(uint64_t tick) = 0;
   virtual void apply_qos_limit(uint64_t flag, uint64_t limit,
-                               uint64_t burst) = 0;
+                               uint64_t burst, uint64_t burst_seconds) = 0;
 
   virtual bool writes_blocked() const = 0;
   virtual int block_writes() = 0;

--- a/src/librbd/io/QosImageDispatch.cc
+++ b/src/librbd/io/QosImageDispatch.cc
@@ -86,7 +86,7 @@ void QosImageDispatch<I>::apply_qos_schedule_tick_min(uint64_t tick) {
 
 template <typename I>
 void QosImageDispatch<I>::apply_qos_limit(uint64_t flag, uint64_t limit,
-                                          uint64_t burst) {
+                                          uint64_t burst, uint64_t burst_seconds) {
   auto cct = m_image_ctx->cct;
   TokenBucketThrottle *throttle = nullptr;
   for (auto pair : m_throttles) {
@@ -97,13 +97,13 @@ void QosImageDispatch<I>::apply_qos_limit(uint64_t flag, uint64_t limit,
   }
   ceph_assert(throttle != nullptr);
 
-  int r = throttle->set_limit(limit, burst);
+  int r = throttle->set_limit(limit, burst, burst_seconds);
   if (r < 0) {
     lderr(cct) << throttle->get_name() << ": invalid qos parameter: "
                << "burst(" << burst << ") is less than "
                << "limit(" << limit << ")" << dendl;
     // if apply failed, we should at least make sure the limit works.
-    throttle->set_limit(limit, 0);
+    throttle->set_limit(limit, 0, 1);
   }
 
   if (limit) {

--- a/src/librbd/io/QosImageDispatch.h
+++ b/src/librbd/io/QosImageDispatch.h
@@ -47,7 +47,8 @@ public:
   void shut_down(Context* on_finish) override;
 
   void apply_qos_schedule_tick_min(uint64_t tick);
-  void apply_qos_limit(uint64_t flag, uint64_t limit, uint64_t burst);
+  void apply_qos_limit(uint64_t flag, uint64_t limit, uint64_t burst,
+                       uint64_t burst_seconds);
 
   bool read(
       AioCompletion* aio_comp, Extents &&image_extents,

--- a/src/test/librbd/io/test_mock_QosImageDispatch.cc
+++ b/src/test/librbd/io/test_mock_QosImageDispatch.cc
@@ -26,7 +26,7 @@ TEST_F(TestMockIoImageRequestWQ, QosNoLimit) {
   MockImageRequestWQ mock_image_request_wq(&mock_image_ctx, "io", 60, nullptr);
 
   mock_image_request_wq.apply_qos_limit(IMAGE_DISPATCH_FLAG_QOS_BPS_THROTTLE, 0,
-                                        0);
+                                        0, 1);
 
   expect_front(mock_image_request_wq, &mock_queued_image_request);
   expect_is_refresh_request(mock_image_ctx, false);
@@ -49,7 +49,7 @@ TEST_F(TestMockIoImageRequestWQ, BPSQosNoBurst) {
   MockImageRequestWQ mock_image_request_wq(&mock_image_ctx, "io", 60, nullptr);
 
   mock_image_request_wq.apply_qos_limit(IMAGE_DISPATCH_FLAG_QOS_BPS_THROTTLE, 1,
-                                        0);
+                                        0, 1);
 
   expect_front(mock_image_request_wq, &mock_queued_image_request);
   expect_tokens_requested(mock_queued_image_request, 2, true);
@@ -74,7 +74,7 @@ TEST_F(TestMockIoImageRequestWQ, BPSQosWithBurst) {
   MockImageRequestWQ mock_image_request_wq(&mock_image_ctx, "io", 60, nullptr);
 
   mock_image_request_wq.apply_qos_limit(IMAGE_DISPATCH_FLAG_QOS_BPS_THROTTLE, 1,
-                                        1);
+                                        1, 1);
 
   expect_front(mock_image_request_wq, &mock_queued_image_request);
   expect_tokens_requested(mock_queued_image_request, 2, true);

--- a/src/test/librbd/mock/io/MockImageDispatcher.h
+++ b/src/test/librbd/mock/io/MockImageDispatcher.h
@@ -28,7 +28,7 @@ public:
   MOCK_METHOD3(finish, void(int r, ImageDispatchLayer, uint64_t));
 
   MOCK_METHOD1(apply_qos_schedule_tick_min, void(uint64_t));
-  MOCK_METHOD3(apply_qos_limit, void(uint64_t, uint64_t, uint64_t));
+  MOCK_METHOD4(apply_qos_limit, void(uint64_t, uint64_t, uint64_t, uint64_t));
 
   MOCK_CONST_METHOD0(writes_blocked, bool());
   MOCK_METHOD0(block_writes, int());


### PR DESCRIPTION
Modify the design of token bucket to save more tokens than burst value,
so as to support continuous burst. The desired burst duration can be
controlled by rbd_qos_XYZ_burst_seconds.

Fixes: https://tracker.ceph.com/issues/45313
Signed-off-by: wencong wan <wanwc@chinatelecom.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
