### PR TITLE
librbd/rwl: remove extra ';' after defining function

### DIFF
--- a/src/librbd/cache/rwl/LogEntry.cc
+++ b/src/librbd/cache/rwl/LogEntry.cc
@@ -40,7 +40,7 @@ std::ostream& SyncPointLogEntry::format(std::ostream &os) const {
      << "prior_sync_point_flushed=" << prior_sync_point_flushed << ", "
      << "next_sync_point_entry=" << next_sync_point_entry;
   return os;
-};
+}
 
 std::ostream &operator<<(std::ostream &os,
                          const SyncPointLogEntry &entry) {
@@ -66,7 +66,7 @@ std::ostream& GenericWriteLogEntry::format(std::ostream &os) const {
   os << "], "
      << "referring_map_entries=" << referring_map_entries;
   return os;
-};
+}
 
 std::ostream &operator<<(std::ostream &os,
                          const GenericWriteLogEntry &entry) {
@@ -125,7 +125,7 @@ buffer::list& WriteLogEntry::get_pmem_bl() {
     ceph_assert(0 != bl_refs);
   }
   return pmem_bl;
-};
+}
 
 /* Constructs a new bl containing copies of pmem_bp */
 void WriteLogEntry::copy_pmem_bl(bufferlist *out_bl) {
@@ -156,7 +156,7 @@ std::ostream& WriteLogEntry::format(std::ostream &os) const {
   os << "pmem_bl=" << pmem_bl << ", ";
   os << "bl_refs=" << bl_refs;
   return os;
-};
+}
 
 std::ostream &operator<<(std::ostream &os,
                          const WriteLogEntry &entry) {
@@ -185,7 +185,7 @@ std::ostream &DiscardLogEntry::format(std::ostream &os) const {
   os << "(Discard) ";
   GenericWriteLogEntry::format(os);
   return os;
-};
+}
 
 std::ostream &operator<<(std::ostream &os,
                          const DiscardLogEntry &entry) {
@@ -200,7 +200,7 @@ void WriteSameLogEntry::init_bl(buffer::ptr &bp, buffer::list &bl) {
   if (trailing_partial) {
     bl.append(bp, 0, trailing_partial);
   }
-};
+}
 
 void WriteSameLogEntry::writeback(librbd::cache::ImageWritebackInterface &image_writeback,
                                   Context *ctx) {
@@ -216,7 +216,7 @@ std::ostream &WriteSameLogEntry::format(std::ostream &os) const {
   os << "(WriteSame) ";
   WriteLogEntry::format(os);
   return os;
-};
+}
 
 std::ostream &operator<<(std::ostream &os,
                          const WriteSameLogEntry &entry) {

--- a/src/librbd/cache/rwl/LogMap.cc
+++ b/src/librbd/cache/rwl/LogMap.cc
@@ -19,7 +19,7 @@ std::ostream &operator<<(std::ostream &os,
   os << "block_extent=" << e.block_extent << ", "
      << "log_entry=[" << e.log_entry << "]";
   return os;
-};
+}
 
 template <typename T>
 LogMapEntry<T>::LogMapEntry(const BlockExtent block_extent,

--- a/src/librbd/cache/rwl/LogOperation.cc
+++ b/src/librbd/cache/rwl/LogOperation.cc
@@ -27,7 +27,7 @@ std::ostream& GenericLogOperation::format(std::ostream &os) const {
      << "log_append_time=[" << log_append_time << "], "
      << "log_append_comp_time=[" << log_append_comp_time << "], ";
   return os;
-};
+}
 
 std::ostream &operator<<(std::ostream &os,
                          const GenericLogOperation &op) {
@@ -50,7 +50,7 @@ std::ostream &SyncPointLogOperation::format(std::ostream &os) const {
   os << ", "
      << "sync_point=[" << *sync_point << "]";
   return os;
-};
+}
 
 std::ostream &operator<<(std::ostream &os,
                          const SyncPointLogOperation &op) {
@@ -125,7 +125,7 @@ GenericWriteLogOperation::~GenericWriteLogOperation() { }
 std::ostream &GenericWriteLogOperation::format(std::ostream &os) const {
   GenericLogOperation::format(os);
   return os;
-};
+}
 
 std::ostream &operator<<(std::ostream &os,
                          const GenericWriteLogOperation &op) {
@@ -197,7 +197,7 @@ std::ostream &WriteLogOperation::format(std::ostream &os) const {
   os << "bl=[" << bl << "],"
      << "buffer_alloc=" << buffer_alloc;
   return os;
-};
+}
 
 std::ostream &operator<<(std::ostream &os,
                          const WriteLogOperation &op) {
@@ -264,7 +264,7 @@ std::ostream &operator<<(std::ostream &os,
      << "extent_ops_appending=[" << s.extent_ops_appending << ", "
      << "extent_ops_persist=[" << s.extent_ops_persist << "]";
   return os;
-};
+}
 
 DiscardLogOperation::DiscardLogOperation(std::shared_ptr<SyncPoint> sync_point,
                                          const uint64_t image_offset_bytes,
@@ -302,7 +302,7 @@ std::ostream &DiscardLogOperation::format(std::ostream &os) const {
     os << "log_entry=nullptr, ";
   }
   return os;
-};
+}
 
 std::ostream &operator<<(std::ostream &os,
                          const DiscardLogOperation &op) {
@@ -326,7 +326,7 @@ std::ostream &WriteSameLogOperation::format(std::ostream &os) const {
   os << "(Write Same) ";
   WriteLogOperation::format(os);
   return os;
-};
+}
 
 std::ostream &operator<<(std::ostream &os,
                          const WriteSameLogOperation &op) {

--- a/src/librbd/cache/rwl/Request.cc
+++ b/src/librbd/cache/rwl/Request.cc
@@ -131,7 +131,7 @@ std::ostream &operator<<(std::ostream &os,
      os << "op_set=" << *req.op_set;
   }
   return os;
-};
+}
 
 template <typename T>
 void C_WriteRequest<T>::blockguard_acquired(GuardedRequestFunctionContext &guard_ctx) {
@@ -408,7 +408,7 @@ std::ostream &operator<<(std::ostream &os,
   os << (C_BlockIORequest<T>&)req
      << " m_resources.allocated=" << req.m_resources.allocated;
   return os;
-};
+}
 
 void C_ReadRequest::finish(int r) {
   ldout(m_cct, 20) << "(" << get_name() << "): r=" << r << dendl;
@@ -563,7 +563,7 @@ std::ostream &operator<<(std::ostream &os,
     os << " op=nullptr";
   }
   return os;
-};
+}
 
 template <typename T>
 C_WriteSameRequest<T>::C_WriteSameRequest(T &rwl, const utime_t arrived, io::Extents &&image_extents,
@@ -621,7 +621,7 @@ std::ostream &operator<<(std::ostream &os,
                          const C_WriteSameRequest<T> &req) {
   os << (C_WriteRequest<T>&)req;
   return os;
-};
+}
 
 template <typename T>
 C_CompAndWriteRequest<T>::C_CompAndWriteRequest(T &rwl, const utime_t arrived, io::Extents &&image_extents,
@@ -669,7 +669,7 @@ std::ostream &operator<<(std::ostream &os,
      << "compare_succeeded=" << req.compare_succeeded << ", "
      << "mismatch_offset=" << req.mismatch_offset;
   return os;
-};
+}
 
 std::ostream &operator<<(std::ostream &os,
                          const BlockGuardReqState &r) {
@@ -678,7 +678,7 @@ std::ostream &operator<<(std::ostream &os,
      << "detained=" << r.detained << ", "
      << "queued=" << r.queued;
   return os;
-};
+}
 
 GuardedRequestFunctionContext::GuardedRequestFunctionContext(boost::function<void(GuardedRequestFunctionContext&)> &&callback)
   : m_callback(std::move(callback)){ }
@@ -696,7 +696,7 @@ std::ostream &operator<<(std::ostream &os,
      << "block_extent.block_start=" << r.block_extent.block_start << ", "
      << "block_extent.block_start=" << r.block_extent.block_end;
   return os;
-};
+}
 
 } // namespace rwl
 } // namespace cache

--- a/src/librbd/cache/rwl/Types.cc
+++ b/src/librbd/cache/rwl/Types.cc
@@ -68,7 +68,7 @@ std::ostream& operator<<(std::ostream& os,
      << "ws_datalen=" << entry.ws_datalen << ", "
      << "entry_index=" << entry.entry_index;
   return os;
-};
+}
 
 template <typename ExtentsType>
 ExtentsSummary<ExtentsType>::ExtentsSummary(const ExtentsType &extents)
@@ -101,7 +101,7 @@ std::ostream &operator<<(std::ostream &os,
      << "first_image_byte=" << s.first_image_byte << ", "
      << "last_image_byte=" << s.last_image_byte << "";
   return os;
-};
+}
 
 io::Extent whole_volume_extent() {
   return io::Extent({0, std::numeric_limits<uint64_t>::max()});


### PR DESCRIPTION
Signed-off-by: Changcheng Liu <changcheng.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
