### PR TITLE
librbd: switch IO path to use new librados asio API

### DIFF
--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -12,6 +12,7 @@
 
 class Context;
 namespace ceph { template <uint8_t> class BitVector; }
+namespace neorados { struct WriteOp; }
 
 namespace librbd {
 namespace cls_client {
@@ -626,17 +627,24 @@ int namespace_list(librados::IoCtx *ioctx,
                    std::list<std::string> *entries);
 
 // operations on data objects
-int assert_snapc_seq(librados::IoCtx *ioctx, const std::string &oid,
-                     uint64_t snapc_seq,
-                     cls::rbd::AssertSnapcSeqState state);
+void assert_snapc_seq(neorados::WriteOp* op,
+                      uint64_t snapc_seq,
+                      cls::rbd::AssertSnapcSeqState state);
 void assert_snapc_seq(librados::ObjectWriteOperation *op,
                       uint64_t snapc_seq,
                       cls::rbd::AssertSnapcSeqState state);
+int assert_snapc_seq(librados::IoCtx *ioctx, const std::string &oid,
+                     uint64_t snapc_seq,
+                     cls::rbd::AssertSnapcSeqState state);
 
+void copyup(neorados::WriteOp* op, ceph::buffer::list data);
 void copyup(librados::ObjectWriteOperation *op, ceph::buffer::list data);
 int copyup(librados::IoCtx *ioctx, const std::string &oid,
            ceph::buffer::list data);
 
+void sparse_copyup(neorados::WriteOp* op,
+                   const std::map<uint64_t, uint64_t> &extent_map,
+                   ceph::buffer::list data);
 void sparse_copyup(librados::ObjectWriteOperation *op,
                    const std::map<uint64_t, uint64_t> &extent_map,
                    ceph::buffer::list data);

--- a/src/common/Timer.cc
+++ b/src/common/Timer.cc
@@ -107,7 +107,8 @@ void SafeTimer::timer_thread()
     if (schedule.empty()) {
       cond.wait(l);
     } else {
-      cond.wait_until(l, schedule.begin()->first);
+      auto when = schedule.begin()->first;
+      cond.wait_until(l, when);
     }
     ldout(cct,20) << "timer_thread awake" << dendl;
   }

--- a/src/include/neorados/RADOS.hpp
+++ b/src/include/neorados/RADOS.hpp
@@ -551,23 +551,25 @@ public:
   template<typename CompletionToken>
   auto execute(const Object& o, const IOContext& ioc, ReadOp&& op,
 	       ceph::buffer::list* bl,
-	       CompletionToken&& token, uint64_t* objver = nullptr) {
+	       CompletionToken&& token, uint64_t* objver = nullptr,
+	       const blkin_trace_info* trace_info = nullptr) {
     boost::asio::async_completion<CompletionToken, Op::Signature> init(token);
     execute(o, ioc, std::move(op), bl,
 	    ReadOp::Completion::create(get_executor(),
 				       std::move(init.completion_handler)),
-	    objver);
+	    objver, trace_info);
     return init.result.get();
   }
 
   template<typename CompletionToken>
   auto execute(const Object& o, const IOContext& ioc, WriteOp&& op,
-	       CompletionToken&& token, uint64_t* objver = nullptr) {
+	       CompletionToken&& token, uint64_t* objver = nullptr,
+	       const blkin_trace_info* trace_info = nullptr) {
     boost::asio::async_completion<CompletionToken, Op::Signature> init(token);
     execute(o, ioc, std::move(op),
 	    Op::Completion::create(get_executor(),
 				   std::move(init.completion_handler)),
-	    objver);
+	    objver, trace_info);
     return init.result.get();
   }
 
@@ -954,10 +956,11 @@ private:
 
   void execute(const Object& o, const IOContext& ioc, ReadOp&& op,
 	       ceph::buffer::list* bl, std::unique_ptr<Op::Completion> c,
-	       uint64_t* objver);
+	       uint64_t* objver, const blkin_trace_info* trace_info);
 
   void execute(const Object& o, const IOContext& ioc, WriteOp&& op,
-	       std::unique_ptr<Op::Completion> c, uint64_t* objver);
+	       std::unique_ptr<Op::Completion> c, uint64_t* objver,
+	       const blkin_trace_info* trace_info);
 
   void execute(const Object& o, std::int64_t pool, ReadOp&& op,
 	       ceph::buffer::list* bl, std::unique_ptr<Op::Completion> c,

--- a/src/include/neorados/RADOS.hpp
+++ b/src/include/neorados/RADOS.hpp
@@ -941,6 +941,15 @@ public:
 					    std::move(init.completion_handler)));
     return init.result.get();
   }
+
+  template<typename CompletionToken>
+  auto wait_for_latest_osd_map(CompletionToken&& token) {
+    boost::asio::async_completion<CompletionToken, SimpleOpSig> init(token);
+    wait_for_latest_osd_map(
+      SimpleOpComp::create(get_executor(), std::move(init.completion_handler)));
+    return init.result.get();
+  }
+
   uint64_t instance_id() const;
 
 private:
@@ -1073,6 +1082,7 @@ private:
   void enable_application(std::string_view pool, std::string_view app_name,
 			  bool force, std::unique_ptr<SimpleOpComp> c);
 
+  void wait_for_latest_osd_map(std::unique_ptr<SimpleOpComp> c);
 
   // Proxy object to provide access to low-level RADOS messaging clients
   std::unique_ptr<detail::Client> impl;

--- a/src/include/rados/librados_fwd.hpp
+++ b/src/include/rados/librados_fwd.hpp
@@ -1,6 +1,8 @@
 #ifndef __LIBRADOS_FWD_HPP
 #define __LIBRADOS_FWD_HPP
 
+struct blkin_trace_info;
+
 namespace libradosstriper {
 
 class RadosStriper;

--- a/src/librbd/AsioEngine.cc
+++ b/src/librbd/AsioEngine.cc
@@ -22,7 +22,7 @@ AsioEngine::AsioEngine(std::shared_ptr<librados::Rados> rados)
     m_cct(m_rados_api->cct()),
     m_io_context(m_rados_api->get_io_context()),
     m_api_strand(m_io_context),
-    m_context_wq(std::make_unique<asio::ContextWQ>(m_io_context)) {
+    m_context_wq(std::make_unique<asio::ContextWQ>(m_cct, m_io_context)) {
   ldout(m_cct, 20) << dendl;
 
   auto rados_threads = m_cct->_conf.get_val<uint64_t>("librados_thread_count");

--- a/src/librbd/AsioEngine.cc
+++ b/src/librbd/AsioEngine.cc
@@ -20,6 +20,7 @@ AsioEngine::AsioEngine(std::shared_ptr<librados::Rados> rados)
       neorados::RADOS::make_with_librados(*rados))),
     m_cct(m_rados_api->cct()),
     m_io_context(m_rados_api->get_io_context()),
+    m_api_strand(m_io_context),
     m_context_wq(std::make_unique<asio::ContextWQ>(m_io_context)) {
   ldout(m_cct, 20) << dendl;
 

--- a/src/librbd/AsioEngine.cc
+++ b/src/librbd/AsioEngine.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "librbd/AsioEngine.h"
+#include "include/Context.h"
 #include "include/stringify.h"
 #include "include/neorados/RADOS.hpp"
 #include "include/rados/librados.hpp"
@@ -39,6 +40,14 @@ AsioEngine::AsioEngine(librados::IoCtx& io_ctx)
 
 AsioEngine::~AsioEngine() {
   ldout(m_cct, 20) << dendl;
+}
+
+void AsioEngine::dispatch(Context* ctx, int r) {
+  dispatch([ctx, r]() { ctx->complete(r); });
+}
+
+void AsioEngine::post(Context* ctx, int r) {
+  post([ctx, r]() { ctx->complete(r); });
 }
 
 } // namespace librbd

--- a/src/librbd/AsioEngine.cc
+++ b/src/librbd/AsioEngine.cc
@@ -21,7 +21,8 @@ AsioEngine::AsioEngine(std::shared_ptr<librados::Rados> rados)
       neorados::RADOS::make_with_librados(*rados))),
     m_cct(m_rados_api->cct()),
     m_io_context(m_rados_api->get_io_context()),
-    m_api_strand(m_io_context),
+    m_api_strand(std::make_unique<boost::asio::io_context::strand>(
+      m_io_context)),
     m_context_wq(std::make_unique<asio::ContextWQ>(m_cct, m_io_context)) {
   ldout(m_cct, 20) << dendl;
 
@@ -40,6 +41,7 @@ AsioEngine::AsioEngine(librados::IoCtx& io_ctx)
 
 AsioEngine::~AsioEngine() {
   ldout(m_cct, 20) << dendl;
+  m_api_strand.reset();
 }
 
 void AsioEngine::dispatch(Context* ctx, int r) {

--- a/src/librbd/AsioEngine.h
+++ b/src/librbd/AsioEngine.h
@@ -7,9 +7,12 @@
 #include "include/common_fwd.h"
 #include "include/rados/librados_fwd.hpp"
 #include <memory>
+#include <boost/asio/dispatch.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/io_context_strand.hpp>
+#include <boost/asio/post.hpp>
 
+struct Context;
 namespace neorados { struct RADOS; }
 
 namespace librbd {
@@ -48,6 +51,18 @@ public:
   inline asio::ContextWQ* get_work_queue() {
     return m_context_wq.get();
   }
+
+  template <typename T>
+  void dispatch(T&& t) {
+    boost::asio::dispatch(m_io_context, std::forward<T>(t));
+  }
+  void dispatch(Context* ctx, int r);
+
+  template <typename T>
+  void post(T&& t) {
+    boost::asio::post(m_io_context, std::forward<T>(t));
+  }
+  void post(Context* ctx, int r);
 
 private:
   std::shared_ptr<neorados::RADOS> m_rados_api;

--- a/src/librbd/AsioEngine.h
+++ b/src/librbd/AsioEngine.h
@@ -5,12 +5,11 @@
 #define CEPH_LIBRBD_ASIO_ENGINE_H
 
 #include "include/common_fwd.h"
+#include "include/rados/librados_fwd.hpp"
 #include <memory>
-#include <optional>
-#include <thread>
-#include <vector>
-#include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
+
+namespace neorados { struct RADOS; }
 
 namespace librbd {
 
@@ -18,34 +17,38 @@ namespace asio { struct ContextWQ; }
 
 class AsioEngine {
 public:
-  explicit AsioEngine(CephContext* cct);
+  explicit AsioEngine(std::shared_ptr<librados::Rados> rados);
+  explicit AsioEngine(librados::IoCtx& io_ctx);
   ~AsioEngine();
+
+  AsioEngine(AsioEngine&&) = delete;
+  AsioEngine(const AsioEngine&) = delete;
+  AsioEngine& operator=(const AsioEngine&) = delete;
+
+  inline neorados::RADOS& get_rados_api() {
+    return *m_rados_api;
+  }
 
   inline boost::asio::io_context& get_io_context() {
     return m_io_context;
   }
+  inline operator boost::asio::io_context&() {
+    return m_io_context;
+  }
+  inline boost::asio::io_context::executor_type get_executor() {
+    return m_io_context.get_executor();
+  }
 
   inline asio::ContextWQ* get_work_queue() {
-    return m_work_queue.get();
+    return m_context_wq.get();
   }
 
 private:
-  typedef std::vector<std::thread> Threads;
-
-  typedef boost::asio::executor_work_guard<
-    boost::asio::io_context::executor_type> WorkGuard;
-
+  std::shared_ptr<neorados::RADOS> m_rados_api;
   CephContext* m_cct;
-  Threads m_threads;
 
-  boost::asio::io_context m_io_context;
-  std::optional<WorkGuard> m_work_guard;
-
-  std::unique_ptr<asio::ContextWQ> m_work_queue;
-
-  void init();
-  void shut_down();
-
+  boost::asio::io_context& m_io_context;
+  std::unique_ptr<asio::ContextWQ> m_context_wq;
 };
 
 } // namespace librbd

--- a/src/librbd/AsioEngine.h
+++ b/src/librbd/AsioEngine.h
@@ -45,7 +45,7 @@ public:
 
   inline boost::asio::io_context::strand& get_api_strand() {
     // API client callbacks should never fire concurrently
-    return m_api_strand;
+    return *m_api_strand;
   }
 
   inline asio::ContextWQ* get_work_queue() {
@@ -69,7 +69,7 @@ private:
   CephContext* m_cct;
 
   boost::asio::io_context& m_io_context;
-  boost::asio::io_context::strand m_api_strand;
+  std::unique_ptr<boost::asio::io_context::strand> m_api_strand;
   std::unique_ptr<asio::ContextWQ> m_context_wq;
 };
 

--- a/src/librbd/AsioEngine.h
+++ b/src/librbd/AsioEngine.h
@@ -8,6 +8,7 @@
 #include "include/rados/librados_fwd.hpp"
 #include <memory>
 #include <boost/asio/io_context.hpp>
+#include <boost/asio/io_context_strand.hpp>
 
 namespace neorados { struct RADOS; }
 
@@ -39,6 +40,11 @@ public:
     return m_io_context.get_executor();
   }
 
+  inline boost::asio::io_context::strand& get_api_strand() {
+    // API client callbacks should never fire concurrently
+    return m_api_strand;
+  }
+
   inline asio::ContextWQ* get_work_queue() {
     return m_context_wq.get();
   }
@@ -48,6 +54,7 @@ private:
   CephContext* m_cct;
 
   boost::asio::io_context& m_io_context;
+  boost::asio::io_context::strand m_api_strand;
   std::unique_ptr<asio::ContextWQ> m_context_wq;
 };
 

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -234,10 +234,11 @@ target_link_libraries(librbd PRIVATE
   rbd_internal
   rbd_types
   journal
+  libneorados
   librados
-  cls_rbd_client 
-  cls_lock_client 
-  cls_journal_client 
+  cls_rbd_client
+  cls_lock_client
+  cls_journal_client
   ceph-common
   pthread
   ${CMAKE_DL_LIBS}

--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -31,7 +31,7 @@ using ML = ManagedLock<I>;
 template <typename I>
 ExclusiveLock<I>::ExclusiveLock(I &image_ctx)
   : RefCountedObject(image_ctx.cct),
-    ML<I>(image_ctx.md_ctx, image_ctx.op_work_queue, image_ctx.header_oid,
+    ML<I>(image_ctx.md_ctx, *image_ctx.asio_engine, image_ctx.header_oid,
           image_ctx.image_watcher, managed_lock::EXCLUSIVE,
           image_ctx.config.template get_val<bool>("rbd_blacklist_on_break_lock"),
           image_ctx.config.template get_val<uint64_t>("rbd_blacklist_expire_seconds")),

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -172,6 +172,11 @@ librados::IoCtx duplicate_io_ctx(librados::IoCtx& io_ctx) {
     delete state;
 
     delete plugin_registry;
+
+    // destroy our AsioEngine via its shared io_context to ensure that we
+    // aren't executing within an AsioEngine-owned strand
+    auto& io_context = asio_engine->get_io_context();
+    boost::asio::post(io_context, [asio_engine=std::move(asio_engine)]() {});
   }
 
   void ImageCtx::init() {

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -117,7 +117,6 @@ librados::IoCtx duplicate_io_ctx(librados::IoCtx& io_ctx) {
       exclusive_lock(nullptr), object_map(nullptr),
       op_work_queue(asio_engine->get_work_queue()),
       plugin_registry(new PluginRegistry<ImageCtx>(this)),
-      external_callback_completions(32),
       event_socket_completions(32),
       asok_hook(nullptr),
       trace_endpoint("librbd")

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -204,9 +204,6 @@ namespace librbd {
       io::AioCompletion*,
       boost::lockfree::allocator<ceph::allocator<void>>> Completions;
 
-    Completions external_callback_completions;
-    std::atomic<bool> external_callback_in_progress = {false};
-
     Completions event_socket_completions;
     EventSocket event_socket;
 

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <list>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -32,13 +33,14 @@
 #include "librbd/AsyncRequest.h"
 #include "librbd/Types.h"
 
-#include <boost/asio/io_context.hpp>
 #include <boost/lockfree/policies.hpp>
 #include <boost/lockfree/queue.hpp>
 
-class Finisher;
-class ThreadPool;
 class SafeTimer;
+
+namespace neorados {
+class RADOS;
+} // namespace neorados
 
 namespace librbd {
 
@@ -109,6 +111,9 @@ namespace librbd {
     std::string name;
     cls::rbd::SnapshotNamespace snap_namespace;
     std::string snap_name;
+
+    std::shared_ptr<AsioEngine> asio_engine;
+
     IoCtx data_ctx, md_ctx;
     ImageWatcher<ImageCtx> *image_watcher;
     Journal<ImageCtx> *journal;
@@ -180,8 +185,6 @@ namespace librbd {
     ObjectMap<ImageCtx> *object_map;
 
     xlist<operation::ResizeRequest<ImageCtx>*> resize_reqs;
-
-    boost::asio::io_context& io_context;
 
     io::ImageDispatcherInterface *io_image_dispatcher = nullptr;
     io::ObjectDispatcherInterface *io_object_dispatcher = nullptr;
@@ -344,9 +347,6 @@ namespace librbd {
     journal::Policy *get_journal_policy() const;
     void set_journal_policy(journal::Policy *policy);
 
-    static AsioEngine* get_asio_engine(CephContext* cct);
-    static void get_work_queue(CephContext *cct,
-                               asio::ContextWQ **op_work_queue);
     static void get_timer_instance(CephContext *cct, SafeTimer **timer,
                                    ceph::mutex **timer_lock);
   };

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -39,6 +39,7 @@
 class SafeTimer;
 
 namespace neorados {
+class IOContext;
 class RADOS;
 } // namespace neorados
 
@@ -114,7 +115,13 @@ namespace librbd {
 
     std::shared_ptr<AsioEngine> asio_engine;
 
-    IoCtx data_ctx, md_ctx;
+    // New ASIO-style RADOS API
+    neorados::RADOS& rados_api;
+
+    // Legacy RADOS API
+    librados::IoCtx data_ctx;
+    librados::IoCtx md_ctx;
+
     ImageWatcher<ImageCtx> *image_watcher;
     Journal<ImageCtx> *journal;
 
@@ -347,8 +354,14 @@ namespace librbd {
     journal::Policy *get_journal_policy() const;
     void set_journal_policy(journal::Policy *policy);
 
+    void rebuild_data_io_context();
+    IOContext get_data_io_context() const;
+
     static void get_timer_instance(CephContext *cct, SafeTimer **timer,
                                    ceph::mutex **timer_lock);
+
+  private:
+    std::shared_ptr<neorados::IOContext> data_io_context;
   };
 }
 

--- a/src/librbd/ManagedLock.h
+++ b/src/librbd/ManagedLock.h
@@ -17,8 +17,8 @@
 
 namespace librbd {
 
+struct AsioEngine;
 struct ImageCtx;
-
 namespace asio { struct ContextWQ; }
 namespace managed_lock { struct Locker; }
 
@@ -30,19 +30,19 @@ private:
 
 public:
   static ManagedLock *create(librados::IoCtx& ioctx,
-                             asio::ContextWQ *work_queue,
+                             AsioEngine& asio_engine,
                              const std::string& oid, Watcher *watcher,
                              managed_lock::Mode mode,
                              bool blacklist_on_break_lock,
                              uint32_t blacklist_expire_seconds) {
-    return new ManagedLock(ioctx, work_queue, oid, watcher, mode,
+    return new ManagedLock(ioctx, asio_engine, oid, watcher, mode,
                            blacklist_on_break_lock, blacklist_expire_seconds);
   }
   void destroy() {
     delete this;
   }
 
-  ManagedLock(librados::IoCtx& ioctx, asio::ContextWQ *work_queue,
+  ManagedLock(librados::IoCtx& ioctx, AsioEngine& asio_engine,
               const std::string& oid, Watcher *watcher,
               managed_lock::Mode mode, bool blacklist_on_break_lock,
               uint32_t blacklist_expire_seconds);
@@ -211,7 +211,8 @@ private:
 
   librados::IoCtx& m_ioctx;
   CephContext *m_cct;
-  asio::ContextWQ *m_work_queue;
+  AsioEngine& m_asio_engine;
+  asio::ContextWQ* m_work_queue;
   std::string m_oid;
   Watcher *m_watcher;
   managed_lock::Mode m_mode;

--- a/src/librbd/Types.h
+++ b/src/librbd/Types.h
@@ -8,7 +8,10 @@
 #include "cls/rbd/cls_rbd_types.h"
 #include "deep_copy/Types.h"
 #include <map>
+#include <memory>
 #include <string>
+
+namespace neorados { class IOContext; }
 
 namespace librbd {
 
@@ -54,6 +57,8 @@ enum {
 
   l_librbd_last,
 };
+
+typedef std::shared_ptr<neorados::IOContext> IOContext;
 
 typedef std::map<uint64_t, uint64_t> SnapSeqs;
 

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -7,6 +7,7 @@
 #include "common/errno.h"
 #include "common/Cond.h"
 #include "cls/rbd/cls_rbd_client.h"
+#include "librbd/AsioEngine.h"
 #include "librbd/DeepCopyRequest.h"
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
@@ -666,7 +667,6 @@ int Image<I>::deep_copy(I *src, librados::IoCtx& dest_md_ctx,
 template <typename I>
 int Image<I>::deep_copy(I *src, I *dest, bool flatten,
                         ProgressContext &prog_ctx) {
-  CephContext *cct = src->cct;
   librados::snap_t snap_id_start = 0;
   librados::snap_t snap_id_end;
   {
@@ -674,15 +674,14 @@ int Image<I>::deep_copy(I *src, I *dest, bool flatten,
     snap_id_end = src->snap_id;
   }
 
-  asio::ContextWQ *op_work_queue;
-  ImageCtx::get_work_queue(cct, &op_work_queue);
+  AsioEngine asio_engine(src->md_ctx);
 
   C_SaferCond cond;
   SnapSeqs snap_seqs;
   deep_copy::ProgressHandler progress_handler{&prog_ctx};
   auto req = DeepCopyRequest<I>::create(
     src, dest, snap_id_start, snap_id_end, 0U, flatten, boost::none,
-    op_work_queue, &snap_seqs, &progress_handler, &cond);
+    asio_engine.get_work_queue(), &snap_seqs, &progress_handler, &cond);
   req->send();
   int r = cond.wait();
   if (r < 0) {
@@ -824,15 +823,15 @@ int Image<I>::remove(IoCtx& io_ctx, const std::string &image_name,
     // fall-through if trash isn't supported
   }
 
-  asio::ContextWQ *op_work_queue;
-  ImageCtx::get_work_queue(cct, &op_work_queue);
+  AsioEngine asio_engine(io_ctx);
 
   // might be a V1 image format that cannot be moved to the trash
   // and would not have been listed in the V2 directory -- or the OSDs
   // are too old and don't support the trash feature
   C_SaferCond cond;
   auto req = librbd::image::RemoveRequest<I>::create(
-    io_ctx, image_name, "", false, false, prog_ctx, op_work_queue, &cond);
+    io_ctx, image_name, "", false, false, prog_ctx,
+    asio_engine.get_work_queue(), &cond);
   req->send();
 
   return cond.wait();

--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -8,6 +8,7 @@
 #include "common/dout.h"
 #include "common/errno.h"
 #include "cls/rbd/cls_rbd_client.h"
+#include "librbd/AsioEngine.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
 #include "librbd/Journal.h"
@@ -1940,8 +1941,7 @@ int Mirror<I>::image_info_list(
       break;
     }
 
-    asio::ContextWQ *op_work_queue;
-    ImageCtx::get_work_queue(cct, &op_work_queue);
+    AsioEngine asio_engine(io_ctx);
 
     for (auto &it : images) {
       auto &image_id = it.first;
@@ -1956,7 +1956,7 @@ int Mirror<I>::image_info_list(
       // need to call get_info for every image to retrieve promotion state
 
       mirror_image_info_t info;
-      r = image_get_info(io_ctx, op_work_queue, image_id, &info);
+      r = image_get_info(io_ctx, asio_engine.get_work_queue(), image_id, &info);
       if (r >= 0) {
         (*entries)[image_id] = std::make_pair(mode, info);
       }

--- a/src/librbd/api/Pool.cc
+++ b/src/librbd/api/Pool.cc
@@ -9,6 +9,7 @@
 #include "common/Throttle.h"
 #include "cls/rbd/cls_rbd_client.h"
 #include "osd/osd_types.h"
+#include "librbd/AsioEngine.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/Utils.h"
 #include "librbd/api/Config.h"
@@ -251,11 +252,11 @@ int Pool<I>::init(librados::IoCtx& io_ctx, bool force) {
     return 0;
   }
 
-  asio::ContextWQ *op_work_queue;
-  ImageCtx::get_work_queue(cct, &op_work_queue);
+  AsioEngine asio_engine(io_ctx);
 
   C_SaferCond ctx;
-  auto req = image::ValidatePoolRequest<I>::create(io_ctx, op_work_queue, &ctx);
+  auto req = image::ValidatePoolRequest<I>::create(
+    io_ctx, asio_engine.get_work_queue(), &ctx);
   req->send();
 
   return ctx.wait();

--- a/src/librbd/asio/ContextWQ.cc
+++ b/src/librbd/asio/ContextWQ.cc
@@ -4,16 +4,28 @@
 #include "librbd/asio/ContextWQ.h"
 #include "include/Context.h"
 #include "common/Cond.h"
+#include "common/dout.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::asio::ContextWQ: " \
+                           << this << " " << __func__ << ": "
 
 namespace librbd {
 namespace asio {
 
-ContextWQ::ContextWQ(boost::asio::io_context& io_context)
-  : m_io_context(io_context), m_strand(io_context),
+ContextWQ::ContextWQ(CephContext* cct, boost::asio::io_context& io_context)
+  : m_cct(cct), m_io_context(io_context), m_strand(io_context),
     m_queued_ops(0) {
+  ldout(m_cct, 20) << dendl;
+}
+
+ContextWQ::~ContextWQ() {
+  ldout(m_cct, 20) << dendl;
 }
 
 void ContextWQ::drain() {
+  ldout(m_cct, 20) << dendl;
   C_SaferCond ctx;
   drain_handler(&ctx);
   ctx.wait();

--- a/src/librbd/asio/ContextWQ.cc
+++ b/src/librbd/asio/ContextWQ.cc
@@ -22,6 +22,7 @@ ContextWQ::ContextWQ(CephContext* cct, boost::asio::io_context& io_context)
 
 ContextWQ::~ContextWQ() {
   ldout(m_cct, 20) << dendl;
+  drain();
 }
 
 void ContextWQ::drain() {

--- a/src/librbd/asio/ContextWQ.h
+++ b/src/librbd/asio/ContextWQ.h
@@ -7,6 +7,7 @@
 #include "include/common_fwd.h"
 #include "include/Context.h"
 #include <atomic>
+#include <memory>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/post.hpp>
@@ -26,7 +27,7 @@ public:
 
     // ensure all legacy ContextWQ users are dispatched sequentially for
     // backwards compatibility (i.e. might not be concurrent thread-safe)
-    boost::asio::post(m_strand, [this, ctx, r]() {
+    boost::asio::post(*m_strand, [this, ctx, r]() {
       ctx->complete(r);
 
       ceph_assert(m_queued_ops > 0);
@@ -37,7 +38,7 @@ public:
 private:
   CephContext* m_cct;
   boost::asio::io_context& m_io_context;
-  boost::asio::io_context::strand m_strand;
+  std::unique_ptr<boost::asio::io_context::strand> m_strand;
 
   std::atomic<uint64_t> m_queued_ops;
 

--- a/src/librbd/asio/ContextWQ.h
+++ b/src/librbd/asio/ContextWQ.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_LIBRBD_ASIO_CONTEXT_WQ_H
 #define CEPH_LIBRBD_ASIO_CONTEXT_WQ_H
 
+#include "include/common_fwd.h"
 #include "include/Context.h"
 #include <atomic>
 #include <boost/asio/io_context.hpp>
@@ -15,7 +16,8 @@ namespace asio {
 
 class ContextWQ {
 public:
-  explicit ContextWQ(boost::asio::io_context& io_context);
+  explicit ContextWQ(CephContext* cct, boost::asio::io_context& io_context);
+  ~ContextWQ();
 
   void drain();
 
@@ -33,6 +35,7 @@ public:
   }
 
 private:
+  CephContext* m_cct;
   boost::asio::io_context& m_io_context;
   boost::asio::io_context::strand m_strand;
 

--- a/src/librbd/asio/Utils.h
+++ b/src/librbd/asio/Utils.h
@@ -1,0 +1,33 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_ASIO_UTILS_H
+#define CEPH_LIBRBD_ASIO_UTILS_H
+
+#include "include/Context.h"
+#include "include/rados/librados_fwd.hpp"
+#include <boost/system/error_code.hpp>
+
+namespace librbd {
+namespace asio {
+namespace util {
+
+template <typename T>
+auto get_context_adapter(T&& t) {
+  return [t = std::move(t)](boost::system::error_code ec) {
+      t->complete(-ec.value());
+    };
+}
+
+template <typename T>
+auto get_callback_adapter(T&& t) {
+  return [t = std::move(t)](boost::system::error_code ec, auto&& ... args) {
+      t(-ec.value(), std::forward<decltype(args)>(args)...);
+    };
+}
+
+} // namespace util
+} // namespace asio
+} // namespace librbd
+
+#endif // CEPH_LIBRBD_ASIO_UTILS_H

--- a/src/librbd/cache/ObjectCacherObjectDispatch.cc
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.cc
@@ -183,7 +183,7 @@ template <typename I>
 bool ObjectCacherObjectDispatch<I>::read(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     librados::snap_t snap_id, int op_flags, const ZTracer::Trace &parent_trace,
-    ceph::bufferlist* read_data, io::ExtentMap* extent_map,
+    ceph::bufferlist* read_data, io::Extents* extent_map,
     int* object_dispatch_flags, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   // IO chained in reverse order

--- a/src/librbd/cache/ObjectCacherObjectDispatch.h
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.h
@@ -45,7 +45,7 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      io::ExtentMap* extent_map, int* object_dispatch_flags,
+      io::Extents* extent_map, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 

--- a/src/librbd/cache/ParentCacheObjectDispatch.cc
+++ b/src/librbd/cache/ParentCacheObjectDispatch.cc
@@ -66,7 +66,7 @@ bool ParentCacheObjectDispatch<I>::read(
     uint64_t object_no, uint64_t object_off,
     uint64_t object_len, librados::snap_t snap_id, int op_flags,
     const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-    io::ExtentMap* extent_map, int* object_dispatch_flags,
+    io::Extents* extent_map, int* object_dispatch_flags,
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/cache/ParentCacheObjectDispatch.h
+++ b/src/librbd/cache/ParentCacheObjectDispatch.h
@@ -43,7 +43,7 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      io::ExtentMap* extent_map, int* object_dispatch_flags,
+      io::Extents* extent_map, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 

--- a/src/librbd/cache/WriteAroundObjectDispatch.cc
+++ b/src/librbd/cache/WriteAroundObjectDispatch.cc
@@ -59,7 +59,7 @@ template <typename I>
 bool WriteAroundObjectDispatch<I>::read(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     librados::snap_t snap_id, int op_flags, const ZTracer::Trace &parent_trace,
-    ceph::bufferlist* read_data, io::ExtentMap* extent_map,
+    ceph::bufferlist* read_data, io::Extents* extent_map,
     int* object_dispatch_flags, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   return dispatch_unoptimized_io(object_no, object_off, object_len,

--- a/src/librbd/cache/WriteAroundObjectDispatch.h
+++ b/src/librbd/cache/WriteAroundObjectDispatch.h
@@ -45,7 +45,7 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      io::ExtentMap* extent_map, int* object_dispatch_flags,
+      io::Extents* extent_map, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 

--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -483,6 +483,7 @@ Context *OpenRequest<I>::handle_v2_get_data_pool(int *result) {
       m_image_ctx->data_ctx.close();
     } else {
       m_image_ctx->data_ctx.set_namespace(m_image_ctx->md_ctx.get_namespace());
+      m_image_ctx->rebuild_data_io_context();
     }
   } else {
     data_pool_id = m_image_ctx->md_ctx.get_id();

--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -1385,6 +1385,7 @@ void RefreshRequest<I>::apply() {
   if (m_image_ctx.data_ctx.is_valid()) {
     m_image_ctx.data_ctx.selfmanaged_snap_set_write_ctx(m_image_ctx.snapc.seq,
                                                         m_image_ctx.snaps);
+    m_image_ctx.rebuild_data_io_context();
   }
 
   // handle dynamically enabled / disabled features

--- a/src/librbd/io/AioCompletion.cc
+++ b/src/librbd/io/AioCompletion.cc
@@ -157,10 +157,9 @@ void AioCompletion::queue_complete() {
   add_request();
 
   // ensure completion fires in clean lock context
-  boost::asio::post(*ictx->asio_engine, boost::asio::bind_executor(
-    ictx->asio_engine->get_api_strand(), [this]() {
+  boost::asio::post(ictx->asio_engine->get_api_strand(), [this]() {
       complete_request(0);
-    }));
+    });
 }
 
 void AioCompletion::block(CephContext* cct) {
@@ -261,12 +260,11 @@ void AioCompletion::complete_external_callback() {
 
   // ensure librbd external users never experience concurrent callbacks
   // from multiple librbd-internal threads.
-  boost::asio::dispatch(*ictx->asio_engine, boost::asio::bind_executor(
-    ictx->asio_engine->get_api_strand(), [this]() {
+  boost::asio::dispatch(ictx->asio_engine->get_api_strand(), [this]() {
       complete_cb(rbd_comp, complete_arg);
       complete_event_socket();
       put();
-    }));
+    });
 }
 
 void AioCompletion::complete_event_socket() {

--- a/src/librbd/io/AioCompletion.cc
+++ b/src/librbd/io/AioCompletion.cc
@@ -9,11 +9,13 @@
 #include "common/errno.h"
 #include "common/perf_counters.h"
 
+#include "librbd/AsioEngine.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/internal.h"
 #include "librbd/Journal.h"
 #include "librbd/Types.h"
-#include "librbd/asio/ContextWQ.h"
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/post.hpp>
 
 #ifdef WITH_LTTNG
 #include "tracing/librbd.h"
@@ -152,8 +154,13 @@ void AioCompletion::queue_complete() {
   pending_count.compare_exchange_strong(zero, 1);
   ceph_assert(zero == 0);
 
+  add_request();
+
   // ensure completion fires in clean lock context
-  ictx->op_work_queue->queue(new C_AioRequest(this), 0);
+  boost::asio::post(ictx->asio_engine, boost::asio::bind_executor(
+    ictx->asio_engine.get_api_strand(), [this]() {
+      complete_request(0);
+    }));
 }
 
 void AioCompletion::block(CephContext* cct) {
@@ -250,29 +257,16 @@ ssize_t AioCompletion::get_return_value() {
 }
 
 void AioCompletion::complete_external_callback() {
+  get();
+
   // ensure librbd external users never experience concurrent callbacks
   // from multiple librbd-internal threads.
-  ictx->external_callback_completions.push(this);
-
-  while (true) {
-    if (ictx->external_callback_in_progress.exchange(true)) {
-      // another thread is concurrently invoking external callbacks
-      break;
-    }
-
-    AioCompletion* aio_comp;
-    while (ictx->external_callback_completions.pop(aio_comp)) {
-      aio_comp->complete_cb(aio_comp->rbd_comp, aio_comp->complete_arg);
-      aio_comp->complete_event_socket();
-    }
-
-    ictx->external_callback_in_progress.store(false);
-    if (ictx->external_callback_completions.empty()) {
-      // queue still empty implies we didn't have a race between the last failed
-      // pop and resetting the in-progress state
-      break;
-    }
-  }
+  boost::asio::dispatch(ictx->asio_engine, boost::asio::bind_executor(
+    ictx->asio_engine.get_api_strand(), [this]() {
+      complete_cb(rbd_comp, complete_arg);
+      complete_event_socket();
+      put();
+    }));
 }
 
 void AioCompletion::complete_event_socket() {

--- a/src/librbd/io/AioCompletion.cc
+++ b/src/librbd/io/AioCompletion.cc
@@ -157,8 +157,8 @@ void AioCompletion::queue_complete() {
   add_request();
 
   // ensure completion fires in clean lock context
-  boost::asio::post(ictx->asio_engine, boost::asio::bind_executor(
-    ictx->asio_engine.get_api_strand(), [this]() {
+  boost::asio::post(*ictx->asio_engine, boost::asio::bind_executor(
+    ictx->asio_engine->get_api_strand(), [this]() {
       complete_request(0);
     }));
 }
@@ -261,8 +261,8 @@ void AioCompletion::complete_external_callback() {
 
   // ensure librbd external users never experience concurrent callbacks
   // from multiple librbd-internal threads.
-  boost::asio::dispatch(ictx->asio_engine, boost::asio::bind_executor(
-    ictx->asio_engine.get_api_strand(), [this]() {
+  boost::asio::dispatch(*ictx->asio_engine, boost::asio::bind_executor(
+    ictx->asio_engine->get_api_strand(), [this]() {
       complete_cb(rbd_comp, complete_arg);
       complete_event_socket();
       put();

--- a/src/librbd/io/AioCompletion.h
+++ b/src/librbd/io/AioCompletion.h
@@ -181,7 +181,7 @@ private:
   void queue_complete();
   void complete_external_callback();
   void complete_event_socket();
-
+  void notify_callbacks_complete();
 };
 
 class C_AioRequest : public Context {

--- a/src/librbd/io/AsyncOperation.cc
+++ b/src/librbd/io/AsyncOperation.cc
@@ -2,10 +2,10 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "librbd/io/AsyncOperation.h"
-#include "librbd/ImageCtx.h"
-#include "librbd/asio/ContextWQ.h"
-#include "common/dout.h"
 #include "include/ceph_assert.h"
+#include "common/dout.h"
+#include "librbd/AsioEngine.h"
+#include "librbd/ImageCtx.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -70,7 +70,7 @@ void AsyncOperation::finish_op() {
   if (!m_flush_contexts.empty()) {
     C_CompleteFlushes *ctx = new C_CompleteFlushes(m_image_ctx,
                                                    std::move(m_flush_contexts));
-    m_image_ctx->op_work_queue->queue(ctx);
+    m_image_ctx->asio_engine->post(ctx, 0);
   }
 }
 
@@ -87,7 +87,7 @@ void AsyncOperation::flush(Context* on_finish) {
     }
   }
 
-  m_image_ctx->op_work_queue->queue(on_finish);
+  m_image_ctx->asio_engine->post(on_finish, 0);
 }
 
 } // namespace io

--- a/src/librbd/io/CopyupRequest.h
+++ b/src/librbd/io/CopyupRequest.h
@@ -5,7 +5,6 @@
 #define CEPH_LIBRBD_IO_COPYUP_REQUEST_H
 
 #include "include/int_types.h"
-#include "include/rados/librados.hpp"
 #include "include/buffer.h"
 #include "common/ceph_mutex.h"
 #include "common/zipkin_trace.h"

--- a/src/librbd/io/CopyupRequest.h
+++ b/src/librbd/io/CopyupRequest.h
@@ -99,6 +99,7 @@ private:
   ceph::mutex m_lock = ceph::make_mutex("CopyupRequest", false);
   WriteRequests m_pending_requests;
   unsigned m_pending_copyups = 0;
+  int m_copyup_ret_val = 0;
 
   WriteRequests m_restart_requests;
   bool m_append_request_permitted = true;

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -42,7 +42,7 @@ struct C_RBD_Readahead : public Context {
   uint64_t length;
 
   bufferlist read_data;
-  io::ExtentMap extent_map;
+  io::Extents extent_map;
 
   C_RBD_Readahead(I *ictx, uint64_t object_no, uint64_t offset, uint64_t length)
     : ictx(ictx), object_no(object_no), offset(offset), length(length) {

--- a/src/librbd/io/ObjectDispatch.cc
+++ b/src/librbd/io/ObjectDispatch.cc
@@ -35,7 +35,7 @@ template <typename I>
 bool ObjectDispatch<I>::read(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     librados::snap_t snap_id, int op_flags, const ZTracer::Trace &parent_trace,
-    ceph::bufferlist* read_data, ExtentMap* extent_map,
+    ceph::bufferlist* read_data, Extents* extent_map,
     int* object_dispatch_flags, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/io/ObjectDispatch.cc
+++ b/src/librbd/io/ObjectDispatch.cc
@@ -3,9 +3,9 @@
 
 #include "librbd/io/ObjectDispatch.h"
 #include "common/dout.h"
+#include "librbd/AsioEngine.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/Utils.h"
-#include "librbd/asio/ContextWQ.h"
 #include "librbd/io/ObjectRequest.h"
 
 #define dout_subsys ceph_subsys_rbd
@@ -28,7 +28,7 @@ void ObjectDispatch<I>::shut_down(Context* on_finish) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 5) << dendl;
 
-  m_image_ctx->op_work_queue->queue(on_finish, 0);
+  m_image_ctx->asio_engine->post(on_finish, 0);
 }
 
 template <typename I>

--- a/src/librbd/io/ObjectDispatch.h
+++ b/src/librbd/io/ObjectDispatch.h
@@ -37,7 +37,7 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      ExtentMap* extent_map, int* object_dispatch_flags,
+      Extents* extent_map, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 

--- a/src/librbd/io/ObjectDispatchInterface.h
+++ b/src/librbd/io/ObjectDispatchInterface.h
@@ -36,7 +36,7 @@ struct ObjectDispatchInterface {
   virtual bool read(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       librados::snap_t snap_id, int op_flags,const ZTracer::Trace &parent_trace,
-      ceph::bufferlist* read_data, ExtentMap* extent_map,
+      ceph::bufferlist* read_data, Extents* extent_map,
       int* object_dispatch_flags, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) = 0;
 

--- a/src/librbd/io/ObjectDispatchSpec.h
+++ b/src/librbd/io/ObjectDispatchSpec.h
@@ -47,11 +47,11 @@ public:
     uint64_t object_len;
     librados::snap_t snap_id;
     ceph::bufferlist* read_data;
-    ExtentMap* extent_map;
+    Extents* extent_map;
 
     ReadRequest(uint64_t object_no, uint64_t object_off, uint64_t object_len,
                 librados::snap_t snap_id, ceph::bufferlist* read_data,
-                ExtentMap* extent_map)
+                Extents* extent_map)
       : RequestBase(object_no, object_off),
         object_len(object_len), snap_id(snap_id), read_data(read_data),
         extent_map(extent_map) {
@@ -156,7 +156,7 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      ExtentMap* extent_map, Context* on_finish) {
+      Extents* extent_map, Context* on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
                                   ReadRequest{object_no, object_off,

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -8,6 +8,7 @@
 #include "common/ceph_mutex.h"
 #include "include/Context.h"
 #include "include/err.h"
+#include "include/neorados/RADOS.hpp"
 #include "osd/osd_types.h"
 
 #include "librbd/AsioEngine.h"
@@ -15,10 +16,12 @@
 #include "librbd/ImageCtx.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/Utils.h"
+#include "librbd/asio/Utils.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/CopyupRequest.h"
 #include "librbd/io/ImageRequest.h"
 #include "librbd/io/ReadResult.h"
+#include "librbd/io/Utils.h"
 
 #include <boost/bind.hpp>
 #include <boost/optional.hpp>
@@ -102,7 +105,7 @@ ObjectRequest<I>::ObjectRequest(
     const ZTracer::Trace &trace, Context *completion)
   : m_ictx(ictx), m_object_no(objectno), m_object_off(off),
     m_object_len(len), m_snap_id(snap_id), m_completion(completion),
-    m_trace(util::create_trace(*ictx, "", trace)) {
+    m_trace(librbd::util::create_trace(*ictx, "", trace)) {
   ceph_assert(m_ictx->data_ctx.is_valid());
   if (m_trace.valid()) {
     m_trace.copy_name(trace_name + std::string(" ") +
@@ -112,14 +115,15 @@ ObjectRequest<I>::ObjectRequest(
 }
 
 template <typename I>
-void ObjectRequest<I>::add_write_hint(I& image_ctx,
-                                      librados::ObjectWriteOperation *wr) {
+void ObjectRequest<I>::add_write_hint(I& image_ctx, neorados::WriteOp* wr) {
+  auto alloc_hint_flags = static_cast<neorados::alloc_hint::alloc_hint_t>(
+    image_ctx.alloc_hint_flags);
   if (image_ctx.enable_alloc_hint) {
-    wr->set_alloc_hint2(image_ctx.get_object_size(),
-                        image_ctx.get_object_size(),
-                        image_ctx.alloc_hint_flags);
+    wr->set_alloc_hint(image_ctx.get_object_size(),
+                       image_ctx.get_object_size(),
+                       alloc_hint_flags);
   } else if (image_ctx.alloc_hint_flags != 0U) {
-    wr->set_alloc_hint2(0, 0, image_ctx.alloc_hint_flags);
+    wr->set_alloc_hint(0, 0, alloc_hint_flags);
   }
 }
 
@@ -181,7 +185,7 @@ template <typename I>
 ObjectReadRequest<I>::ObjectReadRequest(
     I *ictx, uint64_t objectno, uint64_t offset, uint64_t len,
     librados::snap_t snap_id, int op_flags, const ZTracer::Trace &parent_trace,
-    bufferlist* read_data, ExtentMap* extent_map, Context *completion)
+    bufferlist* read_data, Extents* extent_map, Context *completion)
   : ObjectRequest<I>(ictx, objectno, offset, len, snap_id, "read",
                      parent_trace, completion),
     m_op_flags(op_flags), m_read_data(read_data), m_extent_map(extent_map) {
@@ -209,25 +213,22 @@ void ObjectReadRequest<I>::read_object() {
 
   ldout(image_ctx->cct, 20) << dendl;
 
-  librados::ObjectReadOperation op;
+  neorados::ReadOp read_op;
   if (this->m_object_len >= image_ctx->sparse_read_threshold_bytes) {
-    op.sparse_read(this->m_object_off, this->m_object_len, m_extent_map,
-                   m_read_data, nullptr);
+    read_op.sparse_read(this->m_object_off, this->m_object_len, m_read_data,
+                        m_extent_map);
   } else {
-    op.read(this->m_object_off, this->m_object_len, m_read_data, nullptr);
+    read_op.read(this->m_object_off, this->m_object_len, m_read_data);
   }
-  op.set_op_flags2(m_op_flags);
+  util::apply_op_flags(m_op_flags, image_ctx->get_read_flags(this->m_snap_id),
+                       &read_op);
 
-  librados::AioCompletion *rados_completion = util::create_rados_callback<
-    ObjectReadRequest<I>, &ObjectReadRequest<I>::handle_read_object>(this);
-  int flags = image_ctx->get_read_flags(this->m_snap_id);
-  int r = image_ctx->data_ctx.aio_operate(
-    data_object_name(this->m_ictx, this->m_object_no), rados_completion, &op,
-    flags, nullptr,
-    (this->m_trace.valid() ? this->m_trace.get_info() : nullptr));
-  ceph_assert(r == 0);
-
-  rados_completion->release();
+  image_ctx->rados_api.execute(
+    {data_object_name(this->m_ictx, this->m_object_no)},
+    *image_ctx->get_data_io_context(), std::move(read_op), nullptr,
+    librbd::asio::util::get_callback_adapter(
+      [this](int r) { handle_read_object(r); }), nullptr,
+      (this->m_trace.valid() ? this->m_trace.get_info() : nullptr));
 }
 
 template <typename I>
@@ -279,7 +280,7 @@ void ObjectReadRequest<I>::read_parent() {
 
   auto parent_completion = AioCompletion::create_and_start<
     ObjectReadRequest<I>, &ObjectReadRequest<I>::handle_read_parent>(
-      this, util::get_image_ctx(image_ctx->parent), AIO_TYPE_READ);
+      this, librbd::util::get_image_ctx(image_ctx->parent), AIO_TYPE_READ);
   ImageRequest<I>::aio_read(image_ctx->parent, parent_completion,
                             std::move(parent_extents), ReadResult{m_read_data},
                             0, this->m_trace);
@@ -387,7 +388,7 @@ void AbstractObjectWriteRequest<I>::compute_parent_info() {
 
 template <typename I>
 void AbstractObjectWriteRequest<I>::add_write_hint(
-    librados::ObjectWriteOperation *wr) {
+    neorados::WriteOp *wr) {
   I *image_ctx = this->m_ictx;
   std::shared_lock image_locker{image_ctx->image_lock};
   if (image_ctx->object_map == nullptr || !this->m_object_may_exist) {
@@ -477,30 +478,27 @@ void AbstractObjectWriteRequest<I>::write_object() {
   I *image_ctx = this->m_ictx;
   ldout(image_ctx->cct, 20) << dendl;
 
-  librados::ObjectWriteOperation write;
+  neorados::WriteOp write_op;
   if (m_copyup_enabled) {
     ldout(image_ctx->cct, 20) << "guarding write" << dendl;
     if (m_guarding_migration_write) {
       cls_client::assert_snapc_seq(
-        &write, m_snap_seq, cls::rbd::ASSERT_SNAPC_SEQ_LE_SNAPSET_SEQ);
+        &write_op, m_snap_seq, cls::rbd::ASSERT_SNAPC_SEQ_LE_SNAPSET_SEQ);
     } else {
-      write.assert_exists();
+      write_op.assert_exists();
     }
   }
 
-  add_write_hint(&write);
-  add_write_ops(&write);
-  ceph_assert(write.size() != 0);
+  add_write_hint(&write_op);
+  add_write_ops(&write_op);
+  ceph_assert(write_op.size() != 0);
 
-  librados::AioCompletion *rados_completion = util::create_rados_callback<
-    AbstractObjectWriteRequest<I>,
-    &AbstractObjectWriteRequest<I>::handle_write_object>(this);
-  int r = image_ctx->data_ctx.aio_operate(
-    data_object_name(this->m_ictx, this->m_object_no), rados_completion,
-    &write, m_snap_seq, m_snaps,
-    (this->m_trace.valid() ? this->m_trace.get_info() : nullptr));
-  ceph_assert(r == 0);
-  rados_completion->release();
+  image_ctx->rados_api.execute(
+    {data_object_name(this->m_ictx, this->m_object_no)},
+    *image_ctx->get_data_io_context(), std::move(write_op),
+    librbd::asio::util::get_callback_adapter(
+      [this](int r) { handle_write_object(r); }), nullptr,
+      (this->m_trace.valid() ? this->m_trace.get_info() : nullptr));
 }
 
 template <typename I>
@@ -636,33 +634,53 @@ void AbstractObjectWriteRequest<I>::handle_post_write_object_map_update(int r) {
 }
 
 template <typename I>
-void ObjectWriteRequest<I>::add_write_ops(librados::ObjectWriteOperation *wr) {
+void ObjectWriteRequest<I>::add_write_ops(neorados::WriteOp* wr) {
   if (this->m_full_object) {
-    wr->write_full(m_write_data);
+    wr->write_full(bufferlist{m_write_data});
   } else {
-    wr->write(this->m_object_off, m_write_data);
+    wr->write(this->m_object_off, bufferlist{m_write_data});
   }
-  wr->set_op_flags2(m_op_flags);
+  util::apply_op_flags(m_op_flags, 0U, wr);
 }
 
 template <typename I>
-void ObjectWriteSameRequest<I>::add_write_ops(
-    librados::ObjectWriteOperation *wr) {
-  wr->writesame(this->m_object_off, this->m_object_len, m_write_data);
-  wr->set_op_flags2(m_op_flags);
+void ObjectDiscardRequest<I>::add_write_ops(neorados::WriteOp* wr) {
+  switch (m_discard_action) {
+  case DISCARD_ACTION_REMOVE:
+    wr->remove();
+    break;
+  case DISCARD_ACTION_REMOVE_TRUNCATE:
+    wr->create(false);
+    // fall through
+  case DISCARD_ACTION_TRUNCATE:
+    wr->truncate(this->m_object_off);
+    break;
+  case DISCARD_ACTION_ZERO:
+    wr->zero(this->m_object_off, this->m_object_len);
+    break;
+  default:
+    ceph_abort();
+    break;
+  }
 }
 
 template <typename I>
-void ObjectCompareAndWriteRequest<I>::add_write_ops(
-    librados::ObjectWriteOperation *wr) {
-  wr->cmpext(this->m_object_off, m_cmp_bl, nullptr);
+void ObjectWriteSameRequest<I>::add_write_ops(neorados::WriteOp* wr) {
+  wr->writesame(this->m_object_off, this->m_object_len,
+                bufferlist{m_write_data});
+  util::apply_op_flags(m_op_flags, 0U, wr);
+}
+
+template <typename I>
+void ObjectCompareAndWriteRequest<I>::add_write_ops(neorados::WriteOp* wr) {
+  wr->cmpext(this->m_object_off, bufferlist{m_cmp_bl}, nullptr);
 
   if (this->m_full_object) {
-    wr->write_full(m_write_bl);
+    wr->write_full(bufferlist{m_write_bl});
   } else {
-    wr->write(this->m_object_off, m_write_bl);
+    wr->write(this->m_object_off, bufferlist{m_write_bl});
   }
-  wr->set_op_flags2(m_op_flags);
+  util::apply_op_flags(m_op_flags, 0U, wr);
 }
 
 template <typename I>

--- a/src/librbd/io/QosImageDispatch.cc
+++ b/src/librbd/io/QosImageDispatch.cc
@@ -3,8 +3,8 @@
 
 #include "librbd/io/QosImageDispatch.h"
 #include "common/dout.h"
+#include "librbd/AsioEngine.h"
 #include "librbd/ImageCtx.h"
-#include "librbd/asio/ContextWQ.h"
 #include "librbd/io/FlushTracker.h"
 #include <map>
 
@@ -282,7 +282,7 @@ void QosImageDispatch<I>::handle_throttle_ready(Tag&& tag, uint64_t flag) {
 
   if (set_throttle_flag(tag.image_dispatch_flags, flag)) {
     // timer_lock is held -- so dispatch from outside the timer thread
-    m_image_ctx->op_work_queue->queue(tag.on_dispatched, 0);
+    m_image_ctx->asio_engine->post(tag.on_dispatched, 0);
   }
 }
 

--- a/src/librbd/io/QueueImageDispatch.cc
+++ b/src/librbd/io/QueueImageDispatch.cc
@@ -4,9 +4,9 @@
 #include "librbd/io/QueueImageDispatch.h"
 #include "common/dout.h"
 #include "common/Cond.h"
+#include "librbd/AsioEngine.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/Utils.h"
-#include "librbd/asio/ContextWQ.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ImageDispatchSpec.h"
 
@@ -115,7 +115,7 @@ bool QueueImageDispatch<I>::enqueue(
   }
 
   *dispatch_result = DISPATCH_RESULT_CONTINUE;
-  m_image_ctx->op_work_queue->queue(on_dispatched, 0);
+  m_image_ctx->asio_engine->post(on_dispatched, 0);
   return true;
 }
 

--- a/src/librbd/io/ReadResult.h
+++ b/src/librbd/io/ReadResult.h
@@ -43,7 +43,7 @@ public:
     LightweightBufferExtents buffer_extents;
 
     bufferlist bl;
-    ExtentMap extent_map;
+    Extents extent_map;
 
     C_ObjectReadRequest(AioCompletion *aio_completion, uint64_t object_off,
                         uint64_t object_len,

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.cc
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.cc
@@ -213,7 +213,7 @@ template <typename I>
 bool SimpleSchedulerObjectDispatch<I>::read(
     uint64_t object_no, uint64_t object_off, uint64_t object_len,
     librados::snap_t snap_id, int op_flags, const ZTracer::Trace &parent_trace,
-    ceph::bufferlist* read_data, ExtentMap* extent_map,
+    ceph::bufferlist* read_data, Extents* extent_map,
     int* object_dispatch_flags, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.h
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.h
@@ -52,7 +52,7 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      ExtentMap* extent_map, int* object_dispatch_flags,
+      Extents* extent_map, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 

--- a/src/librbd/io/Utils.cc
+++ b/src/librbd/io/Utils.cc
@@ -3,11 +3,31 @@
 
 #include "librbd/io/Utils.h"
 #include "include/buffer.h"
+#include "include/rados/librados.hpp"
+#include "include/neorados/RADOS.hpp"
 #include "osd/osd_types.h"
 
 namespace librbd {
 namespace io {
 namespace util {
+
+void apply_op_flags(uint32_t op_flags, uint32_t flags, neorados::Op* op) {
+  if (op_flags & LIBRADOS_OP_FLAG_FADVISE_RANDOM)
+    op->set_fadvise_random();
+  if (op_flags & LIBRADOS_OP_FLAG_FADVISE_SEQUENTIAL)
+    op->set_fadvise_sequential();
+  if (op_flags & LIBRADOS_OP_FLAG_FADVISE_WILLNEED)
+    op->set_fadvise_willneed();
+  if (op_flags & LIBRADOS_OP_FLAG_FADVISE_DONTNEED)
+    op->set_fadvise_dontneed();
+  if (op_flags & LIBRADOS_OP_FLAG_FADVISE_NOCACHE)
+    op->set_fadvise_nocache();
+
+  if (flags & librados::OPERATION_BALANCE_READS)
+    op->balance_reads();
+  if (flags & librados::OPERATION_LOCALIZE_READS)
+    op->localize_reads();
+}
 
 bool assemble_write_same_extent(
     const LightweightObjectExtent &object_extent, const ceph::bufferlist& data,

--- a/src/librbd/io/Utils.h
+++ b/src/librbd/io/Utils.h
@@ -11,9 +11,13 @@
 
 class ObjectExtent;
 
+namespace neorados { struct Op; }
+
 namespace librbd {
 namespace io {
 namespace util {
+
+void apply_op_flags(uint32_t op_flags, uint32_t flags, neorados::Op* op);
 
 bool assemble_write_same_extent(const LightweightObjectExtent &object_extent,
                                 const ceph::bufferlist& data,

--- a/src/librbd/journal/ObjectDispatch.h
+++ b/src/librbd/journal/ObjectDispatch.h
@@ -41,7 +41,7 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      io::ExtentMap* extent_map, int* object_dispatch_flags,
+      io::Extents* extent_map, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) {
     return false;

--- a/src/librbd/managed_lock/AcquireRequest.h
+++ b/src/librbd/managed_lock/AcquireRequest.h
@@ -16,8 +16,8 @@ class Context;
 
 namespace librbd {
 
+class AsioEngine;
 class Watcher;
-namespace asio { struct ContextWQ; }
 
 namespace managed_lock {
 
@@ -29,7 +29,7 @@ private:
 
 public:
   static AcquireRequest* create(librados::IoCtx& ioctx, Watcher *watcher,
-                                asio::ContextWQ *work_queue,
+                                AsioEngine& asio_engine,
                                 const std::string& oid,
                                 const std::string& cookie,
                                 bool exclusive,
@@ -64,7 +64,7 @@ private:
    */
 
   AcquireRequest(librados::IoCtx& ioctx, Watcher *watcher,
-                 asio::ContextWQ *work_queue, const std::string& oid,
+                 AsioEngine& asio_engine, const std::string& oid,
                  const std::string& cookie, bool exclusive,
                  bool blacklist_on_break_lock,
                  uint32_t blacklist_expire_seconds, Context *on_finish);
@@ -72,7 +72,7 @@ private:
   librados::IoCtx& m_ioctx;
   Watcher *m_watcher;
   CephContext *m_cct;
-  asio::ContextWQ *m_work_queue;
+  AsioEngine& m_asio_engine;
   std::string m_oid;
   std::string m_cookie;
   bool m_exclusive;

--- a/src/librbd/managed_lock/BreakRequest.cc
+++ b/src/librbd/managed_lock/BreakRequest.cc
@@ -12,6 +12,7 @@
 #include "librbd/ImageCtx.h"
 #include "librbd/Utils.h"
 #include "librbd/asio/ContextWQ.h"
+#include "librbd/asio/Utils.h"
 #include "librbd/managed_lock/GetLockerRequest.h"
 
 #define dout_subsys ceph_subsys_rbd
@@ -24,29 +25,6 @@ namespace managed_lock {
 
 using util::create_context_callback;
 using util::create_rados_callback;
-
-namespace {
-
-struct C_BlacklistClient : public Context {
-  librados::IoCtx &ioctx;
-  std::string locker_address;
-  uint32_t expire_seconds;
-  Context *on_finish;
-
-  C_BlacklistClient(librados::IoCtx &ioctx, const std::string &locker_address,
-                    uint32_t expire_seconds, Context *on_finish)
-    : ioctx(ioctx), locker_address(locker_address),
-      expire_seconds(expire_seconds), on_finish(on_finish) {
-  }
-
-  void finish(int r) override {
-    librados::Rados rados(ioctx);
-    r = rados.blacklist_add(locker_address, expire_seconds);
-    on_finish->complete(r);
-  }
-};
-
-} // anonymous namespace
 
 template <typename I>
 BreakRequest<I>::BreakRequest(librados::IoCtx& ioctx,
@@ -173,13 +151,29 @@ void BreakRequest<I>::send_blacklist() {
     return;
   }
 
-  // TODO: need async version of RadosClient::blacklist_add
-  using klass = BreakRequest<I>;
-  Context *ctx = create_context_callback<klass, &klass::handle_blacklist>(
-    this);
-  m_asio_engine.get_work_queue()->queue(
-    new C_BlacklistClient(m_ioctx, m_locker.address,
-                          m_blacklist_expire_seconds, ctx), 0);
+  entity_addr_t locker_addr;
+  if (!locker_addr.parse(m_locker.address.c_str(), 0)) {
+    lderr(m_cct) << "unable to parse locker address: " << m_locker.address
+                 << dendl;
+    finish(-EINVAL);
+    return;
+  }
+
+  std::stringstream cmd;
+  cmd << "{"
+      << "\"prefix\": \"osd blacklist\", "
+      << "\"blacklistop\": \"add\", "
+      << "\"addr\": \"" << locker_addr << "\"";
+  if (m_blacklist_expire_seconds != 0) {
+    cmd << ", \"expire\": " << m_blacklist_expire_seconds << ".0";
+  }
+  cmd << "}";
+
+  bufferlist in_bl;
+  m_asio_engine.get_rados_api().mon_command(
+    {cmd.str()}, in_bl, nullptr, nullptr,
+    librbd::asio::util::get_callback_adapter(
+      [this](int r) { handle_blacklist(r); }));
 }
 
 template <typename I>
@@ -192,6 +186,30 @@ void BreakRequest<I>::handle_blacklist(int r) {
     finish(r);
     return;
   }
+
+  wait_for_osd_map();
+}
+
+template <typename I>
+void BreakRequest<I>::wait_for_osd_map() {
+  ldout(m_cct, 10) << dendl;
+
+  m_asio_engine.get_rados_api().wait_for_latest_osd_map(
+    librbd::asio::util::get_callback_adapter(
+      [this](int r) { handle_wait_for_osd_map(r); }));
+}
+
+template <typename I>
+void BreakRequest<I>::handle_wait_for_osd_map(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to wait for updated OSD map: " << cpp_strerror(r)
+                 << dendl;
+    finish(r);
+    return;
+  }
+
   send_break_lock();
 }
 

--- a/src/librbd/managed_lock/BreakRequest.h
+++ b/src/librbd/managed_lock/BreakRequest.h
@@ -19,6 +19,7 @@ class obj_watch_t;
 
 namespace librbd {
 
+class AsioEngine;
 class ImageCtx;
 template <typename> class Journal;
 namespace asio { struct ContextWQ; }
@@ -29,12 +30,12 @@ template <typename ImageCtxT = ImageCtx>
 class BreakRequest {
 public:
   static BreakRequest* create(librados::IoCtx& ioctx,
-                              asio::ContextWQ *work_queue,
+                              AsioEngine& asio_engine,
                               const std::string& oid, const Locker &locker,
                               bool exclusive, bool blacklist_locker,
                               uint32_t blacklist_expire_seconds,
                               bool force_break_lock, Context *on_finish) {
-    return new BreakRequest(ioctx, work_queue, oid, locker, exclusive,
+    return new BreakRequest(ioctx, asio_engine, oid, locker, exclusive,
                             blacklist_locker, blacklist_expire_seconds,
                             force_break_lock, on_finish);
   }
@@ -67,7 +68,7 @@ private:
 
   librados::IoCtx &m_ioctx;
   CephContext *m_cct;
-  asio::ContextWQ *m_work_queue;
+  AsioEngine& m_asio_engine;
   std::string m_oid;
   Locker m_locker;
   bool m_exclusive;
@@ -83,7 +84,7 @@ private:
 
   Locker m_refreshed_locker;
 
-  BreakRequest(librados::IoCtx& ioctx, asio::ContextWQ *work_queue,
+  BreakRequest(librados::IoCtx& ioctx, AsioEngine& asio_engine,
                const std::string& oid, const Locker &locker,
                bool exclusive, bool blacklist_locker,
                uint32_t blacklist_expire_seconds, bool force_break_lock,

--- a/src/librbd/managed_lock/BreakRequest.h
+++ b/src/librbd/managed_lock/BreakRequest.h
@@ -58,6 +58,9 @@ private:
    * BLACKLIST (skip if disabled)
    *    |
    *    v
+   * WAIT_FOR_OSD_MAP
+   *    |
+   *    v
    * BREAK_LOCK
    *    |
    *    v
@@ -98,6 +101,9 @@ private:
 
   void send_blacklist();
   void handle_blacklist(int r);
+
+  void wait_for_osd_map();
+  void handle_wait_for_osd_map(int r);
 
   void send_break_lock();
   void handle_break_lock(int r);

--- a/src/librbd/operation/SnapshotCreateRequest.cc
+++ b/src/librbd/operation/SnapshotCreateRequest.cc
@@ -433,6 +433,7 @@ void SnapshotCreateRequest<I>::update_snap_context() {
   image_ctx.snapc.snaps.swap(snaps);
   image_ctx.data_ctx.selfmanaged_snap_set_write_ctx(
     image_ctx.snapc.seq, image_ctx.snaps);
+  image_ctx.rebuild_data_io_context();
 
   if (!image_ctx.migration_info.empty()) {
     auto it = image_ctx.migration_info.snap_map.find(CEPH_NOSNAP);

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -27,6 +27,7 @@
 #include "common/ceph_argparse.h"
 #include "common/common_init.h"
 #include "common/hobject.h"
+#include "common/EventTrace.h"
 
 #include "global/global_init.h"
 
@@ -783,19 +784,30 @@ boost::asio::io_context& RADOS::get_io_context() {
 
 void RADOS::execute(const Object& o, const IOContext& _ioc, ReadOp&& _op,
 		    cb::list* bl,
-		    std::unique_ptr<ReadOp::Completion> c, version_t* objver) {
+		    std::unique_ptr<ReadOp::Completion> c, version_t* objver,
+		    const blkin_trace_info *trace_info) {
   auto oid = reinterpret_cast<const object_t*>(&o.impl);
   auto ioc = reinterpret_cast<const IOContextImpl*>(&_ioc.impl);
   auto op = reinterpret_cast<OpImpl*>(&_op.impl);
   auto flags = 0; // Should be in Op.
 
+  ZTracer::Trace trace;
+  if (trace_info) {
+    ZTracer::Trace parent_trace("", nullptr, trace_info);
+    trace.init("rados execute", &impl->objecter->trace_endpoint, &parent_trace);
+  }
+
+  trace.event("init");
   impl->objecter->read(
     *oid, ioc->oloc, std::move(op->op), ioc->snap_seq, bl, flags,
-    std::move(c), objver);
+    std::move(c), objver, nullptr /* data_offset */, 0 /* features */, &trace);
+
+  trace.event("submitted");
 }
 
 void RADOS::execute(const Object& o, const IOContext& _ioc, WriteOp&& _op,
-		    std::unique_ptr<WriteOp::Completion> c, version_t* objver) {
+		    std::unique_ptr<WriteOp::Completion> c, version_t* objver,
+		    const blkin_trace_info *trace_info) {
   auto oid = reinterpret_cast<const object_t*>(&o.impl);
   auto ioc = reinterpret_cast<const IOContextImpl*>(&_ioc.impl);
   auto op = reinterpret_cast<OpImpl*>(&_op.impl);
@@ -806,10 +818,18 @@ void RADOS::execute(const Object& o, const IOContext& _ioc, WriteOp&& _op,
   else
     mtime = ceph::real_clock::now();
 
+  ZTracer::Trace trace;
+  if (trace_info) {
+    ZTracer::Trace parent_trace("", nullptr, trace_info);
+    trace.init("rados execute", &impl->objecter->trace_endpoint, &parent_trace);
+  }
+
+  trace.event("init");
   impl->objecter->mutate(
     *oid, ioc->oloc, std::move(op->op), ioc->snapc,
     mtime, flags,
-    std::move(c), objver);
+    std::move(c), objver, osd_reqid_t{}, &trace);
+  trace.event("submitted");
 }
 
 void RADOS::execute(const Object& o, std::int64_t pool, ReadOp&& _op,

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -789,7 +789,7 @@ void RADOS::execute(const Object& o, const IOContext& _ioc, ReadOp&& _op,
   auto oid = reinterpret_cast<const object_t*>(&o.impl);
   auto ioc = reinterpret_cast<const IOContextImpl*>(&_ioc.impl);
   auto op = reinterpret_cast<OpImpl*>(&_op.impl);
-  auto flags = 0; // Should be in Op.
+  auto flags = op->op.flags;
 
   ZTracer::Trace trace;
   if (trace_info) {
@@ -811,7 +811,7 @@ void RADOS::execute(const Object& o, const IOContext& _ioc, WriteOp&& _op,
   auto oid = reinterpret_cast<const object_t*>(&o.impl);
   auto ioc = reinterpret_cast<const IOContextImpl*>(&_ioc.impl);
   auto op = reinterpret_cast<OpImpl*>(&_op.impl);
-  auto flags = 0; // Should be in Op.
+  auto flags = op->op.flags;
   ceph::real_time mtime;
   if (op->mtime)
     mtime = *op->mtime;

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1558,6 +1558,10 @@ void RADOS::enable_application(std::string_view pool, std::string_view app_name,
   }
 }
 
+void RADOS::wait_for_latest_osd_map(std::unique_ptr<SimpleOpComp> c) {
+  impl->objecter->wait_for_latest_osdmap(std::move(c));
+}
+
 void RADOS::mon_command(std::vector<std::string> command,
 			const cb::list& bl,
 			std::string* outs, cb::list* outbl,

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2931,10 +2931,11 @@ public:
 	      ObjectOperation&& op, const SnapContext& snapc,
 	      ceph::real_time mtime, int flags,
 	      std::unique_ptr<Op::OpComp>&& oncommit,
-	      version_t *objver = NULL, osd_reqid_t reqid = osd_reqid_t()) {
+	      version_t *objver = NULL, osd_reqid_t reqid = osd_reqid_t(),
+	      ZTracer::Trace *parent_trace = nullptr) {
     Op *o = new Op(oid, oloc, std::move(op.ops), flags | global_op_flags |
 		   CEPH_OSD_FLAG_WRITE, std::move(oncommit), objver,
-		   nullptr);
+		   nullptr, parent_trace);
     o->priority = op.priority;
     o->mtime = mtime;
     o->snapc = snapc;
@@ -2990,10 +2991,10 @@ public:
 	    ObjectOperation&& op, snapid_t snapid, ceph::buffer::list *pbl,
 	    int flags, std::unique_ptr<Op::OpComp>&& onack,
 	    version_t *objver = nullptr, int *data_offset = nullptr,
-	    uint64_t features = 0) {
+	    uint64_t features = 0, ZTracer::Trace *parent_trace = nullptr) {
     Op *o = new Op(oid, oloc, std::move(op.ops), flags | global_op_flags |
 		   CEPH_OSD_FLAG_READ, std::move(onack), objver,
-		   data_offset);
+		   data_offset, parent_trace);
     o->priority = op.priority;
     o->snapid = snapid;
     o->outbl = pbl;

--- a/src/osdc/Striper.h
+++ b/src/osdc/Striper.h
@@ -107,8 +107,9 @@
 	const std::vector<std::pair<uint64_t,uint64_t> >& buffer_extents);
       void add_partial_sparse_result(
 	  CephContext *cct, ceph::buffer::list& bl,
-	  const std::map<uint64_t, uint64_t>& bl_map, uint64_t bl_off,
-	  const striper::LightweightBufferExtents& buffer_extents);
+	  const std::vector<std::pair<uint64_t, uint64_t>>& bl_map,
+          uint64_t bl_off,
+          const striper::LightweightBufferExtents& buffer_extents);
 
       void assemble_result(CephContext *cct, ceph::buffer::list& bl,
                            bool zero_tail);
@@ -122,13 +123,6 @@
       void assemble_result(CephContext *cct,
                            std::map<uint64_t, uint64_t> *extent_map,
                            ceph::buffer::list *bl);
-
-    private:
-      void add_partial_sparse_result(
-          CephContext *cct, ceph::buffer::list& bl,
-          std::map<uint64_t, uint64_t>::const_iterator* it,
-          const std::map<uint64_t, uint64_t>::const_iterator& end_it,
-          uint64_t* bl_off, uint64_t tofs, uint64_t tlen);
     };
 
   };

--- a/src/test/cls_rbd/CMakeLists.txt
+++ b/src/test/cls_rbd/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(ceph_test_cls_rbd
 target_link_libraries(ceph_test_cls_rbd
   cls_rbd_client
   cls_lock_client
+  libneorados
   librados
   global
   ${UNITTEST_LIBS}

--- a/src/test/librados_test_stub/CMakeLists.txt
+++ b/src/test/librados_test_stub/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(librados_test_stub_srcs
   LibradosTestStub.cc
+  NeoradosTestStub.cc
   TestClassHandler.cc
   TestIoCtxImpl.cc
   TestMemCluster.cc

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -60,10 +60,6 @@ TestClusterRef get_cluster() {
   return cluster_ref;
 }
 
-} // namespace librados_test_stub
-
-namespace {
-
 librados::TestClassHandler *get_class_handler() {
   static boost::shared_ptr<librados::TestClassHandler> s_class_handler;
   if (!s_class_handler) {
@@ -72,6 +68,10 @@ librados::TestClassHandler *get_class_handler() {
   }
   return s_class_handler.get();
 }
+
+} // namespace librados_test_stub
+
+namespace {
 
 void do_out_buffer(bufferlist& outbl, char **outbuf, size_t *outbuflen) {
   if (outbuf) {
@@ -525,7 +525,8 @@ int IoCtx::exec(const std::string& oid, const char *cls, const char *method,
                 bufferlist& inbl, bufferlist& outbl) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::exec, _1, _2, get_class_handler(), cls,
+    oid, boost::bind(&TestIoCtxImpl::exec, _1, _2,
+                     librados_test_stub::get_class_handler(), cls,
                      method, inbl, &outbl, ctx->get_snap_read(),
                      ctx->get_snap_context()));
 }
@@ -816,8 +817,8 @@ void ObjectOperation::exec(const char *cls, const char *method,
                            bufferlist& inbl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
   o->ops.push_back(boost::bind(&TestIoCtxImpl::exec, _1, _2,
-			       get_class_handler(), cls, method, inbl, _3, _4,
-			       _5));
+			       librados_test_stub::get_class_handler(), cls,
+			       method, inbl, _3, _4, _5));
 }
 
 void ObjectOperation::set_op_flags2(int flags) {
@@ -1492,7 +1493,7 @@ int cls_log(int level, const char *format, ...) {
 }
 
 int cls_register(const char *name, cls_handle_t *handle) {
-  librados::TestClassHandler *cls = get_class_handler();
+  librados::TestClassHandler *cls = librados_test_stub::get_class_handler();
   return cls->create(name, handle);
 }
 
@@ -1500,7 +1501,7 @@ int cls_register_cxx_method(cls_handle_t hclass, const char *method,
     int flags,
     cls_method_cxx_call_t class_call,
     cls_method_handle_t *handle) {
-  librados::TestClassHandler *cls = get_class_handler();
+  librados::TestClassHandler *cls = librados_test_stub::get_class_handler();
   return cls->create_method(hclass, method, class_call, handle);
 }
 
@@ -1509,7 +1510,7 @@ int cls_register_cxx_filter(cls_handle_t hclass,
                             cls_cxx_filter_factory_t fn,
                             cls_filter_handle_t *)
 {
-  librados::TestClassHandler *cls = get_class_handler();
+  librados::TestClassHandler *cls = librados_test_stub::get_class_handler();
   return cls->create_filter(hclass, filter_name, fn);
 }
 

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -428,7 +428,8 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
                        bufferlist *pbl) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
-  return ctx->aio_operate_read(oid, *ops, c->pc, flags, pbl);
+  return ctx->aio_operate_read(oid, *ops, c->pc, flags, pbl,
+                               ctx->get_snap_read());
 }
 
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
@@ -525,7 +526,8 @@ int IoCtx::exec(const std::string& oid, const char *cls, const char *method,
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
     oid, boost::bind(&TestIoCtxImpl::exec, _1, _2, get_class_handler(), cls,
-                     method, inbl, &outbl, ctx->get_snap_context()));
+                     method, inbl, &outbl, ctx->get_snap_read(),
+                     ctx->get_snap_context()));
 }
 
 void IoCtx::from_rados_ioctx_t(rados_ioctx_t p, IoCtx &io) {
@@ -613,7 +615,8 @@ int IoCtx::read(const std::string& oid, bufferlist& bl, size_t len,
                 uint64_t off) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::read, _1, _2, len, off, &bl));
+    oid, boost::bind(&TestIoCtxImpl::read, _1, _2, len, off, &bl,
+                     ctx->get_snap_read()));
 }
 
 int IoCtx::remove(const std::string& oid) {
@@ -663,7 +666,8 @@ int IoCtx::sparse_read(const std::string& oid, std::map<uint64_t,uint64_t>& m,
                        bufferlist& bl, size_t len, uint64_t off) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, &m, &bl));
+    oid, boost::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, &m, &bl,
+                     ctx->get_snap_read()));
 }
 
 int IoCtx::stat(const std::string& oid, uint64_t *psize, time_t *pmtime) {
@@ -733,7 +737,8 @@ int IoCtx::writesame(const std::string& oid, bufferlist& bl, size_t len,
 int IoCtx::cmpext(const std::string& oid, uint64_t off, bufferlist& cmp_bl) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::cmpext, _1, _2, off, cmp_bl));
+    oid, boost::bind(&TestIoCtxImpl::cmpext, _1, _2, off, cmp_bl,
+                     ctx->get_snap_read()));
 }
 
 int IoCtx::application_enable(const std::string& app_name, bool force) {
@@ -804,14 +809,15 @@ ObjectOperation::~ObjectOperation() {
 
 void ObjectOperation::assert_exists() {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::assert_exists, _1, _2));
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::assert_exists, _1, _2, _4));
 }
 
 void ObjectOperation::exec(const char *cls, const char *method,
                            bufferlist& inbl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
   o->ops.push_back(boost::bind(&TestIoCtxImpl::exec, _1, _2,
-			       get_class_handler(), cls, method, inbl, _3, _4));
+			       get_class_handler(), cls, method, inbl, _3, _4,
+			       _5));
 }
 
 void ObjectOperation::set_op_flags2(int flags) {
@@ -825,10 +831,11 @@ size_t ObjectOperation::size() {
 void ObjectOperation::cmpext(uint64_t off, const bufferlist& cmp_bl,
                              int *prval) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  ObjectOperationTestImpl op = boost::bind(&TestIoCtxImpl::cmpext, _1, _2, off, cmp_bl);
+  ObjectOperationTestImpl op = boost::bind(&TestIoCtxImpl::cmpext, _1, _2, off,
+                                           cmp_bl, _4);
   if (prval != NULL) {
     op = boost::bind(save_operation_result,
-                     boost::bind(op, _1, _2, _3, _4), prval);
+                     boost::bind(op, _1, _2, _3, _4, _5), prval);
   }
   o->ops.push_back(op);
 }
@@ -840,7 +847,7 @@ void ObjectReadOperation::list_snaps(snap_set_t *out_snaps, int *prval) {
                                            out_snaps);
   if (prval != NULL) {
     op = boost::bind(save_operation_result,
-                     boost::bind(op, _1, _2, _3, _4), prval);
+                     boost::bind(op, _1, _2, _3, _4, _5), prval);
   }
   o->ops.push_back(op);
 }
@@ -853,7 +860,7 @@ void ObjectReadOperation::list_watchers(std::list<obj_watch_t> *out_watchers,
                                            _2, out_watchers);
   if (prval != NULL) {
     op = boost::bind(save_operation_result,
-                     boost::bind(op, _1, _2, _3, _4), prval);
+                     boost::bind(op, _1, _2, _3, _4, _5), prval);
   }
   o->ops.push_back(op);
 }
@@ -864,14 +871,14 @@ void ObjectReadOperation::read(size_t off, uint64_t len, bufferlist *pbl,
 
   ObjectOperationTestImpl op;
   if (pbl != NULL) {
-    op = boost::bind(&TestIoCtxImpl::read, _1, _2, len, off, pbl);
+    op = boost::bind(&TestIoCtxImpl::read, _1, _2, len, off, pbl, _4);
   } else {
-    op = boost::bind(&TestIoCtxImpl::read, _1, _2, len, off, _3);
+    op = boost::bind(&TestIoCtxImpl::read, _1, _2, len, off, _3, _4);
   }
 
   if (prval != NULL) {
     op = boost::bind(save_operation_result,
-                     boost::bind(op, _1, _2, _3, _4), prval);
+                     boost::bind(op, _1, _2, _3, _4, _5), prval);
   }
   o->ops.push_back(op);
 }
@@ -883,14 +890,14 @@ void ObjectReadOperation::sparse_read(uint64_t off, uint64_t len,
 
   ObjectOperationTestImpl op;
   if (pbl != NULL) {
-    op = boost::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, m, pbl);
+    op = boost::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, m, pbl, _4);
   } else {
-    op = boost::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, m, _3);
+    op = boost::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, m, _3, _4);
   }
 
   if (prval != NULL) {
     op = boost::bind(save_operation_result,
-                     boost::bind(op, _1, _2, _3, _4), prval);
+                     boost::bind(op, _1, _2, _3, _4, _5), prval);
   }
   o->ops.push_back(op);
 }
@@ -903,19 +910,19 @@ void ObjectReadOperation::stat(uint64_t *psize, time_t *pmtime, int *prval) {
 
   if (prval != NULL) {
     op = boost::bind(save_operation_result,
-                     boost::bind(op, _1, _2, _3, _4), prval);
+                     boost::bind(op, _1, _2, _3, _4, _5), prval);
   }
   o->ops.push_back(op);
 }
 
 void ObjectWriteOperation::append(const bufferlist &bl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::append, _1, _2, bl, _4));
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::append, _1, _2, bl, _5));
 }
 
 void ObjectWriteOperation::create(bool exclusive) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::create, _1, _2, exclusive, _4));
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::create, _1, _2, exclusive, _5));
 }
 
 void ObjectWriteOperation::omap_set(const std::map<std::string, bufferlist> &map) {
@@ -925,7 +932,7 @@ void ObjectWriteOperation::omap_set(const std::map<std::string, bufferlist> &map
 
 void ObjectWriteOperation::remove() {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::remove, _1, _2, _4));
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::remove, _1, _2, _5));
 }
 
 void ObjectWriteOperation::selfmanaged_snap_rollback(uint64_t snapid) {
@@ -939,7 +946,7 @@ void ObjectWriteOperation::set_alloc_hint(uint64_t expected_object_size,
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
   o->ops.push_back(boost::bind(&TestIoCtxImpl::set_alloc_hint, _1, _2,
 			       expected_object_size, expected_write_size, 0,
-                               _4));
+                               _5));
 }
 
 void ObjectWriteOperation::set_alloc_hint2(uint64_t expected_object_size,
@@ -948,7 +955,7 @@ void ObjectWriteOperation::set_alloc_hint2(uint64_t expected_object_size,
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
   o->ops.push_back(boost::bind(&TestIoCtxImpl::set_alloc_hint, _1, _2,
 			       expected_object_size, expected_write_size, flags,
-                               _4));
+                               _5));
 }
 
 void ObjectWriteOperation::tmap_update(const bufferlist& cmdbl) {
@@ -959,29 +966,30 @@ void ObjectWriteOperation::tmap_update(const bufferlist& cmdbl) {
 
 void ObjectWriteOperation::truncate(uint64_t off) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::truncate, _1, _2, off, _4));
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::truncate, _1, _2, off, _5));
 }
 
 void ObjectWriteOperation::write(uint64_t off, const bufferlist& bl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
   o->ops.push_back(boost::bind(&TestIoCtxImpl::write, _1, _2, bl, bl.length(),
-			       off, _4));
+			       off, _5));
 }
 
 void ObjectWriteOperation::write_full(const bufferlist& bl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::write_full, _1, _2, bl, _4));
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::write_full, _1, _2, bl, _5));
 }
 
-void ObjectWriteOperation::writesame(uint64_t off, uint64_t len, const bufferlist& bl) {
+void ObjectWriteOperation::writesame(uint64_t off, uint64_t len,
+                                     const bufferlist& bl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
   o->ops.push_back(boost::bind(&TestIoCtxImpl::writesame, _1, _2, bl, len,
-			       off, _4));
+			       off, _5));
 }
 
 void ObjectWriteOperation::zero(uint64_t off, uint64_t len) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::zero, _1, _2, off, len, _4));
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::zero, _1, _2, off, len, _5));
 }
 
 Rados::Rados() : client(NULL) {
@@ -1365,7 +1373,7 @@ int cls_cxx_read2(cls_method_context_t hctx, int ofs, int len,
                   bufferlist *outbl, uint32_t op_flags) {
   librados::TestClassHandler::MethodContext *ctx =
     reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
-  return ctx->io_ctx_impl->read(ctx->oid, len, ofs, outbl);
+  return ctx->io_ctx_impl->read(ctx->oid, len, ofs, outbl, ctx->snap_id);
 }
 
 int cls_cxx_setxattr(cls_method_context_t hctx, const char *name,

--- a/src/test/librados_test_stub/LibradosTestStub.h
+++ b/src/test/librados_test_stub/LibradosTestStub.h
@@ -7,12 +7,23 @@
 #include "include/rados/librados_fwd.hpp"
 #include <boost/shared_ptr.hpp>
 
+namespace neorados {
+struct IOContext;
+struct RADOS;
+} // namespace neorados
+
 namespace librados {
 
 class MockTestMemIoCtxImpl;
+class MockTestMemRadosClient;
 class TestCluster;
+class TestClassHandler;
 
 MockTestMemIoCtxImpl &get_mock_io_ctx(IoCtx &ioctx);
+MockTestMemIoCtxImpl &get_mock_io_ctx(neorados::RADOS& rados,
+                                      neorados::IOContext& io_context);
+
+MockTestMemRadosClient &get_mock_rados_client(neorados::RADOS& rados);
 
 } // namespace librados
 
@@ -22,6 +33,8 @@ typedef boost::shared_ptr<librados::TestCluster> TestClusterRef;
 
 void set_cluster(TestClusterRef cluster);
 TestClusterRef get_cluster();
+
+librados::TestClassHandler* get_class_handler();
 
 } // namespace librados_test_stub
 

--- a/src/test/librados_test_stub/MockTestMemRadosClient.h
+++ b/src/test/librados_test_stub/MockTestMemRadosClient.h
@@ -70,6 +70,19 @@ public:
     return TestMemRadosClient::service_daemon_update_status(std::move(s));
   }
 
+  MOCK_METHOD4(mon_command, int(const std::vector<std::string>&,
+                                const bufferlist&, bufferlist*, std::string*));
+  int do_mon_command(const std::vector<std::string>& cmd,
+                     const bufferlist &inbl, bufferlist *outbl,
+                     std::string *outs) {
+    return mon_command(cmd, inbl, outbl, outs);
+  }
+
+  MOCK_METHOD0(wait_for_latest_osd_map, int());
+  int do_wait_for_latest_osd_map() {
+    return wait_for_latest_osd_map();
+  }
+
   void default_to_dispatch() {
     using namespace ::testing;
 
@@ -80,6 +93,8 @@ public:
     ON_CALL(*this, get_min_compatible_client(_, _)).WillByDefault(Invoke(this, &MockTestMemRadosClient::do_get_min_compatible_client));
     ON_CALL(*this, service_daemon_register(_, _, _)).WillByDefault(Invoke(this, &MockTestMemRadosClient::do_service_daemon_register));
     ON_CALL(*this, service_daemon_update_status_r(_)).WillByDefault(Invoke(this, &MockTestMemRadosClient::do_service_daemon_update_status_r));
+    ON_CALL(*this, mon_command(_, _, _, _)).WillByDefault(Invoke(this, &MockTestMemRadosClient::do_mon_command));
+    ON_CALL(*this, wait_for_latest_osd_map()).WillByDefault(Invoke(this, &MockTestMemRadosClient::do_wait_for_latest_osd_map));
   }
 };
 

--- a/src/test/librados_test_stub/NeoradosTestStub.cc
+++ b/src/test/librados_test_stub/NeoradosTestStub.cc
@@ -1,0 +1,533 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "include/neorados/RADOS.hpp"
+#include "include/rados/librados.hpp"
+#include "common/ceph_mutex.h"
+#include "common/hobject.h"
+#include "librados/AioCompletionImpl.h"
+#include "osd/error_code.h"
+#include "osd/osd_types.h"
+#include "osdc/error_code.h"
+#include "test/librados_test_stub/LibradosTestStub.h"
+#include "test/librados_test_stub/TestClassHandler.h"
+#include "test/librados_test_stub/TestIoCtxImpl.h"
+#include "test/librados_test_stub/TestRadosClient.h"
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <boost/bind.hpp>
+#include <boost/system/system_error.hpp>
+
+namespace bs = boost::system;
+
+namespace neorados {
+namespace detail {
+
+struct Client {
+  ceph::mutex mutex = ceph::make_mutex("NeoradosTestStub::Client");
+
+  librados::TestRadosClient* test_rados_client;
+  boost::asio::io_context& io_context;
+
+  std::map<std::pair<int64_t, std::string>, librados::TestIoCtxImpl*> io_ctxs;
+
+  Client(librados::TestRadosClient* test_rados_client)
+    : test_rados_client(test_rados_client),
+      io_context(test_rados_client->get_io_context()) {
+  }
+
+  ~Client() {
+    for (auto& io_ctx : io_ctxs) {
+      io_ctx.second->put();
+    }
+  }
+
+  librados::TestIoCtxImpl* get_io_ctx(const IOContext& ioc) {
+    int64_t pool_id = ioc.pool();
+    std::string ns = std::string{ioc.ns()};
+
+    auto lock = std::scoped_lock{mutex};
+    auto key = make_pair(pool_id, ns);
+    auto it = io_ctxs.find(key);
+    if (it != io_ctxs.end()) {
+      return it->second;
+    }
+
+    std::list<std::pair<int64_t, std::string>> pools;
+    int r = test_rados_client->pool_list(pools);
+    if (r < 0) {
+      return nullptr;
+    }
+
+    for (auto& pool : pools) {
+      if (pool.first == pool_id) {
+        auto io_ctx = test_rados_client->create_ioctx(pool_id, pool.second);
+        io_ctx->set_namespace(ns);
+        io_ctxs[key] = io_ctx;
+        return io_ctx;
+      }
+    }
+    return nullptr;
+  }
+};
+
+} // namespace detail
+
+namespace {
+
+struct CompletionPayload {
+  std::unique_ptr<Op::Completion> c;
+};
+
+void completion_callback_adapter(rados_completion_t c, void *arg) {
+  auto impl = reinterpret_cast<librados::AioCompletionImpl *>(c);
+  auto r = impl->get_return_value();
+  impl->release();
+
+  auto payload = reinterpret_cast<CompletionPayload*>(arg);
+  payload->c->defer(std::move(payload->c),
+                    (r < 0) ? bs::error_code(-r, osd_category()) :
+                              bs::error_code());
+  delete payload;
+}
+
+librados::AioCompletionImpl* create_aio_completion(
+    std::unique_ptr<Op::Completion>&& c) {
+  auto payload = new CompletionPayload{std::move(c)};
+
+  auto impl = new librados::AioCompletionImpl();
+  impl->set_complete_callback(payload, completion_callback_adapter);
+
+  return impl;
+}
+
+int save_operation_size(int result, size_t* pval) {
+  if (pval != NULL) {
+    *pval = result;
+  }
+  return result;
+}
+
+int save_operation_ec(int result, boost::system::error_code* ec) {
+  if (ec != NULL) {
+    *ec = {std::abs(result), bs::system_category()};
+  }
+  return result;
+}
+
+} // anonymous namespace
+
+Object::Object() {
+  static_assert(impl_size >= sizeof(object_t));
+  new (&impl) object_t();
+}
+
+Object::Object(std::string&& s) {
+  static_assert(impl_size >= sizeof(object_t));
+  new (&impl) object_t(std::move(s));
+}
+
+Object::~Object() {
+  reinterpret_cast<object_t*>(&impl)->~object_t();
+}
+
+Object::operator std::string_view() const {
+  return std::string_view(reinterpret_cast<const object_t*>(&impl)->name);
+}
+
+struct IOContextImpl {
+  object_locator_t oloc;
+  snapid_t snap_seq = CEPH_NOSNAP;
+  SnapContext snapc;
+};
+
+IOContext::IOContext() {
+  static_assert(impl_size >= sizeof(IOContextImpl));
+  new (&impl) IOContextImpl();
+}
+
+IOContext::IOContext(const IOContext& rhs) {
+  static_assert(impl_size >= sizeof(IOContextImpl));
+  new (&impl) IOContextImpl(*reinterpret_cast<const IOContextImpl*>(&rhs.impl));
+}
+
+IOContext::IOContext(int64_t _pool, std::string&& _ns)
+  : IOContext() {
+  pool(_pool);
+  ns(std::move(_ns));
+}
+
+IOContext::~IOContext() {
+  reinterpret_cast<IOContextImpl*>(&impl)->~IOContextImpl();
+}
+
+std::int64_t IOContext::pool() const {
+  return reinterpret_cast<const IOContextImpl*>(&impl)->oloc.pool;
+}
+
+void IOContext::pool(std::int64_t _pool) {
+  reinterpret_cast<IOContextImpl*>(&impl)->oloc.pool = _pool;
+}
+
+std::string_view IOContext::ns() const {
+  return reinterpret_cast<const IOContextImpl*>(&impl)->oloc.nspace;
+}
+
+void IOContext::ns(std::string&& _ns) {
+  reinterpret_cast<IOContextImpl*>(&impl)->oloc.nspace = std::move(_ns);
+}
+
+std::optional<std::uint64_t> IOContext::read_snap() const {
+  auto& snap_seq = reinterpret_cast<const IOContextImpl*>(&impl)->snap_seq;
+  if (snap_seq == CEPH_NOSNAP)
+    return std::nullopt;
+  else
+    return snap_seq;
+}
+void IOContext::read_snap(std::optional<std::uint64_t> _snapid) {
+  auto& snap_seq = reinterpret_cast<IOContextImpl*>(&impl)->snap_seq;
+  snap_seq = _snapid.value_or(CEPH_NOSNAP);
+}
+
+std::optional<
+  std::pair<std::uint64_t,
+            std::vector<std::uint64_t>>> IOContext::write_snap_context() const {
+  auto& snapc = reinterpret_cast<const IOContextImpl*>(&impl)->snapc;
+  if (snapc.empty()) {
+    return std::nullopt;
+  } else {
+    std::vector<uint64_t> v(snapc.snaps.begin(), snapc.snaps.end());
+    return std::make_optional(std::make_pair(uint64_t(snapc.seq), v));
+  }
+}
+
+void IOContext::write_snap_context(
+  std::optional<std::pair<std::uint64_t, std::vector<std::uint64_t>>> _snapc) {
+  auto& snapc = reinterpret_cast<IOContextImpl*>(&impl)->snapc;
+  if (!_snapc) {
+    snapc.clear();
+  } else {
+    SnapContext n(_snapc->first, { _snapc->second.begin(), _snapc->second.end()});
+    if (!n.is_valid()) {
+      throw bs::system_error(EINVAL,
+                             bs::system_category(),
+                             "Invalid snap context.");
+    }
+
+    snapc = n;
+  }
+}
+
+Op::Op() {
+  static_assert(Op::impl_size >= sizeof(librados::TestObjectOperationImpl*));
+  auto& o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  o = new librados::TestObjectOperationImpl();
+  o->get();
+}
+
+Op::~Op() {
+  auto& o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  if (o != nullptr) {
+    o->put();
+    o = nullptr;
+  }
+}
+
+void Op::assert_exists() {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  o->ops.push_back(boost::bind(
+    &librados::TestIoCtxImpl::assert_exists, _1, _2, _4));
+}
+
+void Op::cmpext(uint64_t off, ceph::buffer::list&& cmp_bl, std::size_t* s) {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  librados::ObjectOperationTestImpl op = boost::bind(
+    &librados::TestIoCtxImpl::cmpext, _1, _2, off, cmp_bl, _4);
+  if (s != nullptr) {
+    op = boost::bind(
+      save_operation_size, boost::bind(op, _1, _2, _3, _4, _5), s);
+  }
+  o->ops.push_back(op);
+}
+
+std::size_t Op::size() const {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl* const *>(&impl);
+  return o->ops.size();
+}
+
+void Op::set_fadvise_random() {
+  // no-op
+}
+
+void Op::set_fadvise_sequential() {
+  // no-op
+}
+
+void Op::set_fadvise_willneed() {
+  // no-op
+}
+
+void Op::set_fadvise_dontneed() {
+  // no-op
+}
+
+void Op::set_fadvise_nocache() {
+  // no-op
+}
+
+void Op::balance_reads() {
+  // no-op
+}
+
+void Op::localize_reads() {
+  // no-op
+}
+
+void Op::exec(std::string_view cls, std::string_view method,
+              const ceph::buffer::list& inbl,
+              ceph::buffer::list* out,
+              boost::system::error_code* ec) {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+
+  auto cls_handler = librados_test_stub::get_class_handler();
+  librados::ObjectOperationTestImpl op =
+    [cls_handler, cls, method, inbl = const_cast<bufferlist&>(inbl), out]
+    (librados::TestIoCtxImpl* io_ctx, const std::string& oid, bufferlist* outbl,
+     uint64_t snap_id, const SnapContext& snapc) mutable -> int {
+      return io_ctx->exec(
+        oid, cls_handler, std::string(cls).c_str(),
+        std::string(method).c_str(), inbl,
+        (out != nullptr ? out : outbl), snap_id, snapc);
+    };
+  if (ec != nullptr) {
+    op = boost::bind(
+      save_operation_ec, boost::bind(op, _1, _2, _3, _4, _5), ec);
+  }
+  o->ops.push_back(op);
+}
+
+void Op::exec(std::string_view cls, std::string_view method,
+              const ceph::buffer::list& inbl,
+              boost::system::error_code* ec) {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+
+  auto cls_handler = librados_test_stub::get_class_handler();
+  librados::ObjectOperationTestImpl op =
+    [cls_handler, cls, method, inbl = const_cast<bufferlist&>(inbl)]
+    (librados::TestIoCtxImpl* io_ctx, const std::string& oid, bufferlist* outbl,
+     uint64_t snap_id, const SnapContext& snapc) mutable -> int {
+      return io_ctx->exec(
+        oid, cls_handler, std::string(cls).c_str(),
+        std::string(method).c_str(), inbl, outbl, snap_id, snapc);
+    };
+  if (ec != NULL) {
+    op = boost::bind(
+      save_operation_ec, boost::bind(op, _1, _2, _3, _4, _5), ec);
+  }
+  o->ops.push_back(op);
+}
+
+void ReadOp::read(size_t off, uint64_t len, ceph::buffer::list* out,
+	          boost::system::error_code* ec) {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  librados::ObjectOperationTestImpl op;
+  if (out != nullptr) {
+    op = boost::bind(&librados::TestIoCtxImpl::read, _1, _2, len, off, out, _4);
+  } else {
+    op = boost::bind(&librados::TestIoCtxImpl::read, _1, _2, len, off, _3, _4);
+  }
+
+  if (ec != NULL) {
+    op = boost::bind(
+      save_operation_ec, boost::bind(op, _1, _2, _3, _4, _5), ec);
+  }
+  o->ops.push_back(op);
+}
+
+void ReadOp::sparse_read(uint64_t off, uint64_t len,
+		         ceph::buffer::list* out,
+		         std::vector<std::pair<std::uint64_t,
+                                               std::uint64_t>>* extents,
+		         boost::system::error_code* ec) {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  librados::ObjectOperationTestImpl op =
+    [off, len, out, extents]
+    (librados::TestIoCtxImpl* io_ctx, const std::string& oid, bufferlist* outbl,
+     uint64_t snap_id, const SnapContext& snapc) mutable -> int {
+      std::map<uint64_t,uint64_t> m;
+      int r = io_ctx->sparse_read(
+        oid, off, len, &m, (out != nullptr ? out : outbl), snap_id);
+      if (r >= 0 && extents != nullptr) {
+        extents->clear();
+        extents->insert(extents->end(), m.begin(), m.end());
+      }
+      return r;
+    };
+  if (ec != NULL) {
+    op = boost::bind(save_operation_ec,
+                     boost::bind(op, _1, _2, _3, _4, _5), ec);
+  }
+  o->ops.push_back(op);
+}
+
+void WriteOp::create(bool exclusive) {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  o->ops.push_back(boost::bind(
+    &librados::TestIoCtxImpl::create, _1, _2, exclusive, _5));
+}
+
+void WriteOp::write(uint64_t off, ceph::buffer::list&& bl) {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  o->ops.push_back(boost::bind(
+    &librados::TestIoCtxImpl::write, _1, _2, bl, bl.length(), off, _5));
+}
+
+void WriteOp::write_full(ceph::buffer::list&& bl) {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  o->ops.push_back(boost::bind(
+    &librados::TestIoCtxImpl::write_full, _1, _2, bl, _5));
+}
+
+void WriteOp::remove() {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  o->ops.push_back(boost::bind(
+    &librados::TestIoCtxImpl::remove, _1, _2, _5));
+}
+
+void WriteOp::truncate(uint64_t off) {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  o->ops.push_back(boost::bind(
+    &librados::TestIoCtxImpl::truncate, _1, _2, off, _5));
+}
+
+void WriteOp::zero(uint64_t off, uint64_t len) {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  o->ops.push_back(boost::bind(
+    &librados::TestIoCtxImpl::zero, _1, _2, off, len, _5));
+}
+
+void WriteOp::writesame(std::uint64_t off, std::uint64_t write_len,
+                        ceph::buffer::list&& bl) {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  o->ops.push_back(boost::bind(
+    &librados::TestIoCtxImpl::writesame, _1, _2, bl, write_len, off, _5));
+}
+
+void WriteOp::set_alloc_hint(uint64_t expected_object_size,
+		             uint64_t expected_write_size,
+		             alloc_hint::alloc_hint_t flags) {
+  // no-op
+}
+
+RADOS::RADOS() = default;
+
+RADOS::RADOS(RADOS&&) = default;
+
+RADOS::RADOS(std::unique_ptr<detail::Client> impl)
+  : impl(std::move(impl)) {
+}
+
+RADOS::~RADOS() = default;
+
+RADOS RADOS::make_with_librados(librados::Rados& rados) {
+  auto test_rados_client = reinterpret_cast<librados::TestRadosClient*>(
+    rados.client);
+  return RADOS{std::make_unique<detail::Client>(test_rados_client)};
+}
+
+CephContext* neorados::RADOS::cct() {
+  return impl->test_rados_client->cct();
+}
+
+boost::asio::io_context& neorados::RADOS::get_io_context() {
+  return impl->io_context;
+}
+
+boost::asio::io_context::executor_type neorados::RADOS::get_executor() const {
+  return impl->io_context.get_executor();
+}
+
+void RADOS::execute(const Object& o, const IOContext& ioc, ReadOp&& op,
+                    ceph::buffer::list* bl, std::unique_ptr<Op::Completion> c,
+                    uint64_t* objver, const blkin_trace_info* trace_info) {
+  auto io_ctx = impl->get_io_ctx(ioc);
+  if (io_ctx == nullptr) {
+    c->dispatch(std::move(c), osdc_errc::pool_dne);
+    return;
+  }
+
+  auto ops = *reinterpret_cast<librados::TestObjectOperationImpl**>(&op.impl);
+
+  auto snap_id = CEPH_NOSNAP;
+  auto opt_snap_id = ioc.read_snap();
+  if (opt_snap_id) {
+    snap_id = *opt_snap_id;
+  }
+
+  auto completion = create_aio_completion(std::move(c));
+  auto r = io_ctx->aio_operate_read(std::string{o}, *ops, completion, 0U, bl,
+                                    snap_id);
+  ceph_assert(r == 0);
+}
+
+void RADOS::execute(const Object& o, const IOContext& ioc, WriteOp&& op,
+                    std::unique_ptr<Op::Completion> c, uint64_t* objver,
+                    const blkin_trace_info* trace_info) {
+  auto io_ctx = impl->get_io_ctx(ioc);
+  if (io_ctx == nullptr) {
+    c->dispatch(std::move(c), osdc_errc::pool_dne);
+    return;
+  }
+
+  auto ops = *reinterpret_cast<librados::TestObjectOperationImpl**>(&op.impl);
+
+  SnapContext snapc;
+  auto opt_snapc = ioc.write_snap_context();
+  if (opt_snapc) {
+    snapc.seq = opt_snapc->first;
+    snapc.snaps.assign(opt_snapc->second.begin(), opt_snapc->second.end());
+  }
+
+  auto completion = create_aio_completion(std::move(c));
+  auto r = io_ctx->aio_operate(std::string{o}, *ops, completion, &snapc, 0U);
+  ceph_assert(r == 0);
+}
+
+void RADOS::mon_command(std::vector<std::string> command,
+                        const bufferlist& bl,
+                        std::string* outs, bufferlist* outbl,
+                        std::unique_ptr<Op::Completion> c) {
+  auto r = impl->test_rados_client->mon_command(command, bl, outbl, outs);
+  c->post(std::move(c),
+          (r < 0 ? bs::error_code(-r, osd_category()) : bs::error_code()));
+}
+
+void RADOS::wait_for_latest_osd_map(std::unique_ptr<Op::Completion> c) {
+  auto r = impl->test_rados_client->wait_for_latest_osd_map();
+  c->dispatch(std::move(c),
+              (r < 0 ? bs::error_code(-r, osd_category()) :
+                       bs::error_code()));
+}
+
+} // namespace neorados
+
+namespace librados {
+
+MockTestMemIoCtxImpl& get_mock_io_ctx(neorados::RADOS& rados,
+                                      neorados::IOContext& io_context) {
+  auto& impl = *reinterpret_cast<std::unique_ptr<neorados::detail::Client>*>(
+    &rados);
+  auto io_ctx = impl->get_io_ctx(io_context);
+  ceph_assert(io_ctx != nullptr);
+  return *reinterpret_cast<MockTestMemIoCtxImpl*>(io_ctx);
+}
+
+MockTestMemRadosClient& get_mock_rados_client(neorados::RADOS& rados) {
+  auto& impl = *reinterpret_cast<std::unique_ptr<neorados::detail::Client>*>(
+    &rados);
+  return *reinterpret_cast<MockTestMemRadosClient*>(impl->test_rados_client);
+}
+
+} // namespace librados

--- a/src/test/librados_test_stub/TestClassHandler.cc
+++ b/src/test/librados_test_stub/TestClassHandler.cc
@@ -132,13 +132,14 @@ cls_method_cxx_call_t TestClassHandler::get_method(const std::string &cls,
 }
 
 TestClassHandler::SharedMethodContext TestClassHandler::get_method_context(
-    TestIoCtxImpl *io_ctx_impl, const std::string &oid,
+    TestIoCtxImpl *io_ctx_impl, const std::string &oid, uint64_t snap_id,
     const SnapContext &snapc) {
   SharedMethodContext ctx(new MethodContext());
 
   // clone to ioctx to provide a firewall for gmock expectations
   ctx->io_ctx_impl = io_ctx_impl->clone();
   ctx->oid = oid;
+  ctx->snap_id = snap_id;
   ctx->snapc = snapc;
   return ctx;
 }

--- a/src/test/librados_test_stub/TestClassHandler.h
+++ b/src/test/librados_test_stub/TestClassHandler.h
@@ -27,6 +27,7 @@ public:
 
     TestIoCtxImpl *io_ctx_impl;
     std::string oid;
+    uint64_t snap_id;
     SnapContext snapc;
   };
   typedef boost::shared_ptr<MethodContext> SharedMethodContext;
@@ -54,6 +55,7 @@ public:
                                    const std::string &method);
   SharedMethodContext get_method_context(TestIoCtxImpl *io_ctx_impl,
                                          const std::string &oid,
+                                         uint64_t snap_id,
                                          const SnapContext &snapc);
 
   int create_filter(cls_handle_t hclass, const std::string& filter_name,

--- a/src/test/librados_test_stub/TestIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestIoCtxImpl.h
@@ -22,6 +22,7 @@ class TestRadosClient;
 typedef boost::function<int(TestIoCtxImpl*,
 			    const std::string&,
 			    bufferlist *,
+                            uint64_t,
                             const SnapContext &)> ObjectOperationTestImpl;
 typedef std::list<ObjectOperationTestImpl> ObjectOperations;
 
@@ -89,7 +90,7 @@ public:
                           int flags);
   virtual int aio_operate_read(const std::string& oid, TestObjectOperationImpl &ops,
                                AioCompletionImpl *c, int flags,
-                               bufferlist *pbl);
+                               bufferlist *pbl, uint64_t snap_id);
   virtual int aio_remove(const std::string& oid, AioCompletionImpl *c,
                          int flags = 0) = 0;
   virtual int aio_watch(const std::string& o, AioCompletionImpl *c,
@@ -97,14 +98,14 @@ public:
   virtual int aio_unwatch(uint64_t handle, AioCompletionImpl *c);
   virtual int append(const std::string& oid, const bufferlist &bl,
                      const SnapContext &snapc) = 0;
-  virtual int assert_exists(const std::string &oid) = 0;
+  virtual int assert_exists(const std::string &oid, uint64_t snap_id) = 0;
 
   virtual int create(const std::string& oid, bool exclusive,
                      const SnapContext &snapc) = 0;
   virtual int exec(const std::string& oid, TestClassHandler *handler,
                    const char *cls, const char *method,
                    bufferlist& inbl, bufferlist* outbl,
-                   const SnapContext &snapc);
+                   uint64_t snap_id, const SnapContext &snapc);
   virtual int list_snaps(const std::string& o, snap_set_t *out_snaps) = 0;
   virtual int list_watchers(const std::string& o,
                             std::list<obj_watch_t> *out_watchers);
@@ -131,7 +132,7 @@ public:
   virtual int operate_read(const std::string& oid, TestObjectOperationImpl &ops,
                            bufferlist *pbl);
   virtual int read(const std::string& oid, size_t len, uint64_t off,
-                   bufferlist *bl) = 0;
+                   bufferlist *bl, uint64_t snap_id) = 0;
   virtual int remove(const std::string& oid, const SnapContext &snapc) = 0;
   virtual int selfmanaged_snap_create(uint64_t *snapid) = 0;
   virtual void aio_selfmanaged_snap_create(uint64_t *snapid,
@@ -151,7 +152,7 @@ public:
   virtual void set_snap_read(snap_t seq);
   virtual int sparse_read(const std::string& oid, uint64_t off, uint64_t len,
                           std::map<uint64_t,uint64_t> *m,
-                          bufferlist *data_bl) = 0;
+                          bufferlist *data_bl, uint64_t snap_id) = 0;
   virtual int stat(const std::string& oid, uint64_t *psize, time_t *pmtime) = 0;
   virtual int truncate(const std::string& oid, uint64_t size,
                        const SnapContext &snapc) = 0;
@@ -165,7 +166,8 @@ public:
                          const SnapContext &snapc) = 0;
   virtual int writesame(const std::string& oid, bufferlist& bl, size_t len,
                         uint64_t off, const SnapContext &snapc) = 0;
-  virtual int cmpext(const std::string& oid, uint64_t off, bufferlist& cmp_bl) = 0;
+  virtual int cmpext(const std::string& oid, uint64_t off, bufferlist& cmp_bl,
+                     uint64_t snap_id) = 0;
   virtual int xattr_get(const std::string& oid,
                         std::map<std::string, bufferlist>* attrset) = 0;
   virtual int xattr_set(const std::string& oid, const std::string &name,
@@ -182,7 +184,8 @@ protected:
 
   int execute_aio_operations(const std::string& oid,
                              TestObjectOperationImpl *ops,
-                             bufferlist *pbl, const SnapContext &snapc);
+                             bufferlist *pbl, uint64_t,
+                             const SnapContext &snapc);
 
 private:
   struct C_AioNotify : public Context {

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.h
@@ -26,7 +26,7 @@ public:
   int append(const std::string& oid, const bufferlist &bl,
              const SnapContext &snapc) override;
 
-  int assert_exists(const std::string &oid) override;
+  int assert_exists(const std::string &oid, uint64_t snap_id) override;
 
   int create(const std::string& oid, bool exclusive,
              const SnapContext &snapc) override;
@@ -47,7 +47,7 @@ public:
   int omap_set(const std::string& oid, const std::map<std::string,
                bufferlist> &map) override;
   int read(const std::string& oid, size_t len, uint64_t off,
-           bufferlist *bl) override;
+           bufferlist *bl, uint64_t snap_id) override;
   int remove(const std::string& oid, const SnapContext &snapc) override;
   int selfmanaged_snap_create(uint64_t *snapid) override;
   int selfmanaged_snap_remove(uint64_t snapid) override;
@@ -57,7 +57,8 @@ public:
                      uint64_t expected_write_size, uint32_t flags,
                      const SnapContext &snapc) override;
   int sparse_read(const std::string& oid, uint64_t off, uint64_t len,
-                  std::map<uint64_t,uint64_t> *m, bufferlist *data_bl) override;
+                  std::map<uint64_t,uint64_t> *m, bufferlist *data_bl,
+                  uint64_t snap_id) override;
   int stat(const std::string& oid, uint64_t *psize, time_t *pmtime) override;
   int truncate(const std::string& oid, uint64_t size,
                const SnapContext &snapc) override;
@@ -67,7 +68,8 @@ public:
                  const SnapContext &snapc) override;
   int writesame(const std::string& oid, bufferlist& bl, size_t len,
                 uint64_t off, const SnapContext &snapc) override;
-  int cmpext(const std::string& oid, uint64_t off, bufferlist& cmp_bl) override;
+  int cmpext(const std::string& oid, uint64_t off, bufferlist& cmp_bl,
+             uint64_t snap_id) override;
   int xattr_get(const std::string& oid,
                 std::map<std::string, bufferlist>* attrset) override;
   int xattr_set(const std::string& oid, const std::string &name,
@@ -91,6 +93,7 @@ private:
   void ensure_minimum_length(size_t len, bufferlist *bl);
 
   TestMemCluster::SharedFile get_file(const std::string &oid, bool write,
+                                      uint64_t snap_id,
                                       const SnapContext &snapc);
 
 };

--- a/src/test/librados_test_stub/TestRadosClient.cc
+++ b/src/test/librados_test_stub/TestRadosClient.cc
@@ -9,6 +9,7 @@
 #include "common/Finisher.h"
 #include "common/async/context_pool.h"
 #include <boost/bind.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/thread.hpp>
 #include <errno.h>
 
@@ -222,6 +223,18 @@ int TestRadosClient::mon_command(const std::vector<std::string>& cmd,
       str << "]}";
       outbl->append(str.str());
       return 0;
+    } else if ((*j_it)->get_data() == "osd blacklist") {
+      auto op_it = parser.find("blacklistop");
+      if (!op_it.end() && (*op_it)->get_data() == "add") {
+        uint32_t expire = 0;
+        auto expire_it = parser.find("expire");
+        if (!expire_it.end()) {
+          expire = boost::lexical_cast<uint32_t>((*expire_it)->get_data());
+        }
+
+        auto addr_it = parser.find("addr");
+        return blacklist_add((*addr_it)->get_data(), expire);
+      }
     }
   }
   return -ENOSYS;

--- a/src/test/librados_test_stub/TestRadosClient.cc
+++ b/src/test/librados_test_stub/TestRadosClient.cc
@@ -7,6 +7,7 @@
 #include "include/ceph_assert.h"
 #include "common/ceph_json.h"
 #include "common/Finisher.h"
+#include "common/async/context_pool.h"
 #include <boost/bind.hpp>
 #include <boost/thread.hpp>
 #include <errno.h>
@@ -30,6 +31,15 @@ static int get_concurrency() {
 }
 
 namespace librados {
+
+namespace {
+
+const char *config_keys[] = {
+  "librados_thread_count",
+  NULL
+};
+
+} // anonymous namespace
 
 static void finish_aio_completion(AioCompletionImpl *c, int r) {
   c->lock.lock();
@@ -87,7 +97,8 @@ private:
 TestRadosClient::TestRadosClient(CephContext *cct,
                                  TestWatchNotify *watch_notify)
   : m_cct(cct->get()), m_watch_notify(watch_notify),
-    m_aio_finisher(new Finisher(m_cct))
+    m_aio_finisher(new Finisher(m_cct)),
+    m_io_context_pool(std::make_unique<ceph::async::io_context_pool>())
 {
   get();
 
@@ -100,6 +111,11 @@ TestRadosClient::TestRadosClient(CephContext *cct,
 
   // replicate AIO callback processing
   m_aio_finisher->start();
+
+  // replicate neorados callback processing
+  m_cct->_conf.add_observer(this);
+  m_io_context_pool->start(m_cct->_conf.get_val<uint64_t>(
+    "librados_thread_count"));
 }
 
 TestRadosClient::~TestRadosClient() {
@@ -112,8 +128,28 @@ TestRadosClient::~TestRadosClient() {
   m_aio_finisher->stop();
   delete m_aio_finisher;
 
+  m_cct->_conf.remove_observer(this);
+  m_io_context_pool->stop();
+
   m_cct->put();
   m_cct = NULL;
+}
+
+boost::asio::io_context& TestRadosClient::get_io_context() {
+  return m_io_context_pool->get_io_context();
+}
+
+const char** TestRadosClient::get_tracked_conf_keys() const {
+  return config_keys;
+}
+
+void TestRadosClient::handle_conf_change(
+    const ConfigProxy& conf, const std::set<std::string> &changed) {
+  if (changed.count("librados_thread_count")) {
+    m_io_context_pool->stop();
+    m_io_context_pool->start(conf.get_val<std::uint64_t>(
+      "librados_thread_count"));
+  }
 }
 
 void TestRadosClient::get() {

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -126,22 +126,23 @@ add_executable(unittest_librbd
   ${unittest_librbd_srcs}
   $<TARGET_OBJECTS:common_texttable_obj>)
 target_compile_definitions(unittest_librbd PRIVATE "TEST_LIBRBD_INTERNALS")
-target_link_libraries(unittest_librbd
-  cls_rbd
-  cls_rbd_client
-  cls_lock
-  cls_lock_client
-  journal
-  journal_test_mock
+add_dependencies(unittest_librbd
   cls_journal
-  cls_journal_client
-  rados_test_stub
-  librados
+  cls_lock
+  cls_rbd)
+target_link_libraries(unittest_librbd
   rbd_test
-  rbd_test_mock
   rbd_api
   rbd_internal
+  rbd_test_mock
+  journal
+  journal_test_mock
+  cls_rbd_client
+  cls_lock_client
+  cls_journal_client
   rbd_types
+  rados_test_stub
+  librados
   ceph_immutable_object_cache_lib
   osdc
   ceph-common
@@ -159,6 +160,7 @@ target_link_libraries(ceph_test_librbd
   journal
   cls_journal_client
   cls_rbd_client
+  libneorados
   librados
   ${UNITTEST_LIBS}
   radostest)

--- a/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
@@ -3,6 +3,7 @@
 
 #include "test/librbd/test_mock_fixture.h"
 #include "include/rbd/librbd.hpp"
+#include "librbd/AsioEngine.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
 #include "librbd/internal.h"
@@ -174,7 +175,10 @@ public:
 
   librbd::ImageCtx *m_src_image_ctx;
   librbd::ImageCtx *m_dst_image_ctx;
+
+  std::shared_ptr<librbd::AsioEngine> m_asio_engine;
   asio::ContextWQ *m_work_queue;
+
   librbd::SnapSeqs m_snap_seqs;
   SnapMap m_snap_map;
 
@@ -188,7 +192,9 @@ public:
     ASSERT_EQ(0, create_image_pp(rbd, m_ioctx, dst_image_name, m_image_size));
     ASSERT_EQ(0, open_image(dst_image_name, &m_dst_image_ctx));
 
-    librbd::ImageCtx::get_work_queue(m_src_image_ctx->cct, &m_work_queue);
+    m_asio_engine = std::make_shared<librbd::AsioEngine>(
+      m_src_image_ctx->md_ctx);
+    m_work_queue = m_asio_engine->get_work_queue();
   }
 
   void expect_get_image_size(librbd::MockTestImageCtx &mock_image_ctx,

--- a/src/test/librbd/deep_copy/test_mock_MetadataCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_MetadataCopyRequest.cc
@@ -110,7 +110,7 @@ public:
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                     StrEq("metadata_set"), ContentsEqual(in_bl), _, _))
+                     StrEq("metadata_set"), ContentsEqual(in_bl), _, _, _))
                   .WillOnce(Return(r));
   }
 };

--- a/src/test/librbd/deep_copy/test_mock_MetadataCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_MetadataCopyRequest.cc
@@ -4,6 +4,7 @@
 #include "test/librbd/test_mock_fixture.h"
 #include "include/rbd/librbd.hpp"
 #include "include/stringify.h"
+#include "librbd/AsioEngine.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/deep_copy/MetadataCopyRequest.h"
 #include "librbd/image/GetMetadataRequest.h"
@@ -79,6 +80,8 @@ public:
 
   librbd::ImageCtx *m_src_image_ctx;
   librbd::ImageCtx *m_dst_image_ctx;
+
+  std::shared_ptr<librbd::AsioEngine> m_asio_engine;
   asio::ContextWQ *m_work_queue;
 
   void SetUp() override {
@@ -91,7 +94,9 @@ public:
     ASSERT_EQ(0, create_image_pp(rbd, m_ioctx, dst_image_name, m_image_size));
     ASSERT_EQ(0, open_image(dst_image_name, &m_dst_image_ctx));
 
-    librbd::ImageCtx::get_work_queue(m_src_image_ctx->cct, &m_work_queue);
+    m_asio_engine = std::make_shared<librbd::AsioEngine>(
+      m_src_image_ctx->md_ctx);
+    m_work_queue = m_asio_engine->get_work_queue();
   }
 
   void expect_get_metadata(MockGetMetadataRequest& mock_request,

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -220,7 +220,8 @@ public:
   void expect_sparse_read(librados::MockTestMemIoCtxImpl &mock_io_ctx, uint64_t offset,
                           uint64_t length, int r) {
 
-    auto &expect = EXPECT_CALL(mock_io_ctx, sparse_read(_, offset, length, _, _));
+    auto &expect = EXPECT_CALL(mock_io_ctx, sparse_read(_, offset, length, _, _,
+                                                        _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -5,6 +5,7 @@
 #include "include/interval_set.h"
 #include "include/rbd/librbd.hpp"
 #include "include/rbd/object_map_types.h"
+#include "librbd/AsioEngine.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
 #include "librbd/internal.h"
@@ -112,6 +113,8 @@ public:
 
   librbd::ImageCtx *m_src_image_ctx;
   librbd::ImageCtx *m_dst_image_ctx;
+
+  std::shared_ptr<librbd::AsioEngine> m_asio_engine;
   asio::ContextWQ *m_work_queue;
 
   SnapMap m_snap_map;
@@ -132,7 +135,9 @@ public:
     ASSERT_EQ(0, create_image_pp(rbd, m_ioctx, dst_image_name, m_image_size));
     ASSERT_EQ(0, open_image(dst_image_name, &m_dst_image_ctx));
 
-    librbd::ImageCtx::get_work_queue(m_src_image_ctx->cct, &m_work_queue);
+    m_asio_engine = std::make_shared<librbd::AsioEngine>(
+      m_src_image_ctx->md_ctx);
+    m_work_queue = m_asio_engine->get_work_queue();
   }
 
   bool is_fast_diff(librbd::MockImageCtx &mock_image_ctx) {

--- a/src/test/librbd/deep_copy/test_mock_SetHeadRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SetHeadRequest.cc
@@ -119,7 +119,8 @@ public:
 
   void expect_set_size(librbd::MockTestImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("set_size"), _, _, _))
+                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                     StrEq("set_size"), _, _, _, _))
                   .WillOnce(Return(r));
   }
 

--- a/src/test/librbd/deep_copy/test_mock_SetHeadRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SetHeadRequest.cc
@@ -4,6 +4,7 @@
 #include "test/librbd/test_mock_fixture.h"
 #include "test/librados_test_stub/LibradosTestStub.h"
 #include "include/rbd/librbd.hpp"
+#include "librbd/AsioEngine.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
 #include "osdc/Striper.h"
@@ -97,6 +98,8 @@ public:
   typedef image::DetachParentRequest<MockTestImageCtx> MockDetachParentRequest;
 
   librbd::ImageCtx *m_image_ctx;
+
+  std::shared_ptr<librbd::AsioEngine> m_asio_engine;
   asio::ContextWQ *m_work_queue;
 
   void SetUp() override {
@@ -104,7 +107,9 @@ public:
 
     ASSERT_EQ(0, open_image(m_image_name, &m_image_ctx));
 
-    librbd::ImageCtx::get_work_queue(m_image_ctx->cct, &m_work_queue);
+    m_asio_engine = std::make_shared<librbd::AsioEngine>(
+      m_image_ctx->md_ctx);
+    m_work_queue = m_asio_engine->get_work_queue();
   }
 
   void expect_start_op(librbd::MockExclusiveLock &mock_exclusive_lock) {

--- a/src/test/librbd/deep_copy/test_mock_SnapshotCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SnapshotCopyRequest.cc
@@ -3,6 +3,7 @@
 
 #include "test/librbd/test_mock_fixture.h"
 #include "include/rbd/librbd.hpp"
+#include "librbd/AsioEngine.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
 #include "librbd/Operations.h"
@@ -106,6 +107,8 @@ public:
 
   librbd::ImageCtx *m_src_image_ctx;
   librbd::ImageCtx *m_dst_image_ctx;
+
+  std::shared_ptr<librbd::AsioEngine> m_asio_engine;
   asio::ContextWQ *m_work_queue;
 
   librbd::SnapSeqs m_snap_seqs;
@@ -120,7 +123,9 @@ public:
     ASSERT_EQ(0, create_image_pp(rbd, m_ioctx, dst_image_name, m_image_size));
     ASSERT_EQ(0, open_image(dst_image_name, &m_dst_image_ctx));
 
-    librbd::ImageCtx::get_work_queue(m_src_image_ctx->cct, &m_work_queue);
+    m_asio_engine = std::make_shared<librbd::AsioEngine>(
+      m_src_image_ctx->md_ctx);
+    m_work_queue = m_asio_engine->get_work_queue();
   }
 
   void prepare_exclusive_lock(librbd::MockImageCtx &mock_image_ctx,

--- a/src/test/librbd/deep_copy/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SnapshotCreateRequest.cc
@@ -4,6 +4,7 @@
 #include "test/librbd/test_mock_fixture.h"
 #include "test/librados_test_stub/LibradosTestStub.h"
 #include "include/rbd/librbd.hpp"
+#include "librbd/AsioEngine.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
 #include "librbd/Operations.h"
@@ -76,6 +77,8 @@ public:
   typedef SnapshotCreateRequest<librbd::MockTestImageCtx> MockSnapshotCreateRequest;
 
   librbd::ImageCtx *m_image_ctx;
+
+  std::shared_ptr<librbd::AsioEngine> m_asio_engine;
   asio::ContextWQ *m_work_queue;
 
   void SetUp() override {
@@ -83,7 +86,9 @@ public:
 
     ASSERT_EQ(0, open_image(m_image_name, &m_image_ctx));
 
-    librbd::ImageCtx::get_work_queue(m_image_ctx->cct, &m_work_queue);
+    m_asio_engine = std::make_shared<librbd::AsioEngine>(
+      m_image_ctx->md_ctx);
+    m_work_queue = m_asio_engine->get_work_queue();
   }
 
   void expect_start_op(librbd::MockExclusiveLock &mock_exclusive_lock) {

--- a/src/test/librbd/deep_copy/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SnapshotCreateRequest.cc
@@ -122,7 +122,8 @@ public:
     std::string oid(librbd::ObjectMap<>::object_map_name(mock_image_ctx.id,
                                                          snap_id));
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                exec(oid, _, StrEq("rbd"), StrEq("object_map_resize"), _, _, _))
+                exec(oid, _, StrEq("rbd"), StrEq("object_map_resize"), _, _, _,
+                     _))
                   .WillOnce(Return(r));
   }
 

--- a/src/test/librbd/image/test_mock_AttachChildRequest.cc
+++ b/src/test/librbd/image/test_mock_AttachChildRequest.cc
@@ -92,7 +92,8 @@ public:
 
   void expect_add_child(MockImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                exec(RBD_CHILDREN, _, StrEq("rbd"), StrEq("add_child"), _, _, _))
+                exec(RBD_CHILDREN, _, StrEq("rbd"), StrEq("add_child"), _, _, _,
+                     _))
       .WillOnce(Return(r));
   }
 
@@ -119,7 +120,7 @@ public:
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(util::header_name(mock_image_ctx.id), _, StrEq("rbd"),
-                     StrEq("op_features_set"), ContentsEqual(bl), _, _))
+                     StrEq("op_features_set"), ContentsEqual(bl), _, _, _))
       .WillOnce(Return(r));
   }
 
@@ -131,7 +132,7 @@ public:
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                     StrEq("child_attach"), ContentsEqual(bl), _, _))
+                     StrEq("child_attach"), ContentsEqual(bl), _, _, _))
       .WillOnce(Return(r));
   }
 

--- a/src/test/librbd/image/test_mock_AttachParentRequest.cc
+++ b/src/test/librbd/image/test_mock_AttachParentRequest.cc
@@ -45,14 +45,14 @@ public:
   void expect_parent_attach(MockImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                     StrEq("parent_attach"), _, _, _))
+                     StrEq("parent_attach"), _, _, _, _))
       .WillOnce(Return(r));
   }
 
   void expect_set_parent(MockImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                     StrEq("set_parent"), _, _, _))
+                     StrEq("set_parent"), _, _, _, _))
       .WillOnce(Return(r));
   }
 

--- a/src/test/librbd/image/test_mock_CloneRequest.cc
+++ b/src/test/librbd/image/test_mock_CloneRequest.cc
@@ -332,7 +332,7 @@ public:
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_mode_get"),
-                     _, _, _))
+                     _, _, _, _))
       .WillOnce(WithArg<5>(Invoke([out_bl, r](bufferlist* out) {
                              *out = out_bl;
                              return r;

--- a/src/test/librbd/image/test_mock_DetachChildRequest.cc
+++ b/src/test/librbd/image/test_mock_DetachChildRequest.cc
@@ -130,14 +130,14 @@ public:
     EXPECT_CALL(mock_io_ctx_impl,
                 exec(util::header_name(parent_spec.image_id),
                      _, StrEq("rbd"), StrEq("child_detach"), ContentsEqual(bl),
-                     _, _))
+                     _, _, _))
       .WillOnce(Return(r));
   }
 
   void expect_remove_child(MockImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(RBD_CHILDREN, _, StrEq("rbd"), StrEq("remove_child"), _,
-                     _, _))
+                     _, _, _))
       .WillOnce(Return(r));
   }
 
@@ -149,7 +149,7 @@ public:
     using ceph::encode;
     EXPECT_CALL(mock_io_ctx_impl,
                 exec(parent_header_name, _, StrEq("rbd"),
-                     StrEq("snapshot_get"), _, _, _))
+                     StrEq("snapshot_get"), _, _, _, _))
       .WillOnce(WithArg<5>(Invoke([snap_info, r](bufferlist* bl) {
                              encode(snap_info, *bl);
                              return r;
@@ -194,7 +194,7 @@ public:
     using ceph::encode;
     EXPECT_CALL(mock_io_ctx_impl,
                 exec(RBD_TRASH, _, StrEq("rbd"),
-                     StrEq("trash_get"), _, _, _))
+                     StrEq("trash_get"), _, _, _, _))
       .WillOnce(WithArg<5>(Invoke([trash_spec, r](bufferlist* bl) {
                              encode(trash_spec, *bl);
                              return r;

--- a/src/test/librbd/image/test_mock_DetachParentRequest.cc
+++ b/src/test/librbd/image/test_mock_DetachParentRequest.cc
@@ -45,14 +45,14 @@ public:
   void expect_parent_detach(MockImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                     StrEq("parent_detach"), _, _, _))
+                     StrEq("parent_detach"), _, _, _, _))
       .WillOnce(Return(r));
   }
 
   void expect_remove_parent(MockImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                     StrEq("remove_parent"), _, _, _))
+                     StrEq("remove_parent"), _, _, _, _))
       .WillOnce(Return(r));
   }
 

--- a/src/test/librbd/image/test_mock_PreRemoveRequest.cc
+++ b/src/test/librbd/image/test_mock_PreRemoveRequest.cc
@@ -183,7 +183,7 @@ public:
 
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                                    StrEq("image_group_get"), _, _, _));
+                                    StrEq("image_group_get"), _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {

--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -558,6 +558,7 @@ TEST_F(TestMockImageRefreshRequest, SuccessV1) {
   expect_v1_get_snapshots(mock_image_ctx, 0);
   expect_v1_get_locks(mock_image_ctx, 0);
   expect_init_layout(mock_image_ctx);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -583,6 +584,7 @@ TEST_F(TestMockImageRefreshRequest, SuccessSnapshotV1) {
   expect_v1_get_locks(mock_image_ctx, 0);
   expect_init_layout(mock_image_ctx);
   expect_add_snap(mock_image_ctx, "snap", ictx->snap_ids.begin()->second);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -617,6 +619,7 @@ TEST_F(TestMockImageRefreshRequest, SuccessV2) {
   if (ictx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
     expect_init_exclusive_lock(mock_image_ctx, mock_exclusive_lock, 0);
   }
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -654,6 +657,7 @@ TEST_F(TestMockImageRefreshRequest, SuccessSnapshotV2) {
     expect_init_exclusive_lock(mock_image_ctx, mock_exclusive_lock, 0);
   }
   expect_add_snap(mock_image_ctx, "snap", ictx->snap_ids.begin()->second);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -693,6 +697,7 @@ TEST_F(TestMockImageRefreshRequest, SuccessLegacySnapshotV2) {
     expect_init_exclusive_lock(mock_image_ctx, mock_exclusive_lock, 0);
   }
   expect_add_snap(mock_image_ctx, "snap", ictx->snap_ids.begin()->second);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -733,6 +738,7 @@ TEST_F(TestMockImageRefreshRequest, SuccessLegacySnapshotNoTimestampV2) {
     expect_init_exclusive_lock(mock_image_ctx, mock_exclusive_lock, 0);
   }
   expect_add_snap(mock_image_ctx, "snap", ictx->snap_ids.begin()->second);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -775,6 +781,7 @@ TEST_F(TestMockImageRefreshRequest, SuccessSetSnapshotV2) {
   }
   expect_add_snap(mock_image_ctx, "snap", ictx->snap_ids.begin()->second);
   expect_get_snap_id(mock_image_ctx, "snap", ictx->snap_ids.begin()->second);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -832,6 +839,7 @@ TEST_F(TestMockImageRefreshRequest, SuccessChild) {
     expect_init_exclusive_lock(mock_image_ctx, mock_exclusive_lock, 0);
   }
   expect_refresh_parent_apply(*mock_refresh_parent_request);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
   expect_refresh_parent_finalize(mock_image_ctx, *mock_refresh_parent_request, 0);
 
   C_SaferCond ctx;
@@ -886,6 +894,7 @@ TEST_F(TestMockImageRefreshRequest, SuccessChildDontOpenParent) {
   if (ictx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
     expect_init_exclusive_lock(mock_image_ctx, mock_exclusive_lock, 0);
   }
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, true, &ctx);
@@ -923,6 +932,7 @@ TEST_F(TestMockImageRefreshRequest, SuccessOpFeatures) {
   if (ictx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
     expect_init_exclusive_lock(mock_image_ctx, mock_exclusive_lock, 0);
   }
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -988,6 +998,7 @@ TEST_F(TestMockImageRefreshRequest, DisableExclusiveLock) {
   expect_apply_metadata(mock_image_ctx, 0);
   expect_get_group(mock_image_ctx, 0);
   expect_refresh_parent_is_required(mock_refresh_parent_request, false);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
   expect_shut_down_exclusive_lock(mock_image_ctx, mock_exclusive_lock, 0);
 
   C_SaferCond ctx;
@@ -1042,6 +1053,7 @@ TEST_F(TestMockImageRefreshRequest, DisableExclusiveLockWhileAcquiringLock) {
   expect_apply_metadata(mock_image_ctx, 0);
   expect_get_group(mock_image_ctx, 0);
   expect_refresh_parent_is_required(mock_refresh_parent_request, false);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, true, false, &ctx);
@@ -1090,6 +1102,7 @@ TEST_F(TestMockImageRefreshRequest, JournalDisabledByPolicy) {
   MockJournalPolicy mock_journal_policy;
   expect_get_journal_policy(mock_image_ctx, mock_journal_policy);
   expect_journal_disabled(mock_journal_policy, true);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -1140,6 +1153,7 @@ TEST_F(TestMockImageRefreshRequest, EnableJournalWithExclusiveLock) {
   expect_get_journal_policy(mock_image_ctx, mock_journal_policy);
   expect_journal_disabled(mock_journal_policy, false);
   expect_open_journal(mock_image_ctx, mock_journal, 0);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -1184,6 +1198,7 @@ TEST_F(TestMockImageRefreshRequest, EnableJournalWithoutExclusiveLock) {
   expect_get_group(mock_image_ctx, 0);
   expect_refresh_parent_is_required(mock_refresh_parent_request, false);
   expect_set_require_lock(mock_exclusive_lock, librbd::io::DIRECTION_BOTH);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -1235,6 +1250,7 @@ TEST_F(TestMockImageRefreshRequest, DisableJournal) {
   expect_get_group(mock_image_ctx, 0);
   expect_refresh_parent_is_required(mock_refresh_parent_request, false);
   expect_block_writes(mock_image_ctx, 0);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
   if (!mock_image_ctx.clone_copy_on_read) {
     expect_unset_require_lock(mock_exclusive_lock, librbd::io::DIRECTION_READ);
   }
@@ -1287,6 +1303,7 @@ TEST_F(TestMockImageRefreshRequest, EnableObjectMapWithExclusiveLock) {
   expect_get_group(mock_image_ctx, 0);
   expect_refresh_parent_is_required(mock_refresh_parent_request, false);
   expect_open_object_map(mock_image_ctx, &mock_object_map, 0);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -1330,6 +1347,7 @@ TEST_F(TestMockImageRefreshRequest, EnableObjectMapWithoutExclusiveLock) {
   expect_apply_metadata(mock_image_ctx, 0);
   expect_get_group(mock_image_ctx, 0);
   expect_refresh_parent_is_required(mock_refresh_parent_request, false);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -1380,6 +1398,7 @@ TEST_F(TestMockImageRefreshRequest, DisableObjectMap) {
   expect_apply_metadata(mock_image_ctx, 0);
   expect_get_group(mock_image_ctx, 0);
   expect_refresh_parent_is_required(mock_refresh_parent_request, false);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
   expect_close_object_map(mock_image_ctx, mock_object_map, 0);
 
   C_SaferCond ctx;
@@ -1427,6 +1446,7 @@ TEST_F(TestMockImageRefreshRequest, OpenObjectMapError) {
   expect_get_group(mock_image_ctx, 0);
   expect_refresh_parent_is_required(mock_refresh_parent_request, false);
   expect_open_object_map(mock_image_ctx, &mock_object_map, -EBLACKLISTED);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false,
@@ -1475,6 +1495,7 @@ TEST_F(TestMockImageRefreshRequest, OpenObjectMapTooLarge) {
   expect_get_group(mock_image_ctx, 0);
   expect_refresh_parent_is_required(mock_refresh_parent_request, false);
   expect_open_object_map(mock_image_ctx, &mock_object_map, -EFBIG);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false,
@@ -1511,6 +1532,7 @@ TEST_F(TestMockImageRefreshRequest, ApplyMetadataError) {
   if (ictx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
     expect_init_exclusive_lock(mock_image_ctx, mock_exclusive_lock, 0);
   }
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -1545,6 +1567,7 @@ TEST_F(TestMockImageRefreshRequest, NonPrimaryFeature) {
   expect_apply_metadata(mock_image_ctx, 0);
   expect_get_group(mock_image_ctx, 0);
   expect_refresh_parent_is_required(mock_refresh_parent_request, false);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx1;
   auto req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx1);
@@ -1570,6 +1593,7 @@ TEST_F(TestMockImageRefreshRequest, NonPrimaryFeature) {
   if (ictx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
     expect_init_exclusive_lock(mock_image_ctx, mock_exclusive_lock, 0);
   }
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
 
   C_SaferCond ctx2;
   req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx2);

--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -196,7 +196,7 @@ public:
 
   void expect_v1_read_header(MockRefreshImageCtx &mock_image_ctx, int r) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                               read(mock_image_ctx.header_oid, _, _, _));
+                               read(mock_image_ctx.header_oid, _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -206,7 +206,8 @@ public:
 
   void expect_v1_get_snapshots(MockRefreshImageCtx &mock_image_ctx, int r) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                               exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("snap_list"), _, _, _));
+                               exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                                    StrEq("snap_list"), _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -216,7 +217,8 @@ public:
 
   void expect_v1_get_locks(MockRefreshImageCtx &mock_image_ctx, int r) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                               exec(mock_image_ctx.header_oid, _, StrEq("lock"), StrEq("get_info"), _, _, _));
+                               exec(mock_image_ctx.header_oid, _, StrEq("lock"),
+                                    StrEq("get_info"), _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -227,7 +229,8 @@ public:
   void expect_get_mutable_metadata(MockRefreshImageCtx &mock_image_ctx,
                                    uint64_t features, int r) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                               exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("get_size"), _, _, _));
+                               exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                                    StrEq("get_size"), _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -237,7 +240,8 @@ public:
 
       expect.WillOnce(DoDefault());
       EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("get_features"), _, _, _))
+                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                       StrEq("get_features"), _, _, _, _))
                     .WillOnce(WithArg<5>(Invoke([features, incompatible](bufferlist* out_bl) {
                                            encode(features, *out_bl);
                                            encode(incompatible, *out_bl);
@@ -245,10 +249,12 @@ public:
                                          })));
       expect_get_flags(mock_image_ctx, 0);
       EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("get_snapcontext"), _, _, _))
+                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                       StrEq("get_snapcontext"), _, _, _, _))
                     .WillOnce(DoDefault());
       EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                  exec(mock_image_ctx.header_oid, _, StrEq("lock"), StrEq("get_info"), _, _, _))
+                  exec(mock_image_ctx.header_oid, _, StrEq("lock"),
+                       StrEq("get_info"), _, _, _, _))
                     .WillOnce(DoDefault());
     }
   }
@@ -256,7 +262,7 @@ public:
   void expect_parent_overlap_get(MockRefreshImageCtx &mock_image_ctx, int r) {
     auto& expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                               StrEq("parent_overlap_get"), _, _, _));
+                                    StrEq("parent_overlap_get"), _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -267,7 +273,7 @@ public:
   void expect_get_parent(MockRefreshImageCtx &mock_image_ctx, int r) {
     auto& expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                                    StrEq("parent_get"), _, _, _));
+                                    StrEq("parent_get"), _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -279,7 +285,7 @@ public:
   void expect_get_parent_legacy(MockRefreshImageCtx &mock_image_ctx, int r) {
     auto& expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                                    StrEq("get_parent"), _, _, _));
+                                    StrEq("get_parent"), _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -290,7 +296,7 @@ public:
   void expect_get_migration_header(MockRefreshImageCtx &mock_image_ctx, int r) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                                    StrEq("migration_get"), _, _, _));
+                                    StrEq("migration_get"), _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -313,7 +319,8 @@ public:
 
   void expect_get_flags(MockRefreshImageCtx &mock_image_ctx, int r) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                               exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("get_flags"), _, _, _));
+                               exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                                    StrEq("get_flags"), _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -325,7 +332,7 @@ public:
                               uint64_t op_features, int r) {
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                     StrEq("op_features_get"), _, _, _))
+                     StrEq("op_features_get"), _, _, _, _))
       .WillOnce(WithArg<5>(Invoke([op_features, r](bufferlist* out_bl) {
                              encode(op_features, *out_bl);
                              return r;
@@ -335,7 +342,7 @@ public:
   void expect_get_group(MockRefreshImageCtx &mock_image_ctx, int r) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                                    StrEq("image_group_get"), _, _, _));
+                                    StrEq("image_group_get"), _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -346,21 +353,24 @@ public:
   void expect_get_snapshots(MockRefreshImageCtx &mock_image_ctx,
                             bool legacy_parent, int r) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                               exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("snapshot_get"), _, _, _));
+                               exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                                    StrEq("snapshot_get"), _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
       expect.WillOnce(DoDefault());
       if (legacy_parent) {
         EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                    exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("get_parent"), _, _, _))
+                    exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                         StrEq("get_parent"), _, _, _, _))
                       .WillOnce(DoDefault());
       } else {
         expect_parent_overlap_get(mock_image_ctx, 0);
       }
       expect_get_flags(mock_image_ctx, 0);
       EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("get_protection_status"), _, _, _))
+                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                       StrEq("get_protection_status"), _, _, _, _))
                     .WillOnce(DoDefault());
     }
   }
@@ -368,25 +378,30 @@ public:
   void expect_get_snapshots_legacy(MockRefreshImageCtx &mock_image_ctx,
                                    bool include_timestamp, int r) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                               exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("get_snapshot_name"), _, _, _));
+                               exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                                    StrEq("get_snapshot_name"), _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
       expect.WillOnce(DoDefault());
       EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("get_size"), _, _, _))
+                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                       StrEq("get_size"), _, _, _, _))
                     .WillOnce(DoDefault());
       if (include_timestamp) {
         EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                    exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("get_snapshot_timestamp"), _, _, _))
+                    exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                         StrEq("get_snapshot_timestamp"), _, _, _, _))
                       .WillOnce(DoDefault());
       }
       EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("get_parent"), _, _, _))
+                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                       StrEq("get_parent"), _, _, _, _))
                     .WillOnce(DoDefault());
       expect_get_flags(mock_image_ctx, 0);
       EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("get_protection_status"), _, _, _))
+                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                       StrEq("get_protection_status"), _, _, _, _))
                     .WillOnce(DoDefault());
     }
   }

--- a/src/test/librbd/image/test_mock_RemoveRequest.cc
+++ b/src/test/librbd/image/test_mock_RemoveRequest.cc
@@ -291,15 +291,15 @@ public:
 
   void expect_remove_mirror_image(librados::IoCtx &ioctx, int r) {
     EXPECT_CALL(get_mock_io_ctx(ioctx),
-                exec(StrEq("rbd_mirroring"), _, StrEq("rbd"), StrEq("mirror_image_remove"),
-                     _, _, _))
+                exec(StrEq("rbd_mirroring"), _, StrEq("rbd"),
+                     StrEq("mirror_image_remove"), _, _, _, _))
       .WillOnce(Return(r));
   }
 
   void expect_dir_remove_image(librados::IoCtx &ioctx, int r) {
     EXPECT_CALL(get_mock_io_ctx(ioctx),
                 exec(RBD_DIRECTORY, _, StrEq("rbd"), StrEq("dir_remove_image"),
-                     _, _, _))
+                     _, _, _, _))
       .WillOnce(Return(r));
   }
 

--- a/src/test/librbd/image/test_mock_ValidatePoolRequest.cc
+++ b/src/test/librbd/image/test_mock_ValidatePoolRequest.cc
@@ -52,7 +52,7 @@ public:
 
   void expect_read_rbd_info(librados::MockTestMemIoCtxImpl &mock_io_ctx,
                             const std::string& data, int r) {
-    auto& expect = EXPECT_CALL(mock_io_ctx, read(StrEq(RBD_INFO), 0, 0, _));
+    auto& expect = EXPECT_CALL(mock_io_ctx, read(StrEq(RBD_INFO), 0, 0, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -219,7 +219,7 @@ struct TestMockIoCopyupRequest : public TestMockFixture {
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
                 exec(oid, _, StrEq("rbd"), StrEq("copyup"),
-                     ContentsEqual(in_bl), _, snapc))
+                     ContentsEqual(in_bl), _, _, snapc))
       .WillOnce(Return(r));
   }
 
@@ -241,7 +241,7 @@ struct TestMockIoCopyupRequest : public TestMockFixture {
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
                 exec(oid, _, StrEq("rbd"), StrEq("sparse_copyup"),
-                     ContentsEqual(in_bl), _, snapc))
+                     ContentsEqual(in_bl), _, _, snapc))
       .WillOnce(Return(r));
   }
 

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -175,23 +175,19 @@ struct TestMockIoCopyupRequest : public TestMockFixture {
   void expect_get_parent_overlap(MockTestImageCtx& mock_image_ctx,
                                  librados::snap_t snap_id, uint64_t overlap,
                                  int r) {
-    if (mock_image_ctx.object_map != nullptr) {
-      EXPECT_CALL(mock_image_ctx, get_parent_overlap(snap_id, _))
-        .WillOnce(WithArg<1>(Invoke([overlap, r](uint64_t *o) {
-                               *o = overlap;
-                               return r;
-                             })));
-    }
+    EXPECT_CALL(mock_image_ctx, get_parent_overlap(snap_id, _))
+      .WillOnce(WithArg<1>(Invoke([overlap, r](uint64_t *o) {
+                             *o = overlap;
+                             return r;
+                           })));
   }
 
   void expect_prune_parent_extents(MockTestImageCtx& mock_image_ctx,
                                    uint64_t overlap, uint64_t object_overlap) {
-    if (mock_image_ctx.object_map != nullptr) {
-      EXPECT_CALL(mock_image_ctx, prune_parent_extents(_, overlap))
-        .WillOnce(WithoutArgs(Invoke([object_overlap]() {
-                                return object_overlap;
-                              })));
-    }
+    EXPECT_CALL(mock_image_ctx, prune_parent_extents(_, overlap))
+      .WillOnce(WithoutArgs(Invoke([object_overlap]() {
+                              return object_overlap;
+                            })));
   }
 
   void expect_read_parent(MockTestImageCtx& mock_image_ctx,

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -150,7 +150,7 @@ struct TestMockIoObjectRequest : public TestMockFixture {
     bl.append(data);
 
     auto& expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
-                               read(oid, len, off, _));
+                               read(oid, len, off, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -168,7 +168,7 @@ struct TestMockIoObjectRequest : public TestMockFixture {
     bl.append(data);
 
     auto& expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
-                               sparse_read(oid, off, len, _, _));
+                               sparse_read(oid, off, len, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -225,7 +225,8 @@ struct TestMockIoObjectRequest : public TestMockFixture {
   }
 
   void expect_assert_exists(MockTestImageCtx &mock_image_ctx, int r) {
-    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx), assert_exists(_))
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
+                assert_exists(_, _))
       .WillOnce(Return(r));
   }
 
@@ -299,7 +300,7 @@ struct TestMockIoObjectRequest : public TestMockFixture {
 
   void expect_cmpext(MockTestImageCtx &mock_image_ctx, int offset, int r) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
-                               cmpext(_, offset, _));
+                               cmpext(_, offset, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -149,8 +149,9 @@ struct TestMockIoObjectRequest : public TestMockFixture {
     bufferlist bl;
     bl.append(data);
 
-    auto& expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
-                               read(oid, len, off, _, _));
+    auto& mock_io_ctx = librados::get_mock_io_ctx(
+      mock_image_ctx.rados_api, *mock_image_ctx.get_data_io_context());
+    auto& expect = EXPECT_CALL(mock_io_ctx, read(oid, len, off, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -167,7 +168,9 @@ struct TestMockIoObjectRequest : public TestMockFixture {
     bufferlist bl;
     bl.append(data);
 
-    auto& expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
+    auto& mock_io_ctx = librados::get_mock_io_ctx(
+      mock_image_ctx.rados_api, *mock_image_ctx.get_data_io_context());
+    auto& expect = EXPECT_CALL(mock_io_ctx,
                                sparse_read(oid, off, len, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
@@ -225,14 +228,17 @@ struct TestMockIoObjectRequest : public TestMockFixture {
   }
 
   void expect_assert_exists(MockTestImageCtx &mock_image_ctx, int r) {
-    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
-                assert_exists(_, _))
+    auto& mock_io_ctx = librados::get_mock_io_ctx(
+      mock_image_ctx.rados_api, *mock_image_ctx.get_data_io_context());
+    EXPECT_CALL(mock_io_ctx, assert_exists(_, _))
       .WillOnce(Return(r));
   }
 
   void expect_write(MockTestImageCtx &mock_image_ctx,
                     uint64_t offset, uint64_t length, int r) {
-    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
+    auto& mock_io_ctx = librados::get_mock_io_ctx(
+      mock_image_ctx.rados_api, *mock_image_ctx.get_data_io_context());
+    auto &expect = EXPECT_CALL(mock_io_ctx,
                                write(_, _, length, offset, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
@@ -242,8 +248,9 @@ struct TestMockIoObjectRequest : public TestMockFixture {
   }
 
   void expect_write_full(MockTestImageCtx &mock_image_ctx, int r) {
-    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
-                               write_full(_, _, _));
+    auto& mock_io_ctx = librados::get_mock_io_ctx(
+      mock_image_ctx.rados_api, *mock_image_ctx.get_data_io_context());
+    auto &expect = EXPECT_CALL(mock_io_ctx, write_full(_, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -253,8 +260,9 @@ struct TestMockIoObjectRequest : public TestMockFixture {
 
   void expect_writesame(MockTestImageCtx &mock_image_ctx,
                         uint64_t offset, uint64_t length, int r) {
-    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
-                               writesame(_, _, length, offset, _));
+    auto& mock_io_ctx = librados::get_mock_io_ctx(
+      mock_image_ctx.rados_api, *mock_image_ctx.get_data_io_context());
+    auto &expect = EXPECT_CALL(mock_io_ctx, writesame(_, _, length, offset, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -263,8 +271,9 @@ struct TestMockIoObjectRequest : public TestMockFixture {
   }
 
   void expect_remove(MockTestImageCtx &mock_image_ctx, int r) {
-    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
-                               remove(_, _));
+    auto& mock_io_ctx = librados::get_mock_io_ctx(
+      mock_image_ctx.rados_api, *mock_image_ctx.get_data_io_context());
+    auto &expect = EXPECT_CALL(mock_io_ctx, remove(_, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -273,13 +282,16 @@ struct TestMockIoObjectRequest : public TestMockFixture {
   }
 
   void expect_create(MockTestImageCtx &mock_image_ctx, bool exclusive) {
-    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx), create(_, exclusive, _))
+    auto& mock_io_ctx = librados::get_mock_io_ctx(
+      mock_image_ctx.rados_api, *mock_image_ctx.get_data_io_context());
+    EXPECT_CALL(mock_io_ctx, create(_, exclusive, _))
       .Times(1);
   }
 
   void expect_truncate(MockTestImageCtx &mock_image_ctx, int offset, int r) {
-    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
-                               truncate(_, offset, _));
+    auto& mock_io_ctx = librados::get_mock_io_ctx(
+      mock_image_ctx.rados_api, *mock_image_ctx.get_data_io_context());
+    auto &expect = EXPECT_CALL(mock_io_ctx, truncate(_, offset, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -289,8 +301,9 @@ struct TestMockIoObjectRequest : public TestMockFixture {
 
   void expect_zero(MockTestImageCtx &mock_image_ctx, int offset, int length,
                    int r) {
-    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
-                               zero(_, offset, length, _));
+    auto& mock_io_ctx = librados::get_mock_io_ctx(
+      mock_image_ctx.rados_api, *mock_image_ctx.get_data_io_context());
+    auto &expect = EXPECT_CALL(mock_io_ctx, zero(_, offset, length, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -299,8 +312,9 @@ struct TestMockIoObjectRequest : public TestMockFixture {
   }
 
   void expect_cmpext(MockTestImageCtx &mock_image_ctx, int offset, int r) {
-    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
-                               cmpext(_, offset, _, _));
+    auto& mock_io_ctx = librados::get_mock_io_ctx(
+      mock_image_ctx.rados_api, *mock_image_ctx.get_data_io_context());
+    auto &expect = EXPECT_CALL(mock_io_ctx, cmpext(_, offset, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -328,7 +342,7 @@ TEST_F(TestMockIoObjectRequest, Read) {
               std::string(4096, '1'), 0);
 
   bufferlist bl;
-  ExtentMap extent_map;
+  Extents extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, 0, 0, 4096, CEPH_NOSNAP, 0, {}, &bl, &extent_map, &ctx);
@@ -356,7 +370,7 @@ TEST_F(TestMockIoObjectRequest, SparseReadThreshold) {
                      std::string(ictx->sparse_read_threshold_bytes, '1'), 0);
 
   bufferlist bl;
-  ExtentMap extent_map;
+  Extents extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, 0, 0, ictx->sparse_read_threshold_bytes, CEPH_NOSNAP, 0,
@@ -383,7 +397,7 @@ TEST_F(TestMockIoObjectRequest, ReadError) {
   expect_read(mock_image_ctx, ictx->get_object_name(0), 0, 4096, "", -EPERM);
 
   bufferlist bl;
-  ExtentMap extent_map;
+  Extents extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, 0, 0, 4096, CEPH_NOSNAP, 0, {}, &bl, &extent_map, &ctx);
@@ -430,7 +444,7 @@ TEST_F(TestMockIoObjectRequest, ParentRead) {
   expect_aio_read(mock_image_ctx, mock_image_request, {{0, 4096}}, 0);
 
   bufferlist bl;
-  ExtentMap extent_map;
+  Extents extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, 0, 0, 4096, CEPH_NOSNAP, 0, {}, &bl, &extent_map, &ctx);
@@ -477,7 +491,7 @@ TEST_F(TestMockIoObjectRequest, ParentReadError) {
   expect_aio_read(mock_image_ctx, mock_image_request, {{0, 4096}}, -EPERM);
 
   bufferlist bl;
-  ExtentMap extent_map;
+  Extents extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, 0, 0, 4096, CEPH_NOSNAP, 0, {}, &bl, &extent_map, &ctx);
@@ -529,7 +543,7 @@ TEST_F(TestMockIoObjectRequest, CopyOnRead) {
   expect_copyup(mock_copyup_request, 0);
 
   bufferlist bl;
-  ExtentMap extent_map;
+  Extents extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, 0, 0, 4096, CEPH_NOSNAP, 0, {}, &bl, &extent_map, &ctx);

--- a/src/test/librbd/managed_lock/test_mock_AcquireRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_AcquireRequest.cc
@@ -29,7 +29,7 @@ struct BreakRequest<librbd::MockImageCtx> {
   Context *on_finish = nullptr;
   static BreakRequest *s_instance;
   static BreakRequest* create(librados::IoCtx& ioctx,
-                              asio::ContextWQ *work_queue,
+                              AsioEngine& asio_engine,
                               const std::string& oid, const Locker &locker,
                               bool exclusive, bool blacklist_locker,
                               uint32_t blacklist_expire_seconds,
@@ -156,8 +156,8 @@ TEST_F(TestMockManagedLockAcquireRequest, SuccessExclusive) {
 
   C_SaferCond ctx;
   MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx.md_ctx,
-     mock_image_ctx.image_watcher, ictx->op_work_queue, mock_image_ctx.header_oid,
-     TEST_COOKIE, true, true, 0, &ctx);
+    mock_image_ctx.image_watcher, *ictx->asio_engine, mock_image_ctx.header_oid,
+    TEST_COOKIE, true, true, 0, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -176,8 +176,8 @@ TEST_F(TestMockManagedLockAcquireRequest, SuccessShared) {
 
   C_SaferCond ctx;
   MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx.md_ctx,
-     mock_image_ctx.image_watcher, ictx->op_work_queue, mock_image_ctx.header_oid,
-     TEST_COOKIE, false, true, 0, &ctx);
+    mock_image_ctx.image_watcher, *ictx->asio_engine, mock_image_ctx.header_oid,
+    TEST_COOKIE, false, true, 0, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -201,8 +201,8 @@ TEST_F(TestMockManagedLockAcquireRequest, LockBusy) {
 
   C_SaferCond ctx;
   MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx.md_ctx,
-     mock_image_ctx.image_watcher, ictx->op_work_queue, mock_image_ctx.header_oid,
-     TEST_COOKIE, true, true, 0, &ctx);
+    mock_image_ctx.image_watcher, *ictx->asio_engine, mock_image_ctx.header_oid,
+    TEST_COOKIE, true, true, 0, &ctx);
   req->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
@@ -219,8 +219,8 @@ TEST_F(TestMockManagedLockAcquireRequest, GetLockInfoError) {
 
   C_SaferCond ctx;
   MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx.md_ctx,
-     mock_image_ctx.image_watcher, ictx->op_work_queue, mock_image_ctx.header_oid,
-     TEST_COOKIE, true, true, 0, &ctx);
+    mock_image_ctx.image_watcher, *ictx->asio_engine, mock_image_ctx.header_oid,
+    TEST_COOKIE, true, true, 0, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -238,8 +238,8 @@ TEST_F(TestMockManagedLockAcquireRequest, GetLockInfoEmpty) {
 
   C_SaferCond ctx;
   MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx.md_ctx,
-     mock_image_ctx.image_watcher, ictx->op_work_queue, mock_image_ctx.header_oid,
-     TEST_COOKIE, true, true, 0, &ctx);
+    mock_image_ctx.image_watcher, *ictx->asio_engine, mock_image_ctx.header_oid,
+    TEST_COOKIE, true, true, 0, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -261,8 +261,8 @@ TEST_F(TestMockManagedLockAcquireRequest, BreakLockError) {
 
   C_SaferCond ctx;
   MockAcquireRequest *req = MockAcquireRequest::create(mock_image_ctx.md_ctx,
-     mock_image_ctx.image_watcher, ictx->op_work_queue, mock_image_ctx.header_oid,
-     TEST_COOKIE, true, true, 0, &ctx);
+    mock_image_ctx.image_watcher, *ictx->asio_engine, mock_image_ctx.header_oid,
+    TEST_COOKIE, true, true, 0, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }

--- a/src/test/librbd/managed_lock/test_mock_AcquireRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_AcquireRequest.cc
@@ -120,7 +120,7 @@ public:
                              bool exclusive = true) {
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("lock"),
-                     StrEq("lock"), IsLockType(exclusive), _, _))
+                     StrEq("lock"), IsLockType(exclusive), _, _, _))
                   .WillOnce(Return(r));
   }
 

--- a/src/test/librbd/managed_lock/test_mock_BreakRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_BreakRequest.cc
@@ -113,7 +113,8 @@ public:
 
   void expect_break_lock(MockTestImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                exec(mock_image_ctx.header_oid, _, StrEq("lock"), StrEq("break_lock"), _, _, _))
+                exec(mock_image_ctx.header_oid, _, StrEq("lock"),
+                     StrEq("break_lock"), _, _, _, _))
                   .WillOnce(Return(r));
   }
 

--- a/src/test/librbd/managed_lock/test_mock_BreakRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_BreakRequest.cc
@@ -147,7 +147,7 @@ TEST_F(TestMockManagedLockBreakRequest, DeadLockOwner) {
   C_SaferCond ctx;
   Locker locker{entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123};
   MockBreakRequest *req = MockBreakRequest::create(
-      mock_image_ctx.md_ctx, ictx->op_work_queue, mock_image_ctx.header_oid,
+      mock_image_ctx.md_ctx, *ictx->asio_engine, mock_image_ctx.header_oid,
       locker, true, true, 0, false, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
@@ -176,7 +176,7 @@ TEST_F(TestMockManagedLockBreakRequest, ForceBreak) {
   C_SaferCond ctx;
   Locker locker{entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123};
   MockBreakRequest *req = MockBreakRequest::create(
-      mock_image_ctx.md_ctx, ictx->op_work_queue, mock_image_ctx.header_oid,
+      mock_image_ctx.md_ctx, *ictx->asio_engine, mock_image_ctx.header_oid,
       locker, true, true, 0, true, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
@@ -197,7 +197,7 @@ TEST_F(TestMockManagedLockBreakRequest, GetWatchersError) {
   C_SaferCond ctx;
   Locker locker{entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123};
   MockBreakRequest *req = MockBreakRequest::create(
-      mock_image_ctx.md_ctx, ictx->op_work_queue, mock_image_ctx.header_oid,
+      mock_image_ctx.md_ctx, *ictx->asio_engine, mock_image_ctx.header_oid,
       locker, true, true, 0, false, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -218,7 +218,7 @@ TEST_F(TestMockManagedLockBreakRequest, GetWatchersAlive) {
   C_SaferCond ctx;
   Locker locker{entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123};
   MockBreakRequest *req = MockBreakRequest::create(
-      mock_image_ctx.md_ctx, ictx->op_work_queue, mock_image_ctx.header_oid,
+      mock_image_ctx.md_ctx, *ictx->asio_engine, mock_image_ctx.header_oid,
       locker, true, true, 0, false, &ctx);
   req->send();
   ASSERT_EQ(-EAGAIN, ctx.wait());
@@ -244,7 +244,7 @@ TEST_F(TestMockManagedLockBreakRequest, GetLockerUpdated) {
   C_SaferCond ctx;
   Locker locker{entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123};
   MockBreakRequest *req = MockBreakRequest::create(
-      mock_image_ctx.md_ctx, ictx->op_work_queue, mock_image_ctx.header_oid,
+      mock_image_ctx.md_ctx, *ictx->asio_engine, mock_image_ctx.header_oid,
       locker, true, false, 0, false, &ctx);
   req->send();
   ASSERT_EQ(-EAGAIN, ctx.wait());
@@ -270,7 +270,7 @@ TEST_F(TestMockManagedLockBreakRequest, GetLockerBusy) {
   C_SaferCond ctx;
   Locker locker{entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123};
   MockBreakRequest *req = MockBreakRequest::create(
-      mock_image_ctx.md_ctx, ictx->op_work_queue, mock_image_ctx.header_oid,
+      mock_image_ctx.md_ctx, *ictx->asio_engine, mock_image_ctx.header_oid,
       locker, true, false, 0, false, &ctx);
   req->send();
   ASSERT_EQ(-EAGAIN, ctx.wait());
@@ -296,7 +296,7 @@ TEST_F(TestMockManagedLockBreakRequest, GetLockerMissing) {
   C_SaferCond ctx;
   Locker locker{entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123};
   MockBreakRequest *req = MockBreakRequest::create(
-      mock_image_ctx.md_ctx, ictx->op_work_queue, mock_image_ctx.header_oid,
+      mock_image_ctx.md_ctx, *ictx->asio_engine, mock_image_ctx.header_oid,
       locker, true, false, 0, false, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
@@ -320,7 +320,7 @@ TEST_F(TestMockManagedLockBreakRequest, GetLockerError) {
   C_SaferCond ctx;
   Locker locker{entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123};
   MockBreakRequest *req = MockBreakRequest::create(
-      mock_image_ctx.md_ctx, ictx->op_work_queue, mock_image_ctx.header_oid,
+      mock_image_ctx.md_ctx, *ictx->asio_engine, mock_image_ctx.header_oid,
       locker, true, false, 0, false, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -348,7 +348,7 @@ TEST_F(TestMockManagedLockBreakRequest, BlacklistDisabled) {
   C_SaferCond ctx;
   Locker locker{entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123};
   MockBreakRequest *req = MockBreakRequest::create(
-      mock_image_ctx.md_ctx, ictx->op_work_queue, mock_image_ctx.header_oid,
+      mock_image_ctx.md_ctx, *ictx->asio_engine, mock_image_ctx.header_oid,
       locker, true, false, 0, false, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
@@ -376,7 +376,7 @@ TEST_F(TestMockManagedLockBreakRequest, BlacklistSelf) {
   C_SaferCond ctx;
   Locker locker{entity_name_t::CLIENT(456), "auto 123", "1.2.3.4:0/0", 123};
   MockBreakRequest *req = MockBreakRequest::create(
-      mock_image_ctx.md_ctx, ictx->op_work_queue, mock_image_ctx.header_oid,
+      mock_image_ctx.md_ctx, *ictx->asio_engine, mock_image_ctx.header_oid,
       locker, true, true, 0, false, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -404,7 +404,7 @@ TEST_F(TestMockManagedLockBreakRequest, BlacklistError) {
   C_SaferCond ctx;
   Locker locker{entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123};
   MockBreakRequest *req = MockBreakRequest::create(
-      mock_image_ctx.md_ctx, ictx->op_work_queue, mock_image_ctx.header_oid,
+      mock_image_ctx.md_ctx, *ictx->asio_engine, mock_image_ctx.header_oid,
       locker, true, true, 0, false, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -433,7 +433,7 @@ TEST_F(TestMockManagedLockBreakRequest, BreakLockMissing) {
   C_SaferCond ctx;
   Locker locker{entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123};
   MockBreakRequest *req = MockBreakRequest::create(
-      mock_image_ctx.md_ctx, ictx->op_work_queue, mock_image_ctx.header_oid,
+      mock_image_ctx.md_ctx, *ictx->asio_engine, mock_image_ctx.header_oid,
       locker, true, true, 0, false, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
@@ -462,7 +462,7 @@ TEST_F(TestMockManagedLockBreakRequest, BreakLockError) {
   C_SaferCond ctx;
   Locker locker{entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123};
   MockBreakRequest *req = MockBreakRequest::create(
-      mock_image_ctx.md_ctx, ictx->op_work_queue, mock_image_ctx.header_oid,
+      mock_image_ctx.md_ctx, *ictx->asio_engine, mock_image_ctx.header_oid,
       locker, true, true, 0, false, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());

--- a/src/test/librbd/managed_lock/test_mock_GetLockerRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_GetLockerRequest.cc
@@ -52,7 +52,7 @@ public:
                             ClsLockType lock_type) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                                exec(mock_image_ctx.header_oid, _, StrEq("lock"),
-                               StrEq("get_info"), _, _, _));
+                               StrEq("get_info"), _, _, _, _));
     if (r < 0 && r != -ENOENT) {
       expect.WillOnce(Return(r));
     } else {

--- a/src/test/librbd/managed_lock/test_mock_ReacquireRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_ReacquireRequest.cc
@@ -46,7 +46,7 @@ public:
                          bool exclusive = true) {
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("lock"),
-                     StrEq("set_cookie"), IsLockType(exclusive), _, _))
+                     StrEq("set_cookie"), IsLockType(exclusive), _, _, _))
                   .WillOnce(Return(r));
   }
 };

--- a/src/test/librbd/managed_lock/test_mock_ReleaseRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_ReleaseRequest.cc
@@ -41,7 +41,7 @@ public:
   void expect_unlock(MockImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("lock"),
-                     StrEq("unlock"), _, _, _))
+                     StrEq("unlock"), _, _, _, _))
                         .WillOnce(Return(r));
   }
 

--- a/src/test/librbd/mirror/snapshot/test_mock_CreateNonPrimaryRequest.cc
+++ b/src/test/librbd/mirror/snapshot/test_mock_CreateNonPrimaryRequest.cc
@@ -129,7 +129,7 @@ public:
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_image_get"),
-                     _, _, _))
+                     _, _, _, _))
       .WillOnce(DoAll(WithArg<5>(CopyInBufferlist(bl)),
                       Return(r)));
   }
@@ -149,7 +149,7 @@ public:
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_peer_list"),
-                     _, _, _))
+                     _, _, _, _))
       .WillOnce(DoAll(WithArg<5>(CopyInBufferlist(bl)),
                       Return(r)));
   }

--- a/src/test/librbd/mirror/snapshot/test_mock_CreatePrimaryRequest.cc
+++ b/src/test/librbd/mirror/snapshot/test_mock_CreatePrimaryRequest.cc
@@ -140,7 +140,7 @@ public:
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_peer_list"),
-                     _, _, _))
+                     _, _, _, _))
       .WillOnce(DoAll(WithArg<5>(CopyInBufferlist(bl)),
                       Return(r)));
   }

--- a/src/test/librbd/mirror/snapshot/test_mock_ImageMeta.cc
+++ b/src/test/librbd/mirror/snapshot/test_mock_ImageMeta.cc
@@ -49,7 +49,7 @@ public:
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                     StrEq("metadata_get"), ContentsEqual(in_bl), _, _))
+                     StrEq("metadata_get"), ContentsEqual(in_bl), _, _, _))
       .WillOnce(DoAll(WithArg<5>(CopyInBufferlist(out_bl)),
                       Return(r)));
   }
@@ -68,7 +68,7 @@ public:
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                     StrEq("metadata_set"), ContentsEqual(in_bl), _, _))
+                     StrEq("metadata_set"), ContentsEqual(in_bl), _, _, _))
       .WillOnce(Return(r));
   }
 };

--- a/src/test/librbd/mirror/snapshot/test_mock_UnlinkPeerRequest.cc
+++ b/src/test/librbd/mirror/snapshot/test_mock_UnlinkPeerRequest.cc
@@ -85,7 +85,7 @@ public:
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
                      StrEq("mirror_image_snapshot_unlink_peer"),
-                     ContentsEqual(bl), _, _))
+                     ContentsEqual(bl), _, _, _))
       .WillOnce(Invoke([&mock_image_ctx, snap_id, peer_uuid, r](auto&&... args) -> int {
                          if (r == 0) {
                            auto it = mock_image_ctx.snap_info.find(snap_id);

--- a/src/test/librbd/mirror/test_mock_DisableRequest.cc
+++ b/src/test/librbd/mirror/test_mock_DisableRequest.cc
@@ -228,7 +228,7 @@ public:
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(::journal::Journaler::header_oid(mock_image_ctx.id),
-                     _, StrEq("journal"), StrEq("client_list"), _, _, _))
+                     _, StrEq("journal"), StrEq("client_list"), _, _, _, _))
       .WillOnce(DoAll(WithArg<5>(CopyInBufferlist(bl)),
                       Return(r)));
   }
@@ -243,7 +243,7 @@ public:
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(::journal::Journaler::header_oid(mock_image_ctx.id),
                      _, StrEq("journal"), StrEq("client_unregister"),
-                     ContentsEqual(bl), _, _))
+                     ContentsEqual(bl), _, _, _))
       .WillOnce(Return(r));
   }
 

--- a/src/test/librbd/mock/MockImageCtx.cc
+++ b/src/test/librbd/mock/MockImageCtx.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "include/neorados/RADOS.hpp"
 #include "test/librbd/mock/MockImageCtx.h"
 #include "test/librbd/mock/MockSafeTimer.h"
 #include "librbd/io/AsyncOperation.h"
@@ -33,6 +34,15 @@ void MockImageCtx::wait_for_async_ops() {
   ctx.wait();
 
   async_op.finish_op();
+}
+
+IOContext MockImageCtx::get_data_io_context() {
+  auto ctx = std::make_shared<neorados::IOContext>(
+    data_ctx.get_id(), data_ctx.get_namespace());
+  ctx->read_snap(snap_id);
+  ctx->write_snap_context(
+    {{snapc.seq, {snapc.snaps.begin(), snapc.snaps.end()}}});
+  return ctx;
 }
 
 } // namespace librbd

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -62,6 +62,7 @@ struct MockImageCtx {
       lockers(image_ctx.lockers),
       exclusive_locked(image_ctx.exclusive_locked),
       lock_tag(image_ctx.lock_tag),
+      asio_engine(image_ctx.asio_engine),
       owner_lock(image_ctx.owner_lock),
       image_lock(image_ctx.image_lock),
       timestamp_lock(image_ctx.timestamp_lock),
@@ -248,6 +249,8 @@ struct MockImageCtx {
            rados::cls::lock::locker_info_t> lockers;
   bool exclusive_locked;
   std::string lock_tag;
+
+  std::shared_ptr<AsioEngine> asio_engine;
 
   librados::IoCtx md_ctx;
   librados::IoCtx data_ctx;

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -63,6 +63,7 @@ struct MockImageCtx {
       exclusive_locked(image_ctx.exclusive_locked),
       lock_tag(image_ctx.lock_tag),
       asio_engine(image_ctx.asio_engine),
+      rados_api(image_ctx.rados_api),
       owner_lock(image_ctx.owner_lock),
       image_lock(image_ctx.image_lock),
       timestamp_lock(image_ctx.timestamp_lock),
@@ -220,6 +221,9 @@ struct MockImageCtx {
   MOCK_CONST_METHOD0(get_stripe_count, uint64_t());
   MOCK_CONST_METHOD0(get_stripe_period, uint64_t());
 
+  MOCK_METHOD0(rebuild_data_io_context, void());
+  IOContext get_data_io_context();
+
   static void set_timer_instance(MockSafeTimer *timer, ceph::mutex *timer_lock);
   static void get_timer_instance(CephContext *cct, MockSafeTimer **timer,
                                  ceph::mutex **timer_lock);
@@ -251,6 +255,7 @@ struct MockImageCtx {
   std::string lock_tag;
 
   std::shared_ptr<AsioEngine> asio_engine;
+  neorados::RADOS& rados_api;
 
   librados::IoCtx md_ctx;
   librados::IoCtx data_ctx;

--- a/src/test/librbd/mock/io/MockObjectDispatch.h
+++ b/src/test/librbd/mock/io/MockObjectDispatch.h
@@ -26,12 +26,12 @@ public:
 
   MOCK_METHOD8(execute_read,
                bool(uint64_t, uint64_t, uint64_t, librados::snap_t,
-                    ceph::bufferlist*, ExtentMap*, DispatchResult*, Context*));
+                    ceph::bufferlist*, Extents*, DispatchResult*, Context*));
   bool read(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       librados::snap_t snap_id, int op_flags,
       const ZTracer::Trace& parent_trace, ceph::bufferlist* read_data,
-      ExtentMap* extent_map, int* dispatch_flags,
+      Extents* extent_map, int* dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) {
     return execute_read(object_no, object_off, object_len, snap_id, read_data,

--- a/src/test/librbd/object_map/test_mock_InvalidateRequest.cc
+++ b/src/test/librbd/object_map/test_mock_InvalidateRequest.cc
@@ -36,7 +36,8 @@ TEST_F(TestMockObjectMapInvalidateRequest, UpdatesInMemoryFlag) {
   AsyncRequest<> *request = new InvalidateRequest<>(*ictx, CEPH_NOSNAP, false, &cond_ctx);
 
   EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-              exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _, _))
+              exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _,
+                   _, _))
                 .Times(0);
 
   {
@@ -62,7 +63,8 @@ TEST_F(TestMockObjectMapInvalidateRequest, UpdatesHeadOnDiskFlag) {
   AsyncRequest<> *request = new InvalidateRequest<>(*ictx, CEPH_NOSNAP, false, &cond_ctx);
 
   EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-              exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _, _))
+              exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _,
+                   _, _))
                 .WillOnce(DoDefault());
 
   {
@@ -91,7 +93,8 @@ TEST_F(TestMockObjectMapInvalidateRequest, UpdatesSnapOnDiskFlag) {
                                                 &cond_ctx);
 
   EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-              exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _, _))
+              exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _,
+                   _, _))
                 .WillOnce(DoDefault());
 
   {
@@ -112,7 +115,8 @@ TEST_F(TestMockObjectMapInvalidateRequest, SkipOnDiskUpdateWithoutLock) {
   AsyncRequest<> *request = new InvalidateRequest<>(*ictx, CEPH_NOSNAP, false, &cond_ctx);
 
   EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-              exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _, _))
+              exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _,
+                   _, _))
                 .Times(0);
 
   {
@@ -136,7 +140,8 @@ TEST_F(TestMockObjectMapInvalidateRequest, IgnoresOnDiskUpdateFailure) {
   AsyncRequest<> *request = new InvalidateRequest<>(*ictx, CEPH_NOSNAP, false, &cond_ctx);
 
   EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-              exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _, _))
+              exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _,
+                   _, _))
                 .WillOnce(Return(-EINVAL));
 
   {

--- a/src/test/librbd/object_map/test_mock_LockRequest.cc
+++ b/src/test/librbd/object_map/test_mock_LockRequest.cc
@@ -30,7 +30,7 @@ public:
     std::string oid(ObjectMap<>::object_map_name(mock_image_ctx.id,
                                                  CEPH_NOSNAP));
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                exec(oid, _, StrEq("lock"), StrEq("lock"), _, _, _))
+                exec(oid, _, StrEq("lock"), StrEq("lock"), _, _, _, _))
                   .WillOnce(Return(r));
   }
 
@@ -38,7 +38,8 @@ public:
     std::string oid(ObjectMap<>::object_map_name(mock_image_ctx.id,
                                                  CEPH_NOSNAP));
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                               exec(oid, _, StrEq("lock"), StrEq("get_info"), _, _, _));
+                               exec(oid, _, StrEq("lock"), StrEq("get_info"), _,
+                                    _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -64,7 +65,8 @@ public:
     std::string oid(ObjectMap<>::object_map_name(mock_image_ctx.id,
                                                  CEPH_NOSNAP));
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                               exec(oid, _, StrEq("lock"), StrEq("break_lock"), _, _, _));
+                               exec(oid, _, StrEq("lock"), StrEq("break_lock"),
+                                    _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {

--- a/src/test/librbd/object_map/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/object_map/test_mock_RefreshRequest.cc
@@ -88,7 +88,8 @@ public:
                               int r) {
     std::string oid(ObjectMap<>::object_map_name(mock_image_ctx.id, snap_id));
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                               exec(oid, _, StrEq("rbd"), StrEq("object_map_load"), _, _, _));
+                               exec(oid, _, StrEq("rbd"),
+                                    StrEq("object_map_load"), _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -129,7 +130,8 @@ public:
     std::string oid(ObjectMap<>::object_map_name(mock_image_ctx.id,
                                                  TEST_SNAP_ID));
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                               exec(oid, _, StrEq("rbd"), StrEq("object_map_resize"), _, _, _));
+                               exec(oid, _, StrEq("rbd"),
+                                    StrEq("object_map_resize"), _, _, _, _));
     expect.WillOnce(Return(r));
   }
 

--- a/src/test/librbd/object_map/test_mock_ResizeRequest.cc
+++ b/src/test/librbd/object_map/test_mock_ResizeRequest.cc
@@ -26,24 +26,28 @@ public:
     std::string oid(ObjectMap<>::object_map_name(ictx->id, snap_id));
     if (snap_id == CEPH_NOSNAP) {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                  exec(oid, _, StrEq("lock"), StrEq("assert_locked"), _, _, _))
+                  exec(oid, _, StrEq("lock"), StrEq("assert_locked"), _, _, _,
+                       _))
                     .WillOnce(DoDefault());
     }
 
     if (r < 0) {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                  exec(oid, _, StrEq("rbd"), StrEq("object_map_resize"), _, _, _))
+                  exec(oid, _, StrEq("rbd"), StrEq("object_map_resize"), _, _,
+                       _, _))
                     .WillOnce(Return(r));
     } else {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                  exec(oid, _, StrEq("rbd"), StrEq("object_map_resize"), _, _, _))
+                  exec(oid, _, StrEq("rbd"), StrEq("object_map_resize"), _, _,
+                       _, _))
                     .WillOnce(DoDefault());
     }
   }
 
   void expect_invalidate(librbd::ImageCtx *ictx) {
     EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _, _))
+                exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _,
+                     _, _, _))
                   .WillOnce(DoDefault());
   }
 };

--- a/src/test/librbd/object_map/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/object_map/test_mock_SnapshotCreateRequest.cc
@@ -33,11 +33,11 @@ public:
     if (r < 0) {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
                   read(ObjectMap<>::object_map_name(ictx->id, CEPH_NOSNAP),
-                       0, 0, _)).WillOnce(Return(r));
+                       0, 0, _, _)).WillOnce(Return(r));
     } else {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
                   read(ObjectMap<>::object_map_name(ictx->id, CEPH_NOSNAP),
-                       0, 0, _)).WillOnce(DoDefault());
+                       0, 0, _, _)).WillOnce(DoDefault());
     }
   }
 
@@ -59,21 +59,25 @@ public:
     std::string oid(ObjectMap<>::object_map_name(ictx->id, CEPH_NOSNAP));
     if (r < 0) {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                  exec(oid, _, StrEq("lock"), StrEq("assert_locked"), _, _, _))
+                  exec(oid, _, StrEq("lock"), StrEq("assert_locked"), _, _, _,
+                       _))
                     .WillOnce(Return(r));
     } else {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                  exec(oid, _, StrEq("lock"), StrEq("assert_locked"), _, _, _))
+                  exec(oid, _, StrEq("lock"), StrEq("assert_locked"), _, _, _,
+                       _))
                     .WillOnce(DoDefault());
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                  exec(oid, _, StrEq("rbd"), StrEq("object_map_snap_add"), _, _, _))
+                  exec(oid, _, StrEq("rbd"), StrEq("object_map_snap_add"), _, _,
+                       _, _))
                     .WillOnce(DoDefault());
     }
   }
 
   void expect_invalidate(librbd::ImageCtx *ictx) {
     EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _, _))
+                exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _,
+                     _, _, _))
                   .WillOnce(DoDefault());
   }
 };

--- a/src/test/librbd/object_map/test_mock_SnapshotRemoveRequest.cc
+++ b/src/test/librbd/object_map/test_mock_SnapshotRemoveRequest.cc
@@ -26,11 +26,13 @@ public:
     std::string snap_oid(ObjectMap<>::object_map_name(ictx->id, snap_id));
     if (r < 0) {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                  exec(snap_oid, _, StrEq("rbd"), StrEq("object_map_load"), _, _, _))
+                  exec(snap_oid, _, StrEq("rbd"), StrEq("object_map_load"), _,
+                       _, _, _))
                     .WillOnce(Return(r));
     } else {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                  exec(snap_oid, _, StrEq("rbd"), StrEq("object_map_load"), _, _, _))
+                  exec(snap_oid, _, StrEq("rbd"), StrEq("object_map_load"), _,
+                       _, _, _))
                     .WillOnce(DoDefault());
     }
   }
@@ -39,14 +41,17 @@ public:
     std::string oid(ObjectMap<>::object_map_name(ictx->id, CEPH_NOSNAP));
     if (r < 0) {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                  exec(oid, _, StrEq("lock"), StrEq("assert_locked"), _, _, _))
+                  exec(oid, _, StrEq("lock"), StrEq("assert_locked"), _, _, _,
+                       _))
                     .WillOnce(Return(r));
     } else {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                  exec(oid, _, StrEq("lock"), StrEq("assert_locked"), _, _, _))
+                  exec(oid, _, StrEq("lock"), StrEq("assert_locked"), _, _, _,
+                       _))
                     .WillOnce(DoDefault());
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                  exec(oid, _, StrEq("rbd"), StrEq("object_map_snap_remove"), _, _, _))
+                  exec(oid, _, StrEq("rbd"), StrEq("object_map_snap_remove"), _,
+                       _, _, _))
                     .WillOnce(DoDefault());
     }
   }
@@ -64,7 +69,8 @@ public:
 
   void expect_invalidate(librbd::ImageCtx *ictx) {
     EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _, _))
+                exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _,
+                     _, _, _))
                   .WillOnce(DoDefault());
   }
 };

--- a/src/test/librbd/object_map/test_mock_SnapshotRollbackRequest.cc
+++ b/src/test/librbd/object_map/test_mock_SnapshotRollbackRequest.cc
@@ -25,18 +25,18 @@ public:
     if (r < 0) {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
                   read(ObjectMap<>::object_map_name(ictx->id, snap_id),
-                       0, 0, _)).WillOnce(Return(r));
+                       0, 0, _, _)).WillOnce(Return(r));
     } else {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
                   read(ObjectMap<>::object_map_name(ictx->id, snap_id),
-                       0, 0, _)).WillOnce(DoDefault());
+                       0, 0, _, _)).WillOnce(DoDefault());
     }
   }
 
   void expect_write_map(librbd::ImageCtx *ictx, int r) {
     EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
                 exec(ObjectMap<>::object_map_name(ictx->id, CEPH_NOSNAP), _,
-		     StrEq("lock"), StrEq("assert_locked"), _, _, _))
+		     StrEq("lock"), StrEq("assert_locked"), _, _, _, _))
                   .WillOnce(DoDefault());
     if (r < 0) {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
@@ -53,7 +53,8 @@ public:
 
   void expect_invalidate(librbd::ImageCtx *ictx, uint32_t times) {
     EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _, _))
+                exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _,
+                     _, _, _))
                   .Times(times)
                   .WillRepeatedly(DoDefault());
   }

--- a/src/test/librbd/object_map/test_mock_UnlockRequest.cc
+++ b/src/test/librbd/object_map/test_mock_UnlockRequest.cc
@@ -28,7 +28,7 @@ public:
     std::string oid(ObjectMap<>::object_map_name(mock_image_ctx.id,
                                                  CEPH_NOSNAP));
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                exec(oid, _, StrEq("lock"), StrEq("unlock"), _, _, _))
+                exec(oid, _, StrEq("lock"), StrEq("unlock"), _, _, _, _))
                   .WillOnce(Return(r));
   }
 };

--- a/src/test/librbd/object_map/test_mock_UpdateRequest.cc
+++ b/src/test/librbd/object_map/test_mock_UpdateRequest.cc
@@ -38,26 +38,28 @@ public:
     std::string oid(ObjectMap<>::object_map_name(ictx->id, snap_id));
     if (snap_id == CEPH_NOSNAP) {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                  exec(oid, _, StrEq("lock"), StrEq("assert_locked"), _, _, _))
+                  exec(oid, _, StrEq("lock"), StrEq("assert_locked"), _, _, _,
+                       _))
                     .WillOnce(DoDefault());
     }
 
     if (r < 0) {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
                   exec(oid, _, StrEq("rbd"), StrEq("object_map_update"),
-                       ContentsEqual(bl), _, _))
+                       ContentsEqual(bl), _, _, _))
                     .WillOnce(Return(r));
     } else {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
                   exec(oid, _, StrEq("rbd"), StrEq("object_map_update"),
-                       ContentsEqual(bl), _, _))
+                       ContentsEqual(bl), _, _, _))
                     .WillOnce(DoDefault());
     }
   }
 
   void expect_invalidate(librbd::ImageCtx *ictx) {
     EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
-                exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _, _, _))
+                exec(ictx->header_oid, _, StrEq("rbd"), StrEq("set_flags"), _,
+                     _, _, _))
                   .WillOnce(DoDefault());
   }
 };

--- a/src/test/librbd/operation/test_mock_ResizeRequest.cc
+++ b/src/test/librbd/operation/test_mock_ResizeRequest.cc
@@ -141,7 +141,8 @@ public:
     } else {
       expect_is_lock_owner(mock_image_ctx);
       EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("set_size"), _, _, _))
+                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                       StrEq("set_size"), _, _, _, _))
                     .WillOnce(Return(r));
     }
   }

--- a/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
@@ -105,7 +105,7 @@ public:
                                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
                                StrEq(mock_image_ctx.old_format ? "snap_add" :
                                                                  "snapshot_add"),
-                               _, _, _));
+                               _, _, _, _));
     if (r == -ESTALE) {
       expect.WillOnce(Return(r)).WillOnce(DoDefault());
     } else if (r < 0) {

--- a/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
@@ -179,6 +179,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, Success) {
   if (!mock_image_ctx.old_format) {
     expect_object_map_snap_create(mock_image_ctx);
     expect_update_snap_context(mock_image_ctx);
+    EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
   }
   expect_unblock_writes(mock_image_ctx);
   expect_notify_unquiesce(mock_image_ctx, -EINVAL);
@@ -278,6 +279,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, CreateSnapStale) {
   if (!mock_image_ctx.old_format) {
     expect_object_map_snap_create(mock_image_ctx);
     expect_update_snap_context(mock_image_ctx);
+    EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
   }
   expect_unblock_writes(mock_image_ctx);
   expect_notify_unquiesce(mock_image_ctx, 0);
@@ -387,6 +389,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, SkipObjectMap) {
   expect_allocate_snap_id(mock_image_ctx, 0);
   expect_snap_create(mock_image_ctx, 0);
   expect_update_snap_context(mock_image_ctx);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
   expect_unblock_writes(mock_image_ctx);
   expect_notify_unquiesce(mock_image_ctx, 0);
 
@@ -430,6 +433,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, SkipNotifyQuiesce) {
   if (!mock_image_ctx.old_format) {
     expect_object_map_snap_create(mock_image_ctx);
     expect_update_snap_context(mock_image_ctx);
+    EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
   }
   expect_unblock_writes(mock_image_ctx);
 
@@ -475,6 +479,7 @@ TEST_F(TestMockOperationSnapshotCreateRequest, SetImageState) {
   MockSetImageStateRequest mock_set_image_state_request;
   expect_set_image_state(mock_image_ctx, mock_set_image_state_request, 0);
   expect_update_snap_context(mock_image_ctx);
+  EXPECT_CALL(mock_image_ctx, rebuild_data_io_context());
   expect_unblock_writes(mock_image_ctx);
   expect_notify_unquiesce(mock_image_ctx, 0);
 

--- a/src/test/librbd/operation/test_mock_SnapshotProtectRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotProtectRequest.cc
@@ -48,7 +48,8 @@ public:
   void expect_set_protection_status(MockImageCtx &mock_image_ctx, int r) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                                    StrEq("set_protection_status"), _, _, _));
+                                    StrEq("set_protection_status"), _, _, _,
+                                    _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {

--- a/src/test/librbd/operation/test_mock_SnapshotRemoveRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotRemoveRequest.cc
@@ -121,7 +121,7 @@ public:
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
                                StrEq("snapshot_trash_add"),
-                                _, _, _));
+                               _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -138,7 +138,7 @@ public:
     using ceph::encode;
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                     StrEq("snapshot_get"), _, _, _))
+                     StrEq("snapshot_get"), _, _, _, _))
       .WillOnce(WithArg<5>(Invoke([snap_info, r](bufferlist* bl) {
                              encode(snap_info, *bl);
                              return r;
@@ -154,7 +154,7 @@ public:
     using ceph::encode;
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                     StrEq("children_list"), _, _, _))
+                     StrEq("children_list"), _, _, _, _))
       .WillOnce(WithArg<5>(Invoke([child_images, r](bufferlist* bl) {
                              encode(child_images, *bl);
                              return r;
@@ -171,7 +171,7 @@ public:
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(util::header_name(parent_spec.image_id),
                      _, StrEq("rbd"), StrEq("child_detach"), ContentsEqual(bl),
-                     _, _))
+                     _, _, _))
       .WillOnce(Return(r));
   }
 
@@ -217,7 +217,7 @@ public:
                                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
                                StrEq(mock_image_ctx.old_format ? "snap_remove" :
                                                                   "snapshot_remove"),
-                                _, _, _));
+                                _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {

--- a/src/test/librbd/operation/test_mock_SnapshotUnprotectRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotUnprotectRequest.cc
@@ -56,8 +56,8 @@ public:
 
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
-                                    StrEq("set_protection_status"), ContentsEqual(bl),
-                                    _, _));
+                                    StrEq("set_protection_status"),
+                                    ContentsEqual(bl), _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {
@@ -90,8 +90,8 @@ public:
     encode(children, bl);
 
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                               exec(RBD_CHILDREN, _, StrEq("rbd"), StrEq("get_children"), _,
-                               _, _));
+                               exec(RBD_CHILDREN, _, StrEq("rbd"),
+                               StrEq("get_children"), _, _, _, _));
     if (r < 0) {
       expect.WillRepeatedly(Return(r));
     } else {

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -1026,32 +1026,6 @@ TEST_F(TestInternal, DiscardCopyup)
   }
 }
 
-TEST_F(TestInternal, ShrinkFlushesCache) {
-  librbd::ImageCtx *ictx;
-  ASSERT_EQ(0, open_image(m_image_name, &ictx));
-
-  std::string buffer(4096, '1');
-
-  // ensure write-path is initialized
-  bufferlist write_bl;
-  write_bl.append(buffer);
-  api::Io<>::write(*ictx, 0, buffer.size(), bufferlist{write_bl}, 0);
-
-  C_SaferCond cond_ctx;
-  auto c = librbd::io::AioCompletion::create(&cond_ctx);
-  c->get();
-  api::Io<>::aio_write(*ictx, c, 0, buffer.size(), bufferlist{write_bl}, 0,
-                       true);
-
-  librbd::NoOpProgressContext no_op;
-  ASSERT_EQ(0, ictx->operations->resize(m_image_size >> 1, true, no_op));
-
-  ASSERT_TRUE(c->is_complete());
-  ASSERT_EQ(0, c->wait_for_complete());
-  ASSERT_EQ(0, cond_ctx.wait());
-  c->put();
-}
-
 TEST_F(TestInternal, ImageOptions) {
   rbd_image_options_t opts1 = NULL, opts2 = NULL;
   uint64_t uint64_val1 = 10, uint64_val2 = 0;

--- a/src/test/librbd/test_mock_DeepCopyRequest.cc
+++ b/src/test/librbd/test_mock_DeepCopyRequest.cc
@@ -3,6 +3,7 @@
 
 #include "test/librbd/test_mock_fixture.h"
 #include "include/rbd/librbd.hpp"
+#include "librbd/AsioEngine.h"
 #include "librbd/DeepCopyRequest.h"
 #include "librbd/ImageState.h"
 #include "librbd/Operations.h"
@@ -150,6 +151,8 @@ public:
 
   librbd::ImageCtx *m_src_image_ctx;
   librbd::ImageCtx *m_dst_image_ctx;
+
+  std::shared_ptr<librbd::AsioEngine> m_asio_engine;
   librbd::asio::ContextWQ *m_work_queue;
 
   void SetUp() override {
@@ -160,7 +163,9 @@ public:
 
     ASSERT_EQ(0, open_image(m_image_name, &m_dst_image_ctx));
 
-    librbd::ImageCtx::get_work_queue(m_src_image_ctx->cct, &m_work_queue);
+    m_asio_engine = std::make_shared<librbd::AsioEngine>(
+      m_src_image_ctx->md_ctx);
+    m_work_queue = m_asio_engine->get_work_queue();
   }
 
   void TearDown() override {

--- a/src/test/librbd/test_mock_ExclusiveLock.cc
+++ b/src/test/librbd/test_mock_ExclusiveLock.cc
@@ -40,7 +40,7 @@ struct Traits<MockExclusiveLockImageCtx> {
 
 template <>
 struct ManagedLock<MockExclusiveLockImageCtx> {
-  ManagedLock(librados::IoCtx& ioctx, asio::ContextWQ *work_queue,
+  ManagedLock(librados::IoCtx& ioctx, AsioEngine& asio_engine,
               const std::string& oid, librbd::MockImageWatcher *watcher,
               managed_lock::Mode  mode, bool blacklist_on_break_lock,
               uint32_t blacklist_expire_seconds)

--- a/src/test/librbd/test_mock_fixture.cc
+++ b/src/test/librbd/test_mock_fixture.cc
@@ -53,7 +53,7 @@ void TestMockFixture::TearDown() {
 
 void TestMockFixture::expect_unlock_exclusive_lock(librbd::ImageCtx &ictx) {
   EXPECT_CALL(get_mock_io_ctx(ictx.md_ctx),
-              exec(_, _, StrEq("lock"), StrEq("unlock"), _, _, _))
+              exec(_, _, StrEq("lock"), StrEq("unlock"), _, _, _, _))
                 .WillRepeatedly(DoDefault());
 }
 

--- a/src/test/librbd/trash/test_mock_MoveRequest.cc
+++ b/src/test/librbd/trash/test_mock_MoveRequest.cc
@@ -62,7 +62,7 @@ struct TestMockTrashMoveRequest : public TestMockFixture {
                         int r) {
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(StrEq("rbd_trash"), _, StrEq("rbd"), StrEq("trash_add"),
-                     _, _, _))
+                     _, _, _, _))
       .WillOnce(WithArg<4>(Invoke([=](bufferlist& in_bl) {
                              std::string id;
                              cls::rbd::TrashImageSpec trash_image_spec;
@@ -96,7 +96,7 @@ struct TestMockTrashMoveRequest : public TestMockFixture {
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(StrEq("rbd_directory"), _, StrEq("rbd"), StrEq("dir_remove_image"),
-                     ContentsEqual(in_bl), _, _))
+                     ContentsEqual(in_bl), _, _, _))
       .WillOnce(Return(r));
   }
 };

--- a/src/test/librbd/trash/test_mock_RemoveRequest.cc
+++ b/src/test/librbd/trash/test_mock_RemoveRequest.cc
@@ -103,7 +103,7 @@ struct TestMockTrashRemoveRequest : public TestMockFixture {
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(StrEq("rbd_trash"), _, StrEq("rbd"), StrEq("trash_state_set"),
-                     ContentsEqual(in_bl), _, _))
+                     ContentsEqual(in_bl), _, _, _))
       .WillOnce(Return(r));
   }
 
@@ -140,7 +140,7 @@ struct TestMockTrashRemoveRequest : public TestMockFixture {
 
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(StrEq("rbd_trash"), _, StrEq("rbd"), StrEq("trash_remove"),
-                     ContentsEqual(in_bl), _, _))
+                     ContentsEqual(in_bl), _, _, _))
       .WillOnce(Return(r));
   }
 };

--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -57,7 +57,6 @@ add_dependencies(unittest_rbd_mirror
   cls_rbd)
 target_link_libraries(unittest_rbd_mirror
   rbd_mirror_test
-  rados_test_stub
   rbd_mirror_internal
   rbd_mirror_types
   rbd_api
@@ -69,6 +68,7 @@ target_link_libraries(unittest_rbd_mirror
   cls_lock_client
   cls_journal_client
   rbd_types
+  rados_test_stub
   librados
   osdc
   global
@@ -89,6 +89,7 @@ target_link_libraries(ceph_test_rbd_mirror
   cls_rbd_client
   cls_journal_client
   rbd_types
+  libneorados
   librados
   radostest-cxx
   ${UNITTEST_LIBS}

--- a/src/test/rbd_mirror/image_deleter/test_mock_TrashMoveRequest.cc
+++ b/src/test/rbd_mirror/image_deleter/test_mock_TrashMoveRequest.cc
@@ -201,7 +201,8 @@ public:
     encode(image_id, bl);
 
     EXPECT_CALL(get_mock_io_ctx(m_local_io_ctx),
-                exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_image_get_image_id"), _, _, _))
+                exec(RBD_MIRRORING, _, StrEq("rbd"),
+                     StrEq("mirror_image_get_image_id"), _, _, _, _))
       .WillOnce(DoAll(WithArg<5>(Invoke([bl](bufferlist *out_bl) {
                                           *out_bl = bl;
                                         })),
@@ -272,14 +273,14 @@ public:
 
     EXPECT_CALL(get_mock_io_ctx(m_local_io_ctx),
                 exec(RBD_MIRRORING, _, StrEq("rbd"),
-                     StrEq("mirror_image_set"), ContentsEqual(bl), _, _))
+                     StrEq("mirror_image_set"), ContentsEqual(bl), _, _, _))
       .WillOnce(Return(r));
   }
 
   void expect_mirror_image_remove(librados::IoCtx &ioctx, int r) {
     EXPECT_CALL(get_mock_io_ctx(ioctx),
-                exec(StrEq("rbd_mirroring"), _, StrEq("rbd"), StrEq("mirror_image_remove"),
-                     _, _, _))
+                exec(StrEq("rbd_mirroring"), _, StrEq("rbd"),
+                     StrEq("mirror_image_remove"), _, _, _, _))
       .WillOnce(Return(r));
   }
 

--- a/src/test/rbd_mirror/image_deleter/test_mock_TrashRemoveRequest.cc
+++ b/src/test/rbd_mirror/image_deleter/test_mock_TrashRemoveRequest.cc
@@ -134,7 +134,7 @@ public:
     using ceph::encode;
     EXPECT_CALL(get_mock_io_ctx(m_local_io_ctx),
                 exec(StrEq(RBD_TRASH), _, StrEq("rbd"),
-                     StrEq("trash_get"), _, _, _))
+                     StrEq("trash_get"), _, _, _, _))
       .WillOnce(WithArg<5>(Invoke([trash_spec, r](bufferlist* bl) {
                              encode(trash_spec, *bl);
                              return r;
@@ -150,7 +150,7 @@ public:
     EXPECT_CALL(get_mock_io_ctx(m_local_io_ctx),
                 exec(StrEq(RBD_TRASH), _, StrEq("rbd"),
                      StrEq("trash_state_set"),
-                     ContentsEqual(in_bl), _, _))
+                     ContentsEqual(in_bl), _, _, _))
       .WillOnce(Return(r));
   }
 
@@ -161,7 +161,7 @@ public:
 
     EXPECT_CALL(get_mock_io_ctx(m_local_io_ctx),
                 exec(librbd::util::header_name(image_id), _, StrEq("rbd"),
-                     StrEq("get_snapcontext"), _, _, _))
+                     StrEq("get_snapcontext"), _, _, _, _))
       .WillOnce(DoAll(WithArg<5>(Invoke([bl](bufferlist *out_bl) {
                                           *out_bl = bl;
                                         })),

--- a/src/test/rbd_mirror/image_deleter/test_mock_TrashWatcher.cc
+++ b/src/test/rbd_mirror/image_deleter/test_mock_TrashWatcher.cc
@@ -169,7 +169,7 @@ public:
 
     EXPECT_CALL(get_mock_io_ctx(io_ctx),
                 exec(RBD_TRASH, _, StrEq("rbd"), StrEq("trash_list"),
-                     ContentsEqual(bl), _, _))
+                     ContentsEqual(bl), _, _, _))
       .WillOnce(DoAll(WithArg<5>(Invoke([out_bl](bufferlist *bl) {
                           *bl = out_bl;
                         })),

--- a/src/test/rbd_mirror/image_replayer/snapshot/test_mock_ApplyImageStateRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/snapshot/test_mock_ApplyImageStateRequest.cc
@@ -128,7 +128,7 @@ public:
       ceph::encode(key, bl);
       EXPECT_CALL(get_mock_io_ctx(m_mock_local_image_ctx->md_ctx),
                   exec(m_mock_local_image_ctx->header_oid, _, StrEq("rbd"),
-                  StrEq("metadata_remove"), ContentsEqual(bl), _, _))
+                  StrEq("metadata_remove"), ContentsEqual(bl), _, _, _))
         .WillOnce(Return(r));
       if (r < 0) {
         return;
@@ -140,7 +140,7 @@ public:
       ceph::encode(pairs, bl);
       EXPECT_CALL(get_mock_io_ctx(m_mock_local_image_ctx->md_ctx),
                   exec(m_mock_local_image_ctx->header_oid, _, StrEq("rbd"),
-                  StrEq("metadata_set"), ContentsEqual(bl), _, _))
+                  StrEq("metadata_set"), ContentsEqual(bl), _, _, _))
         .WillOnce(Return(r));
     }
   }

--- a/src/test/rbd_mirror/image_replayer/snapshot/test_mock_CreateLocalImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/snapshot/test_mock_CreateLocalImageRequest.cc
@@ -170,7 +170,7 @@ public:
 
     EXPECT_CALL(get_mock_io_ctx(m_local_io_ctx),
                 exec(RBD_MIRRORING, _, StrEq("rbd"),
-                     StrEq("mirror_image_set"), ContentsEqual(bl), _, _))
+                     StrEq("mirror_image_set"), ContentsEqual(bl), _, _, _))
       .WillOnce(Return(r));
   }
 
@@ -181,7 +181,7 @@ public:
     EXPECT_CALL(get_mock_io_ctx(m_local_io_ctx),
                 exec(StrEq("rbd_mirroring"), _, StrEq("rbd"),
                      StrEq("mirror_image_remove"),
-                     ContentsEqual(bl), _, _))
+                     ContentsEqual(bl), _, _, _))
       .WillOnce(Return(r));
   }
 

--- a/src/test/rbd_mirror/image_replayer/snapshot/test_mock_Replayer.cc
+++ b/src/test/rbd_mirror/image_replayer/snapshot/test_mock_Replayer.cc
@@ -580,7 +580,7 @@ public:
     EXPECT_CALL(get_mock_io_ctx(mock_test_image_ctx.md_ctx),
                 exec(mock_test_image_ctx.header_oid, _, StrEq("rbd"),
                      StrEq("mirror_image_snapshot_set_copy_progress"),
-                     ContentsEqual(bl), _, _))
+                     ContentsEqual(bl), _, _, _))
       .WillOnce(Return(r));
   }
 

--- a/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
@@ -274,7 +274,8 @@ public:
     encode(mirror_image, bl);
 
     EXPECT_CALL(get_mock_io_ctx(io_ctx),
-                exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_image_get"), _, _, _))
+                exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_image_get"),
+                     _, _, _, _))
       .WillOnce(DoAll(WithArg<5>(Invoke([bl](bufferlist *out_bl) {
                                           *out_bl = bl;
                                         })),
@@ -287,7 +288,8 @@ public:
     encode(image_id, bl);
 
     EXPECT_CALL(get_mock_io_ctx(io_ctx),
-                exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_image_get_image_id"), _, _, _))
+                exec(RBD_MIRRORING, _, StrEq("rbd"),
+                     StrEq("mirror_image_get_image_id"), _, _, _, _))
       .WillOnce(DoAll(WithArg<5>(Invoke([bl](bufferlist *out_bl) {
                                           *out_bl = bl;
                                         })),

--- a/src/test/rbd_mirror/image_replayer/test_mock_GetMirrorImageIdRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_GetMirrorImageIdRequest.cc
@@ -49,7 +49,8 @@ public:
     encode(image_id, bl);
 
     EXPECT_CALL(get_mock_io_ctx(io_ctx),
-                exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_image_get_image_id"), _, _, _))
+                exec(RBD_MIRRORING, _, StrEq("rbd"),
+                     StrEq("mirror_image_get_image_id"), _, _, _, _))
       .WillOnce(DoAll(WithArg<5>(Invoke([bl](bufferlist *out_bl) {
                                           *out_bl = bl;
                                         })),

--- a/src/test/rbd_mirror/image_replayer/test_mock_PrepareLocalImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_PrepareLocalImageRequest.cc
@@ -198,7 +198,8 @@ public:
     encode(image_name, bl);
 
     EXPECT_CALL(get_mock_io_ctx(io_ctx),
-                exec(RBD_DIRECTORY, _, StrEq("rbd"), StrEq("dir_get_name"), _, _, _))
+                exec(RBD_DIRECTORY, _, StrEq("rbd"), StrEq("dir_get_name"), _,
+                     _, _, _))
       .WillOnce(DoAll(WithArg<5>(Invoke([bl](bufferlist *out_bl) {
                                           *out_bl = bl;
                                         })),

--- a/src/test/rbd_mirror/pool_watcher/test_mock_RefreshImagesRequest.cc
+++ b/src/test/rbd_mirror/pool_watcher/test_mock_RefreshImagesRequest.cc
@@ -47,7 +47,8 @@ public:
     encode(ids, bl);
 
     EXPECT_CALL(get_mock_io_ctx(io_ctx),
-                exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_image_list"), _, _, _))
+                exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_image_list"),
+                     _, _, _, _))
       .WillOnce(DoAll(WithArg<5>(Invoke([bl](bufferlist *out_bl) {
                                           *out_bl = bl;
                                         })),

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -176,7 +176,7 @@ public:
         cct, "rbd_mirror_concurrent_image_syncs"));
 
     m_instance_watcher = InstanceWatcher<>::create(
-        m_local_ioctx, m_threads->work_queue, nullptr,
+        m_local_ioctx, *m_threads->asio_engine, nullptr,
         m_image_sync_throttler.get());
     m_instance_watcher->handle_acquire_leader();
 

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -170,7 +170,7 @@ public:
     m_global_image_id = get_global_image_id(m_remote_ioctx, m_remote_image_id);
 
     auto cct = reinterpret_cast<CephContext*>(m_local_ioctx.cct());
-    m_threads.reset(new Threads<>(cct));
+    m_threads.reset(new Threads<>(m_local_cluster));
 
     m_image_sync_throttler.reset(new Throttler<>(
         cct, "rbd_mirror_concurrent_image_syncs"));

--- a/src/test/rbd_mirror/test_ImageSync.cc
+++ b/src/test/rbd_mirror/test_ImageSync.cc
@@ -80,7 +80,7 @@ public:
         cct, "rbd_mirror_concurrent_image_syncs");
 
     m_instance_watcher = rbd::mirror::InstanceWatcher<>::create(
-        m_local_io_ctx, m_threads->work_queue, nullptr, m_image_sync_throttler);
+      m_local_io_ctx, *m_threads->asio_engine, nullptr, m_image_sync_throttler);
     m_instance_watcher->handle_acquire_leader();
 
     ContextWQ* context_wq;

--- a/src/test/rbd_mirror/test_InstanceWatcher.cc
+++ b/src/test/rbd_mirror/test_InstanceWatcher.cc
@@ -44,7 +44,7 @@ public:
 
 TEST_F(TestInstanceWatcher, InitShutdown)
 {
-  InstanceWatcher<> instance_watcher(m_local_io_ctx, m_threads->work_queue,
+  InstanceWatcher<> instance_watcher(m_local_io_ctx, *m_threads->asio_engine,
                                      nullptr, nullptr, m_instance_id);
   std::vector<std::string> instance_ids;
   get_instances(&instance_ids);
@@ -93,7 +93,7 @@ TEST_F(TestInstanceWatcher, Remove)
   librados::IoCtx io_ctx;
   ASSERT_EQ("", connect_cluster_pp(cluster));
   ASSERT_EQ(0, cluster.ioctx_create(_local_pool_name.c_str(), io_ctx));
-  InstanceWatcher<> instance_watcher(m_local_io_ctx, m_threads->work_queue,
+  InstanceWatcher<> instance_watcher(m_local_io_ctx, *m_threads->asio_engine,
                                      nullptr, nullptr, "instance_id");
   // Init
   ASSERT_EQ(0, instance_watcher.init());
@@ -109,7 +109,7 @@ TEST_F(TestInstanceWatcher, Remove)
 
   // Remove
   C_SaferCond on_remove;
-  InstanceWatcher<>::remove_instance(m_local_io_ctx, m_threads->work_queue,
+  InstanceWatcher<>::remove_instance(m_local_io_ctx, *m_threads->asio_engine,
                                      "instance_id", &on_remove);
   ASSERT_EQ(0, on_remove.wait());
 
@@ -126,7 +126,7 @@ TEST_F(TestInstanceWatcher, Remove)
 
   // Remove NOENT
   C_SaferCond on_remove_noent;
-  InstanceWatcher<>::remove_instance(m_local_io_ctx, m_threads->work_queue,
+  InstanceWatcher<>::remove_instance(m_local_io_ctx, *m_threads->asio_engine,
                                      instance_id, &on_remove_noent);
   ASSERT_EQ(0, on_remove_noent.wait());
 }

--- a/src/test/rbd_mirror/test_fixture.cc
+++ b/src/test/rbd_mirror/test_fixture.cc
@@ -72,8 +72,7 @@ void TestFixture::SetUp() {
   ASSERT_EQ(0, _rados->ioctx_create(_remote_pool_name.c_str(), m_remote_io_ctx));
   m_image_name = get_temp_image_name();
 
-  m_threads = new rbd::mirror::Threads<>(reinterpret_cast<CephContext*>(
-    m_local_io_ctx.cct()));
+  m_threads = new rbd::mirror::Threads<>(_rados);
 }
 
 void TestFixture::TearDown() {

--- a/src/test/rbd_mirror/test_mock_InstanceWatcher.cc
+++ b/src/test/rbd_mirror/test_mock_InstanceWatcher.cc
@@ -165,14 +165,14 @@ public:
   void expect_register_instance(librados::MockTestMemIoCtxImpl &mock_io_ctx,
                                 int r) {
     EXPECT_CALL(mock_io_ctx, exec(RBD_MIRROR_LEADER, _, StrEq("rbd"),
-                                  StrEq("mirror_instances_add"), _, _, _))
+                                  StrEq("mirror_instances_add"), _, _, _, _))
       .WillOnce(Return(r));
   }
 
   void expect_unregister_instance(librados::MockTestMemIoCtxImpl &mock_io_ctx,
                                   int r) {
     EXPECT_CALL(mock_io_ctx, exec(RBD_MIRROR_LEADER, _, StrEq("rbd"),
-                                  StrEq("mirror_instances_remove"), _, _, _))
+                                  StrEq("mirror_instances_remove"), _, _, _, _))
       .WillOnce(Return(r));
   }
 

--- a/src/test/rbd_mirror/test_mock_LeaderWatcher.cc
+++ b/src/test/rbd_mirror/test_mock_LeaderWatcher.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "librbd/AsioEngine.h"
 #include "librbd/Utils.h"
 #include "test/librbd/mock/MockImageCtx.h"
 #include "test/rbd_mirror/test_mock_fixture.h"
@@ -60,11 +61,11 @@ MockManagedLock *MockManagedLock::s_instance = nullptr;
 
 template <>
 struct ManagedLock<MockTestImageCtx> {
-  ManagedLock(librados::IoCtx& ioctx, librbd::asio::ContextWQ *work_queue,
+  ManagedLock(librados::IoCtx& ioctx, librbd::AsioEngine& asio_engine,
               const std::string& oid, librbd::Watcher *watcher,
               managed_lock::Mode  mode, bool blacklist_on_break_lock,
               uint32_t blacklist_expire_seconds)
-    : m_work_queue(work_queue) {
+    : m_work_queue(asio_engine.get_work_queue()) {
     MockManagedLock::get_instance().construct();
   }
 
@@ -185,10 +186,11 @@ struct Threads<librbd::MockTestImageCtx> {
   ceph::mutex &timer_lock;
   SafeTimer *timer;
   librbd::asio::ContextWQ *work_queue;
+  librbd::AsioEngine* asio_engine;
 
   Threads(Threads<librbd::ImageCtx> *threads)
     : timer_lock(threads->timer_lock), timer(threads->timer),
-      work_queue(threads->work_queue) {
+      work_queue(threads->work_queue), asio_engine(threads->asio_engine) {
   }
 };
 

--- a/src/test/rbd_mirror/test_mock_MirrorStatusUpdater.cc
+++ b/src/test/rbd_mirror/test_mock_MirrorStatusUpdater.cc
@@ -151,7 +151,7 @@ public:
       const cls::rbd::MirrorImageSiteStatus& mirror_image_status, int r) {
     EXPECT_CALL(*m_mock_local_io_ctx,
                 exec(RBD_MIRRORING, _, StrEq("rbd"),
-                     StrEq("mirror_image_status_set"), _, _, _))
+                     StrEq("mirror_image_status_set"), _, _, _, _))
       .WillOnce(WithArg<4>(Invoke(
         [r, global_image_id, mirror_image_status](bufferlist& in_bl) {
           auto bl_it = in_bl.cbegin();

--- a/src/test/rbd_mirror/test_mock_NamespaceReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_NamespaceReplayer.cc
@@ -132,7 +132,7 @@ struct InstanceWatcher<librbd::MockTestImageCtx> {
   static InstanceWatcher* s_instance;
 
   static InstanceWatcher* create(
-      librados::IoCtx &ioctx, librbd::asio::ContextWQ* work_queue,
+      librados::IoCtx &ioctx, librbd::AsioEngine& asio_engine,
       InstanceReplayer<librbd::MockTestImageCtx>* instance_replayer,
       Throttler<librbd::MockTestImageCtx> *image_sync_throttler) {
     ceph_assert(s_instance != nullptr);
@@ -250,10 +250,11 @@ struct Threads<librbd::MockTestImageCtx> {
   ceph::mutex &timer_lock;
   SafeTimer *timer;
   librbd::asio::ContextWQ *work_queue;
+  librbd::AsioEngine* asio_engine;
 
   Threads(Threads<librbd::ImageCtx> *threads)
     : timer_lock(threads->timer_lock), timer(threads->timer),
-      work_queue(threads->work_queue) {
+      work_queue(threads->work_queue), asio_engine(threads->asio_engine) {
   }
 };
 

--- a/src/test/rbd_mirror/test_mock_PoolReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_PoolReplayer.cc
@@ -332,7 +332,7 @@ public:
 
     EXPECT_CALL(*io_ctx_impl,
                 exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_uuid_get"),
-                     _, _, _))
+                     _, _, _, _))
       .WillOnce(DoAll(WithArg<5>(Invoke([out_bl](bufferlist *bl) {
                           *bl = out_bl;
                         })),
@@ -346,7 +346,7 @@ public:
 
     EXPECT_CALL(*io_ctx_impl,
                 exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_mode_get"),
-                     _, _, _))
+                     _, _, _, _))
       .WillOnce(DoAll(WithArg<5>(Invoke([out_bl](bufferlist *bl) {
                                           *bl = out_bl;
                                         })),
@@ -356,7 +356,7 @@ public:
   void expect_mirror_mode_get(librados::MockTestMemIoCtxImpl *io_ctx_impl) {
     EXPECT_CALL(*io_ctx_impl,
                 exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_mode_get"),
-                     _, _, _))
+                     _, _, _, _))
       .WillRepeatedly(DoAll(WithArg<5>(Invoke([](bufferlist *bl) {
                 encode(cls::rbd::MIRROR_MODE_POOL, *bl);
               })),

--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -54,10 +54,13 @@ set(rbd_srcs
 add_executable(rbd ${rbd_srcs}
   $<TARGET_OBJECTS:common_texttable_obj>)
 set_target_properties(rbd PROPERTIES OUTPUT_NAME rbd)
-target_link_libraries(rbd librbd librados
-  cls_journal_client cls_rbd_client
+target_link_libraries(rbd librbd
+  cls_journal_client
+  cls_rbd_client
   rbd_types
   journal
+  libneorados
+  librados
   ceph-common global ${CURSES_LIBRARIES}
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
 if(WITH_KRBD)

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -77,6 +77,7 @@ target_link_libraries(rbd-mirror
   rbd_internal
   rbd_types
   journal
+  libneorados
   librados
   osdc
   cls_rbd_client

--- a/src/tools/rbd_mirror/InstanceWatcher.h
+++ b/src/tools/rbd_mirror/InstanceWatcher.h
@@ -17,9 +17,9 @@
 
 namespace librbd {
 
+class AsioEngine;
 class ImageCtx;
 template <typename> class ManagedLock;
-namespace asio { struct ContextWQ; }
 
 } // namespace librbd
 
@@ -38,19 +38,19 @@ public:
                             std::vector<std::string> *instance_ids,
                             Context *on_finish);
   static void remove_instance(librados::IoCtx &io_ctx,
-                              librbd::asio::ContextWQ *work_queue,
+                              librbd::AsioEngine& asio_engine,
                               const std::string &instance_id,
                               Context *on_finish);
 
   static InstanceWatcher *create(
-    librados::IoCtx &io_ctx, librbd::asio::ContextWQ *work_queue,
+    librados::IoCtx &io_ctx, librbd::AsioEngine& asio_engine,
     InstanceReplayer<ImageCtxT> *instance_replayer,
     Throttler<ImageCtxT> *image_sync_throttler);
   void destroy() {
     delete this;
   }
 
-  InstanceWatcher(librados::IoCtx &io_ctx, librbd::asio::ContextWQ *work_queue,
+  InstanceWatcher(librados::IoCtx &io_ctx, librbd::AsioEngine& asio_engine,
                   InstanceReplayer<ImageCtxT> *instance_replayer,
                   Throttler<ImageCtxT> *image_sync_throttler,
                   const std::string &instance_id);

--- a/src/tools/rbd_mirror/Instances.cc
+++ b/src/tools/rbd_mirror/Instances.cc
@@ -262,7 +262,7 @@ void Instances<I>::remove_instances(const Instances<I>::clock_t::time_point& tim
 
   auto gather_ctx = new C_Gather(m_cct, ctx);
   for (auto& instance_id : instance_ids) {
-    InstanceWatcher<I>::remove_instance(m_ioctx, m_threads->work_queue,
+    InstanceWatcher<I>::remove_instance(m_ioctx, *m_threads->asio_engine,
                                         instance_id, gather_ctx->new_sub());
   }
 

--- a/src/tools/rbd_mirror/LeaderWatcher.cc
+++ b/src/tools/rbd_mirror/LeaderWatcher.cc
@@ -36,8 +36,8 @@ LeaderWatcher<I>::LeaderWatcher(Threads<I> *threads, librados::IoCtx &io_ctx,
 			    io_ctx.get_pool_name())),
     m_notifier_id(librados::Rados(io_ctx).get_instance_id()),
     m_instance_id(stringify(m_notifier_id)),
-    m_leader_lock(new LeaderLock(m_ioctx, m_work_queue, m_oid, this, true,
-                                 m_cct->_conf.get_val<uint64_t>(
+    m_leader_lock(new LeaderLock(m_ioctx, *m_threads->asio_engine, m_oid, this,
+                                 true, m_cct->_conf.get_val<uint64_t>(
                                    "rbd_blacklist_expire_seconds"))) {
 }
 

--- a/src/tools/rbd_mirror/LeaderWatcher.h
+++ b/src/tools/rbd_mirror/LeaderWatcher.h
@@ -119,12 +119,13 @@ private:
   public:
     typedef librbd::ManagedLock<ImageCtxT> Parent;
 
-    LeaderLock(librados::IoCtx& ioctx, librbd::asio::ContextWQ *work_queue,
+    LeaderLock(librados::IoCtx& ioctx, librbd::AsioEngine& asio_engine,
                const std::string& oid, LeaderWatcher *watcher,
                bool blacklist_on_break_lock,
                uint32_t blacklist_expire_seconds)
-      : Parent(ioctx, work_queue, oid, watcher, librbd::managed_lock::EXCLUSIVE,
-               blacklist_on_break_lock, blacklist_expire_seconds),
+      : Parent(ioctx, asio_engine, oid, watcher,
+               librbd::managed_lock::EXCLUSIVE, blacklist_on_break_lock,
+               blacklist_expire_seconds),
         watcher(watcher) {
     }
 

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -487,12 +487,7 @@ Mirror::Mirror(CephContext *cct, const std::vector<const char*> &args) :
   m_local(new librados::Rados()),
   m_cache_manager_handler(new CacheManagerHandler(cct)),
   m_pool_meta_cache(new PoolMetaCache(cct)),
-  m_asok_hook(new MirrorAdminSocketHook(cct, this))
-{
-  m_threads =
-    &(cct->lookup_or_create_singleton_object<Threads<librbd::ImageCtx>>(
-	"rbd_mirror::threads", false, cct));
-  m_service_daemon.reset(new ServiceDaemon<>(m_cct, m_local, m_threads));
+  m_asok_hook(new MirrorAdminSocketHook(cct, this)) {
 }
 
 Mirror::~Mirror()
@@ -538,6 +533,10 @@ int Mirror::init()
     derr << "error connecting to local cluster" << dendl;
     return r;
   }
+
+  m_threads = &(m_cct->lookup_or_create_singleton_object<
+    Threads<librbd::ImageCtx>>("rbd_mirror::threads", false, m_local));
+  m_service_daemon.reset(new ServiceDaemon<>(m_cct, m_local, m_threads));
 
   r = m_service_daemon->init();
   if (r < 0) {

--- a/src/tools/rbd_mirror/NamespaceReplayer.cc
+++ b/src/tools/rbd_mirror/NamespaceReplayer.cc
@@ -386,7 +386,7 @@ void NamespaceReplayer<I>::init_instance_watcher() {
   ceph_assert(!m_instance_watcher);
 
   m_instance_watcher.reset(InstanceWatcher<I>::create(
-      m_local_io_ctx, m_threads->work_queue, m_instance_replayer.get(),
+      m_local_io_ctx, *m_threads->asio_engine, m_instance_replayer.get(),
       m_image_sync_throttler));
   auto ctx = create_context_callback<NamespaceReplayer<I>,
       &NamespaceReplayer<I>::handle_init_instance_watcher>(this);

--- a/src/tools/rbd_mirror/Threads.cc
+++ b/src/tools/rbd_mirror/Threads.cc
@@ -11,8 +11,9 @@ namespace rbd {
 namespace mirror {
 
 template <typename I>
-Threads<I>::Threads(CephContext *cct) {
-  asio_engine = new librbd::AsioEngine(cct);
+Threads<I>::Threads(std::shared_ptr<librados::Rados>& rados) {
+  auto cct = static_cast<CephContext*>(rados->cct());
+  asio_engine = new librbd::AsioEngine(rados);
   work_queue = asio_engine->get_work_queue();
 
   timer = new SafeTimer(cct, timer_lock, true);

--- a/src/tools/rbd_mirror/Threads.h
+++ b/src/tools/rbd_mirror/Threads.h
@@ -5,7 +5,9 @@
 #define CEPH_RBD_MIRROR_THREADS_H
 
 #include "include/common_fwd.h"
+#include "include/rados/librados_fwd.hpp"
 #include "common/ceph_mutex.h"
+#include <memory>
 
 class SafeTimer;
 class ThreadPool;
@@ -30,7 +32,7 @@ public:
   SafeTimer *timer = nullptr;
   ceph::mutex timer_lock = ceph::make_mutex("Threads::timer_lock");
 
-  explicit Threads(CephContext *cct);
+  explicit Threads(std::shared_ptr<librados::Rados>& rados);
   Threads(const Threads&) = delete;
   Threads& operator=(const Threads&) = delete;
 

--- a/src/tools/rbd_mirror/Threads.h
+++ b/src/tools/rbd_mirror/Threads.h
@@ -23,10 +23,8 @@ namespace mirror {
 
 template <typename ImageCtxT = librbd::ImageCtx>
 class Threads {
-private:
-  librbd::AsioEngine* asio_engine = nullptr;
-
 public:
+  librbd::AsioEngine* asio_engine = nullptr;
   librbd::asio::ContextWQ* work_queue = nullptr;
 
   SafeTimer *timer = nullptr;


### PR DESCRIPTION
Switch the librbd IO path to natively use the librbd::AsioEngine execution context. This enables the use of multiple client threads for IO operations.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
