### PR TITLE
rgw/sts: Adding a configurable rgw_sts_min_session_duration

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1547,6 +1547,7 @@ OPTION(rgw_sts_entry, OPT_STR)
 OPTION(rgw_sts_key, OPT_STR)
 OPTION(rgw_s3_auth_use_sts, OPT_BOOL)  // should we try to use sts for s3?
 OPTION(rgw_sts_max_session_duration, OPT_U64) // Max duration in seconds for which the session token is valid.
+OPTION(rgw_sts_min_session_duration, OPT_U64) // Min duration in seconds for which the session token is valid.
 OPTION(fake_statfs_for_testing, OPT_INT) // Set a value for kb and compute kb_used from total of num_bytes
 OPTION(rgw_sts_token_introspection_url, OPT_STR)  // url for introspecting web tokens
 OPTION(rgw_sts_client_id, OPT_STR) // Client Id

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7020,6 +7020,10 @@ std::vector<Option> get_rgw_options() {
     .set_description("Session token max duration")
     .set_long_description("Max duration in seconds for which the session token is valid."),
 
+    Option("rgw_sts_min_session_duration", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(900)
+    .set_description("Minimum allowed duration of a session"),
+
     Option("rgw_max_listing_results", Option::TYPE_UINT,
 	   Option::LEVEL_ADVANCED)
     .set_default(1000)

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -479,7 +479,7 @@ void RGWSTSAssumeRoleWithWebIdentity::execute()
     return;
   }
 
-  STS::AssumeRoleWithWebIdentityRequest req(duration, providerId, policy, roleArn,
+  STS::AssumeRoleWithWebIdentityRequest req(s->cct, duration, providerId, policy, roleArn,
                         roleSessionName, iss, sub, aud);
   STS::AssumeRoleWithWebIdentityResponse response = sts.assumeRoleWithWebIdentity(req);
   op_ret = std::move(response.assumeRoleResp.retCode);
@@ -538,7 +538,7 @@ void RGWSTSAssumeRole::execute()
     return;
   }
 
-  STS::AssumeRoleRequest req(duration, externalId, policy, roleArn,
+  STS::AssumeRoleRequest req(s->cct, duration, externalId, policy, roleArn,
                         roleSessionName, serialNumber, tokenCode);
   STS::AssumeRoleResponse response = sts.assumeRole(req);
   op_ret = std::move(response.retCode);

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -169,12 +169,14 @@ int AssumedRoleUser::generateAssumedRoleUser(CephContext* cct,
   return 0;
 }
 
-AssumeRoleRequestBase::AssumeRoleRequestBase( const string& duration,
+AssumeRoleRequestBase::AssumeRoleRequestBase( CephContext* cct,
+                                              const string& duration,
                                               const string& iamPolicy,
                                               const string& roleArn,
                                               const string& roleSessionName)
   : iamPolicy(iamPolicy), roleArn(roleArn), roleSessionName(roleSessionName)
 {
+  MIN_DURATION_IN_SECS = cct->_conf->rgw_sts_min_session_duration;
   if (duration.empty()) {
     this->duration = DEFAULT_DURATION_IN_SECS;
   } else {

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -15,11 +15,11 @@ protected:
   static constexpr uint64_t MIN_POLICY_SIZE = 1;
   static constexpr uint64_t MAX_POLICY_SIZE = 2048;
   static constexpr uint64_t DEFAULT_DURATION_IN_SECS = 3600;
-  static constexpr uint64_t MIN_DURATION_IN_SECS = 900;
   static constexpr uint64_t MIN_ROLE_ARN_SIZE = 2;
   static constexpr uint64_t MAX_ROLE_ARN_SIZE = 2048;
   static constexpr uint64_t MIN_ROLE_SESSION_SIZE = 2;
   static constexpr uint64_t MAX_ROLE_SESSION_SIZE = 64;
+  uint64_t MIN_DURATION_IN_SECS;
   uint64_t MAX_DURATION_IN_SECS;
   uint64_t duration;
   string err_msg;
@@ -27,7 +27,8 @@ protected:
   string roleArn;
   string roleSessionName;
 public:
-  AssumeRoleRequestBase(const string& duration,
+  AssumeRoleRequestBase(CephContext* cct,
+                        const string& duration,
                         const string& iamPolicy,
                         const string& roleArn,
                         const string& roleSessionName);
@@ -49,7 +50,8 @@ class AssumeRoleWithWebIdentityRequest : public AssumeRoleRequestBase {
   string sub;
   string aud;
 public:
-  AssumeRoleWithWebIdentityRequest( const string& duration,
+  AssumeRoleWithWebIdentityRequest( CephContext* cct,
+                      const string& duration,
                       const string& providerId,
                       const string& iamPolicy,
                       const string& roleArn,
@@ -57,7 +59,7 @@ public:
                       const string& iss,
                       const string& sub,
                       const string& aud)
-    : AssumeRoleRequestBase(duration, iamPolicy, roleArn, roleSessionName),
+    : AssumeRoleRequestBase(cct, duration, iamPolicy, roleArn, roleSessionName),
       providerId(providerId), iss(iss), sub(sub), aud(aud) {}
   const string& getProviderId() const { return providerId; }
   const string& getIss() const { return iss; }
@@ -76,14 +78,15 @@ class AssumeRoleRequest : public AssumeRoleRequestBase {
   string serialNumber;
   string tokenCode;
 public:
-  AssumeRoleRequest(const string& duration,
+  AssumeRoleRequest(CephContext* cct,
+                    const string& duration,
                     const string& externalId,
                     const string& iamPolicy,
                     const string& roleArn,
                     const string& roleSessionName,
                     const string& serialNumber,
                     const string& tokenCode)
-    : AssumeRoleRequestBase(duration, iamPolicy, roleArn, roleSessionName),
+    : AssumeRoleRequestBase(cct, duration, iamPolicy, roleArn, roleSessionName),
       externalId(externalId), serialNumber(serialNumber), tokenCode(tokenCode){}
   int validate_input() const;
 };


### PR DESCRIPTION
that can be used to set the lower limit of duration for
which an STS token is valid.

Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
