### PR TITLE
PriorityCache's perf counters can have custom name

### DIFF
--- a/src/common/PriorityCache.cc
+++ b/src/common/PriorityCache.cc
@@ -62,16 +62,18 @@ namespace PriorityCache
                    uint64_t min,
                    uint64_t max,
                    uint64_t target,
-                   bool reserve_extra) :
+                   bool reserve_extra,
+		   const std::string& name) :
       cct(c),
       caches{},
       min_mem(min),
       max_mem(max),
       target_mem(target),
       tuned_mem(min),
-      reserve_extra(reserve_extra)
+      reserve_extra(reserve_extra),
+      name(name.empty() ? "prioritycache" : name)
   {
-    PerfCountersBuilder b(cct, "prioritycache", 
+    PerfCountersBuilder b(cct, name,
                           MallocStats::M_FIRST, MallocStats::M_LAST);
 
     b.add_u64(MallocStats::M_TARGET_BYTES, "target_bytes",
@@ -170,7 +172,7 @@ namespace PriorityCache
     ceph_assert(end < PERF_COUNTER_MAX_BOUND);
     indexes.emplace(name, std::vector<int>(Extra::E_LAST + 1));
 
-    PerfCountersBuilder b(cct, "prioritycache:" + name, start, end);
+    PerfCountersBuilder b(cct, this->name + ":" + name, start, end);
 
     b.add_u64(cur_index + Priority::PRI0, "pri0_bytes",
               "bytes allocated to pri0", "p0",

--- a/src/common/PriorityCache.h
+++ b/src/common/PriorityCache.h
@@ -117,10 +117,10 @@ namespace PriorityCache {
     uint64_t target_mem = 0;
     uint64_t tuned_mem = 0;
     bool reserve_extra;
-
+    std::string name;
   public:
     Manager(CephContext *c, uint64_t min, uint64_t max, uint64_t target,
-            bool reserve_extra);
+            bool reserve_extra, const std::string& name = std::string());
     ~Manager();
     void set_min_memory(uint64_t min) {
       min_mem = min;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3788,7 +3788,7 @@ void *BlueStore::MempoolThread::entry()
   binned_kv_cache = store->db->get_priority_cache();
   if (store->cache_autotune && binned_kv_cache != nullptr) {
     pcm = std::make_shared<PriorityCache::Manager>(
-        store->cct, min, max, target, true);
+        store->cct, min, max, target, true, "bluestore-pricache");
     pcm->insert("kv", binned_kv_cache, true);
     pcm->insert("meta", meta_cache, true);
     pcm->insert("data", data_cache, true);
@@ -3864,6 +3864,7 @@ void *BlueStore::MempoolThread::entry()
   // do final dump
   store->_record_allocation_stats();
   stop = false;
+  pcm = nullptr;
   return NULL;
 }
 


### PR DESCRIPTION
Added possibility to add PriorityCache::Manager a name, that is used when registering manager.
Also fixed problem that gave perf counters a name with instance suffix, like "PriorityCache-0x4f5acde40".