### PR TITLE
mgr/dashboard: cropped actions menu in nested details

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
@@ -240,6 +240,7 @@
     .datatable-row-detail {
       padding: 20px;
       border-bottom: 2px solid $color-table-header-border;
+      overflow-y: visible !important;
     }
     .expand-collapse-icon {
       display: block;
@@ -259,6 +260,7 @@
     }
   }
   .datatable-footer {
+    display: unset !important;
     .selected-count,
     .page-count {
       font-style: italic;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/45508

Signed-off-by: Avan Thakkar <athakkar@redhat.com>

Screenshot for fixed snapshot list drop-down
![Screenshot from 2020-06-16 19-09-58](https://user-images.githubusercontent.com/23611106/84781903-09905380-b005-11ea-9b36-710a22a07747.png)




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
