### PR TITLE
doc/releases: list archived releases in correct order

### DIFF
--- a/doc/releases/archived-index.rst
+++ b/doc/releases/archived-index.rst
@@ -6,8 +6,8 @@ Archived Releases
    :maxdepth: 1
 
    Luminous <luminous>
-   Jewel <jewel>
    Kraken <kraken>
+   Jewel <jewel>
    Infernalis <infernalis>
    Hammer <hammer>
    Giant <giant>


### PR DESCRIPTION
Somehow the archived releases list got out of order.

Signed-off-by: Nathan Cutler <ncutler@suse.com>
