### PR TITLE
rgw: Normalizing X-Amz- headers for case in RGWHTTPArgs

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -18,6 +18,7 @@
 #include "rgw_crypt_sanitize.h"
 
 #include <boost/container/small_vector.hpp>
+#include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/trim_all.hpp>
 
 #define dout_context g_ceph_context
@@ -267,18 +268,18 @@ static inline int parse_v4_query_string(const req_info& info,              /* in
   /* auth ships with req params ... */
 
   /* look for required params */
-  credential = info.args.get("X-Amz-Credential");
+  credential = info.args.get("x-amz-credential");
   if (credential.size() == 0) {
     return -EPERM;
   }
 
-  date = info.args.get("X-Amz-Date");
+  date = info.args.get("x-amz-date");
   struct tm date_t;
   if (!parse_iso8601(sview2cstr(date).data(), &date_t, nullptr, false)) {
     return -EPERM;
   }
 
-  std::string_view expires = info.args.get("X-Amz-Expires");
+  std::string_view expires = info.args.get("x-amz-expires");
   if (expires.empty()) {
     return -EPERM;
   }
@@ -298,18 +299,18 @@ static inline int parse_v4_query_string(const req_info& info,              /* in
     return -EPERM;
   }
 
-  signedheaders = info.args.get("X-Amz-SignedHeaders");
+  signedheaders = info.args.get("x-amz-signedheaders");
   if (signedheaders.size() == 0) {
     return -EPERM;
   }
 
-  signature = info.args.get("X-Amz-Signature");
+  signature = info.args.get("x-amz-signature");
   if (signature.size() == 0) {
     return -EPERM;
   }
 
-  if (info.args.exists("X-Amz-Security-Token")) {
-    sessiontoken = info.args.get("X-Amz-Security-Token");
+  if (info.args.exists("x-amz-security-token")) {
+    sessiontoken = info.args.get("x-amz-security-token");
     if (sessiontoken.size() == 0) {
       return -EPERM;
     }
@@ -516,7 +517,7 @@ std::string get_v4_canonical_qs(const req_info& info, const bool using_qs)
       key = s;
     }
 
-    if (using_qs && key == "X-Amz-Signature") {
+    if (using_qs && boost::iequals(key, "X-Amz-Signature")) {
       /* Preserving the original behaviour of get_v4_canonical_qs() here. */
       continue;
     }

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -812,8 +812,17 @@ int RGWHTTPArgs::parse()
     int ret = nv.parse();
     if (ret >= 0) {
       string& name = nv.get_name();
+      if (name.find("X-Amz-") != string::npos) {
+        std::for_each(name.begin(),
+          name.end(),
+          [](char &c){
+            if (c != '-') {
+              c = ::tolower(static_cast<unsigned char>(c));
+            }
+        });
+      }
       string& val = nv.get_val();
-
+      dout(10) << "name: " << name << " val: " << val << dendl;
       append(name, val);
     }
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4815,7 +4815,7 @@ discover_aws_flavour(const req_info& info)
   } else {
     route = AwsRoute::QUERY_STRING;
 
-    if (info.args.get("X-Amz-Algorithm") == AWS4_HMAC_SHA256_STR) {
+    if (info.args.get("x-amz-algorithm") == AWS4_HMAC_SHA256_STR) {
       /* AWS v4 */
       version = AwsVersion::V4;
     } else if (!info.args.get("AWSAccessKeyId").empty()) {
@@ -5465,8 +5465,8 @@ AWSGeneralAbstractor::get_auth_data_v2(const req_state* const s) const
     if (now >= exp) {
       throw -EPERM;
     }
-    if (s->info.args.exists("X-Amz-Security-Token")) {
-      session_token = s->info.args.get("X-Amz-Security-Token");
+    if (s->info.args.exists("x-amz-security-token")) {
+      session_token = s->info.args.get("x-amz-security-token");
       if (session_token.size() == 0) {
         throw -EPERM;
       }
@@ -5838,7 +5838,7 @@ rgw::auth::s3::STSEngine::authenticate(
   const completer_factory_t& completer_factory,
   const req_state* const s) const
 {
-  if (! s->info.args.exists("X-Amz-Security-Token") &&
+  if (! s->info.args.exists("x-amz-security-token") &&
       ! s->info.env->exists("HTTP_X_AMZ_SECURITY_TOKEN") &&
       s->auth.s3_postobj_creds.x_amz_security_token.empty()) {
     return result_t::deny();


### PR DESCRIPTION
in req_info, which are used to parse credentials in
query strings.

Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
