### PR TITLE
mgr/dashboard: fix UI of the columns for rgw-bucket-list

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
@@ -103,31 +103,31 @@ export class RgwBucketListComponent extends ListWithDetails implements OnInit {
       {
         name: this.i18n('Owner'),
         prop: 'owner',
-        flexGrow: 3
+        flexGrow: 2.5
       },
       {
         name: this.i18n('Used Capacity'),
         prop: 'bucket_size',
-        flexGrow: 0.5,
+        flexGrow: 0.6,
         pipe: this.dimlessBinaryPipe
       },
       {
         name: this.i18n('Capacity Limit %'),
         prop: 'size_usage',
         cellTemplate: this.bucketSizeTpl,
-        flexGrow: 1
+        flexGrow: 0.8
       },
       {
         name: this.i18n('Objects'),
         prop: 'num_objects',
-        flexGrow: 0.5,
+        flexGrow: 0.6,
         pipe: this.dimlessPipe
       },
       {
         name: this.i18n('Object Limit %'),
         prop: 'object_usage',
         cellTemplate: this.bucketObjectTpl,
-        flexGrow: 1
+        flexGrow: 0.8
       }
     ];
   }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46210

Signed-off-by: Avan Thakkar <athakkar@redhat.com>

Before:
![Screenshot from 2020-06-25 22-17-46](https://user-images.githubusercontent.com/23611106/85840321-e9595500-b7b9-11ea-8aa9-3e4db37a5572.png)

After:
![Screenshot from 2020-06-26 14-40-55](https://user-images.githubusercontent.com/23611106/85841021-1a865500-b7bb-11ea-9ff6-4bfe4e1a45e7.png)

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
