### PR TITLE
octopus: mgr/dashboard: Add button to copy the bootstrap token into the clipboard

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-create-modal/bootstrap-create-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-create-modal/bootstrap-create-modal.component.html
@@ -72,6 +72,14 @@
                     readonly>
           </textarea>
         </div>
+        <button class="btn btn-primary mb-3 float-right"
+                aria-label="Copy to Clipboard"
+                i18n-aria-label
+                title="Copy to Clipboard"
+                i18n-title
+                cdCopy2ClipboardButton="token">
+          <ng-container i18n>Copy to Clipboard</ng-container>
+        </button>
       </div>
 
       <div class="modal-footer">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/copy2clipboard-button.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/copy2clipboard-button.directive.ts
@@ -9,8 +9,6 @@ import { ToastrService } from 'ngx-toastr';
 export class Copy2ClipboardButtonDirective implements OnInit {
   @Input()
   private cdCopy2ClipboardButton: string;
-  @Input()
-  private formatted = 'no';
 
   constructor(
     private elementRef: ElementRef,
@@ -34,17 +32,15 @@ export class Copy2ClipboardButtonDirective implements OnInit {
   @HostListener('click')
   onClick() {
     try {
-      const tagName = this.formatted === '' ? 'textarea' : 'input';
-      // Create the input to hold our text.
-      const tmpInputElement = document.createElement(tagName);
-      tmpInputElement.value = this.getInputElement().value;
-      document.body.appendChild(tmpInputElement);
-      // Copy text to clipboard.
-      tmpInputElement.select();
-      document.execCommand('copy');
-      // Finally remove the element.
-      document.body.removeChild(tmpInputElement);
-
+      // Checking if we have the clipboard-write permission
+      navigator.permissions
+        .query({ name: 'clipboard-write' as PermissionName })
+        .then((result: any) => {
+          if (result.state === 'granted' || result.state === 'prompt') {
+            // Copy text to clipboard.
+            navigator.clipboard.writeText(this.getInputElement().value);
+          }
+        });
       this.toastr.success('Copied text to the clipboard successfully.');
     } catch (err) {
       this.toastr.error('Failed to copy text to the clipboard.');


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45786

---

backport of https://github.com/ceph/ceph/pull/34294
parent tracker: https://tracker.ceph.com/issues/44681

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh