### PR TITLE
octopus: mgr/dashboard: fix wal/db slots controls in the OSD form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
@@ -104,11 +104,9 @@ export class OsdFormComponent implements OnInit {
   createForm() {
     this.form = new CdFormGroup({
       walSlots: new FormControl(0, {
-        updateOn: 'blur',
         validators: [Validators.min(0)]
       }),
       dbSlots: new FormControl(0, {
-        updateOn: 'blur',
         validators: [Validators.min(0)]
       }),
       features: new CdFormGroup(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46314

---

backport of https://github.com/ceph/ceph/pull/35565
parent tracker: https://tracker.ceph.com/issues/44985

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh