### PR TITLE
os/bluestore: Wait for running AIOs to complete if new ops overlap with

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -180,7 +180,7 @@ public:
     return conventional_region_size;
   }
 
-  virtual void aio_submit(IOContext *ioc) = 0;
+  virtual void aio_submit(IOContext *ioc, bool check_if_should_wait) = 0;
 
   void set_no_exclusive_lock() {
     lock_exclusive = false;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9872,7 +9872,7 @@ int BlueStore::_do_read(
   int64_t num_ios = length;
   if (ioc.has_pending_aios()) {
     num_ios = -ioc.get_num_ios();
-    bdev->aio_submit(&ioc);
+    bdev->aio_submit(&ioc, false);
     dout(20) << __func__ << " waiting for aio" << dendl;
     ioc.aio_wait();
     r = ioc.get_return_value();
@@ -10226,7 +10226,7 @@ int BlueStore::_do_readv(
   auto num_ios = m.size();
   if (ioc.has_pending_aios()) {
     num_ios = ioc.get_num_ios();
-    bdev->aio_submit(&ioc);
+    bdev->aio_submit(&ioc, false);
     dout(20) << __func__ << " waiting for aio" << dendl;
     ioc.aio_wait();
     r = ioc.get_return_value();
@@ -12267,7 +12267,7 @@ void BlueStore::_deferred_submit_unlock(OpSequencer *osr)
     ++i;
   }
 
-  bdev->aio_submit(&b->ioc);
+  bdev->aio_submit(&b->ioc, false);
 }
 
 struct C_DeferredTrySubmit : public Context {
@@ -12493,7 +12493,7 @@ int BlueStore::queue_transactions(
 void BlueStore::_txc_aio_submit(TransContext *txc)
 {
   dout(10) << __func__ << " txc " << txc << dendl;
-  bdev->aio_submit(&txc->ioc);
+  bdev->aio_submit(&txc->ioc, false);
 }
 
 void BlueStore::_txc_add_transaction(TransContext *txc, Transaction *t)

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -111,7 +111,7 @@ class KernelDevice : public BlockDevice {
 public:
   KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, aio_callback_t d_cb, void *d_cbpriv);
 
-  void aio_submit(IOContext *ioc) override;
+  void aio_submit(IOContext *ioc, bool check_if_should_wait) override;
   void discard_drain() override;
 
   int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const override;

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -760,7 +760,7 @@ int NVMEDevice::flush()
   return 0;
 }
 
-void NVMEDevice::aio_submit(IOContext *ioc)
+void NVMEDevice::aio_submit(IOContext *ioc, bool /*check_if_should_wait*/)
 {
   dout(20) << __func__ << " ioc " << ioc << " pending "
            << ioc->num_pending.load() << " running "
@@ -887,7 +887,7 @@ int NVMEDevice::write(uint64_t off, bufferlist &bl, bool buffered, int write_hin
   IOContext ioc(cct, NULL);
   write_split(this, off, bl, &ioc);
   dout(5) << __func__ << " " << off << "~" << len << dendl;
-  aio_submit(&ioc);
+  aio_submit(&ioc, false);
   ioc.aio_wait();
   return 0;
 }
@@ -907,7 +907,7 @@ int NVMEDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
   ceph_assert(ioc->nvme_task_last == nullptr);
   make_read_tasks(this, off, ioc, buf, len, &t, off, len);
   dout(5) << __func__ << " " << off << "~" << len << dendl;
-  aio_submit(ioc);
+  aio_submit(ioc, false);
 
   pbl->push_back(std::move(p));
   return t.return_code;
@@ -944,7 +944,7 @@ int NVMEDevice::read_random(uint64_t off, uint64_t len, char *buf, bool buffered
   Task t(this, IOCommand::READ_COMMAND, aligned_off, aligned_len, 1);
 
   make_read_tasks(this, aligned_off, &ioc, buf, aligned_len, &t, off, len);
-  aio_submit(&ioc);
+  aio_submit(&ioc, false);
 
   return t.return_code;
 }

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -55,7 +55,7 @@ class NVMEDevice : public BlockDevice {
 
   bool supported_bdev_label() override { return false; }
 
-  void aio_submit(IOContext *ioc) override;
+  void aio_submit(IOContext *ioc, bool check_if_should_wait) override;
 
   int read(uint64_t off, uint64_t len, bufferlist *pbl,
            IOContext *ioc,

--- a/src/os/bluestore/PMEMDevice.cc
+++ b/src/os/bluestore/PMEMDevice.cc
@@ -171,7 +171,7 @@ int PMEMDevice::flush()
 }
 
 
-void PMEMDevice::aio_submit(IOContext *ioc)
+void PMEMDevice::aio_submit(IOContext *ioc, bool /*check_if_should_wait*/)
 {
   if (ioc->priv) {
     ceph_assert(ioc->num_running == 0);

--- a/src/os/bluestore/PMEMDevice.h
+++ b/src/os/bluestore/PMEMDevice.h
@@ -39,7 +39,7 @@ public:
   PMEMDevice(CephContext *cct, aio_callback_t cb, void *cbpriv);
 
 
-  void aio_submit(IOContext *ioc) override;
+  void aio_submit(IOContext *ioc, bool check_if_should_wait) override;
 
   int collect_metadata(const std::string& prefix, map<std::string,std::string> *pm) const override;
 

--- a/src/test/objectstore/test_bdev.cc
+++ b/src/test/objectstore/test_bdev.cc
@@ -77,7 +77,7 @@ TEST(KernelDevice, Ticket45337) {
   ASSERT_EQ(r, 0);
 
   if (ioc->has_pending_aios()) {
-    b->aio_submit(ioc.get());
+    b->aio_submit(ioc.get(), false);
     ioc->aio_wait();
   }
 


### PR DESCRIPTION
them.

The major candidate for overlapping conflict is code in
BlueFS::_flush_range which zeros preextended WAL.

Fixes: https://tracker.ceph.com/issues/45613
Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
