### PR TITLE
python-common: Add k8s_node_to_hostspec

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -83,8 +83,9 @@ class Inventory:
         for h, hostspec in self._inventory.items():
             if not label or label in hostspec.get('labels', []):
                 if as_hostspec:
-                    yield hostspec
-                yield h
+                    yield self.spec_from_dict(hostspec)
+                else:
+                    yield h
 
     def spec_from_dict(self, info):
         hostname = info['hostname']

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -1,6 +1,7 @@
 from typing import NamedTuple, List
 import pytest
 
+from ceph.deployment.hostspec import HostSpec
 from ceph.deployment.service_spec import ServiceSpec, PlacementSpec, ServiceSpecValidationError
 
 from cephadm.module import HostAssignment
@@ -114,9 +115,15 @@ class NodeAssignmentTest(NamedTuple):
         ),
     ])
 def test_node_assignment(service_type, placement, hosts, daemons, expected):
+    def get_hosts_func(label=None, as_hostspec=False):
+        if as_hostspec:
+            return [HostSpec(h) for h in hosts]
+        return hosts
+
+
     hosts = HostAssignment(
         spec=ServiceSpec(service_type, placement=placement),
-        get_hosts_func=lambda label=None, as_hostspec=False: hosts,
+        get_hosts_func=get_hosts_func,
         get_daemons_func=lambda _: daemons).place()
     assert sorted([h.hostname for h in hosts]) == sorted(expected)
 
@@ -202,9 +209,14 @@ class NodeAssignmentTest2(NamedTuple):
     ])
 def test_node_assignment2(service_type, placement, hosts,
                           daemons, expected_len, in_set):
+    def get_hosts_func(label=None, as_hostspec=False):
+        if as_hostspec:
+            return [HostSpec(h) for h in hosts]
+        return hosts
+
     hosts = HostAssignment(
         spec=ServiceSpec(service_type, placement=placement),
-        get_hosts_func=lambda label=None, as_hostspec=False: hosts,
+        get_hosts_func=get_hosts_func,
         get_daemons_func=lambda _: daemons).place()
     assert len(hosts) == expected_len
     for h in [h.hostname for h in hosts]:
@@ -233,9 +245,14 @@ def test_node_assignment2(service_type, placement, hosts,
     ])
 def test_node_assignment3(service_type, placement, hosts,
                           daemons, expected_len, must_have):
+    def get_hosts_func(label=None, as_hostspec=False):
+        if as_hostspec:
+            return [HostSpec(h) for h in hosts]
+        return hosts
+
     hosts = HostAssignment(
         spec=ServiceSpec(service_type, placement=placement),
-        get_hosts_func=lambda label=None, as_hostspec=False: hosts,
+        get_hosts_func=get_hosts_func,
         get_daemons_func=lambda _: daemons).place()
     assert len(hosts) == expected_len
     for h in must_have:
@@ -291,9 +308,13 @@ class NodeAssignmentTestBadSpec(NamedTuple):
         ),
     ])
 def test_bad_specs(service_type, placement, hosts, daemons, expected):
+    def get_hosts_func(label=None, as_hostspec=False):
+        if as_hostspec:
+            return [HostSpec(h) for h in hosts]
+        return hosts
     with pytest.raises(OrchestratorValidationError) as e:
         hosts = HostAssignment(
             spec=ServiceSpec(service_type, placement=placement),
-            get_hosts_func=lambda label=None, as_hostspec=False: hosts,
+            get_hosts_func=get_hosts_func,
             get_daemons_func=lambda _: daemons).place()
     assert str(e.value) == expected

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -21,6 +21,7 @@ from ceph.deployment import inventory
 from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec, \
     ServiceSpecValidationError, IscsiServiceSpec
 from ceph.deployment.drive_group import DriveGroupSpec
+from ceph.deployment.hostspec import HostSpec
 
 from mgr_module import MgrModule, CLICommand, HandleCommandResult
 
@@ -1161,62 +1162,6 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-
-class HostSpec(object):
-    """
-    Information about hosts. Like e.g. ``kubectl get nodes``
-    """
-    def __init__(self,
-                 hostname,  # type: str
-                 addr=None,  # type: Optional[str]
-                 labels=None,  # type: Optional[List[str]]
-                 status=None,  # type: Optional[str]
-                 ):
-        self.service_type = 'host'
-
-        #: the bare hostname on the host. Not the FQDN.
-        self.hostname = hostname  # type: str
-
-        #: DNS name or IP address to reach it
-        self.addr = addr or hostname  # type: str
-
-        #: label(s), if any
-        self.labels = labels or []  # type: List[str]
-
-        #: human readable status
-        self.status = status or ''  # type: str
-
-    def to_json(self):
-        return {
-            'hostname': self.hostname,
-            'addr': self.addr,
-            'labels': self.labels,
-            'status': self.status,
-        }
-
-    @classmethod
-    def from_json(cls, host_spec):
-        _cls = cls(host_spec['hostname'],
-                   host_spec['addr'] if 'addr' in host_spec else None,
-                   host_spec['labels'] if 'labels' in host_spec else None)
-        return _cls
-
-    def __repr__(self):
-        args = [self.hostname]  # type: List[Any]
-        if self.addr is not None:
-            args.append(self.addr)
-        if self.labels:
-            args.append(self.labels)
-        if self.status:
-            args.append(self.status)
-
-        return "<HostSpec>({})".format(', '.join(map(repr, args)))
-
-    def __eq__(self, other):
-        # Let's omit `status` for the moment, as it is still the very same host.
-        return self.hostname == other.hostname and \
-               self.addr == other.addr and \
-               self.labels == other.labels
 
 GenericSpec = Union[ServiceSpec, HostSpec]
 

--- a/src/python-common/ceph/deployment/hostspec.py
+++ b/src/python-common/ceph/deployment/hostspec.py
@@ -1,0 +1,61 @@
+try:
+    from typing import Optional, List, Any
+except ImportError:
+    pass  # just for type checking
+
+
+class HostSpec(object):
+    """
+    Information about hosts. Like e.g. ``kubectl get nodes``
+    """
+    def __init__(self,
+                 hostname,  # type: str
+                 addr=None,  # type: Optional[str]
+                 labels=None,  # type: Optional[List[str]]
+                 status=None,  # type: Optional[str]
+                 ):
+        self.service_type = 'host'
+
+        #: the bare hostname on the host. Not the FQDN.
+        self.hostname = hostname  # type: str
+
+        #: DNS name or IP address to reach it
+        self.addr = addr or hostname  # type: str
+
+        #: label(s), if any
+        self.labels = labels or []  # type: List[str]
+
+        #: human readable status
+        self.status = status or ''  # type: str
+
+    def to_json(self):
+        return {
+            'hostname': self.hostname,
+            'addr': self.addr,
+            'labels': self.labels,
+            'status': self.status,
+        }
+
+    @classmethod
+    def from_json(cls, host_spec):
+        _cls = cls(host_spec['hostname'],
+                   host_spec['addr'] if 'addr' in host_spec else None,
+                   host_spec['labels'] if 'labels' in host_spec else None)
+        return _cls
+
+    def __repr__(self):
+        args = [self.hostname]  # type: List[Any]
+        if self.addr is not None:
+            args.append(self.addr)
+        if self.labels:
+            args.append(self.labels)
+        if self.status:
+            args.append(self.status)
+
+        return "HostSpec({})".format(', '.join(map(repr, args)))
+
+    def __eq__(self, other):
+        # Let's omit `status` for the moment, as it is still the very same host.
+        return self.hostname == other.hostname and \
+               self.addr == other.addr and \
+               self.labels == other.labels

--- a/src/python-common/ceph/deployment/rook.py
+++ b/src/python-common/ceph/deployment/rook.py
@@ -1,0 +1,28 @@
+
+try:
+    from typing import Dict, Any
+    from .hostspec import HostSpec
+except ImportError:
+    pass  # just for type checking
+
+
+def k8s_node_to_hostspec(node: Dict[str, Any]) -> HostSpec:
+    """
+    >>> k8s_node_to_hostspec({
+    ...   "kind": "Node",
+    ...   "apiVersion": "v1",
+    ...   "metadata": {
+    ...     "name": "10.240.79.157",
+    ...     "labels": {
+    ...       "name": "my-first-k8s-node"
+    ...     }
+    ...   }
+    ... })
+    HostSpec('10.240.79.157', '10.240.79.157', ['name:my-first-k8s-node'])
+
+    """
+    metadata = node.get('metadata', {})
+    return HostSpec(
+        hostname=metadata['name'],
+        labels=[f'{k}:{v}' for k, v in metadata.get('labels', {}).items()]
+    )

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -2,9 +2,11 @@ import fnmatch
 import re
 from collections import namedtuple
 from functools import wraps
-from typing import Optional, Dict, Any, List, Union, Callable
+from typing import Optional, Dict, Any, List, Union, Callable, Iterator
 
 import six
+
+from ceph.deployment.hostspec import HostSpec
 
 
 class ServiceSpecValidationError(Exception):
@@ -174,22 +176,26 @@ class PlacementSpec(object):
         self.hosts = hosts
 
     def filter_matching_hosts(self, _get_hosts_func: Callable) -> List[str]:
+        return self.filter_matching_hostspecs(_get_hosts_func(as_hostspec=True))
+
+    def filter_matching_hostspecs(self, hostspecs: Iterator[HostSpec]) -> List[str]:
         if self.hosts:
-            all_hosts = _get_hosts_func(label=None, as_hostspec=False)
+            all_hosts = [hs.hostname for hs in hostspecs]
             return [h.hostname for h in self.hosts if h.hostname in all_hosts]
         elif self.label:
-            return _get_hosts_func(label=self.label, as_hostspec=False)
+            return [hs.hostname for hs in hostspecs if self.label in hs.labels]
         elif self.host_pattern:
-            return fnmatch.filter(_get_hosts_func(label=None, as_hostspec=False), self.host_pattern)
+            all_hosts = [hs.hostname for hs in hostspecs]
+            return fnmatch.filter(all_hosts, self.host_pattern)
         else:
             # This should be caught by the validation but needs to be here for
             # get_host_selection_size
             return []
 
-    def get_host_selection_size(self, _get_hosts_func):
+    def get_host_selection_size(self, hostspecs: Iterator[HostSpec]):
         if self.count:
             return self.count
-        return len(self.filter_matching_hosts(_get_hosts_func))
+        return len(self.filter_matching_hostspecs(hostspecs))
 
     def pretty_str(self):
         kv = []

--- a/src/python-common/ceph/deployment/test_rook.py
+++ b/src/python-common/ceph/deployment/test_rook.py
@@ -1,0 +1,23 @@
+from ceph.deployment.rook import k8s_node_to_hostspec
+from ceph.deployment.service_spec import PlacementSpec
+
+
+def test_placement_match():
+    """
+    NOTE
+
+    Used by rook. Be careful when changing the API
+    """
+    hostspec = k8s_node_to_hostspec({
+      "kind": "Node",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "name",
+        "labels": {
+          "name": "my-first-k8s-node"
+        }
+      }
+    })
+
+    assert PlacementSpec(label='name:my-first-k8s-node').filter_matching_hostspecs([hostspec]) == [
+        'name']

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -3,6 +3,7 @@ import pytest
 import yaml
 
 from ceph.deployment import drive_selection, translate
+from ceph.deployment.hostspec import HostSpec
 from ceph.deployment.inventory import Device
 from ceph.deployment.service_spec import PlacementSpec, ServiceSpecValidationError
 from ceph.tests.utils import _mk_inventory, _mk_device
@@ -24,7 +25,7 @@ from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection, \
 ])
 def test_DriveGroup(test_input):
     dg = [DriveGroupSpec.from_json(inp) for inp in test_input][0]
-    assert dg.placement.filter_matching_hosts(lambda label=None, as_hostspec=None: ['hostname']) == ['hostname']
+    assert dg.placement.filter_matching_hostspecs([HostSpec('hostname')]) == ['hostname']
     assert dg.service_id == 'testing_drivegroup'
     assert all([isinstance(x, Device) for x in dg.data_devices.paths])
     assert dg.data_devices.paths[0].path == '/dev/sda'
@@ -53,7 +54,7 @@ def test_DriveGroup_fail(test_input):
 
 def test_drivegroup_pattern():
     dg = DriveGroupSpec(PlacementSpec(host_pattern='node[1-3]'), data_devices=DeviceSelection(all=True))
-    assert dg.placement.filter_matching_hosts(lambda label=None, as_hostspec=None: ['node{}'.format(i) for i in range(10)]) == ['node1', 'node2', 'node3']
+    assert dg.placement.filter_matching_hostspecs([HostSpec('node{}'.format(i)) for i in range(10)]) == ['node1', 'node2', 'node3']
 
 
 def test_drive_selection():

--- a/src/python-common/tox.ini
+++ b/src/python-common/tox.ini
@@ -6,7 +6,7 @@ skip_missing_interpreters = true
 deps=
     -rrequirements.txt
 commands=
-    pytest --doctest-modules ceph/deployment/service_spec.py
+    pytest --doctest-modules ceph
     pytest --mypy --mypy-ignore-missing-imports {posargs}
 
 [tool:pytest]


### PR DESCRIPTION
This enables Rook to process drive groups by calling into python-common

Something like

```python
#/usr/bin/python3
import sys
from ceph.deployment.rook import k8s_node_to_hostspec
from ceph.deployment.service_spec import ServiceSpec

# load drive group and k8s nodes form stdin:
drive_group, hosts = json.load(sys.stdin)

# k8s nodes to ceph HostSpec
hosts = [k8s_node_to_hostspec(h) for h in hosts]

# print matching hosts:
print(ServiceSpec.from_json(drive_group).placement.filter_matching_hostspecs(hosts))
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
