### PR TITLE
nautilus: mgr/telemetry: force --license when sending while opted-out

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -123,6 +123,16 @@ The see the current configuration::
 
   ceph telemetry status
 
+Manually sending telemetry
+--------------------------
+
+To ad hoc send telemetry data::
+
+  ceph telemetry send
+
+In case telemetry is not enabled (with 'ceph telemetry on'), you need to add
+'--license sharing-1-0' to 'ceph telemetry send' command.
+
 Sending telemetry through a proxy
 ---------------------------------
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/44506

---

backport of https://github.com/ceph/ceph/pull/33747
parent tracker: https://tracker.ceph.com/issues/44442

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh