### PR TITLE
rados: limiting quantity of shared lock

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -221,6 +221,11 @@ options:
   flags:
   - no_mon_update
   - startup
+- name: max_striper_locks_per_obj
+  type: uint
+  level: basic
+  desc: maximum number of an object can be locked by striper lock at the same time
+  default: 30
 - name: lockdep
   type: bool
   level: dev
@@ -1031,11 +1036,11 @@ options:
   level: advanced
   desc: Allowing compression when on-wire encryption is enabled
   long_desc: Combining encryption with compression reduces the level of security of
-    messages between peers. In case both encryption and compression are enabled, 
-    compression setting will be ignored and message will not be compressed. 
-    This behaviour can be override using this setting. 
+    messages between peers. In case both encryption and compression are enabled,
+    compression setting will be ignored and message will not be compressed.
+    This behaviour can be override using this setting.
   default: false
-  see_also: 
+  see_also:
   - ms_osd_compress_mode
   flags:
   - runtime
@@ -1495,11 +1500,11 @@ options:
 - name: mon_initial_members
   type: str
   level: advanced
-  fmt_desc: The IDs of initial monitors in a cluster during startup. If 
-    specified, Ceph requires an odd number of monitors to form an 
+  fmt_desc: The IDs of initial monitors in a cluster during startup. If
+    specified, Ceph requires an odd number of monitors to form an
     initial quorum (e.g., 3).
-  note: A *majority* of monitors in your cluster must be able to reach 
-    each other in order to establish a quorum. You can decrease the initial 
+  note: A *majority* of monitors in your cluster must be able to reach
+    each other in order to establish a quorum. You can decrease the initial
     number of monitors to establish a quorum with this setting.
   services:
   - mon
@@ -2466,13 +2471,13 @@ options:
   desc: number of PGs for new pools
   fmt_desc: The default number of placement groups for a pool. The default
     value is the same as ``pg_num`` with ``mkpool``.
-  long_desc: With default value of `osd_pool_default_pg_autoscale_mode` being 
-    `on` the number of PGs for new pools will start out with 1 pg, unless the 
+  long_desc: With default value of `osd_pool_default_pg_autoscale_mode` being
+    `on` the number of PGs for new pools will start out with 1 pg, unless the
     user specifies the pg_num.
   default: 32
   services:
   - mon
-  see_also: 
+  see_also:
   - osd_pool_default_pg_autoscale_mode
   flags:
   - runtime

--- a/src/test/librados/lock.cc
+++ b/src/test/librados/lock.cc
@@ -120,6 +120,20 @@ TEST_F(LibRadosLock, BreakLock) {
   ASSERT_EQ(0, rados_break_lock(ioctx, "foo", "TestLock8", clients, "Cookie"));
 }
 
+TEST_F(LibRadosLock, MaxSharedLock) {
+  char buf[128];
+  memset(buf, 0, sizeof(buf));
+  ASSERT_EQ(0, rados_conf_get(cluster, "max_shared_locks_per_obj", buf, sizeof(buf)));
+  auto max_locks = std::stoull(string(buf));
+
+  for (uint64_t i = 0; i < max_locks; i++) {
+    std::stringstream sstm;
+    sstm << "shared_lock_cookie_" << i;
+    ASSERT_EQ(0, rados_lock_shared(ioctx, "foo", "TestLock9", sstm.str().c_str(), "Tag", "", NULL, 0));
+  }
+  ASSERT_EQ(-EBUSY, rados_lock_shared(ioctx, "foo", "TestLock9", "busy_shared_lock_cookie", "Tag", "", NULL, 0));
+}
+
 // EC testing
 TEST_F(LibRadosLockEC, LockExclusive) {
   ASSERT_EQ(0, rados_lock_exclusive(ioctx, "foo", "TestLockEC1", "Cookie", "", NULL,  0));
@@ -225,3 +239,16 @@ TEST_F(LibRadosLockEC, BreakLock) {
   ASSERT_EQ(0, rados_break_lock(ioctx, "foo", "TestLockEC8", clients, "Cookie"));
 }
 
+TEST_F(LibRadosLockEC, MaxSharedLock) {
+  char buf[128];
+  memset(buf, 0, sizeof(buf));
+  ASSERT_EQ(0, rados_conf_get(cluster, "max_shared_locks_per_obj", buf, sizeof(buf)));
+  auto max_locks = std::stoull(string(buf));
+
+  for (uint64_t i = 0; i < max_locks; i++) {
+    std::stringstream sstm;
+    sstm << "shared_lock_cookie_ec_" << i;
+    ASSERT_EQ(0, rados_lock_shared(ioctx, "foo", "TestLockEC9", sstm.str().c_str(), "Tag", "", NULL, 0));
+  }
+  ASSERT_EQ(-EBUSY, rados_lock_shared(ioctx, "foo", "TestLockEC9", "busy_shared_lock_cookie_ec", "Tag", "", NULL, 0));
+}

--- a/src/test/librados/lock_cxx.cc
+++ b/src/test/librados/lock_cxx.cc
@@ -104,6 +104,19 @@ TEST_F(LibRadosLockPP, BreakLockPP) {
   ASSERT_EQ(0, ioctx.break_lock("foo", "TestLockPP8", it->client, "Cookie"));
 }
 
+TEST_F(LibRadosLockPP, MaxSharedLockPP) {
+  std::string max_locks_str;
+  cluster.conf_get("max_shared_locks_per_obj", max_locks_str);
+  auto max_locks = std::stoull(max_locks_str);
+
+  for (uint64_t i = 0; i < max_locks; i++) {
+    std::stringstream sstm;
+    sstm << "shared_lock_cookie_" << i;
+    ASSERT_EQ(0, ioctx.lock_shared("foo", "TestLockPP9", sstm.str(), "Tag", "", NULL, 0));
+  }
+  ASSERT_EQ(-EBUSY, ioctx.lock_shared("foo", "TestLockPP9", "busy_shared_lock_cookie", "Tag", "", NULL, 0));
+}
+
 // EC testing
 TEST_F(LibRadosLockECPP, LockExclusivePP) {
   ASSERT_EQ(0, ioctx.lock_exclusive("foo", "TestLockECPP1", "Cookie", "", NULL,  0));
@@ -190,4 +203,17 @@ TEST_F(LibRadosLockECPP, BreakLockPP) {
   ASSERT_EQ(me, it->client);
   ASSERT_EQ("Cookie", it->cookie);
   ASSERT_EQ(0, ioctx.break_lock("foo", "TestLockECPP8", it->client, "Cookie"));
+}
+
+TEST_F(LibRadosLockECPP, MaxSharedLockPP) {
+  std::string max_locks_str;
+  cluster.conf_get("max_shared_locks_per_obj", max_locks_str);
+  auto max_locks = std::stoull(max_locks_str);
+
+  for (uint64_t i = 0; i < max_locks; i++) {
+    std::stringstream sstm;
+    sstm << "shared_lock_cookie_ec_" << i;
+    ASSERT_EQ(0, ioctx.lock_shared("foo", "TestLockECPP9", sstm.str(), "Tag", "", NULL, 0));
+  }
+  ASSERT_EQ(-EBUSY, ioctx.lock_shared("foo", "TestLockECPP9", "busy_shared_lock_cookie_ec", "Tag", "", NULL, 0));
 }

--- a/src/test/libradosstriper/TestCase.cc
+++ b/src/test/libradosstriper/TestCase.cc
@@ -2,9 +2,15 @@
 // vim: ts=8 sw=2 smarttab
 
 #include <errno.h>
+#include <list>
+#include <thread>
 #include "test/librados/test.h"
 #include "test/librados/test_cxx.h"
 #include "test/libradosstriper/TestCase.h"
+
+using std::function;
+using std::move;
+using std::thread;
 
 using namespace libradosstriper;
 
@@ -77,4 +83,84 @@ void StriperTestParam::SetUp()
 {
   ASSERT_EQ(0, cluster.ioctx_create(pool_name.c_str(), ioctx));
   ASSERT_EQ(0, RadosStriper::striper_create(ioctx, &striper));
+}
+
+std::string StriperMaxSharedLockTest::pool_name;
+librados::Rados StriperMaxSharedLockTest::s_cluster;
+
+void StriperMaxSharedLockTest::init() {
+  connect_cluster_pp(*cluster);
+  cluster->ioctx_create(pool_name.c_str(), *ioctx);
+  RadosStriper::striper_create(*ioctx, striper.get());
+}
+
+void StriperMaxSharedLockTest::destory() {
+  ASSERT_EQ(0, destroy_one_pool_pp(pool_name, s_cluster));
+}
+
+void ParallelStriperMaxSharedLockTest::access(
+  function<int(rados_striper_t&)> rw_access,
+  const size_t n_threads) {
+  refs.clear();
+
+  auto do_access = [&] () {
+    auto multi_striper = std::make_unique<StriperMaxSharedLockTest>();
+    multi_striper->init();
+    rados_striper_t rsc;
+    RadosStriper::to_rados_striper_t(*(multi_striper->striper), &rsc);
+    multi_striper->ret = rw_access(rsc);
+    std::lock_guard<std::mutex> guard(m);
+    refs.push_back(std::move(multi_striper));
+  };
+
+  std::list<thread> threads;
+  for(size_t i = 0; i < n_threads; i++) {
+    threads.push_back(thread{move(do_access)});
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+}
+
+void ParallelStriperMaxSharedLockTest::async_read(char *buf, const size_t size, const size_t n_threads) {
+  auto read_access = [&] (rados_striper_t& rsc) -> int {
+    rados_completion_t comp;
+    rados_aio_create_completion(nullptr, nullptr, nullptr, &comp);
+    int ret = rados_striper_aio_read(rsc, StriperMaxSharedLockTest::pool_name.c_str(), comp, buf, size, 0);
+    if (ret >= 0) {
+      rados_aio_wait_for_complete(comp);
+    }
+    rados_aio_release(comp);
+    return ret;
+  };
+  access(read_access, n_threads);
+}
+
+void ParallelStriperMaxSharedLockTest::async_write(char *buf, const size_t size, const size_t n_threads) {
+  auto write_access = [&] (rados_striper_t& rsc) -> int {
+    rados_completion_t comp;
+    rados_aio_create_completion(nullptr, nullptr, nullptr, &comp);
+    int ret = rados_striper_aio_write(rsc, StriperMaxSharedLockTest::pool_name.c_str(), comp, buf, size, 0);
+    if (ret >= 0) {
+      rados_aio_wait_for_complete(comp);
+    }
+    rados_aio_release(comp);
+    return ret;
+  };
+  access(write_access, n_threads);
+}
+
+void ParallelStriperMaxSharedLockTest::sync_read(char *buf, const size_t size, const size_t n_threads) {
+  auto read_access = [&] (rados_striper_t& rsc) -> int {
+    return rados_striper_read(rsc,  StriperMaxSharedLockTest::pool_name.c_str(), buf, size, 0);
+  };
+  access(read_access, n_threads);
+}
+
+void ParallelStriperMaxSharedLockTest::sync_write(char *buf, const size_t size, const size_t n_threads) {
+  auto write_access = [&] (rados_striper_t& rsc) -> int {
+    return rados_striper_write(rsc, StriperMaxSharedLockTest::pool_name.c_str(), buf, size, 0);
+  };
+  access(write_access, n_threads);
 }

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -661,6 +661,7 @@ prepare_conf() {
         debug asok assert abort = true
         $(format_conf "${msgr_conf}")
         $(format_conf "${extra_conf}")
+        max striper locks per obj = 3
 EOF
     if [ "$lockdep" -eq 1 ] ; then
         wconf <<EOF


### PR DESCRIPTION
Too many of shared lock created libradosstriper api at the same time will cause the attribute named 'lock.striper.lock' bigger and bigger and let node crash finally. To fix this, adding a config item to limit the quantity of shared lock created libradosstriper api.

tracker: https://tracker.ceph.com/issues/45916

Signed-off-by: SHU Zhenyi [shuzhenyi@live.com](mailto:shuzhenyi@live.com)

## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
