### PR TITLE
python-common: clean-up ServiceSpec.service_id handling

### DIFF
--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -478,6 +478,7 @@ Many service specifications can then be applied at once using
       host_pattern: "mgr*"
     ---
     service_type: osd
+    service_id: default_drive_group
     placement:
       host_pattern: "osd*"
     data_devices:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1333,13 +1333,13 @@ class DaemonDescription(object):
             # daemon_id == "service_id"
             return self.daemon_id
 
-        if self.daemon_type in ['mds', 'nfs', 'iscsi', 'rgw']:
+        if self.daemon_type in ServiceSpec.REQUIRES_SERVICE_ID:
             return _match()
 
         return self.daemon_id
 
     def service_name(self):
-        if self.daemon_type in ['rgw', 'mds', 'nfs', 'iscsi']:
+        if self.daemon_type in ServiceSpec.REQUIRES_SERVICE_ID:
             return f'{self.daemon_type}.{self.service_id()}'
         return self.daemon_type
 

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -75,18 +75,7 @@ def test_parse_host_placement_specs_raises_wrong_format(test_input):
         HostPlacementSpec.parse(test_input)
 
 
-@pytest.mark.parametrize(
-    "s_type,o_spec,s_id",
-    [
-        ("mgr", ServiceSpec, 'test'),
-        ("mon", ServiceSpec, 'test'),
-        ("mds", ServiceSpec, 'test'),
-        ("rgw", RGWSpec, 'realm.zone'),
-        ("nfs", NFSServiceSpec, 'test'),
-        ("iscsi", IscsiServiceSpec, 'test'),
-        ("osd", DriveGroupSpec, 'test'),
-    ])
-def test_servicespec_map_test(s_type, o_spec, s_id):
+def _get_dict_spec(s_type, s_id):
     dict_spec = {
         "service_id": s_id,
         "service_type": s_type,
@@ -105,7 +94,26 @@ def test_servicespec_map_test(s_type, o_spec, s_id):
                 'all': True
             }
         }
-    spec = ServiceSpec.from_json(dict_spec)
+    elif s_type == 'rgw':
+        dict_spec['rgw_realm'] = 'realm'
+        dict_spec['rgw_zone'] = 'zone'
+
+    return dict_spec
+
+
+@pytest.mark.parametrize(
+    "s_type,o_spec,s_id",
+    [
+        ("mgr", ServiceSpec, 'test'),
+        ("mon", ServiceSpec, 'test'),
+        ("mds", ServiceSpec, 'test'),
+        ("rgw", RGWSpec, 'realm.zone'),
+        ("nfs", NFSServiceSpec, 'test'),
+        ("iscsi", IscsiServiceSpec, 'test'),
+        ("osd", DriveGroupSpec, 'test'),
+    ])
+def test_servicespec_map_test(s_type, o_spec, s_id):
+    spec = ServiceSpec.from_json(_get_dict_spec(s_type, s_id))
     assert isinstance(spec, o_spec)
     assert isinstance(spec.placement, PlacementSpec)
     assert isinstance(spec.placement.hosts[0], HostPlacementSpec)
@@ -183,7 +191,7 @@ spec:
                                          service_type='mon',
                                          service_id='foo'
                                      ),
-                                     False
+                                     True
                              ),
                              # Add service_type='mgr'
                              (
@@ -225,3 +233,19 @@ def test_spec_hash_eq(spec1: ServiceSpec,
                       eq: bool):
 
     assert (spec1 == spec2) is eq
+
+@pytest.mark.parametrize(
+    "s_type,s_id,s_name",
+    [
+        ('mgr', 's_id', 'mgr'),
+        ('mon', 's_id', 'mon'),
+        ('mds', 's_id', 'mds.s_id'),
+        ('rgw', 's_id', 'rgw.s_id'),
+        ('nfs', 's_id', 'nfs.s_id'),
+        ('iscsi', 's_id', 'iscsi.s_id'),
+        ('osd', 's_id', 'osd.s_id'),
+    ])
+def test_service_name(s_type, s_id, s_name):
+    spec = ServiceSpec.from_json(_get_dict_spec(s_type, s_id))
+    spec.validate()
+    assert spec.service_name() == s_name


### PR DESCRIPTION
ServiceSpec of type 'mon' and 'mgr' must not have a service_id

Fixes: https://tracker.ceph.com/issues/46175
Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
