### PR TITLE
octopus: monitoring: fixing some issues in RBD detail dashboard

### DIFF
--- a/monitoring/grafana/dashboards/rbd-details.json
+++ b/monitoring/grafana/dashboards/rbd-details.json
@@ -27,7 +27,7 @@
       }
     ]
   },
-  "description": "Detailed Performance of RBD Images (IOPS/Latency)",
+  "description": "Detailed Performance of RBD Images (IOPS/Throughput/Latency)",
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
@@ -77,21 +77,21 @@
           "expr": "irate(ceph_rbd_write_ops{pool=\"$Pool\", image=\"$Image\"}[30s])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Write {{instance}}",
+          "legendFormat": "Write",
           "refId": "A"
         },
         {
           "expr": "irate(ceph_rbd_read_ops{pool=\"$Pool\", image=\"$Image\"}[30s])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Read {{instance}}",
+          "legendFormat": "Read",
           "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "IOPS Count",
+      "title": "IOPS",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -168,21 +168,21 @@
           "expr": "irate(ceph_rbd_write_bytes{pool=\"$Pool\", image=\"$Image\"}[30s])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Read {{instance}}",
+          "legendFormat": "Write",
           "refId": "A"
         },
         {
           "expr": "irate(ceph_rbd_read_bytes{pool=\"$Pool\", image=\"$Image\"}[30s])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Write {{instance}}",
+          "legendFormat": "Read",
           "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "IO Bytes per Second",
+      "title": "Throughput",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -259,21 +259,21 @@
           "expr": "irate(ceph_rbd_write_latency_sum{pool=\"$Pool\", image=\"$Image\"}[30s]) / irate(ceph_rbd_write_latency_count{pool=\"$Pool\", image=\"$Image\"}[30s])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Write Latency Sum",
+          "legendFormat": "Write",
           "refId": "A"
         },
         {
           "expr": "irate(ceph_rbd_read_latency_sum{pool=\"$Pool\", image=\"$Image\"}[30s]) / irate(ceph_rbd_read_latency_count{pool=\"$Pool\", image=\"$Image\"}[30s])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Read Latency Sum",
+          "legendFormat": "Read",
           "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Averange Latency",
+      "title": "Average Latency",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45836

---

backport of https://github.com/ceph/ceph/pull/35282
parent tracker: https://tracker.ceph.com/issues/45735

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh