### PR TITLE
use for_each_substr to avoid redundant operation by calling get_str_set

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -386,9 +386,14 @@ public:
     if (changed.count(
 	  "enable_experimental_unrecoverable_data_corrupting_features")) {
       std::lock_guard lg(cct->_feature_lock);
-      get_str_set(
-	conf->enable_experimental_unrecoverable_data_corrupting_features,
-	cct->_experimental_features);
+
+      cct->_experimental_features.clear();
+      auto add_experimental_feature = [this] (auto feature) {
+        cct->_experimental_features.emplace(std::string{feature});
+      };
+      for_each_substr(conf->enable_experimental_unrecoverable_data_corrupting_features,
+          ";,= \t", add_experimental_feature);
+
       if (getenv("CEPH_DEV") == NULL) {
         if (!cct->_experimental_features.empty()) {
           if (cct->_experimental_features.count("*")) {

--- a/src/common/str_list.cc
+++ b/src/common/str_list.cc
@@ -61,24 +61,3 @@ vector<string> get_str_vec(const string& str, const char *delims)
   get_str_vec(str, delims, result);
   return result;
 }
-
-void get_str_set(const string& str, const char *delims, set<string>& str_set)
-{
-  str_set.clear();
-  for_each_substr(str, delims, [&str_set] (auto token) {
-      str_set.emplace(token.begin(), token.end());
-    });
-}
-
-void get_str_set(const string& str, set<string>& str_set)
-{
-  const char *delims = ";,= \t";
-  get_str_set(str, delims, str_set);
-}
-
-set<string> get_str_set(const string& str, const char *delims)
-{
-  set<string> result;
-  get_str_set(str, delims, result);
-  return result;
-}

--- a/src/include/str_list.h
+++ b/src/include/str_list.h
@@ -117,9 +117,9 @@ inline std::string str_join(const std::vector<std::string>& v, const std::string
 {
   if (v.empty())
     return std::string();
-  std::vector<std::string>::const_iterator i = v.begin();
+  auto i = v.cbegin();
   std::string r = *i;
-  for (++i; i != v.end(); ++i) {
+  for (++i; i != v.cend(); ++i) {
     r += sep;
     r += *i;
   }

--- a/src/include/str_list.h
+++ b/src/include/str_list.h
@@ -71,29 +71,29 @@ extern void get_str_vec(const std::string& str,
 std::vector<std::string> get_str_vec(const std::string& str,
                                      const char *delims = ";,= \t");
 /**
- * Split **str** into a set of strings, using the ";,= \t" delimiters and output the result in **str_list**.
+ * Split **str** into a set of strings, using the ";,= \t" delimiters and output the result in **str_set**.
  * 
  * @param [in] str String to split and save as Set
- * @param [out] str_list Set modified containing str after it has been split
+ * @param [out] str_set Set modified containing str after it has been split
 **/
 extern void get_str_set(const std::string& str,
-			std::set<std::string>& str_list);
+			std::set<std::string>& str_set);
 
 /**
- * Split **str** into a set of strings, using the **delims** delimiters and output the result in **str_list**.
+ * Split **str** into a set of strings, using the **delims** delimiters and output the result in **str_set**.
  * 
  * @param [in] str String to split and save as Set
  * @param [in] delims characters used to split **str**
- * @param [out] str_list Set modified containing str after it has been split
+ * @param [out] str_set Set modified containing str after it has been split
 **/
 template<class Compare = std::less<std::string> >
 void get_str_set(const std::string& str,
                  const char *delims,
-                 std::set<std::string, Compare>& str_list)
+                 std::set<std::string, Compare>& str_set)
 {
-  str_list.clear();
-  for_each_substr(str, delims, [&str_list] (auto token) {
-                  str_list.emplace(token.begin(), token.end());
+  str_set.clear();
+  for_each_substr(str, delims, [&str_set] (auto token) {
+                  str_set.emplace(token.begin(), token.end());
                   });
 }
 

--- a/src/include/str_list.h
+++ b/src/include/str_list.h
@@ -49,7 +49,7 @@ std::list<std::string> get_str_list(const std::string& str,
                                     const char *delims = ";,= \t");
 
 /**
- * Split **str** into a list of strings, using the ";,= \t" delimiters and output the result in **str_vec**.
+ * Split **str** into a vector of strings, using the ";,= \t" delimiters and output the result in **str_vec**.
  * 
  * @param [in] str String to split and save as Vector
  * @param [out] str_vec Vector modified containing str after it has been split
@@ -58,7 +58,7 @@ extern void get_str_vec(const std::string& str,
 			 std::vector<std::string>& str_vec);
 
 /**
- * Split **str** into a list of strings, using the **delims** delimiters and output the result in **str_vec**.
+ * Split **str** into a vector of strings, using the **delims** delimiters and output the result in **str_vec**.
  * 
  * @param [in] str String to split and save as Vector
  * @param [in] delims characters used to split **str**
@@ -71,7 +71,7 @@ extern void get_str_vec(const std::string& str,
 std::vector<std::string> get_str_vec(const std::string& str,
                                      const char *delims = ";,= \t");
 /**
- * Split **str** into a list of strings, using the ";,= \t" delimiters and output the result in **str_list**.
+ * Split **str** into a set of strings, using the ";,= \t" delimiters and output the result in **str_list**.
  * 
  * @param [in] str String to split and save as Set
  * @param [out] str_list Set modified containing str after it has been split
@@ -80,7 +80,7 @@ extern void get_str_set(const std::string& str,
 			std::set<std::string>& str_list);
 
 /**
- * Split **str** into a list of strings, using the **delims** delimiters and output the result in **str_list**.
+ * Split **str** into a set of strings, using the **delims** delimiters and output the result in **str_list**.
  * 
  * @param [in] str String to split and save as Set
  * @param [in] delims characters used to split **str**

--- a/src/include/str_list.h
+++ b/src/include/str_list.h
@@ -70,37 +70,6 @@ extern void get_str_vec(const std::string& str,
 
 std::vector<std::string> get_str_vec(const std::string& str,
                                      const char *delims = ";,= \t");
-/**
- * Split **str** into a set of strings, using the ";,= \t" delimiters and output the result in **str_set**.
- * 
- * @param [in] str String to split and save as Set
- * @param [out] str_set Set modified containing str after it has been split
-**/
-extern void get_str_set(const std::string& str,
-			std::set<std::string>& str_set);
-
-/**
- * Split **str** into a set of strings, using the **delims** delimiters and output the result in **str_set**.
- * 
- * @param [in] str String to split and save as Set
- * @param [in] delims characters used to split **str**
- * @param [out] str_set Set modified containing str after it has been split
-**/
-template<class Compare = std::less<std::string> >
-void get_str_set(const std::string& str,
-                 const char *delims,
-                 std::set<std::string, Compare>& str_set)
-{
-  str_set.clear();
-  for_each_substr(str, delims, [&str_set] (auto token) {
-                  str_set.emplace(token.begin(), token.end());
-                  });
-}
-
-std::set<std::string> get_str_set(const std::string& str,
-                                  const char *delims = ";,= \t");
-
-
 
 /**
  * Return a String containing the vector **v** joined with **sep**

--- a/src/rgw/rgw_cors.h
+++ b/src/rgw/rgw_cors.h
@@ -126,7 +126,7 @@ class RGWCORSConfiguration
 };
 WRITE_CLASS_ENCODER(RGWCORSConfiguration)
 
-static inline int validate_name_string(string& o) {
+static inline int validate_name_string(std::string_view o) {
   if (o.length() == 0)
     return -1;
   if (o.find_first_of("*") != o.find_last_of("*"))

--- a/src/test/test_str_list.cc
+++ b/src/test/test_str_list.cc
@@ -7,8 +7,7 @@
 
 // SplitTest is parameterized for list/vector/set
 using Types = ::testing::Types<std::list<std::string>,
-                               std::vector<std::string>,
-                               std::set<std::string>>;
+                               std::vector<std::string>>;
 
 template <typename T>
 struct SplitTest : ::testing::Test {
@@ -19,10 +18,6 @@ struct SplitTest : ::testing::Test {
   void test(const char* input, const char *delim,
             const std::vector<std::string>& expected) {
     EXPECT_EQ(expected, get_str_vec(input, delim));
-  }
-  void test(const char* input, const char *delim,
-            const std::set<std::string>& expected) {
-    EXPECT_EQ(expected, get_str_set(input, delim));
   }
 };
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
