### PR TITLE
doc/man: improve c-o-t commands

### DIFF
--- a/doc/man/8/ceph-objectstore-tool.rst
+++ b/doc/man/8/ceph-objectstore-tool.rst
@@ -12,20 +12,6 @@ Synopsis
 
 
 
-Possible object operations:
-
-* (get|set)-bytes [file]
-* set-(attr|omap) [file]
-* (get|rm)-attr|omap)
-* get-omaphdr
-* set-omaphdr [file]
-* list-attrs
-* list-omap
-* remove|removeall
-* dump
-* set-size
-* clear-data-digest
-* remove-clone-metadata 
 
 
 Description
@@ -35,7 +21,7 @@ Description
 
 **ceph-objectstore-tool** provides two main modes: (1) a mode that specifies the "--op" argument (for example, **ceph-objectstore-tool** --data-path $PATH_TO_OSD --op $SELECT_OPERATION [--pgid $PGID] [--dry-run]), and (2) a mode for positional object operations. If the second mode is used, the object can be specified by ID or by the JSON output of the --op list. 
 
-| **ceph-objectstore-tool** --data-path *path to osd* [--pgid *$PG_ID* ][--op *command*]
+| **ceph-objectstore-tool** --data-path *path to osd* [--pgid *$PG_ID* ] --op *op_command*
 | **ceph-objectstore-tool** --data-path *path to osd* [ --op *list $OBJECT_ID*]
 
 Possible -op commands::
@@ -68,6 +54,21 @@ Possible -op commands::
 * update-mon-db
 * dump-export
 * trim-pg-log
+
+Possible object operations:
+
+* (get|set)-bytes [file]
+* set-(attr|omap) [file]
+* (get|rm)-attr|omap)
+* get-omaphdr
+* set-omaphdr [file]
+* list-attrs
+* list-omap
+* remove|removeall
+* dump
+* set-size
+* clear-data-digest
+* remove-clone-metadata 
 
 Installation
 ============
@@ -173,8 +174,7 @@ Remove an object (syntax)::
 
 Remove an object (example)::
 
-[root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' remove
-
+[root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash": 235010478,"max":0,"pool":1,"namespace":"","max":0}]
 
 Listing the Object Map
 ----------------------
@@ -196,7 +196,7 @@ Use the ceph-objectstore-tool to list the contents of the object map (OMAP). The
 
    Syntax::
 
-    ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT list-omap
+    ceph-objectstore-tool --data-path $PATH_TO_OSD $OBJECT list-omap
 
    Example::
 
@@ -462,7 +462,7 @@ Options
 
 .. option:: --skip-mount-omap
 
-   Disable mounting of omap
+   Disable mounting of omap. This applies only to FileStore.
 
 .. option:: --head
 
@@ -470,7 +470,11 @@ Options
 
 .. option:: --dry-run
 
-   Don't modify the objectstore
+   If run in conjunction with --skip-journal-replay, this command prevents
+   the objectstore from being written to. If this command is run by itself,
+   a dry-run of the operation specified occurs. **ceph-objectstore-tool**
+   'mounts' the objectstore, which might cause a journal replay. See also
+   **--skip-journal-replay**.
 
 .. option:: --namespace arg
 

--- a/doc/man/8/ceph-objectstore-tool.rst
+++ b/doc/man/8/ceph-objectstore-tool.rst
@@ -7,11 +7,7 @@ ceph-objectstore-tool - modify or examine the state of an OSD
 Synopsis
 ========
 
-
 | **ceph-objectstore-tool** --data-path *path to osd* [--op *list* ]
-
-
-
 
 
 Description
@@ -70,6 +66,7 @@ Possible object operations:
 * clear-data-digest
 * remove-clone-metadata 
 
+
 Installation
 ============
 
@@ -100,7 +97,7 @@ Identify all objects within an OSD::
 
 Identify all objects within a placement group::
 
-   ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID --op list
+   ceph-objectstore-tool --data-path $PATH_TO_OSD --op list
 
 Identify the placement group (PG) that an object belongs to::
 
@@ -120,7 +117,7 @@ Fix all lost objects::
 
 Fix all the lost objects within a specified placement group::
 
-   ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID --op fix-lost
+   ceph-objectstore-tool --data-path $PATH_TO_OSD --op fix-lost
 
 Fix a lost object by its identifier::
 
@@ -142,13 +139,13 @@ Manipulating an object's content
 
 3. Before setting the bytes on the object, make a backup and a working copy of the object. Here is the syntactic form of that command::
    
-    ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-bytes > $OBJECT_FILE_NAME
+    ceph-objectstore-tool --data-path $PATH_TO_OSD $OBJECT get-bytes > $OBJECT_FILE_NAME
 
 For example::
 
-   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' get-bytes > zone_info.default.backup
+   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":1,"namespace":"","max":0}] get-bytes > zone_info.default.backup
 
-   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' get-bytes > zone_info.default.working-copy
+   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":1,"namespace":"","max":0}] get-bytes > zone_info.default.working-copy
 
 The first command creates the back-up copy, and the second command creates the working copy.
 
@@ -156,11 +153,11 @@ The first command creates the back-up copy, and the second command creates the w
 
 5. Set the bytes of the object::
      
-     ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT set-bytes < $OBJECT_FILE_NAME
+     ceph-objectstore-tool --data-path $PATH_TO_OSD  $OBJECT set-bytes < $OBJECT_FILE_NAME
 
 For example::
 
-   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' set-bytes < zone_info.default.working-copy
+   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":1,"namespace":"","max":0}] set-bytes < zone_info.default.working-copy
  
 
 Removing an Object
@@ -170,11 +167,11 @@ Use **ceph-objectstore-tool** to remove objects. When an object is removed, its 
 
 Remove an object (syntax)::
 
-   ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT remove
+   ceph-objectstore-tool --data-path $PATH_TO_OSD $OBJECT remove
 
 Remove an object (example)::
 
-[root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash": 235010478,"max":0,"pool":1,"namespace":"","max":0}]
+[root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash": 235010478,"max":0,"pool":1,"namespace":"","max":0}] remove
 
 Listing the Object Map
 ----------------------
@@ -200,8 +197,7 @@ Use the ceph-objectstore-tool to list the contents of the object map (OMAP). The
 
    Example::
 
-    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' list-omap
-
+    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":1,"namespace":"","max":0}] list-omap
 
 Manipulating the Object Map Header
 ----------------------------------
@@ -232,21 +228,21 @@ Procedure
 
   Syntax::
 
-        ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omaphdr > $OBJECT_MAP_FILE_NAME
+        ceph-objectstore-tool --data-path $PATH_TO_OSD  $OBJECT get-omaphdr > $OBJECT_MAP_FILE_NAME
 
   Example::
 
-        [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}'  get-omaphdr > zone_info.default.omaphdr.txt
+        [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":1,"namespace":"","max":0}] get-omaphdr > zone_info.default.omaphdr.txt
 
   Set the object map header:
 
   Syntax::
 
-        ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omaphdr < $OBJECT_MAP_FILE_NAME
+        ceph-objectstore-tool --data-path $PATH_TO_OSD $OBJECT get-omaphdr < $OBJECT_MAP_FILE_NAME
 
   Example::
 
-   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}'  set-omaphdr < zone_info.default.omaphdr.txt
+   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":1,"namespace":"","max":0}] set-omaphdr < zone_info.default.omaphdr.txt
 
 
 Manipulating the Object Map Key
@@ -268,40 +264,44 @@ Procedure
 
     Syntax::
      
-       ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-omap $KEY > $OBJECT_MAP_FILE_NAME
+       ceph-objectstore-tool --data-path $PATH_TO_OSD $OBJECT get-omap $KEY > $OBJECT_MAP_FILE_NAME
 
    Example::
 
-    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}'  get-omap "" > zone_info.default.omap.txt
+    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":1,"namespace":"","max":0}] get-omap "" > zone_info.default.omap.txt
 
    Set the object map key:
 
    Syntax::
 
-    ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT set-omap $KEY < $OBJECT_MAP_FILE_NAME
+    ceph-objectstore-tool --data-path $PATH_TO_OSD $OBJECT set-omap $KEY < $OBJECT_MAP_FILE_NAME
 
    Example::
 
-    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' set-omap "" < zone_info.default.omap.txt
+    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":1,"namespace":"","max":0}] set-omap "" < zone_info.default.omap.txt
 
    Remove the object map key:
 
    Syntax::
 
-    ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT rm-omap $KEY
+    ceph-objectstore-tool --data-path $PATH_TO_OSD  $OBJECT rm-omap $KEY
 
    Example::
 
-    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' rm-omap ""
+    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":1,"namespace":"","max":0}] rm-omap ""
 
 
 Listing an Object's Attributes
 -------------------------------
 
 Use the **ceph-objectstore-tool** utility to list an object's attributes. The output provides you with the object’s keys and values.
-Note
 
-If you are using FileStore as the OSD backend object store and the journal is on a different disk, you must add the `--journal-path $PATH_TO_JOURNAL` argument when listing an object’s attributes, where the `$PATH_TO_JOURNAL` variable is the absolute path to the OSD journal; for example `/var/lib/ceph/osd/ceph-0/journal`.
+.. note::
+        If you are using FileStore as the OSD backend object store and the journal 
+        is on a different disk, you must add the `--journal-path $PATH_TO_JOURNAL` 
+        argument when listing an object’s attributes, where the `$PATH_TO_JOURNAL` 
+        variable is the absolute path to the OSD journal; for example 
+        `/var/lib/ceph/osd/ceph-0/journal`.
 
 Prerequisites
 ^^^^^^^^^^^^^
@@ -326,11 +326,11 @@ Procedure
 
    Syntax::
 
-    ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT list-attrs
+    ceph-objectstore-tool --data-path $PATH_TO_OSD $OBJECT list-attrs
 
    Example::
 
-    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' list-attrs
+    [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":1,"namespace":"","max":0}] list-attrs
 
 
 MANIPULATING THE OBJECT ATTRIBUTE KEY
@@ -362,31 +362,31 @@ Procedure
 
  Syntax::
 
-   ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT get-attrs $KEY > $OBJECT_ATTRS_FILE_NAME
+   ceph-objectstore-tool --data-path $PATH_TO_OSD $OBJECT get-attrs $KEY > $OBJECT_ATTRS_FILE_NAME
 
  Example::
 
-   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0  --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' get-attrs "oid" > zone_info.default.attr.txt
+   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":1,"namespace":"","max":0}] get-attrs "oid" > zone_info.default.attr.txt
 
  Set an object’s attributes:
 
  Syntax::
 
-   ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT  set-attrs $KEY < $OBJECT_ATTRS_FILE_NAME
+   ceph-objectstore-tool --data-path $PATH_TO_OSD $OBJECT  set-attrs $KEY < $OBJECT_ATTRS_FILE_NAME
 
  Example::
 
-   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' set-attrs "oid" < zone_info.default.attr.txt
+   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":1,"namespace":"","max":0}] set-attrs "oid" < zone_info.default.attr.txt
 
  Remove an object’s attributes:
 
  Syntax::
 
-   ceph-objectstore-tool --data-path $PATH_TO_OSD --pgid $PG_ID $OBJECT rm-attrs $KEY
+   ceph-objectstore-tool --data-path $PATH_TO_OSD $OBJECT rm-attrs $KEY
 
  Example::
 
-   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 --pgid 0.1c '{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":11,"namespace":""}' rm-attrs "oid"
+   [root@osd ~]# ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-0 ["1.1c",{"oid":"zone_info.default","key":"","snapid":-2,"hash":235010478,"max":0,"pool":1,"namespace":"","max":0}] rm-attrs "oid"
 
 
 Options


### PR DESCRIPTION
This PR updates the man page for ceph-objectstore-tool with
updated information provided by the tool's author, David
Zafman.

Fixes: https://tracker.ceph.com/issues/46120

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
