### PR TITLE
luminous: cephfs: doc: mds-config-ref: update 'mds_log_max_segments' value.

### DIFF
--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -178,21 +178,7 @@
               we initiate trimming. Set to ``-1`` to disable limits.
 
 :Type:  32-bit Integer
-:Default: ``30``
-
-
-``mds log max expiring``
-
-:Description: The maximum number of segments to expire in parallels
-:Type:  32-bit Integer
-:Default: ``20``
-
-
-``mds log eopen size``
-
-:Description: The maximum number of inodes in an EOpen event.
-:Type:  32-bit Integer
-:Default: ``100``
+:Default: ``128``
 
 
 ``mds bal sample interval``


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45825

---

backport of https://github.com/ceph/ceph/pull/29412
parent tracker: https://tracker.ceph.com/issues/45730

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh