### PR TITLE
nautilus: tests: qa/tasks/cephfs/test_scrub.py: use umount_wait to avoid possible ceph-fuse daemon stuck

### DIFF
--- a/qa/tasks/cephfs/test_scrub.py
+++ b/qa/tasks/cephfs/test_scrub.py
@@ -89,7 +89,7 @@ class DupInodeWorkload(Workload):
 
     def damage(self):
         temp_bin_path = "/tmp/10000000000.00000000_omap.bin"
-        self._mount.umount()
+        self._mount.umount_wait()
         self._filesystem.mds_asok(["flush", "journal"])
         self._filesystem.mds_stop()
         self._filesystem.rados(["getomapval", "10000000000.00000000",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45887

---

backport of https://github.com/ceph/ceph/pull/35328
parent tracker: https://tracker.ceph.com/issues/45665

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh