### PR TITLE
mgr/volumes/nfs: Check cluster exists before creating exports and fetch exports from export objects if mgr restarted

### DIFF
--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -73,6 +73,25 @@ Delete CephFS Export
 
 It deletes an export in cluster based on pseudo root name (binding).
 
+List CephFS Export
+==================
+
+.. code:: bash
+
+    $ ceph nfs export ls <clusterid> [--detailed]
+
+It lists export for a cluster. With detailed option enabled it shows entire
+export block.
+
+Get CephFS Export
+=================
+
+.. code:: bash
+
+    $ ceph nfs export get <clusterid> <binding>
+
+It displays export block for a cluster based on pseudo root name (binding).
+
 Configuring NFS-Ganesha to export CephFS with vstart
 ====================================================
 

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -45,6 +45,15 @@ Delete NFS Ganesha Cluster
 
 This deletes the deployed cluster.
 
+List NFS Ganesha Cluster
+========================
+
+.. code:: bash
+
+    $ ceph nfs cluster ls
+
+This lists deployed clusters.
+
 Create CephFS Export
 ====================
 

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -103,6 +103,10 @@ class TestNFS(MgrTestCase):
     def _delete_export(self):
         self._nfs_cmd('export', 'delete', self.cluster_id, self.pseudo_path)
 
+    def _test_list_export(self):
+        nfs_output = json.loads(self._nfs_cmd('export', 'ls', self.cluster_id))
+        self.assertIn(self.pseudo_path, nfs_output)
+
     def _check_export_obj_deleted(self, conf_obj=False):
         rados_obj_ls = self._sys_cmd(['rados', '-p', 'nfs-ganesha', '-N', self.cluster_id, 'ls'])
 
@@ -152,5 +156,5 @@ class TestNFS(MgrTestCase):
         self._unload_module("cephadm")
         self._load_module("cephadm")
         self._orch_cmd("set", "backend", "cephadm")
-        #Add list export command
+        self._test_list_export()
         self._delete_export()

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -185,3 +185,26 @@ class TestNFS(MgrTestCase):
         self._orch_cmd("set", "backend", "cephadm")
         self._test_list_export()
         self._delete_export()
+
+    def test_export_create_with_non_existing_fsname(self):
+        try:
+            fs_name = 'nfs-test'
+            self._test_create_cluster()
+            self._nfs_cmd('export', 'create', 'cephfs', fs_name, self.cluster_id, self.pseudo_path)
+            self.fail(f"Export created with non-existing filesystem {fs_name}")
+        except CommandFailedError as e:
+            # Command should fail for test to pass
+            if e.exitstatus != errno.ENOENT:
+                raise
+        finally:
+            self._test_delete_cluster()
+
+    def test_export_create_with_non_existing_clusterid(self):
+        try:
+            cluster_id = 'invalidtest'
+            self._nfs_cmd('export', 'create', 'cephfs', self.fs_name, cluster_id, self.pseudo_path)
+            self.fail(f"Export created with non-existing cluster id {cluster_id}")
+        except CommandFailedError as e:
+            # Command should fail for test to pass
+            if e.exitstatus != errno.ENOENT:
+                raise

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -78,6 +78,10 @@ class TestNFS(MgrTestCase):
             wait_time += 10
         self.fail("NFS Ganesha cluster could not be deleted")
 
+    def _test_list_cluster(self):
+        nfs_output = self._nfs_cmd('cluster', 'ls')
+        self.assertEqual(self.cluster_id, nfs_output)
+
     def _create_export(self, export_id, create_fs=False, extra_cmd=None):
         if create_fs:
             self._cmd('fs', 'volume', 'create', self.fs_name)
@@ -107,6 +111,7 @@ class TestNFS(MgrTestCase):
 
     def test_create_and_delete_cluster(self):
         self._test_create_cluster()
+        self._test_list_cluster()
         self._test_delete_cluster()
 
     def test_create_delete_cluster_idempotency(self):

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -140,3 +140,12 @@ class TestNFS(MgrTestCase):
         self._create_export(export_id='4', extra_cmd=[self.pseudo_path+'3', fs_path.strip()])
         self._test_delete_cluster()
         self._check_export_obj_deleted(conf_obj=True)
+
+    def test_exports_on_mgr_restart(self):
+        self._create_default_export()
+        # This will restart the mgr
+        self._unload_module("cephadm")
+        self._load_module("cephadm")
+        self._orch_cmd("set", "backend", "cephadm")
+        #Add list export command
+        self._delete_export()

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -10,6 +10,7 @@ from teuthology.exceptions import CommandFailedError
 log = logging.getLogger(__name__)
 
 
+# TODO Add test for cluster update when ganesha can be deployed on multiple ports.
 class TestNFS(MgrTestCase):
     def _cmd(self, *args):
         return self.mgr_cluster.mon_manager.raw_cluster_cmd(*args)

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -560,6 +560,19 @@ class FSExport(object):
 
         return 0, json.dumps(result, indent=2), ''
 
+    def get_export(self, cluster_id, pseudo_path):
+        if not f"ganesha-{cluster_id}" in available_clusters(self.mgr):
+            return -errno.ENOENT, "", f"NFS cluster '{cluster_id}' not found"
+        export_dict = {}
+        for export in self.exports[cluster_id]:
+            if export.pseudo == pseudo_path:
+                export_dict = export.to_dict()
+                break
+        if not export_dict:
+            return (-errno.ENOENT, "",
+                    f"export with pseudo path '{pseudo_path}' not found in NFS cluster '{cluster_id}'")
+        return 0, json.dumps(export_dict, indent=2), ''
+
     def make_rados_url(self, obj):
         if self.rados_namespace:
             return "rados://{}/{}/{}".format(self.rados_pool, self.rados_namespace, obj)

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -508,8 +508,8 @@ class FSExport(object):
                 return 0, "Successfully deleted export", ""
             return 0, "", "Export does not exist"
         except Exception as e:
-            log.warning("Failed to delete exports")
-            return -errno.EINVAL, "", str(e)
+            log.exception(f"Failed to delete {pseudo_path} export for {cluster_id}")
+            return getattr(e, 'errno', -1), "", str(e)
 
     def format_path(self, path):
         if path:
@@ -560,7 +560,7 @@ class FSExport(object):
                 return (0, json.dumps(result, indent=4), '')
             return 0, "", "Export already exists"
         except Exception as e:
-            log.warning("Failed to create exports")
+            log.exception(f"Failed to create {pseudo_path} export for {cluster_id}")
             return -errno.EINVAL, "", str(e)
 
     @export_cluster_checker
@@ -570,15 +570,16 @@ class FSExport(object):
     def delete_all_exports(self, cluster_id):
         try:
             export_list = list(self.exports[cluster_id])
-            self.rados_namespace = cluster_id
-            for export in export_list:
-               ret, out, err = self._delete_export(cluster_id=cluster_id, pseudo_path=None,
-                                                   export_obj=export)
-               if ret != 0:
-                   raise Exception(f"Failed to delete exports: {err} and {ret}")
-            log.info(f"All exports successfully deleted for cluster id: {cluster_id}")
         except KeyError:
             log.info("No exports to delete")
+            return
+        self.rados_namespace = cluster_id
+        for export in export_list:
+            ret, out, err = self._delete_export(cluster_id=cluster_id, pseudo_path=None,
+                                                export_obj=export)
+            if ret != 0:
+                raise Exception(f"Failed to delete exports: {err} and {ret}")
+        log.info(f"All exports successfully deleted for cluster id: {cluster_id}")
 
     @export_cluster_checker
     def list_exports(self, cluster_id, detailed):
@@ -592,8 +593,8 @@ class FSExport(object):
             log.warning(f"No exports to list for {cluster_id}")
             return 0, '', ''
         except Exception as e:
-            log.error(f"Failed to list exports for {cluster_id}")
-            return -errno.EINVAL, "", str(e)
+            log.exception(f"Failed to list exports for {cluster_id}")
+            return getattr(e, 'errno', -1), "", str(e)
 
     @export_cluster_checker
     def get_export(self, cluster_id, pseudo_path):
@@ -604,8 +605,8 @@ class FSExport(object):
             log.warning(f"No {pseudo_path} export to show for {cluster_id}")
             return 0, '', ''
         except Exception as e:
-            log.error(f"Failed to get {pseudo_path} export for {cluster_id}")
-            return -errno.EINVAL, "", str(e)
+            log.exception(f"Failed to get {pseudo_path} export for {cluster_id}")
+            return getattr(e, 'errno', -1), "", str(e)
 
 
 class NFSCluster:
@@ -670,8 +671,8 @@ class NFSCluster:
                 return 0, "NFS Cluster Created Successfully", ""
             return 0, "", f"{cluster_id} cluster already exists"
         except Exception as e:
-            log.warning("NFS Cluster could not be created")
-            return -errno.EINVAL, "", str(e)
+            log.exception(f"NFS Cluster {cluster_id} could not be created")
+            return getattr(e, 'errno', -1), "", str(e)
 
     @cluster_setter
     def update_nfs_cluster(self, cluster_id, placement):
@@ -681,8 +682,8 @@ class NFSCluster:
                 return 0, "NFS Cluster Updated Successfully", ""
             return -errno.ENOENT, "", "Cluster does not exist"
         except Exception as e:
-            log.warning("NFS Cluster could not be updated")
-            return -errno.EINVAL, "", str(e)
+            log.exception(f"NFS Cluster {cluster_id} could not be updated")
+            return getattr(e, 'errno', -1), "", str(e)
 
     @cluster_setter
     def delete_nfs_cluster(self, cluster_id):
@@ -698,12 +699,12 @@ class NFSCluster:
                 return 0, "NFS Cluster Deleted Successfully", ""
             return 0, "", "Cluster does not exist"
         except Exception as e:
-            log.warning("Failed to delete NFS Cluster")
-            return -errno.EINVAL, "", str(e)
+            log.exception(f"Failed to delete NFS Cluster {cluster_id}")
+            return getattr(e, 'errno', -1), "", str(e)
 
     def list_nfs_cluster(self):
         try:
             return 0, '\n'.join(available_clusters(self.mgr)), ""
         except Exception as e:
-            log.warning("Failed to list NFS Cluster")
-            return -errno.EINVAL, "", str(e)
+            log.exception("Failed to list NFS Cluster")
+            return getattr(e, 'errno', -1), "", str(e)

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -12,6 +12,7 @@ from .fs_util import create_pool
 
 log = logging.getLogger(__name__)
 
+
 def available_clusters(mgr):
     '''
     This method returns list of available cluster ids.
@@ -409,7 +410,7 @@ class FSExport(object):
         ret, out, err = self.mgr.check_mon_command({
             'prefix': 'auth get-or-create',
             'entity': 'client.{}'.format(entity),
-            'caps' : ['mon', 'allow r', 'osd', osd_cap, 'mds', 'allow rw path={}'.format(path)],
+            'caps': ['mon', 'allow r', 'osd', osd_cap, 'mds', 'allow rw path={}'.format(path)],
             'format': 'json',
             })
 
@@ -443,8 +444,8 @@ class FSExport(object):
                     raw_config = obj.read(size)
                     raw_config = raw_config.decode("utf-8")
                     log.debug("read export configuration from rados "
-                            "object %s/%s/%s:\n%s", self.rados_pool,
-                            rados_namespace, obj.key, raw_config)
+                              "object %s/%s/%s:\n%s", self.rados_pool,
+                              rados_namespace, obj.key, raw_config)
                     self.export_conf_objs.append(Export.from_export_block(
                         GaneshaConfParser(raw_config).parse()[0], rados_namespace))
 
@@ -480,8 +481,7 @@ class FSExport(object):
         common_conf = 'conf-nfs.ganesha-{}'.format(cluster_id)
         conf_blocks = {
                 'block_name': '%url',
-                'value': self._make_rados_url(
-                'export-{}'.format(ex_id))
+                'value': self._make_rados_url('export-{}'.format(ex_id))
                 }
         self._write_raw_config(conf_blocks, common_conf, True)
 
@@ -544,7 +544,7 @@ class FSExport(object):
                         'cluster_id': cluster_id,
                         'access_type': access_type,
                         'fsal': {"name": "CEPH", "user_id": user_id,
-                            "fs_name": fs_name, "sec_label_xattr": ""},
+                                 "fs_name": fs_name, "sec_label_xattr": ""},
                         'clients': []
                         }
                 export = Export.from_dict(ex_id, ex_dict)
@@ -662,7 +662,7 @@ class NFSCluster:
                 log.info(f"Pool Status: {out}")
 
                 self.mgr.check_mon_command({'prefix': 'osd pool application enable',
-                    'pool': self.pool_name, 'app': 'nfs'})
+                                            'pool': self.pool_name, 'app': 'nfs'})
 
             self.create_empty_rados_obj()
 

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -683,3 +683,10 @@ class NFSCluster:
         except Exception as e:
             log.warning("Failed to delete NFS Cluster")
             return -errno.EINVAL, "", str(e)
+
+    def list_nfs_cluster(self):
+        try:
+            return 0, '\n'.join(available_clusters(self.mgr)), ""
+        except Exception as e:
+            log.warning("Failed to list NFS Cluster")
+            return -errno.EINVAL, "", str(e)

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -316,7 +316,7 @@ class FSExport(object):
     def __init__(self, mgr, namespace=None):
         self.mgr = mgr
         self.rados_pool = 'nfs-ganesha'
-        self.rados_namespace = namespace #TODO check if cluster exists
+        self.rados_namespace = namespace
         self.exports = {}
 
         try:
@@ -450,9 +450,12 @@ class FSExport(object):
     def create_export(self, fs_name, cluster_id, pseudo_path, read_only, path):
         try:
             if not self.check_fs(fs_name):
-                return -errno.EINVAL,"", "Invalid CephFS name"
+                return -errno.ENOENT, "", f"filesystem {fs_name} not found"
 
-            #TODO Check if valid cluster
+            cluster_check = f"ganesha-{cluster_id}" in available_clusters(self.mgr)
+            if not cluster_check:
+                return -errno.ENOENT, "", "Cluster does not exists"
+
             if cluster_id not in self.exports:
                 self.exports[cluster_id] = []
 
@@ -554,7 +557,7 @@ class NFSCluster:
             log.info(f"Deleted object:{common_conf}")
 
     def _set_cluster_id(self, cluster_id):
-        self.cluster_id = "ganesha-%s" % cluster_id
+        self.cluster_id = f"ganesha-{cluster_id}"
 
     def _set_pool_namespace(self, cluster_id):
         self.pool_ns = cluster_id
@@ -604,7 +607,7 @@ class NFSCluster:
             if self.cluster_id in available_clusters(self.mgr):
                 self._call_orch_apply_nfs(placement)
                 return 0, "NFS Cluster Updated Successfully", ""
-            return -errno.EINVAL, "", "Cluster does not exist"
+            return -errno.ENOENT, "", "Cluster does not exist"
         except Exception as e:
             log.warning("NFS Cluster could not be updated")
             return -errno.EINVAL, "", str(e)

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -273,7 +273,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         {
             'cmd': 'nfs cluster create '
                    'name=type,type=CephString '
-                   'name=clusterid,type=CephString '
+                   'name=clusterid,type=CephString,goodchars=[A-Za-z0-9-_.] '
                    'name=placement,type=CephString,req=false ',
             'desc': "Create an NFS Cluster",
             'perm': 'rw'

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -305,6 +305,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'desc': "Deletes an NFS Cluster",
             'perm': 'rw'
         },
+        {
+            'cmd': 'nfs cluster ls ',
+            'desc': "List NFS Clusters",
+            'perm': 'r'
+        },
         # volume ls [recursive]
         # subvolume ls <volume>
         # volume authorize/deauthorize
@@ -517,3 +522,6 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     def _cmd_nfs_cluster_delete(self, inbuf, cmd):
         return self.nfs.delete_nfs_cluster(cluster_id=cmd['clusterid'])
+
+    def _cmd_nfs_cluster_ls(self, inbuf, cmd):
+        return self.nfs.list_nfs_cluster()

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -271,6 +271,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'perm': 'rw'
         },
         {
+            'cmd': 'nfs export ls '
+                   'name=clusterid,type=CephString '
+                   'name=detailed,type=CephBool,req=false ',
+            'desc': "List exports of a NFS cluster",
+            'perm': 'r'
+        },
+        {
             'cmd': 'nfs cluster create '
                    'name=type,type=CephString '
                    'name=clusterid,type=CephString,goodchars=[A-Za-z0-9-_.] '
@@ -487,6 +494,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     def _cmd_nfs_export_delete(self, inbuf, cmd):
         return self.fs_export.delete_export(cluster_id=cmd['attach'], pseudo_path=cmd['binding'])
+
+    def _cmd_nfs_export_ls(self, inbuf, cmd):
+        return self.fs_export.list_exports(cluster_id=cmd['clusterid'], detailed=cmd.get('detailed', False))
 
     def _cmd_nfs_cluster_create(self, inbuf, cmd):
         return self.nfs.create_nfs_cluster(cluster_id=cmd['clusterid'], export_type=cmd['type'],

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -278,6 +278,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'perm': 'r'
         },
         {
+            'cmd': 'nfs export get '
+                   'name=clusterid,type=CephString '
+                   'name=binding,type=CephString ',
+            'desc': "Fetch a export of a NFS cluster given the pseudo path/binding",
+            'perm': 'r'
+        },
+        {
             'cmd': 'nfs cluster create '
                    'name=type,type=CephString '
                    'name=clusterid,type=CephString,goodchars=[A-Za-z0-9-_.] '
@@ -497,6 +504,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     def _cmd_nfs_export_ls(self, inbuf, cmd):
         return self.fs_export.list_exports(cluster_id=cmd['clusterid'], detailed=cmd.get('detailed', False))
+
+    def _cmd_nfs_export_get(self, inbuf, cmd):
+        return self.fs_export.get_export(cluster_id=cmd['clusterid'], pseudo_path=cmd['binding'])
 
     def _cmd_nfs_cluster_create(self, inbuf, cmd):
         return self.nfs.create_nfs_cluster(cluster_id=cmd['clusterid'], export_type=cmd['type'],


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->
This patch series does the following changes:
* Restrict cluster id to only [A-Za-z0-9-_.] characters
* On restarting mgr, exports are fetched from export rados objects
* Check cluster availability in export command methods
* Add get export interface
* Add ls export interface
* Add nfs cluster ls interface
* Add idempotency test for nfs commands and all the new changes

Fixes: https://tracker.ceph.com/issues/45740
Fixes: https://tracker.ceph.com/issues/45744
Fixes: https://tracker.ceph.com/issues/45741
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
