### PR TITLE
nautilus: qa/suites/upgrade/nautilus-p2: disable more min pg per osd warnings

### DIFF
--- a/qa/suites/upgrade/nautilus-p2p/nautilus-p2p-parallel/point-to-point-upgrade.yaml
+++ b/qa/suites/upgrade/nautilus-p2p/nautilus-p2p-parallel/point-to-point-upgrade.yaml
@@ -39,6 +39,7 @@ overrides:
     conf:
       global:
         mon_warn_on_pool_no_app: false
+        mon pg warn min per osd: 0
       mon:
         mon debug unsafe allow tier with nonempty snaps: true
       osd:

--- a/qa/suites/upgrade/nautilus-p2p/nautilus-p2p-stress-split/0-cluster/start.yaml
+++ b/qa/suites/upgrade/nautilus-p2p/nautilus-p2p-stress-split/0-cluster/start.yaml
@@ -15,6 +15,7 @@ overrides:
     conf:
       global:
         enable experimental unrecoverable data corrupting features: "*"
+        mon pg warn min per osd: 0
       mon:
         mon warn on osd down out interval zero: false
 roles:


### PR DESCRIPTION
This follows 58eb3edc8478c993c5446475df58d659d3f6d356 and
b75907e7575dbdc5888c198f354cb5f71bf21ab3.

This change is not cherry-picked from master since it already has
1ac34a5ea3d1aca299b02e574b295dd4bf6167f4.

Fixes: https://tracker.ceph.com/issues/45772
Signed-off-by: Neha Ojha <nojha@redhat.com>
