### PR TITLE
mgr/dashboard: use relative font sizes

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.scss
@@ -15,7 +15,7 @@ cd-info-card {
     width: 116%;
 
     .popover-body {
-      font-size: 12px;
+      font-size: 1rem;
       max-height: 19vh;
       max-width: 100%;
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/info-card/info-card-popover.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/info-card/info-card-popover.scss
@@ -5,7 +5,7 @@
   max-width: 23vw;
 
   .popover-body {
-    font-size: 12px;
+    font-size: 1rem;
     max-height: 19vh;
     max-width: 100%;
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/info-group/info-group.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/info-group/info-group.component.scss
@@ -1,4 +1,4 @@
 .info-group-title {
-  font-size: 21px;
+  font-size: 1.75rem;
   margin: 0 0 0.5vw 0.5vw;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/forbidden/forbidden.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/forbidden/forbidden.component.scss
@@ -9,5 +9,5 @@ h2 {
 }
 
 i {
-  font-size: 200px;
+  font-size: 16.667rem;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.scss
@@ -29,7 +29,7 @@ ngx-simplebar {
 .separator {
   background-color: $color-popover-seperator-bg;
   color: $color-popover-seperator-text;
-  font-size: 12px;
+  font-size: 1rem;
   padding: 5px 12px;
 }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/select/select.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/select/select.component.scss
@@ -4,7 +4,7 @@
   border-bottom: 1px solid $color-transparent;
   cursor: pointer;
   display: block;
-  font-size: 12px;
+  font-size: 1rem;
 
   &:hover {
     background-color: $color-whitesmoke-gray;

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -322,7 +322,7 @@ a {
 .required::after {
   color: $color-required-text;
   content: '*';
-  font-size: 14px;
+  font-size: 1.167rem;
   padding-left: 4px;
 }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/38890

Signed-off-by: Ishan Rai <ishanrai05@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
