### PR TITLE
fuse: update to newer FUSE_USE_VERSION

### DIFF
--- a/fusetrace/fusetrace_ll.cc
+++ b/fusetrace/fusetrace_ll.cc
@@ -11,8 +11,6 @@
     gcc -Wall `pkg-config fuse --cflags --libs` -lulockmgr fusexmp_fh.c -o fusexmp_fh
 */
 
-#define FUSE_USE_VERSION 30
-
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -42,9 +42,8 @@
 #include <sys/types.h>
 #include <fcntl.h>
 
-#include <fuse.h>
-#include <fuse_lowlevel.h>
 #include "include/ceph_fuse.h"
+#include <fuse_lowlevel.h>
 
 #define dout_context g_ceph_context
 

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -37,7 +37,6 @@
 #include "include/ceph_fuse.h"
 
 #include "fuse_ll.h"
-#include <fuse.h>
 #include <fuse_lowlevel.h>
 
 #define dout_context g_ceph_context
@@ -1262,7 +1261,14 @@ int CephFuse::Handle::loop()
   auto fuse_multithreaded = client->cct->_conf.get_val<bool>(
     "fuse_multithreaded");
   if (fuse_multithreaded) {
-#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 1)
+    {
+      struct fuse_loop_config conf = { 0 };
+
+      conf.clone_fd = opts.clone_fd;
+      return fuse_session_loop_mt(se, &conf);
+    }
+#elif FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
     return fuse_session_loop_mt(se, opts.clone_fd);
 #else
     return fuse_session_loop_mt(se);

--- a/src/client/fuse_ll.h
+++ b/src/client/fuse_ll.h
@@ -12,8 +12,6 @@
  * 
  */
 
-#define FUSE_USE_VERSION 30
-
 class CephFuse {
 public:
   CephFuse(Client *c, int fd);

--- a/src/include/ceph_fuse.h
+++ b/src/include/ceph_fuse.h
@@ -14,7 +14,15 @@
 #ifndef CEPH_FUSE_H
 #define CEPH_FUSE_H
 
-#define FUSE_USE_VERSION 30
+/*
+ * The API version that we want to use, regardless of what the
+ * library version is. Note that this must be defined before
+ * fuse.h is included.
+ */
+#ifndef FUSE_USE_VERSION
+#define FUSE_USE_VERSION	35
+#endif
+
 #include <fuse.h>
 #include "acconfig.h"
 

--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -2,15 +2,13 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "include/compat.h"
+#include "include/ceph_fuse.h"
 #include "FuseStore.h"
 #include "os/ObjectStore.h"
 #include "include/stringify.h"
 #include "common/errno.h"
 
-#define FUSE_USE_VERSION 30
-#include <fuse.h>
 #include <fuse_lowlevel.h>
-#include "include/ceph_fuse.h"
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/rbd_fuse/rbd-fuse.cc
+++ b/src/rbd_fuse/rbd-fuse.cc
@@ -1,8 +1,6 @@
 /*
  * rbd-fuse
  */
-#define FUSE_USE_VERSION 30
-
 #include "include/int_types.h"
 
 #include <stdio.h>
@@ -11,7 +9,6 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <fuse.h>
 #include <pthread.h>
 #include <string.h>
 #include <sys/types.h>


### PR DESCRIPTION
The build was failing for me against fuse-devel v3.9.1. The prototype
for fuse_ll_ioctl was wrong, as it was expecting the old-style one with
signed int args.

In newer libfuse the prototype varies based on FUSE_USE_VERSION. Update to a
newer FUSE_USE_VERSION value to ensure that we use the newer ioctl
prototype. This also means that we need to handle a new prototype for
fuse_session_loop_mt as well.

Fixes: https://tracker.ceph.com/issues/45866
Signed-off-by: Jeff Layton <jlayton@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
