### PR TITLE
crimson/osd: Add support for cls_log

### DIFF
--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -148,7 +148,7 @@ int cls_cxx_write2(cls_method_context_t hctx,
                    bufferlist *inbl,
                    uint32_t op_flags)
 {
-  OSDOp op{ CEPH_OSD_OP_WRITE };
+  OSDOp op{CEPH_OSD_OP_WRITE};
   op.op.extent.offset = ofs;
   op.op.extent.length = len;
   op.op.flags = op_flags;
@@ -251,7 +251,7 @@ int cls_cxx_map_get_keys(cls_method_context_t hctx,
                          std::set<std::string>* const keys,
                          bool* const more)
 {
-  OSDOp op{ CEPH_OSD_OP_OMAPGETKEYS };
+  OSDOp op{CEPH_OSD_OP_OMAPGETKEYS};
   encode(start_obj, op.indata);
   encode(max_to_get, op.indata);
   if (const auto ret = execute_osd_op(hctx, op); ret < 0) {
@@ -274,7 +274,7 @@ int cls_cxx_map_get_vals(cls_method_context_t hctx,
                          std::map<std::string, ceph::bufferlist> *vals,
                          bool* const more)
 {
-  OSDOp op{ CEPH_OSD_OP_OMAPGETVALS };
+  OSDOp op{CEPH_OSD_OP_OMAPGETVALS};
   encode(start_obj, op.indata);
   encode(max_to_get, op.indata);
   encode(filter_prefix, op.indata);
@@ -305,7 +305,7 @@ int cls_cxx_map_get_val(cls_method_context_t hctx,
                         const string &key,
                         bufferlist *outbl)
 {
-  OSDOp op{ CEPH_OSD_OP_OMAPGETVALSBYKEYS };
+  OSDOp op{CEPH_OSD_OP_OMAPGETVALSBYKEYS};
   {
     std::set<std::string> k{key};
     encode(k, op.indata);
@@ -332,7 +332,7 @@ int cls_cxx_map_set_val(cls_method_context_t hctx,
                         const string &key,
                         bufferlist *inbl)
 {
-  OSDOp op{ CEPH_OSD_OP_OMAPSETVALS };
+  OSDOp op{CEPH_OSD_OP_OMAPSETVALS};
   {
     std::map<std::string, ceph::bufferlist> m;
     m[key] = *inbl;
@@ -344,7 +344,7 @@ int cls_cxx_map_set_val(cls_method_context_t hctx,
 int cls_cxx_map_set_vals(cls_method_context_t hctx,
                          const std::map<string, ceph::bufferlist> *map)
 {
-  OSDOp op{ CEPH_OSD_OP_OMAPSETVALS };
+  OSDOp op{CEPH_OSD_OP_OMAPSETVALS};
   encode(*map, op.indata);
   return execute_osd_op(hctx, op);
 }

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -356,7 +356,9 @@ int cls_cxx_map_clear(cls_method_context_t hctx)
 
 int cls_cxx_map_write_header(cls_method_context_t hctx, bufferlist *inbl)
 {
-  return 0;
+  OSDOp op{CEPH_OSD_OP_OMAPSETHEADER};
+  op.indata.claim(*inbl);
+  return execute_osd_op(hctx, op);
 }
 
 int cls_cxx_map_remove_range(cls_method_context_t hctx,

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -293,6 +293,11 @@ int cls_cxx_map_get_vals(cls_method_context_t hctx,
 
 int cls_cxx_map_read_header(cls_method_context_t hctx, bufferlist *outbl)
 {
+  OSDOp op{CEPH_OSD_OP_OMAPGETHEADER};
+  if (const auto ret = execute_osd_op(hctx, op); ret < 0) {
+    return ret;
+  }
+  outbl->claim(op.outdata);
   return 0;
 }
 

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -365,7 +365,10 @@ int cls_cxx_map_remove_range(cls_method_context_t hctx,
                              const std::string& key_begin,
                              const std::string& key_end)
 {
-  return 0;
+  OSDOp op{CEPH_OSD_OP_OMAPRMKEYRANGE};
+  encode(key_begin, op.indata);
+  encode(key_end, op.indata);
+  return execute_osd_op(hctx, op);
 }
 
 int cls_cxx_map_remove_key(cls_method_context_t hctx, const string &key)

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -759,6 +759,15 @@ OpsExecuter::execute_osd_op(OSDOp& osd_op)
       osd_op_params = osd_op_params_t();
       return backend.omap_set_vals(os, osd_op, txn, *osd_op_params);
     }, true);
+  case CEPH_OSD_OP_OMAPSETHEADER:
+#if 0
+    if (!pg.get_pool().info.supports_omap()) {
+      return crimson::ct_error::operation_not_supported::make();
+    }
+#endif
+    return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
+      return backend.omap_set_header(os, osd_op, txn);
+    }, true);
 
   // watch/notify
   case CEPH_OSD_OP_WATCH:

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -768,6 +768,15 @@ OpsExecuter::execute_osd_op(OSDOp& osd_op)
     return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
       return backend.omap_set_header(os, osd_op, txn);
     }, true);
+  case CEPH_OSD_OP_OMAPRMKEYRANGE:
+#if 0
+    if (!pg.get_pool().info.supports_omap()) {
+      return crimson::ct_error::operation_not_supported::make();
+    }
+#endif
+    return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
+      return backend.omap_remove_range(os, osd_op, txn);
+    }, true);
 
   // watch/notify
   case CEPH_OSD_OP_WATCH:

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -741,6 +741,10 @@ OpsExecuter::execute_osd_op(OSDOp& osd_op)
     return do_read_op([&osd_op] (auto& backend, const auto& os) {
       return backend.omap_get_vals(os, osd_op);
     });
+  case CEPH_OSD_OP_OMAPGETHEADER:
+    return do_read_op([&osd_op] (auto& backend, const auto& os) {
+      return backend.omap_get_header(os, osd_op);
+    });
   case CEPH_OSD_OP_OMAPGETVALSBYKEYS:
     return do_read_op([&osd_op] (auto& backend, const auto& os) {
       return backend.omap_get_vals_by_keys(os, osd_op);

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -515,8 +515,8 @@ maybe_get_omap_vals(
 }
 
 seastar::future<ceph::bufferlist> PGBackend::omap_get_header(
-  crimson::os::CollectionRef& c,
-  const ghobject_t& oid)
+  const crimson::os::CollectionRef& c,
+  const ghobject_t& oid) const
 {
   return store->omap_get_header(c, oid);
 }

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -690,6 +690,21 @@ seastar::future<> PGBackend::omap_set_vals(
   return seastar::now();
 }
 
+seastar::future<> PGBackend::omap_set_header(
+  ObjectState& os,
+  const OSDOp& osd_op,
+  ceph::os::Transaction& txn)
+{
+  maybe_create_new_object(os, txn);
+  txn.omap_setheader(coll->get_cid(), ghobject_t{os.oi.soid}, osd_op.indata);
+  //TODO:
+  //ctx->clean_regions.mark_omap_dirty();
+	//ctx->delta_stats.num_wr++;
+  os.oi.set_flag(object_info_t::FLAG_OMAP);
+  os.oi.clear_omap_digest();
+  return seastar::now();
+}
+
 seastar::future<struct stat> PGBackend::stat(
   CollectionRef c,
   const ghobject_t& oid) const

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -615,13 +615,14 @@ seastar::future<> PGBackend::omap_get_vals(
         const auto& [key, value] = *iter;
         if (key.substr(0, filter_prefix.size()) != filter_prefix) {
           break;
-        } else if (num++ >= max_return ||
+        } else if (num >= max_return ||
             result.length() >= local_conf()->osd_max_omap_bytes_per_request) {
           truncated = true;
           break;
         }
         encode(key, result);
         encode(value, result);
+        ++num;
       }
       encode(num, osd_op.outdata);
       osd_op.outdata.claim_append(result);

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -521,6 +521,17 @@ seastar::future<ceph::bufferlist> PGBackend::omap_get_header(
   return store->omap_get_header(c, oid);
 }
 
+seastar::future<> PGBackend::omap_get_header(
+  const ObjectState& os,
+  OSDOp& osd_op) const
+{
+  return omap_get_header(coll, ghobject_t{os.oi.soid}).then(
+    [&osd_op] (ceph::bufferlist&& header) {
+      osd_op.outdata = std::move(header);
+      return seastar::now();
+    });
+}
+
 seastar::future<> PGBackend::omap_get_keys(
   const ObjectState& os,
   OSDOp& osd_op) const

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -134,6 +134,9 @@ public:
   seastar::future<ceph::bufferlist> omap_get_header(
     crimson::os::CollectionRef& c,
     const ghobject_t& oid);
+  seastar::future<> omap_get_header(
+    const ObjectState& os,
+    OSDOp& osd_op) const;
 
   virtual void got_rep_op_reply(const MOSDRepOpReply&) {}
   virtual seastar::future<> stop() = 0;

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -137,6 +137,10 @@ public:
   seastar::future<> omap_get_header(
     const ObjectState& os,
     OSDOp& osd_op) const;
+  seastar::future<> omap_set_header(
+    ObjectState& os,
+    const OSDOp& osd_op,
+    ceph::os::Transaction& trans);
 
   virtual void got_rep_op_reply(const MOSDRepOpReply&) {}
   virtual seastar::future<> stop() = 0;

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -132,8 +132,8 @@ public:
     ceph::os::Transaction& trans,
     osd_op_params_t& osd_op_params);
   seastar::future<ceph::bufferlist> omap_get_header(
-    crimson::os::CollectionRef& c,
-    const ghobject_t& oid);
+    const crimson::os::CollectionRef& c,
+    const ghobject_t& oid) const;
   seastar::future<> omap_get_header(
     const ObjectState& os,
     OSDOp& osd_op) const;

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -141,6 +141,10 @@ public:
     ObjectState& os,
     const OSDOp& osd_op,
     ceph::os::Transaction& trans);
+  seastar::future<> omap_remove_range(
+    ObjectState& os,
+    const OSDOp& osd_op,
+    ceph::os::Transaction& trans);
 
   virtual void got_rep_op_reply(const MOSDRepOpReply&) {}
   virtual seastar::future<> stop() = 0;


### PR DESCRIPTION
Implemented the necessary missing objclass and PGBackend functions for cls_log to work in crimson 
Signed-off-by: Amnon Hanuhov <ahanukov@redhat.com>
CC: @rzarzynski 
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
