### PR TITLE
octopus: mgr/dashboard: fix autocomplete input backgrounds in chrome and firefox

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.scss
@@ -30,6 +30,7 @@
     box-shadow: none;
     color: $color-password-toggle-text;
     background-color: $color-password-toggle-bg;
+    filter: none;
   }
 
   .placeholder {
@@ -52,4 +53,8 @@
 input:-webkit-autofill {
   animation-name: autofill;
   animation-fill-mode: both;
+  box-shadow: 0 0 0px 1000px $color-password-toggle-bg inset;
+  -webkit-text-fill-color: $color-password-toggle-text;
+  transition-property: none;
+  border-radius: 0px;
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46136

---

backport of https://github.com/ceph/ceph/pull/35676
parent tracker: https://tracker.ceph.com/issues/46109

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh