### PR TITLE
cephadm: UX: Change error message when 'orch host add <host>' fails

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2650,7 +2650,10 @@ def command_bootstrap():
 
         host = get_hostname()
         logger.info('Adding host %s...' % host)
-        cli(['orch', 'host', 'add', host])
+        try:
+            cli(['orch', 'host', 'add', host])
+        except RuntimeError as e:
+            raise Error('Failed to add host <%s>: %s' % (host, e))
 
         if not args.orphan_initial_daemons:
             for t in ['mon', 'mgr', 'crash']:


### PR DESCRIPTION
Instead of printing out a traceback if adding the host fails
during bootstrapping process, should now print error message
telling user host failed to be added

Fixes: https://tracker.ceph.com/issues/45097
Signed-off-by: Adam King <adking@redhat.com>