### PR TITLE
test/multi_stress_watch: use internel API to connect cluster

### DIFF
--- a/src/test/multi_stress_watch.cc
+++ b/src/test/multi_stress_watch.cc
@@ -141,30 +141,13 @@ int main(int args, char **argv)
     return 1;
   }
 
-  char *id = getenv("CEPH_CLIENT_ID");
-  if (id) std::cerr << "Client id is: " << id << std::endl;
   Rados cluster;
-  int ret;
-  ret = cluster.init(id);
-  if (ret) {
-    std::cerr << "Error " << ret << " in cluster.init" << std::endl;
-    return ret;
+  std::string err = connect_cluster_pp(cluster);
+  if (err.length()) {
+      std::cerr << "Error " << err << std::endl;
+      return 1;
   }
-  ret = cluster.conf_read_file(NULL);
-  if (ret) {
-    std::cerr << "Error " << ret << " in cluster.conf_read_file" << std::endl;
-    return ret;
-  }
-  ret = cluster.conf_parse_env(NULL);
-  if (ret) {
-    std::cerr << "Error " << ret << " in cluster.conf_read_env" << std::endl;
-    return ret;
-  }
-  ret = cluster.connect();
-  if (ret) {
-    std::cerr << "Error " << ret << " in cluster.connect" << std::endl;
-    return ret;
-  }
+
   if (type == "rep")
     test_replicated(cluster, pool_name, obj_name);
   else if (type == "ec")


### PR DESCRIPTION
use connect_cluster_pp API to connect cluster

Signed-off-by: Changcheng Liu <changcheng.liu@aliyun.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
