### PR TITLE
cephadm: strip whitespace from iscsi version

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -392,7 +392,7 @@ class CephIscsi(object):
             [container_path, 'exec', container_id,
              '/usr/bin/python3', '-c', "import pkg_resources; print(pkg_resources.require('ceph_iscsi')[0].version)"])
         if code == 0:
-            version = out
+            version = out.strip()
         return version
 
     def validate(self):


### PR DESCRIPTION
Remove the `\n` char from the iscsi version.

```
ceph orch ps
NAME                         HOST      STATUS        REFRESHED  AGE  VERSION              IMAGE NAME                                      IMAGE ID      CONTAINER ID  
crash.host1                  host1     running (2d)  11m ago    2d   16.0.0-899-g18734af  docker.io/ceph/daemon-base:latest-master-devel  7bb50d3c5c9a  5b184588ff45
iscsi.iscsi.host1.mkpetc     host1     running (2h)  11m ago    2h   3.4                  docker.io/ceph/daemon-base:latest-master-devel  7bb50d3c5c9a  e695cd698d8a
                                                                                                                                                                      
nfs.foo.host1                host1     running (2d)  11m ago    2d   3.2                  docker.io/ceph/daemon-base:latest-master-devel  7bb50d3c5c9a  50d2f41073b1


$ ceph orch ps --daemon-type iscsi --format json-pretty
[
  {
    "container_id": "e695cd698d8a",
    "container_image_id": "7bb50d3c5c9afcb8d68417890cae4ac782cf68c9b48e2879bc7e610cc7e2d45c",
    "container_image_name": "docker.io/ceph/daemon-base:latest-master-devel",
    "created": "2020-06-11T19:40:44.235423",
    "daemon_id": "iscsi.host1.mkpetc",
    "daemon_type": "iscsi",
    "hostname": "host1",
    "last_refresh": "2020-06-11T20:23:53.395076",
    "started": "2020-06-11T19:40:44.484183",
    "status": 1,
    "status_desc": "running",
    "version": "3.4\n"
  }
]
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
