### PR TITLE
mgr/volumes/nfs: Add cluster show info command

### DIFF
--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -54,6 +54,15 @@ List NFS Ganesha Cluster
 
 This lists deployed clusters.
 
+Show NFS Ganesha Cluster Information
+====================================
+
+.. code:: bash
+
+    $ ceph nfs cluster info [<clusterid>]
+
+This displays ip and port of deployed cluster.
+
 Create CephFS Export
 ====================
 

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -360,3 +360,17 @@ class TestNFS(MgrTestCase):
             # Command should fail for test to pass
             if e.exitstatus != errno.ENOENT:
                 raise
+
+    def test_cluster_info(self):
+        '''
+        Test cluster info outputs correct ip and hostname
+        '''
+        self._test_create_cluster()
+        info_output = json.loads(self._nfs_cmd('cluster', 'info', self.cluster_id))
+        host_details = {self.cluster_id: [{
+            "hostname": self._sys_cmd(['hostname']).decode("utf-8").strip(),
+            "ip": list(set(self._sys_cmd(['hostname', '-I']).decode("utf-8").split())),
+            "port": 2049
+            }]}
+        self.assertDictEqual(info_output, host_details)
+        self._test_delete_cluster()

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -310,6 +310,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'desc': "List NFS Clusters",
             'perm': 'r'
         },
+        {
+            'cmd': 'nfs cluster info '
+                   'name=clusterid,type=CephString,req=false ',
+            'desc': "Displays NFS Cluster info",
+            'perm': 'r'
+        },
         # volume ls [recursive]
         # subvolume ls <volume>
         # volume authorize/deauthorize
@@ -525,3 +531,6 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     def _cmd_nfs_cluster_ls(self, inbuf, cmd):
         return self.nfs.list_nfs_cluster()
+
+    def _cmd_nfs_cluster_info(self, inbuf, cmd):
+        return self.nfs.show_nfs_cluster_info(cluster_id=cmd.get('clusterid', None))


### PR DESCRIPTION
```  
[root@varsha build]# ./bin/ceph nfs cluster info vstart
*** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
2020-06-29T14:22:26.634+0530 7fe5a2c21700 -1 WARNING: all dangerous and experimental features are enabled.
2020-06-29T14:22:26.649+0530 7fe5a2c21700 -1 WARNING: all dangerous and experimental features are enabled.
{
    "hostname": "smithi112",
    "IP": [
        "172.21.15.112"
    ],
    "Port": 2049
}
```
Fixes: https://tracker.ceph.com/issues/45743
Signed-off-by: Varsha Rao <varao@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
