### PR TITLE
python-common: add ServiceSpec type checking

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -163,8 +163,12 @@ class RgwService(CephadmService):
         if spec.rgw_frontend_ssl_certificate:
             if isinstance(spec.rgw_frontend_ssl_certificate, list):
                 cert_data = '\n'.join(spec.rgw_frontend_ssl_certificate)
-            else:
+            elif isinstance(spec.rgw_frontend_ssl_certificate, str):
                 cert_data = spec.rgw_frontend_ssl_certificate
+            else:
+                raise OrchestratorError(
+                        'Invalid rgw_frontend_ssl_certificate: %s'
+                        % spec.rgw_frontend_ssl_certificate)
             ret, out, err = self.mgr.check_mon_command({
                 'prefix': 'config-key set',
                 'key': f'rgw/cert/{spec.rgw_realm}/{spec.rgw_zone}.crt',
@@ -174,8 +178,12 @@ class RgwService(CephadmService):
         if spec.rgw_frontend_ssl_key:
             if isinstance(spec.rgw_frontend_ssl_key, list):
                 key_data = '\n'.join(spec.rgw_frontend_ssl_key)
+            elif isinstance(spec.rgw_frontend_ssl_certificate, str):
+                key_data = spec.rgw_frontend_ssl_key
             else:
-                key_data = spec.rgw_frontend_ssl_key  # type: ignore
+                raise OrchestratorError(
+                        'Invalid rgw_frontend_ssl_key: %s'
+                        % spec.rgw_frontend_ssl_key)
             ret, out, err = self.mgr.check_mon_command({
                 'prefix': 'config-key set',
                 'key': f'rgw/cert/{spec.rgw_realm}/{spec.rgw_zone}.key',

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -436,7 +436,11 @@ class TestCephadm(object):
     def test_nfs(self, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            spec = NFSServiceSpec('name', pool='pool', namespace='namespace', placement=ps)
+            spec = NFSServiceSpec(
+                    service_id='name',
+                    pool='pool',
+                    namespace='namespace',
+                    placement=ps)
             c = cephadm_module.add_nfs(spec)
             [out] = wait(cephadm_module, c)
             match_glob(out, "Deployed nfs.name.* on host 'test'")
@@ -453,8 +457,12 @@ class TestCephadm(object):
     def test_iscsi(self, cephadm_module):
         with self._with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
-            spec = IscsiServiceSpec('name', pool='pool', api_user='user',
-                                    api_password='password', placement=ps)
+            spec = IscsiServiceSpec(
+                    service_id='name',
+                    pool='pool',
+                    api_user='user',
+                    api_password='password',
+                    placement=ps)
             c = cephadm_module.add_iscsi(spec)
             [out] = wait(cephadm_module, c)
             match_glob(out, "Deployed iscsi.name.* on host 'test'")
@@ -504,9 +512,17 @@ class TestCephadm(object):
                     )]
                 )
             ), CephadmOrchestrator.apply_rgw),
-            (NFSServiceSpec('name', pool='pool', namespace='namespace'), CephadmOrchestrator.apply_nfs),
-            (IscsiServiceSpec('name', pool='pool', api_user='user', api_password='password'),
-             CephadmOrchestrator.apply_iscsi),
+            (NFSServiceSpec(
+                service_id='name',
+                pool='pool',
+                namespace='namespace'
+            ), CephadmOrchestrator.apply_nfs),
+            (IscsiServiceSpec(
+                service_id='name',
+                pool='pool',
+                api_user='user',
+                api_password='password'
+            ), CephadmOrchestrator.apply_iscsi),
         ]
     )
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -818,7 +818,8 @@ Usage:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
         spec = ServiceSpec(
-            'mds', fs_name,
+            service_type='mds',
+            service_id=fs_name,
             placement=PlacementSpec.from_string(placement),
         )
 
@@ -878,7 +879,7 @@ Usage:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
         spec = NFSServiceSpec(
-            svc_id,
+            service_id=svc_id,
             pool=pool,
             namespace=namespace,
             placement=PlacementSpec.from_string(placement),
@@ -1023,7 +1024,8 @@ Usage:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
         spec = ServiceSpec(
-            'mds', fs_name,
+            service_type='mds',
+            service_id=fs_name,
             placement=PlacementSpec.from_string(placement),
             unmanaged=unmanaged)
 
@@ -1088,7 +1090,7 @@ Usage:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
         spec = NFSServiceSpec(
-            svc_id,
+            service_id=svc_id,
             pool=pool,
             namespace=namespace,
             placement=PlacementSpec.from_string(placement),

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -521,6 +521,7 @@ class NFSServiceSpec(ServiceSpec):
 
     def rados_config_location(self):
         # type: () -> str
+        assert self.pool
         url = 'rados://' + self.pool + '/'
         if self.namespace:
             url += self.namespace + '/'

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -389,11 +389,11 @@ class ServiceSpec(object):
         return object.__new__(sub_cls)
 
     def __init__(self,
-                 service_type,     # type: str
-                 service_id=None,  # type: Optional[str]
-                 placement=None,   # type: Optional[PlacementSpec]
-                 count=None,       # type: Optional[int]
-                 unmanaged=False,  # type: bool
+                 service_type: str,
+                 service_id: Optional[str] = None,
+                 placement: Optional[PlacementSpec] = None,
+                 count: Optional[int] = None,
+                 unmanaged: bool = False,
                  ):
         self.placement = PlacementSpec() if placement is None else placement  # type: PlacementSpec
 
@@ -490,8 +490,14 @@ def servicespec_validate_add(self: ServiceSpec):
 
 
 class NFSServiceSpec(ServiceSpec):
-    def __init__(self, service_id=None, pool=None, namespace=None, placement=None,
-                 service_type='nfs', unmanaged=False):
+    def __init__(self,
+                 service_type: str = 'nfs',
+                 service_id: Optional[str] = None,
+                 pool: Optional[str] = None,
+                 namespace: Optional[str] = None,
+                 placement: Optional[PlacementSpec] = None,
+                 unmanaged: bool = False,
+                 ):
         assert service_type == 'nfs'
         super(NFSServiceSpec, self).__init__(
             'nfs', service_id=service_id,
@@ -528,17 +534,17 @@ class RGWSpec(ServiceSpec):
 
     """
     def __init__(self,
-                 service_type='rgw',
-                 service_id=None,  # type: Optional[str]
-                 placement=None,
-                 rgw_realm=None,  # type: Optional[str]
-                 rgw_zone=None,  # type: Optional[str]
-                 subcluster=None,  # type: Optional[str]
-                 rgw_frontend_port=None,  # type: Optional[int]
-                 rgw_frontend_ssl_certificate=None,  # type Optional[List[str]]
-                 rgw_frontend_ssl_key=None,  # type: Optional[List[str]]
-                 unmanaged=False,  # type: bool
-                 ssl=False,   # type: bool
+                 service_type: str = 'rgw',
+                 service_id: Optional[str] = None,
+                 placement: Optional[PlacementSpec] = None,
+                 rgw_realm: Optional[str] = None,
+                 rgw_zone: Optional[str] = None,
+                 subcluster: Optional[str] = None,
+                 rgw_frontend_port: Optional[int] = None,
+                 rgw_frontend_ssl_certificate: Optional[List[str]] = None,
+                 rgw_frontend_ssl_key: Optional[List[str]] = None,
+                 unmanaged: bool = False,
+                 ssl: bool = False,
                  ):
         assert service_type == 'rgw', service_type
         if service_id:
@@ -584,17 +590,20 @@ class RGWSpec(ServiceSpec):
 
 
 class IscsiServiceSpec(ServiceSpec):
-    def __init__(self, service_id, pool=None,
-                 placement=None,
-                 trusted_ip_list=None,
-                 api_port=None,
-                 api_user=None,
-                 api_password=None,
-                 api_secure=None,
-                 ssl_cert=None,
-                 ssl_key=None,
-                 service_type='iscsi',
-                 unmanaged=False):
+    def __init__(self,
+                 service_type: str = 'iscsi',
+                 service_id: Optional[str] = None,
+                 pool: Optional[str] = None,
+                 trusted_ip_list: Optional[str] = None,
+                 api_port: Optional[int] = None,
+                 api_user: Optional[str] = None,
+                 api_password: Optional[str] = None,
+                 api_secure: Optional[bool] = None,
+                 ssl_cert: Optional[str] = None,
+                 ssl_key: Optional[str] = None,
+                 placement: Optional[PlacementSpec] = None,
+                 unmanaged: bool = False
+                 ):
         assert service_type == 'iscsi'
         super(IscsiServiceSpec, self).__init__('iscsi', service_id=service_id,
                                                placement=placement, unmanaged=unmanaged)


### PR DESCRIPTION
- add missing type checking to NFSServiceSpec and IscsiServiceSpec
- clean-up type checking for ServiceSpec and RGWSpec

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
