### PR TITLE
rgw: replace '+' with "%20" in canonical query string for s3 v4 auth.

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -498,7 +498,7 @@ std::string get_v4_canonical_qs(const req_info& info, const bool using_qs)
   }
   if (params->find_first_of('+') != std::string::npos) {
     copy_params = *params;
-    boost::replace_all(copy_params, "+", " ");
+    boost::replace_all(copy_params, "+", "%20");
     params = &copy_params;
   }
 


### PR DESCRIPTION
fix https://tracker.ceph.com/issues/45983

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>


when use java s3 sdk list objects with  Delimiter " ", it will cause 403 signature not match error
```
        ListObjectsRequest request = new ListObjectsRequest();
        request.setBucketName(bucketName);
        request.setDelimiter(" ");
        conn.listObjects(request).getObjectSummaries().size();
```

as metion here

https://github.com/ceph/ceph/pull/17040/commits/8ef21a05e6b2a8563ea37345746ade4a9cd189d7

![图片](https://user-images.githubusercontent.com/20007497/84473210-39fd8800-acbb-11ea-9970-f4fae8032fb4.png)

the " " will be trim and final cause signature not match


