### PR TITLE
global, osd/crimson: improve handling of the crimson-osd instance duplication

### DIFF
--- a/src/global/pidfile.cc
+++ b/src/global/pidfile.cc
@@ -177,9 +177,10 @@ int pidfh::open(std::string_view pid_file)
       derr << __func__ << ": failed to lock pidfile "
 	   << pf_path << "': " << cpp_strerror(errno) << dendl;
     }
+    const auto lock_errno = errno;
     ::close(pf_fd);
     reset();
-    return -errno;
+    return -lock_errno;
   }
   return 0;
 }

--- a/src/global/pidfile.h
+++ b/src/global/pidfile.h
@@ -19,7 +19,7 @@
 
 // Write a pidfile with the current pid, using the configuration in the
 // provided conf structure.
-int pidfile_write(std::string_view pid_file);
+[[nodiscard]] int pidfile_write(std::string_view pid_file);
 
 // Remove the pid file that was previously written by pidfile_write.
 // This is safe to call in a signal handler context.


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
