### PR TITLE
mgr/dashboard: Fixes typeahead regression in the silence matcher 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-matcher-modal/silence-matcher-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-matcher-modal/silence-matcher-modal.component.html
@@ -38,6 +38,9 @@
                  i18n>Value</label>
           <div class="cd-col-form-input">
             <input id="value"
+                   (focus)="valueFocus.next($any($event).target.value)"
+                   (click)="valueClick.next($any($event).target.value)"
+                   container="body"
                    class="form-control"
                    type="text"
                    [ngbTypeahead]="search"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-matcher-modal/silence-matcher-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-matcher-modal/silence-matcher-modal.component.spec.ts
@@ -4,6 +4,8 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgbActiveModal, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
+import * as _ from 'lodash';
+import { of } from 'rxjs';
 
 import {
   configureTestBed,
@@ -158,5 +160,51 @@ describe('SilenceMatcherModalComponent', () => {
       done();
     });
     component.onSubmit();
+  });
+
+  describe('typeahead', () => {
+    let equality: { [key: string]: boolean };
+    let expectations: { [key: string]: string[] };
+
+    const search = (s: string) => {
+      Object.keys(expectations).forEach((key) => {
+        formH.setValue('name', key);
+        component.search(of(s)).subscribe((result) => {
+          // Expect won't fail the test inside subscribe
+          equality[key] = _.isEqual(result, expectations[key]);
+        });
+        expect(equality[key]).toBeTruthy();
+      });
+    };
+
+    beforeEach(() => {
+      equality = {
+        alertname: false,
+        instance: false,
+        job: false,
+        severity: false
+      };
+      expectations = {
+        alertname: ['alert0', 'alert1'],
+        instance: ['someInstance'],
+        job: ['someJob'],
+        severity: ['someSeverity']
+      };
+    });
+
+    it('should show all values on name switch', () => {
+      search('');
+    });
+
+    it('should search for "some"', () => {
+      expectations['alertname'] = [];
+      search('some');
+    });
+
+    it('should search for "er"', () => {
+      expectations['instance'] = [];
+      expectations['job'] = [];
+      search('er');
+    });
   });
 });


### PR DESCRIPTION
This regression was introduced by PR #35300 which updated the typeahead
module usage from ngx-bootstrap to ng-bootstrap's typeahead module.

The regression was that the typeahead didn't open on click into the
input field. Another regression was that the suggestions didn't overlap
the modal anymore.

Fixes: https://tracker.ceph.com/issues/46135
Signed-off-by: Stephan Müller <smueller@suse.com>

![add-matcher-typeahead](https://user-images.githubusercontent.com/16167865/85294149-940e0280-b49e-11ea-8237-c1744240b9f7.png)


---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>