### PR TITLE
replace 'whitelist' and 'blacklist' language

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -86,3 +86,28 @@
 * Monitors now have a config option ``mon_osd_warn_num_repaired``, 10 by default.
   If any OSD has repaired more than this many I/O errors in stored data a
  ``OSD_TOO_MANY_REPAIRS`` health warning is generated.
+
+* `blacklist` has been replaced with `blocklist` throughout.  The following commands have changed:
+
+  - ``ceph osd blacklist ...`` are now ``ceph osd blocklist ...``
+  - ``ceph <tell|daemon> osd.<NNN> dump_blacklist`` is now ``ceph <tell|daemon> osd.<NNN> dump_blocklist``
+
+* The following config options have changed:
+
+  - ``mon osd blacklist default expire`` is now ``mon osd blocklist default expire``
+  - ``mon mds blacklist interval`` is now ``mon mds blocklist interval``
+  - ``mon mgr blacklist interval`` is now ''mon mgr blocklist interval``
+  - ``rbd blacklist on break lock`` is now ``rbd blocklist on break lock``
+  - ``rbd blacklist expire seconds`` is now ``rbd blocklist expire seconds``
+  - ``mds session blacklist on timeout`` is now ``mds session blocklist on timeout``
+  - ``mds session blacklist on evict`` is now ``mds session blocklist on evict``
+
+* The following librados API calls have changed:
+
+  - ``rados_blacklist_add`` is now ``rados_blocklist_add``; the former will issue a deprecation warning and be removed in a future release.
+  - ``rados.blacklist_add`` is now ``rados.blocklist_add`` in the C++ API.
+
+* The JSON output for the following commands now shows ``blocklist`` instead of ``blacklist``:
+
+  - ``ceph osd dump``
+  - ``ceph <tell|daemon> osd.<N> dump_blocklist``

--- a/doc/cephfs/eviction.rst
+++ b/doc/cephfs/eviction.rst
@@ -89,30 +89,30 @@ do that using its unique ID, or various other attributes to identify it:
     ceph tell mds.0 client evict client_metadata.=4305
 
 
-Advanced: Un-blacklisting a client
+Advanced: Un-blocklisting a client
 ==================================
 
-Ordinarily, a blacklisted client may not reconnect to the servers: it
+Ordinarily, a blocklisted client may not reconnect to the servers: it
 must be unmounted and then mounted anew.
 
 However, in some situations it may be useful to permit a client that
 was evicted to attempt to reconnect.
 
-Because CephFS uses the RADOS OSD blacklist to control client eviction,
+Because CephFS uses the RADOS OSD blocklist to control client eviction,
 CephFS clients can be permitted to reconnect by removing them from
-the blacklist:
+the blocklist:
 
 ::
 
-    $ ceph osd blacklist ls
+    $ ceph osd blocklist ls
     listed 1 entries
     127.0.0.1:0/3710147553 2018-03-19 11:32:24.716146
-    $ ceph osd blacklist rm 127.0.0.1:0/3710147553
-    un-blacklisting 127.0.0.1:0/3710147553
+    $ ceph osd blocklist rm 127.0.0.1:0/3710147553
+    un-blocklisting 127.0.0.1:0/3710147553
 
 
 Doing this may put data integrity at risk if other clients have accessed
-files that the blacklisted client was doing buffered IO to.  It is also not
+files that the blocklisted client was doing buffered IO to.  It is also not
 guaranteed to result in a fully functional client -- the best way to get
 a fully healthy client back after an eviction is to unmount the client
 and do a fresh mount.
@@ -121,7 +121,7 @@ If you are trying to reconnect clients in this way, you may also
 find it useful to set ``client_reconnect_stale`` to true in the
 FUSE client, to prompt the client to try to reconnect.
 
-Advanced: Configuring blacklisting
+Advanced: Configuring blocklisting
 ==================================
 
 If you are experiencing frequent client evictions, due to slow
@@ -131,27 +131,27 @@ issue, then you may want to ask the MDS to be less strict.
 It is possible to respond to slow clients by simply dropping their
 MDS sessions, but permit them to re-open sessions and permit them
 to continue talking to OSDs.  To enable this mode, set
-``mds_session_blacklist_on_timeout`` to false on your MDS nodes.
+``mds_session_blocklist_on_timeout`` to false on your MDS nodes.
 
 For the equivalent behaviour on manual evictions, set
-``mds_session_blacklist_on_evict`` to false.
+``mds_session_blocklist_on_evict`` to false.
 
-Note that if blacklisting is disabled, then evicting a client will
+Note that if blocklisting is disabled, then evicting a client will
 only have an effect on the MDS you send the command to.  On a system
 with multiple active MDS daemons, you would need to send an
-eviction command to each active daemon.  When blacklisting is enabled 
+eviction command to each active daemon.  When blocklisting is enabled 
 (the default), sending an eviction command to just a single
-MDS is sufficient, because the blacklist propagates it to the others.
+MDS is sufficient, because the blocklist propagates it to the others.
 
-.. _background_blacklisting_and_osd_epoch_barrier:
+.. _background_blocklisting_and_osd_epoch_barrier:
 
-Background: Blacklisting and OSD epoch barrier
+Background: Blocklisting and OSD epoch barrier
 ==============================================
 
-After a client is blacklisted, it is necessary to make sure that
+After a client is blocklisted, it is necessary to make sure that
 other clients and MDS daemons have the latest OSDMap (including
-the blacklist entry) before they try to access any data objects
-that the blacklisted client might have been accessing.
+the blocklist entry) before they try to access any data objects
+that the blocklisted client might have been accessing.
 
 This is ensured using an internal "osdmap epoch barrier" mechanism.
 
@@ -159,12 +159,12 @@ The purpose of the barrier is to ensure that when we hand out any
 capabilities which might allow touching the same RADOS objects, the
 clients we hand out the capabilities to must have a sufficiently recent
 OSD map to not race with cancelled operations (from ENOSPC) or
-blacklisted clients (from evictions).
+blocklisted clients (from evictions).
 
 More specifically, the cases where an epoch barrier is set are:
 
- * Client eviction (where the client is blacklisted and other clients
-   must wait for a post-blacklist epoch to touch the same objects).
+ * Client eviction (where the client is blocklisted and other clients
+   must wait for a post-blocklist epoch to touch the same objects).
  * OSD map full flag handling in the client (where the client may
    cancel some OSD ops from a pre-full epoch, so other clients must
    wait until the full epoch or later before touching the same objects).

--- a/doc/cephfs/full.rst
+++ b/doc/cephfs/full.rst
@@ -40,7 +40,7 @@ time the OSD full flag is sent.  Clients update the ``osd_epoch_barrier``
 when releasing capabilities on files affected by cancelled operations, in
 order to ensure that these cancelled operations do not interfere with
 subsequent access to the data objects by the MDS or other clients.  For
-more on the epoch barrier mechanism, see :ref:`background_blacklisting_and_osd_epoch_barrier`.
+more on the epoch barrier mechanism, see :ref:`background_blocklisting_and_osd_epoch_barrier`.
 
 Legacy (pre-hammer) behavior
 ----------------------------

--- a/doc/cephfs/mdcache.rst
+++ b/doc/cephfs/mdcache.rst
@@ -22,7 +22,7 @@ Clients can request capabilities and will generally get them, but when
 there is competing access or memory pressure on the MDS, they may be
 **revoked**. When a capability is revoked, the client is responsible for
 returning it as soon as it is able. Clients that fail to do so in a
-timely fashion may end up **blacklisted** and unable to communicate with
+timely fashion may end up **blocklisted** and unable to communicate with
 the cluster.
 
 Since the cache is distributed, the MDS must take great care to ensure

--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -69,14 +69,14 @@
 :Default: ``15``
 
 
-``mds blacklist interval``
+``mds blocklist interval``
 
-:Description: The blacklist duration for failed MDSs in the OSD map. Note,
+:Description: The blocklist duration for failed MDSs in the OSD map. Note,
               this controls how long failed MDS daemons will stay in the
-              OSDMap blacklist. It has no effect on how long something is
-              blacklisted when the administrator blacklists it manually. For
-              example, ``ceph osd blacklist add`` will still use the default
-              blacklist time.
+              OSDMap blocklist. It has no effect on how long something is
+              blocklisted when the administrator blocklists it manually. For
+              example, ``ceph osd blocklist add`` will still use the default
+              blocklist time.
 :Type:  Float
 :Default: ``24.0*60.0``
 

--- a/doc/dev/osd_internals/manifest.rst
+++ b/doc/dev/osd_internals/manifest.rst
@@ -455,7 +455,7 @@ Operations:
   Clears manifest chunks or redirect.  Lazily releases references, may
   leak.
 
-  do_osd_ops seems not to include it in the user_modify=false whitelist,
+  do_osd_ops seems not to include it in the user_modify=false ignorelist,
   and so will trigger a snapshot.  Note, this will be true even for a
   redirect though SET_REDIRECT does not flip user_modify.  This should
   be fixed -- unset-manifest should not be a user_modify.
@@ -468,7 +468,7 @@ Operations:
 
         rados -p base_pool tier-flush <obj-name>
 
-  Included in the user_modify=false whitelist, does not trigger a clone.
+  Included in the user_modify=false ignorelist, does not trigger a clone.
 
   Does not evict the extents.
 

--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -37,7 +37,7 @@ Synopsis
 
 | **ceph** **mon** [ *add* \| *dump* \| *getmap* \| *remove* \| *stat* ] ...
 
-| **ceph** **osd** [ *blacklist* \| *blocked-by* \| *create* \| *new* \| *deep-scrub* \| *df* \| *down* \| *dump* \| *erasure-code-profile* \| *find* \| *getcrushmap* \| *getmap* \| *getmaxosd* \| *in* \| *ls* \| *lspools* \| *map* \| *metadata* \| *ok-to-stop* \| *out* \| *pause* \| *perf* \| *pg-temp* \| *force-create-pg* \| *primary-affinity* \| *primary-temp* \| *repair* \| *reweight* \| *reweight-by-pg* \| *rm* \| *destroy* \| *purge* \| *safe-to-destroy* \| *scrub* \| *set* \| *setcrushmap* \| *setmaxosd*  \| *stat* \| *tree* \| *unpause* \| *unset* ] ...
+| **ceph** **osd** [ *blocklist* \| *blocked-by* \| *create* \| *new* \| *deep-scrub* \| *df* \| *down* \| *dump* \| *erasure-code-profile* \| *find* \| *getcrushmap* \| *getmap* \| *getmaxosd* \| *in* \| *ls* \| *lspools* \| *map* \| *metadata* \| *ok-to-stop* \| *out* \| *pause* \| *perf* \| *pg-temp* \| *force-create-pg* \| *primary-affinity* \| *primary-temp* \| *repair* \| *reweight* \| *reweight-by-pg* \| *rm* \| *destroy* \| *purge* \| *safe-to-destroy* \| *scrub* \| *set* \| *setcrushmap* \| *setmaxosd*  \| *stat* \| *tree* \| *unpause* \| *unset* ] ...
 
 | **ceph** **osd** **crush** [ *add* \| *add-bucket* \| *create-or-move* \| *dump* \| *get-tunable* \| *link* \| *move* \| *remove* \| *rename-bucket* \| *reweight* \| *reweight-all* \| *reweight-subtree* \| *rm* \| *rule* \| *set* \| *set-tunable* \| *show-tunables* \| *tunables* \| *unlink* ] ...
 
@@ -613,27 +613,27 @@ osd
 Manage OSD configuration and administration. It uses some additional
 subcommands.
 
-Subcommand ``blacklist`` manage blacklisted clients. It uses some additional
+Subcommand ``blocklist`` manage blocklisted clients. It uses some additional
 subcommands.
 
-Subcommand ``add`` add <addr> to blacklist (optionally until <expire> seconds
+Subcommand ``add`` add <addr> to blocklist (optionally until <expire> seconds
 from now)
 
 Usage::
 
-	ceph osd blacklist add <EntityAddr> {<float[0.0-]>}
+	ceph osd blocklist add <EntityAddr> {<float[0.0-]>}
 
-Subcommand ``ls`` show blacklisted clients
-
-Usage::
-
-	ceph osd blacklist ls
-
-Subcommand ``rm`` remove <addr> from blacklist
+Subcommand ``ls`` show blocklisted clients
 
 Usage::
 
-	ceph osd blacklist rm <EntityAddr>
+	ceph osd blocklist ls
+
+Subcommand ``rm`` remove <addr> from blocklist
+
+Usage::
+
+	ceph osd blocklist rm <EntityAddr>
 
 Subcommand ``blocked-by`` prints a histogram of which OSDs are blocking their peers
 

--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -82,15 +82,15 @@ Basic
     path to file containing the secret key to use with CephX
 
 :command:`recover_session=<no|clean>`
-    Set auto reconnect mode in the case where the client is blacklisted. The
+    Set auto reconnect mode in the case where the client is blocklisted. The
     available modes are ``no`` and ``clean``. The default is ``no``.
 
     - ``no``: never attempt to reconnect when client detects that it has been
-       blacklisted. Blacklisted clients will not attempt to reconnect and
+       blocklisted. Blocklisted clients will not attempt to reconnect and
        their operations will fail too.
 
     - ``clean``: client reconnects to the Ceph cluster automatically when it
-      detects that it has been blacklisted. During reconnect, client drops
+      detects that it has been blocklisted. During reconnect, client drops
       dirty data/metadata, invalidates page caches and writable file handles.
       After reconnect, file locks become stale because the MDS loses track of
       them. If an inode contains any stale file locks, read/write on the inode

--- a/doc/rados/operations/control.rst
+++ b/doc/rados/operations/control.rst
@@ -237,18 +237,18 @@ Deployments utilizing Nautilus (or later revisions of Luminous and Mimic)
 that have no pre-Luminous cients may instead wish to instead enable the
 `balancer`` module for ``ceph-mgr``.
 
-Add/remove an IP address to/from the blacklist. When adding an address,
-you can specify how long it should be blacklisted in seconds; otherwise,
-it will default to 1 hour. A blacklisted address is prevented from
-connecting to any OSD. Blacklisting is most often used to prevent a
+Add/remove an IP address to/from the blocklist. When adding an address,
+you can specify how long it should be blocklisted in seconds; otherwise,
+it will default to 1 hour. A blocklisted address is prevented from
+connecting to any OSD. Blocklisting is most often used to prevent a
 lagging metadata server from making bad changes to data on the OSDs.
 
 These commands are mostly only useful for failure testing, as
-blacklists are normally maintained automatically and shouldn't need
+blocklists are normally maintained automatically and shouldn't need
 manual intervention. ::
 
-	ceph osd blacklist add ADDRESS[:source_port] [TIME]
-	ceph osd blacklist rm ADDRESS[:source_port]
+	ceph osd blocklist add ADDRESS[:source_port] [TIME]
+	ceph osd blocklist rm ADDRESS[:source_port]
 
 Creates/deletes a snapshot of a pool. ::
 

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -275,7 +275,7 @@ The following entries describe valid capability profiles:
 :Description: Gives a user permissions to manipulate RBD images. When used
               as a Monitor cap, it provides the minimal privileges required
               by an RBD client application; this includes the ability
-	      to blacklist other client users. When used as an OSD cap, it
+	      to blocklist other client users. When used as an OSD cap, it
               provides read-write access to the specified pool to an
 	      RBD client application. The Manager cap supports optional
               ``pool`` and ``namespace`` keyword arguments.

--- a/doc/rbd/rbd-exclusive-locks.rst
+++ b/doc/rbd/rbd-exclusive-locks.rst
@@ -60,8 +60,8 @@ accessing RBD data in an uncoordinated and destructive manner.
 
 Thus, in the event that a lock cannot be acquired in the standard
 graceful manner, the overtaking process not only breaks the lock, but
-also blacklists the previous lock holder. This is negotiated between
-the new client process and the Ceph Mon: upon receiving the blacklist
+also blocklists the previous lock holder. This is negotiated between
+the new client process and the Ceph Mon: upon receiving the blocklist
 request,
 
 * the Mon instructs the relevant OSDs to no longer serve requests from
@@ -71,10 +71,10 @@ request,
 * once the new client has acquired the lock, it can commence writing
   to the image.
 
-Blacklisting is thus a form of storage-level resource `fencing`_.
+Blocklisting is thus a form of storage-level resource `fencing`_.
 
-In order for blacklisting to work, the client must have the ``osd
-blacklist`` capability. This capability is included in the ``profile
+In order for blocklisting to work, the client must have the ``osd
+blocklist`` capability. This capability is included in the ``profile
 rbd`` capability profile, which should generally be set on all Ceph
 :ref:`client identities <user-management>` using RBD.
 

--- a/qa/cephfs/overrides/whitelist_health.yaml
+++ b/qa/cephfs/overrides/whitelist_health.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(FS_DEGRADED\)
       - \(MDS_FAILED\)

--- a/qa/cephfs/overrides/whitelist_wrongly_marked_down.yaml
+++ b/qa/cephfs/overrides/whitelist_wrongly_marked_down.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSD_DOWN\)
       - \(OSD_

--- a/qa/cephfs/tasks/cfuse_workunit_suites_ffsb.yaml
+++ b/qa/cephfs/tasks/cfuse_workunit_suites_ffsb.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - SLOW_OPS
     - slow request
     conf:

--- a/qa/overrides/2-size-2-min-size.yaml
+++ b/qa/overrides/2-size-2-min-size.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         osd_pool_default_size: 2
         osd_pool_default_min_size: 2
-    log-whitelist:
+    log-ignorelist:
       - \(REQUEST_STUCK\)

--- a/qa/overrides/whitelist_wrongly_marked_down.yaml
+++ b/qa/overrides/whitelist_wrongly_marked_down.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     conf:
       mds:

--- a/qa/releases/luminous.yaml
+++ b/qa/releases/luminous.yaml
@@ -17,5 +17,5 @@ overrides:
     conf:
       mon:
         mon warn on osd down out interval zero: false
-    log-whitelist:
+    log-ignorelist:
       - no active mgr

--- a/qa/suites/big/rados-thrash/thrashers/default.yaml
+++ b/qa/suites/big/rados-thrash/thrashers/default.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
 tasks:

--- a/qa/suites/fs/basic_functional/tasks/alternate-pool.yaml
+++ b/qa/suites/fs/basic_functional/tasks/alternate-pool.yaml
@@ -1,7 +1,7 @@
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - bad backtrace
       - object missing on disk
       - error reading table object

--- a/qa/suites/fs/basic_functional/tasks/auto-repair.yaml
+++ b/qa/suites/fs/basic_functional/tasks/auto-repair.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - force file system read-only
       - bad backtrace
       - MDS in read-only mode

--- a/qa/suites/fs/basic_functional/tasks/cephfs_scrub_tests.yaml
+++ b/qa/suites/fs/basic_functional/tasks/cephfs_scrub_tests.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - Replacing daemon mds
       - Scrub error on inode
       - Behind on trimming

--- a/qa/suites/fs/basic_functional/tasks/client-limits.yaml
+++ b/qa/suites/fs/basic_functional/tasks/client-limits.yaml
@@ -1,7 +1,7 @@
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - responding to mclientcaps\(revoke\)
       - not advance its oldest_client_tid
       - failing to advance its oldest client/flush tid

--- a/qa/suites/fs/basic_functional/tasks/client-recovery.yaml
+++ b/qa/suites/fs/basic_functional/tasks/client-recovery.yaml
@@ -3,7 +3,7 @@
 # to permit OSDs to complain about that.
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - evicting unresponsive client
       - but it is still running
       - slow request

--- a/qa/suites/fs/basic_functional/tasks/damage.yaml
+++ b/qa/suites/fs/basic_functional/tasks/damage.yaml
@@ -1,7 +1,7 @@
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - bad backtrace
       - object missing on disk
       - error reading table object

--- a/qa/suites/fs/basic_functional/tasks/data-scan.yaml
+++ b/qa/suites/fs/basic_functional/tasks/data-scan.yaml
@@ -1,7 +1,7 @@
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - bad backtrace
       - object missing on disk
       - error reading table object

--- a/qa/suites/fs/basic_functional/tasks/forward-scrub.yaml
+++ b/qa/suites/fs/basic_functional/tasks/forward-scrub.yaml
@@ -1,7 +1,7 @@
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - inode wrongly marked free
       - bad backtrace on inode
       - inode table repaired for inode

--- a/qa/suites/fs/basic_functional/tasks/journal-repair.yaml
+++ b/qa/suites/fs/basic_functional/tasks/journal-repair.yaml
@@ -1,7 +1,7 @@
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - bad backtrace on directory inode
       - error reading table object
       - Metadata damage detected

--- a/qa/suites/fs/basic_functional/tasks/mds-full.yaml
+++ b/qa/suites/fs/basic_functional/tasks/mds-full.yaml
@@ -3,7 +3,7 @@ overrides:
   ceph:
     cephfs_ec_profile:
       - disabled
-    log-whitelist:
+    log-ignorelist:
       - OSD full dropping all updates
       - OSD near full
       - pausewr flag

--- a/qa/suites/fs/basic_functional/tasks/sessionmap/sessionmap.yaml
+++ b/qa/suites/fs/basic_functional/tasks/sessionmap/sessionmap.yaml
@@ -1,7 +1,7 @@
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - client session with non-allowable root
 
 tasks:

--- a/qa/suites/fs/basic_functional/tasks/volume-client/task/test/test.yaml
+++ b/qa/suites/fs/basic_functional/tasks/volume-client/task/test/test.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - MON_DOWN
 tasks:
   - cephfs_test_runner:

--- a/qa/suites/fs/basic_functional/tasks/volumes.yaml
+++ b/qa/suites/fs/basic_functional/tasks/volumes.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - OSD full dropping all updates
       - OSD near full
       - pausewr flag

--- a/qa/suites/fs/bugs/client_trim_caps/tasks/trim-i22073.yaml
+++ b/qa/suites/fs/bugs/client_trim_caps/tasks/trim-i22073.yaml
@@ -4,7 +4,7 @@
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - MDS cache is too large
       - \(MDS_CACHE_OVERSIZED\)
 tasks:

--- a/qa/suites/fs/multiclient/tasks/cephfs_misc_tests.yaml
+++ b/qa/suites/fs/multiclient/tasks/cephfs_misc_tests.yaml
@@ -5,7 +5,7 @@ tasks:
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - evicting unresponsive client
       - POOL_APP_NOT_ENABLED
       - has not responded to cap revoke by MDS for over

--- a/qa/suites/fs/multifs/tasks/failover.yaml
+++ b/qa/suites/fs/multifs/tasks/failover.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - Replacing daemon mds
       - \(MDS_INSUFFICIENT_STANDBY\)
       - \(MDS_ALL_DOWN\)

--- a/qa/suites/fs/thrash/ceph-thrash/mds.yaml
+++ b/qa/suites/fs/thrash/ceph-thrash/mds.yaml
@@ -3,5 +3,5 @@ tasks:
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - Replacing daemon mds

--- a/qa/suites/fs/thrash/ceph-thrash/mon.yaml
+++ b/qa/suites/fs/thrash/ceph-thrash/mon.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
 tasks:

--- a/qa/suites/fs/thrash/msgr-failures/osd-mds-delay.yaml
+++ b/qa/suites/fs/thrash/msgr-failures/osd-mds-delay.yaml
@@ -7,5 +7,5 @@ overrides:
         ms inject delay probability: .005
         ms inject delay max: 1
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/0-nautilus.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/0-nautilus.yaml
@@ -14,7 +14,7 @@ tasks:
     extra_packages: ['librados2']
 - print: "**** done installing nautilus"
 - ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(FS_
       - \(MDS_

--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - scrub mismatch
     - ScrubResult
     - wrongly marked

--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/3-compat_client/pacific.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/3-compat_client/pacific.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - missing required features
 tasks:
 - exec:

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/0-nautilus.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/0-nautilus.yaml
@@ -14,7 +14,7 @@ tasks:
     extra_packages: ['librados2']
 - print: "**** done installing nautilus"
 - ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(FS_
       - \(MDS_

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - scrub mismatch
     - ScrubResult
     - wrongly marked

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/4-compat_client.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/4-compat_client.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - missing required features
 tasks:
 - exec:

--- a/qa/suites/fs/upgrade/volumes/import-legacy/tasks/0-nautilus.yaml
+++ b/qa/suites/fs/upgrade/volumes/import-legacy/tasks/0-nautilus.yaml
@@ -15,7 +15,7 @@ tasks:
     extra_packages: ['librados2']
 - print: "**** done installing nautilus"
 - ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(FS_
       - \(MDS_

--- a/qa/suites/fs/upgrade/volumes/import-legacy/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/volumes/import-legacy/tasks/2-upgrade.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - scrub mismatch
     - ScrubResult
     - wrongly marked

--- a/qa/suites/fs/upgrade/volumes/import-legacy/tasks/3-verify.yaml
+++ b/qa/suites/fs/upgrade/volumes/import-legacy/tasks/3-verify.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - missing required features
 tasks:
 - exec:

--- a/qa/suites/fs/verify/validater/valgrind.yaml
+++ b/qa/suites/fs/verify/validater/valgrind.yaml
@@ -8,7 +8,7 @@ overrides:
       debuginfo: true
   ceph:
     # Valgrind makes everything slow, so ignore slow requests and extend heartbeat grace
-    log-whitelist:
+    log-ignorelist:
       - slow requests are blocked
     conf:
       global:

--- a/qa/suites/kcephfs/cephfs/tasks/kclient_workunit_suites_ffsb.yaml
+++ b/qa/suites/kcephfs/cephfs/tasks/kclient_workunit_suites_ffsb.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - SLOW_OPS
     - slow request
 tasks:

--- a/qa/suites/kcephfs/recovery/tasks/auto-repair.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/auto-repair.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - force file system read-only
       - bad backtrace
       - MDS in read-only mode

--- a/qa/suites/kcephfs/recovery/tasks/client-limits.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/client-limits.yaml
@@ -1,7 +1,7 @@
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - responding to mclientcaps\(revoke\)
       - not advance its oldest_client_tid
       - failing to advance its oldest client/flush tid

--- a/qa/suites/kcephfs/recovery/tasks/client-recovery.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/client-recovery.yaml
@@ -3,7 +3,7 @@
 # to permit OSDs to complain about that.
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - but it is still running
       - slow request
       - evicting unresponsive client

--- a/qa/suites/kcephfs/recovery/tasks/damage.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/damage.yaml
@@ -1,7 +1,7 @@
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - bad backtrace
       - object missing on disk
       - error reading table object

--- a/qa/suites/kcephfs/recovery/tasks/data-scan.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/data-scan.yaml
@@ -1,7 +1,7 @@
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - bad backtrace
       - object missing on disk
       - error reading table object

--- a/qa/suites/kcephfs/recovery/tasks/failover.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/failover.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - Replacing daemon mds
       - \(MDS_INSUFFICIENT_STANDBY\)
       - \(MDS_ALL_DOWN\)

--- a/qa/suites/kcephfs/recovery/tasks/forward-scrub.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/forward-scrub.yaml
@@ -1,7 +1,7 @@
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - inode wrongly marked free
       - bad backtrace on inode
       - inode table repaired for inode

--- a/qa/suites/kcephfs/recovery/tasks/journal-repair.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/journal-repair.yaml
@@ -1,7 +1,7 @@
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - bad backtrace on directory inode
       - error reading table object
       - Metadata damage detected

--- a/qa/suites/kcephfs/recovery/tasks/mds-full.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/mds-full.yaml
@@ -3,7 +3,7 @@ overrides:
   ceph:
     cephfs_ec_profile:
       - disabled
-    log-whitelist:
+    log-ignorelist:
       - OSD full dropping all updates
       - OSD near full
       - pausewr flag

--- a/qa/suites/kcephfs/recovery/tasks/sessionmap.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/sessionmap.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - client session with non-allowable root
 
 tasks:

--- a/qa/suites/kcephfs/recovery/tasks/volume-client.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/volume-client.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - MON_DOWN
 tasks:
   - cephfs_test_runner:

--- a/qa/suites/kcephfs/thrash/thrashers/default.yaml
+++ b/qa/suites/kcephfs/thrash/thrashers/default.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - but it is still running
       - objects unfound and apparently lost
 tasks:

--- a/qa/suites/kcephfs/thrash/thrashers/mds.yaml
+++ b/qa/suites/kcephfs/thrash/thrashers/mds.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - Replacing daemon mds
 
 tasks:

--- a/qa/suites/kcephfs/thrash/thrashers/mon.yaml
+++ b/qa/suites/kcephfs/thrash/thrashers/mon.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - \(MON_DOWN\)
 
 tasks:

--- a/qa/suites/kcephfs/thrash/workloads/kclient_workunit_suites_ffsb.yaml
+++ b/qa/suites/kcephfs/thrash/workloads/kclient_workunit_suites_ffsb.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - SLOW_OPS
     - slow request
     conf:

--- a/qa/suites/krbd/fsx/striping/default/msgr-failures/few.yaml
+++ b/qa/suites/krbd/fsx/striping/default/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/krbd/fsx/striping/default/msgr-failures/many.yaml
+++ b/qa/suites/krbd/fsx/striping/default/msgr-failures/many.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 500
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/krbd/fsx/striping/fancy/msgr-failures/few.yaml
+++ b/qa/suites/krbd/fsx/striping/fancy/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/krbd/rbd-nomount/msgr-failures/few.yaml
+++ b/qa/suites/krbd/rbd-nomount/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/krbd/rbd-nomount/msgr-failures/many.yaml
+++ b/qa/suites/krbd/rbd-nomount/msgr-failures/many.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 500
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/krbd/rbd-nomount/tasks/krbd_udev_netlink_enobufs.yaml
+++ b/qa/suites/krbd/rbd-nomount/tasks/krbd_udev_netlink_enobufs.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - pauserd,pausewr flag\(s\) set
 
 tasks:

--- a/qa/suites/krbd/rbd/msgr-failures/few.yaml
+++ b/qa/suites/krbd/rbd/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/krbd/rbd/msgr-failures/many.yaml
+++ b/qa/suites/krbd/rbd/msgr-failures/many.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 500
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/krbd/singleton/msgr-failures/few.yaml
+++ b/qa/suites/krbd/singleton/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/krbd/singleton/msgr-failures/many.yaml
+++ b/qa/suites/krbd/singleton/msgr-failures/many.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 500
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/krbd/thrash/thrashers/backoff.yaml
+++ b/qa/suites/krbd/thrash/thrashers/backoff.yaml
@@ -4,7 +4,7 @@ overrides:
       osd:
         osd backoff on peering: true
         osd backoff on degraded: true
-    log-whitelist:
+    log-ignorelist:
     - wrongly marked me down
     - objects unfound and apparently lost
 tasks:

--- a/qa/suites/krbd/thrash/thrashers/pggrow.yaml
+++ b/qa/suites/krbd/thrash/thrashers/pggrow.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
 tasks:

--- a/qa/suites/krbd/thrash/thrashers/upmap.yaml
+++ b/qa/suites/krbd/thrash/thrashers/upmap.yaml
@@ -4,7 +4,7 @@ overrides:
     conf:
       mon:
         mon osd initial require min compat client: luminous
-    log-whitelist:
+    log-ignorelist:
     - wrongly marked me down
     - objects unfound and apparently lost
 tasks:

--- a/qa/suites/krbd/wac/wac/verify/many-resets.yaml
+++ b/qa/suites/krbd/wac/wac/verify/many-resets.yaml
@@ -4,7 +4,7 @@ overrides:
       global:
         ms inject socket failures: 500
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME
 tasks:
 - exec:

--- a/qa/suites/multimds/basic/tasks/cephfs_test_snapshots.yaml
+++ b/qa/suites/multimds/basic/tasks/cephfs_test_snapshots.yaml
@@ -2,7 +2,7 @@ overrides:
   check-counter:
     dry_run: true
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - evicting unresponsive client
       - RECENT_CRASH
 

--- a/qa/suites/perf-basic/ceph.yaml
+++ b/qa/suites/perf-basic/ceph.yaml
@@ -15,7 +15,7 @@ tasks:
 - ceph:
     fs: xfs
     wait-for-scrub: false
-    log-whitelist:
+    log-ignorelist:
       - \(PG_
       - \(OSD_
       - \(OBJECT_

--- a/qa/suites/powercycle/osd/tasks/rados_api_tests.yaml
+++ b/qa/suites/powercycle/osd/tasks/rados_api_tests.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - reached quota
       - \(POOL_APP_NOT_ENABLED\)
       - \(PG_AVAILABILITY\)

--- a/qa/suites/powercycle/osd/whitelist_health.yaml
+++ b/qa/suites/powercycle/osd/whitelist_health.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - \(MDS_TRIM\)
       - \(MDS_SLOW_REQUEST\)
       - MDS_SLOW_METADATA_IO

--- a/qa/suites/rados/basic/msgr-failures/few.yaml
+++ b/qa/suites/rados/basic/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/basic/msgr-failures/many.yaml
+++ b/qa/suites/rados/basic/msgr-failures/many.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 1500
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/basic/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/basic/tasks/rados_api_tests.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - reached quota
     - but it is still running
     - overall HEALTH_

--- a/qa/suites/rados/basic/tasks/rados_cls_all.yaml
+++ b/qa/suites/rados/basic/tasks/rados_cls_all.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - \(PG_AVAILABILITY\)
     conf:
       osd:

--- a/qa/suites/rados/basic/tasks/rados_python.yaml
+++ b/qa/suites/rados/basic/tasks/rados_python.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - overall HEALTH_
     - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/basic/tasks/rados_stress_watch.yaml
+++ b/qa/suites/rados/basic/tasks/rados_stress_watch.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(TOO_FEW_PGS\)

--- a/qa/suites/rados/basic/tasks/rados_workunit_loadgen_big.yaml
+++ b/qa/suites/rados/basic/tasks/rados_workunit_loadgen_big.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - overall HEALTH_
     - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rados/basic/tasks/rados_workunit_loadgen_mix.yaml
+++ b/qa/suites/rados/basic/tasks/rados_workunit_loadgen_mix.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - overall HEALTH_
     - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rados/basic/tasks/rados_workunit_loadgen_mostlyread.yaml
+++ b/qa/suites/rados/basic/tasks/rados_workunit_loadgen_mostlyread.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - overall HEALTH_
     - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rados/basic/tasks/repair_test.yaml
+++ b/qa/suites/rados/basic/tasks/repair_test.yaml
@@ -1,7 +1,7 @@
 overrides:
   ceph:
     wait-for-scrub: false
-    log-whitelist:
+    log-ignorelist:
       - candidate had a stat error
       - candidate had a read error
       - deep-scrub 0 missing, 1 inconsistent objects

--- a/qa/suites/rados/basic/tasks/scrub_test.yaml
+++ b/qa/suites/rados/basic/tasks/scrub_test.yaml
@@ -1,7 +1,7 @@
 overrides:
   ceph:
     wait-for-scrub: false
-    log-whitelist:
+    log-ignorelist:
     - '!= data_digest'
     - '!= omap_digest'
     - '!= size'

--- a/qa/suites/rados/cephadm/orchestrator_cli/orchestrator_cli.yaml
+++ b/qa/suites/rados/cephadm/orchestrator_cli/orchestrator_cli.yaml
@@ -5,7 +5,7 @@ tasks:
       # tests may leave mgrs broken, so don't try and call into them
       # to invoke e.g. pg dump during teardown.
       wait-for-scrub: false
-      log-whitelist:
+      log-ignorelist:
         - overall HEALTH_
         - \(MGR_DOWN\)
         - \(DEVICE_IDENT_ON\)

--- a/qa/suites/rados/dashboard/tasks/dashboard.yaml
+++ b/qa/suites/rados/dashboard/tasks/dashboard.yaml
@@ -5,7 +5,7 @@ tasks:
       # tests may leave mgrs broken, so don't try and call into them
       # to invoke e.g. pg dump during teardown.
       wait-for-scrub: false
-      log-whitelist:
+      log-ignorelist:
         - overall HEALTH_
         - \(MGR_DOWN\)
         - \(PG_

--- a/qa/suites/rados/mgr/tasks/crash.yaml
+++ b/qa/suites/rados/mgr/tasks/crash.yaml
@@ -5,7 +5,7 @@ tasks:
       # tests may leave mgrs broken, so don't try and call into them
       # to invoke e.g. pg dump during teardown.
       wait-for-scrub: false
-      log-whitelist:
+      log-ignorelist:
         - overall HEALTH_
         - \(MGR_DOWN\)
         - \(PG_

--- a/qa/suites/rados/mgr/tasks/failover.yaml
+++ b/qa/suites/rados/mgr/tasks/failover.yaml
@@ -5,7 +5,7 @@ tasks:
       # tests may leave mgrs broken, so don't try and call into them
       # to invoke e.g. pg dump during teardown.
       wait-for-scrub: false
-      log-whitelist:
+      log-ignorelist:
         - overall HEALTH_
         - \(MGR_DOWN\)
         - \(PG_

--- a/qa/suites/rados/mgr/tasks/insights.yaml
+++ b/qa/suites/rados/mgr/tasks/insights.yaml
@@ -5,7 +5,7 @@ tasks:
       # tests may leave mgrs broken, so don't try and call into them
       # to invoke e.g. pg dump during teardown.
       wait-for-scrub: false
-      log-whitelist:
+      log-ignorelist:
         - overall HEALTH_
         - \(MGR_DOWN\)
         - \(MGR_INSIGHTS_WARNING\)

--- a/qa/suites/rados/mgr/tasks/module_selftest.yaml
+++ b/qa/suites/rados/mgr/tasks/module_selftest.yaml
@@ -5,7 +5,7 @@ tasks:
       # tests may leave mgrs broken, so don't try and call into them
       # to invoke e.g. pg dump during teardown.
       wait-for-scrub: false
-      log-whitelist:
+      log-ignorelist:
         - overall HEALTH_
         - \(MGR_DOWN\)
         - \(PG_

--- a/qa/suites/rados/mgr/tasks/progress.yaml
+++ b/qa/suites/rados/mgr/tasks/progress.yaml
@@ -9,7 +9,7 @@ tasks:
       # tests may leave mgrs broken, so don't try and call into them
       # to invoke e.g. pg dump during teardown.
       wait-for-scrub: false
-      log-whitelist:
+      log-ignorelist:
         - overall HEALTH_
         - \(MGR_DOWN\)
         - \(MDS_ALL_DOWN\)

--- a/qa/suites/rados/mgr/tasks/prometheus.yaml
+++ b/qa/suites/rados/mgr/tasks/prometheus.yaml
@@ -5,7 +5,7 @@ tasks:
       # tests may leave mgrs broken, so don't try and call into them
       # to invoke e.g. pg dump during teardown.
       wait-for-scrub: false
-      log-whitelist:
+      log-ignorelist:
         - overall HEALTH_
         - \(MGR_DOWN\)
         - \(PG_

--- a/qa/suites/rados/mgr/tasks/workunits.yaml
+++ b/qa/suites/rados/mgr/tasks/workunits.yaml
@@ -4,7 +4,7 @@ tasks:
       # tests may leave mgrs broken, so don't try and call into them
       # to invoke e.g. pg dump during teardown.
       wait-for-scrub: false
-      log-whitelist:
+      log-ignorelist:
         - overall HEALTH_
         - \(MGR_DOWN\)
         - \(PG_

--- a/qa/suites/rados/monthrash/ceph.yaml
+++ b/qa/suites/rados/monthrash/ceph.yaml
@@ -9,7 +9,7 @@ overrides:
         mon osdmap full prune interval: 2
         mon osdmap full prune txsize: 2
 # thrashing monitors may make mgr have trouble w/ its keepalive
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(MGR_DOWN\)
 # slow mons -> slow peering -> PG_AVAILABILITY

--- a/qa/suites/rados/monthrash/msgr-failures/few.yaml
+++ b/qa/suites/rados/monthrash/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/monthrash/msgr-failures/mon-delay.yaml
+++ b/qa/suites/rados/monthrash/msgr-failures/mon-delay.yaml
@@ -10,5 +10,5 @@ overrides:
         mon client directed command retry: 5
       mgr:
         debug monc: 10
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/monthrash/thrashers/force-sync-many.yaml
+++ b/qa/suites/rados/monthrash/thrashers/force-sync-many.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
       - \(TOO_FEW_PGS\)

--- a/qa/suites/rados/monthrash/thrashers/many.yaml
+++ b/qa/suites/rados/monthrash/thrashers/many.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
     conf:

--- a/qa/suites/rados/monthrash/thrashers/one.yaml
+++ b/qa/suites/rados/monthrash/thrashers/one.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
 tasks:

--- a/qa/suites/rados/monthrash/thrashers/sync-many.yaml
+++ b/qa/suites/rados/monthrash/thrashers/sync-many.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
     conf:

--- a/qa/suites/rados/monthrash/thrashers/sync.yaml
+++ b/qa/suites/rados/monthrash/thrashers/sync.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
     conf:

--- a/qa/suites/rados/monthrash/workloads/pool-create-delete.yaml
+++ b/qa/suites/rados/monthrash/workloads/pool-create-delete.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - slow request
       - overall HEALTH_
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rados/monthrash/workloads/rados_5925.yaml
+++ b/qa/suites/rados/monthrash/workloads/rados_5925.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-     log-whitelist:
+     log-ignorelist:
        - overall HEALTH_
        - \(POOL_APP_NOT_ENABLED\)
 tasks:

--- a/qa/suites/rados/monthrash/workloads/rados_api_tests.yaml
+++ b/qa/suites/rados/monthrash/workloads/rados_api_tests.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - reached quota
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)

--- a/qa/suites/rados/monthrash/workloads/rados_mon_osdmap_prune.yaml
+++ b/qa/suites/rados/monthrash/workloads/rados_mon_osdmap_prune.yaml
@@ -10,7 +10,7 @@ overrides:
         mon osdmap full prune txsize: 100
       osd:
         osd beacon report interval: 10
-    log-whitelist:
+    log-ignorelist:
       # setting/unsetting noup will trigger health warns,
       # causing tests to fail due to health warns, even if
       # the tests themselves are successful.

--- a/qa/suites/rados/monthrash/workloads/rados_mon_workunits.yaml
+++ b/qa/suites/rados/monthrash/workloads/rados_mon_workunits.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - overall HEALTH_
     - \(PG_

--- a/qa/suites/rados/multimon/msgr-failures/few.yaml
+++ b/qa/suites/rados/multimon/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/multimon/msgr-failures/many.yaml
+++ b/qa/suites/rados/multimon/msgr-failures/many.yaml
@@ -5,5 +5,5 @@ overrides:
         ms inject socket failures: 1000
         mon client directed command retry: 5
         mon mgr beacon grace: 90
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/multimon/tasks/mon_clock_no_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_no_skews.yaml
@@ -1,7 +1,7 @@
 tasks:
 - install:
 - ceph:
-    log-whitelist:
+    log-ignorelist:
     - slow request
     - .*clock.*skew.*
     - clocks not synchronized

--- a/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
@@ -9,7 +9,7 @@ tasks:
     - date -u -s @$(expr $(date -u +%s) + 2)
 - ceph:
     wait-for-healthy: false
-    log-whitelist:
+    log-ignorelist:
     - .*clock.*skew.*
     - clocks not synchronized
     - overall HEALTH_

--- a/qa/suites/rados/multimon/tasks/mon_recovery.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_recovery.yaml
@@ -1,7 +1,7 @@
 tasks:
 - install:
 - ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
       - \(PG_AVAILABILITY\)

--- a/qa/suites/rados/objectstore/backends/ceph_objectstore_tool.yaml
+++ b/qa/suites/rados/objectstore/backends/ceph_objectstore_tool.yaml
@@ -14,7 +14,7 @@ tasks:
         osd max object namespace len: 64
       osd:
         osd objectstore: filestore
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/suites/rados/perf/ceph.yaml
+++ b/qa/suites/rados/perf/ceph.yaml
@@ -5,7 +5,7 @@ tasks:
 - ceph:
     fs: xfs
     wait-for-scrub: false
-    log-whitelist:
+    log-ignorelist:
       - \(PG_
       - \(OSD_
       - \(OBJECT_

--- a/qa/suites/rados/rest/mgr-restful.yaml
+++ b/qa/suites/rados/rest/mgr-restful.yaml
@@ -7,7 +7,7 @@ roles:
 tasks:
 - install:
 - ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(MGR_DOWN\)
       - \(PG_

--- a/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
+++ b/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
@@ -14,7 +14,7 @@ openstack:
 tasks:
 - install:
 - ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - had wrong client addr
     - had wrong cluster addr

--- a/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
@@ -6,7 +6,7 @@ roles:
 - [mon.a, mds.a, mgr.x, osd.0, osd.1, client.0]
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - MDS in read-only mode
       - force file system read-only
       - overall HEALTH_

--- a/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
@@ -6,7 +6,7 @@ tasks:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     fs: xfs
-    log-whitelist:
+    log-ignorelist:
       - \(PG_AVAILABILITY\)
 - cram:
     clients:

--- a/qa/suites/rados/singleton-nomsgr/all/cache-fs-trunc.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/cache-fs-trunc.yaml
@@ -9,7 +9,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
     conf:

--- a/qa/suites/rados/singleton-nomsgr/all/ceph-kvstore-tool.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/ceph-kvstore-tool.yaml
@@ -9,7 +9,7 @@ overrides:
   ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - overall HEALTH_
     - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rados/singleton-nomsgr/all/export-after-evict.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/export-after-evict.yaml
@@ -14,7 +14,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
     conf:

--- a/qa/suites/rados/singleton-nomsgr/all/full-tiering.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/full-tiering.yaml
@@ -7,7 +7,7 @@ roles:
 - [mon.a, mgr.x, osd.0, osd.1, osd.2, client.0]
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - is full
       - overall HEALTH_
       - \(POOL_FULL\)

--- a/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
@@ -10,7 +10,7 @@ tasks:
 # we may land on ext4
         osd max object name len: 400
         osd max object namespace len: 64
-    log-whitelist:
+    log-ignorelist:
       - but it is still running
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton-nomsgr/all/large-omap-object-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/large-omap-object-warnings.yaml
@@ -8,7 +8,7 @@ overrides:
   ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - \(OSDMAP_FLAGS\)
       - \(OSD_FULL\)
       - \(MDS_READ_ONLY\)

--- a/qa/suites/rados/singleton-nomsgr/all/lazy_omap_stats_output.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/lazy_omap_stats_output.yaml
@@ -6,7 +6,7 @@ roles:
 - [mon.a, mgr.x, osd.0, osd.1, osd.2, client.0]
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - install:

--- a/qa/suites/rados/singleton-nomsgr/all/librados_hello_world.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/librados_hello_world.yaml
@@ -2,7 +2,7 @@ roles:
 - [mon.a, mds.a, mgr.x, osd.0, osd.1, client.0]
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - install:

--- a/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
@@ -17,7 +17,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(PG_
       - \(OSD_

--- a/qa/suites/rados/singleton-nomsgr/all/osd_stale_reads.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/osd_stale_reads.yaml
@@ -6,7 +6,7 @@ roles:
 - [mon.a, mgr.x, osd.0, osd.1, osd.2, client.0]
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_DOWN\)
       - \(POOL_APP_NOT_ENABLED\)
       - \(SLOW_OPS\)

--- a/qa/suites/rados/singleton-nomsgr/all/recovery-unfound-found.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/recovery-unfound-found.yaml
@@ -19,7 +19,7 @@ tasks:
       osd:
         osd recovery sleep: .1
         osd objectstore: filestore
-    log-whitelist:
+    log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/suites/rados/singleton-nomsgr/all/version-number-sanity.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/version-number-sanity.yaml
@@ -2,7 +2,7 @@ roles:
 - [mon.a, mds.a, mgr.x, osd.0, osd.1, client.0]
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - install:

--- a/qa/suites/rados/singleton/all/deduptool.yaml
+++ b/qa/suites/rados/singleton/all/deduptool.yaml
@@ -14,7 +14,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - had wrong client addr
     - had wrong cluster addr

--- a/qa/suites/rados/singleton/all/divergent_priors.yaml
+++ b/qa/suites/rados/singleton/all/divergent_priors.yaml
@@ -12,7 +12,7 @@ openstack:
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/suites/rados/singleton/all/divergent_priors2.yaml
+++ b/qa/suites/rados/singleton/all/divergent_priors2.yaml
@@ -12,7 +12,7 @@ openstack:
 
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/suites/rados/singleton/all/dump-stuck.yaml
+++ b/qa/suites/rados/singleton/all/dump-stuck.yaml
@@ -12,7 +12,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - but it is still running
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton/all/ec-lost-unfound.yaml
+++ b/qa/suites/rados/singleton/all/ec-lost-unfound.yaml
@@ -17,7 +17,7 @@ tasks:
     create_rbd_pool: false
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - objects unfound and apparently lost
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton/all/lost-unfound-delete.yaml
+++ b/qa/suites/rados/singleton/all/lost-unfound-delete.yaml
@@ -15,7 +15,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - objects unfound and apparently lost
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton/all/lost-unfound.yaml
+++ b/qa/suites/rados/singleton/all/lost-unfound.yaml
@@ -15,7 +15,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - objects unfound and apparently lost
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton/all/max-pg-per-osd.from-mon.yaml
+++ b/qa/suites/rados/singleton/all/max-pg-per-osd.from-mon.yaml
@@ -18,7 +18,7 @@ overrides:
       osd:
         mon max pg per osd : 2
         osd max pg per osd hard ratio : 1
-    log-whitelist:
+    log-ignorelist:
       - \(TOO_FEW_PGS\)
       - \(PENDING_CREATING_PGS\)
 tasks:

--- a/qa/suites/rados/singleton/all/max-pg-per-osd.from-primary.yaml
+++ b/qa/suites/rados/singleton/all/max-pg-per-osd.from-primary.yaml
@@ -20,7 +20,7 @@ overrides:
       osd:
         mon max pg per osd : 1
         osd max pg per osd hard ratio : 1
-    log-whitelist:
+    log-ignorelist:
       - \(TOO_FEW_PGS\)
       - \(PG_
       - \(PENDING_CREATING_PGS\)

--- a/qa/suites/rados/singleton/all/max-pg-per-osd.from-replica.yaml
+++ b/qa/suites/rados/singleton/all/max-pg-per-osd.from-replica.yaml
@@ -20,7 +20,7 @@ overrides:
       osd:
         mon max pg per osd : 1
         osd max pg per osd hard ratio : 1
-    log-whitelist:
+    log-ignorelist:
       - \(TOO_FEW_PGS\)
       - \(PG_
       - \(PENDING_CREATING_PGS\)

--- a/qa/suites/rados/singleton/all/mon-auth-caps.yaml
+++ b/qa/suites/rados/singleton/all/mon-auth-caps.yaml
@@ -10,7 +10,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
     - overall HEALTH_
     - \(AUTH_BAD_CAPS\)
 - workunit:

--- a/qa/suites/rados/singleton/all/mon-config-key-caps.yaml
+++ b/qa/suites/rados/singleton/all/mon-config-key-caps.yaml
@@ -10,7 +10,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
     - overall HEALTH_
     - \(AUTH_BAD_CAPS\)
 - workunit:

--- a/qa/suites/rados/singleton/all/mon-memory-target-compliance.yaml.disabled
+++ b/qa/suites/rados/singleton/all/mon-memory-target-compliance.yaml.disabled
@@ -44,7 +44,7 @@ tasks:
     create_rbd_pool: false
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/suites/rados/singleton/all/osd-backfill.yaml
+++ b/qa/suites/rados/singleton/all/osd-backfill.yaml
@@ -15,7 +15,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - but it is still running
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton/all/osd-recovery-incomplete.yaml
+++ b/qa/suites/rados/singleton/all/osd-recovery-incomplete.yaml
@@ -16,7 +16,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - but it is still running
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton/all/osd-recovery.yaml
+++ b/qa/suites/rados/singleton/all/osd-recovery.yaml
@@ -15,7 +15,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - but it is still running
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton/all/peer.yaml
+++ b/qa/suites/rados/singleton/all/peer.yaml
@@ -18,7 +18,7 @@ tasks:
     config:
       global:
         osd pool default min size : 1
-    log-whitelist:
+    log-ignorelist:
       - objects unfound and apparently lost
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton/all/pg-autoscaler.yaml
+++ b/qa/suites/rados/singleton/all/pg-autoscaler.yaml
@@ -22,7 +22,7 @@ tasks:
     create_rbd_pool: false
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/suites/rados/singleton/all/pg-removal-interruption.yaml
+++ b/qa/suites/rados/singleton/all/pg-removal-interruption.yaml
@@ -14,7 +14,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - but it is still running
       - slow request
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/radostool.yaml
+++ b/qa/suites/rados/singleton/all/radostool.yaml
@@ -14,7 +14,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - had wrong client addr
     - had wrong cluster addr

--- a/qa/suites/rados/singleton/all/random-eio.yaml
+++ b/qa/suites/rados/singleton/all/random-eio.yaml
@@ -17,7 +17,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
     - missing primary copy of
     - objects unfound and apparently lost
     - had a read error

--- a/qa/suites/rados/singleton/all/rebuild-mondb.yaml
+++ b/qa/suites/rados/singleton/all/rebuild-mondb.yaml
@@ -16,7 +16,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - no reply from
       - overall HEALTH_
       - \(MON_DOWN\)

--- a/qa/suites/rados/singleton/all/recovery-preemption.yaml
+++ b/qa/suites/rados/singleton/all/recovery-preemption.yaml
@@ -23,7 +23,7 @@ tasks:
         osd max pg log entries: 1000
         osd_target_pg_log_entries_per_osd: 0
         osd pg log trim min: 10
-    log-whitelist:
+    log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/suites/rados/singleton/all/resolve_stuck_peering.yaml
+++ b/qa/suites/rados/singleton/all/resolve_stuck_peering.yaml
@@ -8,7 +8,7 @@ tasks:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
     fs: xfs
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/suites/rados/singleton/all/test-crash.yaml
+++ b/qa/suites/rados/singleton/all/test-crash.yaml
@@ -6,7 +6,7 @@ tasks:
   - ceph:
       pre-mgr-commands:
         - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-      log-whitelist:
+      log-ignorelist:
         - Reduced data availability
         - OSD_.*DOWN
         - \(RECENT_CRASH\)

--- a/qa/suites/rados/singleton/all/test_envlibrados_for_rocksdb.yaml
+++ b/qa/suites/rados/singleton/all/test_envlibrados_for_rocksdb.yaml
@@ -12,7 +12,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(POOL_APP_NOT_ENABLED\)
 - workunit:

--- a/qa/suites/rados/singleton/all/thrash-backfill-full.yaml
+++ b/qa/suites/rados/singleton/all/thrash-backfill-full.yaml
@@ -24,7 +24,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - missing primary copy of
     - objects unfound and apparently lost

--- a/qa/suites/rados/singleton/all/thrash-eio.yaml
+++ b/qa/suites/rados/singleton/all/thrash-eio.yaml
@@ -22,7 +22,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - missing primary copy of
     - objects unfound and apparently lost

--- a/qa/suites/rados/singleton/all/thrash-rados/thrash-rados.yaml
+++ b/qa/suites/rados/singleton/all/thrash-rados/thrash-rados.yaml
@@ -15,7 +15,7 @@ openstack:
 tasks:
 - install:
 - ceph:
-    log-whitelist:
+    log-ignorelist:
       - but it is still running
 - thrashosds:
     op_delay: 30

--- a/qa/suites/rados/singleton/all/thrash_cache_writeback_proxy_none.yaml
+++ b/qa/suites/rados/singleton/all/thrash_cache_writeback_proxy_none.yaml
@@ -17,7 +17,7 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
-    log-whitelist:
+    log-ignorelist:
       - but it is still running
       - slow request
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/watch-notify-same-primary.yaml
+++ b/qa/suites/rados/singleton/all/watch-notify-same-primary.yaml
@@ -23,7 +23,7 @@ tasks:
         debug ms: 1
         debug objecter: 20
         debug rados: 20
-    log-whitelist:
+    log-ignorelist:
       - objects unfound and apparently lost
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton/msgr-failures/few.yaml
+++ b/qa/suites/rados/singleton/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/singleton/msgr-failures/many.yaml
+++ b/qa/suites/rados/singleton/msgr-failures/many.yaml
@@ -8,5 +8,5 @@ overrides:
         mon client directed command retry: 5
       mgr:
         debug monc: 10
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/careful.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     - slow request

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/default.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/default.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     - slow request

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/fastread.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/fastread.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     conf:

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/mapgap.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/mapgap.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     - osd_map_cache_size

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/morepggrow.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/morepggrow.yaml
@@ -5,7 +5,7 @@ overrides:
         osd scrub min interval: 60
         osd scrub max interval: 120
         osd max backfills: 9
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
 tasks:

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/pggrow.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/pggrow.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     conf:

--- a/qa/suites/rados/thrash-erasure-code-shec/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-erasure-code-shec/thrashers/careful.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     - slow request

--- a/qa/suites/rados/thrash-erasure-code-shec/thrashers/default.yaml
+++ b/qa/suites/rados/thrash-erasure-code-shec/thrashers/default.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     - slow request

--- a/qa/suites/rados/thrash-erasure-code/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/careful.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     conf:

--- a/qa/suites/rados/thrash-erasure-code/thrashers/default.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/default.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     conf:

--- a/qa/suites/rados/thrash-erasure-code/thrashers/fastread.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/fastread.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     conf:

--- a/qa/suites/rados/thrash-erasure-code/thrashers/minsize_recovery.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/minsize_recovery.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     create_rbd_pool: False

--- a/qa/suites/rados/thrash-erasure-code/thrashers/morepggrow.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/morepggrow.yaml
@@ -5,7 +5,7 @@ overrides:
         osd scrub min interval: 60
         osd scrub max interval: 120
         osd max backfills: 9
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
 tasks:

--- a/qa/suites/rados/thrash-erasure-code/thrashers/pggrow.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/pggrow.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     conf:

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous-v1only.yaml
@@ -1,7 +1,7 @@
 overrides:
   ceph:
     mon_bind_msgr2: false
-    log-whitelist:
+    log-ignorelist:
       - \(MON_DOWN\)
     conf:
       global:

--- a/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/luminous.yaml
@@ -1,7 +1,7 @@
 overrides:
   ceph:
     mon_bind_msgr2: false
-    log-whitelist:
+    log-ignorelist:
       - \(MON_DOWN\)
     conf:
       global:

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic-v1only.yaml
@@ -1,7 +1,7 @@
 overrides:
   ceph:
     mon_bind_msgr2: false
-    log-whitelist:
+    log-ignorelist:
       - \(MON_DOWN\)
     conf:
       global:

--- a/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/mimic.yaml
@@ -1,7 +1,7 @@
 overrides:
   ceph:
     mon_bind_msgr2: false
-    log-whitelist:
+    log-ignorelist:
       - \(MON_DOWN\)
     conf:
       global:

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus-v1only.yaml
@@ -1,7 +1,7 @@
 overrides:
   ceph:
     mon_bind_msgr2: false
-    log-whitelist:
+    log-ignorelist:
       - \(MON_DOWN\)
     conf:
       global:

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus-v2only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus-v2only.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - \(MON_DOWN\)
     conf:
       global:

--- a/qa/suites/rados/thrash-old-clients/1-install/nautilus.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/nautilus.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - \(MON_DOWN\)
 tasks:
 - install:

--- a/qa/suites/rados/thrash-old-clients/1-install/octopus.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/octopus.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - \(MON_DOWN\)
 tasks:
 - install:

--- a/qa/suites/rados/thrash-old-clients/msgr-failures/fastclose.yaml
+++ b/qa/suites/rados/thrash-old-clients/msgr-failures/fastclose.yaml
@@ -5,5 +5,5 @@ overrides:
         ms inject socket failures: 2500
         ms tcp read timeout: 5
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/thrash-old-clients/msgr-failures/few.yaml
+++ b/qa/suites/rados/thrash-old-clients/msgr-failures/few.yaml
@@ -6,5 +6,5 @@ overrides:
         mon client directed command retry: 5
       osd:
         osd heartbeat use min delay socket: true
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/thrash-old-clients/msgr-failures/osd-delay.yaml
+++ b/qa/suites/rados/thrash-old-clients/msgr-failures/osd-delay.yaml
@@ -8,5 +8,5 @@ overrides:
         ms inject delay max: 1
         ms inject internal delays: .002
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/thrash-old-clients/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-old-clients/thrashers/careful.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     conf:

--- a/qa/suites/rados/thrash-old-clients/thrashers/default.yaml
+++ b/qa/suites/rados/thrash-old-clients/thrashers/default.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     conf:

--- a/qa/suites/rados/thrash-old-clients/thrashers/mapgap.yaml
+++ b/qa/suites/rados/thrash-old-clients/thrashers/mapgap.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     - osd_map_cache_size

--- a/qa/suites/rados/thrash-old-clients/thrashers/morepggrow.yaml
+++ b/qa/suites/rados/thrash-old-clients/thrashers/morepggrow.yaml
@@ -9,7 +9,7 @@ overrides:
         filestore queue throttle high multiple: 2
         filestore queue throttle max multiple: 10
         osd max backfills: 9
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
 tasks:

--- a/qa/suites/rados/thrash-old-clients/thrashers/pggrow.yaml
+++ b/qa/suites/rados/thrash-old-clients/thrashers/pggrow.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     conf:

--- a/qa/suites/rados/thrash-old-clients/workloads/cache-snaps.yaml
+++ b/qa/suites/rados/thrash-old-clients/workloads/cache-snaps.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - must scrub before tier agent can activate
 tasks:
 - exec:

--- a/qa/suites/rados/thrash/msgr-failures/fastclose.yaml
+++ b/qa/suites/rados/thrash/msgr-failures/fastclose.yaml
@@ -5,5 +5,5 @@ overrides:
         ms inject socket failures: 2500
         ms tcp read timeout: 5
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/thrash/msgr-failures/few.yaml
+++ b/qa/suites/rados/thrash/msgr-failures/few.yaml
@@ -6,5 +6,5 @@ overrides:
         mon client directed command retry: 5
       osd:
         osd heartbeat use min delay socket: true
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/thrash/msgr-failures/osd-delay.yaml
+++ b/qa/suites/rados/thrash/msgr-failures/osd-delay.yaml
@@ -8,5 +8,5 @@ overrides:
         ms inject delay max: 1
         ms inject internal delays: .002
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/thrash/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash/thrashers/careful.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     conf:

--- a/qa/suites/rados/thrash/thrashers/default.yaml
+++ b/qa/suites/rados/thrash/thrashers/default.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     conf:

--- a/qa/suites/rados/thrash/thrashers/mapgap.yaml
+++ b/qa/suites/rados/thrash/thrashers/mapgap.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     - osd_map_cache_size

--- a/qa/suites/rados/thrash/thrashers/morepggrow.yaml
+++ b/qa/suites/rados/thrash/thrashers/morepggrow.yaml
@@ -9,7 +9,7 @@ overrides:
         filestore queue throttle high multiple: 2
         filestore queue throttle max multiple: 10
         osd max backfills: 9
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
 tasks:

--- a/qa/suites/rados/thrash/thrashers/pggrow.yaml
+++ b/qa/suites/rados/thrash/thrashers/pggrow.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     conf:

--- a/qa/suites/rados/thrash/workloads/cache-agent-big.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-agent-big.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - must scrub before tier agent can activate
     conf:
       osd:

--- a/qa/suites/rados/thrash/workloads/cache-agent-small.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-agent-small.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - must scrub before tier agent can activate
     conf:
       osd:

--- a/qa/suites/rados/thrash/workloads/cache-pool-snaps-readproxy.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-pool-snaps-readproxy.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - must scrub before tier agent can activate
     conf:
       osd:

--- a/qa/suites/rados/thrash/workloads/cache-pool-snaps.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-pool-snaps.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - must scrub before tier agent can activate
     conf:
       osd:

--- a/qa/suites/rados/thrash/workloads/cache-snaps-balanced.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-snaps-balanced.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - must scrub before tier agent can activate
     conf:
       osd:

--- a/qa/suites/rados/thrash/workloads/cache-snaps.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-snaps.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - must scrub before tier agent can activate
     conf:
       osd:

--- a/qa/suites/rados/thrash/workloads/cache.yaml
+++ b/qa/suites/rados/thrash/workloads/cache.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - must scrub before tier agent can activate
     conf:
       osd:

--- a/qa/suites/rados/thrash/workloads/rados_api_tests.yaml
+++ b/qa/suites/rados/thrash/workloads/rados_api_tests.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - reached quota
       - \(POOL_APP_NOT_ENABLED\)
       - \(PG_AVAILABILITY\)

--- a/qa/suites/rados/valgrind-leaks/1-start.yaml
+++ b/qa/suites/rados/valgrind-leaks/1-start.yaml
@@ -9,7 +9,7 @@ overrides:
       flavor: notcmalloc
       debuginfo: true
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(PG_
     conf:

--- a/qa/suites/rados/verify/d-thrash/default/default.yaml
+++ b/qa/suites/rados/verify/d-thrash/default/default.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
 tasks:

--- a/qa/suites/rados/verify/msgr-failures/few.yaml
+++ b/qa/suites/rados/verify/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rados/verify/tasks/mon_recovery.yaml
+++ b/qa/suites/rados/verify/tasks/mon_recovery.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/verify/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/verify/tasks/rados_api_tests.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - reached quota
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)

--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -16,7 +16,7 @@ overrides:
         osd fast shutdown: false
         debug bluestore: 1
         debug bluefs: 1
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
 # valgrind is slow.. we might get PGs stuck peering etc
       - \(PG_

--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -20,7 +20,7 @@ overrides:
       - overall HEALTH_
 # valgrind is slow.. we might get PGs stuck peering etc
       - \(PG_
-# mons sometimes are left off of initial quorum due to valgrind slowness.  ok to whitelist here because we'll still catch an actual crash due to the core
+# mons sometimes are left off of initial quorum due to valgrind slowness.  ok to ignore here because we'll still catch an actual crash due to the core
       - \(MON_DOWN\)
       - \(SLOW_OPS\)
       - slow request

--- a/qa/suites/rbd/basic/cachepool/small.yaml
+++ b/qa/suites/rbd/basic/cachepool/small.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NEAR_FULL\)
       - \(CACHE_POOL_NO_HIT_SET\)

--- a/qa/suites/rbd/basic/msgr-failures/few.yaml
+++ b/qa/suites/rbd/basic/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rbd/basic/tasks/rbd_api_tests_old_format.yaml
+++ b/qa/suites/rbd/basic/tasks/rbd_api_tests_old_format.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/basic/tasks/rbd_python_api_tests_old_format.yaml
+++ b/qa/suites/rbd/basic/tasks/rbd_python_api_tests_old_format.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - \(SLOW_OPS\)
       - slow request
 tasks:

--- a/qa/suites/rbd/cli/msgr-failures/few.yaml
+++ b/qa/suites/rbd/cli/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rbd/cli/pool/ec-data-pool.yaml
+++ b/qa/suites/rbd/cli/pool/ec-data-pool.yaml
@@ -12,7 +12,7 @@ overrides:
     bdev_inject_crash_probability: .5
   ceph:
     fs: xfs
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
     conf:

--- a/qa/suites/rbd/cli/pool/small-cache-pool.yaml
+++ b/qa/suites/rbd/cli/pool/small-cache-pool.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NEAR_FULL\)
       - \(CACHE_POOL_NO_HIT_SET\)

--- a/qa/suites/rbd/cli_v1/msgr-failures/few.yaml
+++ b/qa/suites/rbd/cli_v1/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rbd/cli_v1/pool/small-cache-pool.yaml
+++ b/qa/suites/rbd/cli_v1/pool/small-cache-pool.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NEAR_FULL\)
       - \(CACHE_POOL_NO_HIT_SET\)

--- a/qa/suites/rbd/librbd/msgr-failures/few.yaml
+++ b/qa/suites/rbd/librbd/msgr-failures/few.yaml
@@ -4,6 +4,6 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - but it is still running
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rbd/librbd/pool/small-cache-pool.yaml
+++ b/qa/suites/rbd/librbd/pool/small-cache-pool.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NEAR_FULL\)
       - \(CACHE_POOL_NO_HIT_SET\)

--- a/qa/suites/rbd/librbd/workloads/c_api_tests.yaml
+++ b/qa/suites/rbd/librbd/workloads/c_api_tests.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/librbd/workloads/c_api_tests_with_defaults.yaml
+++ b/qa/suites/rbd/librbd/workloads/c_api_tests_with_defaults.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/librbd/workloads/c_api_tests_with_journaling.yaml
+++ b/qa/suites/rbd/librbd/workloads/c_api_tests_with_journaling.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/qemu/msgr-failures/few.yaml
+++ b/qa/suites/rbd/qemu/msgr-failures/few.yaml
@@ -4,6 +4,6 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rbd/qemu/pool/ec-cache-pool.yaml
+++ b/qa/suites/rbd/qemu/pool/ec-cache-pool.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NEAR_FULL\)
       - \(CACHE_POOL_NO_HIT_SET\)

--- a/qa/suites/rbd/qemu/pool/small-cache-pool.yaml
+++ b/qa/suites/rbd/qemu/pool/small-cache-pool.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NEAR_FULL\)
       - \(CACHE_POOL_NO_HIT_SET\)

--- a/qa/suites/rbd/singleton-bluestore/all/issue-20295.yaml
+++ b/qa/suites/rbd/singleton-bluestore/all/issue-20295.yaml
@@ -6,7 +6,7 @@ roles:
 tasks:
 - install:
 - ceph:
-    log-whitelist:
+    log-ignorelist:
       - 'application not enabled'
 - workunit:
     timeout: 30m

--- a/qa/suites/rbd/singleton/all/rbd_mirror.yaml
+++ b/qa/suites/rbd/singleton/all/rbd_mirror.yaml
@@ -4,7 +4,7 @@ tasks:
 - install:
 - ceph:
     fs: xfs
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/singleton/all/rbd_tasks.yaml
+++ b/qa/suites/rbd/singleton/all/rbd_tasks.yaml
@@ -4,7 +4,7 @@ tasks:
 - install:
 - ceph:
     fs: xfs
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/thrash/msgr-failures/few.yaml
+++ b/qa/suites/rbd/thrash/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rbd/thrash/thrashers/cache.yaml
+++ b/qa/suites/rbd/thrash/thrashers/cache.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - but it is still running
       - objects unfound and apparently lost
       - overall HEALTH_

--- a/qa/suites/rbd/thrash/thrashers/default.yaml
+++ b/qa/suites/rbd/thrash/thrashers/default.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
 tasks:

--- a/qa/suites/rbd/thrash/workloads/rbd_api_tests.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_api_tests.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/thrash/workloads/rbd_api_tests_copy_on_read.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_api_tests_copy_on_read.yaml
@@ -7,7 +7,7 @@ tasks:
       RBD_FEATURES: "61"
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/thrash/workloads/rbd_api_tests_journaling.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_api_tests_journaling.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/thrash/workloads/rbd_api_tests_no_locking.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_api_tests_no_locking.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/valgrind/workloads/c_api_tests.yaml
+++ b/qa/suites/rbd/valgrind/workloads/c_api_tests.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/valgrind/workloads/c_api_tests_with_defaults.yaml
+++ b/qa/suites/rbd/valgrind/workloads/c_api_tests_with_defaults.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/valgrind/workloads/c_api_tests_with_journaling.yaml
+++ b/qa/suites/rbd/valgrind/workloads/c_api_tests_with_journaling.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/valgrind/workloads/rbd_mirror.yaml
+++ b/qa/suites/rbd/valgrind/workloads/rbd_mirror.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rgw/crypt/1-ceph-install/install.yaml
+++ b/qa/suites/rgw/crypt/1-ceph-install/install.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - \(PG_AVAILABILITY\)
     wait-for-scrub: false
 

--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - \(PG_AVAILABILITY\)
     wait-for-scrub: false
     conf:

--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -40,7 +40,7 @@ tasks:
       object-storage-feature-enabled:
         container_sync: false
         discoverability: true
-      blacklist:
+      blocklist:
         - .*test_account_quotas_negative.AccountQuotasNegativeTest.test_user_modify_quota
         - .*test_container_acl_negative.ObjectACLsNegativeTest.*
         - .*test_container_services_negative.ContainerNegativeTest.test_create_container_metadata_.*

--- a/qa/suites/rgw/verify/msgr-failures/few.yaml
+++ b/qa/suites/rgw/verify/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rgw/verify/tasks/cls.yaml
+++ b/qa/suites/rgw/verify/tasks/cls.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - \(PG_AVAILABILITY\)
 tasks:
 - workunit:

--- a/qa/suites/smoke/basic/tasks/mon_thrash.yaml
+++ b/qa/suites/smoke/basic/tasks/mon_thrash.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - reached quota
       - mons down
       - overall HEALTH_

--- a/qa/suites/smoke/basic/tasks/rados_api_tests.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_api_tests.yaml
@@ -2,7 +2,7 @@ tasks:
 - install: null
 - ceph:
     fs: ext4
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/suites/smoke/basic/tasks/rados_bench.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_bench.yaml
@@ -12,7 +12,7 @@ tasks:
 - install: null
 - ceph:
     fs: xfs
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/suites/smoke/basic/tasks/rados_cache_snaps.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_cache_snaps.yaml
@@ -1,7 +1,7 @@
 tasks:
 - install: null
 - ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/suites/smoke/basic/tasks/rados_ec_snaps.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_ec_snaps.yaml
@@ -2,7 +2,7 @@ tasks:
 - install: null
 - ceph:
     fs: xfs
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/suites/smoke/basic/tasks/rados_python.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_python.yaml
@@ -1,7 +1,7 @@
 tasks:
 - install:
 - ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - overall HEALTH_
     - \(OSDMAP_FLAGS\)

--- a/qa/suites/smoke/basic/tasks/rados_workunit_loadgen_mix.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_workunit_loadgen_mix.yaml
@@ -2,7 +2,7 @@ tasks:
 - install:
 - ceph:
     fs: ext4
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - overall HEALTH_
     - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/smoke/basic/tasks/rbd_api_tests.yaml
+++ b/qa/suites/smoke/basic/tasks/rbd_api_tests.yaml
@@ -1,7 +1,7 @@
 tasks:
 - install:
 - ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/suites/smoke/basic/tasks/rbd_fsx.yaml
+++ b/qa/suites/smoke/basic/tasks/rbd_fsx.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/suites/stress/thrash/thrashers/default.yaml
+++ b/qa/suites/stress/thrash/thrashers/default.yaml
@@ -1,7 +1,7 @@
 tasks:
 - install:
 - ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
 - thrashosds:

--- a/qa/suites/stress/thrash/thrashers/fast.yaml
+++ b/qa/suites/stress/thrash/thrashers/fast.yaml
@@ -1,7 +1,7 @@
 tasks:
 - install:
 - ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
 - thrashosds:

--- a/qa/suites/stress/thrash/thrashers/more-down.yaml
+++ b/qa/suites/stress/thrash/thrashers/more-down.yaml
@@ -1,7 +1,7 @@
 tasks:
 - install:
 - ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
 - thrashosds:

--- a/qa/suites/teuthology/multi-cluster/all/upgrade.yaml
+++ b/qa/suites/teuthology/multi-cluster/all/upgrade.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - failed to encode map
   conf:
     mon:

--- a/qa/suites/tgt/basic/msgr-failures/few.yaml
+++ b/qa/suites/tgt/basic/msgr-failures/few.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/tgt/basic/msgr-failures/many.yaml
+++ b/qa/suites/tgt/basic/msgr-failures/many.yaml
@@ -4,5 +4,5 @@ overrides:
       global:
         ms inject socket failures: 500
         mon client directed command retry: 5
-    log-whitelist:
+    log-ignorelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/upgrade/nautilus-x-singleton/1-install/nautilus.yaml
+++ b/qa/suites/upgrade/nautilus-x-singleton/1-install/nautilus.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - \(MON_DOWN\)
       - \(MGR_DOWN\)
       - slow request

--- a/qa/suites/upgrade/nautilus-x-singleton/3-thrash/default.yaml
+++ b/qa/suites/upgrade/nautilus-x-singleton/3-thrash/default.yaml
@@ -4,7 +4,7 @@ meta:
    small chance to increase the number of pgs
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     - log bound mismatch

--- a/qa/suites/upgrade/nautilus-x-singleton/6-finish-upgrade.yaml
+++ b/qa/suites/upgrade/nautilus-x-singleton/6-finish-upgrade.yaml
@@ -4,7 +4,7 @@ meta:
     restartin remaining osds
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(FS_DEGRADED\)
       - \(MDS_

--- a/qa/suites/upgrade/nautilus-x/parallel/0-cluster/start.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/0-cluster/start.yaml
@@ -28,7 +28,7 @@ roles:
   - client.3
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - scrub mismatch
     - ScrubResult
     - wrongly marked

--- a/qa/suites/upgrade/nautilus-x/parallel/1-ceph-install/nautilus.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/1-ceph-install/nautilus.yaml
@@ -12,7 +12,7 @@ tasks:
     branch: nautilus
 - print: "**** done installing nautilus"
 - ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(FS_
       - \(MDS_

--- a/qa/suites/upgrade/nautilus-x/parallel/5-final-workload/rados_mon_thrash.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/5-final-workload/rados_mon_thrash.yaml
@@ -3,7 +3,7 @@ meta:
    librados C and C++ api tests
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - reached quota
       - \(REQUEST_SLOW\)
 tasks:

--- a/qa/suites/upgrade/nautilus-x/stress-split-erasure-code/3-thrash/default.yaml
+++ b/qa/suites/upgrade/nautilus-x/stress-split-erasure-code/3-thrash/default.yaml
@@ -4,7 +4,7 @@ meta:
    small chance to increase the number of pgs
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - wrongly marked me down
     - objects unfound and apparently lost

--- a/qa/suites/upgrade/nautilus-x/stress-split/0-cluster/start.yaml
+++ b/qa/suites/upgrade/nautilus-x/stress-split/0-cluster/start.yaml
@@ -8,7 +8,7 @@ overrides:
     mon_bind_msgr2: false
     mon_bind_addrvec: false
     fs: xfs
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
       - \(MGR_DOWN\)

--- a/qa/suites/upgrade/nautilus-x/stress-split/1-ceph-install/nautilus.yaml
+++ b/qa/suites/upgrade/nautilus-x/stress-split/1-ceph-install/nautilus.yaml
@@ -14,7 +14,7 @@ tasks:
         bluestore_warn_on_legacy_statfs: false
         bluestore warn on no per pool omap: false
         mon pg warn min per osd: 0
-    log-whitelist:
+    log-ignorelist:
       - Not found or unloadable
 - exec:
     osd.0:

--- a/qa/suites/upgrade/nautilus-x/stress-split/3-thrash/default.yaml
+++ b/qa/suites/upgrade/nautilus-x/stress-split/3-thrash/default.yaml
@@ -4,7 +4,7 @@ meta:
    small chance to increase the number of pgs
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - wrongly marked me down
     - objects unfound and apparently lost

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1092,13 +1092,13 @@ def cluster(ctx, config):
             return stdout or None
 
         if first_in_ceph_log('\[ERR\]|\[WRN\]|\[SEC\]',
-                             config['log_whitelist']) is not None:
+                             config['log_ignorelist']) is not None:
             log.warning('Found errors (ERR|WRN|SEC) in cluster log')
             ctx.summary['success'] = False
             # use the most severe problem as the failure reason
             if 'failure_reason' not in ctx.summary:
                 for pattern in ['\[SEC\]', '\[ERR\]', '\[WRN\]']:
-                    match = first_in_ceph_log(pattern, config['log_whitelist'])
+                    match = first_in_ceph_log(pattern, config['log_ignorelist'])
                     if match is not None:
                         ctx.summary['failure_reason'] = \
                             '"{match}" in cluster log'.format(
@@ -1724,7 +1724,7 @@ def task(ctx, config):
 
         tasks:
         - ceph:
-            log-whitelist: ['foo.*bar', 'bad message']
+            log-ignorelist: ['foo.*bar', 'bad message']
 
     To run multiple ceph clusters, use multiple ceph tasks, and roles
     with a cluster name prefix, e.g. cluster1.client.0. Roles with no
@@ -1796,7 +1796,7 @@ def task(ctx, config):
             mkfs_options=config.get('mkfs_options', None),
             mount_options=config.get('mount_options', None),
             skip_mgr_daemons=config.get('skip_mgr_daemons', False),
-            log_whitelist=config.get('log-whitelist', []),
+            log_ignorelist=config.get('log-ignorelist', []),
             cpu_profile=set(config.get('cpu_profile', []),),
             cluster=config['cluster'],
             mon_bind_msgr2=config.get('mon_bind_msgr2', True),

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1467,7 +1467,7 @@ class CephManager:
                         wait for all specified osds, but some of them could be
                         moved out of osdmap, so we cannot get their updated
                         stat seq from monitor anymore. in that case, you need
-                        to pass a blacklist.
+                        to pass a blocklist.
         :param wait_for_mon: wait for mon to be synced with mgr. 0 to disable
                              it. (5 min by default)
         """

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -200,13 +200,13 @@ def ceph_log(ctx, config):
             return None
 
         if first_in_ceph_log('\[ERR\]|\[WRN\]|\[SEC\]',
-                             config.get('log-whitelist')) is not None:
+                             config.get('log-ignorelist')) is not None:
             log.warning('Found errors (ERR|WRN|SEC) in cluster log')
             ctx.summary['success'] = False
             # use the most severe problem as the failure reason
             if 'failure_reason' not in ctx.summary:
                 for pattern in ['\[SEC\]', '\[ERR\]', '\[WRN\]']:
-                    match = first_in_ceph_log(pattern, config['log-whitelist'])
+                    match = first_in_ceph_log(pattern, config['log-ignorelist'])
                     if match is not None:
                         ctx.summary['failure_reason'] = \
                             '"{match}" in cluster log'.format(

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -102,17 +102,17 @@ class CephFSTestCase(CephTestCase):
         self.fs = None # is now invalid!
         self.recovery_fs = None
 
-        # In case anything is in the OSD blacklist list, clear it out.  This is to avoid
-        # the OSD map changing in the background (due to blacklist expiry) while tests run.
+        # In case anything is in the OSD blocklist list, clear it out.  This is to avoid
+        # the OSD map changing in the background (due to blocklist expiry) while tests run.
         try:
-            self.mds_cluster.mon_manager.raw_cluster_cmd("osd", "blacklist", "clear")
+            self.mds_cluster.mon_manager.raw_cluster_cmd("osd", "blocklist", "clear")
         except CommandFailedError:
             # Fallback for older Ceph cluster
-            blacklist = json.loads(self.mds_cluster.mon_manager.raw_cluster_cmd("osd",
-                                  "dump", "--format=json-pretty"))['blacklist']
-            log.info("Removing {0} blacklist entries".format(len(blacklist)))
-            for addr, blacklisted_at in blacklist.items():
-                self.mds_cluster.mon_manager.raw_cluster_cmd("osd", "blacklist", "rm", addr)
+            blocklist = json.loads(self.mds_cluster.mon_manager.raw_cluster_cmd("osd",
+                                  "dump", "--format=json-pretty"))['blocklist']
+            log.info("Removing {0} blocklist entries".format(len(blocklist)))
+            for addr, blocklisted_at in blocklist.items():
+                self.mds_cluster.mon_manager.raw_cluster_cmd("osd", "blocklist", "rm", addr)
 
         client_mount_ids = [m.client_id for m in self.mounts]
         # In case the test changes the IDs of clients, stash them so that we can

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -421,10 +421,10 @@ class CephFSMount(object):
         finally:
             self.umount_wait()
 
-    def is_blacklisted(self):
+    def is_blocklisted(self):
         addr = self.get_global_addr()
-        blacklist = json.loads(self.fs.mon_manager.raw_cluster_cmd("osd", "blacklist", "ls", "--format=json"))
-        for b in blacklist:
+        blocklist = json.loads(self.fs.mon_manager.raw_cluster_cmd("osd", "blocklist", "ls", "--format=json"))
+        for b in blocklist:
             if addr == b["addr"]:
                 return True
         return False

--- a/qa/tasks/cephfs/test_client_recovery.py
+++ b/qa/tasks/cephfs/test_client_recovery.py
@@ -619,10 +619,10 @@ class TestClientRecovery(CephFSTestCase):
 
         self.mount_a.kill_cleanup()
 
-    def test_reconnect_after_blacklisted(self):
+    def test_reconnect_after_blocklisted(self):
         """
-        Test reconnect after blacklisted.
-        - writing to a fd that was opened before blacklist should return -EBADF
+        Test reconnect after blocklisted.
+        - writing to a fd that was opened before blocklist should return -EBADF
         - reading/writing to a file with lost file locks should return -EIO
         - readonly fd should continue to work
         """
@@ -640,7 +640,7 @@ class TestClientRecovery(CephFSTestCase):
 
         self.mount_a.wait_until_mounted()
 
-        path = os.path.join(self.mount_a.mountpoint, 'testfile_reconnect_after_blacklisted')
+        path = os.path.join(self.mount_a.mountpoint, 'testfile_reconnect_after_blocklisted')
         pyscript = dedent("""
             import os
             import sys
@@ -660,7 +660,7 @@ class TestClientRecovery(CephFSTestCase):
             os.read(fd4, 1);
             fcntl.flock(fd4, fcntl.LOCK_SH | fcntl.LOCK_NB)
 
-            print("blacklist")
+            print("blocklist")
             sys.stdout.flush()
 
             sys.stdin.readline()
@@ -669,7 +669,7 @@ class TestClientRecovery(CephFSTestCase):
             time.sleep(10);
 
             # trigger 'open session' message. kclient relies on 'session reject' message
-            # to detect if itself is blacklisted
+            # to detect if itself is blocklisted
             try:
                 os.stat("{path}.1")
             except:

--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -149,7 +149,7 @@ class TestMisc(CephFSTestCase):
                                 cap_waited, session_timeout
                             ))
 
-            self.assertTrue(self.mount_a.is_blacklisted())
+            self.assertTrue(self.mount_a.is_blocklisted())
             cap_holder.stdin.close()
             try:
                 cap_holder.wait()

--- a/qa/tasks/cephfs/test_sessionmap.py
+++ b/qa/tasks/cephfs/test_sessionmap.py
@@ -188,12 +188,12 @@ class TestSessionMap(CephFSTestCase):
             with self.assertRaises(CommandFailedError):
                 self.mount_b.mount_wait(mount_path="/foo/bar")
 
-    def test_session_evict_blacklisted(self):
+    def test_session_evict_blocklisted(self):
         """
-        Check that mds evicts blacklisted client
+        Check that mds evicts blocklisted client
         """
         if not isinstance(self.mount_a, FuseMount):
-            self.skipTest("Requires FUSE client to use is_blacklisted()")
+            self.skipTest("Requires FUSE client to use is_blocklisted()")
 
         self.fs.set_max_mds(2)
         status = self.fs.wait_for_daemons()
@@ -214,7 +214,7 @@ class TestSessionMap(CephFSTestCase):
         mount_a_client_id = self.mount_a.get_global_id()
         self.fs.mds_asok(['session', 'evict', "%s" % mount_a_client_id],
                          mds_id=self.fs.get_rank(rank=0, status=status)['name'])
-        self.wait_until_true(lambda: self.mount_a.is_blacklisted(), timeout=30)
+        self.wait_until_true(lambda: self.mount_a.is_blocklisted(), timeout=30)
 
         # 10 seconds should be enough for evicting client
         time.sleep(10)

--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -461,7 +461,7 @@ vc.disconnect()
 
         # Evicted guest client, guest_mounts[0], should not be able to do
         # anymore metadata ops.  It should start failing all operations
-        # when it sees that its own address is in the blacklist.
+        # when it sees that its own address is in the blocklist.
         try:
             guest_mounts[0].write_n_mb("rogue.bin", 1)
         except CommandFailedError:
@@ -469,7 +469,7 @@ vc.disconnect()
         else:
             raise RuntimeError("post-eviction write should have failed!")
 
-        # The blacklisted guest client should now be unmountable
+        # The blocklisted guest client should now be unmountable
         guest_mounts[0].umount_wait()
 
         # Guest client, guest_mounts[1], using the same auth ID 'guest', but

--- a/qa/tasks/fs.py
+++ b/qa/tasks/fs.py
@@ -56,11 +56,11 @@ def clients_evicted(ctx, config):
         mount = mounts.get(client)
         if mount is not None:
             if evicted:
-                log.info("confirming client {} is blacklisted".format(client))
-                assert mount.is_blacklisted()
+                log.info("confirming client {} is blocklisted".format(client))
+                assert mount.is_blocklisted()
             elif client in no_session:
                 log.info("client {} should not be evicted but has no session with an MDS".format(client))
-                mount.is_blacklisted() # for debugging
+                mount.is_blocklisted() # for debugging
                 should_assert = True
     if should_assert:
         raise RuntimeError("some clients which should not be evicted have no session with an MDS?")

--- a/qa/tasks/mgr/dashboard/test_auth.py
+++ b/qa/tasks/mgr/dashboard/test_auth.py
@@ -99,12 +99,12 @@ class AuthTest(DashboardTestCase):
         self._ceph_cmd(['dashboard', 'set-jwt-token-ttl', '28800'])
         self.set_jwt_token(None)
 
-    def test_remove_from_blacklist(self):
+    def test_remove_from_blocklist(self):
         self._ceph_cmd(['dashboard', 'set-jwt-token-ttl', '5'])
         self._post("/api/auth", {'username': 'admin', 'password': 'admin'})
         self.assertStatus(201)
         self.set_jwt_token(self.jsonBody()['token'])
-        # the following call adds the token to the blacklist
+        # the following call adds the token to the blocklist
         self._post("/api/auth/logout")
         self.assertStatus(200)
         self._get("/api/host")
@@ -115,7 +115,7 @@ class AuthTest(DashboardTestCase):
         self._post("/api/auth", {'username': 'admin', 'password': 'admin'})
         self.assertStatus(201)
         self.set_jwt_token(self.jsonBody()['token'])
-        # the following call removes expired tokens from the blacklist
+        # the following call removes expired tokens from the blocklist
         self._post("/api/auth/logout")
         self.assertStatus(200)
 

--- a/qa/tasks/osd_failsafe_enospc.py
+++ b/qa/tasks/osd_failsafe_enospc.py
@@ -17,13 +17,13 @@ def task(ctx, config):
     Test handling of osd_failsafe_nearfull_ratio and osd_failsafe_full_ratio
     configuration settings
 
-    In order for test to pass must use log-whitelist as follows
+    In order for test to pass must use log-ignorelist as follows
 
         tasks:
             - chef:
             - install:
             - ceph:
-                log-whitelist: ['OSD near full', 'OSD full dropping all updates']
+                log-ignorelist: ['OSD near full', 'OSD full dropping all updates']
             - osd_failsafe_enospc:
 
     """

--- a/qa/tasks/repair_test.py
+++ b/qa/tasks/repair_test.py
@@ -251,7 +251,7 @@ def task(ctx, config):
 
     The config should be as follows:
 
-      Must include the log-whitelist below
+      Must include the log-ignorelist below
       Must enable filestore_debug_inject_read_err config
 
     example:
@@ -260,7 +260,7 @@ def task(ctx, config):
     - chef:
     - install:
     - ceph:
-        log-whitelist:
+        log-ignorelist:
           - 'candidate had a stat error'
           - 'candidate had a read error'
           - 'deep-scrub 0 missing, 1 inconsistent objects'

--- a/qa/tasks/scrub_test.py
+++ b/qa/tasks/scrub_test.py
@@ -324,7 +324,7 @@ def task(ctx, config):
     - chef:
     - install:
     - ceph:
-        log-whitelist:
+        log-ignorelist:
         - '!= data_digest'
         - '!= omap_digest'
         - '!= size'

--- a/qa/tasks/tempest.py
+++ b/qa/tasks/tempest.py
@@ -149,8 +149,8 @@ def run_tempest(ctx, config):
     log.info('Configuring Tempest')
 
     for (client, cconf) in config.items():
-        blacklist = cconf.get('blacklist', [])
-        assert isinstance(blacklist, list)
+        blocklist = cconf.get('blocklist', [])
+        assert isinstance(blocklist, list)
         run_in_tempest_venv(ctx, client,
             [
                 'tempest',
@@ -160,7 +160,7 @@ def run_tempest(ctx, config):
                 '--workspace',
                 'rgw',
                 '--regex', '^tempest.api.object_storage',
-                '--black-regex', '|'.join(blacklist)
+                '--black-regex', '|'.join(blocklist)
             ])
     try:
         yield
@@ -220,7 +220,7 @@ def task(ctx, config):
             object-storage-feature-enabled:
               container_sync: false
               discoverability: false
-            blacklist:
+            blocklist:
               # please strip half of these items after merging PRs #15369
               # and #12704
               - .*test_list_containers_reverse_order.*

--- a/qa/tasks/thrashosds-health.yaml
+++ b/qa/tasks/thrashosds-health.yaml
@@ -3,7 +3,7 @@ overrides:
     conf:
       osd:
         osd max markdown count: 1000
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1386,34 +1386,37 @@ function test_mon_config_key()
 function test_mon_osd()
 {
   #
-  # osd blacklist
+  # osd blocklist
   #
   bl=192.168.0.1:0/1000
-  ceph osd blacklist add $bl
-  ceph osd blacklist ls | grep $bl
-  ceph osd blacklist ls --format=json-pretty  | sed 's/\\\//\//' | grep $bl
+  ceph osd blocklist add $bl
+  ceph osd blocklist ls | grep $bl
+  ceph osd blocklist ls --format=json-pretty  | sed 's/\\\//\//' | grep $bl
   ceph osd dump --format=json-pretty | grep $bl
   ceph osd dump | grep $bl
-  ceph osd blacklist rm $bl
-  ceph osd blacklist ls | expect_false grep $bl
+  ceph osd blocklist rm $bl
+  ceph osd blocklist ls | expect_false grep $bl
 
   bl=192.168.0.1
   # test without nonce, invalid nonce
-  ceph osd blacklist add $bl
-  ceph osd blacklist ls | grep $bl
-  ceph osd blacklist rm $bl
-  ceph osd blacklist ls | expect_false grep $bl
-  expect_false "ceph osd blacklist $bl/-1"
-  expect_false "ceph osd blacklist $bl/foo"
+  ceph osd blocklist add $bl
+  ceph osd blocklist ls | grep $bl
+  ceph osd blocklist rm $bl
+  ceph osd blocklist ls | expect_false grep $bl
+  expect_false "ceph osd blocklist $bl/-1"
+  expect_false "ceph osd blocklist $bl/foo"
 
   # test with wrong address
-  expect_false "ceph osd blacklist 1234.56.78.90/100"
+  expect_false "ceph osd blocklist 1234.56.78.90/100"
 
   # Test `clear`
-  ceph osd blacklist add $bl
-  ceph osd blacklist ls | grep $bl
-  ceph osd blacklist clear
-  ceph osd blacklist ls | expect_false grep $bl
+  ceph osd blocklist add $bl
+  ceph osd blocklist ls | grep $bl
+  ceph osd blocklist clear
+  ceph osd blocklist ls | expect_false grep $bl
+
+  # deprecated syntax?
+  ceph osd blacklist ls
 
   #
   # osd crush

--- a/qa/workunits/rbd/krbd_exclusive_option.sh
+++ b/qa/workunits/rbd/krbd_exclusive_option.sh
@@ -53,13 +53,13 @@ function assert_unlocked() {
         grep '"lockers":\[\]'
 }
 
-function blacklist_add() {
+function blocklist_add() {
     local dev_id="${1#/dev/rbd}"
 
     local client_addr
     client_addr="$(< $SYSFS_DIR/$dev_id/client_addr)"
 
-    ceph osd blacklist add $client_addr
+    ceph osd blocklist add $client_addr
 }
 
 SYSFS_DIR="/sys/bus/rbd/devices"
@@ -203,7 +203,7 @@ assert_unlocked
 DEV=$(sudo rbd map $IMAGE_NAME)
 assert_locked $DEV
 dd if=/dev/urandom of=$DEV bs=4k count=10 oflag=direct
-{ sleep 10; blacklist_add $DEV; } &
+{ sleep 10; blocklist_add $DEV; } &
 PID=$!
 expect_false dd if=/dev/urandom of=$DEV bs=4k count=200000 oflag=direct
 wait $PID

--- a/qa/workunits/rbd/rbd_mirror_journal.sh
+++ b/qa/workunits/rbd/rbd_mirror_journal.sh
@@ -547,7 +547,7 @@ wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+replaying' 'primary
 
 if [ -z "${RBD_MIRROR_USE_RBD_MIRROR}" ]; then
   # teuthology will trash the daemon
-  testlog "TEST: no blacklists"
-  CEPH_ARGS='--id admin' ceph --cluster ${CLUSTER1} osd blacklist ls 2>&1 | grep -q "listed 0 entries"
-  CEPH_ARGS='--id admin' ceph --cluster ${CLUSTER2} osd blacklist ls 2>&1 | grep -q "listed 0 entries"
+  testlog "TEST: no blocklists"
+  CEPH_ARGS='--id admin' ceph --cluster ${CLUSTER1} osd blocklist ls 2>&1 | grep -q "listed 0 entries"
+  CEPH_ARGS='--id admin' ceph --cluster ${CLUSTER2} osd blocklist ls 2>&1 | grep -q "listed 0 entries"
 fi

--- a/qa/workunits/rbd/rbd_mirror_snapshot.sh
+++ b/qa/workunits/rbd/rbd_mirror_snapshot.sh
@@ -448,7 +448,7 @@ wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+replaying'
 
 if [ -z "${RBD_MIRROR_USE_RBD_MIRROR}" ]; then
   # teuthology will trash the daemon
-  testlog "TEST: no blacklists"
-  CEPH_ARGS='--id admin' ceph --cluster ${CLUSTER1} osd blacklist ls 2>&1 | grep -q "listed 0 entries"
-  CEPH_ARGS='--id admin' ceph --cluster ${CLUSTER2} osd blacklist ls 2>&1 | grep -q "listed 0 entries"
+  testlog "TEST: no blocklists"
+  CEPH_ARGS='--id admin' ceph --cluster ${CLUSTER1} osd blocklist ls 2>&1 | grep -q "listed 0 entries"
+  CEPH_ARGS='--id admin' ceph --cluster ${CLUSTER2} osd blocklist ls 2>&1 | grep -q "listed 0 entries"
 fi

--- a/qa/workunits/rbd/test_lock_fence.sh
+++ b/qa/workunits/rbd/test_lock_fence.sh
@@ -26,7 +26,7 @@ clientid=$(rbd lock list $IMAGE | tail -1 | awk '{print $1;}')
 echo "clientaddr: $clientaddr"
 echo "clientid: $clientid"
 
-ceph osd blacklist add $clientaddr || exit 1
+ceph osd blocklist add $clientaddr || exit 1
 
 wait $iochild
 rbdrw_exitcode=$?
@@ -39,7 +39,7 @@ else
 fi
 
 set -e
-ceph osd blacklist rm $clientaddr
+ceph osd blocklist rm $clientaddr
 rbd lock remove $IMAGE $LOCKID "$clientid"
 # rbdrw will have exited with an existing watch, so, until #3527 is fixed,
 # hang out until the watch expires

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1237,7 +1237,7 @@ private:
   bool   initialized = false;
   bool   mounted = false;
   bool   unmounting = false;
-  bool   blacklisted = false;
+  bool   blocklisted = false;
 
   ceph::unordered_map<vinodeno_t, Inode*> inode_map;
   ceph::unordered_map<ino_t, vinodeno_t> faked_ino_map;

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -303,7 +303,7 @@ OPTION(mon_keyvaluedb, OPT_STR)   // type of keyvaluedb backend
 
 // UNSAFE -- TESTING ONLY! Allows addition of a cache tier with preexisting snaps
 OPTION(mon_debug_unsafe_allow_tier_with_nonempty_snaps, OPT_BOOL)
-OPTION(mon_osd_blacklist_default_expire, OPT_DOUBLE) // default one hour
+OPTION(mon_osd_blocklist_default_expire, OPT_DOUBLE) // default one hour
 OPTION(mon_osd_crush_smoke_test, OPT_BOOL)
 
 OPTION(paxos_stash_full_interval, OPT_INT)   // how often (in commits) to stash a full copy of the PaxosService state
@@ -406,8 +406,8 @@ OPTION(mds_beacon_interval, OPT_FLOAT)
 OPTION(mds_beacon_grace, OPT_FLOAT)
 OPTION(mds_enforce_unique_name, OPT_BOOL)
 
-OPTION(mds_session_blacklist_on_timeout, OPT_BOOL)    // whether to blacklist clients whose sessions are dropped due to timeout
-OPTION(mds_session_blacklist_on_evict, OPT_BOOL)  // whether to blacklist clients whose sessions are dropped via admin commands
+OPTION(mds_session_blocklist_on_timeout, OPT_BOOL)    // whether to blocklist clients whose sessions are dropped due to timeout
+OPTION(mds_session_blocklist_on_evict, OPT_BOOL)  // whether to blocklist clients whose sessions are dropped via admin commands
 
 OPTION(mds_sessionmap_keys_per_op, OPT_U32)    // how many sessions should I try to load/store in a single OMAP operation?
 OPTION(mds_freeze_tree_timeout, OPT_FLOAT)    // detecting freeze tree deadlock

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2123,25 +2123,25 @@ std::vector<Option> get_global_options() {
     .add_service("mon")
     .set_description(""),
 
-    Option("mon_osd_blacklist_default_expire", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    Option("mon_osd_blocklist_default_expire", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(1_hr)
     .add_service("mon")
-    .set_description("Duration in seconds that blacklist entries for clients "
+    .set_description("Duration in seconds that blocklist entries for clients "
                      "remain in the OSD map"),
 
-    Option("mon_mds_blacklist_interval", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    Option("mon_mds_blocklist_interval", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(1_day)
     .set_min(1_hr)
     .add_service("mon")
-    .set_description("Duration in seconds that blacklist entries for MDS "
+    .set_description("Duration in seconds that blocklist entries for MDS "
                      "daemons remain in the OSD map")
     .set_flag(Option::FLAG_RUNTIME),
 
-    Option("mon_mgr_blacklist_interval", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    Option("mon_mgr_blocklist_interval", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(1_day)
     .set_min(1_hr)
     .add_service("mon")
-    .set_description("Duration in seconds that blacklist entries for mgr "
+    .set_description("Duration in seconds that blocklist entries for mgr "
                      "daemons remain in the OSD map")
     .set_flag(Option::FLAG_RUNTIME),
 
@@ -7299,13 +7299,13 @@ static std::vector<Option> get_rbd_options() {
     .set_default(false)
     .set_description("copy-up parent image blocks to clone upon read request"),
 
-    Option("rbd_blacklist_on_break_lock", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    Option("rbd_blocklist_on_break_lock", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
-    .set_description("whether to blacklist clients whose lock was broken"),
+    .set_description("whether to blocklist clients whose lock was broken"),
 
-    Option("rbd_blacklist_expire_seconds", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    Option("rbd_blocklist_expire_seconds", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(0)
-    .set_description("number of seconds to blacklist - set to 0 for OSD default"),
+    .set_description("number of seconds to blocklist - set to 0 for OSD default"),
 
     Option("rbd_request_timed_out_seconds", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(30)
@@ -7864,13 +7864,13 @@ std::vector<Option> get_mds_options() {
     .set_default(true)
     .set_description("require MDS name is unique in the cluster"),
 
-    Option("mds_session_blacklist_on_timeout", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    Option("mds_session_blocklist_on_timeout", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
-    .set_description("blacklist clients whose sessions have become stale"),
+    .set_description("blocklist clients whose sessions have become stale"),
 
-    Option("mds_session_blacklist_on_evict", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    Option("mds_session_blocklist_on_evict", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
-    .set_description("blacklist clients that have been evicted"),
+    .set_description("blocklist clients that have been evicted"),
 
     Option("mds_sessionmap_keys_per_op", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(1024)

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -283,7 +283,7 @@ public:
   void check_recovery_sources(const OSDMapRef& newmap) final {
     // Not needed yet
   }
-  void check_blacklisted_watchers() final {
+  void check_blocklisted_watchers() final {
     // Not needed yet
   }
   void clear_primary_state() final {

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -1803,7 +1803,7 @@ int ceph_ll_lazyio(struct ceph_mount_info *cmount, Fh *fh, int enable);
  * Get the amount of time that the client has to return caps
  * @param cmount the ceph mount handle to use.
  *
- * In the event that a client does not return its caps, the MDS may blacklist
+ * In the event that a client does not return its caps, the MDS may blocklist
  * it after this timeout. Applications should check this value and ensure
  * that they set the delegation timeout to a value lower than this.
  *
@@ -1817,7 +1817,7 @@ uint32_t ceph_get_cap_return_timeout(struct ceph_mount_info *cmount);
  * @param cmount the ceph mount handle to use.
  * @param timeout the delegation timeout (in seconds)
  *
- * Since the client could end up blacklisted if it doesn't return delegations
+ * Since the client could end up blocklisted if it doesn't return delegations
  * in time, we mandate that any application wanting to use delegations
  * explicitly set the timeout beforehand. Until this call is done on the
  * mount, attempts to set a delegation will return -ETIME.

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -487,7 +487,8 @@ enum {
 };
 
 #define EOLDSNAPC    85  /* ORDERSNAP flag set; writer has old snapc*/
-#define EBLACKLISTED 108 /* blacklisted */
+#define EBLOCKLISTED 108 /* blocklisted */
+#define EBLACKLISTED 108 /* deprecated */
 
 /* xattr comparison */
 enum {

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -3655,19 +3655,23 @@ CEPH_RADOS_API int rados_break_lock(rados_ioctx_t io, const char *o,
                                     const char *cookie);
 
 /**
- * Blacklists the specified client from the OSDs
+ * Blocklists the specified client from the OSDs
  *
  * @param cluster cluster handle
  * @param client_address client address
- * @param expire_seconds number of seconds to blacklist (0 for default)
+ * @param expire_seconds number of seconds to blocklist (0 for default)
  * @returns 0 on success, negative error code on failure
  */
-CEPH_RADOS_API int rados_blacklist_add(rados_t cluster,
+CEPH_RADOS_API int rados_blocklist_add(rados_t cluster,
 				       char *client_address,
 				       uint32_t expire_seconds);
+CEPH_RADOS_API int rados_blacklist_add(rados_t cluster,
+				       char *client_address,
+				       uint32_t expire_seconds)
+  __attribute__((deprecated));
 
 /**
- * Gets addresses of the RADOS session, suitable for blacklisting.
+ * Gets addresses of the RADOS session, suitable for blocklisting.
  *
  * @param cluster cluster handle
  * @param addrs the output string.

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1418,7 +1418,7 @@ inline namespace v14_2_0 {
     int ioctx_create2(int64_t pool_id, IoCtx &pioctx);
 
     // Features useful for test cases
-    void test_blacklist_self(bool set);
+    void test_blocklist_self(bool set);
 
     /* pool info */
     int pool_list(std::list<std::string>& v);
@@ -1486,7 +1486,7 @@ inline namespace v14_2_0 {
     /// get/wait for the most recent osdmap
     int wait_for_latest_osdmap();
 
-    int blacklist_add(const std::string& client_address,
+    int blocklist_add(const std::string& client_address,
                       uint32_t expire_seconds);
 
     /*

--- a/src/journal/JournalMetadata.cc
+++ b/src/journal/JournalMetadata.cc
@@ -883,7 +883,7 @@ void JournalMetadata::handle_watch_reset() {
     if (r == -ENOENT) {
       ldout(m_cct, 5) << __func__ << ": journal header not found" << dendl;
     } else if (r == -EBLACKLISTED) {
-      ldout(m_cct, 5) << __func__ << ": client blacklisted" << dendl;
+      ldout(m_cct, 5) << __func__ << ": client blocklisted" << dendl;
     } else {
       lderr(m_cct) << __func__ << ": failed to watch journal: "
                    << cpp_strerror(r) << dendl;
@@ -915,8 +915,8 @@ void JournalMetadata::handle_watch_notify(uint64_t notify_id, uint64_t cookie) {
 void JournalMetadata::handle_watch_error(int err) {
   if (err == -ENOTCONN) {
     ldout(m_cct, 5) << "journal watch error: header removed" << dendl;
-  } else if (err == -EBLACKLISTED) {
-    lderr(m_cct) << "journal watch error: client blacklisted" << dendl;
+  } else if (err == -EBLOCKLISTED) {
+    lderr(m_cct) << "journal watch error: client blocklisted" << dendl;
   } else {
     lderr(m_cct) << "journal watch error: " << cpp_strerror(err) << dendl;
   }

--- a/src/journal/JournalMetadata.cc
+++ b/src/journal/JournalMetadata.cc
@@ -1095,7 +1095,7 @@ void JournalMetadata::schedule_laggy_clients_disconnect(Context *on_finish) {
     for (auto &c : m_registered_clients) {
       if (c.state == cls::journal::CLIENT_STATE_DISCONNECTED ||
           c.id == m_client_id ||
-          m_settings.whitelisted_laggy_clients.count(c.id) > 0) {
+          m_settings.allowlisted_laggy_clients.count(c.id) > 0) {
         continue;
       }
       const std::string &client_id = c.id;

--- a/src/journal/Settings.h
+++ b/src/journal/Settings.h
@@ -12,7 +12,7 @@ struct Settings {
   double commit_interval = 5;         ///< commit position throttle (in secs)
   uint64_t max_payload_bytes = 0;     ///< 0 implies object size limit
   int max_concurrent_object_sets = 0; ///< 0 implies no limit
-  std::set<std::string> whitelisted_laggy_clients;
+  std::set<std::string> allowlisted_laggy_clients;
                                       ///< clients that mustn't be disconnected
 };
 

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -766,9 +766,9 @@ int librados::RadosClient::pool_delete_async(const char *name, PoolAsyncCompleti
   return r;
 }
 
-void librados::RadosClient::blacklist_self(bool set) {
+void librados::RadosClient::blocklist_self(bool set) {
   std::lock_guard l(lock);
-  objecter->blacklist_self(set);
+  objecter->blocklist_self(set);
 }
 
 std::string librados::RadosClient::get_addrs() const {
@@ -777,7 +777,7 @@ std::string librados::RadosClient::get_addrs() const {
   return std::string(cos->strv());
 }
 
-int librados::RadosClient::blacklist_add(const string& client_address,
+int librados::RadosClient::blocklist_add(const string& client_address,
 					 uint32_t expire_seconds)
 {
   entity_addr_t addr;
@@ -788,8 +788,8 @@ int librados::RadosClient::blacklist_add(const string& client_address,
 
   std::stringstream cmd;
   cmd << "{"
-      << "\"prefix\": \"osd blacklist\", "
-      << "\"blacklistop\": \"add\", "
+      << "\"prefix\": \"osd blocklist\", "
+      << "\"blocklistop\": \"add\", "
       << "\"addr\": \"" << client_address << "\"";
   if (expire_seconds != 0) {
     cmd << ", \"expire\": " << expire_seconds << ".0";
@@ -801,6 +801,7 @@ int librados::RadosClient::blacklist_add(const string& client_address,
   bufferlist inbl;
   int r = mon_command(cmds, inbl, NULL, NULL);
   if (r < 0) {
+#warning blocklist fallback
     return r;
   }
 

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -144,7 +144,7 @@ public:
 
   int pool_delete_async(const char *name, PoolAsyncCompletionImpl *c);
 
-  int blacklist_add(const string& client_address, uint32_t expire_seconds);
+  int blocklist_add(const string& client_address, uint32_t expire_seconds);
 
   int mon_command(const vector<string>& cmd, const bufferlist &inbl,
 	          bufferlist *outbl, string *outs);
@@ -173,7 +173,7 @@ public:
 
   void get();
   bool put();
-  void blacklist_self(bool set);
+  void blocklist_self(bool set);
 
   std::string get_addrs() const;
 

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -435,11 +435,18 @@ extern "C" int _rados_wait_for_latest_osdmap(rados_t cluster)
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_wait_for_latest_osdmap);
 
-extern "C" int _rados_blacklist_add(rados_t cluster, char *client_address,
+extern "C" int _rados_blocklist_add(rados_t cluster, char *client_address,
 				    uint32_t expire_seconds)
 {
   librados::RadosClient *radosp = (librados::RadosClient *)cluster;
-  return radosp->blacklist_add(client_address, expire_seconds);
+  return radosp->blocklist_add(client_address, expire_seconds);
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_blocklist_add);
+
+extern "C" int _rados_blacklist_add(rados_t cluster, char *client_address,
+				    uint32_t expire_seconds)
+{
+  return _rados_blocklist_add(cluster, client_address, expire_seconds);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_blacklist_add);
 

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -2625,9 +2625,9 @@ int librados::Rados::ioctx_create2(int64_t pool_id, IoCtx &io)
   return 0;
 }
 
-void librados::Rados::test_blacklist_self(bool set)
+void librados::Rados::test_blocklist_self(bool set)
 {
-  client->blacklist_self(set);
+  client->blocklist_self(set);
 }
 
 int librados::Rados::get_pool_stats(std::list<string>& v,
@@ -2810,10 +2810,10 @@ int librados::Rados::wait_for_latest_osdmap()
   return client->wait_for_latest_osdmap();
 }
 
-int librados::Rados::blacklist_add(const std::string& client_address,
+int librados::Rados::blocklist_add(const std::string& client_address,
 				   uint32_t expire_seconds)
 {
-  return client->blacklist_add(client_address, expire_seconds);
+  return client->blocklist_add(client_address, expire_seconds);
 }
 
 librados::PoolAsyncCompletion *librados::Rados::pool_async_create_completion()

--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -33,8 +33,8 @@ ExclusiveLock<I>::ExclusiveLock(I &image_ctx)
   : RefCountedObject(image_ctx.cct),
     ML<I>(image_ctx.md_ctx, image_ctx.op_work_queue, image_ctx.header_oid,
           image_ctx.image_watcher, managed_lock::EXCLUSIVE,
-          image_ctx.config.template get_val<bool>("rbd_blacklist_on_break_lock"),
-          image_ctx.config.template get_val<uint64_t>("rbd_blacklist_expire_seconds")),
+          image_ctx.config.template get_val<bool>("rbd_blocklist_on_break_lock"),
+          image_ctx.config.template get_val<uint64_t>("rbd_blocklist_expire_seconds")),
     m_image_ctx(image_ctx) {
   std::lock_guard locker{ML<I>::m_lock};
   ML<I>::set_state_uninitialized();
@@ -111,8 +111,8 @@ void ExclusiveLock<I>::unblock_requests() {
 
 template <typename I>
 int ExclusiveLock<I>::get_unlocked_op_error() const {
-  if (m_image_ctx.image_watcher->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_image_ctx.image_watcher->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
   return -EROFS;
 }

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -1119,7 +1119,7 @@ void Journal<I>::create_journaler() {
     m_image_ctx.config.template get_val<uint64_t>("rbd_journal_max_concurrent_object_sets");
   // TODO: a configurable filter to exclude certain peers from being
   // disconnected.
-  settings.whitelisted_laggy_clients = {IMAGE_CLIENT_ID};
+  settings.allowlisted_laggy_clients = {IMAGE_CLIENT_ID};
 
   m_journaler = new Journaler(m_work_queue, m_timer, m_timer_lock,
 			      m_image_ctx.md_ctx, m_image_ctx.id,

--- a/src/librbd/ManagedLock.h
+++ b/src/librbd/ManagedLock.h
@@ -33,10 +33,10 @@ public:
                              asio::ContextWQ *work_queue,
                              const std::string& oid, Watcher *watcher,
                              managed_lock::Mode mode,
-                             bool blacklist_on_break_lock,
-                             uint32_t blacklist_expire_seconds) {
+                             bool blocklist_on_break_lock,
+                             uint32_t blocklist_expire_seconds) {
     return new ManagedLock(ioctx, work_queue, oid, watcher, mode,
-                           blacklist_on_break_lock, blacklist_expire_seconds);
+                           blocklist_on_break_lock, blocklist_expire_seconds);
   }
   void destroy() {
     delete this;
@@ -44,8 +44,8 @@ public:
 
   ManagedLock(librados::IoCtx& ioctx, asio::ContextWQ *work_queue,
               const std::string& oid, Watcher *watcher,
-              managed_lock::Mode mode, bool blacklist_on_break_lock,
-              uint32_t blacklist_expire_seconds);
+              managed_lock::Mode mode, bool blocklist_on_break_lock,
+              uint32_t blocklist_expire_seconds);
   virtual ~ManagedLock();
 
   bool is_lock_owner() const;
@@ -215,8 +215,8 @@ private:
   std::string m_oid;
   Watcher *m_watcher;
   managed_lock::Mode m_mode;
-  bool m_blacklist_on_break_lock;
-  uint32_t m_blacklist_expire_seconds;
+  bool m_blocklist_on_break_lock;
+  uint32_t m_blocklist_expire_seconds;
 
   std::string m_cookie;
   std::string m_new_cookie;

--- a/src/librbd/Watcher.cc
+++ b/src/librbd/Watcher.cc
@@ -108,7 +108,7 @@ void Watcher::register_watch(Context *on_finish) {
   std::unique_lock watch_locker{m_watch_lock};
   ceph_assert(is_unregistered(m_watch_lock));
   m_watch_state = WATCH_STATE_REGISTERING;
-  m_watch_blacklisted = false;
+  m_watch_blocklisted = false;
 
   librados::AioCompletion *aio_comp = create_rados_callback(
     new C_RegisterWatch(this, on_finish));
@@ -140,7 +140,7 @@ void Watcher::handle_register_watch(int r, Context *on_finish) {
       m_watch_state = WATCH_STATE_REWATCHING;
       watch_error = true;
     } else {
-      m_watch_blacklisted = (r == -EBLACKLISTED);
+      m_watch_blocklisted = (r == -EBLOCKLISTED);
     }
   }
 
@@ -175,7 +175,7 @@ void Watcher::unregister_watch(Context *on_finish) {
       aio_comp->release();
 
       m_watch_handle = 0;
-      m_watch_blacklisted = false;
+      m_watch_blocklisted = false;
       return;
     }
   }
@@ -231,8 +231,8 @@ void Watcher::handle_error(uint64_t handle, int err) {
 
   if (is_registered(m_watch_lock)) {
     m_watch_state = WATCH_STATE_REWATCHING;
-    if (err == -EBLACKLISTED) {
-      m_watch_blacklisted = true;
+    if (err == -EBLOCKLISTED) {
+      m_watch_blocklisted = true;
     }
 
     auto ctx = new LambdaContext(
@@ -280,14 +280,14 @@ void Watcher::handle_rewatch(int r) {
     std::unique_lock watch_locker{m_watch_lock};
     ceph_assert(m_watch_state == WATCH_STATE_REWATCHING);
 
-    m_watch_blacklisted = false;
+    m_watch_blocklisted = false;
     if (m_unregister_watch_ctx != nullptr) {
       ldout(m_cct, 10) << "image is closing, skip rewatch" << dendl;
       m_watch_state = WATCH_STATE_IDLE;
       std::swap(unregister_watch_ctx, m_unregister_watch_ctx);
-    } else if (r  == -EBLACKLISTED) {
-      lderr(m_cct) << "client blacklisted" << dendl;
-      m_watch_blacklisted = true;
+    } else if (r  == -EBLOCKLISTED) {
+      lderr(m_cct) << "client blocklisted" << dendl;
+      m_watch_blocklisted = true;
     } else if (r == -ENOENT) {
       ldout(m_cct, 5) << "object does not exist" << dendl;
     } else if (r < 0) {
@@ -325,7 +325,7 @@ void Watcher::handle_rewatch_callback(int r) {
     if (m_unregister_watch_ctx != nullptr) {
       m_watch_state = WATCH_STATE_IDLE;
       std::swap(unregister_watch_ctx, m_unregister_watch_ctx);
-    } else if (r == -EBLACKLISTED || r == -ENOENT) {
+    } else if (r == -EBLOCKLISTED || r == -ENOENT) {
       m_watch_state = WATCH_STATE_IDLE;
     } else if (r < 0 || m_watch_error) {
       watch_error = true;

--- a/src/librbd/Watcher.h
+++ b/src/librbd/Watcher.h
@@ -59,9 +59,9 @@ public:
     std::shared_lock locker{m_watch_lock};
     return is_unregistered(m_watch_lock);
   }
-  bool is_blacklisted() const {
+  bool is_blocklisted() const {
     std::shared_lock locker{m_watch_lock};
-    return m_watch_blacklisted;
+    return m_watch_blocklisted;
   }
 
 protected:
@@ -80,7 +80,7 @@ protected:
   watcher::Notifier m_notifier;
 
   WatchState m_watch_state;
-  bool m_watch_blacklisted = false;
+  bool m_watch_blocklisted = false;
 
   AsyncOpTracker m_async_op_tracker;
 

--- a/src/librbd/cache/ObjectCacherObjectDispatch.cc
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.cc
@@ -49,7 +49,7 @@ struct ObjectCacherObjectDispatch<I>::C_InvalidateCache : public Context {
     auto cct = dispatcher->m_image_ctx->cct;
 
     if (r == -EBLACKLISTED) {
-      lderr(cct) << "blacklisted during flush (purging)" << dendl;
+      lderr(cct) << "blocklisted during flush (purging)" << dendl;
       dispatcher->m_object_cacher->purge_set(dispatcher->m_object_set);
     } else if (r < 0 && purge_on_error) {
       lderr(cct) << "failed to invalidate cache (purging): "

--- a/src/librbd/exclusive_lock/PreReleaseRequest.cc
+++ b/src/librbd/exclusive_lock/PreReleaseRequest.cc
@@ -127,8 +127,8 @@ void PreReleaseRequest<I>::handle_block_writes(int r) {
   ldout(cct, 10) << "r=" << r << dendl;
 
   if (r == -EBLACKLISTED) {
-    // allow clean shut down if blacklisted
-    lderr(cct) << "failed to block writes because client is blacklisted"
+    // allow clean shut down if blocklisted
+    lderr(cct) << "failed to block writes because client is blocklisted"
                << dendl;
   } else if (r < 0) {
     lderr(cct) << "failed to block writes: " << cpp_strerror(r) << dendl;
@@ -176,7 +176,7 @@ void PreReleaseRequest<I>::handle_invalidate_cache(int r) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 10) << "r=" << r << dendl;
 
-  if (r < 0 && r != -EBLACKLISTED && r != -EBUSY) {
+  if (r < 0 && r != -EBLOCKLISTED && r != -EBUSY) {
     lderr(cct) << "failed to invalidate cache: " << cpp_strerror(r)
                << dendl;
     m_image_dispatch->unset_require_lock(io::DIRECTION_BOTH);

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -914,7 +914,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
       return 0;
     }
 
-    // might have been blacklisted by peer -- ensure we still own
+    // might have been blocklisted by peer -- ensure we still own
     // the lock by pinging the OSD
     int r = ictx->exclusive_lock->assert_header_locked();
     if (r == -EBUSY || r == -ENOENT) {
@@ -1444,7 +1444,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
       return -EINVAL;
     }
 
-    if (ictx->config.get_val<bool>("rbd_blacklist_on_break_lock")) {
+    if (ictx->config.get_val<bool>("rbd_blocklist_on_break_lock")) {
       typedef std::map<rados::cls::lock::locker_id_t,
 		       rados::cls::lock::locker_info_t> Lockers;
       Lockers lockers;
@@ -1472,11 +1472,11 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
       }
 
       librados::Rados rados(ictx->md_ctx);
-      r = rados.blacklist_add(
+      r = rados.blocklist_add(
         client_address,
-        ictx->config.get_val<uint64_t>("rbd_blacklist_expire_seconds"));
+        ictx->config.get_val<uint64_t>("rbd_blocklist_expire_seconds"));
       if (r < 0) {
-        lderr(ictx->cct) << "unable to blacklist client: " << cpp_strerror(r)
+        lderr(ictx->cct) << "unable to blocklist client: " << cpp_strerror(r)
           	       << dendl;
         return r;
       }

--- a/src/librbd/managed_lock/AcquireRequest.cc
+++ b/src/librbd/managed_lock/AcquireRequest.cc
@@ -37,12 +37,12 @@ AcquireRequest<I>* AcquireRequest<I>::create(librados::IoCtx& ioctx,
                                              const string& oid,
                                              const string& cookie,
                                              bool exclusive,
-					     bool blacklist_on_break_lock,
-					     uint32_t blacklist_expire_seconds,
+					     bool blocklist_on_break_lock,
+					     uint32_t blocklist_expire_seconds,
                                              Context *on_finish) {
     return new AcquireRequest(ioctx, watcher, work_queue, oid, cookie,
-                              exclusive, blacklist_on_break_lock,
-                              blacklist_expire_seconds, on_finish);
+                              exclusive, blocklist_on_break_lock,
+                              blocklist_expire_seconds, on_finish);
 }
 
 template <typename I>
@@ -50,15 +50,15 @@ AcquireRequest<I>::AcquireRequest(librados::IoCtx& ioctx, Watcher *watcher,
                                   asio::ContextWQ *work_queue,
                                   const string& oid,
                                   const string& cookie, bool exclusive,
-                                  bool blacklist_on_break_lock,
-                                  uint32_t blacklist_expire_seconds,
+                                  bool blocklist_on_break_lock,
+                                  uint32_t blocklist_expire_seconds,
                                   Context *on_finish)
   : m_ioctx(ioctx), m_watcher(watcher),
     m_cct(reinterpret_cast<CephContext *>(m_ioctx.cct())),
     m_work_queue(work_queue), m_oid(oid), m_cookie(cookie),
     m_exclusive(exclusive),
-    m_blacklist_on_break_lock(blacklist_on_break_lock),
-    m_blacklist_expire_seconds(blacklist_expire_seconds),
+    m_blocklist_on_break_lock(blocklist_on_break_lock),
+    m_blocklist_expire_seconds(blocklist_expire_seconds),
     m_on_finish(new C_AsyncCallback<asio::ContextWQ>(work_queue, on_finish)) {
 }
 
@@ -148,7 +148,7 @@ void AcquireRequest<I>::send_break_lock() {
     AcquireRequest<I>, &AcquireRequest<I>::handle_break_lock>(this);
   auto req = BreakRequest<I>::create(
     m_ioctx, m_work_queue, m_oid, m_locker, m_exclusive,
-    m_blacklist_on_break_lock, m_blacklist_expire_seconds, false, ctx);
+    m_blocklist_on_break_lock, m_blocklist_expire_seconds, false, ctx);
   req->send();
 }
 

--- a/src/librbd/managed_lock/AcquireRequest.h
+++ b/src/librbd/managed_lock/AcquireRequest.h
@@ -33,8 +33,8 @@ public:
                                 const std::string& oid,
                                 const std::string& cookie,
                                 bool exclusive,
-                                bool blacklist_on_break_lock,
-                                uint32_t blacklist_expire_seconds,
+                                bool blocklist_on_break_lock,
+                                uint32_t blocklist_expire_seconds,
                                 Context *on_finish);
 
   ~AcquireRequest();
@@ -66,8 +66,8 @@ private:
   AcquireRequest(librados::IoCtx& ioctx, Watcher *watcher,
                  asio::ContextWQ *work_queue, const std::string& oid,
                  const std::string& cookie, bool exclusive,
-                 bool blacklist_on_break_lock,
-                 uint32_t blacklist_expire_seconds, Context *on_finish);
+                 bool blocklist_on_break_lock,
+                 uint32_t blocklist_expire_seconds, Context *on_finish);
 
   librados::IoCtx& m_ioctx;
   Watcher *m_watcher;
@@ -76,8 +76,8 @@ private:
   std::string m_oid;
   std::string m_cookie;
   bool m_exclusive;
-  bool m_blacklist_on_break_lock;
-  uint32_t m_blacklist_expire_seconds;
+  bool m_blocklist_on_break_lock;
+  uint32_t m_blocklist_expire_seconds;
   Context *m_on_finish;
 
   bufferlist m_out_bl;

--- a/src/librbd/managed_lock/BreakRequest.h
+++ b/src/librbd/managed_lock/BreakRequest.h
@@ -31,11 +31,11 @@ public:
   static BreakRequest* create(librados::IoCtx& ioctx,
                               asio::ContextWQ *work_queue,
                               const std::string& oid, const Locker &locker,
-                              bool exclusive, bool blacklist_locker,
-                              uint32_t blacklist_expire_seconds,
+                              bool exclusive, bool blocklist_locker,
+                              uint32_t blocklist_expire_seconds,
                               bool force_break_lock, Context *on_finish) {
     return new BreakRequest(ioctx, work_queue, oid, locker, exclusive,
-                            blacklist_locker, blacklist_expire_seconds,
+                            blocklist_locker, blocklist_expire_seconds,
                             force_break_lock, on_finish);
   }
 
@@ -54,7 +54,7 @@ private:
    * GET_LOCKER
    *    |
    *    v
-   * BLACKLIST (skip if disabled)
+   * BLOCKLIST (skip if disabled)
    *    |
    *    v
    * BREAK_LOCK
@@ -71,8 +71,8 @@ private:
   std::string m_oid;
   Locker m_locker;
   bool m_exclusive;
-  bool m_blacklist_locker;
-  uint32_t m_blacklist_expire_seconds;
+  bool m_blocklist_locker;
+  uint32_t m_blocklist_expire_seconds;
   bool m_force_break_lock;
   Context *m_on_finish;
 
@@ -85,8 +85,8 @@ private:
 
   BreakRequest(librados::IoCtx& ioctx, asio::ContextWQ *work_queue,
                const std::string& oid, const Locker &locker,
-               bool exclusive, bool blacklist_locker,
-               uint32_t blacklist_expire_seconds, bool force_break_lock,
+               bool exclusive, bool blocklist_locker,
+               uint32_t blocklist_expire_seconds, bool force_break_lock,
                Context *on_finish);
 
   void send_get_watchers();
@@ -95,8 +95,8 @@ private:
   void send_get_locker();
   void handle_get_locker(int r);
 
-  void send_blacklist();
-  void handle_blacklist(int r);
+  void send_blocklist();
+  void handle_blocklist(int r);
 
   void send_break_lock();
   void handle_break_lock(int r);

--- a/src/librbd/watcher/RewatchRequest.cc
+++ b/src/librbd/watcher/RewatchRequest.cc
@@ -58,7 +58,7 @@ void RewatchRequest::handle_unwatch(int r) {
   ldout(cct, 10) << "r=" << r << dendl;
 
   if (r == -EBLACKLISTED) {
-    lderr(cct) << "client blacklisted" << dendl;
+    lderr(cct) << "client blocklisted" << dendl;
     finish(r);
     return;
   } else if (r < 0) {

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -975,7 +975,7 @@ void FSMap::assign_standby_replay(
   fs->mds_map.epoch = epoch;
 }
 
-void FSMap::erase(mds_gid_t who, epoch_t blacklist_epoch)
+void FSMap::erase(mds_gid_t who, epoch_t blocklist_epoch)
 {
   if (mds_roles.at(who) == FS_CLUSTER_ID_NONE) {
     standby_daemons.erase(who);
@@ -998,20 +998,20 @@ void FSMap::erase(mds_gid_t who, epoch_t blacklist_epoch)
       fs->mds_map.up.erase(info.rank);
     }
     fs->mds_map.mds_info.erase(who);
-    fs->mds_map.last_failure_osd_epoch = blacklist_epoch;
+    fs->mds_map.last_failure_osd_epoch = blocklist_epoch;
     fs->mds_map.epoch = epoch;
   }
 
   mds_roles.erase(who);
 }
 
-void FSMap::damaged(mds_gid_t who, epoch_t blacklist_epoch)
+void FSMap::damaged(mds_gid_t who, epoch_t blocklist_epoch)
 {
   ceph_assert(mds_roles.at(who) != FS_CLUSTER_ID_NONE);
   auto fs = filesystems.at(mds_roles.at(who));
   mds_rank_t rank = fs->mds_map.mds_info[who].rank;
 
-  erase(who, blacklist_epoch);
+  erase(who, blocklist_epoch);
   fs->mds_map.failed.erase(rank);
   fs->mds_map.damaged.insert(rank);
 

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -215,12 +215,12 @@ public:
    * The rank held by 'who', if any, is to be relinquished, and
    * the state for the daemon GID is to be forgotten.
    */
-  void erase(mds_gid_t who, epoch_t blacklist_epoch);
+  void erase(mds_gid_t who, epoch_t blocklist_epoch);
 
   /**
    * Update to indicate that the rank held by 'who' is damaged
    */
-  void damaged(mds_gid_t who, epoch_t blacklist_epoch);
+  void damaged(mds_gid_t who, epoch_t blocklist_epoch);
 
   /**
    * Update to indicate that the rank `rank` is to be removed

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2449,7 +2449,7 @@ void Locker::revoke_stale_cap(CInode *in, client_t client)
 
   if (cap->revoking() & CEPH_CAP_ANY_WR) {
     std::stringstream ss;
-    mds->evict_client(client.v, false, g_conf()->mds_session_blacklist_on_timeout, ss, nullptr);
+    mds->evict_client(client.v, false, g_conf()->mds_session_blocklist_on_timeout, ss, nullptr);
     return;
   }
 

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -98,7 +98,7 @@ class C_MDL_WriteError : public MDSIOContextBase {
     // assume journal is reliable, so don't choose action based on
     // g_conf()->mds_action_on_write_error.
     if (r == -EBLACKLISTED) {
-      derr << "we have been blacklisted (fenced), respawning..." << dendl;
+      derr << "we have been blocklisted (fenced), respawning..." << dendl;
       mds->respawn();
     } else {
       derr << "unhandled error " << cpp_strerror(r) << ", shutting down..." << dendl;
@@ -974,8 +974,8 @@ void MDLog::_recovery_thread(MDSContext *completion)
     int write_result = jp.save(mds->objecter);
     // Nothing graceful we can do for this
     ceph_assert(write_result >= 0);
-  } else if (read_result == -EBLACKLISTED) {
-    derr << "Blacklisted during JournalPointer read!  Respawning..." << dendl;
+  } else if (read_result == -EBLOCKLISTED) {
+    derr << "Blocklisted during JournalPointer read!  Respawning..." << dendl;
     mds->respawn();
     ceph_abort(); // Should be unreachable because respawn calls execv
   } else if (read_result != 0) {
@@ -1009,8 +1009,8 @@ void MDLog::_recovery_thread(MDSContext *completion)
     C_SaferCond recover_wait;
     back.recover(&recover_wait);
     int recovery_result = recover_wait.wait();
-    if (recovery_result == -EBLACKLISTED) {
-      derr << "Blacklisted during journal recovery!  Respawning..." << dendl;
+    if (recovery_result == -EBLOCKLISTED) {
+      derr << "Blocklisted during journal recovery!  Respawning..." << dendl;
       mds->respawn();
       ceph_abort(); // Should be unreachable because respawn calls execv
     } else if (recovery_result != 0) {
@@ -1057,8 +1057,8 @@ void MDLog::_recovery_thread(MDSContext *completion)
   int recovery_result = recover_wait.wait();
   dout(4) << "Journal " << jp.front << " recovered." << dendl;
 
-  if (recovery_result == -EBLACKLISTED) {
-    derr << "Blacklisted during journal recovery!  Respawning..." << dendl;
+  if (recovery_result == -EBLOCKLISTED) {
+    derr << "Blocklisted during journal recovery!  Respawning..." << dendl;
     mds->respawn();
     ceph_abort(); // Should be unreachable because respawn calls execv
   } else if (recovery_result != 0) {

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -108,7 +108,7 @@ void MDSIOContextBase::complete(int r) {
   }
 
   if (r == -EBLACKLISTED) {
-    derr << "MDSIOContextBase: blacklisted!  Restarting..." << dendl;
+    derr << "MDSIOContextBase: blocklisted!  Restarting..." << dendl;
     mds->respawn();
   } else {
     MDSContext::complete(r);

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -550,7 +550,7 @@ protected:
   uint32_t flags = CEPH_MDSMAP_DEFAULTS; // flags
   epoch_t last_failure = 0;  // mds epoch of last failure
   epoch_t last_failure_osd_epoch = 0; // osd epoch of last failure; any mds entering replay needs
-                                  // at least this osdmap to ensure the blacklist propagates.
+                                  // at least this osdmap to ensure the blocklist propagates.
   utime_t created;
   utime_t modified;
 

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -336,7 +336,7 @@ class MDSRank {
       return map_targets.count(rank);
     }
 
-    bool evict_client(int64_t session_id, bool wait, bool blacklist,
+    bool evict_client(int64_t session_id, bool wait, bool blocklist,
                       std::ostream& ss, Context *on_killed=nullptr);
     int config_client(int64_t session_id, bool remove,
 		      const std::string& option, const std::string& value,

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -129,7 +129,7 @@ public:
   void terminate_sessions();
   void find_idle_sessions();
   void kill_session(Session *session, Context *on_safe, bool need_purge_inos = false);
-  size_t apply_blacklist(const std::set<entity_addr_t> &blacklist);
+  size_t apply_blocklist(const std::set<entity_addr_t> &blocklist);
   void journal_close_session(Session *session, int state, Context *on_safe, bool need_purge_inos = false);
 
   size_t get_num_pending_reclaim() const { return client_reclaim_gather.size(); }

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -1185,10 +1185,10 @@ PyMethodDef BaseMgrModule_methods[] = {
     METH_VARARGS, "Verify the current session caps are valid"},
 
   {"_ceph_register_client", (PyCFunction)ceph_register_client,
-    METH_VARARGS, "Register RADOS instance for potential blacklisting"},
+    METH_VARARGS, "Register RADOS instance for potential blocklisting"},
 
   {"_ceph_unregister_client", (PyCFunction)ceph_unregister_client,
-    METH_VARARGS, "Unregister RADOS instance for potential blacklisting"},
+    METH_VARARGS, "Unregister RADOS instance for potential blocklisting"},
 
   {NULL, NULL, 0, NULL}
 };

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -232,7 +232,7 @@ static void handle_mgr_signal(int signum)
   derr << " *** Got signal " << sig_str(signum) << " ***" << dendl;
 
   // The python modules don't reliably shut down, so don't even
-  // try. The mon will blacklist us (and all of our rados/cephfs
+  // try. The mon will blocklist us (and all of our rados/cephfs
   // clients) anyway. Just exit!
 
   _exit(0);  // exit with 0 result code, as if we had done an orderly shutdown
@@ -269,9 +269,9 @@ void Mgr::init()
   cluster_state.with_mgrmap([&e](const MgrMap& m) {
     e = m.last_failure_osd_epoch;
   });
-  /* wait for any blacklists to be applied to previous mgr instance */
+  /* wait for any blocklists to be applied to previous mgr instance */
   dout(4) << "Waiting for new OSDMap (e=" << e
-          << ") that may blacklist prior active." << dendl;
+          << ") that may blocklist prior active." << dendl;
   objecter->wait_for_osd_map(e);
   lock.lock();
 

--- a/src/mgr/MgrCap.cc
+++ b/src/mgr/MgrCap.cc
@@ -186,7 +186,7 @@ void MgrCapGrant::expand_profile(std::ostream *err) const {
       perms = mgr_rwxa_t{MGR_CAP_R | MGR_CAP_W};
     }
 
-    // whitelist all 'rbd_support' commands (restricted by optional
+    // allow all 'rbd_support' commands (restricted by optional
     // pool/namespace constraints)
     profile_grants.push_back({{}, "rbd_support", {}, {},
                               std::move(filtered_arguments), perms});

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -210,7 +210,7 @@ void MgrStandby::send_beacon()
 
   auto clients = py_module_registry.get_clients();
   for (const auto& client : clients) {
-    dout(15) << "noting RADOS client for blacklist: " << client << dendl;
+    dout(15) << "noting RADOS client for blocklist: " << client << dendl;
   }
 
   // Whether I think I am available (request MgrMonitor to set me

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -775,7 +775,7 @@ class RemoveFilesystemHandler : public FileSystemCommandHandler
       const cmdmap_t& cmdmap,
       std::stringstream &ss) override
   {
-    /* We may need to blacklist ranks. */
+    /* We may need to blocklist ranks. */
     if (!mon->osdmon()->is_writeable()) {
       // not allowed to write yet, so retry when we can
       mon->osdmon()->wait_for_writeable(op, new PaxosService::C_RetryMessage(mon->mdsmon(), op));
@@ -826,7 +826,7 @@ class RemoveFilesystemHandler : public FileSystemCommandHandler
       mon->mdsmon()->fail_mds_gid(fsmap, gid);
     }
     if (!to_fail.empty()) {
-      mon->osdmon()->propose_pending(); /* maybe new blacklists */
+      mon->osdmon()->propose_pending(); /* maybe new blocklists */
     }
 
     fsmap.erase_filesystem(fs->fscid);

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -66,7 +66,7 @@ class MDSMonitor : public PaxosService, public PaxosFSMap, protected CommandHand
   int print_nodes(ceph::Formatter *f);
 
   /**
-   * Return true if a blacklist was done (i.e. OSD propose needed)
+   * Return true if a blocklist was done (i.e. OSD propose needed)
    */
   bool fail_mds_gid(FSMap &fsmap, mds_gid_t gid);
 

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -238,7 +238,7 @@ public:
   /// features
   uint64_t active_mgr_features = 0;
 
-  std::vector<entity_addrvec_t> clients; // for blacklist
+  std::vector<entity_addrvec_t> clients; // for blocklist
 
   std::map<uint64_t, StandbyInfo> standbys;
 

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -496,7 +496,7 @@ bool MgrMonitor::prepare_beacon(MonOpRequestRef op)
                       << " restarted";
     if (!mon->osdmon()->is_writeable()) {
       dout(1) << __func__ << ":  waiting for osdmon writeable to"
-                 " blacklist old instance." << dendl;
+                 " blocklist old instance." << dendl;
       mon->osdmon()->wait_for_writeable(op, new C_RetryMessage(this, op));
       return false;
     }
@@ -885,15 +885,15 @@ void MgrMonitor::drop_active()
 
   ceph_assert(pending_map.active_gid > 0);
   auto until = ceph_clock_now();
-  until += g_conf().get_val<double>("mon_mgr_blacklist_interval");
-  dout(5) << "blacklisting previous mgr." << pending_map.active_name << "."
+  until += g_conf().get_val<double>("mon_mgr_blocklist_interval");
+  dout(5) << "blocklisting previous mgr." << pending_map.active_name << "."
           << pending_map.active_gid << " ("
           << pending_map.active_addrs << ")" << dendl;
-  auto blacklist_epoch = mon->osdmon()->blacklist(pending_map.active_addrs, until);
+  auto blocklist_epoch = mon->osdmon()->blocklist(pending_map.active_addrs, until);
 
-  /* blacklist RADOS clients in use by the mgr */
+  /* blocklist RADOS clients in use by the mgr */
   for (const auto& a : pending_map.clients) {
-    mon->osdmon()->blacklist(a, until);
+    mon->osdmon()->blocklist(a, until);
   }
   request_proposal(mon->osdmon());
 
@@ -907,7 +907,7 @@ void MgrMonitor::drop_active()
   pending_map.active_addrs = entity_addrvec_t();
   pending_map.services.clear();
   pending_map.clients.clear();
-  pending_map.last_failure_osd_epoch = blacklist_epoch;
+  pending_map.last_failure_osd_epoch = blocklist_epoch;
 
   // So that when new active mgr subscribes to mgrdigest, it will
   // get an immediate response instead of waiting for next timer

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -189,7 +189,8 @@ void MonCapGrant::expand_profile(const EntityName& name) const
     profile_grants.push_back(MonCapGrant("osd", MON_CAP_R));
     // This command grant is checked explicitly in MRemoveSnaps handling
     profile_grants.push_back(MonCapGrant("osd pool rmsnap"));
-    profile_grants.push_back(MonCapGrant("osd blacklist"));
+    profile_grants.push_back(MonCapGrant("osd blocklist"));
+    profile_grants.push_back(MonCapGrant("osd blacklist")); // for compat
     profile_grants.push_back(MonCapGrant("log", MON_CAP_W));
   }
   if (profile == "mgr") {
@@ -293,7 +294,14 @@ void MonCapGrant::expand_profile(const EntityName& name) const
     profile_grants.push_back(MonCapGrant("osd", MON_CAP_R));
     profile_grants.push_back(MonCapGrant("pg", MON_CAP_R));
 
-    // exclusive lock dead-client blacklisting (IP+nonce required)
+    // exclusive lock dead-client blocklisting (IP+nonce required)
+    profile_grants.push_back(MonCapGrant("osd blocklist"));
+    profile_grants.back().command_args["blocklistop"] = StringConstraint(
+      StringConstraint::MATCH_TYPE_EQUAL, "add");
+    profile_grants.back().command_args["addr"] = StringConstraint(
+      StringConstraint::MATCH_TYPE_REGEX, "^[^/]+/[0-9]+$");
+
+    // for compat,
     profile_grants.push_back(MonCapGrant("osd blacklist"));
     profile_grants.back().command_args["blacklistop"] = StringConstraint(
       StringConstraint::MATCH_TYPE_EQUAL, "add");

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -970,14 +970,27 @@ COMMAND("osd new "
         "exist and have been previously destroyed. "
         "Reads secrets from JSON file via `-i <file>` (see man page).",
         "osd", "rw")
-COMMAND("osd blacklist "
+COMMAND("osd blocklist "
+	"name=blocklistop,type=CephChoices,strings=add|rm "
+	"name=addr,type=CephEntityAddr "
+	"name=expire,type=CephFloat,range=0.0,req=false",
+	"add (optionally until <expire> seconds from now) or remove <addr> from blocklist",
+	"osd", "rw")
+COMMAND("osd blocklist ls", "show blocklisted clients", "osd", "r")
+COMMAND("osd blocklist clear", "clear all blocklisted clients", "osd", "rw")
+
+COMMAND_WITH_FLAG("osd blacklist "
 	"name=blacklistop,type=CephChoices,strings=add|rm "
 	"name=addr,type=CephEntityAddr "
 	"name=expire,type=CephFloat,range=0.0,req=false",
 	"add (optionally until <expire> seconds from now) or remove <addr> from blacklist",
-	"osd", "rw")
-COMMAND("osd blacklist ls", "show blacklisted clients", "osd", "r")
-COMMAND("osd blacklist clear", "clear all blacklisted clients", "osd", "rw")
+	"osd", "rw",
+	FLAG(DEPRECATED))
+COMMAND_WITH_FLAG("osd blacklist ls", "show blacklisted clients", "osd", "r",
+	FLAG(DEPRECATED))
+COMMAND_WITH_FLAG("osd blacklist clear", "clear all blacklisted clients", "osd", "rw",
+	FLAG(DEPRECATED))
+
 COMMAND("osd pool mksnap "
 	"name=pool,type=CephPoolname "
 	"name=snap,type=CephString",

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3184,7 +3184,7 @@ void Monitor::handle_tell_command(MonOpRequestRef op)
 				"please check usage and/or man page");
     }
   }
-  // see if command is whitelisted
+  // see if command is allowed
   if (!session->caps.is_capable(
       g_ceph_context,
       session->entity_name,
@@ -4253,7 +4253,7 @@ void Monitor::waitlist_or_zap_client(MonOpRequestRef op)
    * tick() will periodically send them back through so we can send
    * the client elsewhere if we don't think we're getting back in.
    *
-   * But we whitelist a few sorts of messages:
+   * But we allow a few sorts of messages:
    * 1) Monitors can talk to us at any time, of course.
    * 2) auth messages. It's unlikely to go through much faster, but
    * it's possible we've just lost our quorum status and we want to take...

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -748,8 +748,8 @@ public:
   int get_inc(version_t ver, OSDMap::Incremental& inc);
   int get_full_from_pinned_map(version_t ver, ceph::buffer::list& bl);
 
-  epoch_t blacklist(const entity_addrvec_t& av, utime_t until);
-  epoch_t blacklist(entity_addr_t a, utime_t until);
+  epoch_t blocklist(const entity_addrvec_t& av, utime_t until);
+  epoch_t blocklist(entity_addr_t a, utime_t until);
 
   void dump_info(ceph::Formatter *f);
   int dump_osd_metadata(int osd, ceph::Formatter *f, std::ostream *err);

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -479,7 +479,7 @@ struct entity_addr_t {
       encode(type, bl);
     } else {
       // map any -> legacy for old clients.  this is primary for the benefit
-      // of OSDMap's blacklist, but is reasonable in general since any: is
+      // of OSDMap's blocklist, but is reasonable in general since any: is
       // meaningless for pre-nautilus clients or daemons.
       auto t = type;
       if (t == TYPE_ANY) {

--- a/src/osd/ClassHandler.cc
+++ b/src/osd/ClassHandler.cc
@@ -126,7 +126,7 @@ ClassHandler::ClassData *ClassHandler::_get_class(const string& cname,
     ldout(cct, 10) << "_get_class adding new class name " << cname << " " << cls << dendl;
     cls->name = cname;
     cls->handler = this;
-    cls->whitelisted = in_class_list(cname, cct->_conf->osd_class_default_list);
+    cls->allowed = in_class_list(cname, cct->_conf->osd_class_default_list);
   }
   return cls;
 }

--- a/src/osd/ClassHandler.h
+++ b/src/osd/ClassHandler.h
@@ -59,7 +59,7 @@ public:
     ClassHandler *handler = nullptr;
     void *handle = nullptr;
 
-    bool whitelisted = false;
+    bool allowed = false;
 
     std::map<std::string, ClassMethod> methods_map;
     std::map<std::string, ClassFilter> filters_map;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2537,12 +2537,12 @@ will start to track new ops received afterwards.";
     f->open_object_section("pq");
     op_shardedwq.dump(f);
     f->close_section();
-  } else if (prefix == "dump_blacklist") {
+  } else if (prefix == "dump_blocklist") {
     list<pair<entity_addr_t,utime_t> > bl;
     OSDMapRef curmap = service.get_osdmap();
 
-    f->open_array_section("blacklist");
-    curmap->get_blacklist(&bl);
+    f->open_array_section("blocklist");
+    curmap->get_blocklist(&bl);
     for (list<pair<entity_addr_t,utime_t> >::iterator it = bl.begin();
 	it != bl.end(); ++it) {
       f->open_object_section("entry");
@@ -2552,7 +2552,7 @@ will start to track new ops received afterwards.";
       it->second.localtime(f->dump_stream("expire_time"));
       f->close_section(); //entry
     }
-    f->close_section(); //blacklist
+    f->close_section(); //blocklist
   } else if (prefix == "dump_watchers") {
     list<obj_watch_item_t> watchers;
     // scan pg's
@@ -3735,9 +3735,9 @@ void OSD::final_init()
 				     asok_hook,
 				     "dump op priority queue state");
   ceph_assert(r == 0);
-  r = admin_socket->register_command("dump_blacklist",
+  r = admin_socket->register_command("dump_blocklist",
 				     asok_hook,
-				     "dump blacklisted clients and times");
+				     "dump blocklisted clients and times");
   ceph_assert(r == 0);
   r = admin_socket->register_command("dump_watchers",
 				     asok_hook,
@@ -8106,7 +8106,7 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
     OSDMapRef newmap = get_map(cur);
     ceph_assert(newmap);  // we just cached it above!
 
-    // start blacklisting messages sent to peers that go down.
+    // start blocklisting messages sent to peers that go down.
     service.pre_publish_map(newmap);
 
     // kill connections to newly down osds

--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -296,8 +296,8 @@ bool OSDCapGrant::is_capable(
             (*class_allowed)[i] = true;
             continue;
           }
-          // check 'allow x | class-{rw}': must be on whitelist
-          if (!classes[i].whitelisted) {
+          // check 'allow x | class-{rw}': must be on allow list
+          if (!classes[i].allowed) {
             continue;
           }
           if ((classes[i].read && !(allow & OSD_CAP_CLS_R)) ||

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -243,7 +243,7 @@ struct OSDCap {
    * @param object name of the object we are accessing
    * @param op_may_read whether the operation may need to read
    * @param op_may_write whether the operation may need to write
-   * @param classes (class-name, rd, wr, whitelisted-flag) tuples
+   * @param classes (class-name, rd, wr, allowed-flag) tuples
    * @return true if the operation is allowed, false otherwise
    */
   bool is_capable(const std::string& pool_name, const std::string& ns,

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -514,8 +514,8 @@ void OSDMap::Incremental::encode_classic(ceph::buffer::list& bl, uint64_t featur
   encode(new_up_thru, bl);
   encode(new_last_clean_interval, bl);
   encode(new_lost, bl);
-  encode(new_blacklist, bl, features);
-  encode(old_blacklist, bl, features);
+  encode(new_blocklist, bl, features);
+  encode(old_blocklist, bl, features);
   encode(new_up_cluster, bl, features);
   encode(cluster_snapshot, bl);
   encode(new_uuid, bl);
@@ -661,8 +661,8 @@ void OSDMap::Incremental::encode(ceph::buffer::list& bl, uint64_t features) cons
     encode(new_up_thru, bl);
     encode(new_last_clean_interval, bl);
     encode(new_lost, bl);
-    encode(new_blacklist, bl, features);
-    encode(old_blacklist, bl, features);
+    encode(new_blocklist, bl, features);
+    encode(old_blocklist, bl, features);
     if (target_v < 7) {
       encode_addrvec_map_as_addr(new_up_cluster, bl, features);
     } else {
@@ -803,8 +803,8 @@ void OSDMap::Incremental::decode_classic(ceph::buffer::list::const_iterator &p)
   decode(new_up_thru, p);
   decode(new_last_clean_interval, p);
   decode(new_lost, p);
-  decode(new_blacklist, p);
-  decode(old_blacklist, p);
+  decode(new_blocklist, p);
+  decode(old_blocklist, p);
   if (ev >= 6)
     decode(new_up_cluster, p);
   if (ev >= 7)
@@ -907,8 +907,8 @@ void OSDMap::Incremental::decode(ceph::buffer::list::const_iterator& bl)
     decode(new_up_thru, bl);
     decode(new_last_clean_interval, bl);
     decode(new_lost, bl);
-    decode(new_blacklist, bl);
-    decode(old_blacklist, bl);
+    decode(new_blocklist, bl);
+    decode(old_blocklist, bl);
     decode(new_up_cluster, bl);
     decode(cluster_snapshot, bl);
     decode(new_uuid, bl);
@@ -1193,15 +1193,15 @@ void OSDMap::Incremental::dump(Formatter *f) const
   }
   f->close_section();
 
-  f->open_array_section("new_blacklist");
-  for (const auto &blist : new_blacklist) {
+  f->open_array_section("new_blocklist");
+  for (const auto &blist : new_blocklist) {
     stringstream ss;
     ss << blist.first;
     f->dump_stream(ss.str().c_str()) << blist.second;
   }
   f->close_section();
-  f->open_array_section("old_blacklist");
-  for (const auto &blist : old_blacklist)
+  f->open_array_section("old_blocklist");
+  for (const auto &blist : old_blocklist)
     f->dump_stream("addr") << blist;
   f->close_section();
 
@@ -1304,13 +1304,13 @@ void OSDMap::set_epoch(epoch_t e)
     pool.second.last_change = e;
 }
 
-bool OSDMap::is_blacklisted(const entity_addr_t& orig) const
+bool OSDMap::is_blocklisted(const entity_addr_t& orig) const
 {
-  if (blacklist.empty()) {
+  if (blocklist.empty()) {
     return false;
   }
 
-  // all blacklist entries are type ANY for nautilus+
+  // all blocklist entries are type ANY for nautilus+
   // FIXME: avoid this copy!
   entity_addr_t a = orig;
   if (require_osd_release < ceph_release_t::nautilus) {
@@ -1320,15 +1320,15 @@ bool OSDMap::is_blacklisted(const entity_addr_t& orig) const
   }
 
   // this specific instance?
-  if (blacklist.count(a)) {
+  if (blocklist.count(a)) {
     return true;
   }
 
-  // is entire ip blacklisted?
+  // is entire ip blocklisted?
   if (a.is_ip()) {
     a.set_port(0);
     a.set_nonce(0);
-    if (blacklist.count(a)) {
+    if (blocklist.count(a)) {
       return true;
     }
   }
@@ -1336,13 +1336,13 @@ bool OSDMap::is_blacklisted(const entity_addr_t& orig) const
   return false;
 }
 
-bool OSDMap::is_blacklisted(const entity_addrvec_t& av) const
+bool OSDMap::is_blocklisted(const entity_addrvec_t& av) const
 {
-  if (blacklist.empty())
+  if (blocklist.empty())
     return false;
 
   for (auto& a : av.v) {
-    if (is_blacklisted(a)) {
+    if (is_blocklisted(a)) {
       return true;
     }
   }
@@ -1350,14 +1350,14 @@ bool OSDMap::is_blacklisted(const entity_addrvec_t& av) const
   return false;
 }
 
-void OSDMap::get_blacklist(list<pair<entity_addr_t,utime_t> > *bl) const
+void OSDMap::get_blocklist(list<pair<entity_addr_t,utime_t> > *bl) const
 {
-   std::copy(blacklist.begin(), blacklist.end(), std::back_inserter(*bl));
+   std::copy(blocklist.begin(), blocklist.end(), std::back_inserter(*bl));
 }
 
-void OSDMap::get_blacklist(std::set<entity_addr_t> *bl) const
+void OSDMap::get_blocklist(std::set<entity_addr_t> *bl) const
 {
-  for (const auto &i : blacklist) {
+  for (const auto &i : blocklist) {
     bl->insert(i.first);
   }
 }
@@ -2028,7 +2028,7 @@ bool OSDMap::clean_pg_upmaps(
 
 int OSDMap::apply_incremental(const Incremental &inc)
 {
-  new_blacklist_entries = false;
+  new_blocklist_entries = false;
   if (inc.epoch == 1)
     fsid = inc.fsid;
   else if (inc.fsid != fsid)
@@ -2235,13 +2235,13 @@ int OSDMap::apply_incremental(const Incremental &inc)
     pg_upmap_items.erase(pg);
   }
 
-  // blacklist
-  if (!inc.new_blacklist.empty()) {
-    blacklist.insert(inc.new_blacklist.begin(),inc.new_blacklist.end());
-    new_blacklist_entries = true;
+  // blocklist
+  if (!inc.new_blocklist.empty()) {
+    blocklist.insert(inc.new_blocklist.begin(),inc.new_blocklist.end());
+    new_blocklist_entries = true;
   }
-  for (const auto &addr : inc.old_blacklist)
-    blacklist.erase(addr);
+  for (const auto &addr : inc.old_blocklist)
+    blocklist.erase(addr);
 
   for (auto& i : inc.new_crush_node_flags) {
     if (i.second) {
@@ -2858,7 +2858,7 @@ void OSDMap::encode_classic(ceph::buffer::list& bl, uint64_t features) const
   encode(ev, bl);
   encode(osd_addrs->hb_back_addrs, bl, features);
   encode(osd_info, bl);
-  encode(blacklist, bl, features);
+  encode(blocklist, bl, features);
   encode(osd_addrs->cluster_addrs, bl, features);
   encode(cluster_snapshot_epoch, bl);
   encode(cluster_snapshot, bl);
@@ -3003,10 +3003,10 @@ void OSDMap::encode(ceph::buffer::list& bl, uint64_t features) const
     {
       // put this in a sorted, ordered map<> so that we encode in a
       // deterministic order.
-      map<entity_addr_t,utime_t> blacklist_map;
-      for (const auto &addr : blacklist)
-	blacklist_map.insert(make_pair(addr.first, addr.second));
-      encode(blacklist_map, bl, features);
+      map<entity_addr_t,utime_t> blocklist_map;
+      for (const auto &addr : blocklist)
+	blocklist_map.insert(make_pair(addr.first, addr.second));
+      encode(blocklist_map, bl, features);
     }
     if (target_v < 7) {
       encode_addrvec_pvec_as_addr(osd_addrs->cluster_addrs, bl, features);
@@ -3165,7 +3165,7 @@ void OSDMap::decode_classic(ceph::buffer::list::const_iterator& p)
   if (v < 5)
     decode(pool_name, p);
 
-  decode(blacklist, p);
+  decode(blocklist, p);
   if (ev >= 6)
     decode(osd_addrs->cluster_addrs, p);
   else
@@ -3304,7 +3304,7 @@ void OSDMap::decode(ceph::buffer::list::const_iterator& bl)
     DECODE_START(9, bl); // extended, osd-only data
     decode(osd_addrs->hb_back_addrs, bl);
     decode(osd_info, bl);
-    decode(blacklist, bl);
+    decode(blocklist, bl);
     decode(osd_addrs->cluster_addrs, bl);
     decode(cluster_snapshot_epoch, bl);
     decode(cluster_snapshot, bl);
@@ -3572,8 +3572,8 @@ void OSDMap::dump(Formatter *f) const
   }
   f->close_section(); // primary_temp
 
-  f->open_object_section("blacklist");
-  for (const auto &addr : blacklist) {
+  f->open_object_section("blocklist");
+  for (const auto &addr : blocklist) {
     stringstream ss;
     ss << addr.first;
     f->dump_stream(ss.str().c_str()) << addr.second;
@@ -3664,7 +3664,7 @@ void OSDMap::generate_test_instances(list<OSDMap*>& o)
   uuid_d fsid;
   o.back()->build_simple(cct, 1, fsid, 16);
   o.back()->created = o.back()->modified = utime_t(1, 2);  // fix timestamp
-  o.back()->blacklist[entity_addr_t()] = utime_t(5, 6);
+  o.back()->blocklist[entity_addr_t()] = utime_t(5, 6);
   cct->put();
 }
 
@@ -3825,8 +3825,8 @@ void OSDMap::print(ostream& out) const
   for (const auto pg : *primary_temp)
     out << "primary_temp " << pg.first << " " << pg.second << "\n";
 
-  for (const auto &addr : blacklist)
-    out << "blacklist " << addr.first << " expires " << addr.second << "\n";
+  for (const auto &addr : blocklist)
+    out << "blocklist " << addr.first << " expires " << addr.second << "\n";
 }
 
 class OSDTreePlainDumper : public CrushTreeDumper::Dumper<TextTable> {

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -389,8 +389,8 @@ public:
     mempool::osdmap::map<int32_t,uuid_d> new_uuid;
     mempool::osdmap::map<int32_t,osd_xinfo_t> new_xinfo;
 
-    mempool::osdmap::map<entity_addr_t,utime_t> new_blacklist;
-    mempool::osdmap::vector<entity_addr_t> old_blacklist;
+    mempool::osdmap::map<entity_addr_t,utime_t> new_blocklist;
+    mempool::osdmap::vector<entity_addr_t> old_blocklist;
     mempool::osdmap::map<int32_t, entity_addrvec_t> new_hb_back_up;
     mempool::osdmap::map<int32_t, entity_addrvec_t> new_hb_front_up;
 
@@ -576,7 +576,7 @@ private:
   std::shared_ptr< mempool::osdmap::vector<uuid_d> > osd_uuid;
   mempool::osdmap::vector<osd_xinfo_t> osd_xinfo;
 
-  mempool::osdmap::unordered_map<entity_addr_t,utime_t> blacklist;
+  mempool::osdmap::unordered_map<entity_addr_t,utime_t> blocklist;
 
   /// queue of snaps to remove
   mempool::osdmap::map<int64_t, snap_interval_set_t> removed_snaps_queue;
@@ -589,7 +589,7 @@ private:
 
   epoch_t cluster_snapshot_epoch;
   std::string cluster_snapshot;
-  bool new_blacklist_entries;
+  bool new_blocklist_entries;
 
   float full_ratio = 0, backfillfull_ratio = 0, nearfull_ratio = 0;
 
@@ -629,7 +629,7 @@ private:
 	     primary_temp(std::make_shared<mempool::osdmap::map<pg_t,int32_t>>()),
 	     osd_uuid(std::make_shared<mempool::osdmap::vector<uuid_d>>()),
 	     cluster_snapshot_epoch(0),
-	     new_blacklist_entries(false),
+	     new_blocklist_entries(false),
 	     cached_up_osd_features(0),
 	     crc_defined(false), crc(0),
 	     crush(std::make_shared<CrushWrapper>()) {
@@ -680,10 +680,10 @@ public:
   const utime_t& get_created() const { return created; }
   const utime_t& get_modified() const { return modified; }
 
-  bool is_blacklisted(const entity_addr_t& a) const;
-  bool is_blacklisted(const entity_addrvec_t& a) const;
-  void get_blacklist(std::list<std::pair<entity_addr_t,utime_t > > *bl) const;
-  void get_blacklist(std::set<entity_addr_t> *bl) const;
+  bool is_blocklisted(const entity_addr_t& a) const;
+  bool is_blocklisted(const entity_addrvec_t& a) const;
+  void get_blocklist(std::list<std::pair<entity_addr_t,utime_t > > *bl) const;
+  void get_blocklist(std::set<entity_addr_t> *bl) const;
 
   std::string get_cluster_snapshot() const {
     if (cluster_snapshot_epoch == epoch)
@@ -1520,7 +1520,7 @@ public:
   void dump_osd(int id, ceph::Formatter *f) const;
   void dump_osds(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<OSDMap*>& o);
-  bool check_new_blacklist_entries() const { return new_blacklist_entries; }
+  bool check_new_blocklist_entries() const { return new_blocklist_entries; }
 
   void check_health(CephContext *cct, health_check_map_t *checks) const;
 

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -462,8 +462,8 @@ void PeeringState::activate_map(PeeringCtx &rctx)
   }
   write_if_dirty(rctx.transaction);
 
-  if (get_osdmap()->check_new_blacklist_entries()) {
-    pl->check_blacklisted_watchers();
+  if (get_osdmap()->check_new_blocklist_entries()) {
+    pl->check_blocklisted_watchers();
   }
 }
 

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -357,8 +357,8 @@ public:
 
     /// Notification to check outstanding operation targets
     virtual void check_recovery_sources(const OSDMapRef& newmap) = 0;
-    /// Notification to check outstanding blacklist
-    virtual void check_blacklisted_watchers() = 0;
+    /// Notification to check outstanding blocklist
+    virtual void check_blocklisted_watchers() = 0;
     /// Notification to clear state associated with primary
     virtual void clear_primary_state() = 0;
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1945,10 +1945,10 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
     return;
   }
 
-  // blacklisted?
-  if (get_osdmap()->is_blacklisted(m->get_source_addr())) {
-    dout(10) << "do_op " << m->get_source_addr() << " is blacklisted" << dendl;
-    osd->reply_op_error(op, -EBLACKLISTED);
+  // blocklisted?
+  if (get_osdmap()->is_blocklisted(m->get_source_addr())) {
+    dout(10) << "do_op " << m->get_source_addr() << " is blocklisted" << dendl;
+    osd->reply_op_error(op, -EBLOCKLISTED);
     return;
   }
 
@@ -10848,17 +10848,17 @@ void PrimaryLogPG::get_obc_watchers(ObjectContextRef obc, list<obj_watch_item_t>
   }
 }
 
-void PrimaryLogPG::check_blacklisted_watchers()
+void PrimaryLogPG::check_blocklisted_watchers()
 {
-  dout(20) << "PrimaryLogPG::check_blacklisted_watchers for pg " << get_pgid() << dendl;
+  dout(20) << "PrimaryLogPG::check_blocklisted_watchers for pg " << get_pgid() << dendl;
   pair<hobject_t, ObjectContextRef> i;
   while (object_contexts.get_next(i.first, &i))
-    check_blacklisted_obc_watchers(i.second);
+    check_blocklisted_obc_watchers(i.second);
 }
 
-void PrimaryLogPG::check_blacklisted_obc_watchers(ObjectContextRef obc)
+void PrimaryLogPG::check_blocklisted_obc_watchers(ObjectContextRef obc)
 {
-  dout(20) << "PrimaryLogPG::check_blacklisted_obc_watchers for obc " << obc->obs.oi.soid << dendl;
+  dout(20) << "PrimaryLogPG::check_blocklisted_obc_watchers for obc " << obc->obs.oi.soid << dendl;
   for (map<pair<uint64_t, entity_name_t>, WatchRef>::iterator k =
 	 obc->watchers.begin();
 	k != obc->watchers.end();
@@ -10868,8 +10868,8 @@ void PrimaryLogPG::check_blacklisted_obc_watchers(ObjectContextRef obc)
     dout(30) << "watch: Found " << j->second->get_entity() << " cookie " << j->second->get_cookie() << dendl;
     entity_addr_t ea = j->second->get_peer_addr();
     dout(30) << "watch: Check entity_addr_t " << ea << dendl;
-    if (get_osdmap()->is_blacklisted(ea)) {
-      dout(10) << "watch: Found blacklisted watcher for " << ea << dendl;
+    if (get_osdmap()->is_blocklisted(ea)) {
+      dout(10) << "watch: Found blocklisted watcher for " << ea << dendl;
       ceph_assert(j->second->get_pg() == this);
       j->second->unregister_cb();
       handle_watch_timeout(j->second);
@@ -10909,8 +10909,8 @@ void PrimaryLogPG::populate_obc_watchers(ObjectContextRef obc)
 	make_pair(p->first.first, p->first.second),
 	watch));
   }
-  // Look for watchers from blacklisted clients and drop
-  check_blacklisted_obc_watchers(obc);
+  // Look for watchers from blocklisted clients and drop
+  check_blocklisted_obc_watchers(obc);
 }
 
 void PrimaryLogPG::handle_watch_timeout(WatchRef watch)

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1053,8 +1053,8 @@ protected:
   std::map<hobject_t, std::map<client_t, ceph_tid_t>> debug_op_order;
 
   void populate_obc_watchers(ObjectContextRef obc);
-  void check_blacklisted_obc_watchers(ObjectContextRef obc);
-  void check_blacklisted_watchers() override;
+  void check_blocklisted_obc_watchers(ObjectContextRef obc);
+  void check_blocklisted_watchers() override;
   void get_watchers(std::list<obj_watch_item_t> *ls) override;
   void get_obc_watchers(ObjectContextRef obc, std::list<obj_watch_item_t> &pg_watchers);
 public:

--- a/src/osd/error_code.cc
+++ b/src/osd/error_code.cc
@@ -51,8 +51,8 @@ const char* osd_error_category::message(int ev, char* buf,
   switch (static_cast<osd_errc>(ev)) {
   case osd_errc::old_snapc:
     return "ORDERSNAP flag set; writer has old snapc";
-  case osd_errc::blacklisted:
-    return "Blacklisted";
+  case osd_errc::blocklisted:
+    return "Blocklisted";
   }
 
   if (len) {
@@ -70,8 +70,8 @@ std::string osd_error_category::message(int ev) const {
   switch (static_cast<osd_errc>(ev)) {
   case osd_errc::old_snapc:
     return "ORDERSNAP flag set; writer has old snapc";
-  case osd_errc::blacklisted:
-    return "Blacklisted";
+  case osd_errc::blocklisted:
+    return "Blocklisted";
   }
 
   return cpp_strerror(ev);
@@ -79,7 +79,7 @@ std::string osd_error_category::message(int ev) const {
 
 boost::system::error_condition osd_error_category::default_error_condition(int ev) const noexcept {
   if (ev == static_cast<int>(osd_errc::old_snapc) ||
-      ev == static_cast<int>(osd_errc::blacklisted))
+      ev == static_cast<int>(osd_errc::blocklisted))
     return { ev, *this };
   else
     return { ev, boost::system::generic_category() };
@@ -89,7 +89,7 @@ bool osd_error_category::equivalent(int ev, const boost::system::error_condition
   switch (static_cast<osd_errc>(ev)) {
   case osd_errc::old_snapc:
       return c == boost::system::errc::invalid_argument;
-  case osd_errc::blacklisted:
+  case osd_errc::blocklisted:
       return c == boost::system::errc::operation_not_permitted;
   }
   return default_error_condition(ev) == c;

--- a/src/osd/error_code.h
+++ b/src/osd/error_code.h
@@ -27,7 +27,7 @@ const boost::system::error_category& osd_category() noexcept;
 
 enum class osd_errc {
   old_snapc = 85,  /* ORDERSNAP flag set; writer has old snapc*/
-  blacklisted = 108 /* blacklisted */
+  blocklisted = 108 /* blocklisted */
 };
 
 namespace boost::system {

--- a/src/osd/osd_op_util.cc
+++ b/src/osd/osd_op_util.cc
@@ -186,7 +186,7 @@ int OpInfo::set_from_op(
         if (is_promote)
           set_promote();
         add_class(std::move(cname), std::move(mname), is_read, is_write,
-                      cls->whitelisted);
+                      cls->allowed);
 	break;
       }
 
@@ -258,6 +258,6 @@ int OpInfo::set_from_op(
 ostream& operator<<(ostream& out, const OpInfo::ClassInfo& i)
 {
   out << "class " << i.class_name << " method " << i.method_name
-      << " rd " << i.read << " wr " << i.write << " wl " << i.whitelisted;
+      << " rd " << i.read << " wr " << i.write << " allowed " << i.allowed;
   return out;
 }

--- a/src/osd/osd_op_util.h
+++ b/src/osd/osd_op_util.h
@@ -14,13 +14,13 @@ class OpInfo {
 public:
   struct ClassInfo {
     ClassInfo(std::string&& class_name, std::string&& method_name,
-              bool read, bool write, bool whitelisted) :
+              bool read, bool write, bool allowed) :
       class_name(std::move(class_name)), method_name(std::move(method_name)),
-      read(read), write(write), whitelisted(whitelisted)
+      read(read), write(write), allowed(allowed)
     {}
     const std::string class_name;
     const std::string method_name;
-    const bool read, write, whitelisted;
+    const bool read, write, allowed;
   };
 
 private:
@@ -30,9 +30,9 @@ private:
   void set_rmw_flags(int flags);
 
   void add_class(std::string&& class_name, std::string&& method_name,
-                 bool read, bool write, bool whitelisted) {
+                 bool read, bool write, bool allowed) {
     classes.emplace_back(std::move(class_name), std::move(method_name),
-                          read, write, whitelisted);
+                          read, write, allowed);
   }
 
 public:

--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -418,8 +418,8 @@ void Journaler::_finish_reread_head_and_probe(int r, C_OnFinisher *onfinish)
   }
 
   // Let the caller know that the operation has failed or was intentionally
-  // failed since the caller has been blacklisted.
-  if (r == -EBLACKLISTED) {
+  // failed since the caller has been blocklisted.
+  if (r == -EBLOCKLISTED) {
     onfinish->complete(r);
     return;
   }

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1651,10 +1651,10 @@ private:
   bool honor_pool_full = true;
   bool pool_full_try = false;
 
-  // If this is true, accumulate a set of blacklisted entities
-  // to be drained by consume_blacklist_events.
-  bool blacklist_events_enabled = false;
-  std::set<entity_addr_t> blacklist_events;
+  // If this is true, accumulate a set of blocklisted entities
+  // to be drained by consume_blocklist_events.
+  bool blocklist_events_enabled = false;
+  std::set<entity_addr_t> blocklist_events;
   struct pg_mapping_t {
     epoch_t epoch = 0;
     std::vector<int> up;
@@ -1716,7 +1716,7 @@ private:
 public:
   void maybe_request_map();
 
-  void enable_blacklist_events();
+  void enable_blocklist_events();
 private:
 
   void _maybe_request_map();
@@ -2675,15 +2675,15 @@ private:
 
 
   /**
-   * Get std::list of entities blacklisted since this was last called,
+   * Get std::list of entities blocklisted since this was last called,
    * and reset the std::list.
    *
    * Uses a std::set because typical use case is to compare some
-   * other std::list of clients to see which overlap with the blacklisted
+   * other std::list of clients to see which overlap with the blocklisted
    * addrs.
    *
    */
-  void consume_blacklist_events(std::set<entity_addr_t> *events);
+  void consume_blocklist_events(std::set<entity_addr_t> *events);
 
   int pool_snap_by_name(int64_t poolid,
 			const char *snap_name,
@@ -2693,8 +2693,8 @@ private:
   int pool_snap_list(int64_t poolid, std::vector<uint64_t> *snaps);
 private:
 
-  void emit_blacklist_events(const OSDMap::Incremental &inc);
-  void emit_blacklist_events(const OSDMap &old_osd_map,
+  void emit_blocklist_events(const OSDMap::Incremental &inc);
+  void emit_blocklist_events(const OSDMap &old_osd_map,
                              const OSDMap &new_osd_map);
 
   // low-level
@@ -3887,7 +3887,7 @@ public:
   void ms_handle_remote_reset(Connection *con) override;
   bool ms_handle_refused(Connection *con) override;
 
-  void blacklist_self(bool set);
+  void blocklist_self(bool set);
 
 private:
   epoch_t epoch_barrier = 0;

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -27,7 +27,7 @@ class IscsiService(CephadmService):
             'prefix': 'auth get-or-create',
             'entity': utils.name_to_auth_entity('iscsi', igw_id),
             'caps': ['mon', 'profile rbd, '
-                            'allow command "osd blacklist", '
+                            'allow command "osd blocklist", '
                             'allow command "config-key get" with "key" prefix "iscsi/"',
                      'osd', f'allow rwx pool={spec.pool}'],
         })

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -160,7 +160,7 @@ cdef extern from "rados/librados.h" nogil:
 
     int rados_cluster_stat(rados_t cluster, rados_cluster_stat_t *result)
     int rados_cluster_fsid(rados_t cluster, char *buf, size_t len)
-    int rados_blacklist_add(rados_t cluster, char *client_address, uint32_t expire_seconds)
+    int rados_blocklist_add(rados_t cluster, char *client_address, uint32_t expire_seconds)
     int rados_getaddrs(rados_t cluster, char** addrs)
     int rados_application_enable(rados_ioctx_t io, const char *app_name,
                                  int force)
@@ -1576,13 +1576,13 @@ Rados object in state %s." % self.state)
             ret = rados_wait_for_latest_osdmap(self.cluster)
         return ret
 
-    def blacklist_add(self, client_address, expire_seconds=0):
+    def blocklist_add(self, client_address, expire_seconds=0):
         """
-        Blacklist a client from the OSDs
+        Blocklist a client from the OSDs
 
         :param client_address: client address
         :type client_address: str
-        :param expire_seconds: number of seconds to blacklist
+        :param expire_seconds: number of seconds to blocklist
         :type expire_seconds: int
 
         :raises: :class:`Error`
@@ -1594,9 +1594,9 @@ Rados object in state %s." % self.state)
             char *_client_address = client_address
 
         with nogil:
-            ret = rados_blacklist_add(self.cluster, _client_address, _expire_seconds)
+            ret = rados_blocklist_add(self.cluster, _client_address, _expire_seconds)
         if ret < 0:
-            raise make_ex(ret, "error blacklisting client '%s'" % client_address)
+            raise make_ex(ret, "error blocklisting client '%s'" % client_address)
 
     def monitor_log(self, level, callback, arg):
         if level not in MONITOR_LEVELS:

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2035,7 +2035,7 @@ static inline int rgw_get_request_metadata(CephContext* const cct,
                                            std::map<std::string, ceph::bufferlist>& attrs,
                                            const bool allow_empty_attrs = true)
 {
-  static const std::set<std::string> blacklisted_headers = {
+  static const std::set<std::string> blocklisted_headers = {
       "x-amz-server-side-encryption-customer-algorithm",
       "x-amz-server-side-encryption-customer-key",
       "x-amz-server-side-encryption-customer-key-md5",
@@ -2047,7 +2047,7 @@ static inline int rgw_get_request_metadata(CephContext* const cct,
     const std::string& name = kv.first;
     std::string& xattr = kv.second;
 
-    if (blacklisted_headers.count(name) == 1) {
+    if (blocklisted_headers.count(name) == 1) {
       lsubdout(cct, rgw, 10) << "skipping x>> " << name << dendl;
       continue;
     } else if (allow_empty_attrs || !xattr.empty()) {

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -24,7 +24,7 @@
 
 
 /*
- * whitelist utility. Config string is a list of entries, where an entry is either an item,
+ * allowlist utility. Config string is a list of entries, where an entry is either an item,
  * a prefix, or a suffix. An item would be the name of the entity that we'd look up,
  * a prefix would be a string ending with an asterisk, a suffix would be a string starting
  * with an asterisk. For example:

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -1027,10 +1027,10 @@ int Rados::aio_watch_flush(AioCompletion* c) {
   return impl->aio_watch_flush(c->pc);
 }
 
-int Rados::blacklist_add(const std::string& client_address,
+int Rados::blocklist_add(const std::string& client_address,
 			 uint32_t expire_seconds) {
   TestRadosClient *impl = reinterpret_cast<TestRadosClient*>(client);
-  return impl->blacklist_add(client_address, expire_seconds);
+  return impl->blocklist_add(client_address, expire_seconds);
 }
 
 config_t Rados::cct() {
@@ -1202,7 +1202,7 @@ void Rados::shutdown() {
   client = NULL;
 }
 
-void Rados::test_blacklist_self(bool set) {
+void Rados::test_blocklist_self(bool set) {
 }
 
 int Rados::wait_for_latest_osdmap() {

--- a/src/test/librados_test_stub/MockTestMemRadosClient.h
+++ b/src/test/librados_test_stub/MockTestMemRadosClient.h
@@ -33,11 +33,11 @@ public:
       get_mem_cluster()->get_pool(pool_name));
   }
 
-  MOCK_METHOD2(blacklist_add, int(const std::string& client_address,
+  MOCK_METHOD2(blocklist_add, int(const std::string& client_address,
                                   uint32_t expire_seconds));
-  int do_blacklist_add(const std::string& client_address,
+  int do_blocklist_add(const std::string& client_address,
                        uint32_t expire_seconds) {
-    return TestMemRadosClient::blacklist_add(client_address, expire_seconds);
+    return TestMemRadosClient::blocklist_add(client_address, expire_seconds);
   }
 
   MOCK_METHOD1(get_min_compatible_osd, int(int8_t*));
@@ -75,7 +75,7 @@ public:
 
     ON_CALL(*this, connect()).WillByDefault(Invoke(this, &MockTestMemRadosClient::do_connect));
     ON_CALL(*this, create_ioctx(_, _)).WillByDefault(Invoke(this, &MockTestMemRadosClient::do_create_ioctx));
-    ON_CALL(*this, blacklist_add(_, _)).WillByDefault(Invoke(this, &MockTestMemRadosClient::do_blacklist_add));
+    ON_CALL(*this, blocklist_add(_, _)).WillByDefault(Invoke(this, &MockTestMemRadosClient::do_blocklist_add));
     ON_CALL(*this, get_min_compatible_osd(_)).WillByDefault(Invoke(this, &MockTestMemRadosClient::do_get_min_compatible_osd));
     ON_CALL(*this, get_min_compatible_client(_, _)).WillByDefault(Invoke(this, &MockTestMemRadosClient::do_get_min_compatible_client));
     ON_CALL(*this, service_daemon_register(_, _, _)).WillByDefault(Invoke(this, &MockTestMemRadosClient::do_service_daemon_register));

--- a/src/test/librados_test_stub/TestIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestIoCtxImpl.cc
@@ -133,8 +133,8 @@ int TestIoCtxImpl::aio_watch(const std::string& o, AioCompletionImpl *c,
   m_pending_ops++;
   c->get();
   C_AioNotify *ctx = new C_AioNotify(this, c);
-  if (m_client->is_blacklisted()) {
-    m_client->get_aio_finisher()->queue(ctx, -EBLACKLISTED);
+  if (m_client->is_blocklisted()) {
+    m_client->get_aio_finisher()->queue(ctx, -EBLOCKLISTED);
   } else {
     m_client->get_watch_notify()->aio_watch(m_client, m_pool_id,
                                             get_namespace(), o,
@@ -148,8 +148,8 @@ int TestIoCtxImpl::aio_unwatch(uint64_t handle, AioCompletionImpl *c) {
   m_pending_ops++;
   c->get();
   C_AioNotify *ctx = new C_AioNotify(this, c);
-  if (m_client->is_blacklisted()) {
-    m_client->get_aio_finisher()->queue(ctx, -EBLACKLISTED);
+  if (m_client->is_blocklisted()) {
+    m_client->get_aio_finisher()->queue(ctx, -EBLOCKLISTED);
   } else {
     m_client->get_watch_notify()->aio_unwatch(m_client, handle, ctx);
   }
@@ -160,8 +160,8 @@ int TestIoCtxImpl::exec(const std::string& oid, TestClassHandler *handler,
                         const char *cls, const char *method,
                         bufferlist& inbl, bufferlist* outbl,
                         const SnapContext &snapc) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   cls_method_cxx_call_t call = handler->get_method(cls, method);
@@ -175,8 +175,8 @@ int TestIoCtxImpl::exec(const std::string& oid, TestClassHandler *handler,
 
 int TestIoCtxImpl::list_watchers(const std::string& o,
                                  std::list<obj_watch_t> *out_watchers) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   return m_client->get_watch_notify()->list_watchers(m_pool_id, get_namespace(),
@@ -185,8 +185,8 @@ int TestIoCtxImpl::list_watchers(const std::string& o,
 
 int TestIoCtxImpl::notify(const std::string& o, bufferlist& bl,
                           uint64_t timeout_ms, bufferlist *pbl) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   return m_client->get_watch_notify()->notify(m_client, m_pool_id,
@@ -269,8 +269,8 @@ void TestIoCtxImpl::set_snap_read(snap_t seq) {
 }
 
 int TestIoCtxImpl::tmap_update(const std::string& oid, bufferlist& cmdbl) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   // TODO: protect against concurrent tmap updates
@@ -326,8 +326,8 @@ int TestIoCtxImpl::tmap_update(const std::string& oid, bufferlist& cmdbl) {
 }
 
 int TestIoCtxImpl::unwatch(uint64_t handle) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   return m_client->get_watch_notify()->unwatch(m_client, handle);
@@ -335,8 +335,8 @@ int TestIoCtxImpl::unwatch(uint64_t handle) {
 
 int TestIoCtxImpl::watch(const std::string& o, uint64_t *handle,
                          librados::WatchCtx *ctx, librados::WatchCtx2 *ctx2) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   return m_client->get_watch_notify()->watch(m_client, m_pool_id,
@@ -347,8 +347,8 @@ int TestIoCtxImpl::watch(const std::string& o, uint64_t *handle,
 
 int TestIoCtxImpl::execute_operation(const std::string& oid,
                                      const Operation &operation) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   TestRadosClient::Transaction transaction(m_client, get_namespace(), oid);
@@ -360,8 +360,8 @@ int TestIoCtxImpl::execute_aio_operations(const std::string& oid,
                                           bufferlist *pbl,
                                           const SnapContext &snapc) {
   int ret = 0;
-  if (m_client->is_blacklisted()) {
-    ret = -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    ret = -EBLOCKLISTED;
   } else {
     TestRadosClient::Transaction transaction(m_client, get_namespace(), oid);
     for (ObjectOperations::iterator it = ops->ops.begin();

--- a/src/test/librados_test_stub/TestMemCluster.cc
+++ b/src/test/librados_test_stub/TestMemCluster.cc
@@ -164,19 +164,19 @@ void TestMemCluster::allocate_client(uint32_t *nonce, uint64_t *global_id) {
 
 void TestMemCluster::deallocate_client(uint32_t nonce) {
   std::lock_guard locker{m_lock};
-  m_blacklist.erase(nonce);
+  m_blocklist.erase(nonce);
 }
 
-bool TestMemCluster::is_blacklisted(uint32_t nonce) const {
+bool TestMemCluster::is_blocklisted(uint32_t nonce) const {
   std::lock_guard locker{m_lock};
-  return (m_blacklist.find(nonce) != m_blacklist.end());
+  return (m_blocklist.find(nonce) != m_blocklist.end());
 }
 
-void TestMemCluster::blacklist(uint32_t nonce) {
-  m_watch_notify.blacklist(nonce);
+void TestMemCluster::blocklist(uint32_t nonce) {
+  m_watch_notify.blocklist(nonce);
 
   std::lock_guard locker{m_lock};
-  m_blacklist.insert(nonce);
+  m_blocklist.insert(nonce);
 }
 
 void TestMemCluster::transaction_start(const ObjectLocator& locator) {

--- a/src/test/librados_test_stub/TestMemCluster.h
+++ b/src/test/librados_test_stub/TestMemCluster.h
@@ -90,8 +90,8 @@ public:
   void allocate_client(uint32_t *nonce, uint64_t *global_id);
   void deallocate_client(uint32_t nonce);
 
-  bool is_blacklisted(uint32_t nonce) const;
-  void blacklist(uint32_t nonce);
+  bool is_blocklisted(uint32_t nonce) const;
+  void blocklist(uint32_t nonce);
 
   void transaction_start(const ObjectLocator& locator);
   void transaction_finish(const ObjectLocator& locator);
@@ -99,7 +99,7 @@ public:
 private:
 
   typedef std::map<std::string, Pool*>		Pools;
-  typedef std::set<uint32_t> Blacklist;
+  typedef std::set<uint32_t> Blocklist;
 
   mutable ceph::mutex m_lock =
     ceph::make_mutex("TestMemCluster::m_lock");
@@ -110,7 +110,7 @@ private:
   uint32_t m_next_nonce;
   uint64_t m_next_global_id = 1234;
 
-  Blacklist m_blacklist;
+  Blocklist m_blocklist;
 
   ceph::condition_variable m_transaction_cond;
   std::set<ObjectLocator> m_transactions;

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -69,8 +69,8 @@ int TestMemIoCtxImpl::append(const std::string& oid, const bufferlist &bl,
                              const SnapContext &snapc) {
   if (get_snap_read() != CEPH_NOSNAP) {
     return -EROFS;
-  } else if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  } else if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   TestMemCluster::SharedFile file;
@@ -87,8 +87,8 @@ int TestMemIoCtxImpl::append(const std::string& oid, const bufferlist &bl,
 }
 
 int TestMemIoCtxImpl::assert_exists(const std::string &oid) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   std::shared_lock l{m_pool->file_lock};
@@ -103,8 +103,8 @@ int TestMemIoCtxImpl::create(const std::string& oid, bool exclusive,
                              const SnapContext &snapc) {
   if (get_snap_read() != CEPH_NOSNAP) {
     return -EROFS;
-  } else if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  } else if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   std::unique_lock l{m_pool->file_lock};
@@ -113,8 +113,8 @@ int TestMemIoCtxImpl::create(const std::string& oid, bool exclusive,
 }
 
 int TestMemIoCtxImpl::list_snaps(const std::string& oid, snap_set_t *out_snaps) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   out_snaps->seq = 0;
@@ -191,8 +191,8 @@ int TestMemIoCtxImpl::omap_get_vals2(const std::string& oid,
                                     bool *pmore) {
   if (out_vals == NULL) {
     return -EINVAL;
-  } else if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  } else if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   TestMemCluster::SharedFile file;
@@ -248,8 +248,8 @@ int TestMemIoCtxImpl::omap_rm_keys(const std::string& oid,
                                    const std::set<std::string>& keys) {
   if (get_snap_read() != CEPH_NOSNAP) {
     return -EROFS;
-  } else if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  } else if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   TestMemCluster::SharedFile file;
@@ -273,8 +273,8 @@ int TestMemIoCtxImpl::omap_set(const std::string& oid,
                                const std::map<std::string, bufferlist> &map) {
   if (get_snap_read() != CEPH_NOSNAP) {
     return -EROFS;
-  } else if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  } else if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   TestMemCluster::SharedFile file;
@@ -299,8 +299,8 @@ int TestMemIoCtxImpl::omap_set(const std::string& oid,
 
 int TestMemIoCtxImpl::read(const std::string& oid, size_t len, uint64_t off,
                            bufferlist *bl) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   TestMemCluster::SharedFile file;
@@ -328,8 +328,8 @@ int TestMemIoCtxImpl::read(const std::string& oid, size_t len, uint64_t off,
 int TestMemIoCtxImpl::remove(const std::string& oid, const SnapContext &snapc) {
   if (get_snap_read() != CEPH_NOSNAP) {
     return -EROFS;
-  } else if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  } else if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   std::unique_lock l{m_pool->file_lock};
@@ -366,8 +366,8 @@ int TestMemIoCtxImpl::remove(const std::string& oid, const SnapContext &snapc) {
 }
 
 int TestMemIoCtxImpl::selfmanaged_snap_create(uint64_t *snapid) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   std::unique_lock l{m_pool->file_lock};
@@ -377,8 +377,8 @@ int TestMemIoCtxImpl::selfmanaged_snap_create(uint64_t *snapid) {
 }
 
 int TestMemIoCtxImpl::selfmanaged_snap_remove(uint64_t snapid) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   std::unique_lock l{m_pool->file_lock};
@@ -395,8 +395,8 @@ int TestMemIoCtxImpl::selfmanaged_snap_remove(uint64_t snapid) {
 
 int TestMemIoCtxImpl::selfmanaged_snap_rollback(const std::string& oid,
                                                 uint64_t snapid) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   std::unique_lock l{m_pool->file_lock};
@@ -449,8 +449,8 @@ int TestMemIoCtxImpl::set_alloc_hint(const std::string& oid,
                                      const SnapContext &snapc) {
   if (get_snap_read() != CEPH_NOSNAP) {
     return -EROFS;
-  } else if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  } else if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   {
@@ -465,8 +465,8 @@ int TestMemIoCtxImpl::sparse_read(const std::string& oid, uint64_t off,
                                   uint64_t len,
                                   std::map<uint64_t,uint64_t> *m,
                                   bufferlist *data_bl) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   // TODO verify correctness
@@ -498,8 +498,8 @@ int TestMemIoCtxImpl::sparse_read(const std::string& oid, uint64_t off,
 
 int TestMemIoCtxImpl::stat(const std::string& oid, uint64_t *psize,
                            time_t *pmtime) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   TestMemCluster::SharedFile file;
@@ -525,8 +525,8 @@ int TestMemIoCtxImpl::truncate(const std::string& oid, uint64_t size,
                                const SnapContext &snapc) {
   if (get_snap_read() != CEPH_NOSNAP) {
     return -EROFS;
-  } else if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  } else if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   TestMemCluster::SharedFile file;
@@ -563,8 +563,8 @@ int TestMemIoCtxImpl::write(const std::string& oid, bufferlist& bl, size_t len,
                             uint64_t off, const SnapContext &snapc) {
   if (get_snap_read() != CEPH_NOSNAP) {
     return -EROFS;
-  } else if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  } else if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   TestMemCluster::SharedFile file;
@@ -590,8 +590,8 @@ int TestMemIoCtxImpl::write_full(const std::string& oid, bufferlist& bl,
                                  const SnapContext &snapc) {
   if (get_snap_read() != CEPH_NOSNAP) {
     return -EROFS;
-  } else if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  } else if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   TestMemCluster::SharedFile file;
@@ -621,8 +621,8 @@ int TestMemIoCtxImpl::writesame(const std::string& oid, bufferlist& bl, size_t l
                                 uint64_t off, const SnapContext &snapc) {
   if (get_snap_read() != CEPH_NOSNAP) {
     return -EROFS;
-  } else if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  } else if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   if (len == 0 || (len % bl.length())) {
@@ -654,8 +654,8 @@ int TestMemIoCtxImpl::writesame(const std::string& oid, bufferlist& bl, size_t l
 
 int TestMemIoCtxImpl::cmpext(const std::string& oid, uint64_t off,
                              bufferlist& cmp_bl) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   bufferlist read_bl;
@@ -682,8 +682,8 @@ int TestMemIoCtxImpl::cmpext(const std::string& oid, uint64_t off,
 
 int TestMemIoCtxImpl::xattr_get(const std::string& oid,
                                 std::map<std::string, bufferlist>* attrset) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   TestMemCluster::SharedFile file;
@@ -699,8 +699,8 @@ int TestMemIoCtxImpl::xattr_get(const std::string& oid,
 
 int TestMemIoCtxImpl::xattr_set(const std::string& oid, const std::string &name,
                                 bufferlist& bl) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   std::unique_lock l{m_pool->file_lock};
@@ -710,8 +710,8 @@ int TestMemIoCtxImpl::xattr_set(const std::string& oid, const std::string &name,
 
 int TestMemIoCtxImpl::zero(const std::string& oid, uint64_t off, uint64_t len,
                            const SnapContext &snapc) {
-  if (m_client->is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (m_client->is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   bool truncate_redirect = false;

--- a/src/test/librados_test_stub/TestMemRadosClient.cc
+++ b/src/test/librados_test_stub/TestMemRadosClient.cc
@@ -42,15 +42,15 @@ void TestMemRadosClient::object_list(int64_t pool_id,
 }
 
 int TestMemRadosClient::pool_create(const std::string &pool_name) {
-  if (is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
   return m_mem_cluster->pool_create(pool_name);
 }
 
 int TestMemRadosClient::pool_delete(const std::string &pool_name) {
-  if (is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
   return m_mem_cluster->pool_delete(pool_name);
 }
@@ -78,14 +78,14 @@ int TestMemRadosClient::watch_flush() {
   return 0;
 }
 
-bool TestMemRadosClient::is_blacklisted() const {
-  return m_mem_cluster->is_blacklisted(m_nonce);
+bool TestMemRadosClient::is_blocklisted() const {
+  return m_mem_cluster->is_blocklisted(m_nonce);
 }
 
-int TestMemRadosClient::blacklist_add(const std::string& client_address,
+int TestMemRadosClient::blocklist_add(const std::string& client_address,
 				      uint32_t expire_seconds) {
-  if (is_blacklisted()) {
-    return -EBLACKLISTED;
+  if (is_blocklisted()) {
+    return -EBLOCKLISTED;
   }
 
   // extract the nonce to use as a unique key to the client
@@ -101,7 +101,7 @@ int TestMemRadosClient::blacklist_add(const std::string& client_address,
     return -EINVAL;
   }
 
-  m_mem_cluster->blacklist(nonce);
+  m_mem_cluster->blocklist(nonce);
   return 0;
 }
 

--- a/src/test/librados_test_stub/TestMemRadosClient.h
+++ b/src/test/librados_test_stub/TestMemRadosClient.h
@@ -62,8 +62,8 @@ public:
 
   int watch_flush() override;
 
-  bool is_blacklisted() const override;
-  int blacklist_add(const std::string& client_address,
+  bool is_blocklisted() const override;
+  int blocklist_add(const std::string& client_address,
                     uint32_t expire_seconds) override;
 protected:
   TestMemCluster *get_mem_cluster() {

--- a/src/test/librados_test_stub/TestRadosClient.h
+++ b/src/test/librados_test_stub/TestRadosClient.h
@@ -99,8 +99,8 @@ public:
   virtual int aio_watch_flush(AioCompletionImpl *c);
   virtual int watch_flush() = 0;
 
-  virtual bool is_blacklisted() const = 0;
-  virtual int blacklist_add(const std::string& client_address,
+  virtual bool is_blocklisted() const = 0;
+  virtual int blocklist_add(const std::string& client_address,
 			    uint32_t expire_seconds) = 0;
 
   Finisher *get_aio_finisher() {

--- a/src/test/librados_test_stub/TestWatchNotify.cc
+++ b/src/test/librados_test_stub/TestWatchNotify.cc
@@ -394,7 +394,7 @@ void TestWatchNotify::finish_notify(TestRadosClient *rados_client,
   maybe_remove_watcher(watcher);
 }
 
-void TestWatchNotify::blacklist(uint32_t nonce) {
+void TestWatchNotify::blocklist(uint32_t nonce) {
   std::lock_guard locker{m_lock};
 
   for (auto file_it = m_file_watchers.begin();

--- a/src/test/librados_test_stub/TestWatchNotify.h
+++ b/src/test/librados_test_stub/TestWatchNotify.h
@@ -97,7 +97,7 @@ public:
             librados::WatchCtx2 *ctx2);
   int unwatch(TestRadosClient *rados_client, uint64_t handle);
 
-  void blacklist(uint32_t nonce);
+  void blocklist(uint32_t nonce);
 
 private:
   typedef std::tuple<int64_t, std::string, std::string> PoolFile;

--- a/src/test/librbd/managed_lock/test_mock_AcquireRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_AcquireRequest.cc
@@ -31,14 +31,14 @@ struct BreakRequest<librbd::MockImageCtx> {
   static BreakRequest* create(librados::IoCtx& ioctx,
                               asio::ContextWQ *work_queue,
                               const std::string& oid, const Locker &locker,
-                              bool exclusive, bool blacklist_locker,
-                              uint32_t blacklist_expire_seconds,
+                              bool exclusive, bool blocklist_locker,
+                              uint32_t blocklist_expire_seconds,
                               bool force_break_lock, Context *on_finish) {
     CephContext *cct = reinterpret_cast<CephContext *>(ioctx.cct());
-    EXPECT_EQ(cct->_conf.get_val<bool>("rbd_blacklist_on_break_lock"),
-              blacklist_locker);
-    EXPECT_EQ(cct->_conf.get_val<uint64_t>("rbd_blacklist_expire_seconds"),
-              blacklist_expire_seconds);
+    EXPECT_EQ(cct->_conf.get_val<bool>("rbd_blocklist_on_break_lock"),
+              blocklist_locker);
+    EXPECT_EQ(cct->_conf.get_val<uint64_t>("rbd_blocklist_expire_seconds"),
+              blocklist_expire_seconds);
     EXPECT_FALSE(force_break_lock);
     ceph_assert(s_instance != nullptr);
     s_instance->on_finish = on_finish;

--- a/src/test/librbd/managed_lock/test_mock_BreakRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_BreakRequest.cc
@@ -105,9 +105,9 @@ public:
   }
 
 
-  void expect_blacklist_add(MockTestImageCtx &mock_image_ctx, int r) {
+  void expect_blocklist_add(MockTestImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(*get_mock_io_ctx(mock_image_ctx.md_ctx).get_mock_rados_client(),
-                blacklist_add(_, _))
+                blocklist_add(_, _))
                   .WillOnce(Return(r));
   }
 
@@ -140,7 +140,7 @@ TEST_F(TestMockManagedLockBreakRequest, DeadLockOwner) {
                     {entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123},
                     0);
 
-  expect_blacklist_add(mock_image_ctx, 0);
+  expect_blocklist_add(mock_image_ctx, 0);
   expect_break_lock(mock_image_ctx, 0);
 
   C_SaferCond ctx;
@@ -169,7 +169,7 @@ TEST_F(TestMockManagedLockBreakRequest, ForceBreak) {
                     {entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123},
                     0);
 
-  expect_blacklist_add(mock_image_ctx, 0);
+  expect_blocklist_add(mock_image_ctx, 0);
   expect_break_lock(mock_image_ctx, 0);
 
   C_SaferCond ctx;
@@ -325,7 +325,7 @@ TEST_F(TestMockManagedLockBreakRequest, GetLockerError) {
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
 
-TEST_F(TestMockManagedLockBreakRequest, BlacklistDisabled) {
+TEST_F(TestMockManagedLockBreakRequest, BlocklistDisabled) {
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librbd::ImageCtx *ictx;
@@ -353,7 +353,7 @@ TEST_F(TestMockManagedLockBreakRequest, BlacklistDisabled) {
   ASSERT_EQ(0, ctx.wait());
 }
 
-TEST_F(TestMockManagedLockBreakRequest, BlacklistSelf) {
+TEST_F(TestMockManagedLockBreakRequest, BlocklistSelf) {
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librbd::ImageCtx *ictx;
@@ -381,7 +381,7 @@ TEST_F(TestMockManagedLockBreakRequest, BlacklistSelf) {
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
 
-TEST_F(TestMockManagedLockBreakRequest, BlacklistError) {
+TEST_F(TestMockManagedLockBreakRequest, BlocklistError) {
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librbd::ImageCtx *ictx;
@@ -398,7 +398,7 @@ TEST_F(TestMockManagedLockBreakRequest, BlacklistError) {
                     {entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123},
                     0);
 
-  expect_blacklist_add(mock_image_ctx, -EINVAL);
+  expect_blocklist_add(mock_image_ctx, -EINVAL);
 
   C_SaferCond ctx;
   Locker locker{entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123};
@@ -426,7 +426,7 @@ TEST_F(TestMockManagedLockBreakRequest, BreakLockMissing) {
                     {entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123},
                     0);
 
-  expect_blacklist_add(mock_image_ctx, 0);
+  expect_blocklist_add(mock_image_ctx, 0);
   expect_break_lock(mock_image_ctx, -ENOENT);
 
   C_SaferCond ctx;
@@ -455,7 +455,7 @@ TEST_F(TestMockManagedLockBreakRequest, BreakLockError) {
                     {entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123},
                     0);
 
-  expect_blacklist_add(mock_image_ctx, 0);
+  expect_blocklist_add(mock_image_ctx, 0);
   expect_break_lock(mock_image_ctx, -EINVAL);
 
   C_SaferCond ctx;

--- a/src/test/librbd/mock/MockImageWatcher.h
+++ b/src/test/librbd/mock/MockImageWatcher.h
@@ -15,7 +15,7 @@ class ProgressContext;
 struct MockImageWatcher {
   MOCK_METHOD0(is_registered, bool());
   MOCK_METHOD0(is_unregistered, bool());
-  MOCK_METHOD0(is_blacklisted, bool());
+  MOCK_METHOD0(is_blocklisted, bool());
   MOCK_METHOD0(unregister_watch, void());
   MOCK_METHOD1(flush, void(Context *));
 

--- a/src/test/librbd/rbdrw.py
+++ b/src/test/librbd/rbdrw.py
@@ -5,7 +5,7 @@ after acquiring exclusive lock named argv[2].  When an exception
 happens, split off the last number in the exception 'args' string
 and use it as the process exit code, if it's convertible to a number.
 
-Designed to run against a blacklist operation and verify the
+Designed to run against a blocklist operation and verify the
 ESHUTDOWN expected from the image operation.
 
 Note: this cannot be run with writeback caching on, currently, as

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -6828,25 +6828,25 @@ TEST_F(TestLibRBD, BreakLock)
 
   static char buf[10];
 
-  rados_t blacklist_cluster;
-  ASSERT_EQ("", connect_cluster(&blacklist_cluster));
+  rados_t blocklist_cluster;
+  ASSERT_EQ("", connect_cluster(&blocklist_cluster));
 
-  rados_ioctx_t ioctx, blacklist_ioctx;
+  rados_ioctx_t ioctx, blocklist_ioctx;
   ASSERT_EQ(0, rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx));
-  ASSERT_EQ(0, rados_ioctx_create(blacklist_cluster, m_pool_name.c_str(),
-                                  &blacklist_ioctx));
+  ASSERT_EQ(0, rados_ioctx_create(blocklist_cluster, m_pool_name.c_str(),
+                                  &blocklist_ioctx));
 
   std::string name = get_temp_image_name();
   uint64_t size = 2 << 20;
   int order = 0;
   ASSERT_EQ(0, create_image(ioctx, name.c_str(), size, &order));
 
-  rbd_image_t image, blacklist_image;
+  rbd_image_t image, blocklist_image;
   ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
-  ASSERT_EQ(0, rbd_open(blacklist_ioctx, name.c_str(), &blacklist_image, NULL));
+  ASSERT_EQ(0, rbd_open(blocklist_ioctx, name.c_str(), &blocklist_image, NULL));
 
-  ASSERT_EQ(0, rbd_metadata_set(image, "conf_rbd_blacklist_on_break_lock", "true"));
-  ASSERT_EQ(0, rbd_lock_acquire(blacklist_image, RBD_LOCK_MODE_EXCLUSIVE));
+  ASSERT_EQ(0, rbd_metadata_set(image, "conf_rbd_blocklist_on_break_lock", "true"));
+  ASSERT_EQ(0, rbd_lock_acquire(blocklist_image, RBD_LOCK_MODE_EXCLUSIVE));
 
   rbd_lock_mode_t lock_mode;
   char *lock_owners[1];
@@ -6859,19 +6859,19 @@ TEST_F(TestLibRBD, BreakLock)
 
   ASSERT_EQ(0, rbd_lock_break(image, RBD_LOCK_MODE_EXCLUSIVE, lock_owners[0]));
   ASSERT_EQ(0, rbd_lock_acquire(image, RBD_LOCK_MODE_EXCLUSIVE));
-  EXPECT_EQ(0, rados_wait_for_latest_osdmap(blacklist_cluster));
+  EXPECT_EQ(0, rados_wait_for_latest_osdmap(blocklist_cluster));
 
   ASSERT_EQ((ssize_t)sizeof(buf), rbd_write(image, 0, sizeof(buf), buf));
-  ASSERT_EQ(-EBLACKLISTED, rbd_write(blacklist_image, 0, sizeof(buf), buf));
+  ASSERT_EQ(-EBLOCKLISTED, rbd_write(blocklist_image, 0, sizeof(buf), buf));
 
   ASSERT_EQ(0, rbd_close(image));
-  ASSERT_EQ(0, rbd_close(blacklist_image));
+  ASSERT_EQ(0, rbd_close(blocklist_image));
 
   rbd_lock_get_owners_cleanup(lock_owners, max_lock_owners);
 
   rados_ioctx_destroy(ioctx);
-  rados_ioctx_destroy(blacklist_ioctx);
-  rados_shutdown(blacklist_cluster);
+  rados_ioctx_destroy(blocklist_ioctx);
+  rados_shutdown(blocklist_cluster);
 }
 
 TEST_F(TestLibRBD, DiscardAfterWrite)

--- a/src/test/librbd/test_mock_ExclusiveLock.cc
+++ b/src/test/librbd/test_mock_ExclusiveLock.cc
@@ -42,8 +42,8 @@ template <>
 struct ManagedLock<MockExclusiveLockImageCtx> {
   ManagedLock(librados::IoCtx& ioctx, asio::ContextWQ *work_queue,
               const std::string& oid, librbd::MockImageWatcher *watcher,
-              managed_lock::Mode  mode, bool blacklist_on_break_lock,
-              uint32_t blacklist_expire_seconds)
+              managed_lock::Mode  mode, bool blocklist_on_break_lock,
+              uint32_t blocklist_expire_seconds)
   {}
 
   virtual ~ManagedLock() = default;
@@ -662,8 +662,8 @@ TEST_F(TestMockExclusiveLock, AcquireLockError) {
   expect_is_state_acquiring(exclusive_lock, true);
   expect_prepare_lock_complete(mock_image_ctx);
   expect_is_action_acquire_lock(exclusive_lock, true);
-  ASSERT_EQ(-EBLACKLISTED, when_post_acquire_lock_handler(exclusive_lock,
-                                                          -EBLACKLISTED));
+  ASSERT_EQ(-EBLOCKLISTED, when_post_acquire_lock_handler(exclusive_lock,
+                                                          -EBLOCKLISTED));
 }
 
 TEST_F(TestMockExclusiveLock, PostAcquireLockError) {

--- a/src/test/librbd/test_mock_Watcher.cc
+++ b/src/test/librbd/test_mock_Watcher.cc
@@ -303,7 +303,7 @@ TEST_F(TestMockWatcher, ReregisterWatchBlacklist) {
 
   // wait for recovery unwatch/watch
   ASSERT_TRUE(wait_for_watch(mock_image_ctx, 2));
-  ASSERT_TRUE(mock_image_watcher.is_blacklisted());
+  ASSERT_TRUE(mock_image_watcher.is_blocklisted());
 
   C_SaferCond unregister_ctx;
   mock_image_watcher.unregister_watch(&unregister_ctx);
@@ -324,7 +324,7 @@ TEST_F(TestMockWatcher, ReregisterUnwatchPendingUnregister) {
 
   // inject an unregister
   C_SaferCond unregister_ctx;
-  expect_aio_unwatch(mock_image_ctx, -EBLACKLISTED,
+  expect_aio_unwatch(mock_image_ctx, -EBLOCKLISTED,
                      [&mock_image_watcher, &unregister_ctx]() {
       mock_image_watcher.unregister_watch(&unregister_ctx);
     });
@@ -334,7 +334,7 @@ TEST_F(TestMockWatcher, ReregisterUnwatchPendingUnregister) {
   ASSERT_EQ(0, register_ctx.wait());
 
   ceph_assert(m_watch_ctx != nullptr);
-  m_watch_ctx->handle_error(0, -EBLACKLISTED);
+  m_watch_ctx->handle_error(0, -EBLOCKLISTED);
 
   ASSERT_EQ(0, unregister_ctx.wait());
 }

--- a/src/test/osd/osdcap.cc
+++ b/src/test/osd/osdcap.cc
@@ -177,7 +177,7 @@ TEST(OSDCap, AllowAll) {
   ASSERT_TRUE(cap.is_capable("foo", "anamespace", {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "anamespace", {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}, addr));
-  // 'allow *' overrides whitelist
+  // 'allow *' overrides allow list
   ASSERT_TRUE(cap.is_capable("foo", "", {}, "asdf", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "anamespace", {}, "asdf", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "asdf", true, true, {{"cls", "", true, true, false}}, addr));
@@ -198,7 +198,7 @@ TEST(OSDCap, AllowPool) {
   ASSERT_TRUE(cap.is_capable("foo", "ns", {}, "", true, true, {{"cls", "", true, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "", {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "ns", {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}, addr));
-  // true->false for classes not on whitelist
+  // true->false for classes not on allow list
   ASSERT_FALSE(cap.is_capable("foo", "", {}, "", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("foo", "ns", {}, "", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("foo", "", {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, false}}, addr));
@@ -221,7 +221,7 @@ TEST(OSDCap, AllowPools) {
   ASSERT_TRUE(cap.is_capable("foo", "ns", {}, "", true, true, {{"cls", "", true, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "", {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "ns", {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}, addr));
-  // true-false for classes not on whitelist
+  // true-false for classes not on allow list
   ASSERT_FALSE(cap.is_capable("foo", "", {}, "", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("foo", "ns", {}, "", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("foo", "", {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, false}}, addr));
@@ -250,7 +250,7 @@ TEST(OSDCap, AllowPools2) {
   ASSERT_TRUE(r);
 
   ASSERT_TRUE(cap.is_capable("foo", "", {}, "", true, true, {{"cls", "", true, true, true}}, addr));
-  // true-false for classes not on whitelist
+  // true-false for classes not on allow list
   ASSERT_FALSE(cap.is_capable("foo", "", {}, "", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "", true, true, {{"cls", "", true, true, true}}, addr));
 
@@ -266,7 +266,7 @@ TEST(OSDCap, ObjectPrefix) {
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "food", true, true, {{"cls", "", true, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo_bar", true, true, {{"cls", "", true, true, true}}, addr));
-  // true-false for classes not on whitelist
+  // true-false for classes not on allow list
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "food", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo_bar", true, true, {{"cls", "", true, true, false}}, addr));
@@ -285,7 +285,7 @@ TEST(OSDCap, ObjectPoolAndPrefix) {
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "food", true, true, {{"cls", "", true, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo_bar", true, true, {{"cls", "", true, true, true}}, addr));
-  // true-false for classes not on whitelist
+  // true-false for classes not on allow list
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "food", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo_bar", true, true, {{"cls", "", true, true, false}}, addr));
@@ -353,7 +353,7 @@ TEST(OSDCap, BasicX) {
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, true, true}}, addr));
-  // true->false when class not on whitelist
+  // true->false when class not on allow list
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", false, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
@@ -387,7 +387,7 @@ TEST(OSDCap, BasicRX) {
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, false, {}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, false, {{"cls", "", true, true, true}}, addr));
-  // true->false for class not on whitelist
+  // true->false for class not on allow list
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", false, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", true, false, {{"cls", "", true, true, false}}, addr));
@@ -405,7 +405,7 @@ TEST(OSDCap, BasicWX) {
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, true, {{"cls", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
-  // true->false for class not on whitelist
+  // true->false for class not on allow list
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, true, {{"cls", "", false, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
@@ -427,7 +427,7 @@ TEST(OSDCap, BasicRWX) {
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, false, {}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
-  // true->false for class not on whitelist
+  // true->false for class not on allow list
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
@@ -449,7 +449,7 @@ TEST(OSDCap, BasicRWClassRClassW) {
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, false, {}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
@@ -464,7 +464,7 @@ TEST(OSDCap, ClassR) {
   ASSERT_TRUE(cap.parse("allow class-read", NULL));
 
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
 
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", true, false, {}, addr));
@@ -479,7 +479,7 @@ TEST(OSDCap, ClassW) {
   ASSERT_TRUE(cap.parse("allow class-write", NULL));
 
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", false, true, true}}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", false, true, false}}, addr));
 
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", true, false, {}, addr));
@@ -496,7 +496,7 @@ TEST(OSDCap, ClassRW) {
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, true, true}}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", false, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
@@ -516,7 +516,7 @@ TEST(OSDCap, BasicRClassR) {
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, false, {}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {{"application", {{"key", "value"}}}}, "foo", true, false, {}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
@@ -530,7 +530,7 @@ TEST(OSDCap, BasicRClassR) {
   ASSERT_TRUE(cap.is_capable("bar", "any", {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "any", {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "any", {}, "foo", true, false, {}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("bar", "any", {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "any", {}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "any", {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
@@ -551,7 +551,7 @@ TEST(OSDCap, PoolClassR) {
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, false, {}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {{"application", {{"key", "value"}}}}, "foo", true, false, {}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
@@ -566,7 +566,7 @@ TEST(OSDCap, PoolClassR) {
   ASSERT_TRUE(cap.is_capable("bar", "ns", {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "ns", {}, "foo", true, false, {}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "ns", {{"application", {{"key", "value"}}}}, "foo", true, false, {}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("bar", "ns", {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "ns", {}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "ns", {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
@@ -586,7 +586,7 @@ TEST(OSDCap, PoolClassR) {
   ASSERT_TRUE(cap.is_capable("foo", "", {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "", {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "", {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("foo", "", {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("foo", "", {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("foo", "", {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
@@ -604,7 +604,7 @@ TEST(OSDCap, PoolClassR) {
   ASSERT_TRUE(cap.is_capable("foo", "ns", {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "ns", {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "ns", {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("foo", "ns", {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("foo", "ns", {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("foo", "ns", {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
@@ -633,7 +633,7 @@ TEST(OSDCap, PoolClassRNS) {
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, false, {}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {{"application", {{"key", "value"}}}}, "foo", true, false, {}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
@@ -674,7 +674,7 @@ TEST(OSDCap, PoolClassRNS) {
   ASSERT_TRUE(cap.is_capable("foo", "ns", {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "ns", {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "ns", {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("foo", "ns", {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("foo", "ns", {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("foo", "ns", {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
@@ -708,7 +708,7 @@ TEST(OSDCap, NSClassR) {
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
@@ -726,7 +726,7 @@ TEST(OSDCap, NSClassR) {
   ASSERT_TRUE(cap.is_capable("foo", "", {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "", {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "", {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("foo", "", {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("foo", "", {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("foo", "", {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
@@ -794,7 +794,7 @@ TEST(OSDCap, PoolTagBasic) {
   ASSERT_TRUE(cap.is_capable("foo", "", {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "", {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "", {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, false, true}}, addr));
-  // true->false when class not whitelisted
+  // true->false when class not allow listed
   ASSERT_FALSE(cap.is_capable("foo", "", {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("foo", "", {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("foo", "", {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, false, false}}, addr));
@@ -968,7 +968,7 @@ TEST(OSDCap, AllowClass) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class foo", NULL));
 
-  // can call any method on class foo regardless of whitelist status
+  // can call any method on class foo regardless of allow list status
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, true, true}}, addr));
@@ -990,7 +990,7 @@ TEST(OSDCap, AllowClassMethod) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class foo xyz", NULL));
 
-  // can call the xyz method on class foo regardless of whitelist status
+  // can call the xyz method on class foo regardless of allow list status
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "xyz", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "xyz", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "xyz", true, true, true}}, addr));
@@ -1038,7 +1038,7 @@ TEST(OSDCap, AllowClassRWX) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rwx, allow class foo", NULL));
 
-  // can call any method on class foo regardless of whitelist status
+  // can call any method on class foo regardless of allow list status
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, true, true}}, addr));
@@ -1051,7 +1051,7 @@ TEST(OSDCap, AllowClassRWX) {
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"bar", "", false, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"bar", "", true, true, false}}, addr));
 
-  // allows class bar if it is whitelisted
+  // allows class bar if it is allow listed
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"bar", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"bar", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"bar", "", true, true, true}}, addr));
@@ -1063,7 +1063,7 @@ TEST(OSDCap, AllowClassMulti) {
   ASSERT_TRUE(cap.parse("allow class foo", NULL));
 
   // can call any method on foo, but not bar, so the entire op is rejected
-  // bar with whitelist is rejected because it still needs rwx/class-read,write
+  // bar with allow list is rejected because it still needs rwx/class-read,write
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, true}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, true}}, addr));
@@ -1128,7 +1128,7 @@ TEST(OSDCap, AllowClassMulti) {
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, false}}, addr));
 
-  // these are OK because 'bar' is on the whitelist BUT the calls don't read or write
+  // these are OK because 'bar' is on the allow list BUT the calls don't read or write
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, true}}, addr));
@@ -1138,7 +1138,7 @@ TEST(OSDCap, AllowClassMulti) {
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, true}}, addr));
 
-  // can call any method on foo or bar regardless of whitelist status
+  // can call any method on foo or bar regardless of allow list status
   OSDCap cap2;
   ASSERT_TRUE(cap2.parse("allow class foo, allow class bar", NULL));
 
@@ -1220,13 +1220,13 @@ TEST(OSDCap, AllowClassMultiRWX) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rwx, allow class foo", NULL));
 
-  // can call anything on foo, but only whitelisted methods on bar
+  // can call anything on foo, but only allow listed methods on bar
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, true}}, addr));
 
-  // fails because bar not whitelisted
+  // fails because bar not allow listed
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, false}}, addr));
   ASSERT_FALSE(cap.is_capable("bar", "", {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, false}}, addr));

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -534,10 +534,10 @@ class TestOSD(TestArgparse):
         assert_equal({}, validate_command(sigdict, ['osd', 'lspools',
                                                     'toomany']))
 
-    def test_blacklist_ls(self):
-        self.assert_valid_command(['osd', 'blacklist', 'ls'])
-        assert_equal({}, validate_command(sigdict, ['osd', 'blacklist']))
-        assert_equal({}, validate_command(sigdict, ['osd', 'blacklist',
+    def test_blocklist_ls(self):
+        self.assert_valid_command(['osd', 'blocklist', 'ls'])
+        assert_equal({}, validate_command(sigdict, ['osd', 'blocklist']))
+        assert_equal({}, validate_command(sigdict, ['osd', 'blocklist',
                                                     'ls', 'toomany']))
 
     def test_crush_rule(self):
@@ -878,25 +878,25 @@ class TestOSD(TestArgparse):
                                                     uuid,
                                                     'toomany']))
 
-    def test_blacklist(self):
+    def test_blocklist(self):
         for action in ('add', 'rm'):
-            self.assert_valid_command(['osd', 'blacklist', action,
+            self.assert_valid_command(['osd', 'blocklist', action,
                                        '1.2.3.4/567'])
-            self.assert_valid_command(['osd', 'blacklist', action,
+            self.assert_valid_command(['osd', 'blocklist', action,
                                        '1.2.3.4'])
-            self.assert_valid_command(['osd', 'blacklist', action,
+            self.assert_valid_command(['osd', 'blocklist', action,
                                        '1.2.3.4/567', '600.40'])
-            self.assert_valid_command(['osd', 'blacklist', action,
+            self.assert_valid_command(['osd', 'blocklist', action,
                                        '1.2.3.4', '600.40'])
-            assert_equal({}, validate_command(sigdict, ['osd', 'blacklist',
+            assert_equal({}, validate_command(sigdict, ['osd', 'blocklist',
                                                         action,
                                                         'invalid',
                                                         '600.40']))
-            assert_equal({}, validate_command(sigdict, ['osd', 'blacklist',
+            assert_equal({}, validate_command(sigdict, ['osd', 'blocklist',
                                                         action,
                                                         '1.2.3.4/567',
                                                         '-1.0']))
-            assert_equal({}, validate_command(sigdict, ['osd', 'blacklist',
+            assert_equal({}, validate_command(sigdict, ['osd', 'blocklist',
                                                         action,
                                                         '1.2.3.4/567',
                                                         '600.40',

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -105,7 +105,7 @@ class TestRadosStateError(object):
         assert_raises(RadosStateError, rados.osd_command, 0, '', b'')
         assert_raises(RadosStateError, rados.pg_command, '', '', b'')
         assert_raises(RadosStateError, rados.wait_for_latest_osdmap)
-        assert_raises(RadosStateError, rados.blacklist_add, '127.0.0.1/123', 0)
+        assert_raises(RadosStateError, rados.blocklist_add, '127.0.0.1/123', 0)
 
     def test_configuring(self):
         rados = Rados(conffile='')
@@ -244,8 +244,8 @@ class TestRados(object):
         fsid = self.rados.get_fsid()
         assert re.match('[0-9a-f\-]{36}', fsid, re.I)
 
-    def test_blacklist_add(self):
-        self.rados.blacklist_add("1.2.3.4/123", 1)
+    def test_blocklist_add(self):
+        self.rados.blocklist_add("1.2.3.4/123", 1)
 
     def test_get_cluster_stats(self):
         stats = self.rados.get_cluster_stats()

--- a/src/test/rbd_mirror/test_mock_ImageMap.cc
+++ b/src/test/rbd_mirror/test_mock_ImageMap.cc
@@ -1308,9 +1308,9 @@ TEST_F(TestMockImageMap, AddErrorAndRemoveImage) {
   expect_listener_images_unmapped(mock_listener, 1, &released_global_image_ids,
                                   &release_peer_ack_ctxs);
 
-  // instance blacklisted -- ACQUIRE request fails
+  // instance blocklisted -- ACQUIRE request fails
   remote_peer_ack_nowait(mock_image_map.get(), shuffled_global_image_ids,
-                         -EBLACKLISTED, &peer_ack_ctxs);
+                         -EBLOCKLISTED, &peer_ack_ctxs);
   ASSERT_TRUE(wait_for_listener_notify(shuffled_global_image_ids.size()));
 
   std::map<std::string, Context*> remap_peer_ack_ctxs;
@@ -1318,7 +1318,7 @@ TEST_F(TestMockImageMap, AddErrorAndRemoveImage) {
                          mock_listener, shuffled_global_image_ids, 0,
                          &remap_peer_ack_ctxs);
 
-  // instance blacklisted -- RELEASE request fails
+  // instance blocklisted -- RELEASE request fails
   remote_peer_ack_listener_wait(mock_image_map.get(), shuffled_global_image_ids,
                                 -ENOENT, &release_peer_ack_ctxs);
   wait_for_scheduled_task();

--- a/src/test/rbd_mirror/test_mock_InstanceReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_InstanceReplayer.cc
@@ -98,7 +98,7 @@ struct ImageReplayer<librbd::MockTestImageCtx> {
   MOCK_METHOD0(get_local_image_id, const std::string &());
   MOCK_METHOD0(is_running, bool());
   MOCK_METHOD0(is_stopped, bool());
-  MOCK_METHOD0(is_blacklisted, bool());
+  MOCK_METHOD0(is_blocklisted, bool());
 
   MOCK_CONST_METHOD0(is_finished, bool());
   MOCK_METHOD1(set_finished, void(bool));
@@ -199,7 +199,7 @@ TEST_F(TestMockInstanceReplayer, AcquireReleaseImage) {
   C_SaferCond on_acquire;
   EXPECT_CALL(mock_image_replayer, add_peer(_));
   EXPECT_CALL(mock_image_replayer, is_stopped()).WillOnce(Return(true));
-  EXPECT_CALL(mock_image_replayer, is_blacklisted()).WillOnce(Return(false));
+  EXPECT_CALL(mock_image_replayer, is_blocklisted()).WillOnce(Return(false));
   EXPECT_CALL(mock_image_replayer, is_finished()).WillOnce(Return(false));
   EXPECT_CALL(mock_image_replayer, start(_, false))
     .WillOnce(CompleteContext(0));
@@ -270,7 +270,7 @@ TEST_F(TestMockInstanceReplayer, RemoveFinishedImage) {
   C_SaferCond on_acquire;
   EXPECT_CALL(mock_image_replayer, add_peer(_));
   EXPECT_CALL(mock_image_replayer, is_stopped()).WillOnce(Return(true));
-  EXPECT_CALL(mock_image_replayer, is_blacklisted()).WillOnce(Return(false));
+  EXPECT_CALL(mock_image_replayer, is_blocklisted()).WillOnce(Return(false));
   EXPECT_CALL(mock_image_replayer, is_finished()).WillOnce(Return(false));
   EXPECT_CALL(mock_image_replayer, start(_, false))
     .WillOnce(CompleteContext(0));
@@ -300,7 +300,7 @@ TEST_F(TestMockInstanceReplayer, RemoveFinishedImage) {
   EXPECT_CALL(mock_image_replayer, get_health_state()).WillOnce(
     Return(image_replayer::HEALTH_STATE_OK));
   EXPECT_CALL(mock_image_replayer, is_stopped()).WillOnce(Return(true));
-  EXPECT_CALL(mock_image_replayer, is_blacklisted()).WillOnce(Return(false));
+  EXPECT_CALL(mock_image_replayer, is_blocklisted()).WillOnce(Return(false));
   EXPECT_CALL(mock_image_replayer, is_finished()).WillOnce(Return(true));
   EXPECT_CALL(mock_image_replayer, destroy());
   EXPECT_CALL(mock_service_daemon,
@@ -344,7 +344,7 @@ TEST_F(TestMockInstanceReplayer, Reacquire) {
 
   EXPECT_CALL(mock_image_replayer, add_peer(_));
   EXPECT_CALL(mock_image_replayer, is_stopped()).WillOnce(Return(true));
-  EXPECT_CALL(mock_image_replayer, is_blacklisted()).WillOnce(Return(false));
+  EXPECT_CALL(mock_image_replayer, is_blocklisted()).WillOnce(Return(false));
   EXPECT_CALL(mock_image_replayer, is_finished()).WillOnce(Return(false));
   EXPECT_CALL(mock_image_replayer, start(_, false))
     .WillOnce(CompleteContext(0));

--- a/src/test/rbd_mirror/test_mock_InstanceWatcher.cc
+++ b/src/test/rbd_mirror/test_mock_InstanceWatcher.cc
@@ -32,8 +32,8 @@ struct ManagedLock<MockTestImageCtx> {
                              librbd::asio::ContextWQ *work_queue,
                              const std::string& oid, librbd::Watcher *watcher,
                              managed_lock::Mode  mode,
-                             bool blacklist_on_break_lock,
-                             uint32_t blacklist_expire_seconds) {
+                             bool blocklist_on_break_lock,
+                             uint32_t blocklist_expire_seconds) {
     ceph_assert(s_instance != nullptr);
     return s_instance;
   }
@@ -562,7 +562,7 @@ TEST_F(TestMockInstanceWatcher, PeerImageAcquireWatchDNE) {
   expect_acquire_lock(mock_managed_lock, 0);
   ASSERT_EQ(0, instance_watcher->init());
 
-  // Acquire image on dead (blacklisted) instance
+  // Acquire image on dead (blocklisted) instance
   C_SaferCond on_acquire;
   instance_watcher->notify_image_acquire("dead instance", "global image id",
                                          &on_acquire);
@@ -594,7 +594,7 @@ TEST_F(TestMockInstanceWatcher, PeerImageReleaseWatchDNE) {
   expect_acquire_lock(mock_managed_lock, 0);
   ASSERT_EQ(0, instance_watcher->init());
 
-  // Release image on dead (blacklisted) instance
+  // Release image on dead (blocklisted) instance
   C_SaferCond on_acquire;
   instance_watcher->notify_image_release("dead instance", "global image id",
                                          &on_acquire);

--- a/src/test/rbd_mirror/test_mock_LeaderWatcher.cc
+++ b/src/test/rbd_mirror/test_mock_LeaderWatcher.cc
@@ -62,8 +62,8 @@ template <>
 struct ManagedLock<MockTestImageCtx> {
   ManagedLock(librados::IoCtx& ioctx, librbd::asio::ContextWQ *work_queue,
               const std::string& oid, librbd::Watcher *watcher,
-              managed_lock::Mode  mode, bool blacklist_on_break_lock,
-              uint32_t blacklist_expire_seconds)
+              managed_lock::Mode  mode, bool blocklist_on_break_lock,
+              uint32_t blocklist_expire_seconds)
     : m_work_queue(work_queue) {
     MockManagedLock::get_instance().construct();
   }

--- a/src/test/rbd_mirror/test_mock_NamespaceReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_NamespaceReplayer.cc
@@ -213,7 +213,7 @@ struct PoolWatcher<librbd::MockTestImageCtx> {
     return s_instances[pool_id];
   }
 
-  MOCK_METHOD0(is_blacklisted, bool());
+  MOCK_METHOD0(is_blocklisted, bool());
 
   MOCK_METHOD0(get_image_count, uint64_t());
 

--- a/src/test/rbd_mirror/test_mock_PoolReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_PoolReplayer.cc
@@ -147,7 +147,7 @@ struct NamespaceReplayer<librbd::MockTestImageCtx> {
     return namespace_replayer;
   }
 
-  MOCK_METHOD0(is_blacklisted, bool());
+  MOCK_METHOD0(is_blocklisted, bool());
   MOCK_METHOD0(get_instance_id, std::string());
 
   MOCK_METHOD1(init, void(Context*));
@@ -186,7 +186,7 @@ struct LeaderWatcher<librbd::MockTestImageCtx> {
     return s_instance;
   }
 
-  MOCK_METHOD0(is_blacklisted, bool());
+  MOCK_METHOD0(is_blocklisted, bool());
   MOCK_METHOD0(is_leader, bool());
   MOCK_METHOD0(release_leader, void());
 
@@ -410,17 +410,17 @@ public:
                 }));
   }
 
-  void expect_leader_watcher_is_blacklisted(
-      MockLeaderWatcher &mock_leader_watcher, bool blacklisted) {
-    EXPECT_CALL(mock_leader_watcher, is_blacklisted())
-      .WillRepeatedly(Return(blacklisted));
+  void expect_leader_watcher_is_blocklisted(
+      MockLeaderWatcher &mock_leader_watcher, bool blocklisted) {
+    EXPECT_CALL(mock_leader_watcher, is_blocklisted())
+      .WillRepeatedly(Return(blocklisted));
   }
 
-  void expect_namespace_replayer_is_blacklisted(
+  void expect_namespace_replayer_is_blocklisted(
       MockNamespaceReplayer &mock_namespace_replayer,
-      bool blacklisted) {
-    EXPECT_CALL(mock_namespace_replayer, is_blacklisted())
-      .WillRepeatedly(Return(blacklisted));
+      bool blocklisted) {
+    EXPECT_CALL(mock_namespace_replayer, is_blocklisted())
+      .WillRepeatedly(Return(blocklisted));
   }
 
   void expect_namespace_replayer_get_instance_id(
@@ -542,7 +542,7 @@ TEST_F(TestMockPoolReplayer, ConfigKeyOverride) {
   peer_spec.key = "234";
 
   auto mock_default_namespace_replayer = new MockNamespaceReplayer();
-  expect_namespace_replayer_is_blacklisted(*mock_default_namespace_replayer,
+  expect_namespace_replayer_is_blocklisted(*mock_default_namespace_replayer,
                                            false);
 
   MockThreads mock_threads(m_threads);
@@ -550,7 +550,7 @@ TEST_F(TestMockPoolReplayer, ConfigKeyOverride) {
 
   auto mock_leader_watcher = new MockLeaderWatcher();
   expect_leader_watcher_get_leader_instance_id(*mock_leader_watcher);
-  expect_leader_watcher_is_blacklisted(*mock_leader_watcher, false);
+  expect_leader_watcher_is_blocklisted(*mock_leader_watcher, false);
 
   InSequence seq;
 
@@ -604,7 +604,7 @@ TEST_F(TestMockPoolReplayer, AcquireReleaseLeader) {
   peer_spec.key = "234";
 
   auto mock_default_namespace_replayer = new MockNamespaceReplayer();
-  expect_namespace_replayer_is_blacklisted(*mock_default_namespace_replayer,
+  expect_namespace_replayer_is_blocklisted(*mock_default_namespace_replayer,
                                            false);
 
   MockThreads mock_threads(m_threads);
@@ -613,7 +613,7 @@ TEST_F(TestMockPoolReplayer, AcquireReleaseLeader) {
   auto mock_leader_watcher = new MockLeaderWatcher();
   expect_leader_watcher_get_leader_instance_id(*mock_leader_watcher);
   expect_leader_watcher_list_instances(*mock_leader_watcher);
-  expect_leader_watcher_is_blacklisted(*mock_leader_watcher, false);
+  expect_leader_watcher_is_blocklisted(*mock_leader_watcher, false);
 
   InSequence seq;
 
@@ -684,15 +684,15 @@ TEST_F(TestMockPoolReplayer, Namespaces) {
   MockNamespace mock_namespace;
 
   auto mock_default_namespace_replayer = new MockNamespaceReplayer();
-  expect_namespace_replayer_is_blacklisted(*mock_default_namespace_replayer,
+  expect_namespace_replayer_is_blocklisted(*mock_default_namespace_replayer,
                                            false);
 
   auto mock_ns1_namespace_replayer = new MockNamespaceReplayer("ns1");
-  expect_namespace_replayer_is_blacklisted(*mock_ns1_namespace_replayer,
+  expect_namespace_replayer_is_blocklisted(*mock_ns1_namespace_replayer,
                                            false);
 
   auto mock_ns2_namespace_replayer = new MockNamespaceReplayer("ns2");
-  expect_namespace_replayer_is_blacklisted(*mock_ns2_namespace_replayer,
+  expect_namespace_replayer_is_blocklisted(*mock_ns2_namespace_replayer,
                                            false);
 
   MockThreads mock_threads(m_threads);
@@ -701,7 +701,7 @@ TEST_F(TestMockPoolReplayer, Namespaces) {
   auto mock_leader_watcher = new MockLeaderWatcher();
   expect_leader_watcher_get_leader_instance_id(*mock_leader_watcher);
   expect_leader_watcher_list_instances(*mock_leader_watcher);
-  expect_leader_watcher_is_blacklisted(*mock_leader_watcher, false);
+  expect_leader_watcher_is_blocklisted(*mock_leader_watcher, false);
 
   auto& mock_cluster = get_mock_cluster();
   auto mock_local_rados_client = mock_cluster.do_create_rados_client(
@@ -805,11 +805,11 @@ TEST_F(TestMockPoolReplayer, NamespacesError) {
   MockNamespace mock_namespace;
 
   auto mock_default_namespace_replayer = new MockNamespaceReplayer();
-  expect_namespace_replayer_is_blacklisted(*mock_default_namespace_replayer,
+  expect_namespace_replayer_is_blocklisted(*mock_default_namespace_replayer,
                                            false);
   auto mock_ns1_namespace_replayer = new MockNamespaceReplayer("ns1");
   auto mock_ns2_namespace_replayer = new MockNamespaceReplayer("ns2");
-  expect_namespace_replayer_is_blacklisted(*mock_ns2_namespace_replayer,
+  expect_namespace_replayer_is_blocklisted(*mock_ns2_namespace_replayer,
                                            false);
   auto mock_ns3_namespace_replayer = new MockNamespaceReplayer("ns3");
 
@@ -819,7 +819,7 @@ TEST_F(TestMockPoolReplayer, NamespacesError) {
   auto mock_leader_watcher = new MockLeaderWatcher();
   expect_leader_watcher_get_leader_instance_id(*mock_leader_watcher);
   expect_leader_watcher_list_instances(*mock_leader_watcher);
-  expect_leader_watcher_is_blacklisted(*mock_leader_watcher, false);
+  expect_leader_watcher_is_blocklisted(*mock_leader_watcher, false);
 
   auto& mock_cluster = get_mock_cluster();
   auto mock_local_rados_client = mock_cluster.do_create_rados_client(

--- a/src/test/rbd_mirror/test_mock_PoolWatcher.cc
+++ b/src/test/rbd_mirror/test_mock_PoolWatcher.cc
@@ -443,7 +443,7 @@ TEST_F(TestMockPoolWatcher, RegisterWatcherBlacklist) {
   C_SaferCond ctx;
   mock_pool_watcher.init(&ctx);
   ASSERT_EQ(-EBLACKLISTED, ctx.wait());
-  ASSERT_TRUE(mock_pool_watcher.is_blacklisted());
+  ASSERT_TRUE(mock_pool_watcher.is_blocklisted());
 
   expect_mirroring_watcher_unregister(mock_mirroring_watcher, 0);
   ASSERT_EQ(0, when_shut_down(mock_pool_watcher));
@@ -509,7 +509,7 @@ TEST_F(TestMockPoolWatcher, RegisterWatcherError) {
   ASSERT_EQ(0, when_shut_down(mock_pool_watcher));
 }
 
-TEST_F(TestMockPoolWatcher, RefreshBlacklist) {
+TEST_F(TestMockPoolWatcher, RefreshBlocklist) {
   MockThreads mock_threads(m_threads);
   expect_work_queue(mock_threads);
 
@@ -519,15 +519,15 @@ TEST_F(TestMockPoolWatcher, RefreshBlacklist) {
   expect_mirroring_watcher_register(mock_mirroring_watcher, 0);
 
   MockRefreshImagesRequest mock_refresh_images_request;
-  expect_refresh_images(mock_refresh_images_request, {}, -EBLACKLISTED);
+  expect_refresh_images(mock_refresh_images_request, {}, -EBLOCKLISTED);
 
   MockListener mock_listener(this);
   MockPoolWatcher mock_pool_watcher(&mock_threads, m_remote_io_ctx,
                                     "remote uuid", mock_listener);
   C_SaferCond ctx;
   mock_pool_watcher.init(&ctx);
-  ASSERT_EQ(-EBLACKLISTED, ctx.wait());
-  ASSERT_TRUE(mock_pool_watcher.is_blacklisted());
+  ASSERT_EQ(-EBLOCKLISTED, ctx.wait());
+  ASSERT_TRUE(mock_pool_watcher.is_blocklisted());
 
   expect_mirroring_watcher_unregister(mock_mirroring_watcher, 0);
   ASSERT_EQ(0, when_shut_down(mock_pool_watcher));
@@ -624,7 +624,7 @@ TEST_F(TestMockPoolWatcher, Rewatch) {
   ASSERT_EQ(0, when_shut_down(mock_pool_watcher));
 }
 
-TEST_F(TestMockPoolWatcher, RewatchBlacklist) {
+TEST_F(TestMockPoolWatcher, RewatchBlocklist) {
   MockThreads mock_threads(m_threads);
   expect_work_queue(mock_threads);
 
@@ -646,8 +646,8 @@ TEST_F(TestMockPoolWatcher, RewatchBlacklist) {
   ASSERT_EQ(0, ctx.wait());
   ASSERT_TRUE(wait_for_update(1));
 
-  MirroringWatcher::get_instance().handle_rewatch_complete(-EBLACKLISTED);
-  ASSERT_TRUE(mock_pool_watcher.is_blacklisted());
+  MirroringWatcher::get_instance().handle_rewatch_complete(-EBLOCKLISTED);
+  ASSERT_TRUE(mock_pool_watcher.is_blocklisted());
 
   expect_mirroring_watcher_unregister(mock_mirroring_watcher, 0);
   ASSERT_EQ(0, when_shut_down(mock_pool_watcher));

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -850,11 +850,11 @@ protected:
   // 192.168.1.0/24
   const rgw::IAM::MaskedIP allowedIPv4Range = { false, rgw::IAM::Address("11000000101010000000000100000000"), 24 };
   // 192.168.1.1/32
-  const rgw::IAM::MaskedIP blacklistedIPv4 = { false, rgw::IAM::Address("11000000101010000000000100000001"), 32 };
+  const rgw::IAM::MaskedIP blocklistedIPv4 = { false, rgw::IAM::Address("11000000101010000000000100000001"), 32 };
   // 2001:db8:85a3:0:0:8a2e:370:7334/128
   const rgw::IAM::MaskedIP allowedIPv6 = { true, rgw::IAM::Address("00100000000000010000110110111000100001011010001100000000000000000000000000000000100010100010111000000011011100000111001100110100"), 128 };
   // ::1
-  const rgw::IAM::MaskedIP blacklistedIPv6 = { true, rgw::IAM::Address(1), 128 };
+  const rgw::IAM::MaskedIP blocklistedIPv6 = { true, rgw::IAM::Address(1), 128 };
   // 2001:db8:85a3:0:0:8a2e:370:7330/124
   const rgw::IAM::MaskedIP allowedIPv6Range = { true, rgw::IAM::Address("00100000000000010000110110111000100001011010001100000000000000000000000000000000100010100010111000000011011100000111001100110000"), 124 };
 public:
@@ -866,11 +866,11 @@ const string IPPolicyTest::arbitrary_tenant = "arbitrary_tenant";
 
 TEST_F(IPPolicyTest, MaskedIPOperations) {
   EXPECT_EQ(stringify(allowedIPv4Range), "192.168.1.0/24");
-  EXPECT_EQ(stringify(blacklistedIPv4), "192.168.1.1/32");
+  EXPECT_EQ(stringify(blocklistedIPv4), "192.168.1.1/32");
   EXPECT_EQ(stringify(allowedIPv6), "2001:db8:85a3:0:0:8a2e:370:7334/128");
   EXPECT_EQ(stringify(allowedIPv6Range), "2001:db8:85a3:0:0:8a2e:370:7330/124");
-  EXPECT_EQ(stringify(blacklistedIPv6), "0:0:0:0:0:0:0:1/128");
-  EXPECT_EQ(allowedIPv4Range, blacklistedIPv4);
+  EXPECT_EQ(stringify(blocklistedIPv6), "0:0:0:0:0:0:0:1/128");
+  EXPECT_EQ(allowedIPv4Range, blocklistedIPv4);
   EXPECT_EQ(allowedIPv6Range, allowedIPv6);
 }
 
@@ -883,7 +883,7 @@ TEST_F(IPPolicyTest, asNetworkIPv4Range) {
 TEST_F(IPPolicyTest, asNetworkIPv4) {
   auto actualIPv4 = rgw::IAM::Condition::as_network("192.168.1.1");
   ASSERT_TRUE(actualIPv4.is_initialized());
-  EXPECT_EQ(*actualIPv4, blacklistedIPv4);
+  EXPECT_EQ(*actualIPv4, blocklistedIPv4);
 }
 
 TEST_F(IPPolicyTest, asNetworkIPv6Range) {
@@ -1016,11 +1016,11 @@ TEST_F(IPPolicyTest, EvalIPAddress) {
   auto fullp  = Policy(cct.get(), arbitrary_tenant,
 		   bufferlist::static_from_string(ip_address_full_example));
   Environment e;
-  Environment allowedIP, blacklistedIP, allowedIPv6, blacklistedIPv6;
+  Environment allowedIP, blocklistedIP, allowedIPv6, blocklistedIPv6;
   allowedIP["aws:SourceIp"] = "192.168.1.2";
   allowedIPv6["aws:SourceIp"] = "::1";
-  blacklistedIP["aws:SourceIp"] = "192.168.1.1";
-  blacklistedIPv6["aws:SourceIp"] = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
+  blocklistedIP["aws:SourceIp"] = "192.168.1.1";
+  blocklistedIPv6["aws:SourceIp"] = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
 
   auto trueacct = FakeIdentity(
     Principal::tenant("ACCOUNT-ID-WITHOUT-HYPHENS"));
@@ -1038,7 +1038,7 @@ TEST_F(IPPolicyTest, EvalIPAddress) {
 			ARN(Partition::aws, Service::s3,
 			    "", arbitrary_tenant, "example_bucket")),
 	    Effect::Allow);
-  EXPECT_EQ(allowp.eval(blacklistedIPv6, trueacct, s3ListBucket,
+  EXPECT_EQ(allowp.eval(blocklistedIPv6, trueacct, s3ListBucket,
 			ARN(Partition::aws, Service::s3,
 			    "", arbitrary_tenant, "example_bucket")),
 	    Effect::Pass);
@@ -1053,20 +1053,20 @@ TEST_F(IPPolicyTest, EvalIPAddress) {
 			   "", arbitrary_tenant, "example_bucket/myobject")),
 	    Effect::Deny);
 
-  EXPECT_EQ(denyp.eval(blacklistedIP, trueacct, s3ListBucket,
+  EXPECT_EQ(denyp.eval(blocklistedIP, trueacct, s3ListBucket,
 		       ARN(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket")),
 	    Effect::Pass);
-  EXPECT_EQ(denyp.eval(blacklistedIP, trueacct, s3ListBucket,
+  EXPECT_EQ(denyp.eval(blocklistedIP, trueacct, s3ListBucket,
 		       ARN(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket/myobject")),
 	    Effect::Pass);
 
-  EXPECT_EQ(denyp.eval(blacklistedIPv6, trueacct, s3ListBucket,
+  EXPECT_EQ(denyp.eval(blocklistedIPv6, trueacct, s3ListBucket,
 		       ARN(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket")),
 	    Effect::Pass);
-  EXPECT_EQ(denyp.eval(blacklistedIPv6, trueacct, s3ListBucket,
+  EXPECT_EQ(denyp.eval(blocklistedIPv6, trueacct, s3ListBucket,
 		       ARN(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket/myobject")),
 	    Effect::Pass);
@@ -1088,11 +1088,11 @@ TEST_F(IPPolicyTest, EvalIPAddress) {
 			   "", arbitrary_tenant, "example_bucket/myobject")),
 	    Effect::Allow);
 
-  EXPECT_EQ(fullp.eval(blacklistedIP, trueacct, s3ListBucket,
+  EXPECT_EQ(fullp.eval(blocklistedIP, trueacct, s3ListBucket,
 		       ARN(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket")),
 	    Effect::Pass);
-  EXPECT_EQ(fullp.eval(blacklistedIP, trueacct, s3ListBucket,
+  EXPECT_EQ(fullp.eval(blocklistedIP, trueacct, s3ListBucket,
 		       ARN(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket/myobject")),
 	    Effect::Pass);
@@ -1106,11 +1106,11 @@ TEST_F(IPPolicyTest, EvalIPAddress) {
 			   "", arbitrary_tenant, "example_bucket/myobject")),
 	    Effect::Allow);
 
-  EXPECT_EQ(fullp.eval(blacklistedIPv6, trueacct, s3ListBucket,
+  EXPECT_EQ(fullp.eval(blocklistedIPv6, trueacct, s3ListBucket,
 		       ARN(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket")),
 	    Effect::Pass);
-  EXPECT_EQ(fullp.eval(blacklistedIPv6, trueacct, s3ListBucket,
+  EXPECT_EQ(fullp.eval(blocklistedIPv6, trueacct, s3ListBucket,
 		       ARN(Partition::aws, Service::s3,
 			   "", arbitrary_tenant, "example_bucket/myobject")),
 	    Effect::Pass);

--- a/src/test/test_stress_watch.cc
+++ b/src/test/test_stress_watch.cc
@@ -89,25 +89,25 @@ TEST_P(WatchStress, Stress1) {
     cluster.ioctx_create(pool_name.c_str(), ioctx);
     ASSERT_EQ(0, ioctx.watch("foo", 0, &handle, &ctx));
 
-    bool do_blacklist = i % 2;
-    if (do_blacklist) {
-      cluster.test_blacklist_self(true);
-      std::cerr << "blacklisted" << std::endl;
+    bool do_blocklist = i % 2;
+    if (do_blocklist) {
+      cluster.test_blocklist_self(true);
+      std::cerr << "blocklisted" << std::endl;
       sleep(1);
     }
 
     bufferlist bl2;
     ASSERT_EQ(0, nioctx.notify("foo", 0, bl2));
 
-    if (do_blacklist) {
+    if (do_blocklist) {
       sleep(1); // Give a change to see an incorrect notify
     } else {
       TestAlarm alarm;
       sem_wait(sem);
     }
 
-    if (do_blacklist) {
-      cluster.test_blacklist_self(false);
+    if (do_blocklist) {
+      cluster.test_blocklist_self(false);
     }
 
     ioctx.unwatch("foo", handle);

--- a/src/tools/rbd_mirror/ImageDeleter.cc
+++ b/src/tools/rbd_mirror/ImageDeleter.cc
@@ -262,9 +262,9 @@ void ImageDeleter<I>::enqueue_failed_delete(DeleteInfoRef* delete_info,
                                             int error_code,
                                             double retry_delay) {
   dout(20) << "info=" << *delete_info << ", r=" << error_code << dendl;
-  if (error_code == -EBLACKLISTED) {
+  if (error_code == -EBLOCKLISTED) {
     std::lock_guard locker{m_lock};
-    derr << "blacklisted while deleting local image" << dendl;
+    derr << "blocklisted while deleting local image" << dendl;
     complete_active_delete(delete_info, error_code);
     return;
   }

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -85,9 +85,9 @@ public:
     m_finished = finished;
   }
 
-  inline bool is_blacklisted() const {
+  inline bool is_blocklisted() const {
     std::lock_guard locker{m_lock};
-    return (m_last_r == -EBLACKLISTED);
+    return (m_last_r == -EBLOCKLISTED);
   }
 
   image_replayer::HealthState get_health_state() const;

--- a/src/tools/rbd_mirror/InstanceReplayer.cc
+++ b/src/tools/rbd_mirror/InstanceReplayer.cc
@@ -57,9 +57,9 @@ InstanceReplayer<I>::~InstanceReplayer() {
 }
 
 template <typename I>
-bool InstanceReplayer<I>::is_blacklisted() const {
+bool InstanceReplayer<I>::is_blocklisted() const {
   std::lock_guard locker{m_lock};
-  return m_blacklisted;
+  return m_blocklisted;
 }
 
 template <typename I>
@@ -335,10 +335,10 @@ void InstanceReplayer<I>::start_image_replayer(
   std::string global_image_id = image_replayer->get_global_image_id();
   if (!image_replayer->is_stopped()) {
     return;
-  } else if (image_replayer->is_blacklisted()) {
-    derr << "global_image_id=" << global_image_id << ": blacklisted detected "
+  } else if (image_replayer->is_blocklisted()) {
+    derr << "global_image_id=" << global_image_id << ": blocklisted detected "
          << "during image replay" << dendl;
-    m_blacklisted = true;
+    m_blocklisted = true;
     return;
   } else if (image_replayer->is_finished()) {
     // TODO temporary until policy integrated

--- a/src/tools/rbd_mirror/InstanceReplayer.h
+++ b/src/tools/rbd_mirror/InstanceReplayer.h
@@ -52,7 +52,7 @@ public:
                    PoolMetaCache* pool_meta_cache);
   ~InstanceReplayer();
 
-  bool is_blacklisted() const;
+  bool is_blocklisted() const;
 
   int init();
   void shut_down();
@@ -111,7 +111,7 @@ private:
   Context *m_image_state_check_task = nullptr;
   Context *m_on_shut_down = nullptr;
   bool m_manual_stop = false;
-  bool m_blacklisted = false;
+  bool m_blocklisted = false;
 
   void wait_for_ops();
   void handle_wait_for_ops(int r);

--- a/src/tools/rbd_mirror/InstanceWatcher.cc
+++ b/src/tools/rbd_mirror/InstanceWatcher.cc
@@ -334,7 +334,7 @@ InstanceWatcher<I>::InstanceWatcher(librados::IoCtx &io_ctx,
       unique_lock_name("rbd::mirror::InstanceWatcher::m_lock", this))),
     m_instance_lock(librbd::ManagedLock<I>::create(
       m_ioctx, m_work_queue, m_oid, this, librbd::managed_lock::EXCLUSIVE, true,
-      m_cct->_conf.get_val<uint64_t>("rbd_blacklist_expire_seconds"))) {
+      m_cct->_conf.get_val<uint64_t>("rbd_blocklist_expire_seconds"))) {
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/Instances.cc
+++ b/src/tools/rbd_mirror/Instances.cc
@@ -278,7 +278,7 @@ void Instances<I>::handle_remove_instances(
   dout(10) << "r=" << r << ", instance_ids=" << instance_ids << dendl;
   ceph_assert(r == 0);
 
-  // fire removed notification now that instances have been blacklisted
+  // fire removed notification now that instances have been blocklisted
   m_threads->work_queue->queue(
     new C_NotifyInstancesRemoved(this, instance_ids), 0);
 

--- a/src/tools/rbd_mirror/LeaderWatcher.cc
+++ b/src/tools/rbd_mirror/LeaderWatcher.cc
@@ -38,7 +38,7 @@ LeaderWatcher<I>::LeaderWatcher(Threads<I> *threads, librados::IoCtx &io_ctx,
     m_instance_id(stringify(m_notifier_id)),
     m_leader_lock(new LeaderLock(m_ioctx, m_work_queue, m_oid, this, true,
                                  m_cct->_conf.get_val<uint64_t>(
-                                   "rbd_blacklist_expire_seconds"))) {
+                                   "rbd_blocklist_expire_seconds"))) {
 }
 
 template <typename I>
@@ -250,9 +250,9 @@ void LeaderWatcher<I>::handle_wait_for_tasks() {
 }
 
 template <typename I>
-bool LeaderWatcher<I>::is_blacklisted() const {
+bool LeaderWatcher<I>::is_blocklisted() const {
   std::lock_guard locker{m_lock};
-  return m_blacklisted;
+  return m_blocklisted;
 }
 
 template <typename I>
@@ -1022,9 +1022,9 @@ template <typename I>
 void LeaderWatcher<I>::handle_rewatch_complete(int r) {
   dout(5) << "r=" << r << dendl;
 
-  if (r == -EBLACKLISTED) {
-    dout(1) << "blacklisted detected" << dendl;
-    m_blacklisted = true;
+  if (r == -EBLOCKLISTED) {
+    dout(1) << "blocklisted detected" << dendl;
+    m_blocklisted = true;
     return;
   }
 

--- a/src/tools/rbd_mirror/LeaderWatcher.h
+++ b/src/tools/rbd_mirror/LeaderWatcher.h
@@ -47,7 +47,7 @@ public:
   void init(Context *on_finish);
   void shut_down(Context *on_finish);
 
-  bool is_blacklisted() const;
+  bool is_blocklisted() const;
   bool is_leader() const;
   bool is_releasing_leader() const;
   bool get_leader_instance_id(std::string *instance_id) const;
@@ -121,10 +121,10 @@ private:
 
     LeaderLock(librados::IoCtx& ioctx, librbd::asio::ContextWQ *work_queue,
                const std::string& oid, LeaderWatcher *watcher,
-               bool blacklist_on_break_lock,
-               uint32_t blacklist_expire_seconds)
+               bool blocklist_on_break_lock,
+               uint32_t blocklist_expire_seconds)
       : Parent(ioctx, work_queue, oid, watcher, librbd::managed_lock::EXCLUSIVE,
-               blacklist_on_break_lock, blacklist_expire_seconds),
+               blocklist_on_break_lock, blocklist_expire_seconds),
         watcher(watcher) {
     }
 
@@ -219,7 +219,7 @@ private:
   Instances<ImageCtxT> *m_instances = nullptr;
   librbd::managed_lock::Locker m_locker;
 
-  bool m_blacklisted = false;
+  bool m_blocklisted = false;
 
   AsyncOpTracker m_timer_op_tracker;
   Context *m_timer_task = nullptr;

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -714,8 +714,8 @@ void Mirror::update_pool_replayers(const PoolPeers &pool_peers,
           // TODO: make async
           pool_replayer->shut_down();
           pool_replayer->init(site_name);
-        } else if (pool_replayer->is_blacklisted()) {
-          derr << "restarting blacklisted pool replayer for " << peer << dendl;
+        } else if (pool_replayer->is_blocklisted()) {
+          derr << "restarting blocklisted pool replayer for " << peer << dendl;
           // TODO: make async
           pool_replayer->shut_down();
           pool_replayer->init(site_name);

--- a/src/tools/rbd_mirror/NamespaceReplayer.cc
+++ b/src/tools/rbd_mirror/NamespaceReplayer.cc
@@ -71,13 +71,13 @@ NamespaceReplayer<I>::NamespaceReplayer(
 }
 
 template <typename I>
-bool NamespaceReplayer<I>::is_blacklisted() const {
+bool NamespaceReplayer<I>::is_blocklisted() const {
   std::lock_guard locker{m_lock};
-  return m_instance_replayer->is_blacklisted() ||
+  return m_instance_replayer->is_blocklisted() ||
          (m_local_pool_watcher &&
-          m_local_pool_watcher->is_blacklisted()) ||
+          m_local_pool_watcher->is_blocklisted()) ||
          (m_remote_pool_watcher &&
-          m_remote_pool_watcher->is_blacklisted());
+          m_remote_pool_watcher->is_blocklisted());
 }
 
 template <typename I>
@@ -809,7 +809,7 @@ void NamespaceReplayer<I>::shut_down_image_map(Context *on_finish) {
 template <typename I>
 void NamespaceReplayer<I>::handle_shut_down_image_map(int r, Context *on_finish) {
   dout(5) << "r=" << r << dendl;
-  if (r < 0 && r != -EBLACKLISTED) {
+  if (r < 0 && r != -EBLOCKLISTED) {
     derr << "failed to shut down image map: " << cpp_strerror(r) << dendl;
   }
 

--- a/src/tools/rbd_mirror/NamespaceReplayer.h
+++ b/src/tools/rbd_mirror/NamespaceReplayer.h
@@ -78,7 +78,7 @@ public:
   NamespaceReplayer(const NamespaceReplayer&) = delete;
   NamespaceReplayer& operator=(const NamespaceReplayer&) = delete;
 
-  bool is_blacklisted() const;
+  bool is_blocklisted() const;
 
   void init(Context *on_finish);
   void shut_down(Context *on_finish);

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -249,9 +249,9 @@ PoolReplayer<I>::~PoolReplayer()
 }
 
 template <typename I>
-bool PoolReplayer<I>::is_blacklisted() const {
+bool PoolReplayer<I>::is_blocklisted() const {
   std::lock_guard locker{m_lock};
-  return m_blacklisted;
+  return m_blocklisted;
 }
 
 template <typename I>
@@ -273,7 +273,7 @@ void PoolReplayer<I>::init(const std::string& site_name) {
 
   // reset state
   m_stopping = false;
-  m_blacklisted = false;
+  m_blocklisted = false;
   m_site_name = site_name;
 
   dout(10) << "replaying for " << m_peer << dendl;
@@ -590,15 +590,15 @@ void PoolReplayer<I>::run() {
 
     std::unique_lock locker{m_lock};
 
-    if (m_leader_watcher->is_blacklisted() ||
-        m_default_namespace_replayer->is_blacklisted()) {
-      m_blacklisted = true;
+    if (m_leader_watcher->is_blocklisted() ||
+        m_default_namespace_replayer->is_blocklisted()) {
+      m_blocklisted = true;
       m_stopping = true;
     }
 
     for (auto &it : m_namespace_replayers) {
-      if (it.second->is_blacklisted()) {
-        m_blacklisted = true;
+      if (it.second->is_blocklisted()) {
+        m_blocklisted = true;
         m_stopping = true;
         break;
       }

--- a/src/tools/rbd_mirror/PoolReplayer.h
+++ b/src/tools/rbd_mirror/PoolReplayer.h
@@ -55,7 +55,7 @@ public:
   PoolReplayer(const PoolReplayer&) = delete;
   PoolReplayer& operator=(const PoolReplayer&) = delete;
 
-  bool is_blacklisted() const;
+  bool is_blocklisted() const;
   bool is_leader() const;
   bool is_running() const;
 
@@ -205,7 +205,7 @@ private:
   std::string m_site_name;
   bool m_stopping = false;
   bool m_manual_stop = false;
-  bool m_blacklisted = false;
+  bool m_blocklisted = false;
 
   RadosRef m_local_rados;
   RadosRef m_remote_rados;

--- a/src/tools/rbd_mirror/PoolWatcher.cc
+++ b/src/tools/rbd_mirror/PoolWatcher.cc
@@ -89,9 +89,9 @@ PoolWatcher<I>::~PoolWatcher() {
 }
 
 template <typename I>
-bool PoolWatcher<I>::is_blacklisted() const {
+bool PoolWatcher<I>::is_blocklisted() const {
   std::lock_guard locker{m_lock};
-  return m_blacklisted;
+  return m_blocklisted;
 }
 
 template <typename I>
@@ -171,11 +171,11 @@ void PoolWatcher<I>::handle_register_watcher(int r) {
   Context *on_init_finish = nullptr;
   if (r >= 0) {
     refresh_images();
-  } else if (r == -EBLACKLISTED) {
-    dout(0) << "detected client is blacklisted" << dendl;
+  } else if (r == -EBLOCKLISTED) {
+    dout(0) << "detected client is blocklisted" << dendl;
 
     std::lock_guard locker{m_lock};
-    m_blacklisted = true;
+    m_blocklisted = true;
     std::swap(on_init_finish, m_on_init_finish);
   } else if (r == -ENOENT) {
     dout(5) << "mirroring directory does not exist" << dendl;
@@ -266,10 +266,10 @@ void PoolWatcher<I>::handle_refresh_images(int r) {
       std::swap(on_init_finish, m_on_init_finish);
 
       schedule_listener();
-    } else if (r == -EBLACKLISTED) {
-      dout(0) << "detected client is blacklisted during image refresh" << dendl;
+    } else if (r == -EBLOCKLISTED) {
+      dout(0) << "detected client is blocklisted during image refresh" << dendl;
 
-      m_blacklisted = true;
+      m_blocklisted = true;
       std::swap(on_init_finish, m_on_init_finish);
     } else {
       retry_refresh = true;
@@ -314,11 +314,11 @@ template <typename I>
 void PoolWatcher<I>::handle_rewatch_complete(int r) {
   dout(5) << "r=" << r << dendl;
 
-  if (r == -EBLACKLISTED) {
-    dout(0) << "detected client is blacklisted" << dendl;
+  if (r == -EBLOCKLISTED) {
+    dout(0) << "detected client is blocklisted" << dendl;
 
     std::lock_guard locker{m_lock};
-    m_blacklisted = true;
+    m_blocklisted = true;
     return;
   } else if (r == -ENOENT) {
     dout(5) << "mirroring directory deleted" << dendl;

--- a/src/tools/rbd_mirror/PoolWatcher.h
+++ b/src/tools/rbd_mirror/PoolWatcher.h
@@ -48,7 +48,7 @@ public:
   PoolWatcher(const PoolWatcher&) = delete;
   PoolWatcher& operator=(const PoolWatcher&) = delete;
 
-  bool is_blacklisted() const;
+  bool is_blocklisted() const;
 
   void init(Context *on_finish = nullptr);
   void shut_down(Context *on_finish);
@@ -127,7 +127,7 @@ private:
   Context *m_timer_ctx = nullptr;
 
   AsyncOpTracker m_async_op_tracker;
-  bool m_blacklisted = false;
+  bool m_blocklisted = false;
   bool m_shutting_down = false;
   bool m_image_ids_invalid = true;
   bool m_refresh_in_progress = false;

--- a/src/tools/rbd_mirror/image_deleter/TrashWatcher.cc
+++ b/src/tools/rbd_mirror/image_deleter/TrashWatcher.cc
@@ -96,7 +96,7 @@ void TrashWatcher<I>::handle_rewatch_complete(int r) {
   dout(5) << "r=" << r << dendl;
 
   if (r == -EBLACKLISTED) {
-    dout(0) << "detected client is blacklisted" << dendl;
+    dout(0) << "detected client is blocklisted" << dendl;
     return;
   } else if (r == -ENOENT) {
     dout(5) << "trash directory deleted" << dendl;
@@ -135,9 +135,9 @@ void TrashWatcher<I>::handle_create_trash(int r) {
   }
 
   Context* on_init_finish = nullptr;
-  if (r == -EBLACKLISTED || r == -ENOENT) {
-    if (r == -EBLACKLISTED) {
-      dout(0) << "detected client is blacklisted" << dendl;
+  if (r == -EBLOCKLISTED || r == -ENOENT) {
+    if (r == -EBLOCKLISTED) {
+      dout(0) << "detected client is blocklisted" << dendl;
     } else {
       dout(0) << "detected pool no longer exists" << dendl;
     }
@@ -201,8 +201,8 @@ void TrashWatcher<I>::handle_register_watcher(int r) {
   Context *on_init_finish = nullptr;
   if (r >= 0) {
     trash_list(true);
-  } else if (r == -EBLACKLISTED) {
-    dout(0) << "detected client is blacklisted" << dendl;
+  } else if (r == -EBLOCKLISTED) {
+    dout(0) << "detected client is blocklisted" << dendl;
 
     std::lock_guard locker{m_lock};
     std::swap(on_init_finish, m_on_init_finish);
@@ -287,8 +287,8 @@ void TrashWatcher<I>::handle_trash_list(int r) {
       r = 0;
     }
 
-    if (r == -EBLACKLISTED) {
-      dout(0) << "detected client is blacklisted during trash refresh" << dendl;
+    if (r == -EBLOCKLISTED) {
+      dout(0) << "detected client is blocklisted during trash refresh" << dendl;
       m_trash_list_in_progress = false;
       std::swap(on_init_finish, m_on_init_finish);
     } else if (r >= 0 && images.size() < MAX_RETURN) {
@@ -303,7 +303,7 @@ void TrashWatcher<I>::handle_trash_list(int r) {
     m_last_image_id = images.rbegin()->first;
     trash_list(false);
     return;
-  } else if (r < 0 && r != -EBLACKLISTED) {
+  } else if (r < 0 && r != -EBLOCKLISTED) {
     derr << "failed to retrieve trash directory: " << cpp_strerror(r) << dendl;
     schedule_trash_list(10);
   }


### PR DESCRIPTION
There is no need to use terms that may be viewed as racially charged.

There are a few compatibility challenges there:

- a few config options are renamed.  These are done without backward compatibility.  The mon will remap them on upgrade.
- a few CLI commands are changed.  The old 'blacklist' variants are deprecated but will still work for now.

TODO
- [x] make mon adjust config options automatically
- [ ] include upgrade test (once initial octopus-x tests merge) that sets old configs to magic values, upgrades, and verifies new config options reflect the same values.