### PR TITLE
octopus: cls/rgw_gc: Clearing off urgent data in bufferlist, before

### DIFF
--- a/src/cls/queue/cls_queue_src.cc
+++ b/src/cls/queue/cls_queue_src.cc
@@ -25,6 +25,11 @@ int queue_write_head(cls_method_context_t hctx, cls_queue_head& head)
 
   bl.claim_append(bl_head);
 
+  if (bl.length() > head.max_head_size) {
+    CLS_LOG(0, "ERROR: queue_write_head: invalid head size = %u and urgent data size = %u \n", bl.length(), head.bl_urgent_data.length());
+    return -EINVAL;
+  }
+
   int ret = cls_cxx_write2(hctx, 0, bl.length(), &bl, CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
   if (ret < 0) {
     CLS_LOG(5, "ERROR: queue_write_head: failed to write head\n");

--- a/src/cls/rgw_gc/cls_rgw_gc.cc
+++ b/src/cls/rgw_gc/cls_rgw_gc.cc
@@ -361,7 +361,9 @@ static int cls_rgw_gc_queue_remove_entries(cls_method_context_t hctx, bufferlist
   }
 
   //Update urgent data map
+  head.bl_urgent_data.clear();
   encode(urgent_data, head.bl_urgent_data);
+  CLS_LOG(5, "INFO: cls_rgw_gc_queue_remove_entries(): Urgent data size is %u\n", head.bl_urgent_data.length());
 
   return queue_write_head(hctx, head);
 }

--- a/src/cls/rgw_gc/cls_rgw_gc.cc
+++ b/src/cls/rgw_gc/cls_rgw_gc.cc
@@ -363,7 +363,7 @@ static int cls_rgw_gc_queue_remove_entries(cls_method_context_t hctx, bufferlist
   //Update urgent data map
   head.bl_urgent_data.clear();
   encode(urgent_data, head.bl_urgent_data);
-  CLS_LOG(5, "INFO: cls_rgw_gc_queue_remove_entries(): Urgent data size is %u\n", head.bl_urgent_data.length());
+  CLS_LOG(5, "INFO: cls_rgw_gc_queue_remove_entries(): Urgent data size is %u\n", head.bl_urgent_data.length());
 
   return queue_write_head(hctx, head);
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45844

---

backport of https://github.com/ceph/ceph/pull/35264
parent tracker: https://tracker.ceph.com/issues/45412

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh