### PR TITLE
mgr/dashboard: Consolidate Osd mark endpoints

### DIFF
--- a/qa/tasks/mgr/dashboard/test_osd.py
+++ b/qa/tasks/mgr/dashboard/test_osd.py
@@ -19,7 +19,7 @@ class OsdTest(DashboardTestCase):
         cls.mgr_cluster.mon_manager.raw_cluster_cmd(*cmd)
 
     def tearDown(self):
-        self._post('/api/osd/0/mark_in')
+        self._put('/api/osd/0/mark', data={'action': 'in'})
 
     @DashboardTestCase.RunAs('test', 'test', ['block-manager'])
     def test_access_permissions(self):
@@ -72,14 +72,14 @@ class OsdTest(DashboardTestCase):
         self.assertStatus(200)
 
     def test_mark_out_and_in(self):
-        self._post('/api/osd/0/mark_out')
+        self._put('/api/osd/0/mark', data={'action': 'out'})
         self.assertStatus(200)
 
-        self._post('/api/osd/0/mark_in')
+        self._put('/api/osd/0/mark', data={'action': 'in'})
         self.assertStatus(200)
 
     def test_mark_down(self):
-        self._post('/api/osd/0/mark_down')
+        self._put('/api/osd/0/mark', data={'action': 'down'})
         self.assertStatus(200)
 
     def test_reweight(self):
@@ -121,7 +121,7 @@ class OsdTest(DashboardTestCase):
         self.assertStatus(400)
 
         # Lost
-        self._post('/api/osd/5/mark_lost')
+        self._put('/api/osd/5/mark', data={'action': 'lost'})
         self.assertStatus(200)
         # Destroy
         self._post('/api/osd/5/destroy')

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -4,7 +4,7 @@ import json
 import logging
 import time
 
-from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupValidationError
+from ceph.deployment.drive_group import DriveGroupSpec, DriveGroupValidationError  # type: ignore
 from mgr_util import get_most_recent_rate
 
 from . import ApiController, RESTController, Endpoint, Task
@@ -18,10 +18,8 @@ from ..services.ceph_service import CephService, SendCommandError
 from ..services.exception import handle_send_command_error, handle_orchestrator_error
 from ..services.orchestrator import OrchClient, OrchFeature
 from ..tools import str_to_bool
-try:
-    from typing import Dict, List, Any, Union  # noqa: F401 pylint: disable=unused-import
-except ImportError:  # pragma: no cover
-    pass  # For typing only
+
+from typing import Any, Dict, List, Union  # pylint: disable=C0411
 
 
 logger = logging.getLogger('controllers.osd')
@@ -44,7 +42,7 @@ def osd_task(name, metadata, wait_for=2.0):
 
 
 @ApiController('/osd', Scope.OSD)
-@ControllerDoc("Get OSD Details", "OSD")
+@ControllerDoc('OSD management API', 'OSD')
 class Osd(RESTController):
     def list(self):
         osds = self.get_osd_map()
@@ -162,7 +160,7 @@ class Osd(RESTController):
     @osd_task('delete', {'svc_id': '{svc_id}'})
     def delete(self, svc_id, preserve_id=None, force=None):  # pragma: no cover
         replace = False
-        check = False
+        check: Union[Dict[str, Any], bool] = False
         try:
             if preserve_id is not None:
                 replace = str_to_bool(preserve_id)
@@ -197,20 +195,25 @@ class Osd(RESTController):
         api_scrub = "osd deep-scrub" if str_to_bool(deep) else "osd scrub"
         CephService.send_command("mon", api_scrub, who=svc_id)
 
-    @RESTController.Resource('POST')
-    @allow_empty_body
-    def mark_out(self, svc_id):
-        CephService.send_command('mon', 'osd out', ids=[svc_id])
+    @RESTController.Resource('PUT')
+    @EndpointDoc("Mark OSD flags (out, in, down, lost, ...)",
+                 parameters={'svc_id': (str, 'SVC ID')})
+    def mark(self, svc_id, action):
+        """
+        Note: osd must be marked `down` before marking lost.
+        """
+        valid_actions = ['out', 'in', 'down', 'lost']
+        args = {'srv_type': 'mon', 'prefix': 'osd ' + action}
+        if action.lower() in valid_actions:
+            if action == 'lost':
+                args['id'] = int(svc_id)
+                args['yes_i_really_mean_it'] = True
+            else:
+                args['ids'] = [svc_id]
 
-    @RESTController.Resource('POST')
-    @allow_empty_body
-    def mark_in(self, svc_id):
-        CephService.send_command('mon', 'osd in', ids=[svc_id])
-
-    @RESTController.Resource('POST')
-    @allow_empty_body
-    def mark_down(self, svc_id):
-        CephService.send_command('mon', 'osd down', ids=[svc_id])
+            CephService.send_command(**args)
+        else:
+            logger.error("Invalid OSD mark action: %s attempted on SVC_ID: %s", action, svc_id)
 
     @RESTController.Resource('POST')
     @allow_empty_body
@@ -233,18 +236,6 @@ class Osd(RESTController):
             'osd reweight',
             id=int(svc_id),
             weight=float(weight))
-
-    @RESTController.Resource('POST')
-    @allow_empty_body
-    def mark_lost(self, svc_id):
-        """
-        Note: osd must be marked `down` before marking lost.
-        """
-        CephService.send_command(
-            'mon',
-            'osd lost',
-            id=int(svc_id),
-            yes_i_really_mean_it=True)
 
     def _create_bare(self, data):
         """Create a OSD container that has no associated device.
@@ -361,7 +352,7 @@ class Osd(RESTController):
 
 
 @ApiController('/osd/flags', Scope.OSD)
-@ControllerDoc("OSD Flags controller Management API", "OsdFlagsController")
+@ControllerDoc(group='OSD')
 class OsdFlagsController(RESTController):
     @staticmethod
     def _osd_flags():

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
@@ -101,20 +101,23 @@ describe('OsdService', () => {
 
   it('should mark the OSD out', () => {
     service.markOut(1).subscribe();
-    const req = httpTesting.expectOne('api/osd/1/mark_out');
-    expect(req.request.method).toBe('POST');
+    const req = httpTesting.expectOne('api/osd/1/mark');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ action: 'out' });
   });
 
   it('should mark the OSD in', () => {
     service.markIn(1).subscribe();
-    const req = httpTesting.expectOne('api/osd/1/mark_in');
-    expect(req.request.method).toBe('POST');
+    const req = httpTesting.expectOne('api/osd/1/mark');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ action: 'in' });
   });
 
   it('should mark the OSD down', () => {
     service.markDown(1).subscribe();
-    const req = httpTesting.expectOne('api/osd/1/mark_down');
-    expect(req.request.method).toBe('POST');
+    const req = httpTesting.expectOne('api/osd/1/mark');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ action: 'down' });
   });
 
   it('should reweight an OSD', () => {
@@ -133,8 +136,9 @@ describe('OsdService', () => {
 
   it('should mark an OSD lost', () => {
     service.markLost(1).subscribe();
-    const req = httpTesting.expectOne('api/osd/1/mark_lost');
-    expect(req.request.method).toBe('POST');
+    const req = httpTesting.expectOne('api/osd/1/mark');
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ action: 'lost' });
   });
 
   it('should purge an OSD', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
@@ -103,15 +103,15 @@ export class OsdService {
   }
 
   markOut(id: number) {
-    return this.http.post(`${this.path}/${id}/mark_out`, null);
+    return this.http.put(`${this.path}/${id}/mark`, { action: 'out' });
   }
 
   markIn(id: number) {
-    return this.http.post(`${this.path}/${id}/mark_in`, null);
+    return this.http.put(`${this.path}/${id}/mark`, { action: 'in' });
   }
 
   markDown(id: number) {
-    return this.http.post(`${this.path}/${id}/mark_down`, null);
+    return this.http.put(`${this.path}/${id}/mark`, { action: 'down' });
   }
 
   reweight(id: number, weight: number) {
@@ -123,7 +123,7 @@ export class OsdService {
   }
 
   markLost(id: number) {
-    return this.http.post(`${this.path}/${id}/mark_lost`, null);
+    return this.http.put(`${this.path}/${id}/mark`, { action: 'lost' });
   }
 
   purge(id: number) {


### PR DESCRIPTION
mgr/dashboard: Instead of 4 different GET requests, there is now one PUT request
that parses the desired action in the request body.
A description was added to describe the usage.

* Osd flag endpoints were grouped with Osd endpoints
* A few mypy issues were also resolved

Fixes: https://tracker.ceph.com/issues/46181
Signed-off-by: Fabrizio D'Angelo <fdangelo@redhat.com>


## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
