### PR TITLE
nautilus: mgr/insights: fix prune-health-history

### DIFF
--- a/src/pybind/mgr/insights/module.py
+++ b/src/pybind/mgr/insights/module.py
@@ -130,6 +130,8 @@ class Module(MgrModule):
         for key in self._health_filter(lambda ts: ts <= cutoff):
             self.log.info("Removing old health slot key {}".format(key))
             self.set_store(key, None)
+        if not hours:
+            self._health_slot = health_util.HealthHistorySlot()
 
     def _health_report(self, hours):
         """


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43990

---

backport of https://github.com/ceph/ceph/pull/32973
parent tracker: https://tracker.ceph.com/issues/43886

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh