### PR TITLE
rgw/sts: Removing references to token introspection url,

### DIFF
--- a/doc/radosgw/keycloak.rst
+++ b/doc/radosgw/keycloak.rst
@@ -21,9 +21,6 @@ The format of token inspection url is https://[base-server-url]/token/introspect
   [client.radosgw.gateway]
   rgw sts key = {sts key for encrypting/ decrypting the session token}
   rgw s3 auth use sts = true
-  rgw_sts_token_introspection_url = {url for token introspection}
-  rgw_sts_client_id = {client-id}
-  rgw_sts_client_secret = {client-password}
 
 Example showing how to fetch a web token from Keycloak
 ======================================================


### PR DESCRIPTION
client id and client password.

Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
