### PR TITLE
nautilus: pybind/rbd: RBD.create() method's 'old_format' parameter now defaults to False

### DIFF
--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -1057,7 +1057,7 @@ class RBD(object):
         rbd_version(&major, &minor, &extra)
         return (major, minor, extra)
 
-    def create(self, ioctx, name, size, order=None, old_format=True,
+    def create(self, ioctx, name, size, order=None, old_format=False,
                features=None, stripe_unit=None, stripe_count=None,
                data_pool=None):
         """

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -183,7 +183,7 @@ def check_default_params(format, order=None, features=None, stripe_count=None,
             feature_data_pool = 128
         image_name = get_temp_image_name()
         if exception is None:
-            RBD().create(ioctx, image_name, IMG_SIZE)
+            RBD().create(ioctx, image_name, IMG_SIZE, old_format=(format == 1))
             try:
                 with Image(ioctx, image_name) as image:
                     eq(format == 1, image.old_format())


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45579

---

backport of https://github.com/ceph/ceph/pull/35011
parent tracker: https://tracker.ceph.com/issues/45504

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh