### PR TITLE
mgr/dashboard/api: move API tests to tox

### DIFF
--- a/qa/tasks/ceph_test_case.py
+++ b/qa/tasks/ceph_test_case.py
@@ -157,6 +157,7 @@ class CephTestCase(unittest.TestCase):
         """
         def is_clear():
             health = self.ceph_cluster.mon_manager.get_mon_health()
+            log.info(health)
             return len(health['checks']) == 0
 
         self.wait_until_true(is_clear, timeout)

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -144,7 +144,10 @@ except ImportError:
 # Must import after teuthology because of gevent monkey patching
 import subprocess
 
-if os.path.exists("./CMakeCache.txt"):
+if os.getenv("CEPH_BUILD_ROOT"):
+    BIN_PREFIX = os.path.join(os.getenv("CEPH_BUILD_ROOT"), "bin")
+    SRC_PREFIX = "../src"
+elif os.path.exists("./CMakeCache.txt"):
     # Running in build dir of a cmake build
     BIN_PREFIX = "./bin/"
     SRC_PREFIX = "../src"
@@ -1250,11 +1253,11 @@ def exec_test():
                 log.error("--brxnet=<ip/mask> option needs one argument: '{0}'".format(f))
                 sys.exit(-1)
             opt_brxnet=f.split('=')[1]
-            try:  
-                IP(opt_brxnet)  
+            try:
+                IP(opt_brxnet)
                 if IP(opt_brxnet).iptype() is 'PUBLIC':
                     raise RuntimeError('is public')
-            except Exception as  e:  
+            except Exception as  e:
                 log.error("Invalid ip '{0}' {1}".format(opt_brxnet, e))
                 sys.exit(-1)
         else:

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -4,6 +4,7 @@ envlist =
     lint,
     fix,
     check,
+    api,
     run,
 skipsdist = true
 minversion = 2.9.1
@@ -40,6 +41,29 @@ setenv =
     WEBTEST_INTERACTIVE = false
 commands =
     pytest {posargs}
+
+[testenv:api]
+basepython = python3
+deps =
+    git+https://github.com/ceph/teuthology#egg=teuthology[test]
+    {[base]deps}
+    #{[base-test]deps}
+    #{[base-lint]deps}
+changedir = ../../../../build
+passenv =
+    PATH
+    CEPH_BUILD_ROOT
+    EC_PATH
+setenv =
+    PATH=./bin:{env:PATH}
+    LD_LIBRARY_PATH=./lib/cython_modules/lib.3/:./lib
+    PYTHONPATH = ./../qa
+    EC_PATH={env:EC_PATH:{env:CEPH_BUILD_ROOT}/lib64/ceph}
+whitelist_externals = *
+tests = tasks.mgr.dashboard.test_auth
+commands =
+    env
+    python ../qa/tasks/vstart_runner.py --create --ignore-missing-binaries {posargs:{[testenv:api]tests}}
 
 [testenv:run]
 basepython=python3


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/45828
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
