### PR TITLE
qa: add omit_sudo=False for commands ran with sudo

### DIFF
--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -277,17 +277,10 @@ class FuseMount(CephFSMount):
         try:
             log.info('Running fusermount -u on {name}...'.format(name=self.client_remote.name))
             stderr = StringIO()
-            self.client_remote.run(
-                args = [
-                    'sudo',
-                    'fusermount',
-                    '-u',
-                    self.mountpoint,
-                ],
-                cwd=self.test_dir,
-                stderr=stderr,
-                timeout=(30*60),
-            )
+            self.client_remote.run(args=['sudo', 'fusermount', '-u',
+                                         self.mountpoint],
+                                   cwd=self.test_dir, stderr=stderr,
+                                   timeout=(30*60), omit_sudo=False)
         except run.CommandFailedError:
             if "mountpoint not found" in stderr.getvalue():
                 # This happens if the mount directory doesn't exist
@@ -298,14 +291,10 @@ class FuseMount(CephFSMount):
             else:
                 log.info('Failed to unmount ceph-fuse on {name}, aborting...'.format(name=self.client_remote.name))
 
-                self.client_remote.run(args=[
-                    'sudo',
-                    run.Raw('PATH=/usr/sbin:$PATH'),
-                    'lsof',
-                    run.Raw(';'),
-                    'ps',
-                    'auxf',
-                ], timeout=(60*15))
+                self.client_remote.run(
+                    args=['sudo', run.Raw('PATH=/usr/sbin:$PATH'), 'lsof',
+                    run.Raw(';'), 'ps', 'auxf'],
+                    timeout=(60*15), omit_sudo=False)
 
                 # abort the fuse mount, killing all hung processes
                 if self._fuse_conn:
@@ -320,17 +309,9 @@ class FuseMount(CephFSMount):
                 stderr = StringIO()
                 # make sure its unmounted
                 try:
-                    self.client_remote.run(
-                        args=[
-                            'sudo',
-                            'umount',
-                            '-l',
-                            '-f',
-                            self.mountpoint,
-                        ],
-                        stderr=stderr,
-                        timeout=(60*15)
-                    )
+                    self.client_remote.run(args=['sudo', 'umount', '-l', '-f',
+                                                 self.mountpoint],
+                                           stderr=stderr, timeout=(60*15), omit_sudo=False)
                 except CommandFailedError:  
                     if self.is_mounted():   
                         raise

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -88,7 +88,7 @@ class CephFSMount(object):
     def _bringup_network_manager_service(self):
         args = ["sudo", "bash", "-c",
                 "systemctl start NetworkManager"]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
 
     def _setup_brx_and_nat(self):
         # The ip for ceph-brx should be
@@ -111,15 +111,15 @@ class CephFSMount(object):
             log.info("Setuping the 'ceph-brx' with {0}/{1}".format(ip, mask))
 
             args = ["sudo", "bash", "-c", "ip link add name ceph-brx type bridge"]
-            self.client_remote.run(args=args, timeout=(5*60))
+            self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
             args = ["sudo", "bash", "-c", "ip link set ceph-brx up"]
-            self.client_remote.run(args=args, timeout=(5*60))
+            self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
             args = ["sudo", "bash", "-c",
                     "ip addr add {0}/{1} brd {2} dev ceph-brx".format(ip, mask, brd)]
-            self.client_remote.run(args=args, timeout=(5*60))
+            self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         
         args = "echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward"
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         
         # Setup the NAT
         p = self.client_remote.run(args=['route'], stderr=StringIO(),
@@ -130,13 +130,13 @@ class CephFSMount(object):
         gw = p[0].split()[7]
         args = ["sudo", "bash", "-c",
                 "iptables -A FORWARD -o {0} -i ceph-brx -j ACCEPT".format(gw)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         args = ["sudo", "bash", "-c",
                 "iptables -A FORWARD -i {0} -o ceph-brx -j ACCEPT".format(gw)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         args = ["sudo", "bash", "-c",
                 "iptables -t nat -A POSTROUTING -s {0}/{1} -o {2} -j MASQUERADE".format(ip, mask, gw)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
 
     def _setup_netns(self):
         p = self.client_remote.run(args=['ip', 'netns', 'list'],
@@ -166,10 +166,10 @@ class CephFSMount(object):
         # Add one new netns and set it id
         args = ["sudo", "bash", "-c",
                 "ip netns add {0}".format(self.netns_name)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         args = ["sudo", "bash", "-c",
                 "ip netns set {0} {1}".format(self.netns_name, nsid)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
 
         # Get one ip address for netns
         ips = IP(self.ceph_brx_net)
@@ -185,7 +185,8 @@ class CephFSMount(object):
                 args = ["sudo", "bash", "-c",
                         "ip netns exec {0} ip addr".format(ns_name)]
                 p = self.client_remote.run(args=args, stderr=StringIO(),
-                                           stdout=StringIO(), timeout=(5*60))
+                                           stdout=StringIO(), timeout=(5*60),
+                                           omit_sudo=False)
                 q = re.search("{0}".format(ip), p.stdout.getvalue())
                 if q is not None:
                     found = True
@@ -202,29 +203,29 @@ class CephFSMount(object):
         # Setup the veth interfaces
         args = ["sudo", "bash", "-c",
                 "ip link add veth0 netns {0} type veth peer name brx.{1}".format(self.netns_name, nsid)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         args = ["sudo", "bash", "-c",
                 "ip netns exec {0} ip addr add {1}/{2} brd {3} dev veth0".format(self.netns_name, ip, mask, brd)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         args = ["sudo", "bash", "-c",
                 "ip netns exec {0} ip link set veth0 up".format(self.netns_name)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         args = ["sudo", "bash", "-c",
                 "ip netns exec {0} ip link set lo up".format(self.netns_name)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
 
         brxip = IP(self.ceph_brx_net)[-2]
         args = ["sudo", "bash", "-c",
                 "ip netns exec {0} ip route add default via {1}".format(self.netns_name, brxip)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
 
         # Bring up the brx interface and join it to 'ceph-brx'
         args = ["sudo", "bash", "-c",
                 "ip link set brx.{0} up".format(nsid)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         args = ["sudo", "bash", "-c",
                 "ip link set dev brx.{0} master ceph-brx".format(nsid)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
 
     def _cleanup_netns(self):
         if self.nsid == -1:
@@ -234,14 +235,14 @@ class CephFSMount(object):
         # Delete the netns and the peer veth interface
         args = ["sudo", "bash", "-c",
                 "ip link set brx.{0} down".format(self.nsid)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         args = ["sudo", "bash", "-c",
                 "ip link delete brx.{0}".format(self.nsid)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
 
         args = ["sudo", "bash", "-c",
                 "ip netns delete {0}".format(self.netns_name)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
 
         self.nsid = -1
 
@@ -255,7 +256,7 @@ class CephFSMount(object):
         # If we are the last netns, will delete the ceph-brx
         args = ["sudo", "bash", "-c", "ip link show"]
         p = self.client_remote.run(args=args, stdout=StringIO(),
-                                   timeout=(5*60))
+                                   timeout=(5*60), omit_sudo=False)
         _list = re.findall(r'brx\.', p.stdout.getvalue().strip())
         if len(_list) != 0:
             return
@@ -264,10 +265,10 @@ class CephFSMount(object):
 
         args = ["sudo", "bash", "-c",
                 "ip link set ceph-brx down"]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         args = ["sudo", "bash", "-c",
                 "ip link delete ceph-brx"]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
 
         # Drop the iptables NAT rules
         ip = IP(self.ceph_brx_net)[-2]
@@ -281,13 +282,13 @@ class CephFSMount(object):
         gw = p[0].split()[7]
         args = ["sudo", "bash", "-c",
                 "iptables -D FORWARD -o {0} -i ceph-brx -j ACCEPT".format(gw)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         args = ["sudo", "bash", "-c",
                 "iptables -D FORWARD -i {0} -o ceph-brx -j ACCEPT".format(gw)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         args = ["sudo", "bash", "-c",
                 "iptables -t nat -D POSTROUTING -s {0}/{1} -o {2} -j MASQUERADE".format(ip, mask, gw)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
 
     def setup_netns(self):
         """
@@ -316,7 +317,7 @@ class CephFSMount(object):
 
         args = ["sudo", "bash", "-c",
                 "ip link set brx.{0} down".format(self.nsid)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
 
     def resume_netns(self):
         """
@@ -329,7 +330,7 @@ class CephFSMount(object):
 
         args = ["sudo", "bash", "-c",
                 "ip link set brx.{0} up".format(self.nsid)]
-        self.client_remote.run(args=args, timeout=(5*60))
+        self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
 
     def mount(self, mount_path=None, mount_fs_name=None, mountpoint=None, mount_options=[]):
         raise NotImplementedError()

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -758,7 +758,7 @@ class LocalFuseMount(FuseMount):
                                   self.mountpoint]
 
         self.fuse_daemon = self.client_remote.run(args=fuse_cmd_args,
-                                                  wait=False)
+                                                  wait=False, omit_sudo=False)
         self._set_fuse_daemon_pid()
         log.info("Mounting client.{0} with pid "
                  "{1}".format(self.client_id, self.fuse_daemon.subproc.pid))


### PR DESCRIPTION
Commands that cleanup FUSE and kernel mount and that setup and
teardown/cleanup network namespaces are that ones that use sudo. Set
omit_sudo to False while running these commands.

Fixes: https://tracker.ceph.com/issues/46101



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>