### PR TITLE
qa/suites/rgw/multisite, qa/suites/rgw/crypt: whitelist PG_AVAILABILITY

### DIFF
--- a/qa/suites/rgw/crypt/1-ceph-install/install.yaml
+++ b/qa/suites/rgw/crypt/1-ceph-install/install.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-whitelist:
+    - \(PG_AVAILABILITY\)
     wait-for-scrub: false
 
 tasks:

--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-whitelist:
+    - \(PG_AVAILABILITY\)
     wait-for-scrub: false
     conf:
       client:


### PR DESCRIPTION
This follows b162541ac21e965a304ee6ffe604c43f22fa96c4.
The balancer was turned on by default in
d4fbaf7, as a result of which we might see
PG_AVAILABILITY health warnings when pg-upmap-items are applied.

Fixes: https://tracker.ceph.com/issues/45802
Signed-off-by: Neha Ojha <nojha@redhat.com>