### PR TITLE
mgr/orch: allow '.' char in hostname

### DIFF
--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -61,12 +61,13 @@ class NFSService(CephadmService):
 
     def config(self, spec):
         self.mgr._check_pool_exists(spec.pool, spec.service_name())
-
         logger.info('Saving service %s spec with placement %s' % (
             spec.service_name(), spec.placement.pretty_str()))
         self.mgr.spec_store.save(spec)
 
     def create(self, daemon_id, host, spec):
+        logger.info('Create daemon %s on host %s with spec %s' % (
+            daemon_id, host, spec))
         return self.mgr._create_daemon('nfs', daemon_id, host)
 
 

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -366,6 +366,31 @@ def test_spec_octopus():
         True
     ),
 
+    # https://tracker.ceph.com/issues/45399
+    (
+        # daemon_id only contains hostname
+        ServiceSpec(
+            service_type='mds',
+            service_id="a",
+        ),
+        DaemonDescription(
+            daemon_type='mds',
+            daemon_id="a.host1.abc123",
+            hostname="host1.site",
+        ),
+        True
+    ),
+    (
+        NFSServiceSpec(
+            service_id="a",
+        ),
+        DaemonDescription(
+            daemon_type='nfs',
+            daemon_id="a.host1",
+            hostname="host1.site",
+        ),
+        True
+    ),
 
     # https://tracker.ceph.com/issues/45293
     (

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1313,19 +1313,22 @@ class DaemonDescription(object):
                 # TODO: can a DaemonDescription exist without a hostname?
                 raise err
 
-            if self.hostname == self.daemon_id:
-                # daemon_id == "hostname"
+            # use the bare hostname, not the FQDN.
+            host = self.hostname.split('.')[0]
+
+            if host == self.daemon_id:
+                # daemon_id == "host"
                 return self.daemon_id
 
-            elif self.hostname in self.daemon_id:
-                # daemon_id == "service_id.hostname"
-                # daemon_id == "service_id.hostname.random"
-                pre, post = self.daemon_id.rsplit(self.hostname, 1)
+            elif host in self.daemon_id:
+                # daemon_id == "service_id.host"
+                # daemon_id == "service_id.host.random"
+                pre, post = self.daemon_id.rsplit(host, 1)
                 if not pre.endswith('.'):
-                    # '.' sep missing at front of hostname
+                    # '.' sep missing at front of host
                     raise err
                 elif post and not post.startswith('.'):
-                    # '.' sep missing at end of hostname
+                    # '.' sep missing at end of host
                     raise err
                 return pre[:-1]
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/45399
Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
