### PR TITLE
rgw: fix return value of get_obj_head. It should return error If read operation fails.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -361,7 +361,7 @@ static int get_obj_head(rgw::sal::RGWRadosStore *store, struct req_state *s,
 
   ret = read_op.read(0, s->cct->_conf->rgw_max_chunk_size, *pbl, s->yield);
 
-  return 0;
+  return ret;
 }
 
 struct multipart_upload_info


### PR DESCRIPTION

Signed-off-by: zhangshaowen <zhangshaowen@cmss.chinamobile.com>

