### PR TITLE
octopus: librbd: make rbd_read_from_replica_policy actually work

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -807,9 +807,9 @@ public:
       read_flags = 0;
       auto read_policy = config.get_val<std::string>("rbd_read_from_replica_policy");
       if (read_policy == "balance") {
-        read_flags |= CEPH_OSD_FLAG_BALANCE_READS;
+        read_flags |= librados::OPERATION_BALANCE_READS;
       } else if (read_policy == "localize") {
-        read_flags |= CEPH_OSD_FLAG_LOCALIZE_READS;
+        read_flags |= librados::OPERATION_LOCALIZE_READS;
       }
     }
 

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -136,7 +136,7 @@ namespace librbd {
     ceph::mutex async_ops_lock; // protects async_ops and async_requests
     ceph::mutex copyup_list_lock; // protects copyup_waiting_list
 
-    unsigned extra_read_flags;
+    unsigned extra_read_flags;  // librados::OPERATION_*
 
     bool old_format;
     uint8_t order;
@@ -208,7 +208,7 @@ namespace librbd {
     bool clone_copy_on_read;
     bool enable_alloc_hint;
     uint32_t alloc_hint_flags = 0U;
-    uint32_t read_flags = 0U;
+    uint32_t read_flags = 0U;  // librados::OPERATION_*
     uint32_t discard_granularity_bytes = 0;
     bool blkin_trace_all;
     uint64_t mirroring_replay_delay;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45799

---

backport of https://github.com/ceph/ceph/pull/35332
parent tracker: https://tracker.ceph.com/issues/45798

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh