### PR TITLE
mgr/dashboard: Action button is not reset after switching tabs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -11,6 +11,7 @@ import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ComponentsModule } from '../../components/components.module';
 import { CdTableColumnFilter } from '../../models/cd-table-column-filter';
 import { CdTableFetchDataContext } from '../../models/cd-table-fetch-data-context';
+import { CdTableSelection } from '../../models/cd-table-selection';
 import { PipesModule } from '../../pipes/pipes.module';
 import { TableComponent } from './table.component';
 
@@ -102,6 +103,16 @@ describe('TableComponent', () => {
       expect(eventName).toBe('mouseenter');
       expect(wasCalled).toBe(true);
       done();
+    });
+    component.ngOnInit();
+  });
+
+  it('should call updateSelection on init', () => {
+    component.updateSelection.subscribe((selection: CdTableSelection) => {
+      expect(selection.hasSelection).toBeFalsy();
+      expect(selection.hasSingleSelection).toBeFalsy();
+      expect(selection.hasMultiSelection).toBeFalsy();
+      expect(selection.selected.length).toBe(0);
     });
     component.ngOnInit();
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -282,6 +282,8 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
     this.filterHiddenColumns();
     this.initColumnFilters();
     this.updateColumnFilterOptions();
+    // Notify all subscribers to reset their current selection.
+    this.updateSelection.emit(new CdTableSelection());
     // Load the data table content every N ms or at least once.
     // Force showing the loading indicator if there are subscribers to the fetchData
     // event. This is necessary because it has been set to False in useData() when


### PR DESCRIPTION
This PR will fix a problem that occurs when switching between tabs. If there is a tab containing a datatable and you select a row, the action button displays the action that is possible for the selection, e.g. `Edit`. If you switch to another tab and reverse, the previously selected row is now unselected in the datatable, but the action button still reflects the action of the previous selected row.

This fix will notify all subscribers of the `updateSelection` datatable output when the datatable is initialized (`ngOnInit`) by submitting an empty selection. Due this the `cd-table-actions` component will be updated automatically and reset the action button to its origin state.

Before:
![screenshot](https://user-images.githubusercontent.com/1897962/85691297-a8d3db80-b6d4-11ea-8da3-3b17d79e6b7b.gif)

After:
![Peek 2020-06-25 11-10](https://user-images.githubusercontent.com/1897962/85691180-8fcb2a80-b6d4-11ea-94ca-9f8f17910879.gif)

Fixes: https://tracker.ceph.com/issues/46145

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
