### PR TITLE
crimson/os: disable alienized bluestore if using seastar allocator

### DIFF
--- a/src/crimson/os/futurized_store.cc
+++ b/src/crimson/os/futurized_store.cc
@@ -12,7 +12,11 @@ FuturizedStore::create(const std::string& type,
   if (type == "memstore") {
     return std::make_unique<crimson::os::CyanStore>(data);
   } else if (type == "bluestore") {
+#ifdef SEASTAR_DEFAULT_ALLOCATOR
     return std::make_unique<crimson::os::AlienStore>(data, values);
+#else
+    #warning please define SEASTAR_DEFAULT_ALLOCATOR for using alien store
+#endif
   } else {
     ceph_abort_msgf("unsupported objectstore type: %s", type.c_str());
     return {};


### PR DESCRIPTION
before figuring out how to colocate alien store and seastar's builtin
allocator. we need to disable alienized bluestore, if
SEASTAR_DEFAULT_ALLOCATOR is not defined.

See-also: https://tracker.ceph.com/issues/45985
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
