### PR TITLE
common, msgr/async: bufferlist::claim_append() doesn't require intermediaries anymore

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1286,10 +1286,7 @@ static ceph::spinlock debug_lock;
     _len += bl._len;
     _num += bl._num;
     _buffers.splice_back(bl._buffers);
-    bl._carriage = &always_empty_bptr;
-    bl._buffers.clear_and_dispose();
-    bl._len = 0;
-    bl._num = 0;
+    bl.clear();
   }
 
   void buffer::list::claim_append_piecewise(list& bl)

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -1066,6 +1066,9 @@ struct error_code;
 
     void claim(list& bl);
     void claim_append(list& bl);
+    void claim_append(list&& bl) {
+      claim_append(bl);
+    }
     // only for bl is bufferlist::page_aligned_appender
     void claim_append_piecewise(list& bl);
 

--- a/src/msg/async/frames_v2.cc
+++ b/src/msg/async/frames_v2.cc
@@ -206,8 +206,7 @@ bufferlist FrameAssembler::asm_secure_rev1(const preamble_block_t& preamble,
   if (segment_bls[0].length() > 0) {
     m_crypto->tx->reset_tx_handler({segment_bls[0].length()});
     m_crypto->tx->authenticated_encrypt_update(segment_bls[0]);
-    auto tmp = m_crypto->tx->authenticated_encrypt_final();
-    frame_bl.claim_append(tmp);
+    frame_bl.claim_append(m_crypto->tx->authenticated_encrypt_final());
   }
   if (m_descs.size() == 1) {
     return frame_bl;  // no epilogue if only one segment
@@ -234,8 +233,7 @@ bufferlist FrameAssembler::asm_secure_rev1(const preamble_block_t& preamble,
     }
   }
   m_crypto->tx->authenticated_encrypt_update(epilogue_bl);
-  auto tmp = m_crypto->tx->authenticated_encrypt_final();
-  frame_bl.claim_append(tmp);
+  frame_bl.claim_append(m_crypto->tx->authenticated_encrypt_final());
   return frame_bl;
 }
 
@@ -396,7 +394,7 @@ void FrameAssembler::disasm_first_secure_rev1(bufferlist& preamble_bl,
     segment_bl.swap(tmp);
     preamble_bl.splice(sizeof(preamble_block_t), FRAME_PREAMBLE_INLINE_SIZE,
                        &segment_bl);
-    segment_bl.claim_append(tmp);
+    segment_bl.claim_append(std::move(tmp));
   } else {
     ceph_assert(segment_bl.length() == 0);
     preamble_bl.splice(sizeof(preamble_block_t), FRAME_PREAMBLE_INLINE_SIZE,


### PR DESCRIPTION
This a follow-up to the #35078.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
