### PR TITLE
mgr/orch: allow MDS with explicit naming

### DIFF
--- a/src/pybind/mgr/cephadm/__init__.py
+++ b/src/pybind/mgr/cephadm/__init__.py
@@ -2,5 +2,6 @@ import os
 
 if 'UNITTEST' in os.environ:
     import tests
+    tests.mock_ceph_modules()  # type: ignore
 
 from .module import CephadmOrchestrator

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -15,7 +15,7 @@ except ImportError:
 from execnet.gateway_bootstrap import HostNotFound
 
 from ceph.deployment.service_spec import ServiceSpec, PlacementSpec, RGWSpec, \
-    NFSServiceSpec, IscsiServiceSpec
+    NFSServiceSpec, IscsiServiceSpec, HostPlacementSpec
 from ceph.deployment.drive_selection.selector import DriveSelection
 from ceph.deployment.inventory import Devices, Device
 from orchestrator import ServiceDescription, DaemonDescription, InventoryHost, \
@@ -455,18 +455,46 @@ class TestCephadm(object):
             (ServiceSpec('alertmanager'), CephadmOrchestrator.apply_alertmanager),
             (ServiceSpec('rbd-mirror'), CephadmOrchestrator.apply_rbd_mirror),
             (ServiceSpec('mds', service_id='fsname'), CephadmOrchestrator.apply_mds),
+            (ServiceSpec(
+                'mds', service_id='fsname',
+                placement=PlacementSpec(
+                    hosts=[HostPlacementSpec(
+                        hostname='test',
+                        name='fsname',
+                        network=''
+                    )]
+                )
+            ), CephadmOrchestrator.apply_mds),
             (RGWSpec(rgw_realm='realm', rgw_zone='zone'), CephadmOrchestrator.apply_rgw),
+            (RGWSpec(
+                rgw_realm='realm', rgw_zone='zone',
+                placement=PlacementSpec(
+                    hosts=[HostPlacementSpec(
+                        hostname='test',
+                        name='realm.zone.a',
+                        network=''
+                    )]
+                )
+            ), CephadmOrchestrator.apply_rgw),
             (NFSServiceSpec('name', pool='pool', namespace='namespace'), CephadmOrchestrator.apply_nfs),
             (IscsiServiceSpec('name', pool='pool'), CephadmOrchestrator.apply_iscsi),
         ]
     )
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
-    def test_apply_save(self, spec: ServiceSpec, meth, cephadm_module):
+    def test_apply_save(self, spec: ServiceSpec, meth, cephadm_module: CephadmOrchestrator):
         with self._with_host(cephadm_module, 'test'):
-            spec.placement = PlacementSpec(hosts=['test'], count=1)
+            if not spec.placement:
+                spec.placement = PlacementSpec(hosts=['test'], count=1)
             c = meth(cephadm_module, spec)
             assert wait(cephadm_module, c) == f'Scheduled {spec.service_name()} update...'
             assert [d.spec for d in wait(cephadm_module, cephadm_module.describe_service())] == [spec]
+
+            cephadm_module._apply_all_services()
+
+            dds = wait(cephadm_module, cephadm_module.list_daemons())
+            for dd in dds:
+                assert dd.service_name() == spec.service_name()
+
 
             assert_rm_service(cephadm_module, spec.service_name())
 

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -422,7 +422,7 @@ def test_spec_octopus():
         ),
         DaemonDescription(
             daemon_type='nfs',
-            daemon_id="a.abc123",
+            daemon_id="ahost1.abc123",
             hostname="host1",
         ),
         False

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -338,6 +338,35 @@ def test_spec_octopus():
         True
     ),
 
+    # https://tracker.ceph.com/issues/45617
+    (
+        # daemon_id does not contain hostname
+        ServiceSpec(
+            service_type='mds',
+            service_id="a",
+        ),
+        DaemonDescription(
+            daemon_type='mds',
+            daemon_id="a",
+            hostname="host1",
+        ),
+        True
+    ),
+    (
+        # daemon_id only contains hostname
+        ServiceSpec(
+            service_type='mds',
+            service_id="host1",
+        ),
+        DaemonDescription(
+            daemon_type='mds',
+            daemon_id="host1",
+            hostname="host1",
+        ),
+        True
+    ),
+
+
     # https://tracker.ceph.com/issues/45293
     (
         NFSServiceSpec(

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -268,6 +268,19 @@ def test_spec_octopus():
         True
     ),
     (
+        # explicit naming
+        RGWSpec(
+            rgw_realm="realm",
+            rgw_zone="zone",
+        ),
+        DaemonDescription(
+            daemon_type='rgw',
+            daemon_id="realm.zone.a",
+            hostname="smithi028",
+        ),
+        True
+    ),
+    (
         # without host
         RGWSpec(
             service_type='rgw',

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1314,6 +1314,11 @@ class DaemonDescription(object):
                 if m:
                     return m.group(1)
 
+            if self.daemon_type == 'rgw':
+                v = self.daemon_id.split('.')
+                if len(v) in [3, 4]:
+                    return '.'.join(v[0:2])
+
             raise OrchestratorError("DaemonDescription: Cannot calculate service_id: " \
                     f"daemon_id='{self.daemon_id}' hostname='{self.hostname}'")
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1306,21 +1306,37 @@ class DaemonDescription(object):
 
     def service_id(self):
         def _match():
-            if self.hostname:
+            err = OrchestratorError("DaemonDescription: Cannot calculate service_id: " \
+                    f"daemon_id='{self.daemon_id}' hostname='{self.hostname}'")
+
+            if not self.hostname:
+                # TODO: can a DaemonDescription exist without a hostname?
+                raise err
+
+            if self.hostname == self.daemon_id:
+                # daemon_id == "hostname"
+                return self.daemon_id
+
+            elif self.hostname in self.daemon_id:
                 # daemon_id == "service_id.hostname"
                 # daemon_id == "service_id.hostname.random"
-                p = re.compile(r'(.*)\.%s(\.{1}\w+)?$' % (self.hostname))
-                m = p.match(self.daemon_id)
-                if m:
-                    return m.group(1)
+                pre, post = self.daemon_id.rsplit(self.hostname, 1)
+                if not pre.endswith('.'):
+                    # '.' sep missing at front of hostname
+                    raise err
+                elif post and not post.startswith('.'):
+                    # '.' sep missing at end of hostname
+                    raise err
+                return pre[:-1]
 
+            # daemon_id == "service_id.random"
             if self.daemon_type == 'rgw':
                 v = self.daemon_id.split('.')
                 if len(v) in [3, 4]:
                     return '.'.join(v[0:2])
 
-            raise OrchestratorError("DaemonDescription: Cannot calculate service_id: " \
-                    f"daemon_id='{self.daemon_id}' hostname='{self.hostname}'")
+            # daemon_id == "service_id"
+            return self.daemon_id
 
         if self.daemon_type in ['mds', 'nfs', 'iscsi', 'rgw']:
             return _match()

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -54,6 +54,8 @@ if 'UNITTEST' in os.environ:
             self._ceph_get_version = mock.Mock()
             self._ceph_get = mock.MagicMock()
             self._ceph_get_option = mock.MagicMock()
+            self._ceph_get_context = mock.MagicMock()
+            self._ceph_register_client = mock.MagicMock()
             self._configure_logging = lambda *_: None
             self._unconfigure_logging = mock.MagicMock()
             self._ceph_log = mock.MagicMock()


### PR DESCRIPTION
Explicitly naming an mds:

```
ceph orch apply mds a --placement '1;host1=a'
```

Breaks the `ls` command:
```
$ ceph orch ls 
Error ENOENT: DaemonDescription: Cannot calculate service_id: daemon_id='a' hostname='host1'
```

Fixes: https://tracker.ceph.com/issues/45617
Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
