### PR TITLE
.githubmap: add Kyr

### DIFF
--- a/.githubmap
+++ b/.githubmap
@@ -43,6 +43,7 @@ jdurgin Josh Durgin <jdurgin@redhat.com>
 jecluis João Eduardo Luís <joao@suse.de>
 joscollin Jos Collin <jcollin@redhat.com>
 jtlayton Jeff Layton <jlayton@redhat.com>
+kshtsk Kyr Shatskyy <kyrylo.shatskyy@suse.com>
 ktdreyer Ken Dreyer <kdreyer@redhat.com>
 LenzGr Lenz Grimmer <lgrimmer@suse.com>
 leseb Sébastien Han <seb@redhat.com>


### PR DESCRIPTION
Updated Kyr Shatskyy in .githubmap as found in [1].
Would be easier for other people while merging PRs.

[1] https://api.github.com/users/kshtsk/events/public