### PR TITLE
octopus: mds: Handle blacklisted error in purge queue

### DIFF
--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -588,8 +588,14 @@ void PurgeQueue::_execute_item(
   gather.set_finisher(new C_OnFinisher(
                       new LambdaContext([this, expire_to](int r){
     std::lock_guard l(lock);
-    _execute_item_complete(expire_to);
 
+    if (r == -EBLACKLISTED) {
+      finisher.queue(on_error, r);
+      on_error = nullptr;
+      return;
+    }
+
+    _execute_item_complete(expire_to);
     _consume();
 
     // Have we gone idle?  If so, do an extra write_head now instead of

--- a/src/osdc/Filer.cc
+++ b/src/osdc/Filer.cc
@@ -302,6 +302,7 @@ struct PurgeRange {
   int flags;
   Context *oncommit;
   int uncommitted;
+  int err = 0;
   PurgeRange(inodeno_t i, const file_layout_t& l, const SnapContext& sc,
 	     uint64_t fo, uint64_t no, ceph::real_time t, int fl,
 	     Context *fin)
@@ -331,7 +332,7 @@ int Filer::purge_range(inodeno_t ino,
   PurgeRange *pr = new PurgeRange(ino, *layout, snapc, first_obj,
 				  num_obj, mtime, flags, oncommit);
 
-  _do_purge_range(pr, 0);
+  _do_purge_range(pr, 0, 0);
   return 0;
 }
 
@@ -340,20 +341,22 @@ struct C_PurgeRange : public Context {
   PurgeRange *pr;
   C_PurgeRange(Filer *f, PurgeRange *p) : filer(f), pr(p) {}
   void finish(int r) override {
-    filer->_do_purge_range(pr, 1);
+    filer->_do_purge_range(pr, 1, r);
   }
 };
 
-void Filer::_do_purge_range(PurgeRange *pr, int fin)
+void Filer::_do_purge_range(PurgeRange *pr, int fin, int err)
 {
   PurgeRange::unique_lock prl(pr->lock);
+  if (err && err != -ENOENT)
+    pr->err = err;
   pr->uncommitted -= fin;
   ldout(cct, 10) << "_do_purge_range " << pr->ino << " objects " << pr->first
 		 << "~" << pr->num << " uncommitted " << pr->uncommitted
 		 << dendl;
 
   if (pr->num == 0 && pr->uncommitted == 0) {
-    pr->oncommit->complete(0);
+    pr->oncommit->complete(pr->err);
     prl.unlock();
     delete pr;
     return;

--- a/src/osdc/Filer.h
+++ b/src/osdc/Filer.h
@@ -253,7 +253,7 @@ class Filer {
 		  uint64_t first_obj, uint64_t num_obj,
 		  ceph::real_time mtime,
 		  int flags, Context *oncommit);
-  void _do_purge_range(struct PurgeRange *pr, int fin);
+  void _do_purge_range(struct PurgeRange *pr, int fin, int err);
 
   /*
    * probe


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45603

---

backport of https://github.com/ceph/ceph/pull/34144
parent tracker: https://tracker.ceph.com/issues/43598

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh