### PR TITLE
qa/suites/rgw, qa/suites/rados: whitelist PG_AVAILABILITY

### DIFF
--- a/qa/suites/rados/basic/tasks/rados_cls_all.yaml
+++ b/qa/suites/rados/basic/tasks/rados_cls_all.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-whitelist:
+    - \(PG_AVAILABILITY\)
     conf:
       osd:
         osd_class_load_list: "*"

--- a/qa/suites/rgw/verify/tasks/cls.yaml
+++ b/qa/suites/rgw/verify/tasks/cls.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+    - \(PG_AVAILABILITY\)
 tasks:
 - workunit:
     clients:


### PR DESCRIPTION
The balancer was turned on by default in
d4fbaf7, as a result of which we might see
PG_AVAILABILITY health warnings when pg-upmap-items are applied.

Fixes: https://tracker.ceph.com/issues/45619
Signed-off-by: Neha Ojha <nojha@redhat.com>