### PR TITLE
Mempool can show string count

### DIFF
--- a/src/common/mempool.cc
+++ b/src/common/mempool.cc
@@ -110,7 +110,11 @@ void mempool::pool_t::get_stats(
     for (auto &p : type_map) {
       std::string n = ceph_demangle(p.second.type_name);
       stats_t &s = (*by_type)[n];
-      s.bytes = p.second.items * p.second.item_size;
+      if (p.second.bytes == 0) {
+	s.bytes = p.second.items * p.second.item_size;
+      } else {
+	s.bytes = p.second.bytes;
+      }
       s.items = p.second.items;
     }
   }


### PR DESCRIPTION
This PR allows to list count of strings in mempool.
Now each allocated string counts as 1 object and contributes as n bytes.
Before each allocated string counted as n chars and contributed n bytes.
To use change one should replace mempool::...::string with mempool::...::block_string.

With changes to bluestore (not in this PR), results can look like this:
Before:
```
"bluestore_onode": {
    "items": 213,
    "bytes": 122688,
    "by_type": {
        "BlueStore::Onode": {
            "items": 213,
            "bytes": 122688
        }
    }
},
"bluestore_onode_data": {
    "items": 14321,
    "bytes": 14321,
    "by_type": {
        "char": {
            "items": 14321,
            "bytes": 14321
        }
    }
},
```
After:
```
"bluestore_onode": {
    "items": 82,
    "bytes": 47232,
    "by_type": {
        "BlueStore::Onode": {
            "items": 82,
            "bytes": 47232
        }
    }
},
"bluestore_onode_data": {
    "items": 82,
    "bytes": 8401,
    "by_type": {
        "char []": {
            "items": 82,
            "bytes": 8401
        }
    }
},
```