### PR TITLE
mgr/dashboard: Migrate Tabs from ngx-bootstrap to ng-bootstrap

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/osds.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/osds.e2e-spec.ts
@@ -42,8 +42,8 @@ describe('OSDs page', () => {
       });
 
       it('should show the correct text for the tab labels', () => {
-        cy.get('#tabset-osd-details > div > tab').then(($tabs) => {
-          const tabHeadings = $tabs.map((_i, e) => e.getAttribute('heading')).get();
+        cy.get('#tabset-osd-details > li > a').then(($tabs) => {
+          const tabHeadings = $tabs.map((_i, e) => e.textContent).get();
 
           expect(tabHeadings).to.eql([
             'Devices',

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/daemons.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/daemons.po.ts
@@ -5,12 +5,12 @@ export class DaemonsPageHelper extends PageHelper {
     index: { url: '#/rgw/daemon', id: 'cd-rgw-daemon-list' }
   };
 
-  getTableCell(tableIndex: number) {
+  getTableCell() {
     return cy
-      .get('.tab-container')
+      .get('.tab-content')
       .its(1)
       .find('cd-table')
-      .its(tableIndex)
+      .should('have.length', 1) // Only 1 table should be renderer
       .find('datatable-body-cell');
   }
 
@@ -20,23 +20,15 @@ export class DaemonsPageHelper extends PageHelper {
 
     // check details table is visible
     // check at least one field is present
-    this.getTableCell(0).should('visible').should('contain.text', 'ceph_version');
-    // check performance counters table is not currently visible
-    this.getTableCell(1).should('not.be.visible');
+    this.getTableCell().should('visible').should('contain.text', 'ceph_version');
 
     // click on performance counters tab and check table is loaded
     cy.contains('.nav-link', 'Performance Counters').click();
 
     // check at least one field is present
-    this.getTableCell(1).should('be.visible').should('contain.text', 'objecter.op_r');
-    // check details table is not currently visible
-    this.getTableCell(0).should('not.be.visible');
+    this.getTableCell().should('be.visible').should('contain.text', 'objecter.op_r');
 
     // click on performance details tab
     cy.contains('.nav-link', 'Performance Details').click();
-
-    // checks the other tabs' content isn't visible
-    this.getTableCell(0).should('not.be.visible');
-    this.getTableCell(1).should('not.be.visible');
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/package-lock.json
+++ b/src/pybind/mgr/dashboard/frontend/package-lock.json
@@ -12613,6 +12613,12 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
+    "mem": {
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      },
+      "version": "4.3.0"
+    },
     "memory-fs": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
@@ -12811,8 +12817,7 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "mini-css-extract-plugin": {
       "version": "0.9.0",
@@ -13882,11 +13887,6 @@
       "dependencies": {
         "mem": {
           "version": "4.3.0"
-        },
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
         }
       }
     },

--- a/src/pybind/mgr/dashboard/frontend/src/app/app.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app.module.ts
@@ -14,7 +14,6 @@ import { I18n } from '@ngx-translate/i18n-polyfill';
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
 
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 
 import { AppRoutingModule } from './app-routing.module';
@@ -47,7 +46,6 @@ export function jwtTokenGetter() {
     SharedModule,
     CephModule,
     BsDropdownModule.forRoot(),
-    TabsModule.forRoot(),
     JwtModule.forRoot({
       config: {
         tokenGetter: jwtTokenGetter

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -3,13 +3,13 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { TreeModule } from 'angular-tree-component';
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
 import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { ProgressbarModule } from 'ngx-bootstrap/progressbar';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { ActionLabels, URLVerbs } from '../../shared/constants/app.constants';
@@ -60,7 +60,7 @@ import { RbdTrashRestoreModalComponent } from './rbd-trash-restore-modal/rbd-tra
     MirroringModule,
     FormsModule,
     ReactiveFormsModule,
-    TabsModule.forRoot(),
+    NgbNavModule,
     ProgressbarModule.forRoot(),
     BsDropdownModule.forRoot(),
     BsDatepickerModule.forRoot(),

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-tabs/iscsi-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-tabs/iscsi-tabs.component.html
@@ -1,12 +1,14 @@
-<tabset>
-  <tab heading="Overview"
-       i18n-heading
-       [active]="url === '/block/iscsi/overview'"
-       (selectTab)="navigateTo('/block/iscsi/overview')">
-  </tab>
-  <tab heading="Targets"
-       i18n-heading
-       [active]="url === '/block/iscsi/targets'"
-       (selectTab)="navigateTo('/block/iscsi/targets')">
-  </tab>
-</tabset>
+<ul ngbNav
+    #nav="ngbNav"
+    [activeId]="router.url"
+    (navChange)="router.navigate([$event.nextId])"
+    class="nav-tabs">
+  <li ngbNavItem="/block/iscsi/overview">
+    <a ngbNavLink
+       i18n>Overview</a>
+  </li>
+  <li ngbNavItem="/block/iscsi/targets">
+    <a ngbNavLink
+       i18n>Targets</a>
+  </li>
+</ul>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-tabs/iscsi-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-tabs/iscsi-tabs.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
@@ -12,7 +12,7 @@ describe('IscsiTabsComponent', () => {
   let fixture: ComponentFixture<IscsiTabsComponent>;
 
   configureTestBed({
-    imports: [SharedModule, TabsModule.forRoot(), RouterTestingModule],
+    imports: [SharedModule, RouterTestingModule, NgbNavModule],
     declarations: [IscsiTabsComponent]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-tabs/iscsi-tabs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-tabs/iscsi-tabs.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { Router } from '@angular/router';
 
@@ -7,16 +7,6 @@ import { Router } from '@angular/router';
   templateUrl: './iscsi-tabs.component.html',
   styleUrls: ['./iscsi-tabs.component.scss']
 })
-export class IscsiTabsComponent implements OnInit {
-  url: string;
-
-  constructor(private router: Router) {}
-
-  ngOnInit() {
-    this.url = this.router.url;
-  }
-
-  navigateTo(url: string) {
-    this.router.navigate([url]);
-  }
+export class IscsiTabsComponent {
+  constructor(public router: Router) {}
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-details/iscsi-target-details.component.ts
@@ -280,7 +280,7 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
       const tempData = this.metadata[node.data.cdId] || {};
 
       if (node.data.cdId === 'root') {
-        this.columns[2].isHidden = false;
+        this.detailTable?.toggleColumn({ target: { name: 'default', checked: true } });
         this.data = _.map(this.settings.target_default_controls, (value, key) => {
           value = this.format(value);
           return {
@@ -300,7 +300,7 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
           });
         }
       } else if (node.data.cdId.toString().startsWith('disk_')) {
-        this.columns[2].isHidden = false;
+        this.detailTable?.toggleColumn({ target: { name: 'default', checked: true } });
         this.data = _.map(this.settings.disk_default_controls[tempData.backstore], (value, key) => {
           value = this.format(value);
           return {
@@ -326,7 +326,7 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
           }
         });
       } else {
-        this.columns[2].isHidden = true;
+        this.detailTable?.toggleColumn({ target: { name: 'default', checked: false } });
         this.data = _.map(tempData, (value, key) => {
           return {
             displayName: key,
@@ -339,9 +339,7 @@ export class IscsiTargetDetailsComponent implements OnChanges, OnInit {
       this.data = undefined;
     }
 
-    if (this.detailTable) {
-      this.detailTable.updateColumns();
-    }
+    this.detailTable?.updateColumns();
   }
 
   onUpdateData() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.scss
@@ -1,9 +1,0 @@
-::ng-deep tabset.tabset > ul {
-  border-bottom: 1px solid #ddd;
-  float: left;
-  display: block;
-  margin-right: 20px;
-  border-bottom: 0;
-  border-right: 1px solid #ddd;
-  padding-right: 15px;
-}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.spec.ts
@@ -3,8 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { TreeModule } from 'angular-tree-component';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 import { BehaviorSubject, of } from 'rxjs';
 
@@ -40,9 +40,9 @@ describe('IscsiTargetListComponent', () => {
       HttpClientTestingModule,
       RouterTestingModule,
       SharedModule,
-      TabsModule.forRoot(),
       TreeModule,
-      ToastrModule.forRoot()
+      ToastrModule.forRoot(),
+      NgbNavModule
     ],
     declarations: [IscsiTargetListComponent, IscsiTabsComponent, IscsiTargetDetailsComponent],
     providers: [TaskListService, i18nProviders]

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/daemon-list/daemon-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/daemon-list/daemon-list.component.spec.ts
@@ -4,7 +4,6 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ProgressbarModule } from 'ngx-bootstrap/progressbar';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../../shared/shared.module';
@@ -21,7 +20,6 @@ describe('DaemonListComponent', () => {
       BrowserAnimationsModule,
       SharedModule,
       BsDropdownModule.forRoot(),
-      TabsModule.forRoot(),
       ProgressbarModule.forRoot(),
       HttpClientTestingModule
     ],

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.html
@@ -1,35 +1,45 @@
-<tabset #tabset>
-  <tab heading="Issues"
-       i18n-heading>
-    <cd-table *ngIf="tabset.tabs[0]?.active"
-              [data]="image_error.data"
-              columnMode="flex"
-              [columns]="image_error.columns"
-              [autoReload]="-1"
-              (fetchData)="refresh()">
-    </cd-table>
-  </tab>
-  <tab heading="Syncing"
-       i18n-heading>
-    <cd-table *ngIf="tabset.tabs[1]?.active"
-              [data]="image_syncing.data"
-              columnMode="flex"
-              [columns]="image_syncing.columns"
-              [autoReload]="-1"
-              (fetchData)="refresh()">
-    </cd-table>
-  </tab>
-  <tab heading="Ready"
-       i18n-heading>
-    <cd-table *ngIf="tabset.tabs[2]?.active"
-              [data]="image_ready.data"
-              columnMode="flex"
-              [columns]="image_ready.columns"
-              [autoReload]="-1"
-              (fetchData)="refresh()">
-    </cd-table>
-  </tab>
-</tabset>
+<ul ngbNav
+    #nav="ngbNav"
+    class="nav-tabs">
+  <li ngbNavItem>
+    <a ngbNavLink
+       i18n>Issues</a>
+    <ng-template ngbNavContent>
+      <cd-table [data]="image_error.data"
+                columnMode="flex"
+                [columns]="image_error.columns"
+                [autoReload]="-1"
+                (fetchData)="refresh()">
+      </cd-table>
+    </ng-template>
+  </li>
+  <li ngbNavItem>
+    <a ngbNavLink
+       i18n>Syncing</a>
+    <ng-template ngbNavContent>
+      <cd-table [data]="image_syncing.data"
+                columnMode="flex"
+                [columns]="image_syncing.columns"
+                [autoReload]="-1"
+                (fetchData)="refresh()">
+      </cd-table>
+    </ng-template>
+  </li>
+  <li ngbNavItem>
+    <a ngbNavLink
+       i18n>Ready</a>
+    <ng-template ngbNavContent>
+      <cd-table [data]="image_ready.data"
+                columnMode="flex"
+                [columns]="image_ready.columns"
+                [autoReload]="-1"
+                (fetchData)="refresh()">
+      </cd-table>
+    </ng-template>
+  </li>
+</ul>
+
+<div [ngbNavOutlet]="nav"></div>
 
 <ng-template #stateTmpl
              let-row="row"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.spec.ts
@@ -2,9 +2,9 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ProgressbarModule } from 'ngx-bootstrap/progressbar';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../../shared/shared.module';
@@ -21,7 +21,7 @@ describe('ImageListComponent', () => {
       BrowserAnimationsModule,
       SharedModule,
       BsDropdownModule.forRoot(),
-      TabsModule.forRoot(),
+      NgbNavModule,
       ProgressbarModule.forRoot(),
       HttpClientTestingModule
     ],

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/mirroring.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/mirroring.module.ts
@@ -3,12 +3,12 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
 import { AlertModule } from 'ngx-bootstrap/alert';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { ProgressbarModule } from 'ngx-bootstrap/progressbar';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { SharedModule } from '../../../shared/shared.module';
@@ -35,8 +35,8 @@ import { PoolListComponent } from './pool-list/pool-list.component';
   ],
   imports: [
     CommonModule,
-    TabsModule.forRoot(),
     SharedModule,
+    NgbNavModule,
     RouterModule,
     FormsModule,
     ReactiveFormsModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.spec.ts
@@ -3,9 +3,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ProgressbarModule } from 'ngx-bootstrap/progressbar';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
@@ -32,7 +32,7 @@ describe('OverviewComponent', () => {
       BrowserAnimationsModule,
       SharedModule,
       BsDropdownModule.forRoot(),
-      TabsModule.forRoot(),
+      NgbNavModule,
       ProgressbarModule.forRoot(),
       HttpClientTestingModule,
       RouterTestingModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-list/pool-list.component.spec.ts
@@ -5,7 +5,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ProgressbarModule } from 'ngx-bootstrap/progressbar';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
@@ -23,7 +22,6 @@ describe('PoolListComponent', () => {
       BrowserAnimationsModule,
       SharedModule,
       BsDropdownModule.forRoot(),
-      TabsModule.forRoot(),
       ProgressbarModule.forRoot(),
       HttpClientTestingModule,
       RouterTestingModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
@@ -2,134 +2,149 @@
   <ng-container i18n>Only available for RBD images with <strong>fast-diff</strong> enabled</ng-container>
 </ng-template>
 
-<tabset *ngIf="selection">
-  <tab i18n-heading
-       heading="Details">
-    <table class="table table-striped table-bordered">
-      <tbody>
-        <tr>
-          <td i18n
-              class="bold w-25">Name</td>
-          <td class="w-75">{{ selection.name }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Pool</td>
-          <td>{{ selection.pool_name }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Data Pool</td>
-          <td>{{ selection.data_pool | empty }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Created</td>
-          <td>{{ selection.timestamp | cdDate }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Size</td>
-          <td>{{ selection.size | dimlessBinary }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Objects</td>
-          <td>{{ selection.num_objs | dimless }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Object size</td>
-          <td>{{ selection.obj_size | dimlessBinary }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Features</td>
-          <td>
-            <span *ngFor="let feature of selection.features_name">
-              <span class="badge badge-dark mr-2">{{ feature }}</span>
-            </span>
-          </td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Provisioned</td>
-          <td>
-            <span *ngIf="selection.features_name?.indexOf('fast-diff') === -1">
-              <span class="form-text text-muted"
-                    [tooltip]="usageNotAvailableTooltipTpl"
-                    placement="right"
-                    i18n>N/A</span>
-            </span>
-            <span *ngIf="selection.features_name?.indexOf('fast-diff') !== -1">
-              {{ selection.disk_usage | dimlessBinary }}
-            </span>
-          </td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Total provisioned</td>
-          <td>
-            <span *ngIf="selection.features_name?.indexOf('fast-diff') === -1">
-              <span class="form-text text-muted"
-                    [tooltip]="usageNotAvailableTooltipTpl"
-                    placement="right"
-                    i18n>N/A</span>
-            </span>
-            <span *ngIf="selection.features_name?.indexOf('fast-diff') !== -1">
-              {{ selection.total_disk_usage | dimlessBinary }}
-            </span>
-          </td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Striping unit</td>
-          <td>{{ selection.stripe_unit | dimlessBinary }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Striping count</td>
-          <td>{{ selection.stripe_count }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Parent</td>
-          <td>
-            <span *ngIf="selection.parent">{{ selection.parent.pool_name }}<span *ngIf="selection.parent.pool_namespace">/{{ selection.parent.pool_namespace }}</span>/{{ selection.parent.image_name }}@{{ selection.parent.snap_name }}</span>
-            <span *ngIf="!selection.parent">-</span>
-          </td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Block name prefix</td>
-          <td>{{ selection.block_name_prefix }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Order</td>
-          <td>{{ selection.order }}</td>
-        </tr>
-      </tbody>
-    </table>
-  </tab>
-  <tab i18n-heading
-       heading="Snapshots">
-    <cd-rbd-snapshot-list [snapshots]="selection.snapshots"
-                          [featuresName]="selection.features_name"
-                          [poolName]="selection.pool_name"
-                          [namespace]="selection.namespace"
-                          [rbdName]="selection.name"></cd-rbd-snapshot-list>
-  </tab>
-  <tab i18n-heading
-       heading="Configuration">
-    <cd-rbd-configuration-table [data]="selection['configuration']"></cd-rbd-configuration-table>
-  </tab>
-</tabset>
+<ng-container *ngIf="selection">
+  <ul ngbNav
+      #nav="ngbNav"
+      class="nav-tabs">
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Details</a>
+      <ng-template ngbNavContent>
+        <table class="table table-striped table-bordered">
+          <tbody>
+            <tr>
+              <td i18n
+                  class="bold w-25">Name</td>
+              <td class="w-75">{{ selection.name }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Pool</td>
+              <td>{{ selection.pool_name }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Data Pool</td>
+              <td>{{ selection.data_pool | empty }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Created</td>
+              <td>{{ selection.timestamp | cdDate }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Size</td>
+              <td>{{ selection.size | dimlessBinary }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Objects</td>
+              <td>{{ selection.num_objs | dimless }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Object size</td>
+              <td>{{ selection.obj_size | dimlessBinary }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Features</td>
+              <td>
+                <span *ngFor="let feature of selection.features_name">
+                  <span class="badge badge-dark mr-2">{{ feature }}</span>
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Provisioned</td>
+              <td>
+                <span *ngIf="selection.features_name?.indexOf('fast-diff') === -1">
+                  <span class="form-text text-muted"
+                        [tooltip]="usageNotAvailableTooltipTpl"
+                        placement="right"
+                        i18n>N/A</span>
+                </span>
+                <span *ngIf="selection.features_name?.indexOf('fast-diff') !== -1">
+                  {{ selection.disk_usage | dimlessBinary }}
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Total provisioned</td>
+              <td>
+                <span *ngIf="selection.features_name?.indexOf('fast-diff') === -1">
+                  <span class="form-text text-muted"
+                        [tooltip]="usageNotAvailableTooltipTpl"
+                        placement="right"
+                        i18n>N/A</span>
+                </span>
+                <span *ngIf="selection.features_name?.indexOf('fast-diff') !== -1">
+                  {{ selection.total_disk_usage | dimlessBinary }}
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Striping unit</td>
+              <td>{{ selection.stripe_unit | dimlessBinary }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Striping count</td>
+              <td>{{ selection.stripe_count }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Parent</td>
+              <td>
+                <span *ngIf="selection.parent">{{ selection.parent.pool_name }}<span
+                        *ngIf="selection.parent.pool_namespace">/{{ selection.parent.pool_namespace }}</span>/{{ selection.parent.image_name }}@{{ selection.parent.snap_name }}</span>
+                <span *ngIf="!selection.parent">-</span>
+              </td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Block name prefix</td>
+              <td>{{ selection.block_name_prefix }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Order</td>
+              <td>{{ selection.order }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </ng-template>
+    </li>
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Snapshots</a>
+      <ng-template ngbNavContent>
+        <cd-rbd-snapshot-list [snapshots]="selection.snapshots"
+                              [featuresName]="selection.features_name"
+                              [poolName]="selection.pool_name"
+                              [namespace]="selection.namespace"
+                              [rbdName]="selection.name"></cd-rbd-snapshot-list>
+      </ng-template>
+    </li>
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Configuration</a>
+      <ng-template ngbNavContent>
+        <cd-rbd-configuration-table [data]="selection['configuration']"></cd-rbd-configuration-table>
+      </ng-template>
+    </li>
+  </ul>
 
-<ng-template
-  #poolConfigurationSourceTpl
-  let-row="row"
-  let-value="value">
+  <div [ngbNavOutlet]="nav"></div>
+</ng-container>
+
+<ng-template #poolConfigurationSourceTpl
+             let-row="row"
+             let-value="value">
   <ng-container *ngIf="+value; else global">
     <strong i18n
             i18n-tooltip
@@ -141,4 +156,3 @@
           tooltip="This is the global value. No value for this option has been set for this image.">Global</span>
   </ng-template>
 </ng-template>
-

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
@@ -16,7 +16,7 @@ describe('RbdDetailsComponent', () => {
 
   configureTestBed({
     declarations: [RbdDetailsComponent, RbdSnapshotListComponent, RbdConfigurationListComponent],
-    imports: [SharedModule, TabsModule.forRoot(), TooltipModule.forRoot(), RouterTestingModule]
+    imports: [SharedModule, TooltipModule.forRoot(), RouterTestingModule, NgbNavModule]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.ts
@@ -1,5 +1,7 @@
 import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
 
+import { NgbNav } from '@ng-bootstrap/ng-bootstrap';
+
 import { RbdFormModel } from '../rbd-form/rbd-form.model';
 
 @Component({
@@ -12,8 +14,12 @@ export class RbdDetailsComponent {
   selection: RbdFormModel;
   @Input()
   images: any;
+
   @ViewChild('poolConfigurationSourceTpl', { static: true })
   poolConfigurationSourceTpl: TemplateRef<any>;
+
+  @ViewChild(NgbNav, { static: true })
+  nav: NgbNav;
 
   constructor() {}
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
@@ -3,10 +3,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { AlertModule } from 'ngx-bootstrap/alert';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ModalModule } from 'ngx-bootstrap/modal';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ToastrModule } from 'ngx-toastr';
 import { BehaviorSubject, of } from 'rxjs';
@@ -46,7 +46,7 @@ describe('RbdListComponent', () => {
       BrowserAnimationsModule,
       SharedModule,
       BsDropdownModule.forRoot(),
-      TabsModule.forRoot(),
+      NgbNavModule,
       ModalModule.forRoot(),
       TooltipModule.forRoot(),
       ToastrModule.forRoot(),

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-list/rbd-namespace-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-list/rbd-namespace-list.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrModule } from 'ngx-toastr';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
@@ -24,7 +24,7 @@ describe('RbdNamespaceListComponent', () => {
       HttpClientTestingModule,
       RouterTestingModule,
       ToastrModule.forRoot(),
-      TabsModule.forRoot()
+      NgbNavModule
     ],
     providers: [TaskListService, i18nProviders]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-performance/rbd-performance.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-performance/rbd-performance.component.spec.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
@@ -14,7 +14,7 @@ describe('RbdPerformanceComponent', () => {
   let fixture: ComponentFixture<RbdPerformanceComponent>;
 
   configureTestBed({
-    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule, TabsModule.forRoot()],
+    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule, NgbNavModule],
     declarations: [RbdPerformanceComponent, RbdTabsComponent],
     providers: i18nProviders
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -3,9 +3,9 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { I18n } from '@ngx-translate/i18n-polyfill';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 import { Subject, throwError as observableThrowError } from 'rxjs';
 
@@ -57,7 +57,7 @@ describe('RbdSnapshotListComponent', () => {
       HttpClientTestingModule,
       PipesModule,
       RouterTestingModule,
-      TabsModule.forRoot(),
+      NgbNavModule,
       ToastrModule.forRoot()
     ],
     providers: [

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-tabs/rbd-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-tabs/rbd-tabs.component.html
@@ -1,23 +1,23 @@
-<tabset>
-  <tab heading="Images"
-       i18n-heading
-       [active]="url === '/block/rbd'"
-       (selectTab)="navigateTo('/block/rbd')">
-  </tab>
-  <tab heading="Namespaces"
-       i18n-heading
-       [active]="url === '/block/rbd/namespaces'"
-       (selectTab)="navigateTo('/block/rbd/namespaces')">
-  </tab>
-  <tab heading="Trash"
-       i18n-heading
-       [active]="url === '/block/rbd/trash'"
-       (selectTab)="navigateTo('/block/rbd/trash')">
-  </tab>
-  <tab heading="Overall Performance"
-       i18n-heading
-       *ngIf="grafanaPermission.read"
-       [active]="url === '/block/rbd/performance'"
-       (selectTab)="navigateTo('/block/rbd/performance')">
-  </tab>
-</tabset>
+<ul ngbNav
+    #nav="ngbNav"
+    [activeId]="router.url"
+    (navChange)="router.navigate([$event.nextId])"
+    class="nav-tabs">
+  <li ngbNavItem="/block/rbd">
+    <a ngbNavLink
+       i18n>Images</a>
+  </li>
+  <li ngbNavItem="/block/rbd/namespaces">
+    <a ngbNavLink
+       i18n>Namespaces</a>
+  </li>
+  <li ngbNavItem="/block/rbd/trash">
+    <a ngbNavLink
+       i18n>Trash</a>
+  </li>
+  <li ngbNavItem="/block/rbd/performance"
+      *ngIf="grafanaPermission.read">
+    <a ngbNavLink
+       i18n>Overall Performance</a>
+  </li>
+</ul>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-tabs/rbd-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-tabs/rbd-tabs.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { RbdTabsComponent } from './rbd-tabs.component';
@@ -11,7 +11,7 @@ describe('RbdTabsComponent', () => {
   let fixture: ComponentFixture<RbdTabsComponent>;
 
   configureTestBed({
-    imports: [TabsModule.forRoot(), RouterTestingModule],
+    imports: [RouterTestingModule, NgbNavModule],
     declarations: [RbdTabsComponent]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-tabs/rbd-tabs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-tabs/rbd-tabs.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { Permission } from '../../../shared/models/permissions';
@@ -9,19 +9,11 @@ import { AuthStorageService } from '../../../shared/services/auth-storage.servic
   templateUrl: './rbd-tabs.component.html',
   styleUrls: ['./rbd-tabs.component.scss']
 })
-export class RbdTabsComponent implements OnInit {
+export class RbdTabsComponent {
   grafanaPermission: Permission;
   url: string;
 
-  constructor(private authStorageService: AuthStorageService, private router: Router) {
+  constructor(private authStorageService: AuthStorageService, public router: Router) {
     this.grafanaPermission = this.authStorageService.getPermissions().grafana;
-  }
-
-  ngOnInit() {
-    this.url = this.router.url;
-  }
-
-  navigateTo(url: string) {
-    this.router.navigate([url]);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.spec.ts
@@ -4,8 +4,8 @@ import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import * as moment from 'moment';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 
@@ -37,7 +37,7 @@ describe('RbdTrashListComponent', () => {
       HttpClientTestingModule,
       RouterTestingModule,
       SharedModule,
-      TabsModule.forRoot(),
+      NgbNavModule,
       ToastrModule.forRoot()
     ],
     providers: [TaskListService, i18nProviders]

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.html
@@ -1,34 +1,48 @@
-<tabset *ngIf="selection">
-  <tab i18n-heading
-       (selectTab)="softRefresh()"
-       heading="Details">
-    <cd-cephfs-detail [data]="details">
-    </cd-cephfs-detail>
-  </tab>
-  <tab (selectTab)="softRefresh()">
-    <ng-template tabHeading>
-      <ng-container i18n>Clients</ng-container>
-      <span class="badge badge-pill badge-tab ml-1">{{ clients.data.length }}</span>
-    </ng-template>
-    <cd-cephfs-clients [id]="id"
-                       [clients]="clients"
-                       (triggerApiUpdate)="refresh()">
-    </cd-cephfs-clients>
-  </tab>
-  <tab i18n-heading
-       (selectTab)="directoriesSelected = true"
-       heading="Directories">
-    <cd-cephfs-directories *ngIf="directoriesSelected"
-                           [id]="id">
-    </cd-cephfs-directories>
-  </tab>
-  <tab i18n-heading
-       *ngIf="grafanaPermission.read && grafanaId"
-       heading="Performance Details">
-    <cd-grafana [grafanaPath]="'mds-performance?var-mds_servers=mds.' + grafanaId"
-                uid="tbO9LAiZz"
-                grafanaStyle="one">
-    </cd-grafana>
-  </tab>
-</tabset>
+<ng-container *ngIf="selection">
+  <ul ngbNav
+      #nav="ngbNav"
+      (navChange)="softRefresh()"
+      class="nav-tabs">
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Details</a>
+      <ng-template ngbNavContent>
+        <cd-cephfs-detail [data]="details">
+        </cd-cephfs-detail>
+      </ng-template>
+    </li>
+    <li ngbNavItem>
+      <a ngbNavLink>
+        <ng-container i18n>Clients</ng-container>
+        <span class="badge badge-pill badge-tab ml-1">{{ clients.data.length }}</span>
+      </a>
+      <ng-template ngbNavContent>
+        <cd-cephfs-clients [id]="id"
+                           [clients]="clients"
+                           (triggerApiUpdate)="refresh()">
+        </cd-cephfs-clients>
+      </ng-template>
+    </li>
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Directories</a>
+      <ng-template ngbNavContent>
+        <cd-cephfs-directories *ngIf="directoriesSelected"
+                               [id]="id">
+        </cd-cephfs-directories>
+      </ng-template>
+    </li>
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Performance Details</a>
+      <ng-template ngbNavContent>
+        <cd-grafana [grafanaPath]="'mds-performance?var-mds_servers=mds.' + grafanaId"
+                    uid="tbO9LAiZz"
+                    grafanaStyle="one">
+        </cd-grafana>
+      </ng-template>
+    </li>
+  </ul>
 
+  <div [ngbNavOutlet]="nav"></div>
+</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.spec.ts
@@ -2,9 +2,9 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { TreeModule } from 'angular-tree-component';
 import * as _ from 'lodash';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 
@@ -80,7 +80,7 @@ describe('CephfsTabsComponent', () => {
   configureTestBed({
     imports: [
       SharedModule,
-      TabsModule.forRoot(),
+      NgbNavModule,
       HttpClientTestingModule,
       TreeModule,
       ToastrModule.forRoot()

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs.module.ts
@@ -1,10 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { TreeModule } from 'angular-tree-component';
 import { ChartsModule } from 'ng2-charts';
 import { ProgressbarModule } from 'ngx-bootstrap/progressbar';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { AppRoutingModule } from '../../app-routing.module';
 import { SharedModule } from '../../shared/shared.module';
@@ -23,7 +23,7 @@ import { CephfsTabsComponent } from './cephfs-tabs/cephfs-tabs.component';
     ChartsModule,
     TreeModule.forRoot(),
     ProgressbarModule.forRoot(),
-    TabsModule.forRoot()
+    NgbNavModule
   ],
   declarations: [
     CephfsDetailComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -3,14 +3,13 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
-import { NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbNavModule, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
 import { TreeModule } from 'angular-tree-component';
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
 import { AlertModule } from 'ngx-bootstrap/alert';
 import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ModalModule } from 'ngx-bootstrap/modal';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TimepickerModule } from 'ngx-bootstrap/timepicker';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
@@ -70,7 +69,7 @@ import { TelemetryComponent } from './telemetry/telemetry.component';
   imports: [
     CommonModule,
     PerformanceCounterModule,
-    TabsModule.forRoot(),
+    NgbNavModule,
     SharedModule,
     RouterModule,
     FormsModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-details/configuration-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-details/configuration-details.component.html
@@ -1,108 +1,117 @@
-<tabset *ngIf="selection">
-  <tab i18n-heading
-       heading="Details">
-    <table class="table table-striped table-bordered">
-      <tbody>
-        <tr>
-          <td i18n
-              class="bold w-25">Name</td>
-          <td class="w-75">{{ selection.name }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Description</td>
-          <td>{{ selection.desc }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Long description</td>
-          <td>{{ selection.long_desc }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Current values</td>
-          <td>
-            <span *ngFor="let conf of selection.value; last as isLast">
-              {{ conf.section }}: {{ conf.value }}{{ !isLast ? "," : "" }}<br />
-            </span>
-          </td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Default</td>
-          <td>{{ selection.default }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Daemon default</td>
-          <td>{{ selection.daemon_default }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Type</td>
-          <td>{{ selection.type }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Min</td>
-          <td>{{ selection.min }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Max</td>
-          <td>{{ selection.max }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Flags</td>
-          <td>
-            <span *ngFor="let flag of selection.flags">
-              <span title="{{ flags[flag] }}">
-                <span class="badge badge-dark mr-2">{{ flag | uppercase }}</span>
-              </span>
-            </span>
-          </td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Services</td>
-          <td>
-            <span *ngFor="let service of selection.services">
-              <span class="badge badge-dark mr-2">{{ service }}</span>
-            </span>
-          </td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Source</td>
-          <td>{{ selection.source }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Level</td>
-          <td>{{ selection.level }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Can be updated at runtime (editable)</td>
-          <td>{{ selection.can_update_at_runtime | booleanText }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Tags</td>
-          <td>{{ selection.tags }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">Enum values</td>
-          <td>{{ selection.enum_values }}</td>
-        </tr>
-        <tr>
-          <td i18n
-              class="bold">See also</td>
-          <td>{{ selection.see_also }}</td>
-        </tr>
-      </tbody>
-    </table>
-  </tab>
-</tabset>
+<ng-container *ngIf="selection">
+  <ul ngbNav
+      #nav="ngbNav"
+      class="nav-tabs">
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Details</a>
+      <ng-template ngbNavContent>
+        <table class="table table-striped table-bordered">
+          <tbody>
+            <tr>
+              <td i18n
+                  class="bold w-25">Name</td>
+              <td class="w-75">{{ selection.name }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Description</td>
+              <td>{{ selection.desc }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Long description</td>
+              <td>{{ selection.long_desc }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Current values</td>
+              <td>
+                <span *ngFor="let conf of selection.value; last as isLast">
+                  {{ conf.section }}: {{ conf.value }}{{ !isLast ? "," : "" }}<br />
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Default</td>
+              <td>{{ selection.default }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Daemon default</td>
+              <td>{{ selection.daemon_default }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Type</td>
+              <td>{{ selection.type }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Min</td>
+              <td>{{ selection.min }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Max</td>
+              <td>{{ selection.max }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Flags</td>
+              <td>
+                <span *ngFor="let flag of selection.flags">
+                  <span title="{{ flags[flag] }}">
+                    <span class="badge badge-dark mr-2">{{ flag | uppercase }}</span>
+                  </span>
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Services</td>
+              <td>
+                <span *ngFor="let service of selection.services">
+                  <span class="badge badge-dark mr-2">{{ service }}</span>
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Source</td>
+              <td>{{ selection.source }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Level</td>
+              <td>{{ selection.level }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Can be updated at runtime (editable)</td>
+              <td>{{ selection.can_update_at_runtime | booleanText }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Tags</td>
+              <td>{{ selection.tags }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Enum values</td>
+              <td>{{ selection.enum_values }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">See also</td>
+              <td>{{ selection.see_also }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </ng-template>
+    </li>
+  </ul>
+
+  <div [ngbNavOutlet]="nav"></div>
+</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-details/configuration-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-details/configuration-details.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
 import { DataTableModule } from '../../../../shared/datatable/datatable.module';
@@ -13,7 +13,7 @@ describe('ConfigurationDetailsComponent', () => {
 
   configureTestBed({
     declarations: [ConfigurationDetailsComponent],
-    imports: [DataTableModule, SharedModule, TabsModule.forRoot()],
+    imports: [DataTableModule, SharedModule, NgbNavModule],
     providers: [i18nProviders]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.spec.ts
@@ -5,7 +5,7 @@ import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
@@ -22,7 +22,7 @@ describe('ConfigurationComponent', () => {
       BrowserAnimationsModule,
       SharedModule,
       FormsModule,
-      TabsModule.forRoot(),
+      NgbNavModule,
       HttpClientTestingModule,
       RouterTestingModule
     ],

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.spec.ts
@@ -3,7 +3,6 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TreeModule } from 'angular-tree-component';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { of } from 'rxjs';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
@@ -16,7 +15,7 @@ describe('CrushmapComponent', () => {
   let fixture: ComponentFixture<CrushmapComponent>;
   let debugElement: DebugElement;
   configureTestBed({
-    imports: [HttpClientTestingModule, TreeModule.forRoot(), TabsModule.forRoot(), SharedModule],
+    imports: [HttpClientTestingModule, TreeModule.forRoot(), SharedModule],
     declarations: [CrushmapComponent],
     providers: [HealthService]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.html
@@ -1,33 +1,54 @@
-<tabset *ngIf="selection">
-  <tab i18n-heading
-       heading="Devices">
-    <cd-device-list [hostname]="selection['hostname']"></cd-device-list>
-  </tab>
-  <tab i18n-heading
-       heading="Inventory"
-       *ngIf="permissions.hosts.read">
-    <cd-inventory [hostname]="selectedHostname"></cd-inventory>
-  </tab>
-  <tab i18n-heading
-       heading="Daemons"
-       *ngIf="permissions.hosts.read">
-    <cd-service-daemon-list [hostname]="selectedHostname">
-    </cd-service-daemon-list>
-  </tab>
-  <tab i18n-heading
-       heading="Performance Details"
-       *ngIf="permissions.grafana.read">
-    <cd-grafana [grafanaPath]="'host-details?var-ceph_hosts=' + selectedHostname"
-                uid="rtOg0AiWz"
-                grafanaStyle="three">
-    </cd-grafana>
-  </tab>
-  <tab heading="Device health"
-       i18n-heading>
-    <cd-smart-list *ngIf="selectedHostname; else noHostname"
-                   [hostname]="selectedHostname"></cd-smart-list>
-  </tab>
-</tabset>
+<ng-container *ngIf="selection">
+  <ul ngbNav
+      #nav="ngbNav"
+      class="nav-tabs">
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Devices</a>
+      <ng-template ngbNavContent>
+        <cd-device-list [hostname]="selection['hostname']"></cd-device-list>
+      </ng-template>
+    </li>
+    <li ngbNavItem
+        *ngIf="permissions.hosts.read">
+      <a ngbNavLink
+         i18n>Inventory</a>
+      <ng-template ngbNavContent>
+        <cd-inventory [hostname]="selectedHostname"></cd-inventory>
+      </ng-template>
+    </li>
+    <li ngbNavItem
+        *ngIf="permissions.hosts.read">
+      <a ngbNavLink
+         i18n>Daemons</a>
+      <ng-template ngbNavContent>
+        <cd-service-daemon-list [hostname]="selectedHostname">
+        </cd-service-daemon-list>
+      </ng-template>
+    </li>
+    <li ngbNavItem
+        *ngIf="permissions.grafana.read">
+      <a ngbNavLink
+         i18n>Performance Details</a>
+      <ng-template ngbNavContent>
+        <cd-grafana [grafanaPath]="'host-details?var-ceph_hosts=' + selectedHostname"
+                    uid="rtOg0AiWz"
+                    grafanaStyle="three">
+        </cd-grafana>
+      </ng-template>
+    </li>
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Device health</a>
+      <ng-template ngbNavContent>
+        <cd-smart-list *ngIf="selectedHostname; else noHostname"
+                       [hostname]="selectedHostname"></cd-smart-list>
+      </ng-template>
+    </li>
+  </ul>
+
+  <div [ngbNavOutlet]="nav"></div>
+</ng-container>
 
 <ng-template #noHostname>
   <cd-alert-panel type="error"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.spec.ts
@@ -5,10 +5,13 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 
-import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
+import {
+  configureTestBed,
+  i18nProviders,
+  TabHelper
+} from '../../../../../testing/unit-test-helper';
 import { CoreModule } from '../../../../core/core.module';
 import { Permissions } from '../../../../shared/models/permissions';
 import { SharedModule } from '../../../../shared/shared.module';
@@ -24,7 +27,6 @@ describe('HostDetailsComponent', () => {
     imports: [
       BrowserAnimationsModule,
       HttpClientTestingModule,
-      TabsModule.forRoot(),
       BsDropdownModule.forRoot(),
       NgBootstrapFormValidationModule.forRoot(),
       RouterTestingModule,
@@ -59,17 +61,17 @@ describe('HostDetailsComponent', () => {
     });
 
     it('should recognize a tabset child', () => {
-      const tabsetChild = component.tabsetChild;
+      const tabsetChild = TabHelper.getNgbNav(fixture);
       expect(tabsetChild).toBeDefined();
     });
 
     it('should show tabs', () => {
-      expect(component.tabsetChild.tabs.map((t) => t.heading)).toEqual([
+      expect(TabHelper.getTextContents(fixture)).toEqual([
         'Devices',
-        'Device health',
         'Inventory',
         'Daemons',
-        'Performance Details'
+        'Performance Details',
+        'Device health'
       ]);
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.ts
@@ -1,6 +1,4 @@
-import { Component, Input, ViewChild } from '@angular/core';
-
-import { TabsetComponent } from 'ngx-bootstrap/tabs';
+import { Component, Input } from '@angular/core';
 
 import { Permissions } from '../../../../shared/models/permissions';
 
@@ -16,12 +14,7 @@ export class HostDetailsComponent {
   @Input()
   selection: any;
 
-  @ViewChild(TabsetComponent)
-  tabsetChild: TabsetComponent;
-
   get selectedHostname(): string {
     return this.selection !== undefined ? this.selection['hostname'] : null;
   }
-
-  constructor() {}
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
@@ -1,48 +1,59 @@
-<tabset>
-  <tab i18n-heading
-       heading="Hosts List">
-    <cd-table [data]="hosts"
-              [columns]="columns"
-              columnMode="flex"
-              (fetchData)="getHosts($event)"
-              selectionType="single"
-              [hasDetails]="true"
-              (setExpandedRow)="setExpandedRow($event)"
-              (updateSelection)="updateSelection($event)">
-      <div class="table-actions btn-toolbar">
-        <cd-table-actions [permission]="permissions.hosts"
-                          [selection]="selection"
-                          class="btn-group"
-                          id="host-actions"
-                          [tableActions]="tableActions">
-        </cd-table-actions>
-      </div>
-      <ng-template #servicesTpl
-                   let-value="value">
-        <span *ngFor="let service of value; last as isLast">
-          <a class="service-link"
-             [routerLink]="[service.cdLink]"
-             [queryParams]="cdParams"
-             *ngIf="service.canRead">{{ service.type }}.{{ service.id }}
-          </a>
-          <span *ngIf="!service.canRead">
-            {{ service.type }}.{{ service.id }}
-          </span>
-          {{ !isLast ? ", " : "" }}
-        </span>
-      </ng-template>
-      <cd-host-details cdTableDetail
-                       [permissions]="permissions"
-                       [selection]="expandedRow">
-      </cd-host-details>
-    </cd-table>
-  </tab>
-  <tab i18n-heading
-       *ngIf="permissions.grafana.read"
-       heading="Overall Performance">
-    <cd-grafana [grafanaPath]="'host-overview?'"
-                uid="y0KGL0iZz"
-                grafanaStyle="two">
-    </cd-grafana>
-  </tab>
-</tabset>
+<ul ngbNav
+    #nav="ngbNav"
+    class="nav-tabs">
+  <li ngbNavItem>
+    <a ngbNavLink
+       i18n>Hosts List</a>
+    <ng-template ngbNavContent>
+      <cd-table [data]="hosts"
+                [columns]="columns"
+                columnMode="flex"
+                (fetchData)="getHosts($event)"
+                selectionType="single"
+                [hasDetails]="true"
+                (setExpandedRow)="setExpandedRow($event)"
+                (updateSelection)="updateSelection($event)">
+        <div class="table-actions btn-toolbar">
+          <cd-table-actions [permission]="permissions.hosts"
+                            [selection]="selection"
+                            class="btn-group"
+                            id="host-actions"
+                            [tableActions]="tableActions">
+          </cd-table-actions>
+        </div>
+        <cd-host-details cdTableDetail
+                         [permissions]="permissions"
+                         [selection]="expandedRow">
+        </cd-host-details>
+      </cd-table>
+    </ng-template>
+  </li>
+  <li ngbNavItem
+      *ngIf="permissions.grafana.read">
+    <a ngbNavLink
+       i18n>Overall Performance</a>
+    <ng-template ngbNavContent>
+      <cd-grafana [grafanaPath]="'host-overview?'"
+                  uid="y0KGL0iZz"
+                  grafanaStyle="two">
+      </cd-grafana>
+    </ng-template>
+  </li>
+</ul>
+
+<div [ngbNavOutlet]="nav"></div>
+
+<ng-template #servicesTpl
+             let-value="value">
+  <span *ngFor="let service of value; last as isLast">
+    <a class="service-link"
+       [routerLink]="[service.cdLink]"
+       [queryParams]="cdParams"
+       *ngIf="service.canRead">{{ service.type }}.{{ service.id }}
+    </a>
+    <span *ngIf="!service.canRead">
+      {{ service.type }}.{{ service.id }}
+    </span>
+    {{ !isLast ? ", " : "" }}
+  </span>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -4,7 +4,6 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 
@@ -35,7 +34,6 @@ describe('HostsComponent', () => {
       CephSharedModule,
       SharedModule,
       HttpClientTestingModule,
-      TabsModule.forRoot(),
       BsDropdownModule.forRoot(),
       RouterTestingModule,
       ToastrModule.forRoot(),

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
@@ -1,41 +1,50 @@
 <div *ngIf="contentData">
   <ng-container *ngTemplateOutlet="logFiltersTpl"></ng-container>
 
-  <tabset>
-    <tab i18n-heading
-         heading="Cluster Logs">
-      <div class="card bg-light mb-3"
-           *ngIf="clog">
-        <div class="card-body">
-          <p *ngFor="let line of clog">
-            <span class="timestamp">{{ line.stamp | cdDate }}</span>
-            <span class="priority {{ line.priority | logPriority }}">{{ line.priority }}</span>
-            <span class="message">{{ line.message }}</span>
-          </p>
+  <ul ngbNav
+      #nav="ngbNav"
+      class="nav-tabs">
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Cluster Logs</a>
+      <ng-template ngbNavContent>
+        <div class="card bg-light mb-3"
+             *ngIf="clog">
+          <div class="card-body">
+            <p *ngFor="let line of clog">
+              <span class="timestamp">{{ line.stamp | cdDate }}</span>
+              <span class="priority {{ line.priority | logPriority }}">{{ line.priority }}</span>
+              <span class="message">{{ line.message }}</span>
+            </p>
 
-          <span *ngIf="contentData.clog.length === 0"
-                i18n>No entries found</span>
+            <span *ngIf="contentData.clog.length === 0"
+                  i18n>No entries found</span>
+          </div>
         </div>
-      </div>
-    </tab>
+      </ng-template>
+    </li>
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Audit Logs</a>
+      <ng-template ngbNavContent>
+        <div class="card bg-light mb-3"
+             *ngIf="audit_log">
+          <div class="card-body">
+            <p *ngFor="let line of audit_log">
+              <span class="timestamp">{{ line.stamp | cdDate }}</span>
+              <span class="priority {{ line.priority | logPriority }}">{{ line.priority }}</span>
+              <span class="message">{{ line.message }}</span>
+            </p>
 
-    <tab i18n-heading
-         heading="Audit Logs">
-      <div class="card bg-light mb-3"
-           *ngIf="audit_log">
-        <div class="card-body">
-          <p *ngFor="let line of audit_log">
-            <span class="timestamp">{{ line.stamp | cdDate }}</span>
-            <span class="priority {{ line.priority | logPriority }}">{{ line.priority }}</span>
-            <span class="message">{{ line.message }}</span>
-          </p>
-
-          <span *ngIf="contentData.audit_log.length === 0"
-                i18n>No entries found</span>
+            <span *ngIf="contentData.audit_log.length === 0"
+                  i18n>No entries found</span>
+          </div>
         </div>
-      </div>
-    </tab>
-  </tabset>
+      </ng-template>
+    </li>
+  </ul>
+
+  <div [ngbNavOutlet]="nav"></div>
 </div>
 
 <ng-template #logFiltersTpl>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.spec.ts
@@ -2,8 +2,8 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TimepickerModule } from 'ngx-bootstrap/timepicker';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
@@ -17,7 +17,7 @@ describe('LogsComponent', () => {
   configureTestBed({
     imports: [
       HttpClientTestingModule,
-      TabsModule.forRoot(),
+      NgbNavModule,
       SharedModule,
       BsDatepickerModule.forRoot(),
       TimepickerModule.forRoot(),

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-details/mgr-module-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-details/mgr-module-details.component.html
@@ -1,7 +1,16 @@
-<tabset *ngIf="selection">
-  <tab i18n-heading
-       heading="Details">
-    <cd-table-key-value [data]="module_config">
-    </cd-table-key-value>
-  </tab>
-</tabset>
+<ng-container *ngIf="selection">
+  <ul ngbNav
+      #nav="ngbNav"
+      class="nav-tabs">
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Details</a>
+      <ng-template ngbNavContent>
+        <cd-table-key-value [data]="module_config">
+        </cd-table-key-value>
+      </ng-template>
+    </li>
+  </ul>
+
+  <div [ngbNavOutlet]="nav"></div>
+</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-details/mgr-module-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-details/mgr-module-details.component.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../../shared/shared.module';
@@ -13,7 +13,7 @@ describe('MgrModuleDetailsComponent', () => {
 
   configureTestBed({
     declarations: [MgrModuleDetailsComponent],
-    imports: [HttpClientTestingModule, SharedModule, TabsModule.forRoot()],
+    imports: [HttpClientTestingModule, SharedModule, NgbNavModule],
     providers: [i18nProviders]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrModule } from 'ngx-toastr';
 import { of as observableOf, throwError as observableThrowError } from 'rxjs';
 
@@ -33,7 +33,7 @@ describe('MgrModuleListComponent', () => {
       RouterTestingModule,
       SharedModule,
       HttpClientTestingModule,
-      TabsModule.forRoot(),
+      NgbNavModule,
       ToastrModule.forRoot()
     ],
     providers: [MgrModuleService, NotificationService, i18nProviders]

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-modules.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-modules.module.ts
@@ -2,8 +2,8 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { AppRoutingModule } from '../../../app-routing.module';
 import { SharedModule } from '../../../shared/shared.module';
@@ -17,7 +17,7 @@ import { MgrModuleListComponent } from './mgr-module-list/mgr-module-list.compon
     CommonModule,
     ReactiveFormsModule,
     SharedModule,
-    TabsModule.forRoot(),
+    NgbNavModule,
     NgBootstrapFormValidationModule
   ],
   declarations: [MgrModuleListComponent, MgrModuleFormComponent, MgrModuleDetailsComponent]

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
@@ -1,71 +1,91 @@
-<tabset *ngIf="selection"
-        id="tabset-osd-details">
-  <tab heading="Devices"
-       i18n-heading>
-    <cd-device-list *ngIf="osd.loaded && osd.id !== null"
-                    [osdId]="osd.id"></cd-device-list>
-  </tab>
+<ng-container *ngIf="selection">
+  <ul ngbNav
+      #nav="ngbNav"
+      id="tabset-osd-details"
+      class="nav-tabs">
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Devices</a>
+      <ng-template ngbNavContent>
+        <cd-device-list *ngIf="osd.loaded && osd.id !== null"
+                        [osdId]="osd.id"></cd-device-list>
+      </ng-template>
+    </li>
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Attributes (OSD map)</a>
+      <ng-template ngbNavContent>
+        <cd-table-key-value *ngIf="osd.loaded"
+                            [data]="osd.details.osd_map">
+        </cd-table-key-value>
+      </ng-template>
+    </li>
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Metadata</a>
+      <ng-template ngbNavContent>
+        <cd-table-key-value *ngIf="osd.loaded && osd.details.osd_metadata; else noMetaData"
+                            (fetchData)="refresh()"
+                            [data]="osd.details.osd_metadata">
+        </cd-table-key-value>
+        <ng-template #noMetaData>
+          <cd-alert-panel type="warning"
+                          i18n>Metadata not available</cd-alert-panel>
+        </ng-template>
+      </ng-template>
+    </li>
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Device health</a>
+      <ng-template ngbNavContent>
+        <cd-smart-list [osdId]="osd.id"></cd-smart-list>
+      </ng-template>
+    </li>
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Performance counter</a>
+      <ng-template ngbNavContent>
+        <cd-table-performance-counter *ngIf="osd.loaded"
+                                      serviceType="osd"
+                                      [serviceId]="osd.id">
+        </cd-table-performance-counter>
+      </ng-template>
+    </li>
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Histogram</a>
+      <ng-template ngbNavContent>
+        <cd-alert-panel *ngIf="osd.loaded && osd.histogram_failed"
+                        type="warning"
+                        i18n>Histogram not available: {{ osd.histogram_failed }}</cd-alert-panel>
 
-  <tab heading="Attributes (OSD map)"
-       i18n-heading>
-    <cd-table-key-value *ngIf="osd.loaded"
-                        [data]="osd.details.osd_map">
-    </cd-table-key-value>
-  </tab>
+        <div class="row"
+             *ngIf="osd.loaded && osd.details.histogram">
+          <div class="col-md-6">
+            <h4 i18n>Writes</h4>
+            <cd-osd-performance-histogram [histogram]="osd.details.histogram.osd.op_w_latency_in_bytes_histogram">
+            </cd-osd-performance-histogram>
+          </div>
+          <div class="col-md-6">
+            <h4 i18n>Reads</h4>
+            <cd-osd-performance-histogram [histogram]="osd.details.histogram.osd.op_r_latency_out_bytes_histogram">
+            </cd-osd-performance-histogram>
+          </div>
+        </div>
+      </ng-template>
+    </li>
+    <li ngbNavItem
+        *ngIf="grafanaPermission.read">
+      <a ngbNavLink
+         i18n>Performance Details</a>
+      <ng-template ngbNavContent>
+        <cd-grafana [grafanaPath]="'osd-device-details?var-osd=osd.' + osd['id']"
+                    uid="CrAHE0iZz"
+                    grafanaStyle="GrafanaStyles.two">
+        </cd-grafana>
+      </ng-template>
+    </li>
+  </ul>
 
-  <tab heading="Metadata"
-       i18n-heading>
-    <cd-table-key-value *ngIf="osd.loaded && osd.details.osd_metadata; else noMetaData"
-                        (fetchData)="refresh()"
-                        [data]="osd.details.osd_metadata">
-    </cd-table-key-value>
-    <ng-template #noMetaData>
-      <cd-alert-panel type="warning"
-                      i18n>Metadata not available</cd-alert-panel>
-    </ng-template>
-  </tab>
-
-  <tab heading="Device health"
-       i18n-heading>
-    <cd-smart-list [osdId]="osd.id"></cd-smart-list>
-  </tab>
-
-  <tab heading="Performance counter"
-       i18n-heading>
-    <cd-table-performance-counter *ngIf="osd.loaded"
-                                  serviceType="osd"
-                                  [serviceId]="osd.id">
-    </cd-table-performance-counter>
-  </tab>
-
-  <tab heading="Histogram"
-       i18n-heading>
-    <cd-alert-panel *ngIf="osd.loaded && osd.histogram_failed"
-                    type="warning"
-                    i18n>Histogram not available: {{ osd.histogram_failed }}</cd-alert-panel>
-
-    <div class="row"
-         *ngIf="osd.loaded && osd.details.histogram">
-      <div class="col-md-6">
-        <h4 i18n>Writes</h4>
-        <cd-osd-performance-histogram [histogram]="osd.details.histogram.osd.op_w_latency_in_bytes_histogram">
-        </cd-osd-performance-histogram>
-      </div>
-      <div class="col-md-6">
-        <h4 i18n>Reads</h4>
-        <cd-osd-performance-histogram [histogram]="osd.details.histogram.osd.op_r_latency_out_bytes_histogram">
-        </cd-osd-performance-histogram>
-      </div>
-    </div>
-  </tab>
-
-  <tab i18n-heading
-       *ngIf="grafanaPermission.read"
-       heading="Performance Details">
-    <cd-grafana [grafanaPath]="'osd-device-details?var-osd=osd.' + osd['id']"
-                uid="CrAHE0iZz"
-                grafanaStyle="GrafanaStyles.two">
-    </cd-grafana>
-  </tab>
-
-</tabset>
+  <div [ngbNavOutlet]="nav"></div>
+</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.spec.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { of } from 'rxjs';
 
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
@@ -22,7 +22,7 @@ describe('OsdDetailsComponent', () => {
   let getDetailsSpy: jasmine.Spy;
 
   configureTestBed({
-    imports: [HttpClientTestingModule, TabsModule.forRoot(), SharedModule],
+    imports: [HttpClientTestingModule, NgbNavModule, SharedModule],
     declarations: [
       OsdDetailsComponent,
       DeviceListComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -1,60 +1,63 @@
-<tabset>
-  <tab i18n-heading
-       heading="OSDs List">
+<ul ngbNav
+    #nav="ngbNav"
+    class="nav-tabs">
+  <li ngbNavItem>
+    <a ngbNavLink
+       i18n>OSDs List</a>
+    <ng-template ngbNavContent>
+      <cd-table [autoReload]="false"
+                [data]="osds"
+                (fetchData)="getOsdList()"
+                [columns]="columns"
+                selectionType="multiClick"
+                [hasDetails]="true"
+                (setExpandedRow)="setExpandedRow($event)"
+                (updateSelection)="updateSelection($event)"
+                [updateSelectionOnRefresh]="'never'">
 
-    <cd-table [autoReload]="false"
-              [data]="osds"
-              (fetchData)="getOsdList()"
-              [columns]="columns"
-              selectionType="multiClick"
-              [hasDetails]="true"
-              (setExpandedRow)="setExpandedRow($event)"
-              (updateSelection)="updateSelection($event)"
-              [updateSelectionOnRefresh]="'never'">
+        <div class="table-actions btn-toolbar">
+          <cd-table-actions [permission]="permissions.osd"
+                            [selection]="selection"
+                            class="btn-group"
+                            id="osd-actions"
+                            [tableActions]="tableActions">
+          </cd-table-actions>
+          <cd-table-actions [permission]="{read: true}"
+                            [selection]="selection"
+                            dropDownOnly="Cluster-wide configuration"
+                            btnColor="light"
+                            class="btn-group"
+                            id="cluster-wide-actions"
+                            [tableActions]="clusterWideActions">
+          </cd-table-actions>
+        </div>
 
-      <div class="table-actions btn-toolbar">
-        <cd-table-actions [permission]="permissions.osd"
-                          [selection]="selection"
-                          class="btn-group"
-                          id="osd-actions"
-                          [tableActions]="tableActions">
-        </cd-table-actions>
-        <cd-table-actions [permission]="{read: true}"
-                          [selection]="selection"
-                          dropDownOnly="Cluster-wide configuration"
-                          btnColor="light"
-                          class="btn-group"
-                          id="cluster-wide-actions"
-                          [tableActions]="clusterWideActions">
-        </cd-table-actions>
-      </div>
-
-      <cd-osd-details cdTableDetail
-                      [selection]="expandedRow">
-      </cd-osd-details>
-    </cd-table>
-
-    <ng-template #osdUsageTpl
-                 let-row="row">
-      <cd-usage-bar [totalBytes]="row.stats.stat_bytes"
-                    [usedBytes]="row.stats.stat_bytes_used">
-      </cd-usage-bar>
+        <cd-osd-details cdTableDetail
+                        [selection]="expandedRow">
+        </cd-osd-details>
+      </cd-table>
     </ng-template>
-  </tab>
-  <tab i18n-heading
-       *ngIf="permissions.grafana.read"
-       heading="Overall Performance">
-    <cd-grafana [grafanaPath]="'osd-overview?'"
-                uid="lo02I1Aiz"
-                grafanaStyle="three">
-    </cd-grafana>
-  </tab>
-</tabset>
+  </li>
+
+  <li ngbNavItem
+      *ngIf="permissions.grafana.read">
+    <a ngbNavLink
+       i18n>Overall Performance</a>
+    <ng-template ngbNavContent>
+      <cd-grafana [grafanaPath]="'osd-overview?'"
+                  uid="lo02I1Aiz"
+                  grafanaStyle="three">
+      </cd-grafana>
+    </ng-template>
+  </li>
+</ul>
+
+<div [ngbNavOutlet]="nav"></div>
 
 <ng-template #markOsdConfirmationTpl
              let-markActionDescription="markActionDescription">
   <ng-container i18n><strong>OSD(s) {{  getSelectedOsdIds() | join }}</strong> will be marked
-<strong>{{ markActionDescription }}</strong> if you proceed.</ng-container>
+  <strong>{{ markActionDescription }}</strong> if you proceed.</ng-container>
 </ng-template>
 
 <ng-template #criticalConfirmationTpl
@@ -64,8 +67,16 @@
   <div *ngIf="!safeToPerform"
        class="danger">
     <cd-alert-panel type="warning"
-                    i18n>The {selection.hasSingleSelection, select, 1 {OSD is} 0 {OSDs are}} not safe to be {{ actionDescription }}! {{ message }}</cd-alert-panel>
+                    i18n>The {selection.hasSingleSelection, select, 1 {OSD is} 0 {OSDs are}} not safe to be
+      {{ actionDescription }}! {{ message }}</cd-alert-panel>
   </div>
   <ng-container i18n><strong>OSD {{ getSelectedOsdIds() | join }}</strong> will be
-<strong>{{ actionDescription }}</strong> if you proceed.</ng-container>
+  <strong>{{ actionDescription }}</strong> if you proceed.</ng-container>
+</ng-template>
+
+<ng-template #osdUsageTpl
+             let-row="row">
+  <cd-usage-bar [totalBytes]="row.stats.stat_bytes"
+                [usedBytes]="row.stats.stat_bytes_used">
+  </cd-usage-bar>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -7,7 +7,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import * as _ from 'lodash';
 import { BsModalService } from 'ngx-bootstrap/modal';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 import { EMPTY, of } from 'rxjs';
 
@@ -93,7 +92,6 @@ describe('OsdListComponent', () => {
       BrowserAnimationsModule,
       HttpClientTestingModule,
       PerformanceCounterModule,
-      TabsModule.forRoot(),
       ToastrModule.forRoot(),
       CephModule,
       ReactiveFormsModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrModule } from 'ngx-toastr';
 
 import {
@@ -27,7 +27,7 @@ describe('ActiveAlertListComponent', () => {
     imports: [
       BrowserAnimationsModule,
       HttpClientTestingModule,
-      TabsModule.forRoot(),
+      NgbNavModule,
       RouterTestingModule,
       ToastrModule.forRoot(),
       SharedModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/monitoring-list/monitoring-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/monitoring-list/monitoring-list.component.html
@@ -1,38 +1,48 @@
-<tabset #tabs>
-  <tab id="active-alerts"
-       heading="Active Alerts"
-       (selectTab)="setFragment($event)"
-       i18n-heading>
-    <cd-active-alert-list *ngIf="isAlertmanagerConfigured"></cd-active-alert-list>
-    <cd-alert-panel type="info"
-                    i18n
-                    *ngIf="!isAlertmanagerConfigured">To see all active Prometheus alerts, please
-      provide the URL to the API of Prometheus' Alertmanager as described in the
-  <a href="{{docsUrl}}"
-     target="_blank">documentation</a>.</cd-alert-panel>
-  </tab>
-  <tab id="all-alerts"
-       heading="All Alerts"
-       (selectTab)="setFragment($event)"
-       i18n-heading>
-    <cd-rules-list *ngIf="isPrometheusConfigured"
-                   [data]="prometheusAlertService.rules"></cd-rules-list>
-    <cd-alert-panel type="info"
-                    *ngIf="!isPrometheusConfigured">To see all configured Prometheus alerts, please provide the URL to
-      the API of Prometheus as described in the
-  <a href="{{docsUrl}}"
-     target="_blank">documentation</a>.</cd-alert-panel>
-  </tab>
-  <tab id="silences"
-       heading="Silences"
-       (selectTab)="setFragment($event)"
-       i18n-heading>
-    <cd-silences-list *ngIf="isAlertmanagerConfigured"></cd-silences-list>
-    <cd-alert-panel *ngIf="!isAlertmanagerConfigured"
-                    type="info"
-                    i18n>To enable Silences, please provide the URL to the API of the Prometheus' Alertmanager as
-      described in the
-  <a href="{{docsUrl}}"
-     target="_blank">documentation</a>.</cd-alert-panel>
-  </tab>
-</tabset>
+<ul ngbNav
+    #nav="ngbNav"
+    [activeId]="route.snapshot.fragment"
+    (navChange)="setFragment($event.nextId)"
+    class="nav-tabs">
+  <li ngbNavItem="active-alerts">
+    <a ngbNavLink
+       i18n>Active Alerts</a>
+    <ng-template ngbNavContent>
+      <cd-active-alert-list *ngIf="isAlertmanagerConfigured"></cd-active-alert-list>
+      <cd-alert-panel type="info"
+                      i18n
+                      *ngIf="!isAlertmanagerConfigured">To see all active Prometheus alerts, please
+        provide the URL to the API of Prometheus' Alertmanager as described in the
+      <a href="{{docsUrl}}"
+         target="_blank">documentation</a>.</cd-alert-panel>
+    </ng-template>
+  </li>
+  <li ngbNavItem="all-alerts">
+    <a ngbNavLink
+       i18n>All Alerts</a>
+    <ng-template ngbNavContent>
+      <cd-rules-list *ngIf="isPrometheusConfigured"
+                     [data]="prometheusAlertService.rules"></cd-rules-list>
+      <cd-alert-panel type="info"
+                      *ngIf="!isPrometheusConfigured">To see all configured Prometheus alerts,
+        please provide the URL to
+        the API of Prometheus as described in the
+      <a href="{{docsUrl}}"
+         target="_blank">documentation</a>.</cd-alert-panel>
+    </ng-template>
+  </li>
+  <li ngbNavItem="silences">
+    <a ngbNavLink
+       i18n>Silences</a>
+    <ng-template ngbNavContent>
+      <cd-silences-list *ngIf="isAlertmanagerConfigured"></cd-silences-list>
+      <cd-alert-panel *ngIf="!isAlertmanagerConfigured"
+                      type="info"
+                      i18n>To enable Silences, please provide the URL to the API of the Prometheus' Alertmanager as
+        described in the
+      <a href="{{docsUrl}}"
+         target="_blank">documentation</a>.</cd-alert-panel>
+    </ng-template>
+  </li>
+</ul>
+
+<div [ngbNavOutlet]="nav"></div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/monitoring-list/monitoring-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/monitoring-list/monitoring-list.component.ts
@@ -1,7 +1,5 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-
-import { TabDirective, TabsetComponent } from 'ngx-bootstrap/tabs';
 
 import { PrometheusService } from '../../../../shared/api/prometheus.service';
 import { CephReleaseNamePipe } from '../../../../shared/pipes/ceph-release-name.pipe';
@@ -17,14 +15,11 @@ export class MonitoringListComponent implements OnInit {
   constructor(
     public prometheusAlertService: PrometheusAlertService,
     private prometheusService: PrometheusService,
-    private route: ActivatedRoute,
+    public route: ActivatedRoute,
     private router: Router,
     private summaryService: SummaryService,
     private cephReleaseNamePipe: CephReleaseNamePipe
   ) {}
-  @ViewChild('tabs', { static: true })
-  tabs: TabsetComponent;
-
   isPrometheusConfigured = false;
   isAlertmanagerConfigured = false;
 
@@ -42,21 +37,9 @@ export class MonitoringListComponent implements OnInit {
       const releaseName = this.cephReleaseNamePipe.transform(summary.version);
       this.docsUrl = `https://docs.ceph.com/docs/${releaseName}/mgr/dashboard/#enabling-prometheus-alerting`;
     });
-
-    // Activate tab according to given fragment
-    if (this.route.snapshot.fragment) {
-      const tab = this.tabs.tabs.find(
-        (t) => t.elementRef.nativeElement.id === this.route.snapshot.fragment
-      );
-      if (tab) {
-        tab.active = true;
-      }
-      // Ensure fragment is not removed, so page can always be reloaded with the same tab open.
-      this.router.navigate([], { fragment: this.route.snapshot.fragment });
-    }
   }
 
-  setFragment(element: TabDirective) {
-    this.router.navigate([], { fragment: element.id });
+  setFragment(element: string) {
+    this.router.navigate([], { fragment: element });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.html
@@ -3,13 +3,22 @@
           [hasDetails]="true"
           (updateSelection)="setExpandedRow($event)"
           [selectionType]="'single'">
-  <tabset cdTableDetail
-          *ngIf="expandedRow">
-    <tab i18n-heading
-         heading="Details">
-      <cd-table-key-value [data]="expandedRow"
-                          [renderObjects]="true"
-                          [hideKeys]="hideKeys"></cd-table-key-value>
-    </tab>
-  </tabset>
+  <ng-container cdTableDetail
+                *ngIf="expandedRow">
+    <ul ngbNav
+        #nav="ngbNav"
+        class="nav-tabs">
+      <li ngbNavItem>
+        <a ngbNavLink
+           i18n>Details</a>
+        <ng-template ngbNavContent>
+          <cd-table-key-value [data]="expandedRow"
+                              [renderObjects]="true"
+                              [hideKeys]="hideKeys"></cd-table-key-value>
+        </ng-template>
+      </li>
+    </ul>
+
+    <div [ngbNavOutlet]="nav"></div>
+  </ng-container>
 </cd-table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.spec.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
 import { PrometheusService } from '../../../../shared/api/prometheus.service';
@@ -16,7 +16,7 @@ describe('RulesListComponent', () => {
 
   configureTestBed({
     declarations: [RulesListComponent],
-    imports: [HttpClientTestingModule, SharedModule, TabsModule.forRoot(), BrowserAnimationsModule],
+    imports: [HttpClientTestingModule, SharedModule, NgbNavModule, BrowserAnimationsModule],
     providers: [PrometheusService, SettingsService, i18nProviders]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-list/silence-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-list/silence-list.component.spec.ts
@@ -5,7 +5,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { BsModalRef, BsModalService, ModalModule } from 'ngx-bootstrap/modal';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 
@@ -32,7 +31,6 @@ describe('SilenceListComponent', () => {
       BrowserAnimationsModule,
       SharedModule,
       BsDropdownModule.forRoot(),
-      TabsModule.forRoot(),
       ModalModule.forRoot(),
       ToastrModule.forRoot(),
       RouterTestingModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-details/service-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-details/service-details.component.html
@@ -1,7 +1,16 @@
-<tabset *ngIf="selection">
-  <tab i18n-heading
-       heading="Daemons">
-    <cd-service-daemon-list [serviceName]="selection['service_name']">
-    </cd-service-daemon-list>
-  </tab>
-</tabset>
+<ng-container *ngIf="selection">
+  <ul ngbNav
+      #nav="ngbNav"
+      class="nav-tabs">
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Daemons</a>
+      <ng-template ngbNavContent>
+        <cd-service-daemon-list [serviceName]="selection['service_name']">
+        </cd-service-daemon-list>
+      </ng-template>
+    </li>
+  </ul>
+
+  <div [ngbNavOutlet]="nav"></div>
+</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-details/service-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-details/service-details.component.spec.ts
@@ -2,9 +2,13 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
-import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
+import {
+  configureTestBed,
+  i18nProviders,
+  TabHelper
+} from '../../../../../testing/unit-test-helper';
 import { CdTableSelection } from '../../../../shared/models/cd-table-selection';
 import { SummaryService } from '../../../../shared/services/summary.service';
 import { SharedModule } from '../../../../shared/shared.module';
@@ -16,7 +20,7 @@ describe('ServiceDetailsComponent', () => {
   let fixture: ComponentFixture<ServiceDetailsComponent>;
 
   configureTestBed({
-    imports: [HttpClientTestingModule, RouterTestingModule, TabsModule.forRoot(), SharedModule],
+    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule, NgbNavModule],
     declarations: [ServiceDetailsComponent, ServiceDaemonListComponent],
     providers: [
       i18nProviders,
@@ -46,13 +50,14 @@ describe('ServiceDetailsComponent', () => {
       fixture.detectChanges();
     });
 
-    it('should recognize a tabset child', () => {
-      const tabsetChild = component.tabsetChild;
-      expect(tabsetChild).toBeDefined();
+    it('should have a NgbNav', () => {
+      const ngbNav = TabHelper.getNgbNav(fixture);
+      expect(ngbNav).toBeDefined();
     });
 
     it('should show tabs', () => {
-      expect(component.tabsetChild.tabs.map((t) => t.heading)).toEqual(['Daemons']);
+      const ngbNavItems = TabHelper.getTextContents(fixture);
+      expect(ngbNavItems).toEqual(['Daemons']);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-details/service-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-details/service-details.component.ts
@@ -1,5 +1,4 @@
-import { Component, Input, OnInit, ViewChild } from '@angular/core';
-import { TabsetComponent } from 'ngx-bootstrap/tabs';
+import { Component, Input } from '@angular/core';
 
 import { CdTableSelection } from '../../../../shared/models/cd-table-selection';
 import { Permissions } from '../../../../shared/models/permissions';
@@ -9,17 +8,10 @@ import { Permissions } from '../../../../shared/models/permissions';
   templateUrl: './service-details.component.html',
   styleUrls: ['./service-details.component.scss']
 })
-export class ServiceDetailsComponent implements OnInit {
-  @ViewChild(TabsetComponent)
-  tabsetChild: TabsetComponent;
-
+export class ServiceDetailsComponent {
   @Input()
   permissions: Permissions;
 
   @Input()
   selection: CdTableSelection;
-
-  constructor() {}
-
-  ngOnInit() {}
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/dashboard.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/dashboard.module.ts
@@ -2,9 +2,9 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { ChartsModule } from 'ng2-charts';
 import { PopoverModule } from 'ngx-bootstrap/popover';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { SharedModule } from '../../shared/shared.module';
 import { CephSharedModule } from '../shared/ceph-shared.module';
@@ -22,7 +22,7 @@ import { OsdSummaryPipe } from './osd-summary.pipe';
   imports: [
     CephSharedModule,
     CommonModule,
-    TabsModule.forRoot(),
+    NgbNavModule,
     SharedModule,
     ChartsModule,
     RouterModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/dashboard/dashboard.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/dashboard/dashboard.component.html
@@ -1,13 +1,28 @@
 <div>
   <cd-refresh-selector></cd-refresh-selector>
-  <tabset *ngIf="hasGrafana">
-    <tab i18n-heading
-         heading="Health">
-      <cd-health></cd-health>
-    </tab>
-    <tab i18n-heading
-         heading="Statistics">
-    </tab>
-  </tabset>
+
+  <ng-container *ngIf="hasGrafana">
+    <ul ngbNav
+        #nav="ngbNav"
+        class="nav-tabs">
+      <li ngbNavItem>
+        <a ngbNavLink
+           i18n>Health</a>
+        <ng-template ngbNavContent>
+          <cd-health></cd-health>
+        </ng-template>
+      </li>
+      <li ngbNavItem>
+        <a ngbNavLink
+           i18n>Statistics</a>
+        <ng-template ngbNavContent>
+        </ng-template>
+      </li>
+
+    </ul>
+
+    <div [ngbNavOutlet]="nav"></div>
+  </ng-container>
+
   <cd-health *ngIf="!hasGrafana"></cd-health>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/dashboard/dashboard.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/dashboard/dashboard.component.spec.ts
@@ -1,6 +1,8 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { DashboardComponent } from './dashboard.component';
 
@@ -9,6 +11,7 @@ describe('DashboardComponent', () => {
   let fixture: ComponentFixture<DashboardComponent>;
 
   configureTestBed({
+    imports: [NgbNavModule],
     declarations: [DashboardComponent],
     schemas: [NO_ERRORS_SCHEMA]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-details/nfs-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-details/nfs-details.component.html
@@ -1,19 +1,31 @@
-<tabset *ngIf="selection">
-  <tab heading="Details"
-       i18n-heading>
-    <cd-table-key-value [data]="data">
-    </cd-table-key-value>
-  </tab>
+<ng-container *ngIf="selection">
+  <ul ngbNav
+      #nav="ngbNav"
+      class="nav-tabs">
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Details</a>
+      <ng-template ngbNavContent>
+        <cd-table-key-value [data]="data">
+        </cd-table-key-value>
+      </ng-template>
+    </li>
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Clients ({{ clients.length }})</a>
+      <ng-template ngbNavContent>
 
-  <tab heading="Clients ({{ clients.length }})"
-       i18n-heading>
-    <cd-table #table
-              [data]="clients"
-              columnMode="flex"
-              [columns]="clientsColumns"
-              identifier="addresses"
-              forceIdentifier="true"
-              selectionType="">
-    </cd-table>
-  </tab>
-</tabset>
+        <cd-table #table
+                  [data]="clients"
+                  columnMode="flex"
+                  [columns]="clientsColumns"
+                  identifier="addresses"
+                  forceIdentifier="true"
+                  selectionType="">
+        </cd-table>
+      </ng-template>
+    </li>
+  </ul>
+
+  <div [ngbNavOutlet]="nav"></div>
+</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-details/nfs-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-details/nfs-details.component.spec.ts
@@ -3,8 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import * as _ from 'lodash';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
@@ -18,7 +18,7 @@ describe('NfsDetailsComponent', () => {
 
   configureTestBed({
     declarations: [NfsDetailsComponent],
-    imports: [BrowserAnimationsModule, SharedModule, TabsModule.forRoot(), HttpClientTestingModule],
+    imports: [BrowserAnimationsModule, SharedModule, HttpClientTestingModule, NgbNavModule],
     providers: i18nProviders
   });
 
@@ -98,7 +98,7 @@ describe('NfsDetailsComponent', () => {
   });
 
   it('should have 1 client', () => {
-    expect(elem('li.nav-item:nth-of-type(2) span').nativeElement.textContent).toBe('Clients (1)');
+    expect(elem('ul.nav-tabs li:nth-of-type(2) a').nativeElement.textContent).toBe('Clients (1)');
     expect(component.clients).toEqual([
       {
         access_type: 'RW',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 
@@ -41,8 +41,8 @@ describe('NfsListComponent', () => {
       HttpClientTestingModule,
       RouterTestingModule,
       SharedModule,
-      ToastrModule.forRoot(),
-      TabsModule.forRoot()
+      NgbNavModule,
+      ToastrModule.forRoot()
     ],
     providers: [TaskListService, i18nProviders]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs.module.ts
@@ -3,9 +3,8 @@ import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
-import { NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbNavModule, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { SharedModule } from '../../shared/shared.module';
 import { Nfs501Component } from './nfs-501/nfs-501.component';
@@ -19,7 +18,7 @@ import { NfsListComponent } from './nfs-list/nfs-list.component';
     ReactiveFormsModule,
     RouterModule,
     SharedModule,
-    TabsModule.forRoot(),
+    NgbNavModule,
     CommonModule,
     NgbTypeaheadModule,
     NgBootstrapFormValidationModule

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
@@ -1,34 +1,50 @@
-<tabset #tabsetChild
-        cdTableDetail
-        *ngIf="selection">
-  <tab i18n-heading
-       heading="Details">
-    <cd-table-key-value [renderObjects]="true"
-                        [data]="filterNonPoolData(selection)"
-                        [autoReload]="false">
-    </cd-table-key-value>
-  </tab>
-  <tab i18n-heading
-       *ngIf="permissions.grafana.read"
-       heading="Performance Details">
-    <cd-grafana [grafanaPath]="'ceph-pool-detail?var-pool_name='
-                + selection['pool_name']"
-                uid="-xyV8KCiz"
-                grafanaStyle="one">
-    </cd-grafana>
-  </tab>
-  <tab *ngIf="selection.type === 'replicated'"
-       i18n-heading
-       heading="Configuration">
-    <cd-rbd-configuration-table [data]="selectedPoolConfiguration"></cd-rbd-configuration-table>
-  </tab>
-  <tab i18n-heading
-       *ngIf="selection['tiers']?.length > 0"
-       heading="Cache Tiers Details">
-    <cd-table [data]="cacheTiers"
-              [columns]="cacheTierColumns"
-              [autoSave]="false"
-              columnMode="flex">
-    </cd-table>
-  </tab>
-</tabset>
+<ng-container *ngIf="selection"
+              cdTableDetail>
+  <ul ngbNav
+      #nav="ngbNav"
+      class="nav-tabs">
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Details</a>
+      <ng-template ngbNavContent>
+        <cd-table-key-value [renderObjects]="true"
+                            [data]="filterNonPoolData(selection)"
+                            [autoReload]="false">
+        </cd-table-key-value>
+      </ng-template>
+    </li>
+    <li ngbNavItem
+        *ngIf="permissions.grafana.read">
+      <a ngbNavLink
+         i18n>Performance Details</a>
+      <ng-template ngbNavContent>
+        <cd-grafana [grafanaPath]="'ceph-pool-detail?var-pool_name='+ selection['pool_name']"
+                    uid="-xyV8KCiz"
+                    grafanaStyle="one">
+        </cd-grafana>
+      </ng-template>
+    </li>
+    <li ngbNavItem
+        *ngIf="selection.type === 'replicated'">
+      <a ngbNavLink
+         i18n>Configuration</a>
+      <ng-template ngbNavContent>
+        <cd-rbd-configuration-table [data]="selectedPoolConfiguration"></cd-rbd-configuration-table>
+      </ng-template>
+    </li>
+    <li ngbNavItem
+        *ngIf="selection['tiers']?.length > 0">
+      <a ngbNavLink
+         i18n>Cache Tiers Details</a>
+      <ng-template ngbNavContent>
+        <cd-table [data]="cacheTiers"
+                  [columns]="cacheTierColumns"
+                  [autoSave]="false"
+                  columnMode="flex">
+        </cd-table>
+      </ng-template>
+    </li>
+  </ul>
+
+  <div [ngbNavOutlet]="nav"></div>
+</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.spec.ts
@@ -3,9 +3,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsetComponent, TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
-import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
+import { configureTestBed, i18nProviders, TabHelper } from '../../../../testing/unit-test-helper';
 import { Permissions } from '../../../shared/models/permissions';
 import { SharedModule } from '../../../shared/shared.module';
 import { RbdConfigurationListComponent } from '../../block/rbd-configuration-list/rbd-configuration-list.component';
@@ -18,7 +18,7 @@ describe('PoolDetailsComponent', () => {
   configureTestBed({
     imports: [
       BrowserAnimationsModule,
-      TabsModule.forRoot(),
+      NgbNavModule,
       SharedModule,
       HttpClientTestingModule,
       RouterTestingModule
@@ -51,16 +51,17 @@ describe('PoolDetailsComponent', () => {
 
     it('should recognize a tabset child', () => {
       fixture.detectChanges();
-      const tabsetChild: TabsetComponent = poolDetailsComponent.tabsetChild;
-      expect(tabsetChild).toBeDefined();
+      const ngbNav = TabHelper.getNgbNav(fixture);
+      expect(ngbNav).toBeDefined();
     });
 
     it('should show "Cache Tiers Details" tab if selected pool has "tiers"', () => {
       fixture.detectChanges();
-      const tabs = poolDetailsComponent.tabsetChild.tabs;
-      expect(tabs.length).toBe(3);
-      expect(tabs[2].heading).toBe('Cache Tiers Details');
-      expect(tabs[0].active).toBeTruthy();
+      const tabsItem = TabHelper.getNgbNavItems(fixture);
+      const tabsText = TabHelper.getTextContents(fixture);
+      expect(tabsItem.length).toBe(3);
+      expect(tabsText[2]).toBe('Cache Tiers Details');
+      expect(tabsItem[0].active).toBeTruthy();
     });
 
     it('should not show "Cache Tiers Details" tab if selected pool has no "tiers"', () => {
@@ -68,17 +69,19 @@ describe('PoolDetailsComponent', () => {
         tiers: []
       };
       fixture.detectChanges();
-      const tabs = poolDetailsComponent.tabsetChild.tabs;
+      const tabs = TabHelper.getNgbNavItems(fixture);
       expect(tabs.length).toEqual(2);
       expect(tabs[0].active).toBeTruthy();
     });
 
     it('current active status of tabs should not change when selection is the same as previous selection', () => {
       fixture.detectChanges();
-      const tabs = poolDetailsComponent.tabsetChild.tabs;
+      const tabs = TabHelper.getNgbNavItems(fixture);
       expect(tabs[0].active).toBeTruthy();
 
-      tabs[1].active = true;
+      const ngbNav = TabHelper.getNgbNav(fixture);
+      ngbNav.select(tabs[1].id);
+
       fixture.detectChanges();
       expect(tabs[1].active).toBeTruthy();
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.ts
@@ -1,8 +1,7 @@
-import { Component, Input, OnChanges, ViewChild } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
 import * as _ from 'lodash';
-import { TabsetComponent } from 'ngx-bootstrap/tabs';
 
 import { PoolService } from '../../../shared/api/pool.service';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
@@ -23,8 +22,6 @@ export class PoolDetailsComponent implements OnChanges {
   permissions: Permissions;
   @Input()
   cacheTiers: any[];
-  @ViewChild(TabsetComponent)
-  tabsetChild: TabsetComponent;
   selectedPoolConfiguration: RbdConfigurationEntry[];
 
   constructor(private i18n: I18n, private poolService: PoolService) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -246,29 +246,37 @@
               <span class="form-text text-muted"
                     id="ecp-info-block"
                     *ngIf="data.erasureInfo && form.getValue('erasureProfile')">
-                <tabset #ecpInfoTabs>
-                  <tab i18n-heading
-                       heading="Profile"
-                       class="ecp-info">
-                    <cd-table-key-value [renderObjects]="true"
-                                        [hideKeys]="['name']"
-                                        [data]="form.getValue('erasureProfile')"
-                                        [autoReload]="false">
-                    </cd-table-key-value>
-                  </tab>
-                  <tab i18n-heading
-                       heading="Used by pools"
-                       class="used-by-pools">
-                    <ng-template #ecpIsNotUsed>
-                      <span i18n>Profile is not in use.</span>
+                <ul ngbNav
+                    #ecpInfoTabs="ngbNav"
+                    class="nav-tabs">
+                  <li ngbNavItem="ecp-info">
+                    <a ngbNavLink
+                       i18n>Profile</a>
+                    <ng-template ngbNavContent>
+                      <cd-table-key-value [renderObjects]="true"
+                                          [hideKeys]="['name']"
+                                          [data]="form.getValue('erasureProfile')"
+                                          [autoReload]="false">
+                      </cd-table-key-value>
                     </ng-template>
-                    <ul *ngIf="ecpUsage; else ecpIsNotUsed">
-                      <li *ngFor="let pool of ecpUsage">
-                        {{ pool }}
-                      </li>
-                    </ul>
-                  </tab>
-                </tabset>
+                  </li>
+                  <li ngbNavItem="used-by-pools">
+                    <a ngbNavLink
+                       i18n>Used by pools</a>
+                    <ng-template ngbNavContent>
+                      <ng-template #ecpIsNotUsed>
+                        <span i18n>Profile is not in use.</span>
+                      </ng-template>
+                      <ul *ngIf="ecpUsage; else ecpIsNotUsed">
+                        <li *ngFor="let pool of ecpUsage">
+                          {{ pool }}
+                        </li>
+                      </ul>
+                    </ng-template>
+                  </li>
+                </ul>
+
+                <div [ngbNavOutlet]="ecpInfoTabs"></div>
               </span>
             </div>
           </div>
@@ -337,42 +345,54 @@
                     </button>
                   </span>
                 </div>
-                <span class="form-text text-muted"
-                      id="crush-info-block"
-                      *ngIf="data.crushInfo && form.getValue('crushRule')">
-                  <tabset #crushInfoTabs>
-                    <tab i18n-heading
-                         heading="Crush rule"
-                         class="crush-rule-info">
-                      <cd-table-key-value [renderObjects]="false"
-                                          [hideKeys]="['steps', 'ruleset', 'type', 'rule_name']"
-                                          [data]="form.getValue('crushRule')"
-                                          [autoReload]="false">
-                      </cd-table-key-value>
-                    </tab>
-                    <tab i18n-heading
-                         heading="Crush steps"
-                         class="crush-rule-steps">
-                      <ol>
-                        <li *ngFor="let step of form.get('crushRule').value.steps">
-                          {{ describeCrushStep(step) }}
-                        </li>
-                      </ol>
-                    </tab>
-                    <tab i18n-heading
-                         heading="Used by pools"
-                         class="used-by-pools">
-                      <ng-template #ruleIsNotUsed>
-                        <span i18n>Rule is not in use.</span>
+
+                <div class="form-text text-muted"
+                     id="crush-info-block"
+                     *ngIf="data.crushInfo && form.getValue('crushRule')">
+                  <ul ngbNav
+                      #crushInfoTabs="ngbNav"
+                      class="nav-tabs">
+                    <li ngbNavItem="crush-rule-info">
+                      <a ngbNavLink
+                         i18n>Crush rule</a>
+                      <ng-template ngbNavContent>
+                        <cd-table-key-value [renderObjects]="false"
+                                            [hideKeys]="['steps', 'ruleset', 'type', 'rule_name']"
+                                            [data]="form.getValue('crushRule')"
+                                            [autoReload]="false">
+                        </cd-table-key-value>
                       </ng-template>
-                      <ul *ngIf="crushUsage; else ruleIsNotUsed">
-                        <li *ngFor="let pool of crushUsage">
-                          {{ pool }}
-                        </li>
-                      </ul>
-                    </tab>
-                  </tabset>
-                </span>
+                    </li>
+                    <li ngbNavItem="crush-rule-steps">
+                      <a ngbNavLink
+                         i18n>Crush steps</a>
+                      <ng-template ngbNavContent>
+                        <ol>
+                          <li *ngFor="let step of form.get('crushRule').value.steps">
+                            {{ describeCrushStep(step) }}
+                          </li>
+                        </ol>
+                      </ng-template>
+                    </li>
+                    <li ngbNavItem="used-by-pools">
+                      <a ngbNavLink
+                         i18n>Used by pools</a>
+                      <ng-template ngbNavContent>
+
+                        <ng-template #ruleIsNotUsed>
+                          <span i18n>Rule is not in use.</span>
+                        </ng-template>
+                        <ul *ngIf="crushUsage; else ruleIsNotUsed">
+                          <li *ngFor="let pool of crushUsage">
+                            {{ pool }}
+                          </li>
+                        </ul>
+                      </ng-template>
+                    </li>
+                  </ul>
+
+                  <div [ngbNavOutlet]="crushInfoTabs"></div>
+                </div>
                 <span class="invalid-feedback"
                       *ngIf="form.showError('crushRule', formDir, 'required')"
                       i18n>This field is required!</span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.scss
@@ -1,3 +1,0 @@
-.crush-rule-steps {
-  margin-top: 10px;
-}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -2,17 +2,17 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Router, Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import * as _ from 'lodash';
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
-import { TabsetComponent, TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import {
   configureTestBed,
   FixtureHelper,
@@ -137,7 +137,7 @@ describe('PoolFormComponent', () => {
       HttpClientTestingModule,
       RouterTestingModule.withRoutes(routes),
       ToastrModule.forRoot(),
-      TabsModule.forRoot(),
+      NgbNavModule,
       PoolModule,
       NgBootstrapFormValidationModule.forRoot()
     ],
@@ -888,7 +888,6 @@ describe('PoolFormComponent', () => {
       describe('rule in use', () => {
         beforeEach(() => {
           spyOn(global, 'setTimeout').and.callFake((fn: Function) => fn());
-          component.crushInfoTabs = { tabs: [{}, {}, {}] } as TabsetComponent; // Mock it
           deleteSpy.calls.reset();
           selectRuleByIndex(2);
           component.deleteCrushRule();
@@ -898,12 +897,6 @@ describe('PoolFormComponent', () => {
           expect(crushRuleService.delete).not.toHaveBeenCalled();
           expect(component.crushDeletionBtn.isOpen).toBe(true);
           expect(component.data.crushInfo).toBe(true);
-        });
-
-        it('should open the third crush info tab', () => {
-          expect(component.crushInfoTabs).toEqual({
-            tabs: [{}, {}, { active: true }]
-          } as TabsetComponent);
         });
 
         it('should hide the tooltip when clicking on delete again', () => {
@@ -1051,7 +1044,6 @@ describe('PoolFormComponent', () => {
       describe('rule in use', () => {
         beforeEach(() => {
           spyOn(global, 'setTimeout').and.callFake((fn: Function) => fn());
-          component.ecpInfoTabs = { tabs: [{}, {}] } as TabsetComponent; // Mock it
           deleteSpy.calls.reset();
           setSelectedEcp('ecp1');
           component.deleteErasureCodeProfile();
@@ -1065,12 +1057,6 @@ describe('PoolFormComponent', () => {
           expect(ecpService.delete).not.toHaveBeenCalled();
           expect(component.ecpDeletionBtn.isOpen).toBe(true);
           expect(component.data.erasureInfo).toBe(true);
-        });
-
-        it('should open the third crush info tab', () => {
-          expect(component.ecpInfoTabs).toEqual({
-            tabs: [{}, { active: true }]
-          } as TabsetComponent);
         });
 
         it('should hide the tooltip when clicking on delete again', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -2,10 +2,11 @@ import { Component, EventEmitter, OnInit, Type, ViewChild } from '@angular/core'
 import { FormControl, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 
+import { NgbNav } from '@ng-bootstrap/ng-bootstrap';
+
 import { I18n } from '@ngx-translate/i18n-polyfill';
 import * as _ from 'lodash';
 import { BsModalService } from 'ngx-bootstrap/modal';
-import { TabsetComponent } from 'ngx-bootstrap/tabs';
 import { TooltipDirective } from 'ngx-bootstrap/tooltip';
 import { Observable, Subscription } from 'rxjs';
 
@@ -54,9 +55,9 @@ interface FormFieldDescription {
   styleUrls: ['./pool-form.component.scss']
 })
 export class PoolFormComponent extends CdForm implements OnInit {
-  @ViewChild('crushInfoTabs') crushInfoTabs: TabsetComponent;
+  @ViewChild('crushInfoTabs') crushInfoTabs: NgbNav;
   @ViewChild('crushDeletionBtn') crushDeletionBtn: TooltipDirective;
-  @ViewChild('ecpInfoTabs') ecpInfoTabs: TabsetComponent;
+  @ViewChild('ecpInfoTabs') ecpInfoTabs: NgbNav;
   @ViewChild('ecpDeletionBtn') ecpDeletionBtn: TooltipDirective;
 
   permission: Permission;
@@ -632,7 +633,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
       deletionBtn: this.ecpDeletionBtn,
       dataName: 'erasureInfo',
       getTabs: () => this.ecpInfoTabs,
-      tabPosition: 1,
+      tabPosition: 'used-by-pools',
       nameAttribute: 'name',
       itemDescription: this.i18n('erasure code profile'),
       reloadFn: () => this.reloadECPs(),
@@ -658,8 +659,8 @@ export class PoolFormComponent extends CdForm implements OnInit {
     usage: string[];
     deletionBtn: TooltipDirective;
     dataName: string;
-    getTabs: () => TabsetComponent;
-    tabPosition: number;
+    getTabs: () => NgbNav;
+    tabPosition: string;
     nameAttribute: string;
     itemDescription: string;
     reloadFn: Function;
@@ -675,7 +676,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
       setTimeout(() => {
         const tabs = getTabs();
         if (tabs) {
-          tabs.tabs[tabPosition].active = true;
+          tabs.select(tabPosition);
         }
       }, 50);
       return;
@@ -722,7 +723,7 @@ export class PoolFormComponent extends CdForm implements OnInit {
       deletionBtn: this.crushDeletionBtn,
       dataName: 'crushInfo',
       getTabs: () => this.crushInfoTabs,
-      tabPosition: 2,
+      tabPosition: 'used-by-pools',
       nameAttribute: 'rule_name',
       itemDescription: this.i18n('crush rule'),
       reloadFn: () => this.reloadCrushRules(),

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.html
@@ -1,47 +1,57 @@
-<tabset>
-  <tab i18n-heading
-       heading="Pools List">
-    <cd-view-cache *ngFor="let viewCacheStatus of viewCacheStatusList"
-                   [status]="viewCacheStatus.status"
-                   [statusFor]="viewCacheStatus.statusFor"></cd-view-cache>
+<ul ngbNav
+    #nav="ngbNav"
+    class="nav-tabs">
+  <li ngbNavItem>
+    <a ngbNavLink
+       i18n>Pools List</a>
+    <ng-template ngbNavContent>
+      <cd-view-cache *ngFor="let viewCacheStatus of viewCacheStatusList"
+                     [status]="viewCacheStatus.status"
+                     [statusFor]="viewCacheStatus.statusFor"></cd-view-cache>
 
-    <cd-table #table
-              id="pool-list"
-              [data]="pools"
-              [columns]="columns"
-              selectionType="single"
-              [hasDetails]="true"
-              (setExpandedRow)="setExpandedRow($event)"
-              (updateSelection)="updateSelection($event)">
-      <cd-table-actions id="pool-list-actions"
-                        class="table-actions"
-                        [permission]="permissions.pool"
-                        [selection]="selection"
-                        [tableActions]="tableActions">
-      </cd-table-actions>
-      <cd-pool-details cdTableDetail
-                       id="pool-list-details"
-                       [selection]="expandedRow"
-                       [permissions]="permissions"
-                       [cacheTiers]="cacheTiers">
-      </cd-pool-details>
-    </cd-table>
-
-    <ng-template #poolUsageTpl
-                 let-row="row">
-      <cd-usage-bar *ngIf="row.stats?.max_avail?.latest"
-                    [totalBytes]="row.stats.bytes_used.latest + row.stats.max_avail.latest"
-                    [usedBytes]="row.stats.bytes_used.latest">
-      </cd-usage-bar>
+      <cd-table #table
+                id="pool-list"
+                [data]="pools"
+                [columns]="columns"
+                selectionType="single"
+                [hasDetails]="true"
+                (setExpandedRow)="setExpandedRow($event)"
+                (updateSelection)="updateSelection($event)">
+        <cd-table-actions id="pool-list-actions"
+                          class="table-actions"
+                          [permission]="permissions.pool"
+                          [selection]="selection"
+                          [tableActions]="tableActions">
+        </cd-table-actions>
+        <cd-pool-details cdTableDetail
+                         id="pool-list-details"
+                         [selection]="expandedRow"
+                         [permissions]="permissions"
+                         [cacheTiers]="cacheTiers">
+        </cd-pool-details>
+      </cd-table>
     </ng-template>
-  </tab>
+  </li>
 
-  <tab i18n-heading
-       *ngIf="permissions.grafana.read"
-       heading="Overall Performance">
-    <cd-grafana [grafanaPath]="'ceph-pools-overview?'"
-                uid="z99hzWtmk"
-                grafanaStyle="two">
-    </cd-grafana>
-  </tab>
-</tabset>
+  <li ngbNavItem
+      *ngIf="permissions.grafana.read">
+    <a ngbNavLink
+       i18n>Overall Performance</a>
+    <ng-template ngbNavContent>
+      <cd-grafana [grafanaPath]="'ceph-pools-overview?'"
+                  uid="z99hzWtmk"
+                  grafanaStyle="two">
+      </cd-grafana>
+    </ng-template>
+  </li>
+</ul>
+
+<div [ngbNavOutlet]="nav"></div>
+
+<ng-template #poolUsageTpl
+             let-row="row">
+  <cd-usage-bar *ngIf="row.stats?.max_avail?.latest"
+                [totalBytes]="row.stats.bytes_used.latest + row.stats.max_avail.latest"
+                [usedBytes]="row.stats.bytes_used.latest">
+  </cd-usage-bar>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -3,9 +3,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import * as _ from 'lodash';
 import { BsModalService } from 'ngx-bootstrap/modal';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 
@@ -54,7 +54,7 @@ describe('PoolListComponent', () => {
       SharedModule,
       ToastrModule.forRoot(),
       RouterTestingModule,
-      TabsModule.forRoot(),
+      NgbNavModule,
       HttpClientTestingModule
     ],
     providers: [i18nProviders, PgCategoryService]

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
@@ -3,10 +3,10 @@ import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { PopoverModule } from 'ngx-bootstrap/popover';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { ActionLabels, URLVerbs } from '../../shared/constants/app.constants';
@@ -23,7 +23,7 @@ import { PoolListComponent } from './pool-list/pool-list.component';
   imports: [
     CephSharedModule,
     CommonModule,
-    TabsModule,
+    NgbNavModule,
     PopoverModule.forRoot(),
     SharedModule,
     RouterModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html
@@ -1,137 +1,144 @@
-<tabset *ngIf="selection">
-  <tab i18n-heading
-       heading="Details">
-    <div *ngIf="selection">
-      <table class="table table-striped table-bordered">
-        <tbody>
-          <tr>
-            <td i18n
-                class="bold w-25">Name</td>
-            <td class="w-75">{{ selection.bid }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">ID</td>
-            <td>{{ selection.id }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">Owner</td>
-            <td>{{ selection.owner }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">Index type</td>
-            <td>{{ selection.index_type }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">Placement rule</td>
-            <td>{{ selection.placement_rule }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">Marker</td>
-            <td>{{ selection.marker }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">Maximum marker</td>
-            <td>{{ selection.max_marker }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">Version</td>
-            <td>{{ selection.ver }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">Master version</td>
-            <td>{{ selection.master_ver }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">Modification time</td>
-            <td>{{ selection.mtime | cdDate }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">Zonegroup</td>
-            <td>{{ selection.zonegroup }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">Versioning</td>
-            <td>{{ selection.versioning }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">MFA Delete</td>
-            <td>{{ selection.mfa_delete }}</td>
-          </tr>
-        </tbody>
-      </table>
+<ng-container *ngIf="selection">
+  <ul ngbNav
+      #nav="ngbNav"
+      class="nav-tabs">
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Details</a>
+      <ng-template ngbNavContent>
+        <table class="table table-striped table-bordered">
+          <tbody>
+            <tr>
+              <td i18n
+                  class="bold w-25">Name</td>
+              <td class="w-75">{{ selection.bid }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">ID</td>
+              <td>{{ selection.id }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Owner</td>
+              <td>{{ selection.owner }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Index type</td>
+              <td>{{ selection.index_type }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Placement rule</td>
+              <td>{{ selection.placement_rule }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Marker</td>
+              <td>{{ selection.marker }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Maximum marker</td>
+              <td>{{ selection.max_marker }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Version</td>
+              <td>{{ selection.ver }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Master version</td>
+              <td>{{ selection.master_ver }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Modification time</td>
+              <td>{{ selection.mtime | cdDate }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Zonegroup</td>
+              <td>{{ selection.zonegroup }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">Versioning</td>
+              <td>{{ selection.versioning }}</td>
+            </tr>
+            <tr>
+              <td i18n
+                  class="bold">MFA Delete</td>
+              <td>{{ selection.mfa_delete }}</td>
+            </tr>
+          </tbody>
+        </table>
 
-      <!-- Bucket quota -->
-      <div *ngIf="selection.bucket_quota">
-        <legend i18n>Bucket quota</legend>
+        <!-- Bucket quota -->
+        <div *ngIf="selection.bucket_quota">
+          <legend i18n>Bucket quota</legend>
+          <table class="table table-striped table-bordered">
+            <tbody>
+              <tr>
+                <td i18n
+                    class="bold w-25">Enabled</td>
+                <td class="w-75">{{ selection.bucket_quota.enabled | booleanText }}</td>
+              </tr>
+              <tr>
+                <td i18n
+                    class="bold">Maximum size</td>
+                <td *ngIf="selection.bucket_quota.max_size <= -1"
+                    i18n>Unlimited</td>
+                <td *ngIf="selection.bucket_quota.max_size > -1">
+                  {{ selection.bucket_quota.max_size | dimless }}
+                </td>
+              </tr>
+              <tr>
+                <td i18n
+                    class="bold">Maximum objects</td>
+                <td *ngIf="selection.bucket_quota.max_objects <= -1"
+                    i18n>Unlimited</td>
+                <td *ngIf="selection.bucket_quota.max_objects > -1">
+                  {{ selection.bucket_quota.max_objects }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Locking -->
+        <legend i18n>Locking</legend>
         <table class="table table-striped table-bordered">
           <tbody>
             <tr>
               <td i18n
                   class="bold w-25">Enabled</td>
-              <td class="w-75">{{ selection.bucket_quota.enabled | booleanText }}</td>
+              <td class="w-75">{{ selection.lock_enabled | booleanText }}</td>
             </tr>
-            <tr>
-              <td i18n
-                  class="bold">Maximum size</td>
-              <td *ngIf="selection.bucket_quota.max_size <= -1"
-                  i18n>Unlimited</td>
-              <td *ngIf="selection.bucket_quota.max_size > -1">
-                {{ selection.bucket_quota.max_size | dimless }}
-              </td>
-            </tr>
-            <tr>
-              <td i18n
-                  class="bold">Maximum objects</td>
-              <td *ngIf="selection.bucket_quota.max_objects <= -1"
-                  i18n>Unlimited</td>
-              <td *ngIf="selection.bucket_quota.max_objects > -1">
-                {{ selection.bucket_quota.max_objects }}
-              </td>
-            </tr>
+            <ng-container *ngIf="selection.lock_enabled">
+              <tr>
+                <td i18n
+                    class="bold">Mode</td>
+                <td>{{ selection.lock_mode }}</td>
+              </tr>
+              <tr>
+                <td i18n
+                    class="bold">Days</td>
+                <td>{{ selection.lock_retention_period_days }}</td>
+              </tr>
+              <tr>
+                <td i18n
+                    class="bold">Years</td>
+                <td>{{ selection.lock_retention_period_years }}</td>
+              </tr>
+            </ng-container>
           </tbody>
         </table>
-      </div>
+      </ng-template>
+    </li>
+  </ul>
 
-      <!-- Locking -->
-      <legend i18n>Locking</legend>
-      <table class="table table-striped table-bordered">
-        <tbody>
-          <tr>
-            <td i18n
-                class="bold w-25">Enabled</td>
-            <td class="w-75">{{ selection.lock_enabled | booleanText }}</td>
-          </tr>
-          <ng-container *ngIf="selection.lock_enabled">
-            <tr>
-              <td i18n
-                  class="bold">Mode</td>
-              <td>{{ selection.lock_mode }}</td>
-            </tr>
-            <tr>
-              <td i18n
-                  class="bold">Days</td>
-              <td>{{ selection.lock_retention_period_days }}</td>
-            </tr>
-            <tr>
-              <td i18n
-                  class="bold">Years</td>
-              <td>{{ selection.lock_retention_period_years }}</td>
-            </tr>
-          </ng-container>
-        </tbody>
-      </table>
-    </div>
-  </tab>
-</tabset>
+  <div [ngbNavOutlet]="nav"></div>
+</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
@@ -13,7 +13,7 @@ describe('RgwBucketDetailsComponent', () => {
 
   configureTestBed({
     declarations: [RgwBucketDetailsComponent],
-    imports: [SharedModule, TabsModule.forRoot()],
+    imports: [SharedModule, NgbNavModule],
     providers: [i18nProviders]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.spec.ts
@@ -3,8 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { ModalModule } from 'ngx-bootstrap/modal';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import {
   configureTestBed,
@@ -27,7 +27,7 @@ describe('RgwBucketListComponent', () => {
       RouterTestingModule,
       ModalModule.forRoot(),
       SharedModule,
-      TabsModule.forRoot(),
+      NgbNavModule,
       HttpClientTestingModule
     ],
     providers: i18nProviders

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html
@@ -1,22 +1,37 @@
-<tabset *ngIf="selection">
-  <tab i18n-heading
-       heading="Details">
-    <cd-table-key-value [data]="metadata"
-                        (fetchData)="getMetaData()">
-    </cd-table-key-value>
-  </tab>
-  <tab i18n-heading
-       heading="Performance Counters">
-    <cd-table-performance-counter serviceType="rgw"
-                                  [serviceId]="serviceId">
-    </cd-table-performance-counter>
-  </tab>
-  <tab i18n-heading
-       *ngIf="grafanaPermission.read"
-       heading="Performance Details">
-    <cd-grafana [grafanaPath]="'rgw-instance-detail?var-rgw_servers=rgw.' + this.serviceId"
-                uid="x5ARzZtmk"
-                grafanaStyle="one">
-    </cd-grafana>
-  </tab>
-</tabset>
+<ng-container *ngIf="selection">
+  <ul ngbNav
+      #nav="ngbNav"
+      class="nav-tabs">
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Details</a>
+      <ng-template ngbNavContent>
+        <cd-table-key-value [data]="metadata"
+                            (fetchData)="getMetaData()">
+        </cd-table-key-value>
+      </ng-template>
+    </li>
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Performance Counters</a>
+      <ng-template ngbNavContent>
+        <cd-table-performance-counter serviceType="rgw"
+                                      [serviceId]="serviceId">
+        </cd-table-performance-counter>
+      </ng-template>
+    </li>
+    <li ngbNavItem
+        *ngIf="grafanaPermission.read">
+      <a ngbNavLink
+         i18n>Performance Details</a>
+      <ng-template ngbNavContent>
+        <cd-grafana [grafanaPath]="'rgw-instance-detail?var-rgw_servers=rgw.' + this.serviceId"
+                    uid="x5ARzZtmk"
+                    grafanaStyle="one">
+        </cd-grafana>
+      </ng-template>
+    </li>
+  </ul>
+
+  <div [ngbNavOutlet]="nav"></div>
+</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
@@ -14,7 +14,7 @@ describe('RgwDaemonDetailsComponent', () => {
 
   configureTestBed({
     declarations: [RgwDaemonDetailsComponent],
-    imports: [SharedModule, PerformanceCounterModule, TabsModule.forRoot(), HttpClientTestingModule]
+    imports: [SharedModule, PerformanceCounterModule, HttpClientTestingModule, NgbNavModule]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.html
@@ -1,33 +1,46 @@
-<tabset>
-  <tab i18n-heading
-       heading="Daemons List">
-    <cd-table [data]="daemons"
-              [columns]="columns"
-              columnMode="flex"
-              [hasDetails]="true"
-              (setExpandedRow)="setExpandedRow($event)"
-              (fetchData)="getDaemonList($event)">
-      <cd-rgw-daemon-details cdTableDetail
-                             [selection]="expandedRow">
-      </cd-rgw-daemon-details>
-    </cd-table>
-  </tab>
+<ul ngbNav
+    #nav="ngbNav"
+    class="nav-tabs">
+  <li ngbNavItem>
+    <a ngbNavLink
+       i18n>Daemons List</a>
+    <ng-template ngbNavContent>
+      <cd-table [data]="daemons"
+                [columns]="columns"
+                columnMode="flex"
+                [hasDetails]="true"
+                (setExpandedRow)="setExpandedRow($event)"
+                (fetchData)="getDaemonList($event)">
+        <cd-rgw-daemon-details cdTableDetail
+                               [selection]="expandedRow">
+        </cd-rgw-daemon-details>
+      </cd-table>
+    </ng-template>
+  </li>
 
-  <tab i18n-heading
-       *ngIf="grafanaPermission.read"
-       heading="Overall Performance">
-    <cd-grafana [grafanaPath]="'rgw-overview?'"
-                uid="WAkugZpiz"
-                grafanaStyle="two">
-    </cd-grafana>
-  </tab>
+  <li ngbNavItem
+      *ngIf="grafanaPermission.read">
+    <a ngbNavLink
+       i18n>Overall Performance</a>
+    <ng-template ngbNavContent>
+      <cd-grafana [grafanaPath]="'rgw-overview?'"
+                  uid="WAkugZpiz"
+                  grafanaStyle="two">
+      </cd-grafana>
+    </ng-template>
+  </li>
 
-  <tab i18n-heading
-       *ngIf="grafanaPermission.read && isMultiSite"
-       heading="Sync Performance">
-    <cd-grafana [grafanaPath]="'radosgw-sync-overview?'"
-                uid="rgw-sync-overview"
-                grafanaStyle="two">
-    </cd-grafana>
-  </tab>
-</tabset>
+  <li ngbNavItem
+      *ngIf="grafanaPermission.read && isMultiSite">
+    <a ngbNavLink
+       i18n>Sync Performance</a>
+    <ng-template ngbNavContent>
+      <cd-grafana [grafanaPath]="'radosgw-sync-overview?'"
+                  uid="rgw-sync-overview"
+                  grafanaStyle="two">
+      </cd-grafana>
+    </ng-template>
+  </li>
+</ul>
+
+<div [ngbNavOutlet]="nav"></div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.spec.ts
@@ -3,10 +3,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { of } from 'rxjs';
 
-import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
+import { configureTestBed, i18nProviders, TabHelper } from '../../../../testing/unit-test-helper';
 import { RgwSiteService } from '../../../shared/api/rgw-site.service';
 import { Permissions } from '../../../shared/models/permissions';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
@@ -21,11 +21,11 @@ describe('RgwDaemonListComponent', () => {
   let getPermissionsSpy: jasmine.Spy;
   let getRealmsSpy: jasmine.Spy;
   const permissions = new Permissions({ grafana: ['read'] });
-  const expectTabsAndHeading = (length: number, heading: string) => {
-    const tabs = fixture.debugElement.nativeElement.querySelectorAll('tab');
 
+  const expectTabsAndHeading = (length: number, heading: string) => {
+    const tabs = TabHelper.getTextContents(fixture);
     expect(tabs.length).toEqual(length);
-    expect(tabs[length - 1].getAttribute('heading')).toEqual(heading);
+    expect(tabs[length - 1]).toEqual(heading);
   };
 
   configureTestBed({
@@ -33,7 +33,7 @@ describe('RgwDaemonListComponent', () => {
     imports: [
       BrowserAnimationsModule,
       HttpClientTestingModule,
-      TabsModule.forRoot(),
+      NgbNavModule,
       PerformanceCounterModule,
       SharedModule,
       RouterTestingModule

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.html
@@ -1,151 +1,162 @@
-<tabset *ngIf="selection">
-  <tab i18n-heading
-       heading="Details">
-    <div *ngIf="user">
-      <table class="table table-striped table-bordered">
-        <tbody>
-          <tr>
-            <td i18n
-                class="bold w-25">Username</td>
-            <td class="w-75">{{ user.uid }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">Full name</td>
-            <td>{{ user.display_name }}</td>
-          </tr>
-          <tr *ngIf="user.email?.length">
-            <td i18n
-                class="bold">Email address</td>
-            <td>{{ user.email }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">Suspended</td>
-            <td>{{ user.suspended | booleanText }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">System</td>
-            <td>{{ user.system === 'true' | booleanText }}</td>
-          </tr>
-          <tr>
-            <td i18n
-                class="bold">Maximum buckets</td>
-            <td>{{ user.max_buckets | map:maxBucketsMap }}</td>
-          </tr>
-          <tr *ngIf="user.subusers && user.subusers.length">
-            <td i18n
-                class="bold">Subusers</td>
-            <td>
-              <div *ngFor="let subuser of user.subusers">
-                {{ subuser.id }} ({{ subuser.permissions }})
-              </div>
-            </td>
-          </tr>
-          <tr *ngIf="user.caps && user.caps.length">
-            <td i18n
-                class="bold">Capabilities</td>
-            <td>
-              <div *ngFor="let cap of user.caps">
-                {{ cap.type }} ({{ cap.perm }})
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+<ng-container *ngIf="selection">
+  <ul ngbNav
+      #nav="ngbNav"
+      class="nav-tabs">
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Details</a>
+      <ng-template ngbNavContent>
+        <div *ngIf="user">
+          <table class="table table-striped table-bordered">
+            <tbody>
+              <tr>
+                <td i18n
+                    class="bold w-25">Username</td>
+                <td class="w-75">{{ user.uid }}</td>
+              </tr>
+              <tr>
+                <td i18n
+                    class="bold">Full name</td>
+                <td>{{ user.display_name }}</td>
+              </tr>
+              <tr *ngIf="user.email?.length">
+                <td i18n
+                    class="bold">Email address</td>
+                <td>{{ user.email }}</td>
+              </tr>
+              <tr>
+                <td i18n
+                    class="bold">Suspended</td>
+                <td>{{ user.suspended | booleanText }}</td>
+              </tr>
+              <tr>
+                <td i18n
+                    class="bold">System</td>
+                <td>{{ user.system === 'true' | booleanText }}</td>
+              </tr>
+              <tr>
+                <td i18n
+                    class="bold">Maximum buckets</td>
+                <td>{{ user.max_buckets | map:maxBucketsMap }}</td>
+              </tr>
+              <tr *ngIf="user.subusers && user.subusers.length">
+                <td i18n
+                    class="bold">Subusers</td>
+                <td>
+                  <div *ngFor="let subuser of user.subusers">
+                    {{ subuser.id }} ({{ subuser.permissions }})
+                  </div>
+                </td>
+              </tr>
+              <tr *ngIf="user.caps && user.caps.length">
+                <td i18n
+                    class="bold">Capabilities</td>
+                <td>
+                  <div *ngFor="let cap of user.caps">
+                    {{ cap.type }} ({{ cap.perm }})
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
 
-      <!-- User quota -->
-      <div *ngIf="user.user_quota">
-        <legend i18n>User quota</legend>
-        <table class="table table-striped table-bordered">
-          <tbody>
-            <tr>
-              <td i18n
-                  class="bold w-25">Enabled</td>
-              <td class="w-75">{{ user.user_quota.enabled | booleanText }}</td>
-            </tr>
-            <tr>
-              <td i18n
-                  class="bold">Maximum size</td>
-              <td *ngIf="!user.user_quota.enabled">-</td>
-              <td *ngIf="user.user_quota.enabled && user.user_quota.max_size <= -1"
-                  i18n>Unlimited</td>
-              <td *ngIf="user.user_quota.enabled && user.user_quota.max_size > -1">
-                {{ user.user_quota.max_size | dimlessBinary }}
-              </td>
-            </tr>
-            <tr>
-              <td i18n
-                  class="bold">Maximum objects</td>
-              <td *ngIf="!user.user_quota.enabled">-</td>
-              <td *ngIf="user.user_quota.enabled && user.user_quota.max_objects <= -1"
-                  i18n>Unlimited</td>
-              <td *ngIf="user.user_quota.enabled && user.user_quota.max_objects > -1">
-                {{ user.user_quota.max_objects }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+          <!-- User quota -->
+          <div *ngIf="user.user_quota">
+            <legend i18n>User quota</legend>
+            <table class="table table-striped table-bordered">
+              <tbody>
+                <tr>
+                  <td i18n
+                      class="bold w-25">Enabled</td>
+                  <td class="w-75">{{ user.user_quota.enabled | booleanText }}</td>
+                </tr>
+                <tr>
+                  <td i18n
+                      class="bold">Maximum size</td>
+                  <td *ngIf="!user.user_quota.enabled">-</td>
+                  <td *ngIf="user.user_quota.enabled && user.user_quota.max_size <= -1"
+                      i18n>Unlimited</td>
+                  <td *ngIf="user.user_quota.enabled && user.user_quota.max_size > -1">
+                    {{ user.user_quota.max_size | dimlessBinary }}
+                  </td>
+                </tr>
+                <tr>
+                  <td i18n
+                      class="bold">Maximum objects</td>
+                  <td *ngIf="!user.user_quota.enabled">-</td>
+                  <td *ngIf="user.user_quota.enabled && user.user_quota.max_objects <= -1"
+                      i18n>Unlimited</td>
+                  <td *ngIf="user.user_quota.enabled && user.user_quota.max_objects > -1">
+                    {{ user.user_quota.max_objects }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
 
-      <!-- Bucket quota -->
-      <div *ngIf="user.bucket_quota">
-        <legend i18n>Bucket quota</legend>
-        <table class="table table-striped table-bordered">
-          <tbody>
-            <tr>
-              <td i18n
-                  class="bold w-25">Enabled</td>
-              <td class="w-75">{{ user.bucket_quota.enabled | booleanText }}</td>
-            </tr>
-            <tr>
-              <td i18n
-                  class="bold">Maximum size</td>
-              <td *ngIf="!user.bucket_quota.enabled">-</td>
-              <td *ngIf="user.bucket_quota.enabled && user.bucket_quota.max_size <= -1"
-                  i18n>Unlimited</td>
-              <td *ngIf="user.bucket_quota.enabled && user.bucket_quota.max_size > -1">
-                {{ user.bucket_quota.max_size | dimlessBinary }}
-              </td>
-            </tr>
-            <tr>
-              <td i18n
-                  class="bold">Maximum objects</td>
-              <td *ngIf="!user.bucket_quota.enabled">-</td>
-              <td *ngIf="user.bucket_quota.enabled && user.bucket_quota.max_objects <= -1"
-                  i18n>Unlimited</td>
-              <td *ngIf="user.bucket_quota.enabled && user.bucket_quota.max_objects > -1">
-                {{ user.bucket_quota.max_objects }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </tab>
-
-  <tab *ngIf="keys.length"
-       i18n-heading
-       heading="Keys">
-    <cd-table [data]="keys"
-              [columns]="keysColumns"
-              columnMode="flex"
-              selectionType="multi"
-              forceIdentifier="true"
-              (updateSelection)="updateKeysSelection($event)">
-      <div class="table-actions">
-        <div class="btn-group"
-             dropdown>
-          <button type="button"
-                  class="btn btn-secondary"
-                  [disabled]="!keysSelection.hasSingleSelection"
-                  (click)="showKeyModal()">
-            <i [ngClass]="[icons.show]"></i>
-            <ng-container i18n>Show</ng-container>
-          </button>
+          <!-- Bucket quota -->
+          <div *ngIf="user.bucket_quota">
+            <legend i18n>Bucket quota</legend>
+            <table class="table table-striped table-bordered">
+              <tbody>
+                <tr>
+                  <td i18n
+                      class="bold w-25">Enabled</td>
+                  <td class="w-75">{{ user.bucket_quota.enabled | booleanText }}</td>
+                </tr>
+                <tr>
+                  <td i18n
+                      class="bold">Maximum size</td>
+                  <td *ngIf="!user.bucket_quota.enabled">-</td>
+                  <td *ngIf="user.bucket_quota.enabled && user.bucket_quota.max_size <= -1"
+                      i18n>Unlimited</td>
+                  <td *ngIf="user.bucket_quota.enabled && user.bucket_quota.max_size > -1">
+                    {{ user.bucket_quota.max_size | dimlessBinary }}
+                  </td>
+                </tr>
+                <tr>
+                  <td i18n
+                      class="bold">Maximum objects</td>
+                  <td *ngIf="!user.bucket_quota.enabled">-</td>
+                  <td *ngIf="user.bucket_quota.enabled && user.bucket_quota.max_objects <= -1"
+                      i18n>Unlimited</td>
+                  <td *ngIf="user.bucket_quota.enabled && user.bucket_quota.max_objects > -1">
+                    {{ user.bucket_quota.max_objects }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
-      </div>
-    </cd-table>
-  </tab>
-</tabset>
+      </ng-template>
+    </li>
+    <li ngbNavItem
+        *ngIf="keys.length">
+      <a ngbNavLink
+         i18n>Keys</a>
+      <ng-template ngbNavContent>
+        <cd-table [data]="keys"
+                  [columns]="keysColumns"
+                  columnMode="flex"
+                  selectionType="multi"
+                  forceIdentifier="true"
+                  (updateSelection)="updateKeysSelection($event)">
+          <div class="table-actions">
+            <div class="btn-group"
+                 dropdown>
+              <button type="button"
+                      class="btn btn-secondary"
+                      [disabled]="!keysSelection.hasSingleSelection"
+                      (click)="showKeyModal()">
+                <i [ngClass]="[icons.show]"></i>
+                <ng-container i18n>Show</ng-container>
+              </button>
+            </div>
+          </div>
+        </cd-table>
+      </ng-template>
+    </li>
+  </ul>
+
+  <div [ngbNavOutlet]="nav"></div>
+</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.spec.ts
@@ -2,10 +2,10 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { BsModalService } from 'ngx-bootstrap/modal';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 
-import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
+import { configureTestBed, i18nProviders, TabHelper } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
 import { RgwUserS3Key } from '../models/rgw-user-s3-key';
 import { RgwUserDetailsComponent } from './rgw-user-details.component';
@@ -16,7 +16,7 @@ describe('RgwUserDetailsComponent', () => {
 
   configureTestBed({
     declarations: [RgwUserDetailsComponent],
-    imports: [BrowserAnimationsModule, HttpClientTestingModule, SharedModule, TabsModule.forRoot()],
+    imports: [BrowserAnimationsModule, HttpClientTestingModule, SharedModule, NgbNavModule],
     providers: [BsModalService, i18nProviders]
   });
 
@@ -30,20 +30,18 @@ describe('RgwUserDetailsComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
 
-    const detailsTab = fixture.debugElement.nativeElement.querySelector('tab[heading="Details"]');
-    expect(detailsTab).toBeTruthy();
-    const keysTab = fixture.debugElement.nativeElement.querySelector('tab[heading="Keys"]');
-    expect(keysTab).toBeFalsy();
+    const tabs = TabHelper.getTextContents(fixture);
+    expect(tabs).toContain('Details');
+    expect(tabs).not.toContain('Keys');
   });
 
   it('should show "Details" tab', () => {
     component.selection = { uid: 'myUsername' };
     fixture.detectChanges();
 
-    const detailsTab = fixture.debugElement.nativeElement.querySelector('tab[heading="Details"]');
-    expect(detailsTab).toBeTruthy();
-    const keysTab = fixture.debugElement.nativeElement.querySelector('tab[heading="Keys"]');
-    expect(keysTab).toBeFalsy();
+    const tabs = TabHelper.getTextContents(fixture);
+    expect(tabs).toContain('Details');
+    expect(tabs).not.toContain('Keys');
   });
 
   it('should show "Keys" tab', () => {
@@ -52,10 +50,9 @@ describe('RgwUserDetailsComponent', () => {
     component.ngOnChanges();
     fixture.detectChanges();
 
-    const detailsTab = fixture.debugElement.nativeElement.querySelector('tab[heading="Details"]');
-    expect(detailsTab).toBeTruthy();
-    const keysTab = fixture.debugElement.nativeElement.querySelector('tab[heading="Keys"]');
-    expect(keysTab).toBeTruthy();
+    const tabs = TabHelper.getTextContents(fixture);
+    expect(tabs).toContain('Details');
+    expect(tabs).toContain('Keys');
   });
 
   it('should show correct "System" info', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -3,11 +3,11 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
 import { AlertModule } from 'ngx-bootstrap/alert';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ModalModule } from 'ngx-bootstrap/modal';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { ActionLabels, URLVerbs } from '../../shared/constants/app.constants';
@@ -46,7 +46,7 @@ import { RgwUserSwiftKeyModalComponent } from './rgw-user-swift-key-modal/rgw-us
     PerformanceCounterModule,
     AlertModule.forRoot(),
     BsDropdownModule.forRoot(),
-    TabsModule.forRoot(),
+    NgbNavModule,
     TooltipModule.forRoot(),
     ModalModule.forRoot(),
     RouterModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/ceph-shared.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/ceph-shared.module.ts
@@ -1,12 +1,15 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { TabsModule } from 'ngx-bootstrap/tabs';
+
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+
 import { DataTableModule } from '../../shared/datatable/datatable.module';
 import { SharedModule } from '../../shared/shared.module';
 import { DeviceListComponent } from './device-list/device-list.component';
 import { SmartListComponent } from './smart-list/smart-list.component';
+
 @NgModule({
-  imports: [CommonModule, DataTableModule, SharedModule, TabsModule],
+  imports: [CommonModule, DataTableModule, SharedModule, NgbNavModule],
   exports: [DeviceListComponent, SmartListComponent],
   declarations: [DeviceListComponent, SmartListComponent]
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.html
@@ -4,63 +4,85 @@
                   i18n>Failed to retrieve SMART data.</cd-alert-panel>
   <cd-alert-panel *ngIf="incompatible"
                   type="warning"
-                  i18n>The data received has the JSON format version 2.x and is currently incompatible with the dashboard.</cd-alert-panel>
+                  i18n>The data received has the JSON format version 2.x and is currently incompatible with the
+    dashboard.</cd-alert-panel>
 
   <ng-container *ngIf="!error && !incompatible">
     <cd-alert-panel *ngIf="!(data | keyvalue).length"
                     type="info"
                     i18n>No SMART data available.</cd-alert-panel>
 
-    <tabset *ngFor="let device of data | keyvalue">
-      <tab [heading]="device.value.device + ' (' + device.value.identifier + ')'">
-        <ng-container *ngIf="device.value.error; else noError">
-          <cd-alert-panel id="alert-error"
-                          type="warning">{{ device.value.userMessage }}</cd-alert-panel>
-        </ng-container>
-        <ng-template #noError>
-          <!-- HDD/NVMe self test -->
-          <ng-container *ngIf="device.value.info.smart_status.passed; else selfTestFailed">
-            <cd-alert-panel id="alert-self-test-passed"
-                            size="slim"
-                            type="info"
-                            i18n-title
-                            title="SMART overall-health self-assessment test result"
-                            i18n>passed</cd-alert-panel>
-          </ng-container>
-          <ng-template #selfTestFailed>
-            <cd-alert-panel id="alert-self-test-failed"
-                            size="slim"
-                            type="warning"
-                            i18n-title
-                            title="SMART overall-health self-assessment test result"
-                            i18n>failed</cd-alert-panel>
+    <ng-container *ngFor="let device of data | keyvalue">
+      <ul ngbNav
+          #nav="ngbNav"
+          class="nav-tabs">
+        <li ngbNavItem>
+          <a ngbNavLink
+             i18n>{{ device.value.device }} ({{ device.value.identifier }})</a>
+          <ng-template ngbNavContent>
+
+            <ng-container *ngIf="device.value.error; else noError">
+              <cd-alert-panel id="alert-error"
+                              type="warning">{{ device.value.userMessage }}</cd-alert-panel>
+            </ng-container>
+
+            <ng-template #noError>
+              <!-- HDD/NVMe self test -->
+              <ng-container *ngIf="device.value.info.smart_status.passed; else selfTestFailed">
+                <cd-alert-panel id="alert-self-test-passed"
+                                size="slim"
+                                type="info"
+                                i18n-title
+                                title="SMART overall-health self-assessment test result"
+                                i18n>passed</cd-alert-panel>
+              </ng-container>
+              <ng-template #selfTestFailed>
+                <cd-alert-panel id="alert-self-test-failed"
+                                size="slim"
+                                type="warning"
+                                i18n-title
+                                title="SMART overall-health self-assessment test result"
+                                i18n>failed</cd-alert-panel>
+              </ng-template>
+            </ng-template>
+
+            <ul ngbNav
+                #innerNav="ngbNav"
+                class="nav-tabs">
+              <li ngbNavItem>
+                <a ngbNavLink
+                   i18n>Device Information</a>
+                <ng-template ngbNavContent>
+                  <cd-table-key-value [renderObjects]="true"
+                                      [data]="device.value.info"></cd-table-key-value>
+                </ng-template>
+              </li>
+              <li ngbNavItem>
+                <a ngbNavLink
+                   i18n>SMART</a>
+                <ng-template ngbNavContent>
+                  <cd-table *ngIf="device.value.smart.attributes"
+                            [data]="device.value.smart.attributes.table"
+                            updateSelectionOnRefresh="never"
+                            [columns]="smartDataColumns"></cd-table>
+                  <cd-table-key-value *ngIf="device.value.smart.nvmeData"
+                                      [renderObjects]="true"
+                                      [data]="device.value.smart.nvmeData"
+                                      updateSelectionOnRefresh="never"></cd-table-key-value>
+                  <cd-alert-panel *ngIf="!device.value.smart.attributes && !device.value.smart.nvmeData"
+                                  type="info"
+                                  i18n>No SMART data available for this device.</cd-alert-panel>
+                </ng-template>
+              </li>
+            </ul>
+
+            <div [ngbNavOutlet]="innerNav"></div>
           </ng-template>
+        </li>
+      </ul>
 
-          <tabset>
-            <tab i18n-heading
-                 heading="Device Information">
-              <cd-table-key-value [renderObjects]="true"
-                                  [data]="device.value.info"></cd-table-key-value>
-            </tab>
-
-            <tab i18n-heading
-                 heading="SMART">
-              <cd-table *ngIf="device.value.smart.attributes"
-                        [data]="device.value.smart.attributes.table"
-                        updateSelectionOnRefresh="never"
-                        [columns]="smartDataColumns"></cd-table>
-              <cd-table-key-value *ngIf="device.value.smart.nvmeData"
-                                  [renderObjects]="true"
-                                  [data]="device.value.smart.nvmeData"
-                                  updateSelectionOnRefresh="never"></cd-table-key-value>
-              <cd-alert-panel *ngIf="!device.value.smart.attributes && !device.value.smart.nvmeData"
-                              type="info"
-                              i18n>No SMART data available for this device.</cd-alert-panel>
-            </tab>
-          </tabset>
-        </ng-template>
-      </tab>
-    </tabset>
+      <div [ngbNavOutlet]="nav"></div>
+    </ng-container>
   </ng-container>
 </ng-container>
 <ng-template #isLoading>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.spec.ts
@@ -4,8 +4,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import * as _ from 'lodash';
-import { TabsetComponent, TabsetConfig, TabsModule } from 'ngx-bootstrap/tabs';
 import { of } from 'rxjs';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
@@ -81,8 +81,8 @@ describe('OsdSmartListComponent', () => {
 
   configureTestBed({
     declarations: [SmartListComponent],
-    imports: [BrowserAnimationsModule, TabsModule, SharedModule, HttpClientTestingModule],
-    providers: [i18nProviders, TabsetComponent, TabsetConfig]
+    imports: [BrowserAnimationsModule, SharedModule, HttpClientTestingModule, NgbNavModule],
+    providers: [i18nProviders]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/auth.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/auth.module.ts
@@ -3,11 +3,11 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgBootstrapFormValidationModule } from 'ng-bootstrap-form-validation';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
 import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
 import { PopoverModule } from 'ngx-bootstrap/popover';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { ActionLabels, URLVerbs } from '../../shared/constants/app.constants';
 import { SharedModule } from '../../shared/shared.module';
@@ -30,7 +30,7 @@ import { UserTabsComponent } from './user-tabs/user-tabs.component';
     PopoverModule.forRoot(),
     ReactiveFormsModule,
     SharedModule,
-    TabsModule.forRoot(),
+    NgbNavModule,
     RouterModule,
     NgBootstrapFormValidationModule,
     BsDatepickerModule.forRoot()

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-details/role-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-details/role-details.component.html
@@ -1,14 +1,23 @@
-<tabset *ngIf="selection">
-  <tab heading="Details"
-       i18n-heading>
-    <cd-table [data]="scopes_permissions"
-              [columns]="columns"
-              columnMode="flex"
-              [toolHeader]="false"
-              [autoReload]="false"
-              [autoSave]="false"
-              [footer]="false"
-              [limit]="0">
-    </cd-table>
-  </tab>
-</tabset>
+<ng-container *ngIf="selection">
+  <ul ngbNav
+      #nav="ngbNav"
+      class="nav-tabs">
+    <li ngbNavItem>
+      <a ngbNavLink
+         i18n>Details</a>
+      <ng-template ngbNavContent>
+        <cd-table [data]="scopes_permissions"
+                  [columns]="columns"
+                  columnMode="flex"
+                  [toolHeader]="false"
+                  [autoReload]="false"
+                  [autoSave]="false"
+                  [footer]="false"
+                  [limit]="0">
+        </cd-table>
+      </ng-template>
+    </li>
+  </ul>
+
+  <div [ngbNavOutlet]="nav"></div>
+</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-details/role-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-details/role-details.component.spec.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
@@ -13,7 +13,7 @@ describe('RoleDetailsComponent', () => {
   let fixture: ComponentFixture<RoleDetailsComponent>;
 
   configureTestBed({
-    imports: [SharedModule, TabsModule.forRoot(), RouterTestingModule, HttpClientTestingModule],
+    imports: [SharedModule, RouterTestingModule, HttpClientTestingModule, NgbNavModule],
     declarations: [RoleDetailsComponent],
     providers: i18nProviders
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-list/role-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-list/role-list.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrModule } from 'ngx-toastr';
 
 import {
@@ -27,7 +27,7 @@ describe('RoleListComponent', () => {
       BrowserAnimationsModule,
       SharedModule,
       ToastrModule.forRoot(),
-      TabsModule.forRoot(),
+      NgbNavModule,
       RouterTestingModule,
       HttpClientTestingModule
     ],

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
@@ -63,7 +63,7 @@ export class UserFormComponent extends CdForm implements OnInit {
     private authService: AuthService,
     private authStorageService: AuthStorageService,
     private route: ActivatedRoute,
-    private router: Router,
+    public router: Router,
     private modalService: BsModalService,
     private roleService: RoleService,
     private userService: UserService,

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrModule } from 'ngx-toastr';
 
 import {
@@ -25,7 +25,7 @@ describe('UserListComponent', () => {
       BrowserAnimationsModule,
       SharedModule,
       ToastrModule.forRoot(),
-      TabsModule.forRoot(),
+      NgbNavModule,
       RouterTestingModule,
       HttpClientTestingModule
     ],

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-tabs/user-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-tabs/user-tabs.component.html
@@ -1,12 +1,14 @@
-<tabset>
-  <tab heading="Users"
-       i18n-heading
-       [active]="url === '/user-management/users'"
-       (selectTab)="navigateTo('/user-management/users')">
-  </tab>
-  <tab heading="Roles"
-       i18n-heading
-       [active]="url === '/user-management/roles'"
-       (selectTab)="navigateTo('/user-management/roles')">
-  </tab>
-</tabset>
+<ul ngbNav
+    #nav="ngbNav"
+    [activeId]="router.url"
+    (navChange)="router.navigate([$event.nextId])"
+    class="nav-tabs">
+  <li ngbNavItem="/user-management/users">
+    <a ngbNavLink
+       i18n>Users</a>
+  </li>
+  <li ngbNavItem="/user-management/roles">
+    <a ngbNavLink
+       i18n>Roles</a>
+  </li>
+</ul>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-tabs/user-tabs.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-tabs/user-tabs.component.spec.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
@@ -13,7 +13,7 @@ describe('UserTabsComponent', () => {
   let fixture: ComponentFixture<UserTabsComponent>;
 
   configureTestBed({
-    imports: [SharedModule, TabsModule.forRoot(), RouterTestingModule, HttpClientTestingModule],
+    imports: [SharedModule, RouterTestingModule, HttpClientTestingModule, NgbNavModule],
     declarations: [UserTabsComponent]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-tabs/user-tabs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-tabs/user-tabs.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { Router } from '@angular/router';
 
@@ -7,16 +7,8 @@ import { Router } from '@angular/router';
   templateUrl: './user-tabs.component.html',
   styleUrls: ['./user-tabs.component.scss']
 })
-export class UserTabsComponent implements OnInit {
+export class UserTabsComponent {
   url: string;
 
-  constructor(private router: Router) {}
-
-  ngOnInit() {
-    this.url = this.router.url;
-  }
-
-  navigateTo(url: string) {
-    this.router.navigate([url]);
-  }
+  constructor(public router: Router) {}
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -52,7 +52,7 @@ describe('TableComponent', () => {
     component = fixture.componentInstance;
 
     component.data = createFakeData(10);
-    component.columns = [
+    component.localColumns = component.columns = [
       { prop: 'a', name: 'Index', filterable: true },
       { prop: 'b', name: 'Index times ten' },
       { prop: 'c', name: 'Odd?', filterable: true }
@@ -295,7 +295,7 @@ describe('TableComponent', () => {
 
       beforeEach(() => {
         component.data = [testObject];
-        component.columns = [{ prop: 'obj', name: 'Object' }];
+        component.localColumns = [{ prop: 'obj', name: 'Object' }];
       });
 
       it('should not search through objects as default case', () => {
@@ -366,7 +366,7 @@ describe('TableComponent', () => {
     });
 
     it('should search through arrays', () => {
-      component.columns = [
+      component.localColumns = [
         { prop: 'a', name: 'Index' },
         { prop: 'b', name: 'ArrayColumn' }
       ];
@@ -454,15 +454,15 @@ describe('TableComponent', () => {
     });
 
     it('should have updated the column definitions', () => {
-      expect(component.columns[0].flexGrow).toBe(1);
-      expect(component.columns[1].flexGrow).toBe(2);
-      expect(component.columns[2].flexGrow).toBe(2);
-      expect(component.columns[2].resizeable).toBe(false);
+      expect(component.localColumns[0].flexGrow).toBe(1);
+      expect(component.localColumns[1].flexGrow).toBe(2);
+      expect(component.localColumns[2].flexGrow).toBe(2);
+      expect(component.localColumns[2].resizeable).toBe(false);
     });
 
     it('should have table columns', () => {
       expect(component.tableColumns.length).toBe(3);
-      expect(component.tableColumns).toEqual(component.columns);
+      expect(component.tableColumns).toEqual(component.localColumns);
     });
 
     it('should have a unique identifier which it searches for', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
@@ -1,4 +1,4 @@
-import { LOCALE_ID, TRANSLATIONS, TRANSLATIONS_FORMAT, Type } from '@angular/core';
+import { DebugElement, LOCALE_ID, TRANSLATIONS, TRANSLATIONS_FORMAT, Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -7,6 +7,7 @@ import { I18n } from '@ngx-translate/i18n-polyfill';
 import { configureTestSuite } from 'ng-bullet';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
+import { NgbNav, NgbNavItem } from '@ng-bootstrap/ng-bootstrap';
 import { TableActionsComponent } from '../app/shared/datatable/table-actions/table-actions.component';
 import { Icons } from '../app/shared/enum/icons.enum';
 import { CdFormGroup } from '../app/shared/forms/cd-form-group';
@@ -540,5 +541,27 @@ export class Mocks {
       }
     ];
     return rule;
+  }
+}
+
+export class TabHelper {
+  static getNgbNav(fixture: ComponentFixture<any>) {
+    const debugElem: DebugElement = fixture.debugElement;
+    return debugElem.query(By.directive(NgbNav)).injector.get(NgbNav);
+  }
+
+  static getNgbNavItems(fixture: ComponentFixture<any>) {
+    const debugElems = this.getNgbNavItemsDebugElems(fixture);
+    return debugElems.map((de) => de.injector.get(NgbNavItem));
+  }
+
+  static getTextContents(fixture: ComponentFixture<any>) {
+    const debugElems = this.getNgbNavItemsDebugElems(fixture);
+    return debugElems.map((de) => de.nativeElement.textContent);
+  }
+
+  private static getNgbNavItemsDebugElems(fixture: ComponentFixture<any>) {
+    const debugElem: DebugElement = fixture.debugElement;
+    return debugElem.queryAll(By.directive(NgbNavItem));
   }
 }


### PR DESCRIPTION
Using ng-bootstrap for Tabs will allow us to easily implement some new features
like only loading 1 tab at a time (already implemented here) and
saving/restoring last opened tab.

Fixes: https://tracker.ceph.com/issues/45017

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
