### PR TITLE
octopus: src/client/fuse_ll: compatible with libfuse3.5 or higher

### DIFF
--- a/cmake/modules/FindFUSE.cmake
+++ b/cmake/modules/FindFUSE.cmake
@@ -19,15 +19,6 @@ if(APPLE)
   list(APPEND fuse_suffixes osxfuse)
 endif()
 
-find_path(
-  FUSE_INCLUDE_DIR
-  NAMES fuse_common.h fuse_lowlevel.h fuse.h
-  PATH_SUFFIXES ${fuse_suffixes})
-
-find_library(FUSE_LIBRARIES
-  NAMES ${fuse_names}
-  PATHS /usr/local/lib64 /usr/local/lib)
-
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
   pkg_search_module(PKG_FUSE QUIET ${fuse_names})
@@ -36,7 +27,28 @@ if(PKG_CONFIG_FOUND)
     "\\1" FUSE_MAJOR_VERSION "${PKG_FUSE_VERSION}")
   string(REGEX REPLACE "([0-9]+)\.([0-9]+)\.([0-9]+)"
     "\\2" FUSE_MINOR_VERSION "${PKG_FUSE_VERSION}")
+
+  find_path(
+    FUSE_INCLUDE_DIR
+    NAMES fuse_common.h fuse_lowlevel.h fuse.h
+    HINTS ${PKG_FUSE_INCLUDE_DIRS}
+    PATH_SUFFIXES ${fuse_suffixes}
+    NO_DEFAULT_PATH)
+
+  find_library(FUSE_LIBRARIES
+    NAMES ${fuse_names}
+    HINTS ${PKG_FUSE_LIBDIR}
+    NO_DEFAULT_PATH)
 else()
+  find_path(
+    FUSE_INCLUDE_DIR
+    NAMES fuse_common.h fuse_lowlevel.h fuse.h
+    PATH_SUFFIXES ${fuse_suffixes})
+
+  find_library(FUSE_LIBRARIES
+    NAMES ${fuse_names}
+    PATHS /usr/local/lib64 /usr/local/lib)
+
   foreach(ver "MAJOR" "MINOR")
     file(STRINGS "${FUSE_INCLUDE_DIR}/fuse_common.h" fuse_ver_${ver}_line
       REGEX "^#define[\t ]+FUSE_${ver}_VERSION[\t ]+[0-9]+$")

--- a/cmake/modules/FindFUSE.cmake
+++ b/cmake/modules/FindFUSE.cmake
@@ -28,14 +28,25 @@ find_library(FUSE_LIBRARIES
   NAMES ${fuse_names}
   PATHS /usr/local/lib64 /usr/local/lib)
 
-foreach(ver "MAJOR" "MINOR")
-  file(STRINGS "${FUSE_INCLUDE_DIR}/fuse_common.h" fuse_ver_${ver}_line
-    REGEX "^#define[\t ]+FUSE_${ver}_VERSION[\t ]+[0-9]+$")
-  string(REGEX REPLACE ".*#define[\t ]+FUSE_${ver}_VERSION[\t ]+([0-9]+)$"
-    "\\1" FUSE_VERSION_${ver} "${fuse_ver_${ver}_line}")
-endforeach()
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_search_module(PKG_FUSE QUIET ${fuse_names})
+
+  string(REGEX REPLACE "([0-9]+)\.([0-9]+)\.([0-9]+)"
+    "\\1" FUSE_MAJOR_VERSION "${PKG_FUSE_VERSION}")
+  string(REGEX REPLACE "([0-9]+)\.([0-9]+)\.([0-9]+)"
+    "\\2" FUSE_MINOR_VERSION "${PKG_FUSE_VERSION}")
+else()
+  foreach(ver "MAJOR" "MINOR")
+    file(STRINGS "${FUSE_INCLUDE_DIR}/fuse_common.h" fuse_ver_${ver}_line
+      REGEX "^#define[\t ]+FUSE_${ver}_VERSION[\t ]+[0-9]+$")
+    string(REGEX REPLACE ".*#define[\t ]+FUSE_${ver}_VERSION[\t ]+([0-9]+)$"
+      "\\1" FUSE_${ver}_VERSION "${fuse_ver_${ver}_line}")
+  endforeach()
+endif()
+
 set(FUSE_VERSION
-  "${FUSE_VERSION_MAJOR}.${FUSE_VERSION_MINOR}")
+  "${FUSE_MAJOR_VERSION}.${FUSE_MINOR_VERSION}")
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(FUSE

--- a/fusetrace/fusetrace_ll.cc
+++ b/fusetrace/fusetrace_ll.cc
@@ -11,8 +11,6 @@
     gcc -Wall `pkg-config fuse --cflags --libs` -lulockmgr fusexmp_fh.c -o fusexmp_fh
 */
 
-#define FUSE_USE_VERSION 30
-
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -40,9 +40,8 @@
 #include <sys/types.h>
 #include <fcntl.h>
 
-#include <fuse.h>
-#include <fuse_lowlevel.h>
 #include "include/ceph_fuse.h"
+#include <fuse_lowlevel.h>
 
 #define dout_context g_ceph_context
 

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -42,6 +42,7 @@
 
 #include <fuse.h>
 #include <fuse_lowlevel.h>
+#include "include/ceph_fuse.h"
 
 #define dout_context g_ceph_context
 

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -641,7 +641,13 @@ static void fuse_ll_flush(fuse_req_t req, fuse_ino_t ino,
 }
 
 #ifdef FUSE_IOCTL_COMPAT
-static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino, int cmd, void *arg, struct fuse_file_info *fi,
+static void fuse_ll_ioctl(fuse_req_t req, fuse_ino_t ino,
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 5)
+                          unsigned int cmd,
+#else
+                          int cmd,
+#endif
+                          void *arg, struct fuse_file_info *fi,
 			  unsigned flags, const void *in_buf, size_t in_bufsz, size_t out_bufsz)
 {
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -34,6 +34,7 @@
 #include "common/config.h"
 #include "include/ceph_assert.h"
 #include "include/cephfs/ceph_ll_client.h"
+#include "include/ceph_fuse.h"
 
 #include "fuse_ll.h"
 #include <fuse.h>

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -37,7 +37,6 @@
 #include "include/ceph_fuse.h"
 
 #include "fuse_ll.h"
-#include <fuse.h>
 #include <fuse_lowlevel.h>
 
 #define dout_context g_ceph_context
@@ -1263,7 +1262,14 @@ int CephFuse::Handle::loop()
   auto fuse_multithreaded = client->cct->_conf.get_val<bool>(
     "fuse_multithreaded");
   if (fuse_multithreaded) {
-#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 1)
+    {
+      struct fuse_loop_config conf = { 0 };
+
+      conf.clone_fd = opts.clone_fd;
+      return fuse_session_loop_mt(se, &conf);
+    }
+#elif FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
     return fuse_session_loop_mt(se, opts.clone_fd);
 #else
     return fuse_session_loop_mt(se);

--- a/src/client/fuse_ll.h
+++ b/src/client/fuse_ll.h
@@ -12,8 +12,6 @@
  * 
  */
 
-#define FUSE_USE_VERSION 30
-
 class CephFuse {
 public:
   CephFuse(Client *c, int fd);

--- a/src/include/ceph_fuse.h
+++ b/src/include/ceph_fuse.h
@@ -14,7 +14,15 @@
 #ifndef CEPH_FUSE_H
 #define CEPH_FUSE_H
 
-#define FUSE_USE_VERSION 30
+/*
+ * The API version that we want to use, regardless of what the
+ * library version is. Note that this must be defined before
+ * fuse.h is included.
+ */
+#ifndef FUSE_USE_VERSION
+#define FUSE_USE_VERSION	35
+#endif
+
 #include <fuse.h>
 #include "acconfig.h"
 

--- a/src/include/ceph_fuse.h
+++ b/src/include/ceph_fuse.h
@@ -15,8 +15,19 @@
 #define CEPH_FUSE_H
 
 #define FUSE_USE_VERSION 30
-#include "acconfig.h"
 #include <fuse.h>
+#include "acconfig.h"
+
+/*
+ * Redefine the FUSE_VERSION macro defined in "fuse_common.h"
+ * header file, because the MINOR numner has been forgotten to
+ * update since libfuse 3.2 to 3.8. We need to fetch the MINOR
+ * number from pkgconfig file.
+ */
+#ifdef FUSE_VERSION
+#undef FUSE_VERSION
+#define FUSE_VERSION FUSE_MAKE_VERSION(CEPH_FUSE_MAJOR_VERSION, CEPH_FUSE_MINOR_VERSION)
+#endif
 
 static inline int filler_compat(fuse_fill_dir_t filler,
                                 void *buf, const char *name,

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -87,6 +87,12 @@
 /* Define if you have fuse */
 #cmakedefine HAVE_LIBFUSE
 
+/* Define version major */
+#define CEPH_FUSE_MAJOR_VERSION @FUSE_MAJOR_VERSION@
+
+/* Define version minor */
+#define CEPH_FUSE_MINOR_VERSION @FUSE_MINOR_VERSION@
+
 /* Define to 1 if you have libxfs */
 #cmakedefine HAVE_LIBXFS 1
 

--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -2,15 +2,13 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "include/compat.h"
+#include "include/ceph_fuse.h"
 #include "FuseStore.h"
 #include "os/ObjectStore.h"
 #include "include/stringify.h"
 #include "common/errno.h"
 
-#define FUSE_USE_VERSION 30
-#include <fuse.h>
 #include <fuse_lowlevel.h>
-#include "include/ceph_fuse.h"
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/rbd_fuse/rbd-fuse.cc
+++ b/src/rbd_fuse/rbd-fuse.cc
@@ -1,8 +1,6 @@
 /*
  * rbd-fuse
  */
-#define FUSE_USE_VERSION 30
-
 #include "include/int_types.h"
 
 #include <stdio.h>
@@ -11,7 +9,6 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <fuse.h>
 #include <pthread.h>
 #include <string.h>
 #include <sys/types.h>


### PR DESCRIPTION
backport trackers: 

* https://tracker.ceph.com/issues/45845
* https://tracker.ceph.com/issues/45941

---

backport of

* https://github.com/ceph/ceph/pull/34719
* https://github.com/ceph/ceph/pull/35368

parent trackers:

* https://tracker.ceph.com/issues/45396
* https://tracker.ceph.com/issues/45866

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh

---

To Do:

- [x] https://github.com/ceph/ceph/pull/35368 merged
- [x] https://github.com/ceph/ceph/pull/35368 cherry-picked into this PR