### PR TITLE
scripts/run-cbt.sh: correct script option usage

### DIFF
--- a/src/script/run-cbt.sh
+++ b/src/script/run-cbt.sh
@@ -10,7 +10,7 @@ usage:
 options:
   -a,--archive-dir    directory in which the test result is stored, default to $PWD/cbt-archive
   --build-dir         directory where CMakeCache.txt is located, default to $PWD
-  --cbt-dir           directory of cbt if you have already a copy of it. ceph/cbt:master will be cloned from github if not specified
+  --cbt               directory of cbt if you have already a copy of it. ceph/cbt:master will be cloned from github if not specified
   -h,--help           print this help message
   --source-dir        the path to the top level of Ceph source tree, default to $PWD/..
   --use-existing      do not setup/teardown a vstart cluster for testing


### PR DESCRIPTION
Signed-off-by: Changcheng Liu <changcheng.liu@aliyun.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
