### PR TITLE
JSONFormattable incorrectly sets a string starting with digit as int

### DIFF
--- a/src/common/ceph_json.cc
+++ b/src/common/ceph_json.cc
@@ -249,7 +249,12 @@ bool JSONParser::parse(const char *buf_, int len)
       if (data.type() == str_type) {
         val.set(data.get_str(), true);
       } else {
-        val.set(json_spirit::write_string(data), false);
+        const std::string& s = json_spirit::write_string(data);
+        if (s.size() == (uint64_t)len) { /* Check if entire string is read */
+          val.set(s, false);
+        } else {
+          set_failure();
+        }
       }
     }
   } else {

--- a/src/test/common/test_json_formattable.cc
+++ b/src/test/common/test_json_formattable.cc
@@ -61,6 +61,12 @@ TEST(formatable, str2) {
 
 }
 
+TEST(formatable, str3) {
+  JSONFormattable f;
+  get_jf("{ \"foo\": \"1234bar56\" }", &f);
+  ASSERT_EQ((string)f["foo"], "1234bar56");
+}
+
 TEST(formatable, int) {
   JSONFormattable f;
   get_jf("{ \"foo\": 1 }", &f);
@@ -191,6 +197,12 @@ TEST(formatable, set) {
   f.set("obj.c", "30");
 
   ASSERT_EQ((int)f["obj"]["c"], 30);
+}
+
+TEST(formatable, set2) {
+  JSONFormattable f;
+  f.set("foo", "1234bar56");
+  ASSERT_EQ((string)f["foo"], "1234bar56");
 }
 
 TEST(formatable, erase) {


### PR DESCRIPTION
JSONFormattable::set calls JSONParser::parse() to check if the given string
is a valid JSON object, which internally uses json_spirit::read to determine
the string type and copy it into data.
This routine incorrectly sets data type to integer if the string starts with
digit and copies only the first set of numeric values of the string.

For eg:
radosgw-admin zone modify --rgw-zone=cloud-zone --rgw-zonegroup=default --tier-config=connection.access_key=312CNV15CC2ZN44IPB24A

Output:
    "tier_config": {
        "connection": {
            "access_key": 312,
            "secret": "W0X3NbPXNW1B7Ru79xuuUI53ftSKieEl2ouuHP8C"
        }
    },

As can be seen in above output only first set of digits of the input string are copied. The same issue exists for even real & bool types.

The right fix seems to be to check if the entire string is read before processing the data value set.

Fixes:  https://tracker.ceph.com/issues/55212
