### PR TITLE
mgr/dashboard: Host delete action should be disabled if not managed by Orchestrator

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -98,7 +98,7 @@ describe('HostsComponent', () => {
         }
       });
       expect(component.getEditDisableDesc(component.selection)).toBe(
-        'Host editing is disabled because the host is not managed by Orchestrator.'
+        'Host editing is disabled because the selected host is not managed by Orchestrator.'
       );
     });
 
@@ -114,6 +114,46 @@ describe('HostsComponent', () => {
         }
       });
       expect(component.getEditDisableDesc(component.selection)).toBeUndefined();
+    });
+  });
+
+  describe('getDeleteDisableDesc', () => {
+    it('should return message (not managed by Orchestrator)', () => {
+      component.selection.add({
+        sources: {
+          ceph: false,
+          orchestrator: true
+        }
+      });
+      component.selection.add({
+        sources: {
+          ceph: true,
+          orchestrator: false
+        }
+      });
+      expect(component.getDeleteDisableDesc(component.selection)).toBe(
+        'Host deletion is disabled because a selected host is not managed by Orchestrator.'
+      );
+    });
+
+    it('should return undefined (no selection)', () => {
+      expect(component.getDeleteDisableDesc(component.selection)).toBeUndefined();
+    });
+
+    it('should return undefined (managed by Orchestrator)', () => {
+      component.selection.add({
+        sources: {
+          ceph: false,
+          orchestrator: true
+        }
+      });
+      component.selection.add({
+        sources: {
+          ceph: false,
+          orchestrator: true
+        }
+      });
+      expect(component.getDeleteDisableDesc(component.selection)).toBeUndefined();
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -107,7 +107,10 @@ export class HostsComponent extends ListWithDetails implements OnInit {
             () => this.deleteAction()
           );
         },
-        disable: () => !this.selection.hasSelection
+        disable: (selection: CdTableSelection) =>
+          !selection.hasSelection ||
+          !selection.selected.every((selected) => selected.sources.orchestrator),
+        disableDesc: this.getDeleteDisableDesc.bind(this)
       }
     ];
   }
@@ -191,7 +194,9 @@ export class HostsComponent extends ListWithDetails implements OnInit {
 
   getEditDisableDesc(selection: CdTableSelection): string | undefined {
     if (selection && selection.hasSingleSelection && !selection.first().sources.orchestrator) {
-      return this.i18n('Host editing is disabled because the host is not managed by Orchestrator.');
+      return this.i18n(
+        'Host editing is disabled because the selected host is not managed by Orchestrator.'
+      );
     }
     return undefined;
   }
@@ -210,6 +215,19 @@ export class HostsComponent extends ListWithDetails implements OnInit {
           })
       }
     });
+  }
+
+  getDeleteDisableDesc(selection: CdTableSelection): string | undefined {
+    if (
+      selection &&
+      selection.hasSelection &&
+      !selection.selected.every((selected) => selected.sources.orchestrator)
+    ) {
+      return this.i18n(
+        'Host deletion is disabled because a selected host is not managed by Orchestrator.'
+      );
+    }
+    return undefined;
   }
 
   getHosts(context: CdTableFetchDataContext) {


### PR DESCRIPTION
![Peek 2020-06-24 13-41](https://user-images.githubusercontent.com/1897962/85550191-027ace00-b621-11ea-8d92-3dfe4948f2b3.gif)

Fixes: https://tracker.ceph.com/issues/46146

Testing:
If you want to test this PR and https://github.com/ceph/ceph/pull/35723 has not been merged in the meanwhile, please pull this in your testing branch to enable the tooltips.

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
