### PR TITLE
octopus: mgr/dashboard: Fix e2e chromium binary validation 

### DIFF
--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -40,10 +40,11 @@ check_device_available() {
 
         case "$DEVICE" in
             chrome)
-                [ -x "$(command -v google-chrome)" ] || [ -x "$(command -v google-chrome-stable)" ] ] || failed=true
+                [ -x "$(command -v chrome)" ] || [ -x "$(command -v google-chrome)" ] ||
+                [ -x "$(command -v google-chrome-stable)" ] || failed=true
                 ;;
             chromium)
-                [ -x "$(command -v chromium)" ] || failed=true
+                [ -x "$(command -v chromium)" ] || [ -x "$(command -v chromium-browser)" ] || failed=true
                 ;;
         esac
     fi


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46111

---

backport of https://github.com/ceph/ceph/pull/35673
parent tracker: https://tracker.ceph.com/issues/46110

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh