### PR TITLE
cephfs: refactor run_as_root() to user run_as_user()

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -534,18 +534,12 @@ class CephFSMount(object):
                                       stdout=StringIO(), stderr=StringIO(),
                                       check_status=check_status, cwd=cwd)
 
-    def run_as_root(self, args, wait=True, stdin=None, check_status=True,
-                    cwd=None):
-        if isinstance(args, str):
-            args = 'sudo ' + args
-        if isinstance(args, list):
-            args.insert(0, 'sudo')
-        if not cwd:
-            cwd = self.mountpoint
-
-        return self.client_remote.run(args=args, wait=wait, stdin=stdin,
-                                      stdout=StringIO(), stderr=StringIO(),
-                                      check_status=check_status, cwd=cwd)
+    def run_as_root(self, **kwargs):
+        """
+        Accepts same arguments as run_shell().
+        """
+        kwargs['user'] = 'root'
+        return self.run_as_user(**kwargs)
 
     def _verify(self, proc, retval=None, errmsg=None):
         if retval:

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -516,23 +516,27 @@ class CephFSMount(object):
                                       stdout=StringIO(), stderr=StringIO(),
                                       cwd=cwd, check_status=check_status)
 
-    def run_as_user(self, args, user, wait=True, stdin=None,
-                    check_status=True, cwd=None):
+    def run_as_user(self, **kwargs):
+        """
+        Besides the arguments defined for run_shell() this method also
+        accepts argument 'user'.
+        """
+        args = kwargs.pop('args')
+        user = kwargs.pop('user')
         if isinstance(args, str):
-            args = 'sudo -u %s -s /bin/bash -c %s' % (user, args)
+            args = ['sudo', '-u', user, '-s', '/bin/bash', '-c', args]
         elif isinstance(args, list):
             cmdlist = args
             cmd = ''
             for i in cmdlist:
                 cmd = cmd + i + ' '
-            args = ['sudo', '-u', user, '-s', '/bin/bash', '-c']
-            args.append(cmd)
-        if not cwd:
-            cwd = self.mountpoint
+            # get rid of extra space at the end.
+            cmd = cmd[:-1]
 
-        return self.client_remote.run(args=args, wait=wait, stdin=stdin,
-                                      stdout=StringIO(), stderr=StringIO(),
-                                      check_status=check_status, cwd=cwd)
+            args = ['sudo', '-u', user, '-s', '/bin/bash', '-c', cmd]
+
+        kwargs['args'] = args
+        return self.run_shell(**kwargs)
 
     def run_as_root(self, **kwargs):
         """


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46057

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>