### PR TITLE
doc/install/ceph-deploy/install-ceph-gateway.rst: make better jump for 'Using SSL with Civetweb' and 'Add Wildcard to DNS'

### DIFF
--- a/doc/install/ceph-deploy/install-ceph-gateway.rst
+++ b/doc/install/ceph-deploy/install-ceph-gateway.rst
@@ -144,9 +144,10 @@ execute the following as the ``root`` user::
 
  iptables-save > /etc/iptables/rules.v4
 
+.. _Using SSL with Civetweb:
+
 Using SSL with Civetweb
 -----------------------
-.. _Using SSL with Civetweb:
 
 Before using SSL with civetweb, you will need a certificate that will match
 the host name that that will be used to access the Ceph Object Gateway.
@@ -298,9 +299,10 @@ For example::
 .. note:: Mapping the index pool (for each zone, if applicable) to a CRUSH
           rule of SSD-based OSDs may also help with bucket index performance.
 
+.. _Add Wildcard to DNS:
+
 Add Wildcard to DNS
 -------------------
-.. _Add Wildcard to DNS:
 
 To use Ceph with S3-style subdomains (e.g., bucket-name.domain-name.com), you
 need to add a wildcard to the DNS record of the DNS server you use with the


### PR DESCRIPTION

The link [Using SSL with Civetweb](https://docs.ceph.com/docs/master/install/ceph-deploy/install-ceph-gateway/#id2) and [Add Wildcard to DNS](https://docs.ceph.com/docs/master/install/ceph-deploy/install-ceph-gateway/#id3) are not friendly because after jump it do not show the title. 

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
