### PR TITLE
qa/cephadm: Add local dockerhub mirror

### DIFF
--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -11,6 +11,7 @@ import re
 import uuid
 
 from io import BytesIO
+import toml
 from six import StringIO
 from tarfile import ReadError
 from tasks.ceph_manager import CephManager
@@ -305,6 +306,7 @@ def ceph_bootstrap(ctx, config):
     ctx.cluster.run(args=[
         'sudo', 'chmod', '777', '/etc/ceph',
         ]);
+    add_mirror_to_cluster(ctx, config.get('docker_registry_mirror', 'vossi04.front.sepia.ceph.com:5000'))
     try:
         # write seed config
         log.info('Writing seed config...')
@@ -1133,3 +1135,52 @@ def task(ctx, config):
 
         finally:
             log.info('Teardown begin')
+
+
+def registries_add_mirror_to_docker_io(conf, mirror):
+    config = toml.loads(conf)
+    is_v1 = 'registries' in config
+    if is_v1:
+        search = config.get('registries', {}).get('search', {}).get('registries', [])
+        insecure = config.get('registries', {}).get('search', {}).get('insecure', [])
+        # v2: MutableMapping[str, Any] = { needs Python 3
+        v2 = {
+            'unqualified-search-registries': search,
+            'registry': [
+                {
+                    'prefix': reg,
+                    'location': reg,
+                    'insecure': reg in insecure,
+                    'blocked': False,
+                } for reg in search
+            ]
+        }
+    else:
+        v2 = config  # type: ignore
+    dockers = [r for r in v2['registry'] if r['prefix'] == 'docker.io']
+    if dockers:
+        docker = dockers[0]
+        docker['mirror'] = [{
+            "location": mirror,
+            "insecure": True,
+        }]
+    return v2
+
+
+def add_mirror_to_cluster(ctx, mirror):
+    log.info('Adding local image mirror %s' % mirror)
+    
+    registries_conf = '/etc/containers/registries.conf'
+    
+    for remote in ctx.cluster.remotes.keys():
+        config = teuthology.get_file(
+            remote=remote,
+            path=registries_conf
+        )
+        new_config = toml.dumps(registries_add_mirror_to_docker_io(config.decode('utf-8'), mirror))
+
+        teuthology.sudo_write_file(
+            remote=remote,
+            path=registries_conf,
+            data=new_config,
+        )

--- a/qa/tasks/tests/test_cephadm.py
+++ b/qa/tasks/tests/test_cephadm.py
@@ -1,0 +1,70 @@
+from tasks import cephadm
+
+v1 = """
+[registries.search]
+registries = ['registry.access.redhat.com', 'registry.redhat.io', 'docker.io', 'quay.io']
+
+[registries.insecure]
+registries = []
+"""
+
+v2 = """
+unqualified-search-registries = ["registry.access.redhat.com", "registry.redhat.io", "docker.io", 'quay.io']
+
+[[registry]]
+prefix = "registry.access.redhat.com"
+location = "registry.access.redhat.com"
+insecure = false
+blocked = false
+
+[[registry]]
+prefix = "registry.redhat.io"
+location = "registry.redhat.io"
+insecure = false
+blocked = false
+
+[[registry]]
+prefix = "docker.io"
+location = "docker.io"
+insecure = false
+blocked = false
+
+[[registry.mirror]]
+location = "vossi04.front.sepia.ceph.com:5000"
+insecure = true
+
+[[registry]]
+prefix = "quay.io"
+location = "quay.io"
+insecure = false
+blocked = false
+"""
+
+expected = {
+    'unqualified-search-registries': ['registry.access.redhat.com', 'registry.redhat.io',
+                                      'docker.io', 'quay.io'],
+    'registry': [
+        {'prefix': 'registry.access.redhat.com',
+         'location': 'registry.access.redhat.com',
+         'insecure': False,
+         'blocked': False},
+        {'prefix': 'registry.redhat.io',
+         'location': 'registry.redhat.io',
+         'insecure': False,
+         'blocked': False},
+        {'prefix': 'docker.io',
+         'location': 'docker.io',
+         'insecure': False,
+         'blocked': False,
+         'mirror': [{'location': 'vossi04.front.sepia.ceph.com:5000',
+                     'insecure': True}]},
+        {'prefix': 'quay.io',
+         'location': 'quay.io',
+         'insecure': False,
+         'blocked': False}
+    ]
+}
+
+def test_add_mirror():
+    assert cephadm.registries_add_mirror_to_docker_io(v1, 'vossi04.front.sepia.ceph.com:5000') == expected
+    assert cephadm.registries_add_mirror_to_docker_io(v2, 'vossi04.front.sepia.ceph.com:5000') == expected

--- a/qa/tox.ini
+++ b/qa/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8-py2, flake8-py3, mypy
+envlist = flake8-py2, flake8-py3, mypy, pytest
 skipsdist = True
 
 [testenv:flake8-py2]
@@ -23,3 +23,10 @@ commands = mypy {posargs:.}
 basepython = python3
 deps = {env:TEUTHOLOGY_GIT:git+https://github.com/ceph/teuthology.git@master}#egg=teuthology[coverage,orchestra,test]
 commands = python test_import.py {posargs:tasks/**/*.py}
+
+[testenv:pytest]
+basepython = python3
+deps =
+  {env:TEUTHOLOGY_GIT:git+https://github.com/ceph/teuthology.git@master}#egg=teuthology[test]
+  httplib2
+commands = pytest -vv tasks/tests


### PR DESCRIPTION
turned out to be more hacky than anticipated. 

Note that I only did run pytest, not the actual code.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]


[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
