### PR TITLE
migrate  to osd slow

### DIFF
--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -747,6 +747,10 @@ int main(int argc, char **argv)
     map<string, int> src_devs;
 
     parse_devices(cct.get(), devs, &cur_devs_map, nullptr, nullptr);
+    int id = -1;
+    id = BlueFS::BDEV_SLOW;
+    cur_devs_map.emplace("slow", id);
+
     for (auto& s :  devs_source) {
       auto i = cur_devs_map.find(s);
       if (i != cur_devs_map.end()) {
@@ -758,6 +762,12 @@ int main(int argc, char **argv)
 	  src_devs.emplace(*i);
 	  src_dev_ids.emplace(i->second);
 	}
+      } else if (s == "slow_to_wal") {
+        id = BlueFS::BDEV_WAL;
+        src_dev_ids.emplace(id);
+      } else if (s == "slow_to_db") {
+        id = BlueFS::BDEV_DB;
+        src_dev_ids.emplace(id);
       } else {
 	cerr << "can't migrate " << s << ", not a valid bluefs volume "
 	      << std::endl;


### PR DESCRIPTION
osd/bluestore：When the server has no extra slots for the new SSD, it can still replace the old SSD.

1、Copy the files of db/wal to the osd slow directory
   ceph-bluestore-tool --path /var/lib/ceph/osd/ceph-0/ --command=bluefs-bdev-migrate --devs-source /var/lib/ceph/osd/ceph-0/block.db --devs-source /var/lib/ceph/osd/ceph-0/block.wal --dev-target slow

2、Copy the files of db/wal from the osd slow directory to the new partition
   ceph-bluestore-tool --path /var/lib/ceph/osd/ceph-0 --command=bluefs-bdev-migrate --devs-source slow_to_wal  --dev-target /dev/bcache15
   ceph-bluestore-tool --path /var/lib/ceph/osd/ceph-0 --command=bluefs-bdev-migrate --devs-source slow_to_db  --dev-target /dev/bcache16

Signed-off-by: 10136502 <huang.wei56@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
