### PR TITLE
octopus: qa: run install task only once

### DIFF
--- a/qa/suites/powercycle/osd/powercycle/default.yaml
+++ b/qa/suites/powercycle/osd/powercycle/default.yaml
@@ -1,8 +1,24 @@
 tasks:
 - install:
     extra_system_packages:
-      deb: ['bison', 'flex', 'libelf-dev', 'libssl-dev']
-      rpm: ['bison', 'flex', 'elfutils-libelf-devel', 'openssl-devel']
+      deb:
+      - bison
+      - flex
+      - libelf-dev
+      - libssl-dev
+      - libaio-dev
+      - libtool-bin
+      - uuid-dev
+      - xfslibs-dev
+      rpm:
+      - bison
+      - flex
+      - elfutils-libelf-devel
+      - openssl-devel
+      - libaio-devel
+      - libtool
+      - libuuid-devel
+      - xfsprogs-devel
 - ceph:
 - thrashosds:
     chance_down: 1.0

--- a/qa/suites/powercycle/osd/tasks/cfuse_workunit_suites_fsx.yaml
+++ b/qa/suites/powercycle/osd/tasks/cfuse_workunit_suites_fsx.yaml
@@ -1,17 +1,5 @@
 tasks:
 - ceph-fuse:
-- install:
-    extra_system_packages:
-      deb:
-      - libaio-dev
-      - libtool-bin
-      - uuid-dev
-      - xfslibs-dev
-      rpm:
-      - libaio-devel
-      - libtool
-      - libuuid-devel
-      - xfsprogs-devel
 - workunit:
     timeout: 6h
     clients:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45673

---

backport of https://github.com/ceph/ceph/pull/35140
parent tracker: https://tracker.ceph.com/issues/45612

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh