### PR TITLE
qa/tasks/tox: use python3 for tox tests

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/barbican.yaml
+++ b/qa/suites/rgw/crypt/2-kms/barbican.yaml
@@ -17,13 +17,7 @@ tasks:
     client.0:
       sha1: 17.0.0.0rc2
       force-branch: master
-      domains:
-        - name: default
-          description: Default Domain
       projects:
-        - name: admin
-          description:  Admin Tenant
-          domain: default
         - name: rgwcrypt
           description: Encryption Tenant
           domain: default
@@ -34,10 +28,6 @@ tasks:
           description: S3 project
           domain: default
       users:
-        - name: admin
-          password: ADMIN
-          project: admin
-          domain: default
         - name: rgwcrypt-user
           password: rgwcrypt-pass
           project: rgwcrypt
@@ -50,11 +40,8 @@ tasks:
           password: s3-pass
           project: s3
           domain: default
-      roles: [ name: admin, name: Member, name: creator ]
+      roles: [ name: Member, name: creator ]
       role-mappings:
-        - name: admin
-          user: admin
-          project: admin
         - name: Member
           user: rgwcrypt-user
           project: rgwcrypt
@@ -65,9 +52,6 @@ tasks:
           user: s3-user
           project: s3
       services:
-        - name: keystone
-          type: identity
-          description: Keystone Identity Service
         - name: swift
           type: object-store
           description: Swift Service

--- a/qa/suites/rgw/crypt/2-kms/barbican.yaml
+++ b/qa/suites/rgw/crypt/2-kms/barbican.yaml
@@ -3,9 +3,21 @@ overrides:
     conf:
       client:
         rgw crypt s3 kms backend: barbican
-        rgw keystone barbican tenant: rgwcrypt
+        rgw keystone barbican project: rgwcrypt
         rgw keystone barbican user: rgwcrypt-user
         rgw keystone barbican password: rgwcrypt-pass
+        rgw keystone barbican domain: Default
+        rgw keystone api version: 3
+        rgw keystone accepted roles: admin,Member,creator
+        rgw keystone implicit tenants: true
+        rgw keystone accepted admin roles: admin
+        rgw swift enforce content length: true
+        rgw swift account in url: true
+        rgw swift versioning enabled: true
+        rgw keystone admin project: admin
+        rgw keystone admin user: admin
+        rgw keystone admin password: ADMIN
+        rgw keystone admin domain: Default
   rgw:
     client.0:
       use-keystone-role: client.0

--- a/qa/suites/rgw/crypt/2-kms/barbican.yaml
+++ b/qa/suites/rgw/crypt/2-kms/barbican.yaml
@@ -15,30 +15,41 @@ tasks:
 - tox: [ client.0 ]
 - keystone:
     client.0:
-      sha1: 12.0.0.0b2
+      sha1: 17.0.0.0rc2
       force-branch: master
-      tenants:
+      domains:
+        - name: default
+          description: Default Domain
+      projects:
         - name: admin
           description:  Admin Tenant
+          domain: default
         - name: rgwcrypt
           description: Encryption Tenant
+          domain: default
         - name: barbican
           description: Barbican
+          domain: default
         - name: s3
           description: S3 project
+          domain: default
       users:
         - name: admin
           password: ADMIN
           project: admin
+          domain: default
         - name: rgwcrypt-user
           password: rgwcrypt-pass
           project: rgwcrypt
+          domain: default
         - name: barbican-user
           password: barbican-pass
           project: barbican
+          domain: default
         - name: s3-user
           password: s3-pass
           project: s3
+          domain: default
       roles: [ name: admin, name: Member, name: creator ]
       role-mappings:
         - name: admin

--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -38,17 +38,16 @@ tasks:
         reseller_admin_role: admin
       object-storage-feature-enabled:
         container_sync: false
-        discoverability: false
+        discoverability: true
       blacklist:
-        # TODO(rzarzynski): we really need to update the list after
-        # merging PRs #15369 and #12704. Additionally, we would be
-        # able to enable the discoverability API testing above.
-        - .*test_list_containers_reverse_order.*
-        - .*test_list_container_contents_with_end_marker.*
-        - .*test_delete_non_empty_container.*
+        - .*test_account_quotas_negative.AccountQuotasNegativeTest.test_user_modify_quota
+        - .*test_container_acl_negative.ObjectACLsNegativeTest.*
+        - .*test_container_services_negative.ContainerNegativeTest.test_create_container_metadata_.*
+        - .*test_container_staticweb.StaticWebTest.test_web_index
+        - .*test_container_staticweb.StaticWebTest.test_web_listing_css
         - .*test_container_synchronization.*
-        - .*test_get_object_after_expiration_time.*
-        - .*test_create_object_with_transfer_encoding.*
+        - .*test_object_services.PublicObjectTest.test_access_public_container_object_without_using_creds
+
 overrides:
   ceph:
     conf:

--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -28,6 +28,7 @@ tasks:
         admin_project_name: admin
         admin_password: ADMIN
         admin_domain_name: Default
+        tempest_roles: admin
       identity:
         uri: http://{keystone_public_host}:{keystone_public_port}/v2.0/
         uri_v3: http://{keystone_public_host}:{keystone_public_port}/v3/
@@ -56,10 +57,13 @@ overrides:
         osd_max_pg_log_entries: 10
       client:
         rgw keystone api version: 3
-        rgw keystone admin token: ADMIN
         rgw keystone accepted roles: admin,Member
         rgw keystone implicit tenants: true
         rgw keystone accepted admin roles: admin
         rgw swift enforce content length: true
         rgw swift account in url: true
         rgw swift versioning enabled: true
+        rgw keystone admin domain: Default
+        rgw keystone admin user: admin
+        rgw keystone admin password: ADMIN
+        rgw keystone admin project: admin

--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -10,27 +10,7 @@ tasks:
     client.0:
       sha1: 17.0.0.0rc2
       force-branch: master
-      domains:
-        - name: default
-          description: Default Domain
-      projects:
-        - name: admin
-          description:  Admin Tenant
-          domain: default
-      users:
-        - name: admin
-          password: ADMIN
-          project: admin
-          domain: default
-      roles: [ name: admin, name: Member ]
-      role-mappings:
-        - name: admin
-          user: admin
-          project: admin
       services:
-        - name: keystone
-          type: identity
-          description: Keystone Identity Service
         - name: swift
           type: object-store
           description: Swift Service
@@ -53,7 +33,7 @@ tasks:
         uri_v3: http://{keystone_public_host}:{keystone_public_port}/v3/
         auth_version: v3
         admin_role: admin
-        default_domain_name: default
+        default_domain_name: Default
       object-storage:
         reseller_admin_role: admin
       object-storage-feature-enabled:

--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -40,7 +40,7 @@ tasks:
       use-keystone-role: client.0
 - tempest:
     client.0:
-      sha1: d3fa46495a78160989120ba39793f7ba2e22d81c
+      sha1: d43223773d75d2e82fb33a1281038e611c41d0f3
       force-branch: master
       use-keystone-role: client.0
       auth:

--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -8,15 +8,20 @@ tasks:
 - tox: [ client.0 ]
 - keystone:
     client.0:
-      sha1: 12.0.0.0b2
+      sha1: 17.0.0.0rc2
       force-branch: master
-      tenants:
+      domains:
+        - name: default
+          description: Default Domain
+      projects:
         - name: admin
           description:  Admin Tenant
+          domain: default
       users:
         - name: admin
           password: ADMIN
           project: admin
+          domain: default
       roles: [ name: admin, name: Member ]
       role-mappings:
         - name: admin
@@ -46,7 +51,9 @@ tasks:
       identity:
         uri: http://{keystone_public_host}:{keystone_public_port}/v2.0/
         uri_v3: http://{keystone_public_host}:{keystone_public_port}/v3/
+        auth_version: v3
         admin_role: admin
+        default_domain_name: default
       object-storage:
         reseller_admin_role: admin
       object-storage-feature-enabled:
@@ -69,6 +76,7 @@ overrides:
         osd_min_pg_log_entries: 10
         osd_max_pg_log_entries: 10
       client:
+        rgw keystone api version: 3
         rgw keystone admin token: ADMIN
         rgw keystone accepted roles: admin,Member
         rgw keystone implicit tenants: true

--- a/qa/tasks/barbican.py
+++ b/qa/tasks/barbican.py
@@ -254,27 +254,35 @@ def create_secrets(ctx, config):
     token_req = http_client.HTTPConnection(keystone_host, keystone_port, timeout=30)
     token_req.request(
         'POST',
-        '/v2.0/tokens',
+        '/v3/auth/tokens',
         headers={'Content-Type':'application/json'},
-        body=json.dumps(
-            {"auth":
-             {"passwordCredentials":
-              {"username": rgw_user["username"],
-               "password": rgw_user["password"]
-              },
-              "tenantName": rgw_user["tenantName"]
-             }
+        body=json.dumps({
+            "auth": {
+                "identity": {
+                    "methods": ["password"],
+                    "password": {
+                        "user": {
+                            "domain": {"id": "default"},
+                            "name": rgw_user["username"],
+                            "password": rgw_user["password"]
+                        }
+                    }
+                },
+                "scope": {
+                    "project": {
+                        "domain": {"id": "default"},
+                        "name": rgw_user["tenantName"]
+                    }
+                }
             }
-        )
-    )
+        }))
     rgw_access_user_resp = token_req.getresponse()
     if not (rgw_access_user_resp.status >= 200 and
             rgw_access_user_resp.status < 300):
         raise Exception("Cannot authenticate user "+rgw_user["username"]+" for secret creation")
     #    baru_resp = json.loads(baru_req.data)
     rgw_access_user_data = json.loads(six.ensure_str(rgw_access_user_resp.read()))
-    rgw_user_id = rgw_access_user_data['access']['user']['id']
-
+    rgw_user_id = rgw_access_user_data['token']['user']['id']
     if 'secrets' in cconfig:
         for secret in cconfig['secrets']:
             if 'name' not in secret:
@@ -291,27 +299,34 @@ def create_secrets(ctx, config):
             token_req = http_client.HTTPConnection(keystone_host, keystone_port, timeout=30)
             token_req.request(
                 'POST',
-                '/v2.0/tokens',
+                '/v3/auth/tokens',
                 headers={'Content-Type':'application/json'},
-                body=json.dumps(
-                    {
-                        "auth": {
-                            "passwordCredentials": {
-                                "username": secret["username"],
-                                "password": secret["password"]
-                            },
-                            "tenantName":secret["tenantName"]
+                body=json.dumps({
+                    "auth": {
+                        "identity": {
+                            "methods": ["password"],
+                            "password": {
+                                "user": {
+                                    "domain": {"id": "default"},
+                                    "name": secret["username"],
+                                    "password": secret["password"]
+                                }
+                            }
+                        },
+                        "scope": {
+                            "project": {
+                                "domain": {"id": "default"},
+                                "name": secret["tenantName"]
+                            }
                         }
                     }
-                )
-            )
+                }))
             token_resp = token_req.getresponse()
             if not (token_resp.status >= 200 and
                     token_resp.status < 300):
                 raise Exception("Cannot authenticate user "+secret["username"]+" for secret creation")
 
-            token_data = json.loads(six.ensure_str(token_resp.read()))
-            token_id = token_data['access']['token']['id']
+            token_id = token_resp.getheader('x-subject-token')
 
             key1_json = json.dumps(
                 {

--- a/qa/tasks/barbican.py
+++ b/qa/tasks/barbican.py
@@ -396,12 +396,7 @@ def task(ctx, config):
           client.0:
             sha1: 17.0.0.0rc2
             force-branch: master
-            domains:
-              - name: default
-                description: Default Domain
             projects:
-              - name: admin
-                description:  Admin Tenant
               - name: rgwcrypt
                 description: Encryption Tenant
               - name: barbican
@@ -409,9 +404,6 @@ def task(ctx, config):
               - name: s3
                 description: S3 project
             users:
-              - name: admin
-                password: ADMIN
-                project: admin
               - name: rgwcrypt-user
                 password: rgwcrypt-pass
                 project: rgwcrypt
@@ -421,11 +413,8 @@ def task(ctx, config):
               - name: s3-user
                 password: s3-pass
                 project: s3
-            roles: [ name: admin, name: Member, name: creator ]
+            roles: [ name: Member, name: creator ]
             role-mappings:
-              - name: admin
-                user: admin
-                project: admin
               - name: Member
                 user: rgwcrypt-user
                 project: rgwcrypt

--- a/qa/tasks/barbican.py
+++ b/qa/tasks/barbican.py
@@ -394,9 +394,12 @@ def task(ctx, config):
       - tox: [ client.0 ]
       - keystone:
           client.0:
-            sha1: 12.0.0.0b2
+            sha1: 17.0.0.0rc2
             force-branch: master
-            tenants:
+            domains:
+              - name: default
+                description: Default Domain
+            projects:
               - name: admin
                 description:  Admin Tenant
               - name: rgwcrypt

--- a/qa/tasks/keystone.py
+++ b/qa/tasks/keystone.py
@@ -172,12 +172,6 @@ def configure_instance(ctx, config):
         run_in_keystone_dir(ctx, client,
             [
                 'sed',
-                '-e', 's/#admin_token =.*/admin_token = ADMIN/',
-                '-i', 'etc/keystone.conf'
-            ])
-        run_in_keystone_dir(ctx, client,
-            [
-                'sed',
                 '-e', 's^#key_repository =.*^key_repository = {kr}^'.format(kr = keyrepo_dir),
                 '-i', 'etc/keystone.conf'
             ])
@@ -294,10 +288,14 @@ def run_section_cmds(ctx, cclient, section_cmd, specials,
     admin_host, admin_port = ctx.keystone.admin_endpoints[cclient]
 
     auth_section = [
-        ( 'os-token', 'ADMIN' ),
+        ( 'os-username', 'admin' ),
+        ( 'os-password', 'ADMIN' ),
+        ( 'os-user-domain-id', 'default' ),
+        ( 'os-project-name', 'admin' ),
+        ( 'os-project-domain-id', 'default' ),
         ( 'os-identity-api-version', '3' ),
-        ( 'os-url', 'http://{host}:{port}/v3'.format(host=admin_host,
-                                                       port=admin_port) ),
+        ( 'os-auth-url', 'http://{host}:{port}/v3'.format(host=admin_host,
+                                                          port=admin_port) ),
     ]
 
     for section_item in section_config_list:

--- a/qa/tasks/keystone.py
+++ b/qa/tasks/keystone.py
@@ -140,9 +140,7 @@ def setup_venv(ctx, config):
             ])
 
         run_in_keystone_venv(ctx, client,
-            [   'pip', 'install', 'python-openstackclient<=3.19.0',
-                '-r', 'requirements.txt'
-            ])
+            [   'pip', 'install', 'python-openstackclient'])
     try:
         yield
     finally:

--- a/qa/tasks/tempest.py
+++ b/qa/tasks/tempest.py
@@ -159,10 +159,8 @@ def run_tempest(ctx, config):
                 get_tempest_dir(ctx) + '/workspace.yaml',
                 '--workspace',
                 'rgw',
-                '--regex',
-                    '(tempest.api.object_storage)' +
-                    ''.join([ '(?!{blackitem})'.format(blackitem=blackitem)
-                        for blackitem in blacklist])
+                '--regex', '^tempest.api.object_storage',
+                '--black-regex', '|'.join(blacklist)
             ])
     try:
         yield

--- a/qa/tasks/tempest.py
+++ b/qa/tasks/tempest.py
@@ -181,13 +181,17 @@ def task(ctx, config):
         ceph:
           conf:
             client:
-              rgw keystone admin token: ADMIN
+              rgw keystone api version: 3
               rgw keystone accepted roles: admin,Member
               rgw keystone implicit tenants: true
               rgw keystone accepted admin roles: admin
               rgw swift enforce content length: true
               rgw swift account in url: true
               rgw swift versioning enabled: true
+              rgw keystone admin domain: Default
+              rgw keystone admin user: admin
+              rgw keystone admin password: ADMIN
+              rgw keystone admin project: admin
       tasks:
       # typically, the task should be preceded with install, ceph, tox,
       # keystone and rgw. Tox and Keystone are specific requirements

--- a/qa/tasks/tempest.py
+++ b/qa/tasks/tempest.py
@@ -60,15 +60,6 @@ def download(ctx, config):
         sha1 = cconf.get('sha1')
         if sha1 is not None:
             run_in_tempest_dir(ctx, client, [ 'git', 'reset', '--hard', sha1 ])
-
-        # tox.ini contains a dead link, replace it with the new one
-        from_url = 'https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt'
-        to_url = 'https://opendev.org/openstack/requirements/raw/branch/stable/pike/upper-constraints.txt'
-        run_in_tempest_dir(ctx, client, [
-                'sed', '-i',
-                run.Raw('"s|{}|{}|"'.format(from_url, to_url)),
-                'tox.ini'
-            ])
     try:
         yield
     finally:

--- a/qa/tasks/tox.py
+++ b/qa/tasks/tox.py
@@ -31,7 +31,7 @@ def task(ctx, config):
         # yup, we have to deploy tox first. The packaged one, available
 	# on Sepia's Ubuntu machines, is outdated for Keystone/Tempest.
         tvdir = get_toxvenv_dir(ctx)
-        ctx.cluster.only(client).run(args=[ 'virtualenv', tvdir ])
+        ctx.cluster.only(client).run(args=[ 'virtualenv', '-p', 'python3', tvdir ])
         ctx.cluster.only(client).run(args=
             [   'source', '{tvdir}/bin/activate'.format(tvdir=tvdir),
                 run.Raw('&&'),

--- a/qa/tasks/tox.py
+++ b/qa/tasks/tox.py
@@ -35,7 +35,7 @@ def task(ctx, config):
         ctx.cluster.only(client).run(args=
             [   'source', '{tvdir}/bin/activate'.format(tvdir=tvdir),
                 run.Raw('&&'),
-                'pip', 'install', 'tox==2.3.1'
+                'pip', 'install', 'tox==3.15.0'
             ])
 
     # export the path Keystone and Tempest


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- changelog
  - use python3 for testing
  - use newer tox version
  - use newer tempest and keystone versions
  - use `keystone-manage bootstrap` for prefilling
  - use V3 identity APIs
  - use username/password based authentication instead of admin token
  - unpin python-openstackclient
  - update the blacklist of tempest tests
- Fixes https://tracker.ceph.com/issues/45691
- tested at
  - http://pulpito.ceph.com/kchai-2020-05-30_17:46:31-rgw-wip-kefu-testing-2020-05-27-2242-distro-basic-smithi/5105719/
  - http://pulpito.ceph.com/kchai-2020-06-02_01:49:31-rgw-master-distro-basic-smithi/

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
