### PR TITLE
mgr/dashboard: Fix redirect after changing password

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -300,8 +300,7 @@ const routes: Routes = [
         path: 'login-change-password',
         component: LoginPasswordFormComponent,
         canActivate: [NoSsoGuardService]
-      },
-      { path: 'logout', children: [] }
+      }
     ]
   },
   {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.spec.ts
@@ -79,6 +79,6 @@ describe('UserPasswordFormComponent', () => {
     });
     request.flush({});
     expect(component.onPasswordChange).toHaveBeenCalled();
-    expect(router.navigate).toHaveBeenCalledWith(['/logout']);
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.ts
@@ -116,10 +116,6 @@ export class UserPasswordFormComponent {
    */
   onPasswordChange() {
     this.notificationService.show(NotificationType.success, this.i18n('Updated user password"'));
-    // Theoretically it is not necessary to navigate to '/logout' because
-    // the auth token gets invalid after changing the password in the
-    // backend, thus the user would be automatically logged out after the
-    // next periodically API request is executed.
-    this.router.navigate(['/logout']);
+    this.router.navigate(['/login']);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.spec.ts
@@ -11,7 +11,7 @@ describe('AuthService', () => {
   let service: AuthService;
   let httpTesting: HttpTestingController;
 
-  const routes: Routes = [{ path: 'logout', children: [] }];
+  const routes: Routes = [{ path: 'login', children: [] }];
 
   configureTestBed({
     providers: [AuthService, AuthStorageService],

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.ts
@@ -41,7 +41,7 @@ export class AuthService {
 
   logout(callback: Function = null) {
     return this.http.post('api/auth/logout', null).subscribe((resp: any) => {
-      this.router.navigate(['/logout'], { skipLocationChange: true });
+      this.router.navigate(['/login'], { skipLocationChange: true });
       this.authStorageService.remove();
       if (callback) {
         callback();


### PR DESCRIPTION
After the changes made to subscriptions, redirecting to the dummy logout page
no longer does anything.

So we removed the logout route and now redirect directly to the login page.

Fixes: https://tracker.ceph.com/issues/45651

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
