### PR TITLE
doc/cephadm: add better wording on step 9

### DIFF
--- a/doc/cephadm/adoption.rst
+++ b/doc/cephadm/adoption.rst
@@ -94,7 +94,8 @@ Adoption process
 
      # ceph orch ps
 
-#. Adopt all OSDs in the cluster.  This needs to be done on ALL the OSD's in the cluster before proceeding with the steps below to adopt mds::
+#. Adopt all OSDs in the cluster.  
+   This needs to be done on ALL the OSD's in the cluster before proceeding with the steps below to adopt mds::
 
      # cephadm adopt --style legacy --name <name>
 
@@ -105,9 +106,8 @@ Adoption process
 
 #. Redeploy MDS daemons by telling cephadm how many daemons to run for
    each file system.  You can list file systems by name with ``ceph fs
-   ls``.  For each file system::
-   
-   This needs to be run on the master nodes.
+   ls``.  For each file system. 
+   This needs to be run on the master nodes::
 
      # ceph orch apply mds <fs-name> <num-daemons>
 

--- a/doc/cephadm/adoption.rst
+++ b/doc/cephadm/adoption.rst
@@ -94,9 +94,7 @@ Adoption process
 
      # ceph orch ps
 
-#. Adopt all OSDs in the cluster::
-   
-   This needs to be done on ALL the OSD's in the cluster before proceeding with the steps below to adopt mds
+#. Adopt all OSDs in the cluster.  This needs to be done on ALL the OSD's in the cluster before proceeding with the steps below to adopt mds::
 
      # cephadm adopt --style legacy --name <name>
 

--- a/doc/cephadm/adoption.rst
+++ b/doc/cephadm/adoption.rst
@@ -143,6 +143,6 @@ Adoption process
      # rm -rf /var/lib/ceph/radosgw/ceph-*
 
 #. Check the ``ceph health detail`` output for cephadm warnings about
-   stray cluster daemons or hosts that are not yet managed.
+   stray cluster daemons or hosts that are not yet managed::
    
      # ceph health detail

--- a/doc/cephadm/adoption.rst
+++ b/doc/cephadm/adoption.rst
@@ -95,6 +95,7 @@ Adoption process
      # ceph orch ps
 
 #. Adopt all OSDs in the cluster::
+   
    This needs to be done on ALL the OSD's in the cluster before proceeding with the steps below to adopt mds
 
      # cephadm adopt --style legacy --name <name>
@@ -107,6 +108,7 @@ Adoption process
 #. Redeploy MDS daemons by telling cephadm how many daemons to run for
    each file system.  You can list file systems by name with ``ceph fs
    ls``.  For each file system::
+   
    This needs to be run on the master nodes.
 
      # ceph orch apply mds <fs-name> <num-daemons>

--- a/doc/cephadm/adoption.rst
+++ b/doc/cephadm/adoption.rst
@@ -142,3 +142,5 @@ Adoption process
 
 #. Check the ``ceph health detail`` output for cephadm warnings about
    stray cluster daemons or hosts that are not yet managed.
+   
+     # ceph health detail

--- a/doc/cephadm/adoption.rst
+++ b/doc/cephadm/adoption.rst
@@ -95,6 +95,7 @@ Adoption process
      # ceph orch ps
 
 #. Adopt all OSDs in the cluster::
+   This needs to be done on ALL the OSD's in the cluster before proceeding with the steps below to adopt mds
 
      # cephadm adopt --style legacy --name <name>
 
@@ -106,6 +107,7 @@ Adoption process
 #. Redeploy MDS daemons by telling cephadm how many daemons to run for
    each file system.  You can list file systems by name with ``ceph fs
    ls``.  For each file system::
+   This needs to be run on the master nodes.
 
      # ceph orch apply mds <fs-name> <num-daemons>
 


### PR DESCRIPTION
add better wording on step 9 to highlight that ALL OSD's on ALL ndoes need to be done before proceeding.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
