### PR TITLE
osd/OSDCap: rbd profile permits use of "rbd_info"

### DIFF
--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -333,6 +333,8 @@ void OSDCapGrant::expand_profile()
 
   if (profile.name == "rbd") {
     // RBD read-write grant
+    profile_grants.emplace_back(OSDCapMatch(string(), "rbd_info"),
+                                OSDCapSpec(osd_rwxa_t(OSD_CAP_R)));
     profile_grants.emplace_back(OSDCapMatch(string(), "rbd_children"),
                                 OSDCapSpec(osd_rwxa_t(OSD_CAP_CLS_R)));
     profile_grants.emplace_back(OSDCapMatch(string(), "rbd_mirroring"),


### PR DESCRIPTION
User restricted to a namespace needs to be able to read rbd_info in
default namespace in order to create volumes.

Fixes: https://tracker.ceph.com/issues/46139

Signed-off-by: Florian Florensa <fflorensa@online.net>