### PR TITLE
python-common: RGW service_id might not contain a zone

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -430,9 +430,16 @@ def test_node_assignment(service_type, placement, hosts, daemons, expected):
             return [HostSpec(h) for h in hosts]
         return hosts
 
+    service_id = None
+    if service_type == 'rgw':
+        service_id = 'realm.zone'
+
+    spec = ServiceSpec(service_type=service_type,
+                       service_id=service_id,
+                       placement=placement)
 
     hosts = HostAssignment(
-        spec=ServiceSpec(service_type, placement=placement),
+        spec=spec,
         get_hosts_func=get_hosts_func,
         get_daemons_func=lambda _: daemons).place()
     assert sorted([h.hostname for h in hosts]) == sorted(expected)

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -612,7 +612,8 @@ class RGWSpec(ServiceSpec):
         if service_id:
             a = service_id.split('.', 2)
             rgw_realm = a[0]
-            rgw_zone = a[1]
+            if len(a) > 1:
+                rgw_zone = a[1]
             if len(a) > 2:
                 subcluster = a[2]
         else:
@@ -649,6 +650,16 @@ class RGWSpec(ServiceSpec):
         else:
             ports.append(f"port={self.get_port()}")
         return f'beast {" ".join(ports)}'
+
+    def validate(self):
+        super(RGWSpec, self).validate()
+
+        if not self.rgw_realm:
+            raise ServiceSpecValidationError(
+                'Cannot add RGW: No realm specified')
+        if not self.rgw_zone:
+            raise ServiceSpecValidationError(
+                'Cannot add RGW: No zone specified')
 
 
 yaml.add_representer(RGWSpec, ServiceSpec.yaml_representer)


### PR DESCRIPTION
also adds missing RGWSpec.validate()

Fixes: https://tracker.ceph.com/issues/46268
Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
