### PR TITLE
mgr/cephadm: Add k8s-style event system

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -136,6 +136,7 @@ class SpecStore():
                 'created': self.spec_created[spec.service_name()].strftime(DATEFMT),
             }, sort_keys=True),
         )
+        self.mgr.events.for_service(spec, OrchestratorEvent.INFO, 'service was created')
 
     def rm(self, service_name):
         # type: (str) -> bool

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Dict, List, Iterator, Optional, Any, Tuple, Se
 import orchestrator
 from ceph.deployment import inventory
 from ceph.deployment.service_spec import ServiceSpec
-from orchestrator import OrchestratorError, HostSpec
+from orchestrator import OrchestratorError, HostSpec, OrchestratorEvent
 
 if TYPE_CHECKING:
     from .module import CephadmOrchestrator
@@ -460,3 +460,56 @@ class HostCache():
         """
         return all((h in self.last_daemon_update or h in self.mgr.offline_hosts)
                    for h in self.get_hosts())
+
+
+class EventStore():
+    def __init__(self, mgr):
+        # type: (CephadmOrchestrator) -> None
+        self.mgr: CephadmOrchestrator = mgr
+        self.events = {} # type: Dict[str, List[OrchestratorEvent]]
+
+    def add(self, event: OrchestratorEvent) -> None:
+
+        if event.kind_subject() not in self.events:
+            self.events[event.kind_subject()] = [event]
+
+        for e in self.events[event.kind_subject()]:
+            if e.message == event.message:
+                return
+
+        self.events[event.kind_subject()].append(event)
+
+        # limit to five events for now.
+        self.events[event.kind_subject()] = self.events[event.kind_subject()][-5:]
+
+    def for_service(self, spec: ServiceSpec, level, message) -> None:
+        e = OrchestratorEvent(datetime.datetime.utcnow(), 'service', spec.service_name(), level, message)
+        self.add(e)
+
+    def for_daemon(self, daemon_name, level, message):
+        e = OrchestratorEvent(datetime.datetime.utcnow(), 'daemon', daemon_name, level, message)
+        self.add(e)
+
+    def cleanup(self) -> None:
+        # Needs to be properly done, in case events are persistently stored.
+
+        unknowns: List[str] = []
+        daemons = self.mgr.cache.get_daemon_names()
+        specs = self.mgr.spec_store.specs.keys()
+        for k_s, v in self.events.keys():
+            kind, subject = k_s.split(':')
+            if kind == 'service':
+                if subject not in specs:
+                    unknowns.append(k_s)
+            elif kind == 'daemon':
+                if subject not in daemons:
+                    unknowns.append(k_s)
+
+        for k_s in unknowns:
+            del self.events[k_s]
+
+    def get_for_service(self, name):
+        return self.events.get('service:' + name, [])
+
+    def get_for_daemon(self, name):
+        return self.events.get('daemon:' + name, [])

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -345,16 +345,16 @@ class HostCache():
         return r
 
     def get_daemons_with_volatile_status(self) -> Iterator[Tuple[str, Dict[str, orchestrator.DaemonDescription]]]:
-        for host, dm in self.daemons.items():
+        def alter(host, dd_orig: orchestrator.DaemonDescription) -> orchestrator.DaemonDescription:
+            dd = copy(dd_orig)
             if host in self.mgr.offline_hosts:
-                def set_offline(dd: orchestrator.DaemonDescription) -> orchestrator.DaemonDescription:
-                    ret = copy(dd)
-                    ret.status = -1
-                    ret.status_desc = 'host is offline'
-                    return ret
-                yield host, {name: set_offline(d) for name, d in dm.items()}
-            else:
-                yield host, dm
+                dd.status = -1
+                dd.status_desc = 'host is offline'
+            dd.events = self.mgr.events.get_for_daemon(dd.name())
+            return dd
+
+        for host, dm in self.daemons.items():
+            yield host, {name: alter(host, d) for name, d in dm.items()}
 
     def get_daemons_by_service(self, service_name):
         # type: (str) -> List[orchestrator.DaemonDescription]
@@ -497,7 +497,7 @@ class EventStore():
         unknowns: List[str] = []
         daemons = self.mgr.cache.get_daemon_names()
         specs = self.mgr.spec_store.specs.keys()
-        for k_s, v in self.events.keys():
+        for k_s, v in self.events.items():
             kind, subject = k_s.split(':')
             if kind == 'service':
                 if subject not in specs:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -43,7 +43,7 @@ from .services.osd import RemoveUtil, OSDRemoval, OSDService
 from .services.monitoring import GrafanaService, AlertmanagerService, PrometheusService, \
     NodeExporterService
 from .schedule import HostAssignment, HostPlacementSpec
-from .inventory import Inventory, SpecStore, HostCache
+from .inventory import Inventory, SpecStore, HostCache, EventStore
 from .upgrade import CEPH_UPGRADE_ORDER, CephadmUpgrade
 from .template import TemplateMgr
 
@@ -338,7 +338,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             if h not in self.inventory:
                 self.cache.rm_host(h)
 
+
         # in-memory only.
+        self.events = EventStore(self)
         self.offline_hosts: Set[str] = set()
 
         self.migration = Migrations(self)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1384,6 +1384,7 @@ you may want to run:
                         container_image_id=dd.container_image_id,
                         container_image_name=dd.container_image_name,
                         spec=spec,
+                        events=self.events.get_for_service(spec.service_name()),
                     )
                 if n in self.spec_store.specs:
                     if dd.daemon_type == 'osd':
@@ -1422,6 +1423,7 @@ you may want to run:
                 spec=spec,
                 size=spec.placement.get_host_selection_size(self.inventory.all_specs()),
                 running=0,
+                events=self.events.get_for_service(spec.service_name()),
             )
             if service_type == 'nfs':
                 spec = cast(NFSServiceSpec, spec)

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -133,9 +133,12 @@ class TestCephadm(object):
                     'service_id': 'r.z',
                     'service_name': 'rgw.r.z',
                     'service_type': 'rgw',
-                    'status': {'running': 0, 'size': 1}
+                    'status': {'running': 0, 'size': 1},
                 }
             ]
+            for o in out:
+                if 'events' in o:
+                    del o['events']  # delete it, as it contains a timestamp
             assert out == expected
             assert [ServiceDescription.from_json(o).to_json() for o in expected] == expected
 

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -92,12 +92,13 @@ class TestCephadm(object):
 
             c = cephadm_module.list_daemons()
 
-            def remove_id(dd):
+            def remove_id_events(dd):
                 out = dd.to_json()
                 del out['daemon_id']
+                del out['events']
                 return out
 
-            assert [remove_id(dd) for dd in wait(cephadm_module, c)] == [
+            assert [remove_id_events(dd) for dd in wait(cephadm_module, c)] == [
                 {
                     'daemon_type': 'mds',
                     'hostname': 'test',

--- a/src/pybind/mgr/orchestrator/__init__.py
+++ b/src/pybind/mgr/orchestrator/__init__.py
@@ -14,5 +14,6 @@ from ._interface import \
     OrchestratorValidationError, OrchestratorError, NoOrchestrator, \
     ServiceDescription, InventoryFilter, HostSpec, \
     DaemonDescription, \
+    OrchestratorEvent, \
     InventoryHost, DeviceLightLoc, \
     UpgradeStatusSpec

--- a/src/pybind/mgr/orchestrator/__init__.py
+++ b/src/pybind/mgr/orchestrator/__init__.py
@@ -14,6 +14,6 @@ from ._interface import \
     OrchestratorValidationError, OrchestratorError, NoOrchestrator, \
     ServiceDescription, InventoryFilter, HostSpec, \
     DaemonDescription, \
-    OrchestratorEvent, \
+    OrchestratorEvent, set_exception_subject, \
     InventoryHost, DeviceLightLoc, \
     UpgradeStatusSpec

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1222,7 +1222,9 @@ class DaemonDescription(object):
                  started=None,
                  last_configured=None,
                  osdspec_affinity=None,
-                 last_deployed=None):
+                 last_deployed=None,
+                 events: Optional[List['OrchestratorEvent']]=None):
+
         # Host is at the same granularity as InventoryHost
         self.hostname: str = hostname
 
@@ -1261,6 +1263,8 @@ class DaemonDescription(object):
 
         # Affinity to a certain OSDSpec
         self.osdspec_affinity = osdspec_affinity  # type: Optional[str]
+
+        self.events: List[OrchestratorEvent] = events or []
 
     def name(self):
         return '%s.%s' % (self.daemon_type, self.daemon_id)
@@ -1339,6 +1343,9 @@ class DaemonDescription(object):
             if getattr(self, k):
                 out[k] = getattr(self, k).strftime(DATEFMT)
 
+        if self.events:
+            out['events'] = [e.to_json() for e in self.events]
+
         empty = [k for k, v in out.items() if v is None]
         for e in empty:
             del out[e]
@@ -1348,11 +1355,13 @@ class DaemonDescription(object):
     @handle_type_error
     def from_json(cls, data):
         c = data.copy()
+        event_strs = c.pop('events', [])
         for k in ['last_refresh', 'created', 'started', 'last_deployed',
                   'last_configured']:
             if k in c:
                 c[k] = datetime.datetime.strptime(c[k], DATEFMT)
-        return cls(**c)
+        events = [OrchestratorEvent.from_json(e) for e in event_strs]
+        return cls(events=events, **c)
 
     def __copy__(self):
         # feel free to change this:
@@ -1387,7 +1396,8 @@ class ServiceDescription(object):
                  last_refresh=None,
                  created=None,
                  size=0,
-                 running=0):
+                 running=0,
+                 events: Optional[List['OrchestratorEvent']]=None):
         # Not everyone runs in containers, but enough people do to
         # justify having the container_image_id (image hash) and container_image
         # (image name)
@@ -1414,6 +1424,8 @@ class ServiceDescription(object):
 
         self.spec: ServiceSpec = spec
 
+        self.events: List[OrchestratorEvent] = events or []
+
     def service_type(self):
         return self.spec.service_type
 
@@ -1430,13 +1442,15 @@ class ServiceDescription(object):
             'size': self.size,
             'running': self.running,
             'last_refresh': self.last_refresh,
-            'created': self.created
+            'created': self.created,
         }
         for k in ['last_refresh', 'created']:
             if getattr(self, k):
                 status[k] = getattr(self, k).strftime(DATEFMT)
         status = {k: v for (k, v) in status.items() if v is not None}
         out['status'] = status
+        if self.events:
+            out['events'] = [e.to_json() for e in self.events]
         return out
 
     @classmethod
@@ -1444,13 +1458,15 @@ class ServiceDescription(object):
     def from_json(cls, data: dict):
         c = data.copy()
         status = c.pop('status', {})
+        event_strs = c.pop('events', [])
         spec = ServiceSpec.from_json(c)
 
         c_status = status.copy()
         for k in ['last_refresh', 'created']:
             if k in c_status:
                 c_status[k] = datetime.datetime.strptime(c_status[k], DATEFMT)
-        return cls(spec=spec, **c_status)
+        events = [OrchestratorEvent.from_json(e) for e in event_strs]
+        return cls(spec=spec, events=events, **c_status)
 
     @staticmethod
     def yaml_representer(dumper: 'yaml.SafeDumper', data: 'DaemonDescription'):
@@ -1556,6 +1572,60 @@ class DeviceLightLoc(namedtuple('DeviceLightLoc', ['host', 'dev', 'path'])):
        See ``ceph osd metadata | jq '.[].device_ids'``
     """
     __slots__ = ()
+
+
+class OrchestratorEvent:
+    """
+    Similar to K8s Events.
+
+    Some form of "important" log message attached to something.
+    """
+    INFO = 'INFO'
+    ERROR = 'ERROR'
+    regex_v1 = re.compile(r'^([^ ]+) ([^:]+):([^ ]+) \[([^\]]+)\] "(.*)"$')
+
+    def __init__(self, created: Union[str, datetime.datetime], kind, subject, level, message):
+        if isinstance(created, str):
+            created = datetime.datetime.strptime(created, DATEFMT)
+        self.created: datetime.datetime = created
+
+        assert kind in "service daemon".split()
+        self.kind: str = kind
+
+        # service name, or daemon danem or something
+        self.subject: str = subject
+
+        # Events are not meant for debugging. debugs should end in the log.
+        assert level in "INFO ERROR".split()
+        self.level = level
+
+        self.message: str = message
+
+    __slots__ = ('created', 'kind', 'subject', 'level', 'message')
+
+    def kind_subject(self) -> str:
+        return f'{self.kind}:{self.subject}'
+
+    def to_json(self) -> str:
+        # Make a long list of events readable.
+        created = self.created.strftime(DATEFMT)
+        return f'{created} {self.kind_subject()} [{self.level}] "{self.message}"'
+
+
+    @classmethod
+    @handle_type_error
+    def from_json(cls, data) -> "OrchestratorEvent":
+        """
+        >>> OrchestratorEvent.from_json('''2020-06-10T10:20:25.691255 daemon:crash.ubuntu [INFO] "Deployed crash.ubuntu on host 'ubuntu'"''').to_json()
+        '2020-06-10T10:20:25.691255 daemon:crash.ubuntu [INFO] "Deployed crash.ubuntu on host \\'ubuntu\\'"'
+
+        :param data:
+        :return:
+        """
+        match = cls.regex_v1.match(data)
+        if match:
+            return cls(*match.groups())
+        raise ValueError(f'Unable to match: "{data}"')
 
 
 def _mk_orch_methods(cls):

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1278,14 +1278,14 @@ Usage:
             raise_if_exception(e1)
             assert False
         except ZeroDivisionError as e:
-            assert e.args == ('hello', 'world')
+            assert e.args == ('hello, world',)
 
         e2 = self.remote('selftest', 'remote_from_orchestrator_cli_self_test', "OrchestratorError")
         try:
             raise_if_exception(e2)
             assert False
         except OrchestratorError as e:
-            assert e.args == ('hello', 'world')
+            assert e.args == ('hello, world',)
 
         c = TrivialReadCompletion(result=True)
         assert c.has_result

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -250,6 +250,9 @@ daemon_id: ubuntu
 hostname: ubuntu
 status: 1
 status_desc: starting
+events:
+- 2020-06-10T10:08:22.933241 daemon:crash.ubuntu [INFO] "Deployed crash.ubuntu on
+  host 'ubuntu'"
 ---
 service_type: crash
 service_name: crash
@@ -262,6 +265,8 @@ status:
   last_refresh: '2020-06-10T10:57:40.715637'
   running: 1
   size: 1
+events:
+- 2020-06-10T10:37:31.139159 service:crash [INFO] "service was created"
 """
     types = (DaemonDescription, ServiceDescription)
 

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -431,11 +431,11 @@ class Module(MgrModule):
         import orchestrator
         if what == 'OrchestratorError':
             c = orchestrator.TrivialReadCompletion(result=None)
-            c.fail(orchestrator.OrchestratorError('hello', 'world'))
+            c.fail(orchestrator.OrchestratorError('hello, world'))
             return c
         elif what == "ZeroDivisionError":
             c = orchestrator.TrivialReadCompletion(result=None)
-            c.fail(ZeroDivisionError('hello', 'world'))
+            c.fail(ZeroDivisionError('hello, world'))
             return c
         assert False, repr(what)
 


### PR DESCRIPTION
**blocked by**

- [x] #35537

We're getting repeated complains that cephadm is not transparent. We still have not enough visibility of what cephadm is actually doing. 

Adding progress events is going to be complicated, as cephadm contains a declarative state and a loop that tries to make the reality match the configured state. Adding progress events requires some non-trivial bookkeeping, which I'm not willing to do by myself right now. 

Well, this is how kubernetes solve this problem? https://kubernetes.io/docs/tasks/debug-application-cluster/

Does this also work for us? Let's give it a try:

```
$ ceph orch ls --format yaml
events:
- 2020-06-06T23:23:46.910845 service:crash [INFO] "service was created"
placement:
  host_pattern: '*'
service_name: crash
service_type: crash
status:
  container_image_id: 74803e884bea289d2d2d3ebdf6d37cd560499e955595695b1390a89800f4e37a
  container_image_name: docker.io/ceph/daemon-base:latest-master-devel
  created: '2020-06-06T23:23:46.744005'
  last_refresh: '2020-06-06T23:23:57.109881'
  running: 1
  size: 1

$ ceph orch ps --format yaml
container_id: c804e5b26fdd
container_image_id: 74803e884bea289d2d2d3ebdf6d37cd560499e955595695b1390a89800f4e37a
container_image_name: docker.io/ceph/daemon-base:latest-master-devel
created: '2020-06-06T23:23:55.416572'
daemon_id: ubuntu
daemon_type: crash
events:
- 2020-06-06T23:23:55.634997 daemon:crash.ubuntu [INFO] "Deployed crash.ubuntu on
  host 'ubuntu'"
hostname: ubuntu
last_refresh: '2020-06-06T23:44:18.474924'
started: '2020-06-06T23:23:55.503624'
status: 1
status_desc: running
version: 16.0.0-901-g713ef3c

$ ceph orch apply --service_type node-exporter                                                                                                       
Scheduled node-exporter update...

$ ceph orch ls --format yaml                  
events:
- 2020-06-06T23:23:46.910845 service:crash [INFO] "service was created"
placement:
  host_pattern: '*'
service_name: crash
service_type: crash
status:
  container_image_id: 74803e884bea289d2d2d3ebdf6d37cd560499e955595695b1390a89800f4e37a
  container_image_name: docker.io/ceph/daemon-base:latest-master-devel
  created: '2020-06-06T23:23:46.744005'
  last_refresh: '2020-06-06T23:23:57.109881'
  running: 1
  size: 1
---
events:
- 2020-06-06T23:24:10.214343 service:node-exporter [INFO] "service was created"
- '2020-06-06T23:24:10.606714 service:node-exporter [ERROR] "cephadm exited with an
  error code: 1, stderr:INFO:cephadm:Deploy daemon node-exporter.ubuntu ...
  INFO:cephadm:Verifying port 9100 ...
  WARNING:cephadm:Cannot bind to IP 0.0.0.0 port 9100: [Errno 98] Address already
  in use
  ERROR: TCP Port(s) ''9100'' required for node-exporter is already in use"'
placement:
  host_pattern: '*'
service_name: node-exporter
service_type: node-exporter
status:
  running: 0
  size: 1
```

There are obviously many open questions. Some of them:

- [x] Is this a bad idea in general, and we should use HEALTH warnings **instead**?
- [ ] How to convert those events into a meaningful HEALTH warning? Especially clearing the warnings again will be interesting: When exactly is the port conflict solved?
- [x] How to properly present the events in a way that looks good?
- [ ] How to properly manage exceptions in `serve()`
- [x] Is storing lots of events in config-key a bad idea?
- [x] Are we going to overload config-key, if we generate events for all OSDs at once? How to avoid this?
- [ ] This needs testing obviously
- [x] The yaml representation is bad. how to show the events then?
- [x] store the events in memory only. 


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
