### PR TITLE
octopus: mgr/dashboard: remove space after service name in the Hosts List table

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
@@ -21,12 +21,11 @@
           <a class="service-link"
              [routerLink]="[service.cdLink]"
              [queryParams]="cdParams"
-             *ngIf="service.canRead">{{ service.type }}.{{ service.id }}
-          </a>
+             *ngIf="service.canRead">{{ service.type }}.{{ service.id }}</a>
           <span *ngIf="!service.canRead">
             {{ service.type }}.{{ service.id }}
           </span>
-          {{ !isLast ? ", " : "" }}
+          <ng-container *ngIf="!isLast">, </ng-container>
         </span>
       </ng-template>
       <cd-host-details cdTableDetail


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45921

---

backport of https://github.com/ceph/ceph/pull/35373
parent tracker: https://tracker.ceph.com/issues/45870

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh