### PR TITLE
doc: rbd-mirroring: Explain snapshot mirroring

### DIFF
--- a/doc/rbd/rbd-mirroring.rst
+++ b/doc/rbd/rbd-mirroring.rst
@@ -21,10 +21,10 @@ capability is available in two modes:
   updates between two mirror-snapshots and copy the deltas to its local copy of
   the image. With the help of the RBD fast-diff image feature, updated data
   blocks can be quickly computed without the need to scan the full RBD image.
-  Since this mode is not point-in-time consistent, the full snapshot delta will
-  need to be synced prior to use during a failover scenario. Any partially
-  applied snapshot deltas will be rolled back to the last fully synced snapshot
-  prior to use.
+  Since this mode is not as fine-grained as journaling, the complete delta 
+  between two snapshots will need to be synced prior to use during a failover
+  scenario. Any partially applied set of deltas will be rolled back at moment
+  of failover.
 
 .. note:: journal-based mirroring requires the Ceph Jewel release or later;
    snapshot-based mirroring requires the Ceph Octopus release or later.


### PR DESCRIPTION
* Rectify that snapshot based mirroring is point-in-time consistent
* Reword slightly s.t. there is less repetition.

Based on the discussion in https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/thread/G6ZW5OP4IXGUBAJTKZDPABK7HCKYISQH/

Signed-off-by: Hans van den Bogert <hansbogert@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
