### PR TITLE
client: Fix incorrect tracking of caps per session by the client

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4150,6 +4150,7 @@ void Client::remove_cap(Cap *cap, bool queue_release)
   }
   size_t n = in.caps.erase(mds);
   ceph_assert(n == 1);
+  cap->remove_cap_item();
   cap = nullptr;
 
   if (!in.is_any_caps()) {

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -40,12 +40,16 @@ public:
     s->caps.push_back(&cap_item);
   }
   ~Cap() {
-    cap_item.remove_myself();
+    remove_cap_item();
   }
 
   void touch(void) {
     // move to back of LRU
     session->caps.push_back(&cap_item);
+  }
+
+  void remove_cap_item(void) {
+    cap_item.remove_myself();
   }
 
   void dump(Formatter *f) const;


### PR DESCRIPTION
When a cap is removed via Client::remove_cap(), the cap is set to nullptr but that does not mean that it is removed from session->caps. As of now the cap is removed from session->caps only when the destructor of Cap is called and this happens when the inode is deleted (i.e during trimming of inode).

Ideally we should remove the cap structure from the session->caps list whenever remove_cap() is called.

Fixes: https://tracker.ceph.com/issues/45749
Signed-off-by: Sidharth Anupkrishnan <sanupkri@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
