### PR TITLE
librbd: skipping update of invalid object map

### DIFF
--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -338,8 +338,11 @@ void ObjectMap<I>::aio_update(uint64_t snap_id, uint64_t start_object_no,
 		 << "->" << static_cast<uint32_t>(new_state) << dendl;
   if (snap_id == CEPH_NOSNAP) {
     ceph_assert(ceph_mutex_is_wlocked(m_lock));
+    uint64_t flags;
+    int r = m_image_ctx.get_flags(CEPH_NOSNAP, &flags);
     end_object_no = std::min(end_object_no, m_object_map.size());
-    if (start_object_no >= end_object_no) {
+    if (start_object_no >= end_object_no || r < 0 ||
+        (flags & RBD_FLAG_OBJECT_MAP_INVALID) != 0) {
       ldout(cct, 20) << "skipping update of invalid object map" << dendl;
       m_image_ctx.op_work_queue->queue(on_finish, 0);
       return;


### PR DESCRIPTION
**Background:**  In our test, the image's object map is invalid, and a large number of `rbd.object_map_update` result in many slow requests (there may be other reasons why the update operation was not completed in time, we donot yet know the essential reason). 

This pr try to fix skipping update of invalid object map.
```
[root@host-192-168-9-11 ~]# ceph daemon osd.34 dump_historic_slow_ops |grep description
            "description": "osd_op(client.11741484.0:1168 7.118 7:18931210:::rbd_object_map.a441277a3f2dd3:head [call lock.assert_locked,call rbd.object_map_update] snapc 0=[] ondisk+write+known_if_redirected e1615)",
            "description": "osd_op(client.11741484.0:1173 7.118 7:18931210:::rbd_object_map.a441277a3f2dd3:head [call lock.assert_locked,call rbd.object_map_update] snapc 0=[] ondisk+write+known_if_redirected e1615)",
            "description": "osd_op(client.11741484.0:1176 7.118 7:18931210:::rbd_object_map.a441277a3f2dd3:head [call lock.assert_locked,call rbd.object_map_update] snapc 0=[] ondisk+write+known_if_redirected e1615)",
            "description": "osd_op(client.11741484.0:1179 7.118 7:18931210:::rbd_object_map.a441277a3f2dd3:head [call lock.assert_locked,call rbd.object_map_update] snapc 0=[] ondisk+write+known_if_redirected e1615)",
            "description": "osd_op(client.11741484.0:1181 7.118 7:18931210:::rbd_object_map.a441277a3f2dd3:head [call lock.assert_locked,call rbd.object_map_update] snapc 0=[] ondisk+write+known_if_redirected e1615)",
            "description": "osd_op(client.11741484.0:1193 7.118 7:18931210:::rbd_object_map.a441277a3f2dd3:head [call lock.assert_locked,call rbd.object_map_update] snapc 0=[] ondisk+write+known_if_redirected e1615)",	
             .....
```	

```
	{
		"time": "2020-06-08 20:23:45.658642",
		"event": "reached_pg"
	},
	{
		"time": "2020-06-08 20:23:45.658651",
		"event": "waiting for rw locks"
	},
	{
		"time": "2020-06-08 20:23:46.529958",
		"event": "reached_pg"
	},
	{
		"time": "2020-06-08 20:23:46.529968",
		"event": "waiting for rw locks"
	},
```					

Signed-off-by: songweibin <song.weibin@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
