### PR TITLE
octopus: qa: use py3 compat list from range

### DIFF
--- a/qa/tasks/mds_thrash.py
+++ b/qa/tasks/mds_thrash.py
@@ -245,7 +245,7 @@ class MDSThrasher(Thrasher, Greenlet):
 
             if random.random() <= self.thrash_max_mds:
                 max_mds = status.get_fsmap(self.fs.id)['mdsmap']['max_mds']
-                options = range(1, max_mds)+range(max_mds+1, self.max_mds+1)
+                options = list(range(1, max_mds))+list(range(max_mds+1, self.max_mds+1))
                 if len(options) > 0:
                     sample = random.sample(options, 1)
                     new_max_mds = sample[0]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45674

---

backport of https://github.com/ceph/ceph/pull/35109
parent tracker: https://tracker.ceph.com/issues/45590

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh