### PR TITLE
nautilus: qa/suites/fs/upgrade: disable mon_pg_warn_min_per_osd

### DIFF
--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
@@ -14,6 +14,7 @@ overrides:
     conf:
       global:
         bluestore warn on legacy statfs: false
+        mon pg warn min per osd: 0
       mon:
         mon warn on osd down out interval zero: false
 

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
@@ -14,6 +14,7 @@ overrides:
     conf:
       global:
         bluestore warn on legacy statfs: false
+        mon pg warn min per osd: 0
       mon:
         mon warn on osd down out interval zero: false
 

--- a/qa/suites/fs/upgrade/snaps/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/snaps/tasks/2-upgrade.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     conf:
       global:
+        mon pg warn min per osd: 0
         bluestore warn on legacy statfs: false
 
 tasks:


### PR DESCRIPTION
if we upgrade from luminous, then a luminous monitor won't have the
1ac34a5ea3d1aca299b02e574b295dd4bf6167f4 or its backport, but after
upgrading to nautilus, mgr detects this issue and translates it to
a warning like

2020-05-21T05:33:26.934 DEBUG:teuthology.misc:Ceph health: HEALTH_WARN
too few PGs per OSD (12 < min 30)

if the number of pg per osd is too low. so we need to disable this
warning as we did in later releases and in master.

this change is not cherry-picked from master, as we don't do
upgrade test from luminous to master.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
