### PR TITLE
cephadm: Allow users to provide ssh keys during bootstrap

### DIFF
--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -61,7 +61,9 @@ Synopsis
 |                           [--initial-dashboard-user INITIAL_DASHBOARD_USER]
 |                           [--initial-dashboard-password INITIAL_DASHBOARD_PASSWORD]
 |                           [--dashboard-key DASHBOARD_KEY]
-|                           [--dashboard-crt DASHBOARD_CRT] [--skip-mon-network]
+|                           [--dashboard-crt DASHBOARD_CRT]
+|                           [--ssh-private-key SSH_PRIVATE_KEY]
+|                           [--ssh-public-key SSH_PUBLIC_KEY] [--skip-mon-network]
 |                           [--skip-dashboard] [--dashboard-password-noupdate]
 |                           [--no-minimize-config] [--skip-ping-check]
 |                           [--skip-pull] [--skip-firewalld] [--allow-overwrite]
@@ -198,6 +200,8 @@ Arguments:
 * [--initial-dashboard-password INITIAL_DASHBOARD_PASSWORD] Initial password for the initial dashboard user
 * [--dashboard-key DASHBOARD_KEY] Dashboard key
 * [--dashboard-crt DASHBOARD_CRT] Dashboard certificate
+* [--ssh-private-key SSH_PRIVATE_KEY] SSH private key
+* [--ssh-public-key SSH_PUBLIC_KEY] SSH public key
 * [--skip-mon-network]            set mon public_network based on bootstrap mon ip
 * [--skip-dashboard]              do not enable the Ceph Dashboard
 * [--dashboard-password-noupdate] stop forced dashboard password change

--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -62,6 +62,7 @@ Synopsis
 |                           [--initial-dashboard-password INITIAL_DASHBOARD_PASSWORD]
 |                           [--dashboard-key DASHBOARD_KEY]
 |                           [--dashboard-crt DASHBOARD_CRT]
+|                           [--ssh-config SSH_CONFIG]
 |                           [--ssh-private-key SSH_PRIVATE_KEY]
 |                           [--ssh-public-key SSH_PUBLIC_KEY] [--skip-mon-network]
 |                           [--skip-dashboard] [--dashboard-password-noupdate]
@@ -200,6 +201,7 @@ Arguments:
 * [--initial-dashboard-password INITIAL_DASHBOARD_PASSWORD] Initial password for the initial dashboard user
 * [--dashboard-key DASHBOARD_KEY] Dashboard key
 * [--dashboard-crt DASHBOARD_CRT] Dashboard certificate
+* [--ssh-config SSH_CONFIG] SSH config
 * [--ssh-private-key SSH_PRIVATE_KEY] SSH private key
 * [--ssh-public-key SSH_PUBLIC_KEY] SSH public key
 * [--skip-mon-network]            set mon public_network based on bootstrap mon ip

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2562,31 +2562,40 @@ def command_bootstrap():
         logger.info('Setting orchestrator backend to cephadm...')
         cli(['orch', 'set', 'backend', 'cephadm'])
 
-        logger.info('Generating ssh key...')
-        cli(['cephadm', 'generate-key'])
-        ssh_pub = cli(['cephadm', 'get-pub-key'])
+        if args.ssh_private_key and args.ssh_public_key:
+            logger.info('Using provided ssh keys...')
+            mounts = {
+                pathify(args.ssh_private_key.name): '/tmp/cephadm-ssh-key:z',
+                pathify(args.ssh_public_key.name): '/tmp/cephadm-ssh-key.pub:z'
+            }
+            cli(['cephadm', 'set-priv-key', '-i', '/tmp/cephadm-ssh-key'], extra_mounts=mounts)
+            cli(['cephadm', 'set-pub-key', '-i', '/tmp/cephadm-ssh-key.pub'], extra_mounts=mounts)
+        else:
+            logger.info('Generating ssh key...')
+            cli(['cephadm', 'generate-key'])
+            ssh_pub = cli(['cephadm', 'get-pub-key'])
 
-        with open(args.output_pub_ssh_key, 'w') as f:
-            f.write(ssh_pub)
-        logger.info('Wrote public SSH key to to %s' % args.output_pub_ssh_key)
+            with open(args.output_pub_ssh_key, 'w') as f:
+                f.write(ssh_pub)
+            logger.info('Wrote public SSH key to to %s' % args.output_pub_ssh_key)
 
-        logger.info('Adding key to root@localhost\'s authorized_keys...')
-        if not os.path.exists('/root/.ssh'):
-            os.mkdir('/root/.ssh', 0o700)
-        auth_keys_file = '/root/.ssh/authorized_keys'
-        add_newline = False
-        if os.path.exists(auth_keys_file):
-            with open(auth_keys_file, 'r') as f:
-                f.seek(0, os.SEEK_END)
-                if f.tell() > 0:
-                    f.seek(f.tell()-1, os.SEEK_SET) # go to last char
-                    if f.read() != '\n':
-                        add_newline = True
-        with open(auth_keys_file, 'a') as f:
-            os.fchmod(f.fileno(), 0o600)  # just in case we created it
-            if add_newline:
-                f.write('\n')
-            f.write(ssh_pub.strip() + '\n')
+            logger.info('Adding key to root@localhost\'s authorized_keys...')
+            if not os.path.exists('/root/.ssh'):
+                os.mkdir('/root/.ssh', 0o700)
+            auth_keys_file = '/root/.ssh/authorized_keys'
+            add_newline = False
+            if os.path.exists(auth_keys_file):
+                with open(auth_keys_file, 'r') as f:
+                    f.seek(0, os.SEEK_END)
+                    if f.tell() > 0:
+                        f.seek(f.tell()-1, os.SEEK_SET) # go to last char
+                        if f.read() != '\n':
+                            add_newline = True
+            with open(auth_keys_file, 'a') as f:
+                os.fchmod(f.fileno(), 0o600)  # just in case we created it
+                if add_newline:
+                    f.write('\n')
+                f.write(ssh_pub.strip() + '\n')
 
         host = get_hostname()
         logger.info('Adding host %s...' % host)
@@ -4463,6 +4472,15 @@ def _get_parser():
     parser_bootstrap.add_argument(
         '--dashboard-crt',
         help='Dashboard certificate')
+
+    parser_bootstrap.add_argument(
+        '--ssh-private-key',
+        type=argparse.FileType('r'),
+        help='SSH private key')
+    parser_bootstrap.add_argument(
+        '--ssh-public-key',
+        type=argparse.FileType('r'),
+        help='SSH public key')
 
     parser_bootstrap.add_argument(
         '--skip-mon-network',

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2562,6 +2562,13 @@ def command_bootstrap():
         logger.info('Setting orchestrator backend to cephadm...')
         cli(['orch', 'set', 'backend', 'cephadm'])
 
+        if args.ssh_config:
+            logger.info('Using provided ssh config...')
+            mounts = {
+                pathify(args.ssh_config.name): '/tmp/cephadm-ssh-config:z',
+            }
+            cli(['cephadm', 'set-ssh-config', '-i', '/tmp/cephadm-ssh-config'], extra_mounts=mounts)
+
         if args.ssh_private_key and args.ssh_public_key:
             logger.info('Using provided ssh keys...')
             mounts = {
@@ -4473,6 +4480,10 @@ def _get_parser():
         '--dashboard-crt',
         help='Dashboard certificate')
 
+    parser_bootstrap.add_argument(
+        '--ssh-config',
+        type=argparse.FileType('r'),
+        help='SSH config')
     parser_bootstrap.add_argument(
         '--ssh-private-key',
         type=argparse.FileType('r'),

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -748,6 +748,28 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         return 0, '', ''
 
     @orchestrator._cli_write_command(
+        'cephadm set-priv-key',
+        desc='Set cluster SSH private key (use -i <private_key>)')
+    def _set_priv_key(self, inbuf=None):
+        if inbuf is None or len(inbuf) == 0:
+            return -errno.EINVAL, "", "empty private ssh key provided"
+        self.set_store("ssh_identity_key", inbuf)
+        self.log.info('Set ssh private key')
+        self._reconfig_ssh()
+        return 0, "", ""
+
+    @orchestrator._cli_write_command(
+        'cephadm set-pub-key',
+        desc='Set cluster SSH public key (use -i <public_key>)')
+    def _set_pub_key(self, inbuf=None):
+        if inbuf is None or len(inbuf) == 0:
+            return -errno.EINVAL, "", "empty public ssh key provided"
+        self.set_store("ssh_identity_pub", inbuf)
+        self.log.info('Set ssh public key')
+        self._reconfig_ssh()
+        return 0, "", ""
+
+    @orchestrator._cli_write_command(
         'cephadm clear-key',
         desc='Clear cluster SSH key')
     def _clear_key(self):


### PR DESCRIPTION
With this PR user will be able to provide their own SSH keys:

```
ceph cephadm set-priv-key -i /root/.ssh/secret
ceph cephadm set-pub-key -i /root/.ssh/secret.pub
```

Even for the bootstrap:
```
cephadm boostrap \
    ...
    --ssh-private-key /root/.ssh/secret \
    --ssh-public-key /root/.ssh/secret.pub
```

Fixes: https://tracker.ceph.com/issues/45629

Signed-off-by: Ricardo Marques <rimarques@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
