### PR TITLE
cephadm: Validate bootstrap "--dashboard-{key|crt}" path

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2612,9 +2612,10 @@ def command_bootstrap():
         # dashboard crt and key
         if args.dashboard_key and args.dashboard_crt:
             logger.info('Using provided dashboard certificate...')
-            mounts = {}
-            mounts[pathify(args.dashboard_crt)] = '/tmp/dashboard.crt:z'
-            mounts[pathify(args.dashboard_key)] = '/tmp/dashboard.key:z'
+            mounts = {
+                pathify(args.dashboard_crt.name): '/tmp/dashboard.crt:z',
+                pathify(args.dashboard_key.name): '/tmp/dashboard.key:z'
+            }
             cli(['dashboard', 'set-ssl-certificate', '-i', '/tmp/dashboard.crt'], extra_mounts=mounts)
             cli(['dashboard', 'set-ssl-certificate-key', '-i', '/tmp/dashboard.key'], extra_mounts=mounts)
         else:
@@ -4459,9 +4460,11 @@ def _get_parser():
 
     parser_bootstrap.add_argument(
         '--dashboard-key',
+        type=argparse.FileType('r'),
         help='Dashboard key')
     parser_bootstrap.add_argument(
         '--dashboard-crt',
+        type=argparse.FileType('r'),
         help='Dashboard certificate')
 
     parser_bootstrap.add_argument(


### PR DESCRIPTION
By using `type=argparse.FileType('r')`, we automatically validate that file exists and can be read.

This PR was inspired by the following comment: https://github.com/ceph/ceph/pull/35195#discussion_r429797150

Fixes: https://tracker.ceph.com/issues/45696

Signed-off-by: Ricardo Marques <rimarques@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
