### PR TITLE
mgr/cephadm: rework --dry-run/previews

### DIFF
--- a/doc/cephadm/drivegroups.rst
+++ b/doc/cephadm/drivegroups.rst
@@ -40,6 +40,14 @@ This will go out on all the matching hosts and deploy these OSDs.
 
 Since we want to have more complex setups, there are more filters than just the 'all' filter.
 
+Also, there is a `--dry-run` flag that can be passed to the `apply osd` command, which gives you a synopsis
+of the proposed layout.
+
+Example::
+
+  [monitor 1] # ceph orch apply osd -i /path/to/osd_spec.yml --dry-run
+
+
 
 Filters
 =======

--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -154,25 +154,23 @@ Example command::
 Create OSDs
 -----------
 
-Create OSDs on a group of devices on a single host::
+Create OSDs on a set of devices on a single host::
 
     ceph orch daemon add osd <host>:device1,device2
 
 Example::
-
-    # ceph orch daemon add osd node1:/dev/vdd
-    Created 1 OSD on host 'node1' using device '/dev/vdd'
-
+=========
 or::
 
-    ceph orch apply osd -i <json_file/yaml_file>
+    ceph orch apply osd -i <json_file/yaml_file> [--dry-run]
+
 
 Where the ``json_file/yaml_file`` is a DriveGroup specification.
 For a more in-depth guide to DriveGroups please refer to :ref:`drivegroups`
 
 or::
 
-    ceph orch apply osd --all-available-devices
+    ceph orch apply osd --all-available-devices [--dry-run]
 
 If the 'apply' method is used. You will be presented with a preview of what will happen.
 
@@ -261,25 +259,18 @@ The previously set the 'destroyed' flag is used to determined osd ids that will 
 If you use OSDSpecs for osd deployment, your newly added disks will be assigned with the osd ids of their replaced
 counterpart, granted the new disk still match the OSDSpecs.
 
-For assistance in this process you can use the 'preview' feature:
-
-Example::
-
-
-    ceph orch apply osd --service-name <name_of_osd_spec> --preview
-    NAME                  HOST  DATA     DB WAL
-    <name_of_osd_spec>    node1 /dev/vdb -  -
+For assistance in this process you can use the '--dry-run' feature:
 
 Tip: The name of your OSDSpec can be retrieved from **ceph orch ls**
 
 Alternatively, you can use your OSDSpec file::
 
-    ceph orch apply osd -i <osd_spec_file> --preview
+    ceph orch apply osd -i <osd_spec_file> --dry-run
     NAME                  HOST  DATA     DB WAL
     <name_of_osd_spec>    node1 /dev/vdb -  -
 
 
-If this matches your anticipated behavior, just omit the --preview flag to execute the deployment.
+If this matches your anticipated behavior, just omit the --dry-run flag to execute the deployment.
 
 
 ..
@@ -318,13 +309,13 @@ error if it doesn't know how to do this transition.
 
 Update the number of monitor hosts::
 
-    ceph orch apply mon <num> [host, host:network...]
+    ceph orch apply mon <num> [host, host:network...] [--dry-run]
 
 Each host can optionally specify a network for the monitor to listen on.
 
 Update the number of manager hosts::
 
-    ceph orch apply mgr <num> [host...]
+    ceph orch apply mgr <num> [host...] [--dry-run]
 
 ..
     .. note::
@@ -400,9 +391,9 @@ The ``name`` parameter is an identifier of the group of instances:
 
 Creating/growing/shrinking/removing services::
 
-    ceph orch apply mds <fs_name> [--placement=<placement>]
-    ceph orch apply rgw <realm> <zone> [--subcluster=<subcluster>] [--port=<port>] [--ssl] [--placement=<placement>]
-    ceph orch apply nfs <name> <pool> [--namespace=<namespace>] [--placement=<placement>]
+    ceph orch apply mds <fs_name> [--placement=<placement>] [--dry-run]
+    ceph orch apply rgw <realm> <zone> [--subcluster=<subcluster>] [--port=<port>] [--ssl] [--placement=<placement>] [--dry-run]
+    ceph orch apply nfs <name> <pool> [--namespace=<namespace>] [--placement=<placement>] [--dry-run]
     ceph orch rm <service_name> [--force]
 
 Where ``placement`` is a :ref:`orchestrator-cli-placement-spec`.
@@ -624,7 +615,7 @@ specification.
 
 3. Apply the new ``ServiceSpec``::
 
-    ceph orch apply -i myservice.yaml
+    ceph orch apply -i myservice.yaml [--dry-run]
 
 Configuring the Orchestrator CLI
 ================================

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -107,6 +107,7 @@ class SpecStore():
         self.mgr = mgr
         self.specs = {} # type: Dict[str, ServiceSpec]
         self.spec_created = {} # type: Dict[str, datetime.datetime]
+        self.spec_preview = {} # type: Dict[str, ServiceSpec]
 
     def load(self):
         # type: () -> None
@@ -127,6 +128,9 @@ class SpecStore():
 
     def save(self, spec):
         # type: (ServiceSpec) -> None
+        if spec.preview_only:
+            self.spec_preview[spec.service_name()] = spec
+            return None
         self.specs[spec.service_name()] = spec
         self.spec_created[spec.service_name()] = datetime.datetime.utcnow()
         self.mgr.set_store(

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -42,8 +42,10 @@ class SimpleScheduler(BaseScheduler):
         if not host_pool:
             return []
         host_pool = [x for x in host_pool]
+        # gen seed off of self.spec to make shuffling deterministic
+        seed = hash(self.spec.service_name())
         # shuffle for pseudo random selection
-        random.shuffle(host_pool)
+        random.Random(seed).shuffle(host_pool)
         return host_pool[:count]
 
 

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -136,7 +136,7 @@ class OSDService(CephadmService):
 
     def get_previews(self, host) -> List[Dict[str, Any]]:
         # Find OSDSpecs that match host.
-        osdspecs = self.mgr.resolve_osdspecs_for_host(host)
+        osdspecs = self.resolve_osdspecs_for_host(host)
         return self.generate_previews(osdspecs, host)
 
     def generate_previews(self, osdspecs: List[DriveGroupSpec], for_host: str) -> List[Dict[str, Any]]:
@@ -189,6 +189,29 @@ class OSDService(CephadmService):
                                     'osdspec': osdspec.service_id,
                                     'host': host})
         return ret_all
+
+    def resolve_hosts_for_osdspecs(self,
+                                   specs: Optional[List[DriveGroupSpec]] = None
+                                   ) -> List[str]:
+        osdspecs = []
+        if specs:
+            osdspecs = [cast(DriveGroupSpec, spec) for spec in specs]
+        if not osdspecs:
+            self.mgr.log.debug("No OSDSpecs found")
+            return []
+        return sum([spec.placement.filter_matching_hosts(self.mgr._get_hosts) for spec in osdspecs], [])
+
+    def resolve_osdspecs_for_host(self, host: str, specs: Optional[List[DriveGroupSpec]] = None):
+        matching_specs = []
+        self.mgr.log.debug(f"Finding OSDSpecs for host: <{host}>")
+        if not specs:
+            specs = [cast(DriveGroupSpec, spec) for (sn, spec) in self.mgr.spec_store.spec_preview.items()
+                     if spec.service_type == 'osd']
+        for spec in specs:
+            if host in spec.placement.filter_matching_hosts(self.mgr._get_hosts):
+                self.mgr.log.debug(f"Found OSDSpecs for host: <{host}> -> <{spec}>")
+                matching_specs.append(spec)
+        return matching_specs
 
     def _run_ceph_volume_command(self, host: str,
                                  cmd: str, env_vars: Optional[List[str]] = None

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -272,7 +272,7 @@ class TestCephadm(object):
                 )
             )
 
-            c = cephadm_module.apply_drivegroups([spec])
+            c = cephadm_module.apply([spec])
             assert wait(cephadm_module, c) == ['Scheduled osd.foo update...']
 
             inventory = Devices([
@@ -302,7 +302,7 @@ class TestCephadm(object):
             json_spec = {'service_type': 'osd', 'placement': {'host_pattern': 'test'}, 'service_id': 'foo', 'data_devices': {'all': True}}
             spec = ServiceSpec.from_json(json_spec)
             assert isinstance(spec, DriveGroupSpec)
-            c = cephadm_module.apply_drivegroups([spec])
+            c = cephadm_module.apply([spec])
             assert wait(cephadm_module, c) == ['Scheduled osd.foo update...']
             _save_spec.assert_called_with(spec)
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -910,6 +910,12 @@ class Orchestrator(object):
             completion = completion.then(next)
         return completion
 
+    def plan(self, spec: List["GenericSpec"]):
+        """
+        Plan (Dry-run, Preview) a List of Specs.
+        """
+        raise NotImplementedError()
+
     def remove_daemons(self, names):
         # type: (List[str]) -> Completion
         """

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -142,7 +142,7 @@ class DriveGroupSpec(ServiceSpec):
         "db_slots", "wal_slots", "block_db_size", "placement", "service_id", "service_type",
         "data_devices", "db_devices", "wal_devices", "journal_devices",
         "data_directories", "osds_per_device", "objectstore", "osd_id_claims",
-        "journal_size", "unmanaged", "filter_logic"
+        "journal_size", "unmanaged", "filter_logic", "preview_only"
     ]
 
     def __init__(self,
@@ -164,12 +164,14 @@ class DriveGroupSpec(ServiceSpec):
                  journal_size=None,  # type: Optional[int]
                  service_type=None,  # type: Optional[str]
                  unmanaged=False,  # type: bool
-                 filter_logic='AND'  # type: str
+                 filter_logic='AND',  # type: str
+                 preview_only=False,  # type: bool
                  ):
         assert service_type is None or service_type == 'osd'
         super(DriveGroupSpec, self).__init__('osd', service_id=service_id,
                                              placement=placement,
-                                             unmanaged=unmanaged)
+                                             unmanaged=unmanaged,
+                                             preview_only=preview_only)
 
         #: A :class:`ceph.deployment.drive_group.DeviceSelection`
         self.data_devices = data_devices
@@ -218,6 +220,9 @@ class DriveGroupSpec(ServiceSpec):
         #: The logic gate we use to match disks with filters.
         #: defaults to 'AND'
         self.filter_logic = filter_logic.upper()
+
+        #: If this should be treated as a 'preview' spec
+        self.preview_only = preview_only
 
     @classmethod
     def _from_json_impl(cls, json_drive_group):

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -408,6 +408,7 @@ class ServiceSpec(object):
                  placement: Optional[PlacementSpec] = None,
                  count: Optional[int] = None,
                  unmanaged: bool = False,
+                 preview_only: bool = False,
                  ):
         self.placement = PlacementSpec() if placement is None else placement  # type: PlacementSpec
 
@@ -415,6 +416,7 @@ class ServiceSpec(object):
         self.service_type = service_type
         self.service_id = service_id
         self.unmanaged = unmanaged
+        self.preview_only = preview_only
 
     @classmethod
     @handle_type_error
@@ -534,6 +536,11 @@ class ServiceSpec(object):
     def __repr__(self):
         return "{}({!r})".format(self.__class__.__name__, self.__dict__)
 
+    def __eq__(self, other):
+        return (self.__class__ == other.__class__
+                and
+                self.__dict__ == other.__dict__)
+
     def one_line_str(self):
         return '<{} for service_name={}>'.format(self.__class__.__name__, self.service_name())
 
@@ -553,17 +560,20 @@ class NFSServiceSpec(ServiceSpec):
                  namespace: Optional[str] = None,
                  placement: Optional[PlacementSpec] = None,
                  unmanaged: bool = False,
+                 preview_only: bool = False
                  ):
         assert service_type == 'nfs'
         super(NFSServiceSpec, self).__init__(
             'nfs', service_id=service_id,
-            placement=placement, unmanaged=unmanaged)
+            placement=placement, unmanaged=unmanaged, preview_only=preview_only)
 
         #: RADOS pool where NFS client recovery data is stored.
         self.pool = pool
 
         #: RADOS namespace where NFS client recovery data is stored in the pool.
         self.namespace = namespace
+
+        self.preview_only = preview_only
 
     def validate(self):
         super(NFSServiceSpec, self).validate()
@@ -606,6 +616,7 @@ class RGWSpec(ServiceSpec):
                  rgw_frontend_ssl_key: Optional[List[str]] = None,
                  unmanaged: bool = False,
                  ssl: bool = False,
+                 preview_only: bool = False,
                  ):
         assert service_type == 'rgw', service_type
         if service_id:
@@ -622,7 +633,8 @@ class RGWSpec(ServiceSpec):
                 service_id = '%s.%s' % (rgw_realm, rgw_zone)
         super(RGWSpec, self).__init__(
             'rgw', service_id=service_id,
-            placement=placement, unmanaged=unmanaged)
+            placement=placement, unmanaged=unmanaged,
+            preview_only=preview_only)
 
         self.rgw_realm = rgw_realm
         self.rgw_zone = rgw_zone
@@ -631,6 +643,7 @@ class RGWSpec(ServiceSpec):
         self.rgw_frontend_ssl_certificate = rgw_frontend_ssl_certificate
         self.rgw_frontend_ssl_key = rgw_frontend_ssl_key
         self.ssl = ssl
+        self.preview_only = preview_only
 
     def get_port(self):
         if self.rgw_frontend_port:
@@ -677,11 +690,13 @@ class IscsiServiceSpec(ServiceSpec):
                  ssl_cert: Optional[str] = None,
                  ssl_key: Optional[str] = None,
                  placement: Optional[PlacementSpec] = None,
-                 unmanaged: bool = False
+                 unmanaged: bool = False,
+                 preview_only: bool = False
                  ):
         assert service_type == 'iscsi'
         super(IscsiServiceSpec, self).__init__('iscsi', service_id=service_id,
-                                               placement=placement, unmanaged=unmanaged)
+                                               placement=placement, unmanaged=unmanaged,
+                                               preview_only=preview_only)
 
         #: RADOS pool where ceph-iscsi config data is stored.
         self.pool = pool
@@ -692,6 +707,7 @@ class IscsiServiceSpec(ServiceSpec):
         self.api_secure = api_secure
         self.ssl_cert = ssl_cert
         self.ssl_key = ssl_key
+        self.preview_only = preview_only
 
         if not self.api_secure and self.ssl_cert and self.ssl_key:
             self.api_secure = True

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -163,3 +163,65 @@ spec:
 
         assert yaml.dump(object) == y
         assert yaml.dump(ServiceSpec.from_json(object.to_json())) == y
+
+@pytest.mark.parametrize("spec1, spec2, eq",
+                         [
+                             (
+                                     ServiceSpec(
+                                         service_type='mon'
+                                     ),
+                                     ServiceSpec(
+                                         service_type='mon'
+                                     ),
+                                     True
+                             ),
+                             (
+                                     ServiceSpec(
+                                         service_type='mon'
+                                     ),
+                                     ServiceSpec(
+                                         service_type='mon',
+                                         service_id='foo'
+                                     ),
+                                     False
+                             ),
+                             # Add service_type='mgr'
+                             (
+                                     ServiceSpec(
+                                         service_type='osd'
+                                     ),
+                                     ServiceSpec(
+                                         service_type='osd',
+                                     ),
+                                     True
+                             ),
+                             (
+                                     ServiceSpec(
+                                         service_type='osd'
+                                     ),
+                                     DriveGroupSpec(),
+                                     True
+                             ),
+                             (
+                                     ServiceSpec(
+                                         service_type='osd'
+                                     ),
+                                     ServiceSpec(
+                                         service_type='osd',
+                                         service_id='foo',
+                                     ),
+                                     False
+                             ),
+                             (
+                                     ServiceSpec(
+                                         service_type='rgw'
+                                     ),
+                                     RGWSpec(),
+                                     True
+                             ),
+                         ])
+def test_spec_hash_eq(spec1: ServiceSpec,
+                      spec2: ServiceSpec,
+                      eq: bool):
+
+    assert (spec1 == spec2) is eq


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Current workflow:

[![asciicast](https://asciinema.org/a/0uWjS86iBqv0i5ra5DQBRTNsV.svg)](https://asciinema.org/a/0uWjS86iBqv0i5ra5DQBRTNsV)

This patchset aims to align the `--dry-run` workflow for all known services by:

* Introduce `preview_only` attribute to `ServiceSpec` that  prevents services from  being deployed.
   This is also visible in `orch ls`
   This attribute is set when an `apply` command is executed with `--dry-run` flag.
   The attribute is unset when an `apply` command is executed without a `--dry-run` flag.
* Return a "promise" string when handling `OSDSpec` as it takes longer to generate a preview for 
   OSDs. Once the preview is generated it will be cached. (but re-generated if the spec changes)
* Base `Random`'s seed on the specs `service_name()` attribute to get deterministic results from the `SimpleScheduler`.
 

TODO:

- [x] ~Fake `DaemonDescription` when multiple `ServiceSpecs` are being previewed~ ( This is no longer needed as the scheduler only inspects the daemons of the type of the service that is being previewed)
- [x] Decide how to present the data to the user (table, yaml, etc..)

The default output will be a table even at the risk of possibly breaking the limit of the columns when _a lot_ of services will be deployed.. There will be a way to output as yaml/json/pretty-json as always. 

- [x] Decice what to do with HostSpecs

Ignore for now.

- [x] Testing in larger deployments

works fine. even in deployments > 30 nodes and 60~ OSDs, the OSD previews are generated in 10-20 seconds. 

- [x] Add support for `--dry-run` in other `apply` commands 
- [x] Unitests
- [x] mypy
- [x] documentation

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
