### PR TITLE
octopus: cephfs: allow pool names with hyphen and period

### DIFF
--- a/doc/cephfs/administration.rst
+++ b/doc/cephfs/administration.rst
@@ -6,6 +6,9 @@ CephFS Administrative commands
 File Systems
 ------------
 
+.. note:: The names of the file systems, metadata pools, and data pools can
+          only have characters in the set [a-zA-Z0-9\_-.].
+
 These commands operate on the CephFS file systems in your Ceph cluster.
 Note that by default only one file system is permitted: to enable
 creation of multiple file systems use ``ceph fs flag set enable_multiple true``.

--- a/doc/cephfs/createfs.rst
+++ b/doc/cephfs/createfs.rst
@@ -35,6 +35,8 @@ Generally, the metadata pool will have at most a few gigabytes of data. For
 this reason, a smaller PG count is usually recommended. 64 or 128 is commonly
 used in practice for large clusters.
 
+.. note:: The names of the file systems, metadata pools, and data pools can
+          only have characters in the set [a-zA-Z0-9\_-.].
 
 Creating a file system
 ======================

--- a/doc/cephfs/file-layouts.rst
+++ b/doc/cephfs/file-layouts.rst
@@ -20,10 +20,10 @@ Layout fields
 -------------
 
 pool
-    String, giving ID or name.  Which RADOS pool a file's data objects will be stored in.
+    String, giving ID or name. String can only have characters in the set [a-zA-Z0-9\_-.]. Which RADOS pool a file's data objects will be stored in.
 
 pool_namespace
-    String.  Within the data pool, which RADOS namespace the objects will
+    String with only characters in the set [a-zA-Z0-9\_-.].  Within the data pool, which RADOS namespace the objects will
     be written to.  Empty by default (i.e. default namespace).
 
 stripe_unit

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -67,6 +67,14 @@ class TestAdminCommands(CephFSTestCase):
         self.mount_a.run_shell("mkdir subdir")
         self.fs.set_dir_layout(self.mount_a, "subdir", FileLayout(pool=p))
 
+    def test_add_data_pool_non_alphamueric_name_as_subdir(self):
+        """
+        That a new data pool with non-alphanumeric name can be added and used for a sub-directory.
+        """
+        p = self.fs.add_data_pool("I-am-data_pool00.")
+        self.mount_a.run_shell("mkdir subdir")
+        self.fs.set_dir_layout(self.mount_a, "subdir", FileLayout(pool=p))
+
     def test_add_data_pool_ec(self):
         """
         That a new EC data pool can be added.

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -1782,7 +1782,7 @@ struct keys_and_values
       query =  pair >> *(qi::lit(' ') >> pair);
       pair  =  key >> '=' >> value;
       key   =  qi::char_("a-zA-Z_") >> *qi::char_("a-zA-Z_0-9");
-      value = +qi::char_("a-zA-Z_0-9");
+      value = +qi::char_("a-zA-Z0-9-_.");
     }
     qi::rule<Iterator, std::map<string, string>()> query;
     qi::rule<Iterator, std::pair<string, string>()> pair;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45678

---

backport of https://github.com/ceph/ceph/pull/35063
parent tracker: https://tracker.ceph.com/issues/45521

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh