### PR TITLE
mgr/dashboard: remove space after service name in the Hosts List table

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
@@ -49,11 +49,10 @@
     <a class="service-link"
        [routerLink]="[service.cdLink]"
        [queryParams]="cdParams"
-       *ngIf="service.canRead">{{ service.type }}.{{ service.id }}
-    </a>
+       *ngIf="service.canRead">{{ service.type }}.{{ service.id }}</a>
     <span *ngIf="!service.canRead">
       {{ service.type }}.{{ service.id }}
     </span>
-    {{ !isLast ? ", " : "" }}
+    <ng-container *ngIf="!isLast">, </ng-container>
   </span>
 </ng-template>


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/45870
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

**Before**
![Screenshot_2020-06-04 Ceph(1)](https://user-images.githubusercontent.com/1691518/83721184-26c03c00-a66d-11ea-8285-78fb9ec7476a.png)

**After**
![Screenshot_2020-06-04 Ceph](https://user-images.githubusercontent.com/1691518/83721192-2b84f000-a66d-11ea-9768-3bb28479e5c3.png)





<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
