### PR TITLE
Mgr/prometheus: add osd df info to prometheus

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -108,6 +108,8 @@ DISK_OCCUPATION = ('ceph_daemon', 'device', 'db_device',
 
 NUM_OBJECTS = ['degraded', 'misplaced', 'unfound']
 
+DF_OSD = ['kb', 'kb_used', 'kb_used_data', 'kb_used_omap', 'kb_used_meta', 'kb_avail', 'utilization']
+
 
 class Metric(object):
     def __init__(self, mtype, name, desc, labels=None):
@@ -409,6 +411,14 @@ class Module(MgrModule):
                 'PG {} per pool'.format(state),
                 ('pool_id',)
             )
+        for stat in DF_OSD:
+            path = 'osd_df_{}'.format(stat)
+            metrics[path] = Metric(
+                'gauge',
+                path,
+                'OSD DF STATS: {}'.format(stat),
+                ('ceph_daemon',)
+            )
         for state in DF_CLUSTER:
             path = 'cluster_{}'.format(state)
             metrics[path] = Metric(
@@ -449,6 +459,15 @@ class Module(MgrModule):
                 self.metrics['pool_{}'.format(stat)].set(
                     pool['recovery_rate'].get(stat, 0),
                     (pool['pool_id'],)
+                )
+    def get_osd_df(self):
+        osd_df = self.get('osd_df')
+        for osd in osd_df['nodes']:
+            name_ = osd['name']
+        for stat in DF_OSD:
+            self.metrics['osd_df_{}'.format(stat)].set(
+                osd[stat], 
+                ('{}'.format(name_),)
                 )
 
     def get_df(self):
@@ -1013,6 +1032,7 @@ class Module(MgrModule):
         self.get_metadata_and_osd_status()
         self.get_pg_status()
         self.get_num_objects()
+        self.get_osd_df()
 
         for daemon, counters in self.get_all_perf_counters().items():
             for path, counter_info in counters.items():


### PR DESCRIPTION
Add ceph osd df information in ceph-mgr/prometheus module


"""
mgr: add ceph osd df information to mgr/prometheus module

In order to observing the info of osd df in grafana which its datasource is prometheus, so the osd df info shoud be obtain 
in the formation of prometheus metrics. Therefore, the pull request is created. 

Signed-off-by: yangly0815 <yangly0815@163.com>
"""


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
