### PR TITLE
nautilus: core: os/bluestore: fix large (>2GB) writes when bluefs_buffered_io = true

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -773,18 +773,42 @@ int KernelDevice::_sync_write(uint64_t off, bufferlist &bl, bool buffered, int w
   }
   vector<iovec> iov;
   bl.prepare_iov(&iov);
-  int r = ::pwritev(choose_fd(buffered, write_hint),
-		    &iov[0], iov.size(), off);
 
-  if (r < 0) {
-    r = -errno;
-    derr << __func__ << " pwritev error: " << cpp_strerror(r) << dendl;
-    return r;
-  }
+  auto left = len;
+  auto o = off;
+  size_t idx = 0;
+  do {
+    auto r = ::pwritev(choose_fd(buffered, write_hint),
+      &iov[idx], iov.size() - idx, o);
+
+    if (r < 0) {
+      r = -errno;
+      derr << __func__ << " pwritev error: " << cpp_strerror(r) << dendl;
+      return r;
+    }
+    o += r;
+    left -= r;
+    if (left) {
+      // skip fully processed IOVs
+      while (idx < iov.size() && (size_t)r >= iov[idx].iov_len) {
+        r -= iov[idx++].iov_len;
+      }
+      // update partially processed one if any
+      if (r) {
+        ceph_assert(idx < iov.size());
+        ceph_assert((size_t)r < iov[idx].iov_len);
+        iov[idx].iov_base = static_cast<char*>(iov[idx].iov_base) + r;
+        iov[idx].iov_len -= r;
+        r = 0;
+      }
+      ceph_assert(r == 0);
+    }
+  } while (left);
+
 #ifdef HAVE_SYNC_FILE_RANGE
   if (buffered) {
     // initiate IO and wait till it completes
-    r = ::sync_file_range(fd_buffereds[WRITE_LIFE_NOT_SET], off, len, SYNC_FILE_RANGE_WRITE|SYNC_FILE_RANGE_WAIT_AFTER|SYNC_FILE_RANGE_WAIT_BEFORE);
+    auto r = ::sync_file_range(fd_buffereds[WRITE_LIFE_NOT_SET], off, len, SYNC_FILE_RANGE_WRITE|SYNC_FILE_RANGE_WAIT_AFTER|SYNC_FILE_RANGE_WAIT_BEFORE);
     if (r < 0) {
       r = -errno;
       derr << __func__ << " sync_file_range error: " << cpp_strerror(r) << dendl;

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -118,6 +118,14 @@ if(WITH_BLUESTORE)
     )
   add_ceph_unittest(unittest_bluestore_types)
   target_link_libraries(unittest_bluestore_types os global)
+
+  # unittest_bdev
+  add_executable(unittest_bdev
+    test_bdev.cc
+    )
+  add_ceph_unittest(unittest_bdev)
+  target_link_libraries(unittest_bdev os global)
+
 endif(WITH_BLUESTORE)
 
 # unittest_transaction

--- a/src/test/objectstore/test_bdev.cc
+++ b/src/test/objectstore/test_bdev.cc
@@ -1,0 +1,111 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <stdio.h>
+#include <string.h>
+#include <iostream>
+#include <gtest/gtest.h>
+#include "global/global_init.h"
+#include "global/global_context.h"
+#include "common/ceph_context.h"
+#include "common/ceph_argparse.h"
+#include "include/stringify.h"
+#include "common/errno.h"
+
+#include "os/bluestore/BlockDevice.h"
+
+class TempBdev {
+public:
+  TempBdev(uint64_t size)
+    : path{get_temp_bdev(size)}
+  {}
+  ~TempBdev() {
+    rm_temp_bdev(path);
+  }
+  const std::string path;
+private:
+  static string get_temp_bdev(uint64_t size)
+  {
+    static int n = 0;
+    string fn = "ceph_test_bluefs.tmp.block." + stringify(getpid())
+      + "." + stringify(++n);
+    int fd = ::open(fn.c_str(), O_CREAT|O_RDWR|O_TRUNC, 0644);
+    ceph_assert(fd >= 0);
+    int r = ::ftruncate(fd, size);
+    ceph_assert(r >= 0);
+    ::close(fd);
+    return fn;
+  }
+  static void rm_temp_bdev(string f)
+  {
+    ::unlink(f.c_str());
+  }
+};
+
+TEST(KernelDevice, Ticket45337) {
+   // Large (>=2 GB) writes are incomplete when bluefs_buffered_io = true
+
+  uint64_t size = 1048576ull * 8192;
+  TempBdev bdev{ size };
+  
+  const bool buffered = true;
+
+  std::unique_ptr<BlockDevice> b(
+    BlockDevice::create(g_ceph_context, bdev.path, NULL, NULL,
+      [](void* handle, void* aio) {}, NULL));
+  bufferlist bl;
+  // writing a bit less than 4GB
+  for (auto i = 0; i < 4000; i++) {
+    string s(1048576, 'a' + (i % 28));
+    bl.append(s);
+  }
+  uint64_t magic_offs = bl.length();
+  string s(4086, 'z');
+  s += "0123456789";
+  bl.append(s);
+
+  {
+    int r = b->open(bdev.path);
+    if (r < 0) {
+      std::cerr << "open " << bdev.path << " failed" << std::endl;
+      return;
+    }
+  }
+  std::unique_ptr<IOContext> ioc(new IOContext(g_ceph_context, NULL));
+
+  auto r = b->aio_write(0, bl, ioc.get(), buffered);
+  ASSERT_EQ(r, 0);
+
+  if (ioc->has_pending_aios()) {
+    b->aio_submit(ioc.get());
+    ioc->aio_wait();
+  }
+
+  char outbuf[0x1000];
+  r = b->read_random(magic_offs, sizeof(outbuf), outbuf, buffered);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(memcmp(s.c_str(), outbuf, sizeof(outbuf)), 0);
+
+  b->close();
+}
+
+int main(int argc, char **argv) {
+  vector<const char*> args;
+  argv_to_vec(argc, (const char **)argv, args);
+
+  map<string,string> defaults = {
+    { "debug_bdev", "1/20" }
+  };
+
+  auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
+			 CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+  g_ceph_context->_conf.set_val(
+    "enable_experimental_unrecoverable_data_corrupting_features",
+    "*");
+  g_ceph_context->_conf.apply_changes(nullptr);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45684

---

backport of https://github.com/ceph/ceph/pull/34836
parent tracker: https://tracker.ceph.com/issues/45337

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh