### PR TITLE
octopus: mds: add ephemeral random and distributed export pins

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,6 +1,11 @@
 >=15.2.5
 --------
 
+* CephFS: Automatic static subtree partitioning policies may now be configured
+  using the new distributed and random ephemeral pinning extended attributes on
+  directories. See the documentation for more information:
+  https://docs.ceph.com/docs/master/cephfs/multimds/
+
 * Monitors now have a config option ``mon_osd_warn_num_repaired``, 10 by default.
   If any OSD has repaired more than this many I/O errors in stored data a
  ``OSD_TOO_MANY_REPAIRS`` health warning is generated.

--- a/qa/suites/multimds/basic/tasks/cephfs_test_exports.yaml
+++ b/qa/suites/multimds/basic/tasks/cephfs_test_exports.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - Replacing daemon mds
 tasks:
 - cephfs_test_runner:
     fail_on_skip: false

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -1,4 +1,3 @@
-import time
 import json
 import logging
 from tasks.ceph_test_case import CephTestCase

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -844,9 +844,11 @@ class Filesystem(MDSCluster):
 
         return result
 
-    def get_rank(self, rank=0, status=None):
+    def get_rank(self, rank=None, status=None):
         if status is None:
             status = self.getinfo()
+        if rank is None:
+            rank = 0
         return status.get_rank(self.id, rank)
 
     def rank_restart(self, rank=0, status=None):
@@ -1015,6 +1017,12 @@ class Filesystem(MDSCluster):
     def rank_tell(self, command, rank=0, status=None):
         info = self.get_rank(rank=rank, status=status)
         return json.loads(self.mon_manager.raw_cluster_cmd("tell", 'mds.{0}'.format(info['name']), *command))
+
+    def ranks_tell(self, command, status=None):
+        if status is None:
+            status = self.status()
+        for r in status.get_ranks(self.id):
+            self.rank_tell(command, rank=r['rank'], status=status)
 
     def read_cache(self, path, depth=None):
         cmd = ["dump", "tree", path]

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -1021,8 +1021,18 @@ class Filesystem(MDSCluster):
     def ranks_tell(self, command, status=None):
         if status is None:
             status = self.status()
+        out = []
         for r in status.get_ranks(self.id):
-            self.rank_tell(command, rank=r['rank'], status=status)
+            result = self.rank_tell(command, rank=r['rank'], status=status)
+            out.append((r['rank'], result))
+        return sorted(out)
+
+    def ranks_perf(self, f, status=None):
+        perf = self.ranks_tell(["perf", "dump"], status=status)
+        out = []
+        for rank, perf in perf:
+            out.append((rank, f(perf)))
+        return out
 
     def read_cache(self, path, depth=None):
         cmd = ["dump", "tree", path]

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -223,12 +223,16 @@ class CephCluster(object):
     def json_asok(self, command, service_type, service_id, timeout=None):
         if timeout is None:
             timeout = 15*60
+        command.insert(0, '--format=json')
         proc = self.mon_manager.admin_socket(service_type, service_id, command, timeout=timeout)
-        response_data = proc.stdout.getvalue()
-        log.info("_json_asok output: {0}".format(response_data))
-        if response_data.strip():
-            return json.loads(response_data)
+        response_data = proc.stdout.getvalue().strip()
+        if len(response_data) > 0:
+            j = json.loads(response_data)
+            pretty = json.dumps(j, sort_keys=True, indent=2)
+            log.debug(f"_json_asok output\n{pretty}")
+            return j
         else:
+            log.debug(f"_json_asok output empty")
             return None
 
 

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -232,7 +232,7 @@ class CephCluster(object):
             log.debug(f"_json_asok output\n{pretty}")
             return j
         else:
-            log.debug(f"_json_asok output empty")
+            log.debug("_json_asok output empty")
             return None
 
 

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -8,7 +8,7 @@ from six import StringIO
 from textwrap import dedent
 import os
 from teuthology.orchestra import run
-from teuthology.orchestra.run import CommandFailedError, ConnectionLostError
+from teuthology.orchestra.run import CommandFailedError, ConnectionLostError, Raw
 from tasks.cephfs.filesystem import Filesystem
 
 log = logging.getLogger(__name__)
@@ -196,6 +196,9 @@ class CephFSMount(object):
         p = self._run_python(pyscript, py_version)
         p.wait()
         return six.ensure_str(p.stdout.getvalue().strip())
+
+    def run_shell_payload(self, payload, **kwargs):
+        return self.run_shell(["bash", "-c", Raw(f"'{payload}'")], **kwargs)
 
     def run_shell(self, args, wait=True, stdin=None, check_status=True,
                   omit_sudo=True):

--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -190,3 +190,200 @@ class TestExports(CephFSTestCase):
         # Check if rank1 changed (standby tookover?)
         new_rank1 = self.fs.get_rank(rank=1)
         self.assertEqual(rank1['gid'], new_rank1['gid'])
+
+    def test_ephememeral_pin_distribution(self):
+
+        # Check if the subtree distribution under ephemeral distributed pin is fairly uniform
+
+        self.fs.set_max_mds(3)
+        self.fs.wait_for_daemons()
+
+        status = self.fs.status()
+
+        self.mount_a.run_shell(["mkdir", "-p", "a"])
+        self._wait_subtrees(status, 0, [])
+
+        for i in range(0,100):
+          self.mount_a.run_shell(["mkdir", "-p", "a/" + str(i) + "/d"])
+          
+        self._wait_subtrees(status, 0, [])
+
+        self.mount_b.setfattr(["a", "ceph.dir.pin.distributed", "1"])
+
+        self._wait_distributed_subtrees([status, 0, 100])
+
+        # Check if distribution is uniform
+        rank0_distributed_subtree_ratio = len(self.get_distributed_auth_subtrees(status, 0))/len(self.get_auth_subtrees(status, 0))
+        self.assertGreaterEqual(rank0_distributed_subtree_ratio, 0.2)
+
+        rank1_distributed_subtree_ratio = len(self.get_distributed_auth_subtrees(status, 1))/len(self.get_auth_subtrees(status, 1))
+        self.assertGreaterEqual(rank1_distributed_subtree_ratio, 0.2)
+
+        rank2_distributed_subtree_ratio = len(self.get_distributed_auth_subtrees(status, 2))/len(self.get_auth_subtrees(status, 2))
+        self.assertGreaterEqual(rank2_distributed_subtree_ratio, 0.2)
+
+    def test_ephemeral_random(self):
+        
+        # Check if export ephemeral random is applied hierarchically
+        
+        self.fs.set_max_mds(3)
+        self.fs.wait_for_daemons()
+
+        status = self.fs.status()
+
+        tmp_dir = ""
+        for i in range(0, 100):
+          tmp_dir = tmp_dir + str(i) + "/"
+          self.mount_a.run_shell(["mkdir", "-p", tmp_dir])
+          self.mount_b.setfattr([temp_dir, "ceph.dir.pin.random", "1"])
+
+        count = len(get_random_auth_subtrees(status,0))
+        self.assertEqual(count, 100)
+
+    def test_ephemeral_pin_grow_mds(self):
+        
+        # Increase the no of MDSs and verify that the no of subtrees that migrate are less than 1/3 of the total no of subtrees that are ephemerally pinned
+
+        self.fs.set_max_mds(3)
+        self.fs.wait_for_daemons()
+
+        status = self.fs.status()
+
+        for i in range(0,100):
+          self.mount_a.run_shell(["mkdir", "-p", "a/" + str(i) + "/d"])
+        self._wait_subtrees(status, 0, [])
+        self.mount_b.setfattr(["a", "ceph.dir.pin.distributed", "1"])
+        self._wait_distributed_subtrees([status, 0, 100])
+
+        subtrees_old = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items()) 
+        self.fs.set_max_mds(4)
+        self.fs.wait_for_daemons()
+        # Sleeping for a while to allow the ephemeral pin migrations to complete
+        time.sleep(15)
+        subtrees_new = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items())
+        for old_subtree in subtrees_old:
+            for new_subtree in subtrees_new:
+                if (old_subtree['dir']['path'] == new_subtree['dir']['path']) and (old_subtree['auth_first'] != new_subtree['auth_first']):
+                    count = count + 1
+                    break
+
+        assertLessEqual((count/subtrees_old), 0.33)
+
+    def test_ephemeral_pin_shrink_mds(self):
+
+        # Shrink the no of MDSs
+
+        self.fs.set_max_mds(3)
+        self.fs.wait_for_daemons()
+
+        status = self.fs.status()
+
+        for i in range(0,100):
+          self.mount_a.run_shell(["mkdir", "-p", "a/" + str(i) + "/d"])
+        self._wait_subtrees(status, 0, [])
+        self.mount_b.setfattr(["a", "ceph.dir.pin.distributed", "1"])
+        self._wait_distributed_subtrees([status, 0, 100])
+
+        subtrees_old = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items())
+        self.fs.set_max_mds(2)
+        self.fs.wait_for_daemons()
+        time.sleep(15)
+
+        subtrees_new = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items())
+        for old_subtree in subtrees_old:
+            for new_subtree in subtrees_new:
+                if (old_subtree['dir']['path'] == new_subtree['dir']['path']) and (old_subtree['auth_first'] != new_subtree['auth_first']):
+                    count = count + 1
+                    break
+
+        assertLessEqual((count/subtrees_old), 0.33)
+
+    def test_ephemeral_pin_unset_config(self):
+
+        # Check if unsetting the distributed pin config results in every distributed pin being unset
+
+        self.fs.set_max_mds(3)
+        self.fs.wait_for_daemons()
+
+        status = self.fs.status()
+
+        for i in range(0, 10):
+            self.mount_a.run_shell(["mkdir", "-p", i +"/dummy_dir"])
+            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "1"])
+
+        self._wait_distributed_subtrees([status, 0, 10])
+
+        self.fs.mds_asok(["config", "set", "mds_export_ephemeral_distributed_config", "false"])
+        # Sleep for a while to facilitate unsetting of the pins
+        time.sleep(15)
+        
+        for i in range(0, 10):
+            self.assertTrue(self.mount_a.getfattr(i, "ceph.dir.pin.distributed") == "0")
+
+    def test_ephemeral_distributed_pin_unset(self):
+
+        # Test if unsetting the distributed ephemeral pin on a parent directory then the children directory should not be ephemerally pinned anymore
+
+        self.fs.set_max_mds(3)
+        self.fs.wait_for_daemons()
+
+        status = self.fs.status()
+
+        for i in range(0, 10):
+            self.mount_a.run_shell(["mkdir", "-p", i +"/a/b"])
+            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "1"])
+
+        self._wait_distributed_subtrees([status, 0, 10])
+
+        for i in range(0, 10):
+            self.mount_a.run_shell(["mkdir", "-p", i +"/a/b"])
+            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "0"])
+
+        time.sleep(15)
+
+        subtree_count = len(get_distributed_auth_subtrees(status, 0))
+        assertEqual(subtree_count, 0)
+
+    def test_ephemeral_standby(self):
+
+        # Test if the distribution is unaltered when a Standby MDS takes up a failed rank
+        
+        # Need all my standbys up as well as the active daemons
+        self.wait_for_daemon_start()
+        status = self.fs.status()
+
+        for i in range(0, 10):
+            self.mount_a.run_shell(["mkdir", "-p", i +"/a/b"])
+            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "1"])
+
+        self._wait_distributed_subtrees([status, 0, 10])
+
+        original_subtrees = get_ephemerally_pinned_auth_subtrees(status, 0)
+
+        # Flush the journal for rank 0
+        self.fs.rank_asok(["flush", "journal"], rank=0, status=status)
+
+        (original_active, ) = self.fs.get_active_names()
+        original_standbys = self.mds_cluster.get_standby_daemons()
+
+        # Kill the rank 0 daemon's physical process
+        self.fs.mds_stop(original_active)
+
+        grace = float(self.fs.get_config("mds_beacon_grace", service_type="mon"))
+
+        # Wait until the monitor promotes his replacement
+        def promoted():
+            active = self.fs.get_active_names()
+            return active and active[0] in original_standbys
+
+        log.info("Waiting for promotion of one of the original standbys {0}".format(
+            original_standbys))
+        self.wait_until_true(
+            promoted,
+            timeout=grace*2)
+
+        self.fs.wait_for_state('up:active', rank=0, timeout=MDS_RESTART_GRACE)
+
+        new_subtrees = get_ephemerally_pinned_auth_subtrees(status, 0)
+
+        assertEqual(original_subtrees, new_subtrees)

--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -1,5 +1,7 @@
 import logging
+import random
 import time
+import unittest
 from tasks.cephfs.fuse_mount import FuseMount
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from teuthology.orchestra.run import CommandFailedError, Raw
@@ -144,9 +146,9 @@ class TestExports(CephFSTestCase):
 
         self.fs.set_max_mds(2)
         status = self.fs.wait_for_daemons()
-        self.mount_a.run_shell(f"mkdir -p foo")
+        self.mount_a.run_shell_payload(f"mkdir -p foo")
         self.mount_a.setfattr(f"foo", "ceph.dir.pin", "0")
-        self.mount_a.run_shell(["bash", "-c", Raw(f"'mkdir -p foo/bar/baz && setfattr -n ceph.dir.pin -v 1 foo/bar'")])
+        self.mount_a.run_shell_payload(f"mkdir -p foo/bar/baz && setfattr -n ceph.dir.pin -v 1 foo/bar")
         self._wait_subtrees([('/foo/bar', 1), ('/foo', 0)], status=status)
         self.mount_a.umount_wait() # release all caps
         def _drop():
@@ -191,199 +193,358 @@ class TestExports(CephFSTestCase):
         new_rank1 = self.fs.get_rank(rank=1)
         self.assertEqual(rank1['gid'], new_rank1['gid'])
 
-    def test_ephememeral_pin_distribution(self):
+class TestEphemeralPins(CephFSTestCase):
+    MDSS_REQUIRED = 3
+    CLIENTS_REQUIRED = 1
 
-        # Check if the subtree distribution under ephemeral distributed pin is fairly uniform
+    def setUp(self):
+        CephFSTestCase.setUp(self)
+
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+        self.config_set('mds', 'mds_export_ephemeral_distributed', True)
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 1.0)
+
+        self.mount_a.run_shell_payload(f"""
+set -e
+
+# Use up a random number of inode numbers so the ephemeral pinning is not the same every test.
+mkdir .inode_number_thrash
+count=$((RANDOM % 1024))
+for ((i = 0; i < count; i++)); do touch .inode_number_thrash/$i; done
+rm -rf .inode_number_thrash
+""")
 
         self.fs.set_max_mds(3)
-        self.fs.wait_for_daemons()
+        self.status = self.fs.wait_for_daemons()
 
-        status = self.fs.status()
+    def _setup_tree(self, path="tree", export=-1, distributed=False, random=0.0, count=100, wait=True):
+        return self.mount_a.run_shell_payload(f"""
+set -e
+mkdir -p {path}
+{f"setfattr -n ceph.dir.pin -v {export} {path}" if export >= 0 else ""}
+{f"setfattr -n ceph.dir.pin.distributed -v 1 {path}" if distributed else ""}
+{f"setfattr -n ceph.dir.pin.random -v {random} {path}" if random > 0.0 else ""}
+for ((i = 0; i < {count}; i++)); do
+    mkdir -p "{path}/$i"
+    echo file > "{path}/$i/file"
+done
+""", wait=wait)
 
-        self.mount_a.run_shell(["mkdir", "-p", "a"])
-        self._wait_subtrees(status, 0, [])
+    def test_ephemeral_pin_dist_override(self):
+        """
+        That an ephemeral distributed pin overrides a normal export pin.
+        """
 
-        for i in range(0,100):
-          self.mount_a.run_shell(["mkdir", "-p", "a/" + str(i) + "/d"])
-          
-        self._wait_subtrees(status, 0, [])
+        self._setup_tree(distributed=True)
+        subtrees = self._wait_distributed_subtrees(100, status=self.status, rank="all")
+        for s in subtrees:
+            path = s['dir']['path']
+            if path == '/tree':
+                self.assertEqual(s['export_pin'], 0)
+                self.assertEqual(s['auth_first'], 0)
+            elif path.startswith('/tree/'):
+                self.assertEqual(s['export_pin'], -1)
+                self.assertTrue(s['distributed_ephemeral_pin'])
 
-        self.mount_b.setfattr(["a", "ceph.dir.pin.distributed", "1"])
+    def test_ephemeral_pin_dist_override_pin(self):
+        """
+        That an export pin overrides an ephemerally pinned directory.
+        """
 
-        self._wait_distributed_subtrees([status, 0, 100])
+        self._setup_tree(distributed=True, export=0)
+        subtrees = self._wait_distributed_subtrees(100, status=self.status, rank="all", path="/tree/")
+        which = None
+        for s in subtrees:
+            if s['auth_first'] == 1:
+                path = s['dir']['path']
+                self.mount_a.setfattr(path[1:], "ceph.dir.pin", "0")
+                which = path
+                break
+        self.assertIsNotNone(which)
+        time.sleep(15)
+        subtrees = self._get_subtrees(status=self.status, rank=0)
+        for s in subtrees:
+            path = s['dir']['path']
+            if path == which:
+                self.assertEqual(s['auth_first'], 0)
+                self.assertFalse(s['distributed_ephemeral_pin'])
+                return
+        # it has been merged into /tree
+
+    def test_ephemeral_pin_dist_off(self):
+        """
+        That turning off ephemeral distributed pin merges subtrees.
+        """
+
+        self._setup_tree(distributed=True, export=0)
+        self._wait_distributed_subtrees(100, status=self.status, rank="all")
+        self.mount_a.setfattr("tree", "ceph.dir.pin.distributed", "0")
+        self._wait_subtrees([('/tree', 0)], status=self.status)
+
+    def test_ephemeral_pin_dist_conf_off(self):
+        """
+        That turning off ephemeral distributed pin config prevents distribution.
+        """
+
+        self._setup_tree(export=0)
+        self.config_set('mds', 'mds_export_ephemeral_distributed', False)
+        self.mount_a.setfattr("tree", "ceph.dir.pin.distributed", "1")
+        time.sleep(30)
+        self._wait_subtrees([('/tree', 0)], status=self.status)
+
+    def test_ephemeral_pin_dist_conf_off_merge(self):
+        """
+        That turning off ephemeral distributed pin config merges subtrees.
+        """
+
+        self._setup_tree(distributed=True, export=0)
+        self._wait_distributed_subtrees(100, status=self.status)
+        self.config_set('mds', 'mds_export_ephemeral_distributed', False)
+        self._wait_subtrees([('/tree', 0)], timeout=60, status=self.status)
+
+    def test_ephemeral_pin_dist_override_before(self):
+        """
+        That a conventional export pin overrides the distributed policy _before_ distributed policy is set.
+        """
+
+        count = 10
+        self._setup_tree(count=count)
+        test = []
+        for i in range(count):
+            path = f"tree/{i}"
+            self.mount_a.setfattr(path, "ceph.dir.pin", "1")
+            test.append(("/"+path, 1))
+        self.mount_a.setfattr("tree", "ceph.dir.pin.distributed", "1")
+        time.sleep(10) # for something to not happen...
+        self._wait_subtrees(test, timeout=60, status=self.status, rank="all", path="/tree/")
+
+    def test_ephemeral_pin_dist_override_after(self):
+        """
+        That a conventional export pin overrides the distributed policy _after_ distributed policy is set.
+        """
+
+        self._setup_tree(count=10, distributed=True)
+        subtrees = self._wait_distributed_subtrees(10, status=self.status, rank="all")
+        victim = None
+        test = []
+        for s in subtrees:
+            path = s['dir']['path']
+            auth = s['auth_first']
+            if auth in (0, 2) and victim is None:
+                victim = path
+                self.mount_a.setfattr(victim[1:], "ceph.dir.pin", "1")
+                test.append((victim, 1))
+            else:
+                test.append((path, auth))
+        self.assertIsNotNone(victim)
+        self._wait_subtrees(test, status=self.status, rank="all", path="/tree/")
+
+    def test_ephemeral_pin_dist_failover(self):
+        """
+        That MDS failover does not cause unnecessary migrations.
+        """
+
+        # pin /tree so it does not export during failover
+        self._setup_tree(distributed=True, export=0)
+        subtrees = self._wait_distributed_subtrees(100, status=self.status, rank="all")
+        test = [(s['dir']['path'], s['auth_first']) for s in subtrees]
+        before = self.fs.ranks_perf(lambda p: p['mds']['exported'])
+        log.info(f"export stats: {before}")
+        self.fs.rank_fail(rank=1)
+        self.status = self.fs.wait_for_daemons()
+        time.sleep(10) # waiting for something to not happen
+        after = self.fs.ranks_perf(lambda p: p['mds']['exported'])
+        log.info(f"export stats: {after}")
+        self.assertEqual(before, after)
+
+    def test_ephemeral_pin_distribution(self):
+        """
+        That ephemerally pinned subtrees are somewhat evenly distributed.
+        """
+
+        self.fs.set_max_mds(3)
+        self.status = self.fs.wait_for_daemons()
+
+        count = 1000
+        self._setup_tree(count=count, distributed=True)
+        subtrees = self._wait_distributed_subtrees(count, status=self.status, rank="all")
+        nsubtrees = len(subtrees)
 
         # Check if distribution is uniform
-        rank0_distributed_subtree_ratio = len(self.get_distributed_auth_subtrees(status, 0))/len(self.get_auth_subtrees(status, 0))
-        self.assertGreaterEqual(rank0_distributed_subtree_ratio, 0.2)
-
-        rank1_distributed_subtree_ratio = len(self.get_distributed_auth_subtrees(status, 1))/len(self.get_auth_subtrees(status, 1))
-        self.assertGreaterEqual(rank1_distributed_subtree_ratio, 0.2)
-
-        rank2_distributed_subtree_ratio = len(self.get_distributed_auth_subtrees(status, 2))/len(self.get_auth_subtrees(status, 2))
-        self.assertGreaterEqual(rank2_distributed_subtree_ratio, 0.2)
+        rank0 = list(filter(lambda x: x['auth_first'] == 0, subtrees))
+        rank1 = list(filter(lambda x: x['auth_first'] == 1, subtrees))
+        rank2 = list(filter(lambda x: x['auth_first'] == 2, subtrees))
+        self.assertGreaterEqual(len(rank0)/nsubtrees, 0.2)
+        self.assertGreaterEqual(len(rank1)/nsubtrees, 0.2)
+        self.assertGreaterEqual(len(rank2)/nsubtrees, 0.2)
 
     def test_ephemeral_random(self):
-        
-        # Check if export ephemeral random is applied hierarchically
-        
-        self.fs.set_max_mds(3)
-        self.fs.wait_for_daemons()
+        """
+        That 100% randomness causes all children to be pinned.
+        """
+        self._setup_tree(random=1.0)
+        self._wait_random_subtrees(100, status=self.status, rank="all")
 
-        status = self.fs.status()
+    def test_ephemeral_random_max(self):
+        """
+        That the config mds_export_ephemeral_random_max is not exceeded.
+        """
 
-        tmp_dir = ""
-        for i in range(0, 100):
-          tmp_dir = tmp_dir + str(i) + "/"
-          self.mount_a.run_shell(["mkdir", "-p", tmp_dir])
-          self.mount_b.setfattr([temp_dir, "ceph.dir.pin.random", "1"])
+        r = 0.5
+        count = 1000
+        self._setup_tree(count=count, random=r)
+        subtrees = self._wait_random_subtrees(int(r*count*.75), status=self.status, rank="all")
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 0.01)
+        self._setup_tree(path="tree/new", count=count)
+        time.sleep(30) # for something not to happen...
+        subtrees = self._get_subtrees(status=self.status, rank="all", path="tree/new/")
+        self.assertLessEqual(len(subtrees), int(.01*count*1.25))
 
-        count = len(get_random_auth_subtrees(status,0))
-        self.assertEqual(count, 100)
+    def test_ephemeral_random_max_config(self):
+        """
+        That the config mds_export_ephemeral_random_max config rejects new OOB policies.
+        """
+
+        self.config_set('mds', 'mds_export_ephemeral_random_max', 0.01)
+        try:
+            p = self._setup_tree(count=1, random=0.02, wait=False)
+            p.wait()
+        except CommandFailedError as e:
+            log.info(f"{e}")
+            self.assertIn("Invalid", p.stderr.getvalue())
+        else:
+            raise RuntimeError("mds_export_ephemeral_random_max ignored!")
+
+    def test_ephemeral_random_dist(self):
+        """
+        That ephemeral random and distributed can coexist with each other.
+        """
+
+        self._setup_tree(random=1.0, distributed=True, export=0)
+        self._wait_distributed_subtrees(100, status=self.status)
+        self._wait_random_subtrees(100, status=self.status)
+
+    def test_ephemeral_random_pin_override_before(self):
+        """
+        That a conventional export pin overrides the random policy before creating new directories.
+        """
+
+        self._setup_tree(count=0, random=1.0)
+        self._setup_tree(path="tree/pin", count=10, export=1)
+        self._wait_subtrees([("/tree/pin", 1)], status=self.status, rank=1, path="/tree/pin")
+
+    def test_ephemeral_random_pin_override_after(self):
+        """
+        That a conventional export pin overrides the random policy after creating new directories.
+        """
+
+        count = 10
+        self._setup_tree(count=0, random=1.0)
+        self._setup_tree(path="tree/pin", count=count)
+        self._wait_random_subtrees(count+1, status=self.status, rank="all")
+        self.mount_a.setfattr(f"tree/pin", "ceph.dir.pin", "1")
+        self._wait_subtrees([("/tree/pin", 1)], status=self.status, rank=1, path="/tree/pin")
+
+    def test_ephemeral_randomness(self):
+        """
+        That the randomness is reasonable.
+        """
+
+        r = random.uniform(0.25, 0.75) # ratios don't work for small r!
+        count = 1000
+        self._setup_tree(count=count, random=r)
+        subtrees = self._wait_random_subtrees(int(r*count*.50), status=self.status, rank="all")
+        time.sleep(30) # for max to not be exceeded
+        subtrees = self._wait_random_subtrees(int(r*count*.50), status=self.status, rank="all")
+        self.assertLessEqual(len(subtrees), int(r*count*1.50))
+
+    def test_ephemeral_random_cache_drop(self):
+        """
+        That the random ephemeral pin does not prevent empty (nothing in cache) subtree merging.
+        """
+
+        count = 100
+        self._setup_tree(count=count, random=1.0)
+        subtrees = self._wait_random_subtrees(count, status=self.status, rank="all")
+        self.mount_a.umount_wait() # release all caps
+        def _drop():
+            self.fs.ranks_tell(["cache", "drop"], status=self.status)
+        self._wait_subtrees([], status=self.status, action=_drop)
+
+    def test_ephemeral_random_failover(self):
+        """
+        That the random ephemeral pins stay pinned across MDS failover.
+        """
+
+        count = 100
+        r = 0.5
+        self._setup_tree(count=count, random=r, export=0)
+        # wait for all random subtrees to be created, not a specific count
+        time.sleep(30)
+        subtrees = self._wait_random_subtrees(1, status=self.status, rank=1)
+        test = [(s['dir']['path'], s['auth_first']) for s in subtrees]
+        before = self.fs.ranks_perf(lambda p: p['mds']['exported'])
+        log.info(f"export stats: {before}")
+        self.fs.rank_fail(rank=1)
+        self.status = self.fs.wait_for_daemons()
+        time.sleep(30) # waiting for something to not happen
+        self._wait_subtrees(test, status=self.status, rank=1)
+        after = self.fs.ranks_perf(lambda p: p['mds']['exported'])
+        log.info(f"export stats: {after}")
+        self.assertEqual(before, after)
 
     def test_ephemeral_pin_grow_mds(self):
-        
-        # Increase the no of MDSs and verify that the no of subtrees that migrate are less than 1/3 of the total no of subtrees that are ephemerally pinned
+        """
+        That consistent hashing works to reduce the number of migrations.
+        """
+
+        self.fs.set_max_mds(2)
+        self.status = self.fs.wait_for_daemons()
+
+        self._setup_tree(distributed=True)
+        subtrees_old = self._wait_distributed_subtrees(100, status=self.status, rank="all")
 
         self.fs.set_max_mds(3)
-        self.fs.wait_for_daemons()
-
-        status = self.fs.status()
-
-        for i in range(0,100):
-          self.mount_a.run_shell(["mkdir", "-p", "a/" + str(i) + "/d"])
-        self._wait_subtrees(status, 0, [])
-        self.mount_b.setfattr(["a", "ceph.dir.pin.distributed", "1"])
-        self._wait_distributed_subtrees([status, 0, 100])
-
-        subtrees_old = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items()) 
-        self.fs.set_max_mds(4)
-        self.fs.wait_for_daemons()
+        self.status = self.fs.wait_for_daemons()
+        
         # Sleeping for a while to allow the ephemeral pin migrations to complete
-        time.sleep(15)
-        subtrees_new = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items())
+        time.sleep(30)
+        
+        subtrees_new = self._wait_distributed_subtrees(100, status=self.status, rank="all")
+        count = 0
         for old_subtree in subtrees_old:
             for new_subtree in subtrees_new:
                 if (old_subtree['dir']['path'] == new_subtree['dir']['path']) and (old_subtree['auth_first'] != new_subtree['auth_first']):
                     count = count + 1
                     break
 
-        assertLessEqual((count/subtrees_old), 0.33)
+        log.info("{0} migrations have occured due to the cluster resizing".format(count))
+        # ~50% of subtrees from the two rank will migrate to another rank
+        self.assertLessEqual((count/len(subtrees_old)), (0.5)*1.25) # with 25% overbudget
 
     def test_ephemeral_pin_shrink_mds(self):
-
-        # Shrink the no of MDSs
+        """
+        That consistent hashing works to reduce the number of migrations.
+        """
 
         self.fs.set_max_mds(3)
-        self.fs.wait_for_daemons()
+        self.status = self.fs.wait_for_daemons()
 
-        status = self.fs.status()
+        self._setup_tree(distributed=True)
+        subtrees_old = self._wait_distributed_subtrees(100, status=self.status, rank="all")
 
-        for i in range(0,100):
-          self.mount_a.run_shell(["mkdir", "-p", "a/" + str(i) + "/d"])
-        self._wait_subtrees(status, 0, [])
-        self.mount_b.setfattr(["a", "ceph.dir.pin.distributed", "1"])
-        self._wait_distributed_subtrees([status, 0, 100])
-
-        subtrees_old = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items())
         self.fs.set_max_mds(2)
-        self.fs.wait_for_daemons()
-        time.sleep(15)
+        self.status = self.fs.wait_for_daemons()
+        time.sleep(30)
 
-        subtrees_new = dict(get_ephemrally_pinned_auth_subtrees(status, 0).items() + get_ephemrally_pinned_auth_subtrees(status, 1).items() + get_ephemrally_pinned_auth_subtrees(status, 2).items())
+        subtrees_new = self._wait_distributed_subtrees(100, status=self.status, rank="all")
+        count = 0
         for old_subtree in subtrees_old:
             for new_subtree in subtrees_new:
                 if (old_subtree['dir']['path'] == new_subtree['dir']['path']) and (old_subtree['auth_first'] != new_subtree['auth_first']):
                     count = count + 1
                     break
 
-        assertLessEqual((count/subtrees_old), 0.33)
-
-    def test_ephemeral_pin_unset_config(self):
-
-        # Check if unsetting the distributed pin config results in every distributed pin being unset
-
-        self.fs.set_max_mds(3)
-        self.fs.wait_for_daemons()
-
-        status = self.fs.status()
-
-        for i in range(0, 10):
-            self.mount_a.run_shell(["mkdir", "-p", i +"/dummy_dir"])
-            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "1"])
-
-        self._wait_distributed_subtrees([status, 0, 10])
-
-        self.fs.mds_asok(["config", "set", "mds_export_ephemeral_distributed_config", "false"])
-        # Sleep for a while to facilitate unsetting of the pins
-        time.sleep(15)
-        
-        for i in range(0, 10):
-            self.assertTrue(self.mount_a.getfattr(i, "ceph.dir.pin.distributed") == "0")
-
-    def test_ephemeral_distributed_pin_unset(self):
-
-        # Test if unsetting the distributed ephemeral pin on a parent directory then the children directory should not be ephemerally pinned anymore
-
-        self.fs.set_max_mds(3)
-        self.fs.wait_for_daemons()
-
-        status = self.fs.status()
-
-        for i in range(0, 10):
-            self.mount_a.run_shell(["mkdir", "-p", i +"/a/b"])
-            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "1"])
-
-        self._wait_distributed_subtrees([status, 0, 10])
-
-        for i in range(0, 10):
-            self.mount_a.run_shell(["mkdir", "-p", i +"/a/b"])
-            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "0"])
-
-        time.sleep(15)
-
-        subtree_count = len(get_distributed_auth_subtrees(status, 0))
-        assertEqual(subtree_count, 0)
-
-    def test_ephemeral_standby(self):
-
-        # Test if the distribution is unaltered when a Standby MDS takes up a failed rank
-        
-        # Need all my standbys up as well as the active daemons
-        self.wait_for_daemon_start()
-        status = self.fs.status()
-
-        for i in range(0, 10):
-            self.mount_a.run_shell(["mkdir", "-p", i +"/a/b"])
-            self.mount_b.setfattr([i, "ceph.dir.pin.distributed", "1"])
-
-        self._wait_distributed_subtrees([status, 0, 10])
-
-        original_subtrees = get_ephemerally_pinned_auth_subtrees(status, 0)
-
-        # Flush the journal for rank 0
-        self.fs.rank_asok(["flush", "journal"], rank=0, status=status)
-
-        (original_active, ) = self.fs.get_active_names()
-        original_standbys = self.mds_cluster.get_standby_daemons()
-
-        # Kill the rank 0 daemon's physical process
-        self.fs.mds_stop(original_active)
-
-        grace = float(self.fs.get_config("mds_beacon_grace", service_type="mon"))
-
-        # Wait until the monitor promotes his replacement
-        def promoted():
-            active = self.fs.get_active_names()
-            return active and active[0] in original_standbys
-
-        log.info("Waiting for promotion of one of the original standbys {0}".format(
-            original_standbys))
-        self.wait_until_true(
-            promoted,
-            timeout=grace*2)
-
-        self.fs.wait_for_state('up:active', rank=0, timeout=MDS_RESTART_GRACE)
-
-        new_subtrees = get_ephemerally_pinned_auth_subtrees(status, 0)
-
-        assertEqual(original_subtrees, new_subtrees)
+        log.info("{0} migrations have occured due to the cluster resizing".format(count))
+        # rebalancing from 3 -> 2 may cause half of rank 0/1 to move and all of rank 2
+        self.assertLessEqual((count/len(subtrees_old)), (1.0/3.0/2.0 + 1.0/3.0/2.0 + 1.0/3.0)*1.25) # aka .66 with 25% overbudget

--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -12,150 +12,6 @@ class TestExports(CephFSTestCase):
     MDSS_REQUIRED = 2
     CLIENTS_REQUIRED = 2
 
-    def test_export_pin(self):
-        self.fs.set_max_mds(2)
-        self.fs.wait_for_daemons()
-
-        status = self.fs.status()
-
-        self.mount_a.run_shell(["mkdir", "-p", "1/2/3"])
-        self._wait_subtrees([], status=status)
-
-        # NOP
-        self.mount_a.setfattr("1", "ceph.dir.pin", "-1")
-        self._wait_subtrees([], status=status)
-
-        # NOP (rank < -1)
-        self.mount_a.setfattr("1", "ceph.dir.pin", "-2341")
-        self._wait_subtrees([], status=status)
-
-        # pin /1 to rank 1
-        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
-        self._wait_subtrees([('/1', 1)], status=status, rank=1)
-
-        # Check export_targets is set properly
-        status = self.fs.status()
-        log.info(status)
-        r0 = status.get_rank(self.fs.id, 0)
-        self.assertTrue(sorted(r0['export_targets']) == [1])
-
-        # redundant pin /1/2 to rank 1
-        self.mount_a.setfattr("1/2", "ceph.dir.pin", "1")
-        self._wait_subtrees([('/1', 1), ('/1/2', 1)], status=status, rank=1)
-
-        # change pin /1/2 to rank 0
-        self.mount_a.setfattr("1/2", "ceph.dir.pin", "0")
-        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=status, rank=1)
-        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=status)
-
-        # change pin /1/2/3 to (presently) non-existent rank 2
-        self.mount_a.setfattr("1/2/3", "ceph.dir.pin", "2")
-        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=status)
-        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=status, rank=1)
-
-        # change pin /1/2 back to rank 1
-        self.mount_a.setfattr("1/2", "ceph.dir.pin", "1")
-        self._wait_subtrees([('/1', 1), ('/1/2', 1)], status=status, rank=1)
-
-        # add another directory pinned to 1
-        self.mount_a.run_shell(["mkdir", "-p", "1/4/5"])
-        self.mount_a.setfattr("1/4/5", "ceph.dir.pin", "1")
-        self._wait_subtrees([('/1', 1), ('/1/2', 1), ('/1/4/5', 1)], status=status, rank=1)
-
-        # change pin /1 to 0
-        self.mount_a.setfattr("1", "ceph.dir.pin", "0")
-        self._wait_subtrees([('/1', 0), ('/1/2', 1), ('/1/4/5', 1)], status=status)
-
-        # change pin /1/2 to default (-1); does the subtree root properly respect it's parent pin?
-        self.mount_a.setfattr("1/2", "ceph.dir.pin", "-1")
-        self._wait_subtrees([('/1', 0), ('/1/4/5', 1)], status=status)
-
-        if len(list(status.get_standbys())):
-            self.fs.set_max_mds(3)
-            self.fs.wait_for_state('up:active', rank=2)
-            self._wait_subtrees([('/1', 0), ('/1/4/5', 1), ('/1/2/3', 2)], status=status)
-
-            # Check export_targets is set properly
-            status = self.fs.status()
-            log.info(status)
-            r0 = status.get_rank(self.fs.id, 0)
-            self.assertTrue(sorted(r0['export_targets']) == [1,2])
-            r1 = status.get_rank(self.fs.id, 1)
-            self.assertTrue(sorted(r1['export_targets']) == [0])
-            r2 = status.get_rank(self.fs.id, 2)
-            self.assertTrue(sorted(r2['export_targets']) == [])
-
-        # Test rename
-        self.mount_a.run_shell(["mkdir", "-p", "a/b", "aa/bb"])
-        self.mount_a.setfattr("a", "ceph.dir.pin", "1")
-        self.mount_a.setfattr("aa/bb", "ceph.dir.pin", "0")
-        if (len(self.fs.get_active_names()) > 2):
-            self._wait_subtrees([('/1', 0), ('/1/4/5', 1), ('/1/2/3', 2), ('/a', 1), ('/aa/bb', 0)], status=status)
-        else:
-            self._wait_subtrees([('/1', 0), ('/1/4/5', 1), ('/a', 1), ('/aa/bb', 0)], status=status)
-        self.mount_a.run_shell(["mv", "aa", "a/b/"])
-        if (len(self.fs.get_active_names()) > 2):
-            self._wait_subtrees([('/1', 0), ('/1/4/5', 1), ('/1/2/3', 2), ('/a', 1), ('/a/b/aa/bb', 0)], status=status)
-        else:
-            self._wait_subtrees([('/1', 0), ('/1/4/5', 1), ('/a', 1), ('/a/b/aa/bb', 0)], status=status)
-
-    def test_export_pin_getfattr(self):
-        self.fs.set_max_mds(2)
-        status = self.fs.wait_for_daemons()
-
-        self.mount_a.run_shell(["mkdir", "-p", "1/2/3"])
-        self._wait_subtrees([], status=status)
-
-        # pin /1 to rank 0
-        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
-        self._wait_subtrees([('/1', 1)], status=status, rank=1)
-
-        # pin /1/2 to rank 1
-        self.mount_a.setfattr("1/2", "ceph.dir.pin", "1")
-        self._wait_subtrees([('/1', 1), ('/1/2', 1)], status=status, rank=1)
-
-        # change pin /1/2 to rank 0
-        self.mount_a.setfattr("1/2", "ceph.dir.pin", "0")
-        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=status, rank=1)
-        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=status)
-
-         # change pin /1/2/3 to (presently) non-existent rank 2
-        self.mount_a.setfattr("1/2/3", "ceph.dir.pin", "2")
-        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=status)
-
-        if len(list(status.get_standbys())):
-            self.fs.set_max_mds(3)
-            self.fs.wait_for_state('up:active', rank=2)
-            self._wait_subtrees([('/1', 1), ('/1/2', 0), ('/1/2/3', 2)], status=status)
-
-        if not isinstance(self.mount_a, FuseMount):
-            p = self.mount_a.client_remote.sh('uname -r', wait=True)
-            dir_pin = self.mount_a.getfattr("1", "ceph.dir.pin")
-            log.debug("mount.getfattr('1','ceph.dir.pin'): %s " % dir_pin)
-            if str(p) < "5" and not(dir_pin):
-                self.skipTest("Kernel does not support getting the extended attribute ceph.dir.pin")
-        self.assertEqual(self.mount_a.getfattr("1", "ceph.dir.pin"), '1')
-        self.assertEqual(self.mount_a.getfattr("1/2", "ceph.dir.pin"), '0')
-        if (len(self.fs.get_active_names()) > 2):
-            self.assertEqual(self.mount_a.getfattr("1/2/3", "ceph.dir.pin"), '2')
-
-    def test_export_pin_cache_drop(self):
-        """
-        That the export pin does not prevent empty (nothing in cache) subtree merging.
-        """
-
-        self.fs.set_max_mds(2)
-        status = self.fs.wait_for_daemons()
-        self.mount_a.run_shell_payload(f"mkdir -p foo")
-        self.mount_a.setfattr(f"foo", "ceph.dir.pin", "0")
-        self.mount_a.run_shell_payload(f"mkdir -p foo/bar/baz && setfattr -n ceph.dir.pin -v 1 foo/bar")
-        self._wait_subtrees([('/foo/bar', 1), ('/foo', 0)], status=status)
-        self.mount_a.umount_wait() # release all caps
-        def _drop():
-            self.fs.ranks_tell(["cache", "drop"], status=status)
-        # drop cache multiple times to clear replica pins
-        self._wait_subtrees([], status=status, action=_drop)
-
     def test_session_race(self):
         """
         Test session creation race.
@@ -192,6 +48,113 @@ class TestExports(CephFSTestCase):
         # Check if rank1 changed (standby tookover?)
         new_rank1 = self.fs.get_rank(rank=1)
         self.assertEqual(rank1['gid'], new_rank1['gid'])
+
+class TestExportPin(CephFSTestCase):
+    MDSS_REQUIRED = 3
+    CLIENTS_REQUIRED = 1
+
+    def setUp(self):
+        CephFSTestCase.setUp(self)
+
+        self.fs.set_max_mds(3)
+        self.status = self.fs.wait_for_daemons()
+
+        self.mount_a.run_shell_payload("mkdir -p 1/2/3/4")
+
+    def test_noop(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "-1")
+        time.sleep(30) # for something to not happen
+        self._wait_subtrees([], status=self.status)
+
+    def test_negative(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "-2341")
+        time.sleep(30) # for something to not happen
+        self._wait_subtrees([], status=self.status)
+
+    def test_empty_pin(self):
+        self.mount_a.setfattr("1/2/3/4", "ceph.dir.pin", "1")
+        time.sleep(30) # for something to not happen
+        self._wait_subtrees([], status=self.status)
+
+    def test_trivial(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+
+    def test_export_targets(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+        self.status = self.fs.status()
+        r0 = self.status.get_rank(self.fs.id, 0)
+        self.assertTrue(sorted(r0['export_targets']) == [1])
+
+    def test_redundant(self):
+        # redundant pin /1/2 to rank 1
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "1")
+        self._wait_subtrees([('/1', 1), ('/1/2', 1)], status=self.status, rank=1)
+
+    def test_reassignment(self):
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "1")
+        self._wait_subtrees([('/1/2', 1)], status=self.status, rank=1)
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "0")
+        self._wait_subtrees([('/1/2', 0)], status=self.status, rank=0)
+
+    def test_phantom_rank(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "0")
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "10")
+        time.sleep(30) # wait for nothing weird to happen
+        self._wait_subtrees([('/1', 0)], status=self.status)
+
+    def test_nested(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "0")
+        self.mount_a.setfattr("1/2/3", "ceph.dir.pin", "2")
+        self._wait_subtrees([('/1', 1), ('/1/2', 0), ('/1/2/3', 2)], status=self.status, rank=2)
+
+    def test_nested_unset(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "2")
+        self._wait_subtrees([('/1', 1), ('/1/2', 2)], status=self.status, rank=1)
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "-1")
+        self._wait_subtrees([('/1', 1)], status=self.status, rank=1)
+
+    def test_rename(self):
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self.mount_a.run_shell_payload("mkdir -p 9/8/7")
+        self.mount_a.setfattr("9/8", "ceph.dir.pin", "0")
+        self._wait_subtrees([('/1', 1), ("/9/8", 0)], status=self.status, rank=0)
+        self.mount_a.run_shell_payload("mv 9/8 1/2")
+        self._wait_subtrees([('/1', 1), ("/1/2/8", 0)], status=self.status, rank=0)
+
+    def test_getfattr(self):
+        # pin /1 to rank 0
+        self.mount_a.setfattr("1", "ceph.dir.pin", "1")
+        self.mount_a.setfattr("1/2", "ceph.dir.pin", "0")
+        self._wait_subtrees([('/1', 1), ('/1/2', 0)], status=self.status, rank=1)
+
+        if not isinstance(self.mount_a, FuseMount):
+            p = self.mount_a.client_remote.sh('uname -r', wait=True)
+            dir_pin = self.mount_a.getfattr("1", "ceph.dir.pin")
+            log.debug("mount.getfattr('1','ceph.dir.pin'): %s " % dir_pin)
+            if str(p) < "5" and not(dir_pin):
+                self.skipTest("Kernel does not support getting the extended attribute ceph.dir.pin")
+        self.assertEqual(self.mount_a.getfattr("1", "ceph.dir.pin"), '1')
+        self.assertEqual(self.mount_a.getfattr("1/2", "ceph.dir.pin"), '0')
+
+    def test_export_pin_cache_drop(self):
+        """
+        That the export pin does not prevent empty (nothing in cache) subtree merging.
+        """
+
+        self.mount_a.setfattr(f"1", "ceph.dir.pin", "0")
+        self.mount_a.setfattr(f"1/2", "ceph.dir.pin", "1")
+        self._wait_subtrees([('/1', 0), ('/1/2', 1)], status=self.status)
+        self.mount_a.umount_wait() # release all caps
+        def _drop():
+            self.fs.ranks_tell(["cache", "drop"], status=self.status)
+        # drop cache multiple times to clear replica pins
+        self._wait_subtrees([], status=self.status, action=_drop)
 
 class TestEphemeralPins(CephFSTestCase):
     MDSS_REQUIRED = 3

--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -98,9 +98,7 @@ class TestExports(CephFSTestCase):
 
     def test_export_pin_getfattr(self):
         self.fs.set_max_mds(2)
-        self.fs.wait_for_daemons()
-
-        status = self.fs.status()
+        status = self.fs.wait_for_daemons()
 
         self.mount_a.run_shell(["mkdir", "-p", "1/2/3"])
         self._wait_subtrees(status, 0, [])

--- a/qa/tasks/cephfs/test_sessionmap.py
+++ b/qa/tasks/cephfs/test_sessionmap.py
@@ -196,10 +196,9 @@ class TestSessionMap(CephFSTestCase):
             self.skipTest("Requires FUSE client to use is_blacklisted()")
 
         self.fs.set_max_mds(2)
-        self.fs.wait_for_daemons()
-        status = self.fs.status()
+        status = self.fs.wait_for_daemons()
 
-        self.mount_a.run_shell(["mkdir", "d0", "d1"])
+        self.mount_a.run_shell_payload("mkdir {d0,d1} && touch {d0,d1}/file")
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d1", "ceph.dir.pin", "1")
         self._wait_subtrees([('/d0', 0), ('/d1', 1)], status=status)

--- a/qa/tasks/cephfs/test_sessionmap.py
+++ b/qa/tasks/cephfs/test_sessionmap.py
@@ -202,7 +202,7 @@ class TestSessionMap(CephFSTestCase):
         self.mount_a.run_shell(["mkdir", "d0", "d1"])
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d1", "ceph.dir.pin", "1")
-        self._wait_subtrees(status, 0, [('/d0', 0), ('/d1', 1)])
+        self._wait_subtrees([('/d0', 0), ('/d1', 1)], status=status)
 
         self.mount_a.run_shell(["touch", "d0/f0"])
         self.mount_a.run_shell(["touch", "d1/f0"])

--- a/qa/tasks/cephfs/test_snapshots.py
+++ b/qa/tasks/cephfs/test_snapshots.py
@@ -55,7 +55,7 @@ class TestSnapshots(CephFSTestCase):
         # setup subtrees
         self.mount_a.run_shell(["mkdir", "-p", "d1/dir"])
         self.mount_a.setfattr("d1", "ceph.dir.pin", "1")
-        self.wait_until_true(lambda: self._check_subtree(1, '/d1', status=status), timeout=30)
+        self._wait_subtrees([("/d1", 1)], rank=1, path="/d1")
 
         last_created = self._get_last_created_snap(rank=0,status=status)
 
@@ -231,9 +231,7 @@ class TestSnapshots(CephFSTestCase):
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d0/d1", "ceph.dir.pin", "1")
         self.mount_a.setfattr("d0/d2", "ceph.dir.pin", "2")
-        self.wait_until_true(lambda: self._check_subtree(2, '/d0/d2', status=status), timeout=30)
-        self.wait_until_true(lambda: self._check_subtree(1, '/d0/d1', status=status), timeout=5)
-        self.wait_until_true(lambda: self._check_subtree(0, '/d0', status=status), timeout=5)
+        self._wait_subtrees([("/d0", 0), ("/d0/d1", 1), ("/d0/d2", 2)], rank="all", status=status, path="/d0")
 
         def _check_snapclient_cache(snaps_dump, cache_dump=None, rank=0):
             if cache_dump is None:
@@ -354,11 +352,10 @@ class TestSnapshots(CephFSTestCase):
         self.fs.set_max_mds(2)
         status = self.fs.wait_for_daemons()
 
-        self.mount_a.run_shell(["mkdir", "-p", "d0/d1"])
+        self.mount_a.run_shell(["mkdir", "-p", "d0/d1/empty"])
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d0/d1", "ceph.dir.pin", "1")
-        self.wait_until_true(lambda: self._check_subtree(1, '/d0/d1', status=status), timeout=30)
-        self.wait_until_true(lambda: self._check_subtree(0, '/d0', status=status), timeout=5)
+        self._wait_subtrees([("/d0", 0), ("/d0/d1", 1)], rank="all", status=status, path="/d0")
 
         self.mount_a.write_test_pattern("d0/d1/file_a", 8 * 1024 * 1024)
         self.mount_a.run_shell(["mkdir", "d0/.snap/s1"])
@@ -376,11 +373,10 @@ class TestSnapshots(CephFSTestCase):
         self.fs.set_max_mds(2)
         status = self.fs.wait_for_daemons()
 
-        self.mount_a.run_shell(["mkdir", "d0", "d1"])
+        self.mount_a.run_shell_payload("mkdir -p {d0,d1}/empty")
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d1", "ceph.dir.pin", "1")
-        self.wait_until_true(lambda: self._check_subtree(1, '/d1', status=status), timeout=30)
-        self.wait_until_true(lambda: self._check_subtree(0, '/d0', status=status), timeout=5)
+        self._wait_subtrees([("/d0", 0), ("/d1", 1)], rank=0, status=status)
 
         self.mount_a.run_shell(["mkdir", "d0/d3"])
         self.mount_a.run_shell(["mkdir", "d0/.snap/s1"])
@@ -404,12 +400,11 @@ class TestSnapshots(CephFSTestCase):
         self.fs.set_max_mds(2)
         status = self.fs.wait_for_daemons()
 
-        self.mount_a.run_shell(["mkdir", "d0", "d1"])
+        self.mount_a.run_shell_payload("mkdir -p {d0,d1}/empty")
 
         self.mount_a.setfattr("d0", "ceph.dir.pin", "0")
         self.mount_a.setfattr("d1", "ceph.dir.pin", "1")
-        self.wait_until_true(lambda: self._check_subtree(1, '/d1', status=status), timeout=30)
-        self.wait_until_true(lambda: self._check_subtree(0, '/d0', status=status), timeout=5)
+        self._wait_subtrees([("/d0", 0), ("/d1", 1)], rank=0, status=status)
 
         self.mount_a.run_python(dedent("""
             import os

--- a/qa/tasks/cephfs/test_strays.py
+++ b/qa/tasks/cephfs/test_strays.py
@@ -614,7 +614,7 @@ ln dir_1/original dir_2/linkto
 
         # Shut down rank 1
         self.fs.set_max_mds(1)
-        status = self.fs.wait_for_daemons(timeout=120)
+        self.fs.wait_for_daemons(timeout=120)
 
         # See that the stray counter on rank 0 has incremented
         self.assertEqual(self.get_mdc_stat("strays_created", rank_0_id), 1)

--- a/qa/tasks/cephfs/test_strays.py
+++ b/qa/tasks/cephfs/test_strays.py
@@ -517,34 +517,16 @@ class TestStrays(CephFSTestCase):
 
         return rank_0_id, rank_1_id
 
-    def _force_migrate(self, to_id, path, watch_ino):
+    def _force_migrate(self, path, rank=1):
         """
         :param to_id: MDS id to move it to
         :param path: Filesystem path (string) to move
         :param watch_ino: Inode number to look for at destination to confirm move
         :return: None
         """
-        self.mount_a.run_shell(["setfattr", "-n", "ceph.dir.pin", "-v", "1", path])
-
-        # Poll the MDS cache dump to watch for the export completing
-        migrated = False
-        migrate_timeout = 60
-        migrate_elapsed = 0
-        while not migrated:
-            data = self.fs.mds_asok(["dump", "cache"], to_id)
-            for inode_data in data:
-                if inode_data['ino'] == watch_ino:
-                    log.debug("Found ino in cache: {0}".format(json.dumps(inode_data, indent=2)))
-                    if inode_data['is_auth'] is True:
-                        migrated = True
-                    break
-
-            if not migrated:
-                if migrate_elapsed > migrate_timeout:
-                    raise RuntimeError("Migration hasn't happened after {0}s!".format(migrate_elapsed))
-                else:
-                    migrate_elapsed += 1
-                    time.sleep(1)
+        self.mount_a.run_shell(["setfattr", "-n", "ceph.dir.pin", "-v", str(rank), path])
+        rpath = "/"+path
+        self._wait_subtrees([(rpath, rank)], rank=rank, path=rpath)
 
     def _is_stopped(self, rank):
         mds_map = self.fs.get_mds_map()
@@ -565,8 +547,7 @@ class TestStrays(CephFSTestCase):
 
         self.mount_a.create_n_files("delete_me/file", file_count)
 
-        self._force_migrate(rank_1_id, "delete_me",
-                            self.mount_a.path_to_ino("delete_me/file_0"))
+        self._force_migrate("delete_me")
 
         self.mount_a.run_shell(["rm", "-rf", Raw("delete_me/*")])
         self.mount_a.umount_wait()
@@ -610,26 +591,21 @@ class TestStrays(CephFSTestCase):
 
         # Create a non-purgeable stray in a ~mds1 stray directory
         # by doing a hard link and deleting the original file
-        self.mount_a.run_shell(["mkdir", "dir_1", "dir_2"])
-        self.mount_a.run_shell(["touch", "dir_1/original"])
-        self.mount_a.run_shell(["ln", "dir_1/original", "dir_2/linkto"])
+        self.mount_a.run_shell_payload("""
+mkdir dir_1 dir_2
+touch dir_1/original
+ln dir_1/original dir_2/linkto
+""")
 
-        self._force_migrate(rank_1_id, "dir_1",
-                            self.mount_a.path_to_ino("dir_1/original"))
+        self._force_migrate("dir_1")
+        self._force_migrate("dir_2", rank=0)
 
         # empty mds cache. otherwise mds reintegrates stray when unlink finishes
         self.mount_a.umount_wait()
-        self.fs.mds_asok(['flush', 'journal'], rank_0_id)
         self.fs.mds_asok(['flush', 'journal'], rank_1_id)
-        self.fs.mds_fail_restart()
-        self.fs.wait_for_daemons()
-
-        active_mds_names = self.fs.get_active_names()
-        rank_0_id = active_mds_names[0]
-        rank_1_id = active_mds_names[1]
+        self.fs.mds_asok(['cache', 'drop'], rank_1_id)
 
         self.mount_a.mount_wait()
-
         self.mount_a.run_shell(["rm", "-f", "dir_1/original"])
         self.mount_a.umount_wait()
 
@@ -638,7 +614,7 @@ class TestStrays(CephFSTestCase):
 
         # Shut down rank 1
         self.fs.set_max_mds(1)
-        self.fs.wait_for_daemons(timeout=120)
+        status = self.fs.wait_for_daemons(timeout=120)
 
         # See that the stray counter on rank 0 has incremented
         self.assertEqual(self.get_mdc_stat("strays_created", rank_0_id), 1)
@@ -955,8 +931,7 @@ class TestStrays(CephFSTestCase):
 
         self.mount_a.create_n_files("delete_me/file", file_count)
 
-        self._force_migrate(rank_1_id, "delete_me",
-                            self.mount_a.path_to_ino("delete_me/file_0"))
+        self._force_migrate("delete_me")
 
         begin = datetime.datetime.now()
         self.mount_a.run_shell(["rm", "-rf", Raw("delete_me/*")])
@@ -969,4 +944,3 @@ class TestStrays(CephFSTestCase):
 
         duration = (end - begin).total_seconds()
         self.assertLess(duration, (file_count * tick_period) * 0.25)
-

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -21,6 +21,7 @@ class TestVolumes(CephFSTestCase):
 
     # for filling subvolume with data
     CLIENTS_REQUIRED = 1
+    MDSS_REQUIRED = 2
 
     # io defaults
     DEFAULT_FILE_SIZE = 1 # MB
@@ -591,6 +592,44 @@ class TestVolumes(CephFSTestCase):
 
         # verify trash dir is clean
         self._wait_for_trash_empty()
+
+    def test_subvolume_pin_export(self):
+        self.fs.set_max_mds(2)
+        status = self.fs.wait_for_daemons()
+
+        subvolume = self._generate_random_subvolume_name()
+        self._fs_cmd("subvolume", "create", self.volname, subvolume)
+        self._fs_cmd("subvolume", "pin", self.volname, subvolume, "export", "1")
+        path = self._fs_cmd("subvolume", "getpath", self.volname, subvolume)
+        path = os.path.dirname(path) # get subvolume path
+
+        subtrees = self._get_subtrees(status=status, rank=1)
+        self._wait_subtrees([(path, 1)], status=status)
+
+    def test_subvolumegroup_pin_distributed(self):
+        self.fs.set_max_mds(2)
+        status = self.fs.wait_for_daemons()
+        self.config_set('mds', 'mds_export_ephemeral_distributed', True)
+
+        group = "pinme"
+        self._fs_cmd("subvolumegroup", "create", self.volname, group)
+        self._fs_cmd("subvolumegroup", "pin", self.volname, group, "distributed", "True")
+        # (no effect on distribution) pin the group directory to 0 so rank 0 has all subtree bounds visible
+        self._fs_cmd("subvolumegroup", "pin", self.volname, group, "export", "0")
+        for i in range(10):
+            subvolume = self._generate_random_subvolume_name()
+            self._fs_cmd("subvolume", "create", self.volname, subvolume, "--group_name", group)
+        self._wait_distributed_subtrees(10, status=status)
+
+    def test_subvolume_pin_random(self):
+        self.fs.set_max_mds(2)
+        status = self.fs.wait_for_daemons()
+        self.config_set('mds', 'mds_export_ephemeral_random', True)
+
+        subvolume = self._generate_random_subvolume_name()
+        self._fs_cmd("subvolume", "create", self.volname, subvolume)
+        self._fs_cmd("subvolume", "pin", self.volname, subvolume, "random", ".01")
+        # no verification
 
     def test_subvolume_create_isolated_namespace(self):
         """

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -603,7 +603,7 @@ class TestVolumes(CephFSTestCase):
         path = self._fs_cmd("subvolume", "getpath", self.volname, subvolume)
         path = os.path.dirname(path) # get subvolume path
 
-        subtrees = self._get_subtrees(status=status, rank=1)
+        self._get_subtrees(status=status, rank=1)
         self._wait_subtrees([(path, 1)], status=status)
 
     def test_subvolumegroup_pin_distributed(self):
@@ -623,7 +623,7 @@ class TestVolumes(CephFSTestCase):
 
     def test_subvolume_pin_random(self):
         self.fs.set_max_mds(2)
-        status = self.fs.wait_for_daemons()
+        self.fs.wait_for_daemons()
         self.config_set('mds', 'mds_export_ephemeral_random', True)
 
         subvolume = self._generate_random_subvolume_name()

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7831,6 +7831,18 @@ std::vector<Option> get_mds_options() {
     .set_default(true)
     .set_description("allow setting directory export pins to particular ranks"),
 
+    Option("mds_export_ephemeral_random", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_flag(Option::FLAG_RUNTIME)
+    .set_description("allow ephemeral random pinning of the loaded subtrees")
+    .set_long_description("probabilistically pin the loaded directory inode and the subtree beneath it to an MDS based on the consistent hash of the inode number. The higher this value the more likely the loaded subtrees get pinned"),
+
+    Option("mds_export_ephemeral_distributed", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_flag(Option::FLAG_RUNTIME)
+    .set_description("allow ephemeral distributed pinning of the loaded subtrees")
+    .set_long_description("pin the immediate child directories of the loaded directory inode based on the consistent hash of the child's inode number. "),
+
     Option("mds_bal_sample_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(3.0)
     .set_description("interval in seconds between balancer ticks"),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7837,6 +7837,13 @@ std::vector<Option> get_mds_options() {
     .set_description("allow ephemeral random pinning of the loaded subtrees")
     .set_long_description("probabilistically pin the loaded directory inode and the subtree beneath it to an MDS based on the consistent hash of the inode number. The higher this value the more likely the loaded subtrees get pinned"),
 
+    Option("mds_export_ephemeral_random_max", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(0.01)
+    .set_flag(Option::FLAG_RUNTIME)
+    .set_description("the maximum percent permitted for random ephemeral pin policy")
+    .set_min_max(0.0, 1.0)
+    .add_see_also("mds_export_ephemeral_random"),
+
     Option("mds_export_ephemeral_distributed", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .set_flag(Option::FLAG_RUNTIME)

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1857,6 +1857,7 @@ CDentry *CDir::_load_dentry(
         if (in->inode.is_dirty_rstat())
           in->mark_dirty_rstat();
 
+        in->maybe_export_ephemeral_random_pin(true);
         //in->hack_accessed = false;
         //in->hack_load_stamp = ceph_clock_now();
         //num_new_inodes_loaded++;

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1857,7 +1857,7 @@ CDentry *CDir::_load_dentry(
         if (in->inode.is_dirty_rstat())
           in->mark_dirty_rstat();
 
-        in->maybe_ephemeral_rand();
+        in->maybe_ephemeral_rand(true);
         //in->hack_accessed = false;
         //in->hack_load_stamp = ceph_clock_now();
         //num_new_inodes_loaded++;

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1857,7 +1857,7 @@ CDentry *CDir::_load_dentry(
         if (in->inode.is_dirty_rstat())
           in->mark_dirty_rstat();
 
-        in->maybe_export_ephemeral_random_pin(true);
+        in->maybe_ephemeral_rand();
         //in->hack_accessed = false;
         //in->hack_load_stamp = ceph_clock_now();
         //num_new_inodes_loaded++;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -454,6 +454,8 @@ void CInode::pop_and_dirty_projected_inode(LogSegment *ls)
   if (new_export_pin)
     maybe_export_pin(true);
 
+  if (front.inode.version == 1)
+    maybe_export_ephemeral_random_pin();
   if (inode.is_backtrace_updated())
     mark_dirty_parent(ls, old_pool != inode.layout.pool_id);
 
@@ -2014,6 +2016,8 @@ void CInode::encode_lock_ipolicy(bufferlist& bl)
     encode(inode.layout, bl, mdcache->mds->mdsmap->get_up_features());
     encode(inode.quota, bl);
     encode(inode.export_pin, bl);
+    encode(inode.export_ephemeral_distributed_pin, bl);
+    encode(inode.export_ephemeral_random_pin, bl);
   }
   ENCODE_FINISH(bl);
 }
@@ -2031,6 +2035,10 @@ void CInode::decode_lock_ipolicy(bufferlist::const_iterator& p)
     mds_rank_t old_pin = inode.export_pin;
     decode(inode.export_pin, p);
     maybe_export_pin(old_pin != inode.export_pin);
+    bool old_ephemeral_pin = inode.export_ephemeral_distributed_pin;
+    decode(inode.export_ephemeral_distributed_pin, p);
+    maybe_export_ephemeral_distributed_pin(old_ephemeral_pin != inode.export_ephemeral_distributed_pin);
+    decode(inode.export_ephemeral_random_pin, p);
   }
   DECODE_FINISH(p);
 }
@@ -5158,8 +5166,10 @@ void CInode::maybe_export_pin(bool update)
     return;
 
   mds_rank_t export_pin = get_export_pin(false);
-  if (export_pin == MDS_RANK_NONE && !update)
+  if (export_pin == MDS_RANK_NONE && !update) {
+    maybe_export_ephemeral_distributed_pin();
     return;
+  }
 
   if (state_test(CInode::STATE_QUEUEDEXPORTPIN))
     return;
@@ -5189,6 +5199,129 @@ void CInode::maybe_export_pin(bool update)
       break;
     }
   }
+}
+
+void CInode::maybe_export_ephemeral_random_pin(bool update)
+{
+  bool export_ephemeral_random_config = mdcache->get_export_ephemeral_random_config();
+
+  //If the config isn't set then return
+  if (!export_ephemeral_random_config)
+    return;
+
+  //Check if it's already ephemerally pinned
+  if (is_export_ephemeral_random_pinned && !update)
+      return;
+
+  if (export_ephemeral_random_config) {
+    double export_ephemeral_random_pin = get_export_ephemeral_random_pin(false);
+    if ((update || export_ephemeral_random_pin >=
+          ceph::util::generate_random_number(0.0, 1.0))
+        && is_export_ephemeral_distributed_pinned == false) {
+
+      dout(10) << "I'm here under ephemeral random because is_export_ephemeral_distributed is" << is_export_ephemeral_distributed_pinned << dendl;
+
+      is_export_ephemeral_random_migrating = true;
+
+      bool queue = false;
+      for (auto& p : dirfrags) {
+        CDir *dir = p.second;
+        if (!dir->is_auth())
+          continue;
+        if (dir->is_subtree_root()) {
+          // set auxsubtree bit or export it
+          if (!dir->state_test(CDir::STATE_AUXSUBTREE) ||
+            mdcache->hash_into_rank_bucket(ino(), mdcache->mds->mdsmap->get_max_mds()) != dir->get_dir_auth().first)
+            queue = true;
+        } else {
+            // create aux subtree or export it
+            queue = true;
+        }
+        if (queue) {
+          if (mdcache->hash_into_rank_bucket(ino(), mdcache->mds->mdsmap->get_max_mds()) == mdcache->mds->get_nodeid())
+            mdcache->ephemeral_pin(ephemeral_pin_inode);
+          state_set(CInode::STATE_QUEUEDEXPORTPIN);
+          mdcache->export_pin_queue.insert(this);
+          break;
+        }
+      }
+      return;
+    }
+  }
+}
+
+void CInode::maybe_export_ephemeral_distributed_pin(bool update)
+{
+  bool export_ephemeral_distributed_config = mdcache->get_export_ephemeral_distributed_config();
+
+  //If both the configs aren't set then return
+  if (!export_ephemeral_distributed_config)
+    return;
+
+  //Check if it's already ephemerally pinned
+  if (is_export_ephemeral_distributed_pinned && !update)
+      return;
+
+  if (export_ephemeral_distributed_config) {
+    CDentry *pdn = get_parent_dn();
+
+    if (!pdn) {
+      return;
+    }
+
+    auto dir = pdn->get_dir();
+
+    if (get_export_ephemeral_distributed_pin() && dir->get_num_head_items()) {
+      for (auto& bound : bounds) {
+        bound->maybe_export_ephemeral_distributed_pin();
+      }
+    }
+
+    else if (update || (dir->get_inode()->get_export_ephemeral_distributed_pin())) {
+      is_export_ephemeral_distributed_migrating = true;
+
+      bool queue = false;
+      for (auto& p : dirfrags) {
+	CDir *dir = p.second;
+	if (!dir->is_auth())
+	  continue;
+	if (dir->is_subtree_root()) {
+	  // set auxsubtree bit or export it
+          if (!dir->state_test(CDir::STATE_AUXSUBTREE) ||
+            mdcache->hash_into_rank_bucket(ino(), mdcache->mds->mdsmap->get_max_mds()) != dir->get_dir_auth().first)
+            queue = true;
+        } else {
+        // create aux subtree or export it
+        queue = true;
+        }
+        if (queue) {
+          dout(10) << "max_mds is" << mdcache->mds->mdsmap->get_max_mds() << "and target mds is:" << mdcache->hash_into_rank_bucket(ino(), mdcache->mds->mdsmap->get_max_mds()) << dendl;
+          if (mdcache->hash_into_rank_bucket(ino(), mdcache->mds->mdsmap->get_max_mds()) == mdcache->mds->get_nodeid()) {
+            mdcache->ephemeral_pin(ephemeral_pin_inode);
+            dout(10) << "Inside if inside the else" << dendl;
+          }
+          state_set(CInode::STATE_QUEUEDEXPORTPIN);
+          mdcache->export_pin_queue.insert(this);
+          break;
+        }
+      }
+      return;
+    }
+  }
+}
+
+void CInode::set_export_ephemeral_random_pin(double probability)
+{
+  ceph_assert(is_dir());
+  ceph_assert(is_projected());
+  get_projected_inode()->export_ephemeral_random_pin = probability;
+}
+
+void CInode::set_export_ephemeral_distributed_pin(bool val)
+{
+  ceph_assert(is_dir());
+  ceph_assert(is_projected());
+  get_projected_inode()->export_ephemeral_distributed_pin = val;
 }
 
 void CInode::set_export_pin(mds_rank_t rank)
@@ -5223,6 +5356,41 @@ mds_rank_t CInode::get_export_pin(bool inherit) const
     in = pdn->get_dir()->inode;
   }
   return MDS_RANK_NONE;
+}
+
+double CInode::get_export_ephemeral_random_pin(bool inherit) const
+{
+  /* An inode that is export pinned may not necessarily be a subtree root, we
+   * need to traverse the parents. A base or system inode cannot be pinned.
+   * N.B. inodes not yet linked into a dir (i.e. anonymous inodes) will not
+   * have a parent yet.
+   */
+  const CInode *in = this;
+  while (true) {
+    if (in->is_system())
+      break;
+    const CDentry *pdn = in->get_parent_dn();
+    if (!pdn)
+      break;
+    // ignore export pin for unlinked directory
+    if (in->get_inode().nlink == 0)
+      break;
+    if (in->get_inode().export_ephemeral_random_pin >= 0)
+      return in->get_inode().export_ephemeral_random_pin;
+
+    if (!inherit)
+      break;
+    in = pdn->get_dir()->inode;
+  }
+  return 0;
+}
+
+bool CInode::get_export_ephemeral_distributed_pin() const
+{
+  if (get_inode().export_ephemeral_distributed_pin)
+    return get_inode().export_ephemeral_distributed_pin;
+  else
+    return false;
 }
 
 bool CInode::is_exportable(mds_rank_t dest) const

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -5474,6 +5474,7 @@ double CInode::get_ephemeral_rand(bool inherit) const
    * have a parent yet.
    */
   const CInode *in = this;
+  double max = mdcache->export_ephemeral_random_max;
   while (true) {
     if (in->is_system())
       break;
@@ -5485,7 +5486,7 @@ double CInode::get_ephemeral_rand(bool inherit) const
       break;
 
     if (in->get_inode().export_ephemeral_random_pin > 0.0)
-      return in->get_inode().export_ephemeral_random_pin;
+      return std::min(in->get_inode().export_ephemeral_random_pin, max);
 
     /* An export_pin overrides only if no closer parent (incl. this one) has a
      * random pin set.

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -835,8 +835,7 @@ CDir *CInode::add_dirfrag(CDir *dir)
     dir->get(CDir::PIN_STICKY);
   }
 
-  maybe_export_pin();
-  maybe_ephemeral_dist();
+  maybe_pin();
 
   return dir;
 }
@@ -4273,9 +4272,20 @@ void CInode::decode_import(bufferlist::const_iterator& p,
 
   _decode_base(p);
 
-  unsigned s;
-  decode(s, p);
-  state_set(STATE_AUTH | (s & MASK_STATE_EXPORTED));
+  {
+    unsigned s;
+    decode(s, p);
+    s &= MASK_STATE_EXPORTED;
+
+    if (s & STATE_RANDEPHEMERALPIN) {
+      set_ephemeral_rand(true);
+    }
+    if (s & STATE_DISTEPHEMERALPIN) {
+      set_ephemeral_dist(true);
+    }
+
+    state_set(STATE_AUTH | s);
+  }
 
   if (is_dirty()) {
     get(PIN_DIRTY);
@@ -5338,7 +5348,7 @@ void CInode::set_ephemeral_rand(bool yes)
   }
 }
 
-void CInode::maybe_ephemeral_rand()
+void CInode::maybe_ephemeral_rand(bool fresh)
 {
   if (!mdcache->get_export_ephemeral_random_config()) {
     dout(15) << __func__ << " config false: cannot ephemeral random pin " << *this << dendl;
@@ -5355,6 +5365,8 @@ void CInode::maybe_ephemeral_rand()
   } else if (state_test(CInode::STATE_RANDEPHEMERALPIN)) {
     dout(10) << __func__ << " already ephemeral random pinned: requeueing " << *this << dendl;
     queue_export_pin(mdcache->hash_into_rank_bucket(ino()));
+    return;
+  } else if (!fresh) {
     return;
   }
 
@@ -5392,6 +5404,34 @@ void CInode::set_export_pin(mds_rank_t rank)
   get_projected_inode()->export_pin = rank;
 }
 
+void CInode::check_pin_policy()
+{
+  const CInode *in = this;
+  mds_rank_t etarget = MDS_RANK_NONE;
+  while (true) {
+    if (in->is_system())
+      break;
+    const CDentry *pdn = in->get_parent_dn();
+    if (!pdn)
+      break;
+    if (in->get_inode().nlink == 0) {
+      // ignore export pin for unlinked directory
+      return;
+    } else if (etarget != MDS_RANK_NONE && in->has_ephemeral_policy()) {
+      return;
+    } else if (in->get_inode().export_pin >= 0) {
+      /* clear any epin policy */
+      set_ephemeral_dist(false);
+      set_ephemeral_rand(false);
+      return;
+    } else if (etarget == MDS_RANK_NONE && in->is_ephemerally_pinned()) {
+      /* If a parent overrides a grandparent ephemeral pin policy with an export pin, we use that export pin instead. */
+      etarget = mdcache->hash_into_rank_bucket(in->ino());
+    }
+    in = pdn->get_dir()->inode;
+  }
+}
+
 mds_rank_t CInode::get_export_pin(bool inherit, bool ephemeral) const
 {
   /* An inode that is export pinned may not necessarily be a subtree root, we
@@ -5410,7 +5450,7 @@ mds_rank_t CInode::get_export_pin(bool inherit, bool ephemeral) const
     if (in->get_inode().nlink == 0) {
       // ignore export pin for unlinked directory
       return MDS_RANK_NONE;
-    } else if (etarget != MDS_RANK_NONE && (in->get_inode().export_ephemeral_random_pin > 0.0 || in->get_inode().export_ephemeral_distributed_pin)) {
+    } else if (etarget != MDS_RANK_NONE && in->has_ephemeral_policy()) {
       return etarget;
     } else if (in->get_inode().export_pin >= 0) {
       return in->get_inode().export_pin;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -273,6 +273,12 @@ ostream& operator<<(ostream& out, const CInode& in)
   if (in.inode.export_pin != MDS_RANK_NONE) {
     out << " export_pin=" << in.inode.export_pin;
   }
+  if (in.state_test(CInode::STATE_DISTEPHEMERALPIN)) {
+    out << " distepin";
+  }
+  if (in.state_test(CInode::STATE_RANDEPHEMERALPIN)) {
+    out << " randepin";
+  }
 
   out << " " << &in;
   out << "]";
@@ -443,19 +449,25 @@ CInode::projected_inode &CInode::project_inode(bool xattr, bool snap)
 void CInode::pop_and_dirty_projected_inode(LogSegment *ls) 
 {
   ceph_assert(!projected_nodes.empty());
-  auto &front = projected_nodes.front();
+  auto& front = projected_nodes.front();
+
   dout(15) << __func__ << " " << front.inode.ino
 	   << " v" << front.inode.version << dendl;
+
   int64_t old_pool = inode.layout.pool_id;
+  bool pin_update = inode.export_pin != front.inode.export_pin;
+  bool dist_update = inode.export_ephemeral_distributed_pin
+                     != front.inode.export_ephemeral_distributed_pin;
 
   mark_dirty(front.inode.version, ls);
-  bool new_export_pin = inode.export_pin != front.inode.export_pin;
-  inode = front.inode;
-  if (new_export_pin)
-    maybe_export_pin(true);
 
-  if (front.inode.version == 1)
-    maybe_export_ephemeral_random_pin();
+  inode = std::move(front.inode);
+
+  if (pin_update)
+    maybe_export_pin(true);
+  if (dist_update)
+    maybe_ephemeral_dist_children(true);
+
   if (inode.is_backtrace_updated())
     mark_dirty_parent(ls, old_pool != inode.layout.pool_id);
 
@@ -824,6 +836,7 @@ CDir *CInode::add_dirfrag(CDir *dir)
   }
 
   maybe_export_pin();
+  maybe_ephemeral_dist();
 
   return dir;
 }
@@ -2009,7 +2022,7 @@ void CInode::decode_lock_iflock(bufferlist::const_iterator& p)
 
 void CInode::encode_lock_ipolicy(bufferlist& bl)
 {
-  ENCODE_START(1, 1, bl);
+  ENCODE_START(2, 1, bl);
   if (inode.is_dir()) {
     encode(inode.version, bl);
     encode(inode.ctime, bl);
@@ -2024,7 +2037,7 @@ void CInode::encode_lock_ipolicy(bufferlist& bl)
 
 void CInode::decode_lock_ipolicy(bufferlist::const_iterator& p)
 {
-  DECODE_START(1, p);
+  DECODE_START(2, p);
   if (inode.is_dir()) {
     decode(inode.version, p);
     utime_t tm;
@@ -2032,13 +2045,19 @@ void CInode::decode_lock_ipolicy(bufferlist::const_iterator& p)
     if (inode.ctime < tm) inode.ctime = tm;
     decode(inode.layout, p);
     decode(inode.quota, p);
-    mds_rank_t old_pin = inode.export_pin;
-    decode(inode.export_pin, p);
-    maybe_export_pin(old_pin != inode.export_pin);
-    bool old_ephemeral_pin = inode.export_ephemeral_distributed_pin;
-    decode(inode.export_ephemeral_distributed_pin, p);
-    maybe_export_ephemeral_distributed_pin(old_ephemeral_pin != inode.export_ephemeral_distributed_pin);
-    decode(inode.export_ephemeral_random_pin, p);
+    {
+      mds_rank_t old_pin = inode.export_pin;
+      decode(inode.export_pin, p);
+      maybe_export_pin(old_pin != inode.export_pin);
+    }
+    if (struct_v >= 2) {
+      {
+        bool old_ephemeral_pin = inode.export_ephemeral_distributed_pin;
+        decode(inode.export_ephemeral_distributed_pin, p);
+        maybe_ephemeral_dist_children(old_ephemeral_pin != inode.export_ephemeral_distributed_pin);
+      }
+      decode(inode.export_ephemeral_random_pin, p);
+    }
   }
   DECODE_FINISH(p);
 }
@@ -5158,32 +5177,21 @@ int64_t CInode::get_backtrace_pool() const
   }
 }
 
-void CInode::maybe_export_pin(bool update)
+void CInode::queue_export_pin(mds_rank_t target)
 {
-  if (!g_conf()->mds_bal_export_pin)
-    return;
-  if (!is_dir() || !is_normal())
-    return;
-
-  mds_rank_t export_pin = get_export_pin(false);
-  if (export_pin == MDS_RANK_NONE && !update) {
-    maybe_export_ephemeral_distributed_pin();
-    return;
-  }
-
   if (state_test(CInode::STATE_QUEUEDEXPORTPIN))
     return;
 
   bool queue = false;
-  for (auto p = dirfrags.begin(); p != dirfrags.end(); p++) {
-    CDir *dir = p->second;
+  for (auto& p : dirfrags) {
+    CDir *dir = p.second;
     if (!dir->is_auth())
       continue;
-    if (export_pin != MDS_RANK_NONE) {
+    if (target != MDS_RANK_NONE) {
       if (dir->is_subtree_root()) {
 	// set auxsubtree bit or export it
 	if (!dir->state_test(CDir::STATE_AUXSUBTREE) ||
-	    export_pin != dir->get_dir_auth().first)
+	    target != dir->get_dir_auth().first)
 	  queue = true;
       } else {
 	// create aux subtree or export it
@@ -5201,123 +5209,176 @@ void CInode::maybe_export_pin(bool update)
   }
 }
 
-void CInode::maybe_export_ephemeral_random_pin(bool update)
+void CInode::maybe_export_pin(bool update)
 {
-  bool export_ephemeral_random_config = mdcache->get_export_ephemeral_random_config();
-
-  //If the config isn't set then return
-  if (!export_ephemeral_random_config)
+  if (!g_conf()->mds_bal_export_pin)
+    return;
+  if (!is_dir() || !is_normal())
     return;
 
-  //Check if it's already ephemerally pinned
-  if (is_export_ephemeral_random_pinned && !update)
-      return;
+  dout(15) << __func__ << " update=" << update << " " << *this << dendl;
 
-  if (export_ephemeral_random_config) {
-    double export_ephemeral_random_pin = get_export_ephemeral_random_pin(false);
-    if ((update || export_ephemeral_random_pin >=
-          ceph::util::generate_random_number(0.0, 1.0))
-        && is_export_ephemeral_distributed_pinned == false) {
+  mds_rank_t export_pin = get_export_pin(false, false);
+  if (export_pin == MDS_RANK_NONE && !update) {
+    return;
+  }
 
-      dout(10) << "I'm here under ephemeral random because is_export_ephemeral_distributed is" << is_export_ephemeral_distributed_pinned << dendl;
+  /* disable ephemeral pins */
+  set_ephemeral_dist(false);
+  set_ephemeral_rand(false);
+  queue_export_pin(export_pin);
+}
 
-      is_export_ephemeral_random_migrating = true;
-
-      bool queue = false;
-      for (auto& p : dirfrags) {
-        CDir *dir = p.second;
-        if (!dir->is_auth())
-          continue;
-        if (dir->is_subtree_root()) {
-          // set auxsubtree bit or export it
-          if (!dir->state_test(CDir::STATE_AUXSUBTREE) ||
-            mdcache->hash_into_rank_bucket(ino(), mdcache->mds->mdsmap->get_max_mds()) != dir->get_dir_auth().first)
-            queue = true;
-        } else {
-            // create aux subtree or export it
-            queue = true;
-        }
-        if (queue) {
-          if (mdcache->hash_into_rank_bucket(ino(), mdcache->mds->mdsmap->get_max_mds()) == mdcache->mds->get_nodeid())
-            mdcache->ephemeral_pin(ephemeral_pin_inode);
-          state_set(CInode::STATE_QUEUEDEXPORTPIN);
-          mdcache->export_pin_queue.insert(this);
-          break;
-        }
-      }
-      return;
+void CInode::set_ephemeral_dist(bool yes)
+{
+  if (yes) {
+    if (!state_test(CInode::STATE_DISTEPHEMERALPIN)) {
+      state_set(CInode::STATE_DISTEPHEMERALPIN);
+      auto p = mdcache->dist_ephemeral_pins.insert(this);
+      ceph_assert(p.second);
+    }
+  } else {
+    /* avoid std::set::erase if unnecessary */
+    if (state_test(CInode::STATE_DISTEPHEMERALPIN)) {
+      dout(10) << "clearing ephemeral distributed pin on " << *this << dendl;
+      state_clear(CInode::STATE_DISTEPHEMERALPIN);
+      auto count = mdcache->dist_ephemeral_pins.erase(this);
+      ceph_assert(count == 1);
+      queue_export_pin(MDS_RANK_NONE);
     }
   }
 }
 
-void CInode::maybe_export_ephemeral_distributed_pin(bool update)
+void CInode::maybe_ephemeral_dist(bool update)
 {
-  bool export_ephemeral_distributed_config = mdcache->get_export_ephemeral_distributed_config();
-
-  //If both the configs aren't set then return
-  if (!export_ephemeral_distributed_config)
+  if (!mdcache->get_export_ephemeral_distributed_config()) {
+    dout(15) << __func__ << " config false: cannot ephemeral distributed pin " << *this << dendl;
+    set_ephemeral_dist(false);
     return;
+  } else if (!is_dir() || !is_normal()) {
+    dout(15) << __func__ << " !dir or !normal: cannot ephemeral distributed pin " << *this << dendl;
+    set_ephemeral_dist(false);
+    return;
+  } else if (get_inode().nlink == 0) {
+    dout(15) << __func__ << " unlinked directory: cannot ephemeral distributed pin " << *this << dendl;
+    set_ephemeral_dist(false);
+    return;
+  } else if (!update && state_test(CInode::STATE_DISTEPHEMERALPIN)) {
+    dout(15) << __func__ << " requeueing already pinned " << *this << dendl;
+    queue_export_pin(mdcache->hash_into_rank_bucket(ino()));
+    return;
+  }
 
-  //Check if it's already ephemerally pinned
-  if (is_export_ephemeral_distributed_pinned && !update)
-      return;
+  dout(15) << __func__ << " update=" << update << " " << *this << dendl;
 
-  if (export_ephemeral_distributed_config) {
-    CDentry *pdn = get_parent_dn();
+  auto dir = get_parent_dir();
+  if (!dir) {
+    return;
+  }
 
-    if (!pdn) {
-      return;
-    }
+  bool pin = dir->get_inode()->get_inode().export_ephemeral_distributed_pin;
+  if (pin) {
+    dout(10) << __func__ << "  ephemeral distributed pinning " << *this << dendl;
+    set_ephemeral_dist(true);
+    queue_export_pin(mdcache->hash_into_rank_bucket(ino()));
+  } else if (update) {
+    set_ephemeral_dist(false);
+    queue_export_pin(MDS_RANK_NONE);
+  }
+}
 
-    auto dir = pdn->get_dir();
+void CInode::maybe_ephemeral_dist_children(bool update)
+{
+  if (!mdcache->get_export_ephemeral_distributed_config()) {
+    dout(15) << __func__ << " config false: cannot ephemeral distributed pin " << *this << dendl;
+    return;
+  } else if (!is_dir() || !is_normal()) {
+    dout(15) << __func__ << " !dir or !normal: cannot ephemeral distributed pin " << *this << dendl;
+    return;
+  } else if (get_inode().nlink == 0) {
+    dout(15) << __func__ << " unlinked directory: cannot ephemeral distributed pin " << *this << dendl;
+    return;
+  }
 
-    if (get_export_ephemeral_distributed_pin() && dir->get_num_head_items()) {
-      for (auto& bound : bounds) {
-        bound->maybe_export_ephemeral_distributed_pin();
+  bool pin = get_inode().export_ephemeral_distributed_pin;
+  /* FIXME: expensive to iterate children when not updating */
+  if (!pin && !update) {
+    return;
+  }
+
+  dout(10) << __func__ << " maybe ephemerally pinning children of " << *this << dendl;
+  for (auto& p : dirfrags) {
+    auto& dir = p.second;
+    for (auto& q : *dir) {
+      auto& dn = q.second;
+      auto&& in = dn->get_linkage()->get_inode();
+      if (in && in->is_dir()) {
+        in->maybe_ephemeral_dist(update);
       }
-    }
-
-    else if (update || (dir->get_inode()->get_export_ephemeral_distributed_pin())) {
-      is_export_ephemeral_distributed_migrating = true;
-
-      bool queue = false;
-      for (auto& p : dirfrags) {
-	CDir *dir = p.second;
-	if (!dir->is_auth())
-	  continue;
-	if (dir->is_subtree_root()) {
-	  // set auxsubtree bit or export it
-          if (!dir->state_test(CDir::STATE_AUXSUBTREE) ||
-            mdcache->hash_into_rank_bucket(ino(), mdcache->mds->mdsmap->get_max_mds()) != dir->get_dir_auth().first)
-            queue = true;
-        } else {
-        // create aux subtree or export it
-        queue = true;
-        }
-        if (queue) {
-          dout(10) << "max_mds is" << mdcache->mds->mdsmap->get_max_mds() << "and target mds is:" << mdcache->hash_into_rank_bucket(ino(), mdcache->mds->mdsmap->get_max_mds()) << dendl;
-          if (mdcache->hash_into_rank_bucket(ino(), mdcache->mds->mdsmap->get_max_mds()) == mdcache->mds->get_nodeid()) {
-            mdcache->ephemeral_pin(ephemeral_pin_inode);
-            dout(10) << "Inside if inside the else" << dendl;
-          }
-          state_set(CInode::STATE_QUEUEDEXPORTPIN);
-          mdcache->export_pin_queue.insert(this);
-          break;
-        }
-      }
-      return;
     }
   }
 }
 
-void CInode::set_export_ephemeral_random_pin(double probability)
+void CInode::set_ephemeral_rand(bool yes)
+{
+  if (yes) {
+    if (!state_test(CInode::STATE_RANDEPHEMERALPIN)) {
+      state_set(CInode::STATE_RANDEPHEMERALPIN);
+      auto p = mdcache->rand_ephemeral_pins.insert(this);
+      ceph_assert(p.second);
+    }
+  } else {
+    if (state_test(CInode::STATE_RANDEPHEMERALPIN)) {
+      dout(10) << "clearing ephemeral random pin on " << *this << dendl;
+      state_clear(CInode::STATE_RANDEPHEMERALPIN);
+      auto count = mdcache->rand_ephemeral_pins.erase(this);
+      ceph_assert(count == 1);
+      queue_export_pin(MDS_RANK_NONE);
+    }
+  }
+}
+
+void CInode::maybe_ephemeral_rand()
+{
+  if (!mdcache->get_export_ephemeral_random_config()) {
+    dout(15) << __func__ << " config false: cannot ephemeral random pin " << *this << dendl;
+    set_ephemeral_rand(false);
+    return;
+  } else if (!is_dir() || !is_normal()) {
+    dout(15) << __func__ << " !dir or !normal: cannot ephemeral random pin " << *this << dendl;
+    set_ephemeral_rand(false);
+    return;
+  } else if (get_inode().nlink == 0) {
+    dout(15) << __func__ << " unlinked directory: cannot ephemeral random pin " << *this << dendl;
+    set_ephemeral_rand(false);
+    return;
+  } else if (state_test(CInode::STATE_RANDEPHEMERALPIN)) {
+    dout(10) << __func__ << " already ephemeral random pinned: requeueing " << *this << dendl;
+    queue_export_pin(mdcache->hash_into_rank_bucket(ino()));
+    return;
+  }
+
+  double threshold = get_ephemeral_rand();
+  double n = ceph::util::generate_random_number(0.0, 1.0);
+
+  dout(15) << __func__ << " rand " << n << " <?= " << threshold
+           << " " << *this << dendl;
+
+  if (n <= threshold) {
+    dout(10) << __func__ << " randomly export pinning " << *this << dendl;
+    set_ephemeral_rand(true);
+    queue_export_pin(mdcache->hash_into_rank_bucket(ino()));
+  }
+}
+
+void CInode::setxattr_ephemeral_rand(double probability)
 {
   ceph_assert(is_dir());
   ceph_assert(is_projected());
   get_projected_inode()->export_ephemeral_random_pin = probability;
 }
 
-void CInode::set_export_ephemeral_distributed_pin(bool val)
+void CInode::setxattr_ephemeral_dist(bool val)
 {
   ceph_assert(is_dir());
   ceph_assert(is_projected());
@@ -5331,7 +5392,7 @@ void CInode::set_export_pin(mds_rank_t rank)
   get_projected_inode()->export_pin = rank;
 }
 
-mds_rank_t CInode::get_export_pin(bool inherit) const
+mds_rank_t CInode::get_export_pin(bool inherit, bool ephemeral) const
 {
   /* An inode that is export pinned may not necessarily be a subtree root, we
    * need to traverse the parents. A base or system inode cannot be pinned.
@@ -5339,30 +5400,37 @@ mds_rank_t CInode::get_export_pin(bool inherit) const
    * have a parent yet.
    */
   const CInode *in = this;
+  mds_rank_t etarget = MDS_RANK_NONE;
   while (true) {
     if (in->is_system())
       break;
     const CDentry *pdn = in->get_parent_dn();
     if (!pdn)
       break;
-    // ignore export pin for unlinked directory
-    if (in->get_inode().nlink == 0)
-      break;
-    if (in->get_inode().export_pin >= 0)
+    if (in->get_inode().nlink == 0) {
+      // ignore export pin for unlinked directory
+      return MDS_RANK_NONE;
+    } else if (etarget != MDS_RANK_NONE && (in->get_inode().export_ephemeral_random_pin > 0.0 || in->get_inode().export_ephemeral_distributed_pin)) {
+      return etarget;
+    } else if (in->get_inode().export_pin >= 0) {
       return in->get_inode().export_pin;
+    } else if (etarget == MDS_RANK_NONE && ephemeral && in->is_ephemerally_pinned()) {
+      /* If a parent overrides a grandparent ephemeral pin policy with an export pin, we use that export pin instead. */
+      etarget = mdcache->hash_into_rank_bucket(in->ino());
+      if (!inherit) return etarget;
+    }
 
-    if (!inherit)
+    if (!inherit) {
       break;
+    }
     in = pdn->get_dir()->inode;
   }
   return MDS_RANK_NONE;
 }
 
-double CInode::get_export_ephemeral_random_pin(bool inherit) const
+double CInode::get_ephemeral_rand(bool inherit) const
 {
-  /* An inode that is export pinned may not necessarily be a subtree root, we
-   * need to traverse the parents. A base or system inode cannot be pinned.
-   * N.B. inodes not yet linked into a dir (i.e. anonymous inodes) will not
+  /* N.B. inodes not yet linked into a dir (i.e. anonymous inodes) will not
    * have a parent yet.
    */
   const CInode *in = this;
@@ -5375,22 +5443,21 @@ double CInode::get_export_ephemeral_random_pin(bool inherit) const
     // ignore export pin for unlinked directory
     if (in->get_inode().nlink == 0)
       break;
-    if (in->get_inode().export_ephemeral_random_pin >= 0)
+
+    if (in->get_inode().export_ephemeral_random_pin > 0.0)
       return in->get_inode().export_ephemeral_random_pin;
+
+    /* An export_pin overrides only if no closer parent (incl. this one) has a
+     * random pin set.
+     */
+    if (in->get_inode().export_pin >= 0)
+      return 0.0;
 
     if (!inherit)
       break;
     in = pdn->get_dir()->inode;
   }
-  return 0;
-}
-
-bool CInode::get_export_ephemeral_distributed_pin() const
-{
-  if (get_inode().export_ephemeral_distributed_pin)
-    return get_inode().export_ephemeral_distributed_pin;
-  else
-    return false;
+  return 0.0;
 }
 
 bool CInode::is_exportable(mds_rank_t dest) const

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -358,6 +358,22 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
   std::map<int, std::unique_ptr<BatchOp>> batch_ops;
 
+  bool is_export_ephemeral_distributed_pinned = false;
+  bool is_export_ephemeral_random_pinned = false;
+
+  bool is_export_ephemeral_distributed_migrating = false;
+  bool is_export_ephemeral_random_migrating = false;
+
+  void finish_export_ephemeral_distributed_migration() {
+    is_export_ephemeral_distributed_migrating = false;
+    is_export_ephemeral_distributed_pinned = true;
+  }
+
+  void finish_export_ephemeral_random_migration() {
+    is_export_ephemeral_random_migrating = false;
+    is_export_ephemeral_random_pinned = true;
+  }
+
   std::string_view pin_name(int p) const override;
 
   ostream& print_db_line_prefix(ostream& out) override;
@@ -906,8 +922,14 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   }
 
   void maybe_export_pin(bool update=false);
+  void maybe_export_ephemeral_random_pin(bool update=false);
+  void maybe_export_ephemeral_distributed_pin(bool update=false);
   void set_export_pin(mds_rank_t rank);
+  void set_export_ephemeral_random_pin(double probablitiy=0);
+  void set_export_ephemeral_distributed_pin(bool val=false);
   mds_rank_t get_export_pin(bool inherit=true) const;
+  double get_export_ephemeral_random_pin(bool inherit=true) const;
+  bool get_export_ephemeral_distributed_pin() const;
   bool is_exportable(mds_rank_t dest) const;
 
   void print(ostream& out) override;
@@ -947,6 +969,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
   // list item node for when we have unpropagated rstat data
   elist<CInode*>::item dirty_rstat_item;
+
+  elist<CInode*>::item ephemeral_pin_inode;
 
   mempool::mds_co::set<client_t> client_snap_caps;
   mempool::mds_co::compact_map<snapid_t, mempool::mds_co::set<client_t> > client_need_snapflush;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -327,11 +327,24 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static const int STATE_ORPHAN =	STATE_NOTIFYREF;
 
   static const int MASK_STATE_EXPORTED =
-    (STATE_DIRTY|STATE_NEEDSRECOVER|STATE_DIRTYPARENT|STATE_DIRTYPOOL);
+    (STATE_DIRTY|STATE_NEEDSRECOVER|STATE_DIRTYPARENT|STATE_DIRTYPOOL|
+    STATE_DISTEPHEMERALPIN|STATE_RANDEPHEMERALPIN);
   static const int MASK_STATE_EXPORT_KEPT =
     (STATE_FROZEN|STATE_AMBIGUOUSAUTH|STATE_EXPORTINGCAPS|
      STATE_QUEUEDEXPORTPIN|STATE_TRACKEDBYOFT|STATE_DELAYEDEXPORTPIN|
      STATE_DISTEPHEMERALPIN|STATE_RANDEPHEMERALPIN);
+
+  /* These are for "permanent" state markers that are passed around between
+   * MDS. Nothing protects/updates it like a typical MDS lock.
+   *
+   * Currently, we just use this for REPLICATED inodes. The reason we need to
+   * replicate the random epin state is because the directory inode is still
+   * under the authority of the parent subtree. So it's not exported normally
+   * and we can't pass around the state that way. The importer of the dirfrags
+   * still needs to know that the inode is random pinned though otherwise it
+   * doesn't know that the dirfrags are pinned.
+   */
+  static const int MASK_STATE_REPLICATED = STATE_RANDEPHEMERALPIN;
 
   // -- waiters --
   static const uint64_t WAIT_DIR         = (1<<0);
@@ -913,6 +926,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   void queue_export_pin(mds_rank_t target);
   void maybe_export_pin(bool update=false);
 
+  void check_pin_policy();
+
   void set_ephemeral_dist(bool yes);
   void maybe_ephemeral_dist(bool update=false);
   void maybe_ephemeral_dist_children(bool update=false);
@@ -923,17 +938,27 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
   double get_ephemeral_rand(bool inherit=true) const;
   void set_ephemeral_rand(bool yes);
-  void maybe_ephemeral_rand();
+  void maybe_ephemeral_rand(bool fresh=false);
   void setxattr_ephemeral_rand(double prob=0.0);
   bool is_ephemeral_rand() const {
     return state_test(STATE_RANDEPHEMERALPIN);
   }
 
+  bool has_ephemeral_policy() const {
+    return get_inode().export_ephemeral_random_pin > 0.0 ||
+           get_inode().export_ephemeral_distributed_pin;
+  }
   bool is_ephemerally_pinned() const {
     return state_test(STATE_DISTEPHEMERALPIN) ||
            state_test(STATE_RANDEPHEMERALPIN);
   }
   bool is_exportable(mds_rank_t dest) const;
+
+  void maybe_pin() {
+    maybe_export_pin();
+    maybe_ephemeral_dist();
+    maybe_ephemeral_rand();
+  }
 
   void print(ostream& out) override;
   void dump(Formatter *f, int flags = DUMP_DEFAULT) const;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -321,6 +321,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static const int STATE_QUEUEDEXPORTPIN	= (1<<17);
   static const int STATE_TRACKEDBYOFT		= (1<<18);  // tracked by open file table
   static const int STATE_DELAYEDEXPORTPIN	= (1<<19);
+  static const int STATE_DISTEPHEMERALPIN       = (1<<20);
+  static const int STATE_RANDEPHEMERALPIN       = (1<<21);
   // orphan inode needs notification of releasing reference
   static const int STATE_ORPHAN =	STATE_NOTIFYREF;
 
@@ -328,7 +330,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     (STATE_DIRTY|STATE_NEEDSRECOVER|STATE_DIRTYPARENT|STATE_DIRTYPOOL);
   static const int MASK_STATE_EXPORT_KEPT =
     (STATE_FROZEN|STATE_AMBIGUOUSAUTH|STATE_EXPORTINGCAPS|
-     STATE_QUEUEDEXPORTPIN|STATE_TRACKEDBYOFT|STATE_DELAYEDEXPORTPIN);
+     STATE_QUEUEDEXPORTPIN|STATE_TRACKEDBYOFT|STATE_DELAYEDEXPORTPIN|
+     STATE_DISTEPHEMERALPIN|STATE_RANDEPHEMERALPIN);
 
   // -- waiters --
   static const uint64_t WAIT_DIR         = (1<<0);
@@ -357,22 +360,6 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   }
 
   std::map<int, std::unique_ptr<BatchOp>> batch_ops;
-
-  bool is_export_ephemeral_distributed_pinned = false;
-  bool is_export_ephemeral_random_pinned = false;
-
-  bool is_export_ephemeral_distributed_migrating = false;
-  bool is_export_ephemeral_random_migrating = false;
-
-  void finish_export_ephemeral_distributed_migration() {
-    is_export_ephemeral_distributed_migrating = false;
-    is_export_ephemeral_distributed_pinned = true;
-  }
-
-  void finish_export_ephemeral_random_migration() {
-    is_export_ephemeral_random_migrating = false;
-    is_export_ephemeral_random_pinned = true;
-  }
 
   std::string_view pin_name(int p) const override;
 
@@ -921,15 +908,31 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     return !projected_parent.empty();
   }
 
-  void maybe_export_pin(bool update=false);
-  void maybe_export_ephemeral_random_pin(bool update=false);
-  void maybe_export_ephemeral_distributed_pin(bool update=false);
+  mds_rank_t get_export_pin(bool inherit=true, bool ephemeral=true) const;
   void set_export_pin(mds_rank_t rank);
-  void set_export_ephemeral_random_pin(double probablitiy=0);
-  void set_export_ephemeral_distributed_pin(bool val=false);
-  mds_rank_t get_export_pin(bool inherit=true) const;
-  double get_export_ephemeral_random_pin(bool inherit=true) const;
-  bool get_export_ephemeral_distributed_pin() const;
+  void queue_export_pin(mds_rank_t target);
+  void maybe_export_pin(bool update=false);
+
+  void set_ephemeral_dist(bool yes);
+  void maybe_ephemeral_dist(bool update=false);
+  void maybe_ephemeral_dist_children(bool update=false);
+  void setxattr_ephemeral_dist(bool val=false);
+  bool is_ephemeral_dist() const {
+    return state_test(STATE_DISTEPHEMERALPIN);
+  }
+
+  double get_ephemeral_rand(bool inherit=true) const;
+  void set_ephemeral_rand(bool yes);
+  void maybe_ephemeral_rand();
+  void setxattr_ephemeral_rand(double prob=0.0);
+  bool is_ephemeral_rand() const {
+    return state_test(STATE_RANDEPHEMERALPIN);
+  }
+
+  bool is_ephemerally_pinned() const {
+    return state_test(STATE_DISTEPHEMERALPIN) ||
+           state_test(STATE_RANDEPHEMERALPIN);
+  }
   bool is_exportable(mds_rank_t dest) const;
 
   void print(ostream& out) override;
@@ -969,8 +972,6 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
   // list item node for when we have unpropagated rstat data
   elist<CInode*>::item dirty_rstat_item;
-
-  elist<CInode*>::item ephemeral_pin_inode;
 
   mempool::mds_co::set<client_t> client_snap_caps;
   mempool::mds_co::compact_map<snapid_t, mempool::mds_co::set<client_t> > client_need_snapflush;

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -129,17 +129,18 @@ void MDBalancer::handle_export_pins(void)
 	  mds->mdcache->try_subtree_merge(dir);
 	}
       } else if (export_pin == mds->get_nodeid()) {
-	if (dir->state_test(CDir::STATE_CREATING) ||
-	    dir->is_frozen() || dir->is_freezing()) {
+        if (dir->state_test(CDir::STATE_AUXSUBTREE)) {
+          ceph_assert(dir->is_subtree_root());
+        } else if (dir->state_test(CDir::STATE_CREATING) ||
+	           dir->is_frozen() || dir->is_freezing()) {
 	  // try again later
 	  remove = false;
 	  continue;
-	}
-	if (!dir->is_subtree_root()) {
+	} else if (!dir->is_subtree_root()) {
 	  dir->state_set(CDir::STATE_AUXSUBTREE);
 	  mds->mdcache->adjust_subtree_auth(dir, mds->get_nodeid());
 	  dout(10) << " create aux subtree on " << *dir << dendl;
-	} else if (!dir->state_test(CDir::STATE_AUXSUBTREE)) {
+	} else {
 	  dout(10) << " set auxsubtree bit on " << *dir << dendl;
 	  dir->state_set(CDir::STATE_AUXSUBTREE);
 	}

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -145,7 +145,12 @@ void MDBalancer::handle_export_pins(void)
 	  dir->state_set(CDir::STATE_AUXSUBTREE);
 	}
       } else {
-	mds->mdcache->migrator->export_dir(dir, export_pin);
+        /* Only export a directory if it's non-empty. An empty directory will
+         * be sent back by the importer.
+         */
+        if (dir->get_num_head_items() > 0) {
+	  mds->mdcache->migrator->export_dir(dir, export_pin);
+        }
 	remove = false;
       }
     }

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -101,13 +101,15 @@ void MDBalancer::handle_export_pins(void)
     ceph_assert(in->is_dir());
     mds_rank_t export_pin = in->get_export_pin(false);
     if (export_pin >= mds->mdsmap->get_max_mds()) {
-      dout(20) << " delay export pin on " << *in << dendl;
+      dout(20) << " delay export_pin=" << export_pin << " on " << *in << dendl;
       in->state_clear(CInode::STATE_QUEUEDEXPORTPIN);
       q.erase(cur);
 
       in->state_set(CInode::STATE_DELAYEDEXPORTPIN);
       mds->mdcache->export_pin_delayed_queue.insert(in);
       continue;
+    } else {
+      dout(20) << " executing export_pin=" << export_pin << " on " << *in << dendl;
     }
 
     bool remove = true;

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -99,14 +99,7 @@ void MDBalancer::handle_export_pins(void)
     auto cur = it++;
     CInode *in = *cur;
     ceph_assert(in->is_dir());
-    mds_rank_t export_pin = MDS_RANK_NONE;
-    // Making sure the ephemeral pin does not override export pin
-    if (in->get_export_pin(false) != MDS_RANK_NONE)
-      export_pin = in->get_export_pin(false);
-    else if (in->is_export_ephemeral_distributed_migrating || in->is_export_ephemeral_random_migrating) {
-      export_pin = mds->mdcache->hash_into_rank_bucket(in->ino(), mds->mdsmap->get_max_mds());
-      dout(10) << "Ephemeral export pin set on" << *in << dendl;
-    }
+    mds_rank_t export_pin = in->get_export_pin(false);
     if (export_pin >= mds->mdsmap->get_max_mds()) {
       dout(20) << " delay export_pin=" << export_pin << " on " << *in << dendl;
       in->state_clear(CInode::STATE_QUEUEDEXPORTPIN);

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -113,8 +113,7 @@ void MDBalancer::handle_export_pins(void)
     }
 
     bool remove = true;
-    auto&& dfls = in->get_dirfrags();
-    for (auto dir : dfls) {
+    for (auto&& dir : in->get_dirfrags()) {
       if (!dir->is_auth())
 	continue;
 

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -49,6 +49,8 @@ public:
    */
   void tick();
 
+  void handle_export_pins(void);
+
   void subtract_export(CDir *ex);
   void add_import(CDir *im);
   void adjust_pop_for_rename(CDir *pdir, CDir *dir, bool inc);
@@ -82,8 +84,6 @@ private:
   //MDSMap is up to date
   void prep_rebalance(int beat);
   int mantle_prep_rebalance();
-
-  void handle_export_pins(void);
 
   mds_load_t get_load();
   int localize_balancer();

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -155,6 +155,7 @@ MDCache::MDCache(MDSRank *m, PurgeQueue &purge_queue_) :
 
   export_ephemeral_distributed_config =  g_conf().get_val<bool>("mds_export_ephemeral_distributed");
   export_ephemeral_random_config =  g_conf().get_val<bool>("mds_export_ephemeral_random");
+  export_ephemeral_random_max = g_conf().get_val<double>("mds_export_ephemeral_random_max");
 
   lru.lru_set_midpoint(g_conf().get_val<double>("mds_cache_mid"));
 
@@ -242,6 +243,9 @@ void MDCache::handle_conf_change(const std::set<std::string>& changed, const MDS
       in->maybe_ephemeral_rand();
     }
     mds->balancer->handle_export_pins();
+  }
+  if (changed.count("mds_export_ephemeral_random_max")) {
+    export_ephemeral_random_max = g_conf().get_val<double>("mds_export_ephemeral_random_max");
   }
   if (changed.count("mds_health_cache_threshold"))
     cache_health_threshold = g_conf().get_val<double>("mds_health_cache_threshold");

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -957,6 +957,11 @@ void MDCache::adjust_subtree_auth(CDir *dir, mds_authority_t auth, bool adjust_p
     }
   }
 
+  if (dir->is_auth()) {
+    /* do this now that we are auth for the CDir */
+    dir->inode->maybe_pin();
+  }
+
   show_subtrees();
 }
 
@@ -10759,7 +10764,7 @@ void MDCache::encode_replica_dentry(CDentry *dn, mds_rank_t to, bufferlist& bl)
 void MDCache::encode_replica_inode(CInode *in, mds_rank_t to, bufferlist& bl,
 			      uint64_t features)
 {
-  ENCODE_START(1, 1, bl);
+  ENCODE_START(2, 1, bl);
   ceph_assert(in->is_auth());
   encode(in->inode.ino, bl);  // bleh, minor assymetry here
   encode(in->last, bl);
@@ -10769,6 +10774,10 @@ void MDCache::encode_replica_inode(CInode *in, mds_rank_t to, bufferlist& bl,
 
   in->_encode_base(bl, features);
   in->_encode_locks_state_for_replica(bl, mds->get_state() < MDSMap::STATE_ACTIVE);
+
+  __u32 state = in->state;
+  encode(state, bl);
+
   ENCODE_FINISH(bl);
 }
 
@@ -10865,7 +10874,7 @@ void MDCache::decode_replica_dentry(CDentry *&dn, bufferlist::const_iterator& p,
 
 void MDCache::decode_replica_inode(CInode *&in, bufferlist::const_iterator& p, CDentry *dn, MDSContext::vec& finished)
 {
-  DECODE_START(1, p);
+  DECODE_START(2, p);
   inodeno_t ino;
   snapid_t last;
   __u32 nonce;
@@ -10899,6 +10908,17 @@ void MDCache::decode_replica_inode(CInode *&in, bufferlist::const_iterator& p, C
     if (!dn->get_linkage()->is_primary() || dn->get_linkage()->get_inode() != in)
       dout(10) << __func__ << " different linkage in dentry " << *dn << dendl;
   }
+
+  if (struct_v >= 2) {
+    __u32 s;
+    decode(s, p);
+    s &= CInode::MASK_STATE_REPLICATED;
+    if (s & CInode::STATE_RANDEPHEMERALPIN) {
+      dout(10) << "replica inode is random ephemeral pinned" << dendl;
+      in->set_ephemeral_rand(true);
+    }
+  }
+
   DECODE_FINISH(p); 
 }
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6736,32 +6736,38 @@ std::pair<bool, uint64_t> MDCache::trim(uint64_t count)
     ++p;
     CInode *diri = dir->get_inode();
     if (dir->is_auth()) {
-      if (!diri->is_auth() && !diri->is_base() &&
-	  dir->get_num_head_items() == 0) {
-	if (dir->state_test(CDir::STATE_EXPORTING) ||
-	    !(mds->is_active() || mds->is_stopping()) ||
-	    dir->is_freezing() || dir->is_frozen())
-	  continue;
+      if (diri->is_auth() && !diri->is_base()) {
+        /* this situation should correspond to an export pin */
+        if (dir->get_num_head_items() == 0 && dir->get_num_ref() == 1) {
+          /* pinned empty subtree, try to drop */
+          if (dir->state_test(CDir::STATE_AUXSUBTREE)) {
+            dout(20) << "trimming empty pinned subtree " << *dir << dendl;
+            dir->state_clear(CDir::STATE_AUXSUBTREE);
+            remove_subtree(dir);
+            diri->close_dirfrag(dir->dirfrag().frag);
+          }
+        }
+      } else if (!diri->is_auth() && !diri->is_base() && dir->get_num_head_items() == 0) {
+        if (dir->state_test(CDir::STATE_EXPORTING) ||
+           !(mds->is_active() || mds->is_stopping()) ||
+           dir->is_freezing() || dir->is_frozen())
+          continue;
 
-	migrator->export_empty_import(dir);
+        migrator->export_empty_import(dir);
         ++trimmed;
       }
-    } else {
-      if (!diri->is_auth()) {
-	if (dir->get_num_ref() > 1)  // only subtree pin
-	  continue;
-	auto&& ls = diri->get_subtree_dirfrags();
-	if (diri->get_num_ref() > (int)ls.size()) // only pinned by subtrees
-	  continue;
+    } else if (!diri->is_auth() && dir->get_num_ref() <= 1) {
+      // only subtree pin
+      auto&& ls = diri->get_subtree_dirfrags();
+      if (diri->get_num_ref() > (int)ls.size()) // only pinned by subtrees
+        continue;
 
-	// don't trim subtree root if its auth MDS is recovering.
-	// This simplify the cache rejoin code.
-	if (dir->is_subtree_root() &&
-	    rejoin_ack_gather.count(dir->get_dir_auth().first))
-	  continue;
-	trim_dirfrag(dir, 0, expiremap);
-        ++trimmed;
-      }
+      // don't trim subtree root if its auth MDS is recovering.
+      // This simplify the cache rejoin code.
+      if (dir->is_subtree_root() && rejoin_ack_gather.count(dir->get_dir_auth().first))
+        continue;
+      trim_dirfrag(dir, 0, expiremap);
+      ++trimmed;
     }
   }
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -140,7 +140,6 @@ MDCache::MDCache(MDSRank *m, PurgeQueue &purge_queue_) :
   filer(m->objecter, m->finisher),
   stray_manager(m, purge_queue_),
   recovery_queue(m),
-  ephemeral_pins(member_offset(CInode, ephemeral_pin_inode)),
   trim_counter(g_conf().get_val<double>("mds_cache_trim_decay_rate"))
 {
   migrator.reset(new Migrator(mds, this));
@@ -217,14 +216,33 @@ MDCache::~MDCache()
 
 void MDCache::handle_conf_change(const std::set<std::string>& changed, const MDSMap& mdsmap)
 {
+  dout(20) << "config changes: " << changed << dendl;
   if (changed.count("mds_cache_memory_limit"))
     cache_memory_limit = g_conf().get_val<Option::size_t>("mds_cache_memory_limit");
   if (changed.count("mds_cache_reservation"))
     cache_reservation = g_conf().get_val<double>("mds_cache_reservation");
-  if (changed.count("mds_export_ephemeral_distributed"))
+  if (changed.count("mds_export_ephemeral_distributed")) {
     export_ephemeral_distributed_config = g_conf().get_val<bool>("mds_export_ephemeral_distributed");
-  if (changed.count("mds_export_ephemeral_random"))
+    dout(10) << "Migrating any ephemeral distributed pinned inodes" << dendl;
+    /* copy to vector to avoid removals during iteration */
+    std::vector<CInode*> migrate;
+    migrate.assign(dist_ephemeral_pins.begin(), dist_ephemeral_pins.end());
+    for (auto& in : migrate) {
+      in->maybe_ephemeral_dist();
+    }
+    mds->balancer->handle_export_pins();
+  }
+  if (changed.count("mds_export_ephemeral_random")) {
     export_ephemeral_random_config = g_conf().get_val<bool>("mds_export_ephemeral_random");
+    dout(10) << "Migrating any ephemeral random pinned inodes" << dendl;
+    /* copy to vector to avoid removals during iteration */
+    std::vector<CInode*> migrate;
+    migrate.assign(rand_ephemeral_pins.begin(), rand_ephemeral_pins.end());
+    for (auto& in : migrate) {
+      in->maybe_ephemeral_rand();
+    }
+    mds->balancer->handle_export_pins();
+  }
   if (changed.count("mds_health_cache_threshold"))
     cache_health_threshold = g_conf().get_val<double>("mds_health_cache_threshold");
   if (changed.count("mds_cache_mid"))
@@ -309,6 +327,8 @@ void MDCache::add_inode(CInode *in)
   if (cache_toofull()) {
     exceeded_size_limit = true;
   }
+
+  in->maybe_ephemeral_dist(false);
 }
 
 void MDCache::remove_inode(CInode *o) 
@@ -331,13 +351,14 @@ void MDCache::remove_inode(CInode *o)
 
   o->item_open_file.remove_myself();
 
-  o->ephemeral_pin_inode.remove_myself();
-
   if (o->state_test(CInode::STATE_QUEUEDEXPORTPIN))
     export_pin_queue.erase(o);
 
   if (o->state_test(CInode::STATE_DELAYEDEXPORTPIN))
     export_pin_delayed_queue.erase(o);
+
+  o->set_ephemeral_dist(false);
+  o->set_ephemeral_rand(false);
 
   // remove from inode map
   if (o->last == CEPH_NOSNAP) {
@@ -846,8 +867,9 @@ MDSCacheObject *MDCache::get_object(const MDSCacheObjectInfo &info)
 /*
  * hashing implementation based on Lamping and Veach's Jump Consistent Hash: https://arxiv.org/pdf/1406.2294.pdf
 */
-mds_rank_t MDCache::hash_into_rank_bucket(inodeno_t ino, mds_rank_t max_mds)
+mds_rank_t MDCache::hash_into_rank_bucket(inodeno_t ino)
 {
+  const mds_rank_t max_mds = mds->mdsmap->get_max_mds();
   uint64_t hash = rjhash64(ino);
   int64_t b = -1, j = 0;
   while (j < max_mds) {
@@ -7819,46 +7841,43 @@ bool MDCache::shutdown_pass()
   trim(UINT64_MAX);
   dout(5) << "lru size now " << lru.lru_get_size() << "/" << bottom_lru.lru_get_size() << dendl;
 
+
+  {
+    dout(10) << "Migrating any ephemerally pinned inodes" << dendl;
+    /* copy to vector to avoid removals during iteration */
+    std::vector<CInode*> migrate;
+    migrate.assign(rand_ephemeral_pins.begin(), rand_ephemeral_pins.end());
+    for (auto& in : migrate) {
+      in->maybe_ephemeral_rand();
+    }
+    migrate.assign(dist_ephemeral_pins.begin(), dist_ephemeral_pins.end());
+    for (auto& in : migrate) {
+      in->maybe_ephemeral_dist();
+    }
+    mds->balancer->handle_export_pins();
+  }
+
   // Export all subtrees to another active (usually rank 0) if not rank 0
   int num_auth_subtree = 0;
-  if (!subtrees.empty() &&
-      mds->get_nodeid() != 0) {
-    dout(7) << "looking for subtrees to export to mds0" << dendl;
+  if (!subtrees.empty() && mds->get_nodeid() != 0) {
+    dout(7) << "looking for subtrees to export" << dendl;
     std::vector<CDir*> ls;
-    for (map<CDir*, set<CDir*> >::iterator it = subtrees.begin();
-         it != subtrees.end();
-         ++it) {
-      CDir *dir = it->first;
-      if (dir->get_inode()->is_mdsdir())
+    for (auto& [dir, bounds] : subtrees) {
+      dout(10) << "  examining " << *dir << " bounds " << bounds << dendl;
+      if (dir->get_inode()->is_mdsdir() || !dir->is_auth())
 	continue;
-      if (dir->is_auth()) {
-	num_auth_subtree++;
-	if (dir->is_frozen() ||
-	    dir->is_freezing() ||
-	    dir->is_ambiguous_dir_auth() ||
-	    dir->state_test(CDir::STATE_EXPORTING))
-	  continue;
-	ls.push_back(dir);
+      num_auth_subtree++;
+      if (dir->is_frozen() ||
+          dir->is_freezing() ||
+          dir->is_ambiguous_dir_auth() ||
+          dir->state_test(CDir::STATE_EXPORTING) ||
+          dir->get_inode()->is_ephemerally_pinned()) {
+        continue;
       }
+      ls.push_back(dir);
     }
 
     migrator->clear_export_queue();
-
-    if (export_ephemeral_random_config ||
-        export_ephemeral_distributed_config) {
-       dout(10) << "Migrating ephemerally pinned inodes due to shutdown" << dendl;
-       elist<CInode*>::iterator it = ephemeral_pins.begin(member_offset(CInode, ephemeral_pin_inode));
-       while (!it.end()) {
-         if ((*it) == NULL || !((*it)->is_auth()))
-           dout(10) << "Inode is not auth to this rank" << dendl;
-         else {
-           dout(10) << "adding inode to export queue" << dendl;
-           (*it)->maybe_export_ephemeral_distributed_pin(true);
-	   (*it)->maybe_export_ephemeral_random_pin(true);
-         }
-         ++it;
-       }
-    }
 
     for (const auto& dir : ls) {
       mds_rank_t dest = dir->get_inode()->authority().first;
@@ -13323,6 +13342,9 @@ void MDCache::handle_mdsmap(const MDSMap &mdsmap, const MDSMap &oldmap) {
   for (auto it = q.begin(); it != q.end(); ) {
     auto *in = *it;
     mds_rank_t export_pin = in->get_export_pin(false);
+    if (in->is_ephemerally_pinned()) {
+      dout(10) << "ephemeral export pin to " << export_pin << " for " << *in << dendl;
+    }
     dout(10) << " delayed export_pin=" << export_pin << " on " << *in 
       << " max_mds=" << mdsmap.get_max_mds() << dendl;
     if (export_pin >= mdsmap.get_max_mds()) {
@@ -13332,28 +13354,20 @@ void MDCache::handle_mdsmap(const MDSMap &mdsmap, const MDSMap &oldmap) {
 
     in->state_clear(CInode::STATE_DELAYEDEXPORTPIN);
     it = q.erase(it);
-    in->maybe_export_pin();
+    in->queue_export_pin(export_pin);
   }
 
-  /* Handle consistent hash ring during cluster resizes */
   if (mdsmap.get_max_mds() != oldmap.get_max_mds()) {
-    dout(10) << "Checking ephemerally pinned directories for re-export due to max_mds change." << dendl;
-    auto it = ephemeral_pins.begin(member_offset(CInode, ephemeral_pin_inode));
-    while (!it.end()) {
-      auto in = *it;
-      ++it;
-      // Migrate if the inodes hash elsewhere
-      if (hash_into_rank_bucket(in->ino(), mdsmap.get_max_mds()) != mds->get_nodeid()) {
-        if (in == NULL || !in->is_auth()) {
-          dout(10) << "Inode is not auth to this rank" << dendl;
-          // ++it; ??? - batrick
-        }
-      } else {
-        dout(10) << "adding inode to export queue" << dendl;
-        in->maybe_export_ephemeral_distributed_pin(true);
-        in->maybe_export_ephemeral_random_pin(true);
-        in->ephemeral_pin_inode.remove_myself();
-      }
+    dout(10) << "Checking ephemerally pinned directories for redistribute due to max_mds change." << dendl;
+    /* copy to vector to avoid removals during iteration */
+    std::vector<CInode*> migrate;
+    migrate.assign(rand_ephemeral_pins.begin(), rand_ephemeral_pins.end());
+    for (auto& in : migrate) {
+      in->maybe_ephemeral_rand();
+    }
+    migrate.assign(dist_ephemeral_pins.begin(), dist_ephemeral_pins.end());
+    for (auto& in : migrate) {
+      in->maybe_ephemeral_dist();
     }
   }
 }

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -1265,14 +1265,16 @@ CDir *MDCache::get_projected_subtree_root(CDir *dir)
 void MDCache::remove_subtree(CDir *dir)
 {
   dout(10) << "remove_subtree " << *dir << dendl;
-  ceph_assert(subtrees.count(dir));
-  ceph_assert(subtrees[dir].empty());
-  subtrees.erase(dir);
+  auto it = subtrees.find(dir);
+  ceph_assert(it != subtrees.end());
+  subtrees.erase(it);
   dir->put(CDir::PIN_SUBTREE);
   if (dir->get_parent_dir()) {
     CDir *p = get_subtree_root(dir->get_parent_dir());
-    ceph_assert(subtrees[p].count(dir));
-    subtrees[p].erase(dir);
+    auto it = subtrees.find(p);
+    ceph_assert(it != subtrees.end());
+    auto count = it->second.erase(dir);
+    ceph_assert(count == 1);
   }
 }
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -2513,11 +2513,7 @@ ESubtreeMap *MDCache::create_subtree_map()
 
   // include all auth subtrees, and their bounds.
   // and a spanning tree to tie it to the root.
-  for (map<CDir*, set<CDir*> >::iterator p = subtrees.begin();
-       p != subtrees.end();
-       ++p) {
-    CDir *dir = p->first;
-
+  for (auto& [dir, bounds] : subtrees) {
     // journal subtree as "ours" if we are
     //   me, -2
     //   me, me
@@ -2533,19 +2529,21 @@ ESubtreeMap *MDCache::create_subtree_map()
       dout(15) << " ambig subtree " << *dir << dendl;
       le->ambiguous_subtrees.insert(dir->dirfrag());
     } else {
-      dout(15) << " subtree " << *dir << dendl;
+      dout(15) << " auth subtree " << *dir << dendl;
     }
 
     dirs_to_add[dir->dirfrag()] = dir;
     le->subtrees[dir->dirfrag()].clear();
 
-
     // bounds
-    for (set<CDir*>::iterator q = p->second.begin();
-	 q != p->second.end();
-	 ++q) {
-      CDir *bound = *q;
-      dout(15) << " subtree bound " << *bound << dendl;
+    size_t nbounds = bounds.size();
+    if (nbounds > 3) {
+      dout(15) << "  subtree has " << nbounds << " bounds" << dendl;
+    }
+    for (auto& bound : bounds) {
+      if (nbounds <= 3) {
+        dout(15) << "  subtree bound " << *bound << dendl;
+      }
       dirs_to_add[bound->dirfrag()] = bound;
       le->subtrees[dir->dirfrag()].push_back(bound->dirfrag());
     }
@@ -2554,18 +2552,18 @@ ESubtreeMap *MDCache::create_subtree_map()
   // apply projected renames
   for (const auto& [diri, renames] : projected_subtree_renames) {
     for (const auto& [olddir, newdir] : renames) {
-      dout(10) << " adjusting for projected rename of " << *diri << " to " << *newdir << dendl;
+      dout(15) << " adjusting for projected rename of " << *diri << " to " << *newdir << dendl;
 
       auto&& dfls = diri->get_dirfrags();
       for (const auto& dir : dfls) {
-	dout(10) << "dirfrag " << dir->dirfrag() << " " << *dir << dendl;
+	dout(15) << "dirfrag " << dir->dirfrag() << " " << *dir << dendl;
 	CDir *oldparent = get_projected_subtree_root(olddir);
-	dout(10) << " old parent " << oldparent->dirfrag() << " " << *oldparent << dendl;
+	dout(15) << " old parent " << oldparent->dirfrag() << " " << *oldparent << dendl;
 	CDir *newparent = get_projected_subtree_root(newdir);
-	dout(10) << " new parent " << newparent->dirfrag() << " " << *newparent << dendl;
+	dout(15) << " new parent " << newparent->dirfrag() << " " << *newparent << dendl;
 
 	if (oldparent == newparent) {
-	  dout(10) << "parent unchanged for " << dir->dirfrag() << " at "
+	  dout(15) << "parent unchanged for " << dir->dirfrag() << " at "
 		   << oldparent->dirfrag() << dendl;
 	  continue;
 	}
@@ -2596,10 +2594,7 @@ ESubtreeMap *MDCache::create_subtree_map()
 	  }
 	  
 	  // see if any old bounds move to the new parent.
-	  for (set<CDir*>::iterator p = subtrees[oldparent].begin();
-	       p != subtrees[oldparent].end();
-	       ++p) {
-	    CDir *bound = *p;
+	  for (auto& bound : subtrees.at(oldparent)) {
 	    if (dir->contains(bound->get_parent_dir()))
 	      _move_subtree_map_bound(bound->dirfrag(), oldparent->dirfrag(), newparent->dirfrag(),
 				      le->subtrees);
@@ -2613,21 +2608,22 @@ ESubtreeMap *MDCache::create_subtree_map()
   // subtrees than needed due to migrations that are just getting
   // started or just completing.  but on replay, the "live" map will
   // be simple and we can do a straight comparison.
-  for (map<dirfrag_t, vector<dirfrag_t> >::iterator p = le->subtrees.begin(); p != le->subtrees.end(); ++p) {
-    if (le->ambiguous_subtrees.count(p->first))
+  for (auto& [frag, bfrags] : le->subtrees) {
+    if (le->ambiguous_subtrees.count(frag))
       continue;
     unsigned i = 0;
-    while (i < p->second.size()) {
-      dirfrag_t b = p->second[i];
+    while (i < bfrags.size()) {
+      dirfrag_t b = bfrags[i];
       if (le->subtrees.count(b) &&
 	  le->ambiguous_subtrees.count(b) == 0) {
-	vector<dirfrag_t>& bb = le->subtrees[b];
-	dout(10) << "simplify: " << p->first << " swallowing " << b << " with bounds " << bb << dendl;
-	for (vector<dirfrag_t>::iterator r = bb.begin(); r != bb.end(); ++r)
-	  p->second.push_back(*r);
+	auto& bb = le->subtrees.at(b);
+	dout(10) << "simplify: " << frag << " swallowing " << b << " with bounds " << bb << dendl;
+	for (auto& r : bb) {
+	  bfrags.push_back(r);
+        }
 	dirs_to_add.erase(b);
 	le->subtrees.erase(b);
-	p->second.erase(p->second.begin() + i);
+	bfrags.erase(bfrags.begin() + i);
       } else {
 	++i;
       }

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -140,6 +140,7 @@ MDCache::MDCache(MDSRank *m, PurgeQueue &purge_queue_) :
   filer(m->objecter, m->finisher),
   stray_manager(m, purge_queue_),
   recovery_queue(m),
+  ephemeral_pins(member_offset(CInode, ephemeral_pin_inode)),
   trim_counter(g_conf().get_val<double>("mds_cache_trim_decay_rate"))
 {
   migrator.reset(new Migrator(mds, this));
@@ -152,6 +153,9 @@ MDCache::MDCache(MDSRank *m, PurgeQueue &purge_queue_) :
   cache_reservation = g_conf().get_val<double>("mds_cache_reservation");
   cache_health_threshold = g_conf().get_val<double>("mds_health_cache_threshold");
   forward_all_requests_to_auth = g_conf().get_val<bool>("mds_forward_all_requests_to_auth");
+
+  export_ephemeral_distributed_config =  g_conf().get_val<bool>("mds_export_ephemeral_distributed");
+  export_ephemeral_random_config =  g_conf().get_val<bool>("mds_export_ephemeral_random");
 
   lru.lru_set_midpoint(g_conf().get_val<double>("mds_cache_mid"));
 
@@ -217,6 +221,10 @@ void MDCache::handle_conf_change(const std::set<std::string>& changed, const MDS
     cache_memory_limit = g_conf().get_val<Option::size_t>("mds_cache_memory_limit");
   if (changed.count("mds_cache_reservation"))
     cache_reservation = g_conf().get_val<double>("mds_cache_reservation");
+  if (changed.count("mds_export_ephemeral_distributed"))
+    export_ephemeral_distributed_config = g_conf().get_val<bool>("mds_export_ephemeral_distributed");
+  if (changed.count("mds_export_ephemeral_random"))
+    export_ephemeral_random_config = g_conf().get_val<bool>("mds_export_ephemeral_random");
   if (changed.count("mds_health_cache_threshold"))
     cache_health_threshold = g_conf().get_val<double>("mds_health_cache_threshold");
   if (changed.count("mds_cache_mid"))
@@ -322,6 +330,8 @@ void MDCache::remove_inode(CInode *o)
   o->clear_scatter_dirty();
 
   o->item_open_file.remove_myself();
+
+  o->ephemeral_pin_inode.remove_myself();
 
   if (o->state_test(CInode::STATE_QUEUEDEXPORTPIN))
     export_pin_queue.erase(o);
@@ -830,6 +840,26 @@ MDSCacheObject *MDCache::get_object(const MDSCacheObjectInfo &info)
 }
 
 
+// ====================================================================
+// consistent hash ring
+
+/*
+ * hashing implementation based on Lamping and Veach's Jump Consistent Hash: https://arxiv.org/pdf/1406.2294.pdf
+*/
+mds_rank_t MDCache::hash_into_rank_bucket(inodeno_t ino, mds_rank_t max_mds)
+{
+  uint64_t hash = rjhash64(ino);
+  int64_t b = -1, j = 0;
+  while (j < max_mds) {
+    b = j;
+    hash = hash*2862933555777941757ULL + 1;
+    j = (b + 1) * (double(1LL << 31) / double((hash >> 33) + 1));
+  }
+  // verify bounds before returning
+  auto result = mds_rank_t(b);
+  ceph_assert(result >= 0 && result < max_mds);
+  return result;
+}
 
 
 // ====================================================================
@@ -7813,6 +7843,23 @@ bool MDCache::shutdown_pass()
     }
 
     migrator->clear_export_queue();
+
+    if (export_ephemeral_random_config ||
+        export_ephemeral_distributed_config) {
+       dout(10) << "Migrating ephemerally pinned inodes due to shutdown" << dendl;
+       elist<CInode*>::iterator it = ephemeral_pins.begin(member_offset(CInode, ephemeral_pin_inode));
+       while (!it.end()) {
+         if ((*it) == NULL || !((*it)->is_auth()))
+           dout(10) << "Inode is not auth to this rank" << dendl;
+         else {
+           dout(10) << "adding inode to export queue" << dendl;
+           (*it)->maybe_export_ephemeral_distributed_pin(true);
+	   (*it)->maybe_export_ephemeral_random_pin(true);
+         }
+         ++it;
+       }
+    }
+
     for (const auto& dir : ls) {
       mds_rank_t dest = dir->get_inode()->authority().first;
       if (dest > 0 && !mds->mdsmap->is_active(dest))
@@ -13270,7 +13317,7 @@ bool MDCache::dump_inode(Formatter *f, uint64_t number) {
   return true;
 }
 
-void MDCache::handle_mdsmap(const MDSMap &mdsmap) {
+void MDCache::handle_mdsmap(const MDSMap &mdsmap, const MDSMap &oldmap) {
   // process export_pin_delayed_queue whenever a new MDSMap received
   auto &q = export_pin_delayed_queue;
   for (auto it = q.begin(); it != q.end(); ) {
@@ -13287,5 +13334,26 @@ void MDCache::handle_mdsmap(const MDSMap &mdsmap) {
     it = q.erase(it);
     in->maybe_export_pin();
   }
-}
 
+  /* Handle consistent hash ring during cluster resizes */
+  if (mdsmap.get_max_mds() != oldmap.get_max_mds()) {
+    dout(10) << "Checking ephemerally pinned directories for re-export due to max_mds change." << dendl;
+    auto it = ephemeral_pins.begin(member_offset(CInode, ephemeral_pin_inode));
+    while (!it.end()) {
+      auto in = *it;
+      ++it;
+      // Migrate if the inodes hash elsewhere
+      if (hash_into_rank_bucket(in->ino(), mdsmap.get_max_mds()) != mds->get_nodeid()) {
+        if (in == NULL || !in->is_auth()) {
+          dout(10) << "Inode is not auth to this rank" << dendl;
+          // ++it; ??? - batrick
+        }
+      } else {
+        dout(10) << "adding inode to export queue" << dendl;
+        in->maybe_export_ephemeral_distributed_pin(true);
+        in->maybe_export_ephemeral_random_pin(true);
+        in->ephemeral_pin_inode.remove_myself();
+      }
+    }
+  }
+}

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -237,7 +237,7 @@ class MDCache {
     stray_manager.eval_stray(dn);
   }
 
-  mds_rank_t hash_into_rank_bucket(inodeno_t ino, mds_rank_t max_mds);
+  mds_rank_t hash_into_rank_bucket(inodeno_t ino);
 
   void maybe_eval_stray(CInode *in, bool delay=false);
   void clear_dirty_bits_for_stray(CInode* diri);
@@ -999,6 +999,8 @@ class MDCache {
   /* Because exports may fail, this set lets us keep track of inodes that need exporting. */
   std::set<CInode *> export_pin_queue;
   std::set<CInode *> export_pin_delayed_queue;
+  std::set<CInode *> rand_ephemeral_pins;
+  std::set<CInode *> dist_ephemeral_pins;
 
   OpenFileTable open_file_table;
 
@@ -1330,8 +1332,6 @@ class MDCache {
   map<dirfrag_t, ufragment> uncommitted_fragments;
 
   map<dirfrag_t,fragment_info_t> fragments;
-
-  elist<CInode*> ephemeral_pins;
 
   DecayCounter trim_counter;
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1004,6 +1004,8 @@ class MDCache {
 
   OpenFileTable open_file_table;
 
+  double export_ephemeral_random_max = 0.0;
+
  protected:
   // track master requests whose slaves haven't acknowledged commit
   struct umaster {

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -217,6 +217,14 @@ class MDCache {
     stray_index = (stray_index+1)%NUM_STRAY;
   }
 
+  bool get_export_ephemeral_distributed_config(void) const {
+    return export_ephemeral_distributed_config;
+  }
+
+  bool get_export_ephemeral_random_config(void) const {
+    return export_ephemeral_random_config;
+  }
+
   /**
    * Call this when you know that a CDentry is ready to be passed
    * on to StrayManager (i.e. this is a stray you've just created)
@@ -228,6 +236,8 @@ class MDCache {
 
     stray_manager.eval_stray(dn);
   }
+
+  mds_rank_t hash_into_rank_bucket(inodeno_t ino, mds_rank_t max_mds);
 
   void maybe_eval_stray(CInode *in, bool delay=false);
   void clear_dirty_bits_for_stray(CInode* diri);
@@ -901,7 +911,7 @@ class MDCache {
   void discard_delayed_expire(CDir *dir);
 
   // -- mdsmap --
-  void handle_mdsmap(const MDSMap &mdsmap);
+  void handle_mdsmap(const MDSMap &mdsmap, const MDSMap &oldmap);
 
   int dump_cache() { return dump_cache({}, nullptr); }
   int dump_cache(std::string_view filename);
@@ -1301,6 +1311,9 @@ class MDCache {
   bool forward_all_requests_to_auth;
   std::array<CInode *, NUM_STRAY> strays{}; // my stray dir
 
+  bool export_ephemeral_distributed_config;
+  bool export_ephemeral_random_config;
+
   // File size recovery
   RecoveryQueue recovery_queue;
 
@@ -1317,6 +1330,8 @@ class MDCache {
   map<dirfrag_t, ufragment> uncommitted_fragments;
 
   map<dirfrag_t,fragment_info_t> fragments;
+
+  elist<CInode*> ephemeral_pins;
 
   DecayCounter trim_counter;
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2865,7 +2865,10 @@ void MDSRank::command_get_subtrees(Formatter *f)
       f->dump_bool("is_auth", dir->is_auth());
       f->dump_int("auth_first", dir->get_dir_auth().first);
       f->dump_int("auth_second", dir->get_dir_auth().second);
-      f->dump_int("export_pin", dir->inode->get_export_pin());
+      f->dump_int("export_pin", dir->inode->get_export_pin(false, false));
+      f->dump_bool("distributed_ephemeral_pin", dir->inode->is_ephemeral_dist());
+      f->dump_bool("random_ephemeral_pin", dir->inode->is_ephemeral_rand());
+      f->dump_int("ephemeral_pin", mdcache->hash_into_rank_bucket(dir->inode->ino()));
       f->open_object_section("dir");
       dir->dump(f);
       f->close_section();
@@ -3521,8 +3524,8 @@ const char** MDSRankDispatcher::get_tracked_conf_keys() const
     "mds_dump_cache_threshold_file",
     "mds_dump_cache_threshold_formatter",
     "mds_enable_op_tracker",
-    "mds_export_ephemeral_random"
-    "mds_export_ephemeral_distributed"
+    "mds_export_ephemeral_random",
+    "mds_export_ephemeral_distributed",
     "mds_health_cache_threshold",
     "mds_inject_migrator_session_race",
     "mds_log_pause",
@@ -3573,6 +3576,8 @@ void MDSRankDispatcher::handle_conf_change(const ConfigProxy& conf, const std::s
 
   finisher->queue(new LambdaContext([this, changed](int) {
     std::scoped_lock lock(mds_lock);
+
+    dout(10) << "flushing conf change to components: " << changed << dendl;
 
     if (changed.count("mds_log_pause") && !g_conf()->mds_log_pause) {
       mdlog->kick_submitter();

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3525,6 +3525,7 @@ const char** MDSRankDispatcher::get_tracked_conf_keys() const
     "mds_dump_cache_threshold_formatter",
     "mds_enable_op_tracker",
     "mds_export_ephemeral_random",
+    "mds_export_ephemeral_random_max",
     "mds_export_ephemeral_distributed",
     "mds_health_cache_threshold",
     "mds_inject_migrator_session_race",

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2399,7 +2399,7 @@ void MDSRankDispatcher::handle_mds_map(
       scrubstack->scrub_abort(c);
     }
   }
-  mdcache->handle_mdsmap(*mdsmap);
+  mdcache->handle_mdsmap(*mdsmap, oldmap);
 }
 
 void MDSRank::handle_mds_recovery(mds_rank_t who)
@@ -3521,6 +3521,8 @@ const char** MDSRankDispatcher::get_tracked_conf_keys() const
     "mds_dump_cache_threshold_file",
     "mds_dump_cache_threshold_formatter",
     "mds_enable_op_tracker",
+    "mds_export_ephemeral_random"
+    "mds_export_ephemeral_distributed"
     "mds_health_cache_threshold",
     "mds_inject_migrator_session_race",
     "mds_log_pause",

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -790,7 +790,7 @@ void Migrator::export_dir(CDir *dir, mds_rank_t dest)
   ceph_assert(dest != mds->get_nodeid());
    
   CDir* parent = dir->inode->get_projected_parent_dir();
-  if (!mds->is_stopping() && !dir->inode->is_exportable(dest)) {
+  if (!mds->is_stopping() && !dir->inode->is_exportable(dest) && dir->get_num_head_items() > 0) {
     dout(7) << "Cannot export to mds." << dest << " " << *dir << ": dir is export pinned" << dendl;
     return;
   } else if (!(mds->is_active() || mds->is_stopping())) {

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -2236,6 +2236,11 @@ void Migrator::export_finish(CDir *dir)
     mut->cleanup();
   }
 
+  if (dir->get_inode()->is_export_ephemeral_distributed_migrating)
+    dir->get_inode()->finish_export_ephemeral_distributed_migration();
+  else if (dir->get_inode()->is_export_ephemeral_random_migrating)
+    dir->get_inode()->finish_export_ephemeral_random_migration();
+
   if (parent)
     child_export_finish(parent, true);
 
@@ -3135,7 +3140,29 @@ void Migrator::import_finish(CDir *dir, bool notify, bool last)
   MutationRef mut = it->second.mut;
   import_state.erase(it);
 
-  mds->mdlog->start_submit_entry(new EImportFinish(dir, true));
+  // start the journal entry
+  EImportFinish *le = new EImportFinish(dir, true);
+  mds->mdlog->start_entry(le);
+
+  CInode *in = dir->get_inode();
+
+  CDentry *pdn = in->get_parent_dn();
+
+  if (in->get_export_ephemeral_random_pin(false)) {    // Lazy checks. FIXME
+    le->metablob.add_primary_dentry(pdn, in, false, false, false, false,
+          false, true);
+    in->is_export_ephemeral_random_pinned = true;
+    cache->ephemeral_pins.push_back(&in->ephemeral_pin_inode);
+  } else if (pdn->get_dir()->get_inode()
+        && pdn->get_dir()->get_inode()->get_export_ephemeral_distributed_pin()) {
+      le->metablob.add_primary_dentry(pdn, in, false, false, false, false,
+          true, false);
+      in->is_export_ephemeral_distributed_pinned = true;
+      cache->ephemeral_pins.push_back(&in->ephemeral_pin_inode);
+  }
+
+  // log it
+  mds->mdlog->submit_entry(le);
 
   // process delayed expires
   cache->process_delayed_expire(dir);
@@ -3175,7 +3202,6 @@ void Migrator::import_finish(CDir *dir, bool notify, bool last)
     export_empty_import(dir);
   }
 }
-
 
 void Migrator::decode_import_inode(CDentry *dn, bufferlist::const_iterator& blp,
 				   mds_rank_t oldauth, LogSegment *ls,

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5603,7 +5603,7 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
 
     client_t exclude_ct = mdr->get_client();
     mdcache->broadcast_quota_to_client(cur, exclude_ct, true);
-  } else if (name.find("ceph.dir.pin") == 0) {
+  } else if (name == "ceph.dir.pin"sv) {
     if (!cur->is_dir() || cur->is_root()) {
       respond_to_request(mdr, -EINVAL);
       return;
@@ -5625,7 +5625,7 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
     auto &pi = cur->project_inode();
     cur->set_export_pin(rank);
     pip = &pi.inode;
-  }  else if (name.find("ceph.dir.pin.random") == 0) {
+  } else if (name == "ceph.dir.pin.random"sv) {
     if (!cur->is_dir() || cur->is_root()) {
       respond_to_request(mdr, -EINVAL);
       return;
@@ -5646,7 +5646,7 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
     auto &pi = cur->project_inode();
     cur->set_export_ephemeral_random_pin(val);
     pip = &pi.inode;
-  } else if (name.find("ceph.dir.pin.distributed") == 0) {
+  } else if (name == "ceph.dir.pin.distributed"sv) {
     if (!cur->is_dir() || cur->is_root()) {
       respond_to_request(mdr, -EINVAL);
       return;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5644,7 +5644,7 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
       return;
 
     auto &pi = cur->project_inode();
-    cur->set_export_ephemeral_random_pin(val);
+    cur->setxattr_ephemeral_rand(val);
     pip = &pi.inode;
   } else if (name == "ceph.dir.pin.distributed"sv) {
     if (!cur->is_dir() || cur->is_root()) {
@@ -5665,9 +5665,8 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
       return;
 
     auto &pi = cur->project_inode();
-    cur->set_export_ephemeral_distributed_pin(val);
+    cur->setxattr_ephemeral_dist(val);
     pip = &pi.inode;
-    dout(10) << "Here is the distrib pin value" << pip->export_ephemeral_distributed_pin << dendl;
   } else {
     dout(10) << " unknown vxattr " << name << dendl;
     respond_to_request(mdr, -EINVAL);
@@ -5972,8 +5971,13 @@ public:
     MDRequestRef null_ref;
     get_mds()->mdcache->send_dentry_link(dn, null_ref);
 
-    if (newi->inode.is_file())
+    if (newi->inode.is_file()) {
       get_mds()->locker->share_inode_max_size(newi);
+    } else if (newi->inode.is_dir()) {
+      // We do this now so that the linkages on the new directory are stable.
+      newi->maybe_ephemeral_dist();
+      newi->maybe_ephemeral_rand();
+    }
 
     // hit pop
     get_mds()->balancer->hit_inode(newi, META_POP_IWR);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5976,7 +5976,7 @@ public:
     } else if (newi->inode.is_dir()) {
       // We do this now so that the linkages on the new directory are stable.
       newi->maybe_ephemeral_dist();
-      newi->maybe_ephemeral_rand();
+      newi->maybe_ephemeral_rand(true);
     }
 
     // hit pop

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5625,6 +5625,49 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
     auto &pi = cur->project_inode();
     cur->set_export_pin(rank);
     pip = &pi.inode;
+  }  else if (name.find("ceph.dir.pin.random") == 0) {
+    if (!cur->is_dir() || cur->is_root()) {
+      respond_to_request(mdr, -EINVAL);
+      return;
+    }
+
+    double val;
+    try {
+      val = boost::lexical_cast<double>(value);
+    } catch (boost::bad_lexical_cast const&) {
+      dout(10) << "bad vxattr value, unable to parse float for " << name << dendl;
+      respond_to_request(mdr, -EINVAL);
+      return;
+    }
+
+    if (!xlock_policylock(mdr, cur))
+      return;
+
+    auto &pi = cur->project_inode();
+    cur->set_export_ephemeral_random_pin(val);
+    pip = &pi.inode;
+  } else if (name.find("ceph.dir.pin.distributed") == 0) {
+    if (!cur->is_dir() || cur->is_root()) {
+      respond_to_request(mdr, -EINVAL);
+      return;
+    }
+
+    bool val;
+    try {
+      val = boost::lexical_cast<bool>(value);
+    } catch (boost::bad_lexical_cast const&) {
+      dout(10) << "bad vxattr value, unable to parse bool for " << name << dendl;
+      respond_to_request(mdr, -EINVAL);
+      return;
+    }
+
+    if (!xlock_policylock(mdr, cur))
+      return;
+
+    auto &pi = cur->project_inode();
+    cur->set_export_ephemeral_distributed_pin(val);
+    pip = &pi.inode;
+    dout(10) << "Here is the distrib pin value" << pip->export_ephemeral_distributed_pin << dendl;
   } else {
     dout(10) << " unknown vxattr " << name << dendl;
     respond_to_request(mdr, -EINVAL);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5640,6 +5640,14 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
       return;
     }
 
+    if (val < 0.0 || 1.0 < val) {
+      respond_to_request(mdr, -EDOM);
+      return;
+    } else if (mdcache->export_ephemeral_random_max < val) {
+      respond_to_request(mdr, -EINVAL);
+      return;
+    }
+
     if (!xlock_policylock(mdr, cur))
       return;
 

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -65,6 +65,8 @@ public:
     static const int STATE_DIRTYPARENT = (1<<1);
     static const int STATE_DIRTYPOOL   = (1<<2);
     static const int STATE_NEED_SNAPFLUSH = (1<<3);
+    static const int STATE_EPHEMERAL_DISTRIBUTED = (1<<4);
+    static const int STATE_EPHEMERAL_RANDOM = (1<<5);
     std::string  dn;         // dentry
     snapid_t dnfirst, dnlast;
     version_t dnv{0};
@@ -111,6 +113,8 @@ public:
     bool is_dirty_parent() const { return (state & STATE_DIRTYPARENT); }
     bool is_dirty_pool() const { return (state & STATE_DIRTYPOOL); }
     bool need_snapflush() const { return (state & STATE_NEED_SNAPFLUSH); }
+    bool is_export_ephemeral_distributed() const { return (state & STATE_EPHEMERAL_DISTRIBUTED); }
+    bool is_export_ephemeral_random() const { return (state & STATE_EPHEMERAL_RANDOM); }
 
     void print(ostream& out) const {
       out << " fullbit dn " << dn << " [" << dnfirst << "," << dnlast << "] dnv " << dnv
@@ -434,12 +438,15 @@ private:
   // return remote pointer to to-be-journaled inode
   void add_primary_dentry(CDentry *dn, CInode *in, bool dirty,
 			  bool dirty_parent=false, bool dirty_pool=false,
-			  bool need_snapflush=false) {
+			  bool need_snapflush=false, bool export_ephemeral_distributed=false,
+			  bool export_ephemeral_random=false) {
     __u8 state = 0;
     if (dirty) state |= fullbit::STATE_DIRTY;
     if (dirty_parent) state |= fullbit::STATE_DIRTYPARENT;
     if (dirty_pool) state |= fullbit::STATE_DIRTYPOOL;
     if (need_snapflush) state |= fullbit::STATE_NEED_SNAPFLUSH;
+    if (export_ephemeral_distributed) state |= fullbit::STATE_EPHEMERAL_DISTRIBUTED;
+    if (export_ephemeral_random) state |= fullbit::STATE_EPHEMERAL_RANDOM;
     add_primary_dentry(add_dir(dn->get_dir(), false), dn, in, state);
   }
   void add_primary_dentry(dirlump& lump, CDentry *dn, CInode *in, __u8 state) {

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -65,8 +65,7 @@ public:
     static const int STATE_DIRTYPARENT = (1<<1);
     static const int STATE_DIRTYPOOL   = (1<<2);
     static const int STATE_NEED_SNAPFLUSH = (1<<3);
-    static const int STATE_EPHEMERAL_DISTRIBUTED = (1<<4);
-    static const int STATE_EPHEMERAL_RANDOM = (1<<5);
+    static const int STATE_EPHEMERAL_RANDOM = (1<<4);
     std::string  dn;         // dentry
     snapid_t dnfirst, dnlast;
     version_t dnv{0};
@@ -113,7 +112,6 @@ public:
     bool is_dirty_parent() const { return (state & STATE_DIRTYPARENT); }
     bool is_dirty_pool() const { return (state & STATE_DIRTYPOOL); }
     bool need_snapflush() const { return (state & STATE_NEED_SNAPFLUSH); }
-    bool is_export_ephemeral_distributed() const { return (state & STATE_EPHEMERAL_DISTRIBUTED); }
     bool is_export_ephemeral_random() const { return (state & STATE_EPHEMERAL_RANDOM); }
 
     void print(ostream& out) const {
@@ -438,20 +436,21 @@ private:
   // return remote pointer to to-be-journaled inode
   void add_primary_dentry(CDentry *dn, CInode *in, bool dirty,
 			  bool dirty_parent=false, bool dirty_pool=false,
-			  bool need_snapflush=false, bool export_ephemeral_distributed=false,
-			  bool export_ephemeral_random=false) {
+			  bool need_snapflush=false) {
     __u8 state = 0;
     if (dirty) state |= fullbit::STATE_DIRTY;
     if (dirty_parent) state |= fullbit::STATE_DIRTYPARENT;
     if (dirty_pool) state |= fullbit::STATE_DIRTYPOOL;
     if (need_snapflush) state |= fullbit::STATE_NEED_SNAPFLUSH;
-    if (export_ephemeral_distributed) state |= fullbit::STATE_EPHEMERAL_DISTRIBUTED;
-    if (export_ephemeral_random) state |= fullbit::STATE_EPHEMERAL_RANDOM;
     add_primary_dentry(add_dir(dn->get_dir(), false), dn, in, state);
   }
   void add_primary_dentry(dirlump& lump, CDentry *dn, CInode *in, __u8 state) {
     if (!in) 
       in = dn->get_projected_linkage()->get_inode();
+
+    if (in->is_ephemeral_rand()) {
+      state |= fullbit::STATE_EPHEMERAL_RANDOM;
+    }
 
     // make note of where this inode was last journaled
     in->last_journaled = event_seq;

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -530,7 +530,7 @@ void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
     if (is_export_ephemeral_random()) {
       dout(15) << "random ephemeral pin on " << *in << dendl;
       in->set_ephemeral_rand(true);
-      in->maybe_ephemeral_rand();
+      in->maybe_ephemeral_rand(true);
     }
     in->maybe_ephemeral_dist();
     in->maybe_export_pin();

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -526,6 +526,11 @@ void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
 {
   in->inode = inode;
   in->xattrs = xattrs;
+  if (in->inode.is_dir()) {
+    in->is_export_ephemeral_distributed_pinned = is_export_ephemeral_distributed();
+    in->is_export_ephemeral_random_pinned = is_export_ephemeral_random();
+    dout(10) << "I'm in update_inode inside journal.cc and is_export_ephemeral_distrib for inode " << *in << "is" << in->is_export_ephemeral_distributed_pinned << dendl;
+  }
   in->maybe_export_pin();
   if (in->inode.is_dir()) {
     if (!(in->dirfragtree == dirfragtree)) {

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -527,12 +527,13 @@ void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
   in->inode = inode;
   in->xattrs = xattrs;
   if (in->inode.is_dir()) {
-    in->is_export_ephemeral_distributed_pinned = is_export_ephemeral_distributed();
-    in->is_export_ephemeral_random_pinned = is_export_ephemeral_random();
-    dout(10) << "I'm in update_inode inside journal.cc and is_export_ephemeral_distrib for inode " << *in << "is" << in->is_export_ephemeral_distributed_pinned << dendl;
-  }
-  in->maybe_export_pin();
-  if (in->inode.is_dir()) {
+    if (is_export_ephemeral_random()) {
+      dout(15) << "random ephemeral pin on " << *in << dendl;
+      in->set_ephemeral_rand(true);
+      in->maybe_ephemeral_rand();
+    }
+    in->maybe_ephemeral_dist();
+    in->maybe_export_pin();
     if (!(in->dirfragtree == dirfragtree)) {
       dout(10) << "EMetaBlob::fullbit::update_inode dft " << in->dirfragtree << " -> "
 	       << dirfragtree << " on " << *in << dendl;

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -586,6 +586,9 @@ struct inode_t {
 
   mds_rank_t export_pin = MDS_RANK_NONE;
 
+  double export_ephemeral_random_pin = 0;
+  bool export_ephemeral_distributed_pin = false;
+
   // special stuff
   version_t version = 0;           // auth only
   version_t file_data_version = 0; // auth only
@@ -608,7 +611,7 @@ private:
 template<template<typename> class Allocator>
 void inode_t<Allocator>::encode(bufferlist &bl, uint64_t features) const
 {
-  ENCODE_START(15, 6, bl);
+  ENCODE_START(16, 6, bl);
 
   encode(ino, bl);
   encode(rdev, bl);
@@ -660,13 +663,16 @@ void inode_t<Allocator>::encode(bufferlist &bl, uint64_t features) const
 
   encode(export_pin, bl);
 
+  encode(export_ephemeral_random_pin, bl);
+  encode(export_ephemeral_distributed_pin, bl);
+
   ENCODE_FINISH(bl);
 }
 
 template<template<typename> class Allocator>
 void inode_t<Allocator>::decode(bufferlist::const_iterator &p)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(15, 6, 6, p);
+  DECODE_START_LEGACY_COMPAT_LEN(16, 6, 6, p);
 
   decode(ino, p);
   decode(rdev, p);
@@ -757,6 +763,14 @@ void inode_t<Allocator>::decode(bufferlist::const_iterator &p)
     export_pin = MDS_RANK_NONE;
   }
 
+  if (struct_v >= 16) {
+    decode(export_ephemeral_random_pin, p);
+    decode(export_ephemeral_distributed_pin, p);
+  } else {
+    export_ephemeral_random_pin = 0;
+    export_ephemeral_distributed_pin = false;
+  }
+
   DECODE_FINISH(p);
 }
 
@@ -794,6 +808,8 @@ void inode_t<Allocator>::dump(Formatter *f) const
   f->dump_unsigned("time_warp_seq", time_warp_seq);
   f->dump_unsigned("change_attr", change_attr);
   f->dump_int("export_pin", export_pin);
+  f->dump_int("export_ephemeral_random_pin", export_ephemeral_random_pin);
+  f->dump_int("export_ephemeral_distributed_pin", export_ephemeral_distributed_pin);
 
   f->open_array_section("client_ranges");
   for (const auto &p : client_ranges) {

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -809,7 +809,7 @@ void inode_t<Allocator>::dump(Formatter *f) const
   f->dump_unsigned("change_attr", change_attr);
   f->dump_int("export_pin", export_pin);
   f->dump_int("export_ephemeral_random_pin", export_ephemeral_random_pin);
-  f->dump_int("export_ephemeral_distributed_pin", export_ephemeral_distributed_pin);
+  f->dump_bool("export_ephemeral_distributed_pin", export_ephemeral_distributed_pin);
 
   f->open_array_section("client_ranges");
   for (const auto &p : client_ranges) {

--- a/src/pybind/mgr/volumes/fs/operations/group.py
+++ b/src/pybind/mgr/volumes/fs/operations/group.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 import cephfs
 
 from .snapshot_util import mksnap, rmsnap
+from .pin_util import pin
 from .template import GroupTemplate
 from ..fs_util import listdir, get_ancestor_xattr
 from ..exception import VolumeException
@@ -60,6 +61,9 @@ class Group(GroupTemplate):
             if ve.errno == -errno.ENOENT and self.is_default_group():
                 return []
             raise
+
+    def pin(self, pin_type, pin_setting):
+        return pin(self.fs, self.path, pin_type, pin_setting)
 
     def create_snapshot(self, snapname):
         snappath = os.path.join(self.path,

--- a/src/pybind/mgr/volumes/fs/operations/pin_util.py
+++ b/src/pybind/mgr/volumes/fs/operations/pin_util.py
@@ -1,0 +1,34 @@
+import os
+import errno
+
+import cephfs
+
+from ..exception import VolumeException
+from distutils.util import strtobool
+
+_pin_value = {
+    "export": lambda x: int(x),
+    "distributed": lambda x: int(strtobool(x)),
+    "random": lambda x: float(x),
+}
+_pin_xattr = {
+    "export": "ceph.dir.pin",
+    "distributed": "ceph.dir.pin.distributed",
+    "random": "ceph.dir.pin.random",
+}
+
+def pin(fs, path, pin_type, pin_setting):
+    """
+    Set a pin on a directory.
+    """
+    assert pin_type in _pin_xattr
+
+    try:
+        pin_setting = _pin_value[pin_type](pin_setting)
+    except ValueError as e:
+        raise VolumeException(-errno.EINVAL, f"pin value wrong type: {pin_setting}")
+
+    try:
+        fs.setxattr(path, _pin_xattr[pin_type], str(pin_setting).encode('utf-8'), 0)
+    except cephfs.Error as e:
+        raise VolumeException(-e.args[0], e.args[1])

--- a/src/pybind/mgr/volumes/fs/operations/template.py
+++ b/src/pybind/mgr/volumes/fs/operations/template.py
@@ -95,6 +95,16 @@ class SubvolumeTemplate(object):
         """
         raise VolumeException(-errno.ENOTSUP, "operation not supported.")
 
+    def pin(self, pin_type, pin_setting):
+        """
+        pin a subvolume
+
+        :param pin_type: type of pin
+        :param pin_setting: setting for pin
+        :return: None
+        """
+        raise VolumeException(-errno.ENOTSUP, "operation not supported.")
+
     def create_snapshot(self, snapname):
         """
         snapshot a subvolume.

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
@@ -6,6 +6,7 @@ from hashlib import md5
 
 import cephfs
 
+from ..pin_util import pin
 from .metadata_manager import MetadataManager
 from ..trash import create_trashcan, open_trashcan
 from ...fs_util import get_ancestor_xattr
@@ -194,6 +195,9 @@ class SubvolumeBase(object):
             except cephfs.Error as e:
                 raise VolumeException(-e.args[0], "Cannot set new size for the subvolume. '{0}'".format(e.args[1]))
         return newsize, subvolstat.st_size
+
+    def pin(self, pin_type, pin_setting):
+        return pin(self.fs, self.base_path, pin_type, pin_setting)
 
     def init_config(self, version, subvolume_type, subvolume_path, subvolume_state):
         self.metadata_mgr.init(version, subvolume_type, subvolume_path, subvolume_state)

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -203,6 +203,24 @@ class VolumeClient(object):
             ret = self.volume_exception_to_retval(ve)
         return ret
 
+    def subvolume_pin(self, **kwargs):
+        ret         = 0, "", ""
+        volname     = kwargs['vol_name']
+        subvolname  = kwargs['sub_name']
+        pin_type    = kwargs['pin_type']
+        pin_setting = kwargs['pin_setting']
+        groupname   = kwargs['group_name']
+
+        try:
+            with open_volume(self, volname) as fs_handle:
+                with open_group(fs_handle, self.volspec, groupname) as group:
+                    with open_subvol(fs_handle, self.volspec, group, subvolname) as subvolume:
+                        subvolume.pin(pin_type, pin_setting)
+                        ret = 0, json.dumps({}), ""
+        except VolumeException as ve:
+            ret = self.volume_exception_to_retval(ve)
+        return ret
+
     def subvolume_getpath(self, **kwargs):
         ret        = None
         volname    = kwargs['vol_name']
@@ -500,6 +518,22 @@ class VolumeClient(object):
         except VolumeException as ve:
             if not ve.errno == -errno.ENOENT:
                 ret = self.volume_exception_to_retval(ve)
+        return ret
+
+    def pin_subvolume_group(self, **kwargs):
+        ret           = 0, "", ""
+        volname       = kwargs['vol_name']
+        groupname     = kwargs['group_name']
+        pin_type      = kwargs['pin_type']
+        pin_setting   = kwargs['pin_setting']
+
+        try:
+            with open_volume(self, volname) as fs_handle:
+                with open_group(fs_handle, self.volspec, groupname) as group:
+                    group.pin(pin_type, pin_setting)
+                    ret = 0, json.dumps({}), ""
+        except VolumeException as ve:
+            ret = self.volume_exception_to_retval(ve)
         return ret
 
     ### group snapshot

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -113,6 +113,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'perm': 'r'
         },
         {
+            'cmd': 'fs subvolumegroup pin'
+                   ' name=vol_name,type=CephString'
+                   ' name=group_name,type=CephString,req=true'
+                   ' name=pin_type,type=CephChoices,strings=export|distributed|random'
+                   ' name=pin_setting,type=CephString,req=true',
+            'desc': "Set MDS pinning policy for subvolumegroup",
+            'perm': 'rw'
+        },
+        {
             'cmd': 'fs subvolumegroup snapshot ls '
                    'name=vol_name,type=CephString '
                    'name=group_name,type=CephString ',
@@ -183,6 +192,16 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=group_name,type=CephString,req=false '
                    'name=no_shrink,type=CephBool,req=false ',
             'desc': "Resize a CephFS subvolume",
+            'perm': 'rw'
+        },
+        {
+            'cmd': 'fs subvolume pin'
+                   ' name=vol_name,type=CephString'
+                   ' name=sub_name,type=CephString'
+                   ' name=pin_type,type=CephChoices,strings=export|distributed|random'
+                   ' name=pin_setting,type=CephString,req=true'
+                   ' name=group_name,type=CephString,req=false',
+            'desc': "Set MDS pinning policy for subvolume",
             'perm': 'rw'
         },
         {
@@ -344,6 +363,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                       sub_name=cmd['sub_name'],
                                       group_name=cmd.get('group_name', None))
 
+    def _cmd_fs_subvolumegroup_pin(self, inbuf, cmd):
+        return self.vc.pin_subvolume_group(vol_name=cmd['vol_name'],
+            group_name=cmd['group_name'], pin_type=cmd['pin_type'],
+            pin_setting=cmd['pin_setting'])
+
     def _cmd_fs_subvolumegroup_snapshot_create(self, inbuf, cmd):
         return self.vc.create_subvolume_group_snapshot(vol_name=cmd['vol_name'],
                                                        group_name=cmd['group_name'],
@@ -387,6 +411,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.vc.resize_subvolume(vol_name=cmd['vol_name'], sub_name=cmd['sub_name'],
                                         new_size=cmd['new_size'], group_name=cmd.get('group_name', None),
                                         no_shrink=cmd.get('no_shrink', False))
+
+    def _cmd_fs_subvolume_pin(self, inbuf, cmd):
+        return self.vc.subvolume_pin(vol_name=cmd['vol_name'],
+            sub_name=cmd['sub_name'], pin_type=cmd['pin_type'],
+            pin_setting=cmd['pin_setting'],
+            group_name=cmd.get('group_name', None))
 
     def _cmd_fs_subvolume_snapshot_protect(self, inbuf, cmd):
         return self.vc.protect_subvolume_snapshot(vol_name=cmd['vol_name'], sub_name=cmd['sub_name'],


### PR DESCRIPTION
https://tracker.ceph.com/issues/46201

This backport PR drops 4d62ca69147b80eaa7075995913b25ce9a85069e. Ephemeral pinning is disabled by default in Octopus.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
