### PR TITLE
nautilus: tests: src/test/compressor: Add missing gtest

### DIFF
--- a/src/test/compressor/CMakeLists.txt
+++ b/src/test/compressor/CMakeLists.txt
@@ -6,5 +6,5 @@ add_executable(unittest_compression
   $<TARGET_OBJECTS:unit-main>
   )
 add_ceph_unittest(unittest_compression)
-target_link_libraries(unittest_compression global)
+target_link_libraries(unittest_compression global GTest::GTest)
 add_dependencies(unittest_compression ceph_example)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45642

---

backport of https://github.com/ceph/ceph/pull/33731
parent tracker: https://tracker.ceph.com/issues/45639

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh