### PR TITLE
rgw: not resolve cname with ip like address

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -2066,7 +2066,7 @@ int RGWREST::preprocess(struct req_state *s, rgw::io::BasicClient* cio)
     if (s3website_enabled) {
       in_hosted_domain_s3website = rgw_find_host_in_domains(info.host, &s3website_domain, &s3website_subdomain, hostnames_s3website_set);
       if (in_hosted_domain_s3website) {
-	in_hosted_domain = true; // TODO: should hostnames be a strict superset of hostnames_s3website?
+        in_hosted_domain = true; // TODO: should hostnames be a strict superset of hostnames_s3website?
         domain = s3website_domain;
         subdomain = s3website_subdomain;
       }
@@ -2080,35 +2080,36 @@ int RGWREST::preprocess(struct req_state *s, rgw::io::BasicClient* cio)
       << dendl;
 
     if (g_conf()->rgw_resolve_cname
-	&& !in_hosted_domain
-	&& !in_hosted_domain_s3website) {
+        && !in_hosted_domain
+        && !in_hosted_domain_s3website
+        && !looks_like_ip_address(info.host.c_str())) {
       string cname;
       bool found;
       int r = rgw_resolver->resolve_cname(info.host, cname, &found);
       if (r < 0) {
-	ldout(s->cct, 0)
-	  << "WARNING: rgw_resolver->resolve_cname() returned r=" << r
-	  << dendl;
+        ldout(s->cct, 0)
+          << "WARNING: rgw_resolver->resolve_cname() returned r=" << r
+          << dendl;
       }
 
       if (found) {
-	ldout(s->cct, 5) << "resolved host cname " << info.host << " -> "
-			 << cname << dendl;
-	in_hosted_domain =
-	  rgw_find_host_in_domains(cname, &domain, &subdomain, hostnames_set);
+        ldout(s->cct, 5) << "resolved host cname " << info.host << " -> "
+                         << cname << dendl;
+        in_hosted_domain =
+          rgw_find_host_in_domains(cname, &domain, &subdomain, hostnames_set);
 
         if (s3website_enabled
-	    && !in_hosted_domain_s3website) {
-	  in_hosted_domain_s3website =
-	    rgw_find_host_in_domains(cname, &s3website_domain,
-				     &s3website_subdomain,
-				     hostnames_s3website_set);
-	  if (in_hosted_domain_s3website) {
-	    in_hosted_domain = true; // TODO: should hostnames be a
-				     // strict superset of hostnames_s3website?
-	    domain = s3website_domain;
-	    subdomain = s3website_subdomain;
-	  }
+            && !in_hosted_domain_s3website) {
+          in_hosted_domain_s3website =
+            rgw_find_host_in_domains(cname, &s3website_domain,
+                                     &s3website_subdomain,
+                                     hostnames_s3website_set);
+          if (in_hosted_domain_s3website) {
+            in_hosted_domain = true; // TODO: should hostnames be a
+                                     // strict superset of hostnames_s3website?
+            domain = s3website_domain;
+            subdomain = s3website_subdomain;
+          }
         }
 
         ldout(s->cct, 20)


### PR DESCRIPTION
When set the rgw_resolve_cname as true for rgw, it will resolve the host  from the dns when the host is not in the hosted_domain set or hosted_domain_s3website set. For production, it will has mutil zongroups and zones, and the rgw instances usually sync metadata and data using the instance ip. While the ip is not in in_hosted_domain or hosted_domain_s3website, so it will step into the branch and slow the response. Besides, we could not resolve any cname from dns because ip like address is not a domain. So I think we can just not reslove the ip like address.


Signed-off-by: wangyunqing <wangyunqing@inspur.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
