### PR TITLE
octopus: rbd-mirror: stop local journal replayer first during shut down

### DIFF
--- a/src/test/rbd_mirror/image_replayer/journal/test_mock_Replayer.cc
+++ b/src/test/rbd_mirror/image_replayer/journal/test_mock_Replayer.cc
@@ -1088,12 +1088,14 @@ TEST_F(TestMockImageReplayerJournalReplayer, Replay) {
   EXPECT_CALL(mock_local_journal_replay, decode(_, _)).WillOnce(Return(0));
   expect_preprocess(mock_event_preprocessor, false, 0);
   expect_process(mock_local_journal_replay, 0, 0);
+  EXPECT_CALL(mock_replay_status_formatter, handle_entry_processed(_));
 
   // the next event with preprocess
   expect_try_pop_front(mock_remote_journaler, tag.tid, true);
   EXPECT_CALL(mock_local_journal_replay, decode(_, _)).WillOnce(Return(0));
   expect_preprocess(mock_event_preprocessor, true, 0);
   expect_process(mock_local_journal_replay, 0, 0);
+  EXPECT_CALL(mock_replay_status_formatter, handle_entry_processed(_));
 
   // attempt to process the next event
   C_SaferCond replay_ctx;
@@ -1249,6 +1251,7 @@ TEST_F(TestMockImageReplayerJournalReplayer, DelayedReplay) {
             ReturnArg<1>()));
   expect_preprocess(mock_event_preprocessor, false, 0);
   expect_process(mock_local_journal_replay, 0, 0);
+  EXPECT_CALL(mock_replay_status_formatter, handle_entry_processed(_));
 
   // attempt to process the next event
   C_SaferCond replay_ctx;
@@ -1830,6 +1833,7 @@ TEST_F(TestMockImageReplayerJournalReplayer, AllocateTagDemotion) {
   EXPECT_CALL(mock_local_journal_replay, decode(_, _)).WillOnce(Return(0));
   expect_preprocess(mock_event_preprocessor, false, 0);
   expect_process(mock_local_journal_replay, 0, 0);
+  EXPECT_CALL(mock_replay_status_formatter, handle_entry_processed(_));
 
   remote_replay_handler->handle_entries_available();
   wait_for_notification();
@@ -2017,6 +2021,7 @@ TEST_F(TestMockImageReplayerJournalReplayer, ProcessError) {
   EXPECT_CALL(mock_local_journal_replay, decode(_, _)).WillOnce(Return(0));
   expect_preprocess(mock_event_preprocessor, false, 0);
   expect_process(mock_local_journal_replay, 0, -EINVAL);
+  EXPECT_CALL(mock_replay_status_formatter, handle_entry_processed(_));
 
   // attempt to process the next event
   C_SaferCond replay_ctx;
@@ -2089,6 +2094,7 @@ TEST_F(TestMockImageReplayerJournalReplayer, ImageNameUpdated) {
   EXPECT_CALL(mock_local_journal_replay, decode(_, _)).WillOnce(Return(0));
   expect_preprocess(mock_event_preprocessor, false, 0);
   expect_process(mock_local_journal_replay, 0, 0);
+  EXPECT_CALL(mock_replay_status_formatter, handle_entry_processed(_));
 
   // attempt to process the next event
   C_SaferCond replay_ctx;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45885

---

backport of https://github.com/ceph/ceph/pull/35348
parent tracker: https://tracker.ceph.com/issues/45714

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh