### PR TITLE
cephadm: call `podman rm --storage`

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1887,6 +1887,9 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
 
         # Sometimes, adding `--rm` to a run_cmd doesn't work. Let's remove the container manually
         f.write(' '.join(c.rm_cmd()) + '\n')
+        # Sometimes, `podman rm` doesn't find the container. Then you'll have to add `--storage`
+        if 'podman' in container_path:
+            f.write(' '.join(c.rm_cmd(storage=True)) + '\n')
 
         # container run command
         f.write(' '.join(c.run_cmd()) + '\n')
@@ -2212,13 +2215,16 @@ class CephContainer:
             self.cname,
         ] + cmd
 
-    def rm_cmd(self):
-        # type: () -> List[str]
-        return [
+    def rm_cmd(self, storage=False):
+        # type: (bool) -> List[str]
+        ret = [
             str(container_path),
             'rm', '-f',
-            self.cname
         ]
+        if storage:
+            ret.append('--storage')
+        ret.append(self.cname)
+        return ret
 
     def run(self, timeout=DEFAULT_TIMEOUT):
         # type: (Optional[int]) -> str


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

This should fix

```
systemd[1]: ceph-36889d04-a982-11ea-a06d-001a4aab830c@mon.b.service holdoff time over, scheduling restart.
systemd[1]: Stopped Ceph mon.b for 36889d04-a982-11ea-a06d-001a4aab830c.
systemd[1]: Starting Ceph mon.b for 36889d04-a982-11ea-a06d-001a4aab830c...
podman[9425]: Error: no container with name or ID ceph-36889d04-a982-11ea-a06d-001a4aab830c-mon.b found: no such container
systemd[1]: Started Ceph mon.b for 36889d04-a982-11ea-a06d-001a4aab830c.
bash[9449]: Error: no container with name or ID ceph-36889d04-a982-11ea-a06d-001a4aab830c-mon.b found: no such container
bash[9449]: Error: error creating container storage: the container name "ceph-36889d04-a982-11ea-a06d-001a4aab830c-mon.b" is already in use by "f265ae83cb9ed32b7ed6fd6e62a2e764549
systemd[1]: ceph-36889d04-a982-11ea-a06d-001a4aab830c@mon.b.service: main process exited, code=exited, status=125/n/a
podman[9489]: Error: no container with name or ID ceph-36889d04-a982-11ea-a06d-001a4aab830c-mon.b found: no such container
systemd[1]: Unit ceph-36889d04-a982-11ea-a06d-001a4aab830c@mon.b.service entered failed state.
systemd[1]: ceph-36889d04-a982-11ea-a06d-001a4aab830c@mon.b.service failed.
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
