### PR TITLE
man/conf.py: replace f-string with format

### DIFF
--- a/man/conf.py
+++ b/man/conf.py
@@ -50,7 +50,7 @@ def _get_manpages():
             try:
                 description = _get_description(path, base)
             except UnicodeDecodeError as e:
-                print(f"unable to decode {path}", file=sys.stderr)
+                print("unable to decode {path}".format(path=path), file=sys.stderr)
                 raise e
             yield (
                 os.path.join(section, base),


### PR DESCRIPTION
I'm pretty sure this is causing https://jenkins.ceph.com/job/ceph-dev-new-build/ARCH=x86_64,AVAILABLE_ARCH=x86_64,AVAILABLE_DIST=centos7,DIST=centos7,MACHINE_SIZE=gigantic/42172//consoleFull

---
I hope this fixes:

```
Running Sphinx v1.1.3

Configuration error:
There is a syntax error in your configuration file: invalid syntax (conf.py, line 53)
make[2]: *** [doc/man/ceph-syn.8] Error 1
make[1]: *** [doc/man/CMakeFiles/manpages.dir/all] Error 2
```

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
