### PR TITLE
pybind/*/setup.py: fix clang detection with ccache

### DIFF
--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -72,7 +72,7 @@ def get_python_flags(libs):
         libraries=libs + py_libs,
         extra_compile_args=filter_unsupported_flags(
             compiler.compiler[0],
-            distutils.sysconfig.get_config_var('CFLAGS').split()),
+            compiler.compiler[1:] + distutils.sysconfig.get_config_var('CFLAGS').split()),
         extra_link_args=(distutils.sysconfig.get_config_var('LDFLAGS').split() +
                          ldflags))
 

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -75,7 +75,7 @@ def get_python_flags(libs):
         libraries=libs + py_libs,
         extra_compile_args=filter_unsupported_flags(
             compiler.compiler[0],
-            distutils.sysconfig.get_config_var('CFLAGS').split()),
+            compiler.compiler[1:] + distutils.sysconfig.get_config_var('CFLAGS').split()),
         extra_link_args=(distutils.sysconfig.get_config_var('LDFLAGS').split() +
                          ldflags))
 

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -72,7 +72,7 @@ def get_python_flags(libs):
         libraries=libs + py_libs,
         extra_compile_args=filter_unsupported_flags(
             compiler.compiler[0],
-            distutils.sysconfig.get_config_var('CFLAGS').split()),
+            compiler.compiler[1:] + distutils.sysconfig.get_config_var('CFLAGS').split()),
         extra_link_args=(distutils.sysconfig.get_config_var('LDFLAGS').split() +
                          ldflags))
 

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -73,7 +73,7 @@ def get_python_flags(libs):
         libraries=libs + py_libs,
         extra_compile_args=filter_unsupported_flags(
             compiler.compiler[0],
-            distutils.sysconfig.get_config_var('CFLAGS').split()),
+            compiler.compiler[1:] + distutils.sysconfig.get_config_var('CFLAGS').split()),
         extra_link_args=(distutils.sysconfig.get_config_var('LDFLAGS').split() +
                          ldflags))
 


### PR DESCRIPTION
Signed-off-by: Samuel Just <sjust@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
