### PR TITLE
rgw: include string header

### DIFF
--- a/src/rgw/rgw_b64.h
+++ b/src/rgw/rgw_b64.h
@@ -10,6 +10,7 @@
 #include <boost/archive/iterators/transform_width.hpp>
 #include <boost/archive/iterators/remove_whitespace.hpp>
 #include <limits>
+#include <string>
 #include <string_view>
 
 namespace rgw {


### PR DESCRIPTION
Otherwise we get complaints from the compiler on FreeBS/Clang:
In file included from /home/jenkins/workspace/ceph-master/src/rgw/rgw_sync_module_es.cc:4:
/home/jenkins/workspace/ceph-master/src/rgw/rgw_b64.h:28:22: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
  inline std::string to_base64(std::string_view sview)
                     ^
/usr/include/c++/v1/iosfwd:210:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
In file included from /home/jenkins/workspace/ceph-master/src/rgw/rgw_sync_module_es.cc:4:
/home/jenkins/workspace/ceph-master/src/rgw/rgw_b64.h:51:17: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
    std::string outstr(b64_iter(sview.data()),
                ^
/usr/include/c++/v1/iosfwd:210:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;

.............. more errors
                               ^
/home/jenkins/workspace/ceph-master/src/rgw/rgw_sync_module_es.cc:193:59: error: no matching function for call to 'to_base64'
      default_headers.emplace("AUTHORIZATION", "Basic " + rgw::to_base64(auth_string));
                                                          ^~~~~~~~~~~~~~
/home/jenkins/workspace/ceph-master/src/rgw/rgw_b64.h:28:22: note: candidate template ignored: substitution failure [with wrap_width = 2147483647]
  inline std::string to_base64(std::string_view sview)




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>