### PR TITLE
nautilus: tests: specify random distros in multimds

### DIFF
--- a/qa/suites/fs/verify/centos_latest.yaml
+++ b/qa/suites/fs/verify/centos_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/centos_latest.yaml

--- a/qa/suites/fs/verify/validater/valgrind.yaml
+++ b/qa/suites/fs/verify/validater/valgrind.yaml
@@ -1,5 +1,5 @@
-# see http://tracker.ceph.com/issues/20360 and http://tracker.ceph.com/issues/18126
-os_type: centos
+# Only works on os_type: centos
+# See http://tracker.ceph.com/issues/20360 and http://tracker.ceph.com/issues/18126
 
 overrides:
   install:

--- a/qa/suites/multimds/basic/0-supported-random-distro$
+++ b/qa/suites/multimds/basic/0-supported-random-distro$
@@ -1,0 +1,1 @@
+.qa/distros/supported-random-distro$/

--- a/qa/suites/multimds/thrash/0-supported-random-distro$
+++ b/qa/suites/multimds/thrash/0-supported-random-distro$
@@ -1,0 +1,1 @@
+.qa/distros/supported-random-distro$/

--- a/qa/suites/multimds/verify/centos_latest.yaml
+++ b/qa/suites/multimds/verify/centos_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/centos_latest.yaml


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/45804
* https://tracker.ceph.com/issues/44330

---

backport of

* https://github.com/ceph/ceph/pull/32535
* https://github.com/ceph/ceph/pull/33080

parent trackers:

* https://tracker.ceph.com/issues/43516
* https://tracker.ceph.com/issues/43968

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh