### PR TITLE
osdc: Add timeout to homeless session

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2349,6 +2349,12 @@ std::vector<Option> get_global_options() {
     .set_default(10.0)
     .set_description("Seconds before in-flight op is considered 'laggy' and we query mon for the latest OSDMap"),
 
+    Option("objecter_homeless_timeout", Option::TYPE_SECS, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("Timeout homeless session : Duration (in seconds) after which the op is cancelled")
+    .set_long_description("It will cancel the op associated with a homeless session after the specified duration. "
+                          "Homeless session means that there is no availiable osd in the PG to process the I/O"),
+
     Option("objecter_inflight_op_bytes", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
     .set_default(100_M)
     .set_description("Max in-flight data in bytes (both directions)"),

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1913,7 +1913,7 @@ public:
     std::variant<std::unique_ptr<OpComp>, fu2::unique_function<OpSig>,
 		 Context*> onfinish;
     uint64_t ontimeout = 0;
-
+    uint64_t on_noosd_timeout = 0;
     ceph_tid_t tid = 0;
     int attempts = 0;
 


### PR DESCRIPTION
There is no point in indefinitely waiting when all the osd's for an object are down. It is appropriate to cancel the op in such scenarios. Also, this tunable should be configurable from the ceph.conf as to enable or disable this feature.
Thanks to Biswajeet for the initial PR:
#https://github.com/ceph/ceph/pull/34365

Signed-off-by: Biswajeet <biswajeet.patra@flipkart.com>
Signed-off-by: Or Friedmann <ofriedma@redhat.com>