### PR TITLE
rgw: refactor boilerplate coroutine drain callers

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -924,22 +924,58 @@ ostream& operator<<(ostream& out, const RGWCoroutine& cr)
   return out;
 }
 
-bool RGWCoroutine::drain_children(int num_cr_left, RGWCoroutinesStack *skip_stack)
+bool RGWCoroutine::drain_children(int num_cr_left,
+                                  RGWCoroutinesStack *skip_stack,
+                                  std::optional<std::function<void(int ret)> > err_cb)
 {
   bool done = false;
   ceph_assert(num_cr_left >= 0);
   if (num_cr_left == 0 && skip_stack) {
     num_cr_left = 1;
   }
-  reenter(&drain_cr) {
+  reenter(&drain_status.cr) {
     while (num_spawned() > (size_t)num_cr_left) {
       yield wait_for_child();
       int ret;
       while (collect(&ret, skip_stack)) {
         if (ret < 0) {
+          if (!err_cb) {
+            ldout(cct, 10) << "collect() returned ret=" << ret << dendl;
+            /* we should have reported this error */
+            log_error() << "ERROR: collect() returned error (ret=" << ret << ")";
+          } else {
+            (*err_cb)(ret);
+          }
+        }
+      }
+    }
+    done = true;
+  }
+  return done;
+}
+
+bool RGWCoroutine::drain_children(int num_cr_left,
+                                  std::optional<std::function<int(int ret)> > err_cb)
+{
+  bool done = false;
+  ceph_assert(num_cr_left >= 0);
+
+  reenter(&drain_status.cr) {
+    while (num_spawned() > (size_t)num_cr_left) {
+      yield wait_for_child();
+      int ret;
+      while (collect(&ret, nullptr)) {
+        if (ret < 0) {
           ldout(cct, 10) << "collect() returned ret=" << ret << dendl;
           /* we should have reported this error */
           log_error() << "ERROR: collect() returned error (ret=" << ret << ")";
+          if (err_cb && !drain_status.should_exit) {
+            int r = (*err_cb)(ret);
+            if (r < 0) {
+              drain_status.ret = r;
+              num_cr_left = 0; /* need to drain all */
+            }
+          }
         }
       }
     }

--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -222,6 +222,10 @@ RGWCoroutinesStack::~RGWCoroutinesStack()
   for (auto stack : spawned.entries) {
     stack->put();
   }
+
+  if (preallocated_stack) {
+    preallocated_stack->put();
+  }
 }
 
 int RGWCoroutinesStack::operate(RGWCoroutinesEnv *_env)
@@ -293,7 +297,12 @@ RGWCoroutinesStack *RGWCoroutinesStack::spawn(RGWCoroutine *source_op, RGWCorout
 
   rgw_spawned_stacks *s = (source_op ? &source_op->spawned : &spawned);
 
-  RGWCoroutinesStack *stack = env->manager->allocate_stack();
+  RGWCoroutinesStack *stack = preallocated_stack;
+  if (!stack) {
+    stack = env->manager->allocate_stack();
+  }
+  preallocated_stack = nullptr;
+
   s->add_pending(stack);
   stack->parent = this;
 
@@ -312,6 +321,14 @@ RGWCoroutinesStack *RGWCoroutinesStack::spawn(RGWCoroutine *source_op, RGWCorout
 RGWCoroutinesStack *RGWCoroutinesStack::spawn(RGWCoroutine *op, bool wait)
 {
   return spawn(NULL, op, wait);
+}
+
+RGWCoroutinesStack *RGWCoroutinesStack::prealloc_stack()
+{
+  if (!preallocated_stack) {
+    preallocated_stack = env->manager->allocate_stack();
+  }
+  return preallocated_stack;
 }
 
 int RGWCoroutinesStack::wait(const utime_t& interval)
@@ -890,6 +907,16 @@ void RGWCoroutine::call(RGWCoroutine *op)
 RGWCoroutinesStack *RGWCoroutine::spawn(RGWCoroutine *op, bool wait)
 {
   return stack->spawn(this, op, wait);
+}
+
+RGWCoroutinesStack *RGWCoroutine::prealloc_stack()
+{
+  return stack->prealloc_stack();
+}
+
+uint64_t RGWCoroutine::prealloc_stack_id()
+{
+  return prealloc_stack()->get_id();
 }
 
 bool RGWCoroutine::collect(int *ret, RGWCoroutinesStack *skip_stack, uint64_t *stack_id) /* returns true if needs to be called again */

--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -196,12 +196,17 @@ int64_t RGWCoroutinesManager::get_next_io_id()
   return (int64_t)++max_io_id;
 }
 
+uint64_t RGWCoroutinesManager::get_next_stack_id() {
+  return (uint64_t)++max_stack_id;
+}
+
 RGWCoroutinesStack::RGWCoroutinesStack(CephContext *_cct, RGWCoroutinesManager *_ops_mgr, RGWCoroutine *start) : cct(_cct), ops_mgr(_ops_mgr),
                                                                                                          done_flag(false), error_flag(false), blocked_flag(false),
                                                                                                          sleep_flag(false), interval_wait_flag(false), is_scheduled(false), is_waiting_for_child(false),
 													 retcode(0), run_count(0),
 													 env(NULL), parent(NULL)
 {
+  id = ops_mgr->get_next_stack_id();
   if (start) {
     ops.push_back(start);
   }
@@ -360,7 +365,7 @@ void RGWCoroutinesStack::cancel()
   put();
 }
 
-bool RGWCoroutinesStack::collect(RGWCoroutine *op, int *ret, RGWCoroutinesStack *skip_stack) /* returns true if needs to be called again */
+bool RGWCoroutinesStack::collect(RGWCoroutine *op, int *ret, RGWCoroutinesStack *skip_stack, uint64_t *stack_id) /* returns true if needs to be called again */
 {
   bool need_retry = false;
   rgw_spawned_stacks *s = (op ? &op->spawned : &spawned);
@@ -377,6 +382,9 @@ bool RGWCoroutinesStack::collect(RGWCoroutine *op, int *ret, RGWCoroutinesStack 
         ldout(cct, 20) << "collect(): s=" << (void *)this << " stack=" << (void *)stack << " explicitly skipping stack" << dendl;
       }
       continue;
+    }
+    if (stack_id) {
+      *stack_id = stack->get_id();
     }
     int r = stack->get_ret_status();
     stack->put();
@@ -426,9 +434,9 @@ bool RGWCoroutinesStack::collect_next(RGWCoroutine *op, int *ret, RGWCoroutinesS
   return false;
 }
 
-bool RGWCoroutinesStack::collect(int *ret, RGWCoroutinesStack *skip_stack) /* returns true if needs to be called again */
+bool RGWCoroutinesStack::collect(int *ret, RGWCoroutinesStack *skip_stack, uint64_t  *stack_id) /* returns true if needs to be called again */
 {
-  return collect(NULL, ret, skip_stack);
+  return collect(NULL, ret, skip_stack, stack_id);
 }
 
 static void _aio_completion_notifier_cb(librados::completion_t cb, void *arg)
@@ -884,9 +892,9 @@ RGWCoroutinesStack *RGWCoroutine::spawn(RGWCoroutine *op, bool wait)
   return stack->spawn(this, op, wait);
 }
 
-bool RGWCoroutine::collect(int *ret, RGWCoroutinesStack *skip_stack) /* returns true if needs to be called again */
+bool RGWCoroutine::collect(int *ret, RGWCoroutinesStack *skip_stack, uint64_t *stack_id) /* returns true if needs to be called again */
 {
-  return stack->collect(this, ret, skip_stack);
+  return stack->collect(this, ret, skip_stack, stack_id);
 }
 
 bool RGWCoroutine::collect_next(int *ret, RGWCoroutinesStack **collected_stack) /* returns true if found a stack to collect */
@@ -926,7 +934,7 @@ ostream& operator<<(ostream& out, const RGWCoroutine& cr)
 
 bool RGWCoroutine::drain_children(int num_cr_left,
                                   RGWCoroutinesStack *skip_stack,
-                                  std::optional<std::function<void(int ret)> > cb)
+                                  std::optional<std::function<void(uint64_t stack_id, int ret)> > cb)
 {
   bool done = false;
   ceph_assert(num_cr_left >= 0);
@@ -937,14 +945,15 @@ bool RGWCoroutine::drain_children(int num_cr_left,
     while (num_spawned() > (size_t)num_cr_left) {
       yield wait_for_child();
       int ret;
-      while (collect(&ret, skip_stack)) {
+      uint64_t stack_id;
+      while (collect(&ret, skip_stack, &stack_id)) {
         if (ret < 0) {
             ldout(cct, 10) << "collect() returned ret=" << ret << dendl;
             /* we should have reported this error */
             log_error() << "ERROR: collect() returned error (ret=" << ret << ")";
         }
         if (cb) {
-          (*cb)(ret);
+          (*cb)(stack_id, ret);
         }
       }
     }
@@ -954,7 +963,7 @@ bool RGWCoroutine::drain_children(int num_cr_left,
 }
 
 bool RGWCoroutine::drain_children(int num_cr_left,
-                                  std::optional<std::function<int(int ret)> > cb)
+                                  std::optional<std::function<int(uint64_t stack_id, int ret)> > cb)
 {
   bool done = false;
   ceph_assert(num_cr_left >= 0);
@@ -963,14 +972,15 @@ bool RGWCoroutine::drain_children(int num_cr_left,
     while (num_spawned() > (size_t)num_cr_left) {
       yield wait_for_child();
       int ret;
-      while (collect(&ret, nullptr)) {
+      uint64_t stack_id;
+      while (collect(&ret, nullptr, &stack_id)) {
         if (ret < 0) {
           ldout(cct, 10) << "collect() returned ret=" << ret << dendl;
           /* we should have reported this error */
           log_error() << "ERROR: collect() returned error (ret=" << ret << ")";
         }
         if (cb && !drain_status.should_exit) {
-          int r = (*cb)(ret);
+          int r = (*cb)(stack_id, ret);
           if (r < 0) {
             drain_status.ret = r;
             num_cr_left = 0; /* need to drain all */

--- a/src/rgw/rgw_coroutine.h
+++ b/src/rgw/rgw_coroutine.h
@@ -302,6 +302,9 @@ public:
   bool collect(int *ret, RGWCoroutinesStack *skip_stack, uint64_t *stack_id = nullptr); /* returns true if needs to be called again */
   bool collect_next(int *ret, RGWCoroutinesStack **collected_stack = NULL); /* returns true if found a stack to collect */
 
+  RGWCoroutinesStack *prealloc_stack(); /* prepare a stack that will be used in the next spawn operation */
+  uint64_t prealloc_stack_id(); /* prepare a stack that will be used in the next spawn operation, return its id */
+
   int wait(const utime_t& interval);
   bool drain_children(int num_cr_left,
                       RGWCoroutinesStack *skip_stack = nullptr,
@@ -434,6 +437,8 @@ class RGWCoroutinesStack : public RefCountedObject {
 
   rgw_spawned_stacks spawned;
 
+  RGWCoroutinesStack *preallocated_stack{nullptr};
+
   set<RGWCoroutinesStack *> blocked_by_stack;
   set<RGWCoroutinesStack *> blocking_stacks;
 
@@ -531,6 +536,7 @@ public:
 
   void call(RGWCoroutine *next_op);
   RGWCoroutinesStack *spawn(RGWCoroutine *next_op, bool wait);
+  RGWCoroutinesStack *prealloc_stack();
   int unwind(int retcode);
 
   int wait(const utime_t& interval);

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1577,7 +1577,9 @@ public:
 
           drain_all_but_stack_cb(lease_stack.get(),
                                  [&](int ret) {
-                                   tn->log(10, "a sync operation returned error");
+                                   if (ret < 0) {
+                                     tn->log(10, "a sync operation returned error");
+                                   }
                                  });
         }
       } while (omapvals->more);
@@ -1723,7 +1725,9 @@ public:
 
           drain_all_but_stack_cb(lease_stack.get(),
                                  [&](int ret) {
-                                   tn->log(10, "a sync operation returned error");
+                                   if (ret < 0) {
+                                     tn->log(10, "a sync operation returned error");
+                                   }
                                  });
         }
 
@@ -3789,8 +3793,10 @@ int RGWBucketShardFullSyncCR::operate()
         }
         drain_with_cb(BUCKET_SYNC_SPAWN_WINDOW,
                       [&](int ret) {
-                tn->log(10, "a sync operation returned error");
-                sync_status = ret;
+                if (ret < 0) {
+                  tn->log(10, "a sync operation returned error");
+                  sync_status = ret;
+                }
                 return 0;
               });
       }
@@ -3799,8 +3805,10 @@ int RGWBucketShardFullSyncCR::operate()
     /* wait for all operations to complete */
 
     drain_all_cb([&](int ret) {
-      tn->log(10, "a sync operation returned error");
-      sync_status = ret;
+      if (ret < 0) {
+        tn->log(10, "a sync operation returned error");
+        sync_status = ret;
+      }
       return 0;
     });
     tn->unset_flag(RGW_SNS_FLAG_ACTIVE);
@@ -4082,16 +4090,20 @@ int RGWBucketShardIncrementalSyncCR::operate()
         // }
         drain_with_cb(BUCKET_SYNC_SPAWN_WINDOW,
                       [&](int ret) {
-                tn->log(10, "a sync operation returned error");
-                sync_status = ret;
+                if (ret < 0) {
+                  tn->log(10, "a sync operation returned error");
+                  sync_status = ret;
+                }
                 return 0;
               });
       }
     } while (!list_result.empty() && sync_status == 0 && !syncstopped);
 
     drain_all_cb([&](int ret) {
-      tn->log(10, "a sync operation returned error");
-      sync_status = ret;
+      if (ret < 0) {
+        tn->log(10, "a sync operation returned error");
+        sync_status = ret;
+      }
       return 0;
     });
     tn->unset_flag(RGW_SNS_FLAG_ACTIVE);
@@ -4340,13 +4352,17 @@ int RGWRunBucketSourcesSyncCR::operate()
                                                          &*cur_shard_progress),
                            BUCKET_SYNC_SPAWN_WINDOW,
                            [&](int ret) {
-                             tn->log(10, "a sync operation returned error");
+                             if (ret < 0) {
+                               tn->log(10, "a sync operation returned error");
+                             }
                              return ret;
                            });
       }
     }
     drain_all_cb([&](int ret) {
-                   tn->log(10, "a sync operation returned error");
+                   if (ret < 0) {
+                     tn->log(10, "a sync operation returned error");
+                   }
                    return ret;
                  });
     if (progress) {

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1576,7 +1576,7 @@ public:
           sync_marker.marker = iter->first;
 
           drain_all_but_stack_cb(lease_stack.get(),
-                                 [&](int ret) {
+                                 [&](uint64_t stack_id, int ret) {
                                    if (ret < 0) {
                                      tn->log(10, "a sync operation returned error");
                                    }
@@ -1724,7 +1724,7 @@ public:
           }
 
           drain_all_but_stack_cb(lease_stack.get(),
-                                 [&](int ret) {
+                                 [&](uint64_t stack_id, int ret) {
                                    if (ret < 0) {
                                      tn->log(10, "a sync operation returned error");
                                    }
@@ -3792,7 +3792,7 @@ int RGWBucketShardFullSyncCR::operate()
                       false);
         }
         drain_with_cb(BUCKET_SYNC_SPAWN_WINDOW,
-                      [&](int ret) {
+                      [&](uint64_t stack_id, int ret) {
                 if (ret < 0) {
                   tn->log(10, "a sync operation returned error");
                   sync_status = ret;
@@ -3804,7 +3804,7 @@ int RGWBucketShardFullSyncCR::operate()
     set_status("done iterating over all objects");
     /* wait for all operations to complete */
 
-    drain_all_cb([&](int ret) {
+    drain_all_cb([&](uint64_t stack_id, int ret) {
       if (ret < 0) {
         tn->log(10, "a sync operation returned error");
         sync_status = ret;
@@ -4089,7 +4089,7 @@ int RGWBucketShardIncrementalSyncCR::operate()
           }
         // }
         drain_with_cb(BUCKET_SYNC_SPAWN_WINDOW,
-                      [&](int ret) {
+                      [&](uint64_t stack_id, int ret) {
                 if (ret < 0) {
                   tn->log(10, "a sync operation returned error");
                   sync_status = ret;
@@ -4099,7 +4099,7 @@ int RGWBucketShardIncrementalSyncCR::operate()
       }
     } while (!list_result.empty() && sync_status == 0 && !syncstopped);
 
-    drain_all_cb([&](int ret) {
+    drain_all_cb([&](uint64_t stack_id, int ret) {
       if (ret < 0) {
         tn->log(10, "a sync operation returned error");
         sync_status = ret;
@@ -4351,7 +4351,7 @@ int RGWRunBucketSourcesSyncCR::operate()
         yield_spawn_window(new RGWRunBucketSyncCoroutine(sc, lease_cr, sync_pair, tn,
                                                          &*cur_shard_progress),
                            BUCKET_SYNC_SPAWN_WINDOW,
-                           [&](int ret) {
+                           [&](uint64_t stack_id, int ret) {
                              if (ret < 0) {
                                tn->log(10, "a sync operation returned error");
                              }
@@ -4359,7 +4359,7 @@ int RGWRunBucketSourcesSyncCR::operate()
                            });
       }
     }
-    drain_all_cb([&](int ret) {
+    drain_all_cb([&](uint64_t stack_id, int ret) {
                    if (ret < 0) {
                      tn->log(10, "a sync operation returned error");
                    }


### PR DESCRIPTION
Add new helpers that make it easier to deal with concurrent coroutine spawn with a specific execution window. Use new helpers in the sync code.
Just moving code into macros was a bit tricky due to to the way `yield` works.
There are now two different `RGWCoroutine::drain_children()`. We could have a single method that handles both cases, but it seemed that the changes would be harder to validate and there is no real need for it currently.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
