### PR TITLE
rgw:gc: use XXHash for gc queue selection

### DIFF
--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -17,6 +17,7 @@
 
 #include <list> // XXX
 #include <sstream>
+#include "xxhash.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
@@ -60,7 +61,7 @@ void RGWGC::finalize()
 
 int RGWGC::tag_index(const string& tag)
 {
-  return rgw_shard_id(tag, max_objs);
+  return rgw_shards_mod(XXH64(tag.c_str(), tag.size(), seed), max_objs);
 }
 
 int RGWGC::send_chain(cls_rgw_obj_chain& chain, const string& tag)

--- a/src/rgw/rgw_gc.h
+++ b/src/rgw/rgw_gc.h
@@ -25,6 +25,8 @@ class RGWGC : public DoutPrefixProvider {
   string *obj_names;
   std::atomic<bool> down_flag = { false };
 
+  static constexpr uint64_t seed = 8675309;
+
   int tag_index(const string& tag);
 
   class GCWorker : public Thread {


### PR DESCRIPTION
We've observed significant imbalance in gc queue loading, most
likely due to poor ceph_str_hash_linux dispersion for common
key forms.

XXHash64 should be an effective and fast replacement for all
current RGW users of ceph_str_hash_linux (which also include
bucket-index sharding and bucket-lifecycle shard selection).

Unlike the other users, gc queue selection appears safe to
"just switch" as only defer-gc operations (which are non-critical
and of brief temporal locality) make any sort of rendezvous
on specific enqueued tags.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
