### PR TITLE
msgr, tests: bring unit testing for the crypto stream handlers

### DIFF
--- a/src/msg/async/crypto_onwire.cc
+++ b/src/msg/async/crypto_onwire.cc
@@ -5,6 +5,7 @@
 #include <openssl/evp.h>
 
 #include "crypto_onwire.h"
+#include "crypto_onwire_aesgcm.h"
 
 #include "common/debug.h"
 #include "common/ceph_crypto.h"
@@ -13,50 +14,6 @@
 #define dout_subsys ceph_subsys_ms
 
 namespace ceph::crypto::onwire {
-
-static constexpr const std::size_t AESGCM_KEY_LEN{16};
-static constexpr const std::size_t AESGCM_IV_LEN{12};
-static constexpr const std::size_t AESGCM_TAG_LEN{16};
-static constexpr const std::size_t AESGCM_BLOCK_LEN{16};
-
-struct nonce_t {
-  ceph_le32 fixed;
-  ceph_le64 counter;
-
-  bool operator==(const nonce_t& rhs) const {
-    return !memcmp(this, &rhs, sizeof(*this));
-  }
-} __attribute__((packed));
-static_assert(sizeof(nonce_t) == AESGCM_IV_LEN);
-
-using key_t = std::array<std::uint8_t, AESGCM_KEY_LEN>;
-
-// http://www.mindspring.com/~dmcgrew/gcm-nist-6.pdf
-// https://www.openssl.org/docs/man1.0.2/crypto/EVP_aes_128_gcm.html#GCM-mode
-// https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption
-// https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
-class AES128GCM_OnWireTxHandler : public ceph::crypto::onwire::TxHandler {
-  CephContext* const cct;
-  std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)> ectx;
-  ceph::bufferlist buffer;
-  nonce_t nonce, initial_nonce;
-  bool used_initial_nonce;
-  bool new_nonce_format;  // 64-bit counter?
-  static_assert(sizeof(nonce) == AESGCM_IV_LEN);
-
-public:
-  AES128GCM_OnWireTxHandler(CephContext* const cct,
-			    const key_t& key,
-			    const nonce_t& nonce,
-                            bool new_nonce_format);
-  ~AES128GCM_OnWireTxHandler() override;
-
-  void reset_tx_handler(const uint32_t* first, const uint32_t* last) override;
-
-  void authenticated_encrypt_update(const ceph::bufferlist& plaintext) override;
-  ceph::bufferlist authenticated_encrypt_final() override;
-};
-
 
 AES128GCM_OnWireTxHandler::AES128GCM_OnWireTxHandler(
   CephContext* const cct,
@@ -173,28 +130,6 @@ ceph::bufferlist AES128GCM_OnWireTxHandler::authenticated_encrypt_final()
 }
 
 // RX PART
-class AES128GCM_OnWireRxHandler : public ceph::crypto::onwire::RxHandler {
-  std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)> ectx;
-  nonce_t nonce;
-  bool new_nonce_format;  // 64-bit counter?
-  static_assert(sizeof(nonce) == AESGCM_IV_LEN);
-
-public:
-  AES128GCM_OnWireRxHandler(CephContext* const cct,
-			    const key_t& key,
-			    const nonce_t& nonce,
-			    bool new_nonce_format);
-  ~AES128GCM_OnWireRxHandler() override;
-
-  std::uint32_t get_extra_size_at_final() override {
-    return AESGCM_TAG_LEN;
-  }
-  void reset_rx_handler() override;
-  void authenticated_decrypt_update(ceph::bufferlist& bl) override;
-  void authenticated_decrypt_update_final(ceph::bufferlist& bl) override;
-};
-
-
 AES128GCM_OnWireRxHandler::AES128GCM_OnWireRxHandler(
   CephContext* const cct,
   const key_t& key,

--- a/src/msg/async/crypto_onwire_aesgcm.h
+++ b/src/msg/async/crypto_onwire_aesgcm.h
@@ -1,0 +1,81 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_CRYPTO_ONWIRE_AESGCM_H
+#define CEPH_CRYPTO_ONWIRE_AESGCM_H
+
+#include <array>
+
+#include "crypto_onwire.h"
+
+namespace ceph::crypto::onwire {
+
+static constexpr const std::size_t AESGCM_KEY_LEN{16};
+static constexpr const std::size_t AESGCM_IV_LEN{12};
+static constexpr const std::size_t AESGCM_TAG_LEN{16};
+static constexpr const std::size_t AESGCM_BLOCK_LEN{16};
+
+struct nonce_t {
+  ceph_le32 fixed;
+  ceph_le64 counter;
+
+  bool operator==(const nonce_t& rhs) const {
+    return !memcmp(this, &rhs, sizeof(*this));
+  }
+} __attribute__((packed));
+static_assert(sizeof(nonce_t) == AESGCM_IV_LEN);
+
+using key_t = std::array<std::uint8_t, AESGCM_KEY_LEN>;
+
+// http://www.mindspring.com/~dmcgrew/gcm-nist-6.pdf
+// https://www.openssl.org/docs/man1.0.2/crypto/EVP_aes_128_gcm.html#GCM-mode
+// https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption
+// https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
+class AES128GCM_OnWireTxHandler : public ceph::crypto::onwire::TxHandler {
+  CephContext* const cct;
+  std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)> ectx;
+  ceph::bufferlist buffer;
+  nonce_t nonce, initial_nonce;
+  bool used_initial_nonce;
+  bool new_nonce_format;  // 64-bit counter?
+  static_assert(sizeof(nonce) == AESGCM_IV_LEN);
+
+public:
+  AES128GCM_OnWireTxHandler(CephContext* const cct,
+			    const key_t& key,
+			    const nonce_t& nonce,
+                            bool new_nonce_format);
+  ~AES128GCM_OnWireTxHandler() override;
+
+  void reset_tx_handler(const uint32_t* first, const uint32_t* last) override;
+
+  void authenticated_encrypt_update(const ceph::bufferlist& plaintext) override;
+  ceph::bufferlist authenticated_encrypt_final() override;
+};
+
+
+// RX PART
+class AES128GCM_OnWireRxHandler : public ceph::crypto::onwire::RxHandler {
+  std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)> ectx;
+  nonce_t nonce;
+  bool new_nonce_format;  // 64-bit counter?
+  static_assert(sizeof(nonce) == AESGCM_IV_LEN);
+
+public:
+  AES128GCM_OnWireRxHandler(CephContext* const cct,
+			    const key_t& key,
+			    const nonce_t& nonce,
+			    bool new_nonce_format);
+  ~AES128GCM_OnWireRxHandler() override;
+
+  std::uint32_t get_extra_size_at_final() override {
+    return AESGCM_TAG_LEN;
+  }
+  void reset_rx_handler() override;
+  void authenticated_decrypt_update(ceph::bufferlist& bl) override;
+  void authenticated_decrypt_update_final(ceph::bufferlist& bl) override;
+};
+
+} // namespace ceph::crypto::onwire
+
+#endif // CEPH_CRYPTO_ONWIRE_AESGCM_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -733,6 +733,14 @@ add_executable(unittest_crypto_init
 add_ceph_unittest(unittest_crypto_init)
 target_link_libraries(unittest_crypto_init global)
 
+# unittest_crypto_onwire
+add_executable(unittest_crypto_onwire
+  crypto_onwire.cc
+  $<TARGET_OBJECTS:unit-main>
+  )
+add_ceph_unittest(unittest_crypto_onwire)
+target_link_libraries(unittest_crypto_onwire global)
+
 # unittest_perf_counters
 add_executable(unittest_perf_counters
   perf_counters.cc

--- a/src/test/crypto_onwire.cc
+++ b/src/test/crypto_onwire.cc
@@ -131,6 +131,15 @@ struct ciphertext_generator_t {
     tx->authenticated_encrypt_update(std::move(plainchunk));
     return tx->authenticated_encrypt_final();
   }
+
+  ceph::bufferlist from_4k_zeros() {
+    ceph::bufferlist plainchunk;
+    plainchunk.append_zero(4096);
+    auto lengths = { plainchunk.length() };
+    tx->reset_tx_handler(std::begin(lengths), std::end(lengths));
+    tx->authenticated_encrypt_update(std::move(plainchunk));
+    return tx->authenticated_encrypt_final();
+  }
 };
 
 TEST(AESGCMTxHandler, fits_recording)
@@ -240,6 +249,30 @@ TEST(AESGCMRxHandler, mismatched_tag)
     ceph::crypto::onwire::MsgAuthError);
 }
 
+static ceph::bufferlist decrypt_multi_chunk(
+  AES128GCM_OnWireRxHandler& rx,
+  ceph::bufferlist&& ciphertext,
+  const std::size_t chunk_size)
+{
+  ceph::bufferlist plaintext;
+
+  while (ciphertext.length() >= chunk_size) {
+    ceph::bufferlist cipherchunk;
+    ciphertext.splice(0, chunk_size, &cipherchunk);
+
+    ceph::bufferlist plainchunk = authenticated_decrypt_update(
+      rx, std::move(cipherchunk));
+    plaintext.claim_append(plainchunk);
+  }
+
+  if (ciphertext.length() > 0) {
+    ceph::bufferlist last_plainchunk = authenticated_decrypt_update(
+      rx, std::move(ciphertext));
+    plaintext.claim_append(last_plainchunk);
+  }
+  return plaintext;
+}
+
 TEST(AESGCMRxHandler, multi_chunked_fits_recording)
 {
   // verify whether the ciphertext matches plaintext over the entire
@@ -253,23 +286,8 @@ TEST(AESGCMRxHandler, multi_chunked_fits_recording)
 
     rx->reset_rx_handler();
 
-    ceph::bufferlist plaintext;
-    ceph::bufferlist ciphertext = to_bl(aes_gcm_sample_t::ciphertext);
-    while (ciphertext.length() >= chunk_size) {
-      ceph::bufferlist cipherchunk;
-      ciphertext.splice(0, chunk_size, &cipherchunk);
-
-      ceph::bufferlist plainchunk = authenticated_decrypt_update(
-        *rx, std::move(cipherchunk));
-      plaintext.claim_append(plainchunk);
-    }
-
-    if (ciphertext.length() > 0) {
-      ceph::bufferlist last_plainchunk = authenticated_decrypt_update(
-        *rx, std::move(ciphertext));
-      plaintext.claim_append(last_plainchunk);
-    }
-
+    auto plaintext = \
+      decrypt_multi_chunk(*rx, to_bl(aes_gcm_sample_t::ciphertext), chunk_size);
     // if tag doesn't match, exception will be thrown.
     auto final_plainchunk = \
       authenticated_decrypt_update_final(*rx, to_bl(aes_gcm_sample_t::tag));
@@ -322,5 +340,33 @@ TEST(AESGCMRxHandler, reset_with_cipertext_and_tag_separated)
     EXPECT_NO_THROW({
       final_plaintext = authenticated_decrypt_update_final(*rx, std::move(tag));
     });
+  }
+}
+
+TEST(AESGCMRxHandler, reset_in_multi_chunked)
+{
+  // main intention behind this test is to isolate an uninitialized condition
+  // reported by Valgrind (https://tracker.ceph.com/issues/44430).
+  ciphertext_generator_t ctg;
+  auto rx = create_crypto_handler<AES128GCM_OnWireRxHandler>(g_ceph_context);
+
+  for (std::size_t chunk_size = 1;
+       chunk_size <= std::size(aes_gcm_sample_t::ciphertext);
+       chunk_size++) {
+    for (std::size_t i = 0; i < 5; i++) {
+      rx->reset_rx_handler();
+
+      auto [ ciphertext, tag ] = \
+        split2ciphertext_and_tag(ctg.from_4k_zeros());
+      auto plaintext = \
+        decrypt_multi_chunk(*rx, std::move(ciphertext), chunk_size);
+
+      // If tag doesn't match, exception will be thrown.
+      ceph::bufferlist final_plaintext;
+      EXPECT_NO_THROW({
+        final_plaintext = authenticated_decrypt_update_final(
+          *rx, std::move(tag));
+      });
+    }
   }
 }

--- a/src/test/crypto_onwire.cc
+++ b/src/test/crypto_onwire.cc
@@ -1,0 +1,326 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <array>
+#include <iostream>
+#include <string_view>
+
+#include "include/buffer.h"
+#include "gtest/gtest.h"
+#include "common/ceph_crypto.h"
+#include "common/ceph_context.h"
+#include "global/global_context.h"
+
+#include "msg/async/crypto_onwire_aesgcm.h"
+
+#define dout_context g_ceph_context
+
+class CryptoEnvironment: public ::testing::Environment {
+public:
+  void SetUp() override {
+    ceph::crypto::init();
+  }
+};
+
+struct aes_gcm_sample_t {
+  static constexpr std::string_view key_and_nonce {
+    "mock of crypto material for deriving key and nonce for AES GCM"
+  };
+
+  static constexpr std::string_view plaintext {
+    "mock of plain text for AES GCM cipher"
+  };
+
+  // AES GCM doesn't do padding. The size of ciphertext is actually the same
+  // as its corresponding plaintext except the AE (authenticated encryption)
+  // tag at the end.
+  //
+  // These outputs have been collected before the nonce fix.
+  static constexpr std::array<unsigned char,
+                              std::size(plaintext)> ciphertext {
+    0x4d, 0xa2, 0xa6, 0x1b, 0xa5, 0x2e, 0x20, 0x0d,
+    0xa3, 0x3e, 0x56, 0x6f, 0x36, 0x8c, 0xf3, 0x43,
+    0x1a, 0xe5, 0x81, 0x55, 0xb2, 0x31, 0x8c, 0x79,
+    0xe5, 0x16, 0xae, 0xab, 0x80, 0xab, 0xd9, 0xe4,
+    0x13, 0x91, 0xad, 0x44, 0x7d
+  };
+
+  static constexpr std::array<unsigned char,
+                              ceph::crypto::onwire::AESGCM_TAG_LEN> tag {
+    0xf4, 0x91, 0x9e, 0x37, 0x0e, 0xdc, 0xa8, 0xb2,
+    0xc6, 0xeb, 0xf8, 0x03, 0xe9, 0x62, 0x42, 0xc5
+  };
+};
+
+template <class T>
+static std::unique_ptr<T> create_crypto_handler(CephContext* const cct)
+{
+  using ceph::crypto::onwire::key_t;
+  using ceph::crypto::onwire::nonce_t;
+
+  const auto& connection_secret = aes_gcm_sample_t::key_and_nonce;
+  ceph_assert_always(
+    connection_secret.length() >= sizeof(key_t) + sizeof(nonce_t));
+  const char* secbuf = connection_secret.data();
+
+  key_t key;
+  {
+    ::memcpy(key.data(), secbuf, sizeof(key));
+    secbuf += sizeof(key);
+  }
+
+  nonce_t nonce;
+  {
+    ::memcpy(&nonce, secbuf, sizeof(nonce));
+    secbuf += sizeof(nonce);
+  }
+
+  return std::make_unique<T>(cct, key, nonce, /* new_nonce_format = */false);
+}
+
+template <std::size_t N>
+static ceph::bufferlist to_bl(const std::array<unsigned char, N>& arr)
+{
+  ceph::bufferlist bl;
+  bl.push_back(ceph::buffer::copy(reinterpret_cast<const char*>(arr.data()),
+                                  arr.size())); 
+  return bl;
+}
+
+static ceph::bufferlist to_bl(const std::string_view& sv)
+{
+  ceph::bufferlist bl;
+  bl.push_back(ceph::buffer::copy(sv.data(), sv.size())); 
+  return bl;
+}
+
+static std::pair<ceph::bufferlist, ceph::bufferlist> split2ciphertext_and_tag(
+  ceph::bufferlist&& ciphertext_with_tag)
+{
+  ceph_assert_always(
+    ciphertext_with_tag.length() > ceph::crypto::onwire::AESGCM_TAG_LEN);
+  const std::size_t ciphertext_size = \
+    ciphertext_with_tag.length() - ceph::crypto::onwire::AESGCM_TAG_LEN;
+
+  ceph::bufferlist ciphertext;
+  ceph::bufferlist tag;
+  ciphertext_with_tag.splice(0, ciphertext_size, &ciphertext);
+
+  // ciphertext has been moved out; the remaning is tag.
+  tag = std::move(ciphertext_with_tag);
+
+  return std::make_pair(ciphertext, tag);
+}
+
+using AES128GCM_OnWireTxHandler = \
+  ceph::crypto::onwire::AES128GCM_OnWireTxHandler;
+using AES128GCM_OnWireRxHandler = \
+  ceph::crypto::onwire::AES128GCM_OnWireRxHandler;
+
+struct ciphertext_generator_t {
+  std::unique_ptr<AES128GCM_OnWireTxHandler> tx;
+
+  ciphertext_generator_t()
+    : tx(create_crypto_handler<AES128GCM_OnWireTxHandler>(g_ceph_context)) {
+  }
+
+  ceph::bufferlist from_recorded_plaintext() {
+    auto plainchunk = to_bl(aes_gcm_sample_t::plaintext);
+    auto lengths = { plainchunk.length() };
+    tx->reset_tx_handler(std::begin(lengths), std::end(lengths));
+    tx->authenticated_encrypt_update(std::move(plainchunk));
+    return tx->authenticated_encrypt_final();
+  }
+};
+
+TEST(AESGCMTxHandler, fits_recording)
+{
+  ciphertext_generator_t ctg;
+  auto ciphertext_with_tag = ctg.from_recorded_plaintext();
+  auto plaintext = to_bl(aes_gcm_sample_t::plaintext);
+
+  using ceph::crypto::onwire::AESGCM_TAG_LEN;
+  const auto plaintext_size = aes_gcm_sample_t::plaintext.size();
+  ASSERT_EQ(plaintext_size + AESGCM_TAG_LEN,
+            ciphertext_with_tag.length());
+  ASSERT_EQ(0, ::memcmp(ciphertext_with_tag.c_str(),
+                        aes_gcm_sample_t::ciphertext.data(),
+                        aes_gcm_sample_t::ciphertext.size()));
+  ASSERT_EQ(0, ::memcmp(ciphertext_with_tag.c_str() + plaintext_size,
+                        aes_gcm_sample_t::tag.data(),
+                        aes_gcm_sample_t::tag.size()));
+  // let's ensure the input bufferlist is untouched.
+  ASSERT_TRUE(plaintext.contents_equal(aes_gcm_sample_t::plaintext.data(),
+                                       aes_gcm_sample_t::plaintext.size()));
+}
+
+TEST(AESGCMTxHandler, nonce_is_being_updated)
+{
+  // we want to ensure that two ciphertexts (and their tags!) from same
+  // plaintext are truly different across two final'led rounds. This is
+  // expected because each reset() should trigger nonce update.
+  ciphertext_generator_t ctg;
+  auto [ ciphertext1, tag1 ] = \
+    split2ciphertext_and_tag(ctg.from_recorded_plaintext());
+  auto [ ciphertext2, tag2 ] = \
+    split2ciphertext_and_tag(ctg.from_recorded_plaintext());
+
+  ASSERT_FALSE(ciphertext1.contents_equal(ciphertext2));
+  ASSERT_FALSE(tag1.contents_equal(tag2));
+
+  // extra assertions. Just to ensure that split2ciphertext_and_tag()
+  // hasn't messed up.
+  ASSERT_EQ(ciphertext1.length(), aes_gcm_sample_t::ciphertext.size());
+  ASSERT_EQ(tag1.length(), aes_gcm_sample_t::tag.size());
+  ASSERT_EQ(0, ::memcmp(ciphertext1.c_str(),
+                        aes_gcm_sample_t::ciphertext.data(),
+                        aes_gcm_sample_t::ciphertext.size()));
+  ASSERT_EQ(0, ::memcmp(tag1.c_str(),
+                        aes_gcm_sample_t::tag.data(),
+                        aes_gcm_sample_t::tag.size()));
+}
+
+static ceph::bufferlist authenticated_decrypt_update(
+  AES128GCM_OnWireRxHandler& rx,
+  ceph::bufferlist&& input_bl)
+{
+  rx.authenticated_decrypt_update(input_bl);
+  return std::move(input_bl);
+}
+
+static ceph::bufferlist authenticated_decrypt_update_final(
+  AES128GCM_OnWireRxHandler& rx,
+  ceph::bufferlist&& input_bl)
+{
+  rx.authenticated_decrypt_update_final(input_bl);
+  return std::move(input_bl);
+}
+
+TEST(AESGCMRxHandler, singly_chunked_fits_recording)
+{
+  // decrypt and authenticate at once – using the authenticated_decrypt_update_final
+  auto rx = create_crypto_handler<AES128GCM_OnWireRxHandler>(g_ceph_context);
+  rx->reset_rx_handler();
+
+  ceph::bufferlist ciphertext_with_tag;
+  {
+    // claim_append() needs l-value reference.
+    auto ciphertext = to_bl(aes_gcm_sample_t::ciphertext);
+    auto tag = to_bl(aes_gcm_sample_t::tag);
+    ciphertext_with_tag.claim_append(ciphertext);
+    ciphertext_with_tag.claim_append(tag);
+  }
+
+  // If tag doesn't match, exception will be thrown.
+  auto plaintext = authenticated_decrypt_update_final(
+    *rx, std::move(ciphertext_with_tag));
+  ASSERT_EQ(plaintext.length(), aes_gcm_sample_t::plaintext.size());
+  ASSERT_TRUE(plaintext.contents_equal(aes_gcm_sample_t::plaintext.data(),
+                                       aes_gcm_sample_t::plaintext.size()));
+}
+
+TEST(AESGCMRxHandler, mismatched_tag)
+{
+  auto rx = create_crypto_handler<AES128GCM_OnWireRxHandler>(g_ceph_context);
+  rx->reset_rx_handler();
+
+  ceph::bufferlist ciphertext_with_badtag;
+  {
+    // claim_append() needs l-value reference.
+    auto ciphertext = to_bl(aes_gcm_sample_t::ciphertext);
+    ceph::bufferlist tag;
+    tag.append_zero(ceph::crypto::onwire::AESGCM_TAG_LEN);
+    ciphertext_with_badtag.claim_append(ciphertext);
+    ciphertext_with_badtag.claim_append(tag);
+  }
+
+  // If tag doesn't match, exception will be thrown.
+  ASSERT_THROW(
+    authenticated_decrypt_update_final(*rx, std::move(ciphertext_with_badtag)),
+    ceph::crypto::onwire::MsgAuthError);
+}
+
+TEST(AESGCMRxHandler, multi_chunked_fits_recording)
+{
+  // verify whether the ciphertext matches plaintext over the entire
+  // space of chunk sizes. by chunk we understood the fragment passed
+  // to authenticated_decrypt_update() – the auth tag in this test is
+  // provided separately.
+  for (std::size_t chunk_size = 1;
+       chunk_size <= std::size(aes_gcm_sample_t::ciphertext);
+       chunk_size++) {
+    auto rx = create_crypto_handler<AES128GCM_OnWireRxHandler>(g_ceph_context);
+
+    rx->reset_rx_handler();
+
+    ceph::bufferlist plaintext;
+    ceph::bufferlist ciphertext = to_bl(aes_gcm_sample_t::ciphertext);
+    while (ciphertext.length() >= chunk_size) {
+      ceph::bufferlist cipherchunk;
+      ciphertext.splice(0, chunk_size, &cipherchunk);
+
+      ceph::bufferlist plainchunk = authenticated_decrypt_update(
+        *rx, std::move(cipherchunk));
+      plaintext.claim_append(plainchunk);
+    }
+
+    if (ciphertext.length() > 0) {
+      ceph::bufferlist last_plainchunk = authenticated_decrypt_update(
+        *rx, std::move(ciphertext));
+      plaintext.claim_append(last_plainchunk);
+    }
+
+    // if tag doesn't match, exception will be thrown.
+    auto final_plainchunk = \
+      authenticated_decrypt_update_final(*rx, to_bl(aes_gcm_sample_t::tag));
+    ASSERT_EQ(0, final_plainchunk.length());
+    ASSERT_TRUE(plaintext.contents_equal(aes_gcm_sample_t::plaintext.data(),
+                                         aes_gcm_sample_t::plaintext.size()));
+  }
+}
+
+TEST(AESGCMRxHandler, reset_is_compatible_with_tx)
+{
+  ciphertext_generator_t ctg;
+  auto rx = create_crypto_handler<AES128GCM_OnWireRxHandler>(g_ceph_context);
+
+  for (std::size_t i = 0; i < 5; i++) {
+    rx->reset_rx_handler();
+
+    auto ciphertext_with_tag = ctg.from_recorded_plaintext();
+
+    // If tag doesn't match, exception will be thrown.
+    ceph::bufferlist plaintext;
+    EXPECT_NO_THROW({
+      plaintext = authenticated_decrypt_update_final(
+        *rx, std::move(ciphertext_with_tag));
+    });
+    ASSERT_TRUE(plaintext.contents_equal(aes_gcm_sample_t::plaintext.data(),
+                                         aes_gcm_sample_t::plaintext.size()));
+  }
+}
+
+TEST(AESGCMRxHandler, reset_with_cipertext_and_tag_separated)
+{
+  ciphertext_generator_t ctg;
+  auto rx = create_crypto_handler<AES128GCM_OnWireRxHandler>(g_ceph_context);
+
+  for (std::size_t i = 0; i < 5; i++) {
+    rx->reset_rx_handler();
+
+    auto [ ciphertext, tag ] = \
+      split2ciphertext_and_tag(ctg.from_recorded_plaintext());
+    ceph::bufferlist plaintext;
+    EXPECT_NO_THROW({
+      plaintext = authenticated_decrypt_update(*rx, std::move(ciphertext));
+    });
+    ASSERT_TRUE(plaintext.contents_equal(aes_gcm_sample_t::plaintext.data(),
+                                         aes_gcm_sample_t::plaintext.size()));
+
+    // If tag doesn't match, exception will be thrown.
+    ceph::bufferlist final_plaintext;
+    EXPECT_NO_THROW({
+      final_plaintext = authenticated_decrypt_update_final(*rx, std::move(tag));
+    });
+  }
+}


### PR DESCRIPTION
This PR brings unit tests for `AES128GCM_OnWireRxHandler` and `AES128GCM_OnWireTxHandler` made on the occasion of investigating the Valgrind false-positive uninitialized memory issue. They are rebased and put on top of Ilya's changes of #35078.

The code might useful as the outputs-for-comparisons have been gathered before the msgr2.1 alternations.

Original branch: [wip-test-msg-onwire-crypto-orig](https://github.com/rzarzynski/ceph/commits/wip-test-msg-onwire-crypto-orig).

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
