### PR TITLE
mgr/cephadm: re-enable osdspec affinity passing

### DIFF
--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -30,9 +30,7 @@ class OSDService(CephadmService):
             if not cmd:
                 logger.debug("No data_devices, skipping DriveGroup: {}".format(drive_group.service_id))
                 continue
-            # env_vars = [f"CEPH_VOLUME_OSDSPEC_AFFINITY={drive_group.service_id}"]
-            # disable this until https://github.com/ceph/ceph/pull/34835 is merged
-            env_vars: List[str] = []
+            env_vars: List[str] = [f"CEPH_VOLUME_OSDSPEC_AFFINITY={drive_group.service_id}"]
             ret_msg = self.create_single_host(
                 host, cmd, replace_osd_ids=drive_group.osd_id_claims.get(host, []), env_vars=env_vars
             )

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -285,7 +285,7 @@ class TestCephadm(object):
             _run_cephadm.assert_any_call(
                 'test', 'osd', 'ceph-volume',
                 ['--config-json', '-', '--', 'lvm', 'prepare', '--bluestore', '--data', '/dev/sdb', '--no-systemd'],
-                env_vars=[], error_ok=True, stdin='{"config": "", "keyring": ""}')
+                env_vars=['CEPH_VOLUME_OSDSPEC_AFFINITY=foo'], error_ok=True, stdin='{"config": "", "keyring": ""}')
             _run_cephadm.assert_called_with('test', 'osd', 'ceph-volume', ['--', 'lvm', 'list', '--format', 'json'])
 
 


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

https://github.com/ceph/ceph/pull/34835 is merged now.

There is a big pitfall to this patch:

When the mgr is updated _before_ the osd daemons, the mgr will crash. Currently there is no safeguard against this scenario besides the 'update order' itself.