### PR TITLE
rgw : add check for ACL when create existing bucket

### DIFF
--- a/src/rgw/rgw_acl.cc
+++ b/src/rgw/rgw_acl.cc
@@ -201,3 +201,32 @@ bool RGWAccessControlPolicy::is_public() const
                          );
 
 }
+
+bool operator==(const RGWAccessControlPolicy& lhs,
+                                        const RGWAccessControlPolicy& rhs) {
+  auto lhs_acl_map = lhs.get_acl().get_grant_map();
+  auto rhs_acl_map = rhs.get_acl().get_grant_map();
+
+  if (lhs_acl_map.size() != rhs_acl_map.size()) {
+    return false;
+  }
+
+  std::map<string, ACLGrant>::iterator lhs_it = lhs_acl_map.begin();
+  while (lhs_it != lhs_acl_map.end()) {
+    std::map<string, ACLGrant>::iterator rhs_it =
+        rhs_acl_map.find(lhs_it->first);
+    if (rhs_it != rhs_acl_map.end()) {
+      bufferlist bl_lhs;
+      bufferlist bl_rhs;
+      rhs_it->second.encode(bl_rhs);
+      lhs_it->second.encode(bl_lhs);
+      if (bl_rhs.to_str() != bl_lhs.to_str()) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+    lhs_it++;
+  }
+  return true;
+}

--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -467,7 +467,8 @@ public:
 
   virtual bool compare_group_name(string& id, ACLGroupTypeEnum group) { return false; }
   bool is_public() const;
+  
 };
 WRITE_CLASS_ENCODER(RGWAccessControlPolicy)
-
+bool operator==(const RGWAccessControlPolicy& lhs, const RGWAccessControlPolicy& rhs);
 #endif

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3201,7 +3201,7 @@ void RGWCreateBucket::execute()
 				info.swift_ver_location,
 				pquota_info, attrs, info, ep_objv,
 				true, obj_lock_enabled, &s->bucket_exists, s->info,
-				&s->bucket);
+				&s->bucket, &policy);
 
   /* continue if EEXIST and create_bucket will fail below.  this way we can
    * recover from a partial create by retrying it. */

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -745,7 +745,8 @@ int RGWRadosStore::create_bucket(RGWUser& u, const rgw_bucket& b,
 				 bool obj_lock_enabled,
 				 bool *existed,
 				 req_info& req_info,
-				 std::unique_ptr<RGWBucket>* bucket_out)
+				 std::unique_ptr<RGWBucket>* bucket_out,
+				 RGWAccessControlPolicy* policy)
 {
   int ret;
   bufferlist in_data;
@@ -777,6 +778,14 @@ int RGWRadosStore::create_bucket(RGWUser& u, const rgw_bucket& b,
 	return ret;
       }
     }
+
+    if (policy) {
+      if (!(old_policy == *policy)) {
+        ret = -EEXIST;
+        return ret;
+      }
+    }
+
   } else {
     bucket = std::unique_ptr<RGWBucket>(new RGWRadosBucket(this, b, &u));
     *existed = false;

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -80,7 +80,8 @@ class RGWStore : public DoutPrefixProvider {
 			    bool obj_lock_enabled,
 			    bool *existed,
 			    req_info& req_info,
-			    std::unique_ptr<RGWBucket>* bucket) = 0;
+			    std::unique_ptr<RGWBucket>* bucket,
+			    RGWAccessControlPolicy* policy = NULL) = 0;
     virtual RGWBucketList* list_buckets(void) = 0;
     virtual bool is_meta_master() = 0;
     virtual int forward_request_to_master(RGWUser* user, obj_version *objv,
@@ -628,7 +629,8 @@ class RGWRadosStore : public RGWStore {
 			    bool obj_lock_enabled,
 			    bool *existed,
 			    req_info& req_info,
-			    std::unique_ptr<RGWBucket>* bucket);
+			    std::unique_ptr<RGWBucket>* bucket,
+			    RGWAccessControlPolicy* policy = NULL);
     virtual RGWBucketList* list_buckets(void) { return new RGWBucketList(); }
     virtual bool is_meta_master() override;
     virtual int forward_request_to_master(RGWUser* user, obj_version *objv,


### PR DESCRIPTION
I try to create a bucket with the same name as an existing bucket, but specify different ACL, rgw return "200 OK". Run "rados_admin metadata get" to view the instance metadata object of the bucket, i found the bucket's ACL has not changed. It really should n’t change. But, it's not appropriate to return 200.  Similar to specifying a different placemen when creating an existing bucket, rgw should return "409 Conflict" in this scenario.

Signed-off-by: caolei <halei15848934852@163.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
