### PR TITLE
nautilus: ceph-volume: add dmcrypt support in raw mode

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/raw/common.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/common.py
@@ -45,4 +45,9 @@ def create_parser(prog, description):
         dest='block_wal',
         help='Path to bluestore block.wal block device'
     )
+    parser.add_argument(
+        '--dmcrypt',
+        action='store_true',
+        help='Enable device encryption via dm-crypt',
+    )
     return parser

--- a/src/ceph-volume/ceph_volume/devices/raw/common.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/common.py
@@ -27,10 +27,6 @@ def create_parser(prog, description):
         help='Crush device class to assign this OSD to',
     )
     parser.add_argument(
-        '--cluster-fsid',
-        help='Specify the cluster fsid, useful when no ceph.conf is available',
-    )
-    parser.add_argument(
         '--no-tmpfs',
         action='store_true',
         help='Do not use a tmpfs mount for OSD data dir'

--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -30,8 +30,34 @@ class List(object):
         if not devs:
             logger.debug('Listing block devices via lsblk...')
             devs = []
+            # adding '--inverse' allows us to get the mapper devices list in that command output.
+            # not listing root devices containing partitions shouldn't have side effect since we are
+            # in `ceph-volume raw` context.
+            #
+            #   example:
+            #   running `lsblk --paths --nodeps --output=NAME --noheadings` doesn't allow to get the mapper list
+            #   because the output is like following :
+            #
+            #   $ lsblk --paths --nodeps --output=NAME --noheadings
+            #   /dev/sda
+            #   /dev/sdb
+            #   /dev/sdc
+            #   /dev/sdd
+            #
+            #   the dmcrypt mappers are hidden because of the `--nodeps` given they are displayed as a dependency.
+            #
+            #   $ lsblk --paths --output=NAME --noheadings
+            #   /dev/sda
+            #   |-/dev/mapper/ceph-3b52c90d-6548-407d-bde1-efd31809702f-sda-block-dmcrypt
+            #   `-/dev/mapper/ceph-3b52c90d-6548-407d-bde1-efd31809702f-sda-db-dmcrypt
+            #   /dev/sdb
+            #   /dev/sdc
+            #   /dev/sdd
+            #
+            #   adding `--inverse` is a trick to get around this issue, the counterpart is that we can't list root devices if they contain
+            #   at least one partition but this shouldn't be an issue in `ceph-volume raw` context given we only deal with raw devices.
             out, err, ret = process.call([
-                'lsblk', '--paths', '--nodeps', '--output=NAME', '--noheadings'
+                'lsblk', '--paths', '--nodeps', '--output=NAME', '--noheadings', '--inverse'
             ])
             assert not ret
             devs = out

--- a/src/ceph-volume/ceph_volume/devices/raw/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/prepare.py
@@ -7,7 +7,7 @@ from ceph_volume.util import prepare as prepare_utils
 from ceph_volume.util import encryption as encryption_utils
 from ceph_volume.util import disk
 from ceph_volume.util import system
-from ceph_volume import conf, decorators, terminal
+from ceph_volume import decorators, terminal
 from ceph_volume.devices.lvm.common import rollback_osd
 from .common import create_parser
 
@@ -97,15 +97,6 @@ class Prepare(object):
         dmcrypt_log = 'dmcrypt' if args.dmcrypt else 'clear'
         terminal.success("ceph-volume raw {} prepare successful for: {}".format(dmcrypt_log, self.args.data))
 
-    def get_cluster_fsid(self):
-        """
-        Allows using --cluster-fsid as an argument, but can fallback to reading
-        from ceph.conf if that is unset (the default behavior).
-        """
-        if self.args.cluster_fsid:
-            return self.args.cluster_fsid
-
-        return conf.ceph.get('global', 'fsid')
 
     @decorators.needs_root
     def prepare(self):

--- a/src/ceph-volume/ceph_volume/tests/devices/raw/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/raw/test_prepare.py
@@ -1,0 +1,97 @@
+import pytest
+from ceph_volume.devices import raw
+from mock.mock import patch
+
+
+class TestRaw(object):
+
+    def test_main_spits_help_with_no_arguments(self, capsys):
+        raw.main.Raw([]).main()
+        stdout, stderr = capsys.readouterr()
+        assert 'Manage a single-device OSD on a raw block device.' in stdout
+
+    def test_main_shows_activate_subcommands(self, capsys):
+        raw.main.Raw([]).main()
+        stdout, stderr = capsys.readouterr()
+        assert 'activate ' in stdout
+        assert 'Discover and prepare' in stdout
+
+    def test_main_shows_prepare_subcommands(self, capsys):
+        raw.main.Raw([]).main()
+        stdout, stderr = capsys.readouterr()
+        assert 'prepare ' in stdout
+        assert 'Format a raw device' in stdout
+
+
+class TestPrepare(object):
+
+    def test_main_spits_help_with_no_arguments(self, capsys):
+        raw.prepare.Prepare([]).main()
+        stdout, stderr = capsys.readouterr()
+        assert 'Prepare an OSD by assigning an ID and FSID' in stdout
+
+    def test_main_shows_full_help(self, capsys):
+        with pytest.raises(SystemExit):
+            raw.prepare.Prepare(argv=['--help']).main()
+        stdout, stderr = capsys.readouterr()
+        assert 'a raw device to use for the OSD' in stdout
+        assert 'Crush device class to assign this OSD to' in stdout
+        assert 'Use BlueStore backend' in stdout
+        assert 'Path to bluestore block.db block device' in stdout
+        assert 'Path to bluestore block.wal block device' in stdout
+        assert 'Enable device encryption via dm-crypt' in stdout
+
+    @patch('ceph_volume.util.arg_validators.ValidDevice.__call__')
+    def test_prepare_dmcrypt_no_secret_passed(self, m_valid_device, capsys):
+        m_valid_device.return_value = '/dev/foo'
+        with pytest.raises(SystemExit):
+            raw.prepare.Prepare(argv=['--bluestore', '--data', '/dev/foo', '--dmcrypt']).main()
+        stdout, stderr = capsys.readouterr()
+        assert 'CEPH_VOLUME_DMCRYPT_SECRET is not set, you must set' in stderr
+
+    @patch('ceph_volume.util.encryption.luks_open')
+    @patch('ceph_volume.util.encryption.luks_format')
+    @patch('ceph_volume.util.disk.lsblk')
+    def test_prepare_dmcrypt_block(self, m_lsblk, m_luks_format, m_luks_open):
+        m_lsblk.return_value = {'KNAME': 'foo'}
+        m_luks_format.return_value = True
+        m_luks_open.return_value = True
+        result = raw.prepare.prepare_dmcrypt('foo', '/dev/foo', 'block', '123')
+        m_luks_open.assert_called_with('foo', '/dev/foo', 'ceph-123-foo-block-dmcrypt')
+        m_luks_format.assert_called_with('foo', '/dev/foo')
+        assert result == '/dev/mapper/ceph-123-foo-block-dmcrypt'
+
+    @patch('ceph_volume.util.encryption.luks_open')
+    @patch('ceph_volume.util.encryption.luks_format')
+    @patch('ceph_volume.util.disk.lsblk')
+    def test_prepare_dmcrypt_db(self, m_lsblk, m_luks_format, m_luks_open):
+        m_lsblk.return_value = {'KNAME': 'foo'}
+        m_luks_format.return_value = True
+        m_luks_open.return_value = True
+        result = raw.prepare.prepare_dmcrypt('foo', '/dev/foo', 'db', '123')
+        m_luks_open.assert_called_with('foo', '/dev/foo', 'ceph-123-foo-db-dmcrypt')
+        m_luks_format.assert_called_with('foo', '/dev/foo')
+        assert result == '/dev/mapper/ceph-123-foo-db-dmcrypt'
+
+    @patch('ceph_volume.util.encryption.luks_open')
+    @patch('ceph_volume.util.encryption.luks_format')
+    @patch('ceph_volume.util.disk.lsblk')
+    def test_prepare_dmcrypt_wal(self, m_lsblk, m_luks_format, m_luks_open):
+        m_lsblk.return_value = {'KNAME': 'foo'}
+        m_luks_format.return_value = True
+        m_luks_open.return_value = True
+        result = raw.prepare.prepare_dmcrypt('foo', '/dev/foo', 'wal', '123')
+        m_luks_open.assert_called_with('foo', '/dev/foo', 'ceph-123-foo-wal-dmcrypt')
+        m_luks_format.assert_called_with('foo', '/dev/foo')
+        assert result == '/dev/mapper/ceph-123-foo-wal-dmcrypt'
+
+    @patch('ceph_volume.devices.raw.prepare.rollback_osd')
+    @patch('ceph_volume.devices.raw.prepare.Prepare.prepare')
+    @patch('ceph_volume.util.arg_validators.ValidDevice.__call__')
+    def test_safe_prepare_exception_raised(self, m_valid_device, m_prepare, m_rollback_osd):
+        m_valid_device.return_value = '/dev/foo'
+        m_prepare.side_effect=Exception('foo')
+        m_rollback_osd.return_value = 'foobar'
+        with pytest.raises(Exception):
+            raw.prepare.Prepare(argv=['--bluestore', '--data', '/dev/foo']).main()
+        m_rollback_osd.assert_called()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46250

---

backport of https://github.com/ceph/ceph/pull/35468
parent tracker: https://tracker.ceph.com/issues/45959

this backport was staged using ceph-backport.sh version 15.1.0.1009
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh