### PR TITLE
nautilus: rbd: librbd: Watcher should not attempt to re-watch after detecting blacklisting

### DIFF
--- a/src/librbd/Watcher.cc
+++ b/src/librbd/Watcher.cc
@@ -324,7 +324,7 @@ void Watcher::handle_rewatch_callback(int r) {
     if (m_unregister_watch_ctx != nullptr) {
       m_watch_state = WATCH_STATE_IDLE;
       std::swap(unregister_watch_ctx, m_unregister_watch_ctx);
-    } else if (r == -ENOENT) {
+    } else if (r == -EBLACKLISTED || r == -ENOENT) {
       m_watch_state = WATCH_STATE_IDLE;
     } else if (r < 0 || m_watch_error) {
       watch_error = true;

--- a/src/test/librbd/test_mock_Watcher.cc
+++ b/src/test/librbd/test_mock_Watcher.cc
@@ -293,12 +293,6 @@ TEST_F(TestMockWatcher, ReregisterWatchBlacklist) {
   expect_aio_unwatch(mock_image_ctx, 0);
   expect_aio_watch(mock_image_ctx, -EBLACKLISTED);
 
-  C_SaferCond blacklist_ctx;
-  expect_aio_watch(mock_image_ctx, 0, [&blacklist_ctx]() {
-      blacklist_ctx.wait();
-    });
-  expect_aio_unwatch(mock_image_ctx, 0);
-
   C_SaferCond register_ctx;
   mock_image_watcher.register_watch(&register_ctx);
   ASSERT_TRUE(wait_for_watch(mock_image_ctx, 1));
@@ -309,17 +303,11 @@ TEST_F(TestMockWatcher, ReregisterWatchBlacklist) {
 
   // wait for recovery unwatch/watch
   ASSERT_TRUE(wait_for_watch(mock_image_ctx, 2));
-
   ASSERT_TRUE(mock_image_watcher.is_blacklisted());
-  blacklist_ctx.complete(0);
-
-  // wait for post-blacklist recovery watch
-  ASSERT_TRUE(wait_for_watch(mock_image_ctx, 1));
 
   C_SaferCond unregister_ctx;
   mock_image_watcher.unregister_watch(&unregister_ctx);
   ASSERT_EQ(0, unregister_ctx.wait());
-  ASSERT_FALSE(mock_image_watcher.is_blacklisted());
 }
 
 TEST_F(TestMockWatcher, ReregisterUnwatchPendingUnregister) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45800

---

backport of https://github.com/ceph/ceph/pull/35301
parent tracker: https://tracker.ceph.com/issues/45715

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh