### PR TITLE
mgr/dashboard: Fixes ICU selection regression

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html
@@ -1,7 +1,6 @@
 <cd-modal [modalRef]="activeModal">
-  <ng-container class="modal-title"
-                i18n>{mode, select, edit {Edit} other {Add}}
-  pool mirror peer</ng-container>
+  <span class="modal-title"
+        i18n>{mode, select, edit {Edit} other {Add}} pool mirror peer</span>
 
   <ng-container class="modal-content">
     <form name="editPeerForm"
@@ -11,9 +10,9 @@
           novalidate>
       <div class="modal-body">
         <p>
-          <ng-container i18n>{mode, select, edit {Edit} other {Add}} the pool
+          <span i18n>{mode, select, edit {Edit} other {Add}} the pool
           mirror peer attributes for pool <kbd>{{ poolName }}</kbd> and click
-          <kbd>Submit</kbd>.</ng-container>
+          <kbd>Submit</kbd>.</span>
         </p>
 
         <div class="form-group">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -68,7 +68,7 @@
   <div *ngIf="!safeToPerform"
        class="danger">
     <cd-alert-panel type="warning"
-                    i18n>The {selection.hasSingleSelection, select, true {OSD is} false {OSDs are}} not safe to be
+                    i18n>The {selection.hasSingleSelection, select, true {OSD is} other {OSDs are}} not safe to be
       {{ actionDescription }}! {{ message }}</cd-alert-panel>
   </div>
   <ng-container i18n><strong>OSD {{ osdIds | join }}</strong> will be

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.html
@@ -1,6 +1,6 @@
 <cd-modal [modalRef]="activeModal">
-  <ng-container class="modal-title"
-                i18n>OSDs {deep, select, 1 {Deep }}Scrub</ng-container>
+  <span class="modal-title"
+        i18n>OSDs {deep, select, true {Deep } other {}}Scrub</span>
 
   <ng-container class="modal-content">
     <form name="scrubForm"
@@ -8,7 +8,7 @@
           [formGroup]="scrubForm"
           novalidate>
       <div class="modal-body">
-        <p i18n>You are about to apply a {deep, select, 1 {deep }}scrub to
+        <p i18n>You are about to apply a {deep, select, true {deep } other {}}scrub to
           the OSD(s): <strong>{{ selected | join }}</strong>.</p>
       </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-matcher-modal/silence-matcher-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-matcher-modal/silence-matcher-modal.component.html
@@ -1,6 +1,6 @@
 <cd-modal [modalRef]="activeModal">
-  <ng-container class="modal-title"
-                i18n>Matcher</ng-container>
+  <span class="modal-title"
+        i18n>{editMode, select, true {Edit} other {Add}} Matcher</span>
 
   <ng-container class="modal-content">
     <form class="form"
@@ -75,7 +75,7 @@
       <div class="modal-footer">
         <cd-submit-button (submitAction)="onSubmit()"
                           [form]="form">
-          <ng-container i18n>{editMode, select, 1 {Update} other {Add}}</ng-container>
+          <span i18n>{editMode, select, true {Edit} other {Add}}</span>
         </cd-submit-button>
         <cd-back-button [back]="activeModal.close"
                         name="Close"


### PR DESCRIPTION
This regression came through the update to angular 9. The regression was
that ICU expressions inside ng-containers are not resolved anymore since
the update to angular 9.

Fixes: https://tracker.ceph.com/issues/45650
Signed-off-by: Stephan Müller <smueller@suse.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
