### PR TITLE
mgr/cephadm: mgr/cephadm: Add `ceph orch generate-service-specs`

### DIFF
--- a/src/pybind/mgr/cephadm/templates/spec_templates/alertmanager.yaml.j2
+++ b/src/pybind/mgr/cephadm/templates/spec_templates/alertmanager.yaml.j2
@@ -1,0 +1,3 @@
+service_type: alertmanager
+placement:
+{{ placement | indent(2, True) }}

--- a/src/pybind/mgr/cephadm/templates/spec_templates/crash.yaml.j2
+++ b/src/pybind/mgr/cephadm/templates/spec_templates/crash.yaml.j2
@@ -1,0 +1,3 @@
+service_type: crash
+placement:
+{{ placement | indent(2, True) }}

--- a/src/pybind/mgr/cephadm/templates/spec_templates/grafana.yaml.j2
+++ b/src/pybind/mgr/cephadm/templates/spec_templates/grafana.yaml.j2
@@ -1,0 +1,4 @@
+service_type: grafana
+# MONs don't have a service_id
+placement:
+{{ placement | indent(2, True) }}

--- a/src/pybind/mgr/cephadm/templates/spec_templates/iscsi.yaml.j2
+++ b/src/pybind/mgr/cephadm/templates/spec_templates/iscsi.yaml.j2
@@ -1,0 +1,4 @@
+service_type: mon
+# MONs don't have a service_id
+placement:
+{{ placement | indent(2, True) }}

--- a/src/pybind/mgr/cephadm/templates/spec_templates/mds.yaml.j2
+++ b/src/pybind/mgr/cephadm/templates/spec_templates/mds.yaml.j2
@@ -1,0 +1,4 @@
+service_type: mds
+service_id: {{ service_id }}
+placement:
+{{ placement | indent(2, True) }}

--- a/src/pybind/mgr/cephadm/templates/spec_templates/mgr.yaml.j2
+++ b/src/pybind/mgr/cephadm/templates/spec_templates/mgr.yaml.j2
@@ -1,0 +1,4 @@
+service_type: mgr
+# MGRs don't have a service_id
+placement:
+{{ placement | indent(2, True) }}

--- a/src/pybind/mgr/cephadm/templates/spec_templates/mon.yaml.j2
+++ b/src/pybind/mgr/cephadm/templates/spec_templates/mon.yaml.j2
@@ -1,0 +1,4 @@
+service_type: mon
+# MONs don't have a service_id
+placement:
+{{ placement | indent(2, True) }}

--- a/src/pybind/mgr/cephadm/templates/spec_templates/nfs.yaml.j2
+++ b/src/pybind/mgr/cephadm/templates/spec_templates/nfs.yaml.j2
@@ -1,0 +1,4 @@
+service_type: mon
+# MONs don't have a service_id
+placement:
+{{ placement | indent(2, True) }}

--- a/src/pybind/mgr/cephadm/templates/spec_templates/node-exporter.yaml.j2
+++ b/src/pybind/mgr/cephadm/templates/spec_templates/node-exporter.yaml.j2
@@ -1,0 +1,3 @@
+service_type: node-exporter
+placement:
+{{ placement | indent(2, True) }}

--- a/src/pybind/mgr/cephadm/templates/spec_templates/osd.yaml.j2
+++ b/src/pybind/mgr/cephadm/templates/spec_templates/osd.yaml.j2
@@ -1,0 +1,4 @@
+service_type: osd
+# MONs don't have a service_id
+placement:
+{{ placement | indent(2, True) }}

--- a/src/pybind/mgr/cephadm/templates/spec_templates/prometheus.yaml.j2
+++ b/src/pybind/mgr/cephadm/templates/spec_templates/prometheus.yaml.j2
@@ -1,0 +1,3 @@
+service_type: prometheus
+placement:
+{{ placement | indent(2, True) }}

--- a/src/pybind/mgr/cephadm/templates/spec_templates/rbd-mirror.yaml.j2
+++ b/src/pybind/mgr/cephadm/templates/spec_templates/rbd-mirror.yaml.j2
@@ -1,0 +1,4 @@
+service_type: rbd-mirror
+# MONs don't have a service_id
+placement:
+{{ placement | indent(2, True) }}

--- a/src/pybind/mgr/cephadm/templates/spec_templates/rgw.yaml.j2
+++ b/src/pybind/mgr/cephadm/templates/spec_templates/rgw.yaml.j2
@@ -1,0 +1,12 @@
+service_type: rgw
+service_id: {{ service_id }}
+placement:
+{{ placement | indent(2, True) }}
+#spec:
+#  subcluster: ...
+#  rgw_frontend_port: <port>
+#  rgw_frontend_ssl_certificate: <cert>
+#  rgw_frontend_ssl_key: <key
+#  ssl: <true or false>
+unmanaged: false
+

--- a/src/pybind/mgr/cephadm/templates/spec_templates/rgw.yaml.j2
+++ b/src/pybind/mgr/cephadm/templates/spec_templates/rgw.yaml.j2
@@ -3,10 +3,11 @@ service_id: {{ service_id }}
 placement:
 {{ placement | indent(2, True) }}
 #spec:
-#  subcluster: ...
+#  subcluster: <subcluster>
 #  rgw_frontend_port: <port>
-#  rgw_frontend_ssl_certificate: <cert>
-#  rgw_frontend_ssl_key: <key
+#  rgw_frontend_ssl_certificate: |
+#    <cert>
+#  rgw_frontend_ssl_key: |
+#    <key>
 #  ssl: <true or false>
 unmanaged: false
-

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -479,13 +479,26 @@ def test_spec_octopus():
         ),
         True
     ),
+    (
+        # There is only one MON cluster
+        ServiceSpec(
+            service_type='mon',
+            service_id='',
+        ),
+        DaemonDescription(
+            daemon_type='mon',
+            daemon_id="host1",
+            hostname="host1",
+        ),
+        True
+    )
 ])
 def test_daemon_description_service_name(spec: ServiceSpec,
                                          dd: DaemonDescription,
                                          valid: bool):
     if valid:
         assert spec.service_name() == dd.service_name()
+        assert spec.service_id == dd.service_id()
     else:
         with pytest.raises(OrchestratorError):
             dd.service_name()
-

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -1,9 +1,12 @@
 import json
+from collections import namedtuple
 
 import pytest
+import yaml
 
 from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec, \
     ServiceSpecValidationError, IscsiServiceSpec, PlacementSpec
+from cephadm.tests.fixtures import cephadm_module
 from cephadm.utils import generate_specs_for_daemons
 
 from orchestrator import DaemonDescription, OrchestratorError
@@ -504,115 +507,43 @@ def test_daemon_description_service_name(spec: ServiceSpec,
         with pytest.raises(OrchestratorError):
             dd.service_name()
 
-
-def test_generate_specs_for_daemons():
+def test_generate_specs_for_daemons(cephadm_module):
+    from_tuple = namedtuple('from_tuple', 'daemon_type,daemon_id,hostname')
     all_dds = [
-        DaemonDescription(
-            daemon_type='rgw',
-            daemon_id='realm.zone.host1',
-            hostname='host1',
-        ),
-        DaemonDescription(
-            daemon_type='rgw',
-            daemon_id='realm.zone.host2',
-            hostname='host1',
-        ),
-        DaemonDescription.from_json(
-            {
-                "container_image_name": "docker.io/ceph/daemon-base:latest-master-devel",
-                "created": "2020-06-19T09:33:32.265147",
-                "daemon_id": "ubuntu",
-                "daemon_type": "mon",
-                "hostname": "ubuntu",
-                "last_refresh": "2020-06-19T09:33:50.400690",
-                "status": -1,
-                "status_desc": "unknown"
-            }
-        ),
-        DaemonDescription.from_json(
-            {
-                "container_id": "8c00d50397fd",
-                "container_image_id": "74803e884bea289d2d2d3ebdf6d37cd560499e955595695b1390a89800f4e37a",
-                "container_image_name": "docker.io/ceph/daemon-base:latest-master-devel",
-                "created": "2020-06-19T10:15:22.927302",
-                "daemon_id": "ubuntu.uxsnuk",
-                "daemon_type": "mgr",
-                "hostname": "ubuntu",
-                "last_refresh": "2020-06-19T10:15:25.763212",
-                "started": "2020-06-19T10:15:23.053042",
-                "status": 1,
-                "status_desc": "running",
-                "version": "16.0.0-901-g713ef3c"
-            }
-        ),
-        DaemonDescription.from_json(
-            {
-                "container_id": "d176c4cf08bb",
-                "container_image_id": "de242295e2257c37c8cadfd962369228f8f10b2d48a44259b65fef44ad4f6490",
-                "container_image_name": "docker.io/prom/prometheus:v2.18.1",
-                "created": "2020-06-19T10:19:25.968255",
-                "daemon_id": "ubuntu",
-                "daemon_type": "prometheus",
-                "hostname": "ubuntu",
-                "last_refresh": "2020-06-19T10:19:27.724052",
-                "started": "2020-06-19T10:19:26.093273",
-                "status": 1,
-                "status_desc": "running",
-                "version": "2.18.1"
-            }
-        )
-    ]
-    assert generate_specs_for_daemons(all_dds, []) == [
-        ServiceSpec.from_json(
-            {
-                'service_type': 'rgw',
-                'service_id': 'realm.zone',
-                'service_name': 'rgw.realm.zone',
-                'placement': {
-                    'hosts': [
-                        {'hostname': 'host1', 'network': '', 'name': 'realm.zone.host1'},
-                        {'hostname': 'host1', 'network': '', 'name': 'realm.zone.host2'}
-                    ]
-                },
-                'unmanaged': True,
-                'rgw_realm': 'realm',
-                'rgw_zone': 'zone',
-            }),
-        ServiceSpec.from_json(
-            {
-                "service_type": "mon",
-                "service_id": "",
-                "placement": {
-                    "hosts": [
-                        {
-                            "hostname": "ubuntu",
-                            "name": "ubuntu",
-                            "network": ""
-                        }
-                    ]
-                },
-                "service_name": "mon",
-                "unmanaged": True
-            }
+        DaemonDescription(**from_tuple(*s.split(','))._asdict()) for s in [
+        "rgw,realm.zone.host1,host1",
+        "rgw,realm.zone.host1,host2",
+        "mon,ubuntu,ubuntu",
+        "mgr,ubuntu,ubuntu",
+        "alertmanager,ubuntu,ubuntu",
+        "node-exporter,ubuntu,ubuntu",
+        "prometheus,ubuntu,ubuntu",
+        "grafana,ubuntu,ubuntu",
+        "crash,ubuntu,ubuntu",
+        "iscsi,iscsi.iscsi.ubuntu,ubuntu",
+        "mds,fs.ubuntu,ubuntu",
+        "nfs,ubuntu,ubuntu",
+        "osd,0,host1",
+        "rbd-mirror,ubuntu,ubuntu"
+        ]]
 
-        ),
-        ServiceSpec.from_json(
-            {
-                'service_type': 'mgr',
-                'service_name': 'mgr',
-                'placement': {
-                    'hosts': [{'hostname': 'ubuntu', 'network': '', 'name': 'ubuntu.uxsnuk'}]},
-                'unmanaged': True,
-            }
-        ),
-        ServiceSpec.from_json(
-            {
-                'service_type': 'prometheus',
-                'service_name': 'prometheus',
-                'placement': {
-                    'hosts': [{'hostname': 'ubuntu', 'network': '', 'name': 'ubuntu'}]
-                },
-                'unmanaged': True,
-            }
-        )
-    ]
+    yamls = list(generate_specs_for_daemons(cephadm_module, all_dds, []))
+    assert len(yamls) == len(ServiceSpec.KNOWN_SERVICE_TYPES)
+
+    assert yamls[0] == """service_type: rgw
+service_id: realm.zone
+placement:
+  hosts
+#spec:
+#  subcluster: ...
+#  rgw_frontend_port: <port>
+#  rgw_frontend_ssl_certificate: <cert>
+#  rgw_frontend_ssl_key: <key
+#  ssl: <true or false>
+unmanaged: false
+"""
+    ServiceSpec.from_json(yaml.load(yamls[0]))
+
+    specs = [ServiceSpec.from_json(yaml.load(y)) for y in yamls]
+    assert {s.service_type for s in specs} == set(ServiceSpec.KNOWN_SERVICE_TYPES)
+

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -533,15 +533,18 @@ def test_generate_specs_for_daemons(cephadm_module):
     assert yamls[0] == """service_type: rgw
 service_id: realm.zone
 placement:
-  hosts
+  hosts:
+  - host1=realm.zone.host1
+  - host2=realm.zone.host1
 #spec:
-#  subcluster: ...
+#  subcluster: <subcluster>
 #  rgw_frontend_port: <port>
-#  rgw_frontend_ssl_certificate: <cert>
-#  rgw_frontend_ssl_key: <key
+#  rgw_frontend_ssl_certificate: |
+#    <cert>
+#  rgw_frontend_ssl_key: |
+#    <key>
 #  ssl: <true or false>
-unmanaged: false
-"""
+unmanaged: false"""
     ServiceSpec.from_json(yaml.load(yamls[0]))
 
     specs = [ServiceSpec.from_json(yaml.load(y)) for y in yamls]

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -70,8 +70,9 @@ def generate_specs_for_daemons(mgr: "CephadmOrchestrator", all_dds: List[DaemonD
     for key, placement in placements.items():
         service_type, service_id = key
         context = {
-            'placement': to_yaml_or_json(placement.to_json(), 'yaml'),
+            'placement': to_yaml_or_json(placement.to_json(), 'yaml', many=False).strip(),
             'service_id': service_id
         }
+
         yml = mgr.template.render(f'spec_templates/{service_type}.yaml.j2', context)
         yield yml

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -320,7 +320,7 @@ def format_bytes(n, width, colored=False):
     return format_units(n, width, colored, decimal=False)
 
 
-def to_yaml_or_json(what: Any, format: str) -> str:
+def to_yaml_or_json(what: Any, format: str, many=True) -> str:
     """
     >>> to_yaml_or_json({'a': 1}, 'json')
     '{"a": 1}'
@@ -333,7 +333,10 @@ def to_yaml_or_json(what: Any, format: str) -> str:
     elif format == 'json-pretty':
         return json.dumps(what, indent=2, sort_keys=True)
     elif format == 'yaml':
-        return yaml.safe_dump_all(what, default_flow_style=False)
+        if many:
+            return yaml.safe_dump_all(what, default_flow_style=False)
+        else:
+            return yaml.safe_dump(what, default_flow_style=False)
     assert False, f'{format} unsupported.'
 
 

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -1,4 +1,3 @@
-import cephfs
 import contextlib
 import datetime
 import errno
@@ -8,16 +7,17 @@ import time
 import logging
 import sys
 from threading import Lock, Condition, Event
-from typing import no_type_check
+from typing import Tuple, no_type_check, Any
+
 if sys.version_info >= (3, 3):
     from threading import Timer
 else:
     from threading import _Timer as Timer
 
-try:
-    from typing import Tuple
-except ImportError:
-    TYPE_CHECKING = False  # just for type checking
+import cephfs
+import json
+import yaml
+
 
 (
     BLACK,
@@ -318,6 +318,23 @@ def format_dimless(n, width, colored=False):
 
 def format_bytes(n, width, colored=False):
     return format_units(n, width, colored, decimal=False)
+
+
+def to_yaml_or_json(what: Any, format: str) -> str:
+    """
+    >>> to_yaml_or_json({'a': 1}, 'json')
+    '{"a": 1}'
+
+    >>> to_yaml_or_json([{'a': 1}], 'yaml')
+    'a: 1\\n'
+    """
+    if format == 'json':
+        return json.dumps(what, sort_keys=True)
+    elif format == 'json-pretty':
+        return json.dumps(what, indent=2, sort_keys=True)
+    elif format == 'yaml':
+        return yaml.safe_dump_all(what, default_flow_style=False)
+    assert False, f'{format} unsupported.'
 
 
 def merge_dicts(*args):

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1309,7 +1309,7 @@ class DaemonDescription(object):
         if self.daemon_type in ['mds', 'nfs', 'iscsi', 'rgw']:
             return _match()
 
-        return self.daemon_id
+        return ''
 
     def service_name(self):
         if self.daemon_type in ['rgw', 'mds', 'nfs', 'iscsi']:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -13,7 +13,7 @@ from ceph.deployment.inventory import Device
 from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection
 from ceph.deployment.service_spec import PlacementSpec, ServiceSpec
 
-from mgr_util import format_bytes, to_pretty_timedelta
+from mgr_util import format_bytes, to_pretty_timedelta, to_yaml_or_json
 from mgr_module import MgrModule, HandleCommandResult
 
 from ._interface import OrchestratorClientMixin, DeviceLightLoc, _cli_read_command, \
@@ -28,15 +28,6 @@ def nice_delta(now, t, suffix=''):
         return to_pretty_timedelta(now - t) + suffix
     else:
         return '-'
-
-
-def to_format(what, format):
-    if format == 'json':
-        return json.dumps(what, sort_keys=True)
-    elif format == 'json-pretty':
-        return json.dumps(what, indent=2, sort_keys=True)
-    elif format == 'yaml':
-        return yaml.safe_dump_all(what, default_flow_style=False)
 
 
 @six.add_metaclass(CLICommandMeta)
@@ -218,7 +209,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
         if format != 'plain':
             hosts = [host.to_json()
                      for host in completion.result]
-            output = to_format(hosts, format)
+            output = to_yaml_or_json(hosts, format)
         else:
             table = PrettyTable(
                 ['HOST', 'ADDR', 'LABELS', 'STATUS'],
@@ -277,7 +268,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
 
         if format != 'plain':
             data = [n.to_json() for n in completion.result]
-            return HandleCommandResult(stdout=to_format(data, format))
+            return HandleCommandResult(stdout=to_yaml_or_json(data, format))
         else:
             out = []
 
@@ -352,7 +343,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
                 data = [s.spec.to_json() for s in services]
             else:
                 data = [s.to_json() for s in services]
-            return HandleCommandResult(stdout=to_format(data, format))
+            return HandleCommandResult(stdout=to_yaml_or_json(data, format))
         else:
             now = datetime.datetime.utcnow()
             table = PrettyTable(
@@ -417,7 +408,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
             return HandleCommandResult(stdout="No daemons reported")
         elif format != 'plain':
             data = [s.to_json() for s in daemons]
-            return HandleCommandResult(stdout=to_format(data, format))
+            return HandleCommandResult(stdout=to_yaml_or_json(data, format))
         else:
             now = datetime.datetime.utcnow()
             table = PrettyTable(
@@ -536,7 +527,7 @@ Examples:
 
         def print_preview(previews, format_to):
             if format != 'plain':
-                return to_format(previews, format_to)
+                return to_yaml_or_json(previews, format_to)
             else:
                 table = PrettyTable(
                     ['NAME', 'HOST', 'DATA', 'DB', 'WAL'],

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -58,11 +58,12 @@ class HostPlacementSpec(namedtuple('HostPlacementSpec', ['hostname', 'network', 
         return cls(**data)
 
     def to_json(self):
-        return {
-            'hostname': self.hostname,
-            'network': self.network,
-            'name': self.name
-        }
+        ret = [self.hostname]
+        if self.network:
+            ret.append(f':{self.network}')
+        if self.name:
+            ret.append(f'={self.name}')
+        return ''.join(ret)
 
     @classmethod
     def parse(cls, host, require_network=True):

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -492,10 +492,15 @@ class ServiceSpec(object):
             self.placement.validate()
 
     def __repr__(self):
-        return "{}({!r})".format(self.__class__.__name__, self.__dict__)
+        return "ServiceSpec.from_json({!r})".format(self.to_json())
 
     def one_line_str(self):
         return '<{} for service_name={}>'.format(self.__class__.__name__, self.service_name())
+
+    def __eq__(self, other):
+        if self.__class__ != other.__class__:
+            return False
+        return self.to_json() == other.to_json()
 
 
 class NFSServiceSpec(ServiceSpec):


### PR DESCRIPTION
the adoption process doesn't create service specifications.

This command prints out a set of service specifications that can be used to
finalize the adoption process

Fixes: https://tracker.ceph.com/issues/45973

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
