### PR TITLE
librbd: quiesce/unquiesce support for group_snap_create 

### DIFF
--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -340,9 +340,10 @@ void ImageWatcher<I>::notify_header_update(librados::IoCtx &io_ctx,
 }
 
 template <typename I>
-void ImageWatcher<I>::notify_quiesce(uint64_t request_id,
-                                     ProgressContext &prog_ctx,
-                                     Context *on_finish) {
+uint64_t ImageWatcher<I>::notify_quiesce(ProgressContext &prog_ctx,
+                                         Context *on_finish) {
+  uint64_t request_id = m_image_ctx.operations->reserve_async_request_id();
+
   ldout(m_image_ctx.cct, 10) << this << " " << __func__ << ": request_id="
                              << request_id << dendl;
 
@@ -352,6 +353,8 @@ void ImageWatcher<I>::notify_quiesce(uint64_t request_id,
     "rbd_quiesce_notification_attempts");
 
   notify_quiesce(async_request_id, attempts, prog_ctx, on_finish);
+
+  return request_id;
 }
 
 template <typename I>

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -72,8 +72,7 @@ public:
   static void notify_header_update(librados::IoCtx &io_ctx,
                                    const std::string &oid);
 
-  void notify_quiesce(uint64_t request_id, ProgressContext &prog_ctx,
-                      Context *on_finish);
+  uint64_t notify_quiesce(ProgressContext &prog_ctx, Context *on_finish);
   void notify_unquiesce(uint64_t request_id, Context *on_finish);
 
 private:

--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -742,7 +742,7 @@ void Operations<I>::snap_create(const cls::rbd::SnapshotNamespace &snap_namespac
     m_image_ctx, "snap_create", exclusive_lock::OPERATION_REQUEST_TYPE_GENERAL,
     true,
     boost::bind(&Operations<I>::execute_snap_create, this, snap_namespace, snap_name,
-		_1, 0, false, boost::ref(*prog_ctx)),
+		_1, 0, 0, boost::ref(*prog_ctx)),
     boost::bind(&ImageWatcher<I>::notify_snap_create, m_image_ctx.image_watcher,
                 request_id, snap_namespace, snap_name, boost::ref(*prog_ctx),
                 _1),
@@ -755,7 +755,7 @@ void Operations<I>::execute_snap_create(const cls::rbd::SnapshotNamespace &snap_
 					const std::string &snap_name,
                                         Context *on_finish,
                                         uint64_t journal_op_tid,
-                                        bool skip_object_map,
+                                        uint64_t flags,
                                         ProgressContext &prog_ctx) {
   ceph_assert(ceph_mutex_is_locked(m_image_ctx.owner_lock));
   ceph_assert(m_image_ctx.exclusive_lock == nullptr ||
@@ -781,7 +781,7 @@ void Operations<I>::execute_snap_create(const cls::rbd::SnapshotNamespace &snap_
   operation::SnapshotCreateRequest<I> *req =
     new operation::SnapshotCreateRequest<I>(
       m_image_ctx, new C_NotifyUpdate<I>(m_image_ctx, on_finish),
-      snap_namespace, snap_name, journal_op_tid, skip_object_map, prog_ctx);
+      snap_namespace, snap_name, journal_op_tid, flags, prog_ctx);
   req->send();
 }
 

--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -778,12 +778,10 @@ void Operations<I>::execute_snap_create(const cls::rbd::SnapshotNamespace &snap_
   }
   m_image_ctx.image_lock.unlock_shared();
 
-  uint64_t request_id = ++m_async_request_seq;
   operation::SnapshotCreateRequest<I> *req =
     new operation::SnapshotCreateRequest<I>(
       m_image_ctx, new C_NotifyUpdate<I>(m_image_ctx, on_finish),
-      snap_namespace, snap_name, journal_op_tid, request_id, skip_object_map,
-      prog_ctx);
+      snap_namespace, snap_name, journal_op_tid, skip_object_map, prog_ctx);
   req->send();
 }
 

--- a/src/librbd/Operations.h
+++ b/src/librbd/Operations.h
@@ -54,9 +54,8 @@ public:
   void snap_create(const cls::rbd::SnapshotNamespace &snap_namespace,
 		   const std::string& snap_name, Context *on_finish);
   void execute_snap_create(const cls::rbd::SnapshotNamespace &snap_namespace,
-			   const std::string &snap_name,
-			   Context *on_finish,
-                           uint64_t journal_op_tid, bool skip_object_map,
+			   const std::string &snap_name, Context *on_finish,
+                           uint64_t journal_op_tid, uint64_t flags,
                            ProgressContext &prog_ctx);
 
   int snap_rollback(const cls::rbd::SnapshotNamespace& snap_namespace,

--- a/src/librbd/Operations.h
+++ b/src/librbd/Operations.h
@@ -24,6 +24,10 @@ class Operations {
 public:
   Operations(ImageCtxT &image_ctx);
 
+  uint64_t reserve_async_request_id() {
+    return ++m_async_request_seq;
+  }
+
   int flatten(ProgressContext &prog_ctx);
   void execute_flatten(ProgressContext &prog_ctx, Context *on_finish);
 
@@ -114,7 +118,7 @@ public:
 
 private:
   ImageCtxT &m_image_ctx;
-  std::atomic<int> m_async_request_seq;
+  std::atomic<uint64_t> m_async_request_seq;
 
   int invoke_async_request(const std::string& name,
                            exclusive_lock::OperationRequestType request_type,

--- a/src/librbd/Types.h
+++ b/src/librbd/Types.h
@@ -101,6 +101,7 @@ enum ImageReadOnlyFlag {
 
 enum SnapCreateFlag {
   SNAP_CREATE_FLAG_SKIP_OBJECT_MAP     = 1 << 0,
+  SNAP_CREATE_FLAG_SKIP_NOTIFY_QUIESCE = 1 << 1,
 };
 
 struct MigrationInfo {

--- a/src/librbd/Types.h
+++ b/src/librbd/Types.h
@@ -99,6 +99,10 @@ enum ImageReadOnlyFlag {
   IMAGE_READ_ONLY_FLAG_NON_PRIMARY = 1 << 1,
 };
 
+enum SnapCreateFlag {
+  SNAP_CREATE_FLAG_SKIP_OBJECT_MAP     = 1 << 0,
+};
+
 struct MigrationInfo {
   int64_t pool_id = -1;
   std::string pool_namespace;

--- a/src/librbd/deep_copy/SnapshotCreateRequest.cc
+++ b/src/librbd/deep_copy/SnapshotCreateRequest.cc
@@ -81,9 +81,9 @@ void SnapshotCreateRequest<I>::send_create_snap() {
       finish_op_ctx->complete(0);
     });
   std::shared_lock owner_locker{m_dst_image_ctx->owner_lock};
-  m_dst_image_ctx->operations->execute_snap_create(m_snap_namespace,
-                                                   m_snap_name.c_str(), ctx, 0U,
-                                                   true, m_prog_ctx);
+  m_dst_image_ctx->operations->execute_snap_create(
+      m_snap_namespace, m_snap_name.c_str(), ctx, 0U,
+      SNAP_CREATE_FLAG_SKIP_OBJECT_MAP, m_prog_ctx);
 }
 
 template <typename I>

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -42,7 +42,7 @@ struct ExecuteOp : public Context {
     image_ctx.operations->execute_snap_create(event.snap_namespace,
 					      event.snap_name,
                                               on_op_complete,
-                                              event.op_tid, false,
+                                              event.op_tid, 0,
                                               no_op_progress_callback);
   }
 

--- a/src/librbd/operation/SnapshotCreateRequest.cc
+++ b/src/librbd/operation/SnapshotCreateRequest.cc
@@ -30,13 +30,11 @@ SnapshotCreateRequest<I>::SnapshotCreateRequest(I &image_ctx,
 						const cls::rbd::SnapshotNamespace &snap_namespace,
                                                 const std::string &snap_name,
                                                 uint64_t journal_op_tid,
-                                                uint64_t request_id,
                                                 bool skip_object_map,
                                                 ProgressContext &prog_ctx)
   : Request<I>(image_ctx, on_finish, journal_op_tid),
     m_snap_namespace(snap_namespace), m_snap_name(snap_name),
-    m_request_id(request_id), m_skip_object_map(skip_object_map),
-    m_prog_ctx(prog_ctx) {
+    m_skip_object_map(skip_object_map), m_prog_ctx(prog_ctx) {
 }
 
 template <typename I>
@@ -60,8 +58,8 @@ void SnapshotCreateRequest<I>::send_notify_quiesce() {
   CephContext *cct = image_ctx.cct;
   ldout(cct, 5) << this << " " << __func__ << dendl;
 
-  image_ctx.image_watcher->notify_quiesce(
-    m_request_id, m_prog_ctx, create_async_context_callback(
+  m_request_id = image_ctx.image_watcher->notify_quiesce(
+    m_prog_ctx, create_async_context_callback(
       image_ctx, create_context_callback<SnapshotCreateRequest<I>,
       &SnapshotCreateRequest<I>::handle_notify_quiesce>(this)));
 }

--- a/src/librbd/operation/SnapshotCreateRequest.cc
+++ b/src/librbd/operation/SnapshotCreateRequest.cc
@@ -30,11 +30,12 @@ SnapshotCreateRequest<I>::SnapshotCreateRequest(I &image_ctx,
 						const cls::rbd::SnapshotNamespace &snap_namespace,
                                                 const std::string &snap_name,
                                                 uint64_t journal_op_tid,
-                                                bool skip_object_map,
+                                                uint64_t flags,
                                                 ProgressContext &prog_ctx)
   : Request<I>(image_ctx, on_finish, journal_op_tid),
     m_snap_namespace(snap_namespace), m_snap_name(snap_name),
-    m_skip_object_map(skip_object_map), m_prog_ctx(prog_ctx) {
+    m_skip_object_map(flags & SNAP_CREATE_FLAG_SKIP_OBJECT_MAP),
+    m_prog_ctx(prog_ctx) {
 }
 
 template <typename I>

--- a/src/librbd/operation/SnapshotCreateRequest.h
+++ b/src/librbd/operation/SnapshotCreateRequest.h
@@ -71,8 +71,7 @@ public:
   SnapshotCreateRequest(ImageCtxT &image_ctx, Context *on_finish,
                         const cls::rbd::SnapshotNamespace &snap_namespace,
                         const std::string &snap_name, uint64_t journal_op_tid,
-                        uint64_t request_id, bool skip_object_map,
-                        ProgressContext &prog_ctx);
+                        bool skip_object_map, ProgressContext &prog_ctx);
 
 protected:
   void send_op() override;
@@ -89,10 +88,10 @@ protected:
 private:
   cls::rbd::SnapshotNamespace m_snap_namespace;
   std::string m_snap_name;
-  uint64_t m_request_id;
   bool m_skip_object_map;
   ProgressContext &m_prog_ctx;
 
+  uint64_t m_request_id = 0;
   int m_ret_val = 0;
 
   uint64_t m_snap_id = CEPH_NOSNAP;

--- a/src/librbd/operation/SnapshotCreateRequest.h
+++ b/src/librbd/operation/SnapshotCreateRequest.h
@@ -71,7 +71,7 @@ public:
   SnapshotCreateRequest(ImageCtxT &image_ctx, Context *on_finish,
                         const cls::rbd::SnapshotNamespace &snap_namespace,
                         const std::string &snap_name, uint64_t journal_op_tid,
-                        bool skip_object_map, ProgressContext &prog_ctx);
+                        uint64_t flags, ProgressContext &prog_ctx);
 
 protected:
   void send_op() override;

--- a/src/librbd/operation/SnapshotCreateRequest.h
+++ b/src/librbd/operation/SnapshotCreateRequest.h
@@ -89,6 +89,7 @@ private:
   cls::rbd::SnapshotNamespace m_snap_namespace;
   std::string m_snap_name;
   bool m_skip_object_map;
+  bool m_skip_notify_quiesce;
   ProgressContext &m_prog_ctx;
 
   uint64_t m_request_id = 0;
@@ -125,7 +126,7 @@ private:
   void send_release_snap_id();
   Context *handle_release_snap_id(int *result);
 
-  void send_notify_unquiesce();
+  Context *send_notify_unquiesce();
   Context *handle_notify_unquiesce(int *result);
 
   void update_snap_context();

--- a/src/test/librbd/deep_copy/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SnapshotCreateRequest.cc
@@ -108,7 +108,8 @@ public:
   void expect_snap_create(librbd::MockTestImageCtx &mock_image_ctx,
                           const std::string &snap_name, uint64_t snap_id, int r) {
     EXPECT_CALL(*mock_image_ctx.operations,
-                execute_snap_create(_, StrEq(snap_name), _, 0, true, _))
+                execute_snap_create(_, StrEq(snap_name), _, 0,
+                                    SNAP_CREATE_FLAG_SKIP_OBJECT_MAP, _))
                   .WillOnce(DoAll(InvokeWithoutArgs([&mock_image_ctx, snap_id, snap_name]() {
                                     inject_snap(mock_image_ctx, snap_id, snap_name);
                                   }),

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -219,7 +219,7 @@ public:
                           Context **on_finish, const char *snap_name,
                           uint64_t op_tid) {
     EXPECT_CALL(*mock_image_ctx.operations, execute_snap_create(_, StrEq(snap_name), _,
-                                                                op_tid, false, _))
+                                                                op_tid, 0, _))
                   .WillOnce(DoAll(SaveArg<2>(on_finish),
                                   NotifyInvoke(&m_invoke_lock, &m_invoke_cond)));
   }

--- a/src/test/librbd/mock/MockImageWatcher.h
+++ b/src/test/librbd/mock/MockImageWatcher.h
@@ -25,7 +25,7 @@ struct MockImageWatcher {
   MOCK_METHOD0(notify_released_lock, void());
   MOCK_METHOD0(notify_request_lock, void());
 
-  MOCK_METHOD3(notify_quiesce, void(uint64_t, ProgressContext &, Context *));
+  MOCK_METHOD2(notify_quiesce, uint64_t(ProgressContext &, Context *));
   MOCK_METHOD2(notify_unquiesce, void(uint64_t, Context *));
 };
 

--- a/src/test/librbd/mock/MockOperations.h
+++ b/src/test/librbd/mock/MockOperations.h
@@ -32,7 +32,7 @@ struct MockOperations {
 					 const std::string &snap_name,
                                          Context *on_finish,
                                          uint64_t journal_op_tid,
-                                         bool skip_object_map,
+                                         uint64_t flags,
                                          ProgressContext &prog_ctx));
   MOCK_METHOD3(snap_remove, void(const cls::rbd::SnapshotNamespace &snap_namespace,
 				 const std::string &snap_name,

--- a/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
@@ -188,7 +188,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, Success) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, false, prog_ctx);
+    "snap1", 0, 0, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -211,7 +211,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, NotifyQuiesceError) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, false, prog_ctx);
+    "snap1", 0, 0, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -244,7 +244,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, AllocateSnapIdError) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, false, prog_ctx);
+    "snap1", 0, 0, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -286,7 +286,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, CreateSnapStale) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, false, prog_ctx);
+    "snap1", 0, 0, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -320,7 +320,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, CreateSnapError) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, false, prog_ctx);
+    "snap1", 0, 0, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -354,7 +354,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, ReleaseSnapIdError) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, false, prog_ctx);
+    "snap1", 0, 0, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -394,7 +394,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, SkipObjectMap) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, true, prog_ctx);
+    "snap1", 0, SNAP_CREATE_FLAG_SKIP_OBJECT_MAP, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -441,7 +441,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, SetImageState) {
     mock_image_ctx, &cond_ctx,
     cls::rbd::MirrorSnapshotNamespace{
       cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY, {}, "", CEPH_NOSNAP},
-    "snap1", 0, false, prog_ctx);
+    "snap1", 0, 0, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();

--- a/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
@@ -63,9 +63,10 @@ public:
   typedef mirror::snapshot::SetImageStateRequest<MockImageCtx> MockSetImageStateRequest;
 
   void expect_notify_quiesce(MockImageCtx &mock_image_ctx, int r) {
-    EXPECT_CALL(*mock_image_ctx.image_watcher, notify_quiesce(_, _, _))
-      .WillOnce(WithArg<2>(
-                  CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue)));
+    EXPECT_CALL(*mock_image_ctx.image_watcher, notify_quiesce(_, _))
+      .WillOnce(DoAll(WithArg<1>(CompleteContext(
+                                   r, mock_image_ctx.image_ctx->op_work_queue)),
+                      Return(0)));
   }
 
   void expect_block_writes(MockImageCtx &mock_image_ctx) {
@@ -187,7 +188,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, Success) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, 0, false, prog_ctx);
+    "snap1", 0, false, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -210,7 +211,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, NotifyQuiesceError) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, 0, false, prog_ctx);
+    "snap1", 0, false, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -243,7 +244,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, AllocateSnapIdError) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, 0, false, prog_ctx);
+    "snap1", 0, false, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -285,7 +286,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, CreateSnapStale) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, 0, false, prog_ctx);
+    "snap1", 0, false, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -319,7 +320,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, CreateSnapError) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, 0, false, prog_ctx);
+    "snap1", 0, false, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -353,7 +354,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, ReleaseSnapIdError) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, 0, false, prog_ctx);
+    "snap1", 0, false, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -393,7 +394,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, SkipObjectMap) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, 0, true, prog_ctx);
+    "snap1", 0, true, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();
@@ -440,7 +441,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, SetImageState) {
     mock_image_ctx, &cond_ctx,
     cls::rbd::MirrorSnapshotNamespace{
       cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY, {}, "", CEPH_NOSNAP},
-    "snap1", 0, 0, false, prog_ctx);
+    "snap1", 0, false, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();


### PR DESCRIPTION
Signed-off-by: Mykola Golub <mgolub@suse.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
