### PR TITLE
test/unittest_lockdep: skip lockdep test if CEPH_DEBUG_MUTEX is not d…

### DIFF
--- a/src/test/common/test_lockdep.cc
+++ b/src/test/common/test_lockdep.cc
@@ -16,7 +16,7 @@ class lockdep : public ::testing::Test
 {
 protected:
   void SetUp() override {
-#ifdef CEPH_DEBUG_MUTEX
+#ifndef CEPH_DEBUG_MUTEX
     GTEST_SKIP() << "WARNING: CEPH_DEBUG_MUTEX is not defined, lockdep will not work";
 #endif
     CephInitParameters params(CEPH_ENTITY_TYPE_CLIENT);


### PR DESCRIPTION
…efined

this change addresses a regression introduced by
2dc50b5f91476cf10429dbcdd52b00e32f599d5c

Fixes: https://tracker.ceph.com/issues/46267
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
