### PR TITLE
mgr/dashboard: Hide password notification when expiration date is far

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.spec.ts
@@ -23,6 +23,11 @@ describe('PwdExpirationNotificationComponent', () => {
 
   const routes: Routes = [{ path: 'login', component: FakeComponent }];
 
+  const spyOnDate = (fakeDate: string) => {
+    const dateValue = Date;
+    spyOn(global, 'Date').and.callFake((date) => new dateValue(date ? date : fakeDate));
+  };
+
   configureTestBed({
     declarations: [PwdExpirationNotificationComponent, FakeComponent],
     imports: [NgbAlertModule, HttpClientTestingModule, RouterTestingModule.withRoutes(routes)],
@@ -58,42 +63,29 @@ describe('PwdExpirationNotificationComponent', () => {
     });
 
     it('should calculate password expiration in days', () => {
-      const dateValue = Date;
-      spyOn(global, 'Date').and.callFake((date) => {
-        if (date) {
-          return new dateValue(date);
-        } else {
-          return new Date('2022-02-18T00:00:00.000Z');
-        }
-      });
+      spyOnDate('2022-02-18T00:00:00.000Z');
       component.ngOnInit();
       expect(component['expirationDays']).toBe(4);
     });
 
     it('should set alert type warning correctly', () => {
-      const dateValue = Date;
-      spyOn(global, 'Date').and.callFake((date) => {
-        if (date) {
-          return new dateValue(date);
-        } else {
-          return new Date('2022-02-14T00:00:00.000Z');
-        }
-      });
+      spyOnDate('2022-02-14T00:00:00.000Z');
       component.ngOnInit();
       expect(component['alertType']).toBe('warning');
+      expect(component.displayNotification).toBeTruthy();
     });
 
     it('should set alert type danger correctly', () => {
-      const dateValue = Date;
-      spyOn(global, 'Date').and.callFake((date) => {
-        if (date) {
-          return new dateValue(date);
-        } else {
-          return new Date('2022-02-18T00:00:00.000Z');
-        }
-      });
+      spyOnDate('2022-02-18T00:00:00.000Z');
       component.ngOnInit();
       expect(component['alertType']).toBe('danger');
+      expect(component.displayNotification).toBeTruthy();
+    });
+
+    it('should not display if date is far', () => {
+      spyOnDate('2022-01-01T00:00:00.000Z');
+      component.ngOnInit();
+      expect(component.displayNotification).toBeFalsy();
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/pwd-expiration-notification/pwd-expiration-notification.component.ts
@@ -31,8 +31,9 @@ export class PwdExpirationNotificationComponent implements OnInit, OnDestroy {
         } else {
           this.alertType = 'warning';
         }
-        this.displayNotification = true;
-        this.authStorageService.isPwdDisplayedSource.next(true);
+        this.displayNotification =
+          this.expirationDays <= this.pwdExpirationSettings.pwdExpirationWarning1;
+        this.authStorageService.isPwdDisplayedSource.next(this.displayNotification);
       }
     });
   }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46306

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
