### PR TITLE
octopus: bluestore, common/options.cc: disable bluefs_preextend_wal_files

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4008,7 +4008,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("bluefs_preextend_wal_files", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
+    .set_default(false)
     .set_description("Preextent rocksdb wal files on mkfs to avoid performance penalty"),
 
     Option("bluefs_log_replay_check_allocations", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
This is a temporary fix for https://tracker.ceph.com/issues/45613
to avoid WAL corruption because of enabling bluefs_preextend_wal_files
and bluefs_buffered_io together.

Fixes: https://tracker.ceph.com/issues/45613
Signed-off-by: Neha Ojha <nojha@redhat.com>