### PR TITLE
luminous: osd/PeeringState.h: Fix pg stuck in WaitActingChange

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2014,8 +2014,7 @@ protected:
 
       typedef boost::mpl::list <
 	boost::statechart::custom_reaction< ActMap >,
-	boost::statechart::custom_reaction< MNotifyRec >,
-	boost::statechart::transition< NeedActingChange, WaitActingChange >
+	boost::statechart::custom_reaction< MNotifyRec >
 	> reactions;
       boost::statechart::result react(const ActMap&);
       boost::statechart::result react(const MNotifyRec&);
@@ -2399,6 +2398,7 @@ protected:
 	boost::statechart::custom_reaction< MLogRec >,
 	boost::statechart::custom_reaction< GotLog >,
 	boost::statechart::custom_reaction< AdvMap >,
+	boost::statechart::transition< NeedActingChange, WaitActingChange >,
 	boost::statechart::transition< IsIncomplete, Incomplete >
 	> reactions;
       boost::statechart::result react(const AdvMap&);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45891

---

backport of https://github.com/ceph/ceph/pull/29669
parent tracker: https://tracker.ceph.com/issues/41190

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh