### PR TITLE
qa/suites/perf-basic: remove supported-all-distro

### DIFF
--- a/qa/suites/perf-basic/supported-all-distro
+++ b/qa/suites/perf-basic/supported-all-distro
@@ -1,1 +1,0 @@
-.qa/distros/supported-all-distro


### PR DESCRIPTION
d4a04809fd7fd8aaf447005f76a1090db99d75c5 did not serve it's purpose, we
need to remove supported-all-distro to only run on ubuntu_latest

Signed-off-by: Neha Ojha <nojha@redhat.com>