### PR TITLE
doc/dev/cephadm.rst: clarify, fix spelling nits

### DIFF
--- a/doc/dev/cephadm.rst
+++ b/doc/dev/cephadm.rst
@@ -25,11 +25,12 @@ cephadm/cephadm script into memory.)
    MON=1 MGR=1 OSD=0 MDS=0 ../src/vstart.sh -d -n -x --cephadm
 
 - ``~/.ssh/id_dsa[.pub]`` is used as the cluster key.  It is assumed that
-  this key is authorized to ssh to root@`hostname`.
-- No service spec is defined for mon or mgr, which means that cephadm
-  does not try to manage them.
+  this key is authorized to ssh with no passphrase to root@`hostname`.
+- cephadm does not try to manage any daemons started by vstart.sh (any
+  nonzero number in the environment variables).  No service spec is defined
+  for mon or mgr.
 - You'll see health warnings from cephadm about stray daemons--that's because
-  the vstart-launched mon and mgr aren't controlled by cephadm.
+  the vstart-launched daemons aren't controlled by cephadm.
 - The default image is ``quay.io/ceph-ci/ceph:master``, but you can change
   this by passing ``-o container_image=...`` or ``ceph config set global container_image ...``.
 
@@ -89,14 +90,15 @@ When you're done, you can tear down the cluster with::
 Note regarding network calls from CLI handlers
 ==============================================
 
-Executing any cephadm CLI commands like ``ceph orch ls`` will block
-the mon command handler thread within the MGR, thus preventing any
-concurrent CLI calls. Note that pressing ``^C`` will not resolve this
-situation, as *only* the client will be aborted, but not exceution
-itself. This means, cephadm will be completely unresonsive, until the
-execution of the CLI handler is fully completed. Note that even
-``ceph orch ps`` will not respond, while another handler is executed.
+Executing any cephadm CLI commands like ``ceph orch ls`` will block the
+mon command handler thread within the MGR, thus preventing any concurrent
+CLI calls. Note that pressing ``^C`` will not resolve this situation,
+as *only* the client will be aborted, but not execution of the command
+within the orchestrator manager module itself. This means, cephadm will
+be completely unresponsive until the execution of the CLI handler is
+fully completed. Note that even ``ceph orch ps`` will not respond while
+another handler is executing.
 
-This means, we should only do very few calls to remote hosts synchronously. 
-As a guideline, cephadm should do at most ``O(1)`` network calls in CLI handlers. 
+This means we should do very few synchronous calls to remote hosts.
+As a guideline, cephadm should do at most ``O(1)`` network calls in CLI handlers.
 Everything else should be done asynchronously in other threads, like ``serve()``.


### PR DESCRIPTION
Signed-off-by: Dan Mick <dmick@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
