### PR TITLE
Revert "Revert "qa/suites/rados/mgr/tasks/module_selftest: whitelist …

### DIFF
--- a/qa/suites/rados/mgr/tasks/module_selftest.yaml
+++ b/qa/suites/rados/mgr/tasks/module_selftest.yaml
@@ -19,6 +19,7 @@ tasks:
         - \(MGR_ZABBIX_
         - foo bar
         - Failed to open Telegraf
+        - evicting unresponsive client
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_module_selftest


### PR DESCRIPTION
This is a revert of a revert -- whitelists "evicting unresponsive client" warning message.