### PR TITLE
doc: Updated mailing list addresses

### DIFF
--- a/doc/rados/troubleshooting/community.rst
+++ b/doc/rados/troubleshooting/community.rst
@@ -4,7 +4,7 @@
 
 The Ceph community is an excellent source of information and help. For
 operational issues with Ceph releases we recommend you `subscribe to the
-ceph-users email list`_. When  you no longer want to receive emails, you can
+ceph-users email list`_. When you no longer want to receive emails, you can
 `unsubscribe from the ceph-users email list`_.
 
 You may also `subscribe to the ceph-devel email list`_. You should do so if
@@ -22,8 +22,7 @@ may `unsubscribe from the ceph-devel email list`_.
    you if you provide them with detailed information about your problem. You
    can attach the output of the ``ceph report`` command to help people understand your issues.
 
-.. _subscribe to the ceph-devel email list: mailto:majordomo@vger.kernel.org?body=subscribe+ceph-devel
-.. _unsubscribe from the ceph-devel email list: mailto:majordomo@vger.kernel.org?body=unsubscribe+ceph-devel
-.. _subscribe to the ceph-users email list: mailto:ceph-users-join@lists.ceph.com
-.. _unsubscribe from the ceph-users email list: mailto:ceph-users-leave@lists.ceph.com
-.. _ceph-devel: ceph-devel@vger.kernel.org
+.. _subscribe to the ceph-devel email list: mailto:dev-join@ceph.io
+.. _unsubscribe from the ceph-devel email list: mailto:dev-leave@ceph.io
+.. _subscribe to the ceph-users email list: mailto:ceph-users-join@ceph.io
+.. _unsubscribe from the ceph-users email list: mailto:ceph-users-leave@ceph.io


### PR DESCRIPTION
The "Community" chapter of the RADOS troubleshooting section was still pointing to the old mailing list addresses.

Updated to point to the new ceph.io addresses.

Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] Updates documentation if necessary

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
