### PR TITLE
cephadm: error trying to get ceph auth entry for crash daemon

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -888,15 +888,15 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     def _run_cephadm(self,
                      host: str,
-                     entity: Optional[str],
+                     entity: str,
                      command: str,
                      args: List[str],
-                     addr: Optional[str] = None,
-                     stdin: Optional[str] = None,
-                     no_fsid=False,
-                     error_ok=False,
-                     image: Optional[str] = None,
-                     env_vars: Optional[List[str]] = None,
+                     addr: Optional[str] = "",
+                     stdin: Optional[str] = "",
+                     no_fsid: Optional[bool] = False,
+                     error_ok: Optional[bool] = False,
+                     image: Optional[str] = "",
+                     env_vars: Optional[List[str]]= None,
                      ) -> Tuple[List[str], List[str], int]:
         """
         Run cephadm on the remote host with the given command + args
@@ -1296,7 +1296,7 @@ you may want to run:
                     if dd.daemon_type == 'osd':
                         """
                         The osd count can't be determined by the Placement spec.
-                        It's rather pointless to show a actual/expected representation 
+                        It's rather pointless to show a actual/expected representation
                         here. So we're setting running = size for now.
                         """
                         osd_count += 1
@@ -1594,13 +1594,13 @@ you may want to run:
                 deps.append(dd.name())
         return sorted(deps)
 
-    def _get_config_and_keyring(self, daemon_type, daemon_id,
+    def _get_config_and_keyring(self, daemon_type, daemon_id, host=None,
                                 keyring=None,
                                 extra_ceph_config=None):
-        # type: (str, str, Optional[str], Optional[str]) -> Dict[str, Any]
+        # type: (str, str, Optional[str], Optional[str], Optional[str]) -> Dict[str, Any]
         # keyring
         if not keyring:
-            ename = utils.name_to_auth_entity(daemon_type + '.' + daemon_id)
+            ename = utils.name_to_auth_entity(daemon_type, daemon_id, host=host)
             ret, keyring, err = self.check_mon_command({
                 'prefix': 'auth get',
                 'entity': ename,
@@ -1658,7 +1658,7 @@ you may want to run:
         else:
             # Ceph.daemons (mon, mgr, mds, osd, etc)
             cephadm_config = self._get_config_and_keyring(
-                    daemon_type, daemon_id,
+                    daemon_type, daemon_id, host,
                     keyring=keyring,
                     extra_ceph_config=extra_config.pop('config', ''))
             if extra_config:
@@ -1894,7 +1894,7 @@ you may want to run:
             last_monmap = None   # just in case clocks are skewed
 
         daemons = self.cache.get_daemons()
-        daemons_post = defaultdict(list)
+        daemons_post: Dict[str, List[orchestrator.DaemonDescription]] = defaultdict(list)
         for dd in daemons:
             # orphan?
             spec = self.spec_store.specs.get(dd.service_name(), None)
@@ -2163,7 +2163,7 @@ you may want to run:
         if not host:
             raise OrchestratorError('no hosts defined')
         out, err, code = self._run_cephadm(
-            host, None, 'pull', [],
+            host, '', 'pull', [],
             image=image_name,
             no_fsid=True,
             error_ok=True)

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -23,7 +23,7 @@ class IscsiService(CephadmService):
     def create(self, igw_id, host, spec) -> str:
         ret, keyring, err = self.mgr.check_mon_command({
             'prefix': 'auth get-or-create',
-            'entity': utils.name_to_auth_entity('iscsi') + '.' + igw_id,
+            'entity': utils.name_to_auth_entity('iscsi', igw_id),
             'caps': ['mon', 'profile rbd, '
                             'allow command "osd blacklist", '
                             'allow command "config-key get" with "key" prefix "iscsi/"',

--- a/src/pybind/mgr/cephadm/tests/test_utils.py
+++ b/src/pybind/mgr/cephadm/tests/test_utils.py
@@ -1,0 +1,34 @@
+import pytest
+
+from orchestrator import OrchestratorError
+from cephadm.utils import name_to_auth_entity
+
+def test_name_to_auth_entity(fs):
+
+    for daemon_type in ['rgw', 'rbd-mirror', 'nfs', "iscsi"]:
+        assert "client.%s.id1" % (daemon_type) == name_to_auth_entity(daemon_type, "id1", "host")
+        assert "client.%s.id1" % (daemon_type) == name_to_auth_entity(daemon_type, "id1", "")
+        assert "client.%s.id1" % (daemon_type) == name_to_auth_entity(daemon_type, "id1")
+
+    assert "client.crash.host" == name_to_auth_entity("crash", "id1", "host")
+    with pytest.raises(OrchestratorError):
+        t = name_to_auth_entity("crash", "id1", "")
+        t = name_to_auth_entity("crash", "id1")
+
+    assert "mon." == name_to_auth_entity("mon", "id1", "host")
+    assert "mon." == name_to_auth_entity("mon", "id1", "")
+    assert "mon." == name_to_auth_entity("mon", "id1")
+
+    assert "mgr.id1" == name_to_auth_entity("mgr", "id1", "host")
+    assert "mgr.id1" == name_to_auth_entity("mgr", "id1", "")
+    assert "mgr.id1" == name_to_auth_entity("mgr", "id1")
+
+    for daemon_type in ["osd", "mds", "client"]:
+        assert "%s.id1" % daemon_type == name_to_auth_entity(daemon_type, "id1", "host")
+        assert "%s.id1" % daemon_type == name_to_auth_entity(daemon_type, "id1", "")
+        assert "%s.id1" % daemon_type == name_to_auth_entity(daemon_type, "id1")
+
+    with pytest.raises(OrchestratorError):
+         name_to_auth_entity("whatever", "id1", "host")
+         name_to_auth_entity("whatever", "id1", "")
+         name_to_auth_entity("whatever", "id1")

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -236,13 +236,13 @@ class CephadmUpgrade:
 
                 # make sure host has latest container image
                 out, err, code = self.mgr._run_cephadm(
-                    d.hostname, None, 'inspect-image', [],
+                    d.hostname, '', 'inspect-image', [],
                     image=target_name, no_fsid=True, error_ok=True)
                 if code or json.loads(''.join(out)).get('image_id') != target_id:
                     logger.info('Upgrade: Pulling %s on %s' % (target_name,
                                                                  d.hostname))
                     out, err, code = self.mgr._run_cephadm(
-                        d.hostname, None, 'pull', [],
+                        d.hostname, '', 'pull', [],
                         image=target_name, no_fsid=True, error_ok=True)
                     if code:
                         self._fail_upgrade('UPGRADE_FAILED_PULL', {

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -2,7 +2,9 @@ import re
 
 from orchestrator import OrchestratorError
 
-def name_to_config_section(name):
+from typing import Optional
+
+def name_to_config_section(name: str) -> str:
     """
     Map from daemon names to ceph entity names (as seen in config)
     """
@@ -14,17 +16,24 @@ def name_to_config_section(name):
     else:
         return 'mon'
 
-
-def name_to_auth_entity(name) -> str:
+def name_to_auth_entity(daemon_type,  # type: str
+                        daemon_id,    # type: str
+                        host = ""     # type  Optional[str] = ""
+                        ):
     """
-    Map from daemon names to ceph entity names (as seen in config)
+    Map from daemon names/host to ceph entity names (as seen in config)
     """
-    daemon_type = name.split('.', 1)[0]
-    if daemon_type in ['rgw', 'rbd-mirror', 'nfs', 'crash', 'iscsi']:
-        return 'client.' + name
+    if daemon_type in ['rgw', 'rbd-mirror', 'nfs', "iscsi"]:
+        return 'client.' + daemon_type + "." + daemon_id
+    elif daemon_type == 'crash':
+        if host == "":
+            raise OrchestratorError("Host not provided to generate <crash> auth entity name")
+        return 'client.' + daemon_type + "." + host
     elif daemon_type == 'mon':
         return 'mon.'
-    elif daemon_type in ['osd', 'mds', 'mgr', 'client']:
-        return name
+    elif daemon_type == 'mgr':
+        return daemon_type + "." + daemon_id
+    elif daemon_type in ['osd', 'mds', 'client']:
+        return daemon_type + "." + daemon_id
     else:
         raise OrchestratorError("unknown auth entity name")


### PR DESCRIPTION
If your cluster has nodes with a <.> in the name. This will happen.

Is the case if your hosts use a FQDN.

It seems that we changed the name of the host when using the <get_unique_name> function... Maybe I miss something .. probably ... but why we needed to change the name of the host?

I have removed the "problematic lines"

Fixes: https://tracker.ceph.com/issues/45726

**Details:**

Extracted the line where we tried to get auth details for the crash daemon, and executed alone:

```
[ceph: root@ceph-node-00 /]# ceph auth get client.crash.ceph-node-00
Error ENOENT: failed to find client.crash.ceph-node-00 in keyring
```

Checking what entries we have with "crash":
```
[ceph: root@ceph-node-00 /]# ceph auth list | grep crash
installed auth entries:

client.crash.ceph-node-00.cephlab.com
	caps: [mgr] profile crash
	caps: [mon] profile crash
client.crash.ceph-node-01.cephlab.com
	caps: [mgr] profile crash
	caps: [mon] profile crash
client.crash.ceph-node-02.cephlab.com
	caps: [mgr] profile crash
	caps: [mon] profile crash
```
so.. it seems that we are searching using a **wrong key** (client.crash.ceph-node-00) instead the valid key (client.crash.ceph-node-00.cephlab.com)

Digging in the code results that we need "ename" in the daemonid...
and the daemon_id is wrong ...

```
"mgr/cephadm/host.ceph-node-00.cephlab.com":
"{\"daemons\": {\"mon.ceph-node-00.cephlab.com\": {\"hostname\": \"ceph-node-00.cephlab.com\",
\"container_id\": \"f1b3200819e7\", \"container_image_id\": \"79566b1db52fa6ab71e3436643a0f40c0d24c19b04eaebe2d322adbaa94c7c9a\", \"container_image_name\": \"docker.io/ceph/daemon-base:latest-master-devel\", 

\"daemon_id\": \"ceph-node-00.cephlab.com\",

 \"daemon_type\": \"mon\", \"version\": \"16.0.0-1574-gacefe44a49\", \"status\": 1, \"status_desc\": \"running\", \"last_refresh\": \"2020-05-21T09:57:48.428738\", \"created\": \"2020-05-21T09:32:45.075442\", \"started\": \"2020-05-21T09:32:48.270246\"}, \"mgr.ceph-node-00.cephlab.com.tqtzkd\": {\"hostname\": \"ceph-node-00.cephlab.com\", \"container_id\": \"2d756ba85004\", \"container_image_id\": \"79566b1db52fa6ab71e3436643a0f40c0d24c19b04eaebe2d322adbaa94c7c9a\", \"container_image_name\": \"docker.io/ceph/daemon-base:latest-master-devel\", \"daemon_id\": \"ceph-node-00.cephlab.com.tqtzkd\", \"daemon_type\": \"mgr\", \"version\": \"16.0.0-1574-gacefe44a49\", \"status\": 1, \"status_desc\": \"running\", \"last_refresh\": \"2020-05-21T09:57:48.428847\", \"created\": \"2020-05-21T09:32:49.420484\", \"started\": \"2020-05-21T09:32:49.501113\"}, \"alertmanager.ceph-node-00\": {\"hostname\": \"ceph-node-00.cephlab.com\", \"container_id\": \"3b96e076fbe9\", \"container_image_id\": \"0881eb8f169f5556a292b4e2c01d683172b12830a62a9225a98a8e206bb734f0\", \"container_image_name\": \"docker.io/prom/alertmanager:latest\", \"daemon_id\": \"ceph-node-00\", \"daemon_type\": \"alertmanager\", \"version\": \"0.20.0\", \"status\": 1, \"status_desc\": \"running\", \"last_refresh\": \"2020-05-21T09:57:48.428899\", \"created\": \"2020-05-21T09:33:58.626047\", \"started\": \"2020-05-21T09:38:05.240100\"}, \"crash.ceph-node-00\": {\"hostname\": \"ceph-node-00.cephlab.com\", \"container_id\": \"56148085cc2d\", \"container_image_id\": \"79566b1db52fa6ab71e3436643a0f40c0d24c19b04eaebe2d322adbaa94c7c9a\", \"container_image_name\": \"docker.io/ceph/daemon-base:latest-master-devel\", \"daemon_id\": \"ceph-node-00\", \"daemon_type\": \"crash\", \"version\": \"16.0.0-1574-gacefe44a49\
```", 

And the daemon id is not generated properly **because** the `get_unique_name` function changes the real name of the host (removing all starting in the firts point)

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
