### PR TITLE
octopus: mgr/rbd_support: rename "rbd_trash_trash_purge_schedule" oid

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -38,3 +38,19 @@
   the cluster, which could fill a nearly-full cluster.  They have been
   replaced by a tool, currently considered experimental,
   ``rgw-orphan-list``.
+
+* RBD: The name of the rbd pool object that is used to store
+  rbd trash purge schedule is changed from "rbd_trash_trash_purge_schedule"
+  to "rbd_trash_purge_schedule". Users that have already started using
+  ``rbd trash purge schedule`` functionality and have per pool or namespace
+  schedules configured should copy "rbd_trash_trash_purge_schedule"
+  object to "rbd_trash_purge_schedule" before the upgrade and remove
+  "rbd_trash_purge_schedule" using the following commands in every RBD
+  pool and namespace where a trash purge schedule was previously
+  configured::
+
+    rados -p <pool-name> [-N namespace] cp rbd_trash_trash_purge_schedule rbd_trash_purge_schedule
+    rados -p <pool-name> [-N namespace] rm rbd_trash_trash_purge_schedule
+
+  or use any other convenient way to restore the schedule after the
+  upgrade.

--- a/src/pybind/mgr/rbd_support/trash_purge_schedule.py
+++ b/src/pybind/mgr/rbd_support/trash_purge_schedule.py
@@ -14,7 +14,7 @@ from .schedule import LevelSpec, Interval, StartTime, Schedule, Schedules
 
 class TrashPurgeScheduleHandler:
     MODULE_OPTION_NAME = "trash_purge_schedule"
-    SCHEDULE_OID = "rbd_trash_trash_purge_schedule"
+    SCHEDULE_OID = "rbd_trash_purge_schedule"
 
     lock = Lock()
     condition = Condition(lock)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45597

---

backport of https://github.com/ceph/ceph/pull/35108
parent tracker: https://tracker.ceph.com/issues/45589

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh