### PR TITLE
rpm, deb: Use /usr/libexec for libexecdir whenever possible

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -88,8 +88,6 @@
 %if 0%{?rhel} == 7
 %define __python %{__python3}
 %endif
-# unify libexec for all targets
-%global _libexecdir %{_exec_prefix}/lib
 
 # disable dwz which compresses the debuginfo
 %global _find_debuginfo_dwz_opts %{nil}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1198,6 +1198,7 @@ ${CMAKE} .. \
     -DCMAKE_INSTALL_MANDIR=%{_mandir} \
     -DCMAKE_INSTALL_DOCDIR=%{_docdir}/ceph \
     -DCMAKE_INSTALL_INCLUDEDIR=%{_includedir} \
+    -DCMAKE_INSTALL_SYSTEMD_SERVICEDIR=%{_unitdir} \
     -DWITH_MANPAGE=ON \
     -DWITH_PYTHON3=%{python3_version} \
     -DWITH_MGR_DASHBOARD_FRONTEND=OFF \

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1281,7 +1281,7 @@ install -m 0644 -D etc/sysconfig/ceph %{buildroot}%{_sysconfdir}/sysconfig/ceph
 install -m 0644 -D etc/sysconfig/ceph %{buildroot}%{_fillupdir}/sysconfig.%{name}
 %endif
 install -m 0644 -D systemd/ceph.tmpfiles.d %{buildroot}%{_tmpfilesdir}/ceph-common.conf
-install -m 0644 -D systemd/50-ceph.preset %{buildroot}%{_libexecdir}/systemd/system-preset/50-ceph.preset
+install -m 0644 -D systemd/50-ceph.preset %{buildroot}%{_presetdir}/50-ceph.preset
 mkdir -p %{buildroot}%{_sbindir}
 install -m 0644 -D src/logrotate.conf %{buildroot}%{_sysconfdir}/logrotate.d/ceph
 chmod 0644 %{buildroot}%{_docdir}/ceph/sample.ceph.conf
@@ -1363,7 +1363,7 @@ rm -rf %{buildroot}
 %{_bindir}/osdmaptool
 %{_bindir}/ceph-kvstore-tool
 %{_bindir}/ceph-run
-%{_libexecdir}/systemd/system-preset/50-ceph.preset
+%{_presetdir}/50-ceph.preset
 %{_sbindir}/ceph-create-keys
 %dir %{_libexecdir}/ceph
 %{_libexecdir}/ceph/ceph_common.sh

--- a/debian/ceph-base.install
+++ b/debian/ceph-base.install
@@ -7,7 +7,7 @@ usr/bin/crushtool
 usr/bin/monmaptool
 usr/bin/osdmaptool
 usr/bin/ceph-kvstore-tool
-usr/lib/ceph/ceph_common.sh
+usr/libexec/ceph/ceph_common.sh
 usr/lib/ceph/erasure-code/*
 usr/lib/rados-classes/*
 usr/sbin/ceph-create-keys

--- a/debian/ceph-osd.install
+++ b/debian/ceph-osd.install
@@ -9,7 +9,7 @@ usr/bin/ceph-objectstore-tool
 usr/bin/ceph-osdomap-tool
 usr/bin/${CEPH_OSD_BASENAME} => /usr/bin/ceph-osd
 usr/bin/ceph_objectstore_bench
-usr/lib/ceph/ceph-osd-prestart.sh
+usr/libexec/ceph/ceph-osd-prestart.sh
 usr/lib/libos_tp.so*
 usr/lib/libosd_tp.so*
 usr/sbin/ceph-volume

--- a/debian/control
+++ b/debian/control
@@ -99,7 +99,7 @@ Build-Depends: cmake (>= 3.5),
 # Make-Check   xmlstarlet,
                yasm [amd64],
                zlib1g-dev,
-Standards-Version: 3.9.3
+Standards-Version: 4.4.0
 
 Package: ceph
 Architecture: linux-any

--- a/debian/rules
+++ b/debian/rules
@@ -26,7 +26,7 @@ extraopts += -DWITH_SYSTEMD=ON -DCEPH_SYSTEMD_ENV_DIR=/etc/default
 extraopts += -DWITH_GRAFANA=ON
 # assumes that ceph is exmpt from multiarch support, so we override the libdir.
 extraopts += -DCMAKE_INSTALL_LIBDIR=/usr/lib
-extraopts += -DCMAKE_INSTALL_LIBEXECDIR=/usr/lib
+extraopts += -DCMAKE_INSTALL_LIBEXECDIR=/usr/libexec
 extraopts += -DCMAKE_INSTALL_SYSCONFDIR=/etc
 extraopts += -DCMAKE_INSTALL_SYSTEMD_SERVICEDIR=/lib/systemd/system
 ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))


### PR DESCRIPTION
All major distributions have aligned on /usr/libexec for libexecdir now.

Fedora has been using /usr/libexec since the beginning, and
openSUSE has accepted software installed into /usr/libexec since
September 2019 in openSUSE:Factory. openSUSE Leap 15.x still uses
/usr/lib for %_libexecdir, but the rest of the spec should handle the
change gracefully.

Debian has adopted FHS 3.0 with Debian Policy Standard version 4.4.0,
and now defaults to /usr/libexec for libexecdir as well. This is
present in Ubuntu 20.04 LTS, for example.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
