### PR TITLE
librbd: Watcher should not attempt to re-watch after detecting blacklisting

### DIFF
--- a/src/librbd/Watcher.cc
+++ b/src/librbd/Watcher.cc
@@ -324,7 +324,7 @@ void Watcher::handle_rewatch_callback(int r) {
     if (m_unregister_watch_ctx != nullptr) {
       m_watch_state = WATCH_STATE_IDLE;
       std::swap(unregister_watch_ctx, m_unregister_watch_ctx);
-    } else if (r == -ENOENT) {
+    } else if (r == -EBLACKLISTED || r == -ENOENT) {
       m_watch_state = WATCH_STATE_IDLE;
     } else if (r < 0 || m_watch_error) {
       watch_error = true;

--- a/src/test/librbd/test_mock_Watcher.cc
+++ b/src/test/librbd/test_mock_Watcher.cc
@@ -293,12 +293,6 @@ TEST_F(TestMockWatcher, ReregisterWatchBlacklist) {
   expect_aio_unwatch(mock_image_ctx, 0);
   expect_aio_watch(mock_image_ctx, -EBLACKLISTED);
 
-  C_SaferCond blacklist_ctx;
-  expect_aio_watch(mock_image_ctx, 0, [&blacklist_ctx]() {
-      blacklist_ctx.wait();
-    });
-  expect_aio_unwatch(mock_image_ctx, 0);
-
   C_SaferCond register_ctx;
   mock_image_watcher.register_watch(&register_ctx);
   ASSERT_TRUE(wait_for_watch(mock_image_ctx, 1));
@@ -309,17 +303,11 @@ TEST_F(TestMockWatcher, ReregisterWatchBlacklist) {
 
   // wait for recovery unwatch/watch
   ASSERT_TRUE(wait_for_watch(mock_image_ctx, 2));
-
   ASSERT_TRUE(mock_image_watcher.is_blacklisted());
-  blacklist_ctx.complete(0);
-
-  // wait for post-blacklist recovery watch
-  ASSERT_TRUE(wait_for_watch(mock_image_ctx, 1));
 
   C_SaferCond unregister_ctx;
   mock_image_watcher.unregister_watch(&unregister_ctx);
   ASSERT_EQ(0, unregister_ctx.wait());
-  ASSERT_FALSE(mock_image_watcher.is_blacklisted());
 }
 
 TEST_F(TestMockWatcher, ReregisterUnwatchPendingUnregister) {


### PR DESCRIPTION
Currently, the Watcher state machine will spin as fast as it can sending
re-watch requests to the OSD and then retrying after it fails with the
EBLACKLISTED error. Treat a blacklisting similarly to how removal of the
object is treated: stop attempting to re-watch.

Fixes: https://tracker.ceph.com/issues/45715
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
