### PR TITLE
ceph-volume: fix lvm functional tests

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -34,7 +34,7 @@ changedir=
   centos8-bluestore-mixed_type_explicit: {toxinidir}/centos8/bluestore/mixed-type-explicit
   centos8-bluestore-mixed_type_dmcrypt_explicit: {toxinidir}/centos8/bluestore/mixed-type-dmcrypt-explicit
 commands=
-  git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
+  git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch {env:CEPH_ANSIBLE_CLONE:"https://github.com/ceph/ceph-ansible.git"} {envdir}/tmp/ceph-ansible
   python -m pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
 
   # bash {toxinidir}/../scripts/vagrant_up.sh {env:VAGRANT_UP_FLAGS:""} {posargs:--provider=virtualbox}

--- a/src/ceph-volume/ceph_volume/tests/functional/group_vars/bluestore_lvm
+++ b/src/ceph-volume/ceph_volume/tests/functional/group_vars/bluestore_lvm
@@ -11,6 +11,9 @@ osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
 copy_admin_key: false
+pv_devices:
+  - /dev/vdb
+  - /dev/vdc
 lvm_volumes:
   - data: data-lv1
     data_vg: test_group

--- a/src/ceph-volume/ceph_volume/tests/functional/group_vars/bluestore_lvm_dmcrypt
+++ b/src/ceph-volume/ceph_volume/tests/functional/group_vars/bluestore_lvm_dmcrypt
@@ -12,6 +12,9 @@ osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
 copy_admin_key: false
+pv_devices:
+  - /dev/vdb
+  - /dev/vdc
 lvm_volumes:
   - data: data-lv1
     data_vg: test_group

--- a/src/ceph-volume/ceph_volume/tests/functional/group_vars/filestore_lvm
+++ b/src/ceph-volume/ceph_volume/tests/functional/group_vars/filestore_lvm
@@ -11,6 +11,9 @@ osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
 copy_admin_key: false
+pv_devices:
+  - /dev/vdb
+  - /dev/vdc
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sda
 lvm_volumes:
   - data: data-lv1

--- a/src/ceph-volume/ceph_volume/tests/functional/group_vars/filestore_lvm_dmcrypt
+++ b/src/ceph-volume/ceph_volume/tests/functional/group_vars/filestore_lvm_dmcrypt
@@ -12,6 +12,9 @@ osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
 copy_admin_key: false
+pv_devices:
+  - /dev/vdb
+  - /dev/vdc
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sda
 lvm_volumes:
   - data: data-lv1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_bluestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_bluestore.yml
@@ -114,8 +114,8 @@
         suffix: sparse
       register: tmpdir
 
-    - name: create a 5GB sparse file
-      command: fallocate -l 5G {{ tmpdir.path }}/sparse.file
+    - name: create a 1GB sparse file
+      command: fallocate -l 1G {{ tmpdir.path }}/sparse.file
 
     - name: find an empty loop device
       command: losetup -f

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
@@ -135,8 +135,8 @@
         suffix: sparse
       register: tmpdir
 
-    - name: create a 5GB sparse file
-      command: fallocate -l 5G {{ tmpdir.path }}/sparse.file
+    - name: create a 1GB sparse file
+      command: fallocate -l 1G {{ tmpdir.path }}/sparse.file
 
     - name: find an empty loop device
       command: losetup -f

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -32,7 +32,7 @@ changedir=
   centos8-filestore-prepare_activate: {toxinidir}/xenial/filestore/prepare_activate
   centos8-bluestore-prepare_activate: {toxinidir}/xenial/bluestore/prepare_activate
 commands=
-  git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
+  git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch {env:CEPH_ANSIBLE_CLONE:"https://github.com/ceph/ceph-ansible.git"} {envdir}/tmp/ceph-ansible
   pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
 
   bash {toxinidir}/../scripts/vagrant_up.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}


### PR DESCRIPTION
This is related to https://github.com/ceph/ceph-ansible/pull/5413 and
adjusts the tests to work with the related ansible fix.

Fixes: https://tracker.ceph.com/issues/46131
Signed-off-by: Jan Fajerski <jfajerski@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
