### PR TITLE
test: fix unused variable warning in test_ino_release_cb.cc.

### DIFF
--- a/src/test/fs/test_ino_release_cb.cc
+++ b/src/test/fs/test_ino_release_cb.cc
@@ -22,7 +22,7 @@ int main(int argc, char *argv[])
 	ceph_conf_read_file(cmount, NULL);
 	ceph_init(cmount);
 
-	int ret = ceph_mount(cmount, NULL);
+	[[maybe_unused]] int ret = ceph_mount(cmount, NULL);
 	assert(ret >= 0);
 	ret = ceph_mkdir(cmount, DIRNAME, 0755);
 	assert(ret >= 0);


### PR DESCRIPTION
It can happen in non-debug builds.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
