### PR TITLE
[docs] Advise cephadm user to install repo keys

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -133,9 +133,21 @@ command.  There are several ways to do this:
   ceph commands, including ``ceph``, ``rbd``, ``mount.ceph`` (for mounting
   CephFS file systems), etc.::
 
+First, install the APT/RPM repo keys.
+ 
+APT:
+
+    # sudo rpm --import 'https://download.ceph.com/keys/release.asc'
+ 
+RPM:
+
+    # wget -q -O- 'https://download.ceph.com/keys/release.asc' | sudo apt-key add -
+    
+And then install the release repo, and the ceph-common tooling:
+    
     # cephadm add-repo --release octopus
     # cephadm install ceph-common
-
+    
 Confirm that the ``ceph`` command is accessible with::
 
   # ceph -v


### PR DESCRIPTION
Hey guys,

I may have messed up my commit message format - if you'd like me to fix it, let me know.

When writing up the cephadm install process for https://geek-cookbook.funkypenguin.co.nz/ha-docker-swarm/shared-storage-ceph/, I found that (at least under Ubuntu 18.04) apt would refuse to install the ceph-common packages from the ceph repo, unless I'd already installed the repo key (per https://docs.ceph.com/docs/mimic/install/get-packages/).

This PR simply adds a step to the cephadm docs to indicate that this key is required :)