### PR TITLE
qa/cephadm: sudo_write_file doesn't support unicode

### DIFF
--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -12,6 +12,7 @@ import uuid
 
 from io import BytesIO
 import toml
+import six
 from six import StringIO
 from tarfile import ReadError
 from tasks.ceph_manager import CephManager
@@ -1183,7 +1184,7 @@ def add_mirror_to_cluster(ctx, mirror):
             teuthology.sudo_write_file(
                 remote=remote,
                 path=registries_conf,
-                data=new_config,
+                data=six.ensure_str(new_config),
             )
         except FileNotFoundError as e:
             # Docker doesn't ship a registries.conf


### PR DESCRIPTION
76524358594a00ef2e7a1acf4e186aae9d39d4d8 was a python 2 fix that was necessary to make octopus compatible to teuthology:py2. Now, let's forward-port this commit to keep both branches aligned. 


Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

(cherry picked from commit 76524358594a00ef2e7a1acf4e186aae9d39d4d8)

Conflicts:
	qa/tasks/cephadm.py


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
