### PR TITLE
octopus: cephfs: vstart_runner: set mounted to True at the end of mount()

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -866,6 +866,8 @@ class LocalFuseMount(FuseMount):
 
         self.gather_mount_info()
 
+        self.mounted = True
+
     def _run_python(self, pyscript, py_version='python'):
         """
         Override this to remove the daemon-helper prefix that is used otherwise


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45773

---

backport of https://github.com/ceph/ceph/pull/35267
parent tracker: https://tracker.ceph.com/issues/45723

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh