### PR TITLE
python-common: add placement_spec_to_k8s 

### DIFF
--- a/src/pybind/mgr/pytest.ini
+++ b/src/pybind/mgr/pytest.ini
@@ -1,0 +1,3 @@
+# content of pytest.ini
+[pytest]
+norecursedirs = rook-client-python

--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -9,4 +9,4 @@ execnet
 remoto
 Jinja2
 pyfakefs
-
+jsonpatch

--- a/src/pybind/mgr/rook/__init__.py
+++ b/src/pybind/mgr/rook/__init__.py
@@ -1,2 +1,6 @@
+import os
+
+if 'UNITTEST' in os.environ:
+    import tests
 
 from .module import RookOrchestrator

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -493,13 +493,8 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         def execute(all_hosts_):
             # type: (List[orchestrator.HostSpec]) -> orchestrator.Completion
-            matching_hosts = drive_group.placement.filter_matching_hosts(lambda label=None, as_hostspec=None: all_hosts_)
+            matching_hosts = drive_group.placement.filter_matching_hostspecs(all_hosts_)
 
-            assert len(matching_hosts) == 1
-
-            if not self.rook_cluster.node_exists(matching_hosts[0]):
-                raise RuntimeError("Node '{0}' is not in the Kubernetes "
-                                   "cluster".format(matching_hosts))
 
             # Validate whether cluster CRD can accept individual OSD
             # creations (i.e. not useAllDevices)
@@ -512,7 +507,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
                         matching_hosts,
                         targets),
                 mgr=self,
-                on_complete=lambda _:self.rook_cluster.add_osds(drive_group, matching_hosts),
+                on_complete=lambda _:self.rook_cluster.add_osds(drive_group, all_hosts_),
                 calc_percent=lambda: has_osds(matching_hosts)
             )
 

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -528,7 +528,6 @@ class RookCluster(object):
         treat all drive groups as just a list of individual OSDs.
         """
         block_devices = drive_group.data_devices.paths if drive_group.data_devices else []
-        directories = drive_group.data_directories
 
         assert drive_group.objectstore in ("bluestore", "filestore")
 
@@ -557,10 +556,6 @@ class RookCluster(object):
                     pd.devices = ccl.DevicesList(
                         ccl.DevicesItem(name=d.path) for d in block_devices
                     )
-                if directories:
-                    pd.directories = ccl.DirectoriesList(
-                        ccl.DirectoriesItem(path=p) for p in directories
-                    )
                 new_cluster.spec.storage.nodes.append(pd)
             else:
                 for _node in new_cluster.spec.storage.nodes:
@@ -574,13 +569,6 @@ class RookCluster(object):
                                 ccl.DevicesItem(name=n.path) for n in new_devices
                             )
 
-                        if directories:
-                            if not hasattr(current_node, 'directories'):
-                                current_node.directories = ccl.DirectoriesList()
-                            new_dirs = list(set(directories) - set([d.path for d in current_node.directories]))
-                            current_node.directories.extend(
-                                ccl.DirectoriesItem(path=n) for n in new_dirs
-                            )
             return new_cluster
 
         return self._patch(ccl.CephCluster, 'cephclusters', self.rook_env.cluster_name, _add_osds)

--- a/src/pybind/mgr/rook/tests/test_rook_cluster.py
+++ b/src/pybind/mgr/rook/tests/test_rook_cluster.py
@@ -1,0 +1,29 @@
+import json
+from unittest.mock import Mock, call, ANY
+
+from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection
+from ceph.deployment.hostspec import HostSpec
+from rook.rook_client.ceph.cephcluster import CephCluster, Spec
+from rook.rook_cluster import RookCluster
+
+
+def test_rook_add_dg():
+    cl = CephCluster(
+        apiVersion='',
+        spec=Spec(),
+        metadata={},
+    ).to_json()
+    core = Mock()
+    core.api_client.call_api.return_value = cl
+    rc = RookCluster(core, Mock(), Mock())
+    s = rc.add_osds(
+        DriveGroupSpec(
+            service_type='osd',
+            service_id='all-osds',
+            data_devices=DeviceSelection(all=True)
+        ),
+        [HostSpec(hostname='host')]
+    )
+    assert s == 'Success'
+    print(repr(core.api_client.call_api.mock_calls[1]))
+    core.api_client.call_api.assert_called_with(ANY, 'PATCH', _preload_content=True, _return_http_data_only=True, auth_settings=['BearerToken'], body=[{'op': 'add', 'path': '/spec/driveGroups', 'value': [{'name': 'all-osds', 'spec': {'data_devices': {'all': True}, 'filter_logic': 'AND', 'objectstore': 'bluestore'}, 'placement': {'node_affinity': None, 'pod_affinity': None, 'pod_anti_affinity': None}}]}], header_params={'Content-Type': 'application/json-patch+json'}, response_type='object')

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -12,7 +12,7 @@ deps =
     cython
     -rrequirements.txt
 commands =
-    pytest --cov --cov-append --cov-report= --doctest-modules {posargs: \
+    pytest -vv --cov --cov-append --cov-report= --doctest-modules {posargs: \
         mgr_util.py \
         tests/ \
         cephadm/ \

--- a/src/python-common/ceph/deployment/rook.py
+++ b/src/python-common/ceph/deployment/rook.py
@@ -1,0 +1,81 @@
+from typing import Tuple, List, Optional
+
+from kubernetes.client import V1Affinity, V1NodeAffinity, V1NodeSelector, \
+    V1NodeSelectorTerm, V1NodeSelectorRequirement
+
+from ceph.deployment.hostspec import HostSpec
+from ceph.deployment.service_spec import PlacementSpec, ServiceSpecValidationError
+
+
+def placement_spec_to_k8s(
+        all_hosts: List[HostSpec],
+        spec: PlacementSpec
+) -> Tuple[Optional[int], V1Affinity]:
+    """
+    - node list
+    - labels
+    - count (?)
+    - all nodes?
+    - host glob?
+
+    Q: podAntiAffinity
+    A: might required in the future for scheduling pods.
+
+    Q: topologySpreadConstraints
+    A: might required in the future for scheduling pods.
+
+    Q: pod(Anti)Affinity
+    A: not yet supported in PlacementSpec
+
+    :returns: <replica count>, V1Affinity
+    """
+
+    if spec.label:
+        try:
+            key, value = spec.label.split(':', 1)
+        except ValueError:
+            msg = f'label "{spec.label}" needs to be in the form of `key:value`'
+            raise ServiceSpecValidationError(msg)
+
+        return spec.count, V1Affinity(
+            node_affinity=V1NodeAffinity(
+                required_during_scheduling_ignored_during_execution=V1NodeSelector(
+                    node_selector_terms=[
+                        V1NodeSelectorTerm(
+                            match_expressions=[
+                                V1NodeSelectorRequirement(
+                                    key=key,
+                                    operator='In',
+                                    values=[
+                                        value
+                                    ]
+                                )
+                            ]
+                        )
+                    ]
+                )
+            )
+        )
+    hostnames = spec.filter_matching_hostspecs(all_hosts)
+    if not hostnames or len(hostnames) == len(all_hosts):
+        return spec.count, V1Affinity()
+    return spec.count, V1Affinity(
+            node_affinity=V1NodeAffinity(
+                required_during_scheduling_ignored_during_execution=V1NodeSelector(
+                    node_selector_terms=[
+                        V1NodeSelectorTerm(
+                            match_expressions=[
+                                V1NodeSelectorRequirement(
+                                    key='kubernetes.io/hostname',
+                                    operator='In',
+                                    values=[
+                                        h
+                                    ]
+                                )
+                            ]
+                        )
+                        for h in hostnames
+                    ]
+                )
+            )
+        )

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -2,7 +2,7 @@ import fnmatch
 import re
 from collections import namedtuple, OrderedDict
 from functools import wraps
-from typing import Optional, Dict, Any, List, Union, Callable, Iterator
+from typing import Optional, Dict, Any, List, Union, Callable, Iterable
 
 import six
 import yaml
@@ -187,7 +187,7 @@ class PlacementSpec(object):
     def filter_matching_hosts(self, _get_hosts_func: Callable) -> List[str]:
         return self.filter_matching_hostspecs(_get_hosts_func(as_hostspec=True))
 
-    def filter_matching_hostspecs(self, hostspecs: Iterator[HostSpec]) -> List[str]:
+    def filter_matching_hostspecs(self, hostspecs: Iterable[HostSpec]) -> List[str]:
         if self.hosts:
             all_hosts = [hs.hostname for hs in hostspecs]
             return [h.hostname for h in self.hosts if h.hostname in all_hosts]
@@ -201,7 +201,7 @@ class PlacementSpec(object):
             # get_host_selection_size
             return []
 
-    def get_host_selection_size(self, hostspecs: Iterator[HostSpec]):
+    def get_host_selection_size(self, hostspecs: Iterable[HostSpec]):
         if self.count:
             return self.count
         return len(self.filter_matching_hostspecs(hostspecs))

--- a/src/python-common/ceph/tests/test_rook.py
+++ b/src/python-common/ceph/tests/test_rook.py
@@ -1,0 +1,23 @@
+import yaml
+
+from ceph.deployment.rook import placement_spec_to_k8s
+from ceph.deployment.service_spec import PlacementSpec
+
+
+def test_placement_spec_to_k8s():
+    spec = PlacementSpec(label='app:ceph-rook-rgw')
+    count, aff = placement_spec_to_k8s([], spec)
+    yml = yaml.dump(aff.to_dict())
+    assert yml == """node_affinity:
+  preferred_during_scheduling_ignored_during_execution: null
+  required_during_scheduling_ignored_during_execution:
+    node_selector_terms:
+    - match_expressions:
+      - key: app
+        operator: In
+        values:
+        - ceph-rook-rgw
+      match_fields: null
+pod_affinity: null
+pod_anti_affinity: null
+"""

--- a/src/python-common/requirements.txt
+++ b/src/python-common/requirements.txt
@@ -5,3 +5,4 @@ mypy==0.782; python_version >= '3'
 pytest-mypy; python_version >= '3'
 pytest >= 2.1.3; python_version >= '3'
 pyyaml
+kubernetes


### PR DESCRIPTION
Depends on https://github.com/rook/rook-client-python/pull/1

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
