### PR TITLE
cmake, librados: don't link buffer.cc twice.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -384,7 +384,6 @@ set(ceph_common_objs
   $<TARGET_OBJECTS:common-auth-objs>
   $<TARGET_OBJECTS:common-common-objs>
   $<TARGET_OBJECTS:common-msg-objs>
-  $<TARGET_OBJECTS:common_buffer_obj>
   $<TARGET_OBJECTS:common_texttable_obj>
   $<TARGET_OBJECTS:compressor_objs>
   $<TARGET_OBJECTS:common-objs>

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,6 +1,3 @@
-add_library(common_buffer_obj OBJECT
-  buffer.cc)
-
 add_library(common_texttable_obj OBJECT
   TextTable.cc)
 
@@ -46,6 +43,7 @@ set(common_srcs
   assert.cc
   bit_str.cc
   bloom_filter.cc
+  buffer.cc
   ceph_argparse.cc
   ceph_context.cc
   ceph_crypto.cc

--- a/src/librados/CMakeLists.txt
+++ b/src/librados/CMakeLists.txt
@@ -8,8 +8,7 @@ add_library(librados_impl STATIC
 # C/C++ API
 add_library(librados ${CEPH_SHARED}
   librados_c.cc
-  librados_cxx.cc
-  $<TARGET_OBJECTS:common_buffer_obj>)
+  librados_cxx.cc)
 if(ENABLE_SHARED)
   set_target_properties(librados PROPERTIES
     OUTPUT_NAME rados

--- a/src/neorados/CMakeLists.txt
+++ b/src/neorados/CMakeLists.txt
@@ -14,7 +14,6 @@ target_link_libraries(libneorados PRIVATE
 #   add_library(libneorados ${CEPH_SHARED}
 #     $<TARGET_OBJECTS:neorados_api_obj>
 #     $<TARGET_OBJECTS:neorados_objs>
-#     $<TARGET_OBJECTS:common_buffer_obj>)
 #   set_target_properties(libneorados PROPERTIES
 #     OUTPUT_NAME RADOS
 #     VERSION 0.0.1

--- a/src/test/lazy-omap-stats/CMakeLists.txt
+++ b/src/test/lazy-omap-stats/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(ceph_test_lazy_omap_stats
   main.cc
   lazy_omap_stats_test.cc)
 target_link_libraries(ceph_test_lazy_omap_stats
-  librados ${UNITTEST_LIBS} Boost::system)
+  librados ceph-common ${UNITTEST_LIBS} Boost::system)
 install(TARGETS
   ceph_test_lazy_omap_stats
   DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Definitions of `ceph::buffer` reside in `libceph-common`. This library is a dependency for many other components, also for `librados`.  Before the patch, `librados` was satisfying its requirements towards the symbols defined in the `buffer.cc` file in duplicative way by:

  1. pulling the file directly **while also**
  2. linking with `libceph-common`.

This duplication resulted in calling constructors and destructors for `static` objects of `buffer.cc` twice. Moreover, they operated on the same memory disturbing already alive instance.
See: https://gist.github.com/rzarzynski/9d46459765e89ce1459ccee56d85c4d1.

Fixes: https://tracker.ceph.com/issues/46298
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
