### PR TITLE
mgr/dashboard: Add host labels in UI

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -88,4 +88,32 @@ describe('HostsComponent', () => {
       expect(spans[0].textContent).toBe(hostname);
     });
   }));
+
+  describe('getEditDisableDesc', () => {
+    it('should return message (not managed by Orchestrator)', () => {
+      component.selection.add({
+        sources: {
+          ceph: true,
+          orchestrator: false
+        }
+      });
+      expect(component.getEditDisableDesc(component.selection)).toBe(
+        'Host editing is disabled because the host is not managed by Orchestrator.'
+      );
+    });
+
+    it('should return undefined (no selection)', () => {
+      expect(component.getEditDisableDesc()).toBeUndefined();
+    });
+
+    it('should return undefined (managed by Orchestrator)', () => {
+      component.selection.add({
+        sources: {
+          ceph: false,
+          orchestrator: true
+        }
+      });
+      expect(component.getEditDisableDesc()).toBeUndefined();
+    });
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -103,7 +103,7 @@ describe('HostsComponent', () => {
     });
 
     it('should return undefined (no selection)', () => {
-      expect(component.getEditDisableDesc()).toBeUndefined();
+      expect(component.getEditDisableDesc(component.selection)).toBeUndefined();
     });
 
     it('should return undefined (managed by Orchestrator)', () => {
@@ -113,7 +113,7 @@ describe('HostsComponent', () => {
           orchestrator: true
         }
       });
-      expect(component.getEditDisableDesc()).toBeUndefined();
+      expect(component.getEditDisableDesc(component.selection)).toBeUndefined();
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -94,7 +94,7 @@ export class HostsComponent extends ListWithDetails implements OnInit {
         },
         disable: (selection: CdTableSelection) =>
           !selection.hasSingleSelection || !selection.first().sources.orchestrator,
-        disableDesc: () => this.getEditDisableDesc()
+        disableDesc: this.getEditDisableDesc.bind(this)
       },
       {
         name: this.actionLabels.DELETE,
@@ -189,12 +189,8 @@ export class HostsComponent extends ListWithDetails implements OnInit {
     });
   }
 
-  getEditDisableDesc(): string | undefined {
-    if (
-      this.selection &&
-      this.selection.hasSingleSelection &&
-      !this.selection.first().sources.orchestrator
-    ) {
+  getEditDisableDesc(selection: CdTableSelection): string | undefined {
+    if (selection && selection.hasSingleSelection && !selection.first().sources.orchestrator) {
       return this.i18n('Host editing is disabled because the host is not managed by Orchestrator.');
     }
     return undefined;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.ts
@@ -193,13 +193,15 @@ export class InventoryDevicesComponent implements OnInit, OnDestroy {
             name: 'duration',
             value: 300,
             required: true,
-            options: [
-              { text: this.i18n('1 minute'), value: 60 },
-              { text: this.i18n('2 minutes'), value: 120 },
-              { text: this.i18n('5 minutes'), value: 300 },
-              { text: this.i18n('10 minutes'), value: 600 },
-              { text: this.i18n('15 minutes'), value: 900 }
-            ]
+            typeConfig: {
+              options: [
+                { text: this.i18n('1 minute'), value: 60 },
+                { text: this.i18n('2 minutes'), value: 120 },
+                { text: this.i18n('5 minutes'), value: 300 },
+                { text: this.i18n('10 minutes'), value: 600 },
+                { text: this.i18n('15 minutes'), value: 900 }
+              ]
+            }
           }
         ],
         submitButtonText: this.i18n('Execute'),

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.spec.ts
@@ -42,4 +42,11 @@ describe('HostService', () => {
     const req = httpTesting.expectOne(`api/host/${hostname}/devices`);
     expect(req.request.method).toBe('GET');
   });
+
+  it('should update host', fakeAsync(() => {
+    service.update('mon0', ['foo', 'bar']).subscribe();
+    const req = httpTesting.expectOne('api/host/mon0');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ labels: ['foo', 'bar'] });
+  }));
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.ts
@@ -42,4 +42,12 @@ export class HostService {
   getDaemons(hostname: string): Observable<Daemon[]> {
     return this.http.get<Daemon[]>(`${this.baseURL}/${hostname}/daemons`);
   }
+
+  getLabels(): Observable<string[]> {
+    return this.http.get<string[]>('ui-api/host/labels');
+  }
+
+  update(hostname: string, labels: string[]) {
+    return this.http.put(`${this.baseURL}/${hostname}`, { labels: labels });
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
@@ -13,6 +13,7 @@
           <div class="form-group row cd-{{field.name}}-form-group">
             <label *ngIf="field.label"
                    class="cd-col-form-label"
+                   [ngClass]="{'required': field?.required === true}"
                    [for]="field.name">
               {{ field.label }}
             </label>
@@ -34,15 +35,22 @@
                       class="form-control custom-select"
                       [id]="field.name"
                       [formControlName]="field.name">
-                <option *ngIf="field.placeholder"
+                <option *ngIf="field?.typeConfig?.placeholder"
                         [ngValue]="null">
-                  {{ field.placeholder }}
+                  {{ field?.typeConfig?.placeholder }}
                 </option>
-                <option *ngFor="let option of field.options"
+                <option *ngFor="let option of field?.typeConfig?.options"
                         [value]="option.value">
                   {{ option.text }}
                 </option>
               </select>
+              <cd-select-badges *ngIf="field.type === 'select-badges'"
+                                [id]="field.name"
+                                [data]="field.value"
+                                [customBadges]="field?.typeConfig?.customBadges"
+                                [options]="field?.typeConfig?.options"
+                                [messages]="field?.typeConfig?.messages">
+              </cd-select-badges>
               <span *ngIf="formGroup.showError(field.name, formDir)"
                     class="invalid-feedback">
                 {{ getError(field) }}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/select/select.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/select/select.component.html
@@ -63,16 +63,16 @@
 <a class="select-menu-edit float-left"
    [ngClass]="elemClass"
    [ngbPopover]="popTemplate"
-   *ngIf="options.length > 0">
+   *ngIf="customBadges || options.length > 0">
   <ng-content></ng-content>
 </a>
 
 <span class="form-text text-muted float-left"
-      *ngIf="data.length === 0 && options.length > 0">
+      *ngIf="data.length === 0 && !(!customBadges && options.length === 0)">
   {{ messages.empty }}
 </span>
 
 <span class="form-text text-muted  float-left"
-      *ngIf="options.length === 0">
+      *ngIf="!customBadges && options.length === 0">
   {{ messages.noOptions }}
 </span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-actions/table-actions.component.ts
@@ -146,6 +146,6 @@ export class TableActionsComponent implements OnInit {
   }
 
   useDisableDesc(action: CdTableAction) {
-    return action.disableDesc && action.disableDesc();
+    return action.disableDesc && action.disableDesc(this.selection);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-form-modal-field-config.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-form-modal-field-config.ts
@@ -1,19 +1,32 @@
 import { ValidatorFn } from '@angular/forms';
 
 export class CdFormModalFieldConfig {
+  // --- Generic field properties ---
   name: string;
   // 'binary' will use cdDimlessBinary directive on input element
   // 'select' will use select element
-  type: 'number' | 'text' | 'binary' | 'select';
+  type: 'number' | 'text' | 'binary' | 'select' | 'select-badges';
   label?: string;
   required?: boolean;
   value?: any;
   errors?: { [errorName: string]: string };
   validators: ValidatorFn[];
-  // only for type select
-  placeholder?: string;
-  options?: Array<{
-    text: string;
-    value: any;
-  }>;
+
+  // --- Specific field properties ---
+  typeConfig?: {
+    [prop: string]: any;
+    // 'select':
+    // ---------
+    // placeholder?: string;
+    // options?: Array<{
+    //   text: string;
+    //   value: any;
+    // }>;
+    //
+    // 'select-badges':
+    // ----------------
+    // customBadges: boolean;
+    // options: Array<SelectOption>;
+    // messages: SelectMessages;
+  };
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-table-action.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-table-action.ts
@@ -29,7 +29,7 @@ export class CdTableAction {
    * disabled. The specified message will be shown to the user as a button
    * tooltip.
    */
-  disableDesc?: Function;
+  disableDesc?: (_: CdTableSelection) => string | undefined;
 
   /**
    * Defines if the button can become 'primary' (displayed as button and not

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -66,6 +66,14 @@ class HostManger(ResourceManager):
     def remove(self, hostname: str):
         return self.api.remove_host(hostname)
 
+    @wait_api_result
+    def add_label(self, host: str, label: str) -> Completion:
+        return self.api.add_host_label(host, label)
+
+    @wait_api_result
+    def remove_label(self, host: str, label: str) -> Completion:
+        return self.api.remove_host_label(host, label)
+
 
 class InventoryManager(ResourceManager):
     @wait_api_result

--- a/src/pybind/mgr/dashboard/tests/test_host.py
+++ b/src/pybind/mgr/dashboard/tests/test_host.py
@@ -8,7 +8,7 @@ except ImportError:
 from orchestrator import HostSpec
 
 from . import ControllerTestCase
-from ..controllers.host import get_hosts, Host
+from ..controllers.host import get_hosts, Host, HostUi
 from .. import mgr
 
 
@@ -23,26 +23,25 @@ class HostControllerTest(ControllerTestCase):
 
     @mock.patch('dashboard.controllers.host.get_hosts')
     def test_host_list(self, mock_get_hosts):
-        hosts = [
-            {
-                'hostname': 'host-0',
-                'sources': {
-                    'ceph': True, 'orchestrator': False
-                }
-            },
-            {
-                'hostname': 'host-1',
-                'sources': {
-                    'ceph': False, 'orchestrator': True
-                }
-            },
-            {
-                'hostname': 'host-2',
-                'sources': {
-                    'ceph': True, 'orchestrator': True
-                }
+        hosts = [{
+            'hostname': 'host-0',
+            'sources': {
+                'ceph': True,
+                'orchestrator': False
             }
-        ]
+        }, {
+            'hostname': 'host-1',
+            'sources': {
+                'ceph': False,
+                'orchestrator': True
+            }
+        }, {
+            'hostname': 'host-2',
+            'sources': {
+                'ceph': True,
+                'orchestrator': True
+            }
+        }]
 
         def _get_hosts(from_ceph=True, from_orchestrator=True):
             _hosts = []
@@ -52,6 +51,7 @@ class HostControllerTest(ControllerTestCase):
                 _hosts.append(hosts[1])
                 _hosts.append(hosts[2])
             return _hosts
+
         mock_get_hosts.side_effect = _get_hosts
 
         self._get(self.URL_HOST)
@@ -70,25 +70,118 @@ class HostControllerTest(ControllerTestCase):
         self.assertStatus(200)
         self.assertJsonBody(hosts)
 
+    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    def test_get_1(self, instance):
+        mgr.list_servers.return_value = []
 
-class TestHosts(unittest.TestCase):
+        fake_client = mock.Mock()
+        fake_client.available.return_value = False
+        instance.return_value = fake_client
+
+        self._get('{}/node1'.format(self.URL_HOST))
+        self.assertStatus(404)
 
     @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
-    def test_get_hosts(self, instance):
-        mgr.list_servers.return_value = [{'hostname': 'node1'}, {'hostname': 'localhost'}]
+    def test_get_2(self, instance):
+        mgr.list_servers.return_value = [{'hostname': 'node1'}]
+
+        fake_client = mock.Mock()
+        fake_client.available.return_value = False
+        instance.return_value = fake_client
+
+        self._get('{}/node1'.format(self.URL_HOST))
+        self.assertStatus(200)
+        self.assertIn('labels', self.json_body())
+
+    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    def test_get_3(self, instance):
+        mgr.list_servers.return_value = []
+
+        fake_client = mock.Mock()
+        fake_client.available.return_value = True
+        fake_client.hosts.list.return_value = [HostSpec('node1')]
+        instance.return_value = fake_client
+
+        self._get('{}/node1'.format(self.URL_HOST))
+        self.assertStatus(200)
+        self.assertIn('labels', self.json_body())
+
+    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    def test_set_labels(self, instance):
+        mgr.list_servers.return_value = []
 
         fake_client = mock.Mock()
         fake_client.available.return_value = True
         fake_client.hosts.list.return_value = [
-            HostSpec('node1'), HostSpec('node2')]
+            HostSpec('node0', labels=['aaa', 'bbb'])
+        ]
+        fake_client.hosts.remove_label = mock.Mock()
+        fake_client.hosts.add_label = mock.Mock()
+        instance.return_value = fake_client
+
+        self._put('{}/node0'.format(self.URL_HOST), {'labels': ['bbb', 'ccc']})
+        self.assertStatus(200)
+        fake_client.hosts.remove_label.assert_called_once_with('node0', 'aaa')
+        fake_client.hosts.add_label.assert_called_once_with('node0', 'ccc')
+
+
+class HostUiControllerTest(ControllerTestCase):
+    URL_HOST = '/ui-api/host'
+
+    @classmethod
+    def setup_server(cls):
+        # pylint: disable=protected-access
+        HostUi._cp_config['tools.authenticate.on'] = False
+        cls.setup_controllers([HostUi])
+
+    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    def test_labels(self, instance):
+        fake_client = mock.Mock()
+        fake_client.available.return_value = True
+        fake_client.hosts.list.return_value = [
+            HostSpec('node1', labels=['foo']),
+            HostSpec('node2', labels=['foo', 'bar'])
+        ]
+        instance.return_value = fake_client
+
+        self._get('{}/labels'.format(self.URL_HOST))
+        self.assertStatus(200)
+        labels = self.json_body()
+        labels.sort()
+        self.assertListEqual(labels, ['bar', 'foo'])
+
+
+class TestHosts(unittest.TestCase):
+    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    def test_get_hosts(self, instance):
+        mgr.list_servers.return_value = [{
+            'hostname': 'node1'
+        }, {
+            'hostname': 'localhost'
+        }]
+
+        fake_client = mock.Mock()
+        fake_client.available.return_value = True
+        fake_client.hosts.list.return_value = [
+            HostSpec('node1'), HostSpec('node2')
+        ]
         instance.return_value = fake_client
 
         hosts = get_hosts()
         self.assertEqual(len(hosts), 3)
         check_sources = {
-            'localhost': {'ceph': True, 'orchestrator': False},
-            'node1': {'ceph': True, 'orchestrator': True},
-            'node2': {'ceph': False, 'orchestrator': True}
+            'localhost': {
+                'ceph': True,
+                'orchestrator': False
+            },
+            'node1': {
+                'ceph': True,
+                'orchestrator': True
+            },
+            'node2': {
+                'ceph': False,
+                'orchestrator': True
+            }
         }
         for host in hosts:
             hostname = host['hostname']


### PR DESCRIPTION
![Peek 2020-06-05 18-11](https://user-images.githubusercontent.com/1897962/83899071-1d5fce00-a758-11ea-889e-83ad1a501869.gif)

Fixes: https://tracker.ceph.com/issues/45897

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
