### PR TITLE
octopus: qa/tasks/vstart_runner.py: add def mountpoint parameter

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -622,7 +622,7 @@ class LocalKernelMount(KernelMount):
         log.info("I think my launching pid was {0}".format(self.fuse_daemon.subproc.pid))
         return path
 
-    def mount(self, mount_path=None, mount_fs_name=None, mount_options=[]):
+    def mount(self, mount_path=None, mount_fs_name=None, mount_options=[], **kwargs):
         self.setupfs(name=mount_fs_name)
 
         log.info('Mounting kclient client.{id} at {remote} {mnt}...'.format(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45848

---

backport of https://github.com/ceph/ceph/pull/34782
parent tracker: https://tracker.ceph.com/issues/45300

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh