### PR TITLE
octopus: rgw/url: fix amqp urls with vhosts

### DIFF
--- a/src/rgw/rgw_url.cc
+++ b/src/rgw/rgw_url.cc
@@ -14,32 +14,33 @@ namespace {
   const std::string schema_re = "([[:alpha:]]+:\\/\\/)";
   const std::string user_pass_re = "(([^:\\s]+):([^@\\s]+)@)?";
   const std::string host_port_re = "([[:alnum:].:-]+)";
+  const std::string vhost_re = "(/[[:print:]]+)?";
 }
 
 bool parse_url_authority(const std::string& url, std::string& host, std::string& user, std::string& password) {
-  const std::string re = schema_re + user_pass_re + host_port_re;
+  const std::string re = schema_re + user_pass_re + host_port_re + vhost_re;
   const std::regex url_regex(re, std::regex::icase);
   std::smatch url_match_result;
 
   if (std::regex_match(url, url_match_result, url_regex)) {
     host = url_match_result[HOST_GROUP_IDX];
-    user = url_match_result[USER_GROUP_IDX];  
+    user = url_match_result[USER_GROUP_IDX];
     password = url_match_result[PASSWORD_GROUP_IDX];
-	return true; 
+    return true;
   }
 
   return false;
 }
 
 bool parse_url_userinfo(const std::string& url, std::string& user, std::string& password) {
-  const std::string re = schema_re + user_pass_re + host_port_re;
+  const std::string re = schema_re + user_pass_re + host_port_re + vhost_re;
   const std::regex url_regex(re);
   std::smatch url_match_result;
 
   if (std::regex_match(url, url_match_result, url_regex)) {
-    user = url_match_result[USER_GROUP_IDX];  
+    user = url_match_result[USER_GROUP_IDX];
     password = url_match_result[PASSWORD_GROUP_IDX];
-	return true; 
+    return true;
   }
 
   return false;

--- a/src/rgw/rgw_url.cc
+++ b/src/rgw/rgw_url.cc
@@ -14,11 +14,11 @@ namespace {
   const std::string schema_re = "([[:alpha:]]+:\\/\\/)";
   const std::string user_pass_re = "(([^:\\s]+):([^@\\s]+)@)?";
   const std::string host_port_re = "([[:alnum:].:-]+)";
-  const std::string vhost_re = "(/[[:print:]]+)?";
+  const std::string path_re = "(/[[:print:]]+)?";
 }
 
 bool parse_url_authority(const std::string& url, std::string& host, std::string& user, std::string& password) {
-  const std::string re = schema_re + user_pass_re + host_port_re + vhost_re;
+  const std::string re = schema_re + user_pass_re + host_port_re + path_re;
   const std::regex url_regex(re, std::regex::icase);
   std::smatch url_match_result;
 
@@ -33,7 +33,7 @@ bool parse_url_authority(const std::string& url, std::string& host, std::string&
 }
 
 bool parse_url_userinfo(const std::string& url, std::string& user, std::string& password) {
-  const std::string re = schema_re + user_pass_re + host_port_re + vhost_re;
+  const std::string re = schema_re + user_pass_re + host_port_re + path_re;
   const std::regex url_regex(re);
   std::smatch url_match_result;
 

--- a/src/test/rgw/rgw_multi/tests_ps.py
+++ b/src/test/rgw/rgw_multi/tests_ps.py
@@ -840,7 +840,7 @@ def test_ps_s3_topic_on_master():
     delete_all_s3_topics(master_zone, zonegroup.name)
    
     # create s3 topics
-    endpoint_address = 'amqp://127.0.0.1:7001'
+    endpoint_address = 'amqp://127.0.0.1:7001/vhost_1'
     endpoint_args = 'push-endpoint='+endpoint_address+'&amqp-exchange=amqp.direct&amqp-ack-level=none'
     topic_conf1 = PSTopicS3(master_zone.conn, topic_name+'_1', zonegroup.name, endpoint_args=endpoint_args)
     topic_arn = topic_conf1.set_config()

--- a/src/test/rgw/test_rgw_url.cc
+++ b/src/test/rgw/test_rgw_url.cc
@@ -48,7 +48,7 @@ TEST(TestURL, AuthorityWithUserinfo)
     std::string host;
     std::string user;
     std::string password;
-    const std::string url = "http://user:password@example.com";
+    const std::string url = "https://user:password@example.com";
     ASSERT_TRUE(parse_url_authority(url, host, user, password));
     EXPECT_STREQ(host.c_str(), "example.com"); 
     EXPECT_STREQ(user.c_str(), "user"); 
@@ -86,5 +86,14 @@ TEST(TestURL, InvalidHost)
     std::string password;
     const std::string url = "http://exa_mple.com";
     ASSERT_FALSE(parse_url_authority(url, host, user, password));
+}
+
+TEST(TestURL, WithPath)
+{
+    std::string host;
+    std::string user;
+    std::string password;
+    const std::string url = "amqps://www.example.com:1234/vhost_name";
+    ASSERT_TRUE(parse_url_authority(url, host, user, password));
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45777

---

backport of https://github.com/ceph/ceph/pull/35128
parent tracker: https://tracker.ceph.com/issues/45269

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh