### PR TITLE
octopus: New msgr2 crc and secure modes (msgr2.1)

### DIFF
--- a/doc/dev/msgr2.rst
+++ b/doc/dev/msgr2.rst
@@ -1,7 +1,7 @@
 .. _msgr2-protocol:
 
-msgr2 protocol
-==============
+msgr2 protocol (msgr2.0 and msgr2.1)
+====================================
 
 This is a revision of the legacy Ceph on-wire protocol that was
 implemented by the SimpleMessenger.  It addresses performance and
@@ -20,7 +20,7 @@ This protocol revision has several goals relative to the original protocol:
   (e.g., padding) that keep computation and memory copies out of the
   fast path where possible.
 * *Signing*.  We will allow for traffic to be signed (but not
-  necessarily encrypted).  This may not be implemented in the initial version.
+  necessarily encrypted).  This is not implemented.
 
 Definitions
 -----------
@@ -56,10 +56,19 @@ Banner
 
 Both the client and server, upon connecting, send a banner::
 
-  "ceph %x %x\n", protocol_features_suppored, protocol_features_required
+  "ceph v2\n"
+  __le16 banner payload length
+  banner payload
 
-The protocol features are a new, distinct namespace.  Initially no
-features are defined or required, so this will be "ceph 0 0\n".
+A banner payload has the form::
+
+  __le64 peer_supported_features
+  __le64 peer_required_features
+
+This is a new, distinct feature bit namespace (CEPH_MSGR2_*).
+Currently, only CEPH_MSGR2_FEATURE_REVISION_1 is defined. It is
+supported but not required, so that msgr2.0 and msgr2.1 peers
+can talk to each other.
 
 If the remote party advertises required features we don't support, we
 can disconnect.
@@ -79,27 +88,150 @@ can disconnect.
 Frame format
 ------------
 
-All further data sent or received is contained by a frame.  Each frame has
-the form::
+After the banners are exchanged, all further communication happens
+in frames.  The exact format of the frame depends on the connection
+mode (msgr2.0-crc, msgr2.0-secure, msgr2.1-crc or msgr2.1-secure).
+All connections start in crc mode (either msgr2.0-crc or msgr2.1-crc,
+depending on peer_supported_features from the banner).
 
-  frame_len (le32)
-  tag (TAG_* le32)
-  frame_header_checksum (le32)
-  payload
-  [payload padding -- only present after stream auth phase]
-  [signature -- only present after stream auth phase]
+Each frame has a 32-byte preamble::
 
+  __u8 tag
+  __u8 number of segments
+  {
+    __le32 segment length
+    __le16 segment alignment
+  } * 4
+  reserved (2 bytes)
+  __le32 preamble crc
 
-* The frame_header_checksum is over just the frame_len and tag values (8 bytes).
+An empty frame has one empty segment.  A non-empty frame can have
+between one and four segments, all segments except the last may be
+empty.
 
-* frame_len includes everything after the frame_len le32 up to the end of the
-  frame (all payloads, signatures, and padding).
+If there are less than four segments, unused (trailing) segment
+length and segment alignment fields are zeroed.
 
-* The payload format and length is determined by the tag.
+The reserved bytes are zeroed.
 
-* The signature portion is only present if the authentication phase
-  has completed (TAG_AUTH_DONE has been sent) and signatures are
-  enabled.
+The preamble checksum is CRC32-C.  It covers everything up to
+itself (28 bytes) and is calculated and verified irrespective of
+the connection mode (i.e. even if the frame is encrypted).
+
+### msgr2.0-crc mode
+
+A msgr2.0-crc frame has the form::
+
+  preamble (32 bytes)
+  {
+    segment payload
+  } * number of segments
+  epilogue (17 bytes)
+
+where epilogue is::
+
+  __u8 late_flags
+  {
+    __le32 segment crc
+  } * 4
+
+late_flags is used for frame abortion.  After transmitting the
+preamble and the first segment, the sender can fill the remaining
+segments with zeros and set a flag to indicate that the receiver must
+drop the frame.  This allows the sender to avoid extra buffering
+when a frame that is being put on the wire is revoked (i.e. yanked
+out of the messenger): payload buffers can be unpinned and handed
+back to the user immediately, without making a copy or blocking
+until the whole frame is transmitted.  Currently this is used only
+by the kernel client, see ceph_msg_revoke().
+
+The segment checksum is CRC32-C.  For "used" empty segments, it is
+set to (__le32)-1.  For unused (trailing) segments, it is zeroed.
+
+The crcs are calculated just to protect against bit errors.
+No authenticity guarantees are provided, unlike in msgr1 which
+attempted to provide some authenticity guarantee by optionally
+signing segment lengths and crcs with the session key.
+
+Issues:
+
+1. As part of introducing a structure for a generic frame with
+   variable number of segments suitable for both control and
+   message frames, msgr2.0 moved the crc of the first segment of
+   the message frame (ceph_msg_header2) into the epilogue.
+
+   As a result, ceph_msg_header2 can no longer be safely
+   interpreted before the whole frame is read off the wire.
+   This is a regression from msgr1, because in order to scatter
+   the payload directly into user-provided buffers and thus avoid
+   extra buffering and copying when receiving message frames,
+   ceph_msg_header2 must be available in advance -- it stores
+   the transaction id which the user buffers are keyed on.
+   The implementation has to choose between forgoing this
+   optimization or acting on an unverified segment.
+
+2. late_flags is not covered by any crc.  Since it stores the
+   abort flag, a single bit flip can result in a completed frame
+   being dropped (causing the sender to hang waiting for a reply)
+   or, worse, in an aborted frame with garbage segment payloads
+   being dispatched.
+
+   This was the case with msgr1 and got carried over to msgr2.0.
+
+### msgr2.1-crc mode
+
+Differences from msgr2.0-crc:
+
+1. The crc of the first segment is stored at the end of the
+   first segment, not in the epilogue.  The epilogue stores up to
+   three crcs, not up to four.
+
+   If the first segment is empty, (__le32)-1 crc is not generated.
+
+2. The epilogue is generated only if the frame has more than one
+   segment (i.e. at least one of second to fourth segments is not
+   empty).  Rationale: If the frame has only one segment, it cannot
+   be aborted and there are no crcs to store in the epilogue.
+
+3. Unchecksummed late_flags is replaced with late_status which
+   builds in bit error detection by using a 4-bit nibble per flag
+   and two code words that are Hamming Distance = 4 apart (and not
+   all zeros or ones).  This comes at the expense of having only
+   one reserved flag, of course.
+
+Some example frames:
+
+* A 0+0+0+0 frame (empty, no epilogue)::
+
+    preamble (32 bytes)
+
+* A 20+0+0+0 frame (no epilogue)::
+
+    preamble (32 bytes)
+    segment1 payload (20 bytes)
+    __le32 segment1 crc
+
+* A 0+70+0+0 frame::
+
+    preamble (32 bytes)
+    segment2 payload (70 bytes)
+    epilogue (13 bytes)
+
+* A 20+70+0+350 frame::
+
+    preamble (32 bytes)
+    segment1 payload (20 bytes)
+    __le32 segment1 crc
+    segment2 payload (70 bytes)
+    segment4 payload (350 bytes)
+    epilogue (13 bytes)
+
+where epilogue is::
+
+  __u8 late_status
+  {
+    __le32 segment crc
+  } * 3
 
 Hello
 -----
@@ -198,47 +330,197 @@ authentication method as the first attempt:
 Post-auth frame format
 ----------------------
 
-The frame format is fixed (see above), but can take three different
-forms, depending on the AUTH_DONE flags:
+Depending on the negotiated connection mode from TAG_AUTH_DONE, the
+connection either stays in crc mode or switches to the corresponding
+secure mode (msgr2.0-secure or msgr2.1-secure).
 
-* If neither FLAG_SIGNED or FLAG_ENCRYPTED is specified, things are simple::
+### msgr2.0-secure mode
 
-    frame_len
-    tag
-    payload
-    payload_padding (out to auth block_size)
+A msgr2.0-secure frame has the form::
 
-  - The padding is some number of bytes < the auth block_size that
-    brings the total length of the payload + payload_padding to a
-    multiple of block_size.  It does not include the frame_len or tag.  Padding
-    content can be zeros or (better) random bytes.
-
-* If FLAG_SIGNED has been specified::
-
-    frame_len
-    tag
-    payload
-    payload_padding (out to auth block_size)
-    signature (sig_size bytes)
-
-  Here the padding just makes life easier for the signature.  It can be
-  random data to add additional confounder.  Note also that the
-  signature input must include some state from the session key and the
-  previous message.
-
-* If FLAG_ENCRYPTED has been specified::
-
-    frame_len
-    tag
+  {
+    preamble (32 bytes)
     {
-      payload
-      payload_padding (out to auth block_size)
-    } ^ stream cipher
+      segment payload
+      zero padding (out to 16 bytes)
+    } * number of segments
+    epilogue (16 bytes)
+  } ^ AES-128-GCM cipher
+  auth tag (16 bytes)
 
-  Note that the padding ensures that the total frame is a multiple of
-  the auth method's block_size so that the message can be sent out over
-  the wire without waiting for the next frame in the stream.
+where epilogue is::
 
+    __u8 late_flags
+    zero padding (15 bytes)
+
+late_flags has the same meaning as in msgr2.0-crc mode.
+
+Each segment and the epilogue are zero padded out to 16 bytes.
+Technically, GCM doesn't require any padding because Counter mode
+(the C in GCM) essentially turns a block cipher into a stream cipher.
+But, if the overall input length is not a multiple of 16 bytes, some
+implicit zero padding would occur internally because GHASH function
+used by GCM for generating auth tags only works on 16-byte blocks.
+
+Issues:
+
+1. The sender encrypts the whole frame using a single nonce
+   and generating a single auth tag.  Because segment lengths are
+   stored in the preamble, the receiver has no choice but to decrypt
+   and interpret the preamble without verifying the auth tag -- it
+   can't even tell how much to read off the wire to get the auth tag
+   otherwise!  This creates a decryption oracle, which, in conjunction
+   with Counter mode malleability, could lead to recovery of sensitive
+   information.
+
+   This issue extends to the first segment of the message frame as
+   well.  As in msgr2.0-crc mode, ceph_msg_header2 cannot be safely
+   interpreted before the whole frame is read off the wire.
+
+2. Deterministic nonce construction with a 4-byte counter field
+   followed by an 8-byte fixed field is used.  The initial values are
+   taken from the connection secret -- a random byte string generated
+   during the authentication phase.  Because the counter field is
+   only four bytes long, it can wrap and then repeat in under a day,
+   leading to GCM nonce reuse and therefore a potential complete
+   loss of both authenticity and confidentiality for the connection.
+   This was addressed by disconnecting before the counter repeats
+   (CVE-2020-1759).
+
+### msgr2.1-secure mode
+
+Differences from msgr2.0-secure:
+
+1. The preamble, the first segment and the rest of the frame are
+   encrypted separately, using separate nonces and generating
+   separate auth tags.  This gets rid of unverified plaintext use
+   and keeps msgr2.1-secure mode close to msgr2.1-crc mode, allowing
+   the implementation to receive message frames in a similar fashion
+   (little to no buffering, same scatter/gather logic, etc).
+
+   In order to reduce the number of en/decryption operations per
+   frame, the preamble is grown by a fixed size inline buffer (48
+   bytes) that the first segment is inlined into, either fully or
+   partially.  The preamble auth tag covers both the preamble and the
+   inline buffer, so if the first segment is small enough to be fully
+   inlined, it becomes available after a single decryption operation.
+
+2. As in msgr2.1-crc mode, the epilogue is generated only if the
+   frame has more than one segment.  The rationale is even stronger,
+   as it would require an extra en/decryption operation.
+
+3. For consistency with msgr2.1-crc mode, late_flags is replaced
+   with late_status (the built-in bit error detection isn't really
+   needed in secure mode).
+
+4. In accordance with `NIST Recommendation for GCM`_, deterministic
+   nonce construction with a 4-byte fixed field followed by an 8-byte
+   counter field is used.  An 8-byte counter field should never repeat
+   but the nonce reuse protection put in place for msgr2.0-secure mode
+   is still there.
+
+   The initial values are the same as in msgr2.0-secure mode.
+
+   .. _`NIST Recommendation for GCM`: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
+
+As in msgr2.0-secure mode, each segment is zero padded out to
+16 bytes.  If the first segment is fully inlined, its padding goes
+to the inline buffer.  Otherwise, the padding is on the remainder.
+The corollary to this is that the inline buffer is consumed in
+16-byte chunks.
+
+The unused portion of the inline buffer is zeroed.
+
+Some example frames:
+
+* A 0+0+0+0 frame (empty, nothing to inline, no epilogue)::
+
+    {
+      preamble (32 bytes)
+      zero padding (48 bytes)
+    } ^ AES-128-GCM cipher
+    auth tag (16 bytes)
+
+* A 20+0+0+0 frame (first segment fully inlined, no epilogue)::
+
+    {
+      preamble (32 bytes)
+      segment1 payload (20 bytes)
+      zero padding (28 bytes)
+    } ^ AES-128-GCM cipher
+    auth tag (16 bytes)
+
+* A 0+70+0+0 frame (nothing to inline)::
+
+    {
+      preamble (32 bytes)
+      zero padding (48 bytes)
+    } ^ AES-128-GCM cipher
+    auth tag (16 bytes)
+    {
+      segment2 payload (70 bytes)
+      zero padding (10 bytes)
+      epilogue (16 bytes)
+    } ^ AES-128-GCM cipher
+    auth tag (16 bytes)
+
+* A 20+70+0+350 frame (first segment fully inlined)::
+
+    {
+      preamble (32 bytes)
+      segment1 payload (20 bytes)
+      zero padding (28 bytes)
+    } ^ AES-128-GCM cipher
+    auth tag (16 bytes)
+    {
+      segment2 payload (70 bytes)
+      zero padding (10 bytes)
+      segment4 payload (350 bytes)
+      zero padding (2 bytes)
+      epilogue (16 bytes)
+    } ^ AES-128-GCM cipher
+    auth tag (16 bytes)
+
+* A 105+0+0+0 frame (first segment partially inlined, no epilogue)::
+
+    {
+      preamble (32 bytes)
+      segment1 payload (48 bytes)
+    } ^ AES-128-GCM cipher
+    auth tag (16 bytes)
+    {
+      segment1 payload remainder (57 bytes)
+      zero padding (7 bytes)
+    } ^ AES-128-GCM cipher
+    auth tag (16 bytes)
+
+* A 105+70+0+350 frame (first segment partially inlined)::
+
+    {
+      preamble (32 bytes)
+      segment1 payload (48 bytes)
+    } ^ AES-128-GCM cipher
+    auth tag (16 bytes)
+    {
+      segment1 payload remainder (57 bytes)
+      zero padding (7 bytes)
+    } ^ AES-128-GCM cipher
+    auth tag (16 bytes)
+    {
+      segment2 payload (70 bytes)
+      zero padding (10 bytes)
+      segment4 payload (350 bytes)
+      zero padding (2 bytes)
+      epilogue (16 bytes)
+    } ^ AES-128-GCM cipher
+    auth tag (16 bytes)
+
+where epilogue is::
+
+    __u8 late_status
+    zero padding (15 bytes)
+
+late_status has the same meaning as in msgr2.1-crc mode.
 
 Message flow handshake
 ----------------------

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -155,6 +155,7 @@ set(crimson_mon_srcs
   mon/MonClient.cc
   ${PROJECT_SOURCE_DIR}/src/mon/MonSub.cc)
 set(crimson_net_srcs
+  ${PROJECT_SOURCE_DIR}/src/msg/async/frames_v2.cc
   net/Errors.cc
   net/Messenger.cc
   net/SocketConnection.cc

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1908,7 +1908,7 @@ seastar::future<> ProtocolV2::read_message(utime_t throttle_stamp)
 
     // we need to get the size before std::moving segments data
     const size_t cur_msg_size = get_current_msg_size();
-    auto msg_frame = MessageFrame::Decode(std::move(rx_segments_data));
+    auto msg_frame = MessageFrame::Decode(rx_segments_data);
     // XXX: paranoid copy just to avoid oops
     ceph_msg_header2 current_header = msg_frame.header();
 

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -403,7 +403,7 @@ seastar::future<> ProtocolV2::read_frame_payload()
     // we do have a mechanism that allows transmitter to start sending message
     // and abort after putting entire data field on wire. This will be used by
     // the kernel client to avoid unnecessary buffering.
-    if (late_flags & FRAME_FLAGS_LATEABRT) {
+    if (late_flags & FRAME_LATE_FLAG_ABORTED) {
       // TODO
       ceph_assert(false);
     }

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -178,7 +178,8 @@ ProtocolV2::ProtocolV2(Dispatcher& dispatcher,
                        SocketMessenger& messenger)
   : Protocol(proto_t::v2, dispatcher, conn),
     messenger{messenger},
-    protocol_timer{conn}
+    protocol_timer{conn},
+    tx_frame_asm(&session_stream_handlers)
 {}
 
 ProtocolV2::~ProtocolV2() {}
@@ -412,7 +413,7 @@ seastar::future<> ProtocolV2::read_frame_payload()
 template <class F>
 seastar::future<> ProtocolV2::write_frame(F &frame, bool flush)
 {
-  auto bl = frame.get_buffer(session_stream_handlers);
+  auto bl = frame.get_buffer(tx_frame_asm);
   const auto main_preamble = reinterpret_cast<const preamble_block_t*>(bl.front().c_str());
   logger().trace("{} SEND({}) frame: tag={}, num_segments={}, crc={}",
                  conn, bl.length(), (int)main_preamble->tag,
@@ -1852,19 +1853,19 @@ ceph::bufferlist ProtocolV2::do_sweep_messages(
 
   if (unlikely(require_keepalive)) {
     auto keepalive_frame = KeepAliveFrame::Encode();
-    bl.append(keepalive_frame.get_buffer(session_stream_handlers));
+    bl.append(keepalive_frame.get_buffer(tx_frame_asm));
     INTERCEPT_FRAME(ceph::msgr::v2::Tag::KEEPALIVE2, bp_type_t::WRITE);
   }
 
   if (unlikely(_keepalive_ack.has_value())) {
     auto keepalive_ack_frame = KeepAliveFrameAck::Encode(*_keepalive_ack);
-    bl.append(keepalive_ack_frame.get_buffer(session_stream_handlers));
+    bl.append(keepalive_ack_frame.get_buffer(tx_frame_asm));
     INTERCEPT_FRAME(ceph::msgr::v2::Tag::KEEPALIVE2_ACK, bp_type_t::WRITE);
   }
 
   if (require_ack && !num_msgs) {
     auto ack_frame = AckFrame::Encode(conn.in_seq);
-    bl.append(ack_frame.get_buffer(session_stream_handlers));
+    bl.append(ack_frame.get_buffer(tx_frame_asm));
     INTERCEPT_FRAME(ceph::msgr::v2::Tag::ACK, bp_type_t::WRITE);
   }
 
@@ -1893,7 +1894,7 @@ ceph::bufferlist ProtocolV2::do_sweep_messages(
         msg->get_payload(), msg->get_middle(), msg->get_data());
     logger().debug("{} --> #{} === {} ({})",
 		   conn, msg->get_seq(), *msg, msg->get_type());
-    bl.append(message.get_buffer(session_stream_handlers));
+    bl.append(message.get_buffer(tx_frame_asm));
     INTERCEPT_FRAME(ceph::msgr::v2::Tag::MESSAGE, bp_type_t::WRITE);
   });
 

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -179,7 +179,7 @@ ProtocolV2::ProtocolV2(Dispatcher& dispatcher,
   : Protocol(proto_t::v2, dispatcher, conn),
     messenger{messenger},
     protocol_timer{conn},
-    tx_frame_asm(&session_stream_handlers)
+    tx_frame_asm(&session_stream_handlers, false)
 {}
 
 ProtocolV2::~ProtocolV2() {}

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -113,6 +113,7 @@ class ProtocolV2 final : public Protocol {
   ceph::crypto::onwire::rxtx_t session_stream_handlers;
   boost::container::static_vector<ceph::msgr::v2::segment_t,
 				  ceph::msgr::v2::MAX_NUM_SEGMENTS> rx_segments_desc;
+  ceph::msgr::v2::FrameAssembler tx_frame_asm;
   ceph::msgr::v2::segment_bls_t rx_segments_data;
 
   size_t get_current_msg_size() const;

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -113,8 +113,7 @@ class ProtocolV2 final : public Protocol {
   ceph::crypto::onwire::rxtx_t session_stream_handlers;
   boost::container::static_vector<ceph::msgr::v2::segment_t,
 				  ceph::msgr::v2::MAX_NUM_SEGMENTS> rx_segments_desc;
-  boost::container::static_vector<ceph::bufferlist,
-				  ceph::msgr::v2::MAX_NUM_SEGMENTS> rx_segments_data;
+  ceph::msgr::v2::segment_bls_t rx_segments_data;
 
   size_t get_current_msg_size() const;
   seastar::future<ceph::msgr::v2::Tag> read_main_preamble();

--- a/src/include/msgr.h
+++ b/src/include/msgr.h
@@ -52,15 +52,16 @@
 #define DEFINE_MSGR2_FEATURE(bit, incarnation, name)               \
 	const static uint64_t CEPH_MSGR2_FEATURE_##name = (1ULL << bit); \
 	const static uint64_t CEPH_MSGR2_FEATUREMASK_##name =            \
-			(1ULL << bit | CEPH_FEATURE_INCARNATION_##incarnation);
+			(1ULL << bit | CEPH_MSGR2_INCARNATION_##incarnation);
 
 #define HAVE_MSGR2_FEATURE(x, name) \
 	(((x) & (CEPH_MSGR2_FEATUREMASK_##name)) == (CEPH_MSGR2_FEATUREMASK_##name))
 
+DEFINE_MSGR2_FEATURE( 0, 1, REVISION_1)   // msgr2.1
 
-#define CEPH_MSGR2_SUPPORTED_FEATURES (0ull)
+#define CEPH_MSGR2_SUPPORTED_FEATURES (CEPH_MSGR2_FEATURE_REVISION_1)
 
-#define CEPH_MSGR2_REQUIRED_FEATURES (CEPH_MSGR2_SUPPORTED_FEATURES)
+#define CEPH_MSGR2_REQUIRED_FEATURES  (0ull)
 
 
 /*

--- a/src/msg/CMakeLists.txt
+++ b/src/msg/CMakeLists.txt
@@ -17,6 +17,7 @@ list(APPEND msg_srcs
   async/PosixStack.cc
   async/Stack.cc
   async/crypto_onwire.cc
+  async/frames_v2.cc
   async/net_handler.cc)
 
 if(LINUX)

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1148,9 +1148,12 @@ CtPtr ProtocolV2::read_frame_segment() {
   rx_segments_data.emplace_back();
 
   uint32_t onwire_len = rx_frame_asm.get_segment_onwire_len(seg_idx);
-  uint16_t align = rx_frame_asm.get_segment_align(seg_idx);
+  if (onwire_len == 0) {
+    return _handle_read_frame_segment();
+  }
 
   rx_buffer_t rx_buffer;
+  uint16_t align = rx_frame_asm.get_segment_align(seg_idx);
   try {
     rx_buffer = buffer::ptr_node::create(buffer::create_aligned(
         onwire_len, align));
@@ -1176,11 +1179,17 @@ CtPtr ProtocolV2::handle_read_frame_segment(rx_buffer_t &&rx_buffer, int r) {
   }
 
   rx_segments_data.back().push_back(std::move(rx_buffer));
+  return _handle_read_frame_segment();
+}
 
+CtPtr ProtocolV2::_handle_read_frame_segment() {
   if (rx_segments_data.size() == rx_frame_asm.get_num_segments()) {
     // OK, all segments planned to read are read. Can go with epilogue.
-    return READ(rx_frame_asm.get_epilogue_onwire_len(),
-                handle_read_frame_epilogue_main);
+    uint32_t epilogue_onwire_len = rx_frame_asm.get_epilogue_onwire_len();
+    if (epilogue_onwire_len == 0) {
+      return _handle_read_frame_epilogue_main();
+    }
+    return READ(epilogue_onwire_len, handle_read_frame_epilogue_main);
   }
   // TODO: for makeshift only. This will be more generic and throttled
   return read_frame_segment();
@@ -1284,7 +1293,10 @@ CtPtr ProtocolV2::handle_read_frame_epilogue_main(rx_buffer_t &&buffer, int r)
   }
 
   rx_epilogue.push_back(std::move(buffer));
+  return _handle_read_frame_epilogue_main();
+}
 
+CtPtr ProtocolV2::_handle_read_frame_epilogue_main() {
   bool aborted;
   try {
     rx_frame_asm.disassemble_first_segment(rx_preamble, rx_segments_data[0]);

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -93,6 +93,7 @@ ProtocolV2::ProtocolV2(AsyncConnection *connection)
       can_write(false),
       bannerExchangeCallback(nullptr),
       tx_frame_asm(&session_stream_handlers),
+      rx_frame_asm(&session_stream_handlers),
       next_tag(static_cast<Tag>(0)),
       keepalive(false) {
 }
@@ -264,11 +265,11 @@ void ProtocolV2::reset_recv_state() {
 }
 
 size_t ProtocolV2::get_current_msg_size() const {
-  ceph_assert(!rx_segments_desc.empty());
+  ceph_assert(rx_frame_asm.get_num_segments() > 0);
   size_t sum = 0;
   // we don't include SegmentIndex::Msg::HEADER.
-  for (__u8 idx = 1; idx < rx_segments_desc.size(); idx++) {
-    sum += rx_segments_desc[idx].length;
+  for (size_t i = 1; i < rx_frame_asm.get_num_segments(); i++) {
+    sum += rx_frame_asm.get_segment_logical_len(i);
   }
   return sum;
 }
@@ -736,26 +737,6 @@ bool ProtocolV2::is_queued() {
   return !out_queue.empty() || connection->is_queued();
 }
 
-uint32_t ProtocolV2::get_onwire_size(const uint32_t logical_size) const {
-  if (session_stream_handlers.rx) {
-    return segment_onwire_size(logical_size);
-  } else {
-    return logical_size;
-  }
-}
-
-uint32_t ProtocolV2::get_epilogue_size() const {
-  // In secure mode size of epilogue is flexible and depends on particular
-  // cipher implementation. See the comment for epilogue_secure_block_t or
-  // epilogue_plain_block_t.
-  if (session_stream_handlers.rx) {
-    return FRAME_SECURE_EPILOGUE_SIZE + \
-        session_stream_handlers.rx->get_extra_size_at_final();
-  } else {
-    return FRAME_PLAIN_EPILOGUE_SIZE;
-  }
-}
-
 CtPtr ProtocolV2::read(CONTINUATION_RXBPTR_TYPE<ProtocolV2> &next,
                        rx_buffer_t &&buffer) {
   const auto len = buffer->length();
@@ -1068,7 +1049,12 @@ CtPtr ProtocolV2::read_frame() {
   }
 
   ldout(cct, 20) << __func__ << dendl;
-  return READ(FRAME_PREAMBLE_SIZE, handle_read_frame_preamble_main);
+  rx_preamble.clear();
+  rx_epilogue.clear();
+  rx_segments_data.clear();
+
+  return READ(rx_frame_asm.get_preamble_onwire_len(),
+              handle_read_frame_preamble_main);
 }
 
 CtPtr ProtocolV2::handle_read_frame_preamble_main(rx_buffer_t &&buffer, int r) {
@@ -1080,71 +1066,29 @@ CtPtr ProtocolV2::handle_read_frame_preamble_main(rx_buffer_t &&buffer, int r) {
     return _fault();
   }
 
-  ceph::bufferlist preamble;
-  preamble.push_back(std::move(buffer));
+  rx_preamble.push_back(std::move(buffer));
 
   ldout(cct, 30) << __func__ << " preamble\n";
-  preamble.hexdump(*_dout);
+  rx_preamble.hexdump(*_dout);
   *_dout << dendl;
 
-  if (session_stream_handlers.rx) {
-    ceph_assert(session_stream_handlers.rx);
-
-    session_stream_handlers.rx->reset_rx_handler();
-    session_stream_handlers.rx->authenticated_decrypt_update(preamble);
-
-    ldout(cct, 10) << __func__ << " got encrypted preamble."
-                   << " after decrypt premable.length()=" << preamble.length()
-                   << dendl;
-
-    ldout(cct, 30) << __func__ << " preamble after decrypt\n";
-    preamble.hexdump(*_dout);
-    *_dout << dendl;
+  try {
+    next_tag = rx_frame_asm.disassemble_preamble(rx_preamble);
+  } catch (FrameError& e) {
+    ldout(cct, 1) << __func__ << " " << e.what() << dendl;
+    return _fault();
+  } catch (ceph::crypto::onwire::MsgAuthError&) {
+    ldout(cct, 1) << __func__ << "bad auth tag" << dendl;
+    return _fault();
   }
 
-  {
-    // I expect ceph_le32 will make the endian conversion for me. Passing
-    // everything through ::Decode is unnecessary.
-    const auto& main_preamble = \
-      reinterpret_cast<preamble_block_t&>(*preamble.c_str());
+  ldout(cct, 25) << __func__ << " disassembled preamble " << rx_frame_asm
+                 << dendl;
 
-    // verify preamble's CRC before any further processing
-    const auto rx_crc = ceph_crc32c(0,
-      reinterpret_cast<const unsigned char*>(&main_preamble),
-      sizeof(main_preamble) - sizeof(main_preamble.crc));
-    if (rx_crc != main_preamble.crc) {
-      ldout(cct, 10) << __func__ << " crc mismatch for main preamble"
-		     << " rx_crc=" << rx_crc
-		     << " tx_crc=" << main_preamble.crc << dendl;
-      return _fault();
-    }
-
-    // currently we do support between 1 and MAX_NUM_SEGMENTS segments
-    if (main_preamble.num_segments < 1 ||
-        main_preamble.num_segments > MAX_NUM_SEGMENTS) {
-      ldout(cct, 10) << __func__ << " unsupported num_segments="
-		     << " tx_crc=" << main_preamble.num_segments << dendl;
-      return _fault();
-    }
-
-    next_tag = static_cast<Tag>(main_preamble.tag);
-
-    rx_segments_desc.clear();
-    rx_segments_data.clear();
-
-    if (main_preamble.num_segments > MAX_NUM_SEGMENTS) {
-      ldout(cct, 30) << __func__
-		     << " num_segments=" << main_preamble.num_segments
-		     << " is too much" << dendl;
-      return _fault();
-    }
-    for (std::uint8_t idx = 0; idx < main_preamble.num_segments; idx++) {
-      ldout(cct, 10) << __func__ << " got new segment:"
-		     << " len=" << main_preamble.segments[idx].length
-		     << " align=" << main_preamble.segments[idx].alignment
-		     << dendl;
-      rx_segments_desc.emplace_back(main_preamble.segments[idx]);
-    }
+  if (session_stream_handlers.rx) {
+    ldout(cct, 30) << __func__ << " preamble after decrypt\n";
+    rx_preamble.hexdump(*_dout);
+    *_dout << dendl;
   }
 
   // does it need throttle?
@@ -1199,21 +1143,23 @@ CtPtr ProtocolV2::handle_read_frame_dispatch() {
 }
 
 CtPtr ProtocolV2::read_frame_segment() {
-  ldout(cct, 20) << __func__ << dendl;
-  ceph_assert(!rx_segments_desc.empty());
+  size_t seg_idx = rx_segments_data.size();
+  ldout(cct, 20) << __func__ << " seg_idx=" << seg_idx << dendl;
+  rx_segments_data.emplace_back();
 
-  // description of current segment to read
-  const auto& cur_rx_desc = rx_segments_desc.at(rx_segments_data.size());
+  uint32_t onwire_len = rx_frame_asm.get_segment_onwire_len(seg_idx);
+  uint16_t align = rx_frame_asm.get_segment_align(seg_idx);
+
   rx_buffer_t rx_buffer;
   try {
     rx_buffer = buffer::ptr_node::create(buffer::create_aligned(
-      get_onwire_size(cur_rx_desc.length), cur_rx_desc.alignment));
+        onwire_len, align));
   } catch (std::bad_alloc&) {
     // Catching because of potential issues with satisfying alignment.
     ldout(cct, 1) << __func__ << " can't allocate aligned rx_buffer"
-		   << " len=" << get_onwire_size(cur_rx_desc.length)
-		   << " align=" << cur_rx_desc.alignment
-		   << dendl;
+                  << " len=" << onwire_len
+                  << " align=" << align
+                  << dendl;
     return _fault();
   }
 
@@ -1229,36 +1175,15 @@ CtPtr ProtocolV2::handle_read_frame_segment(rx_buffer_t &&rx_buffer, int r) {
     return _fault();
   }
 
-  rx_segments_data.emplace_back();
   rx_segments_data.back().push_back(std::move(rx_buffer));
 
-  // decrypt incoming data
-  // FIXME: if (auth_meta->is_mode_secure()) {
-  if (session_stream_handlers.rx) {
-    ceph_assert(session_stream_handlers.rx);
-
-    auto& new_seg = rx_segments_data.back();
-    if (new_seg.length()) {
-      session_stream_handlers.rx->authenticated_decrypt_update(new_seg);
-      const auto idx = rx_segments_data.size() - 1;
-      if (new_seg.length() > rx_segments_desc[idx].length) {
-        new_seg.splice(rx_segments_desc[idx].length,
-                       new_seg.length() - rx_segments_desc[idx].length);
-      }
-
-      ldout(cct, 20) << __func__
-                     << " unpadded new_seg.length()=" << new_seg.length()
-                     << dendl;
-    }
-  }
-
-  if (rx_segments_desc.size() == rx_segments_data.size()) {
+  if (rx_segments_data.size() == rx_frame_asm.get_num_segments()) {
     // OK, all segments planned to read are read. Can go with epilogue.
-    return READ(get_epilogue_size(), handle_read_frame_epilogue_main);
-  } else {
-    // TODO: for makeshift only. This will be more generic and throttled
-    return read_frame_segment();
+    return READ(rx_frame_asm.get_epilogue_onwire_len(),
+                handle_read_frame_epilogue_main);
   }
+  // TODO: for makeshift only. This will be more generic and throttled
+  return read_frame_segment();
 }
 
 CtPtr ProtocolV2::handle_frame_payload() {
@@ -1358,61 +1283,29 @@ CtPtr ProtocolV2::handle_read_frame_epilogue_main(rx_buffer_t &&buffer, int r)
     return _fault();
   }
 
-  __u8 late_flags;
+  rx_epilogue.push_back(std::move(buffer));
 
-  // FIXME: if (auth_meta->is_mode_secure()) {
-  if (session_stream_handlers.rx) {
-    ldout(cct, 1) << __func__ << " read frame epilogue bytes="
-                  << get_epilogue_size() << dendl;
-
-    // decrypt epilogue and authenticate entire frame.
-    ceph::bufferlist epilogue_bl;
-    {
-      epilogue_bl.push_back(std::move(buffer));
-      try {
-        session_stream_handlers.rx->authenticated_decrypt_update_final(
-            epilogue_bl);
-      } catch (ceph::crypto::onwire::MsgAuthError &e) {
-        ldout(cct, 5) << __func__ << " message authentication failed: "
-                      << e.what() << dendl;
-        return _fault();
-      }
-    }
-    auto& epilogue =
-        reinterpret_cast<epilogue_plain_block_t&>(*epilogue_bl.c_str());
-    late_flags = epilogue.late_flags;
-  } else {
-    auto& epilogue = reinterpret_cast<epilogue_plain_block_t&>(*buffer->c_str());
-
-    for (std::uint8_t idx = 0; idx < rx_segments_data.size(); idx++) {
-      const __u32 expected_crc = epilogue.crc_values[idx];
-      const __u32 calculated_crc = rx_segments_data[idx].crc32c(-1);
-      if (expected_crc != calculated_crc) {
-	ldout(cct, 5) << __func__ << " message integrity check failed: "
-		      << " expected_crc=" << expected_crc
-		      << " calculated_crc=" << calculated_crc
-		      << dendl;
-	return _fault();
-      } else {
-	ldout(cct, 20) << __func__ << " message integrity check success: "
-		       << " expected_crc=" << expected_crc
-		       << " calculated_crc=" << calculated_crc
-		       << dendl;
-      }
-    }
-    late_flags = epilogue.late_flags;
+  bool aborted;
+  try {
+    aborted = !rx_frame_asm.disassemble_segments(rx_segments_data.data(),
+                                                 rx_epilogue);
+  } catch (FrameError& e) {
+    ldout(cct, 1) << __func__ << " " << e.what() << dendl;
+    return _fault();
+  } catch (ceph::crypto::onwire::MsgAuthError&) {
+    ldout(cct, 1) << __func__ << "bad auth tag" << dendl;
+    return _fault();
   }
 
   // we do have a mechanism that allows transmitter to start sending message
   // and abort after putting entire data field on wire. This will be used by
   // the kernel client to avoid unnecessary buffering.
-  if (late_flags & FRAME_FLAGS_LATEABRT) {
+  if (aborted) {
     reset_throttle();
     state = READY;
     return CONTINUE(read_frame);
-  } else {
-    return handle_read_frame_dispatch();
   }
+  return handle_read_frame_dispatch();
 }
 
 CtPtr ProtocolV2::handle_message() {

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1084,8 +1084,7 @@ CtPtr ProtocolV2::handle_read_frame_preamble_main(rx_buffer_t &&buffer, int r) {
     ceph_assert(session_stream_handlers.rx);
 
     session_stream_handlers.rx->reset_rx_handler();
-    preamble = session_stream_handlers.rx->authenticated_decrypt_update(
-      std::move(preamble), segment_t::DEFAULT_ALIGNMENT);
+    session_stream_handlers.rx->authenticated_decrypt_update(preamble);
 
     ldout(cct, 10) << __func__ << " got encrypted preamble."
                    << " after decrypt premable.length()=" << preamble.length()
@@ -1233,11 +1232,12 @@ CtPtr ProtocolV2::handle_read_frame_segment(rx_buffer_t &&rx_buffer, int r) {
 
     auto& new_seg = rx_segments_data.back();
     if (new_seg.length()) {
-      auto padded = session_stream_handlers.rx->authenticated_decrypt_update(
-          std::move(new_seg), segment_t::DEFAULT_ALIGNMENT);
+      session_stream_handlers.rx->authenticated_decrypt_update(new_seg);
       const auto idx = rx_segments_data.size() - 1;
-      new_seg.clear();
-      padded.splice(0, rx_segments_desc[idx].length, &new_seg);
+      if (new_seg.length() > rx_segments_desc[idx].length) {
+        new_seg.splice(rx_segments_desc[idx].length,
+                       new_seg.length() - rx_segments_desc[idx].length);
+      }
 
       ldout(cct, 20) << __func__
                      << " unpadded new_seg.length()=" << new_seg.length()
@@ -1362,9 +1362,8 @@ CtPtr ProtocolV2::handle_read_frame_epilogue_main(rx_buffer_t &&buffer, int r)
     {
       epilogue_bl.push_back(std::move(buffer));
       try {
-        epilogue_bl =
-            session_stream_handlers.rx->authenticated_decrypt_update_final(
-	        std::move(epilogue_bl), segment_t::DEFAULT_ALIGNMENT);
+        session_stream_handlers.rx->authenticated_decrypt_update_final(
+            epilogue_bl);
       } catch (ceph::crypto::onwire::MsgAuthError &e) {
         ldout(cct, 5) << __func__ << " message authentication failed: "
                       << e.what() << dendl;

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -92,8 +92,8 @@ ProtocolV2::ProtocolV2(AsyncConnection *connection)
       replacing(false),
       can_write(false),
       bannerExchangeCallback(nullptr),
-      tx_frame_asm(&session_stream_handlers),
-      rx_frame_asm(&session_stream_handlers),
+      tx_frame_asm(&session_stream_handlers, false),
+      rx_frame_asm(&session_stream_handlers, false),
       next_tag(static_cast<Tag>(0)),
       keepalive(false) {
 }
@@ -1287,8 +1287,9 @@ CtPtr ProtocolV2::handle_read_frame_epilogue_main(rx_buffer_t &&buffer, int r)
 
   bool aborted;
   try {
-    aborted = !rx_frame_asm.disassemble_segments(rx_segments_data.data(),
-                                                 rx_epilogue);
+    rx_frame_asm.disassemble_first_segment(rx_preamble, rx_segments_data[0]);
+    aborted = !rx_frame_asm.disassemble_remaining_segments(
+        rx_segments_data.data(), rx_epilogue);
   } catch (FrameError& e) {
     ldout(cct, 1) << __func__ << " " << e.what() << dendl;
     return _fault();

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -81,7 +81,7 @@ if(connection->interceptor) { \
 ProtocolV2::ProtocolV2(AsyncConnection *connection)
     : Protocol(2, connection),
       state(NONE),
-      peer_required_features(0),
+      peer_supported_features(0),
       client_cookie(0),
       server_cookie(0),
       global_seq(0),
@@ -927,13 +927,10 @@ CtPtr ProtocolV2::_handle_peer_banner_payload(rx_buffer_t &&buffer, int r) {
     return nullptr;
   }
 
-  this->peer_required_features = peer_required_features;
-  if (this->peer_required_features == 0) {
+  this->peer_supported_features = peer_supported_features;
+  if (peer_required_features == 0) {
     this->connection_features = msgr2_required;
   }
-
-  // at this point we can change how the client protocol behaves based on
-  // this->peer_required_features
 
   if (state == BANNER_CONNECTING) {
     state = HELLO_CONNECTING;

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -2642,6 +2642,10 @@ CtPtr ProtocolV2::reuse_connection(const AsyncConnectionRef& existing,
   exproto->pre_auth.enabled = false;
 
   if (!reconnecting) {
+    exproto->peer_supported_features = peer_supported_features;
+    exproto->tx_frame_asm.set_is_rev1(tx_frame_asm.get_is_rev1());
+    exproto->rx_frame_asm.set_is_rev1(rx_frame_asm.get_is_rev1());
+
     exproto->client_cookie = client_cookie;
     exproto->peer_name = peer_name;
     exproto->connection_features = connection_features;

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1068,7 +1068,7 @@ CtPtr ProtocolV2::handle_read_frame_preamble_main(rx_buffer_t &&buffer, int r) {
   ldout(cct, 20) << __func__ << " r=" << r << dendl;
 
   if (r < 0) {
-    ldout(cct, 1) << __func__ << " read frame length and tag failed r=" << r
+    ldout(cct, 1) << __func__ << " read frame preamble failed r=" << r
                   << " (" << cpp_strerror(r) << ")" << dendl;
     return _fault();
   }
@@ -1203,7 +1203,7 @@ CtPtr ProtocolV2::read_frame_segment() {
       get_onwire_size(cur_rx_desc.length), cur_rx_desc.alignment));
   } catch (std::bad_alloc&) {
     // Catching because of potential issues with satisfying alignment.
-    ldout(cct, 20) << __func__ << " can't allocate aligned rx_buffer "
+    ldout(cct, 1) << __func__ << " can't allocate aligned rx_buffer"
 		   << " len=" << get_onwire_size(cur_rx_desc.length)
 		   << " align=" << cur_rx_desc.alignment
 		   << dendl;
@@ -1346,7 +1346,8 @@ CtPtr ProtocolV2::handle_read_frame_epilogue_main(rx_buffer_t &&buffer, int r)
   ldout(cct, 20) << __func__ << " r=" << r << dendl;
 
   if (r < 0) {
-    ldout(cct, 1) << __func__ << " read data error " << dendl;
+    ldout(cct, 1) << __func__ << " read frame epilogue failed r=" << r
+                  << " (" << cpp_strerror(r) << ")" << dendl;
     return _fault();
   }
 

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1419,7 +1419,7 @@ CtPtr ProtocolV2::handle_message() {
 
   // we need to get the size before std::moving segments data
   const size_t cur_msg_size = get_current_msg_size();
-  auto msg_frame = MessageFrame::Decode(std::move(rx_segments_data));
+  auto msg_frame = MessageFrame::Decode(rx_segments_data);
 
   // XXX: paranoid copy just to avoid oops
   ceph_msg_header2 current_header = msg_frame.header();

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -2047,8 +2047,8 @@ CtPtr ProtocolV2::handle_server_ident(ceph::bufferlist &payload)
                 << " features_supported=" << std::hex
                 << server_ident.supported_features()
                 << " features_required=" << server_ident.required_features()
-                << " flags=" << server_ident.flags() << " cookie=" << std::dec
-                << server_ident.cookie() << dendl;
+                << " flags=" << server_ident.flags()
+                << " cookie=" << server_ident.cookie() << std::dec << dendl;
 
   // is this who we intended to talk to?
   // be a bit forgiving here, since we may be connecting based on addresses parsed out
@@ -2794,8 +2794,8 @@ CtPtr ProtocolV2::send_server_ident() {
                 << connection->policy.features_supported
                 << " features_required="
 		            << (connection->policy.features_required | msgr2_required)
-                << " flags=" << flags << " cookie=" << std::dec << server_cookie
-                << dendl;
+                << " flags=" << flags
+                << " cookie=" << server_cookie << std::dec << dendl;
 
   connection->lock.unlock();
   // Because "replacing" will prevent other connections preempt this addr,

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -24,6 +24,8 @@ ostream &ProtocolV2::_conn_prefix(std::ostream *_dout) {
 		<< " :" << connection->port
                 << " s=" << get_state_name(state) << " pgs=" << peer_global_seq
                 << " cs=" << connect_seq << " l=" << connection->policy.lossy
+                << " rev1=" << HAVE_MSGR2_FEATURE(peer_supported_features,
+                                                  REVISION_1)
                 << " rx=" << session_stream_handlers.rx.get()
                 << " tx=" << session_stream_handlers.tx.get()
                 << ").";
@@ -932,6 +934,11 @@ CtPtr ProtocolV2::_handle_peer_banner_payload(rx_buffer_t &&buffer, int r) {
     this->connection_features = msgr2_required;
   }
 
+  // if the peer supports msgr2.1, switch to it
+  bool is_rev1 = HAVE_MSGR2_FEATURE(peer_supported_features, REVISION_1);
+  tx_frame_asm.set_is_rev1(is_rev1);
+  rx_frame_asm.set_is_rev1(is_rev1);
+
   if (state == BANNER_CONNECTING) {
     state = HELLO_CONNECTING;
   }
@@ -1803,8 +1810,9 @@ CtPtr ProtocolV2::handle_auth_done(ceph::bufferlist &payload)
     return _fault();
   }
   auth_meta->con_mode = auth_done.con_mode();
+  bool is_rev1 = HAVE_MSGR2_FEATURE(peer_supported_features, REVISION_1);
   session_stream_handlers = ceph::crypto::onwire::rxtx_t::create_handler_pair(
-      cct, *auth_meta, /*new_nonce_format=*/false, /*crossed=*/false);
+      cct, *auth_meta, /*new_nonce_format=*/is_rev1, /*crossed=*/false);
 
   state = AUTH_CONNECTING_SIGN;
 
@@ -2183,8 +2191,9 @@ CtPtr ProtocolV2::finish_auth()
   ceph_assert(auth_meta);
   // TODO: having a possibility to check whether we're server or client could
   // allow reusing finish_auth().
+  bool is_rev1 = HAVE_MSGR2_FEATURE(peer_supported_features, REVISION_1);
   session_stream_handlers = ceph::crypto::onwire::rxtx_t::create_handler_pair(
-      cct, *auth_meta, /*new_nonce_format=*/false, /*crossed=*/true);
+      cct, *auth_meta, /*new_nonce_format=*/is_rev1, /*crossed=*/true);
 
   const auto sig = auth_meta->session_key.empty() ? sha256_digest_t() :
     auth_meta->session_key.hmac_sha256(cct, pre_auth.rxbuf);

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1794,8 +1794,8 @@ CtPtr ProtocolV2::handle_auth_done(ceph::bufferlist &payload)
     return _fault();
   }
   auth_meta->con_mode = auth_done.con_mode();
-  session_stream_handlers = \
-    ceph::crypto::onwire::rxtx_t::create_handler_pair(cct, *auth_meta, false);
+  session_stream_handlers = ceph::crypto::onwire::rxtx_t::create_handler_pair(
+      cct, *auth_meta, /*new_nonce_format=*/false, /*crossed=*/false);
 
   state = AUTH_CONNECTING_SIGN;
 
@@ -2174,8 +2174,8 @@ CtPtr ProtocolV2::finish_auth()
   ceph_assert(auth_meta);
   // TODO: having a possibility to check whether we're server or client could
   // allow reusing finish_auth().
-  session_stream_handlers = \
-    ceph::crypto::onwire::rxtx_t::create_handler_pair(cct, *auth_meta, true);
+  session_stream_handlers = ceph::crypto::onwire::rxtx_t::create_handler_pair(
+      cct, *auth_meta, /*new_nonce_format=*/false, /*crossed=*/true);
 
   const auto sig = auth_meta->session_key.empty() ? sha256_digest_t() :
     auth_meta->session_key.hmac_sha256(cct, pre_auth.rxbuf);

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1317,7 +1317,6 @@ CtPtr ProtocolV2::handle_message() {
 #endif
   recv_stamp = ceph_clock_now();
 
-  // we need to get the size before std::moving segments data
   const size_t cur_msg_size = get_current_msg_size();
   auto msg_frame = MessageFrame::Decode(rx_segments_data);
 
@@ -1441,9 +1440,8 @@ CtPtr ProtocolV2::handle_message() {
   }
 
   connection->logger->inc(l_msgr_recv_messages);
-  connection->logger->inc(
-      l_msgr_recv_bytes,
-      cur_msg_size + sizeof(ceph_msg_header) + sizeof(ceph_msg_footer));
+  connection->logger->inc(l_msgr_recv_bytes,
+                          rx_frame_asm.get_frame_onwire_len());
 
   messenger->ms_fast_preprocess(message);
   fast_dispatch_time = ceph::mono_clock::now();

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -98,6 +98,7 @@ private:
 
   boost::container::static_vector<ceph::msgr::v2::segment_t,
 				  ceph::msgr::v2::MAX_NUM_SEGMENTS> rx_segments_desc;
+  ceph::msgr::v2::FrameAssembler tx_frame_asm;
   ceph::msgr::v2::segment_bls_t rx_segments_data;
   ceph::msgr::v2::Tag next_tag;
   utime_t backoff;  // backoff time

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -70,7 +70,7 @@ private:
 
   entity_name_t peer_name;
   State state;
-  uint64_t peer_required_features;
+  uint64_t peer_supported_features;  // CEPH_MSGR2_FEATURE_*
 
   uint64_t client_cookie;
   uint64_t server_cookie;

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -98,8 +98,7 @@ private:
 
   boost::container::static_vector<ceph::msgr::v2::segment_t,
 				  ceph::msgr::v2::MAX_NUM_SEGMENTS> rx_segments_desc;
-  boost::container::static_vector<ceph::bufferlist,
-				  ceph::msgr::v2::MAX_NUM_SEGMENTS> rx_segments_data;
+  ceph::msgr::v2::segment_bls_t rx_segments_data;
   ceph::msgr::v2::Tag next_tag;
   utime_t backoff;  // backoff time
   utime_t recv_stamp;

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -67,10 +67,9 @@ private:
     return statenames[state];
   }
 
-public:
   // TODO: move into auth_meta?
   ceph::crypto::onwire::rxtx_t session_stream_handlers;
-private:
+
   entity_name_t peer_name;
   State state;
   uint64_t peer_required_features;

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -4,8 +4,6 @@
 #ifndef _MSG_ASYNC_PROTOCOL_V2_
 #define _MSG_ASYNC_PROTOCOL_V2_
 
-#include <boost/container/static_vector.hpp>
-
 #include "Protocol.h"
 #include "crypto_onwire.h"
 #include "frames_v2.h"
@@ -96,9 +94,11 @@ private:
   using ProtFuncPtr = void (ProtocolV2::*)();
   Ct<ProtocolV2> *bannerExchangeCallback;
 
-  boost::container::static_vector<ceph::msgr::v2::segment_t,
-				  ceph::msgr::v2::MAX_NUM_SEGMENTS> rx_segments_desc;
   ceph::msgr::v2::FrameAssembler tx_frame_asm;
+  ceph::msgr::v2::FrameAssembler rx_frame_asm;
+
+  ceph::bufferlist rx_preamble;
+  ceph::bufferlist rx_epilogue;
   ceph::msgr::v2::segment_bls_t rx_segments_data;
   ceph::msgr::v2::Tag next_tag;
   utime_t backoff;  // backoff time
@@ -251,8 +251,6 @@ private:
   Ct<ProtocolV2> *send_reconnect_ok();
   Ct<ProtocolV2> *server_ready();
 
-  uint32_t get_onwire_size(uint32_t logical_size) const;
-  uint32_t get_epilogue_size() const;
   size_t get_current_msg_size() const;
 };
 

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -169,7 +169,9 @@ private:
   Ct<ProtocolV2> *handle_read_frame_preamble_main(rx_buffer_t &&buffer, int r);
   Ct<ProtocolV2> *read_frame_segment();
   Ct<ProtocolV2> *handle_read_frame_segment(rx_buffer_t &&rx_buffer, int r);
+  Ct<ProtocolV2> *_handle_read_frame_segment();
   Ct<ProtocolV2> *handle_read_frame_epilogue_main(rx_buffer_t &&buffer, int r);
+  Ct<ProtocolV2> *_handle_read_frame_epilogue_main();
   Ct<ProtocolV2> *handle_read_frame_dispatch();
   Ct<ProtocolV2> *handle_frame_payload();
 

--- a/src/msg/async/crypto_onwire.cc
+++ b/src/msg/async/crypto_onwire.cc
@@ -74,15 +74,14 @@ public:
     return size;
   }
 
-  void reset_tx_handler(
-    std::initializer_list<std::uint32_t> update_size_sequence) override;
+  void reset_tx_handler(const uint32_t* first, const uint32_t* last) override;
 
   void authenticated_encrypt_update(const ceph::bufferlist& plaintext) override;
   ceph::bufferlist authenticated_encrypt_final() override;
 };
 
-void AES128GCM_OnWireTxHandler::reset_tx_handler(
-  std::initializer_list<std::uint32_t> update_size_sequence)
+void AES128GCM_OnWireTxHandler::reset_tx_handler(const uint32_t* first,
+                                                 const uint32_t* last)
 {
   if (nonce == initial_nonce) {
     if (used_initial_nonce) {
@@ -96,8 +95,7 @@ void AES128GCM_OnWireTxHandler::reset_tx_handler(
     throw std::runtime_error("EVP_EncryptInit_ex failed");
   }
 
-  buffer.reserve(std::accumulate(std::begin(update_size_sequence),
-    std::end(update_size_sequence), AESGCM_TAG_LEN));
+  buffer.reserve(std::accumulate(first, last, AESGCM_TAG_LEN));
 
   nonce.random_seq = nonce.random_seq + 1;
 }

--- a/src/msg/async/crypto_onwire.cc
+++ b/src/msg/async/crypto_onwire.cc
@@ -69,11 +69,6 @@ public:
     ::ceph::crypto::zeroize_for_security(&initial_nonce, sizeof(initial_nonce));
   }
 
-  std::uint32_t calculate_segment_size(std::uint32_t size) override
-  {
-    return size;
-  }
-
   void reset_tx_handler(const uint32_t* first, const uint32_t* last) override;
 
   void authenticated_encrypt_update(const ceph::bufferlist& plaintext) override;

--- a/src/msg/async/crypto_onwire.h
+++ b/src/msg/async/crypto_onwire.h
@@ -53,8 +53,6 @@ struct TxHandlerError : public std::runtime_error {
 struct TxHandler {
   virtual ~TxHandler() = default;
 
-  virtual std::uint32_t calculate_segment_size(std::uint32_t size) = 0;
-
   // Instance of TxHandler must be reset before doing any encrypt-update
   // step. This applies also to situation when encrypt-final was already
   // called and another round of update-...-update-final will take place.

--- a/src/msg/async/crypto_onwire.h
+++ b/src/msg/async/crypto_onwire.h
@@ -67,8 +67,17 @@ struct TxHandler {
   // It's undefined what will happen if client doesn't follow the order.
   //
   // TODO: switch to always_aligned_t
-  virtual void reset_tx_handler(
-    std::initializer_list<std::uint32_t> update_size_sequence) = 0;
+  virtual void reset_tx_handler(const uint32_t* first,
+                                const uint32_t* last) = 0;
+
+  void reset_tx_handler(std::initializer_list<uint32_t> update_size_sequence) {
+    if (update_size_sequence.size() > 0) {
+      const uint32_t* first = &*update_size_sequence.begin();
+      reset_tx_handler(first, first + update_size_sequence.size());
+    } else {
+      reset_tx_handler(nullptr, nullptr);
+    }
+  }
 
   // Perform encryption. Client gives full ownership right to provided
   // bufferlist. The method MUST NOT be called after _final() if there

--- a/src/msg/async/crypto_onwire.h
+++ b/src/msg/async/crypto_onwire.h
@@ -103,17 +103,12 @@ public:
   virtual void reset_rx_handler() = 0;
 
   // Perform decryption ciphertext must be ALWAYS aligned to 16 bytes.
-  // TODO: switch to always_aligned_t
-  virtual ceph::bufferlist authenticated_decrypt_update(
-    ceph::bufferlist&& ciphertext,
-    std::uint32_t alignment) = 0;
+  virtual void authenticated_decrypt_update(ceph::bufferlist& bl) = 0;
 
   // Perform decryption of last cipertext's portion and verify signature
   // for overall decryption sequence.
   // Throws on integrity/authenticity checks
-  virtual ceph::bufferlist authenticated_decrypt_update_final(
-    ceph::bufferlist&& ciphertext,
-    std::uint32_t alignment) = 0;
+  virtual void authenticated_decrypt_update_final(ceph::bufferlist& bl) = 0;
 };
 
 struct rxtx_t {

--- a/src/msg/async/crypto_onwire.h
+++ b/src/msg/async/crypto_onwire.h
@@ -121,6 +121,7 @@ struct rxtx_t {
   static rxtx_t create_handler_pair(
     CephContext* ctx,
     const class AuthConnectionMeta& auth_meta,
+    bool new_nonce_format,
     bool crossed);
 };
 

--- a/src/msg/async/frames_v2.cc
+++ b/src/msg/async/frames_v2.cc
@@ -50,6 +50,17 @@ static void check_segment_crc(const bufferlist& segment_bl,
   }
 }
 
+// Returns true if the frame is ready for dispatching, or false if
+// it was aborted by the sender and must be dropped.
+static bool check_epilogue_late_status(__u8 late_status) {
+  __u8 aborted = late_status & FRAME_LATE_STATUS_ABORTED_MASK;
+  if (aborted != FRAME_LATE_STATUS_ABORTED &&
+      aborted != FRAME_LATE_STATUS_COMPLETE) {
+    throw FrameError(fmt::format("bad late_status"));
+  }
+  return aborted == FRAME_LATE_STATUS_COMPLETE;
+}
+
 void FrameAssembler::fill_preamble(Tag tag,
                                    preamble_block_t& preamble) const {
   // FIPS zeroization audit 20191115: this memset is not security related.
@@ -136,6 +147,98 @@ bufferlist FrameAssembler::asm_secure_rev0(const preamble_block_t& preamble,
   return m_crypto->tx->authenticated_encrypt_final();
 }
 
+bufferlist FrameAssembler::asm_crc_rev1(const preamble_block_t& preamble,
+                                        bufferlist segment_bls[]) const {
+  epilogue_crc_rev1_block_t epilogue;
+  // FIPS zeroization audit 20191115: this memset is not security related.
+  ::memset(&epilogue, 0, sizeof(epilogue));
+  epilogue.late_status |= FRAME_LATE_STATUS_COMPLETE;
+
+  bufferlist frame_bl(sizeof(preamble) + FRAME_CRC_SIZE + sizeof(epilogue));
+  frame_bl.append(reinterpret_cast<const char*>(&preamble), sizeof(preamble));
+
+  ceph_assert(segment_bls[0].length() == m_descs[0].logical_len);
+  if (segment_bls[0].length() > 0) {
+    uint32_t crc = segment_bls[0].crc32c(-1);
+    frame_bl.claim_append(segment_bls[0]);
+    encode(crc, frame_bl);
+  }
+  if (m_descs.size() == 1) {
+    return frame_bl;  // no epilogue if only one segment
+  }
+
+  for (size_t i = 1; i < m_descs.size(); i++) {
+    ceph_assert(segment_bls[i].length() == m_descs[i].logical_len);
+    epilogue.crc_values[i - 1] = segment_bls[i].crc32c(-1);
+    if (segment_bls[i].length() > 0) {
+      frame_bl.claim_append(segment_bls[i]);
+    }
+  }
+  frame_bl.append(reinterpret_cast<const char*>(&epilogue), sizeof(epilogue));
+  return frame_bl;
+}
+
+bufferlist FrameAssembler::asm_secure_rev1(const preamble_block_t& preamble,
+                                           bufferlist segment_bls[]) const {
+  bufferlist preamble_bl;
+  if (segment_bls[0].length() > FRAME_PREAMBLE_INLINE_SIZE) {
+    // first segment is partially inlined, inline buffer is full
+    preamble_bl.reserve(sizeof(preamble));
+    preamble_bl.append(reinterpret_cast<const char*>(&preamble),
+                       sizeof(preamble));
+    segment_bls[0].splice(0, FRAME_PREAMBLE_INLINE_SIZE, &preamble_bl);
+  } else {
+    // first segment is fully inlined, inline buffer may need padding
+    uint32_t pad_len = FRAME_PREAMBLE_INLINE_SIZE - segment_bls[0].length();
+    preamble_bl.reserve(sizeof(preamble) + pad_len);
+    preamble_bl.append(reinterpret_cast<const char*>(&preamble),
+                       sizeof(preamble));
+    preamble_bl.claim_append(segment_bls[0]);
+    if (pad_len > 0) {
+      preamble_bl.append_zero(pad_len);
+    }
+  }
+
+  m_crypto->tx->reset_tx_handler({preamble_bl.length()});
+  m_crypto->tx->authenticated_encrypt_update(preamble_bl);
+  auto frame_bl = m_crypto->tx->authenticated_encrypt_final();
+
+  if (segment_bls[0].length() > 0) {
+    m_crypto->tx->reset_tx_handler({segment_bls[0].length()});
+    m_crypto->tx->authenticated_encrypt_update(segment_bls[0]);
+    auto tmp = m_crypto->tx->authenticated_encrypt_final();
+    frame_bl.claim_append(tmp);
+  }
+  if (m_descs.size() == 1) {
+    return frame_bl;  // no epilogue if only one segment
+  }
+
+  epilogue_secure_rev1_block_t epilogue;
+  // FIPS zeroization audit 20191115: this memset is not security related.
+  ::memset(&epilogue, 0, sizeof(epilogue));
+  epilogue.late_status |= FRAME_LATE_STATUS_COMPLETE;
+  bufferlist epilogue_bl(sizeof(epilogue));
+  epilogue_bl.append(reinterpret_cast<const char*>(&epilogue),
+                     sizeof(epilogue));
+
+  // MAX_NUM_SEGMENTS - 1 + epilogue
+  uint32_t onwire_lens[MAX_NUM_SEGMENTS];
+  for (size_t i = 1; i < m_descs.size(); i++) {
+    onwire_lens[i - 1] = segment_bls[i].length();  // already padded
+  }
+  onwire_lens[m_descs.size() - 1] = epilogue_bl.length();
+  m_crypto->tx->reset_tx_handler(onwire_lens, onwire_lens + m_descs.size());
+  for (size_t i = 1; i < m_descs.size(); i++) {
+    if (segment_bls[i].length() > 0) {
+      m_crypto->tx->authenticated_encrypt_update(segment_bls[i]);
+    }
+  }
+  m_crypto->tx->authenticated_encrypt_update(epilogue_bl);
+  auto tmp = m_crypto->tx->authenticated_encrypt_final();
+  frame_bl.claim_append(tmp);
+  return frame_bl;
+}
+
 bufferlist FrameAssembler::assemble_frame(Tag tag, bufferlist segment_bls[],
                                           const uint16_t segment_aligns[],
                                           size_t segment_count) {
@@ -161,16 +264,30 @@ bufferlist FrameAssembler::assemble_frame(Tag tag, bufferlist segment_bls[],
         segment_bls[i].append_zero(pad_len);
       }
     }
+    if (m_is_rev1) {
+      return asm_secure_rev1(preamble, segment_bls);
+    }
     return asm_secure_rev0(preamble, segment_bls);
+  }
+  if (m_is_rev1) {
+    return asm_crc_rev1(preamble, segment_bls);
   }
   return asm_crc_rev0(preamble, segment_bls);
 }
 
 Tag FrameAssembler::disassemble_preamble(bufferlist& preamble_bl) {
-  ceph_assert(preamble_bl.length() == sizeof(preamble_block_t));
   if (m_crypto->rx) {
     m_crypto->rx->reset_rx_handler();
-    m_crypto->rx->authenticated_decrypt_update(preamble_bl);
+    if (m_is_rev1) {
+      ceph_assert(preamble_bl.length() == FRAME_PREAMBLE_WITH_INLINE_SIZE +
+                                          get_auth_tag_len());
+      m_crypto->rx->authenticated_decrypt_update_final(preamble_bl);
+    } else {
+      ceph_assert(preamble_bl.length() == sizeof(preamble_block_t));
+      m_crypto->rx->authenticated_decrypt_update(preamble_bl);
+    }
+  } else {
+    ceph_assert(preamble_bl.length() == sizeof(preamble_block_t));
   }
 
   // I expect ceph_le32 will make the endian conversion for me. Passing
@@ -236,9 +353,106 @@ bool FrameAssembler::disasm_all_secure_rev0(bufferlist segment_bls[],
   return !(epilogue->late_flags & FRAME_LATE_FLAG_ABORTED);
 }
 
-bool FrameAssembler::disassemble_segments(bufferlist segment_bls[],
-                                          bufferlist& epilogue_bl) const {
+void FrameAssembler::disasm_first_crc_rev1(bufferlist& preamble_bl,
+                                           bufferlist& segment_bl) const {
+  ceph_assert(preamble_bl.length() == sizeof(preamble_block_t));
+  if (m_descs[0].logical_len > 0) {
+    ceph_assert(segment_bl.length() == m_descs[0].logical_len +
+                                       FRAME_CRC_SIZE);
+    bufferlist::const_iterator it(&segment_bl, m_descs[0].logical_len);
+    uint32_t expected_crc;
+    decode(expected_crc, it);
+    segment_bl.splice(m_descs[0].logical_len, FRAME_CRC_SIZE);
+    check_segment_crc(segment_bl, expected_crc);
+  } else {
+    ceph_assert(segment_bl.length() == 0);
+  }
+}
+
+bool FrameAssembler::disasm_remaining_crc_rev1(bufferlist segment_bls[],
+                                               bufferlist& epilogue_bl) const {
+  ceph_assert(epilogue_bl.length() == sizeof(epilogue_crc_rev1_block_t));
+  auto epilogue = reinterpret_cast<const epilogue_crc_rev1_block_t*>(
+      epilogue_bl.c_str());
+
+  for (size_t i = 1; i < m_descs.size(); i++) {
+    ceph_assert(segment_bls[i].length() == m_descs[i].logical_len);
+    check_segment_crc(segment_bls[i], epilogue->crc_values[i - 1]);
+  }
+  return check_epilogue_late_status(epilogue->late_status);
+}
+
+void FrameAssembler::disasm_first_secure_rev1(bufferlist& preamble_bl,
+                                              bufferlist& segment_bl) const {
+  ceph_assert(preamble_bl.length() == FRAME_PREAMBLE_WITH_INLINE_SIZE);
+  uint32_t padded_len = get_segment_padded_len(0);
+  if (padded_len > FRAME_PREAMBLE_INLINE_SIZE) {
+    ceph_assert(segment_bl.length() == padded_len + get_auth_tag_len() -
+                                       FRAME_PREAMBLE_INLINE_SIZE);
+    m_crypto->rx->reset_rx_handler();
+    m_crypto->rx->authenticated_decrypt_update_final(segment_bl);
+    // prepend the inline buffer (already decrypted) to segment_bl
+    bufferlist tmp;
+    segment_bl.swap(tmp);
+    preamble_bl.splice(sizeof(preamble_block_t), FRAME_PREAMBLE_INLINE_SIZE,
+                       &segment_bl);
+    segment_bl.claim_append(tmp);
+  } else {
+    ceph_assert(segment_bl.length() == 0);
+    preamble_bl.splice(sizeof(preamble_block_t), FRAME_PREAMBLE_INLINE_SIZE,
+                       &segment_bl);
+  }
+  unpad_zero(segment_bl, m_descs[0].logical_len);
+  ceph_assert(segment_bl.length() == m_descs[0].logical_len);
+}
+
+bool FrameAssembler::disasm_remaining_secure_rev1(
+    bufferlist segment_bls[], bufferlist& epilogue_bl) const {
+  m_crypto->rx->reset_rx_handler();
+  for (size_t i = 1; i < m_descs.size(); i++) {
+    ceph_assert(segment_bls[i].length() == get_segment_padded_len(i));
+    if (segment_bls[i].length() > 0) {
+      m_crypto->rx->authenticated_decrypt_update(segment_bls[i]);
+      unpad_zero(segment_bls[i], m_descs[i].logical_len);
+    }
+  }
+
+  ceph_assert(epilogue_bl.length() == sizeof(epilogue_secure_rev1_block_t) +
+                                      get_auth_tag_len());
+  m_crypto->rx->authenticated_decrypt_update_final(epilogue_bl);
+  auto epilogue = reinterpret_cast<const epilogue_secure_rev1_block_t*>(
+      epilogue_bl.c_str());
+  return check_epilogue_late_status(epilogue->late_status);
+}
+
+void FrameAssembler::disassemble_first_segment(bufferlist& preamble_bl,
+                                               bufferlist& segment_bl) const {
   ceph_assert(!m_descs.empty());
+  if (m_is_rev1) {
+    if (m_crypto->rx) {
+      disasm_first_secure_rev1(preamble_bl, segment_bl);
+    } else {
+      disasm_first_crc_rev1(preamble_bl, segment_bl);
+    }
+  } else {
+    // noop, everything is handled in disassemble_remaining_segments()
+  }
+}
+
+bool FrameAssembler::disassemble_remaining_segments(
+    bufferlist segment_bls[], bufferlist& epilogue_bl) const {
+  ceph_assert(!m_descs.empty());
+  if (m_is_rev1) {
+    if (m_descs.size() == 1) {
+      // no epilogue if only one segment
+      ceph_assert(epilogue_bl.length() == 0);
+      return true;
+    }
+    if (m_crypto->rx) {
+      return disasm_remaining_secure_rev1(segment_bls, epilogue_bl);
+    }
+    return disasm_remaining_crc_rev1(segment_bls, epilogue_bl);
+  }
   if (m_crypto->rx) {
     return disasm_all_secure_rev0(segment_bls, epilogue_bl);
   }
@@ -255,7 +469,8 @@ std::ostream& operator<<(std::ostream& os, const FrameAssembler& frame_asm) {
     }
     os << " + " << frame_asm.get_epilogue_onwire_len() << " ";
   }
-  os << "rx=" << frame_asm.m_crypto->rx.get()
+  os << "rev1=" << frame_asm.m_is_rev1
+     << " rx=" << frame_asm.m_crypto->rx.get()
      << " tx=" << frame_asm.m_crypto->tx.get();
   return os;
 }

--- a/src/msg/async/frames_v2.cc
+++ b/src/msg/async/frames_v2.cc
@@ -215,7 +215,7 @@ bool FrameAssembler::disasm_all_crc_rev0(bufferlist segment_bls[],
     ceph_assert(segment_bls[i].length() == m_descs[i].logical_len);
     check_segment_crc(segment_bls[i], epilogue->crc_values[i]);
   }
-  return !(epilogue->late_flags & FRAME_FLAGS_LATEABRT);
+  return !(epilogue->late_flags & FRAME_LATE_FLAG_ABORTED);
 }
 
 bool FrameAssembler::disasm_all_secure_rev0(bufferlist segment_bls[],
@@ -233,7 +233,7 @@ bool FrameAssembler::disasm_all_secure_rev0(bufferlist segment_bls[],
   m_crypto->rx->authenticated_decrypt_update_final(epilogue_bl);
   auto epilogue = reinterpret_cast<const epilogue_secure_rev0_block_t*>(
       epilogue_bl.c_str());
-  return !(epilogue->late_flags & FRAME_FLAGS_LATEABRT);
+  return !(epilogue->late_flags & FRAME_LATE_FLAG_ABORTED);
 }
 
 bool FrameAssembler::disassemble_segments(bufferlist segment_bls[],

--- a/src/msg/async/frames_v2.cc
+++ b/src/msg/async/frames_v2.cc
@@ -1,0 +1,167 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "frames_v2.h"
+
+#include <ostream>
+
+#include <fmt/format.h>
+
+namespace ceph::msgr::v2 {
+
+// Discards trailing empty segments, unless there is just one segment.
+// A frame always has at least one (possibly empty) segment.
+static size_t calc_num_segments(const bufferlist segment_bls[],
+                                size_t segment_count) {
+  ceph_assert(segment_count > 0 && segment_count <= MAX_NUM_SEGMENTS);
+  for (size_t i = segment_count; i-- > 0; ) {
+    if (segment_bls[i].length() > 0) {
+      return i + 1;
+    }
+  }
+  return 1;
+}
+
+void FrameAssembler::fill_preamble(Tag tag,
+                                   preamble_block_t& preamble) const {
+  // FIPS zeroization audit 20191115: this memset is not security related.
+  ::memset(&preamble, 0, sizeof(preamble));
+
+  preamble.tag = static_cast<__u8>(tag);
+  for (size_t i = 0; i < m_descs.size(); i++) {
+    preamble.segments[i].length = m_descs[i].logical_len;
+    preamble.segments[i].alignment = m_descs[i].align;
+  }
+  preamble.num_segments = m_descs.size();
+  preamble.crc = ceph_crc32c(
+      0, reinterpret_cast<const unsigned char*>(&preamble),
+      sizeof(preamble) - sizeof(preamble.crc));
+}
+
+uint64_t FrameAssembler::get_frame_logical_len() const {
+  ceph_assert(!m_descs.empty());
+  uint64_t logical_len = 0;
+  for (size_t i = 0; i < m_descs.size(); i++) {
+    logical_len += m_descs[i].logical_len;
+  }
+  return logical_len;
+}
+
+uint64_t FrameAssembler::get_frame_onwire_len() const {
+  ceph_assert(!m_descs.empty());
+  uint64_t onwire_len = get_preamble_onwire_len();
+  for (size_t i = 0; i < m_descs.size(); i++) {
+    onwire_len += get_segment_onwire_len(i);
+  }
+  onwire_len += get_epilogue_onwire_len();
+  return onwire_len;
+}
+
+bufferlist FrameAssembler::asm_crc_rev0(const preamble_block_t& preamble,
+                                        bufferlist segment_bls[]) const {
+  epilogue_plain_block_t epilogue;
+  // FIPS zeroization audit 20191115: this memset is not security related.
+  ::memset(&epilogue, 0, sizeof(epilogue));
+
+  bufferlist frame_bl(sizeof(preamble) + sizeof(epilogue));
+  frame_bl.append(reinterpret_cast<const char*>(&preamble), sizeof(preamble));
+  for (size_t i = 0; i < m_descs.size(); i++) {
+    ceph_assert(segment_bls[i].length() == m_descs[i].logical_len);
+    epilogue.crc_values[i] = segment_bls[i].crc32c(-1);
+    if (segment_bls[i].length() > 0) {
+      frame_bl.claim_append(segment_bls[i]);
+    }
+  }
+  frame_bl.append(reinterpret_cast<const char*>(&epilogue), sizeof(epilogue));
+  return frame_bl;
+}
+
+bufferlist FrameAssembler::asm_secure_rev0(const preamble_block_t& preamble,
+                                           bufferlist segment_bls[]) const {
+  bufferlist preamble_bl(sizeof(preamble));
+  preamble_bl.append(reinterpret_cast<const char*>(&preamble),
+                     sizeof(preamble));
+
+  epilogue_secure_block_t epilogue;
+  // FIPS zeroization audit 20191115: this memset is not security related.
+  ::memset(&epilogue, 0, sizeof(epilogue));
+  bufferlist epilogue_bl(sizeof(epilogue));
+  epilogue_bl.append(reinterpret_cast<const char*>(&epilogue),
+                     sizeof(epilogue));
+
+  // preamble + MAX_NUM_SEGMENTS + epilogue
+  uint32_t onwire_lens[MAX_NUM_SEGMENTS + 2];
+  onwire_lens[0] = preamble_bl.length();
+  for (size_t i = 0; i < m_descs.size(); i++) {
+    onwire_lens[i + 1] = segment_bls[i].length();  // already padded
+  }
+  onwire_lens[m_descs.size() + 1] = epilogue_bl.length();
+  m_crypto->tx->reset_tx_handler(onwire_lens,
+                                 onwire_lens + m_descs.size() + 2);
+  m_crypto->tx->authenticated_encrypt_update(preamble_bl);
+  for (size_t i = 0; i < m_descs.size(); i++) {
+    if (segment_bls[i].length() > 0) {
+      m_crypto->tx->authenticated_encrypt_update(segment_bls[i]);
+    }
+  }
+  m_crypto->tx->authenticated_encrypt_update(epilogue_bl);
+  return m_crypto->tx->authenticated_encrypt_final();
+}
+
+bufferlist FrameAssembler::assemble_frame(Tag tag, bufferlist segment_bls[],
+                                          const uint16_t segment_aligns[],
+                                          size_t segment_count) {
+  m_descs.resize(calc_num_segments(segment_bls, segment_count));
+  for (size_t i = 0; i < m_descs.size(); i++) {
+    m_descs[i].logical_len = segment_bls[i].length();
+    m_descs[i].align = segment_aligns[i];
+  }
+
+  preamble_block_t preamble;
+  fill_preamble(tag, preamble);
+
+  if (m_crypto->rx) {
+    for (size_t i = 0; i < m_descs.size(); i++) {
+      ceph_assert(segment_bls[i].length() == m_descs[i].logical_len);
+      // We're padding segments to biggest cipher's block size. Although
+      // AES-GCM can live without that as it's a stream cipher, we don't
+      // want to be fixed to stream ciphers only.
+      uint32_t padded_len = get_segment_padded_len(i);
+      if (padded_len > segment_bls[i].length()) {
+        uint32_t pad_len = padded_len - segment_bls[i].length();
+        segment_bls[i].reserve(pad_len);
+        segment_bls[i].append_zero(pad_len);
+      }
+    }
+    return asm_secure_rev0(preamble, segment_bls);
+  }
+  return asm_crc_rev0(preamble, segment_bls);
+}
+
+std::ostream& operator<<(std::ostream& os, const FrameAssembler& frame_asm) {
+  if (!frame_asm.m_descs.empty()) {
+    os << frame_asm.get_preamble_onwire_len();
+    for (size_t i = 0; i < frame_asm.m_descs.size(); i++) {
+      os << " + " << frame_asm.get_segment_onwire_len(i)
+         << " (logical " << frame_asm.m_descs[i].logical_len
+         << "/" << frame_asm.m_descs[i].align << ")";
+    }
+    os << " + " << frame_asm.get_epilogue_onwire_len() << " ";
+  }
+  os << "rx=" << frame_asm.m_crypto->rx.get()
+     << " tx=" << frame_asm.m_crypto->tx.get();
+  return os;
+}
+
+}  // namespace ceph::msgr::v2

--- a/src/msg/async/frames_v2.cc
+++ b/src/msg/async/frames_v2.cc
@@ -87,7 +87,7 @@ uint64_t FrameAssembler::get_frame_onwire_len() const {
 
 bufferlist FrameAssembler::asm_crc_rev0(const preamble_block_t& preamble,
                                         bufferlist segment_bls[]) const {
-  epilogue_plain_block_t epilogue;
+  epilogue_crc_rev0_block_t epilogue;
   // FIPS zeroization audit 20191115: this memset is not security related.
   ::memset(&epilogue, 0, sizeof(epilogue));
 
@@ -110,7 +110,7 @@ bufferlist FrameAssembler::asm_secure_rev0(const preamble_block_t& preamble,
   preamble_bl.append(reinterpret_cast<const char*>(&preamble),
                      sizeof(preamble));
 
-  epilogue_secure_block_t epilogue;
+  epilogue_secure_rev0_block_t epilogue;
   // FIPS zeroization audit 20191115: this memset is not security related.
   ::memset(&epilogue, 0, sizeof(epilogue));
   bufferlist epilogue_bl(sizeof(epilogue));
@@ -207,8 +207,8 @@ Tag FrameAssembler::disassemble_preamble(bufferlist& preamble_bl) {
 
 bool FrameAssembler::disasm_all_crc_rev0(bufferlist segment_bls[],
                                          bufferlist& epilogue_bl) const {
-  ceph_assert(epilogue_bl.length() == sizeof(epilogue_plain_block_t));
-  auto epilogue = reinterpret_cast<const epilogue_plain_block_t*>(
+  ceph_assert(epilogue_bl.length() == sizeof(epilogue_crc_rev0_block_t));
+  auto epilogue = reinterpret_cast<const epilogue_crc_rev0_block_t*>(
       epilogue_bl.c_str());
 
   for (size_t i = 0; i < m_descs.size(); i++) {
@@ -228,10 +228,10 @@ bool FrameAssembler::disasm_all_secure_rev0(bufferlist segment_bls[],
     }
   }
 
-  ceph_assert(epilogue_bl.length() == sizeof(epilogue_secure_block_t) +
+  ceph_assert(epilogue_bl.length() == sizeof(epilogue_secure_rev0_block_t) +
                                       get_auth_tag_len());
   m_crypto->rx->authenticated_decrypt_update_final(epilogue_bl);
-  auto epilogue = reinterpret_cast<const epilogue_secure_block_t*>(
+  auto epilogue = reinterpret_cast<const epilogue_secure_rev0_block_t*>(
       epilogue_bl.c_str());
   return !(epilogue->late_flags & FRAME_FLAGS_LATEABRT);
 }

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -129,27 +129,20 @@ static_assert(std::is_standard_layout<preamble_block_t>::value);
 // In addition to integrity/authenticity data each variant of epilogue
 // conveys late_flags. The initial user of this field will be the late
 // frame abortion facility.
-struct epilogue_plain_block_t {
+struct epilogue_crc_rev0_block_t {
   __u8 late_flags;
   ceph_le32 crc_values[MAX_NUM_SEGMENTS];
 } __attribute__((packed));
-static_assert(std::is_standard_layout<epilogue_plain_block_t>::value);
+static_assert(std::is_standard_layout_v<epilogue_crc_rev0_block_t>);
 
-struct epilogue_secure_block_t {
+struct epilogue_secure_rev0_block_t {
   __u8 late_flags;
   __u8 padding[CRYPTO_BLOCK_SIZE - sizeof(late_flags)];
 
   __u8 ciphers_private_data[];
 } __attribute__((packed));
-static_assert(sizeof(epilogue_secure_block_t) % CRYPTO_BLOCK_SIZE == 0);
-static_assert(std::is_standard_layout<epilogue_secure_block_t>::value);
-
-
-static constexpr uint32_t FRAME_PREAMBLE_SIZE = sizeof(preamble_block_t);
-static constexpr uint32_t FRAME_PLAIN_EPILOGUE_SIZE =
-    sizeof(epilogue_plain_block_t);
-static constexpr uint32_t FRAME_SECURE_EPILOGUE_SIZE =
-    sizeof(epilogue_secure_block_t);
+static_assert(sizeof(epilogue_secure_rev0_block_t) % CRYPTO_BLOCK_SIZE == 0);
+static_assert(std::is_standard_layout_v<epilogue_secure_rev0_block_t>);
 
 #define FRAME_FLAGS_LATEABRT      (1<<0)   /* frame was aborted after txing data */
 
@@ -193,9 +186,9 @@ public:
   uint32_t get_epilogue_onwire_len() const {
     ceph_assert(!m_descs.empty());
     if (m_crypto->rx) {
-      return sizeof(epilogue_secure_block_t) + get_auth_tag_len();
+      return sizeof(epilogue_secure_rev0_block_t) + get_auth_tag_len();
     }
-    return sizeof(epilogue_plain_block_t);
+    return sizeof(epilogue_crc_rev0_block_t);
   }
 
   uint64_t get_frame_logical_len() const;

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -130,13 +130,13 @@ static_assert(std::is_standard_layout<preamble_block_t>::value);
 // conveys late_flags. The initial user of this field will be the late
 // frame abortion facility.
 struct epilogue_crc_rev0_block_t {
-  __u8 late_flags;
+  __u8 late_flags;  // FRAME_LATE_FLAG_ABORTED
   ceph_le32 crc_values[MAX_NUM_SEGMENTS];
 } __attribute__((packed));
 static_assert(std::is_standard_layout_v<epilogue_crc_rev0_block_t>);
 
 struct epilogue_secure_rev0_block_t {
-  __u8 late_flags;
+  __u8 late_flags;  // FRAME_LATE_FLAG_ABORTED
   __u8 padding[CRYPTO_BLOCK_SIZE - sizeof(late_flags)];
 
   __u8 ciphers_private_data[];
@@ -144,7 +144,10 @@ struct epilogue_secure_rev0_block_t {
 static_assert(sizeof(epilogue_secure_rev0_block_t) % CRYPTO_BLOCK_SIZE == 0);
 static_assert(std::is_standard_layout_v<epilogue_secure_rev0_block_t>);
 
-#define FRAME_FLAGS_LATEABRT      (1<<0)   /* frame was aborted after txing data */
+// A frame can be aborted by the sender after transmitting the
+// preamble and the first segment.  The remainder of the frame
+// is filled with zeros, up until the epilogue.
+#define FRAME_LATE_FLAG_ABORTED           (1<<0)
 
 struct FrameError : std::runtime_error {
   using runtime_error::runtime_error;

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -184,6 +184,10 @@ public:
     m_is_rev1 = is_rev1;
   }
 
+  bool get_is_rev1() {
+    return m_is_rev1;
+  }
+
   size_t get_num_segments() const {
     ceph_assert(!m_descs.empty());
     return m_descs.size();

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -153,11 +153,6 @@ static constexpr uint32_t FRAME_SECURE_EPILOGUE_SIZE =
 
 #define FRAME_FLAGS_LATEABRT      (1<<0)   /* frame was aborted after txing data */
 
-static uint32_t segment_onwire_size(const uint32_t logical_size)
-{
-  return p2roundup<uint32_t>(logical_size, CRYPTO_BLOCK_SIZE);
-}
-
 struct FrameError : std::runtime_error {
   using runtime_error::runtime_error;
 };
@@ -210,6 +205,11 @@ public:
                             const uint16_t segment_aligns[],
                             size_t segment_count);
 
+  Tag disassemble_preamble(bufferlist& preamble_bl);
+
+  bool disassemble_segments(bufferlist segment_bls[],
+                            bufferlist& epilogue_bl) const;
+
 private:
   struct segment_desc_t {
     uint32_t logical_len;
@@ -229,6 +229,11 @@ private:
                           bufferlist segment_bls[]) const;
   bufferlist asm_secure_rev0(const preamble_block_t& preamble,
                              bufferlist segment_bls[]) const;
+
+  bool disasm_all_crc_rev0(bufferlist segment_bls[],
+                           bufferlist& epilogue_bl) const;
+  bool disasm_all_secure_rev0(bufferlist segment_bls[],
+                              bufferlist& epilogue_bl) const;
 
   void fill_preamble(Tag tag, preamble_block_t& preamble) const;
   friend std::ostream& operator<<(std::ostream& os,

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -179,6 +179,11 @@ public:
   FrameAssembler(const ceph::crypto::onwire::rxtx_t* crypto, bool is_rev1)
       : m_crypto(crypto), m_is_rev1(is_rev1) {}
 
+  void set_is_rev1(bool is_rev1) {
+    m_descs.clear();
+    m_is_rev1 = is_rev1;
+  }
+
   size_t get_num_segments() const {
     ceph_assert(!m_descs.empty());
     return m_descs.size();

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -5,6 +5,7 @@
 #include "common/Clock.h"
 #include "crypto_onwire.h"
 #include <array>
+#include <iosfwd>
 #include <utility>
 
 #include <boost/container/static_vector.hpp>
@@ -157,14 +158,85 @@ static uint32_t segment_onwire_size(const uint32_t logical_size)
   return p2roundup<uint32_t>(logical_size, CRYPTO_BLOCK_SIZE);
 }
 
-static inline ceph::bufferlist segment_onwire_bufferlist(ceph::bufferlist&& bl)
-{
-  const auto padding_size = segment_onwire_size(bl.length()) - bl.length();
-  if (padding_size) {
-    bl.append_zero(padding_size);
+struct FrameError : std::runtime_error {
+  using runtime_error::runtime_error;
+};
+
+class FrameAssembler {
+public:
+  // crypto must be non-null
+  FrameAssembler(const ceph::crypto::onwire::rxtx_t* crypto)
+      : m_crypto(crypto) {}
+
+  size_t get_num_segments() const {
+    ceph_assert(!m_descs.empty());
+    return m_descs.size();
   }
-  return std::move(bl);
-}
+
+  uint32_t get_segment_logical_len(size_t seg_idx) const {
+    ceph_assert(seg_idx < m_descs.size());
+    return m_descs[seg_idx].logical_len;
+  }
+
+  uint16_t get_segment_align(size_t seg_idx) const {
+    ceph_assert(seg_idx < m_descs.size());
+    return m_descs[seg_idx].align;
+  }
+
+  uint32_t get_preamble_onwire_len() const {
+    return sizeof(preamble_block_t);
+  }
+
+  uint32_t get_segment_onwire_len(size_t seg_idx) const {
+    ceph_assert(seg_idx < m_descs.size());
+    if (m_crypto->rx) {
+      return get_segment_padded_len(seg_idx);
+    }
+    return m_descs[seg_idx].logical_len;
+  }
+
+  uint32_t get_epilogue_onwire_len() const {
+    ceph_assert(!m_descs.empty());
+    if (m_crypto->rx) {
+      return sizeof(epilogue_secure_block_t) + get_auth_tag_len();
+    }
+    return sizeof(epilogue_plain_block_t);
+  }
+
+  uint64_t get_frame_logical_len() const;
+  uint64_t get_frame_onwire_len() const;
+
+  bufferlist assemble_frame(Tag tag, bufferlist segment_bls[],
+                            const uint16_t segment_aligns[],
+                            size_t segment_count);
+
+private:
+  struct segment_desc_t {
+    uint32_t logical_len;
+    uint16_t align;
+  };
+
+  uint32_t get_segment_padded_len(size_t seg_idx) const {
+    return p2roundup<uint32_t>(m_descs[seg_idx].logical_len,
+                               CRYPTO_BLOCK_SIZE);
+  }
+
+  uint32_t get_auth_tag_len() const {
+    return m_crypto->rx->get_extra_size_at_final();
+  }
+
+  bufferlist asm_crc_rev0(const preamble_block_t& preamble,
+                          bufferlist segment_bls[]) const;
+  bufferlist asm_secure_rev0(const preamble_block_t& preamble,
+                             bufferlist segment_bls[]) const;
+
+  void fill_preamble(Tag tag, preamble_block_t& preamble) const;
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const FrameAssembler& frame_asm);
+
+  boost::container::static_vector<segment_desc_t, MAX_NUM_SEGMENTS> m_descs;
+  const ceph::crypto::onwire::rxtx_t* m_crypto;
+};
 
 template <class T, uint16_t... SegmentAlignmentVs>
 struct Frame {
@@ -177,135 +249,15 @@ private:
   static constexpr std::array<uint16_t, SegmentsNumV> alignments {
     SegmentAlignmentVs...
   };
-  ceph::bufferlist::contiguous_filler preamble_filler;
-
-  __u8 calc_num_segments(const segment_t segments[])
-  {
-    for (__u8 num = SegmentsNumV; num > 0; num--) {
-      if (segments[num-1].length) {
-        return num;
-      }
-    }
-    // frame always has at least one segment.
-    return 1;
-  }
-
-  // craft the main preamble. It's always present regardless of the number
-  // of segments message is composed from.
-  void fill_preamble() {
-    ceph_assert(std::size(segments) <= MAX_NUM_SEGMENTS);
-
-    preamble_block_t main_preamble;
-    // FIPS zeroization audit 20191115: this memset is not security related.
-    ::memset(&main_preamble, 0, sizeof(main_preamble));
-
-    main_preamble.tag = static_cast<__u8>(T::tag);
-    ceph_assert(main_preamble.tag != 0);
-
-    // implementation detail: the first bufferlist of Frame::segments carries
-    // space for preamble. This glueing isn't a part of the onwire format but
-    // just our private detail.
-    main_preamble.segments[0].length =
-        segments[0].length() - FRAME_PREAMBLE_SIZE;
-    main_preamble.segments[0].alignment = alignments[0];
-
-    // there is no business in issuing frame without at least one segment
-    // filled.
-    if constexpr(SegmentsNumV > 1) {
-      for (__u8 idx = 1; idx < SegmentsNumV; idx++) {
-        main_preamble.segments[idx].length = segments[idx].length();
-        main_preamble.segments[idx].alignment = alignments[idx];
-      }
-    }
-    // calculate the number of non-empty segments.
-    // TODO: reorder segments to get DATA first
-    main_preamble.num_segments = calc_num_segments(main_preamble.segments);
-
-    main_preamble.crc =
-        ceph_crc32c(0, reinterpret_cast<unsigned char *>(&main_preamble),
-                    sizeof(main_preamble) - sizeof(main_preamble.crc));
-
-    preamble_filler.copy_in(sizeof(main_preamble),
-                            reinterpret_cast<const char *>(&main_preamble));
-  }
-
-  template <size_t... Is>
-  void reset_tx_handler(
-    ceph::crypto::onwire::rxtx_t &session_stream_handlers,
-    std::index_sequence<Is...>)
-  {
-    session_stream_handlers.tx->reset_tx_handler({ segments[Is].length()... });
-  }
 
 public:
-  ceph::bufferlist get_buffer(
-    ceph::crypto::onwire::rxtx_t &session_stream_handlers)
-  {
-    fill_preamble();
-    if (session_stream_handlers.tx) {
-      // we're padding segments to biggest cipher's block size. Although
-      // AES-GCM can live without that as it's a stream cipher, we don't
-      // to be fixed to stream ciphers only.
-      for (auto& segment : segments) {
-        segment = segment_onwire_bufferlist(std::move(segment));
-      }
-
-      // let's cipher allocate one huge buffer for entire ciphertext.
-      reset_tx_handler(
-          session_stream_handlers, std::make_index_sequence<SegmentsNumV>());
-
-      for (auto& segment : segments) {
-        if (segment.length()) {
-          session_stream_handlers.tx->authenticated_encrypt_update(
-            std::move(segment));
-        }
-      }
-
-      // in secure mode we craft only the late_flags. Signature (for AES-GCM
-      // called auth tag) will be added by the cipher.
-      {
-        epilogue_secure_block_t epilogue;
-        // FIPS zeroization audit 20191115: this memset is not security
-        // related.
-        ::memset(&epilogue, 0, sizeof(epilogue));
-        ceph::bufferlist epilogue_bl;
-        epilogue_bl.append(reinterpret_cast<const char*>(&epilogue),
-                           sizeof(epilogue));
-        session_stream_handlers.tx->authenticated_encrypt_update(epilogue_bl);
-      }
-      return session_stream_handlers.tx->authenticated_encrypt_final();
-    } else {
-      // plain mode
-      epilogue_plain_block_t epilogue;
-      // FIPS zeroization audit 20191115: this memset is not security related.
-      ::memset(&epilogue, 0, sizeof(epilogue));
-
-      ceph::bufferlist::const_iterator hdriter(&segments.front(),
-                                               FRAME_PREAMBLE_SIZE);
-      epilogue.crc_values[SegmentIndex::Control::PAYLOAD] =
-          hdriter.crc32c(hdriter.get_remaining(), -1);
-      if constexpr(SegmentsNumV > 1) {
-        for (__u8 idx = 1; idx < SegmentsNumV; idx++) {
-          epilogue.crc_values[idx] = segments[idx].crc32c(-1);
-        }
-      }
-
-      ceph::bufferlist ret;
-      for (auto& segment : segments) {
-        ret.claim_append(segment);
-      }
-      ret.append(reinterpret_cast<const char*>(&epilogue), sizeof(epilogue));
-      return ret;
-    }
+  ceph::bufferlist get_buffer(FrameAssembler& tx_frame_asm) {
+    auto bl = tx_frame_asm.assemble_frame(T::tag, segments.data(),
+                                          alignments.data(), SegmentsNumV);
+    ceph_assert(bl.length() == tx_frame_asm.get_frame_onwire_len());
+    return bl;
   }
-
-  Frame()
-    : preamble_filler(segments.front().append_hole(FRAME_PREAMBLE_SIZE)) {
-  }
-
-public:
 };
-
 
 // ControlFrames are used to manage transceiver state (like connections) and
 // orchestrate transfers of MessageFrames. They use only single segment with

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -7,6 +7,8 @@
 #include <array>
 #include <utility>
 
+#include <boost/container/static_vector.hpp>
+
 /**
  * Protocol V2 Frame Structures
  * 
@@ -673,6 +675,9 @@ protected:
   using ControlFrame::ControlFrame;
 };
 
+using segment_bls_t =
+    boost::container::static_vector<bufferlist, MAX_NUM_SEGMENTS>;
+
 // This class is used for encoding/decoding header of the message frame.
 // Body is processed almost independently with the sole junction point
 // being the `extra_payload_len` passed to get_buffer().
@@ -682,12 +687,6 @@ struct MessageFrame : public Frame<MessageFrame,
                                    segment_t::DEFAULT_ALIGNMENT,
                                    segment_t::DEFAULT_ALIGNMENT,
                                    segment_t::PAGE_SIZE_ALIGNMENT> {
-  struct {
-    uint32_t front;
-    uint32_t middle;
-    uint32_t data;
-  } len;
-
   static const Tag tag = Tag::MESSAGE;
 
   static MessageFrame Encode(const ceph_msg_header2 &msg_header,
@@ -705,10 +704,7 @@ struct MessageFrame : public Frame<MessageFrame,
     return f;
   }
 
-  using rx_segments_t =
-    boost::container::static_vector<ceph::bufferlist,
-                                    ceph::msgr::v2::MAX_NUM_SEGMENTS>;
-  static MessageFrame Decode(rx_segments_t &&recv_segments) {
+  static MessageFrame Decode(segment_bls_t& recv_segments) {
     MessageFrame f;
     // transfer segments' bufferlists. If a MessageFrame contains less
     // SegmentsNumV segments, the missing ones will be seen as zeroed.

--- a/src/test/msgr/CMakeLists.txt
+++ b/src/test/msgr/CMakeLists.txt
@@ -26,6 +26,11 @@ target_link_libraries(ceph_perf_msgr_server os global ${UNITTEST_LIBS})
 add_executable(ceph_perf_msgr_client perf_msgr_client.cc)
 target_link_libraries(ceph_perf_msgr_client os global ${UNITTEST_LIBS})
 
+# unitttest_frames_v2
+add_executable(unittest_frames_v2 test_frames_v2.cc)
+add_ceph_unittest(unittest_frames_v2)
+target_link_libraries(unittest_frames_v2 os global ${UNITTEST_LIBS})
+
 # test_userspace_event
 if(HAVE_DPDK)
   add_executable(ceph_test_userspace_event

--- a/src/test/msgr/test_frames_v2.cc
+++ b/src/test/msgr/test_frames_v2.cc
@@ -1,0 +1,450 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "msg/async/frames_v2.h"
+
+#include <numeric>
+#include <ostream>
+#include <string>
+#include <tuple>
+
+#include "auth/Auth.h"
+#include "common/ceph_argparse.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+#include "include/Context.h"
+
+#include <gtest/gtest.h>
+
+namespace ceph::msgr::v2 {
+
+// MessageFrame with the first segment not fixed to ceph_msg_header2
+struct TestFrame : Frame<TestFrame,
+                         /* four segments */
+                         segment_t::DEFAULT_ALIGNMENT,
+                         segment_t::DEFAULT_ALIGNMENT,
+                         segment_t::DEFAULT_ALIGNMENT,
+                         segment_t::PAGE_SIZE_ALIGNMENT> {
+  static constexpr Tag tag = static_cast<Tag>(123);
+
+  static TestFrame Encode(const bufferlist& header,
+                          const bufferlist& front,
+                          const bufferlist& middle,
+                          const bufferlist& data) {
+    TestFrame f;
+    f.segments[SegmentIndex::Msg::HEADER] = header;
+    f.segments[SegmentIndex::Msg::FRONT] = front;
+    f.segments[SegmentIndex::Msg::MIDDLE] = middle;
+    f.segments[SegmentIndex::Msg::DATA] = data;
+
+    // discard cached crcs for perf tests
+    f.segments[SegmentIndex::Msg::HEADER].invalidate_crc();
+    f.segments[SegmentIndex::Msg::FRONT].invalidate_crc();
+    f.segments[SegmentIndex::Msg::MIDDLE].invalidate_crc();
+    f.segments[SegmentIndex::Msg::DATA].invalidate_crc();
+    return f;
+  }
+
+  static TestFrame Decode(segment_bls_t& segment_bls) {
+    TestFrame f;
+    // Transfer segments' bufferlists.  If segment_bls contains
+    // less than SegmentsNumV segments, the missing ones will be
+    // seen as empty.
+    for (size_t i = 0; i < segment_bls.size(); i++) {
+      f.segments[i] = std::move(segment_bls[i]);
+    }
+    return f;
+  }
+
+  bufferlist& header() {
+    return segments[SegmentIndex::Msg::HEADER];
+  }
+  bufferlist& front() {
+    return segments[SegmentIndex::Msg::FRONT];
+  }
+  bufferlist& middle() {
+    return segments[SegmentIndex::Msg::MIDDLE];
+  }
+  bufferlist& data() {
+    return segments[SegmentIndex::Msg::DATA];
+  }
+
+protected:
+  using Frame::Frame;
+};
+
+struct mode_t {
+  bool is_rev1;
+  bool is_secure;
+};
+
+static std::ostream& operator<<(std::ostream& os, const mode_t& m) {
+  os << "msgr2." << (m.is_rev1 ? "1" : "0")
+     << (m.is_secure ? "-secure" : "-crc");
+  return os;
+}
+
+static const mode_t modes[] = {
+  {false, false},
+  {false, true},
+  {true, false},
+  {true, true},
+};
+
+struct round_trip_instance_t {
+  uint32_t header_len;
+  uint32_t front_len;
+  uint32_t middle_len;
+  uint32_t data_len;
+
+  // expected number of segments (same for each mode)
+  size_t num_segments;
+  // expected layout (different for each mode)
+  uint32_t onwire_lens[4][MAX_NUM_SEGMENTS + 2];
+};
+
+static std::ostream& operator<<(std::ostream& os,
+                                const round_trip_instance_t& rti) {
+  os << rti.header_len << "+" << rti.front_len << "+"
+     << rti.middle_len << "+" << rti.data_len;
+  return os;
+}
+
+static bufferlist make_bufferlist(size_t len, char c) {
+  bufferlist bl;
+  if (len > 0) {
+    bl.reserve(len);
+    bl.append(std::string(len, c));
+  }
+  return bl;
+}
+
+bool disassemble_frame(FrameAssembler& frame_asm, bufferlist& frame_bl,
+                       Tag& tag, segment_bls_t& segment_bls) {
+  bufferlist preamble_bl;
+  frame_bl.splice(0, frame_asm.get_preamble_onwire_len(), &preamble_bl);
+  tag = frame_asm.disassemble_preamble(preamble_bl);
+
+  do {
+    size_t seg_idx = segment_bls.size();
+    segment_bls.emplace_back();
+
+    uint32_t onwire_len = frame_asm.get_segment_onwire_len(seg_idx);
+    if (onwire_len > 0) {
+      frame_bl.splice(0, onwire_len, &segment_bls.back());
+    }
+  } while (segment_bls.size() < frame_asm.get_num_segments());
+
+  bufferlist epilogue_bl;
+  uint32_t epilogue_onwire_len = frame_asm.get_epilogue_onwire_len();
+  if (epilogue_onwire_len > 0) {
+    frame_bl.splice(0, epilogue_onwire_len, &epilogue_bl);
+  }
+  frame_asm.disassemble_first_segment(preamble_bl, segment_bls[0]);
+  return frame_asm.disassemble_remaining_segments(segment_bls.data(),
+                                                  epilogue_bl);
+}
+
+class RoundTripTestBase : public ::testing::TestWithParam<
+                              std::tuple<round_trip_instance_t, mode_t>> {
+protected:
+  RoundTripTestBase()
+      : m_tx_frame_asm(&m_tx_crypto, std::get<1>(GetParam()).is_rev1),
+        m_rx_frame_asm(&m_rx_crypto, std::get<1>(GetParam()).is_rev1),
+        m_header(make_bufferlist(std::get<0>(GetParam()).header_len, 'H')),
+        m_front(make_bufferlist(std::get<0>(GetParam()).front_len, 'F')),
+        m_middle(make_bufferlist(std::get<0>(GetParam()).middle_len, 'M')),
+        m_data(make_bufferlist(std::get<0>(GetParam()).data_len, 'D')) {
+    const auto& m = std::get<1>(GetParam());
+    if (m.is_secure) {
+      AuthConnectionMeta auth_meta;
+      auth_meta.con_mode = CEPH_CON_MODE_SECURE;
+      // see AuthConnectionMeta::get_connection_secret_length()
+      auth_meta.connection_secret.resize(64);
+      g_ceph_context->random()->get_bytes(auth_meta.connection_secret.data(),
+                                          auth_meta.connection_secret.size());
+      m_tx_crypto = ceph::crypto::onwire::rxtx_t::create_handler_pair(
+          g_ceph_context, auth_meta, /*new_nonce_format=*/m.is_rev1,
+          /*crossed=*/false);
+      m_rx_crypto = ceph::crypto::onwire::rxtx_t::create_handler_pair(
+          g_ceph_context, auth_meta, /*new_nonce_format=*/m.is_rev1,
+          /*crossed=*/true);
+    }
+  }
+
+  void check_frame_assembler(const FrameAssembler& frame_asm) {
+    const auto& [rti, m] = GetParam();
+    const auto& onwire_lens = rti.onwire_lens[m.is_rev1 << 1 | m.is_secure];
+    EXPECT_EQ(rti.header_len + rti.front_len + rti.middle_len + rti.data_len,
+              frame_asm.get_frame_logical_len());
+    ASSERT_EQ(rti.num_segments, frame_asm.get_num_segments());
+    EXPECT_EQ(onwire_lens[0], frame_asm.get_preamble_onwire_len());
+    for (size_t i = 0; i < rti.num_segments; i++) {
+      EXPECT_EQ(onwire_lens[i + 1], frame_asm.get_segment_onwire_len(i));
+    }
+    EXPECT_EQ(onwire_lens[rti.num_segments + 1],
+              frame_asm.get_epilogue_onwire_len());
+    EXPECT_EQ(std::accumulate(std::begin(onwire_lens), std::end(onwire_lens),
+                              uint64_t(0)),
+              frame_asm.get_frame_onwire_len());
+  }
+
+  void test_round_trip() {
+    auto tx_frame = TestFrame::Encode(m_header, m_front, m_middle, m_data);
+    auto onwire_bl = tx_frame.get_buffer(m_tx_frame_asm);
+    check_frame_assembler(m_tx_frame_asm);
+    EXPECT_EQ(m_tx_frame_asm.get_frame_onwire_len(), onwire_bl.length());
+
+    Tag rx_tag;
+    segment_bls_t rx_segment_bls;
+    EXPECT_TRUE(disassemble_frame(m_rx_frame_asm, onwire_bl, rx_tag,
+                                  rx_segment_bls));
+    check_frame_assembler(m_rx_frame_asm);
+    EXPECT_EQ(0, onwire_bl.length());
+    EXPECT_EQ(TestFrame::tag, rx_tag);
+    EXPECT_EQ(m_rx_frame_asm.get_num_segments(), rx_segment_bls.size());
+
+    auto rx_frame = TestFrame::Decode(rx_segment_bls);
+    EXPECT_TRUE(m_header.contents_equal(rx_frame.header()));
+    EXPECT_TRUE(m_front.contents_equal(rx_frame.front()));
+    EXPECT_TRUE(m_middle.contents_equal(rx_frame.middle()));
+    EXPECT_TRUE(m_data.contents_equal(rx_frame.data()));
+  }
+
+  ceph::crypto::onwire::rxtx_t m_tx_crypto;
+  ceph::crypto::onwire::rxtx_t m_rx_crypto;
+  FrameAssembler m_tx_frame_asm;
+  FrameAssembler m_rx_frame_asm;
+
+  const bufferlist m_header;
+  const bufferlist m_front;
+  const bufferlist m_middle;
+  const bufferlist m_data;
+};
+
+class RoundTripTest : public RoundTripTestBase {};
+
+TEST_P(RoundTripTest, Basic) {
+  test_round_trip();
+}
+
+TEST_P(RoundTripTest, Reuse) {
+  for (int i = 0; i < 3; i++) {
+    test_round_trip();
+  }
+}
+
+static const round_trip_instance_t round_trip_instances[] = {
+  // first segment is empty
+  { 0,   0,   0,   0, 1, {{32,  0,  17,   0,   0,  0},
+                          {32,  0,  32,   0,   0,  0},
+                          {32,  0,   0,   0,   0,  0},
+                          {96,  0,   0,   0,   0,  0}}},
+  { 0,   0,   0, 303, 4, {{32,  0,   0,   0, 303, 17},
+                          {32,  0,   0,   0, 304, 32},
+                          {32,  0,   0,   0, 303, 13},
+                          {96,  0,   0,   0, 304, 32}}},
+  { 0,   0, 202,   0, 3, {{32,  0,   0, 202,  17,  0},
+                          {32,  0,   0, 208,  32,  0},
+                          {32,  0,   0, 202,  13,  0},
+                          {96,  0,   0, 208,  32,  0}}},
+  { 0,   0, 202, 303, 4, {{32,  0,   0, 202, 303, 17},
+                          {32,  0,   0, 208, 304, 32},
+                          {32,  0,   0, 202, 303, 13},
+                          {96,  0,   0, 208, 304, 32}}},
+  { 0, 101,   0,   0, 2, {{32,  0, 101,  17,   0,  0},
+                          {32,  0, 112,  32,   0,  0},
+                          {32,  0, 101,  13,   0,  0},
+                          {96,  0, 112,  32,   0,  0}}},
+  { 0, 101,   0, 303, 4, {{32,  0, 101,   0, 303, 17},
+                          {32,  0, 112,   0, 304, 32},
+                          {32,  0, 101,   0, 303, 13},
+                          {96,  0, 112,   0, 304, 32}}},
+  { 0, 101, 202,   0, 3, {{32,  0, 101, 202,  17,  0},
+                          {32,  0, 112, 208,  32,  0},
+                          {32,  0, 101, 202,  13,  0},
+                          {96,  0, 112, 208,  32,  0}}},
+  { 0, 101, 202, 303, 4, {{32,  0, 101, 202, 303, 17},
+                          {32,  0, 112, 208, 304, 32},
+                          {32,  0, 101, 202, 303, 13},
+                          {96,  0, 112, 208, 304, 32}}},
+
+  // first segment is fully inlined, inline buffer is not full
+  { 1,   0,   0,   0, 1, {{32,  1,  17,   0,   0,  0},
+                          {32, 16,  32,   0,   0,  0},
+                          {32,  5,   0,   0,   0,  0},
+                          {96,  0,   0,   0,   0,  0}}},
+  { 1,   0,   0, 303, 4, {{32,  1,   0,   0, 303, 17},
+                          {32, 16,   0,   0, 304, 32},
+                          {32,  5,   0,   0, 303, 13},
+                          {96,  0,   0,   0, 304, 32}}},
+  { 1,   0, 202,   0, 3, {{32,  1,   0, 202,  17,  0},
+                          {32, 16,   0, 208,  32,  0},
+                          {32,  5,   0, 202,  13,  0},
+                          {96,  0,   0, 208,  32,  0}}},
+  { 1,   0, 202, 303, 4, {{32,  1,   0, 202, 303, 17},
+                          {32, 16,   0, 208, 304, 32},
+                          {32,  5,   0, 202, 303, 13},
+                          {96,  0,   0, 208, 304, 32}}},
+  { 1, 101,   0,   0, 2, {{32,  1, 101,  17,   0,  0},
+                          {32, 16, 112,  32,   0,  0},
+                          {32,  5, 101,  13,   0,  0},
+                          {96,  0, 112,  32,   0,  0}}},
+  { 1, 101,   0, 303, 4, {{32,  1, 101,   0, 303, 17},
+                          {32, 16, 112,   0, 304, 32},
+                          {32,  5, 101,   0, 303, 13},
+                          {96,  0, 112,   0, 304, 32}}},
+  { 1, 101, 202,   0, 3, {{32,  1, 101, 202,  17,  0},
+                          {32, 16, 112, 208,  32,  0},
+                          {32,  5, 101, 202,  13,  0},
+                          {96,  0, 112, 208,  32,  0}}},
+  { 1, 101, 202, 303, 4, {{32,  1, 101, 202, 303, 17},
+                          {32, 16, 112, 208, 304, 32},
+                          {32,  5, 101, 202, 303, 13},
+                          {96,  0, 112, 208, 304, 32}}},
+
+  // first segment is fully inlined, inline buffer is full
+  {48,   0,   0,   0, 1, {{32, 48,  17,   0,   0,  0},
+                          {32, 48,  32,   0,   0,  0},
+                          {32, 52,   0,   0,   0,  0},
+                          {96,  0,   0,   0,   0,  0}}},
+  {48,   0,   0, 303, 4, {{32, 48,   0,   0, 303, 17},
+                          {32, 48,   0,   0, 304, 32},
+                          {32, 52,   0,   0, 303, 13},
+                          {96,  0,   0,   0, 304, 32}}},
+  {48,   0, 202,   0, 3, {{32, 48,   0, 202,  17,  0},
+                          {32, 48,   0, 208,  32,  0},
+                          {32, 52,   0, 202,  13,  0},
+                          {96,  0,   0, 208,  32,  0}}},
+  {48,   0, 202, 303, 4, {{32, 48,   0, 202, 303, 17},
+                          {32, 48,   0, 208, 304, 32},
+                          {32, 52,   0, 202, 303, 13},
+                          {96,  0,   0, 208, 304, 32}}},
+  {48, 101,   0,   0, 2, {{32, 48, 101,  17,   0,  0},
+                          {32, 48, 112,  32,   0,  0},
+                          {32, 52, 101,  13,   0,  0},
+                          {96,  0, 112,  32,   0,  0}}},
+  {48, 101,   0, 303, 4, {{32, 48, 101,   0, 303, 17},
+                          {32, 48, 112,   0, 304, 32},
+                          {32, 52, 101,   0, 303, 13},
+                          {96,  0, 112,   0, 304, 32}}},
+  {48, 101, 202,   0, 3, {{32, 48, 101, 202,  17,  0},
+                          {32, 48, 112, 208,  32,  0},
+                          {32, 52, 101, 202,  13,  0},
+                          {96,  0, 112, 208,  32,  0}}},
+  {48, 101, 202, 303, 4, {{32, 48, 101, 202, 303, 17},
+                          {32, 48, 112, 208, 304, 32},
+                          {32, 52, 101, 202, 303, 13},
+                          {96,  0, 112, 208, 304, 32}}},
+
+  // first segment is partially inlined
+  {49,   0,   0,   0, 1, {{32, 49,  17,   0,   0,  0},
+                          {32, 64,  32,   0,   0,  0},
+                          {32, 53,   0,   0,   0,  0},
+                          {96, 32,   0,   0,   0,  0}}},
+  {49,   0,   0, 303, 4, {{32, 49,   0,   0, 303, 17},
+                          {32, 64,   0,   0, 304, 32},
+                          {32, 53,   0,   0, 303, 13},
+                          {96, 32,   0,   0, 304, 32}}},
+  {49,   0, 202,   0, 3, {{32, 49,   0, 202,  17,  0},
+                          {32, 64,   0, 208,  32,  0},
+                          {32, 53,   0, 202,  13,  0},
+                          {96, 32,   0, 208,  32,  0}}},
+  {49,   0, 202, 303, 4, {{32, 49,   0, 202, 303, 17},
+                          {32, 64,   0, 208, 304, 32},
+                          {32, 53,   0, 202, 303, 13},
+                          {96, 32,   0, 208, 304, 32}}},
+  {49, 101,   0,   0, 2, {{32, 49, 101,  17,   0,  0},
+                          {32, 64, 112,  32,   0,  0},
+                          {32, 53, 101,  13,   0,  0},
+                          {96, 32, 112,  32,   0,  0}}},
+  {49, 101,   0, 303, 4, {{32, 49, 101,   0, 303, 17},
+                          {32, 64, 112,   0, 304, 32},
+                          {32, 53, 101,   0, 303, 13},
+                          {96, 32, 112,   0, 304, 32}}},
+  {49, 101, 202,   0, 3, {{32, 49, 101, 202,  17,  0},
+                          {32, 64, 112, 208,  32,  0},
+                          {32, 53, 101, 202,  13,  0},
+                          {96, 32, 112, 208,  32,  0}}},
+  {49, 101, 202, 303, 4, {{32, 49, 101, 202, 303, 17},
+                          {32, 64, 112, 208, 304, 32},
+                          {32, 53, 101, 202, 303, 13},
+                          {96, 32, 112, 208, 304, 32}}},
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    RoundTripTests, RoundTripTest, ::testing::Combine(
+        ::testing::ValuesIn(round_trip_instances),
+        ::testing::ValuesIn(modes)));
+
+class RoundTripPerfTest : public RoundTripTestBase {};
+
+TEST_P(RoundTripPerfTest, DISABLED_Basic) {
+  for (int i = 0; i < 100000; i++) {
+    auto tx_frame = TestFrame::Encode(m_header, m_front, m_middle, m_data);
+    auto onwire_bl = tx_frame.get_buffer(m_tx_frame_asm);
+
+    Tag rx_tag;
+    segment_bls_t rx_segment_bls;
+    ASSERT_TRUE(disassemble_frame(m_rx_frame_asm, onwire_bl, rx_tag,
+                                  rx_segment_bls));
+  }
+}
+
+static const round_trip_instance_t round_trip_perf_instances[] = {
+  {41, 250, 0,       0, 2, {{32, 41, 250, 17,       0,  0},
+                            {32, 48, 256, 32,       0,  0},
+                            {32, 45, 250, 13,       0,  0},
+                            {96,  0, 256, 32,       0,  0}}},
+  {41, 250, 0,     512, 4, {{32, 41, 250,  0,     512, 17},
+                            {32, 48, 256,  0,     512, 32},
+                            {32, 45, 250,  0,     512, 13},
+                            {96,  0, 256,  0,     512, 32}}},
+  {41, 250, 0,    4096, 4, {{32, 41, 250,  0,    4096, 17},
+                            {32, 48, 256,  0,    4096, 32},
+                            {32, 45, 250,  0,    4096, 13},
+                            {96,  0, 256,  0,    4096, 32}}},
+  {41, 250, 0,   32768, 4, {{32, 41, 250,  0,   32768, 17},
+                            {32, 48, 256,  0,   32768, 32},
+                            {32, 45, 250,  0,   32768, 13},
+                            {96,  0, 256,  0,   32768, 32}}},
+  {41, 250, 0,  131072, 4, {{32, 41, 250,  0,  131072, 17},
+                            {32, 48, 256,  0,  131072, 32},
+                            {32, 45, 250,  0,  131072, 13},
+                            {96,  0, 256,  0,  131072, 32}}},
+  {41, 250, 0, 4194304, 4, {{32, 41, 250,  0, 4194304, 17},
+                            {32, 48, 256,  0, 4194304, 32},
+                            {32, 45, 250,  0, 4194304, 13},
+                            {96,  0, 256,  0, 4194304, 32}}},
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    RoundTripPerfTests, RoundTripPerfTest, ::testing::Combine(
+        ::testing::ValuesIn(round_trip_perf_instances),
+        ::testing::ValuesIn(modes)));
+
+}  // namespace ceph::msgr::v2
+
+int main(int argc, char* argv[]) {
+  vector<const char*> args;
+  argv_to_vec(argc, (const char**)argv, args);
+
+  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+                         CODE_ENVIRONMENT_UTILITY,
+                         CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Backport of #35078 and #35816 (changes from #34927 which got merged via #35078 already in octopus).

Two minor conflicts, documented inline.