### PR TITLE
octopus: mgr/dashboard: Display check icon instead of true|false in various datatables

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.ts
@@ -116,7 +116,9 @@ export class InventoryDevicesComponent implements OnInit, OnDestroy {
       {
         name: this.i18n('Available'),
         prop: 'available',
-        flexGrow: 1
+        flexGrow: 1,
+        cellClass: 'text-center',
+        cellTransformation: CellTemplate.checkIcon
       },
       {
         name: this.i18n('Vendor'),

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -72,7 +72,9 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
       {
         name: this.i18n('Running'),
         prop: 'status.running',
-        flexGrow: 1
+        flexGrow: 1,
+        cellClass: 'text-center',
+        cellTransformation: CellTemplate.checkIcon
       },
       {
         name: this.i18n('Size'),

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.html
@@ -20,8 +20,3 @@
     {{ role }}{{ !isLast ? ", " : "" }}
   </span>
 </ng-template>
-
-<ng-template #userEnabledTpl
-             let-value="value">
-  <span>{{ value | booleanText }}</span>
-</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
@@ -30,8 +30,6 @@ const BASE_URL = 'user-management/users';
 export class UserListComponent implements OnInit {
   @ViewChild('userRolesTpl', { static: true })
   userRolesTpl: TemplateRef<any>;
-  @ViewChild('userEnabledTpl', { static: true })
-  userEnabledTpl: TemplateRef<any>;
 
   permission: Permission;
   tableActions: CdTableAction[];


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46308

---

backport of https://github.com/ceph/ceph/pull/35779
parent tracker: https://tracker.ceph.com/issues/46209

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh