### PR TITLE
Client:: subtract ref of Dentry and Inode only when Inode::ll_ref changes from a positive number to zero.

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11004,9 +11004,10 @@ void Client::_ll_get(Inode *in)
 
 int Client::_ll_put(Inode *in, uint64_t num)
 {
+  uint64_t old_ll_ref = in->ll_ref;
   in->ll_put(num);
   ldout(cct, 20) << __func__ << " " << in << " " << in->ino << " " << num << " -> " << in->ll_ref << dendl;
-  if (in->ll_ref == 0) {
+  if (old_ll_ref > 0 && in->ll_ref == 0) {
     if (in->is_dir() && !in->dentries.empty()) {
       ceph_assert(in->dentries.size() == 1); // dirs can't be hard-linked
       in->get_first_parent()->put(); // unpin dentry


### PR DESCRIPTION

when ll_ref becomes a positive number from zero we increase
ref correspondingly represents the kernel have a reference
on the inode. Similarly, we should decrease the ref only
when ll_ref changes from a positive number to zero.

Fixes: https://tracker.ceph.com/issues/40775
Signed-off-by: Guan yunfei <yunfei.guan@xtaotech.com>
