### PR TITLE
RGW: Alias ES permissions to permissions.keyword

### DIFF
--- a/src/rgw/rgw_es_main.cc
+++ b/src/rgw/rgw_es_main.cc
@@ -39,6 +39,7 @@ int main(int argc, char *argv[])
                                   { "mtime", "meta.mtime" },
                                   { "lastmodified", "meta.mtime" },
                                   { "contenttype", "meta.contenttype" },
+                                  { "permissions", "permissions.keyword" },
   };
   es_query.set_field_aliases(&aliases);
 
@@ -48,7 +49,8 @@ int main(int argc, char *argv[])
                                                            {"meta.etag", ESEntityTypeMap::ES_ENTITY_STR},
                                                            {"meta.contenttype", ESEntityTypeMap::ES_ENTITY_STR},
                                                            {"meta.mtime", ESEntityTypeMap::ES_ENTITY_DATE},
-                                                           {"meta.size", ESEntityTypeMap::ES_ENTITY_INT} };
+                                                           {"meta.size", ESEntityTypeMap::ES_ENTITY_INT},
+                                                           {"permissions.keyword", ESEntityTypeMap::ES_ENTITY_STR} };
   ESEntityTypeMap gm(generic_map);
   es_query.set_generic_type_map(&gm);
 


### PR DESCRIPTION
When `rgw_keystone_implicit_tenants = true` and using the Elasticsearch
sync module the search module when searching for `permissions` don't
work for buckets.

With `rgw_keystone_implicit_tenants` enabled buckets are stored as
`PROJECT_ID$BUCKET_NAME`. And when using permissions it splits by the
'$' and treats the bucket name as 2 word.

If we change permissions to permissions.keyword, then it'll be treated
as a single word.

This patch adds and alias for permissions to map to permissions.keyword.

Before the patch:

  $ radosgw-es 'permissions == projectname$bucketname'
  {"query":{"term":{"permissions":"projectname$bucketname"}}}

afterwards:

  $ radosgw-es 'permissions == projectname$bucketname'
  {"query":{"term":{"permissions.keyword":"projectname$bucketname"}}}

Fixes: https://tracker.ceph.com/issues/45607
Signed-off-by: Matthew Oliver <moliver@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
