### PR TITLE
osd/scheduler: add white space for better readability

### DIFF
--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -293,7 +293,7 @@ public:
   }
   std::ostream &print(std::ostream &rhs) const final {
     return rhs << "PGSnapTrim(pgid=" << get_pgid()
-	       << "epoch_queued=" << epoch_queued
+	       << " epoch_queued=" << epoch_queued
 	       << ")";
   }
   void run(
@@ -341,8 +341,8 @@ public:
   }
   std::ostream &print(std::ostream &rhs) const final {
     return rhs << "PGRecovery(pgid=" << get_pgid()
-	       << "epoch_queued=" << epoch_queued
-	       << "reserved_pushes=" << reserved_pushes
+	       << " epoch_queued=" << epoch_queued
+	       << " reserved_pushes=" << reserved_pushes
 	       << ")";
   }
   uint64_t get_reserved_pushes() const final {


### PR DESCRIPTION
or we will see log like: PGRecovery(pgid=30.0epoch_queued=37778reserved_pushes=1)
Signed-off-by: wuxingyi <wuxingyi2015@outlook.com>