### PR TITLE
rgw: chunk encoding fixes

### DIFF
--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -296,13 +296,8 @@ class AWSv4ComplMulti : public rgw::auth::Completer,
   public:
     static constexpr size_t SIG_SIZE = 64;
 
-    /* Let's suppose the data length fields can't exceed uint64_t. */
-    static constexpr size_t META_MAX_SIZE = \
-      sarrlen("\r\nffffffffffffffff;chunk-signature=") + SIG_SIZE + sarrlen("\r\n");
-
-    /* The metadata size of for the last, empty chunk. */
-    static constexpr size_t META_MIN_SIZE = \
-      sarrlen("0;chunk-signature=") + SIG_SIZE + sarrlen("\r\n");
+    /* Let's try to be slightly generous about future chunk header fields */
+    static constexpr size_t META_MAX_SIZE = 256;
 
     /* Detect whether a given stream_pos fits in boundaries of a chunk. */
     bool is_new_chunk_in_stream(size_t stream_pos) const;

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -296,8 +296,12 @@ class AWSv4ComplMulti : public rgw::auth::Completer,
   public:
     static constexpr size_t SIG_SIZE = 64;
 
-    /* Let's try to be slightly generous about future chunk header fields */
-    static constexpr size_t META_MAX_SIZE = 256;
+    /* Let's try to be more generous about future chunk header fields */
+    static constexpr size_t META_MAX_SIZE = 1024;
+    static constexpr size_t META_MID_SIZE = sarrlen(
+	"\r\nffffffffffffffff;chunk-signature=") + SIG_SIZE + sarrlen("\r\n");
+    static constexpr size_t META_MIN_SIZE =
+	sarrlen("0;chunk-signature=") + SIG_SIZE + sarrlen("\r\n");
 
     /* Detect whether a given stream_pos fits in boundaries of a chunk. */
     bool is_new_chunk_in_stream(size_t stream_pos) const;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -461,7 +461,7 @@ int RGWGetObj_ObjStore_S3::get_decrypt_filter(std::unique_ptr<RGWGetObj_Filter> 
   }
   return res;
 }
-int RGWGetObj_ObjStore_S3::verify_requester(const rgw::auth::StrategyRegistry& auth_registry, optional_yield y) 
+int RGWGetObj_ObjStore_S3::verify_requester(const rgw::auth::StrategyRegistry& auth_registry, optional_yield y)
 {
   int ret = -EINVAL;
   ret = RGWOp::verify_requester(auth_registry, y);
@@ -2351,6 +2351,8 @@ int RGWPutObj_ObjStore_S3::get_params(optional_yield y)
   if (!s->length)
     return -ERR_LENGTH_REQUIRED;
 
+  map<string, bufferlist> src_attrs;
+  size_t pos;
   int ret;
 
   map_qs_metadata(s);
@@ -6374,7 +6376,7 @@ int RGWSelectObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t ofs, off_
     if(it.length() == 0) {
       ldpp_dout(this, 10) << "s3select:it->_len is zero. segment " << i << " out of " << bl_len
                         <<  " obj-size " << s->obj_size << dendl;
-      continue; 
+      continue;
     }
 
     status = run_s3select(m_sql_query.c_str(), &(it)[0], it.length());

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2357,6 +2357,16 @@ int RGWPutObj_ObjStore_S3::get_params(optional_yield y)
 
   map_qs_metadata(s);
 
+  if (!s->length) {
+    const char *encoding = s->info.env->get("HTTP_TRANSFER_ENCODING");
+    if (!encoding || strcmp(encoding, "chunked") != 0) {
+      ldout(s->cct, 20) << "neither length nor chunked encoding" << dendl;
+      return -ERR_LENGTH_REQUIRED;
+    }
+
+    chunked_upload = true;
+  }
+
   RGWAccessControlPolicy_S3 s3policy(s->cct);
   ret = create_s3_policy(s, store, s3policy, s->owner);
   if (ret < 0)


### PR DESCRIPTION
This is a set of fixes related to transfer-encoding: chunked, which are ready to review.

DNM - pending civetweb changes.
This includes fixes to civetweb - I'll make a separate PR for that to merge into our civetweb repo.  That will need to be completed, and this PR will need to be updated to reflect that.

This PR mainly addresses civetweb - although some of the fixes also apply to beast.

I don't have any test logic here - most of the problems arise only with esoteric client software.  Most client frameworks (such as boto3) are simply not designed to exercise the edge cases this PR addresses.

This PR addresses these 2 related PR's,
https://tracker.ceph.com/issues/45789
https://tracker.ceph.com/issues/45790