### PR TITLE
cephadm: Make easy manager modules development

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -87,6 +87,12 @@ cached_stdin = None
 
 DATEFMT = '%Y-%m-%dT%H:%M:%S.%f'
 
+
+class termcolor:
+    yellow = '\033[93m'
+    red = '\033[31m'
+    end = '\033[0m'
+
 class Error(Exception):
     pass
 
@@ -1111,14 +1117,12 @@ def infer_config(func):
 
 def _get_default_image():
     if DEFAULT_IMAGE_IS_MASTER:
-        yellow = '\033[93m'
-        end = '\033[0m'
         warn = '''This is a development version of cephadm.
 For information regarding the latest stable release:
     https://docs.ceph.com/docs/{}/cephadm/install
 '''.format(LATEST_STABLE_RELEASE)
         for line in warn.splitlines():
-            logger.warning('{}{}{}'.format(yellow, line, end))
+            logger.warning('{}{}{}'.format(termcolor.yellow, line, termcolor.end))
     return DEFAULT_IMAGE
 
 def infer_image(func):
@@ -1619,6 +1623,22 @@ def get_container_mounts(fsid, daemon_type, daemon_id,
         mounts['/sys'] = '/sys'  # for numa.cc, pick_address, cgroups, ...
         mounts['/run/lvm'] = '/run/lvm'
         mounts['/run/lock/lvm'] = '/run/lock/lvm'
+
+    try:
+        if args.shared_ceph_folder:  # make easy manager modules/ceph-volume development
+            ceph_folder = pathify(args.shared_ceph_folder)
+            if os.path.exists(ceph_folder):
+                mounts[ceph_folder + '/src/ceph-volume/ceph_volume'] = '/usr/lib/python3.6/site-packages/ceph_volume'
+                mounts[ceph_folder + '/src/pybind/mgr'] = '/usr/share/ceph/mgr'
+                mounts[ceph_folder + '/src/python-common/ceph'] = '/usr/lib/python3.6/site-packages/ceph'
+                mounts[ceph_folder + '/monitoring/grafana/dashboards'] = '/etc/grafana/dashboards/ceph-dashboard'
+                mounts[ceph_folder + '/monitoring/prometheus/alerts'] = '/etc/prometheus/ceph'
+            else:
+                logger.error('{}{}{}'.format(termcolor.red,
+                'Ceph shared source folder does not exist.',
+                termcolor.end))
+    except AttributeError:
+        pass
 
     if daemon_type in Monitoring.components and daemon_id:
         data_dir = get_data_dir(fsid, daemon_type, daemon_id)
@@ -4541,6 +4561,11 @@ def _get_parser():
         '--skip-monitoring-stack',
         action='store_true',
         help='Do not automatically provision monitoring stack (prometheus, grafana, alertmanager, node-exporter)')
+
+    parser_bootstrap.add_argument(
+        '--shared_ceph_folder',
+        metavar='CEPH_SOURCE_FOLDER',
+        help='Development mode. Several folders in containers are volumes mapped to different sub-folders in the ceph source folder')
 
     parser_deploy = subparsers.add_parser(
         'deploy', help='deploy a daemon')


### PR DESCRIPTION
Using a volume, the content  in _</usr/share/mgr>_ folder in manager containers is replaced by
the content existing in one host folder.

The source host can be set using the new parameter `shared_mgr_folder`

This make easy to develop/debug because it is possible to make modifications "on-flight" in the manager modules:

A typical use can be:
`cephadm bootstrap --mon-ip $mon_ip --allow-fqdn-hostname --skip-dashboard --shared_mgr_folder /mnt/MyCode/ceph/src/pybind/mgr`

After the cluster is created, you can make modifications in your source folder: /mnt/MyCode/ceph/src/pybind/mgr
for example in the cephadm manager module, and after that test the modification just disabling and re-enabling the module again.

Note 1:
We have a couple of manager modules that need a special procedure in order to be able to modify code "on-flight":

- Dashboard: 
You will need to have generated the folder dist with the frontend components in your source folder

- Rook: 
Needed to install manually in the manager a rpm with  "rook shared" libraries. use for example:
```
https://download.ceph.com/rpm-octopus/el8/noarch/
ceph-mgr-rook-15.2.2-0.el8.noarch.rpm 
```

Probably we have room for more improvements ... any feedback will be welcome.

Note 2: 
Thanks @alfonsomthd for the idea and for the help testing! One (or more) Vermouth pending ...

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>