### PR TITLE
qa/cephadm/upgrade: Exclude RGW for now

### DIFF
--- a/qa/suites/rados/cephadm/upgrade/2-start-upgrade.yaml
+++ b/qa/suites/rados/cephadm/upgrade/2-start-upgrade.yaml
@@ -2,4 +2,4 @@ tasks:
 - cephadm.shell:
     env: [sha1]
     mon.a:
-      - ceph orch upgrade start --image quay.io/ceph-ci/ceph:$sha1
+      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1

--- a/qa/suites/rados/cephadm/upgrade/fixed-2.yaml
+++ b/qa/suites/rados/cephadm/upgrade/fixed-2.yaml
@@ -1,1 +1,31 @@
-../smoke/fixed-2.yaml
+roles:
+- - mon.a
+  - mon.c
+  - mgr.y
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+  - client.0
+#   - ceph.rgw.realm.zone.a # Disabled, needs 15.2.4 as an upgrade start
+  - node-exporter.a
+  - alertmanager.a
+- - mon.b
+  - mgr.x
+  - osd.4
+  - osd.5
+  - osd.6
+  - osd.7
+  - client.1
+  - prometheus.a
+  - grafana.a
+  - node-exporter.b
+openstack:
+- volumes: # attached to each instance
+    count: 4
+    size: 10 # GB
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd shutdown pgref assert: true


### PR DESCRIPTION
tasks/cephadm.py gained RGW support very recently and
I'm now facing a dilemman:

* Either we set the upgrade start to 15.2.4 and thus
  no longer upgrade from an old version, or
* Disable RGW upgrade for now.

I think doing both would be optinal, but for now, let's
disable RGW, in order to keep the coverage for everything
else.

Fixes: https://tracker.ceph.com/issues/46157

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
