### PR TITLE
rgw: gc send_chain aio

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4762,7 +4762,9 @@ int RGWRados::Object::complete_atomic_modification()
   }
 
   string tag = (state->tail_tag.length() > 0 ? state->tail_tag.to_str() : state->obj_tag.to_str());
+
   auto ret = store->gc->send_chain(chain, tag); // do it synchronously
+  ldout(store->ctx(), 0) << "ret= " << ret << dendl;
   if (ret < 0) {
     //Delete objects inline if send chain to gc fails
     store->delete_objs_inline(chain, tag);


### PR DESCRIPTION
Initial work to make gc send_chain to use gc_aio_operate

From several testing on overwriting objects that have tails this PR is reducing the total latency for the put request.
TO DO:
Add mechanism for dealing with failures in the send_chain operation (ENOSPC from the queue and pending gc requests - off RGW context).
Suggestion to solve the issue:
Add delete_objs_inline into the send_chain in case of failure
Signed-off-by: Or Friedmann <ofriedma@redhat.com>