### PR TITLE
rgw: radosgw-admin: standardize command format of radosgw-admin period pull

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1593,6 +1593,10 @@ static int send_to_url(const string& url, const string& access,
                        const string& secret, req_info& info,
                        bufferlist& in_data, JSONParser& parser)
 {
+  if (url.empty()) {
+    cerr << "A --url must be provided." << std::endl;
+    return -EINVAL;
+  }
   if (access.empty() || secret.empty()) {
     cerr << "An --access-key and --secret must be provided with --url." << std::endl;
     return -EINVAL;
@@ -1620,9 +1624,6 @@ static int send_to_remote_or_url(RGWRESTConn *conn, const string& url,
                                  req_info& info, bufferlist& in_data,
                                  JSONParser& parser)
 {
-  if (url.empty()) {
-    return send_to_remote_gateway(conn, info, in_data, parser);
-  }
   return send_to_url(url, access, secret, info, in_data, parser);
 }
 


### PR DESCRIPTION
when execute "radosgw-admin period pull --access-key=xxx --secret-key=xxx", "request failed: (13) Permission denied" returned. It looks like wrong sync-user key was provided, but i checked the system_key in zone info and its consistent with what i provided.
or "radosgw-admin period pull" would return same error information. This is obviously unreasonable and its likely to perverted cluster administrators. 
By looking at the code, I found get_remote_conn() return a RGWRESTConn with null key when "--url=" wasnt provided, because store returned by get_raw_storage() only takes init_rados() and doesnt take init_complete() before period pull. In this case, the zone_params in store is not initialized. Then conn->forward() send request to master zone with null ak ad sk, response must be "Permission denied".
radosgw-admin period pull should be standardized, --url, --ak and --sk should be provided.

Signed-off-by: cao.leilc <cao.leilc@inspur.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
