### PR TITLE
librbd: new 'write_zeroes' API methods to suppliment the `discard` APIs

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -47,6 +47,7 @@ extern "C" {
 #define LIBRBD_SUPPORTS_IOVEC 1
 #define LIBRBD_SUPPORTS_WATCH 0
 #define LIBRBD_SUPPORTS_WRITESAME 1
+#define LIBRBD_SUPPORTS_WRITE_ZEROES 1
 
 #if __GNUC__ >= 4
   #define CEPH_RBD_API          __attribute__ ((visibility ("default")))
@@ -1100,10 +1101,15 @@ CEPH_RBD_API ssize_t rbd_write2(rbd_image_t image, uint64_t ofs, size_t len,
                                 const char *buf, int op_flags);
 CEPH_RBD_API int rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len);
 CEPH_RBD_API ssize_t rbd_writesame(rbd_image_t image, uint64_t ofs, size_t len,
-                                   const char *buf, size_t data_len, int op_flags);
+                                   const char *buf, size_t data_len,
+                                   int op_flags);
+CEPH_RBD_API ssize_t rbd_write_zeroes(rbd_image_t image, uint64_t ofs,
+                                      uint64_t len, int zero_flags,
+                                      int op_flags);
 CEPH_RBD_API ssize_t rbd_compare_and_write(rbd_image_t image, uint64_t ofs,
                                            size_t len, const char *cmp_buf,
-                                           const char *buf, uint64_t *mismatch_off,
+                                           const char *buf,
+                                           uint64_t *mismatch_off,
                                            int op_flags);
 
 CEPH_RBD_API int rbd_aio_write(rbd_image_t image, uint64_t off, size_t len,
@@ -1131,10 +1137,15 @@ CEPH_RBD_API int rbd_aio_discard(rbd_image_t image, uint64_t off, uint64_t len,
 CEPH_RBD_API int rbd_aio_writesame(rbd_image_t image, uint64_t off, size_t len,
                                    const char *buf, size_t data_len,
                                    rbd_completion_t c, int op_flags);
+CEPH_RBD_API int rbd_aio_write_zeroes(rbd_image_t image, uint64_t off,
+                                      size_t len, rbd_completion_t c,
+                                      int zero_flags, int op_flags);
 CEPH_RBD_API ssize_t rbd_aio_compare_and_write(rbd_image_t image,
                                                uint64_t off, size_t len,
-                                               const char *cmp_buf, const char *buf,
-                                               rbd_completion_t c, uint64_t *mismatch_off,
+                                               const char *cmp_buf,
+                                               const char *buf,
+                                               rbd_completion_t c,
+                                               uint64_t *mismatch_off,
                                                int op_flags);
 
 CEPH_RBD_API int rbd_aio_create_completion(void *cb_arg,

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -679,8 +679,11 @@ public:
   ssize_t write(uint64_t ofs, size_t len, ceph::bufferlist& bl);
   /* @param op_flags see librados.h constants beginning with LIBRADOS_OP_FLAG */
   ssize_t write2(uint64_t ofs, size_t len, ceph::bufferlist& bl, int op_flags);
+
   int discard(uint64_t ofs, uint64_t len);
   ssize_t writesame(uint64_t ofs, size_t len, ceph::bufferlist &bl, int op_flags);
+  ssize_t write_zeroes(uint64_t ofs, size_t len, int zero_flags, int op_flags);
+
   ssize_t compare_and_write(uint64_t ofs, size_t len, ceph::bufferlist &cmp_bl,
                             ceph::bufferlist& bl, uint64_t *mismatch_off, int op_flags);
 
@@ -688,11 +691,17 @@ public:
   /* @param op_flags see librados.h constants beginning with LIBRADOS_OP_FLAG */
   int aio_write2(uint64_t off, size_t len, ceph::bufferlist& bl,
 		  RBD::AioCompletion *c, int op_flags);
+
+  int aio_discard(uint64_t off, uint64_t len, RBD::AioCompletion *c);
   int aio_writesame(uint64_t off, size_t len, ceph::bufferlist& bl,
                     RBD::AioCompletion *c, int op_flags);
+  int aio_write_zeroes(uint64_t ofs, size_t len, RBD::AioCompletion *c,
+                       int zero_flags, int op_flags);
+
   int aio_compare_and_write(uint64_t off, size_t len, ceph::bufferlist& cmp_bl,
                             ceph::bufferlist& bl, RBD::AioCompletion *c,
                             uint64_t *mismatch_off, int op_flags);
+
   /**
    * read async from image
    *
@@ -714,7 +723,6 @@ public:
   /* @param op_flags see librados.h constants beginning with LIBRADOS_OP_FLAG */
   int aio_read2(uint64_t off, size_t len, ceph::bufferlist& bl,
 		  RBD::AioCompletion *c, int op_flags);
-  int aio_discard(uint64_t off, uint64_t len, RBD::AioCompletion *c);
 
   int flush();
   /**

--- a/src/librbd/api/Io.cc
+++ b/src/librbd/api/Io.cc
@@ -134,6 +134,32 @@ ssize_t Io<I>::write_same(
 }
 
 template <typename I>
+ssize_t Io<I>::write_zeroes(I& image_ctx, uint64_t off, uint64_t len,
+                            int zero_flags, int op_flags) {
+  auto cct = image_ctx.cct;
+  ldout(cct, 20) << "ictx=" << &image_ctx << ", off=" << off << ", "
+                 << "len = " << len << dendl;
+
+  image_ctx.image_lock.lock_shared();
+  int r = clip_io(util::get_image_ctx(&image_ctx), off, &len);
+  image_ctx.image_lock.unlock_shared();
+  if (r < 0) {
+    lderr(cct) << "invalid IO request: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  C_SaferCond ctx;
+  auto aio_comp = io::AioCompletion::create(&ctx);
+  aio_write_zeroes(image_ctx, aio_comp, off, len, zero_flags, op_flags, false);
+
+  r = ctx.wait();
+  if (r < 0) {
+    return r;
+  }
+  return len;
+}
+
+template <typename I>
 ssize_t Io<I>::compare_and_write(
     I &image_ctx, uint64_t off, uint64_t len, bufferlist &&cmp_bl,
     bufferlist &&bl, uint64_t *mismatch_off, int op_flags) {
@@ -300,6 +326,46 @@ void Io<I>::aio_write_same(I &image_ctx, io::AioCompletion *aio_comp,
   auto req = io::ImageDispatchSpec<I>::create_write_same(
     image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, off, len,
     std::move(bl), op_flags, trace, 0);
+  req->send();
+}
+
+template <typename I>
+void Io<I>::aio_write_zeroes(I& image_ctx, io::AioCompletion *aio_comp,
+                             uint64_t off, uint64_t len, int zero_flags,
+                             int op_flags, bool native_async) {
+  auto cct = image_ctx.cct;
+  FUNCTRACE(cct);
+  ZTracer::Trace trace;
+  if (image_ctx.blkin_trace_all) {
+    trace.init("io: write_zeroes", &image_ctx.trace_endpoint);
+    trace.event("init");
+  }
+
+  aio_comp->init_time(util::get_image_ctx(&image_ctx), io::AIO_TYPE_DISCARD);
+  ldout(cct, 20) << "ictx=" << &image_ctx << ", "
+                 << "completion=" << aio_comp << ", off=" << off << ", "
+                 << "len=" << len << dendl;
+
+  if (native_async && image_ctx.event_socket.is_valid()) {
+    aio_comp->set_event_notify(true);
+  }
+
+  // validate the supported flags
+  if (zero_flags != 0U) {
+    aio_comp->fail(-EINVAL);
+    return;
+  }
+
+  if (!is_valid_io(image_ctx, aio_comp)) {
+    return;
+  }
+
+  // enable partial discard (zeroing) of objects
+  uint32_t discard_granularity_bytes = 0;
+
+  auto req = io::ImageDispatchSpec<I>::create_discard(
+    image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp, off, len,
+    discard_granularity_bytes, trace, 0);
   req->send();
 }
 

--- a/src/librbd/api/Io.h
+++ b/src/librbd/api/Io.h
@@ -24,6 +24,8 @@ struct Io {
                          uint32_t discard_granularity_bytes);
   static ssize_t write_same(ImageCtxT &image_ctx, uint64_t off, uint64_t len,
                             bufferlist &&bl, int op_flags);
+  static ssize_t write_zeroes(ImageCtxT &image_ctx, uint64_t off, uint64_t len,
+                              int zero_flags, int op_flags);
   static ssize_t compare_and_write(ImageCtxT &image_ctx, uint64_t off,
                                    uint64_t len, bufferlist &&cmp_bl,
                                    bufferlist &&bl, uint64_t *mismatch_off,
@@ -43,6 +45,9 @@ struct Io {
   static void aio_write_same(ImageCtxT &image_ctx, io::AioCompletion *c,
                              uint64_t off, uint64_t len, bufferlist &&bl,
                              int op_flags, bool native_async);
+  static void aio_write_zeroes(ImageCtxT &image_ctx, io::AioCompletion *c,
+                               uint64_t off, uint64_t len, int zero_flags,
+                               int op_flags, bool native_async);
   static void aio_compare_and_write(ImageCtxT &image_ctx, io::AioCompletion *c,
                                     uint64_t off, uint64_t len,
                                     bufferlist &&cmp_bl, bufferlist &&bl,

--- a/src/tools/rbd/action/Import.cc
+++ b/src/tools/rbd/action/Import.cc
@@ -80,9 +80,9 @@ struct ImportDiffContext {
 class C_ImportDiff : public Context {
 public:
   C_ImportDiff(ImportDiffContext *idiffctx, bufferlist data, uint64_t offset,
-               uint64_t length, bool discard)
+               uint64_t length, bool write_zeroes)
     : m_idiffctx(idiffctx), m_data(data), m_offset(offset), m_length(length),
-      m_discard(discard) {
+      m_write_zeroes(write_zeroes) {
     // use block offset (stdin) or import file position to report
     // progress.
     if (m_idiffctx->fd == STDIN_FILENO) {
@@ -103,11 +103,14 @@ public:
       new librbd::RBD::AioCompletion(ctx, &utils::aio_context_callback);
 
     int r;
-    if (m_discard) {
-      r = m_idiffctx->image->aio_discard(m_offset, m_length, aio_completion);
+    if (m_write_zeroes) {
+      r = m_idiffctx->image->aio_write_zeroes(m_offset, m_length,
+                                              aio_completion, 0U,
+                                              LIBRADOS_OP_FLAG_FADVISE_NOCACHE);
     } else {
       r = m_idiffctx->image->aio_write2(m_offset, m_length, m_data,
-                                        aio_completion, LIBRADOS_OP_FLAG_FADVISE_NOCACHE);
+                                        aio_completion,
+                                        LIBRADOS_OP_FLAG_FADVISE_NOCACHE);
     }
 
     if (r < 0) {
@@ -129,7 +132,7 @@ private:
   bufferlist m_data;
   uint64_t m_offset;
   uint64_t m_length;
-  bool m_discard;
+  bool m_write_zeroes;
   uint64_t m_prog_offset;
 };
 
@@ -233,7 +236,8 @@ static int do_image_resize(ImportDiffContext *idiffctx)
   return 0;
 }
 
-static int do_image_io(ImportDiffContext *idiffctx, bool discard, size_t sparse_size)
+static int do_image_io(ImportDiffContext *idiffctx, bool write_zeroes,
+                       size_t sparse_size)
 {
   int r;
   char buf[16];
@@ -251,7 +255,7 @@ static int do_image_io(ImportDiffContext *idiffctx, bool discard, size_t sparse_
   decode(image_offset, p);
   decode(buffer_length, p);
 
-  if (!discard) {
+  if (!write_zeroes) {
     bufferptr bp = buffer::create(buffer_length);
     r = safe_read_exact(idiffctx->fd, bp.c_str(), buffer_length);
     if (r < 0) {
@@ -391,14 +395,6 @@ int do_import_diff_fd(librados::Rados &rados, librbd::Image &image, int fd,
                            utils::RBD_DIFF_BANNER_V2));
   if (r < 0) {
     return r;
-  }
-
-  std::string skip_partial_discard;
-  r = rados.conf_get("rbd_skip_partial_discard", skip_partial_discard);
-  if (r < 0 || skip_partial_discard != "false") {
-    dout(1) << "disabling sparse import" << dendl;
-    sparse_size = 0;
-    r = 0;
   }
 
   // begin image import


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
