### PR TITLE
rbd/rwl: correct m_perfcounter access scope

### DIFF
--- a/src/librbd/cache/ReplicatedWriteLog.cc
+++ b/src/librbd/cache/ReplicatedWriteLog.cc
@@ -2385,6 +2385,9 @@ void ReplicatedWriteLog<I>::new_sync_point(DeferredContexts &later) {
    * nullptr, but m_current_sync_gen may not be zero. */
   if (old_sync_point) {
     new_sync_point->setup_earlier_sync_point(old_sync_point, m_last_op_sequence_num);
+    m_perfcounter->hinc(l_librbd_rwl_syncpoint_hist,
+                        old_sync_point->log_entry->writes,
+                        old_sync_point->log_entry->bytes);
     /* This sync point will acquire no more sub-ops. Activation needs
      * to acquire m_lock, so defer to later*/
     later.add(new LambdaContext(

--- a/src/librbd/cache/rwl/SyncPoint.cc
+++ b/src/librbd/cache/rwl/SyncPoint.cc
@@ -93,8 +93,6 @@ void SyncPoint::add_in_on_appending_ctxs(Context* ctx) {
 
 void SyncPoint::setup_earlier_sync_point(std::shared_ptr<SyncPoint> sync_point,
                                          uint64_t last_op_sequence_num) {
-    m_perfcounter->inc(l_librbd_rwl_syncpoint_hist,
-                       sync_point->log_entry->writes, sync_point->log_entry->bytes);
     earlier_sync_point = sync_point;
     log_entry->prior_sync_point_flushed = false;
     earlier_sync_point->log_entry->next_sync_point_entry = log_entry;


### PR DESCRIPTION
There's no m_perfcounter in SyncPoint. Its scope is in
ReplicatedWriteLog.

Signed-off-by: Changcheng Liu <changcheng.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
