### PR TITLE
octopus: client: expose Client::ll_register_callback via libcephfs

### DIFF
--- a/alpine/APKBUILD.in
+++ b/alpine/APKBUILD.in
@@ -396,7 +396,7 @@ libcephfs_dev() {
 	pkgdesc="Ceph distributed file system client library headers"
 	depends="libcephfs librados-devel"
 
-	_pkg $_includedir/cephfs ceph_statx.h libcephfs.h
+	_pkg $_includedir/cephfs ceph_ll_client.h libcephfs.h
 	_pkg $_libdir libcephfs.so
 }
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2167,7 +2167,7 @@ fi
 %files -n libcephfs-devel
 %dir %{_includedir}/cephfs
 %{_includedir}/cephfs/libcephfs.h
-%{_includedir}/cephfs/ceph_statx.h
+%{_includedir}/cephfs/ceph_ll_client.h
 %{_libdir}/libcephfs.so
 
 %files -n python%{python3_pkgversion}-cephfs

--- a/debian/libcephfs-dev.install
+++ b/debian/libcephfs-dev.install
@@ -1,3 +1,3 @@
-usr/include/cephfs/ceph_statx.h
+usr/include/cephfs/ceph_ll_client.h
 usr/include/cephfs/libcephfs.h
 usr/lib/libcephfs.so

--- a/qa/suites/fs/bugs/client_trim_caps/tasks/trim-i22073.yaml
+++ b/qa/suites/fs/bugs/client_trim_caps/tasks/trim-i22073.yaml
@@ -17,3 +17,4 @@ tasks:
 - exec:
     client.0:
     - ceph_test_trim_caps
+    - ceph_test_ino_release_cb

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5135,7 +5135,7 @@ void Client::_async_dentry_invalidate(vinodeno_t dirino, vinodeno_t ino, string&
     return;
   ldout(cct, 10) << __func__ << " '" << name << "' ino " << ino
 		 << " in dir " << dirino << dendl;
-  dentry_invalidate_cb(callback_handle, dirino, ino, name);
+  dentry_invalidate_cb(callback_handle, dirino, ino, name.c_str(), name.length());
 }
 
 void Client::_schedule_invalidate_dentry_callback(Dentry *dn, bool del)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10420,7 +10420,7 @@ int Client::ll_statfs(Inode *in, struct statvfs *stbuf, const UserPerm& perms)
   return statfs(0, stbuf, perms);
 }
 
-void Client::ll_register_callbacks(struct client_callback_args *args)
+void Client::ll_register_callbacks(struct ceph_client_callback_args *args)
 {
   if (!args)
     return;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -270,6 +270,7 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
     async_dentry_invalidator(m->cct),
     interrupt_finisher(m->cct),
     remount_finisher(m->cct),
+    async_ino_releasor(m->cct),
     objecter_finisher(m->cct),
     m_command_hook(this),
     fscid(0)
@@ -580,6 +581,12 @@ void Client::shutdown()
     ldout(cct, 10) << "shutdown stopping remount finisher" << dendl;
     remount_finisher.wait_for_empty();
     remount_finisher.stop();
+  }
+
+  if (ino_release_cb) {
+    ldout(cct, 10) << "shutdown stopping inode release finisher" << dendl;
+    async_ino_releasor.wait_for_empty();
+    async_ino_releasor.stop();
   }
 
   objectcacher->stop();  // outside of client_lock! this does a join.
@@ -4265,6 +4272,39 @@ void Client::_trim_negative_child_dentries(InodeRef& in)
   }
 }
 
+class C_Client_CacheRelease : public Context  {
+private:
+  Client *client;
+  vinodeno_t ino;
+public:
+  C_Client_CacheRelease(Client *c, Inode *in) :
+    client(c) {
+    if (client->use_faked_inos())
+      ino = vinodeno_t(in->faked_ino, CEPH_NOSNAP);
+    else
+      ino = in->vino();
+  }
+  void finish(int r) override {
+    ceph_assert(ceph_mutex_is_not_locked_by_me(client->client_lock));
+    client->_async_inode_release(ino);
+  }
+};
+
+void Client::_async_inode_release(vinodeno_t ino)
+{
+  if (unmounting)
+    return;
+  ldout(cct, 10) << __func__ << " " << ino << dendl;
+  ino_release_cb(callback_handle, ino);
+}
+
+void Client::_schedule_ino_release_callback(Inode *in) {
+
+  if (ino_release_cb)
+    // we queue the invalidate, which calls the callback and decrements the ref
+    async_ino_releasor.queue(new C_Client_CacheRelease(this, in));
+}
+
 void Client::trim_caps(MetaSession *s, uint64_t max)
 {
   mds_rank_t mds = s->mds_num;
@@ -4319,6 +4359,7 @@ void Client::trim_caps(MetaSession *s, uint64_t max)
       if (all && in->ino != MDS_INO_ROOT) {
         ldout(cct, 20) << __func__ << " counting as trimmed: " << *in << dendl;
 	trimmed++;
+	_schedule_ino_release_callback(in.get());
       }
     }
   }
@@ -10447,6 +10488,10 @@ void Client::ll_register_callbacks(struct ceph_client_callback_args *args)
   if (args->remount_cb) {
     remount_cb = args->remount_cb;
     remount_finisher.start();
+  }
+  if (args->ino_release_cb) {
+    ino_release_cb = args->ino_release_cb;
+    async_ino_releasor.start();
   }
   if (args->umask_cb)
     umask_cb = args->umask_cb;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -96,7 +96,7 @@
 #include "include/ceph_assert.h"
 #include "include/stat.h"
 
-#include "include/cephfs/ceph_statx.h"
+#include "include/cephfs/ceph_ll_client.h"
 
 #if HAVE_GETGROUPLIST
 #include <grp.h>

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10448,7 +10448,8 @@ void Client::ll_register_callbacks(struct ceph_client_callback_args *args)
     remount_cb = args->remount_cb;
     remount_finisher.start();
   }
-  umask_cb = args->umask_cb;
+  if (args->umask_cb)
+    umask_cb = args->umask_cb;
 }
 
 int Client::test_dentry_handling(bool can_invalidate)

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -121,29 +121,6 @@ struct CapSnap;
 struct MetaRequest;
 class ceph_lock_state_t;
 
-
-typedef void (*client_ino_callback_t)(void *handle, vinodeno_t ino, int64_t off, int64_t len);
-
-typedef void (*client_dentry_callback_t)(void *handle, vinodeno_t dirino,
-					 vinodeno_t ino, const char *name,
-					 size_t len);
-typedef int (*client_remount_callback_t)(void *handle);
-
-typedef void(*client_switch_interrupt_callback_t)(void *handle, void *data);
-typedef mode_t (*client_umask_callback_t)(void *handle);
-
-/* Callback for delegation recalls */
-typedef void (*ceph_deleg_cb_t)(Fh *fh, void *priv);
-
-struct client_callback_args {
-  void *handle;
-  client_ino_callback_t ino_cb;
-  client_dentry_callback_t dentry_cb;
-  client_switch_interrupt_callback_t switch_intr_cb;
-  client_remount_callback_t remount_cb;
-  client_umask_callback_t umask_cb;
-};
-
 // ========================================================
 // client interface
 
@@ -602,7 +579,7 @@ public:
   int ll_osdaddr(int osd, uint32_t *addr);
   int ll_osdaddr(int osd, char* buf, size_t size);
 
-  void ll_register_callbacks(struct client_callback_args *args);
+  void ll_register_callbacks(struct ceph_client_callback_args *args);
   int test_dentry_handling(bool can_invalidate);
 
   const char** get_tracked_conf_keys() const override;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -23,7 +23,7 @@
 #include "common/cmdparse.h"
 #include "common/compiler_extensions.h"
 #include "include/common_fwd.h"
-#include "include/cephfs/ceph_statx.h"
+#include "include/cephfs/ceph_ll_client.h"
 #include "include/filepath.h"
 #include "include/interval_set.h"
 #include "include/lru.h"

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -125,7 +125,8 @@ class ceph_lock_state_t;
 typedef void (*client_ino_callback_t)(void *handle, vinodeno_t ino, int64_t off, int64_t len);
 
 typedef void (*client_dentry_callback_t)(void *handle, vinodeno_t dirino,
-					 vinodeno_t ino, string& name);
+					 vinodeno_t ino, const char *name,
+					 size_t len);
 typedef int (*client_remount_callback_t)(void *handle);
 
 typedef void(*client_switch_interrupt_callback_t)(void *handle, void *data);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -232,6 +232,7 @@ public:
   friend class C_Client_Remount;
   friend class C_Client_RequestInterrupt;
   friend class C_Deleg_Timeout; // Asserts on client_lock, called when a delegation is unreturned
+  friend class C_Client_CacheRelease; // Asserts on client_lock
   friend class SyntheticClient;
   friend void intrusive_ptr_release(Inode *in);
 
@@ -673,6 +674,10 @@ public:
   void _invalidate_inode_cache(Inode *in);
   void _invalidate_inode_cache(Inode *in, int64_t off, int64_t len);
   void _async_invalidate(vinodeno_t ino, int64_t off, int64_t len);
+
+  void _schedule_ino_release_callback(Inode *in);
+  void _async_inode_release(vinodeno_t ino);
+
   bool _release(Inode *in);
 
   /**
@@ -1182,6 +1187,7 @@ private:
   client_ino_callback_t ino_invalidate_cb = nullptr;
   client_dentry_callback_t dentry_invalidate_cb = nullptr;
   client_umask_callback_t umask_cb = nullptr;
+  client_ino_release_t ino_release_cb = nullptr;
   void *callback_handle = nullptr;
   bool can_invalidate_dentries = false;
 
@@ -1189,6 +1195,7 @@ private:
   Finisher async_dentry_invalidator;
   Finisher interrupt_finisher;
   Finisher remount_finisher;
+  Finisher async_ino_releasor;
   Finisher objecter_finisher;
 
   Context *tick_event = nullptr;

--- a/src/client/Delegation.h
+++ b/src/client/Delegation.h
@@ -5,8 +5,7 @@
 
 #include "common/Clock.h"
 #include "common/Timer.h"
-
-class Fh;
+#include "include/cephfs/ceph_ll_client.h"
 
 /* Commands for manipulating delegation state */
 #ifndef CEPH_DELEGATION_NONE
@@ -14,9 +13,6 @@ class Fh;
 # define CEPH_DELEGATION_RD	1
 # define CEPH_DELEGATION_WR	2
 #endif
-
-/* Callback for delegation recalls */
-typedef void (*ceph_deleg_cb_t)(Fh *fh, void *priv);
 
 /* Converts CEPH_DELEGATION_* to cap mask */
 int ceph_deleg_caps_for_type(unsigned type);

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -36,7 +36,7 @@
 
 #include "common/errno.h"
 #include "include/ceph_assert.h"
-#include "include/cephfs/ceph_statx.h"
+#include "include/cephfs/ceph_ll_client.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_client

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -937,7 +937,7 @@ static void ino_invalidate_cb(void *handle, vinodeno_t vino, int64_t off,
 }
 
 static void dentry_invalidate_cb(void *handle, vinodeno_t dirino,
-				 vinodeno_t ino, string& name)
+				 vinodeno_t ino, const char *name, size_t len)
 {
   CephFuse::Handle *cfuse = (CephFuse::Handle *)handle;
   fuse_ino_t fdirino = cfuse->make_fake_ino(dirino.ino, dirino.snapid);
@@ -946,12 +946,12 @@ static void dentry_invalidate_cb(void *handle, vinodeno_t dirino,
   if (ino.ino != inodeno_t())
     fino = cfuse->make_fake_ino(ino.ino, ino.snapid);
 #if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
-  fuse_lowlevel_notify_delete(cfuse->se, fdirino, fino, name.c_str(), name.length());
+  fuse_lowlevel_notify_delete(cfuse->se, fdirino, fino, name, len);
 #else
-  fuse_lowlevel_notify_delete(cfuse->ch, fdirino, fino, name.c_str(), name.length());
+  fuse_lowlevel_notify_delete(cfuse->ch, fdirino, fino, name, len);
 #endif
 #elif FUSE_VERSION >= FUSE_MAKE_VERSION(2, 8)
-  fuse_lowlevel_notify_inval_entry(cfuse->ch, fdirino, name.c_str(), name.length());
+  fuse_lowlevel_notify_inval_entry(cfuse->ch, fdirino, name, len);
 #endif
 }
 

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -33,7 +33,7 @@
 #include "ioctl.h"
 #include "common/config.h"
 #include "include/ceph_assert.h"
-#include "include/cephfs/ceph_statx.h"
+#include "include/cephfs/ceph_ll_client.h"
 
 #include "fuse_ll.h"
 #include <fuse.h>

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -1233,7 +1233,7 @@ int CephFuse::Handle::start()
 #endif
 
 
-  struct client_callback_args args = {
+  struct ceph_client_callback_args args = {
     handle: this,
     ino_cb: client->cct->_conf.get_val<bool>("fuse_use_invalidate_cb") ?
       ino_invalidate_cb : NULL,

--- a/src/include/cephfs/ceph_ll_client.h
+++ b/src/include/cephfs/ceph_ll_client.h
@@ -119,6 +119,9 @@ typedef void (*client_switch_interrupt_callback_t)(void *handle, void *data);
 /* fetch umask of actor */
 typedef mode_t (*client_umask_callback_t)(void *handle);
 
+/* request that application release Inode references */
+typedef void (*client_ino_release_t)(void *handle, vinodeno_t ino);
+
 /*
  * The handle is an opaque value that gets passed to some callbacks. Any fields
  * set to NULL will be left alone. There is no way to unregister callbacks.
@@ -130,6 +133,7 @@ struct ceph_client_callback_args {
   client_switch_interrupt_callback_t switch_intr_cb;
   client_remount_callback_t remount_cb;
   client_umask_callback_t umask_cb;
+  client_ino_release_t ino_release_cb;
 };
 
 #ifdef __cplusplus

--- a/src/include/cephfs/ceph_ll_client.h
+++ b/src/include/cephfs/ceph_ll_client.h
@@ -5,17 +5,14 @@
  *
  * Copyright (C) Jeff Layton <jlayton@redhat.com>
  *
- * Heavily borrowed from David Howells' draft statx patchset.
- *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- *
  */
 
-#ifndef CEPH_CEPH_STATX_H
-#define CEPH_CEPH_STATX_H
+#ifndef CEPH_CEPH_LL_CLIENT_H
+#define CEPH_CEPH_LL_CLIENT_H
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -23,6 +20,8 @@ extern "C" {
 #endif
 
 /*
+ * Heavily borrowed from David Howells' draft statx patchset.
+ *
  * Since the xstat patches are still a work in progress, we borrow its data
  * structures and #defines to implement ceph_getattrx. Once the xstat stuff
  * has been merged we should drop this and switch over to using that instead.

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -27,7 +27,7 @@
 #include <stdbool.h>
 #include <fcntl.h>
 
-#include "ceph_statx.h"
+#include "ceph_ll_client.h"
 
 #ifdef __cplusplus
 namespace ceph::common {

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -78,27 +78,7 @@ struct ceph_file_layout {
 	uint32_t fl_pg_pool;      /* namespace, crush ruleset, rep level */
 } __attribute__ ((packed));
 
-
-typedef struct inodeno_t {
-  uint64_t val;
-} inodeno_t;
-
-typedef struct _snapid_t {
-  uint64_t val;
-} snapid_t;
-
-typedef struct vinodeno_t {
-  inodeno_t ino;
-  snapid_t snapid;
-} vinodeno_t;
-
-typedef struct Fh Fh;
 struct CephContext;
-#else /* _cplusplus */
-
-struct inodeno_t;
-struct vinodeno_t;
-typedef struct vinodeno_t vinodeno;
 #endif /* ! __cplusplus */
 
 struct UserPerm;
@@ -1794,7 +1774,6 @@ int ceph_ll_lazyio(struct ceph_mount_info *cmount, Fh *fh, int enable);
  * needs, but it should take care to choose a value that allows it to avoid
  * forcible eviction from the cluster in the event of an application bug.
  */
-typedef void (*ceph_deleg_cb_t)(struct Fh *fh, void *priv);
 
 /* Commands for manipulating delegation state */
 #ifndef CEPH_DELEGATION_NONE

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -1872,6 +1872,16 @@ int ceph_start_reclaim(struct ceph_mount_info *cmount,
  */
 void ceph_finish_reclaim(struct ceph_mount_info *cmount);
 
+/**
+ * Register a set of callbacks to be used with this cmount
+ * @param cmount the ceph mount handle on which the cb's should be registerd
+ * @param args   callback arguments to register with the cmount
+ *
+ * Any fields set to NULL will be ignored. There currently is no way to
+ * unregister these callbacks, so this is a one-way change.
+ */
+void ceph_ll_register_callbacks(struct ceph_mount_info *cmount,
+				struct ceph_client_callback_args *args);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -2007,3 +2007,9 @@ extern "C" void ceph_finish_reclaim(class ceph_mount_info *cmount)
 {
   cmount->get_client()->finish_reclaim();
 }
+
+extern "C" void ceph_ll_register_callbacks(class ceph_mount_info *cmount,
+					   struct ceph_client_callback_args *args)
+{
+  cmount->get_client()->ll_register_callbacks(args);
+}

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -116,7 +116,7 @@ public:
       goto fail;
 
     {
-      client_callback_args args = {};
+      ceph_client_callback_args args = {};
       args.handle = this;
       args.umask_cb = umask_cb;
       client->ll_register_callbacks(&args);

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -106,7 +106,7 @@ cdef extern from "sys/time.h":
         long tv_sec
         long tv_usec
 
-cdef extern from "cephfs/ceph_statx.h":
+cdef extern from "cephfs/ceph_ll_client.h":
     cdef struct statx "ceph_statx":
         uint32_t    stx_mask
         uint32_t    stx_blksize

--- a/src/test/fs/CMakeLists.txt
+++ b/src/test/fs/CMakeLists.txt
@@ -1,5 +1,4 @@
 if(${WITH_CEPHFS})
-
   # unittest_mds_types
   add_executable(unittest_mds_types
     mds_types.cc
@@ -13,4 +12,9 @@ if(${WITH_CEPHFS})
   target_link_libraries(ceph_test_trim_caps ceph-common cephfs)
   install(TARGETS ceph_test_trim_caps DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+  add_executable(ceph_test_ino_release_cb
+    test_ino_release_cb.cc
+  )
+  target_link_libraries(ceph_test_ino_release_cb ceph-common cephfs)
+  install(TARGETS ceph_test_ino_release_cb DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif(${WITH_CEPHFS})

--- a/src/test/fs/test_ino_release_cb.cc
+++ b/src/test/fs/test_ino_release_cb.cc
@@ -1,0 +1,77 @@
+#include <string>
+#include <include/fs_types.h>
+#include <mds/mdstypes.h>
+#include <include/cephfs/libcephfs.h>
+
+#define MAX_CEPH_FILES	1000
+#define DIRNAME		"ino_release_cb"
+
+static volatile bool cb_done = false;
+
+static void cb(void *hdl, vinodeno_t vino)
+{
+	cb_done = true;
+}
+
+int main(int argc, char *argv[])
+{
+	inodeno_t inos[MAX_CEPH_FILES];
+	struct ceph_mount_info *cmount = NULL;
+
+	ceph_create(&cmount, "admin");
+	ceph_conf_read_file(cmount, NULL);
+	ceph_init(cmount);
+
+	int ret = ceph_mount(cmount, NULL);
+	assert(ret >= 0);
+	ret = ceph_mkdir(cmount, DIRNAME, 0755);
+	assert(ret >= 0);
+	ret = ceph_chdir(cmount, DIRNAME);
+	assert(ret >= 0);
+
+	/* Create a bunch of files, get their inode numbers and close them */
+	int i;
+	for (i = 0; i < MAX_CEPH_FILES; ++i) {
+		int fd;
+		struct ceph_statx stx;
+
+		string name = std::to_string(i);
+
+		fd = ceph_open(cmount, name.c_str(), O_RDWR|O_CREAT, 0644);
+		assert(fd >= 0);
+
+		ret = ceph_fstatx(cmount, fd, &stx, CEPH_STATX_INO, 0);
+		assert(ret >= 0);
+
+		inos[i] = stx.stx_ino;
+		ceph_close(cmount, fd);
+	}
+
+	/* Remount */
+	ceph_unmount(cmount);
+	ceph_release(cmount);
+	ceph_create(&cmount, "admin");
+	ceph_conf_read_file(cmount, NULL);
+	ceph_init(cmount);
+
+	struct ceph_client_callback_args args = { 0 };
+	args.ino_release_cb = cb;
+	ceph_ll_register_callbacks(cmount, &args);
+
+	ret = ceph_mount(cmount, NULL);
+	assert(ret >= 0);
+
+	Inode	*inodes[MAX_CEPH_FILES];
+
+	for (i = 0; i < MAX_CEPH_FILES; ++i) {
+		/* We can stop if we got a callback */
+		if (cb_done)
+			break;
+
+		ret = ceph_ll_lookup_inode(cmount, inos[i], &inodes[i]);
+		assert(ret >= 0);
+	}
+
+	assert(cb_done);
+	return 0;
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45688

---

backport of https://github.com/ceph/ceph/pull/34596
parent trackers:

* https://tracker.ceph.com/issues/12334
* https://tracker.ceph.com/issues/45114

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh