### PR TITLE
octopus: qa: return a string via getfattr

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -714,7 +714,7 @@ class CephFSMount(object):
             else:
                 raise
 
-        return p.stdout.getvalue()
+        return str(p.stdout.getvalue())
 
     def df(self):
         """

--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -134,10 +134,10 @@ class TestExports(CephFSTestCase):
             log.debug("mount.getfattr('1','ceph.dir.pin'): %s " % dir_pin)
             if str(p) < "5" and not(dir_pin):
                 self.skipTest("Kernel does not support getting the extended attribute ceph.dir.pin")
-        self.assertEqual(self.mount_a.getfattr("1", "ceph.dir.pin"), b'1')
-        self.assertEqual(self.mount_a.getfattr("1/2", "ceph.dir.pin"), b'0')
+        self.assertEqual(self.mount_a.getfattr("1", "ceph.dir.pin"), '1')
+        self.assertEqual(self.mount_a.getfattr("1/2", "ceph.dir.pin"), '0')
         if (len(self.fs.get_active_names()) > 2):
-            self.assertEqual(self.mount_a.getfattr("1/2/3", "ceph.dir.pin"), b'2')
+            self.assertEqual(self.mount_a.getfattr("1/2/3", "ceph.dir.pin"), '2')
 
     def test_session_race(self):
         """

--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -132,12 +132,12 @@ class TestExports(CephFSTestCase):
             p = self.mount_a.client_remote.run(args=['uname', '-r'], stdout=StringIO(), wait=True)
             dir_pin = self.mount_a.getfattr("1", "ceph.dir.pin")
             log.debug("mount.getfattr('1','ceph.dir.pin'): %s " % dir_pin)
-            if str(p.stdout.getvalue()) < "5" and not(dir_pin):
+            if str(p) < "5" and not(dir_pin):
                 self.skipTest("Kernel does not support getting the extended attribute ceph.dir.pin")
-        self.assertTrue(self.mount_a.getfattr("1", "ceph.dir.pin") == "1")
-        self.assertTrue(self.mount_a.getfattr("1/2", "ceph.dir.pin") == "0")
+        self.assertEqual(self.mount_a.getfattr("1", "ceph.dir.pin"), b'1')
+        self.assertEqual(self.mount_a.getfattr("1/2", "ceph.dir.pin"), b'0')
         if (len(self.fs.get_active_names()) > 2):
-            self.assertTrue(self.mount_a.getfattr("1/2/3", "ceph.dir.pin") == "2")
+            self.assertEqual(self.mount_a.getfattr("1/2/3", "ceph.dir.pin"), b'2')
 
     def test_session_race(self):
         """


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45886

---

backport of https://github.com/ceph/ceph/pull/35202
parent tracker: https://tracker.ceph.com/issues/45666

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh