### PR TITLE
cephadm: add --registry-{password,username} options

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -62,6 +62,7 @@ except ImportError:
     pass
 import uuid
 
+from contextlib import contextmanager
 from functools import wraps
 from glob import glob
 from threading import Thread
@@ -1154,6 +1155,21 @@ def default_image(func):
 
     return _default_image
 
+@contextmanager
+def container_registry_credentials(args):
+    if getattr(container_registry_credentials, 'do_login', True):
+        username = args.registry_username
+        password = args.registry_password
+        if username and password:
+            out, err, code = call([container_path, 'login',
+                                   '-u', username,
+                                   '-p', password])
+            if code != 0:
+                logger.warning('unable to login: %s', err)
+        # don't try again even if we fail to login
+        container_registry_credentials.do_login = False
+    yield
+
 def get_last_local_ceph_image():
     """
     :return: The most recent local ceph image (already pulled)
@@ -2179,9 +2195,10 @@ class CephContainer:
     def run(self, timeout=DEFAULT_TIMEOUT):
         # type: (Optional[int]) -> str
         logger.debug(self.run_cmd())
-        out, _, _ = call_throws(
+        with container_registry_credentials(args):
+            out, _, _ = call_throws(
                 self.run_cmd(), desc=self.entrypoint, timeout=timeout)
-        return out
+            return out
 
 ##################################
 
@@ -2198,7 +2215,8 @@ def command_version():
 def command_pull():
     # type: () -> int
     logger.info('Pulling latest %s...' % args.image)
-    call_throws([container_path, 'pull', args.image])
+    with container_registry_credentials(args):
+        call_throws([container_path, 'pull', args.image])
     return command_inspect_image()
 
 ##################################
@@ -2330,7 +2348,8 @@ def command_bootstrap():
 
     if not args.skip_pull:
         logger.info('Pulling latest %s container...' % args.image)
-        call_throws([container_path, 'pull', args.image])
+        with container_registry_credentials(args):
+            call_throws([container_path, 'pull', args.image])
 
     logger.info('Extracting ceph user uid/gid from container image...')
     (uid, gid) = extract_uid_gid()
@@ -3139,7 +3158,8 @@ def command_adopt():
 
     if not args.skip_pull:
         logger.info('Pulling latest %s container...' % args.image)
-        call_throws([container_path, 'pull', args.image])
+        with container_registry_credentials(args):
+            call_throws([container_path, 'pull', args.image])
 
     (daemon_type, daemon_id) = args.name.split('.', 1)
 
@@ -4210,6 +4230,12 @@ def _get_parser():
         action='append',
         default=[],
         help='set environment variable')
+    parser.add_argument(
+        '--registry-password',
+        help='password for container registry server')
+    parser.add_argument(
+        '--registry-username',
+        help='username for container registry server')
 
     subparsers = parser.add_subparsers(help='sub-command')
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2,8 +2,9 @@ import json
 import errno
 import logging
 import time
-from threading import Event
 from functools import wraps
+from tempfile import TemporaryDirectory
+from threading import Event
 
 import string
 from typing import List, Dict, Optional, Callable, Tuple, TypeVar, Type, \
@@ -70,27 +71,6 @@ DATEFMT = '%Y-%m-%dT%H:%M:%S.%f'
 CEPH_DATEFMT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 CEPH_TYPES = set(CEPH_UPGRADE_ORDER)
-
-
-# for py2 compat
-try:
-    from tempfile import TemporaryDirectory # py3
-except ImportError:
-    # define a minimal (but sufficient) equivalent for <= py 3.2
-    class TemporaryDirectory(object): # type: ignore
-        def __init__(self):
-            self.name = tempfile.mkdtemp()
-
-        def __enter__(self):
-            if not self.name:
-                self.name = tempfile.mkdtemp()
-            return self.name
-
-        def cleanup(self):
-            shutil.rmtree(self.name)
-
-        def __exit__(self, exc_type, exc_value, traceback):
-            self.cleanup()
 
 
 def forall_hosts(f: Callable[..., T]) -> Callable[..., List[T]]:


### PR DESCRIPTION
allow user to log into container registry with the specified
credentials. this helps user to address the issue if the registry is
protected by authentication machinary.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
