### PR TITLE
octopus: mds: cleanup uncommitted fragments before mds goes to active

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -12209,6 +12209,12 @@ void MDCache::rollback_uncommitted_fragment(dirfrag_t basedirfrag, frag_vec_t&& 
   }
 }
 
+void MDCache::wait_for_uncommitted_fragments(MDSGather *gather)
+{
+  for (auto& p : uncommitted_fragments)
+    p.second.waiters.push_back(gather->new_sub());
+}
+
 void MDCache::rollback_uncommitted_fragments()
 {
   dout(10) << "rollback_uncommitted_fragments: " << uncommitted_fragments.size() << " pending" << dendl;

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -872,12 +872,16 @@ class MDCache {
   void send_dentry_unlink(CDentry *dn, CDentry *straydn, MDRequestRef& mdr);
 
   void wait_for_uncommitted_fragment(dirfrag_t dirfrag, MDSContext *c) {
-    ceph_assert(uncommitted_fragments.count(dirfrag));
-    uncommitted_fragments[dirfrag].waiters.push_back(c);
+    uncommitted_fragments.at(dirfrag).waiters.push_back(c);
   }
+  bool is_any_uncommitted_fragment() const {
+    return !uncommitted_fragments.empty();
+  }
+  void wait_for_uncommitted_fragments(MDSGather *gather);
+  void rollback_uncommitted_fragments();
+
   void split_dir(CDir *dir, int byn);
   void merge_dir(CInode *diri, frag_t fg);
-  void rollback_uncommitted_fragments();
 
   void find_stale_fragment_freeze();
   void fragment_freeze_inc_num_waiters(CDir *dir);

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1890,6 +1890,14 @@ void MDSRank::rejoin_done()
   mdcache->show_subtrees();
   mdcache->show_cache();
 
+  if (mdcache->is_any_uncommitted_fragment()) {
+    dout(1) << " waiting for uncommitted fragments" << dendl;
+    MDSGatherBuilder gather(g_ceph_context, new C_MDS_VoidFn(this, &MDSRank::rejoin_done));
+    mdcache->wait_for_uncommitted_fragments(gather.get());
+    gather.activate();
+    return;
+  }
+
   // funny case: is our cache empty?  no subtrees?
   if (!mdcache->is_subtrees()) {
     if (whoami == 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45838

---

backport of https://github.com/ceph/ceph/pull/35234
parent tracker: https://tracker.ceph.com/issues/45699

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh