### PR TITLE
rgw: add try catch for user policies decode

### DIFF
--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -156,6 +156,9 @@ void RGWPutUserPolicy::execute(optional_yield y)
     if (op_ret < 0) {
       op_ret = -ERR_INTERNAL_ERROR;
     }
+  } catch (buffer::error& err) {
+    ldpp_dout(this, 0) << "ERROR: failed to decode user policies" << dendl;
+    op_ret = -EIO;
   } catch (rgw::IAM::PolicyParseException& e) {
     ldpp_dout(this, 20) << "failed to parse policy: " << e.what() << dendl;
     op_ret = -ERR_MALFORMED_DOC;
@@ -213,7 +216,13 @@ void RGWGetUserPolicy::execute(optional_yield y)
     map<string, string> policies;
     if (auto it = user->get_attrs().find(RGW_ATTR_USER_POLICY); it != user->get_attrs().end()) {
       bufferlist bl = it->second;
-      decode(policies, bl);
+      try {
+        decode(policies, bl);
+      } catch (buffer::error& err) {
+        ldpp_dout(this, 0) << "ERROR: failed to decode user policies" << dendl;
+        op_ret = -EIO;
+        return;
+      }
       if (auto it = policies.find(policy_name); it != policies.end()) {
         policy = policies[policy_name];
         dump(s->formatter);
@@ -276,7 +285,13 @@ void RGWListUserPolicies::execute(optional_yield y)
       s->formatter->close_section();
       s->formatter->open_object_section("ListUserPoliciesResult");
       bufferlist bl = it->second;
-      decode(policies, bl);
+      try {
+        decode(policies, bl);
+      } catch (buffer::error& err) {
+        ldpp_dout(this, 0) << "ERROR: failed to decode user policies" << dendl;
+        op_ret = -EIO;
+        return;
+      }
       for (const auto& p : policies) {
         s->formatter->open_object_section("PolicyNames");
         s->formatter->dump_string("member", p.first);
@@ -348,7 +363,13 @@ void RGWDeleteUserPolicy::execute(optional_yield y)
   map<string, string> policies;
   if (auto it = user->get_attrs().find(RGW_ATTR_USER_POLICY); it != user->get_attrs().end()) {
     bufferlist out_bl = it->second;
-    decode(policies, out_bl);
+    try {
+      decode(policies, out_bl);
+    } catch (buffer::error& err) {
+      ldpp_dout(this, 0) << "ERROR: failed to decode user policies" << dendl;
+      op_ret = -EIO;
+      return;
+    }
 
     if (auto p = policies.find(policy_name); p != policies.end()) {
       bufferlist in_bl;


### PR DESCRIPTION
add try catch for user policies decode

Signed-off-by: wangyunqing <wangyunqing@inspur.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
