### PR TITLE
cls/rgw_gc: Clearing off urgent data in bufferlist, before

### DIFF
--- a/src/cls/queue/cls_queue_src.cc
+++ b/src/cls/queue/cls_queue_src.cc
@@ -27,6 +27,11 @@ int queue_write_head(cls_method_context_t hctx, cls_queue_head& head)
 
   bl.claim_append(bl_head);
 
+  if (bl.length() > head.max_head_size) {
+    CLS_LOG(0, "ERROR: queue_write_head: invalid head size = %u and urgent data size = %u \n", bl.length(), head.bl_urgent_data.length());
+    return -EINVAL;
+  }
+
   int ret = cls_cxx_write2(hctx, 0, bl.length(), &bl, CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
   if (ret < 0) {
     CLS_LOG(5, "ERROR: queue_write_head: failed to write head");

--- a/src/cls/rgw_gc/cls_rgw_gc.cc
+++ b/src/cls/rgw_gc/cls_rgw_gc.cc
@@ -371,7 +371,7 @@ static int cls_rgw_gc_queue_remove_entries(cls_method_context_t hctx, bufferlist
   //Update urgent data map
   head.bl_urgent_data.clear();
   encode(urgent_data, head.bl_urgent_data);
-  CLS_LOG(5, "INFO: cls_rgw_gc_queue_remove_entries(): Urgent data size is %u\n", head.bl_urgent_data.length());
+  CLS_LOG(5, "INFO: cls_rgw_gc_queue_remove_entries(): Urgent data size is %u\n", head.bl_urgent_data.length());
 
   return queue_write_head(hctx, head);
 }

--- a/src/cls/rgw_gc/cls_rgw_gc.cc
+++ b/src/cls/rgw_gc/cls_rgw_gc.cc
@@ -369,7 +369,9 @@ static int cls_rgw_gc_queue_remove_entries(cls_method_context_t hctx, bufferlist
   }
 
   //Update urgent data map
+  head.bl_urgent_data.clear();
   encode(urgent_data, head.bl_urgent_data);
+  CLS_LOG(5, "INFO: cls_rgw_gc_queue_remove_entries(): Urgent data size is %u\n", head.bl_urgent_data.length());
 
   return queue_write_head(hctx, head);
 }


### PR DESCRIPTION
encoding the updated one.

If this is not done, urgent data keeps getting appended
to the head, finally overwriting queue data that results
in invalid entries.

Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
