### PR TITLE
octopus: mgr/dashboard: remove cdCopy2ClipboardButton `formatted` attribute

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -269,8 +269,7 @@
                 </button>
                 <button type="button"
                         class="btn btn-light"
-                        cdCopy2ClipboardButton="report"
-                        formatted>
+                        cdCopy2ClipboardButton="report">
                 </button>
               </div>
             </div>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46328

---

backport of https://github.com/ceph/ceph/pull/35803
parent tracker: https://tracker.ceph.com/issues/46232

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh