### PR TITLE
rook-client-python: switch over to rook project repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,7 +66,7 @@
 	url = https://github.com/ceph/spawn.git
 [submodule "src/pybind/mgr/rook/rook-client-python"]
 	path = src/pybind/mgr/rook/rook-client-python
-	url = https://github.com/ceph/rook-client-python.git
+	url = https://github.com/rook/rook-client-python.git
 [submodule "s3select"]
 	path = src/s3select
 	url = https://github.com/ceph/s3select.git


### PR DESCRIPTION
I noticed that the rook-client-python project repo was a bit out of
date. Sebastian also suggested changing it over to use the rook project
repo.

Testing it now. My main impetus for this was that we were missing a gitignore patch in this repo. Let me know if I need to open a tracker for this.