### PR TITLE
osd: Add config option to compact OSD's object store on start

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -92,3 +92,7 @@
     ceph fs required_client_features <fs name> add <feature>
     ceph fs required_client_features <fs name> rm <feature>
     ceph fs feature ls
+
+* OSD: A new configuration option ``osd_compact_on_start`` has been added which triggers
+  an OSD compaction on start. Setting this option to ``true`` and restarting an OSD
+  will result in an offline compaction of the OSD prior to booting.

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2514,6 +2514,10 @@ std::vector<Option> get_global_options() {
     .set_default(true)
     .set_description("flush FileStore journal contents during clean OSD shutdown"),
 
+    Option("osd_compact_on_start", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("compact OSD's object store's OMAP on start"),
+
     Option("osd_os_flags", Option::TYPE_UINT, Option::LEVEL_DEV)
     .set_default(0)
     .set_description("flags to skip filestore omap or journal initialization"),

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3500,6 +3500,10 @@ int OSD::init()
 
   dout(2) << "superblock: I am osd." << superblock.whoami << dendl;
 
+  if (cct->_conf.get_val<bool>("osd_compact_on_start")) {
+    dout(2) << "compacting object store's omap" << dendl;
+    store->compact();
+  }
 
   // prime osd stats
   {


### PR DESCRIPTION
By setting this configuration option an OSD will compact it's
store's OMAP on start.

This way admin's can trigger an offline compaction by setting this
configuration value to 'true' and then restarting the OSD.

This is easier than using tools like 'ceph-kvstore-tool' with requires
more manual work on the CLI and might be more difficult for users.

Signed-off-by: Wido den Hollander <wido@42on.com>
