### PR TITLE
mgr/dashboard: fix UI for Device class column in OSDs list

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -295,7 +295,7 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
       {
         prop: 'tree.device_class',
         name: this.i18n('Device class'),
-        flexGrow: 1,
+        flexGrow: 1.2,
         cellTransformation: CellTemplate.badge,
         customTemplateConfig: {
           map: {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46144

Signed-off-by: Avan Thakkar <athakkar@redhat.com>

UI for Device class column - > sort 

Before:
![Screenshot from 2020-06-22 23-14-13](https://user-images.githubusercontent.com/23611106/85321931-1a4c3800-b4e3-11ea-9821-408a57c4cc3d.png)

After:
![Screenshot from 2020-06-22 23-28-52](https://user-images.githubusercontent.com/23611106/85321956-2b954480-b4e3-11ea-9912-4b9067cd2c8c.png)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
