### PR TITLE
qa,test,pybind: drop py2 support

### DIFF
--- a/doc/_ext/ceph_releases.py
+++ b/doc/_ext/ceph_releases.py
@@ -5,7 +5,6 @@
 #   https://bitbucket.org/prometheus/sphinxcontrib-htsql/src/331a542c29a102eec9f8cba44797e53a49de2a49/sphinxcontrib/htsql.py?at=default&fileviewer=file-view-default
 # into the glory that follows:
 import json
-import six
 import yaml
 import sphinx
 import datetime
@@ -49,7 +48,7 @@ class CephReleases(Directive):
         row_node.extend(nodes.entry(h, nodes.paragraph(text=h))
             for h in ["Version", "Initial release", "Latest", "End of life (estimated)"])
 
-        releases = six.iteritems(releases)
+        releases = releases.items()
         releases = sorted(releases, key=lambda t: t[0], reverse=True)
 
         tbody = nodes.tbody()
@@ -127,7 +126,7 @@ class CephTimeline(Directive):
         display_releases = self.arguments[1:]
 
         timeline = []
-        for code_name, info in six.iteritems(releases["releases"]):
+        for code_name, info in releases["releases"].items():
             if code_name in display_releases:
                 for release in info.get("releases", []):
                     released = release["released"]

--- a/qa/standalone/special/ceph_objectstore_tool.py
+++ b/qa/standalone/special/ceph_objectstore_tool.py
@@ -688,10 +688,7 @@ def test_removeall(CFSD_PREFIX, db, OBJREPPGS, REP_POOL, CEPH_BIN, OSDDIR, REP_N
 
 
 def main(argv):
-    if sys.version_info[0] < 3:
-        sys.stdout = stdout = os.fdopen(sys.stdout.fileno(), 'wb', 0)
-    else:
-        stdout = sys.stdout.buffer
+    stdout = sys.stdout.buffer
     if len(argv) > 1 and argv[1] == "debug":
         nullfd = stdout
     else:

--- a/qa/tasks/barbican.py
+++ b/qa/tasks/barbican.py
@@ -4,10 +4,10 @@ Deploy and configure Barbican for Teuthology
 import argparse
 import contextlib
 import logging
-import six
-from six.moves import http_client
-from six.moves.urllib.parse import urlparse
+import http
 import json
+
+from urllib.parse import urlparse
 
 from teuthology import misc as teuthology
 from teuthology import contextutil
@@ -251,7 +251,7 @@ def create_secrets(ctx, config):
                                                  port=barbican_port)
     log.info("barbican_url=%s", barbican_url)
     #fetching user_id of user that gets secrets for radosgw
-    token_req = http_client.HTTPConnection(keystone_host, keystone_port, timeout=30)
+    token_req = http.client.HTTPConnection(keystone_host, keystone_port, timeout=30)
     token_req.request(
         'POST',
         '/v3/auth/tokens',
@@ -281,7 +281,7 @@ def create_secrets(ctx, config):
             rgw_access_user_resp.status < 300):
         raise Exception("Cannot authenticate user "+rgw_user["username"]+" for secret creation")
     #    baru_resp = json.loads(baru_req.data)
-    rgw_access_user_data = json.loads(six.ensure_str(rgw_access_user_resp.read()))
+    rgw_access_user_data = json.loads(rgw_access_user_resp.read().decode())
     rgw_user_id = rgw_access_user_data['token']['user']['id']
     if 'secrets' in cconfig:
         for secret in cconfig['secrets']:
@@ -296,7 +296,7 @@ def create_secrets(ctx, config):
             if 'password' not in secret:
                 raise ConfigError('barbican.secrets must have "password" field')
 
-            token_req = http_client.HTTPConnection(keystone_host, keystone_port, timeout=30)
+            token_req = http.client.HTTPConnection(keystone_host, keystone_port, timeout=30)
             token_req.request(
                 'POST',
                 '/v3/auth/tokens',
@@ -340,7 +340,7 @@ def create_secrets(ctx, config):
                     "payload_content_encoding": "base64"
                 })
 
-            sec_req = http_client.HTTPConnection(barbican_host, barbican_port, timeout=30)
+            sec_req = http.client.HTTPConnection(barbican_host, barbican_port, timeout=30)
             try:
                 sec_req.request(
                     'POST',
@@ -358,7 +358,7 @@ def create_secrets(ctx, config):
             if not (barbican_sec_resp.status >= 200 and
                     barbican_sec_resp.status < 300):
                 raise Exception("Cannot create secret")
-            barbican_data = json.loads(six.ensure_str(barbican_sec_resp.read()))
+            barbican_data = json.loads(barbican_sec_resp.read().decode())
             if 'secret_ref' not in barbican_data:
                 raise ValueError("Malformed secret creation response")
             secret_ref = barbican_data["secret_ref"]
@@ -371,7 +371,7 @@ def create_secrets(ctx, config):
                         "project-access": True
                     }
                 })
-            acl_req = http_client.HTTPConnection(secret_url_parsed.netloc, timeout=30)
+            acl_req = http.client.HTTPConnection(secret_url_parsed.netloc, timeout=30)
             acl_req.request(
                 'PUT',
                 secret_url_parsed.path+'/acl',

--- a/qa/tasks/ceph_objectstore_tool.py
+++ b/qa/tasks/ceph_objectstore_tool.py
@@ -7,7 +7,6 @@ import contextlib
 import json
 import logging
 import os
-import six
 import sys
 import tempfile
 import time
@@ -487,8 +486,8 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
                                 log.error("failed with " +
                                           str(proc.exitstatus))
                                 log.error(" ".join([
-                                    six.ensure_str(proc.stdout.getvalue()),
-                                    six.ensure_str(proc.stderr.getvalue()),
+                                    proc.stdout.getvalue().decode(),
+                                    proc.stderr.getvalue().decode(),
                                     ]))
                                 ERRORS += 1
 

--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -2,7 +2,6 @@ from io import StringIO
 import json
 import time
 import logging
-import six
 
 from textwrap import dedent
 
@@ -217,7 +216,7 @@ class FuseMount(CephFSMount):
                 log.info('mount point does not exist: %s', self.mountpoint)
                 return False
 
-        fstype = six.ensure_str(proc.stdout.getvalue()).rstrip('\n')
+        fstype = proc.stdout.getvalue().rstrip('\n')
         if fstype == 'fuseblk':
             log.info('ceph-fuse is mounted on %s', self.mountpoint)
             return True

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -2,9 +2,8 @@ from contextlib import contextmanager
 import json
 import logging
 import datetime
-import six
 import time
-from six import StringIO
+from io import StringIO
 from textwrap import dedent
 import os
 import re
@@ -498,7 +497,7 @@ class CephFSMount(object):
     def run_python(self, pyscript, py_version='python3'):
         p = self._run_python(pyscript, py_version)
         p.wait()
-        return six.ensure_str(p.stdout.getvalue().strip())
+        return p.stdout.getvalue().strip()
 
     def run_shell(self, args, wait=True, stdin=None, check_status=True,
                   cwd=None, omit_sudo=True):

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -9,8 +9,6 @@ import logging
 from tempfile import mkstemp as tempfile_mkstemp
 import math
 from six import ensure_str
-from sys import version_info as sys_version_info
-from re import search as re_search
 from time import sleep
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from teuthology.misc import sudo_write_file
@@ -518,12 +516,7 @@ class TestDU(TestCephFSShell):
         expected_output = r'{}{}{}'.format(size, " +", regfilename)
 
         du_output = self.get_cephfs_shell_cmd_output('du ' + regfilename)
-        if sys_version_info.major >= 3:
-            self.assertRegex(du_output, expected_output)
-        elif sys_version_info.major < 3:
-            assert re_search(expected_output, du_output) != None, "\n" + \
-                   "expected_output -\n{}\ndu_output -\n{}\n".format(
-                   expected_output, du_output)
+        self.assertRegex(du_output, expected_output)
 
     def test_du_works_for_non_empty_dirs(self):
         dirname = 'some_directory'
@@ -540,12 +533,7 @@ class TestDU(TestCephFSShell):
 
         sleep(10)
         du_output = self.get_cephfs_shell_cmd_output('du ' + dirname)
-        if sys_version_info.major >= 3:
-            self.assertRegex(du_output, expected_output)
-        elif sys_version_info.major < 3:
-            assert re_search(expected_output, du_output) != None, "\n" + \
-                   "expected_output -\n{}\ndu_output -\n{}\n".format(
-                   expected_output, du_output)
+        self.assertRegex(du_output, expected_output)
 
     def test_du_works_for_empty_dirs(self):
         dirname = 'some_directory'
@@ -556,12 +544,7 @@ class TestDU(TestCephFSShell):
         expected_output = r'{}{}{}'.format(size, " +", dirname)
 
         du_output = self.get_cephfs_shell_cmd_output('du ' + dirname)
-        if sys_version_info.major >= 3:
-            self.assertRegex(du_output, expected_output)
-        elif sys_version_info.major < 3:
-            assert re_search(expected_output, du_output) != None, "\n" + \
-                   "expected_output -\n{}\ndu_output -\n{}\n".format(
-                   expected_output, du_output)
+        self.assertRegex(du_output, expected_output)
 
     def test_du_works_for_hardlinks(self):
         regfilename = 'some_regfile'
@@ -577,12 +560,7 @@ class TestDU(TestCephFSShell):
         expected_output = r'{}{}{}'.format(size, " +", hlinkname)
 
         du_output = self.get_cephfs_shell_cmd_output('du ' + hlinkname)
-        if sys_version_info.major >= 3:
-            self.assertRegex(du_output, expected_output)
-        elif sys_version_info.major < 3:
-            assert re_search(expected_output, du_output) != None, "\n" + \
-                   "expected_output -\n{}\ndu_output -\n{}\n".format(
-                   expected_output, du_output)
+        self.assertRegex(du_output, expected_output)
 
     def test_du_works_for_softlinks_to_files(self):
         regfilename = 'some_regfile'
@@ -596,12 +574,7 @@ class TestDU(TestCephFSShell):
         expected_output = r'{}{}{}'.format((size), " +", slinkname)
 
         du_output = self.get_cephfs_shell_cmd_output('du ' + slinkname)
-        if sys_version_info.major >= 3:
-            self.assertRegex(du_output, expected_output)
-        elif sys_version_info.major < 3:
-            assert re_search(expected_output, du_output) != None, "\n" + \
-                   "expected_output -\n{}\ndu_output -\n{}\n".format(
-                   expected_output, du_output)
+        self.assertRegex(du_output, expected_output)
 
     def test_du_works_for_softlinks_to_dirs(self):
         dirname = 'some_directory'
@@ -615,12 +588,7 @@ class TestDU(TestCephFSShell):
         expected_output = r'{}{}{}'.format(size, " +", slinkname)
 
         du_output = self.get_cephfs_shell_cmd_output('du ' + slinkname)
-        if sys_version_info.major >= 3:
-            self.assertRegex(du_output, expected_output)
-        elif sys_version_info.major < 3:
-            assert re_search(expected_output, du_output) != None, "\n" + \
-                   "expected_output -\n{}\ndu_output -\n{}\n".format(
-                   expected_output, du_output)
+        self.assertRegex(du_output, expected_output)
 
     # NOTE: tests using these are pretty slow since to this methods sleeps for
     # 15 seconds
@@ -706,12 +674,7 @@ class TestDU(TestCephFSShell):
         du_output = self.get_cephfs_shell_cmd_output('du -r')
 
         for expected_output in expected_patterns_in_output:
-            if sys_version_info.major >= 3:
-                self.assertRegex(du_output, expected_output)
-            elif sys_version_info.major < 3:
-                assert re_search(expected_output, du_output) != None, "\n" + \
-                       "expected_output -\n{}\ndu_output -\n{}\n".format(
-                       expected_output, du_output)
+            self.assertRegex(du_output, expected_output)
 
     def test_du_with_path_in_args(self):
         expected_patterns_in_output, path_to_files = self._setup_files(True,
@@ -723,12 +686,7 @@ class TestDU(TestCephFSShell):
         du_output = self.get_cephfs_shell_cmd_output(args)
 
         for expected_output in expected_patterns_in_output:
-            if sys_version_info.major >= 3:
-                self.assertRegex(du_output, expected_output)
-            elif sys_version_info.major < 3:
-                assert re_search(expected_output, du_output) != None, "\n" +\
-                       "expected_output -\n{}\ndu_output -\n{}\n".format(
-                       expected_output, du_output)
+            self.assertRegex(du_output, expected_output)
 
     def test_du_with_no_args(self):
         expected_patterns_in_output = self._setup_files()
@@ -739,12 +697,7 @@ class TestDU(TestCephFSShell):
             # Since CWD is CephFS root and being non-recursive expect only
             # CWD in DU report.
             if expected_output.find('/') == len(expected_output) - 1:
-                if sys_version_info.major >= 3:
-                    self.assertRegex(du_output, expected_output)
-                elif sys_version_info.major < 3:
-                    assert re_search(expected_output, du_output) != None, "\n" + \
-                        "expected_output -\n{}\ndu_output -\n{}\n".format(
-                        expected_output, du_output)
+                self.assertRegex(du_output, expected_output)
 
 
 class TestDF(TestCephFSShell):
@@ -956,12 +909,7 @@ class TestMisc(TestCephFSShell):
         output = self.mount_a.client_remote.sh(['cephfs-shell', 'ls']).\
             strip()
 
-        if sys_version_info.major >= 3:
-            self.assertRegex(output, dirname)
-        elif sys_version_info.major < 3:
-            assert re_search(dirname, output) != None, "\n" + \
-                   "expected_output -\n{}\ndu_output -\n{}\n".format(
-                   dirname, output)
+        self.assertRegex(output, dirname)
 
     def test_help(self):
         """

--- a/qa/tasks/cephfs/test_forward_scrub.py
+++ b/qa/tasks/cephfs/test_forward_scrub.py
@@ -7,10 +7,8 @@ This is *not* the real testing for forward scrub, which will need to test
 how the functionality responds to damaged metadata.
 
 """
-import json
-
 import logging
-import six
+import json
 
 from collections import namedtuple
 from io import BytesIO
@@ -37,7 +35,7 @@ class TestForwardScrub(CephFSTestCase):
         output = self.fs.rados(["getxattr", obj, attr], pool=pool,
                                stdout_data=BytesIO())
         strlen = struct.unpack('i', output[0:4])[0]
-        return six.ensure_str(output[4:(4 + strlen)], encoding='ascii')
+        return output[4:(4 + strlen)].decode(encoding='ascii')
 
     def _get_paths_to_ino(self):
         inos = {}

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -1,5 +1,4 @@
 from io import BytesIO
-import six
 import logging
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 
@@ -51,16 +50,10 @@ class XFSTestsDev(CephFSTestCase):
 
     def get_admin_key(self):
         import configparser
-        from sys import version_info as sys_version_info
 
         cp = configparser.ConfigParser()
-        if sys_version_info.major > 2:
-            cp.read_string(self.fs.mon_manager.raw_cluster_cmd(
-                'auth', 'get-or-create', 'client.admin'))
-        # TODO: remove this part when we stop supporting Python 2
-        elif sys_version_info.major <= 2:
-            cp.read_string(six.text_type(self.fs.mon_manager.raw_cluster_cmd(
-                'auth', 'get-or-create', 'client.admin')))
+        cp.read_string(self.fs.mon_manager.raw_cluster_cmd(
+            'auth', 'get-or-create', 'client.admin'))
 
         return cp['client.admin']['key']
 

--- a/qa/tasks/osd_failsafe_enospc.py
+++ b/qa/tasks/osd_failsafe_enospc.py
@@ -1,9 +1,8 @@
 """
 Handle osdfailsafe configuration settings (nearfull ratio and full ratio)
 """
-from io import BytesIO
+from io import StringIO
 import logging
-import six
 import time
 
 from teuthology.orchestra import run
@@ -65,7 +64,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=BytesIO(),
+             stdout=StringIO(),
              wait=False,
         )
 
@@ -75,7 +74,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
+    lines = proc.stdout.getvalue().split('\n')
 
     count = len(filter(lambda line: '[WRN] OSD near full' in line, lines))
     assert count == 2, 'Incorrect number of warning messages expected 2 got %d' % count
@@ -93,7 +92,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=BytesIO(),
+             stdout=StringIO(),
              wait=False,
         )
 
@@ -103,7 +102,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
+    lines = proc.stdout.getvalue().split('\n')
 
     count = len(filter(lambda line: '[ERR] OSD full dropping all updates' in line, lines))
     assert count == 2, 'Incorrect number of error messages expected 2 got %d' % count
@@ -135,7 +134,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=BytesIO(),
+             stdout=StringIO(),
              wait=False,
         )
 
@@ -143,7 +142,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
+    lines = proc.stdout.getvalue().split('\n')
 
     count = len(filter(lambda line: '[WRN] OSD near full' in line, lines))
     assert count == 1 or count == 2, 'Incorrect number of warning messages expected 1 or 2 got %d' % count
@@ -164,7 +163,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=BytesIO(),
+             stdout=StringIO(),
              wait=False,
         )
 
@@ -174,7 +173,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
+    lines = proc.stdout.getvalue().split('\n')
 
     count = len(filter(lambda line: '[WRN] OSD near full' in line, lines))
     assert count == 0, 'Incorrect number of warning messages expected 0 got %d' % count
@@ -195,7 +194,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=BytesIO(),
+             stdout=StringIO(),
              wait=False,
         )
 
@@ -203,7 +202,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
+    lines = proc.stdout.getvalue().split('\n')
 
     count = len(filter(lambda line: '[WRN] OSD near full' in line, lines))
     assert count == 0, 'Incorrect number of warning messages expected 0 got %d' % count

--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -14,12 +14,10 @@ import json
 import logging
 import time
 import datetime
-from six.moves import queue
-
 import sys
-import six
 
 from io import BytesIO
+from queue import Queue
 
 import boto.exception
 import boto.s3.connection
@@ -196,7 +194,7 @@ def ignore_this_entry(cat, bucket, user, out, b_in, err):
     pass
 class requestlog_queue():
     def __init__(self, add):
-        self.q = queue.Queue(1000)
+        self.q = Queue(1000)
         self.adder = add
     def handle_request_data(self, request, response, error=False):
         now = datetime.datetime.now()
@@ -215,7 +213,7 @@ class requestlog_queue():
             if 'Content-Length' in j['o'].headers:
                 bytes_out = int(j['o'].headers['Content-Length'])
             bytes_in = 0
-            msg = j['i'].msg if six.PY3 else j['i'].msg.dict
+            msg = j['i'].msg
             if 'content-length'in msg:
                 bytes_in = int(msg['content-length'])
             log.info('RL: %s %s %s bytes_out=%d bytes_in=%d failed=%r'
@@ -245,7 +243,7 @@ def get_acl(key):
     Helper function to get the xml acl from a key, ensuring that the xml
     version tag is removed from the acl response
     """
-    raw_acl = six.ensure_str(key.get_xml_acl())
+    raw_acl = key.get_xml_acl().decode()
 
     def remove_version(string):
         return string.split(
@@ -800,7 +798,7 @@ def task(ctx, config):
     rl.log_and_clear("put_acls", bucket_name, user1)
 
     (err, out) = rgwadmin(ctx, client,
-        ['policy', '--bucket', bucket.name, '--object', six.ensure_str(key.key)],
+        ['policy', '--bucket', bucket.name, '--object', key.key.decode()],
         check_status=True, format='xml')
 
     acl = get_acl(key)
@@ -813,7 +811,7 @@ def task(ctx, config):
     rl.log_and_clear("put_acls", bucket_name, user1)
 
     (err, out) = rgwadmin(ctx, client,
-        ['policy', '--bucket', bucket.name, '--object', six.ensure_str(key.key)],
+        ['policy', '--bucket', bucket.name, '--object', key.key.decode()],
         check_status=True, format='xml')
 
     acl = get_acl(key)
@@ -1040,7 +1038,7 @@ def task(ctx, config):
     out['placement_pools'].append(rule)
 
     (err, out) = rgwadmin(ctx, client, ['zone', 'set'],
-        stdin=BytesIO(six.ensure_binary(json.dumps(out))),
+        stdin=BytesIO(json.dumps(out).encode()),
         check_status=True)
 
     (err, out) = rgwadmin(ctx, client, ['zone', 'get'])

--- a/qa/tasks/rbd.py
+++ b/qa/tasks/rbd.py
@@ -7,7 +7,7 @@ import os
 import tempfile
 import sys
 
-from io import BytesIO
+from io import StringIO
 from teuthology.orchestra import run
 from teuthology import misc as teuthology
 from teuthology import contextutil
@@ -303,12 +303,12 @@ def canonical_path(ctx, role, path):
     representing the given role.  A canonical path contains no
     . or .. components, and includes no symbolic links.
     """
-    version_fp = BytesIO()
+    version_fp = StringIO()
     ctx.cluster.only(role).run(
         args=[ 'readlink', '-f', path ],
         stdout=version_fp,
         )
-    canonical_path = six.ensure_str(version_fp.getvalue()).rstrip('\n')
+    canonical_path = version_fp.getvalue().rstrip('\n')
     version_fp.close()
     return canonical_path
 

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -8,7 +8,6 @@ import contextlib
 import logging
 import os
 import random
-import six
 import string
 
 from teuthology import misc as teuthology
@@ -82,11 +81,11 @@ def _config_user(s3tests_conf, section, user):
     s3tests_conf[section].setdefault('access_key',
         ''.join(random.choice(string.ascii_uppercase) for i in range(20)))
     s3tests_conf[section].setdefault('secret_key',
-        six.ensure_str(base64.b64encode(os.urandom(40))))
+        base64.b64encode(os.urandom(40)).decode())
     s3tests_conf[section].setdefault('totp_serial',
         ''.join(random.choice(string.digits) for i in range(10)))
     s3tests_conf[section].setdefault('totp_seed',
-        six.ensure_str(base64.b32encode(os.urandom(40))))
+        base64.b32encode(os.urandom(40)).decode())
     s3tests_conf[section].setdefault('totp_seconds', '5')
 
 
@@ -245,15 +244,15 @@ def configure(ctx, config):
     log.info('Configuring boto...')
     boto_src = os.path.join(os.path.dirname(__file__), 'boto.cfg.template')
     for client, properties in config['clients'].items():
-        with open(boto_src, 'rb') as f:
+        with open(boto_src) as f:
             (remote,) = ctx.cluster.only(client).remotes.keys()
-            conf = six.ensure_str(f.read()).format(
+            conf = f.read().format(
                 idle_timeout=config.get('idle_timeout', 30)
                 )
             teuthology.write_file(
                 remote=remote,
                 path='{tdir}/boto.cfg'.format(tdir=testdir),
-                data=six.ensure_binary(conf),
+                data=conf.encode(),
                 )
 
     try:

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -6,8 +6,6 @@ import pipes
 import os
 import re
 
-import six
-
 from tasks.util import get_remote_for_role
 from tasks.util.workunit import get_refspec_after_overrides
 
@@ -105,7 +103,7 @@ def task(ctx, config):
     # Create scratch dirs for any non-all workunits
     log.info('Making a separate scratch dir for every client...')
     for role in clients.keys():
-        assert isinstance(role, six.string_types)
+        assert isinstance(role, str)
         if role == "all":
             continue
 
@@ -316,7 +314,7 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
                     to False is passed, the 'timeout' command is not used.
     """
     testdir = misc.get_testdir(ctx)
-    assert isinstance(role, six.string_types)
+    assert isinstance(role, str)
     cluster, type_, id_ = misc.split_role(role)
     assert type_ == 'client'
     remote = get_remote_for_role(ctx, role)
@@ -364,7 +362,7 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
     )
 
     workunits_file = '{tdir}/workunits.list.{role}'.format(tdir=testdir, role=role)
-    workunits = sorted(six.ensure_str(misc.get_file(remote, workunits_file)).split('\0'))
+    workunits = sorted(misc.get_file(remote, workunits_file).decode().split('\0'))
     assert workunits
 
     try:

--- a/qa/workunits/restart/test-backtraces.py
+++ b/qa/workunits/restart/test-backtraces.py
@@ -8,12 +8,6 @@ import os
 import time
 import sys
 
-if sys.version_info[0] == 2:
-    range = xrange # noqa
-
-elif sys.version_info[0] == 3:
-    range = range
-
 import rados as rados
 import cephfs as cephfs
 

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -13,14 +13,7 @@ from collections import namedtuple
 from datetime import datetime
 import errno
 import os
-import sys
 import time
-
-# Are we running Python 2.x
-if sys.version_info[0] < 3:
-    str_type = basestring
-else:
-    str_type = str
 
 AT_NO_ATTR_SYNC = 0x4000
 AT_SYMLINK_NOFOLLOW = 0x100
@@ -634,7 +627,7 @@ cdef class LibCephFS(object):
                 conffile = None
             self.conf_read_file(conffile)
         if conf is not None:
-            for key, value in conf.iteritems():
+            for key, value in conf.items():
                 self.conf_set(key, value)
 
     def get_addrs(self):

--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -208,9 +208,7 @@ setup(
         'License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Cython',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3',
     ],
     cmdclass=cmdclass,
 )

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -4,8 +4,6 @@ import json
 import logging
 from typing import TYPE_CHECKING, Dict, List, Iterator, Optional, Any, Tuple, Set
 
-import six
-
 import orchestrator
 from ceph.deployment import inventory
 from ceph.deployment.service_spec import ServiceSpec
@@ -112,7 +110,7 @@ class SpecStore():
 
     def load(self):
         # type: () -> None
-        for k, v in six.iteritems(self.mgr.get_store_prefix(SPEC_STORE_PREFIX)):
+        for k, v in self.mgr.get_store_prefix(SPEC_STORE_PREFIX).items():
             service_name = k[len(SPEC_STORE_PREFIX):]
             try:
                 v = json.loads(v)
@@ -179,7 +177,7 @@ class HostCache():
 
     def load(self):
         # type: () -> None
-        for k, v in six.iteritems(self.mgr.get_store_prefix(HOST_CACHE_PREFIX)):
+        for k, v in self.mgr.get_store_prefix(HOST_CACHE_PREFIX).items():
             host = k[len(HOST_CACHE_PREFIX):]
             if host not in self.mgr.inventory:
                 self.mgr.log.warning('removing stray HostCache host record %s' % (

--- a/src/pybind/mgr/dashboard/cherrypy_backports.py
+++ b/src/pybind/mgr/dashboard/cherrypy_backports.py
@@ -118,12 +118,7 @@ def accept_socket_error_0(v):
         pass
 
     if v < StrictVersion("9.0.0") or cheroot_version < StrictVersion("6.5.5"):
-        import six
-        if six.PY3:
-            generic_socket_error = OSError
-        else:
-            import socket
-            generic_socket_error = socket.error
+        generic_socket_error = OSError
 
         def accept_socket_error_0(func):
             def wrapper(self, sock):

--- a/src/pybind/mgr/dashboard/ci/check_grafana_uids.py
+++ b/src/pybind/mgr/dashboard/ci/check_grafana_uids.py
@@ -18,18 +18,13 @@ import copy
 import json
 import os
 
-import six
-from six.moves.html_parser import HTMLParser
+from html.parser import HTMLParser
 
 
 class TemplateParser(HTMLParser):
 
     def __init__(self, _file, search_tag):
-        if six.PY3:
-            super(TemplateParser, self).__init__()
-        else:
-            # HTMLParser is not a new-style class in py2
-            HTMLParser.__init__(self)
+        super().__init__()
         self.search_tag = search_tag
         self.file = _file
         self.parsed_data = []
@@ -52,10 +47,6 @@ class TemplateParser(HTMLParser):
         error_msg = 'fail to parse file {} (@{}): {}'.\
             format(self.file, self.getpos(), message)
         exit(error_msg)
-
-
-def stdout(msg):
-    six.print_(msg)
 
 
 def get_files(base_dir, file_ext):
@@ -132,7 +123,7 @@ def main():
         exit(error_msg)
 
     if verbose:
-        stdout('Found mappings:')
+        print('Found mappings:')
     no_dashboard_tags = []
     for tag in tags:
         uid = tag['attrs']['uid']
@@ -144,7 +135,7 @@ def main():
                 format(uid, tag['file'], tag['line'],
                        grafana_dashboards[uid]['title'],
                        grafana_dashboards[uid]['file'])
-            stdout(msg)
+            print(msg)
 
     if no_dashboard_tags:
         title = ('Checking Grafana dashboards UIDs: ERROR\n'
@@ -156,7 +147,7 @@ def main():
         error_msg = title + '\n'.join(lines)
         exit(error_msg)
     else:
-        stdout('Checking Grafana dashboards UIDs: OK')
+        print('Checking Grafana dashboards UIDs: OK')
 
 
 if __name__ == '__main__':

--- a/src/pybind/mgr/dashboard/constraints.txt
+++ b/src/pybind/mgr/dashboard/constraints.txt
@@ -7,4 +7,3 @@ bcrypt==3.1.4
 python3-saml==1.4.1
 requests==2.20.0
 Routes==2.4.1
-six==1.14.0

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -11,15 +11,15 @@ import os
 import pkgutil
 import re
 import sys
+import urllib
 
-import six
-from six.moves.urllib.parse import unquote
+from functools import wraps
 
 # pylint: disable=wrong-import-position
 import cherrypy
 
 from ..security import Scope, Permission
-from ..tools import wraps, getargspec, TaskManager, get_request_body_params
+from ..tools import getargspec, TaskManager, get_request_body_params
 from ..exceptions import ScopeNotValid, PermissionNotValid
 from ..services.auth import AuthManager, JwtManager
 from ..plugins import PLUGIN_MANAGER
@@ -655,8 +655,8 @@ class BaseController(object):
         @wraps(func)
         def inner(*args, **kwargs):
             for key, value in kwargs.items():
-                if isinstance(value, six.text_type):
-                    kwargs[key] = unquote(value)
+                if isinstance(value, str):
+                    kwargs[key] = urllib.parse.unquote(value)
 
             # Process method arguments.
             params = get_request_body_params(cherrypy.request)

--- a/src/pybind/mgr/dashboard/controllers/orchestrator.py
+++ b/src/pybind/mgr/dashboard/controllers/orchestrator.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import os.path
 
 import time
+from functools import wraps
 
 from . import ApiController, Endpoint, ReadPermission, UpdatePermission
 from . import RESTController, Task
@@ -11,7 +12,7 @@ from ..exceptions import DashboardException
 from ..security import Scope
 from ..services.exception import handle_orchestrator_error
 from ..services.orchestrator import OrchClient
-from ..tools import TaskManager, wraps
+from ..tools import TaskManager
 
 
 def get_device_osd_map():

--- a/src/pybind/mgr/dashboard/plugins/__init__.py
+++ b/src/pybind/mgr/dashboard/plugins/__init__.py
@@ -2,13 +2,11 @@
 from __future__ import absolute_import
 
 import abc
-import six
 
 from .pluggy import HookspecMarker, HookimplMarker, PluginManager
 
 
-@six.add_metaclass(abc.ABCMeta)
-class Interface(object):
+class Interface(object, metaclass=abc.ABCMeta):
     pass
 
 

--- a/src/pybind/mgr/dashboard/requirements.txt
+++ b/src/pybind/mgr/dashboard/requirements.txt
@@ -7,7 +7,6 @@ pyopenssl
 python3-saml
 requests
 Routes
-six
 -e ../../../python-common
 prettytable
 pyyaml

--- a/src/pybind/mgr/dashboard/services/cephfs.py
+++ b/src/pybind/mgr/dashboard/services/cephfs.py
@@ -6,7 +6,6 @@ import logging
 
 import datetime
 import os
-import six
 import cephfs
 
 from .. import mgr
@@ -92,7 +91,7 @@ class CephFS(object):
             ]
         :rtype: list
         """
-        if isinstance(path, six.string_types):
+        if isinstance(path, str):
             path = path.encode()
         logger.debug("get_dir_list dirpath=%s depth=%s", path,
                      depth)

--- a/src/pybind/mgr/dashboard/services/exception.py
+++ b/src/pybind/mgr/dashboard/services/exception.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 import json
 from contextlib import contextmanager
 import logging
-import six
 
 import cherrypy
 
@@ -14,55 +13,9 @@ import rados
 
 from ..services.ceph_service import SendCommandError
 from ..exceptions import ViewCacheNoDataException, DashboardException
-from ..tools import wraps
 
 
 logger = logging.getLogger('exception')
-
-
-if six.PY2:
-    # Monkey-patch a __call__ method into @contextmanager to make
-    # it compatible to Python 3
-
-    # pylint: disable=no-name-in-module,ungrouped-imports
-    from contextlib import GeneratorContextManager
-
-    def init(self, *args):
-        if len(args) == 1:
-            self.gen = args[0]
-        elif len(args) == 3:
-            self.func, self.args, self.kwargs = args
-        else:
-            raise TypeError()
-
-    def enter(self):
-        if hasattr(self, 'func'):
-            self.gen = self.func(*self.args, **self.kwargs)
-        try:
-            return self.gen.next()
-        except StopIteration:
-            raise RuntimeError("generator didn't yield")
-
-    def call(self, f):
-        @wraps(f)
-        def wrapper(*args, **kwargs):
-            with self:
-                return f(*args, **kwargs)
-
-        return wrapper
-
-    GeneratorContextManager.__init__ = init
-    GeneratorContextManager.__enter__ = enter
-    GeneratorContextManager.__call__ = call
-
-    # pylint: disable=function-redefined
-    def contextmanager(func):  # noqa: F811
-
-        @wraps(func)
-        def helper(*args, **kwds):
-            return GeneratorContextManager(func, args, kwds)
-
-        return helper
 
 
 def serialize_dashboard_exception(e, include_http_status=False, task=None):

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 import logging
 
+from functools import wraps
 from typing import List, Optional
 
 from orchestrator import InventoryFilter, DeviceLightLoc, Completion
@@ -9,7 +10,6 @@ from orchestrator import ServiceDescription, DaemonDescription
 from orchestrator import OrchestratorClientMixin, raise_if_exception, OrchestratorError
 from orchestrator import HostSpec
 from .. import mgr
-from ..tools import wraps
 
 logger = logging.getLogger('orchestrator')
 

--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -2,8 +2,6 @@
 # pylint: disable=unused-argument
 from __future__ import absolute_import
 
-import six
-
 import cherrypy
 
 import rbd
@@ -57,7 +55,7 @@ def format_features(features):
     @DISABLEDOCTEST: >>> format_features('deep-flatten, exclusive-lock')
     32
     """
-    if isinstance(features, six.string_types):
+    if isinstance(features, str):
         features = features.split(',')
 
     if not isinstance(features, list):

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -6,7 +6,6 @@ import logging
 import ipaddress
 from distutils.util import strtobool
 import xml.etree.ElementTree as ET  # noqa: N814
-import six
 from ..awsauth import S3Auth
 from ..exceptions import DashboardException
 from ..settings import Settings, Options
@@ -139,7 +138,7 @@ def _parse_addr(value):
         #   Group 2: 2001:db8:85a3::8a2e:370:7334
         addr = match.group(3) if match.group(3) else match.group(2)
         try:
-            ipaddress.ip_address(six.u(addr))
+            ipaddress.ip_address(addr)
             return addr
         except ValueError:
             raise LookupError('Invalid RGW address \'{}\' found'.format(addr))

--- a/src/pybind/mgr/dashboard/services/sso.py
+++ b/src/pybind/mgr/dashboard/services/sso.py
@@ -9,15 +9,11 @@ import logging
 import threading
 import warnings
 
-import six
-from six.moves.urllib import parse
+from urllib import parse
 
 from .. import mgr
 from ..tools import prepare_url_prefix
 
-
-if six.PY2:
-    FileNotFoundError = IOError  # pylint: disable=redefined-builtin
 
 logger = logging.getLogger('sso')
 

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 
 import errno
 import inspect
-from six import add_metaclass
 
 from . import mgr
 
@@ -112,8 +111,7 @@ class SettingsMeta(type):
 
 
 # pylint: disable=no-init
-@add_metaclass(SettingsMeta)
-class Settings(object):
+class Settings(object, metaclass=SettingsMeta):
     pass
 
 

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 import json
 import logging
 import threading
-import sys
 import time
 
 import cherrypy
@@ -94,11 +93,7 @@ class FakeFsMixin(object):
     fs = fake_filesystem.FakeFilesystem()
     f_open = fake_filesystem.FakeFileOpen(fs)
     f_os = fake_filesystem.FakeOsModule(fs)
-
-    if sys.version_info > (3, 0):
-        builtins_open = 'builtins.open'
-    else:
-        builtins_open = '__builtin__.open'
+    builtins_open = 'builtins.open'
 
 
 class ControllerTestCase(helper.CPWebCase):

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import sys
 import inspect
 import json
-import functools
 import ipaddress
 import logging
 
@@ -14,14 +12,9 @@ from distutils.util import strtobool
 import fnmatch
 import time
 import threading
-import six
-from six.moves import urllib
-import cherrypy
+import urllib
 
-try:
-    from urlparse import urljoin
-except ImportError:
-    from urllib.parse import urljoin
+import cherrypy
 
 from . import mgr
 from .exceptions import ViewCacheNoDataException
@@ -694,12 +687,7 @@ def build_url(host, scheme=None, port=None):
     :rtype: str
     """
     try:
-        try:
-            u_host = six.u(host)
-        except TypeError:
-            u_host = host
-
-        ipaddress.IPv6Address(u_host)
+        ipaddress.IPv6Address(host)
         netloc = '[{}]'.format(host)
     except ValueError:
         netloc = host
@@ -719,7 +707,7 @@ def prepare_url_prefix(url_prefix):
     """
     return '' if no prefix, or '/prefix' without slash in the end.
     """
-    url_prefix = urljoin('/', url_prefix)
+    url_prefix = urllib.parse.urljoin('/', url_prefix)
     return url_prefix.rstrip('/')
 
 
@@ -757,20 +745,6 @@ def dict_get(obj, path, default=None):
     return current
 
 
-if sys.version_info > (3, 0):
-    wraps = functools.wraps
-    _getargspec = inspect.getfullargspec
-else:
-    def wraps(func):
-        def decorator(wrapper):
-            new_wrapper = functools.wraps(func)(wrapper)
-            new_wrapper.__wrapped__ = func  # set __wrapped__ even for Python 2
-            return new_wrapper
-        return decorator
-
-    _getargspec = inspect.getargspec
-
-
 def getargspec(func):
     try:
         while True:
@@ -778,7 +752,7 @@ def getargspec(func):
     except AttributeError:
         pass
     # pylint: disable=deprecated-method
-    return _getargspec(func)
+    return inspect.getfullargspec(func)
 
 
 def str_to_bool(val):

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -137,7 +137,5 @@ commands =
 
 
 [testenv:check]
-deps = 
-    six==1.14.0
 commands =
     python ci/check_grafana_uids.py frontend/src/app ../../../../monitoring/grafana/dashboards

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -9,7 +9,6 @@ import operator
 import rados
 from threading import Event
 from datetime import datetime, timedelta, date, time
-from six import iteritems
 
 TIME_FORMAT = '%Y%m%d-%H%M%S'
 
@@ -559,7 +558,7 @@ class Module(MgrModule):
                 did += 1
             if to_mark_out:
                 self.mark_out_etc(to_mark_out)
-        for warning, ls in iteritems(health_warnings):
+        for warning, ls in health_warnings.items():
             n = len(ls)
             if n:
                 checks[warning] = {

--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -2,12 +2,9 @@ from contextlib import contextmanager
 from datetime import datetime
 from threading import Event, Thread
 from itertools import chain
-from six import next
-from six.moves import queue
-from six.moves import xrange as range
+import queue
 import json
 import errno
-import six
 import time
 
 from mgr_module import MgrModule
@@ -214,7 +211,7 @@ class Module(MgrModule):
     def get_pg_summary_osd(self, pool_info, now):
         pg_sum = self.get('pg_summary')
         osd_sum = pg_sum['by_osd']
-        for osd_id, stats in six.iteritems(osd_sum):
+        for osd_id, stats in osd_sum.items():
             metadata = self.get_metadata('osd', "%s" % osd_id)
             if not metadata:
                 continue
@@ -235,7 +232,7 @@ class Module(MgrModule):
 
     def get_pg_summary_pool(self, pool_info, now):
         pool_sum = self.get('pg_summary')['by_pool']
-        for pool_id, stats in six.iteritems(pool_sum):
+        for pool_id, stats in pool_sum.items():
             for stat in stats:
                 yield {
                     "measurement": "ceph_pg_summary_pool",
@@ -251,7 +248,7 @@ class Module(MgrModule):
                 }
 
     def get_daemon_stats(self, now):
-        for daemon, counters in six.iteritems(self.get_all_perf_counters()):
+        for daemon, counters in self.get_all_perf_counters().items():
             svc_type, svc_id = daemon.split(".", 1)
             metadata = self.get_metadata(svc_type, svc_id)
 

--- a/src/pybind/mgr/insights/health.py
+++ b/src/pybind/mgr/insights/health.py
@@ -1,5 +1,4 @@
 import json
-import six
 from collections import defaultdict
 import datetime
 
@@ -44,7 +43,7 @@ class HealthCheckAccumulator(object):
         """
         changed = False
 
-        for check, info in six.iteritems(checks):
+        for check, info in checks.items():
 
             # only keep the icky stuff
             severity = info["severity"]

--- a/src/pybind/mgr/insights/module.py
+++ b/src/pybind/mgr/insights/module.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import re
 import threading
-import six
+
 from mgr_module import MgrModule, CommandResult
 from . import health as health_util
 
@@ -121,7 +121,7 @@ class Module(MgrModule):
         """Filter hourly health reports timestamp"""
         matches = filter(
             lambda t: f(health_util.HealthHistorySlot.key_to_time(t[0])),
-            six.iteritems(self.get_store_prefix(health_util.HEALTH_HISTORY_KEY_PREFIX)))
+            self.get_store_prefix(health_util.HEALTH_HISTORY_KEY_PREFIX).items())
         return map(lambda t: t[0], matches)
 
     def _health_prune_history(self, hours):
@@ -171,7 +171,7 @@ class Module(MgrModule):
             "major": m.group("major"),
             "minor": m.group("minor")
         }
-        return { k:int(v) for k,v in six.iteritems(ver) }
+        return { k:int(v) for k,v in ver.items() }
 
     def _crash_history(self, hours):
         """

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -8,7 +8,6 @@ except ImportError:
 import logging
 import errno
 import json
-import six
 import threading
 from collections import defaultdict, namedtuple
 import rados
@@ -197,7 +196,7 @@ class CRUSHMap(ceph_module.BasePyCRUSH):
 
     def get_take_weight_osd_map(self, root):
         uglymap = self._get_take_weight_osd_map(root)
-        return {int(k): v for k, v in six.iteritems(uglymap.get('weights', {}))}
+        return {int(k): v for k, v in uglymap.get('weights', {}).items()}
 
     @staticmethod
     def have_default_choose_args(dump):

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -6,7 +6,6 @@ import json
 import mgr_util
 import threading
 import uuid
-from six import itervalues, iteritems
 from prettytable import PrettyTable
 from mgr_module import MgrModule
 
@@ -244,7 +243,7 @@ class PgAutoscaler(MgrModule):
 
             # do we intersect an existing root?
             s = None
-            for prev in itervalues(result):
+            for prev in result.values():
                 if osds & prev.osds:
                     s = prev
                     break
@@ -308,7 +307,7 @@ class PgAutoscaler(MgrModule):
         ret = []
 
         # iterate over all pools to determine how they should be sized
-        for pool_name, p in iteritems(pools):
+        for pool_name, p in pools.items():
             pool_id = p['pool']
             if pool_id not in pool_stats:
                 # race with pool deletion; skip
@@ -506,7 +505,7 @@ class PgAutoscaler(MgrModule):
             }
 
         too_much_target_bytes = []
-        for root_id, total in iteritems(total_bytes):
+        for root_id, total in total_bytes.items():
             total_target = total_target_bytes[root_id]
             if total_target > 0 and total > root_map[root_id].capacity and root_map[root_id].capacity:
                 too_much_target_bytes.append(

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -11,7 +11,6 @@ import inspect
 import tempfile
 import threading
 import traceback
-import six
 import socket
 import fcntl
 
@@ -22,7 +21,6 @@ from uuid import uuid4
 from pecan import jsonify, make_app
 from OpenSSL import crypto
 from pecan.rest import RestController
-from six import iteritems
 from werkzeug.serving import make_server, make_ssl_devcert
 
 from .hooks import ErrorHook
@@ -264,7 +262,7 @@ class Module(MgrModule):
     def refresh_keys(self):
         self.keys = {}
         rawkeys = self.get_store_prefix('keys/') or {}
-        for k, v in six.iteritems(rawkeys):
+        for k, v in rawkeys.items():
             self.keys[k[5:]] = v  # strip of keys/ prefix
 
     def _serve(self):

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -4,7 +4,6 @@ import threading
 import random
 import json
 import errno
-import six
 
 
 class Module(MgrModule):
@@ -173,7 +172,7 @@ class Module(MgrModule):
             return -1, "", "Failed to decode JSON input: {}".format(e)
 
         try:
-            for check, info in six.iteritems(checks):
+            for check, info in checks.items():
                 self._health[check] = {
                     "severity": str(info["severity"]),
                     "summary": str(info["summary"]),

--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -9,7 +9,6 @@ import errno
 import fnmatch
 import mgr_util
 import prettytable
-import six
 import json
 
 from mgr_module import MgrModule, HandleCommandResult
@@ -147,7 +146,7 @@ class Module(MgrModule):
                         ])
 
             # Find the standby replays
-            for gid_str, daemon_info in six.iteritems(mdsmap['info']):
+            for gid_str, daemon_info in mdsmap['info'].items():
                 if daemon_info['state'] != "up:standby-replay":
                     continue
 
@@ -257,7 +256,7 @@ class Module(MgrModule):
                                         border=False)
             version_table.left_padding_width = 0
             version_table.right_padding_width = 2
-            for version, daemons in six.iteritems(mds_versions):
+            for version, daemons in mds_versions.items():
                 if output_format in ('json', 'json-pretty'):
                     json_output['mds_version'].append({
                         'version': version,

--- a/src/pybind/mgr/telegraf/module.py
+++ b/src/pybind/mgr/telegraf/module.py
@@ -1,7 +1,6 @@
 import errno
 import json
 import itertools
-import six
 import socket
 import time
 from threading import Event
@@ -99,7 +98,7 @@ class Module(MgrModule):
                 }
 
     def get_daemon_stats(self):
-        for daemon, counters in six.iteritems(self.get_all_perf_counters()):
+        for daemon, counters in self.get_all_perf_counters().items():
             svc_type, svc_id = daemon.split('.', 1)
             metadata = self.get_metadata(svc_type, svc_id)
             if not metadata:

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -19,7 +19,6 @@ from libc cimport errno
 from libc.stdint cimport *
 from libc.stdlib cimport malloc, realloc, free
 
-import sys
 import threading
 import time
 
@@ -30,12 +29,6 @@ except ImportError:
 from datetime import datetime, timedelta
 from functools import partial, wraps
 from itertools import chain
-
-# Are we running Python 2.x
-if sys.version_info[0] < 3:
-    str_type = basestring
-else:
-    str_type = str
 
 
 cdef extern from "Python.h":
@@ -715,8 +708,8 @@ cdef class Rados(object):
         PyEval_InitThreads()
         self.__setup(*args, **kwargs)
 
-    @requires(('rados_id', opt(str_type)), ('name', opt(str_type)), ('clustername', opt(str_type)),
-              ('conffile', opt(str_type)))
+    @requires(('rados_id', opt(str)), ('name', opt(str)), ('clustername', opt(str)),
+              ('conffile', opt(str)))
     def __setup(self, rados_id=None, name=None, clustername=None,
                 conf_defaults=None, conffile=None, conf=None, flags=0,
                 context=None):
@@ -832,7 +825,7 @@ Rados object in state %s." % self.state)
             rados_version(&major, &minor, &extra)
         return Version(major, minor, extra)
 
-    @requires(('path', opt(str_type)))
+    @requires(('path', opt(str)))
     def conf_read_file(self, path=None):
         """
         Configure the cluster handle using a Ceph config file.
@@ -900,7 +893,7 @@ Rados object in state %s." % self.state)
         if ret != 0:
             raise make_ex(ret, "error calling conf_parse_env")
 
-    @requires(('option', str_type))
+    @requires(('option', str))
     def conf_get(self, option):
         """
         Get the value of a configuration option
@@ -934,7 +927,7 @@ Rados object in state %s." % self.state)
         finally:
             free(ret_buf)
 
-    @requires(('option', str_type), ('val', str_type))
+    @requires(('option', str), ('val', str))
     def conf_set(self, option, val):
         """
         Set the value of a configuration option
@@ -1046,7 +1039,7 @@ Rados object in state %s." % self.state)
                 'kb_avail': stats.kb_avail,
                 'num_objects': stats.num_objects}
 
-    @requires(('pool_name', str_type))
+    @requires(('pool_name', str))
     def pool_exists(self, pool_name):
         """
         Checks if a given pool exists.
@@ -1072,7 +1065,7 @@ Rados object in state %s." % self.state)
         else:
             raise make_ex(ret, "error looking up pool '%s'" % pool_name)
 
-    @requires(('pool_name', str_type))
+    @requires(('pool_name', str))
     def pool_lookup(self, pool_name):
         """
         Returns a pool's ID based on its name.
@@ -1133,7 +1126,7 @@ Rados object in state %s." % self.state)
         finally:
             free(name)
 
-    @requires(('pool_name', str_type), ('crush_rule', opt(int)), ('auid', opt(int)))
+    @requires(('pool_name', str), ('crush_rule', opt(int)), ('auid', opt(int)))
     def create_pool(self, pool_name, crush_rule=None, auid=None):
         """
         Create a pool:
@@ -1196,7 +1189,7 @@ Rados object in state %s." % self.state)
             raise make_ex(ret, "get_pool_base_tier(%d)" % pool_id)
         return int(base_tier)
 
-    @requires(('pool_name', str_type))
+    @requires(('pool_name', str))
     def delete_pool(self, pool_name):
         """
         Delete a pool and all data inside it.
@@ -1303,7 +1296,7 @@ Rados object in state %s." % self.state)
         finally:
             free(ret_buf)
 
-    @requires(('ioctx_name', str_type))
+    @requires(('ioctx_name', str))
     def open_ioctx(self, ioctx_name):
         """
         Create an io context
@@ -1654,7 +1647,7 @@ Rados object in state %s." % self.state)
         self.monitor_callback = None
         self.monitor_callback2 = cb
 
-    @requires(('service', str_type), ('daemon', str_type), ('metadata', dict))
+    @requires(('service', str), ('daemon', str), ('metadata', dict))
     def service_daemon_register(self, service, daemon, metadata):
         """
         :param str service: service name (e.g. "rgw")
@@ -2096,7 +2089,7 @@ cdef class WriteOp(object):
         with nogil:
             rados_write_op_set_flags(self.write_op, _flags)
 
-    @requires(('xattr_name', str_type), ('xattr_value', bytes))
+    @requires(('xattr_name', str), ('xattr_value', bytes))
     def set_xattr(self, xattr_name, xattr_value):
         """
         Set an extended attribute on an object.
@@ -2113,7 +2106,7 @@ cdef class WriteOp(object):
         with nogil:
             rados_write_op_setxattr(self.write_op, _xattr_name, _xattr_value, _xattr_value_len)
 
-    @requires(('xattr_name', str_type))
+    @requires(('xattr_name', str))
     def rm_xattr(self, xattr_name):
         """  
         Removes an extended attribute on from an object.
@@ -2218,7 +2211,7 @@ cdef class WriteOp(object):
         with nogil:
             rados_write_op_truncate(self.write_op,  _offset)
 
-    @requires(('cls', str_type), ('method', str_type), ('data', bytes))
+    @requires(('cls', str), ('method', str), ('data', bytes))
     def execute(self, cls, method, data):
         """
         Execute an OSD class method on an object
@@ -2525,7 +2518,7 @@ cdef class Ioctx(object):
         ioctx.set_namespace(self.get_namespace())
         return ioctx
 
-    @requires(('object_name', str_type), ('oncomplete', opt(Callable)))
+    @requires(('object_name', str), ('oncomplete', opt(Callable)))
     def aio_stat(self, object_name, oncomplete):
         """
         Asynchronously get object stats (size/mtime)
@@ -2571,7 +2564,7 @@ cdef class Ioctx(object):
             raise make_ex(ret, "error stating %s" % object_name)
         return completion
 
-    @requires(('object_name', str_type), ('to_write', bytes), ('offset', int),
+    @requires(('object_name', str), ('to_write', bytes), ('offset', int),
               ('oncomplete', opt(Callable)), ('onsafe', opt(Callable)))
     def aio_write(self, object_name, to_write, offset=0,
                   oncomplete=None, onsafe=None):
@@ -2616,7 +2609,7 @@ cdef class Ioctx(object):
             raise make_ex(ret, "error writing object %s" % object_name)
         return completion
 
-    @requires(('object_name', str_type), ('to_write', bytes), ('oncomplete', opt(Callable)),
+    @requires(('object_name', str), ('to_write', bytes), ('oncomplete', opt(Callable)),
               ('onsafe', opt(Callable)))
     def aio_write_full(self, object_name, to_write,
                        oncomplete=None, onsafe=None):
@@ -2661,7 +2654,7 @@ cdef class Ioctx(object):
             raise make_ex(ret, "error writing object %s" % object_name)
         return completion
 
-    @requires(('object_name', str_type), ('to_write', bytes), ('write_len', int),
+    @requires(('object_name', str), ('to_write', bytes), ('write_len', int),
               ('offset', int), ('oncomplete', opt(Callable)))
     def aio_writesame(self, object_name, to_write, write_len, offset=0,
                       oncomplete=None):
@@ -2704,7 +2697,7 @@ cdef class Ioctx(object):
             raise make_ex(ret, "error writing object %s" % object_name)
         return completion
 
-    @requires(('object_name', str_type), ('to_append', bytes), ('oncomplete', opt(Callable)),
+    @requires(('object_name', str), ('to_append', bytes), ('oncomplete', opt(Callable)),
               ('onsafe', opt(Callable)))
     def aio_append(self, object_name, to_append, oncomplete=None, onsafe=None):
         """
@@ -2758,7 +2751,7 @@ cdef class Ioctx(object):
         if ret < 0:
             raise make_ex(ret, "error flushing")
 
-    @requires(('object_name', str_type), ('length', int), ('offset', int),
+    @requires(('object_name', str), ('length', int), ('offset', int),
               ('oncomplete', opt(Callable)))
     def aio_read(self, object_name, length, offset, oncomplete):
         """
@@ -2811,7 +2804,7 @@ cdef class Ioctx(object):
             raise make_ex(ret, "error reading %s" % object_name)
         return completion
 
-    @requires(('object_name', str_type), ('cls', str_type), ('method', str_type),
+    @requires(('object_name', str), ('cls', str), ('method', str),
               ('data', bytes), ('length', int),
               ('oncomplete', opt(Callable)), ('onsafe', opt(Callable)))
     def aio_execute(self, object_name, cls, method, data,
@@ -2882,7 +2875,7 @@ cdef class Ioctx(object):
             raise make_ex(ret, "error executing %s::%s on %s" % (cls, method, object_name))
         return completion
 
-    @requires(('object_name', str_type), ('oncomplete', opt(Callable)), ('onsafe', opt(Callable)))
+    @requires(('object_name', str), ('oncomplete', opt(Callable)), ('onsafe', opt(Callable)))
     def aio_remove(self, object_name, oncomplete=None, onsafe=None):
         """
         Asynchronously remove an object
@@ -2924,7 +2917,7 @@ cdef class Ioctx(object):
         if self.state != "open":
             raise IoctxStateError("The pool is %s" % self.state)
 
-    @requires(('loc_key', str_type))
+    @requires(('loc_key', str))
     def set_locator_key(self, loc_key):
         """
         Set the key for mapping objects to pgs within an io context.
@@ -2972,7 +2965,7 @@ cdef class Ioctx(object):
         with nogil:
             rados_ioctx_snap_set_read(self.io, _snap_id)
 
-    @requires(('nspace', str_type))
+    @requires(('nspace', str))
     def set_namespace(self, nspace):
         """
         Set the namespace for objects within an io context.
@@ -3020,7 +3013,7 @@ cdef class Ioctx(object):
             self.state = "closed"
 
 
-    @requires(('key', str_type), ('data', bytes))
+    @requires(('key', str), ('data', bytes))
     def write(self, key, data, offset=0):
         """
         Write data to an object synchronously
@@ -3056,7 +3049,7 @@ cdef class Ioctx(object):
             raise LogicError("Ioctx.write(%s): rados_write \
 returned %d, but should return zero on success." % (self.name, ret))
 
-    @requires(('key', str_type), ('data', bytes))
+    @requires(('key', str), ('data', bytes))
     def write_full(self, key, data):
         """
         Write an entire object synchronously.
@@ -3091,7 +3084,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             raise LogicError("Ioctx.write_full(%s): rados_write_full \
 returned %d, but should return zero on success." % (self.name, ret))
 
-    @requires(('key', str_type), ('data', bytes), ('write_len', int), ('offset', int))
+    @requires(('key', str), ('data', bytes), ('write_len', int), ('offset', int))
     def writesame(self, key, data, write_len, offset=0):
         """
         Write the same buffer multiple times
@@ -3124,7 +3117,7 @@ returned %d, but should return zero on success." % (self.name, ret))
                            % (self.name, key))
         assert(ret == 0)
 
-    @requires(('key', str_type), ('data', bytes))
+    @requires(('key', str), ('data', bytes))
     def append(self, key, data):
         """
         Append data to an object synchronously
@@ -3156,7 +3149,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             raise LogicError("Ioctx.append(%s): rados_append \
 returned %d, but should return zero on success." % (self.name, ret))
 
-    @requires(('key', str_type))
+    @requires(('key', str))
     def read(self, key, length=8192, offset=0):
         """
         Read data from an object synchronously
@@ -3200,7 +3193,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             # itself and set ret_s to NULL, hence XDECREF).
             ref.Py_XDECREF(ret_s)
 
-    @requires(('key', str_type), ('cls', str_type), ('method', str_type), ('data', bytes))
+    @requires(('key', str), ('cls', str), ('method', str), ('data', bytes))
     def execute(self, key, cls, method, data, length=8192):
         """
         Execute an OSD class method on an object.
@@ -3306,7 +3299,7 @@ returned %d, but should return zero on success." % (self.name, ret))
                 "num_wr": stats.num_wr,
                 "num_wr_kb": stats.num_wr_kb}
 
-    @requires(('key', str_type))
+    @requires(('key', str))
     def remove_object(self, key):
         """
         Delete an object
@@ -3331,7 +3324,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             raise make_ex(ret, "Failed to remove '%s'" % key)
         return True
 
-    @requires(('key', str_type))
+    @requires(('key', str))
     def trunc(self, key, size):
         """
         Resize an object
@@ -3361,7 +3354,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             raise make_ex(ret, "Ioctx.trunc(%s): failed to truncate %s" % (self.name, key))
         return ret
    
-    @requires(('key', str_type), ('cmp_buf', bytes), ('offset', int))
+    @requires(('key', str), ('cmp_buf', bytes), ('offset', int))
     def cmpext(self, key, cmp_buf, offset=0):
         '''
         Compare an on-disk object range with a buffer
@@ -3389,7 +3382,7 @@ returned %d, but should return zero on success." % (self.name, ret))
         assert ret < -MAX_ERRNO or ret == 0, "Ioctx.cmpext(%s): failed to compare %s" % (self.name, key)        
         return ret
 
-    @requires(('key', str_type))
+    @requires(('key', str))
     def stat(self, key):
         """
         Get object stats (size/mtime)
@@ -3415,7 +3408,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             raise make_ex(ret, "Failed to stat %r" % key)
         return psize, time.localtime(pmtime)
 
-    @requires(('key', str_type), ('xattr_name', str_type))
+    @requires(('key', str), ('xattr_name', str))
     def get_xattr(self, key, xattr_name):
         """
         Get the value of an extended attribute on an object.
@@ -3454,7 +3447,7 @@ returned %d, but should return zero on success." % (self.name, ret))
         finally:
             free(ret_buf)
 
-    @requires(('oid', str_type))
+    @requires(('oid', str))
     def get_xattrs(self, oid):
         """
         Start iterating over xattrs on an object.
@@ -3469,7 +3462,7 @@ returned %d, but should return zero on success." % (self.name, ret))
         self.require_ioctx_open()
         return XattrIterator(self, oid)
 
-    @requires(('key', str_type), ('xattr_name', str_type), ('xattr_value', bytes))
+    @requires(('key', str), ('xattr_name', str), ('xattr_value', bytes))
     def set_xattr(self, key, xattr_name, xattr_value):
         """
         Set an extended attribute on an object.
@@ -3502,7 +3495,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             raise make_ex(ret, "Failed to set xattr %r" % xattr_name)
         return True
 
-    @requires(('key', str_type), ('xattr_name', str_type))
+    @requires(('key', str), ('xattr_name', str))
     def rm_xattr(self, key, xattr_name):
         """
         Removes an extended attribute on from an object.
@@ -3531,7 +3524,7 @@ returned %d, but should return zero on success." % (self.name, ret))
                           (key, xattr_name))
         return True
 
-    @requires(('obj', str_type), ('msg', str_type), ('timeout_ms', int))
+    @requires(('obj', str), ('msg', str), ('timeout_ms', int))
     def notify(self, obj, msg='', timeout_ms=5000):
         """
         Send a rados notification to an object.
@@ -3565,7 +3558,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             raise make_ex(ret, "Failed to notify %r" % (obj))
         return True
 
-    @requires(('obj', str_type), ('callback', opt(Callable)),
+    @requires(('obj', str), ('callback', opt(Callable)),
               ('error_callback', opt(Callable)), ('timeout', int))
     def watch(self, obj, callback, error_callback=None, timeout=None):
         """
@@ -3643,7 +3636,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             free(name)
 
 
-    @requires(('snap_name', str_type))
+    @requires(('snap_name', str))
     def create_snap(self, snap_name):
         """
         Create a pool-wide snapshot
@@ -3663,7 +3656,7 @@ returned %d, but should return zero on success." % (self.name, ret))
         if ret != 0:
             raise make_ex(ret, "Failed to create snap %s" % snap_name)
 
-    @requires(('snap_name', str_type))
+    @requires(('snap_name', str))
     def remove_snap(self, snap_name):
         """
         Removes a pool-wide snapshot
@@ -3683,7 +3676,7 @@ returned %d, but should return zero on success." % (self.name, ret))
         if ret != 0:
             raise make_ex(ret, "Failed to remove snap %s" % snap_name)
 
-    @requires(('snap_name', str_type))
+    @requires(('snap_name', str))
     def lookup_snap(self, snap_name):
         """
         Get the id of a pool snapshot
@@ -3707,7 +3700,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             raise make_ex(ret, "Failed to lookup snap %s" % snap_name)
         return Snap(self, snap_name, int(snap_id))
 
-    @requires(('oid', str_type), ('snap_name', str_type))
+    @requires(('oid', str), ('snap_name', str))
     def snap_rollback(self, oid, snap_name):
         """
         Rollback an object to a snapshot
@@ -3804,7 +3797,7 @@ returned %d, but should return zero on success." % (self.name, ret))
         finally:
             free(_snaps)
 
-    @requires(('oid', str_type), ('snap_id', int))
+    @requires(('oid', str), ('snap_id', int))
     def rollback_self_managed_snap(self, oid, snap_id):
         """
         Rolls an specific object back to a self-managed snapshot revision
@@ -3905,7 +3898,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             free(_values)
             free(_lens)
 
-    @requires(('write_op', WriteOp), ('oid', str_type), ('mtime', opt(int)), ('flags', opt(int)))
+    @requires(('write_op', WriteOp), ('oid', str), ('mtime', opt(int)), ('flags', opt(int)))
     def operate_write_op(self, write_op, oid, mtime=0, flags=LIBRADOS_OPERATION_NOFLAG):
         """
         execute the real write operation
@@ -3931,7 +3924,7 @@ returned %d, but should return zero on success." % (self.name, ret))
         if ret != 0:
             raise make_ex(ret, "Failed to operate write op for oid %s" % oid)
 
-    @requires(('write_op', WriteOp), ('oid', str_type), ('oncomplete', opt(Callable)), ('onsafe', opt(Callable)), ('mtime', opt(int)), ('flags', opt(int)))
+    @requires(('write_op', WriteOp), ('oid', str), ('oncomplete', opt(Callable)), ('onsafe', opt(Callable)), ('mtime', opt(int)), ('flags', opt(int)))
     def operate_aio_write_op(self, write_op, oid, oncomplete=None, onsafe=None, mtime=0, flags=LIBRADOS_OPERATION_NOFLAG):
         """
         execute the real write operation asynchronously
@@ -3973,7 +3966,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             raise make_ex(ret, "Failed to operate aio write op for oid %s" % oid)
         return completion
 
-    @requires(('read_op', ReadOp), ('oid', str_type), ('flag', opt(int)))
+    @requires(('read_op', ReadOp), ('oid', str), ('flag', opt(int)))
     def operate_read_op(self, read_op, oid, flag=LIBRADOS_OPERATION_NOFLAG):
         """
         execute the real read operation
@@ -3995,7 +3988,7 @@ returned %d, but should return zero on success." % (self.name, ret))
         if ret != 0:
             raise make_ex(ret, "Failed to operate read op for oid %s" % oid)
 
-    @requires(('read_op', ReadOp), ('oid', str_type), ('oncomplete', opt(Callable)), ('onsafe', opt(Callable)), ('flag', opt(int)))
+    @requires(('read_op', ReadOp), ('oid', str), ('oncomplete', opt(Callable)), ('onsafe', opt(Callable)), ('flag', opt(int)))
     def operate_aio_read_op(self, read_op, oid, oncomplete=None, onsafe=None, flag=LIBRADOS_OPERATION_NOFLAG):
         """
         execute the real read operation
@@ -4029,7 +4022,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             raise make_ex(ret, "Failed to operate aio read op for oid %s" % oid)
         return completion
 
-    @requires(('read_op', ReadOp), ('start_after', str_type), ('filter_prefix', str_type), ('max_return', int))
+    @requires(('read_op', ReadOp), ('start_after', str), ('filter_prefix', str), ('max_return', int))
     def get_omap_vals(self, read_op, start_after, filter_prefix, max_return):
         """
         get the omap values
@@ -4060,7 +4053,7 @@ returned %d, but should return zero on success." % (self.name, ret))
         it.ctx = iter_addr
         return it, 0   # 0 is meaningless; there for backward-compat
 
-    @requires(('read_op', ReadOp), ('start_after', str_type), ('max_return', int))
+    @requires(('read_op', ReadOp), ('start_after', str), ('max_return', int))
     def get_omap_keys(self, read_op, start_after, max_return):
         """
         get the omap keys
@@ -4150,7 +4143,7 @@ returned %d, but should return zero on success." % (self.name, ret))
         with nogil:
             rados_write_op_omap_clear(_write_op.write_op)
 
-    @requires(('key', str_type), ('name', str_type), ('cookie', str_type), ('desc', str_type),
+    @requires(('key', str), ('name', str), ('cookie', str), ('desc', str),
               ('duration', opt(int)), ('flags', int))
     def lock_exclusive(self, key, name, cookie, desc="", duration=None, flags=0):
 
@@ -4201,8 +4194,8 @@ returned %d, but should return zero on success." % (self.name, ret))
         if ret < 0:
             raise make_ex(ret, "Ioctx.rados_lock_exclusive(%s): failed to set lock %s on %s" % (self.name, name, key))
 
-    @requires(('key', str_type), ('name', str_type), ('cookie', str_type), ('tag', str_type),
-              ('desc', str_type), ('duration', opt(int)), ('flags', int))
+    @requires(('key', str), ('name', str), ('cookie', str), ('tag', str),
+              ('desc', str), ('duration', opt(int)), ('flags', int))
     def lock_shared(self, key, name, cookie, tag, desc="", duration=None, flags=0):
 
         """
@@ -4255,7 +4248,7 @@ returned %d, but should return zero on success." % (self.name, ret))
         if ret < 0:
             raise make_ex(ret, "Ioctx.rados_lock_exclusive(%s): failed to set lock %s on %s" % (self.name, name, key))
 
-    @requires(('key', str_type), ('name', str_type), ('cookie', str_type))
+    @requires(('key', str), ('name', str), ('cookie', str))
     def unlock(self, key, name, cookie):
 
         """

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -203,9 +203,7 @@ setup(
         'License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Cython',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3'
     ],
     cmdclass=cmdclass,
 )

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -1036,8 +1036,6 @@ def cstr(val, name, encoding="utf-8", opt=False):
         return val
     elif isinstance(val, str):
         return val.encode(encoding)
-    elif sys.version_info < (3, 0) and isinstance(val, unicode):
-        return val.encode(encoding)
     else:
         raise InvalidArgument('%s must be a string' % name)
 

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -206,9 +206,7 @@ setup(
         'License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Cython',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3'
     ],
     cmdclass=cmdclass,
 )

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -206,9 +206,7 @@ setup(
         'License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Cython',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3',
     ],
     cmdclass=cmdclass,
 )

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -14,9 +14,6 @@ import os
 import re
 import sys
 
-# Are we running Python 2.x
-_python2 = sys.version_info[0] < 3
-
 def test_rados_init_error():
     assert_raises(Error, Rados, conffile='', rados_id='admin',
                   name='client.admin')
@@ -160,20 +157,13 @@ class TestRados(object):
         self.rados.delete_pool('foo')
 
     def test_create_utf8(self):
-        if _python2:
-            # Use encoded bytestring
-            poolname = b"\351\273\204"
-        else:
-            poolname = "\u9ec4"
+        poolname = "\u9ec4"
         self.rados.create_pool(poolname)
         assert self.rados.pool_exists(u"\u9ec4")
         self.rados.delete_pool(poolname)
 
     def test_pool_lookup_utf8(self):
-        if _python2:
-            poolname = u'\u9ec4'
-        else:
-            poolname = '\u9ec4'
+        poolname = '\u9ec4'
         self.rados.create_pool(poolname)
         try:
             poolid = self.rados.pool_lookup(poolname)
@@ -1203,11 +1193,7 @@ class TestCommand(object):
         eq(out['bytes_written'], cmd['count'])
 
     def test_ceph_osd_pool_create_utf8(self):
-        if _python2:
-            # Use encoded bytestring
-            poolname = b"\351\273\205"
-        else:
-            poolname = "\u9ec5"
+        poolname = "\u9ec5"
 
         cmd = {"prefix": "osd pool create", "pg_num": 16, "pool": poolname}
         ret, buf, out = self.rados.mon_command(json.dumps(cmd), b'')


### PR DESCRIPTION
the goal is to ditch `six` module, and drop py2 support. 

this patchset is the first one in a serial.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
