### PR TITLE
qa/tasks/radosbench: use long form of option for compatibility

### DIFF
--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -84,12 +84,12 @@ def task(ctx, config):
                 pool = manager.create_pool_with_unique_name(erasure_code_profile_name=profile_name)
 
         concurrency = config.get('concurrency', 16)
-        size = ['-b', str(config.get('size', 65536))]
         osize = config.get('objectsize', 65536)
-        if osize == 0 or osize == size:
+        if osize == 0:
             objectsize = []
         else:
             objectsize = ['-O', str(osize)]
+        size = ['-b', str(config.get('size', 65536))]
         # If doing a reading run then populate data
         if runtype != "write":
             proc = remote.run(

--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -88,7 +88,7 @@ def task(ctx, config):
         if osize == 0:
             objectsize = []
         else:
-            objectsize = ['-O', str(osize)]
+            objectsize = ['--object-size', str(osize)]
         size = ['-b', str(config.get('size', 65536))]
         # If doing a reading run then populate data
         if runtype != "write":

--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -83,15 +83,13 @@ def task(ctx, config):
             else:
                 pool = manager.create_pool_with_unique_name(erasure_code_profile_name=profile_name)
 
-        size = config.get('size', 65536)
         concurrency = config.get('concurrency', 16)
+        size = ['-b', str(config.get('size', 65536))]
         osize = config.get('objectsize', 65536)
-        sizeargs = ['-b', str(size)]
-        if osize != 0 and osize != size:
-            # only use -O if this varies from size. kludgey workaround the
-            # fact that -O was -o in older releases.
-            sizeargs.extend(['-O', str(osize)])
-
+        if osize == 0 or osize == size:
+            objectsize = []
+        else:
+            objectsize = ['-O', str(osize)]
         # If doing a reading run then populate data
         if runtype != "write":
             proc = remote.run(
@@ -102,9 +100,9 @@ def task(ctx, config):
                               '{tdir}/archive/coverage',
                               'rados',
                               '--no-log-to-stderr',
-                              '--name', role]
-                              + sizeargs +
-                              ['-t', str(concurrency)] +
+                              '--name', role] +
+                              ['-t', str(concurrency)]
+                              + size + objectsize +
                               ['-p' , pool,
                           'bench', str(60), "write", "--no-cleanup"
                           ]).format(tdir=testdir),
@@ -112,7 +110,8 @@ def task(ctx, config):
             logger=log.getChild('radosbench.{id}'.format(id=id_)),
             wait=True
             )
-            sizeargs = []
+            size = []
+            objectsize = []
 
         proc = remote.run(
             args=[
@@ -123,7 +122,7 @@ def task(ctx, config):
                           'rados',
 			  '--no-log-to-stderr',
                           '--name', role]
-                          + sizeargs +
+                          + size + objectsize +
                           ['-p' , pool,
                           'bench', str(config.get('time', 360)), runtype,
                           ] + write_to_omap + cleanup).format(tdir=testdir),


### PR DESCRIPTION
Since the short version of --object-size changed from -o to -O, it does not work with upgrade tests.

Revert the prior workarounds for easy backporting.