### PR TITLE
qa/cephadm: Docker doesn't ship a registries.conf

### DIFF
--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -1173,14 +1173,18 @@ def add_mirror_to_cluster(ctx, mirror):
     registries_conf = '/etc/containers/registries.conf'
     
     for remote in ctx.cluster.remotes.keys():
-        config = teuthology.get_file(
-            remote=remote,
-            path=registries_conf
-        )
-        new_config = toml.dumps(registries_add_mirror_to_docker_io(config.decode('utf-8'), mirror))
+        try:
+            config = teuthology.get_file(
+                remote=remote,
+                path=registries_conf
+            )
+            new_config = toml.dumps(registries_add_mirror_to_docker_io(config.decode('utf-8'), mirror))
 
-        teuthology.sudo_write_file(
-            remote=remote,
-            path=registries_conf,
-            data=new_config,
-        )
+            teuthology.sudo_write_file(
+                remote=remote,
+                path=registries_conf,
+                data=new_config,
+            )
+        except FileNotFoundError as e:
+            # Docker doesn't ship a registries.conf
+            log.info('Failed to add mirror: %s' % str(e))


### PR DESCRIPTION
I guess not using the mirror for docker based tests is ok for now.

For adding docker support, we need to:

1. change the docker config
2. restart the docker daemon

Note that Docker's config only supports to mirror the docker.io registry.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
