### PR TITLE
src/cstart: fix typo in cstart script

### DIFF
--- a/doc/dev/cephadm.rst
+++ b/doc/dev/cephadm.rst
@@ -61,18 +61,18 @@ To start a test cluster::
 The last line of this will be a line you can cut+paste to update the
 container image.  For instance::
 
-  sudo ../src/script/cpach -t quay.io/ceph-ci/ceph:8f509f4e
+  sudo ../src/script/cpatch -t quay.io/ceph-ci/ceph:8f509f4e
 
 By default, cpatch will patch everything it can think of from the local
 build dir into the container image.  If you are working on a specific
 part of the system, though, can you get away with smaller changes so that
 cpatch runs faster.  For instance::
 
-  sudo ../src/script/cpach -t quay.io/ceph-ci/ceph:8f509f4e --py
+  sudo ../src/script/cpatch -t quay.io/ceph-ci/ceph:8f509f4e --py
 
 will update the mgr modules (minus the dashboard).  Or::
 
-  sudo ../src/script/cpach -t quay.io/ceph-ci/ceph:8f509f4e --core
+  sudo ../src/script/cpatch -t quay.io/ceph-ci/ceph:8f509f4e --core
 
 will do most binaries and libraries.  Pass ``-h`` to cpatch for all options.
 

--- a/src/cstart.sh
+++ b/src/cstart.sh
@@ -63,5 +63,5 @@ sudo chmod 755 ceph.client.admin.keyring
 echo 'keyring = ceph.client.admin.keyring' >> ceph.conf
 
 echo
-echo "sudo ../src/script/cpach -t $image_base:$shortid"
+echo "sudo ../src/script/cpatch -t $image_base:$shortid"
 echo


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
