### PR TITLE
doc: replacing https://ceph.com/ by http://download.ceph.com/

### DIFF
--- a/doc/install/ceph-deploy/quick-start-preflight.rst
+++ b/doc/install/ceph-deploy/quick-start-preflight.rst
@@ -37,7 +37,7 @@ For Debian and Ubuntu distributions, perform the following steps:
 	sudo apt update
 	sudo apt install ceph-deploy
 
-.. note:: You can also use the EU mirror eu.ceph.com for downloading your packages by replacing ``https://ceph.com/`` by ``http://eu.ceph.com/``
+.. note:: You can also use the EU mirror eu.ceph.com for downloading your packages by replacing ``https://download.ceph.com/`` by ``http://eu.ceph.com/``
 
 
 RHEL/CentOS
@@ -80,7 +80,7 @@ For CentOS 7, perform the following steps:
 	sudo yum update
 	sudo yum install ceph-deploy
 
-.. note:: You can also use the EU mirror eu.ceph.com for downloading your packages by replacing ``https://ceph.com/`` by ``http://eu.ceph.com/``
+.. note:: You can also use the EU mirror eu.ceph.com for downloading your packages by replacing ``https://download.ceph.com/`` by ``http://eu.ceph.com/``
 
 
 openSUSE


### PR DESCRIPTION
The mirror downloading ceph packages is http://download.ceph.com/, not https://ceph.com/, and https://ceph.com/ is the Ceph Homepage.
Signed-off-by: Shengming Zhang <zhangsm01@inspur.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
