### PR TITLE
osd: make "missing incremental map" a debug log message

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1436,7 +1436,7 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
     if (get_inc_map_bl(e, bl)) {
       m->incremental_maps[e].claim(bl);
     } else {
-      derr << __func__ << " missing incremental map " << e << dendl;
+      dout(10) << __func__ << " missing incremental map " << e << dendl;
       if (!get_map_bl(e, bl)) {
 	derr << __func__ << " also missing full map " << e << dendl;
 	goto panic;


### PR DESCRIPTION
47a3f63ef71522d6b9572e81674598dd3e19df9d introduced the following error
message

    build_incremental_map_msg missing incremental map 33087

The message causes users to be concerned, yet it does not require action
on their part.

Fixes: https://tracker.ceph.com/issues/45606
Signed-off-by: Nathan Cutler <ncutler@suse.com>
