### PR TITLE
librbd: quiesce/unquiesce API improvements

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7580,6 +7580,11 @@ static std::vector<Option> get_rbd_options() {
     .set_min(1)
     .set_description("the number of quiesce notification attempts"),
 
+    Option("rbd_default_snapshot_quiesce_mode", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("required")
+    .set_enum_allowed({"required", "ignore-error", "skip"})
+    .set_description("default snapshot quiesce mode"),
+
     Option("rbd_plugins", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("")
     .set_description("comma-delimited list of librbd plugins to enable"),

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -1385,9 +1385,9 @@ CEPH_RBD_API int rbd_quiesce_watch(rbd_image_t image,
  * Notify quiesce is complete
  *
  * @param image the image to notify
- * @returns 0 on success
+ * @param r the return code
  */
-CEPH_RADOS_API void rbd_quiesce_complete(rbd_image_t image);
+CEPH_RADOS_API void rbd_quiesce_complete(rbd_image_t image, int r);
 
 /**
  * Unregister a quiesce/unquiesce watcher.

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -1204,6 +1204,9 @@ CEPH_RBD_API int rbd_mirror_image_demote(rbd_image_t image);
 CEPH_RBD_API int rbd_mirror_image_resync(rbd_image_t image);
 CEPH_RBD_API int rbd_mirror_image_create_snapshot(rbd_image_t image,
                                                   uint64_t *snap_id);
+CEPH_RBD_API int rbd_mirror_image_create_snapshot2(rbd_image_t image,
+                                                   uint32_t flags,
+                                                   uint64_t *snap_id);
 CEPH_RBD_API int rbd_mirror_image_get_info(rbd_image_t image,
                                            rbd_mirror_image_info_t *mirror_image_info,
                                            size_t info_size);

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -117,6 +117,9 @@ typedef struct {
 #define RBD_MAX_IMAGE_NAME_SIZE 96
 #define RBD_MAX_BLOCK_NAME_SIZE 24
 
+#define RBD_SNAP_CREATE_SKIP_QUIESCE		1 << 0
+#define RBD_SNAP_CREATE_IGNORE_QUIESCE_ERROR	1 << 1
+
 #define RBD_SNAP_REMOVE_UNPROTECT	1 << 0
 #define RBD_SNAP_REMOVE_FLATTEN		1 << 1
 #define RBD_SNAP_REMOVE_FORCE		(RBD_SNAP_REMOVE_UNPROTECT | RBD_SNAP_REMOVE_FLATTEN)
@@ -780,6 +783,9 @@ CEPH_RBD_API int rbd_snap_list(rbd_image_t image, rbd_snap_info_t *snaps,
 CEPH_RBD_API void rbd_snap_list_end(rbd_snap_info_t *snaps);
 CEPH_RBD_API int rbd_snap_exists(rbd_image_t image, const char *snapname, bool *exists);
 CEPH_RBD_API int rbd_snap_create(rbd_image_t image, const char *snapname);
+CEPH_RBD_API int rbd_snap_create2(rbd_image_t image, const char *snap_name,
+                                  uint32_t flags, librbd_progress_fn_t cb,
+                                  void *cbdata);
 CEPH_RBD_API int rbd_snap_remove(rbd_image_t image, const char *snapname);
 CEPH_RBD_API int rbd_snap_remove2(rbd_image_t image, const char *snap_name,
                                   uint32_t flags, librbd_progress_fn_t cb,

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -612,6 +612,7 @@ public:
   bool snap_exists(const char *snapname) CEPH_RBD_DEPRECATED;
   int snap_exists2(const char *snapname, bool *exists);
   int snap_create(const char *snapname);
+  int snap_create2(const char *snapname, uint32_t flags, ProgressContext& pctx);
   int snap_remove(const char *snapname);
   int snap_remove2(const char *snapname, uint32_t flags, ProgressContext& pctx);
   int snap_remove_by_id(uint64_t snap_id);

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -752,6 +752,7 @@ public:
   int mirror_image_demote();
   int mirror_image_resync();
   int mirror_image_create_snapshot(uint64_t *snap_id);
+  int mirror_image_create_snapshot2(uint32_t flags, uint64_t *snap_id);
   int mirror_image_get_info(mirror_image_info_t *mirror_image_info,
                             size_t info_size);
   int mirror_image_get_mode(mirror_image_mode_t *mode);

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -784,7 +784,7 @@ public:
 
   int quiesce_watch(QuiesceWatchCtx *ctx, uint64_t *handle);
   int quiesce_unwatch(uint64_t handle);
-  void quiesce_complete();
+  void quiesce_complete(int r);
 
 private:
   friend class RBD;

--- a/src/librbd/ImageState.cc
+++ b/src/librbd/ImageState.cc
@@ -295,7 +295,7 @@ public:
     notify(UNQUIESCE, on_finish);
   }
 
-  void quiesce_complete() {
+  void quiesce_complete(int r) {
     Context *on_notify = nullptr;
     {
       std::lock_guard locker{m_lock};
@@ -311,7 +311,7 @@ public:
       std::swap(on_notify, m_on_notify);
     }
 
-    on_notify->complete(0);
+    on_notify->complete(r);
   }
 
 private:
@@ -980,8 +980,8 @@ void ImageState<I>::notify_unquiesce(Context *on_finish) {
 }
 
 template <typename I>
-void ImageState<I>::quiesce_complete() {
-  m_quiesce_watchers->quiesce_complete();
+void ImageState<I>::quiesce_complete(int r) {
+  m_quiesce_watchers->quiesce_complete(r);
 }
 
 } // namespace librbd

--- a/src/librbd/ImageState.h
+++ b/src/librbd/ImageState.h
@@ -57,7 +57,7 @@ public:
   int unregister_quiesce_watcher(uint64_t handle);
   void notify_quiesce(Context *on_finish);
   void notify_unquiesce(Context *on_finish);
-  void quiesce_complete();
+  void quiesce_complete(int r);
 
 private:
   enum State {

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -341,21 +341,20 @@ void ImageWatcher<I>::notify_header_update(librados::IoCtx &io_ctx,
 }
 
 template <typename I>
-uint64_t ImageWatcher<I>::notify_quiesce(ProgressContext &prog_ctx,
-                                         Context *on_finish) {
-  uint64_t request_id = m_image_ctx.operations->reserve_async_request_id();
+void ImageWatcher<I>::notify_quiesce(uint64_t *request_id,
+                                     ProgressContext &prog_ctx,
+                                     Context *on_finish) {
+  *request_id = m_image_ctx.operations->reserve_async_request_id();
 
   ldout(m_image_ctx.cct, 10) << this << " " << __func__ << ": request_id="
                              << request_id << dendl;
 
-  AsyncRequestId async_request_id(get_client_id(), request_id);
+  AsyncRequestId async_request_id(get_client_id(), *request_id);
 
   auto attempts = m_image_ctx.config.template get_val<uint64_t>(
     "rbd_quiesce_notification_attempts");
 
   notify_quiesce(async_request_id, attempts, prog_ctx, on_finish);
-
-  return request_id;
 }
 
 template <typename I>

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -689,7 +689,7 @@ Context *ImageWatcher<I>::prepare_quiesce_request(
       delete it->second.first;
       it->second.first = ack_ctx;
     } else {
-      m_task_finisher->queue(new C_ResponseMessage(ack_ctx), -ESTALE);
+      m_task_finisher->queue(new C_ResponseMessage(ack_ctx));
     }
     locker.unlock();
 

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -196,6 +196,7 @@ template <typename I>
 void ImageWatcher<I>::notify_snap_create(uint64_t request_id,
                                          const cls::rbd::SnapshotNamespace &snap_namespace,
 					 const std::string &snap_name,
+                                         uint64_t flags,
                                          ProgressContext &prog_ctx,
                                          Context *on_finish) {
   ceph_assert(ceph_mutex_is_locked(m_image_ctx.owner_lock));
@@ -206,7 +207,7 @@ void ImageWatcher<I>::notify_snap_create(uint64_t request_id,
 
   notify_async_request(async_request_id,
                        new SnapCreatePayload(async_request_id, snap_namespace,
-                                             snap_name),
+                                             snap_name, flags),
                        prog_ctx, on_finish);
 }
 
@@ -992,11 +993,13 @@ bool ImageWatcher<I>::handle_payload(const SnapCreatePayload &payload,
         ldout(m_image_ctx.cct, 10) << this << " remote snap_create request: "
 				   << payload.async_request_id << " "
                                    << payload.snap_namespace << " "
-                                   << payload.snap_name << dendl;
+                                   << payload.snap_name << " "
+                                   << payload.flags << dendl;
 
         m_image_ctx.operations->execute_snap_create(payload.snap_namespace,
                                                     payload.snap_name,
-                                                    ctx, 0, false, *prog_ctx);
+                                                    ctx, 0, payload.flags,
+                                                    *prog_ctx);
       }
       return complete;
     } else if (r < 0) {

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -37,6 +37,7 @@ public:
   void notify_snap_create(uint64_t request_id,
                           const cls::rbd::SnapshotNamespace &snap_namespace,
 			  const std::string &snap_name,
+                          uint64_t flags,
                           ProgressContext &prog_ctx,
 			  Context *on_finish);
   void notify_snap_rename(const snapid_t &src_snap_id,

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -73,7 +73,8 @@ public:
   static void notify_header_update(librados::IoCtx &io_ctx,
                                    const std::string &oid);
 
-  uint64_t notify_quiesce(ProgressContext &prog_ctx, Context *on_finish);
+  void notify_quiesce(uint64_t *request_id, ProgressContext &prog_ctx,
+                      Context *on_finish);
   void notify_unquiesce(uint64_t request_id, Context *on_finish);
 
 private:

--- a/src/librbd/Operations.h
+++ b/src/librbd/Operations.h
@@ -50,9 +50,11 @@ public:
                       Context *on_finish, uint64_t journal_op_tid);
 
   int snap_create(const cls::rbd::SnapshotNamespace &snap_namespace,
-		  const std::string& snap_name);
+		  const std::string& snap_name, uint64_t flags,
+                  ProgressContext& prog_ctx);
   void snap_create(const cls::rbd::SnapshotNamespace &snap_namespace,
-		   const std::string& snap_name, Context *on_finish);
+		   const std::string& snap_name, uint64_t flags,
+                   ProgressContext& prog_ctx, Context *on_finish);
   void execute_snap_create(const cls::rbd::SnapshotNamespace &snap_namespace,
 			   const std::string &snap_name, Context *on_finish,
                            uint64_t journal_op_tid, uint64_t flags,

--- a/src/librbd/Types.h
+++ b/src/librbd/Types.h
@@ -100,8 +100,9 @@ enum ImageReadOnlyFlag {
 };
 
 enum SnapCreateFlag {
-  SNAP_CREATE_FLAG_SKIP_OBJECT_MAP     = 1 << 0,
-  SNAP_CREATE_FLAG_SKIP_NOTIFY_QUIESCE = 1 << 1,
+  SNAP_CREATE_FLAG_SKIP_OBJECT_MAP             = 1 << 0,
+  SNAP_CREATE_FLAG_SKIP_NOTIFY_QUIESCE         = 1 << 1,
+  SNAP_CREATE_FLAG_IGNORE_NOTIFY_QUIESCE_ERROR = 1 << 2,
 };
 
 struct MigrationInfo {

--- a/src/librbd/Utils.cc
+++ b/src/librbd/Utils.cc
@@ -164,5 +164,20 @@ int snap_create_flags_api_to_internal(CephContext *cct, uint32_t api_flags,
   return 0;
 }
 
+uint32_t get_default_snap_create_flags(ImageCtx *ictx) {
+  auto mode = ictx->config.get_val<std::string>(
+      "rbd_default_snapshot_quiesce_mode");
+
+  if (mode == "required") {
+    return 0;
+  } else if (mode == "ignore-error") {
+    return RBD_SNAP_CREATE_IGNORE_QUIESCE_ERROR;
+  } else if (mode == "skip") {
+    return RBD_SNAP_CREATE_SKIP_QUIESCE;
+  } else {
+    ceph_abort_msg("invalid rbd_default_snapshot_quiesce_mode");
+  }
+}
+
 } // namespace util
 } // namespace librbd

--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -260,6 +260,9 @@ int create_ioctx(librados::IoCtx& src_io_ctx, const std::string& pool_desc,
                  const std::optional<std::string>& pool_namespace,
                  librados::IoCtx* dst_io_ctx);
 
+int snap_create_flags_api_to_internal(CephContext *cct, uint32_t api_flags,
+                                      uint64_t *internal_flags);
+
 } // namespace util
 } // namespace librbd
 

--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -263,6 +263,8 @@ int create_ioctx(librados::IoCtx& src_io_ctx, const std::string& pool_desc,
 int snap_create_flags_api_to_internal(CephContext *cct, uint32_t api_flags,
                                       uint64_t *internal_flags);
 
+uint32_t get_default_snap_create_flags(ImageCtx *ictx);
+
 } // namespace util
 } // namespace librbd
 

--- a/src/librbd/WatchNotifyTypes.cc
+++ b/src/librbd/WatchNotifyTypes.cc
@@ -196,6 +196,7 @@ void SnapCreatePayload::encode(bufferlist &bl) const {
   using ceph::encode;
   SnapPayloadBase::encode(bl);
   encode(async_request_id, bl);
+  encode(flags, bl);
 }
 
 void SnapCreatePayload::decode(__u8 version, bufferlist::const_iterator &iter) {
@@ -206,6 +207,7 @@ void SnapCreatePayload::decode(__u8 version, bufferlist::const_iterator &iter) {
   }
   if (version >= 7) {
     decode(async_request_id, iter);
+    decode(flags, iter);
   }
 }
 
@@ -214,6 +216,7 @@ void SnapCreatePayload::dump(Formatter *f) const {
   async_request_id.dump(f);
   f->close_section();
   SnapPayloadBase::dump(f);
+  f->dump_unsigned("flags", flags);
 }
 
 void SnapRenamePayload::encode(bufferlist &bl) const {
@@ -395,7 +398,7 @@ void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {
   o.push_back(new NotifyMessage(new ResizePayload(123, true, AsyncRequestId(ClientId(0, 1), 2))));
   o.push_back(new NotifyMessage(new SnapCreatePayload(AsyncRequestId(ClientId(0, 1), 2),
                                                       cls::rbd::UserSnapshotNamespace(),
-                                                      "foo")));
+                                                      "foo", 1)));
   o.push_back(new NotifyMessage(new SnapRemovePayload(cls::rbd::UserSnapshotNamespace(), "foo")));
   o.push_back(new NotifyMessage(new SnapProtectPayload(cls::rbd::UserSnapshotNamespace(), "foo")));
   o.push_back(new NotifyMessage(new SnapUnprotectPayload(cls::rbd::UserSnapshotNamespace(), "foo")));

--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -262,12 +262,14 @@ protected:
 
 struct SnapCreatePayload : public SnapPayloadBase {
   AsyncRequestId async_request_id;
+  uint64_t flags = 0;
 
   SnapCreatePayload() {}
   SnapCreatePayload(const AsyncRequestId &id,
                     const cls::rbd::SnapshotNamespace &snap_namespace,
-		    const std::string &name)
-    : SnapPayloadBase(snap_namespace, name), async_request_id(id) {
+		    const std::string &name, uint64_t flags)
+    : SnapPayloadBase(snap_namespace, name), async_request_id(id),
+      flags(flags) {
   }
 
   NotifyOp get_notify_op() const override {

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -467,8 +467,8 @@ int notify_quiesce(std::vector<I*> &ictxs, ProgressContext &prog_ctx,
   for (int i = 0; i < image_count; ++i) {
     auto ictx = ictxs[i];
 
-    (*requests)[i] = ictx->image_watcher->notify_quiesce(prog_ctx,
-                                                         &on_finishes[i]);
+    ictx->image_watcher->notify_quiesce(&(*requests)[i], prog_ctx,
+                                        &on_finishes[i]);
   }
 
   int ret_code = 0;

--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -1970,11 +1970,19 @@ int Mirror<I>::image_info_list(
 }
 
 template <typename I>
-int Mirror<I>::image_snapshot_create(I *ictx, uint64_t *snap_id) {
+int Mirror<I>::image_snapshot_create(I *ictx, uint32_t flags,
+                                     uint64_t *snap_id) {
   CephContext *cct = ictx->cct;
   ldout(cct, 20) << "ictx=" << ictx << dendl;
 
-  int r = ictx->state->refresh_if_required();
+  uint64_t snap_create_flags = 0;
+  int r = util::snap_create_flags_api_to_internal(cct, flags,
+                                                  &snap_create_flags);
+  if (r < 0) {
+    return r;
+  }
+
+  r = ictx->state->refresh_if_required();
   if (r < 0) {
     return r;
   }
@@ -1997,7 +2005,8 @@ int Mirror<I>::image_snapshot_create(I *ictx, uint64_t *snap_id) {
 
   C_SaferCond on_finish;
   auto req = mirror::snapshot::CreatePrimaryRequest<I>::create(
-    ictx, mirror_image.global_image_id, CEPH_NOSNAP, 0U, snap_id, &on_finish);
+    ictx, mirror_image.global_image_id, CEPH_NOSNAP, snap_create_flags, 0U,
+    snap_id, &on_finish);
   req->send();
   return on_finish.wait();
 }

--- a/src/librbd/api/Mirror.h
+++ b/src/librbd/api/Mirror.h
@@ -113,7 +113,8 @@ struct Mirror {
                                       Context *on_finish);
   static int image_get_instance_id(ImageCtxT *ictx, std::string *instance_id);
 
-  static int image_snapshot_create(ImageCtxT *ictx, uint64_t *snap_id);
+  static int image_snapshot_create(ImageCtxT *ictx, uint32_t flags,
+                                   uint64_t *snap_id);
 };
 
 } // namespace api

--- a/src/librbd/api/Snapshot.h
+++ b/src/librbd/api/Snapshot.h
@@ -41,6 +41,9 @@ struct Snapshot {
   static int exists(ImageCtxT *ictx, const cls::rbd::SnapshotNamespace& snap_namespace,
 		    const char *snap_name, bool *exists);
 
+  static int create(ImageCtxT *ictx, const char *snap_name, uint32_t flags,
+                    ProgressContext& pctx);
+
   static int remove(ImageCtxT *ictx, const char *snap_name, uint32_t flags, ProgressContext& pctx);
 
   static int get_limit(ImageCtxT *ictx, uint64_t *limit);

--- a/src/librbd/deep_copy/SnapshotCreateRequest.cc
+++ b/src/librbd/deep_copy/SnapshotCreateRequest.cc
@@ -80,10 +80,11 @@ void SnapshotCreateRequest<I>::send_create_snap() {
       handle_create_snap(r);
       finish_op_ctx->complete(0);
     });
+  uint64_t flags = SNAP_CREATE_FLAG_SKIP_OBJECT_MAP |
+                   SNAP_CREATE_FLAG_SKIP_NOTIFY_QUIESCE;
   std::shared_lock owner_locker{m_dst_image_ctx->owner_lock};
   m_dst_image_ctx->operations->execute_snap_create(
-      m_snap_namespace, m_snap_name.c_str(), ctx, 0U,
-      SNAP_CREATE_FLAG_SKIP_OBJECT_MAP, m_prog_ctx);
+      m_snap_namespace, m_snap_name.c_str(), ctx, 0U, flags, m_prog_ctx);
 }
 
 template <typename I>

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -42,7 +42,8 @@ struct ExecuteOp : public Context {
     image_ctx.operations->execute_snap_create(event.snap_namespace,
 					      event.snap_name,
                                               on_op_complete,
-                                              event.op_tid, 0,
+                                              event.op_tid,
+                                              SNAP_CREATE_FLAG_SKIP_NOTIFY_QUIESCE,
                                               no_op_progress_callback);
   }
 

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -3036,9 +3036,9 @@ namespace librbd {
     return r;
   }
 
-  void Image::quiesce_complete() {
+  void Image::quiesce_complete(int r) {
     ImageCtx *ictx = (ImageCtx *)ctx;
-    ictx->state->quiesce_complete();
+    ictx->state->quiesce_complete(r);
   }
 
 } // namespace librbd
@@ -7162,8 +7162,8 @@ extern "C" int rbd_quiesce_unwatch(rbd_image_t image, uint64_t handle)
   return r;
 }
 
-extern "C" void rbd_quiesce_complete(rbd_image_t image)
+extern "C" void rbd_quiesce_complete(rbd_image_t image, int r)
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
-  ictx->state->quiesce_complete();
+  ictx->state->quiesce_complete(r);
 }

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -28,6 +28,7 @@
 #include "librbd/ImageState.h"
 #include "librbd/internal.h"
 #include "librbd/Operations.h"
+#include "librbd/Utils.h"
 #include "librbd/api/Config.h"
 #include "librbd/api/DiffIterate.h"
 #include "librbd/api/Group.h"
@@ -2180,8 +2181,9 @@ namespace librbd {
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
     tracepoint(librbd, snap_create_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, snap_name);
+    auto flags = librbd::util::get_default_snap_create_flags(ictx);
     librbd::NoOpProgressContext prog_ctx;
-    int r = librbd::api::Snapshot<>::create(ictx, snap_name, 0, prog_ctx);
+    int r = librbd::api::Snapshot<>::create(ictx, snap_name, flags, prog_ctx);
     tracepoint(librbd, snap_create_exit, r);
     return r;
   }
@@ -2846,7 +2848,8 @@ namespace librbd {
   int Image::mirror_image_create_snapshot(uint64_t *snap_id)
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
-    return librbd::api::Mirror<>::image_snapshot_create(ictx, 0, snap_id);
+    auto flags = librbd::util::get_default_snap_create_flags(ictx);
+    return librbd::api::Mirror<>::image_snapshot_create(ictx, flags, snap_id);
   }
 
   int Image::mirror_image_create_snapshot2(uint32_t flags, uint64_t *snap_id)
@@ -5237,8 +5240,9 @@ extern "C" int rbd_snap_create(rbd_image_t image, const char *snap_name)
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   tracepoint(librbd, snap_create_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, snap_name);
+  auto flags = librbd::util::get_default_snap_create_flags(ictx);
   librbd::NoOpProgressContext prog_ctx;
-  int r = librbd::api::Snapshot<>::create(ictx, snap_name, 0, prog_ctx);
+  int r = librbd::api::Snapshot<>::create(ictx, snap_name, flags, prog_ctx);
   tracepoint(librbd, snap_create_exit, r);
   return r;
 }
@@ -6335,7 +6339,8 @@ extern "C" int rbd_mirror_image_create_snapshot(rbd_image_t image,
                                                 uint64_t *snap_id)
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
-  return librbd::api::Mirror<>::image_snapshot_create(ictx, 0, snap_id);
+  auto flags = librbd::util::get_default_snap_create_flags(ictx);
+  return librbd::api::Mirror<>::image_snapshot_create(ictx, flags, snap_id);
 }
 
 extern "C" int rbd_mirror_image_create_snapshot2(rbd_image_t image,

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2846,7 +2846,13 @@ namespace librbd {
   int Image::mirror_image_create_snapshot(uint64_t *snap_id)
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
-    return librbd::api::Mirror<>::image_snapshot_create(ictx, snap_id);
+    return librbd::api::Mirror<>::image_snapshot_create(ictx, 0, snap_id);
+  }
+
+  int Image::mirror_image_create_snapshot2(uint32_t flags, uint64_t *snap_id)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    return librbd::api::Mirror<>::image_snapshot_create(ictx, flags, snap_id);
   }
 
   int Image::mirror_image_get_info(mirror_image_info_t *mirror_image_info,
@@ -6329,7 +6335,15 @@ extern "C" int rbd_mirror_image_create_snapshot(rbd_image_t image,
                                                 uint64_t *snap_id)
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
-  return librbd::api::Mirror<>::image_snapshot_create(ictx, snap_id);
+  return librbd::api::Mirror<>::image_snapshot_create(ictx, 0, snap_id);
+}
+
+extern "C" int rbd_mirror_image_create_snapshot2(rbd_image_t image,
+                                                 uint32_t flags,
+                                                 uint64_t *snap_id)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  return librbd::api::Mirror<>::image_snapshot_create(ictx, flags, snap_id);
 }
 
 extern "C" int rbd_mirror_image_get_info(rbd_image_t image,

--- a/src/librbd/mirror/EnableRequest.cc
+++ b/src/librbd/mirror/EnableRequest.cc
@@ -192,6 +192,7 @@ void EnableRequest<I>::create_primary_snapshot() {
   auto req = snapshot::CreatePrimaryRequest<I>::create(
     m_image_ctx, m_mirror_image.global_image_id,
     (m_image_clean ? 0 : CEPH_NOSNAP),
+    SNAP_CREATE_FLAG_IGNORE_NOTIFY_QUIESCE_ERROR,
     snapshot::CREATE_PRIMARY_FLAG_IGNORE_EMPTY_PEERS, &m_snap_id, ctx);
   req->send();
 }

--- a/src/librbd/mirror/EnableRequest.cc
+++ b/src/librbd/mirror/EnableRequest.cc
@@ -186,13 +186,17 @@ void EnableRequest<I>::create_primary_snapshot() {
   ldout(m_cct, 10) << dendl;
 
   ceph_assert(m_image_ctx != nullptr);
+  uint64_t snap_create_flags;
+  int r = util::snap_create_flags_api_to_internal(
+      m_cct, util::get_default_snap_create_flags(m_image_ctx),
+      &snap_create_flags);
+  ceph_assert(r == 0);
   auto ctx = create_context_callback<
     EnableRequest<I>,
     &EnableRequest<I>::handle_create_primary_snapshot>(this);
   auto req = snapshot::CreatePrimaryRequest<I>::create(
     m_image_ctx, m_mirror_image.global_image_id,
-    (m_image_clean ? 0 : CEPH_NOSNAP),
-    SNAP_CREATE_FLAG_IGNORE_NOTIFY_QUIESCE_ERROR,
+    (m_image_clean ? 0 : CEPH_NOSNAP), snap_create_flags,
     snapshot::CREATE_PRIMARY_FLAG_IGNORE_EMPTY_PEERS, &m_snap_id, ctx);
   req->send();
 }

--- a/src/librbd/mirror/snapshot/CreateNonPrimaryRequest.cc
+++ b/src/librbd/mirror/snapshot/CreateNonPrimaryRequest.cc
@@ -194,7 +194,7 @@ void CreateNonPrimaryRequest<I>::create_snapshot() {
   auto ctx = create_context_callback<
     CreateNonPrimaryRequest<I>,
     &CreateNonPrimaryRequest<I>::handle_create_snapshot>(this);
-  m_image_ctx->operations->snap_create(ns, m_snap_name, ctx);
+  m_image_ctx->operations->snap_create(ns, m_snap_name, 0, m_prog_ctx, ctx);
 }
 
 template <typename I>

--- a/src/librbd/mirror/snapshot/CreateNonPrimaryRequest.h
+++ b/src/librbd/mirror/snapshot/CreateNonPrimaryRequest.h
@@ -7,6 +7,7 @@
 #include "include/buffer.h"
 #include "cls/rbd/cls_rbd_types.h"
 #include "librbd/Types.h"
+#include "librbd/internal.h"
 #include "librbd/mirror/snapshot/Types.h"
 
 #include <string>
@@ -89,6 +90,7 @@ private:
   std::string m_snap_name;
 
   bufferlist m_out_bl;
+  NoOpProgressContext m_prog_ctx;
 
   bool is_orphan() const {
     return m_primary_mirror_uuid.empty();

--- a/src/librbd/mirror/snapshot/CreatePrimaryRequest.cc
+++ b/src/librbd/mirror/snapshot/CreatePrimaryRequest.cc
@@ -121,7 +121,7 @@ void CreatePrimaryRequest<I>::create_snapshot() {
   auto ctx = create_context_callback<
     CreatePrimaryRequest<I>,
     &CreatePrimaryRequest<I>::handle_create_snapshot>(this);
-  m_image_ctx->operations->snap_create(ns, m_snap_name, ctx);
+  m_image_ctx->operations->snap_create(ns, m_snap_name, 0, m_prog_ctx, ctx);
 }
 
 template <typename I>

--- a/src/librbd/mirror/snapshot/CreatePrimaryRequest.cc
+++ b/src/librbd/mirror/snapshot/CreatePrimaryRequest.cc
@@ -28,11 +28,12 @@ using librbd::util::create_rados_callback;
 template <typename I>
 CreatePrimaryRequest<I>::CreatePrimaryRequest(
     I *image_ctx, const std::string& global_image_id,
-    uint64_t clean_since_snap_id, uint32_t flags, uint64_t *snap_id,
-    Context *on_finish)
+    uint64_t clean_since_snap_id, uint64_t snap_create_flags, uint32_t flags,
+    uint64_t *snap_id, Context *on_finish)
   : m_image_ctx(image_ctx), m_global_image_id(global_image_id),
-    m_clean_since_snap_id(clean_since_snap_id), m_flags(flags),
-    m_snap_id(snap_id), m_on_finish(on_finish) {
+    m_clean_since_snap_id(clean_since_snap_id),
+    m_snap_create_flags(snap_create_flags), m_flags(flags), m_snap_id(snap_id),
+    m_on_finish(on_finish) {
   m_default_ns_ctx.dup(m_image_ctx->md_ctx);
   m_default_ns_ctx.set_namespace("");
 }
@@ -121,7 +122,8 @@ void CreatePrimaryRequest<I>::create_snapshot() {
   auto ctx = create_context_callback<
     CreatePrimaryRequest<I>,
     &CreatePrimaryRequest<I>::handle_create_snapshot>(this);
-  m_image_ctx->operations->snap_create(ns, m_snap_name, 0, m_prog_ctx, ctx);
+  m_image_ctx->operations->snap_create(ns, m_snap_name, m_snap_create_flags,
+                                       m_prog_ctx, ctx);
 }
 
 template <typename I>

--- a/src/librbd/mirror/snapshot/CreatePrimaryRequest.h
+++ b/src/librbd/mirror/snapshot/CreatePrimaryRequest.h
@@ -28,17 +28,18 @@ public:
   static CreatePrimaryRequest *create(ImageCtxT *image_ctx,
                                       const std::string& global_image_id,
                                       uint64_t clean_since_snap_id,
+                                      uint64_t snap_create_flags,
                                       uint32_t flags, uint64_t *snap_id,
                                       Context *on_finish) {
     return new CreatePrimaryRequest(image_ctx, global_image_id,
-                                    clean_since_snap_id, flags, snap_id,
-                                    on_finish);
+                                    clean_since_snap_id, snap_create_flags, flags,
+                                    snap_id, on_finish);
   }
 
   CreatePrimaryRequest(ImageCtxT *image_ctx,
                        const std::string& global_image_id,
-                       uint64_t clean_since_snap_id, uint32_t flags,
-                       uint64_t *snap_id, Context *on_finish);
+                       uint64_t clean_since_snap_id, uint64_t snap_create_flags,
+                       uint32_t flags, uint64_t *snap_id, Context *on_finish);
 
   void send();
 
@@ -69,6 +70,7 @@ private:
   ImageCtxT *m_image_ctx;
   std::string m_global_image_id;
   uint64_t m_clean_since_snap_id;
+  const uint64_t m_snap_create_flags;
   const uint32_t m_flags;
   uint64_t *m_snap_id;
   Context *m_on_finish;

--- a/src/librbd/mirror/snapshot/CreatePrimaryRequest.h
+++ b/src/librbd/mirror/snapshot/CreatePrimaryRequest.h
@@ -7,6 +7,7 @@
 #include "include/buffer.h"
 #include "include/rados/librados.hpp"
 #include "cls/rbd/cls_rbd_types.h"
+#include "librbd/internal.h"
 #include "librbd/mirror/snapshot/Types.h"
 
 #include <string>
@@ -77,6 +78,7 @@ private:
   std::string m_snap_name;
 
   bufferlist m_out_bl;
+  NoOpProgressContext m_prog_ctx;
 
   void get_mirror_peers();
   void handle_get_mirror_peers(int r);

--- a/src/librbd/mirror/snapshot/DemoteRequest.cc
+++ b/src/librbd/mirror/snapshot/DemoteRequest.cc
@@ -73,6 +73,7 @@ void DemoteRequest<I>::create_snapshot() {
 
   auto req = CreatePrimaryRequest<I>::create(
     m_image_ctx, m_global_image_id, CEPH_NOSNAP,
+    SNAP_CREATE_FLAG_SKIP_NOTIFY_QUIESCE,
     (snapshot::CREATE_PRIMARY_FLAG_IGNORE_EMPTY_PEERS |
      snapshot::CREATE_PRIMARY_FLAG_DEMOTED), nullptr, ctx);
   req->send();

--- a/src/librbd/mirror/snapshot/PromoteRequest.cc
+++ b/src/librbd/mirror/snapshot/PromoteRequest.cc
@@ -296,6 +296,7 @@ void PromoteRequest<I>::create_promote_snapshot() {
 
   auto req = CreatePrimaryRequest<I>::create(
     m_image_ctx, m_global_image_id, CEPH_NOSNAP,
+    SNAP_CREATE_FLAG_SKIP_NOTIFY_QUIESCE,
     (snapshot::CREATE_PRIMARY_FLAG_IGNORE_EMPTY_PEERS |
      snapshot::CREATE_PRIMARY_FLAG_FORCE), nullptr, ctx);
   req->send();

--- a/src/librbd/operation/SnapshotCreateRequest.cc
+++ b/src/librbd/operation/SnapshotCreateRequest.cc
@@ -65,8 +65,8 @@ void SnapshotCreateRequest<I>::send_notify_quiesce() {
   CephContext *cct = image_ctx.cct;
   ldout(cct, 5) << this << " " << __func__ << dendl;
 
-  m_request_id = image_ctx.image_watcher->notify_quiesce(
-    m_prog_ctx, create_async_context_callback(
+  image_ctx.image_watcher->notify_quiesce(
+      &m_request_id, m_prog_ctx, create_async_context_callback(
       image_ctx, create_context_callback<SnapshotCreateRequest<I>,
       &SnapshotCreateRequest<I>::handle_notify_quiesce>(this)));
 }

--- a/src/librbd/operation/SnapshotCreateRequest.h
+++ b/src/librbd/operation/SnapshotCreateRequest.h
@@ -90,6 +90,7 @@ private:
   std::string m_snap_name;
   bool m_skip_object_map;
   bool m_skip_notify_quiesce;
+  bool m_ignore_notify_quiesce_error;
   ProgressContext &m_prog_ctx;
 
   uint64_t m_request_id = 0;

--- a/src/librbd/operation/SnapshotCreateRequest.h
+++ b/src/librbd/operation/SnapshotCreateRequest.h
@@ -29,12 +29,12 @@ public:
    *            <start>
    *               |
    *               v
-   *           STATE_NOTIFY_QUIESCE
-   *               |
-   *               v
-   *           STATE_SUSPEND_REQUESTS
-   *               |
-   *               v
+   *           STATE_NOTIFY_QUIESCE  * * * * * * * * * * * * *
+   *               |                                         *
+   *               v                                         *
+   *           STATE_SUSPEND_REQUESTS                        *
+   *               |                                         *
+   *               v                                         *
    *           STATE_SUSPEND_AIO * * * * * * * * * * * * * * *
    *               |                                         *
    *               v                                         *
@@ -94,6 +94,7 @@ private:
 
   uint64_t m_request_id = 0;
   int m_ret_val = 0;
+  bool m_writes_blocked = false;
 
   uint64_t m_snap_id = CEPH_NOSNAP;
   uint64_t m_size;

--- a/src/test/cli-integration/rbd/formatted-output.t
+++ b/src/test/cli-integration/rbd/formatted-output.t
@@ -22,21 +22,21 @@ create
 
 snapshot
 ========
-  $ rbd snap create bar@snap
+  $ rbd snap create bar@snap --no-progress
   $ rbd resize -s 1024 --no-progress bar
   $ rbd resize -s 2G --no-progress quuy
-  $ rbd snap create bar@snap2
-  $ rbd snap create foo@snap
+  $ rbd snap create bar@snap2 --no-progress
+  $ rbd snap create foo@snap --no-progress
 
 clone
 =====
   $ rbd snap protect bar@snap
   $ rbd clone --image-feature layering,exclusive-lock,object-map,fast-diff bar@snap rbd_other/child
-  $ rbd snap create rbd_other/child@snap
+  $ rbd snap create rbd_other/child@snap --no-progress
   $ rbd flatten rbd_other/child 2> /dev/null
   $ rbd bench rbd_other/child --io-type write --io-pattern seq --io-total 1B > /dev/null 2>&1
   $ rbd clone bar@snap rbd_other/deep-flatten-child
-  $ rbd snap create rbd_other/deep-flatten-child@snap
+  $ rbd snap create rbd_other/deep-flatten-child@snap --no-progress
   $ rbd flatten rbd_other/deep-flatten-child 2> /dev/null
 
 lock

--- a/src/test/cli-integration/rbd/snap-diff.t
+++ b/src/test/cli-integration/rbd/snap-diff.t
@@ -8,7 +8,7 @@
   $ rbd create --size 1M xrbddiff1/xtestdiff1
   $ rbd diff xrbddiff1/xtestdiff1 --format json
   []
-  $ rbd snap create xrbddiff1/xtestdiff1 --snap=allzeroes
+  $ rbd snap create xrbddiff1/xtestdiff1 --snap=allzeroes --no-progress
   $ rbd diff xrbddiff1/xtestdiff1 --format json
   []
   $ rbd diff --from-snap=allzeroes xrbddiff1/xtestdiff1 --format json
@@ -18,7 +18,7 @@
   [{"offset":0,"length":1048576,"exists":"true"}]
   $ rbd diff --from-snap=allzeroes xrbddiff1/xtestdiff1 --format json
   [{"offset":0,"length":1048576,"exists":"true"}]
-  $ rbd snap create xrbddiff1/xtestdiff1 --snap=snap1
+  $ rbd snap create xrbddiff1/xtestdiff1 --snap=snap1 --no-progress
   $ rbd snap list xrbddiff1/xtestdiff1 --format json | python3 -mjson.tool --sort-keys | sed 's/,$/, /'
   [
       {

--- a/src/test/cli-integration/rbd/unmap.t
+++ b/src/test/cli-integration/rbd/unmap.t
@@ -3,13 +3,13 @@ Setup
 =====
 
   $ rbd create --size 1 img
-  $ rbd snap create img@snap
+  $ rbd snap create img@snap --no-progress
   $ rbd create --size 1 anotherimg
   $ ceph osd pool create custom >/dev/null 2>&1
   $ rbd pool init custom
   $ rbd create --size 1 custom/img
-  $ rbd snap create custom/img@snap
-  $ rbd snap create custom/img@anothersnap
+  $ rbd snap create custom/img@snap --no-progress
+  $ rbd snap create custom/img@anothersnap --no-progress
 
 Spell out device instead of using $DEV - sfdisk is not a joke.
 

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -602,7 +602,7 @@
     --snap arg               snapshot name
     --read-only              map read-only
     --exclusive              disable automatic exclusive lock transitions
-    --quiesce                use quiesce callbacks
+    --quiesce                use quiesce hooks
     --quiesce-hook arg       quiesce hook path
     -o [ --options ] arg     device specific options
   
@@ -1603,19 +1603,22 @@
   
   rbd help mirror image snapshot
   usage: rbd mirror image snapshot [--pool <pool>] [--namespace <namespace>] 
-                                   [--image <image>] 
+                                   [--image <image>] [--skip-quiesce] 
+                                   [--ignore-quiesce-error] 
                                    <image-spec> 
   
   Create RBD mirroring image snapshot.
   
   Positional arguments
-    <image-spec>         image specification
-                         (example: [<pool-name>/[<namespace>/]]<image-name>)
+    <image-spec>            image specification
+                            (example: [<pool-name>/[<namespace>/]]<image-name>)
   
   Optional arguments
-    -p [ --pool ] arg    pool name
-    --namespace arg      namespace name
-    --image arg          image name
+    -p [ --pool ] arg       pool name
+    --namespace arg         namespace name
+    --image arg             image name
+    --skip-quiesce          do not run quiesce hooks
+    --ignore-quiesce-error  ignore quiesce hook error
   
   rbd help mirror image status
   usage: rbd mirror image status [--pool <pool>] [--namespace <namespace>] 
@@ -2102,21 +2105,26 @@
   
   rbd help snap create
   usage: rbd snap create [--pool <pool>] [--namespace <namespace>] 
-                         [--image <image>] [--snap <snap>] 
+                         [--image <image>] [--snap <snap>] [--skip-quiesce] 
+                         [--ignore-quiesce-error] [--no-progress] 
                          <snap-spec> 
   
   Create a snapshot.
   
   Positional arguments
-    <snap-spec>          snapshot specification
-                         (example:
-                         [<pool-name>/[<namespace>/]]<image-name>@<snapshot-name>)
+    <snap-spec>             snapshot specification
+                            (example:
+                            [<pool-name>/[<namespace>/]]<image-name>@<snapshot-nam
+                            e>)
   
   Optional arguments
-    -p [ --pool ] arg    pool name
-    --namespace arg      namespace name
-    --image arg          image name
-    --snap arg           snapshot name
+    -p [ --pool ] arg       pool name
+    --namespace arg         namespace name
+    --image arg             image name
+    --snap arg              snapshot name
+    --skip-quiesce          do not run quiesce hooks
+    --ignore-quiesce-error  ignore quiesce hook error
+    --no-progress           disable progress output
   
   rbd help snap limit clear
   usage: rbd snap limit clear [--pool <pool>] [--namespace <namespace>] 

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -229,8 +229,8 @@
   Positional arguments
     <source-snap-spec>        source snapshot specification
                               (example:
-                              [<pool-name>/[<namespace>/]]<image-name>@<snapshot-n
-                              ame>)
+                              [<pool-name>/[<namespace>/]]<image-name>@<snap-name>
+                              )
     <dest-image-spec>         destination image specification
                               (example: [<pool-name>/[<namespace>/]]<image-name>)
   
@@ -615,8 +615,8 @@
   
   Positional arguments
     <image-or-snap-or-device-spec>  image, snapshot, or device specification
-                                    [<pool-name>/]<image-name>[@<snapshot-name>]
-                                    or <device-path>
+                                    [<pool-name>/]<image-name>[@<snap-name>] or
+                                    <device-path>
   
   Optional arguments
     -t [ --device-type ] arg        device type [ggate, krbd (default), nbd]
@@ -993,7 +993,7 @@
                          (example:
                          [<pool-name>/[<namespace>/]]<group-name>@<snap-name>)
     <dest-snap>          destination snapshot name
-                         (example: <snapshot-name>)
+                         (example: <snap-name>)
   
   Optional arguments
     -p [ --pool ] arg    pool name
@@ -2114,8 +2114,7 @@
   Positional arguments
     <snap-spec>             snapshot specification
                             (example:
-                            [<pool-name>/[<namespace>/]]<image-name>@<snapshot-nam
-                            e>)
+                            [<pool-name>/[<namespace>/]]<image-name>@<snap-name>)
   
   Optional arguments
     -p [ --pool ] arg       pool name
@@ -2190,7 +2189,7 @@
   Positional arguments
     <snap-spec>          snapshot specification
                          (example:
-                         [<pool-name>/[<namespace>/]]<image-name>@<snapshot-name>)
+                         [<pool-name>/[<namespace>/]]<image-name>@<snap-name>)
   
   Optional arguments
     -p [ --pool ] arg    pool name
@@ -2228,7 +2227,7 @@
   Positional arguments
     <snap-spec>          snapshot specification
                          (example:
-                         [<pool-name>/[<namespace>/]]<image-name>@<snapshot-name>)
+                         [<pool-name>/[<namespace>/]]<image-name>@<snap-name>)
   
   Optional arguments
     -p [ --pool ] arg    pool name
@@ -2253,10 +2252,10 @@
   Positional arguments
     <source-snap-spec>   source snapshot specification
                          (example:
-                         [<pool-name>/[<namespace>/]]<image-name>@<snapshot-name>)
+                         [<pool-name>/[<namespace>/]]<image-name>@<snap-name>)
     <dest-snap-spec>     destination snapshot specification
                          (example:
-                         [<pool-name>/[<namespace>/]]<image-name>@<snapshot-name>)
+                         [<pool-name>/[<namespace>/]]<image-name>@<snap-name>)
   
   Optional arguments
     -p [ --pool ] arg    source pool name
@@ -2278,7 +2277,7 @@
   Positional arguments
     <snap-spec>          snapshot specification
                          (example:
-                         [<pool-name>/[<namespace>/]]<image-name>@<snapshot-name>)
+                         [<pool-name>/[<namespace>/]]<image-name>@<snap-name>)
   
   Optional arguments
     -p [ --pool ] arg    pool name
@@ -2298,7 +2297,7 @@
   Positional arguments
     <snap-spec>          snapshot specification
                          (example:
-                         [<pool-name>/[<namespace>/]]<image-name>@<snapshot-name>)
+                         [<pool-name>/[<namespace>/]]<image-name>@<snap-name>)
   
   Optional arguments
     -p [ --pool ] arg    pool name

--- a/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
@@ -246,8 +246,9 @@ public:
 
   int create_snap(librbd::ImageCtx *image_ctx, const char* snap_name,
                   librados::snap_t *snap_id) {
+    NoOpProgressContext prog_ctx;
     int r = image_ctx->operations->snap_create(
-        cls::rbd::UserSnapshotNamespace(), snap_name);
+        cls::rbd::UserSnapshotNamespace(), snap_name, 0, prog_ctx);
     if (r < 0) {
       return r;
     }

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -305,8 +305,9 @@ public:
 
   int create_snap(librbd::ImageCtx *image_ctx, const char* snap_name,
                   librados::snap_t *snap_id) {
+    NoOpProgressContext prog_ctx;
     int r = image_ctx->operations->snap_create(
-        cls::rbd::UserSnapshotNamespace(), snap_name);
+        cls::rbd::UserSnapshotNamespace(), snap_name, 0, prog_ctx);
     if (r < 0) {
       return r;
     }

--- a/src/test/librbd/deep_copy/test_mock_SnapshotCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SnapshotCopyRequest.cc
@@ -241,7 +241,9 @@ public:
   int create_snap(librbd::ImageCtx *image_ctx,
                   const cls::rbd::SnapshotNamespace& snap_ns,
                   const std::string &snap_name, bool protect) {
-    int r = image_ctx->operations->snap_create(snap_ns, snap_name.c_str());
+    NoOpProgressContext prog_ctx;
+    int r = image_ctx->operations->snap_create(snap_ns, snap_name.c_str(), 0,
+                                               prog_ctx);
     if (r < 0) {
       return r;
     }

--- a/src/test/librbd/deep_copy/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SnapshotCreateRequest.cc
@@ -107,9 +107,10 @@ public:
 
   void expect_snap_create(librbd::MockTestImageCtx &mock_image_ctx,
                           const std::string &snap_name, uint64_t snap_id, int r) {
+    uint64_t flags = SNAP_CREATE_FLAG_SKIP_OBJECT_MAP |
+                     SNAP_CREATE_FLAG_SKIP_NOTIFY_QUIESCE;
     EXPECT_CALL(*mock_image_ctx.operations,
-                execute_snap_create(_, StrEq(snap_name), _, 0,
-                                    SNAP_CREATE_FLAG_SKIP_OBJECT_MAP, _))
+                execute_snap_create(_, StrEq(snap_name), _, 0, flags, _))
                   .WillOnce(DoAll(InvokeWithoutArgs([&mock_image_ctx, snap_id, snap_name]() {
                                     inject_snap(mock_image_ctx, snap_id, snap_name);
                                   }),

--- a/src/test/librbd/image/test_mock_AttachChildRequest.cc
+++ b/src/test/librbd/image/test_mock_AttachChildRequest.cc
@@ -10,6 +10,7 @@
 #include "librbd/Operations.h"
 #include "librbd/image/AttachChildRequest.h"
 #include "librbd/image/RefreshRequest.h"
+#include "librbd/internal.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -72,8 +73,9 @@ public:
     TestMockFixture::SetUp();
 
     ASSERT_EQ(0, open_image(m_image_name, &image_ctx));
+    NoOpProgressContext prog_ctx;
     ASSERT_EQ(0, image_ctx->operations->snap_create(
-                   cls::rbd::UserSnapshotNamespace{}, "snap"));
+                   cls::rbd::UserSnapshotNamespace{}, "snap", 0, prog_ctx));
     if (is_feature_enabled(RBD_FEATURE_LAYERING)) {
       ASSERT_EQ(0, image_ctx->operations->snap_protect(
                      cls::rbd::UserSnapshotNamespace{}, "snap"));

--- a/src/test/librbd/image/test_mock_CloneRequest.cc
+++ b/src/test/librbd/image/test_mock_CloneRequest.cc
@@ -237,8 +237,9 @@ public:
     ASSERT_EQ(0, _rados.conf_set("rbd_default_clone_format", "2"));
 
     ASSERT_EQ(0, open_image(m_image_name, &image_ctx));
+    NoOpProgressContext prog_ctx;
     ASSERT_EQ(0, image_ctx->operations->snap_create(
-                   cls::rbd::UserSnapshotNamespace{}, "snap"));
+                   cls::rbd::UserSnapshotNamespace{}, "snap", 0, prog_ctx));
     if (is_feature_enabled(RBD_FEATURE_LAYERING)) {
       ASSERT_EQ(0, image_ctx->operations->snap_protect(
                      cls::rbd::UserSnapshotNamespace{}, "snap"));

--- a/src/test/librbd/journal/test_Replay.cc
+++ b/src/test/librbd/journal/test_Replay.cc
@@ -338,9 +338,10 @@ TEST_F(TestJournalReplay, SnapCreate) {
 					     "snap"));
   }
 
-  // verify lock ordering constraints
+  // verify lock ordering constraints  
+  librbd::NoOpProgressContext no_op_progress;
   ASSERT_EQ(0, ictx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					     "snap2"));
+					     "snap2", 0, no_op_progress));
 }
 
 TEST_F(TestJournalReplay, SnapProtect) {
@@ -351,8 +352,9 @@ TEST_F(TestJournalReplay, SnapProtect) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, when_acquired_lock(ictx));
 
+  librbd::NoOpProgressContext no_op_progress;
   ASSERT_EQ(0, ictx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					     "snap"));
+					     "snap", 0, no_op_progress));
 
   // get current commit position
   int64_t initial_tag;
@@ -383,7 +385,7 @@ TEST_F(TestJournalReplay, SnapProtect) {
 
   // verify lock ordering constraints
   ASSERT_EQ(0, ictx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					     "snap2"));
+					     "snap2", 0, no_op_progress));
   ASSERT_EQ(0, ictx->operations->snap_protect(cls::rbd::UserSnapshotNamespace(),
 					      "snap2"));
 }
@@ -396,8 +398,9 @@ TEST_F(TestJournalReplay, SnapUnprotect) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, when_acquired_lock(ictx));
 
+  librbd::NoOpProgressContext no_op_progress;
   ASSERT_EQ(0, ictx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					     "snap"));
+					     "snap", 0, no_op_progress));
   uint64_t snap_id;
   {
     std::shared_lock image_locker{ictx->image_lock};
@@ -436,7 +439,7 @@ TEST_F(TestJournalReplay, SnapUnprotect) {
 
   // verify lock ordering constraints
   ASSERT_EQ(0, ictx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					     "snap2"));
+					     "snap2", 0, no_op_progress));
   ASSERT_EQ(0, ictx->operations->snap_protect(cls::rbd::UserSnapshotNamespace(),
 					      "snap2"));
   ASSERT_EQ(0, ictx->operations->snap_unprotect(cls::rbd::UserSnapshotNamespace(),
@@ -451,8 +454,9 @@ TEST_F(TestJournalReplay, SnapRename) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, when_acquired_lock(ictx));
 
+  librbd::NoOpProgressContext no_op_progress;
   ASSERT_EQ(0, ictx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					     "snap"));
+					     "snap", 0, no_op_progress));
   uint64_t snap_id;
   {
     std::shared_lock image_locker{ictx->image_lock};
@@ -500,8 +504,9 @@ TEST_F(TestJournalReplay, SnapRollback) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, when_acquired_lock(ictx));
 
+  librbd::NoOpProgressContext no_op_progress;
   ASSERT_EQ(0, ictx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					     "snap"));
+					     "snap", 0, no_op_progress));
 
   // get current commit position
   int64_t initial_tag;
@@ -527,7 +532,6 @@ TEST_F(TestJournalReplay, SnapRollback) {
   ASSERT_EQ(initial_entry + 2, current_entry);
 
   // verify lock ordering constraints
-  librbd::NoOpProgressContext no_op_progress;
   ASSERT_EQ(0, ictx->operations->snap_rollback(cls::rbd::UserSnapshotNamespace(),
 					       "snap",
 					       no_op_progress));
@@ -541,8 +545,9 @@ TEST_F(TestJournalReplay, SnapRemove) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_EQ(0, when_acquired_lock(ictx));
 
+  librbd::NoOpProgressContext no_op_progress;
   ASSERT_EQ(0, ictx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					     "snap"));
+					     "snap", 0, no_op_progress));
 
   // get current commit position
   int64_t initial_tag;
@@ -576,7 +581,7 @@ TEST_F(TestJournalReplay, SnapRemove) {
 
   // verify lock ordering constraints
   ASSERT_EQ(0, ictx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					     "snap"));
+					     "snap", 0, no_op_progress));
   ASSERT_EQ(0, ictx->operations->snap_remove(cls::rbd::UserSnapshotNamespace(),
 					     "snap"));
 }
@@ -653,8 +658,9 @@ TEST_F(TestJournalReplay, Flatten) {
 
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  librbd::NoOpProgressContext no_op_progress;
   ASSERT_EQ(0, ictx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					     "snap"));
+					     "snap", 0, no_op_progress));
   ASSERT_EQ(0, ictx->operations->snap_protect(cls::rbd::UserSnapshotNamespace(),
 					      "snap"));
 

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -218,8 +218,9 @@ public:
   void expect_snap_create(MockReplayImageCtx &mock_image_ctx,
                           Context **on_finish, const char *snap_name,
                           uint64_t op_tid) {
-    EXPECT_CALL(*mock_image_ctx.operations, execute_snap_create(_, StrEq(snap_name), _,
-                                                                op_tid, 0, _))
+    EXPECT_CALL(*mock_image_ctx.operations,
+                execute_snap_create(_, StrEq(snap_name), _, op_tid,
+                                    SNAP_CREATE_FLAG_SKIP_NOTIFY_QUIESCE, _))
                   .WillOnce(DoAll(SaveArg<2>(on_finish),
                                   NotifyInvoke(&m_invoke_lock, &m_invoke_cond)));
   }

--- a/src/test/librbd/mirror/snapshot/test_mock_CreateNonPrimaryRequest.cc
+++ b/src/test/librbd/mirror/snapshot/test_mock_CreateNonPrimaryRequest.cc
@@ -155,8 +155,8 @@ public:
   }
 
   void expect_create_snapshot(MockTestImageCtx &mock_image_ctx, int r) {
-    EXPECT_CALL(*mock_image_ctx.operations, snap_create(_, _, _))
-      .WillOnce(WithArg<2>(CompleteContext(
+    EXPECT_CALL(*mock_image_ctx.operations, snap_create(_, _, _, _, _))
+      .WillOnce(WithArg<4>(CompleteContext(
                              r, mock_image_ctx.image_ctx->op_work_queue)));
   }
 

--- a/src/test/librbd/mirror/snapshot/test_mock_CreatePrimaryRequest.cc
+++ b/src/test/librbd/mirror/snapshot/test_mock_CreatePrimaryRequest.cc
@@ -146,18 +146,20 @@ public:
   }
 
   void expect_create_snapshot(MockTestImageCtx &mock_image_ctx, int r) {
-    EXPECT_CALL(*mock_image_ctx.operations, snap_create(_, _, _))
+    EXPECT_CALL(*mock_image_ctx.operations, snap_create(_, _, _, _, _))
       .WillOnce(DoAll(
                   Invoke([this, &mock_image_ctx, r](
                              const cls::rbd::SnapshotNamespace &ns,
                              const std::string& snap_name,
+                             uint64_t flags,
+                             ProgressContext &prog_ctx,
                              Context *on_finish) {
                            if (r != 0) {
                              return;
                            }
                            snap_create(mock_image_ctx, ns, snap_name);
                          }),
-                  WithArg<2>(CompleteContext(
+                  WithArg<4>(CompleteContext(
                                r, mock_image_ctx.image_ctx->op_work_queue))
                   ));
   }

--- a/src/test/librbd/mirror/snapshot/test_mock_CreatePrimaryRequest.cc
+++ b/src/test/librbd/mirror/snapshot/test_mock_CreatePrimaryRequest.cc
@@ -213,7 +213,7 @@ TEST_F(TestMockMirrorSnapshotCreatePrimaryRequest, Success) {
 
   C_SaferCond ctx;
   auto req = new MockCreatePrimaryRequest(&mock_image_ctx, "gid", CEPH_NOSNAP,
-                                          0U, nullptr, &ctx);
+                                          0U, 0U, nullptr, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -234,7 +234,7 @@ TEST_F(TestMockMirrorSnapshotCreatePrimaryRequest, CanNotError) {
 
   C_SaferCond ctx;
   auto req = new MockCreatePrimaryRequest(&mock_image_ctx, "gid", CEPH_NOSNAP,
-                                          0U, nullptr, &ctx);
+                                          0U, 0U, nullptr, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -258,7 +258,7 @@ TEST_F(TestMockMirrorSnapshotCreatePrimaryRequest, GetMirrorPeersError) {
 
   C_SaferCond ctx;
   auto req = new MockCreatePrimaryRequest(&mock_image_ctx, "gid", CEPH_NOSNAP,
-                                          0U, nullptr, &ctx);
+                                          0U, 0U, nullptr, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -283,7 +283,7 @@ TEST_F(TestMockMirrorSnapshotCreatePrimaryRequest, CreateSnapshotError) {
 
   C_SaferCond ctx;
   auto req = new MockCreatePrimaryRequest(&mock_image_ctx, "gid", CEPH_NOSNAP,
-                                          0U, nullptr, &ctx);
+                                          0U, 0U, nullptr, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -318,7 +318,7 @@ TEST_F(TestMockMirrorSnapshotCreatePrimaryRequest, SuccessUnlinkPeer) {
                      0);
   C_SaferCond ctx;
   auto req = new MockCreatePrimaryRequest(&mock_image_ctx, "gid", CEPH_NOSNAP,
-                                          0U, nullptr, &ctx);
+                                          0U, 0U, nullptr, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }

--- a/src/test/librbd/mirror/snapshot/test_mock_PromoteRequest.cc
+++ b/src/test/librbd/mirror/snapshot/test_mock_PromoteRequest.cc
@@ -123,6 +123,7 @@ struct CreatePrimaryRequest<MockTestImageCtx> {
   static CreatePrimaryRequest *create(MockTestImageCtx *image_ctx,
                                       const std::string& global_image_id,
                                       uint64_t clean_since_snap_id,
+                                      uint64_t snap_create_flags,
                                       uint32_t flags, uint64_t *snap_id,
                                       Context *on_finish) {
     ceph_assert(s_instance != nullptr);

--- a/src/test/librbd/mock/MockImageWatcher.h
+++ b/src/test/librbd/mock/MockImageWatcher.h
@@ -25,7 +25,7 @@ struct MockImageWatcher {
   MOCK_METHOD0(notify_released_lock, void());
   MOCK_METHOD0(notify_request_lock, void());
 
-  MOCK_METHOD2(notify_quiesce, uint64_t(ProgressContext &, Context *));
+  MOCK_METHOD3(notify_quiesce, void(uint64_t *, ProgressContext &, Context *));
   MOCK_METHOD2(notify_unquiesce, void(uint64_t, Context *));
 };
 

--- a/src/test/librbd/mock/MockOperations.h
+++ b/src/test/librbd/mock/MockOperations.h
@@ -25,8 +25,10 @@ struct MockOperations {
                                     ProgressContext &prog_ctx,
                                     Context *on_finish,
                                     uint64_t journal_op_tid));
-  MOCK_METHOD3(snap_create, void(const cls::rbd::SnapshotNamespace &snapshot_namespace,
+  MOCK_METHOD5(snap_create, void(const cls::rbd::SnapshotNamespace &snapshot_namespace,
 				 const std::string &snap_name,
+                                 uint64_t flags,
+                                 ProgressContext &prog_ctx,
                                  Context *on_finish));
   MOCK_METHOD6(execute_snap_create, void(const cls::rbd::SnapshotNamespace &snapshot_namespace,
 					 const std::string &snap_name,

--- a/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
@@ -206,6 +206,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, NotifyQuiesceError) {
 
   ::testing::InSequence seq;
   expect_notify_quiesce(mock_image_ctx, -EINVAL);
+  expect_notify_unquiesce(mock_image_ctx, 0);
 
   C_SaferCond cond_ctx;
   librbd::NoOpProgressContext prog_ctx;

--- a/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
@@ -63,10 +63,9 @@ public:
   typedef mirror::snapshot::SetImageStateRequest<MockImageCtx> MockSetImageStateRequest;
 
   void expect_notify_quiesce(MockImageCtx &mock_image_ctx, int r) {
-    EXPECT_CALL(*mock_image_ctx.image_watcher, notify_quiesce(_, _))
-      .WillOnce(DoAll(WithArg<1>(CompleteContext(
-                                   r, mock_image_ctx.image_ctx->op_work_queue)),
-                      Return(0)));
+    EXPECT_CALL(*mock_image_ctx.image_watcher, notify_quiesce(_, _, _))
+      .WillOnce(WithArg<2>(CompleteContext(
+                             r, mock_image_ctx.image_ctx->op_work_queue)));
   }
 
   void expect_block_writes(MockImageCtx &mock_image_ctx) {

--- a/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
@@ -173,7 +173,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, Success) {
   expect_op_work_queue(mock_image_ctx);
 
   ::testing::InSequence seq;
-  expect_notify_quiesce(mock_image_ctx, 0);
+  expect_notify_quiesce(mock_image_ctx, -EINVAL);
   expect_block_writes(mock_image_ctx);
   expect_allocate_snap_id(mock_image_ctx, 0);
   expect_snap_create(mock_image_ctx, 0);
@@ -188,7 +188,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, Success) {
   librbd::NoOpProgressContext prog_ctx;
   MockSnapshotCreateRequest *req = new MockSnapshotCreateRequest(
     mock_image_ctx, &cond_ctx, cls::rbd::UserSnapshotNamespace(),
-    "snap1", 0, 0, prog_ctx);
+    "snap1", 0, SNAP_CREATE_FLAG_IGNORE_NOTIFY_QUIESCE_ERROR, prog_ctx);
   {
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
     req->send();

--- a/src/test/librbd/operation/test_mock_SnapshotRemoveRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotRemoveRequest.cc
@@ -446,8 +446,9 @@ TEST_F(TestMockOperationSnapshotRemoveRequest, TrashCloneParent) {
 
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  NoOpProgressContext prog_ctx;
   ASSERT_EQ(0, ictx->operations->snap_create(
-                 {cls::rbd::TrashSnapshotNamespace{}}, "snap1"));
+                 {cls::rbd::TrashSnapshotNamespace{}}, "snap1", 0, prog_ctx));
   ASSERT_EQ(0, ictx->state->refresh_if_required());
 
   MockImageCtx mock_image_ctx(*ictx);

--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -293,7 +293,7 @@ struct SnapCreateTask {
     std::shared_lock l{ictx->owner_lock};
     C_SaferCond ctx;
     ictx->image_watcher->notify_snap_create(0, cls::rbd::UserSnapshotNamespace(),
-                                            "snap", *progress_context, &ctx);
+                                            "snap", 0, *progress_context, &ctx);
     ASSERT_EQ(0, ctx.wait());
   }
 };
@@ -486,7 +486,7 @@ TEST_F(TestImageWatcher, NotifySnapCreateError) {
   C_SaferCond notify_ctx;
   librbd::NoOpProgressContext prog_ctx;
   ictx->image_watcher->notify_snap_create(0, cls::rbd::UserSnapshotNamespace(),
-       "snap", prog_ctx, &notify_ctx);
+                                          "snap", 0, prog_ctx, &notify_ctx);
   ASSERT_EQ(-EEXIST, notify_ctx.wait());
 
   NotifyOps expected_notify_ops;

--- a/src/test/librbd/test_fixture.cc
+++ b/src/test/librbd/test_fixture.cc
@@ -85,8 +85,9 @@ int TestFixture::open_image(const std::string &image_name,
 
 int TestFixture::snap_create(librbd::ImageCtx &ictx,
                              const std::string &snap_name) {
+  librbd::NoOpProgressContext prog_ctx;
   return ictx.operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-				      snap_name.c_str());
+				      snap_name.c_str(), 0, prog_ctx);
 }
 
 int TestFixture::snap_protect(librbd::ImageCtx &ictx,

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -1157,7 +1157,7 @@ TEST_F(TestInternal, WriteFullCopyup) {
 
   ASSERT_EQ(0, open_image(clone_name, &ictx2));
   ASSERT_EQ(0, ictx2->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					      "snap1"));
+					      "snap1", 0, no_op));
 
   bufferlist write_full_bl;
   write_full_bl.append(std::string(1 << ictx2->order, '2'));

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -8362,16 +8362,17 @@ TEST_F(TestLibRBD, QuiesceWatchError)
     ASSERT_EQ(0, image2.quiesce_watch(&watcher2, &handle2));
 
     ASSERT_EQ(-EINVAL, image1.snap_create("snap1"));
-    ASSERT_EQ(1U, watcher1.quiesce_count);
+    ASSERT_LT(0U, watcher1.quiesce_count);
     ASSERT_EQ(0U, watcher1.unquiesce_count);
     ASSERT_EQ(1U, watcher2.quiesce_count);
     ASSERT_EQ(1U, watcher2.unquiesce_count);
 
     PrintProgress prog_ctx;
+    watcher1.quiesce_count = 0;
     ASSERT_EQ(0, image2.snap_create2("snap2",
                                      RBD_SNAP_CREATE_IGNORE_QUIESCE_ERROR,
                                      prog_ctx));
-    ASSERT_EQ(2U, watcher1.quiesce_count);
+    ASSERT_LT(0U, watcher1.quiesce_count);
     ASSERT_EQ(0U, watcher1.unquiesce_count);
     ASSERT_EQ(2U, watcher2.quiesce_count);
     ASSERT_EQ(2U, watcher2.unquiesce_count);

--- a/src/test/rbd_mirror/image_replayer/snapshot/test_mock_CreateLocalImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/snapshot/test_mock_CreateLocalImageRequest.cc
@@ -142,10 +142,11 @@ public:
   }
 
   void snap_create(librbd::ImageCtx *image_ctx, const std::string &snap_name) {
+    librbd::NoOpProgressContext prog_ctx;
     ASSERT_EQ(0, image_ctx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					            snap_name.c_str()));
+					            snap_name, 0, prog_ctx));
     ASSERT_EQ(0, image_ctx->operations->snap_protect(cls::rbd::UserSnapshotNamespace(),
-						     snap_name.c_str()));
+						     snap_name));
     ASSERT_EQ(0, image_ctx->state->refresh());
   }
 

--- a/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
@@ -230,10 +230,11 @@ public:
   }
 
   void snap_create(librbd::ImageCtx *image_ctx, const std::string &snap_name) {
+    librbd::NoOpProgressContext prog_ctx;
     ASSERT_EQ(0, image_ctx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					            snap_name.c_str()));
+					            snap_name, 0, prog_ctx));
     ASSERT_EQ(0, image_ctx->operations->snap_protect(cls::rbd::UserSnapshotNamespace(),
-						     snap_name.c_str()));
+						     snap_name));
     ASSERT_EQ(0, image_ctx->state->refresh());
   }
 

--- a/src/test/rbd_mirror/image_sync/test_mock_SyncPointCreateRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_SyncPointCreateRequest.cc
@@ -77,8 +77,8 @@ public:
   }
 
   void expect_snap_create(librbd::MockTestImageCtx &mock_remote_image_ctx, int r) {
-    EXPECT_CALL(*mock_remote_image_ctx.operations, snap_create(_, _, _))
-      .WillOnce(WithArg<2>(CompleteContext(r)));
+    EXPECT_CALL(*mock_remote_image_ctx.operations, snap_create(_, _, _, _, _))
+      .WillOnce(WithArg<4>(CompleteContext(r)));
   }
 
   MockSyncPointCreateRequest *create_request(librbd::MockTestImageCtx &mock_remote_image_ctx,

--- a/src/test/rbd_mirror/test_ImageDeleter.cc
+++ b/src/test/rbd_mirror/test_ImageDeleter.cc
@@ -170,12 +170,13 @@ public:
       ictx->set_journal_policy(new librbd::journal::DisabledPolicy());
     }
 
+    librbd::NoOpProgressContext prog_ctx;
     EXPECT_EQ(0, ictx->operations->snap_create(
-                   cls::rbd::UserSnapshotNamespace(), snap_name.c_str()));
+                   cls::rbd::UserSnapshotNamespace(), snap_name, 0, prog_ctx));
 
     if (protect) {
       EXPECT_EQ(0, ictx->operations->snap_protect(
-                     cls::rbd::UserSnapshotNamespace(), snap_name.c_str()));
+                     cls::rbd::UserSnapshotNamespace(), snap_name));
     }
 
     EXPECT_EQ(0, ictx->state->close());
@@ -190,8 +191,9 @@ public:
       ictx->set_journal_policy(new librbd::journal::DisabledPolicy());
     }
 
+    librbd::NoOpProgressContext prog_ctx;
     EXPECT_EQ(0, ictx->operations->snap_create(
-                   cls::rbd::UserSnapshotNamespace(), "snap1"));
+                   cls::rbd::UserSnapshotNamespace(), "snap1", 0, prog_ctx));
     EXPECT_EQ(0, ictx->operations->snap_protect(
                    cls::rbd::UserSnapshotNamespace(), "snap1"));
     EXPECT_EQ(0, librbd::api::Image<>::snap_set(

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -536,7 +536,7 @@ public:
     } else {
       uint64_t snap_id = CEPH_NOSNAP;
       ASSERT_EQ(0, librbd::api::Mirror<>::image_snapshot_create(
-                     ictx, &snap_id));
+                  ictx, 0, &snap_id));
     }
 
     printf("flushed\n");

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -1008,8 +1008,9 @@ TEST_F(TestImageReplayerJournal, MultipleReplayFailures_SingleEpoch) {
   librbd::ImageCtx *ictx;
   this->open_image(this->m_local_ioctx, this->m_image_name, false, &ictx);
   ictx->features &= ~RBD_FEATURE_JOURNALING;
+  librbd::NoOpProgressContext prog_ctx;
   ASSERT_EQ(0, ictx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					     "foo"));
+					     "foo", 0, prog_ctx));
   ASSERT_EQ(0, ictx->operations->snap_protect(cls::rbd::UserSnapshotNamespace(),
 					      "foo"));
   ASSERT_EQ(0, librbd::cls_client::add_child(&ictx->md_ctx, RBD_CHILDREN,
@@ -1061,8 +1062,9 @@ TEST_F(TestImageReplayerJournal, MultipleReplayFailures_MultiEpoch) {
   librbd::ImageCtx *ictx;
   this->open_image(this->m_local_ioctx, this->m_image_name, false, &ictx);
   ictx->features &= ~RBD_FEATURE_JOURNALING;
+  librbd::NoOpProgressContext prog_ctx;
   ASSERT_EQ(0, ictx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					     "foo"));
+					     "foo", 0, prog_ctx));
   ASSERT_EQ(0, ictx->operations->snap_protect(cls::rbd::UserSnapshotNamespace(),
 					      "foo"));
   ASSERT_EQ(0, librbd::cls_client::add_child(&ictx->md_ctx, RBD_CHILDREN,
@@ -1465,8 +1467,9 @@ TYPED_TEST(TestImageReplayer, SnapshotUnprotect) {
   this->open_remote_image(&remote_image_ctx);
 
   // create a protected snapshot
+  librbd::NoOpProgressContext prog_ctx;
   ASSERT_EQ(0, remote_image_ctx->operations->snap_create(
-                 cls::rbd::UserSnapshotNamespace{}, "snap1"));
+              cls::rbd::UserSnapshotNamespace{}, "snap1", 0, prog_ctx));
   ASSERT_EQ(0, remote_image_ctx->operations->snap_protect(
                  cls::rbd::UserSnapshotNamespace{}, "snap1"));
   this->flush(remote_image_ctx);
@@ -1508,8 +1511,9 @@ TYPED_TEST(TestImageReplayer, SnapshotProtect) {
   this->open_remote_image(&remote_image_ctx);
 
   // create an unprotected snapshot
+  librbd::NoOpProgressContext prog_ctx;
   ASSERT_EQ(0, remote_image_ctx->operations->snap_create(
-                 cls::rbd::UserSnapshotNamespace{}, "snap1"));
+                 cls::rbd::UserSnapshotNamespace{}, "snap1", 0, prog_ctx));
   this->flush(remote_image_ctx);
 
   this->create_replayer();
@@ -1549,8 +1553,9 @@ TYPED_TEST(TestImageReplayer, SnapshotRemove) {
   this->open_remote_image(&remote_image_ctx);
 
   // create a user snapshot
+  librbd::NoOpProgressContext prog_ctx;
   ASSERT_EQ(0, remote_image_ctx->operations->snap_create(
-                 cls::rbd::UserSnapshotNamespace{}, "snap1"));
+                 cls::rbd::UserSnapshotNamespace{}, "snap1", 0, prog_ctx));
   this->flush(remote_image_ctx);
 
   this->create_replayer();
@@ -1584,8 +1589,9 @@ TYPED_TEST(TestImageReplayer, SnapshotRename) {
   this->open_remote_image(&remote_image_ctx);
 
   // create a user snapshot
+  librbd::NoOpProgressContext prog_ctx;
   ASSERT_EQ(0, remote_image_ctx->operations->snap_create(
-                 cls::rbd::UserSnapshotNamespace{}, "snap1"));
+                 cls::rbd::UserSnapshotNamespace{}, "snap1", 0, prog_ctx));
   this->flush(remote_image_ctx);
 
   this->create_replayer();

--- a/src/test/rbd_mirror/test_PoolWatcher.cc
+++ b/src/test/rbd_mirror/test_PoolWatcher.cc
@@ -170,10 +170,11 @@ public:
       librbd::ImageCtx *ictx = new librbd::ImageCtx(parent_image_name.c_str(),
 						    "", "", pioctx, false);
       ictx->state->open(0);
+      librbd::NoOpProgressContext prog_ctx;
       EXPECT_EQ(0, ictx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-						 snap_name.c_str()));
+						 snap_name, 0, prog_ctx));
       EXPECT_EQ(0, ictx->operations->snap_protect(cls::rbd::UserSnapshotNamespace(),
-						  snap_name.c_str()));
+						  snap_name));
       ictx->state->close();
     }
 

--- a/src/test/rbd_mirror/test_fixture.cc
+++ b/src/test/rbd_mirror/test_fixture.cc
@@ -8,6 +8,7 @@
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
 #include "librbd/Operations.h"
+#include "librbd/internal.h"
 #include "test/librados/test_cxx.h"
 #include "tools/rbd_mirror/Threads.h"
 
@@ -105,8 +106,9 @@ int TestFixture::open_image(librados::IoCtx &io_ctx,
 
 int TestFixture::create_snap(librbd::ImageCtx *image_ctx, const char* snap_name,
                              librados::snap_t *snap_id) {
+  librbd::NoOpProgressContext prog_ctx;
   int r = image_ctx->operations->snap_create(cls::rbd::UserSnapshotNamespace(),
-					     snap_name);
+					     snap_name, 0, prog_ctx);
   if (r < 0) {
     return r;
   }

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -201,7 +201,7 @@ void add_snap_spec_options(po::options_description *pos,
   pos->add_options()
     ((get_name_prefix(modifier) + SNAPSHOT_SPEC).c_str(),
      (get_description_prefix(modifier) + "snapshot specification\n" +
-      "(example: [<pool-name>/[<namespace>/]]<image-name>@<snapshot-name>)").c_str());
+      "(example: [<pool-name>/[<namespace>/]]<image-name>@<snap-name>)").c_str());
   add_pool_option(opt, modifier);
   add_namespace_option(opt, modifier);
   add_image_option(opt, modifier);

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -321,6 +321,13 @@ void add_flatten_option(boost::program_options::options_description *opt) {
      "fill clone with parent data (make it independent)");
 }
 
+void add_snap_create_options(po::options_description *opt) {
+  opt->add_options()
+    (SKIP_QUIESCE.c_str(), po::bool_switch(), "do not run quiesce hooks")
+    (IGNORE_QUIESCE_ERROR.c_str(), po::bool_switch(),
+     "ignore quiesce hook error");
+}
+
 std::string get_short_features_help(bool append_suffix) {
   std::ostringstream oss;
   bool first_feature = true;

--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -83,8 +83,13 @@ static const std::string NO_ERROR("no-error");
 
 static const std::string LIMIT("limit");
 
+static const std::string SKIP_QUIESCE("skip-quiesce");
+static const std::string IGNORE_QUIESCE_ERROR("ignore-quiesce-error");
+
 static const std::set<std::string> SWITCH_ARGUMENTS = {
-  WHOLE_OBJECT, NO_PROGRESS, PRETTY_FORMAT, VERBOSE, NO_ERROR};
+  WHOLE_OBJECT, NO_PROGRESS, PRETTY_FORMAT, VERBOSE, NO_ERROR, SKIP_QUIESCE,
+  IGNORE_QUIESCE_ERROR
+};
 
 struct ImageSize {};
 struct ImageOrder {};
@@ -187,6 +192,8 @@ void add_verbose_option(boost::program_options::options_description *opt);
 void add_no_error_option(boost::program_options::options_description *opt);
 
 void add_flatten_option(boost::program_options::options_description *opt);
+
+void add_snap_create_options(boost::program_options::options_description *opt);
 
 std::string get_short_features_help(bool append_suffix);
 std::string get_long_features_help();

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -656,6 +656,24 @@ int get_formatter(const po::variables_map &vm,
   return 0;
 }
 
+int get_snap_create_flags(const po::variables_map &vm, uint32_t *flags) {
+  if (vm[at::SKIP_QUIESCE].as<bool>() &&
+      vm[at::IGNORE_QUIESCE_ERROR].as<bool>()) {
+    std::cerr << "rbd: " << at::IGNORE_QUIESCE_ERROR
+              << " cannot be used together with " << at::SKIP_QUIESCE
+              << std::endl;
+    return -EINVAL;
+  }
+
+  *flags = 0;
+  if (vm[at::SKIP_QUIESCE].as<bool>()) {
+    *flags |= RBD_SNAP_CREATE_SKIP_QUIESCE;
+  } else if (vm[at::IGNORE_QUIESCE_ERROR].as<bool>()) {
+    *flags |= RBD_SNAP_CREATE_IGNORE_QUIESCE_ERROR;
+  }
+  return 0;
+}
+
 void init_context() {
   g_conf().set_val_or_die("rbd_cache_writethrough_until_flush", "false");
   g_conf().apply_changes(nullptr);

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -150,6 +150,9 @@ int get_path(const boost::program_options::variables_map &vm,
 int get_formatter(const boost::program_options::variables_map &vm,
                   argument_types::Format::Formatter *formatter);
 
+int get_snap_create_flags(const boost::program_options::variables_map &vm,
+                          uint32_t *flags);
+
 void init_context();
 
 int init_rados(librados::Rados *rados);

--- a/src/tools/rbd/action/Device.cc
+++ b/src/tools/rbd/action/Device.cc
@@ -137,7 +137,7 @@ void get_map_arguments(po::options_description *positional,
   options->add_options()
     ("read-only", po::bool_switch(), "map read-only")
     ("exclusive", po::bool_switch(), "disable automatic exclusive lock transitions")
-    ("quiesce", po::bool_switch(), "use quiesce callbacks")
+    ("quiesce", po::bool_switch(), "use quiesce hooks")
     ("quiesce-hook", po::value<std::string>(), "quiesce hook path");
   add_device_specific_options(options);
 }

--- a/src/tools/rbd/action/Device.cc
+++ b/src/tools/rbd/action/Device.cc
@@ -153,7 +153,7 @@ void get_unmap_arguments(po::options_description *positional,
   positional->add_options()
     ("image-or-snap-or-device-spec",
      "image, snapshot, or device specification\n"
-     "[<pool-name>/]<image-name>[@<snapshot-name>] or <device-path>");
+     "[<pool-name>/]<image-name>[@<snap-name>] or <device-path>");
   at::add_pool_option(options, at::ARGUMENT_MODIFIER_NONE);
   at::add_image_option(options, at::ARGUMENT_MODIFIER_NONE);
   at::add_snap_option(options, at::ARGUMENT_MODIFIER_NONE);

--- a/src/tools/rbd/action/Group.cc
+++ b/src/tools/rbd/action/Group.cc
@@ -839,7 +839,7 @@ void get_group_snap_rename_arguments(po::options_description *positional,
 
   positional->add_options()
     (at::DEST_SNAPSHOT_NAME.c_str(),
-     "destination snapshot name\n(example: <snapshot-name>)");
+     "destination snapshot name\n(example: <snap-name>)");
   at::add_snap_option(options, at::ARGUMENT_MODIFIER_DEST);
 }
 

--- a/src/tools/rbd/action/Nbd.cc
+++ b/src/tools/rbd/action/Nbd.cc
@@ -263,7 +263,7 @@ void get_unmap_arguments_deprecated(po::options_description *positional,
   positional->add_options()
     ("image-or-snap-or-device-spec",
      "image, snapshot, or device specification\n"
-     "[<pool-name>/]<image-name>[@<snapshot-name>] or <device-path>");
+     "[<pool-name>/]<image-name>[@<snap-name>] or <device-path>");
   at::add_pool_option(options, at::ARGUMENT_MODIFIER_NONE);
   at::add_image_option(options, at::ARGUMENT_MODIFIER_NONE);
   at::add_snap_option(options, at::ARGUMENT_MODIFIER_NONE);

--- a/src/tools/rbd_mirror/image_sync/SyncPointCreateRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/SyncPointCreateRequest.cc
@@ -113,7 +113,8 @@ void SyncPointCreateRequest<I>::send_create_snap() {
     SyncPointCreateRequest<I>, &SyncPointCreateRequest<I>::handle_create_snap>(
       this);
   m_remote_image_ctx->operations->snap_create(
-    cls::rbd::UserSnapshotNamespace(), sync_point.snap_name.c_str(), ctx);
+    cls::rbd::UserSnapshotNamespace(), sync_point.snap_name.c_str(),
+    librbd::SNAP_CREATE_FLAG_SKIP_NOTIFY_QUIESCE, m_prog_ctx, ctx);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_sync/SyncPointCreateRequest.h
+++ b/src/tools/rbd_mirror/image_sync/SyncPointCreateRequest.h
@@ -4,6 +4,7 @@
 #ifndef RBD_MIRROR_IMAGE_SYNC_SYNC_POINT_CREATE_REQUEST_H
 #define RBD_MIRROR_IMAGE_SYNC_SYNC_POINT_CREATE_REQUEST_H
 
+#include "librbd/internal.h"
 #include "Types.h"
 #include <string>
 
@@ -66,6 +67,7 @@ private:
   Context *m_on_finish;
 
   SyncPoints m_sync_points_copy;
+  librbd::NoOpProgressContext m_prog_ctx;
 
   void send_update_sync_points();
   void handle_update_sync_points(int r);

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -463,7 +463,7 @@ signal:
 
       wait_inflight_io();
 
-      image.quiesce_complete();
+      image.quiesce_complete(0); // TODO: return quiesce hook exit code
 
       wait_unquiesce();
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
