### PR TITLE
mgr/dashboard: Fix e2e chromium binary validation

### DIFF
--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -40,10 +40,11 @@ check_device_available() {
 
         case "$DEVICE" in
             chrome)
-                [ -x "$(command -v google-chrome)" ] || [ -x "$(command -v google-chrome-stable)" ] || failed=true
+                [ -x "$(command -v chrome)" ] || [ -x "$(command -v google-chrome)" ] ||
+                [ -x "$(command -v google-chrome-stable)" ] || failed=true
                 ;;
             chromium)
-                [ -x "$(command -v chromium)" ] || failed=true
+                [ -x "$(command -v chromium)" ] || [ -x "$(command -v chromium-browser)" ] || failed=true
                 ;;
         esac
     fi


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46110

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
