### PR TITLE
doc/man/8/ceph-objectstore-tool.rst: remove duplicate lines

### DIFF
--- a/doc/man/8/ceph-objectstore-tool.rst
+++ b/doc/man/8/ceph-objectstore-tool.rst
@@ -89,10 +89,6 @@ Make sure that the target OSD is down::
 
    systemctl status ceph-osd@$OSD_NUMBER
 
-List objects with ceph-objectstore-tool::
-
-    systemctl status ceph-osd@$OSD_NUMBER
-
 Identify all objects within an OSD::
 
    ceph-objectstore-tool --data-path $PATH_TO_OSD --op list


### PR DESCRIPTION
`systemctl status ceph-osd@$OSD_NUMBER` was mistakenly listed twice; once with a wrong title. I believe `List objects with ceph-objectstore-tool` and `Identify all objects within an OSD` mean the same.

Signed-off-by: Fabian Bonk <fabian.bonk@croit.io>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
