### PR TITLE
blk:BlockDevice.cc: use pending_aios instead of iovec size as ios num

### DIFF
--- a/src/blk/BlockDevice.cc
+++ b/src/blk/BlockDevice.cc
@@ -73,9 +73,7 @@ uint64_t IOContext::get_num_ios() const
   // that to the bytes value.
   uint64_t ios = 0;
 #if defined(HAVE_LIBAIO) || defined(HAVE_POSIXAIO)
-  for (auto& p : pending_aios) {
-    ios += p.iov.size();
-  }
+  ios += pending_aios.size();
 #endif
 #ifdef HAVE_SPDK
   ios += total_nseg;


### PR DESCRIPTION
We have a ceph cluster(v 14.2.9) with 3 hosts, and there are 6 HDD OSDs on each host.
An EC pool was created with the default erasure-code-profile(k=2,m=1), and nothing changes in ceph.conf

After we use 'rados bench 30 write -b 2M -t 256 -p ecpool clean-up' to test the bandwidth, and use iostat to monitor disk utilization. Got the results: 30MB/s per disk.
With osd perf dump we found lots throttle-bluestore_throttle_bytes, it seems that BlueStore.cc::queue_transactions() was blocked in throttle_bytes.get(txc->cost);

Then we open blustore log and rerun the aboving test. In ceph-osd.log, appeared some logs "_txc_calc_cost 0x564c308b0b00 cost 173240518 (257 ios * 670000 + 1050518 bytes)". It seems the transactions packaged by ECBackend consist of many address discontinuity 4K IO, but these IO will be write once to kernel by pwritev.

Last, we simply set 'bluestore_throttle_bytes = 0', the bandwidth was up(80MB/s per disk).

So in _txc_calc_cost(), would it be more appropriate to calc potential cost in terms of pending_aio size instead of iovec size?

Signed-off-by: weixinwei <xinweiwei90@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
