### PR TITLE
cephfs: Fix error printing from buffer::error

### DIFF
--- a/src/tools/cephfs/MetaTool.cc
+++ b/src/tools/cephfs/MetaTool.cc
@@ -416,7 +416,7 @@ int MetaTool::_show_fn(inode_meta_t& inode_meta, const string& fn){
                 ::decode(got_fnode, p);
             }catch (const buffer::error &err){
                 cerr << "corrupt fnode header in " << oid
-                     << ": " << err << std::endl;
+                     << ": " << err.what() << std::endl;
                 return -1;
             }
             if (oids.size() != 0)


### PR DESCRIPTION
Clang complains:
/home/jenkins/workspace/ceph-master/src/tools/cephfs/MetaTool.cc:419:30: error: invalid operands to binary expression ('basic_ostream<char, std::__1::char_traits<char> >' and 'buffer::error')
                     << ": " << err << std::endl;
                     ~~~~~~~ ^  ~~~
/usr/include/c++/v1/ostream:219:20: note: candidate function not viable: no known conversion from 'buffer::error' to 'const void *' for 1st argument; take the address of the argument with &
    basic_ostream& operator<<(const void* __p);
                   ^
/usr/include/c++/v1/type_traits:4843:3: note: candidate function template not viable: no known conversion from 'basic_ostream<char, std::__1::char_traits<char> >' to 'std::byte' for 1st argument
  operator<< (byte  __lhs, _Integer __shift) noexcept
  ^

Tracker: https://tracker.ceph.com/issues/45669
fixes: https://github.com/ceph/ceph/pull/34755



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>