### PR TITLE
vstart: Support deployment of ganesha daemon by cephadm with NFS option

### DIFF
--- a/src/pybind/mgr/test_orchestrator/dummy_data.json
+++ b/src/pybind/mgr/test_orchestrator/dummy_data.json
@@ -311,6 +311,35 @@
         "running": 2,
         "size": 2
       }
+    },
+    {
+      "placement": {
+        "hosts": [
+          {
+            "hostname": "mgr0",
+            "name": "",
+            "network": ""
+          },
+          {
+            "hostname": "osd0",
+            "name": "",
+            "network": ""
+          }
+        ]
+      },
+      "service_id": "ganesha-vstart",
+      "service_name": "nfs.ganesha-vstart",
+      "service_type": "nfs",
+      "pool": "nfs-ganesha",
+      "namespace": "vstart",
+      "status": {
+        "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
+        "container_image_name": "quay.io/ceph-ci/ceph:master",
+        "created": "2020-04-16T03:39:39.512721",
+        "last_refresh": "2020-04-16T06:51:42.412980",
+        "running": 1,
+        "size": 1
+      }
     }
   ],
   "daemons": [
@@ -369,6 +398,20 @@
       "status": 1,
       "status_desc": "running",
       "version": "16.0.0-827-g61ad12e"
+    },
+    {
+      "container_id": "aeba86ca1655",
+      "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
+      "container_image_name": "quay.io/ceph-ci/ceph:master",
+      "created": "2020-04-16T05:44:41.551646",
+      "daemon_id": "ganesha-vstart.osd0",
+      "daemon_type": "nfs",
+      "hostname": "osd0",
+      "last_refresh": "2020-04-16T06:51:43.182937",
+      "started": "2020-04-16T05:44:41.606514",
+      "status": 1,
+      "status_desc": "running",
+      "version": "3.2"
     }
   ]
 }

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -162,7 +162,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
     def _get_ceph_daemons(self):
         # type: () -> List[orchestrator.DaemonDescription]
         """ Return ceph daemons on the running host."""
-        types = ("mds", "osd", "mon", "rgw", "mgr")
+        types = ("mds", "osd", "mon", "rgw", "mgr", "nfs")
         out = map(str, check_output(['ps', 'aux']).splitlines())
         processes = [p for p in out if any(
             [('ceph-{} '.format(t) in p) for t in types])]
@@ -225,7 +225,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         it returns the mgr we're running in.
         """
         if daemon_type:
-            daemon_types = ("mds", "osd", "mon", "rgw", "mgr", "iscsi", "crash")
+            daemon_types = ("mds", "osd", "mon", "rgw", "mgr", "iscsi", "crash", "nfs")
             assert daemon_type in daemon_types, daemon_type + " unsupported"
 
         daemons = self._daemons if self._daemons else self._get_ceph_daemons()

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1072,8 +1072,25 @@ EOF
 # https://launchpad.net/~nfs-ganesha/+archive/ubuntu/nfs-ganesha-2.8
 
 start_ganesha() {
+    cluster_id="vstart"
     GANESHA_PORT=$(($CEPH_PORT + 4000))
     local ganesha=0
+    test_user="ganesha-$cluster_id"
+    pool_name="nfs-ganesha"
+    namespace=$cluster_id
+    url="rados://$pool_name/$namespace/conf-nfs.$test_user"
+
+    prun ceph_adm auth get-or-create client.$test_user \
+        mon "allow r" \
+        osd "allow rw pool=$pool_name namespace=$namespace, allow rw tag cephfs data=a" \
+        mds "allow rw path=/" \
+        >> "$keyring_fn"
+
+    ceph_adm mgr module enable test_orchestrator
+    ceph_adm orch set backend test_orchestrator
+    ceph_adm test_orchestrator load_data -i $CEPH_ROOT/src/pybind/mgr/test_orchestrator/dummy_data.json
+    prun ceph_adm nfs cluster create cephfs $cluster_id
+    prun ceph_adm nfs export create cephfs "a" $cluster_id "/cephfs"
 
     for name in a b c d e f g h i j k l m n o p
     do
@@ -1082,22 +1099,8 @@ start_ganesha() {
         port=$(($GANESHA_PORT + ganesha))
         ganesha=$(($ganesha + 1))
         ganesha_dir="$CEPH_DEV_DIR/ganesha.$name"
-        test_user="ganesha-$name"
-        pool_name="nfs-ganesha"
-        namespace=$name
-        url="rados://$pool_name/$namespace/conf-nfs.$test_user"
-
         prun rm -rf $ganesha_dir
         prun mkdir -p $ganesha_dir
-        prun ceph_adm auth get-or-create client.$test_user \
-            mon "allow r" \
-            osd "allow rw pool=$pool_name namespace=$namespace, allow rw tag cephfs data=a" \
-            mds "allow rw path=/" \
-            >> "$keyring_fn"
-
-        ceph_adm mgr module enable test_orchestrator
-        ceph_adm orch set backend test_orchestrator
-        prun ceph_adm nfs cluster create cephfs $name
 
         echo "NFS_CORE_PARAM {
             Enable_NLM = false;
@@ -1139,7 +1142,6 @@ start_ganesha() {
         pid file = $ganesha_dir/ganesha.pid
 EOF
 
-        prun ceph_adm nfs export create cephfs "a" $name "/cephfs"
         prun ganesha-rados-grace -p $pool_name -n $namespace add $name
         prun ganesha-rados-grace -p $pool_name -n $namespace
 
@@ -1154,13 +1156,12 @@ EOF
             $CEPH_BIN/rados -p $pool_name put "conf-$name" "$ganesha_dir/ganesha.conf"
         fi
 
-        echo "$test_user started on port: $port"
+        echo "$test_user ganesha daemon $name started on port: $port"
     done
 
     if $with_mgr_dashboard; then
         ceph_adm dashboard set-ganesha-clusters-rados-pool-namespace $pool_name
     fi
-
     echo "Mount using: mount -t nfs -o port=<ganesha-port-num> <address>:<ganesha pseudo path>"
 }
 
@@ -1369,8 +1370,15 @@ EOF
 fi
 
 # Ganesha Daemons
-if [ $GANESHA_DAEMON_NUM -gt 0 ] && [ "$cephadm" -eq 0 ]; then
-    start_ganesha
+if [ $GANESHA_DAEMON_NUM -gt 0 ]; then
+    if [ "$cephadm" -gt 0 ]; then
+        cluster_id="vstart"
+        prun ceph_adm nfs cluster create cephfs $cluster_id
+        prun ceph_adm nfs export create cephfs "a" $cluster_id "/cephfs"
+        echo "Mount using: mount -t nfs -o port=2049 <address>:/cephfs"
+    else
+        start_ganesha
+    fi
 fi
 
 do_cache() {


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->
NFS Ganesha cluster can be created in two ways with vstart
cluster:

1) With test_orchestrator
NFS=1 ../src/vstart.sh
This type of deployment can have multiple ganesha daemons on random port.

2) With Cephadm
NFS=1 ../src/vstart.sh --cephadm
It can deploy only single ganesha daemon with vstart on default ganesha port.

Both can create multiple cephfs exports.

Fixes: https://tracker.ceph.com/issues/45830
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
