### PR TITLE
cephadm: unit.run: add `set -e`

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1859,6 +1859,7 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
     # cmd
     data_dir = get_data_dir(fsid, daemon_type, daemon_id)
     with open(data_dir + '/unit.run.new', 'w') as f:
+        f.write('set -e\n')
         # pre-start cmd(s)
         if daemon_type == 'osd':
             # osds have a pre-start step
@@ -1894,10 +1895,10 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
             f.write('{install_path} -d -m0770 -o {uid} -g {gid} /var/run/ceph/{fsid}\n'.format(install_path=install_path, fsid=fsid, uid=uid, gid=gid))
 
         # Sometimes, adding `--rm` to a run_cmd doesn't work. Let's remove the container manually
-        f.write(' '.join(c.rm_cmd()) + '\n')
+        f.write('! '+ ' '.join(c.rm_cmd()) + '\n')
         # Sometimes, `podman rm` doesn't find the container. Then you'll have to add `--storage`
         if 'podman' in container_path:
-            f.write(' '.join(c.rm_cmd(storage=True)) + '\n')
+            f.write('! '+ ' '.join(c.rm_cmd(storage=True)) + '\n')
 
         # container run command
         f.write(' '.join(c.run_cmd()) + '\n')


### PR DESCRIPTION
In case LVM activates fails for some
unknown reason, prevent the script from
continuing with starting the OSD container.

This leads to faild systemd services with active OSD containers.

Fixes: https://tracker.ceph.com/issues/46036
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
