### PR TITLE
mgr/dashboard: Fix NFS Edit page loading problem

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { FormArray, FormControl, NgForm, Validators } from '@angular/forms';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
@@ -13,15 +13,25 @@ import { CdFormGroup } from '../../../shared/forms/cd-form-group';
   templateUrl: './nfs-form-client.component.html',
   styleUrls: ['./nfs-form-client.component.scss']
 })
-export class NfsFormClientComponent {
+export class NfsFormClientComponent implements OnInit {
   @Input()
   form: CdFormGroup;
+
+  @Input()
+  clients: any[];
 
   nfsSquash: any[] = this.nfsService.nfsSquash;
   nfsAccessType: any[] = this.nfsService.nfsAccessType;
   icons = Icons;
 
   constructor(private nfsService: NfsService, private i18n: I18n) {}
+
+  ngOnInit() {
+    _.forEach(this.clients, (client) => {
+      const fg = this.addClient();
+      fg.patchValue(client);
+    });
+  }
 
   getNoAccessTypeDescr() {
     if (this.form.getValue('access_type')) {
@@ -75,13 +85,6 @@ export class NfsFormClientComponent {
     const clients = this.form.get('clients') as FormArray;
     const client = clients.at(index) as CdFormGroup;
     return client.getValue(control);
-  }
-
-  resolveModel(clients: any[]) {
-    _.forEach(clients, (client) => {
-      const fg = this.addClient();
-      fg.patchValue(client);
-    });
   }
 
   trackByFn(index: number) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -479,6 +479,7 @@
 
         <!-- Clients -->
         <cd-nfs-form-client [form]="nfsForm"
+                            [clients]="clients"
                             #nfsClients>
         </cd-nfs-form-client>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -34,6 +34,8 @@ export class NfsFormComponent extends CdForm implements OnInit {
   @ViewChild('nfsClients', { static: true })
   nfsClients: NfsFormClientComponent;
 
+  clients: any[] = [];
+
   permission: Permission;
   nfsForm: CdFormGroup;
   isEdit = false;
@@ -266,7 +268,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
 
     this.nfsForm.patchValue(res);
     this.setPathValidation();
-    this.nfsClients.resolveModel(res.clients);
+    this.clients = res.clients;
   }
 
   resolveDaemons(daemons: Record<string, any>) {


### PR DESCRIPTION
We were trying to access a component that is only created
after the form loading is finished, before it was finished.

Fixes: https://tracker.ceph.com/issues/46276

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
