### PR TITLE
nautilus: qa/workunits: Remove redundant Xenial cmake3 requirements

### DIFF
--- a/qa/workunits/ceph-helpers-root.sh
+++ b/qa/workunits/ceph-helpers-root.sh
@@ -59,15 +59,6 @@ function install_cmake3_on_centos7 {
     sudo yum install -y cmake3
 }
 
-function install_cmake3_on_xenial {
-    install_pkg_on_ubuntu \
-	ceph-cmake \
-	d278b9d28de0f6b88f56dfe1e8bf684a41577210 \
-	xenial \
-	force \
-	cmake
-}
-
 function install_pkg_on_ubuntu {
     local project=$1
     shift

--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -20,15 +20,7 @@ CURRENT_PATH=`pwd`
 # for rocksdb
 case $(distro_id) in
 	ubuntu|debian|devuan)
-		install git g++ libsnappy-dev zlib1g-dev libbz2-dev libradospp-dev
-        case $(distro_version) in
-            *Xenial*)
-                install_cmake3_on_xenial
-                ;;
-            *)
-                install cmake
-                ;;
-        esac
+		install git g++ libsnappy-dev zlib1g-dev libbz2-dev libradospp-dev cmake
 		;;
 	centos|fedora|rhel)
 		install git gcc-c++.x86_64 snappy-devel zlib zlib-devel bzip2 bzip2-devel libradospp-devel.x86_64


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45677

---

backport of https://github.com/ceph/ceph/pull/35082
parent tracker: https://tracker.ceph.com/issues/45561

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh