### PR TITLE
octopus: mgr/dashboard: allow preserving OSD IDs when deleting OSDs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -69,3 +69,24 @@
   <ng-container i18n><strong>OSD {{ getSelectedOsdIds() | join }}</strong> will be
 <strong>{{ actionDescription }}</strong> if you proceed.</ng-container>
 </ng-template>
+
+<ng-template #deleteOsdExtraTpl
+             let-form="form">
+  <ng-container [formGroup]="form">
+    <ng-container formGroupName="child">
+      <div class="form-group">
+        <div class="custom-control custom-checkbox">
+          <input type="checkbox"
+                 class="custom-control-input"
+                 name="preserve"
+                 id="preserve"
+                 formControlName="preserve"
+                 autofocus>
+          <label class="custom-control-label"
+                 for="preserve"
+                 i18n>Preserve OSD ID(s) for replacement.</label>
+        </div>
+      </div>
+    </ng-container>
+  </ng-container>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -60,14 +60,16 @@
 <ng-template #criticalConfirmationTpl
              let-safeToPerform="safeToPerform"
              let-message="message"
-             let-actionDescription="actionDescription">
+             let-actionDescription="actionDescription"
+             let-osdIds="osdIds">
   <div *ngIf="!safeToPerform"
        class="danger">
     <cd-alert-panel type="warning"
-                    i18n>The {selection.hasSingleSelection, select, 1 {OSD is} 0 {OSDs are}} not safe to be {{ actionDescription }}! {{ message }}</cd-alert-panel>
+                    i18n>The {selection.hasSingleSelection, select, true {OSD is} false {OSDs are}} not safe to be
+      {{ actionDescription }}! {{ message }}</cd-alert-panel>
   </div>
-  <ng-container i18n><strong>OSD {{ getSelectedOsdIds() | join }}</strong> will be
-<strong>{{ actionDescription }}</strong> if you proceed.</ng-container>
+  <ng-container i18n><strong>OSD {{ osdIds | join }}</strong> will be
+  <strong>{{ actionDescription }}</strong> if you proceed.</ng-container>
 </ng-template>
 
 <ng-template #deleteOsdExtraTpl

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -56,7 +56,7 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
   reweightBodyTpl: TemplateRef<any>;
   @ViewChild('safeToDestroyBodyTpl', { static: false })
   safeToDestroyBodyTpl: TemplateRef<any>;
-  @ViewChild('deleteOsdExtraTpl')
+  @ViewChild('deleteOsdExtraTpl', { static: false })
   deleteOsdExtraTpl: TemplateRef<any>;
 
   permissions: Permissions;
@@ -518,7 +518,8 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
           bodyContext: {
             safeToPerform: result[checkKey],
             message: result.message,
-            actionDescription: templateItemDescription
+            actionDescription: templateItemDescription,
+            osdIds: this.getSelectedOsdIds()
           },
           childFormGroup: childFormGroup,
           childFormGroupTemplate: childFormGroupTemplate,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { FormControl } from '@angular/forms';
 import { Router } from '@angular/router';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
@@ -16,6 +17,7 @@ import { TableComponent } from '../../../../shared/datatable/table/table.compone
 import { CellTemplate } from '../../../../shared/enum/cell-template.enum';
 import { Icons } from '../../../../shared/enum/icons.enum';
 import { NotificationType } from '../../../../shared/enum/notification-type.enum';
+import { CdFormGroup } from '../../../../shared/forms/cd-form-group';
 import { CdTableAction } from '../../../../shared/models/cd-table-action';
 import { CdTableColumn } from '../../../../shared/models/cd-table-column';
 import { CdTableSelection } from '../../../../shared/models/cd-table-selection';
@@ -54,6 +56,8 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
   reweightBodyTpl: TemplateRef<any>;
   @ViewChild('safeToDestroyBodyTpl', { static: false })
   safeToDestroyBodyTpl: TemplateRef<any>;
+  @ViewChild('deleteOsdExtraTpl')
+  deleteOsdExtraTpl: TemplateRef<any>;
 
   permissions: Permissions;
   tableActions: CdTableAction[];
@@ -217,33 +221,7 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
       {
         name: this.actionLabels.DELETE,
         permission: 'delete',
-        click: () => {
-          this.depCheckerService.checkOrchestratorOrModal(
-            this.actionLabels.DELETE,
-            this.i18n('OSD'),
-            () => {
-              this.showCriticalConfirmationModal(
-                this.i18n('delete'),
-                this.i18n('OSD'),
-                this.i18n('deleted'),
-                (ids: number[]) => {
-                  return this.osdService.safeToDelete(JSON.stringify(ids));
-                },
-                'is_safe_to_delete',
-                (id: number) => {
-                  this.selection = new CdTableSelection();
-                  return this.taskWrapper.wrapTaskAroundCall({
-                    task: new FinishedTask('osd/' + URLVerbs.DELETE, {
-                      svc_id: id
-                    }),
-                    call: this.osdService.delete(id, true)
-                  });
-                },
-                true
-              );
-            }
-          );
-        },
+        click: () => this.delete(),
         disable: () => !this.hasOsdSelected,
         icon: Icons.destroy
       }
@@ -474,6 +452,40 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
     });
   }
 
+  delete() {
+    const deleteFormGroup = new CdFormGroup({
+      preserve: new FormControl(false)
+    });
+
+    this.depCheckerService.checkOrchestratorOrModal(
+      this.actionLabels.DELETE,
+      this.i18n('OSD'),
+      () => {
+        this.showCriticalConfirmationModal(
+          this.i18n('delete'),
+          this.i18n('OSD'),
+          this.i18n('deleted'),
+          (ids: number[]) => {
+            return this.osdService.safeToDelete(JSON.stringify(ids));
+          },
+          'is_safe_to_delete',
+          (id: number) => {
+            this.selection = new CdTableSelection();
+            return this.taskWrapper.wrapTaskAroundCall({
+              task: new FinishedTask('osd/' + URLVerbs.DELETE, {
+                svc_id: id
+              }),
+              call: this.osdService.delete(id, deleteFormGroup.value.preserve, true)
+            });
+          },
+          true,
+          deleteFormGroup,
+          this.deleteOsdExtraTpl
+        );
+      }
+    );
+  }
+
   /**
    * Perform check first and display a critical confirmation modal.
    * @param {string} actionDescription name of the action.
@@ -482,8 +494,9 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
    * @param {Function} check the function is called to check if the action is safe.
    * @param {string} checkKey the safe indicator's key in the check response.
    * @param {Function} action the action function.
-   * @param {boolean} oneshot if true, action function is called with all items as parameter.
-   *   Otherwise, multiple action functions with individual items are sent.
+   * @param {boolean} taskWrapped if true, hide confirmation modal after action
+   * @param {CdFormGroup} childFormGroup additional child form group to be passed to confirmation modal
+   * @param {TemplateRef<any>} childFormGroupTemplate template for additional child form group
    */
   showCriticalConfirmationModal(
     actionDescription: string,
@@ -492,7 +505,9 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
     check: (ids: number[]) => Observable<any>,
     checkKey: string,
     action: (id: number | number[]) => Observable<any>,
-    taskWrapped: boolean = false
+    taskWrapped: boolean = false,
+    childFormGroup?: CdFormGroup,
+    childFormGroupTemplate?: TemplateRef<any>
   ): void {
     check(this.getSelectedOsdIds()).subscribe((result) => {
       const modalRef = this.modalService.show(CriticalConfirmationModalComponent, {
@@ -505,6 +520,8 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
             message: result.message,
             actionDescription: templateItemDescription
           },
+          childFormGroup: childFormGroup,
+          childFormGroupTemplate: childFormGroupTemplate,
           submitAction: () => {
             const observable = observableForkJoin(
               this.getSelectedOsdIds().map((osd: any) => action.call(this.osdService, osd))

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
@@ -55,6 +55,13 @@ describe('OsdService', () => {
     expect(req.request.body).toEqual(post_data);
   });
 
+  it('should call delete', () => {
+    const id = 1;
+    service.delete(id, true, true).subscribe();
+    const req = httpTesting.expectOne(`api/osd/${id}?preserve_id=true&force=true`);
+    expect(req.request.method).toBe('DELETE');
+  });
+
   it('should call getList', () => {
     service.getList().subscribe();
     const req = httpTesting.expectOne('api/osd');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
@@ -137,10 +137,12 @@ export class OsdService {
     return this.http.post(`${this.path}/${id}/destroy`, null);
   }
 
-  delete(id: number, force?: boolean) {
-    const options = force ? { params: new HttpParams().set('force', 'true') } : {};
-    options['observe'] = 'response';
-    return this.http.delete(`${this.path}/${id}`, options);
+  delete(id: number, preserveId?: boolean, force?: boolean) {
+    const params = {
+      preserve_id: preserveId ? 'true' : 'false',
+      force: force ? 'true' : 'false'
+    };
+    return this.http.delete(`${this.path}/${id}`, { observe: 'response', params: params });
   }
 
   safeToDestroy(ids: string) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html
@@ -25,6 +25,7 @@
           <ng-template #noNames>
             <p i18n>Are you sure that you want to {{ actionDescription | lowercase }} the selected {{ itemDescription }}?</p>
           </ng-template>
+          <ng-container *ngTemplateOutlet="childFormGroupTemplate; context:{form:deletionForm}"></ng-container>
           <div class="form-group">
             <div class="custom-control custom-checkbox">
               <input type="checkbox"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.ts
@@ -24,13 +24,19 @@ export class CriticalConfirmationModalComponent implements OnInit {
   itemNames: string[];
   actionDescription = 'delete';
 
+  childFormGroup: CdFormGroup;
+  childFormGroupTemplate: TemplateRef<any>;
+
   constructor(public modalRef: BsModalRef) {}
 
   ngOnInit() {
-    this.deletionForm = new CdFormGroup({
+    const controls = {
       confirmation: new FormControl(false, [Validators.requiredTrue])
-    });
-
+    };
+    if (this.childFormGroup) {
+      controls['child'] = this.childFormGroup;
+    }
+    this.deletionForm = new CdFormGroup(controls);
     if (!(this.submitAction || this.submitActionObservable)) {
       throw new Error('No submit action defined');
     }

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -109,8 +109,8 @@ class OsdManager(ResourceManager):
         return self.api.apply_drivegroups(drive_group_specs)
 
     @wait_api_result
-    def remove(self, osd_ids):
-        return self.api.remove_osds(osd_ids)
+    def remove(self, osd_ids, replace=False, force=False):
+        return self.api.remove_osds(osd_ids, replace, force)
 
     @wait_api_result
     def removing_status(self):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46173

---

backport of https://github.com/ceph/ceph/pull/35242
parent tracker: https://tracker.ceph.com/issues/38234

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh