### PR TITLE
mds: Add killpoints for directory fragmentation

### DIFF
--- a/qa/cephfs/begin.yaml
+++ b/qa/cephfs/begin.yaml
@@ -54,3 +54,8 @@ tasks:
         - libuuid-devel
         - xfsprogs-devel
   - ceph:
+  - exec:
+      mon.a:
+        - ceph config set mds mds_bal_fragment_size_max 10000
+        - ceph config set mds mds_bal_split_size 100
+        - ceph config set mds mds_bal_merge_size 5

--- a/qa/cephfs/overrides/frag_enable.yaml
+++ b/qa/cephfs/overrides/frag_enable.yaml
@@ -1,9 +1,0 @@
-overrides:
-  ceph:
-    conf:
-      mds:
-        mds bal frag: true
-        mds bal fragment size max: 10000
-        mds bal split size: 100
-        mds bal merge size: 5
-        mds bal split bits: 3

--- a/qa/suites/fs/32bits/overrides/frag_enable.yaml
+++ b/qa/suites/fs/32bits/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/bugs/client_trim_caps/overrides/frag_enable.yaml
+++ b/qa/suites/fs/bugs/client_trim_caps/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/functional/overrides/frag_enable.yaml
+++ b/qa/suites/fs/functional/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/libcephfs/overrides/frag_enable.yaml
+++ b/qa/suites/fs/libcephfs/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/mixed-clients/overrides/frag_enable.yaml
+++ b/qa/suites/fs/mixed-clients/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/multiclient/overrides/frag_enable.yaml
+++ b/qa/suites/fs/multiclient/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/multifs/overrides/frag_enable.yaml
+++ b/qa/suites/fs/multifs/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/permission/overrides/frag_enable.yaml
+++ b/qa/suites/fs/permission/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/shell/overrides/frag_enable.yaml
+++ b/qa/suites/fs/shell/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/snaps/overrides/frag_enable.yaml
+++ b/qa/suites/fs/snaps/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/thrash/multifs/overrides/frag_enable.yaml
+++ b/qa/suites/fs/thrash/multifs/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/thrash/workloads/overrides/frag_enable.yaml
+++ b/qa/suites/fs/thrash/workloads/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/traceless/overrides/frag_enable.yaml
+++ b/qa/suites/fs/traceless/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/upgrade/featureful_client/old_client/overrides/frag_enable.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/overrides/frag_enable.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/verify/overrides/frag_enable.yaml
+++ b/qa/suites/fs/verify/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/volumes/overrides/frag_enable.yaml
+++ b/qa/suites/fs/volumes/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/workload/overrides/frag_enable.yaml
+++ b/qa/suites/fs/workload/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -207,6 +207,17 @@ class FSStatus(object):
         #all matching
         return False
 
+    def hadfailover_rank(self, fscid, status, rank):
+        """
+        Compares two statuses for mds failovers for a
+        particular rank
+        """
+        rank_info = self.get_rank(fscid, rank)
+        orig_rank_info = status.get_rank(fscid, rank)
+        if ((rank_info['gid'] != orig_rank_info['gid']) or (rank_info['incarnation'] != orig_rank_info['incarnation'])):
+            return True
+        return False
+
 class CephCluster(object):
     @property
     def admin_remote(self):
@@ -585,6 +596,10 @@ class Filesystem(MDSCluster):
     def set_flag(self, var, *args):
         a = map(lambda x: str(x).lower(), args)
         self.mon_manager.raw_cluster_cmd("fs", "flag", "set", var, *a)
+
+    def set_config(self, opt, val, rank=0, status=None):
+        command = ["config", "set", opt, val]
+        self.rank_asok(command, rank, status=status)
 
     def set_allow_multifs(self, yes=True):
         self.set_flag("enable_multiple", yes)

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -961,6 +961,14 @@ options:
   fmt_desc: Ceph will inject MDS failure in the subtree import code
     (for developers only).
   with_legacy: true
+- name: mds_kill_dirfrag_at
+  type: int
+  level: dev
+  default: 0
+  services:
+  - mds
+  flags:
+  - runtime
 - name: mds_kill_link_at
   type: int
   level: dev

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -3596,7 +3596,7 @@ std::string CDir::get_path() const
 bool CDir::should_split_fast() const
 {
   // Max size a fragment can be before trigger fast splitting
-  int fast_limit = g_conf()->mds_bal_split_size * g_conf()->mds_bal_fragment_fast_factor;
+  int fast_limit = g_conf().get_val<int64_t>("mds_bal_split_size") * g_conf().get_val<double>("mds_bal_fragment_fast_factor");
 
   // Fast path: the sum of accounted size and null dentries does not
   // exceed threshold: we definitely are not over it.
@@ -3633,7 +3633,7 @@ bool CDir::should_merge() const
       return false;
   }
 
-  return (int)get_frag_size() < g_conf()->mds_bal_merge_size;
+  return (int)get_frag_size() < g_conf().get_val<int64_t>("mds_bal_merge_size");
 }
 
 MEMPOOL_DEFINE_OBJECT_FACTORY(CDir, co_dir, mds_co);

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -396,8 +396,8 @@ public:
   void merge(const std::vector<CDir*>& subs, MDSContext::vec& waiters, bool replay);
 
   bool should_split() const {
-    return g_conf()->mds_bal_split_size > 0 &&
-           (int)get_frag_size() > g_conf()->mds_bal_split_size;
+    return g_conf().get_val<int64_t>("mds_bal_split_size") > 0 &&
+           (int)get_frag_size() > g_conf().get_val<int64_t>("mds_bal_split_size");
   }
   bool should_split_fast() const;
   bool should_merge() const;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -5252,7 +5252,7 @@ void CInode::queue_export_pin(mds_rank_t export_pin)
 
 void CInode::maybe_export_pin(bool update)
 {
-  if (!g_conf()->mds_bal_export_pin)
+  if (!mdcache->mds->get_bal_export_pin())
     return;
   if (!is_dir() || !is_normal())
     return;

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -51,6 +51,11 @@ public:
 
   void handle_export_pins(void);
 
+  // Is export pins allowed
+  bool get_bal_export_pin(void) {
+    return bal_export_pin;
+  }
+
   void subtract_export(CDir *ex);
   void add_import(CDir *im);
   void adjust_pop_for_rename(CDir *pdir, CDir *dir, bool inc);
@@ -120,6 +125,16 @@ private:
 
   bool bal_fragment_dirs;
   int64_t bal_fragment_interval;
+  int64_t bal_interval;
+  int64_t bal_max_until;
+  int64_t bal_mode;
+  bool bal_export_pin;
+  double bal_sample_interval;
+  double bal_split_rd;
+  double bal_split_wr;
+  double bal_replicate_threshold;
+  double bal_unreplicate_threshold;
+  int64_t num_bal_times;
   static const unsigned int AUTH_TREES_THRESHOLD = 5;
 
   MDSRank *mds;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -206,7 +206,7 @@ void MDCache::handle_conf_change(const std::set<std::string>& changed, const MDS
     export_ephemeral_random_max = g_conf().get_val<double>("mds_export_ephemeral_random_max");
   }
 
-  if (changed.count("mds_kill_dirgrag_at")) {
+  if (changed.count("mds_kill_dirfrag_at")) {
     kill_dirfrag_at = g_conf().get_val<int64_t>("mds_kill_dirfrag_at");
   }
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1315,6 +1315,8 @@ class MDCache {
   bool export_ephemeral_random_config;
   unsigned export_ephemeral_dist_frag_bits;
 
+  int64_t kill_dirfrag_at;
+
   // File size recovery
   RecoveryQueue recovery_queue;
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3670,6 +3670,7 @@ const char** MDSRankDispatcher::get_tracked_conf_keys() const
     "mds_export_ephemeral_distributed",
     "mds_health_cache_threshold",
     "mds_inject_migrator_session_race",
+    "mds_kill_dirfrag_at",
     "mds_log_pause",
     "mds_max_export_size",
     "mds_max_purge_files",

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -218,6 +218,8 @@ class MDSRank {
     bool is_cluster_degraded() const { return cluster_degraded; }
     bool allows_multimds_snaps() const { return mdsmap->allows_multimds_snaps(); }
 
+    bool get_bal_export_pin() { return bal_export_pin; }
+
     bool is_cache_trimmable() const {
       return is_standby_replay() || is_clientreplay() || is_active() || is_stopping();
     }
@@ -596,6 +598,8 @@ class MDSRank {
 
     Context *respawn_hook;
     Context *suicide_hook;
+
+    bool bal_export_pin;
 
     bool standby_replaying = false;  // true if current replay pass is in standby-replay mode
 private:

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -260,6 +260,7 @@ Server::Server(MDSRank *m, MetricsHandler *metrics_handler) :
   cap_acquisition_throttle = g_conf().get_val<uint64_t>("mds_session_cap_acquisition_throttle");
   max_caps_throttle_ratio = g_conf().get_val<double>("mds_session_max_caps_throttle_ratio");
   caps_throttle_retry_request_timeout = g_conf().get_val<double>("mds_cap_acquisition_throttle_retry_request_timeout");
+  bal_fragment_size_max = g_conf().get_val<int64_t>("mds_bal_fragment_size_max");
   supported_features = feature_bitset_t(CEPHFS_FEATURES_MDS_SUPPORTED);
 }
 
@@ -1252,6 +1253,9 @@ void Server::handle_conf_change(const std::set<std::string>& changed) {
   }
   if (changed.count("mds_alternate_name_max")) {
     alternate_name_max  = g_conf().get_val<Option::size_t>("mds_alternate_name_max");
+  }
+  if (changed.count("mds_bal_fragment_size_max")) {
+    bal_fragment_size_max = g_conf().get_val<int64_t>("mds_bal_fragment_size_max");
   }
 }
 
@@ -3186,9 +3190,15 @@ bool Server::check_access(MDRequestRef& mdr, CInode *in, unsigned mask)
 bool Server::check_fragment_space(MDRequestRef &mdr, CDir *in)
 {
   const auto size = in->get_frag_size();
+<<<<<<< HEAD
   if (size >= g_conf()->mds_bal_fragment_size_max) {
     dout(10) << "fragment " << *in << " size exceeds " << g_conf()->mds_bal_fragment_size_max << " (CEPHFS_ENOSPC)" << dendl;
     respond_to_request(mdr, -CEPHFS_ENOSPC);
+=======
+  if (size >= bal_fragment_size_max) {
+    dout(10) << "fragment " << *in << " size exceeds " << bal_fragment_size_max << " (ENOSPC)" << dendl;
+    respond_to_request(mdr, -ENOSPC);
+>>>>>>> mds: Optimize Balancer code path to use newer config fetch and also cache the fetched values when there is a hot code path
     return false;
   }
 

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -458,6 +458,7 @@ private:
   double cap_revoke_eviction_timeout = 0;
   uint64_t max_snaps_per_dir = 100;
   unsigned delegate_inos_pct = 0;
+  int64_t bal_fragment_size_max;
 
   DecayCounter recall_throttle;
   time last_recall_state;

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -1818,7 +1818,7 @@ struct mds_load_t {
 
   double cpu_load_avg = 0.0;
 
-  double mds_load() const;  // defiend in MDBalancer.cc
+  double mds_load(int64_t bal_mode) const;  // defiend in MDBalancer.cc
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;


### PR DESCRIPTION
Defined Killpoints for testing completion/recovery of directory fragmentation during failure.

Fixes: https://tracker.ceph.com/issues/7320
Signed-off-by: Sidharth Anupkrishnan <sanupkri@redhat.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
