### PR TITLE
librbd: initial implementation of plugin support

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -385,3 +385,13 @@
 
   or use any other convenient way to restore the schedule after the
   upgrade.
+
+
+>=16.0.0
+---------
+
+* librbd: The shared, read-only parent cache has been moved to a separate librbd
+  plugin. If the parent cache was previously in-use, you must also instruct
+  librbd to load the plugin by adding the following to your configuration::
+
+    rbd_plugins = parent_cache

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2128,6 +2128,8 @@ fi
 %if %{with lttng}
 %{_libdir}/librbd_tp.so.*
 %endif
+%dir %{_libdir}/ceph/librbd
+%{_libdir}/ceph/librbd/libceph_*.so*
 
 %post -n librbd1 -p /sbin/ldconfig
 

--- a/debian/librbd1.install
+++ b/debian/librbd1.install
@@ -1,2 +1,3 @@
 usr/lib/librbd.so.*
 usr/lib/librbd_tp.so.*
+usr/lib/ceph/librbd/*

--- a/doc/rbd/rbd-persistent-cache.rst
+++ b/doc/rbd/rbd-persistent-cache.rst
@@ -38,10 +38,10 @@ Enable RBD Shared Read-only Parent Image Cache
 ----------------------------------------------
 
 To enable RBD shared read-only parent image cache, the following Ceph settings
-need to added in the ``[client]`` `section`_ of your ``ceph.conf`` file.
+need to added in the ``[client]`` `section`_ of your ``ceph.conf`` file::
 
-``rbd parent cache enabled = true``
-
+        rbd parent cache enabled = true
+        rbd plugins = parent_cache
 
 Immutable Object Cache Daemon
 =============================

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7513,6 +7513,11 @@ static std::vector<Option> get_rbd_options() {
     .set_default(10)
     .set_min(1)
     .set_description("the number of quiesce notification attempts"),
+
+    Option("rbd_plugins", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("")
+    .set_description("comma-delimited list of librbd plugins to enable"),
+
   });
 }
 

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -38,7 +38,6 @@ set(librbd_internal_srcs
   api/Trash.cc
   cache/ImageWriteback.cc
   cache/ObjectCacherObjectDispatch.cc
-  cache/ParentCacheObjectDispatch.cc
   cache/ObjectCacherWriteback.cc
   cache/PassthroughImageCache.cc
   cache/WriteAroundObjectDispatch.cc
@@ -170,6 +169,19 @@ set(librbd_internal_srcs
 add_custom_target(librbd_plugins)
 set(librbd_plugins_dir ${CEPH_INSTALL_PKGLIBDIR}/librbd)
 
+set(rbd_plugin_parent_cache_srcs
+  cache/ParentCacheObjectDispatch.cc
+  plugin/ParentCache.cc)
+add_library(librbd_plugin_parent_cache SHARED ${rbd_plugin_parent_cache_srcs})
+target_link_libraries(librbd_plugin_parent_cache PRIVATE
+  ceph_immutable_object_cache_lib)
+set_target_properties(librbd_plugin_parent_cache PROPERTIES
+  OUTPUT_NAME ceph_librbd_parent_cache
+  VERSION 1.0.0
+  SOVERSION 1)
+install(TARGETS librbd_plugin_parent_cache DESTINATION ${librbd_plugins_dir})
+add_dependencies(librbd_plugins librbd_plugin_parent_cache)
+
 if(WITH_EVENTTRACE)
   list(APPEND librbd_internal_srcs ../common/EventTrace.cc)
 endif()
@@ -201,7 +213,6 @@ if(WITH_EVENTTRACE)
   add_dependencies(rbd_internal eventtrace_tp)
 endif()
 target_link_libraries(rbd_internal PRIVATE
-  ceph_immutable_object_cache_lib
   osdc)
 
 if(WITH_RBD_RWL)

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -20,6 +20,7 @@ set(librbd_internal_srcs
   MirroringWatcher.cc
   ObjectMap.cc
   Operations.cc
+  PluginRegistry.cc
   TrashWatcher.cc
   Utils.cc
   Watcher.cc
@@ -166,6 +167,9 @@ set(librbd_internal_srcs
   watcher/RewatchRequest.cc
   ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc)
 
+add_custom_target(librbd_plugins)
+set(librbd_plugins_dir ${CEPH_INSTALL_PKGLIBDIR}/librbd)
+
 if(WITH_EVENTTRACE)
   list(APPEND librbd_internal_srcs ../common/EventTrace.cc)
 endif()
@@ -211,6 +215,7 @@ add_library(librbd ${CEPH_SHARED}
 if(WITH_LTTNG)
   add_dependencies(librbd librbd-tp)
 endif()
+add_dependencies(librbd librbd_plugins)
 
 target_link_libraries(librbd PRIVATE
   rbd_internal

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -21,7 +21,7 @@
 #include "librbd/LibrbdAdminSocketHook.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/Operations.h"
-#include "librbd/operation/ResizeRequest.h"
+#include "librbd/PluginRegistry.h"
 #include "librbd/Types.h"
 #include "librbd/Utils.h"
 #include "librbd/exclusive_lock/AutomaticPolicy.h"
@@ -32,6 +32,7 @@
 #include "librbd/io/ObjectDispatcher.h"
 #include "librbd/io/QosImageDispatch.h"
 #include "librbd/journal/StandardPolicy.h"
+#include "librbd/operation/ResizeRequest.h"
 
 #include "osdc/Striper.h"
 #include <boost/bind.hpp>
@@ -123,6 +124,7 @@ public:
       operations(new Operations<>(*this)),
       exclusive_lock(nullptr), object_map(nullptr),
       op_work_queue(nullptr),
+      plugin_registry(new PluginRegistry<ImageCtx>(this)),
       external_callback_completions(32),
       event_socket_completions(32),
       asok_hook(nullptr),
@@ -179,6 +181,8 @@ public:
     delete exclusive_lock_policy;
     delete operations;
     delete state;
+
+    delete plugin_registry;
   }
 
   void ImageCtx::init() {

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -49,6 +49,7 @@ namespace librbd {
   class LibrbdAdminSocketHook;
   template <typename> class ObjectMap;
   template <typename> class Operations;
+  template <typename> class PluginRegistry;
 
   namespace cache {
   template <typename> class ImageCache;
@@ -184,6 +185,8 @@ namespace librbd {
     io::ObjectDispatcherInterface *io_object_dispatcher = nullptr;
 
     ContextWQ *op_work_queue;
+
+    PluginRegistry<ImageCtx>* plugin_registry;
 
     typedef boost::lockfree::queue<
       io::AioCompletion*,

--- a/src/librbd/PluginRegistry.cc
+++ b/src/librbd/PluginRegistry.cc
@@ -1,0 +1,52 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/PluginRegistry.h"
+#include "include/Context.h"
+#include "common/dout.h"
+#include "librbd/ImageCtx.h"
+#include <boost/tokenizer.hpp>
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::PluginRegistry: " \
+                           << this << " " << __func__ << ": "
+
+namespace librbd {
+
+template <typename I>
+PluginRegistry<I>::PluginRegistry(I* image_ctx) : m_image_ctx(image_ctx) {
+}
+
+template <typename I>
+void PluginRegistry<I>::init(const std::string& plugins, Context* on_finish) {
+  auto cct = m_image_ctx->cct;
+  auto plugin_registry = cct->get_plugin_registry();
+
+  auto gather_ctx = new C_Gather(cct, on_finish);
+
+  boost::tokenizer<boost::escaped_list_separator<char>> tokenizer(plugins);
+  for (auto token : tokenizer) {
+    ldout(cct, 5) << "attempting to load plugin: " << token << dendl;
+
+    auto ctx = gather_ctx->new_sub();
+
+    auto plugin = dynamic_cast<plugin::Interface<I>*>(
+      plugin_registry->get_with_load("librbd", "librbd_" + token));
+    if (plugin == nullptr) {
+      lderr(cct) << "failed to load plugin: " << token << dendl;
+      ctx->complete(-ENOENT);
+      break;
+    }
+
+    m_plugin_hook_points.emplace_back();
+    auto hook_points = &m_plugin_hook_points.back();
+    plugin->init(m_image_ctx, hook_points, ctx);
+  }
+
+  gather_ctx->activate();
+}
+
+} // namespace librbd
+
+template class librbd::PluginRegistry<librbd::ImageCtx>;

--- a/src/librbd/PluginRegistry.h
+++ b/src/librbd/PluginRegistry.h
@@ -1,0 +1,38 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_PLUGIN_REGISTRY_H
+#define CEPH_LIBRBD_PLUGIN_REGISTRY_H
+
+#include "librbd/plugin/Types.h"
+#include <string>
+#include <list>
+
+struct Context;
+
+namespace librbd {
+
+struct ImageCtx;
+
+template <typename ImageCtxT>
+class PluginRegistry {
+public:
+  PluginRegistry(ImageCtxT* image_ctx);
+
+  void init(const std::string& plugins, Context* on_finish);
+
+private:
+  typedef std::list<plugin::HookPoints> PluginHookPoints;
+
+  ImageCtxT* m_image_ctx;
+  std::string m_plugins;
+
+  PluginHookPoints m_plugin_hook_points;
+
+};
+
+} // namespace librbd
+
+extern template class librbd::PluginRegistry<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_PLUGIN_REGISTRY_H

--- a/src/librbd/cache/ParentCacheObjectDispatch.cc
+++ b/src/librbd/cache/ParentCacheObjectDispatch.cc
@@ -45,8 +45,11 @@ void ParentCacheObjectDispatch<I>::init(Context* on_finish) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 5) << dendl;
 
-  if (m_image_ctx->parent != nullptr) {
-    ldout(cct, 5) << "child image: skipping" << dendl;
+  if (m_image_ctx->child == nullptr) {
+    ldout(cct, 5) << "non-parent image: skipping" << dendl;
+    if (on_finish != nullptr) {
+      on_finish->complete(-EINVAL);
+    }
     return;
   }
 

--- a/src/librbd/image/OpenRequest.h
+++ b/src/librbd/image/OpenRequest.h
@@ -61,6 +61,9 @@ private:
    *            V2_GET_DATA_POOL --------------> REFRESH
    *                                                |
    *                                                v
+   *                                             INIT_PLUGIN_REGISTRY
+   *                                                |
+   *                                                v
    *                                             INIT_PARENT_CACHE(skip if
    *                                                |               disable)
    *                                                v
@@ -122,6 +125,9 @@ private:
 
   void send_refresh();
   Context *handle_refresh(int *result);
+
+  void send_init_plugin_registry();
+  Context* handle_init_plugin_registry(int *result);
 
   Context* send_parent_cache(int *result);
   Context* handle_parent_cache(int *result);

--- a/src/librbd/image/OpenRequest.h
+++ b/src/librbd/image/OpenRequest.h
@@ -64,9 +64,6 @@ private:
    *                                             INIT_PLUGIN_REGISTRY
    *                                                |
    *                                                v
-   *                                             INIT_PARENT_CACHE(skip if
-   *                                                |               disable)
-   *                                                v
    *                                             INIT_CACHE
    *                                                |
    *                                                v
@@ -128,9 +125,6 @@ private:
 
   void send_init_plugin_registry();
   Context* handle_init_plugin_registry(int *result);
-
-  Context* send_parent_cache(int *result);
-  Context* handle_parent_cache(int *result);
 
   Context *send_init_cache(int *result);
 

--- a/src/librbd/plugin/ParentCache.cc
+++ b/src/librbd/plugin/ParentCache.cc
@@ -1,0 +1,79 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/plugin/ParentCache.h"
+#include "ceph_ver.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "common/PluginRegistry.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/cache/ParentCacheObjectDispatch.h"
+
+extern "C" {
+
+const char *__ceph_plugin_version() {
+  return CEPH_GIT_NICE_VER;
+}
+
+int __ceph_plugin_init(CephContext *cct, const std::string& type,
+                       const std::string& name) {
+  auto plugin_registry = cct->get_plugin_registry();
+  return plugin_registry->add(
+    type, name, new librbd::plugin::ParentCache<librbd::ImageCtx>(cct));
+}
+
+} // extern "C"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::plugin::ParentCache: " \
+                           << this << " " << __func__ << ": "
+
+namespace librbd {
+namespace plugin {
+
+template <typename I>
+void ParentCache<I>::init(I* image_ctx, HookPoints* hook_points,
+                          Context* on_finish) {
+  m_image_ctx = image_ctx;
+  bool parent_cache_enabled = m_image_ctx->config.template get_val<bool>(
+    "rbd_parent_cache_enabled");
+  if (m_image_ctx->child == nullptr || !parent_cache_enabled) {
+    on_finish->complete(0);
+    return;
+  }
+
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 5) << dendl;
+
+  auto parent_cache = cache::ParentCacheObjectDispatch<I>::create(m_image_ctx);
+  on_finish = new LambdaContext([this, on_finish, parent_cache](int r) {
+      if (r < 0) {
+        // the object dispatcher will handle cleanup if successfully initialized
+        delete parent_cache;
+      }
+
+      handle_init_parent_cache(r, on_finish);
+    });
+  parent_cache->init(on_finish);
+}
+
+template <typename I>
+void ParentCache<I>::handle_init_parent_cache(int r, Context* on_finish) {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 5) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "Failed to initialize parent cache object dispatch layer: "
+               << cpp_strerror(r) << dendl;
+    on_finish->complete(r);
+    return;
+  }
+
+  on_finish->complete(0);
+}
+
+} // namespace plugin
+} // namespace librbd
+
+template class librbd::plugin::ParentCache<librbd::ImageCtx>;

--- a/src/librbd/plugin/ParentCache.h
+++ b/src/librbd/plugin/ParentCache.h
@@ -1,0 +1,37 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_PLUGIN_PARENT_CACHE_H
+#define CEPH_LIBRBD_PLUGIN_PARENT_CACHE_H
+
+#include "librbd/plugin/Types.h"
+#include "include/Context.h"
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace plugin {
+
+template <typename ImageCtxT>
+class ParentCache : public Interface<ImageCtxT> {
+public:
+  ParentCache(CephContext* cct) : Interface<ImageCtxT>(cct) {
+  }
+
+  void init(ImageCtxT* image_ctx, HookPoints* hook_points,
+            Context* on_finish) override;
+
+private:
+  ImageCtxT* m_image_ctx = nullptr;
+
+  void handle_init_parent_cache(int r, Context* on_finish);
+
+};
+
+} // namespace plugin
+} // namespace librbd
+
+extern template class librbd::plugin::ParentCache<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_PLUGIN_PARENT_CACHE_H

--- a/src/librbd/plugin/Types.h
+++ b/src/librbd/plugin/Types.h
@@ -1,0 +1,31 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_PLUGIN_TYPES_H
+#define CEPH_LIBRBD_PLUGIN_TYPES_H
+
+#include "common/PluginRegistry.h"
+
+struct CephContext;
+struct Context;
+
+namespace librbd {
+namespace plugin {
+
+struct HookPoints {
+  // TODO later commits will add support for exclusive-lock hook points
+};
+
+template <typename ImageCtxT>
+struct Interface : public ceph::Plugin {
+  Interface(CephContext* cct) : Plugin(cct) {
+  }
+
+  virtual void init(ImageCtxT* image_ctx, HookPoints* hook_points,
+                    Context* on_finish) = 0;
+};
+
+} // namespace plugin
+} // namespace librbd
+
+#endif // CEPH_LIBRBD_PLUGIN_TYPES_H

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -142,6 +142,7 @@ target_link_libraries(unittest_librbd
   rbd_api
   rbd_internal
   rbd_types
+  ceph_immutable_object_cache_lib
   osdc
   ceph-common
   global

--- a/src/test/librbd/cache/test_mock_ParentImageCache.cc
+++ b/src/test/librbd/cache/test_mock_ParentImageCache.cc
@@ -55,10 +55,10 @@ using ::testing::WithArg;
 using ::testing::WithArgs;
 
 class TestMockParentImageCache : public TestMockFixture {
-  public : 
+public :
   typedef cache::ParentCacheObjectDispatch<librbd::MockParentImageCacheImageCtx> MockParentImageCache;
 
-  // ====== mock cache client ==== 
+  // ====== mock cache client ====
   void expect_cache_run(MockParentImageCache& mparent_image_cache, bool ret_val) {
     auto& expect = EXPECT_CALL(*(mparent_image_cache.get_cache_client()), run());
 
@@ -119,7 +119,7 @@ class TestMockParentImageCache : public TestMockFixture {
   void expect_cache_register(MockParentImageCache& mparent_image_cache, Context* mock_handle_register, int ret_val) {
     auto& expect = EXPECT_CALL(*(mparent_image_cache.get_cache_client()), register_client(_));
 
-    expect.WillOnce(WithArg<0>(Invoke([mock_handle_register, ret_val](Context* ctx) { 
+    expect.WillOnce(WithArg<0>(Invoke([mock_handle_register, ret_val](Context* ctx) {
       if(ret_val == 0) {
         mock_handle_register->complete(true);
       } else {
@@ -130,7 +130,7 @@ class TestMockParentImageCache : public TestMockFixture {
     })));
   }
 
-  void expect_io_object_dispatcher_register_state(MockParentImageCache& mparent_image_cache, 
+  void expect_io_object_dispatcher_register_state(MockParentImageCache& mparent_image_cache,
                                                   int ret_val) {
     auto& expect = EXPECT_CALL((*(mparent_image_cache.get_image_ctx()->io_object_dispatcher)),
                                register_dispatch(_));
@@ -145,7 +145,8 @@ class TestMockParentImageCache : public TestMockFixture {
 TEST_F(TestMockParentImageCache, test_initialization_success) {
   librbd::ImageCtx* ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  MockParentImageCacheImageCtx mock_image_ctx(*ictx); 
+  MockParentImageCacheImageCtx mock_image_ctx(*ictx);
+  mock_image_ctx.child = &mock_image_ctx;
 
   auto mock_parent_image_cache = MockParentImageCache::create(&mock_image_ctx);
 
@@ -183,7 +184,8 @@ TEST_F(TestMockParentImageCache, test_initialization_success) {
 TEST_F(TestMockParentImageCache, test_initialization_fail_at_connect) {
   librbd::ImageCtx* ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  MockParentImageCacheImageCtx mock_image_ctx(*ictx); 
+  MockParentImageCacheImageCtx mock_image_ctx(*ictx);
+  mock_image_ctx.child = &mock_image_ctx;
 
   auto mock_parent_image_cache = MockParentImageCache::create(&mock_image_ctx);
 
@@ -217,7 +219,8 @@ TEST_F(TestMockParentImageCache, test_initialization_fail_at_connect) {
 TEST_F(TestMockParentImageCache, test_initialization_fail_at_register) {
   librbd::ImageCtx* ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  MockParentImageCacheImageCtx mock_image_ctx(*ictx); 
+  MockParentImageCacheImageCtx mock_image_ctx(*ictx);
+  mock_image_ctx.child = &mock_image_ctx;
 
   auto mock_parent_image_cache = MockParentImageCache::create(&mock_image_ctx);
 
@@ -245,7 +248,7 @@ TEST_F(TestMockParentImageCache, test_initialization_fail_at_register) {
   ASSERT_EQ(mock_parent_image_cache->get_state(), true);
   expect_cache_session_state(*mock_parent_image_cache, true);
   ASSERT_EQ(mock_parent_image_cache->get_cache_client()->is_session_work(), true);
- 
+
   mock_parent_image_cache->get_cache_client()->close();
   mock_parent_image_cache->get_cache_client()->stop();
 
@@ -255,7 +258,8 @@ TEST_F(TestMockParentImageCache, test_initialization_fail_at_register) {
 TEST_F(TestMockParentImageCache, test_disble_interface) {
   librbd::ImageCtx* ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  MockParentImageCacheImageCtx mock_image_ctx(*ictx); 
+  MockParentImageCacheImageCtx mock_image_ctx(*ictx);
+  mock_image_ctx.child = &mock_image_ctx;
 
   auto mock_parent_image_cache = MockParentImageCache::create(&mock_image_ctx);
 
@@ -270,7 +274,7 @@ TEST_F(TestMockParentImageCache, test_disble_interface) {
   Context* temp_on_dispatched = nullptr;
   ZTracer::Trace* temp_trace = nullptr;
   io::LightweightBufferExtents buffer_extents;
-  
+
   ASSERT_EQ(mock_parent_image_cache->discard(0, 0, 0, *temp_snapc, 0, *temp_trace, temp_op_flags,
             temp_journal_tid, temp_dispatch_result, temp_on_finish, temp_on_dispatched), false);
   ASSERT_EQ(mock_parent_image_cache->write(0, 0, std::move(temp_bl), *temp_snapc, 0,
@@ -294,7 +298,8 @@ TEST_F(TestMockParentImageCache, test_disble_interface) {
 TEST_F(TestMockParentImageCache, test_read) {
   librbd::ImageCtx* ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
-  MockParentImageCacheImageCtx mock_image_ctx(*ictx); 
+  MockParentImageCacheImageCtx mock_image_ctx(*ictx);
+  mock_image_ctx.child = &mock_image_ctx;
 
   auto mock_parent_image_cache = MockParentImageCache::create(&mock_image_ctx);
 
@@ -329,7 +334,7 @@ TEST_F(TestMockParentImageCache, test_read) {
   auto& expect = EXPECT_CALL(*(mock_parent_image_cache->get_cache_client()), is_session_work());
   expect.WillOnce(Return(true)).WillOnce(Return(true));
 
-  expect_cache_lookup_object(*mock_parent_image_cache, on_finish); 
+  expect_cache_lookup_object(*mock_parent_image_cache, on_finish);
 
   mock_parent_image_cache->read(0, 0, 4096, CEPH_NOSNAP, 0, {},
                         nullptr, nullptr, nullptr, nullptr, &on_finish, nullptr);

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -294,6 +294,7 @@ struct MockImageCtx {
 
   EventSocket &event_socket;
 
+  MockImageCtx *child = nullptr;
   MockImageCtx *parent;
   MockOperations *operations;
   MockImageState *state;

--- a/src/tools/immutable_object_cache/CacheClient.cc
+++ b/src/tools/immutable_object_cache/CacheClient.cc
@@ -58,6 +58,7 @@ namespace immutable_obj_cache {
         thd->join();
         delete thd;
       }
+      delete m_worker_io_service_work;
       delete m_worker;
     }
     return 0;


### PR DESCRIPTION
Future commits will move RWL cache to a plugin, add a new S3 parent image IO dispatch layer, encryption/decryption, and potentially compression.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
