### PR TITLE
octopus: mgr/dashboard: Prometheus query error in the metrics of Pools, OSDs and RBD images

### DIFF
--- a/monitoring/grafana/dashboards/osds-overview.json
+++ b/monitoring/grafana/dashboards/osds-overview.json
@@ -431,7 +431,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "count by(device_class) (ceph_osd_metadata)",
+          "expr": "count by (device_class) (ceph_osd_metadata)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{device_class}}",

--- a/monitoring/grafana/dashboards/rbd-overview.json
+++ b/monitoring/grafana/dashboards/rbd-overview.json
@@ -416,7 +416,7 @@
       ],
       "targets": [
         {
-          "expr": "topk(10, (sort((irate(ceph_rbd_write_ops[30s]) + on(image, pool, namespace) irate(ceph_rbd_read_ops[30s])))))",
+          "expr": "topk(10, (sort((irate(ceph_rbd_write_ops[30s]) + on (image, pool, namespace) irate(ceph_rbd_read_ops[30s])))))",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46313

---

backport of https://github.com/ceph/ceph/pull/34532
parent tracker: https://tracker.ceph.com/issues/45068

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh