### PR TITLE
nautilus: cephfs: allow pool names with hyphen and period

### DIFF
--- a/doc/cephfs/administration.rst
+++ b/doc/cephfs/administration.rst
@@ -6,6 +6,9 @@ CephFS Administrative commands
 Filesystems
 -----------
 
+.. note:: The names of the file systems, metadata pools, and data pools can
+          only have characters in the set [a-zA-Z0-9\_-.].
+
 These commands operate on the CephFS filesystems in your Ceph cluster.
 Note that by default only one filesystem is permitted: to enable
 creation of multiple filesystems use ``ceph fs flag set enable_multiple true``.

--- a/doc/cephfs/createfs.rst
+++ b/doc/cephfs/createfs.rst
@@ -35,6 +35,8 @@ Generally, the metadata pool will have at most a few gigabytes of data. For
 this reason, a smaller PG count is usually recommended. 64 or 128 is commonly
 used in practice for large clusters.
 
+.. note:: The names of the file systems, metadata pools, and data pools can
+          only have characters in the set [a-zA-Z0-9\_-.].
 
 Creating a filesystem
 =====================

--- a/doc/cephfs/file-layouts.rst
+++ b/doc/cephfs/file-layouts.rst
@@ -20,10 +20,10 @@ Layout fields
 -------------
 
 pool
-    String, giving ID or name.  Which RADOS pool a file's data objects will be stored in.
+    String, giving ID or name. String can only have characters in the set [a-zA-Z0-9\_-.]. Which RADOS pool a file's data objects will be stored in.
 
 pool_namespace
-    String.  Within the data pool, which RADOS namespace the objects will
+    String with only characters in the set [a-zA-Z0-9\_-.].  Within the data pool, which RADOS namespace the objects will
     be written to.  Empty by default (i.e. default namespace).
 
 stripe_unit

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -158,6 +158,9 @@ class CephFSMount(object):
         return six.ensure_str(p.stdout.getvalue().strip())
 
     def run_shell(self, args, wait=True, check_status=True, omit_sudo=True):
+        if isinstance(args, str):
+            args = args.split()
+
         args = ["cd", self.mountpoint, run.Raw('&&'), "sudo"] + args
         return self.client_remote.run(args=args, stdout=StringIO(),
                                       stderr=StringIO(), wait=wait,

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -68,6 +68,14 @@ class TestAdminCommands(CephFSTestCase):
         self.mount_a.run_shell(["mkdir", "subdir"])
         self.fs.set_dir_layout(self.mount_a, "subdir", FileLayout(pool=p))
 
+    def test_add_data_pool_non_alphamueric_name_as_subdir(self):
+        """
+        That a new data pool with non-alphanumeric name can be added and used for a sub-directory.
+        """
+        p = self.fs.add_data_pool("I-am-data_pool00.")
+        self.mount_a.run_shell("mkdir subdir")
+        self.fs.set_dir_layout(self.mount_a, "subdir", FileLayout(pool=p))
+
     def test_add_data_pool_ec(self):
         """
         That a new EC data pool can be added.

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -1811,7 +1811,7 @@ struct keys_and_values
       query =  pair >> *(qi::lit(' ') >> pair);
       pair  =  key >> '=' >> value;
       key   =  qi::char_("a-zA-Z_") >> *qi::char_("a-zA-Z_0-9");
-      value = +qi::char_("a-zA-Z_0-9");
+      value = +qi::char_("a-zA-Z0-9-_.");
     }
     qi::rule<Iterator, std::map<string, string>()> query;
     qi::rule<Iterator, std::pair<string, string>()> pair;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45679

---

backport of https://github.com/ceph/ceph/pull/35063
parent tracker: https://tracker.ceph.com/issues/45521

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh