### PR TITLE
Make mempool assignment same after bufferlist rebuild

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1175,6 +1175,8 @@ static ceph::spinlock debug_lock;
     std::unique_ptr<buffer::ptr_node, buffer::ptr_node::disposer> nb)
   {
     unsigned pos = 0;
+    int mempool = _buffers.front().get_mempool();
+    nb->reassign_to_mempool(mempool);
     for (auto& node : _buffers) {
       nb->copy_in(pos, node.length(), node.c_str(), false);
       pos += node.length();

--- a/src/test/test_mempool.cc
+++ b/src/test/test_mempool.cc
@@ -366,6 +366,21 @@ TEST(mempool, bufferlist_reassign)
   ASSERT_EQ(bytes_before, mempool::osd::allocated_bytes());
 }
 
+TEST(mempool, bufferlist_c_str)
+{
+  bufferlist bl;
+  int len = 1048576;
+  size_t before = mempool::osd::allocated_bytes();
+  bl.append(buffer::create_aligned(len, 4096));
+  bl.append(buffer::create_aligned(len, 4096));
+  bl.reassign_to_mempool(mempool::mempool_osd);
+  size_t after = mempool::osd::allocated_bytes();
+  ASSERT_GE(after, before + len * 2);
+  bl.c_str();
+  size_t after_c_str = mempool::osd::allocated_bytes();
+  ASSERT_EQ(after, after_c_str);
+}
+
 TEST(mempool, btree_map_test)
 {
   typedef mempool::pool_allocator<mempool::mempool_osd,


### PR DESCRIPTION
I believe that c_str() should not lose mempool assignment if it was forced to rebuild underlying buffer::raw structure.

Tracked by https://tracker.ceph.com/issues/46027