### PR TITLE
nautilus: doc: obsolete entries for allow_standby_replay

### DIFF
--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -2,17 +2,6 @@
  MDS Config Reference
 ======================
 
-``mon force standby active`` 
-
-:Description: If ``true`` monitors force standby-replay to be active. Set
-              under ``[mon]`` or ``[global]``.
-
-:Type: Boolean
-:Default: ``true``
-:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
-
-.. deprecated:: 14.2.0
-
 ``mds cache memory limit``
 
 :Description: The memory limit the MDS should enforce for its cache.
@@ -555,40 +544,6 @@
               
 :Type:  32-bit Integer
 :Default: ``0``
-
-
-``mds standby for name``
-
-:Description: An MDS daemon will standby for another MDS daemon of the name 
-              specified in this setting.
-
-:Type:  String
-:Default: N/A
-:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
-
-.. deprecated:: 14.2.0
-
-
-``mds standby for rank``
-
-:Description: An MDS daemon will standby for an MDS daemon of this rank. 
-:Type:  32-bit Integer
-:Default: ``-1``
-:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
-
-.. deprecated:: 14.2.0
-
-
-``mds standby replay``
-
-:Description: Determines whether a ``ceph-mds`` daemon should poll and replay 
-              the log of an active MDS (hot standby).
-              
-:Type:  Boolean
-:Default:  ``false``
-:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
-
-.. deprecated:: 14.2.0
 
 
 ``mds min caps per client``

--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -8,7 +8,10 @@
               under ``[mon]`` or ``[global]``.
 
 :Type: Boolean
-:Default: ``true`` 
+:Default: ``true``
+:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
+
+.. deprecated:: 14.2.0
 
 ``mds cache memory limit``
 
@@ -561,6 +564,9 @@
 
 :Type:  String
 :Default: N/A
+:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
+
+.. deprecated:: 14.2.0
 
 
 ``mds standby for rank``
@@ -568,6 +574,9 @@
 :Description: An MDS daemon will standby for an MDS daemon of this rank. 
 :Type:  32-bit Integer
 :Default: ``-1``
+:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
+
+.. deprecated:: 14.2.0
 
 
 ``mds standby replay``
@@ -577,6 +586,9 @@
               
 :Type:  Boolean
 :Default:  ``false``
+:Obsoleted: Please see "Configuring standby-replay" in :doc:`/cephfs/standby`.
+
+.. deprecated:: 14.2.0
 
 
 ``mds min caps per client``


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
