### PR TITLE
mgr/dashboard: Fix CephFS's Directories not showing

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.html
@@ -27,9 +27,7 @@
       <a ngbNavLink
          i18n>Directories</a>
       <ng-template ngbNavContent>
-        <cd-cephfs-directories *ngIf="directoriesSelected"
-                               [id]="id">
-        </cd-cephfs-directories>
+        <cd-cephfs-directories [id]="id"></cd-cephfs-directories>
       </ng-template>
     </li>
     <li ngbNavItem>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.ts
@@ -37,9 +37,6 @@ export class CephfsTabsComponent implements OnChanges, OnDestroy {
     name: ''
   };
 
-  // Directories
-  directoriesSelected = false;
-
   private data: any;
   private reloadSubscriber: Subscription;
 


### PR DESCRIPTION
This is a regression introduced in fdd8ec8ca9e38bc0cf9a7b31f232b0322b46782a.

We no longer need to check if a tab is selected to load the content.

In that commit we removed the logic that updated the conditional variable,
but missed removing its use.

Fixes: https://tracker.ceph.com/issues/45877

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
