### PR TITLE
mimic: ceph-mgr's finisher queue can grow indefinitely, making python modules/commands unresponsive

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -310,7 +310,7 @@ PyObject *ActivePyModules::get_python(const std::string &what)
     PyFormatter f;
     cluster_state.with_pgmap(
         [&f](const PGMap &pg_map) {
-      pg_map.dump_osd_stats(&f);
+      pg_map.dump_osd_stats(&f, false);
     });
     return f.get();
   } else if (what == "osd_pool_stats") {

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1435,7 +1435,7 @@ void PGMap::dump_pool_stats(Formatter *f) const
   f->close_section();
 }
 
-void PGMap::dump_osd_stats(Formatter *f) const
+void PGMap::dump_osd_stats(ceph::Formatter *f, bool with_net) const
 {
   f->open_array_section("osd_stats");
   for (auto q = osd_stat.begin();
@@ -1443,7 +1443,7 @@ void PGMap::dump_osd_stats(Formatter *f) const
        ++q) {
     f->open_object_section("osd_stat");
     f->dump_int("osd", q->first);
-    q->second.dump(f);
+    q->second.dump(f, with_net);
     f->close_section();
   }
   f->close_section();

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -400,7 +400,7 @@ public:
   void dump_basic(Formatter *f) const;
   void dump_pg_stats(Formatter *f, bool brief) const;
   void dump_pool_stats(Formatter *f) const;
-  void dump_osd_stats(Formatter *f, bool with_net = true) const;
+  void dump_osd_stats(Formatter *f, bool with_net = false) const;
   void dump_delta(Formatter *f) const;
   void dump_filtered_pg_stats(Formatter *f, set<pg_t>& pgs) const;
   void dump_pool_stats_full(const OSDMap &osd_map, stringstream *ss,

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -400,7 +400,7 @@ public:
   void dump_basic(Formatter *f) const;
   void dump_pg_stats(Formatter *f, bool brief) const;
   void dump_pool_stats(Formatter *f) const;
-  void dump_osd_stats(Formatter *f) const;
+  void dump_osd_stats(Formatter *f, bool with_net = true) const;
   void dump_delta(Formatter *f) const;
   void dump_filtered_pg_stats(Formatter *f, set<pg_t>& pgs) const;
   void dump_pool_stats_full(const OSDMap &osd_map, stringstream *ss,

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -336,7 +336,7 @@ void objectstore_perf_stat_t::generate_test_instances(std::list<objectstore_perf
 }
 
 // -- osd_stat_t --
-void osd_stat_t::dump(Formatter *f) const
+void osd_stat_t::dump(Formatter *f, bool with_net) const
 {
   f->dump_unsigned("up_from", up_from);
   f->dump_unsigned("seq", seq);
@@ -359,6 +359,7 @@ void osd_stat_t::dump(Formatter *f) const
   f->open_object_section("perf_stat");
   os_perf_stat.dump(f);
   f->close_section();
+  if (with_net) {
   f->open_array_section("network_ping_times");
   for (auto &i : hb_pingtime) {
     f->open_object_section("entry");
@@ -414,6 +415,7 @@ void osd_stat_t::dump(Formatter *f) const
     f->close_section(); // entry
   }
   f->close_section(); // network_ping_time
+  }
 }
 
 void osd_stat_t::encode(bufferlist &bl, uint64_t features) const

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -973,7 +973,7 @@ struct osd_stat_t {
     num_pgs -= o.num_pgs;
   }
 
-  void dump(Formatter *f) const;
+  void dump(Formatter *f, bool with_net = true) const;
   void encode(bufferlist &bl, uint64_t features) const;
   void decode(bufferlist::iterator &bl);
   static void generate_test_instances(std::list<osd_stat_t*>& o);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43467

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
