### PR TITLE
doc/cephadm: adopt: fix misleading `apply` examples

### DIFF
--- a/doc/cephadm/adoption.rst
+++ b/doc/cephadm/adoption.rst
@@ -113,7 +113,7 @@ Adoption process
    each file system.  You can list file systems by name with ``ceph fs
    ls``.  For each file system::
 
-     # ceph orch apply mds <fs-name> <num-daemons>
+     # ceph orch apply mds <fs-name> [--placement=<placement>]
 
    For example, in a cluster with a single file system called `foo`::
 
@@ -133,7 +133,7 @@ Adoption process
 #. Redeploy RGW daemons.  Cephadm manages RGW daemons by zone.  For each
    zone, deploy new RGW daemons with cephadm::
 
-     # ceph orch apply rgw <realm> <zone> <placement> [--port <port>] [--ssl]
+     # ceph orch apply rgw <realm> <zone> [--subcluster=<subcluster>] [--port=<port>] [--ssl] [--placement=<placement>]
 
    where *<placement>* can be a simple daemon count, or a list of
    specific hosts (see :ref:`orchestrator-cli-placement-spec`).


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46052
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
