### PR TITLE
mgr/cephadm: move ok_to_stop to CephadmService 

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -381,28 +381,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         self.log.debug('_kick_serve_loop')
         self.event.set()
 
-    def _check_safe_to_destroy_mon(self, mon_id):
-        # type: (str) -> None
-        ret, out, err = self.check_mon_command({
-            'prefix': 'quorum_status',
-        })
-        try:
-            j = json.loads(out)
-        except Exception as e:
-            raise OrchestratorError('failed to parse quorum status')
-
-        mons = [m['name'] for m in j['monmap']['mons']]
-        if mon_id not in mons:
-            self.log.info('Safe to remove mon.%s: not in monmap (%s)' % (
-                mon_id, mons))
-            return
-        new_mons = [m for m in mons if m != mon_id]
-        new_quorum = [m for m in j['quorum_names'] if m != mon_id]
-        if len(new_quorum) > len(new_mons) / 2:
-            self.log.info('Safe to remove mon.%s: new quorum should be %s (from %s)' % (mon_id, new_quorum, new_mons))
-            return
-        raise OrchestratorError('Removing %s would break mon quorum (new quorum %s, new mons %s)' % (mon_id, new_quorum, new_mons))
-
     def _check_host(self, host):
         if host not in self.inventory:
             return
@@ -1714,15 +1692,8 @@ you may want to run:
         Remove a daemon
         """
         (daemon_type, daemon_id) = name.split('.', 1)
-        if daemon_type == 'mon':
-            self._check_safe_to_destroy_mon(daemon_id)
 
-            # remove mon from quorum before we destroy the daemon
-            self.log.info('Removing monitor %s from monmap...' % name)
-            ret, out, err = self.check_mon_command({
-                'prefix': 'mon rm',
-                'name': daemon_id,
-            })
+        self.cephadm_services[daemon_type].pre_remove(daemon_id)
 
         args = ['--name', name, '--force']
         self.log.info('Removing daemon %s from %s' % (name, host))

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1828,6 +1828,10 @@ you may want to run:
             r = True
 
         # remove any?
+        while remove_daemon_hosts and not self.cephadm_services[daemon_type].ok_to_stop(
+                [d.daemon_id for d in remove_daemon_hosts]):
+            # let's find a subset that is ok-to-stop
+            remove_daemon_hosts.pop()
         for d in remove_daemon_hosts:
             # NOTE: we are passing the 'force' flag here, which means
             # we can delete a mon instances data.

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 
 
 class IscsiService(CephadmService):
+    TYPE = 'iscsi'
+
     def config(self, spec: IscsiServiceSpec):
         self.mgr._check_pool_exists(spec.pool, spec.service_name())
 

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -9,6 +9,7 @@ from mgr_util import verify_tls, ServerConfigException, create_self_signed_cert
 logger = logging.getLogger(__name__)
 
 class GrafanaService(CephadmService):
+    TYPE = 'grafana'
     DEFAULT_SERVICE_PORT = 3000
 
     def create(self, daemon_id, host):
@@ -73,6 +74,7 @@ class GrafanaService(CephadmService):
         )
 
 class AlertmanagerService(CephadmService):
+    TYPE = 'alertmanager'
     DEFAULT_SERVICE_PORT = 9093
 
     def create(self, daemon_id, host) -> str:
@@ -140,6 +142,7 @@ class AlertmanagerService(CephadmService):
 
 
 class PrometheusService(CephadmService):
+    TYPE = 'prometheus'
     DEFAULT_SERVICE_PORT = 9095
 
     def create(self, daemon_id, host) -> str:
@@ -228,6 +231,8 @@ class PrometheusService(CephadmService):
         )
 
 class NodeExporterService(CephadmService):
+    TYPE = 'node-exporter'
+
     def create(self, daemon_id, host) -> str:
         return self.mgr._create_daemon('node-exporter', daemon_id, host)
 

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 
 
 class NFSService(CephadmService):
+    TYPE = 'nfs'
+
     def _generate_nfs_config(self, daemon_type, daemon_id, host):
         # type: (str, str, str) -> Tuple[Dict[str, Any], List[str]]
         deps = []  # type: List[str]

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 
 class OSDService(CephadmService):
+    TYPE = 'osd'
+
     def create(self, drive_group: DriveGroupSpec) -> str:
         logger.debug(f"Processing DriveGroup {drive_group}")
         ret = []

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from cephadm.services.cephadmservice import CephadmService
+from cephadm.services.monitoring import GrafanaService
 
 
 class FakeMgr:
@@ -23,7 +23,7 @@ class TestCephadmService:
         # pylint: disable=protected-access
         mgr = FakeMgr()
         service_url = 'http://svc:1000'
-        service = CephadmService(mgr)
+        service = GrafanaService(mgr)
         service._set_service_url_on_dashboard('svc', 'get-cmd', 'set-cmd', service_url)
         assert mgr.config == service_url
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1238,7 +1238,7 @@ class DaemonDescription(object):
         # typically either based on hostnames or on pod names.
         # This is the <foo> in mds.<foo>, the ID that will appear
         # in the FSMap/ServiceMap.
-        self.daemon_id = daemon_id
+        self.daemon_id: str = daemon_id
 
         # Service version that was deployed
         self.version = version

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -151,11 +151,7 @@ class PlacementSpec(object):
         self.hosts = []  # type: List[HostPlacementSpec]
 
         if hosts:
-            if all([isinstance(host, HostPlacementSpec) for host in hosts]):
-                self.hosts = hosts  # type: ignore
-            else:
-                self.hosts = [HostPlacementSpec.parse(x, require_network=False)  # type: ignore
-                              for x in hosts if x]
+            self.set_hosts(hosts)
 
         self.count = count  # type: Optional[int]
 
@@ -181,7 +177,11 @@ class PlacementSpec(object):
     def set_hosts(self, hosts):
         # To backpopulate the .hosts attribute when using labels or count
         # in the orchestrator backend.
-        self.hosts = hosts
+        if all([isinstance(host, HostPlacementSpec) for host in hosts]):
+            self.hosts = hosts  # type: ignore
+        else:
+            self.hosts = [HostPlacementSpec.parse(x, require_network=False)  # type: ignore
+                          for x in hosts if x]
 
     def filter_matching_hosts(self, _get_hosts_func: Callable) -> List[str]:
         return self.filter_matching_hostspecs(_get_hosts_func(as_hostspec=True))


### PR DESCRIPTION
This PR is on the edge of being unnecessary. MDS is the only service that will benefit from this. Still:

* it thought me how to proceed with #34617
* helps with #32731 
* Moves code into better places.
* introduces structure for future PRs. 

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
