### PR TITLE
python-common: fix ServiceSpec validation

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -885,7 +885,6 @@ Usage:
             placement=PlacementSpec.from_string(placement),
         )
 
-        spec.validate_add()
         completion = self.add_nfs(spec)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -471,6 +471,9 @@ class ServiceSpec(object):
         if not self.service_type:
             raise ServiceSpecValidationError('Cannot add Service: type required')
 
+        if self.service_type in ['mds', 'rgw', 'nfs', 'iscsi'] and not self.service_id:
+            raise ServiceSpecValidationError('Cannot add Service: id required')
+
         if self.placement is not None:
             self.placement.validate()
 
@@ -479,14 +482,6 @@ class ServiceSpec(object):
 
     def one_line_str(self):
         return '<{} for service_name={}>'.format(self.__class__.__name__, self.service_name())
-
-
-def servicespec_validate_add(self: ServiceSpec):
-    # This must not be a method of ServiceSpec, otherwise you'll hunt
-    # sub-interpreter affinity bugs.
-    ServiceSpec.validate(self)
-    if self.service_type in ['mds', 'rgw', 'nfs', 'iscsi'] and not self.service_id:
-        raise ServiceSpecValidationError('Cannot add Service: id required')
 
 
 class NFSServiceSpec(ServiceSpec):

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -509,11 +509,12 @@ class NFSServiceSpec(ServiceSpec):
         #: RADOS namespace where NFS client recovery data is stored in the pool.
         self.namespace = namespace
 
-    def validate_add(self):
-        servicespec_validate_add(self)
+    def validate(self):
+        super(NFSServiceSpec, self).validate()
 
         if not self.pool:
-            raise ServiceSpecValidationError('Cannot add NFS: No Pool specified')
+            raise ServiceSpecValidationError(
+                'Cannot add NFS: No Pool specified')
 
     def rados_config_name(self):
         # type: () -> str

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -5,8 +5,7 @@ import yaml
 import pytest
 
 from ceph.deployment.service_spec import HostPlacementSpec, PlacementSpec, \
-    RGWSpec, NFSServiceSpec, IscsiServiceSpec, \
-    servicespec_validate_add, ServiceSpec, ServiceSpecValidationError
+    ServiceSpec, ServiceSpecValidationError, RGWSpec, NFSServiceSpec, IscsiServiceSpec
 from ceph.deployment.drive_group import DriveGroupSpec
 
 
@@ -107,6 +106,6 @@ def test_servicespec_map_test(s_type, o_spec, s_id):
     assert spec.placement.hosts[0].hostname == 'host1'
     assert spec.placement.hosts[0].network == '1.1.1.1'
     assert spec.placement.hosts[0].name == ''
-    assert servicespec_validate_add(spec) is None
+    assert spec.validate() is None
     ServiceSpec.from_json(spec.to_json())
 

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -4,7 +4,8 @@ import yaml
 
 import pytest
 
-from ceph.deployment.service_spec import HostPlacementSpec, PlacementSpec, RGWSpec, NFSServiceSpec, \
+from ceph.deployment.service_spec import HostPlacementSpec, PlacementSpec, \
+    RGWSpec, NFSServiceSpec, IscsiServiceSpec, \
     servicespec_validate_add, ServiceSpec, ServiceSpecValidationError
 from ceph.deployment.drive_group import DriveGroupSpec
 
@@ -83,6 +84,7 @@ def test_parse_host_placement_specs_raises_wrong_format(test_input):
         ("mds", ServiceSpec, 'test'),
         ("rgw", RGWSpec, 'realm.zone'),
         ("nfs", NFSServiceSpec, 'test'),
+        ("iscsi", IscsiServiceSpec, 'test'),
         ("osd", DriveGroupSpec, 'test'),
     ])
 def test_servicespec_map_test(s_type, o_spec, s_id):
@@ -94,6 +96,10 @@ def test_servicespec_map_test(s_type, o_spec, s_id):
     }
     if s_type == 'nfs':
         dict_spec['pool'] = 'pool'
+    elif s_type == 'iscsi':
+        dict_spec['pool'] = 'pool'
+        dict_spec['api_user'] = 'api_user'
+        dict_spec['api_password'] = 'api_password'
     spec = ServiceSpec.from_json(dict_spec)
     assert isinstance(spec, o_spec)
     assert isinstance(spec.placement, PlacementSpec)

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -92,6 +92,8 @@ def test_servicespec_map_test(s_type, o_spec, s_id):
         "placement":
             dict(hosts=["host1:1.1.1.1"])
     }
+    if s_type == 'nfs':
+        dict_spec['pool'] = 'pool'
     spec = ServiceSpec.from_json(dict_spec)
     assert isinstance(spec, o_spec)
     assert isinstance(spec.placement, PlacementSpec)


### PR DESCRIPTION
Fixes various issues around validation of a ServiceSpec during `orch apply`.

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
