### PR TITLE
mimic: qa/tasks/radosbench: use long form of option for compatibility

### DIFF
--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -80,7 +80,7 @@ def task(ctx, config):
         if osize is 0:
             objectsize = []
         else:
-            objectsize = ['-o', str(osize)]
+            objectsize = ['--object-size', str(osize)]
         size = ['-b', str(config.get('size', 65536))]
         # If doing a reading run then populate data
         if runtype != "write":


### PR DESCRIPTION
Since the short version of --object-size changed from -o to -O, it
does not work with upgrade tests.

Signed-off-by: Josh Durgin <jdurgin@redhat.com>
(cherry picked from commit 82baed3f42ffbd89b851997951851c8f4658ca5e)