### PR TITLE
mgr/dashboard: fix ui api endpoints

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -8,7 +8,7 @@ import os
 import cherrypy
 import cephfs
 
-from . import ApiController, RESTController, UiApiController
+from . import ApiController, ControllerDoc, RESTController, UiApiController
 from .. import mgr
 from ..exceptions import DashboardException
 from ..security import Scope
@@ -467,6 +467,7 @@ class CephFSClients(object):
 
 
 @UiApiController('/cephfs', Scope.CEPHFS)
+@ControllerDoc("Dashboard UI helper function; not part of the public API", "CephFSUi")
 class CephFsUi(CephFS):
     RESOURCE_ID = 'fs_id'
 

--- a/src/pybind/mgr/dashboard/controllers/crush_rule.py
+++ b/src/pybind/mgr/dashboard/controllers/crush_rule.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 
 from cherrypy import NotFound
 
-from . import ApiController, RESTController, Endpoint, ReadPermission, UiApiController
+from . import ApiController, ControllerDoc, RESTController, Endpoint, ReadPermission, \
+    UiApiController
 from ..security import Scope
 from ..services.ceph_service import CephService
 from .. import mgr
@@ -35,6 +36,7 @@ class CrushRule(RESTController):
 
 
 @UiApiController('/crush_rule', Scope.POOL)
+@ControllerDoc("Dashboard UI helper function; not part of the public API", "CrushRuleUi")
 class CrushRuleUi(CrushRule):
     @Endpoint()
     @ReadPermission

--- a/src/pybind/mgr/dashboard/controllers/docs.py
+++ b/src/pybind/mgr/dashboard/controllers/docs.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+from typing import Any, Dict, Union
 
 import logging
 import cherrypy
@@ -31,7 +32,7 @@ class Docs(BaseController):
                 if endpoint.is_api or all_endpoints:
                     list_of_ctrl.add(endpoint.ctrl)
 
-        tag_map = {}
+        tag_map: Dict[str, str] = {}
         for ctrl in list_of_ctrl:
             tag_name = ctrl.__name__
             tag_descr = ""
@@ -183,7 +184,7 @@ class Docs(BaseController):
 
     @classmethod
     def _gen_responses(cls, method, resp_object=None):
-        resp = {
+        resp: Dict[str, Dict[str, Union[str, Any]]] = {
             '400': {
                 "description": "Operation exception. Please check the "
                                "response body for details."
@@ -252,7 +253,7 @@ class Docs(BaseController):
         return parameters
 
     @classmethod
-    def _gen_paths(cls, all_endpoints, base_url):
+    def _gen_paths(cls, all_endpoints):
         method_order = ['get', 'post', 'put', 'delete']
         paths = {}
         for path, endpoints in sorted(list(ENDPOINT_MAP.items()),
@@ -308,7 +309,7 @@ class Docs(BaseController):
                     methods[method.lower()]['security'] = [{'jwt': []}]
 
             if not skip:
-                paths[path[len(base_url):]] = methods
+                paths[path] = methods
 
         return paths
 
@@ -320,7 +321,7 @@ class Docs(BaseController):
         host = host[host.index(':')+3:]
         logger.debug("Host: %s", host)
 
-        paths = self._gen_paths(all_endpoints, base_url)
+        paths = self._gen_paths(all_endpoints)
 
         if not base_url:
             base_url = "/"
@@ -363,11 +364,11 @@ class Docs(BaseController):
 
     @Endpoint(path="api.json")
     def api_json(self):
-        return self._gen_spec(False, "/api")
+        return self._gen_spec(False, "/")
 
     @Endpoint(path="api-all.json")
     def api_all_json(self):
-        return self._gen_spec(True, "/api")
+        return self._gen_spec(True, "/")
 
     def _swagger_ui_page(self, all_endpoints=False, token=None):
         base = cherrypy.request.base

--- a/src/pybind/mgr/dashboard/controllers/erasure_code_profile.py
+++ b/src/pybind/mgr/dashboard/controllers/erasure_code_profile.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 
 from cherrypy import NotFound
 
-from . import ApiController, RESTController, Endpoint, ReadPermission, UiApiController
+from . import ApiController, ControllerDoc, RESTController, Endpoint, ReadPermission, \
+    UiApiController
 from ..security import Scope
 from ..services.ceph_service import CephService
 from .. import mgr
@@ -36,6 +37,7 @@ class ErasureCodeProfile(RESTController):
 
 
 @UiApiController('/erasure_code_profile', Scope.POOL)
+@ControllerDoc("Dashboard UI helper function; not part of the public API", "ErasureCodeProfileUi")
 class ErasureCodeProfileUi(ErasureCodeProfile):
     @Endpoint()
     @ReadPermission

--- a/src/pybind/mgr/dashboard/tests/test_docs.py
+++ b/src/pybind/mgr/dashboard/tests/test_docs.py
@@ -60,11 +60,16 @@ class DocsTest(ControllerTestCase):
         self.assertEqual(Docs()._type_to_str(str), "string")
 
     def test_gen_paths(self):
-        outcome = Docs()._gen_paths(False, "")['/api/doctest//decorated_func/{parameter}']['get']
+        outcome = Docs()._gen_paths(False)['/api/doctest//decorated_func/{parameter}']['get']
         self.assertIn('tags', outcome)
         self.assertIn('summary', outcome)
         self.assertIn('parameters', outcome)
         self.assertIn('responses', outcome)
+
+    def test_gen_paths_all(self):
+        paths = Docs()._gen_paths(False)
+        for key in paths:
+            self.assertTrue(any(base in key.split('/')[1] for base in ['api', 'ui-api']))
 
     def test_gen_tags(self):
         outcome = Docs()._gen_tags(False)[0]


### PR DESCRIPTION
mgr/dashboard: UiApi endpoints were broken because the same base URL was used
for both UiApi and Api endpoints.

There were two issues with this:

- The `paths` dict keys were based off a string split of `path` that used base URL length. This caused the wrong keys to be created and the duplicate `apiapi` seen in the cURL requests generated by OpenAPI.
- Fixing the above issue was not enough, as then both Api and UiApi endpoints would have the same base URL. This causes conflicts with doc generation that result in only UiApi endpoints to be generated.

Passing only `/` as the base URL argument for `api_json` and `api_all_json` and using the full path as the `paths` keys solves this issue.

Other changes:

* `base_url` variable was removed from  `controllers/docs.py:_gen_paths` and `tests/test_docs.py` because it was unused after my change.

* Added type hints for dicts in `controllers/docs.py` and `controllers/pool.py` because they were not passing mypy checks.

Fixes: https://tracker.ceph.com/issues/45957
Signed-off-by: Fabrizio D'Angelo <fdangelo@redhat.com>



## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
