### PR TITLE
mgr/dashboard: allow preserving OSD IDs when deleting OSDs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -63,14 +63,15 @@
 <ng-template #criticalConfirmationTpl
              let-safeToPerform="safeToPerform"
              let-message="message"
-             let-actionDescription="actionDescription">
+             let-actionDescription="actionDescription"
+             let-osdIds="osdIds">
   <div *ngIf="!safeToPerform"
        class="danger">
     <cd-alert-panel type="warning"
-                    i18n>The {selection.hasSingleSelection, select, 1 {OSD is} 0 {OSDs are}} not safe to be
+                    i18n>The {selection.hasSingleSelection, select, true {OSD is} false {OSDs are}} not safe to be
       {{ actionDescription }}! {{ message }}</cd-alert-panel>
   </div>
-  <ng-container i18n><strong>OSD {{ getSelectedOsdIds() | join }}</strong> will be
+  <ng-container i18n><strong>OSD {{ osdIds | join }}</strong> will be
   <strong>{{ actionDescription }}</strong> if you proceed.</ng-container>
 </ng-template>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -80,3 +80,24 @@
                 [usedBytes]="row.stats.stat_bytes_used">
   </cd-usage-bar>
 </ng-template>
+
+<ng-template #deleteOsdExtraTpl
+             let-form="form">
+  <ng-container [formGroup]="form">
+    <ng-container formGroupName="child">
+      <div class="form-group">
+        <div class="custom-control custom-checkbox">
+          <input type="checkbox"
+                 class="custom-control-input"
+                 name="preserve"
+                 id="preserve"
+                 formControlName="preserve"
+                 autofocus>
+          <label class="custom-control-label"
+                 for="preserve"
+                 i18n>Preserve OSD ID(s) for replacement.</label>
+        </div>
+      </div>
+    </ng-container>
+  </ng-container>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -518,7 +518,8 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
           bodyContext: {
             safeToPerform: result[checkKey],
             message: result.message,
-            actionDescription: templateItemDescription
+            actionDescription: templateItemDescription,
+            osdIds: this.getSelectedOsdIds()
           },
           childFormGroup: childFormGroup,
           childFormGroupTemplate: childFormGroupTemplate,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
@@ -55,6 +55,13 @@ describe('OsdService', () => {
     expect(req.request.body).toEqual(post_data);
   });
 
+  it('should call delete', () => {
+    const id = 1;
+    service.delete(id, true, true).subscribe();
+    const req = httpTesting.expectOne(`api/osd/${id}?preserve_id=true&force=true`);
+    expect(req.request.method).toBe('DELETE');
+  });
+
   it('should call getList', () => {
     service.getList().subscribe();
     const req = httpTesting.expectOne('api/osd');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
@@ -137,10 +137,12 @@ export class OsdService {
     return this.http.post(`${this.path}/${id}/destroy`, null);
   }
 
-  delete(id: number, force?: boolean) {
-    const options = force ? { params: new HttpParams().set('force', 'true') } : {};
-    options['observe'] = 'response';
-    return this.http.delete(`${this.path}/${id}`, options);
+  delete(id: number, preserveId?: boolean, force?: boolean) {
+    const params = {
+      preserve_id: preserveId ? 'true' : 'false',
+      force: force ? 'true' : 'false'
+    };
+    return this.http.delete(`${this.path}/${id}`, { observe: 'response', params: params });
   }
 
   safeToDestroy(ids: string) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html
@@ -25,6 +25,7 @@
           <ng-template #noNames>
             <p i18n>Are you sure that you want to {{ actionDescription | lowercase }} the selected {{ itemDescription }}?</p>
           </ng-template>
+          <ng-container *ngTemplateOutlet="childFormGroupTemplate; context:{form:deletionForm}"></ng-container>
           <div class="form-group">
             <div class="custom-control custom-checkbox">
               <input type="checkbox"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.ts
@@ -24,13 +24,19 @@ export class CriticalConfirmationModalComponent implements OnInit {
   itemNames: string[];
   actionDescription = 'delete';
 
+  childFormGroup: CdFormGroup;
+  childFormGroupTemplate: TemplateRef<any>;
+
   constructor(public modalRef: BsModalRef) {}
 
   ngOnInit() {
-    this.deletionForm = new CdFormGroup({
+    const controls = {
       confirmation: new FormControl(false, [Validators.requiredTrue])
-    });
-
+    };
+    if (this.childFormGroup) {
+      controls['child'] = this.childFormGroup;
+    }
+    this.deletionForm = new CdFormGroup(controls);
     if (!(this.submitAction || this.submitActionObservable)) {
       throw new Error('No submit action defined');
     }

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -109,8 +109,8 @@ class OsdManager(ResourceManager):
         return self.api.apply_drivegroups(drive_group_specs)
 
     @wait_api_result
-    def remove(self, osd_ids):
-        return self.api.remove_osds(osd_ids)
+    def remove(self, osd_ids, replace=False, force=False):
+        return self.api.remove_osds(osd_ids, replace, force)
 
     @wait_api_result
     def removing_status(self):


### PR DESCRIPTION
Ask users if they want to preserve OSD ID(s) for replacement after
OSD deletion in confirmation modal.

Fixes: https://tracker.ceph.com/issues/38234
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

![Screenshot_20200526_182935](https://user-images.githubusercontent.com/1691518/82890647-19c18f80-9f7f-11ea-9a1c-d7821dccb391.png)


## TODO
- [ ] add frontend unittest for adding more form controls in the confirmation modal

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:



"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst




-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
