### PR TITLE
[DNM] mgr: Do not overwrite dashboard's grafana url

### DIFF
--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -61,16 +61,15 @@ class GrafanaService(CephadmService):
         return daemon_descrs[-1]
 
     def config_dashboard(self, daemon_descrs: List[DaemonDescription]):
-        # TODO: signed cert
         dd = self.get_active_daemon(daemon_descrs)
         service_url = 'https://{}:{}'.format(
             self._inventory_get_addr(dd.hostname), self.DEFAULT_SERVICE_PORT)
-        self._set_service_url_on_dashboard(
-            'Grafana',
-            'dashboard get-grafana-api-url',
-            'dashboard set-grafana-api-url',
-            service_url
-        )
+
+        current_url = self.mgr.get_module_option_ex('orchestrator', 'GRAFANA_API_URL')
+        if current_url != service_url:
+            logger.info('Setting dashboard grafana config to %s' % service_url)
+            self.mgr.set_module_option_ex('orchestrator', 'GRAFANA_API_URL', service_url)
+
 
 class AlertmanagerService(CephadmService):
     DEFAULT_SERVICE_PORT = 9093

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -98,6 +98,10 @@ class SettingsMeta(type):
             value = False
         else:
             value = stype(mgr.get_module_option(attr, default))
+
+        if value == default and attr in ['GRAFANA_API_URL']:
+            value = stype(mgr.get_module_option_ex('orchestrator', attr, default))
+
         return value
 
     def __setattr__(cls, attr, value):

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -51,6 +51,13 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
                              'test_orchestrator'],
             'runtime': True,
         },
+        {
+            'name': 'GRAFANA_API_URL',
+            'type': 'str',
+            'default': None,
+            'desc': 'A default for mgr/dashboard',
+        },
+
     ]
     NATIVE_OPTIONS = []  # type: List[dict]
 


### PR DESCRIPTION
DNM, As I'd do this differently this time by saving things in the cephadm module. 

* Don't be more intelligent then the user
* never overwrite the user provided setting
* let the user overwrite the default with a new value using the dashboard native settings
* provide a good default, even update the default if we know something changed

Fixes: https://tracker.ceph.com/issues/44877
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
