### PR TITLE
msg/Message.cc: fix build error when WITH_BLKIN is on

### DIFF
--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -211,6 +211,10 @@
 #include "messages/MOSDPGUpdateLogMissing.h"
 #include "messages/MOSDPGUpdateLogMissingReply.h"
 
+#ifdef WITH_BLKIN
+#include "Messenger.h"
+#endif
+
 #define DEBUGLVL  10    // debug level of output
 
 #define dout_subsys ceph_subsys_ms
@@ -973,12 +977,12 @@ void Message::decode_trace(ceph::bufferlist::const_iterator &p, bool create)
   const auto msgr = connection->get_messenger();
   const auto endpoint = msgr->get_trace_endpoint();
   if (info.trace_id) {
-    trace.init(get_type_name(), endpoint, &info, true);
+    trace.init(get_type_name().data(), endpoint, &info, true);
     trace.event("decoded trace");
   } else if (create || (msgr->get_myname().is_osd() &&
                         msgr->cct->_conf->osd_blkin_trace_all)) {
     // create a trace even if we didn't get one on the wire
-    trace.init(get_type_name(), endpoint);
+    trace.init(get_type_name().data(), endpoint);
     trace.event("created trace");
   }
   trace.keyval("tid", get_tid());

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -86,6 +86,7 @@ target_link_libraries(ceph_test_rgw_obj
   cls_user_client
   librados
   global
+  ceph-common
   ${CURL_LIBRARIES}
   ${EXPAT_LIBRARIES}
   ${CMAKE_DL_LIBS}


### PR DESCRIPTION
```text
./do_cmake.sh -DWITH_BLKIN=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
```

```text
/data/work/ceph-master/src/msg/Message.cc: In member function ‘void Message::decode_trace(ceph::buffer::v15_2_0::list::const_iterator&, bool)’:
/data/work/ceph-master/src/msg/Message.cc:974:29: error: invalid use of incomplete type ‘class Messenger’
   const auto endpoint = msgr->get_trace_endpoint();
                             ^~
In file included from /data/work/ceph-master/src/msg/Message.h:34,
                 from /data/work/ceph-master/src/msg/Message.cc:15:
/data/work/ceph-master/src/msg/Connection.h:37:7: note: forward declaration of ‘class Messenger’
 class Messenger;
       ^~~~~~~~~
/data/work/ceph-master/src/msg/Message.cc:978:29: error: invalid use of incomplete type ‘class Messenger’
   } else if (create || (msgr->get_myname().is_osd() &&
                             ^~
In file included from /data/work/ceph-master/src/msg/Message.h:34,
                 from /data/work/ceph-master/src/msg/Message.cc:15:
/data/work/ceph-master/src/msg/Connection.h:37:7: note: forward declaration of ‘class Messenger’
 class Messenger;
       ^~~~~~~~~
/data/work/ceph-master/src/msg/Message.cc:979:29: error: invalid use of incomplete type ‘class Messenger’
                         msgr->cct->_conf->osd_blkin_trace_all)) {
                             ^~
In file included from /data/work/ceph-master/src/msg/Message.h:34,
                 from /data/work/ceph-master/src/msg/Message.cc:15:
/data/work/ceph-master/src/msg/Connection.h:37:7: note: forward declaration of ‘class Messenger’
 class Messenger;
```

```text
/data/work/ceph-master/src/msg/Message.cc: In member function ‘void Message::decode_trace(ceph::buffer::v15_2_0::list::const_iterator&, bool)’:
/data/work/ceph-master/src/msg/Message.cc:978:54: error: no matching function for call to ‘ZTracer::Trace::init(std::string_view, const ZTracer::Endpoint* const&, blkin_trace_info*, bool)’
     trace.init(get_type_name(), endpoint, &info, true);
                                                      ^
In file included from /data/work/ceph-master/src/common/zipkin_trace.h:11,
                 from /data/work/ceph-master/src/msg/Message.h:30,
                 from /data/work/ceph-master/src/msg/Message.cc:15:
/data/work/ceph-master/src/blkin/blkin-lib/ztracer.hpp:179:6: note: candidate: ‘int ZTracer::Trace::init(const char*, const ZTracer::Endpoint*, const ZTracer::Trace*)’
  int init(const char *name, const Endpoint *ep,
      ^~~~
/data/work/ceph-master/src/blkin/blkin-lib/ztracer.hpp:179:6: note:   candidate expects 3 arguments, 4 provided
/data/work/ceph-master/src/blkin/blkin-lib/ztracer.hpp:190:6: note: candidate: ‘int ZTracer::Trace::init(const char*, const ZTracer::Endpoint*, const blkin_trace_info*, bool)’
  int init(const char *name, const Endpoint *ep,
      ^~~~
/data/work/ceph-master/src/blkin/blkin-lib/ztracer.hpp:190:6: note:   no known conversion for argument 1 from ‘std::string_view’ {aka ‘std::basic_string_view<char>’} to ‘const char*’
/data/work/ceph-master/src/msg/Message.cc:983:41: error: no matching function for call to ‘ZTracer::Trace::init(std::string_view, const ZTracer::Endpoint* const&)’
     trace.init(get_type_name(), endpoint);
                                         ^
In file included from /data/work/ceph-master/src/common/zipkin_trace.h:11,
                 from /data/work/ceph-master/src/msg/Message.h:30,
                 from /data/work/ceph-master/src/msg/Message.cc:15:
/data/work/ceph-master/src/blkin/blkin-lib/ztracer.hpp:179:6: note: candidate: ‘int ZTracer::Trace::init(const char*, const ZTracer::Endpoint*, const ZTracer::Trace*)’
  int init(const char *name, const Endpoint *ep,
      ^~~~
/data/work/ceph-master/src/blkin/blkin-lib/ztracer.hpp:179:6: note:   no known conversion for argument 1 from ‘std::string_view’ {aka ‘std::basic_string_view<char>’} to ‘const char*’
/data/work/ceph-master/src/blkin/blkin-lib/ztracer.hpp:190:6: note: candidate: ‘int ZTracer::Trace::init(const char*, const ZTracer::Endpoint*, const blkin_trace_info*, bool)’
  int init(const char *name, const Endpoint *ep,
```

```text
Scanning dependencies of target ceph_test_rgw_obj
[ 95%] Building CXX object src/test/rgw/CMakeFiles/ceph_test_rgw_obj.dir/test_rgw_obj.cc.o
/opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: ../lib/libblkin.a(tp.c.o): undefined reference to symbol 'lttng_probe_register'
//lib64/liblttng-ust.so.0: error adding symbols: DSO missing from command line 
collect2: error: ld returned 1 exit status
make[2]: *** [bin/ceph-osd] Error 1
make[1]: *** [src/CMakeFiles/ceph-osd.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```
