### PR TITLE
octopus: osd: make "missing incremental map" a debug log message

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1408,7 +1408,7 @@ MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
     if (get_inc_map_bl(e, bl)) {
       m->incremental_maps[e].claim(bl);
     } else {
-      derr << __func__ << " missing incremental map " << e << dendl;
+      dout(10) << __func__ << " missing incremental map " << e << dendl;
       if (!get_map_bl(e, bl)) {
 	derr << __func__ << " also missing full map " << e << dendl;
 	goto panic;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45775

---

backport of https://github.com/ceph/ceph/pull/35222
parent tracker: https://tracker.ceph.com/issues/45606

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh