### PR TITLE
nautilus: mds: Handle blacklisted error in purge queue

### DIFF
--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -584,8 +584,14 @@ void PurgeQueue::_execute_item(
   gather.set_finisher(new C_OnFinisher(
                       new FunctionContext([this, expire_to](int r){
     std::lock_guard l(lock);
-    _execute_item_complete(expire_to);
 
+    if (r == -EBLACKLISTED) {
+      finisher.queue(on_error, r);
+      on_error = nullptr;
+      return;
+    }
+
+    _execute_item_complete(expire_to);
     _consume();
 
     // Have we gone idle?  If so, do an extra write_head now instead of

--- a/src/osdc/Filer.h
+++ b/src/osdc/Filer.h
@@ -255,7 +255,7 @@ class Filer {
 		  uint64_t first_obj, uint64_t num_obj,
 		  ceph::real_time mtime,
 		  int flags, Context *oncommit);
-  void _do_purge_range(struct PurgeRange *pr, int fin);
+  void _do_purge_range(struct PurgeRange *pr, int fin, int err);
 
   /*
    * probe


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45602

---

backport of https://github.com/ceph/ceph/pull/34144
parent tracker: https://tracker.ceph.com/issues/43598

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh