### PR TITLE
nautilus: tools/cephfs: don't bind to public_addr

### DIFF
--- a/src/ceph_syn.cc
+++ b/src/ceph_syn.cc
@@ -63,7 +63,6 @@ int main(int argc, const char **argv, char *envp[])
   for (int i=0; i<num_client; i++) {
     messengers[i] = Messenger::create_client_messenger(g_ceph_context,
 						       "synclient");
-    messengers[i]->bind(g_conf()->public_addr);
     mclients[i] = new MonClient(g_ceph_context);
     mclients[i]->build_initial_monmap();
     auto client = new StandaloneClient(messengers[i], mclients[i]);

--- a/src/tools/cephfs/MDSUtility.cc
+++ b/src/tools/cephfs/MDSUtility.cc
@@ -49,10 +49,6 @@ MDSUtility::~MDSUtility()
 int MDSUtility::init()
 {
   // Initialize Messenger
-  int r = messenger->bind(g_conf()->public_addr);
-  if (r < 0)
-    return r;
-
   messenger->start();
 
   objecter->set_client_incarnation(0);
@@ -73,7 +69,7 @@ int MDSUtility::init()
   monc->set_want_keys(CEPH_ENTITY_TYPE_MON|CEPH_ENTITY_TYPE_OSD|CEPH_ENTITY_TYPE_MDS);
   monc->set_messenger(messenger);
   monc->init();
-  r = monc->authenticate();
+  int r = monc->authenticate();
   if (r < 0) {
     derr << "Authentication failed, did you specify an MDS ID with a valid keyring?" << dendl;
     monc->shutdown();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45854

---

backport of https://github.com/ceph/ceph/pull/34942
parent tracker: https://tracker.ceph.com/issues/41034

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh