### PR TITLE
admin/doc-requirements: pin sphinx-autodoc-typehints to 1.10.3 

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,10 +1,10 @@
-Sphinx == 2.4.3
+Sphinx == 2.4.4
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
-breathe == 4.14.0
+breathe == 4.14.2
 pyyaml >= 5.1.2
 Cython
 prettytable
-sphinx-autodoc-typehints
+sphinx-autodoc-typehints == 1.10.3
 typed-ast
 pcpp
 -e../src/python-common

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -99,7 +99,7 @@ edit_on_github_branch = 'master'
 
 # handles edit-on-github and old version warning display
 def setup(app):
-    app.add_javascript('js/ceph.js')
+    app.add_js_file('js/ceph.js')
     if ditaa is None:
         # add "ditaa" as an alias of "diagram"
         from plantweb.directive import DiagramDirective


### PR DESCRIPTION
to silence following error:

ERROR: sphinx-autodoc-typehints 1.11.0 has requirement Sphinx>=3.0, but you'll have sphinx 2.4.3 which is incompatible.

and update breathe to 4.19.2, as breathe 4.19.1 is the first version
compatible with sphinx 3.1. see
https://github.com/michaeljones/breathe/blob/v4.19.1/README.rst#change-log

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
