### PR TITLE
mgr/cephadm: Manage /etc/ceph/ceph.conf

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1120,7 +1120,7 @@ you may want to run:
         self.log.debug(f'Refreshed OSDSpec previews for host <{host}>')
         return True
 
-    def _refresh_hosts_and_daemons(self):
+    def _refresh_hosts_and_daemons(self) -> None:
         bad_hosts = []
         failures = []
 
@@ -1175,7 +1175,7 @@ you may want to run:
         if health_changed:
             self.set_health_checks(self.health_checks)
 
-    def _refresh_host_daemons(self, host):
+    def _refresh_host_daemons(self, host) -> Optional[str]:
         try:
             out, err, code = self._run_cephadm(
                 host, 'mon', 'ls', [], no_fsid=True)
@@ -1228,7 +1228,7 @@ you may want to run:
         self.cache.save_host(host)
         return None
 
-    def _refresh_host_devices(self, host):
+    def _refresh_host_devices(self, host) -> Optional[str]:
         try:
             out, err, code = self._run_cephadm(
                 host, 'osd',

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -141,7 +141,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
 
     instance = None
     NATIVE_OPTIONS = []  # type: List[Any]
-    MODULE_OPTIONS = [
+    MODULE_OPTIONS: List[dict] = [
         {
             'name': 'ssh_config_file',
             'type': 'str',
@@ -521,20 +521,33 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
     def config_notify(self):
         """
         This method is called whenever one of our config options is changed.
+
+        TODO: this method should be moved into mgr_module.py
         """
+        module_options_changed: List[str] = []
         for opt in self.MODULE_OPTIONS:
+            old_val = getattr(self, opt['name'], None)
+            new_val = self.get_module_option(opt['name'])
             setattr(self,
                     opt['name'],  # type: ignore
-                    self.get_module_option(opt['name']))  # type: ignore
+                    new_val)  # type: ignore
             self.log.debug(' mgr option %s = %s',
                            opt['name'], getattr(self, opt['name']))  # type: ignore
+            if old_val != new_val:
+                module_options_changed.append(opt['name'])
         for opt in self.NATIVE_OPTIONS:
             setattr(self,
                     opt,  # type: ignore
                     self.get_ceph_option(opt))
             self.log.debug(' native option %s = %s', opt, getattr(self, opt))  # type: ignore
 
+        for what in module_options_changed:
+            self.config_notify_one(what)
+
         self.event.set()
+
+    def config_notify_one(self, what):
+        pass
 
     def notify(self, notify_type, notify_id):
         pass

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 from contextlib import contextmanager
+from unittest.mock import ANY
 
 import pytest
 
@@ -597,3 +598,25 @@ class TestCephadm(object):
                     # code will blow up here triggering the BOOM!
                     code, out, err = cephadm_module.check_host('test')
                     assert err is None
+
+    @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
+    @mock.patch("remoto.process.check")
+    def test_etc_ceph(self, _check, _get_connection, cephadm_module: CephadmOrchestrator):
+        _get_connection.return_value = mock.Mock(), mock.Mock()
+        _check.return_value = '{}', '', 0
+
+        with with_host(cephadm_module, 'test'):
+            assert not cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')
+
+        with with_host(cephadm_module, 'test'):
+            cephadm_module.set_module_option('manage_etc_ceph_ceph_conf', True)
+            cephadm_module.config_notify()
+            assert cephadm_module.manage_etc_ceph_ceph_conf == True
+
+            cephadm_module._refresh_hosts_and_daemons()
+            _check.assert_called_with(ANY, ['dd', 'of=/etc/ceph/ceph.conf'], stdin=b'')
+
+            assert not cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')
+
+            cephadm_module.notify('mon_map', mock.MagicMock())
+            assert cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -66,6 +66,7 @@ if 'UNITTEST' in os.environ:
             self._ceph_get_option = mock.MagicMock()
             self._ceph_get_context = mock.MagicMock()
             self._ceph_register_client = mock.MagicMock()
+            self._ceph_set_health_checks = mock.MagicMock()
             self._configure_logging = lambda *_: None
             self._unconfigure_logging = mock.MagicMock()
             self._ceph_log = mock.MagicMock()

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -36,7 +36,17 @@ if 'UNITTEST' in os.environ:
             }
 
         def _ceph_get_module_option(self, module, key, localized_prefix: None):
-            return self._ceph_get_store(f'{module}/{key}')
+            val =  self._ceph_get_store(f'{module}/{key}')
+            mo = [o for o in self.MODULE_OPTIONS if o['name'] == key]
+            if len(mo) == 1 and val is not None:
+                cls = {
+                    'str': str,
+                    'secs': int,
+                    'bool': lambda s: bool(s) and s != 'false' and s != 'False',
+                    'int': int,
+                }[mo[0].get('type', 'str')]
+                return cls(val)
+            return val
 
         def _ceph_set_module_option(self, module, key, val):
             return self._ceph_set_store(f'{module}/{key}', val)

--- a/src/python-common/ceph/deployment/hostspec.py
+++ b/src/python-common/ceph/deployment/hostspec.py
@@ -54,6 +54,11 @@ class HostSpec(object):
 
         return "HostSpec({})".format(', '.join(map(repr, args)))
 
+    def __str__(self):
+        if self.hostname != self.addr:
+            return f'{self.hostname} ({self.addr})'
+        return self.hostname
+
     def __eq__(self, other):
         # Let's omit `status` for the moment, as it is still the very same host.
         return self.hostname == other.hostname and \


### PR DESCRIPTION
**TODO**

- [x] replace ceph.conf handling in qa/tasks/cephadm.py
  
 https://github.com/ceph/ceph/blob/b2de27be3f6f2eaba22df31e9e45d5633c941596/qa/tasks/cephadm.py#L961-L964

- [x] pytest

**Considerations**

* This is now embedded using the usual check_* methods, which means it's using a different code path than the daemon's reconfig calls. otoh, we're not dealing with daemons here.
* I don't like `error_ok=True`, as id detours the normal python error handling. Making it necessary to add special code for it.

**To enable the management of ceph.conf**

`ceph config set mgr mgr/cephadm/manage_etc_ceph_ceph_conf true`


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
