### PR TITLE
mgr/dashboard: Use a unified quoting style across all UI elements

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-clients/cephfs-clients.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-clients/cephfs-clients.component.ts
@@ -82,7 +82,7 @@ export class CephfsClientsComponent implements OnInit {
         this.modalRef.hide();
         this.notificationService.show(
           NotificationType.success,
-          this.i18n('Evicted client "{{clientId}}"', { clientId: clientId })
+          this.i18n(`Evicted client '{{clientId}}'`, { clientId: clientId })
         );
       },
       () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
@@ -783,9 +783,9 @@ describe('CephfsDirectoriesComponent', () => {
 
         it('shows the right texts', () => {
           assert.quotaUpdateModalTexts(
-            "Update CephFS files quota for '/a/c/b'",
-            "The inherited files quota 10 from '/a' is the maximum value to be used.",
-            "Updated CephFS files quota for '/a/c/b'"
+            `Update CephFS files quota for '/a/c/b'`,
+            `The inherited files quota 10 from '/a' is the maximum value to be used.`,
+            `Updated CephFS files quota for '/a/c/b'`
           );
         });
       });
@@ -807,9 +807,9 @@ describe('CephfsDirectoriesComponent', () => {
 
         it('shows the right texts', () => {
           assert.quotaUpdateModalTexts(
-            "Update CephFS size quota for '/a/c/b'",
-            "The inherited size quota 1 KiB from '/a' is the maximum value to be used.",
-            "Updated CephFS size quota for '/a/c/b'"
+            `Update CephFS size quota for '/a/c/b'`,
+            `The inherited size quota 1 KiB from '/a' is the maximum value to be used.`,
+            `Updated CephFS size quota for '/a/c/b'`
           );
         });
       });
@@ -821,13 +821,13 @@ describe('CephfsDirectoriesComponent', () => {
           assert.quotaUpdateModalField('binary', 'Max size', 'max_bytes', 512, 1024);
         });
 
-        it("uses 'Set' action instead of 'Update' if the quota is not set (0)", () => {
+        it(`uses 'Set' action instead of 'Update' if the quota is not set (0)`, () => {
           mockLib.updateQuotaThroughModal('max_bytes', 0);
           mockLib.updateQuotaThroughModal('max_bytes', 200);
           assert.quotaUpdateModalTexts(
-            "Set CephFS size quota for '/a/c/b'",
-            "The inherited size quota 1 KiB from '/a' is the maximum value to be used.",
-            "Set CephFS size quota for '/a/c/b'"
+            `Set CephFS size quota for '/a/c/b'`,
+            `The inherited size quota 1 KiB from '/a' is the maximum value to be used.`,
+            `Set CephFS size quota for '/a/c/b'`
           );
         });
       });
@@ -847,9 +847,9 @@ describe('CephfsDirectoriesComponent', () => {
 
         it('shows the right texts', () => {
           assert.quotaUnsetModalTexts(
-            "Unset CephFS files quota for '/a/c/b'",
-            "Unset files quota 5 from '/a/c/b' in order to inherit files quota 10 from '/a'.",
-            "Unset CephFS files quota for '/a/c/b'"
+            `Unset CephFS files quota for '/a/c/b'`,
+            `Unset files quota 5 from '/a/c/b' in order to inherit files quota 10 from '/a'.`,
+            `Unset CephFS files quota for '/a/c/b'`
           );
         });
       });
@@ -867,9 +867,9 @@ describe('CephfsDirectoriesComponent', () => {
 
         it('shows the right texts', () => {
           assert.quotaUnsetModalTexts(
-            "Unset CephFS size quota for '/a/c/b'",
-            "Unset size quota 512 B from '/a/c/b' in order to inherit size quota 1 KiB from '/a'.",
-            "Unset CephFS size quota for '/a/c/b'"
+            `Unset CephFS size quota for '/a/c/b'`,
+            `Unset size quota 512 B from '/a/c/b' in order to inherit size quota 1 KiB from '/a'.`,
+            `Unset CephFS size quota for '/a/c/b'`
           );
         });
       });
@@ -879,19 +879,19 @@ describe('CephfsDirectoriesComponent', () => {
           mockLib.selectNode('/a');
           mockLib.unsetQuotaThroughModal('max_bytes');
           assert.quotaUnsetModalTexts(
-            "Unset CephFS size quota for '/a'",
-            "Unset size quota 1 KiB from '/a' in order to have no quota on the directory.",
-            "Unset CephFS size quota for '/a'"
+            `Unset CephFS size quota for '/a'`,
+            `Unset size quota 1 KiB from '/a' in order to have no quota on the directory.`,
+            `Unset CephFS size quota for '/a'`
           );
         });
 
         it('uses different Text if quota is already inherited', () => {
           mockLib.unsetQuotaThroughModal('max_bytes');
           assert.quotaUnsetModalTexts(
-            "Unset CephFS size quota for '/a/c/b'",
-            "Unset size quota 2 KiB from '/a/c/b' which isn't used because of the inheritance " +
-              "of size quota 1 KiB from '/a'.",
-            "Unset CephFS size quota for '/a/c/b'"
+            `Unset CephFS size quota for '/a/c/b'`,
+            `Unset size quota 2 KiB from '/a/c/b' which isn't used because of the inheritance ` +
+              `of size quota 1 KiB from '/a'.`,
+            `Unset CephFS size quota for '/a/c/b'`
           );
         });
       });
@@ -913,21 +913,21 @@ describe('CephfsDirectoriesComponent', () => {
       actions = component.quota.tableActions;
     });
 
-    it("shows 'Set' for empty and not set quotas", () => {
+    it(`shows 'Set' for empty and not set quotas`, () => {
       const isSetVisible = actions[0].visible;
       expect(isSetVisible(empty())).toBe(true);
       expect(isSetVisible(select(0))).toBe(true);
       expect(isSetVisible(select(1))).toBe(false);
     });
 
-    it("shows 'Update' for set quotas only", () => {
+    it(`shows 'Update' for set quotas only`, () => {
       const isUpdateVisible = actions[1].visible;
       expect(isUpdateVisible(empty())).toBeFalsy();
       expect(isUpdateVisible(select(0))).toBe(false);
       expect(isUpdateVisible(select(1))).toBe(true);
     });
 
-    it("only enables 'Unset' for set quotas only", () => {
+    it(`only enables 'Unset' for set quotas only`, () => {
       const isUnsetDisabled = actions[2].disable;
       expect(isUnsetDisabled(empty())).toBe(true);
       expect(isUnsetDisabled(select(0))).toBe(true);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.ts
@@ -434,7 +434,7 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
   }
 
   private getModalQuotaTitle(action: string, path: string): string {
-    return this.i18n("{{action}} CephFS {{quotaName}} quota for '{{path}}'", {
+    return this.i18n(`{{action}} CephFS {{quotaName}} quota for '{{path}}'`, {
       action,
       quotaName: this.getQuotaName(),
       path
@@ -450,7 +450,7 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
   }
 
   private getQuotaValueFromPathMsg(value: number, path: string): string {
-    return this.i18n("{{quotaName}} quota {{value}} from '{{path}}'", {
+    return this.i18n(`{{quotaName}} quota {{value}} from '{{path}}'`, {
       value: this.isBytesQuotaSelected() ? this.dimlessBinaryPipe.transform(value) : value,
       quotaName: this.getQuotaName(),
       path
@@ -526,7 +526,7 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
                 ? this.i18n('in order to inherit {{quotaValue}}', {
                     quotaValue: this.getQuotaValueFromPathMsg(nextMax.value, nextMax.path)
                   })
-                : this.i18n("which isn't used because of the inheritance of {{quotaValue}}", {
+                : this.i18n(`which isn't used because of the inheritance of {{quotaValue}}`, {
                     quotaValue: this.getQuotaValueFromPathMsg(nextMax.value, nextMax.path)
                   })
               : this.i18n('in order to have no quota on the directory')
@@ -556,7 +556,7 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
           this.cephfsService.mkSnapshot(this.id, path, values.name).subscribe((name) => {
             this.notificationService.show(
               NotificationType.success,
-              this.i18n('Created snapshot "{{name}}" for "{{path}}"', {
+              this.i18n(`Created snapshot '{{name}}' for '{{path}}'`, {
                 name: name,
                 path: path
               })
@@ -690,7 +690,7 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
       this.cephfsService.rmSnapshot(this.id, path, name).subscribe(() => {
         this.notificationService.show(
           NotificationType.success,
-          this.i18n('Deleted snapshot "{{name}}" for "{{path}}"', {
+          this.i18n(`Deleted snapshot '{{name}}' for '{{path}}'`, {
             name: name,
             path: path
           })

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.ts
@@ -129,7 +129,7 @@ export class MgrModuleFormComponent extends CdForm implements OnInit {
       () => {
         this.notificationService.show(
           NotificationType.success,
-          this.i18n('Updated options for module "{{name}}".', { name: this.moduleName })
+          this.i18n(`Updated options for module '{{name}}'.`, { name: this.moduleName })
         );
         this.goToListView();
       },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -418,7 +418,7 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
           this.osdService.update(selectedOsd.id, values.deviceClass).subscribe(() => {
             this.notificationService.show(
               NotificationType.success,
-              this.i18n('Updated OSD "{{id}}"', {
+              this.i18n(`Updated OSD '{{id}}'`, {
                 id: selectedOsd.id
               })
             );

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.ts
@@ -224,7 +224,7 @@ export class OsdRecvSpeedModalComponent implements OnInit {
       () => {
         this.notificationService.show(
           NotificationType.success,
-          this.i18n('Updated OSD recovery speed priority "{{value}}"', {
+          this.i18n(`Updated OSD recovery speed priority '{{value}}'`, {
             value: this.osdRecvSpeedForm.getValue('priority')
           })
         );

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
@@ -204,7 +204,7 @@ describe('RgwBucketFormComponent', () => {
       component.submit();
       expect(notificationService.show).toHaveBeenCalledWith(
         NotificationType.success,
-        'Created Object Gateway bucket ""'
+        `Created Object Gateway bucket ''`
       );
     });
 
@@ -215,7 +215,7 @@ describe('RgwBucketFormComponent', () => {
       component.submit();
       expect(notificationService.show).toHaveBeenCalledWith(
         NotificationType.success,
-        'Updated Object Gateway bucket "".'
+        `Updated Object Gateway bucket ''.`
       );
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
@@ -189,7 +189,7 @@ export class RgwBucketFormComponent extends CdForm implements OnInit {
           () => {
             this.notificationService.show(
               NotificationType.success,
-              this.i18n('Updated Object Gateway bucket "{{bid}}".', values)
+              this.i18n(`Updated Object Gateway bucket '{{bid}}'.`, values)
             );
             this.goToListView();
           },
@@ -215,7 +215,7 @@ export class RgwBucketFormComponent extends CdForm implements OnInit {
           () => {
             this.notificationService.show(
               NotificationType.success,
-              this.i18n('Created Object Gateway bucket "{{bid}}"', values)
+              this.i18n(`Created Object Gateway bucket '{{bid}}'`, values)
             );
             this.goToListView();
           },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
@@ -296,7 +296,7 @@ describe('RgwUserFormComponent', () => {
       component.onSubmit();
       expect(notificationService.show).toHaveBeenCalledWith(
         NotificationType.success,
-        'Created Object Gateway user ""'
+        `Created Object Gateway user ''`
       );
     });
 
@@ -307,7 +307,7 @@ describe('RgwUserFormComponent', () => {
       component.onSubmit();
       expect(notificationService.show).toHaveBeenCalledWith(
         NotificationType.success,
-        'Updated Object Gateway user ""'
+        `Updated Object Gateway user ''`
       );
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
@@ -250,12 +250,12 @@ export class RgwUserFormComponent extends CdForm implements OnInit {
         const args = this._getUpdateArgs();
         this.submitObservables.push(this.rgwUserService.update(uid, args));
       }
-      notificationTitle = this.i18n('Updated Object Gateway user "{{uid}}"', { uid: uid });
+      notificationTitle = this.i18n(`Updated Object Gateway user '{{uid}}'`, { uid: uid });
     } else {
       // Add
       const args = this._getCreateArgs();
       this.submitObservables.push(this.rgwUserService.create(args));
-      notificationTitle = this.i18n('Created Object Gateway user "{{uid}}"', { uid: uid });
+      notificationTitle = this.i18n(`Created Object Gateway user '{{uid}}'`, { uid: uid });
     }
     // Check if user quota has been modified.
     if (this._isUserQuotaDirty()) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
@@ -209,7 +209,7 @@ export class UserFormComponent extends CdForm implements OnInit {
       () => {
         this.notificationService.show(
           NotificationType.success,
-          this.i18n('Created user "{{username}}"', { username: userFormModel.username })
+          this.i18n(`Created user '{{username}}'`, { username: userFormModel.username })
         );
         this.router.navigate(['/user-management/users']);
       },
@@ -284,7 +284,7 @@ export class UserFormComponent extends CdForm implements OnInit {
         } else {
           this.notificationService.show(
             NotificationType.success,
-            this.i18n('Updated user "{{username}}"', { username: userFormModel.username })
+            this.i18n(`Updated user '{{username}}'`, { username: userFormModel.username })
           );
           this.router.navigate(['/user-management/users']);
         }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
@@ -137,7 +137,7 @@ export class UserListComponent implements OnInit {
         this.modalRef.hide();
         this.notificationService.show(
           NotificationType.success,
-          this.i18n('Deleted user "{{username}}"', { username: username })
+          this.i18n(`Deleted user '{{username}}'`, { username: username })
         );
       },
       () => {
@@ -152,8 +152,8 @@ export class UserListComponent implements OnInit {
     if (sessionUsername === username) {
       this.notificationService.show(
         NotificationType.error,
-        this.i18n('Failed to delete user "{{username}}"', { username: username }),
-        this.i18n('You are currently logged in as "{{username}}".', { username: username })
+        this.i18n(`Failed to delete user '{{username}}'`, { username: username }),
+        this.i18n(`You are currently logged in as '{{username}}'.`, { username: username })
       );
       return;
     }

--- a/src/pybind/mgr/dashboard/frontend/tslint.json
+++ b/src/pybind/mgr/dashboard/frontend/tslint.json
@@ -45,7 +45,7 @@
     "object-literal-sort-keys": false,
     "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],
     "prefer-const": true,
-    "quotemark": [true, "single", "avoid-escape"],
+    "quotemark": [true, "single"],
     "radix": true,
     "triple-equals": [true, "allow-null-check"],
     "typedef-whitespace": [


### PR DESCRIPTION
Use single quotes across all UI elements such as notifications

Fixes: https://tracker.ceph.com/issues/36070
Signed-off-by: Ishan Rai <ishanrai05@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
