### PR TITLE
rgwlc: add lifecycle perf counters

### DIFF
--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -473,6 +473,7 @@ public:
     WorkPool* workpool{nullptr};
 
   public:
+
     using lock_guard = std::lock_guard<std::mutex>;
     using unique_lock = std::unique_lock<std::mutex>;
 

--- a/src/rgw/rgw_perf_counters.cc
+++ b/src/rgw/rgw_perf_counters.cc
@@ -35,7 +35,20 @@ int rgw_perf_start(CephContext *cct)
   plb.add_u64_counter(l_rgw_keystone_token_cache_miss, "keystone_token_cache_miss", "Keystone token cache miss");
 
   plb.add_u64_counter(l_rgw_gc_retire, "gc_retire_object", "GC object retires");
-  plb.add_u64_counter(l_rgw_lc_remove_expired, "lc_remove_expired", "LC removed objects");
+
+  plb.add_u64_counter(l_rgw_lc_expire_current, "lc_expire_current",
+		      "Lifecycle current expiration");
+  plb.add_u64_counter(l_rgw_lc_expire_noncurrent, "lc_expire_noncurrent",
+		      "Lifecycle non-current expiration");
+  plb.add_u64_counter(l_rgw_lc_expire_dm, "lc_expire_dm",
+		      "Lifecycle delete-marker expiration");
+  plb.add_u64_counter(l_rgw_lc_transition_current, "lc_transition_current",
+		      "Lifecycle current transition");
+  plb.add_u64_counter(l_rgw_lc_transition_noncurrent,
+		      "lc_transition_noncurrent",
+		      "Lifecycle non-current transition");
+  plb.add_u64_counter(l_rgw_lc_abort_mpu, "lc_abort_mpu",
+		      "Lifecycle abort multipart upload");
 
   plb.add_u64_counter(l_rgw_pubsub_event_triggered, "pubsub_event_triggered", "Pubsub events with at least one topic");
   plb.add_u64_counter(l_rgw_pubsub_event_lost, "pubsub_event_lost", "Pubsub events lost");

--- a/src/rgw/rgw_perf_counters.h
+++ b/src/rgw/rgw_perf_counters.h
@@ -32,7 +32,13 @@ enum {
   l_rgw_keystone_token_cache_miss,
 
   l_rgw_gc_retire,
-  l_rgw_lc_remove_expired,
+
+  l_rgw_lc_expire_current,
+  l_rgw_lc_expire_noncurrent,
+  l_rgw_lc_expire_dm,
+  l_rgw_lc_transition_current,
+  l_rgw_lc_transition_noncurrent,
+  l_rgw_lc_abort_mpu,
 
   l_rgw_pubsub_event_triggered,
   l_rgw_pubsub_event_lost,


### PR DESCRIPTION
Historically, RGW lifecycle processing has not provided perfcounters.
A single expire counter was added in recent parallel lifecycle changes,
but granular counters for

    current expiration
    non-current expiration
    delete-marker expiration
    current transition
    non-current transition
    mpu aborts

are arguably much more useful, and can be summed in reports.

Fixes: https://tracker.ceph.com/issues/45667

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
