### PR TITLE
Prevent huge WAL sizes when rocksdb sharding enabled

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4413,7 +4413,7 @@ std::vector<Option> get_global_options() {
     .set_description("max duration to force deferred submit"),
 
     Option("bluestore_rocksdb_options", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4,write_buffer_size=268435456,writable_file_max_buffer_size=0,compaction_readahead_size=2097152,max_background_compactions=2")
+    .set_default("compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4,write_buffer_size=268435456,writable_file_max_buffer_size=0,compaction_readahead_size=2097152,max_background_compactions=2,max_total_wal_size=1073741824")
     .set_description("Rocksdb options"),
 
     Option("bluestore_rocksdb_cf", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
This fixes problem in case when sharding is turned on ('bluestore_rocksdb_cf=true').
Default value (0) caused rocksdb to set maximum of 16GB for WALs.
Now this is 1GB. This still can be overridden by setting rocksdb options
'max_total_wal_size' and 'max_write_buffer_number'.
