### PR TITLE
octopus: librbd: copy API should not inherit v1 image format by default

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1123,7 +1123,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     uint64_t features = src->features;
     uint64_t src_size = src->get_image_size(src->snap_id);
     src->image_lock.unlock_shared();
-    uint64_t format = src->old_format ? 1 : 2;
+    uint64_t format = 2;
     if (opts.get(RBD_IMAGE_OPTION_FORMAT, &format) != 0) {
       opts.set(RBD_IMAGE_OPTION_FORMAT, format);
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45578

---

backport of https://github.com/ceph/ceph/pull/35025
parent tracker: https://tracker.ceph.com/issues/45518

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh