### PR TITLE
crimson: bring assert_all to errorator

### DIFF
--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -724,7 +724,7 @@ public:
 
   struct discard_all {
     template <class ErrorT, EnableIf<ErrorT>...>
-    decltype(auto) operator()(ErrorT&&) {
+    void operator()(ErrorT&&) {
       static_assert(contains_once_v<std::decay_t<ErrorT>>,
                     "discarding disallowed ErrorT");
     }
@@ -971,7 +971,7 @@ namespace ct_error {
 
   struct discard_all {
     template <class ErrorT>
-    decltype(auto) operator()(ErrorT&&) {
+    void operator()(ErrorT&&) {
     }
   };
 

--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -8,6 +8,8 @@
 
 #include <seastar/core/future-util.hh>
 
+#include "include/ceph_assert.h"
+
 namespace crimson {
 
 template<typename Iterator, typename AsyncAction>
@@ -728,6 +730,28 @@ public:
     }
   };
 
+  // assert_all{ "TODO" };
+  class assert_all {
+    const char* const msg = nullptr;
+  public:
+    template <std::size_t N>
+    assert_all(const char (&msg)[N])
+      : msg(msg) {
+    }
+    assert_all() = default;
+
+    template <class ErrorT, EnableIf<ErrorT>...>
+    void operator()(ErrorT&&) {
+      static_assert(contains_once_v<std::decay_t<ErrorT>>,
+                    "discarding disallowed ErrorT");
+      if (msg) {
+        ceph_abort(msg);
+      } else {
+        ceph_abort();
+      }
+    }
+  };
+
   template <class ErrorFunc>
   static decltype(auto) all_same_way(ErrorFunc&& error_func) {
     return all_same_way_t<ErrorFunc>{std::forward<ErrorFunc>(error_func)};
@@ -948,6 +972,25 @@ namespace ct_error {
   struct discard_all {
     template <class ErrorT>
     decltype(auto) operator()(ErrorT&&) {
+    }
+  };
+
+  class assert_all {
+    const char* const msg = nullptr;
+  public:
+    template <std::size_t N>
+    assert_all(const char (&msg)[N])
+      : msg(msg) {
+    }
+    assert_all() = default;
+
+    template <class ErrorT>
+    void operator()(ErrorT&&) {
+      if (msg) {
+        ceph_abort(msg);
+      } else {
+        ceph_abort();
+      }
     }
   };
 

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -41,7 +41,7 @@ Journal::initialize_segment_ertr::future<> Journal::initialize_segment(
   written_to = segment_manager.get_block_size();
   return segment.write(0, bl).handle_error(
     init_ertr::pass_further{},
-    crimson::ct_error::all_same_way([] { ceph_assert(0 == "TODO"); }));
+    crimson::ct_error::assert_all{ "TODO" });
 }
 
 ceph::bufferlist Journal::encode_record(
@@ -92,7 +92,7 @@ Journal::write_record_ertr::future<> Journal::write_record(
     rsize.dlength);
   return current_journal_segment->write(target, to_write).handle_error(
     write_record_ertr::pass_further{},
-    crimson::ct_error::all_same_way([] { ceph_assert(0 == "TODO"); }));
+    crimson::ct_error::assert_all{ "TODO" });
 }
 
 Journal::record_size_t Journal::get_encoded_record_length(


### PR DESCRIPTION
`assert_all` has been mentioned during the backfill review. However, it looks there are potential users also in other parts of crimson.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
