### PR TITLE
doc/dev: add info on how to retest QA changes without rebuilding

### DIFF
--- a/doc/dev/developer_guide/running-tests-using-teuth.rst
+++ b/doc/dev/developer_guide/running-tests-using-teuth.rst
@@ -67,6 +67,34 @@ Other frequently used/useful options are ``-d`` (or ``--distro``),
 Run ``teuthology-suite --help`` to read description of these and every other
 options available.
 
+Testing QA changes (without re-building binaires)
+-------------------------------------------------
+While writing a PR you might need to test your PR repeatedly using teuthology.
+If you are making non-QA changes, you need to follow the standard process of
+triggering builds, waiting for it to finish and then triggering tests and
+wait for the result. But if changes you made are purely changes in qa/,
+you don't need rebuild the binaries. Instead you can test binaries built for
+the ceph-ci branch and instruct ``teuthology-suite`` command to use a separate
+branch for running tests. The separate branch can be passed to the command
+by using ``--suite-repo`` and ``--suite-branch``. Pass the link to the GitHub
+fork where your PR branch exists to the first option and pass the PR branch
+name to the second option.
+
+For example, if you want to make changes in ``qa/`` after testing ``branch-x``
+(of which has ceph-ci branch is ``wip-username-branch-x``) by running
+following command::
+
+    teuthology-suite -v -m smithi -c wip-username-branch-x -s fs -p 50 --filter cephfs-shell
+
+You can make the modifications locally, update the PR branch and then
+trigger tests from your PR branch as follows::
+
+    teuthology-suite -v -m smithi -c wip-username-branch-x -s fs -p 50 --filter cephfs-shell --suite-repo https://github.com/username/ceph --suite-branch branch-x
+
+You can verify if the tests were run using this branch by looking at values
+for the keys ``suite_branch``, ``suite_repo`` and ``suite_sha1`` in the job
+config printed at the very beginning of the teuthology job.
+
 About Suites and Filters
 ------------------------
 See `Suites Inventory`_ for a list of suites of integration tests present

--- a/doc/dev/developer_guide/running-tests-using-teuth.rst
+++ b/doc/dev/developer_guide/running-tests-using-teuth.rst
@@ -63,9 +63,10 @@ After building is complete, proceed to trigger tests -
    `Pulpito`_ page created for the tests triggered.
 
 Other frequently used/useful options are ``-d`` (or ``--distro``),
-``--distroversion``, ``--filter-out``, ``--timeout``, ``flavor``, ``-rerun``.
-Run ``teuthology-suite --help`` to read description of these and every other
-options available.
+``--distroversion``, ``--filter-out``, ``--timeout``, ``flavor``, ``-rerun``,
+``-l`` (for limiting number of jobs) , ``-n`` (for how many times job would
+run) and ``-e`` (for email notifications). Run ``teuthology-suite --help``
+to read description of these and every other options available.
 
 Testing QA changes (without re-building binaires)
 -------------------------------------------------


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>