### PR TITLE
tools/cephfs/MetaTool: print buffer::error::what()

### DIFF
--- a/src/tools/cephfs/MetaTool.cc
+++ b/src/tools/cephfs/MetaTool.cc
@@ -392,7 +392,8 @@ int MetaTool::show_fn(meta_op &op){
     }
     return 0;
 }
-int MetaTool::_show_fn(inode_meta_t& inode_meta, const string& fn){
+int MetaTool::_show_fn(inode_meta_t& inode_meta, const string& fn)
+{
     std::list<frag_t> frags;
     inode_meta.get_meta()->dirfragtree.get_leaves(frags);
     std::stringstream ds;
@@ -414,12 +415,12 @@ int MetaTool::_show_fn(inode_meta_t& inode_meta, const string& fn){
             try {
                 auto p = hbl.cbegin();
                 ::decode(got_fnode, p);
-            }catch (const buffer::error &err){
+            } catch (const buffer::error &err) {
                 cerr << "corrupt fnode header in " << oid
-                     << ": " << err << std::endl;
+                     << ": " << err.what() << std::endl;
                 return -1;
             }
-            if (oids.size() != 0)
+            if (!oids.empty())
                 oids += ",";
             oids += oid;
             f->open_object_section(oid.c_str());


### PR DESCRIPTION
* buffer::error does not offer operator<<(ostream&, const
  buffer::error&). so in this change, err.what() is used instead.
* also add spaces to follow our coding style convention.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
