### PR TITLE
mypy.ini: Remove global `ignore_missing_imports = True`

### DIFF
--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -1,7 +1,65 @@
 [mypy]
 strict_optional = True
 no_implicit_optional = True
-ignore_missing_imports = True
 warn_incomplete_stub = True
 check_untyped_defs = True
 show_error_context = True
+
+[mypy-rados]
+# This would require a rados.pyi file
+ignore_missing_imports = True
+
+[mypy-rbd]
+# This would require a rbd.pyi file
+ignore_missing_imports = True
+
+[mypy-cephfs]
+# This would require a cephfs.pyi file
+ignore_missing_imports = True
+
+
+# Make cephadm and rook happy
+[mypy-OpenSSL]
+ignore_missing_imports = True
+
+[mypy-prettytable]
+ignore_missing_imports = True
+
+[mypy-jsonpatch]
+ignore_missing_imports = True
+
+[mypy-urllib3.*]
+ignore_missing_imports = True
+
+[mypy-execnet.*]
+ignore_missing_imports = True
+
+[mypy-remoto.*]
+ignore_missing_imports = True
+
+[mypy-kubernetes.*]
+ignore_missing_imports = True
+
+
+# Make dashboard happy:
+[mypy-coverage]
+ignore_missing_imports = True
+
+[mypy-urlparse]
+ignore_missing_imports = True
+
+[mypy-cherrypy.*]
+ignore_missing_imports = True
+
+[mypy-cheroot.*]
+ignore_missing_imports = True
+
+[mypy-bcrypt]
+ignore_missing_imports = True
+
+[mypy-onelogin.*]
+ignore_missing_imports = True
+
+# Make volumes happy:
+[mypy-StringIO]
+ignore_missing_imports = True


### PR DESCRIPTION
A global flag hides errors when we actually want to
import something. Like ceph-pyhton-common etc.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

Replaces: #33436


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
