### PR TITLE
rgw: dynamic resharding modifies existing bucket instance

### DIFF
--- a/qa/workunits/rgw/test_rgw_reshard.py
+++ b/qa/workunits/rgw/test_rgw_reshard.py
@@ -5,6 +5,8 @@ import time
 import subprocess
 import json
 import boto3
+from pprint import pprint
+import re
 
 """
 Rgw manual and dynamic resharding  testing against a running instance
@@ -16,7 +18,7 @@ Rgw manual and dynamic resharding  testing against a running instance
 #
 #
 
-log.basicConfig(level=log.DEBUG)
+log.basicConfig(format = '%(message)s', level=log.DEBUG)
 log.getLogger('botocore').setLevel(log.CRITICAL)
 log.getLogger('boto3').setLevel(log.CRITICAL)
 log.getLogger('urllib3').setLevel(log.CRITICAL)
@@ -26,33 +28,35 @@ USER = 'tester'
 DISPLAY_NAME = 'Testing'
 ACCESS_KEY = 'NX5QOQKC6BH2IDN8HC7A'
 SECRET_KEY = 'LnEsqNNqZIpkzauboDcLXLcYaWwLQ3Kop0zAnKIn'
-BUCKET_NAME1 = 'myfoo'
-BUCKET_NAME2 = 'mybar'
+BUCKET_NAME1 = 'a-bucket'
+BUCKET_NAME2 = 'b-bucket'
+BUCKET_NAME3 = 'c-bucket'
+BUCKET_NAME4 = 'd-bucket'
+BUCKET_NAME5 = 'e-bucket'
 VER_BUCKET_NAME = 'myver'
-
 
 def exec_cmd(cmd):
     try:
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         out, err = proc.communicate()
+        log.info(proc.args)
         if proc.returncode == 0:
-            log.info('command succeeded')
-            if out is not None: log.info(out)
+            if out is not None: log.debug('{} \n {}'.format(out.decode('utf-8'), err.decode('utf-8')))
             return out
         else:
-            raise Exception("error: %s \nreturncode: %s" % (err, proc.returncode))
+            raise Exception("error: {} \nreturncode: {}".format(err, proc.returncode))
     except Exception as e:
-        log.error('command failed')
+        log.error('command failed\n')
         log.error(e)
         return False
 
 
 def get_radosgw_port():
     out = exec_cmd('sudo netstat -nltp | grep radosgw')
-    log.debug('output: %s' % out)
+    log.debug('output: {}'.format(out))
     x = out.decode('utf8').split(" ")
     port = [i for i in x if ':' in i][0].split(':')[1]
-    log.info('radosgw port: %s' % port)
+    log.info('radosgw port: {}'.format(port))
     return port
 
 
@@ -72,19 +76,20 @@ def get_bucket_stats(bucket_name):
     """
     function to get bucket stats
     """
-    cmd = exec_cmd("radosgw-admin bucket stats --bucket %s" % bucket_name)
+    cmd = exec_cmd("radosgw-admin bucket stats --bucket {}".format(bucket_name))
     json_op = json.loads(cmd)
+    #print(json.dumps(json_op, indent = 4, sort_keys=True))
     bucket_id = json_op['id']
-    num_shards_op = json_op['num_shards']
+    num_shards = json_op['num_shards']
     if len(json_op['usage']) > 0:
         num_objects = json_op['usage']['rgw.main']['num_objects']
         size_kb = json_op['usage']['rgw.main']['size_kb']
     else:
         num_objects = 0
         size_kb = 0
-    log.debug("bucket %s id %s num_objects %d size_kb %d num_shards %d", bucket_name, bucket_id,
-              num_objects, size_kb, num_shards_op)
-    return BucketStats(bucket_name, bucket_id, num_objects, size_kb, num_shards_op)
+    log.debug(" \nBUCKET_STATS: \nbucket: {} id: {} num_objects: {} size_kb: {} num_shards: {}\n".format(bucket_name, bucket_id,
+              num_objects, size_kb, num_shards))
+    return BucketStats(bucket_name, bucket_id, num_objects, size_kb, num_shards)
 
 
 def get_bucket_num_shards(bucket_name, bucket_id):
@@ -92,21 +97,29 @@ def get_bucket_num_shards(bucket_name, bucket_id):
     function to get bucket num shards
     """
     metadata = 'bucket.instance:' + bucket_name + ':' + bucket_id
-    log.debug("metadata %s", metadata)
-    cmd = exec_cmd('radosgw-admin metadata get %s' % metadata)
+    cmd = exec_cmd('radosgw-admin metadata get {}'.format(metadata))
     json_op = json.loads(cmd)
     num_shards = json_op['data']['bucket_info']['num_shards']
-    log.debug("bucket %s id %s num_shards %d", bucket_name, bucket_id, num_shards)
     return num_shards
 
+def run_bucket_reshard_cmd(bucket_name, num_shards, **location):
+
+    # TODO: Get rid of duplication. use list
+    if ('error_location' in location):
+        return exec_cmd('radosgw-admin bucket reshard --bucket {} --num-shards {} --inject-error-at {}'.format(bucket_name,
+                        num_shards, location.get('error_location', None)))
+    elif ('abort_location' in location):
+        return exec_cmd('radosgw-admin bucket reshard --bucket {} --num-shards {} --inject-abort-at {}'.format(bucket_name,
+                        num_shards, location.get('abort_location', None)))
+    else:
+        return exec_cmd('radosgw-admin bucket reshard --bucket {} --num-shards {}'.format(bucket_name, num_shards))
 
 def main():
     """
     execute manual and dynamic resharding commands
     """
     # create user
-    exec_cmd('radosgw-admin user create --uid %s --display-name %s --access-key %s --secret %s'
-                   % (USER, DISPLAY_NAME, ACCESS_KEY, SECRET_KEY))
+    exec_cmd('radosgw-admin user create --uid {} --display-name {} --access-key {} --secret {}'.format(USER, DISPLAY_NAME, ACCESS_KEY, SECRET_KEY))
 
     def boto_connect(portnum, ssl, proto):
         endpoint = proto + '://localhost:' + portnum
@@ -122,90 +135,227 @@ def main():
 
     port = get_radosgw_port()
 
-    if port == '80':
-        connection = boto_connect(port, ssl=False, proto='http')
-    elif port == '443':
-        connection = boto_connect(port, ssl=True, proto='https')
+    proto = ('https' if port == '443' else 'http')
+    connection = boto_connect(port, ssl=False, proto='http')
 
     # create a bucket
     bucket1 = connection.create_bucket(Bucket=BUCKET_NAME1)
     bucket2 = connection.create_bucket(Bucket=BUCKET_NAME2)
+    bucket3 = connection.create_bucket(Bucket=BUCKET_NAME3)
+    bucket4 = connection.create_bucket(Bucket=BUCKET_NAME4)
+    bucket5 = connection.create_bucket(Bucket=BUCKET_NAME5)
     ver_bucket = connection.create_bucket(Bucket=VER_BUCKET_NAME)
     connection.BucketVersioning('ver_bucket')
-
-    bucket_stats1 = get_bucket_stats(BUCKET_NAME1)
-    bucket_stats2 = get_bucket_stats(BUCKET_NAME2)
-    ver_bucket_stats = get_bucket_stats(VER_BUCKET_NAME)
 
     bucket1_acl = connection.BucketAcl(BUCKET_NAME1).load()
     bucket2_acl = connection.BucketAcl(BUCKET_NAME2).load()
     ver_bucket_acl = connection.BucketAcl(VER_BUCKET_NAME).load()
 
     # TESTCASE 'reshard-add','reshard','add','add bucket to resharding queue','succeeds'
-    log.debug(' test: reshard add')
-    num_shards_expected = bucket_stats1.num_shards + 1
-    cmd = exec_cmd('radosgw-admin reshard add --bucket %s --num-shards %s' % (BUCKET_NAME1, num_shards_expected))
+    log.debug('TEST: reshard add\n')
+    
+    num_shards_expected = get_bucket_stats(BUCKET_NAME1).num_shards + 1
+    cmd = exec_cmd('radosgw-admin reshard add --bucket {} --num-shards {}'.format(BUCKET_NAME1, num_shards_expected))
     cmd = exec_cmd('radosgw-admin reshard list')
     json_op = json.loads(cmd)
-    log.debug('bucket name %s', json_op[0]['bucket_name'])
+    log.debug('bucket name {}'.format(json_op[0]['bucket_name']))
     assert json_op[0]['bucket_name'] == BUCKET_NAME1
     assert json_op[0]['new_num_shards'] == num_shards_expected
 
     # TESTCASE 'reshard-process','reshard','','process bucket resharding','succeeds'
-    log.debug(' test: reshard process')
+    log.debug('TEST: reshard process\n')
     cmd = exec_cmd('radosgw-admin reshard process')
     time.sleep(5)
     # check bucket shards num
     bucket_stats1 = get_bucket_stats(BUCKET_NAME1)
-    bucket_stats1.get_num_shards()
     if bucket_stats1.num_shards != num_shards_expected:
-        log.error("Resharding failed on bucket %s. Expected number of shards are not created" % BUCKET_NAME1)
+        log.error("Resharding failed on bucket {}. Expected number of shards are not created\n".format(BUCKET_NAME1))
 
     # TESTCASE 'reshard-add','reshard','add','add non empty bucket to resharding queue','succeeds'
-    log.debug(' test: reshard add non empty bucket')
+    log.debug('TEST: reshard add non empty bucket\n')
     # create objs
     num_objs = 8
     for i in range(0, num_objs):
         connection.Object(BUCKET_NAME1, ('key'+str(i))).put(Body=b"some_data")
 
-    num_shards_expected = bucket_stats1.num_shards + 1
-    cmd = exec_cmd('radosgw-admin reshard add --bucket %s --num-shards %s' % (BUCKET_NAME1, num_shards_expected))
+    num_shards_expected = get_bucket_stats(BUCKET_NAME1).num_shards + 1
+    cmd = exec_cmd('radosgw-admin reshard add --bucket {} --num-shards {}'.format(BUCKET_NAME1, num_shards_expected))
     cmd = exec_cmd('radosgw-admin reshard list')
     json_op = json.loads(cmd)
-    log.debug('bucket name %s', json_op[0]['bucket_name'])
     assert json_op[0]['bucket_name'] == BUCKET_NAME1
     assert json_op[0]['new_num_shards'] == num_shards_expected
 
     # TESTCASE 'reshard process ,'reshard','process','reshard non empty bucket','succeeds'
-    log.debug(' test: reshard process non empty bucket')
+    log.debug(' TEST: reshard process non empty bucket\n')
     cmd = exec_cmd('radosgw-admin reshard process')
     # check bucket shards num
     bucket_stats1 = get_bucket_stats(BUCKET_NAME1)
-    bucket_stats1.get_num_shards()
     if bucket_stats1.num_shards != num_shards_expected:
-        log.error("Resharding failed on bucket %s. Expected number of shards are not created" % BUCKET_NAME1)
+        log.error("Resharding failed on bucket {}. Expected number of shards are not created\n".format(BUCKET_NAME1))
 
-    # TESTCASE 'manual resharding','bucket', 'reshard','','manual bucket resharding','succeeds'
-    log.debug(' test: manual reshard bucket')
+    # TESTCASE 'manual bucket resharding','inject error','fail','check bucket accessibility', 'retry reshard'
+    log.debug('TEST: reshard bucket with error injection\n')
     # create objs
     num_objs = 11
     for i in range(0, num_objs):
         connection.Object(BUCKET_NAME2, ('key' + str(i))).put(Body=b"some_data")
 
-    time.sleep(10)
-    num_shards_expected = bucket_stats2.num_shards + 1
-    cmd = exec_cmd('radosgw-admin bucket reshard --bucket %s --num-shards %s' % (BUCKET_NAME2,
-                                                                                 num_shards_expected))
+    time.sleep(5)
+    old_shard_count = get_bucket_stats(BUCKET_NAME2).num_shards
+    num_shards_expected = old_shard_count + 1
+    run_bucket_reshard_cmd(BUCKET_NAME2, num_shards_expected, error_location = "before_target_shard_entry")
+
     # check bucket shards num
-    bucket_stats2 = get_bucket_stats(BUCKET_NAME2)
-    bucket_stats2.get_num_shards()
-    if bucket_stats2.num_shards != num_shards_expected:
-        log.error("Resharding failed on bucket %s. Expected number of shards are not created" % BUCKET_NAME2)
+    cur_shard_count = get_bucket_stats(BUCKET_NAME2).num_shards
+    assert(cur_shard_count == old_shard_count)
+
+    #verify if bucket is accessible
+    log.info('List objects from bucket: {}'.format(BUCKET_NAME2))
+    for key in bucket2.objects.all():
+        print(key.key)
+
+    #verify if new objects can be added
+    num_objs = 5
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME2, ('key' + str(i))).put(Body=b"some_data")
+
+    #retry reshard
+    run_bucket_reshard_cmd(BUCKET_NAME2, num_shards_expected)
+
+    #TESTCASE 'manual bucket resharding','inject error','fail','check bucket accessibility', 'retry reshard'
+    log.debug('TEST: reshard bucket with error injection')
+    # create objs
+    num_objs = 11
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME3, ('key' + str(i))).put(Body=b"some_data")
+
+    time.sleep(5)
+    old_shard_count = get_bucket_stats(BUCKET_NAME3).num_shards
+    num_shards_expected = old_shard_count + 1
+    run_bucket_reshard_cmd(BUCKET_NAME3, num_shards_expected, error_location = "after_target_shard_entry")
+    # check bucket shards num
+    bucket_stats3 = get_bucket_stats(BUCKET_NAME3)
+    cur_shard_count = bucket_stats3.num_shards
+    assert(cur_shard_count == old_shard_count)
+
+    #verify if bucket is accessible
+    log.info('List objects from bucket: {}'.format(BUCKET_NAME3))
+    for key in bucket3.objects.all():
+        print(key.key)
+
+    #verify if new objects can be added
+    num_objs = 5
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME3, ('key' + str(i))).put(Body=b"some_data")
+
+    #retry reshard
+    run_bucket_reshard_cmd(BUCKET_NAME3, num_shards_expected)
+    
+    #TESTCASE 'manual bucket resharding','inject error','fail','check bucket accessibility', 'retry reshard'
+    log.debug('TEST: reshard bucket with error injection')
+    # create objs
+    num_objs = 11
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME4, ('key' + str(i))).put(Body=b"some_data")
+
+    time.sleep(10)
+    old_shard_count = get_bucket_stats(BUCKET_NAME4).num_shards
+    num_shards_expected = old_shard_count + 1
+    run_bucket_reshard_cmd(BUCKET_NAME4, num_shards_expected, error_location = "before_layout_overwrite")
+
+    # check bucket shards num
+    cur_shard_count = get_bucket_stats(BUCKET_NAME4).num_shards
+    assert(cur_shard_count == old_shard_count)
+
+    #verify if bucket is accessible
+    log.info('List objects from bucket: {}'.format(BUCKET_NAME3))
+    for key in bucket4.objects.all():
+        print(key.key)
+
+    #verify if new objects can be added
+    num_objs = 5
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME4, ('key' + str(i))).put(Body=b"some_data")
+
+    #retry reshard
+    run_bucket_reshard_cmd(BUCKET_NAME4, num_shards_expected)
+
+    # TESTCASE 'manual bucket resharding','inject crash','fail','check bucket accessibility', 'retry reshard'
+    log.debug('TEST: reshard bucket with crash injection\n')
+
+    old_shard_count = get_bucket_stats(BUCKET_NAME2).num_shards
+    num_shards_expected = old_shard_count + 1
+    run_bucket_reshard_cmd(BUCKET_NAME2, num_shards_expected, abort_location = "before_target_shard_entry")
+
+    # check bucket shards num
+    cur_shard_count = get_bucket_stats(BUCKET_NAME2).num_shards
+    assert(cur_shard_count == old_shard_count)
+
+    #verify if bucket is accessible
+    log.info('List objects from bucket: {}'.format(BUCKET_NAME2))
+    for key in bucket2.objects.all():
+        print(key.key)
+
+    #verify if new objects can be added
+    num_objs = 5
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME2, ('key' + str(i))).put(Body=b"some_data")
+
+    #retry reshard
+    run_bucket_reshard_cmd(BUCKET_NAME2, num_shards_expected)
+
+    #TESTCASE 'manual bucket resharding','inject crash','fail','check bucket accessibility', 'retry reshard'
+    log.debug('TEST: reshard bucket with error injection')
+
+    old_shard_count = get_bucket_stats(BUCKET_NAME3).num_shards
+    num_shards_expected = old_shard_count + 1
+    run_bucket_reshard_cmd(BUCKET_NAME3, num_shards_expected, abort_location = "after_target_shard_entry")
+
+    # check bucket shards num
+    cur_shard_count = get_bucket_stats(BUCKET_NAME3).num_shards
+    assert(cur_shard_count == old_shard_count)
+
+    #verify if bucket is accessible
+    log.info('List objects from bucket: {}'.format(BUCKET_NAME3))
+    for key in bucket3.objects.all():
+        print(key.key)
+
+    #verify if new objects can be added
+    num_objs = 5
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME3, ('key' + str(i))).put(Body=b"some_data")
+
+    #retry reshard
+    run_bucket_reshard_cmd(BUCKET_NAME3, num_shards_expected)
+
+    #TESTCASE 'manual bucket resharding','inject error','fail','check bucket accessibility', 'retry reshard'
+    log.debug('TEST: reshard bucket with error injection')
+
+    old_shard_count = get_bucket_stats(BUCKET_NAME4).num_shards
+    num_shards_expected = old_shard_count + 1
+    run_bucket_reshard_cmd(BUCKET_NAME4, num_shards_expected, abort_location = "before_layout_overwrite")
+    # check bucket shards num
+    bucket_stats4 = get_bucket_stats(BUCKET_NAME4)
+    cur_shard_count = bucket_stats4.num_shards
+    assert(cur_shard_count == old_shard_count)
+
+    #verify if bucket is accessible
+    log.info('List objects from bucket: {}'.format(BUCKET_NAME3))
+    for key in bucket4.objects.all():
+        print(key.key)
+
+    #verify if new objects can be added
+    num_objs = 5
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME4, ('key' + str(i))).put(Body=b"some_data")
+
+    #retry reshard
+    run_bucket_reshard_cmd(BUCKET_NAME4, num_shards_expected)
 
     # TESTCASE 'versioning reshard-','bucket', reshard','versioning reshard','succeeds'
     log.debug(' test: reshard versioned bucket')
-    num_shards_expected = ver_bucket_stats.num_shards + 1
-    cmd = exec_cmd('radosgw-admin bucket reshard --bucket %s --num-shards %s' % (VER_BUCKET_NAME,
+    num_shards_expected = get_bucket_stats(VER_BUCKET_NAME).num_shards + 1
+    cmd = exec_cmd('radosgw-admin bucket reshard --bucket {} --num-shards {}'.format(VER_BUCKET_NAME,
                                                                                  num_shards_expected))
     # check bucket shards num
     ver_bucket_stats = get_bucket_stats(VER_BUCKET_NAME)
@@ -220,13 +370,13 @@ def main():
     assert new_ver_bucket_acl == ver_bucket_acl
 
     # Clean up
-    log.debug("Deleting bucket %s", BUCKET_NAME1)
+    log.debug("Deleting bucket {}".format(BUCKET_NAME1))
     bucket1.objects.all().delete()
     bucket1.delete()
-    log.debug("Deleting bucket %s", BUCKET_NAME2)
+    log.debug("Deleting bucket {}".format(BUCKET_NAME2))
     bucket2.objects.all().delete()
     bucket2.delete()
-    log.debug("Deleting bucket %s", VER_BUCKET_NAME)
+    log.debug("Deleting bucket {}".format(VER_BUCKET_NAME))
     ver_bucket.delete()
 
 

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -3972,7 +3972,7 @@ static int rgw_set_bucket_resharding(cls_method_context_t hctx, bufferlist *in, 
     return rc;
   }
 
-  header.new_instance.set_status(op.entry.new_bucket_instance_id, op.entry.num_shards, op.entry.reshard_status);
+  header.new_instance.set_status(op.entry.bucket_instance_id, op.entry.num_shards, op.entry.reshard_status);
 
   return write_bucket_header(hctx, &header);
 }

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -3972,7 +3972,7 @@ static int rgw_set_bucket_resharding(cls_method_context_t hctx, bufferlist *in, 
     return rc;
   }
 
-  header.new_instance.set_status(op.entry.bucket_instance_id, op.entry.num_shards, op.entry.reshard_status);
+  header.new_instance.set_status(op.entry.reshard_status);
 
   return write_bucket_header(hctx, &header);
 }

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -720,9 +720,10 @@ void cls_rgw_reshard_entry::dump(Formatter *f) const
   encode_json("tenant", tenant, f);
   encode_json("bucket_name", bucket_name, f);
   encode_json("bucket_id", bucket_id, f);
-  encode_json("new_instance_id", new_instance_id, f);
+  encode_json("instance_id", instance_id, f);
   encode_json("old_num_shards", old_num_shards, f);
   encode_json("new_num_shards", new_num_shards, f);
+
 
 }
 
@@ -734,7 +735,7 @@ void cls_rgw_reshard_entry::generate_test_instances(list<cls_rgw_reshard_entry*>
   ls.back()->tenant = "tenant";
   ls.back()->bucket_name = "bucket1""";
   ls.back()->bucket_id = "bucket_id";
-  ls.back()->new_instance_id = "new_instance_id";
+  ls.back()->instance_id = "instance_id";
   ls.back()->old_num_shards = 8;
   ls.back()->new_num_shards = 64;
 }
@@ -742,7 +743,7 @@ void cls_rgw_reshard_entry::generate_test_instances(list<cls_rgw_reshard_entry*>
 void cls_rgw_bucket_instance_entry::dump(Formatter *f) const
 {
   encode_json("reshard_status", to_string(reshard_status), f);
-  encode_json("new_bucket_instance_id", new_bucket_instance_id, f);
+  encode_json("bucket_instance_id", bucket_instance_id, f);
   encode_json("num_shards", num_shards, f);
 
 }
@@ -753,7 +754,7 @@ void cls_rgw_bucket_instance_entry::generate_test_instances(
   ls.push_back(new cls_rgw_bucket_instance_entry);
   ls.push_back(new cls_rgw_bucket_instance_entry);
   ls.back()->reshard_status = RESHARD_STATUS::IN_PROGRESS;
-  ls.back()->new_bucket_instance_id = "new_instance_id";
+  ls.back()->bucket_instance_id = "instance_id";
 }
   
 void cls_rgw_lc_obj_head::dump(Formatter *f) const 

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -720,7 +720,6 @@ void cls_rgw_reshard_entry::dump(Formatter *f) const
   encode_json("tenant", tenant, f);
   encode_json("bucket_name", bucket_name, f);
   encode_json("bucket_id", bucket_id, f);
-  encode_json("instance_id", instance_id, f);
   encode_json("old_num_shards", old_num_shards, f);
   encode_json("new_num_shards", new_num_shards, f);
 
@@ -735,7 +734,6 @@ void cls_rgw_reshard_entry::generate_test_instances(list<cls_rgw_reshard_entry*>
   ls.back()->tenant = "tenant";
   ls.back()->bucket_name = "bucket1""";
   ls.back()->bucket_id = "bucket_id";
-  ls.back()->instance_id = "instance_id";
   ls.back()->old_num_shards = 8;
   ls.back()->new_num_shards = 64;
 }

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -743,9 +743,6 @@ void cls_rgw_reshard_entry::generate_test_instances(list<cls_rgw_reshard_entry*>
 void cls_rgw_bucket_instance_entry::dump(Formatter *f) const
 {
   encode_json("reshard_status", to_string(reshard_status), f);
-  encode_json("bucket_instance_id", bucket_instance_id, f);
-  encode_json("num_shards", num_shards, f);
-
 }
 
 void cls_rgw_bucket_instance_entry::generate_test_instances(
@@ -754,7 +751,6 @@ void cls_rgw_bucket_instance_entry::generate_test_instances(
   ls.push_back(new cls_rgw_bucket_instance_entry);
   ls.push_back(new cls_rgw_bucket_instance_entry);
   ls.back()->reshard_status = RESHARD_STATUS::IN_PROGRESS;
-  ls.back()->bucket_instance_id = "instance_id";
 }
   
 void cls_rgw_lc_obj_head::dump(Formatter *f) const 

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -722,8 +722,6 @@ void cls_rgw_reshard_entry::dump(Formatter *f) const
   encode_json("bucket_id", bucket_id, f);
   encode_json("old_num_shards", old_num_shards, f);
   encode_json("new_num_shards", new_num_shards, f);
-
-
 }
 
 void cls_rgw_reshard_entry::generate_test_instances(list<cls_rgw_reshard_entry*>& ls)

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -765,7 +765,6 @@ struct cls_rgw_bucket_instance_entry {
 
   void clear() {
     reshard_status = RESHARD_STATUS::NOT_RESHARDING;
-    //bucket_instance_id.clear();
   }
 
   void set_status(const std::string& instance_id,

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -1238,7 +1238,6 @@ struct cls_rgw_reshard_entry
   std::string tenant;
   std::string bucket_name;
   std::string bucket_id;
-  std::string instance_id;
   uint32_t old_num_shards{0};
   uint32_t new_num_shards{0};
 
@@ -1250,7 +1249,6 @@ struct cls_rgw_reshard_entry
     encode(tenant, bl);
     encode(bucket_name, bl);
     encode(bucket_id, bl);
-    encode(instance_id, bl);
     encode(old_num_shards, bl);
     encode(new_num_shards, bl);
     ENCODE_FINISH(bl);
@@ -1262,7 +1260,6 @@ struct cls_rgw_reshard_entry
     decode(tenant, bl);
     decode(bucket_name, bl);
     decode(bucket_id, bl);
-    decode(instance_id, bl);
     decode(old_num_shards, bl);
     decode(new_num_shards, bl);
     DECODE_FINISH(bl);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -744,6 +744,8 @@ struct cls_rgw_bucket_instance_entry {
   using RESHARD_STATUS = cls_rgw_reshard_status;
   
   cls_rgw_reshard_status reshard_status{RESHARD_STATUS::NOT_RESHARDING};
+  std::string new_bucket_instance_id;
+  int32_t num_shards{-1};
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
@@ -756,6 +758,10 @@ struct cls_rgw_bucket_instance_entry {
     uint8_t s;
     decode(s, bl);
     reshard_status = (cls_rgw_reshard_status)s;
+    if (struct_v < 2) {
+      decode(new_bucket_instance_id, bl);
+      decode(num_shards, bl);
+    }
     DECODE_FINISH(bl);
   }
 
@@ -1238,6 +1244,7 @@ struct cls_rgw_reshard_entry
   std::string tenant;
   std::string bucket_name;
   std::string bucket_id;
+  std::string new_instance_id;
   uint32_t old_num_shards{0};
   uint32_t new_num_shards{0};
 
@@ -1262,6 +1269,9 @@ struct cls_rgw_reshard_entry
     decode(bucket_id, bl);
     decode(old_num_shards, bl);
     decode(new_num_shards, bl);
+    if (struct_v < 2) {
+      decode(new_instance_id, bl);
+    }
     DECODE_FINISH(bl);
   }
 

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -746,13 +746,13 @@ struct cls_rgw_bucket_instance_entry {
   cls_rgw_reshard_status reshard_status{RESHARD_STATUS::NOT_RESHARDING};
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode((uint8_t)reshard_status, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     uint8_t s;
     decode(s, bl);
     reshard_status = (cls_rgw_reshard_status)s;
@@ -1244,7 +1244,7 @@ struct cls_rgw_reshard_entry
   cls_rgw_reshard_entry() {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(time, bl);
     encode(tenant, bl);
     encode(bucket_name, bl);
@@ -1255,7 +1255,7 @@ struct cls_rgw_reshard_entry
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(time, bl);
     decode(tenant, bl);
     decode(bucket_name, bl);

--- a/src/common/fault_injector.h
+++ b/src/common/fault_injector.h
@@ -1,0 +1,135 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <type_traits>
+#include <boost/type_traits/has_equal_to.hpp>
+#include <boost/type_traits/has_left_shift.hpp>
+#include <variant>
+#include "include/ceph_assert.h"
+#include "common/dout.h"
+
+/// @file
+
+/// A failure type that aborts the process with a failed assertion.
+struct InjectAbort {};
+
+/// A failure type that injects an error code and optionally logs a message.
+struct InjectError {
+  /// error code to inject
+  int error;
+  /// an optional log channel to print an error message
+  const DoutPrefixProvider* dpp = nullptr;
+};
+
+/** @class FaultInjector
+ * @brief Used to instrument a code path with deterministic fault injection
+ * by making one or more calls to check().
+ *
+ * A default-constructed FaultInjector contains no failure. It can also be
+ * constructed with a failure of type InjectAbort or InjectError, along with
+ * a location to inject that failure.
+ *
+ * The contained failure can be overwritten with a call to inject() or clear().
+ * This is not thread-safe with respect to other member functions on the same
+ * instance.
+ *
+ * @tparam Key  The location can be represented by any Key type that is
+ * movable, default-constructible, inequality-comparable and stream-outputable.
+ * A string or string_view Key may be preferable when the location comes from
+ * user input, or to describe the steps like "before-foo" and "after-foo".
+ * An integer Key may be preferable for a code path with many steps, where you
+ * just want to check 1, 2, 3, etc. without inventing names for each.
+ */
+template <typename Key>
+class FaultInjector {
+ public:
+  /// Default-construct with no injected failure.
+  constexpr FaultInjector() noexcept : location() {}
+
+  /// Construct with an injected assertion failure at the given location.
+  constexpr FaultInjector(Key location, InjectAbort a)
+    : location(std::move(location)), failure(a) {}
+
+  /// Construct with an injected error code at the given location.
+  constexpr FaultInjector(Key location, InjectError e)
+    : location(std::move(location)), failure(e) {}
+
+  /// Inject an assertion failure at the given location.
+  void inject(Key location, InjectAbort a) {
+    this->location = std::move(location);
+    this->failure = a;
+  }
+
+  /// Inject an error at the given location.
+  void inject(Key location, InjectError e) {
+    this->location = std::move(location);
+    this->failure = e;
+  }
+
+  /// Clear any injected failure.
+  void clear() {
+    this->failure = Empty{};
+  }
+
+  /// Check for an injected failure at the given location. If the location
+  /// matches an InjectAbort failure, the process aborts here with an assertion
+  /// failure.
+  /// @returns 0 or InjectError::error if the location matches an InjectError
+  /// failure
+  [[nodiscard]] constexpr int check(const Key& location) const {
+    struct visitor {
+      const Key& check_location;
+      const Key& this_location;
+      constexpr int operator()(const std::monostate&) const {
+        return 0;
+      }
+      int operator()(const InjectAbort&) const {
+        if (check_location == this_location) {
+          ceph_assert_always(!"FaultInjector");
+        }
+        return 0;
+      }
+      int operator()(const InjectError& e) const {
+        if (check_location == this_location) {
+          ldpp_dout(e.dpp, -1) << "Injecting error=" << e.error
+              << " at location=" << this_location << dendl;
+          return e.error;
+        }
+        return 0;
+      }
+    };
+    return std::visit(visitor{location, this->location}, failure);
+  }
+
+ private:
+  // Key requirements:
+  static_assert(std::is_default_constructible_v<Key>,
+                "Key must be default-constrible");
+  static_assert(std::is_move_constructible_v<Key>,
+                "Key must be move-constructible");
+  static_assert(std::is_move_assignable_v<Key>,
+                "Key must be move-assignable");
+  static_assert(boost::has_equal_to<Key, Key, bool>::value,
+                "Key must be equality-comparable");
+  static_assert(boost::has_left_shift<std::ostream, Key, std::ostream&>::value,
+                "Key must have an ostream operator<<");
+
+  Key location; // location of the check that should fail
+
+  using Empty = std::monostate; // empty state for std::variant
+
+  std::variant<Empty, InjectAbort, InjectError> failure;
+};

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1066,8 +1066,8 @@ static void show_reshard_status(
   for (const auto& entry : status) {
     formatter->open_object_section("entry");
     formatter->dump_string("reshard_status", to_string(entry.reshard_status));
-    formatter->dump_string("new_bucket_instance_id",
-			   entry.new_bucket_instance_id);
+    formatter->dump_string("bucket_instance_id",
+			   entry.bucket_instance_id);
     formatter->dump_int("num_shards", entry.num_shards);
     formatter->close_section();
   }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2728,7 +2728,7 @@ int check_reshard_bucket_params(rgw::sal::RGWRadosStore *store,
     return ret;
   }
 
-  if (bucket_info.reshard_status != cls_rgw_reshard_status::NOT_RESHARDING) {
+  if (bucket_info.reshard_status != rgw::BucketReshardState::NOT_RESHARDING) {
     // if in_progress or done then we have an old BucketInfo
     cerr << "ERROR: the bucket is currently undergoing resharding and "
       "cannot be added to the reshard list at this time" << std::endl;
@@ -6548,8 +6548,8 @@ next:
     for (; i < max_shards; i++) {
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-
-      int ret = bs.init(bucket, shard_id, bucket_info.layout.current_index, nullptr /* no RGWBucketInfo */);
+      const auto& current = bucket_info.layout.current_index;
+      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
       marker.clear();
 
       if (ret < 0) {
@@ -6613,7 +6613,8 @@ next:
     for (int i = 0; i < max_shards; i++) {
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-      int ret = bs.init(bucket, shard_id, bucket_info.layout.current_index, nullptr /* no RGWBucketInfo */);
+      const auto& current = bucket_info.layout.current_index;
+      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
       if (ret < 0) {
         cerr << "ERROR: bs.init(bucket=" << bucket << ", shard=" << shard_id << "): " << cpp_strerror(-ret) << std::endl;
         return -ret;
@@ -6919,6 +6920,7 @@ next:
     entry.tenant = tenant;
     entry.bucket_name = bucket_name;
     entry.bucket_id = bucket_info.bucket.bucket_id;
+    entry.instance_id = bucket_info.bucket_instance_id;
     entry.old_num_shards = num_source_shards;
     entry.new_num_shards = num_shards;
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6557,7 +6557,7 @@ next:
       do {
         entries.clear();
         ret = store->getRados()->bi_list(bs, object, marker, max_entries, &entries, &is_truncated);
-        if (ret < 0) {
+        if (ret < 0) {            
           cerr << "ERROR: bi_list(): " << cpp_strerror(-ret) << std::endl;
           return -ret;
         }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6546,7 +6546,7 @@ next:
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
       const auto& current = bucket_info.layout.current_index;
-      int ret = bs.init(bucket, shard_id, current, std::nullopt, nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
       marker.clear();
 
       if (ret < 0) {
@@ -6611,7 +6611,7 @@ next:
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
       const auto& current = bucket_info.layout.current_index;
-      int ret = bs.init(bucket, shard_id, current, std::nullopt, nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
       if (ret < 0) {
         cerr << "ERROR: bs.init(bucket=" << bucket << ", shard=" << shard_id << "): " << cpp_strerror(-ret) << std::endl;
         return -ret;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6546,7 +6546,7 @@ next:
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
       const auto& current = bucket_info.layout.current_index;
-      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket, shard_id, current, std::nullopt, nullptr /* no RGWBucketInfo */);
       marker.clear();
 
       if (ret < 0) {
@@ -6611,7 +6611,7 @@ next:
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
       const auto& current = bucket_info.layout.current_index;
-      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket, shard_id, current, std::nullopt, nullptr /* no RGWBucketInfo */);
       if (ret < 0) {
         cerr << "ERROR: bs.init(bucket=" << bucket << ", shard=" << shard_id << "): " << cpp_strerror(-ret) << std::endl;
         return -ret;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2732,7 +2732,7 @@ int check_reshard_bucket_params(rgw::sal::RGWRadosStore *store,
     return -EBUSY;
   }
 
-  int num_source_shards = (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+  int num_source_shards = rgw::current_num_shards(bucket_info.layout);
 
   if (num_shards <= num_source_shards && !yes_i_really_mean_it) {
     cerr << "num shards is less or equal to current shards count" << std::endl
@@ -6537,7 +6537,7 @@ next:
       max_entries = 1000;
     }
 
-    int max_shards = (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+    int max_shards = rgw::current_num_shards(bucket_info.layout);
 
     formatter->open_array_section("entries");
 
@@ -6605,7 +6605,7 @@ next:
       return EINVAL;
     }
 
-    int max_shards = (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+    int max_shards = rgw::current_num_shards(bucket_info.layout);
 
     for (int i = 0; i < max_shards; i++) {
       RGWRados::BucketShard bs(store->getRados());
@@ -6909,7 +6909,7 @@ next:
       return ret;
     }
 
-    int num_source_shards = (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+    int num_source_shards = rgw::current_num_shards(bucket_info.layout);
 
     RGWReshard reshard(store);
     cls_rgw_reshard_entry entry;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1066,9 +1066,6 @@ static void show_reshard_status(
   for (const auto& entry : status) {
     formatter->open_object_section("entry");
     formatter->dump_string("reshard_status", to_string(entry.reshard_status));
-    formatter->dump_string("bucket_instance_id",
-			   entry.bucket_instance_id);
-    formatter->dump_int("num_shards", entry.num_shards);
     formatter->close_section();
   }
   formatter->close_section();
@@ -2728,7 +2725,7 @@ int check_reshard_bucket_params(rgw::sal::RGWRadosStore *store,
     return ret;
   }
 
-  if (bucket_info.reshard_status != rgw::BucketReshardState::NOT_RESHARDING) {
+  if (bucket_info.reshard_status != cls_rgw_reshard_status::NOT_RESHARDING) {
     // if in_progress or done then we have an old BucketInfo
     cerr << "ERROR: the bucket is currently undergoing resharding and "
       "cannot be added to the reshard list at this time" << std::endl;
@@ -6920,7 +6917,6 @@ next:
     entry.tenant = tenant;
     entry.bucket_name = bucket_name;
     entry.bucket_id = bucket_info.bucket.bucket_id;
-    entry.instance_id = bucket_info.bucket_instance_id;
     entry.old_num_shards = num_source_shards;
     entry.new_num_shards = num_shards;
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6545,8 +6545,8 @@ next:
     for (; i < max_shards; i++) {
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-      const auto& current = bucket_info.layout.current_index;
-      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket, shard_id, bucket_info.layout.current_index,
+      nullptr /* no RGWBucketInfo */);
       marker.clear();
 
       if (ret < 0) {
@@ -6610,8 +6610,8 @@ next:
     for (int i = 0; i < max_shards; i++) {
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-      const auto& current = bucket_info.layout.current_index;
-      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket, shard_id, bucket_info.layout.current_index,
+      nullptr /* no RGWBucketInfo */);
       if (ret < 0) {
         cerr << "ERROR: bs.init(bucket=" << bucket << ", shard=" << shard_id << "): " << cpp_strerror(-ret) << std::endl;
         return -ret;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6557,7 +6557,7 @@ next:
       do {
         entries.clear();
         ret = store->getRados()->bi_list(bs, object, marker, max_entries, &entries, &is_truncated);
-        if (ret < 0) {            
+        if (ret < 0) {
           cerr << "ERROR: bi_list(): " << cpp_strerror(-ret) << std::endl;
           return -ret;
         }

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1699,7 +1699,8 @@ static int purge_bucket_instance(rgw::sal::RGWRadosStore *store, const RGWBucket
   for (int i = 0; i < max_shards; i++) {
     RGWRados::BucketShard bs(store->getRados());
     int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-    int ret = bs.init(bucket_info.bucket, shard_id, bucket_info.layout.current_index, nullptr);
+    const auto& current = bucket_info.layout.current_index;
+    int ret = bs.init(bucket_info.bucket, shard_id, current, nullptr);
     if (ret < 0) {
       cerr << "ERROR: bs.init(bucket=" << bucket_info.bucket << ", shard=" << shard_id
            << "): " << cpp_strerror(-ret) << std::endl;
@@ -1744,7 +1745,7 @@ void get_stale_instances(rgw::sal::RGWRadosStore *store, const std::string& buck
                           << cpp_strerror(-r) << dendl;
       continue;
     }
-    if (binfo.reshard_status == cls_rgw_reshard_status::DONE)
+    if (binfo.reshard_status == rgw::BucketReshardState::DONE)
       stale_instances.emplace_back(std::move(binfo));
     else {
       other_instances.emplace_back(std::move(binfo));

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1700,7 +1700,7 @@ static int purge_bucket_instance(rgw::sal::RGWRadosStore *store, const RGWBucket
     RGWRados::BucketShard bs(store->getRados());
     int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
     const auto& current = bucket_info.layout.current_index;
-    int ret = bs.init(bucket_info.bucket, shard_id, current, nullptr);
+    int ret = bs.init(bucket_info.bucket, shard_id, current, std::nullopt, nullptr);
     if (ret < 0) {
       cerr << "ERROR: bs.init(bucket=" << bucket_info.bucket << ", shard=" << shard_id
            << "): " << cpp_strerror(-ret) << std::endl;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1700,7 +1700,7 @@ static int purge_bucket_instance(rgw::sal::RGWRadosStore *store, const RGWBucket
     RGWRados::BucketShard bs(store->getRados());
     int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
     const auto& current = bucket_info.layout.current_index;
-    int ret = bs.init(bucket_info.bucket, shard_id, current, std::nullopt, nullptr);
+    int ret = bs.init(bucket_info.bucket, shard_id, current, nullptr);
     if (ret < 0) {
       cerr << "ERROR: bs.init(bucket=" << bucket_info.bucket << ", shard=" << shard_id
            << "): " << cpp_strerror(-ret) << std::endl;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -3136,7 +3136,7 @@ int RGWMetadataHandlerPut_BucketInstance::put_post()
 
   objv_tracker = bci.info.objv_tracker;
 
-  int ret = bihandler->svc.bi->init_index(bci.info);
+  int ret = bihandler->svc.bi->init_index(bci.info, bci.info.layout.current_index);
   if (ret < 0) {
     return ret;
   }

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1695,7 +1695,7 @@ int RGWBucketAdminOp::set_quota(rgw::sal::RGWRadosStore *store, RGWBucketAdminOp
 
 static int purge_bucket_instance(rgw::sal::RGWRadosStore *store, const RGWBucketInfo& bucket_info)
 {
-  int max_shards = (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+  int max_shards = rgw::current_num_shards(bucket_info.layout);
   for (int i = 0; i < max_shards; i++) {
     RGWRados::BucketShard bs(store->getRados());
     int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1745,7 +1745,7 @@ void get_stale_instances(rgw::sal::RGWRadosStore *store, const std::string& buck
                           << cpp_strerror(-r) << dendl;
       continue;
     }
-    if (binfo.reshard_status == rgw::BucketReshardState::DONE)
+    if (binfo.reshard_status == cls_rgw_reshard_status::DONE)
       stale_instances.emplace_back(std::move(binfo));
     else {
       other_instances.emplace_back(std::move(binfo));

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1699,8 +1699,7 @@ static int purge_bucket_instance(rgw::sal::RGWRadosStore *store, const RGWBucket
   for (int i = 0; i < max_shards; i++) {
     RGWRados::BucketShard bs(store->getRados());
     int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-    const auto& current = bucket_info.layout.current_index;
-    int ret = bs.init(bucket_info.bucket, shard_id, current, nullptr);
+    int ret = bs.init(bucket_info.bucket, shard_id, bucket_info.layout.current_index, nullptr);
     if (ret < 0) {
       cerr << "ERROR: bs.init(bucket=" << bucket_info.bucket << ", shard=" << shard_id
            << "): " << cpp_strerror(-ret) << std::endl;

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -66,7 +66,6 @@ void decode(bucket_index_layout& l, bufferlist::const_iterator& bl);
 struct bucket_index_layout_generation {
   uint64_t gen = 0;
   bucket_index_layout layout;
-
 };
 
 void encode(const bucket_index_layout_generation& l, bufferlist& bl, uint64_t f=0);

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -73,14 +73,13 @@ void decode(bucket_index_layout_generation& l, bufferlist::const_iterator& bl);
 
 
 enum class BucketReshardState : uint8_t {
-  NOT_RESHARDING,
+  NONE,
   IN_PROGRESS,
-  DONE,
 };
 
 // describes the layout of bucket index objects
 struct BucketLayout {
-  BucketReshardState resharding = BucketReshardState::NOT_RESHARDING;
+  BucketReshardState resharding = BucketReshardState::NONE;
 
   // current bucket index layout
   bucket_index_layout_generation current_index;

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -73,19 +73,20 @@ void decode(bucket_index_layout_generation& l, bufferlist::const_iterator& bl);
 
 
 enum class BucketReshardState : uint8_t {
-  None,
-  InProgress,
+  NOT_RESHARDING,
+  IN_PROGRESS,
+  DONE,
 };
 
 // describes the layout of bucket index objects
 struct BucketLayout {
-  BucketReshardState resharding = BucketReshardState::None;
+  BucketReshardState resharding = BucketReshardState::NOT_RESHARDING;
 
   // current bucket index layout
   bucket_index_layout_generation current_index;
 
   // target index layout of a resharding operation
-  std::optional<bucket_index_layout_generation> target_index;
+  bucket_index_layout_generation target_index;
 };
 
 void encode(const BucketLayout& l, bufferlist& bl, uint64_t f=0);

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -66,6 +66,7 @@ void decode(bucket_index_layout& l, bufferlist::const_iterator& bl);
 struct bucket_index_layout_generation {
   uint64_t gen = 0;
   bucket_index_layout layout;
+
 };
 
 void encode(const bucket_index_layout_generation& l, bufferlist& bl, uint64_t f=0);
@@ -85,7 +86,7 @@ struct BucketLayout {
   bucket_index_layout_generation current_index;
 
   // target index layout of a resharding operation
-  bucket_index_layout_generation target_index;
+  std::optional<bucket_index_layout_generation> target_index;
 };
 
 void encode(const BucketLayout& l, bufferlist& bl, uint64_t f=0);

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -91,4 +91,8 @@ struct BucketLayout {
 void encode(const BucketLayout& l, bufferlist& bl, uint64_t f=0);
 void decode(BucketLayout& l, bufferlist::const_iterator& bl);
 
+inline uint32_t current_num_shards(const BucketLayout& layout) {
+  return std::max(layout.current_index.layout.normal.num_shards, 1u);
+  }
+
 } // namespace rgw

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2127,7 +2127,7 @@ void RGWBucketInfo::decode(bufferlist::const_iterator& bl) {
     decode(swift_versioning, bl);
     if (swift_versioning) {
       decode(swift_ver_location, bl);
-    }
+   }
   }
   if (struct_v >= 17) {
     decode(creation_time, bl);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1114,11 +1114,6 @@ struct RGWBucketInfo {
   // layout of bucket index objects
   rgw::BucketLayout layout;
 
-  // Represents the number of bucket index object shards:
-  //   - value of 0 indicates there is no sharding (this is by default
-  //     before this feature is implemented).
-  //   - value of UINT32_T::MAX indicates this is a blind bucket.
-
   // Represents the shard number for blind bucket.
   const static uint32_t NUM_SHARDS_BLIND_BUCKET;
 

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -520,7 +520,7 @@ int RGWOrphanSearch::build_linked_oids_for_bucket(const string& bucket_instance_
     return 0;
   }
 
-  if (cur_bucket_info.reshard_status == rgw::BucketReshardState::IN_PROGRESS) {
+  if (cur_bucket_info.reshard_status == cls_rgw_reshard_status::IN_PROGRESS) {
     ldout(store->ctx(), 0) << __func__ << ": reshard in progress. Skipping "
                            << orphan_bucket.name << ": "
                            << orphan_bucket.bucket_id << dendl;

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -520,7 +520,7 @@ int RGWOrphanSearch::build_linked_oids_for_bucket(const string& bucket_instance_
     return 0;
   }
 
-  if (cur_bucket_info.reshard_status == cls_rgw_reshard_status::IN_PROGRESS) {
+  if (cur_bucket_info.reshard_status == rgw::BucketReshardState::IN_PROGRESS) {
     ldout(store->ctx(), 0) << __func__ << ": reshard in progress. Skipping "
                            << orphan_bucket.name << ": "
                            << orphan_bucket.bucket_id << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2221,7 +2221,7 @@ int RGWRados::create_bucket(const RGWUserInfo& owner, rgw_bucket& bucket,
       info.quota = *pquota_info;
     }
 
-    int r = svc.bi->init_index(info);
+    int r = svc.bi->init_index(info, info.layout.current_index);
     if (r < 0) {
       return r;
     }
@@ -2244,7 +2244,7 @@ int RGWRados::create_bucket(const RGWUserInfo& owner, rgw_bucket& bucket,
 
       /* only remove it if it's a different bucket instance */
       if (orig_info.bucket.bucket_id != bucket.bucket_id) {
-	int r = svc.bi->clean_index(info, std::nullopt);
+	int r = svc.bi->clean_index(info, info.layout.current_index.gen);
         if (r < 0) {
 	  ldout(cct, 0) << "WARNING: could not remove bucket index (r=" << r << ")" << dendl;
 	}
@@ -2671,7 +2671,7 @@ int RGWRados::BucketShard::init(const RGWBucketInfo& bucket_info, const rgw::buc
   bucket = bucket_info.bucket;
   shard_id = sid;
 
-  int ret = store->svc.bi_rados->open_bucket_index_shard(bucket_info, shard_id, current_layout.layout.normal.num_shards, std::nullopt, &bucket_obj);
+  int ret = store->svc.bi_rados->open_bucket_index_shard(bucket_info, shard_id, current_layout.layout.normal.num_shards, current_layout.gen, &bucket_obj);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2509,7 +2509,7 @@ done_err:
  * fixes an issue where head objects were supposed to have a locator created, but ended
  * up without one
  */
-int RGWRados::fix_tail_obj_locator(const RGWBucketInfo& bucket_info, rgw_obj_key& key, bool fix, bool *need_fix, optional_yield y)
+int RGWRados::fix_tail_obj_locator(RGWBucketInfo& bucket_info, rgw_obj_key& key, bool fix, bool *need_fix, optional_yield y)
 {
   const rgw_bucket& bucket = bucket_info.bucket;
   rgw_obj obj(bucket, key);
@@ -2617,8 +2617,7 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 }
 
 int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
-				int sid, const rgw::bucket_index_layout_generation& current_layout,
-        std::optional<rgw::bucket_index_layout_generation> target_layout,
+				int sid, std::optional<rgw::bucket_index_layout_generation> idx_layout,
 				RGWBucketInfo* bucket_info_out)
 {
   bucket = _bucket;
@@ -2637,13 +2636,9 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 
   string oid;
 
-  if (target_layout) {
-    ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, target_layout->layout.normal.num_shards,
-                                                      target_layout->gen, &bucket_obj);
-  } else {
-    ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, current_layout.layout.normal.num_shards,
-                                                      current_layout.gen, &bucket_obj);
-  }
+  ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, idx_layout->layout.normal.num_shards,
+                                                    idx_layout->gen, &bucket_obj);
+
   if (ret < 0) {
   ldout(store->ctx(), 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
   return ret;
@@ -4894,7 +4889,7 @@ int RGWRados::bucket_set_reshard(const RGWBucketInfo& bucket_info, const cls_rgw
   return CLSRGWIssueSetBucketResharding(index_pool.ioctx(), bucket_objs, entry, cct->_conf->rgw_bucket_index_max_aio)();
 }
 
-int RGWRados::defer_gc(void *ctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y)
+int RGWRados::defer_gc(void *ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y)
 {
   RGWObjectCtx *rctx = static_cast<RGWObjectCtx *>(ctx);
   std::string oid, key;
@@ -5262,7 +5257,7 @@ static bool has_olh_tag(map<string, bufferlist>& attrs)
   return (iter != attrs.end());
 }
 
-int RGWRados::get_olh_target_state(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
+int RGWRados::get_olh_target_state(RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj,
                                    RGWObjState *olh_state, RGWObjState **target_state, optional_yield y)
 {
   ceph_assert(olh_state->is_olh);
@@ -5280,7 +5275,7 @@ int RGWRados::get_olh_target_state(RGWObjectCtx& obj_ctx, const RGWBucketInfo& b
   return 0;
 }
 
-int RGWRados::get_obj_state_impl(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
+int RGWRados::get_obj_state_impl(RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj,
                                  RGWObjState **state, bool follow_olh, optional_yield y, bool assume_noent)
 {
   if (obj.empty()) {
@@ -5458,7 +5453,7 @@ int RGWRados::get_obj_state_impl(RGWObjectCtx *rctx, const RGWBucketInfo& bucket
   return 0;
 }
 
-int RGWRados::get_obj_state(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state,
+int RGWRados::get_obj_state(RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state,
                             bool follow_olh, optional_yield y, bool assume_noent)
 {
   int ret;
@@ -5577,7 +5572,7 @@ int RGWRados::Object::Stat::finish()
 }
 
 int RGWRados::append_atomic_test(RGWObjectCtx *rctx,
-                                 const RGWBucketInfo& bucket_info, const rgw_obj& obj,
+                                 RGWBucketInfo& bucket_info, const rgw_obj& obj,
                                  ObjectOperation& op, RGWObjState **pstate, optional_yield y)
 {
   if (!rctx)
@@ -5717,14 +5712,14 @@ int RGWRados::Object::prepare_atomic_modification(ObjectWriteOperation& op, bool
  * bl: the contents of the attr
  * Returns: 0 on success, -ERR# otherwise.
  */
-int RGWRados::set_attr(void *ctx, const RGWBucketInfo& bucket_info, rgw_obj& obj, const char *name, bufferlist& bl)
+int RGWRados::set_attr(void *ctx, RGWBucketInfo& bucket_info, rgw_obj& obj, const char *name, bufferlist& bl)
 {
   map<string, bufferlist> attrs;
   attrs[name] = bl;
   return set_attrs(ctx, bucket_info, obj, attrs, NULL, null_yield);
 }
 
-int RGWRados::set_attrs(void *ctx, const RGWBucketInfo& bucket_info, rgw_obj& src_obj,
+int RGWRados::set_attrs(void *ctx, RGWBucketInfo& bucket_info, rgw_obj& src_obj,
                         map<string, bufferlist>& attrs,
                         map<string, bufferlist>* rmattrs,
                         optional_yield y)
@@ -6409,7 +6404,7 @@ int RGWRados::Object::Read::iterate(int64_t ofs, int64_t end, RGWGetDataCB *cb,
 }
 
 int RGWRados::iterate_obj(RGWObjectCtx& obj_ctx,
-                          const RGWBucketInfo& bucket_info, const rgw_obj& obj,
+                          RGWBucketInfo& bucket_info, const rgw_obj& obj,
                           off_t ofs, off_t end, uint64_t max_chunk_size,
                           iterate_obj_cb cb, void *arg, optional_yield y)
 {
@@ -6740,7 +6735,7 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
   return -ERR_BUSY_RESHARDING;
 }
 
-int RGWRados::bucket_index_link_olh(RGWBucketInfo bucket_info, RGWObjState& olh_state, const rgw_obj& obj_instance,
+int RGWRados::bucket_index_link_olh(RGWBucketInfo& bucket_info, RGWObjState& olh_state, const rgw_obj& obj_instance,
                                     bool delete_marker,
                                     const string& op_tag,
                                     struct rgw_bucket_dir_entry_meta *meta,
@@ -6793,7 +6788,7 @@ void RGWRados::bucket_index_guard_olh_op(RGWObjState& olh_state, ObjectOperation
   op.cmpxattr(RGW_ATTR_OLH_ID_TAG, CEPH_OSD_CMPXATTR_OP_EQ, olh_state.olh_tag);
 }
 
-int RGWRados::bucket_index_unlink_instance(RGWBucketInfo bucket_info, const rgw_obj& obj_instance,
+int RGWRados::bucket_index_unlink_instance(RGWBucketInfo& bucket_info, const rgw_obj& obj_instance,
                                            const string& op_tag, const string& olh_tag, uint64_t olh_epoch, rgw_zone_set *_zones_trace)
 {
   rgw_rados_ref ref;
@@ -6828,7 +6823,7 @@ int RGWRados::bucket_index_unlink_instance(RGWBucketInfo bucket_info, const rgw_
   return 0;
 }
 
-int RGWRados::bucket_index_read_olh_log(RGWBucketInfo bucket_info, RGWObjState& state,
+int RGWRados::bucket_index_read_olh_log(RGWBucketInfo& bucket_info, RGWObjState& state,
                                         const rgw_obj& obj_instance, uint64_t ver_marker,
                                         map<uint64_t, vector<rgw_bucket_olh_log_entry> > *log,
                                         bool *is_truncated)
@@ -6936,7 +6931,7 @@ int RGWRados::repair_olh(RGWObjState* state, const RGWBucketInfo& bucket_info,
   return 0;
 }
 
-int RGWRados::bucket_index_trim_olh_log(RGWBucketInfo bucket_info, RGWObjState& state, const rgw_obj& obj_instance, uint64_t ver)
+int RGWRados::bucket_index_trim_olh_log(RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance, uint64_t ver)
 {
   rgw_rados_ref ref;
   int r = get_obj_head_ref(bucket_info, obj_instance, &ref);
@@ -6971,7 +6966,7 @@ int RGWRados::bucket_index_trim_olh_log(RGWBucketInfo bucket_info, RGWObjState& 
   return 0;
 }
 
-int RGWRados::bucket_index_clear_olh(RGWBucketInfo bucket_info, RGWObjState& state, const rgw_obj& obj_instance)
+int RGWRados::bucket_index_clear_olh(RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance)
 {
   rgw_rados_ref ref;
   int r = get_obj_head_ref(bucket_info, obj_instance, &ref);
@@ -7013,7 +7008,7 @@ static int decode_olh_info(CephContext* cct, const bufferlist& bl, RGWOLHInfo *o
   }
 }
 
-int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
+int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, RGWBucketInfo& bucket_info, const rgw_obj& obj,
                             bufferlist& olh_tag, map<uint64_t, vector<rgw_bucket_olh_log_entry> >& log,
                             uint64_t *plast_ver, rgw_zone_set* zones_trace)
 {
@@ -7180,7 +7175,7 @@ int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, const RGW
 /*
  * read olh log and apply it
  */
-int RGWRados::update_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_zone_set *zones_trace)
+int RGWRados::update_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_zone_set *zones_trace)
 {
   map<uint64_t, vector<rgw_bucket_olh_log_entry> > log;
   bool is_truncated;
@@ -7200,7 +7195,7 @@ int RGWRados::update_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, const RGWBuc
   return 0;
 }
 
-int RGWRados::set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, const rgw_obj& target_obj, bool delete_marker, rgw_bucket_dir_entry_meta *meta,
+int RGWRados::set_olh(RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, const rgw_obj& target_obj, bool delete_marker, rgw_bucket_dir_entry_meta *meta,
                       uint64_t olh_epoch, real_time unmod_since, bool high_precision_time,
                       optional_yield y, rgw_zone_set *zones_trace, bool log_data_change)
 {
@@ -7430,7 +7425,7 @@ int RGWRados::remove_olh_pending_entries(const RGWBucketInfo& bucket_info, RGWOb
   return 0;
 }
 
-int RGWRados::follow_olh(const RGWBucketInfo& bucket_info, RGWObjectCtx& obj_ctx, RGWObjState *state, const rgw_obj& olh_obj, rgw_obj *target)
+int RGWRados::follow_olh(RGWBucketInfo& bucket_info, RGWObjectCtx& obj_ctx, RGWObjState *state, const rgw_obj& olh_obj, rgw_obj *target)
 {
   map<string, bufferlist> pending_entries;
   rgw_filter_attrset(state->attrset, RGW_ATTR_OLH_PENDING_PREFIX, &pending_entries);
@@ -8077,7 +8072,7 @@ int RGWRados::bi_list(const RGWBucketInfo& bucket_info, int shard_id, const stri
 {
   BucketShard bs(this);
   const auto& current = bucket_info.layout.current_index;
-  int ret = bs.init(bucket_info.bucket, shard_id, current, std::nullopt, nullptr /* no RGWBucketInfo */);
+  int ret = bs.init(bucket_info.bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
   if (ret < 0) {
     ldout(cct, 5) << "bs.init() returned ret=" << ret << dendl;
     return ret;
@@ -8800,7 +8795,7 @@ int RGWRados::remove_objs_from_index(RGWBucketInfo& bucket_info, list<rgw_obj_in
 }
 
 int RGWRados::check_disk_state(librados::IoCtx io_ctx,
-                               const RGWBucketInfo& bucket_info,
+                               RGWBucketInfo& bucket_info,
                                rgw_bucket_dir_entry& list_state,
                                rgw_bucket_dir_entry& object,
                                bufferlist& suggested_updates,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8925,7 +8925,6 @@ int RGWRados::cls_bucket_head(const RGWBucketInfo& bucket_info, int shard_id, ve
   map<int, string> oids;
   map<int, struct rgw_cls_list_ret> list_results;
   int r = svc.bi_rados->open_bucket_index(bucket_info, shard_id, &index_pool, &oids, bucket_instance_ids);
-  ldout(cct, 20) << "open_bucket_index() run" << dendl;
   if (r < 0) {
     ldout(cct, 20) << "cls_bucket_head: open_bucket_index() returned "
                    << r << dendl;
@@ -8933,7 +8932,6 @@ int RGWRados::cls_bucket_head(const RGWBucketInfo& bucket_info, int shard_id, ve
   }
 
   r = CLSRGWIssueGetDirHeader(index_pool.ioctx(), oids, list_results, cct->_conf->rgw_bucket_index_max_aio)();
-  ldout(cct, 20) << "CLSRGWIssueGetDirHeader issued" << dendl;
   if (r < 0) {
     ldout(cct, 20) << "cls_bucket_head: CLSRGWIssueGetDirHeader() returned "
                    << r << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2244,7 +2244,7 @@ int RGWRados::create_bucket(const RGWUserInfo& owner, rgw_bucket& bucket,
 
       /* only remove it if it's a different bucket instance */
       if (orig_info.bucket.bucket_id != bucket.bucket_id) {
-	int r = svc.bi->clean_index(info, info.layout.current_index.gen);
+	int r = svc.bi->clean_index(info, info.layout.current_index);
         if (r < 0) {
 	  ldout(cct, 0) << "WARNING: could not remove bucket index (r=" << r << ")" << dendl;
 	}

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8960,8 +8960,7 @@ int RGWRados::check_bucket_shards(const RGWBucketInfo& bucket_info,
   }
 
   bool need_resharding = false;
-  uint32_t num_source_shards =
-    (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+  uint32_t num_source_shards = rgw::current_num_shards(bucket_info.layout);
   const uint32_t max_dynamic_shards =
     uint32_t(cct->_conf.get_val<uint64_t>("rgw_max_dynamic_shards"));
 
@@ -8999,7 +8998,7 @@ int RGWRados::add_bucket_to_reshard(const RGWBucketInfo& bucket_info, uint32_t n
 {
   RGWReshard reshard(this->store);
 
-  uint32_t num_source_shards = (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+  uint32_t num_source_shards = rgw::current_num_shards(bucket_info.layout);
 
   new_num_shards = std::min(new_num_shards, get_max_bucket_shards());
   if (new_num_shards <= num_source_shards) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7669,7 +7669,6 @@ int RGWRados::try_refresh_bucket_info(RGWBucketInfo& info,
 				      .set_mtime(pmtime)
 				      .set_attrs(pattrs)
 				      .set_refresh_version(rv));
-            
 }
 
 int RGWRados::put_bucket_instance_info(RGWBucketInfo& info, bool exclusive,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8070,8 +8070,8 @@ int RGWRados::bi_remove(BucketShard& bs)
 int RGWRados::bi_list(const RGWBucketInfo& bucket_info, int shard_id, const string& filter_obj, const string& marker, uint32_t max, list<rgw_cls_bi_entry> *entries, bool *is_truncated)
 {
   BucketShard bs(this);
-  const auto& current = bucket_info.layout.current_index;
-  int ret = bs.init(bucket_info.bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
+  int ret = bs.init(bucket_info.bucket, shard_id, bucket_info.layout.current_index,
+  nullptr /* no RGWBucketInfo */);
   if (ret < 0) {
     ldout(cct, 5) << "bs.init() returned ret=" << ret << dendl;
     return ret;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1277,28 +1277,27 @@ public:
 
   int guard_reshard(BucketShard *bs,
 		    const rgw_obj& obj_instance,
-		    const RGWBucketInfo& bucket_info,
+		    RGWBucketInfo& bucket_info,
 		    std::function<int(BucketShard *)> call);
   int block_while_resharding(RGWRados::BucketShard *bs,
-			     string *new_bucket_id,
-			     const RGWBucketInfo& bucket_info,
+			     RGWBucketInfo& bucket_info,
                              optional_yield y);
 
   void bucket_index_guard_olh_op(RGWObjState& olh_state, librados::ObjectOperation& op);
   int olh_init_modification(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, string *op_tag);
   int olh_init_modification_impl(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, string *op_tag);
-  int bucket_index_link_olh(const RGWBucketInfo& bucket_info, RGWObjState& olh_state,
+  int bucket_index_link_olh(RGWBucketInfo bucket_info, RGWObjState& olh_state,
                             const rgw_obj& obj_instance, bool delete_marker,
                             const string& op_tag, struct rgw_bucket_dir_entry_meta *meta,
                             uint64_t olh_epoch,
                             ceph::real_time unmod_since, bool high_precision_time,
                             rgw_zone_set *zones_trace = nullptr,
                             bool log_data_change = false);
-  int bucket_index_unlink_instance(const RGWBucketInfo& bucket_info, const rgw_obj& obj_instance, const string& op_tag, const string& olh_tag, uint64_t olh_epoch, rgw_zone_set *zones_trace = nullptr);
-  int bucket_index_read_olh_log(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance, uint64_t ver_marker,
+  int bucket_index_unlink_instance(RGWBucketInfo bucket_info, const rgw_obj& obj_instance, const string& op_tag, const string& olh_tag, uint64_t olh_epoch, rgw_zone_set *zones_trace = nullptr);
+  int bucket_index_read_olh_log(RGWBucketInfo bucket_info, RGWObjState& state, const rgw_obj& obj_instance, uint64_t ver_marker,
                                 map<uint64_t, vector<rgw_bucket_olh_log_entry> > *log, bool *is_truncated);
-  int bucket_index_trim_olh_log(const RGWBucketInfo& bucket_info, RGWObjState& obj_state, const rgw_obj& obj_instance, uint64_t ver);
-  int bucket_index_clear_olh(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance);
+  int bucket_index_trim_olh_log(RGWBucketInfo bucket_info, RGWObjState& obj_state, const rgw_obj& obj_instance, uint64_t ver);
+  int bucket_index_clear_olh(RGWBucketInfo bucket_info, RGWObjState& state, const rgw_obj& obj_instance);
   int apply_olh_log(RGWObjectCtx& ctx, RGWObjState& obj_state, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
                     bufferlist& obj_tag, map<uint64_t, vector<rgw_bucket_olh_log_entry> >& log,
                     uint64_t *plast_ver, rgw_zone_set *zones_trace = nullptr);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -682,7 +682,8 @@ public:
 
     explicit BucketShard(RGWRados *_store) : store(_store), shard_id(-1) {}
     int init(const rgw_bucket& _bucket, const rgw_obj& obj, RGWBucketInfo* out);
-    int init(const rgw_bucket& _bucket, int sid, const rgw::bucket_index_layout_generation& idx_layout, RGWBucketInfo* out);
+    int init(const rgw_bucket& _bucket, int sid, const rgw::bucket_index_layout_generation& current_layout,
+            std::optional<rgw::bucket_index_layout_generation> target_layout, RGWBucketInfo* out);
     int init(const RGWBucketInfo& bucket_info, const rgw_obj& obj);
     int init(const RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int sid);
   };

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -317,20 +317,28 @@ int RGWBucketReshard::clear_index_shard_reshard_status(rgw::sal::RGWRadosStore* 
 
 static int set_target_layout(rgw::sal::RGWRadosStore *store,
 				      int new_num_shards,
-				      RGWBucketInfo& bucket_info,
-				      map<string, bufferlist>& attrs)
+				      RGWBucketInfo& bucket_info)
 {
   assert(!bucket_info.layout.target_index);
   bucket_info.layout.target_index.emplace();
 
   bucket_info.layout.target_index->layout.normal.num_shards = new_num_shards;
+  
+  //increment generation number
+  bucket_info.layout.target_index->gen = bucket_info.layout.current_index.gen;
+  bucket_info.layout.target_index->gen++;
 
   bucket_info.layout.resharding = rgw::BucketReshardState::IN_PROGRESS;
 
-  int ret = store->getRados()->put_bucket_instance_info(bucket_info, true, real_time(), &attrs);
+  int ret = store->getRados()->put_bucket_instance_info(bucket_info, true, real_time(), nullptr);
   if (ret < 0) {
     cerr << "ERROR: failed to store updated bucket instance info: " << cpp_strerror(-ret) << std::endl;
     return ret;
+  }
+
+    ret = store->svc()->bi->init_index(bucket_info, *(bucket_info.layout.target_index));
+  if (ret < 0) {
+      return ret;
   }
 
   return 0;
@@ -339,7 +347,7 @@ static int set_target_layout(rgw::sal::RGWRadosStore *store,
 int RGWBucketReshard::set_target_layout(int new_num_shards)
 {
   return ::set_target_layout(store, new_num_shards,
-				      bucket_info, bucket_attrs);
+				      bucket_info);
 }
 
 int RGWBucketReshard::cancel()
@@ -359,13 +367,12 @@ class BucketInfoReshardUpdate
 {
   rgw::sal::RGWRadosStore *store;
   RGWBucketInfo& bucket_info;
-  std::map<string, bufferlist> bucket_attrs;
 
   bool in_progress{false};
 
   int set_status(rgw::BucketReshardState s) {
     bucket_info.layout.resharding = s;
-    int ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), &bucket_attrs);
+    int ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), nullptr);
     if (ret < 0) {
       ldout(store->ctx(), 0) << "ERROR: failed to write bucket info, ret=" << ret << dendl;
       return ret;
@@ -375,11 +382,9 @@ class BucketInfoReshardUpdate
 
 public:
   BucketInfoReshardUpdate(rgw::sal::RGWRadosStore *_store,
-			  RGWBucketInfo& _bucket_info,
-                          map<string, bufferlist>& _bucket_attrs) :
+			  RGWBucketInfo& _bucket_info) :
     store(_store),
-    bucket_info(_bucket_info),
-    bucket_attrs(_bucket_attrs)
+    bucket_info(_bucket_info)
   {}
 
   ~BucketInfoReshardUpdate() {
@@ -514,7 +519,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
 
   // NB: destructor cleans up sharding state if reshard does not
   // complete successfully
-  BucketInfoReshardUpdate bucket_info_updater(store, bucket_info, bucket_attrs);
+  BucketInfoReshardUpdate bucket_info_updater(store, bucket_info);
 
 
   int ret = bucket_info_updater.start();
@@ -522,10 +527,6 @@ int RGWBucketReshard::do_reshard(int num_shards,
     ldout(store->ctx(), 0) << __func__ << ": failed to update bucket info ret=" << ret << dendl;
     return ret;
   }
-
-  //increment generation number
-  bucket_info.layout.target_index->gen = bucket_info.layout.current_index.gen;
-  bucket_info.layout.target_index->gen++;
 
   auto target_shards = bucket_info.layout.target_index->layout.normal.num_shards;
   int num_target_shards = (target_shards > 0 ? num_shards : 1);
@@ -639,17 +640,13 @@ int RGWBucketReshard::do_reshard(int num_shards,
   }
 
   //overwrite current_index for the next reshard process
+  const auto prev_index = bucket_info.layout.current_index;
   bucket_info.layout.current_index = *bucket_info.layout.target_index;
   bucket_info.layout.target_index = std::nullopt; // target_layout doesn't need to exist after reshard
   bucket_info.layout.resharding = rgw::BucketReshardState::NONE;
-  ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), &bucket_attrs);
+  ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), nullptr);
   if (ret < 0) {
     lderr(store->ctx()) << "ERROR: failed writing bucket instance info: " << dendl;
-      return ret;
-  }
-
-  ret = store->svc()->bi->init_index(bucket_info, bucket_info.layout.current_index);
-  if (ret < 0) {
       return ret;
   }
 
@@ -735,7 +732,7 @@ error_out:
 
   // restore old index if reshard fails
   bucket_info.layout.current_index = prev_index;
-  ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), &bucket_attrs);
+  ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), nullptr);
   if (ret < 0) {
     lderr(store->ctx()) << "ERROR: failed writing bucket instance info: " << dendl;
       return ret;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -648,6 +648,12 @@ int RGWBucketReshard::do_reshard(int num_shards,
       return ret;
   }
 
+  ret = bucket_info_updater.complete();
+  if (ret < 0) {
+    ldout(store->ctx(), 0) << __func__ << ": failed to update bucket info ret=" << ret << dendl;
+    /* don't error out, reshard process succeeded */
+  }
+
   return 0;
   // NB: some error clean-up is done by ~BucketInfoReshardUpdate
 } // RGWBucketReshard::do_reshard

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -639,6 +639,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
   }
 
   //overwrite current_index for the next reshard process
+  const auto prev_index = bucket_info.layout.current_index;
   bucket_info.layout.current_index = *bucket_info.layout.target_index;
   bucket_info.layout.target_index = std::nullopt; // target_layout doesn't need to exist after reshard
   bucket_info.layout.resharding = rgw::BucketReshardState::NONE;
@@ -652,6 +653,18 @@ int RGWBucketReshard::do_reshard(int num_shards,
   if (ret < 0) {
       return ret;
   }
+
+  // resharding successful, so remove old bucket index shards; use
+  // best effort and don't report out an error; the lock isn't needed
+  // at this point since all we're using a best effor to to remove old
+  // shard objects
+
+  ret = store->svc()->bi->clean_index(bucket_info, prev_index);
+  if (ret < 0) {
+    lderr(store->ctx()) << "Error: " << __func__ <<
+    " failed to clean up old shards; " <<
+    "RGWRados::clean_bucket_index returned " << ret << dendl;
+}
 
   return 0;
   // NB: some error clean-up is done by ~BucketInfoReshardUpdate
@@ -698,18 +711,6 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
 
   reshard_lock.unlock();
 
-   // resharding successful, so remove old bucket index shards; use
-   // best effort and don't report out an error; the lock isn't needed
-   // at this point since all we're using a best effor to to remove old
-   // shard objects
-
-   ret = store->svc()->bi->clean_index(bucket_info, (bucket_info.layout.current_index.gen - 1));
-   if (ret < 0) {
-     lderr(store->ctx()) << "Error: " << __func__ <<
-      " failed to clean up old shards; " <<
-     "RGWRados::clean_bucket_index returned " << ret << dendl;
-  }
-
   ldout(store->ctx(), 1) << __func__ <<
     " INFO: reshard of bucket \"" << bucket_info.bucket.name << "\" completed successfully" << dendl;
 
@@ -724,7 +725,7 @@ error_out:
   // since the real problem is the issue that led to this error code
   // path, we won't touch ret and instead use another variable to
   // temporarily error codes
-  int ret2 = store->svc()->bi->clean_index(bucket_info, bucket_info.layout.target_index->gen);
+  int ret2 = store->svc()->bi->clean_index(bucket_info, bucket_info.layout.current_index);
   if (ret2 < 0) {
     lderr(store->ctx()) << "Error: " << __func__ <<
       " failed to clean up shards from failed incomplete resharding; " <<

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -259,12 +259,10 @@ RGWBucketReshard::RGWBucketReshard(rgw::sal::RGWRadosStore *_store,
 
 int RGWBucketReshard::set_resharding_status(rgw::sal::RGWRadosStore* store,
 					    const RGWBucketInfo& bucket_info,
-					    const string& instance_id,
-					    int32_t num_shards,
-					    rgw::BucketReshardState status)
+					    cls_rgw_reshard_status status)
 {
   cls_rgw_bucket_instance_entry instance_entry;
-  instance_entry.set_status(instance_id, num_shards, status);
+  instance_entry.set_status(status);
 
   int ret = store->getRados()->bucket_set_reshard(bucket_info, instance_entry);
   if (ret < 0) {
@@ -306,9 +304,7 @@ int RGWBucketReshard::clear_index_shard_reshard_status(rgw::sal::RGWRadosStore* 
 
   if (num_shards < std::numeric_limits<uint32_t>::max()) {
     int ret = set_resharding_status(store, bucket_info,
-				    bucket_info.bucket.bucket_id,
-				    (num_shards < 1 ? 1 : num_shards),
-				    rgw::BucketReshardState::NOT_RESHARDING);
+				    cls_rgw_reshard_status::NOT_RESHARDING);
     if (ret < 0) {
       ldout(store->ctx(), 0) << "RGWBucketReshard::" << __func__ <<
 	" ERROR: error clearing reshard status from index shard " <<
@@ -394,9 +390,6 @@ public:
 	lderr(store->ctx()) << "Error: " << __func__ <<
 	  " clear_index_shard_status returned " << ret << dendl;
       }
-
-      // clears new_bucket_instance as well
-      set_status(rgw::BucketReshardState::NOT_RESHARDING);
     }
   }
 
@@ -410,7 +403,7 @@ public:
   }
 
   int complete() {
-    int ret = set_status(rgw::BucketReshardState::DONE);
+    int ret = set_status(rgw::BucketReshardState::NONE);
     if (ret < 0) {
       return ret;
     }
@@ -689,8 +682,7 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
 
   // set resharding status of current bucket_info & shards with
   // information about planned resharding
-  ret = set_resharding_status(bucket_info.bucket.bucket_id,
-			      num_shards, rgw::BucketReshardState::IN_PROGRESS);
+  ret = set_resharding_status(cls_rgw_reshard_status::IN_PROGRESS);
   if (ret < 0) {
     return ret;
     goto error_out;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -385,13 +385,13 @@ public:
     if (in_progress) {
       // resharding must not have ended correctly, clean up
       int ret =
-	RGWBucketReshard::clear_index_shard_reshard_status(store, bucket_info);
+       RGWBucketReshard::clear_index_shard_reshard_status(store, bucket_info);
       if (ret < 0) {
 	lderr(store->ctx()) << "Error: " << __func__ <<
 	  " clear_index_shard_status returned " << ret << dendl;
       }
     }
-  }
+  } 
 
   int start() {
     int ret = set_status(rgw::BucketReshardState::IN_PROGRESS);
@@ -648,12 +648,6 @@ int RGWBucketReshard::do_reshard(int num_shards,
       return ret;
   }
 
-  ret = bucket_info_updater.complete();
-  if (ret < 0) {
-    ldout(store->ctx(), 0) << __func__ << ": failed to update bucket info ret=" << ret << dendl;
-    /* don't error out, reshard process succeeded */
-  }
-
   return 0;
   // NB: some error clean-up is done by ~BucketInfoReshardUpdate
 } // RGWBucketReshard::do_reshard
@@ -686,13 +680,6 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
     }
   }
 
-  // set resharding status of current bucket_info & shards with
-  // information about planned resharding
-  ret = set_resharding_status(cls_rgw_reshard_status::IN_PROGRESS);
-  if (ret < 0) {
-    return ret;
-    goto error_out;
-  }
 
   ret = do_reshard(num_shards,
 		   max_op_entries,

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -556,7 +556,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
       if (ret < 0 && ret != -ENOENT) {
         derr << "ERROR: bi_list(): " << cpp_strerror(-ret) << dendl;
         return ret;
-		}
+		    }
 
       for (auto iter = entries.begin(); iter != entries.end(); ++iter) {
 	rgw_cls_bi_entry& entry = *iter;
@@ -583,8 +583,8 @@ int RGWBucketReshard::do_reshard(int num_shards,
 	  // place the multipart .meta object on the same shard as its head object
 	  obj.index_hash_source = mp.get_key();
 	}
-	int ret = store->getRados()->get_target_shard_id(bucket_info.layout.target_index->layout.normal, obj
-	.get_hash_object(),	&target_shard_id);
+	int ret = store->getRados()->get_target_shard_id(bucket_info.layout.target_index->layout.normal,
+                                                   obj.get_hash_object(), &target_shard_id);
 	if (ret < 0) {
 	  lderr(store->ctx()) << "ERROR: get_target_shard_id() returned ret=" << ret << dendl;
 	  return ret;
@@ -1022,37 +1022,37 @@ int RGWReshard::process_single_logshard(int logshard_num)
 	}
 
 	{
-	RGWBucketReshard br(store, bucket_info, attrs, nullptr);
-	ret = br.execute(entry.new_num_shards, max_entries, false, nullptr,
-			 nullptr, this);
-	if (ret < 0) {
-	  ldout(store->ctx(), 0) <<  __func__ <<
-	    ": Error during resharding bucket " << entry.bucket_name << ":" <<
-	    cpp_strerror(-ret)<< dendl;
-	  return ret;
-	}
+    RGWBucketReshard br(store, bucket_info, attrs, nullptr);
+    ret = br.execute(entry.new_num_shards, max_entries, false, nullptr,
+        nullptr, this);
+    if (ret < 0) {
+      ldout(store->ctx(), 0) <<  __func__ <<
+        ": Error during resharding bucket " << entry.bucket_name << ":" <<
+        cpp_strerror(-ret)<< dendl;
+      return ret;
+    }
 
-	ldout(store->ctx(), 20) << __func__ <<
-	  " removing reshard queue entry for bucket " << entry.bucket_name <<
-	  dendl;
+    ldout(store->ctx(), 20) << __func__ <<
+      " removing reshard queue entry for bucket " << entry.bucket_name <<
+      dendl;
 
-      	ret = remove(entry);
-	if (ret < 0) {
-	  ldout(cct, 0) << __func__ << ": Error removing bucket " <<
-	    entry.bucket_name << " from resharding queue: " <<
-	    cpp_strerror(-ret) << dendl;
-	  return ret;
-	  }
+    ret = remove(entry);
+    if (ret < 0) {
+      ldout(cct, 0) << __func__ << ": Error removing bucket " <<
+        entry.bucket_name << " from resharding queue: " <<
+        cpp_strerror(-ret) << dendl;
+      return ret;
+      }
 	}
 
     finished_entry:
 
       Clock::time_point now = Clock::now();
       if (logshard_lock.should_renew(now)) {
-	ret = logshard_lock.renew(now);
-	if (ret < 0) {
-	  return ret;
-	}
+	      ret = logshard_lock.renew(now);
+	      if (ret < 0) {
+	        return ret;
+	      }
       }
 
       entry.get_key(&marker);

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -62,7 +62,7 @@ class BucketReshardShard {
   rgw::sal::RGWRadosStore *store;
   const RGWBucketInfo& bucket_info;
   int num_shard;
-  const rgw::bucket_index_layout_generation& idx_layout;
+  const rgw::bucket_index_layout_generation& target_layout;
   RGWRados::BucketShard bs;
   vector<rgw_cls_bi_entry> entries;
   map<RGWObjCategory, rgw_bucket_category_stats> stats;
@@ -103,14 +103,14 @@ class BucketReshardShard {
 
 public:
   BucketReshardShard(rgw::sal::RGWRadosStore *_store, const RGWBucketInfo& _bucket_info,
-                     int _num_shard, const rgw::bucket_index_layout_generation& _idx_layout,
+                     int _num_shard, const rgw::bucket_index_layout_generation& _target_layout,
                      deque<librados::AioCompletion *>& _completions) :
-    store(_store), bucket_info(_bucket_info), idx_layout(_idx_layout), bs(store->getRados()),
+    store(_store), bucket_info(_bucket_info), target_layout(_target_layout), bs(store->getRados()),
     aio_completions(_completions)
   {
-    num_shard = (idx_layout.layout.normal.num_shards > 0 ? _num_shard : -1);
+    num_shard = (target_layout.layout.normal.num_shards > 0 ? _num_shard : -1);
 
-    bs.init(bucket_info.bucket, num_shard, idx_layout, nullptr /* no RGWBucketInfo */);
+    bs.init(bucket_info.bucket, num_shard, target_layout, nullptr /* no RGWBucketInfo */);
 
     max_aio_completions =
       store->ctx()->_conf.get_val<uint64_t>("rgw_reshard_max_aio");
@@ -195,10 +195,10 @@ public:
     store(_store), target_bucket_info(_target_bucket_info),
     num_target_shards(_num_target_shards)
   { 
-    const auto& idx_layout = target_bucket_info.layout.current_index;
+    const auto& target_layout = target_bucket_info.layout.target_index;
     target_shards.resize(num_target_shards);
     for (int i = 0; i < num_target_shards; ++i) {
-      target_shards[i] = new BucketReshardShard(store, target_bucket_info, i, idx_layout, completions);
+      target_shards[i] = new BucketReshardShard(store, target_bucket_info, i, target_layout, completions);
     }
   }
 
@@ -320,41 +320,29 @@ int RGWBucketReshard::clear_index_shard_reshard_status(rgw::sal::RGWRadosStore* 
   return 0;
 }
 
-static int create_new_bucket_instance(rgw::sal::RGWRadosStore *store,
+static int update_num_shards(rgw::sal::RGWRadosStore *store,
 				      int new_num_shards,
-				      const RGWBucketInfo& bucket_info,
-				      map<string, bufferlist>& attrs,
-				      RGWBucketInfo& new_bucket_info)
+				      RGWBucketInfo& bucket_info,
+				      map<string, bufferlist>& attrs)
 {
-  new_bucket_info = bucket_info;
 
-  store->getRados()->create_bucket_id(&new_bucket_info.bucket.bucket_id);
+  bucket_info.layout.target_index.layout.normal.num_shards = new_num_shards;
 
   bucket_info.layout.resharding = rgw::BucketReshardState::NONE;
 
-  new_bucket_info.new_bucket_instance_id.clear();
-  new_bucket_info.reshard_status = cls_rgw_reshard_status::NOT_RESHARDING;
-
-  int ret = store->svc()->bi->init_index(new_bucket_info);
+  int ret = store->getRados()->put_bucket_instance_info(bucket_info, true, real_time(), &attrs);
   if (ret < 0) {
-    cerr << "ERROR: failed to init new bucket indexes: " << cpp_strerror(-ret) << std::endl;
-    return ret;
-  }
-
-  ret = store->getRados()->put_bucket_instance_info(new_bucket_info, true, real_time(), &attrs);
-  if (ret < 0) {
-    cerr << "ERROR: failed to store new bucket instance info: " << cpp_strerror(-ret) << std::endl;
+    cerr << "ERROR: failed to store updated bucket instance info: " << cpp_strerror(-ret) << std::endl;
     return ret;
   }
 
   return 0;
 }
 
-int RGWBucketReshard::create_new_bucket_instance(int new_num_shards,
-                                                 RGWBucketInfo& new_bucket_info)
+int RGWBucketReshard::update_num_shards(int new_num_shards)
 {
-  return ::create_new_bucket_instance(store, new_num_shards,
-				      bucket_info, bucket_attrs, new_bucket_info);
+  return ::update_num_shards(store, new_num_shards,
+				      bucket_info, bucket_attrs);
 }
 
 int RGWBucketReshard::cancel()
@@ -391,14 +379,11 @@ class BucketInfoReshardUpdate
 public:
   BucketInfoReshardUpdate(rgw::sal::RGWRadosStore *_store,
 			  RGWBucketInfo& _bucket_info,
-                          map<string, bufferlist>& _bucket_attrs,
-			  const string& new_bucket_id) :
+                          map<string, bufferlist>& _bucket_attrs) :
     store(_store),
     bucket_info(_bucket_info),
     bucket_attrs(_bucket_attrs)
-  {
-    bucket_info.new_bucket_instance_id = new_bucket_id;
-  }
+  {}
 
   ~BucketInfoReshardUpdate() {
     if (in_progress) {
@@ -409,15 +394,14 @@ public:
 	lderr(store->ctx()) << "Error: " << __func__ <<
 	  " clear_index_shard_status returned " << ret << dendl;
       }
-      bucket_info.new_bucket_instance_id.clear();
 
       // clears new_bucket_instance as well
-      set_status(cls_rgw_reshard_status::NOT_RESHARDING);
+      set_status(rgw::BucketReshardState::NOT_RESHARDING);
     }
   }
 
   int start() {
-    int ret = set_status(cls_rgw_reshard_status::IN_PROGRESS);
+    int ret = set_status(rgw::BucketReshardState::IN_PROGRESS);
     if (ret < 0) {
       return ret;
     }
@@ -426,7 +410,7 @@ public:
   }
 
   int complete() {
-    int ret = set_status(cls_rgw_reshard_status::DONE);
+    int ret = set_status(rgw::BucketReshardState::DONE);
     if (ret < 0) {
       return ret;
     }
@@ -544,9 +528,13 @@ int RGWBucketReshard::do_reshard(int num_shards,
     return ret;
   }
 
-  int num_target_shards = (new_bucket_info.layout.current_index.layout.normal.num_shards > 0 ? new_bucket_info.layout.current_index.layout.normal.num_shards : 1);
+  //increment generation number
+  bucket_info.layout.target_index.gen++;
 
-  BucketReshardManager target_shards_mgr(store, new_bucket_info, num_target_shards);
+  auto target_shards = bucket_info.layout.target_index.layout.normal.num_shards;
+  int num_target_shards = (target_shards > 0 ? num_shards : 1);
+
+  BucketReshardManager target_shards_mgr(store, bucket_info, num_target_shards);
 
   bool verbose_json_out = verbose && (formatter != nullptr) && (out != nullptr);
 
@@ -560,8 +548,9 @@ int RGWBucketReshard::do_reshard(int num_shards,
     (*out) << "total entries:";
   }
 
+  auto current_shards = bucket_info.layout.current_index.layout.normal.num_shards;
   const int num_source_shards =
-    (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+    (current_shards > 0 ? current_shards : 1);
   string marker;
   for (int i = 0; i < num_source_shards; ++i) {
     bool is_truncated = true;
@@ -569,10 +558,14 @@ int RGWBucketReshard::do_reshard(int num_shards,
     while (is_truncated) {
       entries.clear();
       ret = store->getRados()->bi_list(bucket_info, i, string(), marker, max_entries, &entries, &is_truncated);
-      if (ret < 0 && ret != -ENOENT) {
-	derr << "ERROR: bi_list(): " << cpp_strerror(-ret) << dendl;
-	return ret;
-      }
+      if (ret < 0) {
+		if (ret == -ENOENT && i < (num_source_shards - 1)) {
+		  continue;
+		} else {
+		  derr << "ERROR: bi_list(): " << cpp_strerror(-ret) << dendl;
+		  return ret;
+		}
+	  }
 
       for (auto iter = entries.begin(); iter != entries.end(); ++iter) {
 	rgw_cls_bi_entry& entry = *iter;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -341,7 +341,7 @@ int RGWBucketReshard::set_target_layout(int new_num_shards)
 {
   int ret = RGWBucketReshard::set_reshard_status(rgw::BucketReshardState::IN_PROGRESS);
   if (ret < 0) {
-    cerr << "ERROR: failed to store updated bucket instance info: " << cpp_strerror(-ret) << std::endl;
+    lderr(store->ctx()) << "ERROR: failed to store updated bucket instance info: " << dendl;
     return ret;
   }
   return ::set_target_layout(store, new_num_shards,
@@ -583,8 +583,10 @@ int RGWBucketReshard::do_reshard(int num_shards,
 	  // place the multipart .meta object on the same shard as its head object
 	  obj.index_hash_source = mp.get_key();
 	}
-	int ret = store->getRados()->get_target_shard_id(bucket_info.layout.target_index->layout.normal,
-                                                   obj.get_hash_object(), &target_shard_id);
+	int ret = store->getRados()->get_target_shard_id(
+    bucket_info.layout.target_index->layout.normal,
+    obj.get_hash_object(),
+    &target_shard_id);
 	if (ret < 0) {
 	  lderr(store->ctx()) << "ERROR: get_target_shard_id() returned ret=" << ret << dendl;
 	  return ret;
@@ -704,7 +706,7 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
 
   // resharding successful, so remove old bucket index shards; use
   // best effort and don't report out an error; the lock isn't needed
-  // at this point since all we're using a best effor to to remove old
+  // at this point since all we're using a best effort to remove old
   // shard objects
 
   ret = store->svc()->bi->clean_index(bucket_info, prev_index);
@@ -746,7 +748,7 @@ error_out:
 
   ret = RGWBucketReshard::set_reshard_status(rgw::BucketReshardState::NONE);
   if (ret < 0) {
-    cerr << "ERROR: failed to store updated bucket instance info: " << cpp_strerror(-ret) << std::endl;
+    lderr(store->ctx()) << "ERROR: failed to store updated bucket instance info: " << dendl;
     return ret;
   }
   

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -84,10 +84,8 @@ private:
   // allocated in at once
   static const std::initializer_list<uint16_t> reshard_primes;
 
-  int create_new_bucket_instance(int new_num_shards,
-				 RGWBucketInfo& new_bucket_info);
+  int update_num_shards(int new_num_shards);
   int do_reshard(int num_shards,
-		 RGWBucketInfo& new_bucket_info,
 		 int max_entries,
                  bool verbose,
                  ostream *os,
@@ -228,7 +226,7 @@ protected:
 public:
   RGWReshard(rgw::sal::RGWRadosStore* _store, bool _verbose = false, ostream *_out = nullptr, Formatter *_formatter = nullptr);
   int add(cls_rgw_reshard_entry& entry);
-  int update(const RGWBucketInfo& bucket_info, const RGWBucketInfo& new_bucket_info);
+  int update(const RGWBucketInfo& bucket_info);
   int get(cls_rgw_reshard_entry& entry);
   int remove(cls_rgw_reshard_entry& entry);
   int list(int logshard_num, string& marker, uint32_t max, std::list<cls_rgw_reshard_entry>& entries, bool *is_truncated);

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -76,6 +76,7 @@ private:
   rgw::sal::RGWRadosStore *store;
   RGWBucketInfo bucket_info;
   std::map<string, bufferlist> bucket_attrs;
+  rgw::bucket_index_layout_generation prev_index;
 
   RGWBucketReshardLock reshard_lock;
   RGWBucketReshardLock* outer_reshard_lock;

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -84,7 +84,7 @@ private:
   // allocated in at once
   static const std::initializer_list<uint16_t> reshard_primes;
 
-  int update_num_shards(int new_num_shards);
+  int set_target_layout(int new_num_shards);
   int do_reshard(int num_shards,
 		 int max_entries,
                  bool verbose,

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -116,14 +116,14 @@ public:
   }
   static int set_resharding_status(rgw::sal::RGWRadosStore* store,
 				   const RGWBucketInfo& bucket_info,
-				   const string& new_instance_id,
+				   const string& instance_id,
 				   int32_t num_shards,
-				   cls_rgw_reshard_status status);
-  int set_resharding_status(const string& new_instance_id,
+				   rgw::BucketReshardState status);
+  int set_resharding_status(const string& instance_id,
 			    int32_t num_shards,
-			    cls_rgw_reshard_status status) {
+			    rgw::BucketReshardState status) {
     return set_resharding_status(store, bucket_info,
-				 new_instance_id, num_shards, status);
+			instance_id, num_shards, status);
   }
 
   static uint32_t get_max_prime_shards() {

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -86,6 +86,8 @@ private:
   static const std::initializer_list<uint16_t> reshard_primes;
 
   int set_target_layout(int new_num_shards);
+  int set_reshard_status(rgw::BucketReshardState s);
+  
   int do_reshard(int num_shards,
 		 int max_entries,
                  bool verbose,

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -116,14 +116,9 @@ public:
   }
   static int set_resharding_status(rgw::sal::RGWRadosStore* store,
 				   const RGWBucketInfo& bucket_info,
-				   const string& instance_id,
-				   int32_t num_shards,
-				   rgw::BucketReshardState status);
-  int set_resharding_status(const string& instance_id,
-			    int32_t num_shards,
-			    rgw::BucketReshardState status) {
-    return set_resharding_status(store, bucket_info,
-			instance_id, num_shards, status);
+				   cls_rgw_reshard_status status);
+  int set_resharding_status(cls_rgw_reshard_status status) {
+    return set_resharding_status(store, bucket_info, status);
   }
 
   static uint32_t get_max_prime_shards() {

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -21,6 +21,7 @@
 #include "cls/lock/cls_lock_client.h"
 
 #include "rgw_common.h"
+#include "common/fault_injector.h"
 
 
 class RGWReshard;
@@ -87,12 +88,11 @@ private:
 
   int set_target_layout(int new_num_shards);
   int update_bucket(rgw::BucketReshardState s);
-  
   int do_reshard(int num_shards,
-		 int max_entries,
+                 int max_entries, FaultInjector<std::string_view>& f,
                  bool verbose,
                  ostream *os,
-		 Formatter *formatter);
+                 Formatter *formatter);
 public:
 
   // pass nullptr for the final parameter if no outer reshard lock to
@@ -101,7 +101,7 @@ public:
 		   const RGWBucketInfo& _bucket_info,
                    const std::map<string, bufferlist>& _bucket_attrs,
 		   RGWBucketReshardLock* _outer_reshard_lock);
-  int execute(int num_shards, int max_op_entries,
+  int execute(int num_shards, FaultInjector<std::string_view>& f, int max_op_entries,
               bool verbose = false, ostream *out = nullptr,
               Formatter *formatter = nullptr,
 	      RGWReshard *reshard_log = nullptr);

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -86,7 +86,7 @@ private:
   static const std::initializer_list<uint16_t> reshard_primes;
 
   int set_target_layout(int new_num_shards);
-  int set_reshard_status(rgw::BucketReshardState s);
+  int update_bucket(rgw::BucketReshardState s);
   
   int do_reshard(int num_shards,
 		 int max_entries,

--- a/src/rgw/services/svc_bi.h
+++ b/src/rgw/services/svc_bi.h
@@ -29,8 +29,8 @@ public:
   RGWSI_BucketIndex(CephContext *cct) : RGWServiceInstance(cct) {}
   virtual ~RGWSI_BucketIndex() {}
 
-  virtual int init_index(RGWBucketInfo& bucket_info) = 0;
-  virtual int clean_index(RGWBucketInfo& bucket_info, std::optional<uint64_t> gen) = 0;
+  virtual int init_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout) = 0;
+  virtual int clean_index(RGWBucketInfo& bucket_info, uint64_t gen) = 0;
 
   virtual int read_stats(const RGWBucketInfo& bucket_info,
                          RGWBucketEnt *stats,

--- a/src/rgw/services/svc_bi.h
+++ b/src/rgw/services/svc_bi.h
@@ -30,7 +30,7 @@ public:
   virtual ~RGWSI_BucketIndex() {}
 
   virtual int init_index(RGWBucketInfo& bucket_info) = 0;
-  virtual int clean_index(RGWBucketInfo& bucket_info) = 0;
+  virtual int clean_index(RGWBucketInfo& bucket_info, std::optional<uint64_t> gen) = 0;
 
   virtual int read_stats(const RGWBucketInfo& bucket_info,
                          RGWBucketEnt *stats,

--- a/src/rgw/services/svc_bi.h
+++ b/src/rgw/services/svc_bi.h
@@ -30,7 +30,7 @@ public:
   virtual ~RGWSI_BucketIndex() {}
 
   virtual int init_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout) = 0;
-  virtual int clean_index(RGWBucketInfo& bucket_info, uint64_t gen) = 0;
+  virtual int clean_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout) = 0;
 
   virtual int read_stats(const RGWBucketInfo& bucket_info,
                          RGWBucketEnt *stats,

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -112,12 +112,11 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const RGWBucketInfo& bucket_info,
 }
 
 static void get_bucket_index_objects(const string& bucket_oid_base,
-                                     uint32_t num_shards, std::optional<uint64_t> _gen_id,
+                                     uint32_t num_shards, uint64_t gen_id,
                                      map<int, string> *_bucket_objects,
                                      int shard_id = -1)
 {
   auto& bucket_objects = *_bucket_objects;
-  auto gen_id = _gen_id.value_or(0);
   if (!num_shards) {
     bucket_objects[0] = bucket_oid_base;
   } else {
@@ -202,10 +201,9 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const RGWBucketInfo& bucket_info,
 void RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_base,
                                                       uint32_t num_shards,
                                                       int shard_id,
-                                                      std::optional<uint64_t> _gen_id,
+                                                      uint64_t gen_id,
                                                       string *bucket_obj)
 {
-  auto gen_id = _gen_id.value_or(0);
   if (!num_shards) {
     // By default with no sharding, we use the bucket oid as itself
     (*bucket_obj) = bucket_oid_base;
@@ -285,7 +283,7 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket
 int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket_info,
                                                      int shard_id,
                                                      uint32_t num_shards,
-                                                     std::optional<uint64_t> gen,
+                                                     uint64_t gen,
                                                      RGWSI_RADOS::Obj *bucket_obj)
 {
   RGWSI_RADOS::Pool index_pool;
@@ -335,7 +333,7 @@ int RGWSI_BucketIndex_RADOS::cls_bucket_head(const RGWBucketInfo& bucket_info,
   return 0;
 }
 
-int RGWSI_BucketIndex_RADOS::init_index(RGWBucketInfo& bucket_info)
+int RGWSI_BucketIndex_RADOS::init_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout)
 {
   RGWSI_RADOS::Pool index_pool;
 
@@ -348,7 +346,7 @@ int RGWSI_BucketIndex_RADOS::init_index(RGWBucketInfo& bucket_info)
   dir_oid.append(bucket_info.bucket.bucket_id);
 
   map<int, string> bucket_objs;
-  get_bucket_index_objects(dir_oid, bucket_info.layout.current_index.layout.normal.num_shards, std::nullopt, &bucket_objs);
+  get_bucket_index_objects(dir_oid, idx_layout.layout.normal.num_shards, idx_layout.gen, &bucket_objs);
 
   return CLSRGWIssueBucketIndexInit(index_pool.ioctx(),
 				    bucket_objs,
@@ -356,7 +354,7 @@ int RGWSI_BucketIndex_RADOS::init_index(RGWBucketInfo& bucket_info)
 }
 
 
-int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info, std::optional<uint64_t> gen)
+int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info, uint64_t gen)
 {
   RGWSI_RADOS::Pool index_pool;
 
@@ -370,7 +368,7 @@ int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info, std::option
 
   std::map<int, std::string> bucket_objs;
   get_bucket_index_objects(dir_oid, bucket_info.layout.current_index.layout.normal.num_shards,
-  gen, &bucket_objs);
+                          gen, &bucket_objs);
 
   return CLSRGWIssueBucketIndexClean(index_pool.ioctx(),
 				     bucket_objs,

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -202,15 +202,16 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const RGWBucketInfo& bucket_info,
 void RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_base,
                                                       uint32_t num_shards,
                                                       int shard_id,
-                                                      uint64_t gen_id,
+                                                      std::optional<uint64_t> _gen_id,
                                                       string *bucket_obj)
 {
+  auto gen_id = _gen_id.value_or(0);
   if (!num_shards) {
     // By default with no sharding, we use the bucket oid as itself
     (*bucket_obj) = bucket_oid_base;
   } else {
     char buf[bucket_oid_base.size() + 64];
-    if (gen_id != 0) {
+    if (gen_id) {
       snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id);
       (*bucket_obj) = buf;
 	  ldout(cct, 10) << "bucket_obj is " << (*bucket_obj) << dendl;
@@ -283,7 +284,8 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket
 
 int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket_info,
                                                      int shard_id,
-                                                     const rgw::bucket_index_layout_generation& target_layout,
+                                                     uint32_t num_shards,
+                                                     std::optional<uint64_t> gen,
                                                      RGWSI_RADOS::Obj *bucket_obj)
 {
   RGWSI_RADOS::Pool index_pool;
@@ -297,8 +299,8 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket
 
   string oid;
 
-  get_bucket_index_object(bucket_oid_base, target_layout.layout.normal.num_shards,
-                          shard_id, target_layout.gen, &oid);
+  get_bucket_index_object(bucket_oid_base, num_shards,
+                          shard_id, gen, &oid);
 
   *bucket_obj = svc.rados->obj(index_pool, oid);
 

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -223,7 +223,7 @@ void RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_b
 
 int RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_base, const string& obj_key,
                                                      uint32_t num_shards, rgw::BucketHashType hash_type,
-                                                     string *bucket_obj, int *shard_id)
+                                                     uint64_t gen_id, string *bucket_obj, int *shard_id)
 {
   int r = 0;
   switch (hash_type) {
@@ -236,8 +236,12 @@ int RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_ba
         }
       } else {
         uint32_t sid = bucket_shard_index(obj_key, num_shards);
-        char buf[bucket_oid_base.size() + 32];
-        snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), sid);
+        char buf[bucket_oid_base.size() + 64];
+        if (gen_id) {
+          snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, sid);
+        } else {
+          snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), sid);
+        }
         (*bucket_obj) = buf;
         if (shard_id) {
           *shard_id = (int)sid;
@@ -269,7 +273,7 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket
   string oid;
 
   ret = get_bucket_index_object(bucket_oid_base, obj_key, bucket_info.layout.current_index.layout.normal.num_shards,
-        bucket_info.layout.current_index.layout.normal.hash_type, &oid, shard_id);
+        bucket_info.layout.current_index.layout.normal.hash_type, bucket_info.layout.current_index.gen, &oid, shard_id);
   if (ret < 0) {
     ldout(cct, 10) << "get_bucket_index_object() returned ret=" << ret << dendl;
     return ret;
@@ -354,7 +358,7 @@ int RGWSI_BucketIndex_RADOS::init_index(RGWBucketInfo& bucket_info, const rgw::b
 }
 
 
-int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info, uint64_t gen)
+int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout)
 {
   RGWSI_RADOS::Pool index_pool;
 
@@ -367,8 +371,8 @@ int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info, uint64_t ge
   dir_oid.append(bucket_info.bucket.bucket_id);
 
   std::map<int, std::string> bucket_objs;
-  get_bucket_index_objects(dir_oid, bucket_info.layout.current_index.layout.normal.num_shards,
-                          gen, &bucket_objs);
+  get_bucket_index_objects(dir_oid, idx_layout.layout.normal.num_shards,
+                          idx_layout.gen, &bucket_objs);
 
   return CLSRGWIssueBucketIndexClean(index_pool.ioctx(),
 				     bucket_objs,

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -112,6 +112,45 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const RGWBucketInfo& bucket_info,
 }
 
 static void get_bucket_index_objects(const string& bucket_oid_base,
+                                     uint32_t num_shards, std::optional<uint64_t> _gen_id,
+                                     map<int, string> *_bucket_objects,
+                                     int shard_id = -1)
+{
+  auto& bucket_objects = *_bucket_objects;
+  auto gen_id = _gen_id.value_or(0);
+  if (!num_shards) {
+    bucket_objects[0] = bucket_oid_base;
+  } else {
+    char buf[bucket_oid_base.size() + 64];
+    if (shard_id < 0) {
+      for (uint32_t i = 0; i < num_shards; ++i) {
+        if (gen_id) {
+          snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, i);
+          bucket_objects[i] = buf;
+          } else {
+            snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), i);
+            bucket_objects[i] = buf;
+          }
+      }
+    } else {
+      if ((uint32_t)shard_id > num_shards) {
+        return;
+      } else {
+		if (gen_id) {
+		  snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id);
+		  bucket_objects[shard_id] = buf;
+		} else {
+		  // for backward compatibility, gen_id(0) will not be added in the object name
+		  snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), shard_id);
+		  bucket_objects[shard_id] = buf;
+		}
+      }
+    }
+  }
+}
+
+/*
+static void get_bucket_index_objects(const string& bucket_oid_base,
                                      uint32_t num_shards,
                                      map<int, string> *_bucket_objects,
                                      int shard_id = -1)
@@ -135,6 +174,7 @@ static void get_bucket_index_objects(const string& bucket_oid_base,
     }
   }
 }
+*/
 
 static void get_bucket_instance_ids(const RGWBucketInfo& bucket_info,
                                     int shard_id,
@@ -177,7 +217,9 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const RGWBucketInfo& bucket_info,
     return ret;
   }
 
-  get_bucket_index_objects(bucket_oid_base, bucket_info.layout.current_index.layout.normal.num_shards, bucket_objs, shard_id);
+  auto gen = bucket_info.layout.current_index.gen;
+
+  get_bucket_index_objects(bucket_oid_base, bucket_info.layout.current_index.layout.normal.num_shards, gen, bucket_objs, shard_id);
   if (bucket_instance_ids) {
     get_bucket_instance_ids(bucket_info, shard_id, bucket_instance_ids);
   }
@@ -196,8 +238,9 @@ void RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_b
   } else {
     char buf[bucket_oid_base.size() + 64];
     if (gen_id != 0) {
-      snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id); 
+      snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id);
       (*bucket_obj) = buf;
+	  ldout(cct, 10) << "bucket_obj is " << (*bucket_obj) << dendl;
     } else {
       // for backward compatibility, gen_id(0) will not be added in the object name
       snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), shard_id);
@@ -267,7 +310,7 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket
 
 int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket_info,
                                                      int shard_id,
-                                                     const rgw::bucket_index_layout_generation& idx_layout,
+                                                     const rgw::bucket_index_layout_generation& target_layout,
                                                      RGWSI_RADOS::Obj *bucket_obj)
 {
   RGWSI_RADOS::Pool index_pool;
@@ -281,8 +324,8 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket
 
   string oid;
 
-  get_bucket_index_object(bucket_oid_base, idx_layout.layout.normal.num_shards,
-                          shard_id, idx_layout.gen, &oid);
+  get_bucket_index_object(bucket_oid_base, target_layout.layout.normal.num_shards,
+                          shard_id, target_layout.gen, &oid);
 
   *bucket_obj = svc.rados->obj(index_pool, oid);
 
@@ -317,7 +360,6 @@ int RGWSI_BucketIndex_RADOS::cls_bucket_head(const RGWBucketInfo& bucket_info,
   return 0;
 }
 
-
 int RGWSI_BucketIndex_RADOS::init_index(RGWBucketInfo& bucket_info)
 {
   RGWSI_RADOS::Pool index_pool;
@@ -331,14 +373,15 @@ int RGWSI_BucketIndex_RADOS::init_index(RGWBucketInfo& bucket_info)
   dir_oid.append(bucket_info.bucket.bucket_id);
 
   map<int, string> bucket_objs;
-  get_bucket_index_objects(dir_oid, bucket_info.layout.current_index.layout.normal.num_shards, &bucket_objs);
+  get_bucket_index_objects(dir_oid, bucket_info.layout.current_index.layout.normal.num_shards, std::nullopt, &bucket_objs);
 
   return CLSRGWIssueBucketIndexInit(index_pool.ioctx(),
 				    bucket_objs,
 				    cct->_conf->rgw_bucket_index_max_aio)();
 }
 
-int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info)
+
+int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info, std::optional<uint64_t> gen)
 {
   RGWSI_RADOS::Pool index_pool;
 

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -351,7 +351,8 @@ int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info)
   dir_oid.append(bucket_info.bucket.bucket_id);
 
   std::map<int, std::string> bucket_objs;
-  get_bucket_index_objects(dir_oid, bucket_info.layout.current_index.layout.normal.num_shards, &bucket_objs);
+  get_bucket_index_objects(dir_oid, bucket_info.layout.current_index.layout.normal.num_shards,
+  gen, &bucket_objs);
 
   return CLSRGWIssueBucketIndexClean(index_pool.ioctx(),
 				     bucket_objs,

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -454,7 +454,7 @@ int RGWSI_BucketIndex_RADOS::handle_overwrite(const RGWBucketInfo& info,
   bool old_sync_enabled = orig_info.datasync_flag_enabled();
 
   if (old_sync_enabled != new_sync_enabled) {
-    int shards_num = info.layout.current_index.layout.normal.num_shards? info.layout.current_index.layout.normal.num_shards : 1;
+    int shards_num = rgw::current_num_shards(info.layout);
     int shard_id = info.layout.current_index.layout.normal.num_shards? 0 : -1;
 
     int ret;

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -149,33 +149,6 @@ static void get_bucket_index_objects(const string& bucket_oid_base,
   }
 }
 
-/*
-static void get_bucket_index_objects(const string& bucket_oid_base,
-                                     uint32_t num_shards,
-                                     map<int, string> *_bucket_objects,
-                                     int shard_id = -1)
-{
-  auto& bucket_objects = *_bucket_objects;
-  if (!num_shards) {
-    bucket_objects[0] = bucket_oid_base;
-  } else {
-    char buf[bucket_oid_base.size() + 32];
-    if (shard_id < 0) {
-      for (uint32_t i = 0; i < num_shards; ++i) {
-        snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), i);
-        bucket_objects[i] = buf;
-      }
-    } else {
-      if ((uint32_t)shard_id > num_shards) {
-        return;
-      }
-      snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), shard_id);
-      bucket_objects[shard_id] = buf;
-    }
-  }
-}
-*/
-
 static void get_bucket_instance_ids(const RGWBucketInfo& bucket_info,
                                     int shard_id,
                                     map<int, string> *result)

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -111,6 +111,17 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const RGWBucketInfo& bucket_info,
   return 0;
 }
 
+static char bucket_obj_with_generation(char *buf, size_t len, const string& bucket_oid_base, uint64_t gen_id,
+                                    uint32_t shard_id)
+{
+  return snprintf(buf, len, "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id);
+}
+
+static char bucket_obj_without_generation(char *buf, size_t len, const string& bucket_oid_base, uint32_t shard_id)
+{
+  return snprintf(buf, len, "%s.%d", bucket_oid_base.c_str(), shard_id);
+}
+
 static void get_bucket_index_objects(const string& bucket_oid_base,
                                      uint32_t num_shards, uint64_t gen_id,
                                      map<int, string> *_bucket_objects,
@@ -124,25 +135,23 @@ static void get_bucket_index_objects(const string& bucket_oid_base,
     if (shard_id < 0) {
       for (uint32_t i = 0; i < num_shards; ++i) {
         if (gen_id) {
-          snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, i);
-          bucket_objects[i] = buf;
-          } else {
-            snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), i);
-            bucket_objects[i] = buf;
-          }
+          bucket_obj_with_generation(buf, sizeof(buf), bucket_oid_base, gen_id, i);
+        } else {
+          bucket_obj_without_generation(buf, sizeof(buf), bucket_oid_base, i);
+        }
+        bucket_objects[i] = buf;
       }
     } else {
-      if ((uint32_t)shard_id > num_shards) {
+      if (static_cast<uint32_t>(shard_id) > num_shards) {
         return;
       } else {
-		if (gen_id) {
-		  snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id);
-		  bucket_objects[shard_id] = buf;
-		} else {
-		  // for backward compatibility, gen_id(0) will not be added in the object name
-		  snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), shard_id);
-		  bucket_objects[shard_id] = buf;
-		}
+        if (gen_id) {
+          bucket_obj_with_generation(buf, sizeof(buf), bucket_oid_base, gen_id, shard_id);
+        } else {
+          // for backward compatibility, gen_id(0) will not be added in the object name
+          bucket_obj_without_generation(buf, sizeof(buf), bucket_oid_base, shard_id);
+        }
+        bucket_objects[shard_id] = buf;
       }
     }
   }
@@ -165,7 +174,7 @@ static void get_bucket_instance_ids(const RGWBucketInfo& bucket_info,
         (*result)[i] = plain_id + buf;
       }
     } else {
-      if ((uint32_t)shard_id > bucket_info.layout.current_index.layout.normal.num_shards) {
+      if (static_cast<uint32_t>(shard_id) > bucket_info.layout.current_index.layout.normal.num_shards) {
         return;
       }
       snprintf(buf, sizeof(buf), ":%d", shard_id);
@@ -210,12 +219,12 @@ void RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_b
   } else {
     char buf[bucket_oid_base.size() + 64];
     if (gen_id) {
-      snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id);
+      bucket_obj_with_generation(buf, sizeof(buf), bucket_oid_base, gen_id, shard_id);
       (*bucket_obj) = buf;
 	  ldout(cct, 10) << "bucket_obj is " << (*bucket_obj) << dendl;
     } else {
       // for backward compatibility, gen_id(0) will not be added in the object name
-      snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), shard_id);
+      bucket_obj_without_generation(buf, sizeof(buf), bucket_oid_base, shard_id);
       (*bucket_obj) = buf;
     }
   }
@@ -238,9 +247,9 @@ int RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_ba
         uint32_t sid = bucket_shard_index(obj_key, num_shards);
         char buf[bucket_oid_base.size() + 64];
         if (gen_id) {
-          snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, sid);
+          bucket_obj_with_generation(buf, sizeof(buf), bucket_oid_base, gen_id, sid);
         } else {
-          snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), sid);
+          bucket_obj_without_generation(buf, sizeof(buf), bucket_oid_base, sid);
         }
         (*bucket_obj) = buf;
         if (shard_id) {

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -50,7 +50,7 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
   void get_bucket_index_object(const string& bucket_oid_base,
                                uint32_t num_shards,
                                int shard_id,
-                               uint64_t gen_id,
+                               std::optional<uint64_t> gen_id,
                                string *bucket_obj);
   int get_bucket_index_object(const string& bucket_oid_base, const string& obj_key,
                               uint32_t num_shards, rgw::BucketHashType hash_type,
@@ -115,7 +115,8 @@ public:
 
   int open_bucket_index_shard(const RGWBucketInfo& bucket_info,
                               int shard_id,
-                              const rgw::bucket_index_layout_generation& idx_layout,
+                              uint32_t num_shards,
+                              std::optional<uint64_t> gen,
                               RGWSI_RADOS::Obj *bucket_obj);
 
   int open_bucket_index(const RGWBucketInfo& bucket_info,

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -54,7 +54,7 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
                                string *bucket_obj);
   int get_bucket_index_object(const string& bucket_oid_base, const string& obj_key,
                               uint32_t num_shards, rgw::BucketHashType hash_type,
-                              string *bucket_obj, int *shard_id);
+                              uint64_t gen_id, string *bucket_obj, int *shard_id);
 
   int cls_bucket_head(const RGWBucketInfo& bucket_info,
                       int shard_id,
@@ -94,7 +94,7 @@ public:
   }
 
   int init_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout);
-  int clean_index(RGWBucketInfo& bucket_info, uint64_t gen);
+  int clean_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout);
 
   /* RADOS specific */
 

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -50,7 +50,7 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
   void get_bucket_index_object(const string& bucket_oid_base,
                                uint32_t num_shards,
                                int shard_id,
-                               std::optional<uint64_t> gen_id,
+                               uint64_t gen_id,
                                string *bucket_obj);
   int get_bucket_index_object(const string& bucket_oid_base, const string& obj_key,
                               uint32_t num_shards, rgw::BucketHashType hash_type,
@@ -93,8 +93,8 @@ public:
     return rgw_shards_mod(sid2, num_shards);
   }
 
-  int init_index(RGWBucketInfo& bucket_info);
-  int clean_index(RGWBucketInfo& bucket_info, std::optional<uint64_t> gen);
+  int init_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout);
+  int clean_index(RGWBucketInfo& bucket_info, uint64_t gen);
 
   /* RADOS specific */
 
@@ -116,7 +116,7 @@ public:
   int open_bucket_index_shard(const RGWBucketInfo& bucket_info,
                               int shard_id,
                               uint32_t num_shards,
-                              std::optional<uint64_t> gen,
+                              uint64_t gen,
                               RGWSI_RADOS::Obj *bucket_obj);
 
   int open_bucket_index(const RGWBucketInfo& bucket_info,

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -94,8 +94,7 @@ public:
   }
 
   int init_index(RGWBucketInfo& bucket_info);
-  int clean_index(RGWBucketInfo& bucket_info);
-
+  int clean_index(RGWBucketInfo& bucket_info, std::optional<uint64_t> gen);
 
   /* RADOS specific */
 

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -337,6 +337,11 @@ add_ceph_unittest(unittest_cdc)
 add_executable(unittest_ceph_timer test_ceph_timer.cc)
 add_ceph_unittest(unittest_ceph_timer)
 
+add_executable(unittest_fault_injector test_fault_injector.cc
+  $<TARGET_OBJECTS:unit-main>)
+target_link_libraries(unittest_fault_injector global)
+add_ceph_unittest(unittest_fault_injector)
+
 add_executable(unittest_blocked_completion test_blocked_completion.cc)
 add_ceph_unittest(unittest_blocked_completion)
 target_link_libraries(unittest_blocked_completion Boost::system GTest::GTest)

--- a/src/test/common/test_fault_injector.cc
+++ b/src/test/common/test_fault_injector.cc
@@ -1,0 +1,224 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "common/fault_injector.h"
+#include <gtest/gtest.h>
+
+static const DoutPrefixProvider* dpp() {
+  static NoDoutPrefix d{g_ceph_context, ceph_subsys_context};
+  return &d;
+}
+
+TEST(FaultInjectorDeathTest, InjectAbort)
+{
+  constexpr FaultInjector f{false, InjectAbort{}};
+  EXPECT_EQ(f.check(true), 0);
+  EXPECT_DEATH([[maybe_unused]] int r = f.check(false), "FaultInjector");
+}
+
+TEST(FaultInjectorDeathTest, AssignAbort)
+{
+  FaultInjector<bool> f;
+  ASSERT_EQ(f.check(false), 0);
+  f.inject(false, InjectAbort{});
+  EXPECT_DEATH([[maybe_unused]] int r = f.check(false), "FaultInjector");
+}
+
+// test int as a Key type
+TEST(FaultInjectorInt, Default)
+{
+  constexpr FaultInjector<int> f;
+  EXPECT_EQ(f.check(0), 0);
+  EXPECT_EQ(f.check(1), 0);
+  EXPECT_EQ(f.check(2), 0);
+  EXPECT_EQ(f.check(3), 0);
+}
+
+TEST(FaultInjectorInt, InjectError)
+{
+  constexpr FaultInjector f{2, InjectError{-EINVAL}};
+  EXPECT_EQ(f.check(0), 0);
+  EXPECT_EQ(f.check(1), 0);
+  EXPECT_EQ(f.check(2), -EINVAL);
+  EXPECT_EQ(f.check(3), 0);
+}
+
+TEST(FaultInjectorInt, InjectErrorMessage)
+{
+  FaultInjector f{2, InjectError{-EINVAL, dpp()}};
+  EXPECT_EQ(f.check(0), 0);
+  EXPECT_EQ(f.check(1), 0);
+  EXPECT_EQ(f.check(2), -EINVAL);
+  EXPECT_EQ(f.check(3), 0);
+}
+
+TEST(FaultInjectorInt, AssignError)
+{
+  FaultInjector<int> f;
+  ASSERT_EQ(f.check(0), 0);
+  f.inject(0, InjectError{-EINVAL});
+  EXPECT_EQ(f.check(0), -EINVAL);
+}
+
+TEST(FaultInjectorInt, AssignErrorMessage)
+{
+  FaultInjector<int> f;
+  ASSERT_EQ(f.check(0), 0);
+  f.inject(0, InjectError{-EINVAL, dpp()});
+  EXPECT_EQ(f.check(0), -EINVAL);
+}
+
+// test std::string_view as a Key type
+TEST(FaultInjectorString, Default)
+{
+  constexpr FaultInjector<std::string_view> f;
+  EXPECT_EQ(f.check("Red"), 0);
+  EXPECT_EQ(f.check("Green"), 0);
+  EXPECT_EQ(f.check("Blue"), 0);
+}
+
+TEST(FaultInjectorString, InjectError)
+{
+  FaultInjector<std::string_view> f{"Red", InjectError{-EIO}};
+  EXPECT_EQ(f.check("Red"), -EIO);
+  EXPECT_EQ(f.check("Green"), 0);
+  EXPECT_EQ(f.check("Blue"), 0);
+}
+
+TEST(FaultInjectorString, InjectErrorMessage)
+{
+  FaultInjector<std::string_view> f{"Red", InjectError{-EIO, dpp()}};
+  EXPECT_EQ(f.check("Red"), -EIO);
+  EXPECT_EQ(f.check("Green"), 0);
+  EXPECT_EQ(f.check("Blue"), 0);
+}
+
+TEST(FaultInjectorString, AssignError)
+{
+  FaultInjector<std::string_view> f;
+  ASSERT_EQ(f.check("Red"), 0);
+  f.inject("Red", InjectError{-EINVAL});
+  EXPECT_EQ(f.check("Red"), -EINVAL);
+}
+
+TEST(FaultInjectorString, AssignErrorMessage)
+{
+  FaultInjector<std::string_view> f;
+  ASSERT_EQ(f.check("Red"), 0);
+  f.inject("Red", InjectError{-EINVAL, dpp()});
+  EXPECT_EQ(f.check("Red"), -EINVAL);
+}
+
+// test enum class as a Key type
+enum class Color { Red, Green, Blue };
+
+static std::ostream& operator<<(std::ostream& out, const Color& c) {
+  switch (c) {
+    case Color::Red: return out << "Red";
+    case Color::Green: return out << "Green";
+    case Color::Blue: return out << "Blue";
+  }
+  return out;
+}
+
+TEST(FaultInjectorEnum, Default)
+{
+  constexpr FaultInjector<Color> f;
+  EXPECT_EQ(f.check(Color::Red), 0);
+  EXPECT_EQ(f.check(Color::Green), 0);
+  EXPECT_EQ(f.check(Color::Blue), 0);
+}
+
+TEST(FaultInjectorEnum, InjectError)
+{
+  FaultInjector f{Color::Red, InjectError{-EIO}};
+  EXPECT_EQ(f.check(Color::Red), -EIO);
+  EXPECT_EQ(f.check(Color::Green), 0);
+  EXPECT_EQ(f.check(Color::Blue), 0);
+}
+
+TEST(FaultInjectorEnum, InjectErrorMessage)
+{
+  FaultInjector f{Color::Red, InjectError{-EIO, dpp()}};
+  EXPECT_EQ(f.check(Color::Red), -EIO);
+  EXPECT_EQ(f.check(Color::Green), 0);
+  EXPECT_EQ(f.check(Color::Blue), 0);
+}
+
+TEST(FaultInjectorEnum, AssignError)
+{
+  FaultInjector<Color> f;
+  ASSERT_EQ(f.check(Color::Red), 0);
+  f.inject(Color::Red, InjectError{-EINVAL});
+  EXPECT_EQ(f.check(Color::Red), -EINVAL);
+}
+
+TEST(FaultInjectorEnum, AssignErrorMessage)
+{
+  FaultInjector<Color> f;
+  ASSERT_EQ(f.check(Color::Red), 0);
+  f.inject(Color::Red, InjectError{-EINVAL, dpp()});
+  EXPECT_EQ(f.check(Color::Red), -EINVAL);
+}
+
+// test custom move-only Key type
+struct MoveOnlyKey {
+  MoveOnlyKey() = default;
+  MoveOnlyKey(const MoveOnlyKey&) = delete;
+  MoveOnlyKey& operator=(const MoveOnlyKey&) = delete;
+  MoveOnlyKey(MoveOnlyKey&&) = default;
+  MoveOnlyKey& operator=(MoveOnlyKey&&) = default;
+  ~MoveOnlyKey() = default;
+};
+
+static bool operator==(const MoveOnlyKey&, const MoveOnlyKey&) {
+  return true; // all keys are equal
+}
+static std::ostream& operator<<(std::ostream& out, const MoveOnlyKey&) {
+  return out;
+}
+
+TEST(FaultInjectorMoveOnly, Default)
+{
+  constexpr FaultInjector<MoveOnlyKey> f;
+  EXPECT_EQ(f.check(MoveOnlyKey{}), 0);
+}
+
+TEST(FaultInjectorMoveOnly, InjectError)
+{
+  FaultInjector f{MoveOnlyKey{}, InjectError{-EIO}};
+  EXPECT_EQ(f.check(MoveOnlyKey{}), -EIO);
+}
+
+TEST(FaultInjectorMoveOnly, InjectErrorMessage)
+{
+  FaultInjector f{MoveOnlyKey{}, InjectError{-EIO, dpp()}};
+  EXPECT_EQ(f.check(MoveOnlyKey{}), -EIO);
+}
+
+TEST(FaultInjectorMoveOnly, AssignError)
+{
+  FaultInjector<MoveOnlyKey> f;
+  ASSERT_EQ(f.check({}), 0);
+  f.inject({}, InjectError{-EINVAL});
+  EXPECT_EQ(f.check({}), -EINVAL);
+}
+
+TEST(FaultInjectorMoveOnly, AssignErrorMessage)
+{
+  FaultInjector<MoveOnlyKey> f;
+  ASSERT_EQ(f.check({}), 0);
+  f.inject({}, InjectError{-EINVAL, dpp()});
+  EXPECT_EQ(f.check({}), -EINVAL);
+}


### PR DESCRIPTION
With these changes dynamic resharding does not require a new bucket instance anymore, thus facilitating the upcoming multisite support use case. 
In continuation with #34096 and #34352, a property called bucket layout is introduced in RGWBucketInfo. With every reshard process, the bucket index transitions from current_index to target_index layout and each can have its own properties like BucketIndexType and BucketHashType. To do this, it maintains a generation number that is incremented in every reshard cycle.

This PR is part of multisite work documented in:
https://github.com/ceph/ceph/blob/master/src/doc/rgw/multisite-reshard.md#bucket-index-resharding