### PR TITLE
octopus: mgr/dashboard: The max. buckets field in RGW user form should be pre-filled

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/users.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/users.po.ts
@@ -21,6 +21,7 @@ export class UsersPageHelper extends PageHelper {
 
     // Enter max buckets
     this.selectOption('max_buckets_mode', 'Custom');
+    cy.get('#max_buckets').should('exist').should('have.value', '1000');
     cy.get('#max_buckets').click().clear().type(maxbuckets);
 
     // Click the create button and wait for user to be made
@@ -102,7 +103,7 @@ export class UsersPageHelper extends PageHelper {
     const uname = '000invalid_edit_user';
     // creating this user to edit for the test
     this.navigateTo('create');
-    this.create(uname, 'xxx', 'xxx@xxx', '1');
+    this.create(uname, 'xxx', 'xxx@xxx', '50');
 
     this.navigateEdit(name);
 
@@ -120,7 +121,10 @@ export class UsersPageHelper extends PageHelper {
     cy.contains('#display_name + .invalid-feedback', 'This field is required.');
 
     // put negative max buckets to make field invalid
-    this.expectSelectOption('max_buckets_mode', 'Custom');
+    this.selectOption('max_buckets_mode', 'Disabled');
+    cy.get('#max_buckets').should('not.exist');
+    this.selectOption('max_buckets_mode', 'Custom');
+    cy.get('#max_buckets').should('exist').should('have.value', '50');
     cy.get('#max_buckets').clear().type('-5').blur().should('have.class', 'ng-invalid');
     cy.contains('#max_buckets + .invalid-feedback', 'The entered value must be >= 1.');
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
@@ -82,7 +82,8 @@
             <select class="form-control custom-select"
                     formControlName="max_buckets_mode"
                     name="max_buckets_mode"
-                    id="max_buckets_mode">
+                    id="max_buckets_mode"
+                    (change)="onMaxBucketsModeChange($event.target.value)">
               <option i18n
                       value="-1">Disabled</option>
               <option i18n

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
@@ -705,4 +705,17 @@ export class RgwUserFormComponent implements OnInit {
     result = _.uniq(result);
     return result;
   }
+
+  onMaxBucketsModeChange(mode: string) {
+    if (mode === '1') {
+      // If 'Custom' mode is selected, then ensure that the form field
+      // 'Max. buckets' contains a valid value. Set it to default if
+      // necessary.
+      if (!this.userForm.get('max_buckets').valid) {
+        this.userForm.patchValue({
+          max_buckets: 1000
+        });
+      }
+    }
+  }
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45449

---

backport of https://github.com/ceph/ceph/pull/34709
parent tracker: https://tracker.ceph.com/issues/45204

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh