### PR TITLE
mgr/cephadm: set Ganesha pool/namespace settings in the Dashboard

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -247,6 +247,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             'desc': 'internal - do not modify',
             # used to track track spec and other data migrations.
         },
+        {
+            'name': 'config_dashboard',
+            'type': 'bool',
+            'default': True,
+            'desc': 'manage configs like API endpoints in Dashboard.'
+        }
     ]
 
     def __init__(self, *args, **kwargs):
@@ -280,6 +286,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.allow_ptrace = False
             self.prometheus_alerts_path = ''
             self.migration_current = None
+            self.config_dashboard = True
 
         self._cons = {}  # type: Dict[str, Tuple[remoto.backends.BaseConnection,remoto.backends.LegacyModuleExecute]]
 
@@ -1897,7 +1904,7 @@ you may want to run:
                 continue
 
             # These daemon types require additional configs after creation
-            if dd.daemon_type in ['grafana', 'iscsi', 'prometheus', 'alertmanager']:
+            if dd.daemon_type in ['grafana', 'iscsi', 'prometheus', 'alertmanager', 'nfs']:
                 daemons_post[dd.daemon_type].append(dd)
 
             deps = self._calc_daemon_deps(dd.daemon_type, dd.daemon_id)

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -60,7 +60,7 @@ class GrafanaService(CephadmService):
         # Use the least-created one as the active daemon
         return daemon_descrs[-1]
 
-    def daemon_check_post(self, daemon_descrs: List[DaemonDescription]):
+    def config_dashboard(self, daemon_descrs: List[DaemonDescription]):
         # TODO: signed cert
         dd = self.get_active_daemon(daemon_descrs)
         service_url = 'https://{}:{}'.format(
@@ -128,7 +128,7 @@ class AlertmanagerService(CephadmService):
         # TODO: if there are multiple daemons, who is the active one?
         return daemon_descrs[0]
 
-    def daemon_check_post(self, daemon_descrs: List[DaemonDescription]):
+    def config_dashboard(self, daemon_descrs: List[DaemonDescription]):
         dd = self.get_active_daemon(daemon_descrs)
         service_url = 'http://{}:{}'.format(self._inventory_get_addr(dd.hostname), self.DEFAULT_SERVICE_PORT)
         self._set_service_url_on_dashboard(
@@ -216,7 +216,7 @@ class PrometheusService(CephadmService):
         # TODO: if there are multiple daemons, who is the active one?
         return daemon_descrs[0]
 
-    def daemon_check_post(self, daemon_descrs: List[DaemonDescription]):
+    def config_dashboard(self, daemon_descrs: List[DaemonDescription]):
         dd = self.get_active_daemon(daemon_descrs)
         service_url = 'http://{}:{}'.format(
             self._inventory_get_addr(dd.hostname), self.DEFAULT_SERVICE_PORT)


### PR DESCRIPTION
- Config Ganesha pool and namespace settings in Dashboard.
- New `config_dashboard` option in cephadm. If the flag is Flase,
  cephadm won't manage Dashboard settings for daemons. This might be
  useful when users want to config API URLs by themselves or for debugging.

Fixes: https://tracker.ceph.com/issues/45155
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
