### PR TITLE
mgr/dashboard: Remove useless tab in monitoring/alerts datatable details

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.html
@@ -3,22 +3,10 @@
           [hasDetails]="true"
           (updateSelection)="setExpandedRow($event)"
           [selectionType]="'single'">
-  <ng-container cdTableDetail
-                *ngIf="expandedRow">
-    <ul ngbNav
-        #nav="ngbNav"
-        class="nav-tabs">
-      <li ngbNavItem>
-        <a ngbNavLink
-           i18n>Details</a>
-        <ng-template ngbNavContent>
-          <cd-table-key-value [data]="expandedRow"
-                              [renderObjects]="true"
-                              [hideKeys]="hideKeys"></cd-table-key-value>
-        </ng-template>
-      </li>
-    </ul>
-
-    <div [ngbNavOutlet]="nav"></div>
-  </ng-container>
+  <cd-table-key-value cdTableDetail
+                      *ngIf="expandedRow"
+                      [data]="expandedRow"
+                      [renderObjects]="true"
+                      [hideKeys]="hideKeys">
+  </cd-table-key-value>
 </cd-table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.spec.ts
@@ -2,8 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
-
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
 import { PrometheusService } from '../../../../shared/api/prometheus.service';
 import { SettingsService } from '../../../../shared/api/settings.service';
@@ -16,7 +14,7 @@ describe('RulesListComponent', () => {
 
   configureTestBed({
     declarations: [RulesListComponent],
-    imports: [HttpClientTestingModule, SharedModule, NgbNavModule, BrowserAnimationsModule],
+    imports: [HttpClientTestingModule, SharedModule, BrowserAnimationsModule],
     providers: [PrometheusService, SettingsService, i18nProviders]
   });
 


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/1897962/85992576-5e649e80-b9f5-11ea-9134-afdba4b14387.gif)

Fixes: https://tracker.ceph.com/issues/46249

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
