### PR TITLE
octopus: mgr/dashboard: fix Source column i18n issue in RBD configuration tables

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-configuration-list/rbd-configuration-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-configuration-list/rbd-configuration-list.component.html
@@ -10,11 +10,11 @@
 
   <div [ngSwitch]="value">
     <span *ngSwitchCase="'global'"
-          i18n>{{ value | titlecase }}</span>
+          i18n>Global</span>
     <strong *ngSwitchCase="'image'"
-            i18n>{{ value | titlecase }}</strong>
+            i18n>Image</strong>
     <strong *ngSwitchCase="'pool'"
-            i18n>{{ value | titlecase }}</strong>
+            i18n>Pool</strong>
   </div>
 </ng-template>
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46197

---

backport of https://github.com/ceph/ceph/pull/35721
parent tracker: https://tracker.ceph.com/issues/43971

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh