### PR TITLE
luminous: osd: too many store transactions when osd got an incremental osdmap but failed encode full with correct crc again and again

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8392,6 +8392,12 @@ void OSD::handle_osd_map(MOSDMap *m)
     assert(0 == "MOSDMap lied about what maps it had?");
   }
 
+  if (start > last) {
+  	dout(10) << "handle_osd_map  crc err, no transaction" << dendl;
+  	m->put();
+	return;
+  }
+
   // even if this map isn't from a mon, we may have satisfied our subscription
   monc->sub_got("osdmap", last);
 


### PR DESCRIPTION
Suppose osd got an message containing only one incremental osdmap(epoch 123), but failed to encode full with correct crc due to osdmap data structure change from an old code version to a new version during online upgrading.
1. In this case, we should go through osdmap epoch from start=123 to last=123, but crc err occured, and last epoch changed to 122(last = e - 1), we quit the osdmap epoch loop in func handle_osd_map in OSD.cc
2. However, store transaction will be delivered as normal even osd did not get any correct osdmap.
3. For a cluster big enough, too many crc err inc osdmap messages will lead to too many store transactions, and lead to too many callback func _committed_osd_maps invoked.
4. In func _committed_osd_maps when we consume_map, we need to iterate over all pgs. So we need to get pg_lock again and again.
5. this will lead to slow osdmap update, peering stuck, io timeout, etc.
So skip store transactions to avoid this case as we don't get any correct osdmap at all.
fixbug: https://tracker.ceph.com/issues/45670

Signed-off-by: eugeneswan <45633237+eugeneswan@users.noreply.github.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
