### PR TITLE
os/bluestore: Force Onode cache to trim when quota changes

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3926,6 +3926,7 @@ void BlueStore::MempoolThread::_resize_shards(bool interval_stats)
 
   for (auto i : store->onode_cache_shards) {
     i->set_max(max_shard_onodes);
+    i->trim();
   }
   for (auto i : store->buffer_cache_shards) {
     i->set_max(max_shard_buffer);


### PR DESCRIPTION
Solves case when there is fixed amount of Onodes and all operations only operate on existing ones.
Without this fix, there is no trigger to actually drop some cached Onodes.

Problem was detected during BlueStore compression tests, where all objects were created before filling them with data. 
Initially there was 10000 objects, each taking ~100 bytes Onode space.
When each object size grew to 32MB, each used ~1.1MB of Onode(+Extents+Blobs+SharedBlobs), for a total of ~12GB.

Each OnodeCacheShard separately could be triggered to trim() if some dummy rados object was added, but it only works for affected shard.