### PR TITLE
nautilus: qa/workunits/rados/test_envlibrados_rocksdb: Build correct rocksdb

### DIFF
--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -63,7 +63,11 @@ echo "Compile rocksdb"
 if [ -e rocksdb ]; then
 	rm -fr rocksdb
 fi
-git clone https://github.com/facebook/rocksdb.git --depth 1
+
+pushd $(dirname /home/ubuntu/cephtest/clone.client.0/qa/workunits/rados/bash.sh)/../../../
+git submodule update --init src/rocksdb
+popd
+git clone $(dirname /home/ubuntu/cephtest/clone.client.0/qa/workunits/rados/bash.sh)/../../../src/rocksdb rocksdb
 
 # compile code
 cd rocksdb


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45780

---

backport of https://github.com/ceph/ceph/pull/35033
parent tracker: https://tracker.ceph.com/issues/44981

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh