### PR TITLE
blk: add option to set device type to select blk driver

### DIFF
--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -152,6 +152,7 @@ private:
 #endif
   };
   static block_device_t detect_device_type(const std::string& path);
+  static block_device_t device_type_from_name(const std::string& blk_dev_name);
   static BlockDevice *create_with_type(block_device_t device_type,
     CephContext* cct, const std::string& path, aio_callback_t cb,
     void *cbpriv, aio_callback_t d_cb, void *d_cbpriv);

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -136,6 +136,25 @@ private:
   ceph::mutex ioc_reap_lock = ceph::make_mutex("BlockDevice::ioc_reap_lock");
   std::vector<IOContext*> ioc_reap_queue;
   std::atomic_int ioc_reap_count = {0};
+  enum class block_device_t {
+    unknown,
+#if defined(HAVE_LIBAIO) || defined(HAVE_POSIXAIO)
+    aio,
+#if defined(HAVE_LIBZBC)
+    hm_smr,
+#endif
+#endif
+#if defined(HAVE_SPDK)
+    spdk,
+#endif
+#if defined(HAVE_BLUESTORE_PMEM)
+    pmem,
+#endif
+  };
+  static block_device_t detect_device_type(const std::string& path);
+  static BlockDevice *create_with_type(block_device_t device_type,
+    CephContext* cct, const std::string& path, aio_callback_t cb,
+    void *cbpriv, aio_callback_t d_cb, void *d_cbpriv);
 
 protected:
   uint64_t size = 0;

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -66,7 +66,7 @@ KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, ai
   fd_directs.resize(WRITE_LIFE_MAX, -1);
   fd_buffereds.resize(WRITE_LIFE_MAX, -1);
 
-  bool use_ioring = cct->_conf.get_val<bool>("bluestore_ioring");
+  bool use_ioring = cct->_conf.get_val<bool>("bdev_ioring");
   unsigned int iodepth = cct->_conf->bdev_aio_max_queue_depth;
 
   if (use_ioring && ioring_queue_t::supported()) {

--- a/src/blk/pmem/PMEMDevice.cc
+++ b/src/blk/pmem/PMEMDevice.cc
@@ -164,6 +164,20 @@ int PMEMDevice::collect_metadata(const string& prefix, map<string,string> *pm) c
   return 0;
 }
 
+bool PMEMDevice::support(const std::string &path)
+{
+  int is_pmem = 0;
+  size_t map_len = 0;
+  void *addr = pmem_map_file(path.c_str(), 0, PMEM_FILE_EXCL, O_RDONLY, &map_len, &is_pmem);
+  if (addr != NULL) {
+    if (is_pmem) {
+      return true;
+    }
+    pmem_unmap(addr, map_len);
+  }
+  return false;
+}
+
 int PMEMDevice::flush()
 {
   //Because all write is persist. So no need

--- a/src/blk/pmem/PMEMDevice.h
+++ b/src/blk/pmem/PMEMDevice.h
@@ -43,6 +43,8 @@ public:
 
   int collect_metadata(const std::string& prefix, map<std::string,std::string> *pm) const override;
 
+  static bool support(const std::string& path);
+
   int read(uint64_t off, uint64_t len, bufferlist *pbl,
 	   IOContext *ioc,
 	   bool buffered) override;

--- a/src/blk/spdk/NVMEDevice.cc
+++ b/src/blk/spdk/NVMEDevice.cc
@@ -698,6 +698,20 @@ NVMEDevice::NVMEDevice(CephContext* cct, aio_callback_t cb, void *cbpriv)
 {
 }
 
+bool NVMEDevice::support(const std::string& path)
+{
+  char buf[PATH_MAX + 1];
+  int r = ::readlink(path.c_str(), buf, sizeof(buf) - 1);
+  if (r >= 0) {
+    buf[r] = '\0';
+    char *bname = ::basename(buf);
+    if (strncmp(bname, SPDK_PREFIX, sizeof(SPDK_PREFIX)-1) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 int NVMEDevice::open(const string& p)
 {
   dout(1) << __func__ << " path " << p << dendl;

--- a/src/blk/spdk/NVMEDevice.h
+++ b/src/blk/spdk/NVMEDevice.h
@@ -55,6 +55,8 @@ class NVMEDevice : public BlockDevice {
 
   bool supported_bdev_label() override { return false; }
 
+  static bool support(const std::string& path);
+
   void aio_submit(IOContext *ioc) override;
 
   int read(uint64_t off, uint64_t len, bufferlist *pbl,

--- a/src/blk/zoned/HMSMRDevice.cc
+++ b/src/blk/zoned/HMSMRDevice.cc
@@ -60,7 +60,7 @@ HMSMRDevice::HMSMRDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, aio_
   fd_directs.resize(WRITE_LIFE_MAX, -1);
   fd_buffereds.resize(WRITE_LIFE_MAX, -1);
 
-  bool use_ioring = cct->_conf.get_val<bool>("bluestore_ioring");
+  bool use_ioring = cct->_conf.get_val<bool>("bdev_ioring");
   unsigned int iodepth = cct->_conf->bdev_aio_max_queue_depth;
 
   if (use_ioring && ioring_queue_t::supported()) {

--- a/src/blk/zoned/HMSMRDevice.cc
+++ b/src/blk/zoned/HMSMRDevice.cc
@@ -76,6 +76,18 @@ HMSMRDevice::HMSMRDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, aio_
   }
 }
 
+bool HMSMRDevice::support(const std::string& path)
+{
+  int r = zbc_device_is_zoned(path.c_str(), false, nullptr);
+  if (r == 1) {
+    return true;
+  } else if (r < 0) {
+    derr << __func__ << " zbc_device_is_zoned(" << path << ") failed: "
+         << cpp_strerror(r) << dendl;
+  }
+  return false;
+}
+
 int HMSMRDevice::_lock()
 {
   dout(10) << __func__ << " " << fd_directs[WRITE_LIFE_NOT_SET] << dendl;

--- a/src/blk/zoned/HMSMRDevice.h
+++ b/src/blk/zoned/HMSMRDevice.h
@@ -117,6 +117,7 @@ class HMSMRDevice final : public BlockDevice {
 public:
   HMSMRDevice(CephContext* cct, aio_callback_t cb, void *cbpriv,
               aio_callback_t d_cb, void *d_cbpriv);
+  static bool support(const std::string& path);
 
   void aio_submit(IOContext *ioc) final;
   void discard_drain() final;

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5418,7 +5418,13 @@ std::vector<Option> get_global_options() {
 
     Option("crimson_osd_scheduler_concurrency", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(0)
-    .set_description("The maximum number concurrent IO operations, 0 for unlimited")
+    .set_description("The maximum number concurrent IO operations, 0 for unlimited"),
+
+    // ----------------------------
+    // blk specific options
+    Option("bdev_type", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_description("Explicitly set the device type to select the driver if it's needed")
+    .set_enum_allowed({"aio", "spdk", "pmem", "hm_smr"})
 
   });
 }

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4712,7 +4712,7 @@ std::vector<Option> get_global_options() {
       .set_default(0)
       .set_description("Space reserved at DB device and not allowed for 'use some extra' policy usage. Overrides 'bluestore_volume_selection_reserved_factor' setting and introduces straightforward limit."),
 
-    Option("bluestore_ioring", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    Option("bdev_ioring", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .set_description("Enables Linux io_uring API instead of libaio"),
 


### PR DESCRIPTION
The current variant BlockDevice will fetch some bluestore specific
configuration in ceph.conf to control BlockDevice behavior. The
other FrontEnd may have different configuration.
It needs to configure according to different FrontEnd e.g. BlueStore,
RBD.

Signed-off-by: Changcheng Liu <changcheng.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
