### PR TITLE
[WIP] nautilus: mgr/dashboard: Access control database does not restore disabled users correctly

### DIFF
--- a/qa/tasks/mgr/dashboard/test_user.py
+++ b/qa/tasks/mgr/dashboard/test_user.py
@@ -59,6 +59,34 @@ class UserTest(DashboardTestCase):
         self._delete('/api/user/user1')
         self.assertStatus(204)
 
+    def test_crd_disabled_user(self):
+        self._create_user(username='klara',
+                          password='123456789',
+                          name='Klara Musterfrau',
+                          email='klara@musterfrau.com',
+                          roles=['administrator'],
+                          enabled=False)
+        self.assertStatus(201)
+        user = self.jsonBody()
+
+        # Restart dashboard module.
+        self._unload_module('dashboard')
+        self._load_module('dashboard')
+
+        self._get('/api/user/klara')
+        self.assertStatus(200)
+        self.assertJsonBody({
+            'username': 'klara',
+            'name': 'Klara Musterfrau',
+            'email': 'klara@musterfrau.com',
+            'roles': ['administrator'],
+            'lastUpdate': user['lastUpdate'],
+            'enabled': False
+        })
+
+        self._delete('/api/user/klara')
+        self.assertStatus(204)
+
     def test_list_users(self):
         self._get('/api/user')
         self.assertStatus(200)

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -170,11 +170,12 @@ SYSTEM_ROLES = {
 
 class User(object):
     def __init__(self, username, password, name=None, email=None, roles=None,
-                 lastUpdate=None):
+                 lastUpdate=None, enabled=None):
         self.username = username
         self.password = password
         self.name = name
         self.email = email
+        self.enabled = enabled
         if roles is None:
             self.roles = set()
         else:
@@ -231,14 +232,15 @@ class User(object):
             'roles': sorted([r.name for r in self.roles]),
             'name': self.name,
             'email': self.email,
-            'lastUpdate': self.lastUpdate
+            'lastUpdate': self.lastUpdate,
+            'enabled': self.enabled
         }
 
     @classmethod
     def from_dict(cls, u_dict, roles):
         return User(u_dict['username'], u_dict['password'], u_dict['name'],
                     u_dict['email'], {roles[r] for r in u_dict['roles']},
-                    u_dict['lastUpdate'])
+                    u_dict['lastUpdate'], u_dict['enabled'])
 
 
 class AccessControlDB(object):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41598

---

backport of https://github.com/ceph/ceph/pull/29614
parent tracker: https://tracker.ceph.com/issues/41205

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh