### PR TITLE
pybind: volume_client handle purge of directory names encoded in utf-8

### DIFF
--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -529,6 +529,9 @@ vc.disconnect()
         self.mount_a.run_shell(["touch", os.path.join(mount_path, "noperms")])
         self.mount_a.run_shell(["chmod", "0000", os.path.join(mount_path, "noperms")])
 
+        # A folder with non-ascii characters
+        self.mount_a.run_shell(["mkdir", os.path.join(mount_path, u"f\u00F6n")
+
         self._volume_client_python(self.mount_b, dedent("""
             vp = VolumePath("{group_id}", u"{volume_id}")
             vc.delete_volume(vp)

--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -731,7 +731,7 @@ class CephFSVolumeClient(object):
             return
 
         def rmtree(root_path):
-            log.debug("rmtree {0}".format(root_path))
+            log.debug(u"rmtree {0}".format(root_path))
             dir_handle = self.fs.opendir(root_path)
             d = self.fs.readdir(dir_handle)
             while d:


### PR DESCRIPTION

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
