### PR TITLE
nautilus: ceph-volume: don't use container classes in api/lvm.py

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -135,6 +135,7 @@ class Prepare(object):
             raise RuntimeError('unable to use device')
         return uuid
 
+    # TODO: get rid of this method?
     def get_lv(self, argument):
         """
         Perform some parsing of the command-line value so that the process
@@ -148,7 +149,8 @@ class Prepare(object):
             vg_name, lv_name = argument.split('/')
         except (ValueError, AttributeError):
             return None
-        return api.get_lv(lv_name=lv_name, vg_name=vg_name)
+        return api.get_first_lv(filters={'lv_name': lv_name, 'vg_name':
+                                         vg_name})
 
     def setup_device(self, device_type, device_name, tags, size):
         """

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -130,7 +130,6 @@ class MixedType(MixedStrategy):
         super(MixedType, self).__init__(args, data_devs, db_devs, wal_devs)
         self.block_db_size = self.get_block_db_size()
         self.block_wal_size = self.get_block_wal_size()
-        self.system_vgs = lvm.VolumeGroups()
         self.common_vg = None
         self.common_wal_vg = None
         self.dbs_needed = len(self.data_devs) * self.osds_per_device

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -184,7 +184,6 @@ class MixedType(MixedStrategy):
         self.blank_journal_devs = []
         self.journals_needed = len(self.data_devs) * self.osds_per_device
         self.journal_size = get_journal_size(args)
-        self.system_vgs = lvm.VolumeGroups()
         self.validate_compute()
 
     @classmethod

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -165,7 +165,8 @@ class Zap(object):
         Device examples: vg-name/lv-name, /dev/vg-name/lv-name
         Requirements: Must be a logical volume (LV)
         """
-        lv = api.get_lv(lv_name=device.lv_name, vg_name=device.vg_name)
+        lv = api.get_first_lv(filters={'lv_name': device.lv_name, 'vg_name':
+                                       device.vg_name})
         self.unmount_lv(lv)
 
         wipefs(device.abspath)

--- a/src/ceph-volume/ceph_volume/devices/simple/scan.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/scan.py
@@ -80,7 +80,7 @@ class Scan(object):
             device = os.readlink(path)
         else:
             device = path
-        lvm_device = lvm.get_lv_from_argument(device)
+        lvm_device = lvm.get_first_lv(filters={'lv_path': device})
         if lvm_device:
             device_uuid = lvm_device.lv_uuid
         else:

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -290,7 +290,7 @@ def device_info(monkeypatch, patch_bluestore_label):
         monkeypatch.setattr("ceph_volume.sys_info.devices", {})
         monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda: devices)
         if not devices:
-            monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: lv)
+            monkeypatch.setattr("ceph_volume.util.device.lvm.get_first_lv", lambda filters: lv)
         else:
             monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: None)
             monkeypatch.setattr("ceph_volume.util.device.lvm.get_device_lvs",

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
@@ -61,7 +61,7 @@ class TestMixedType(object):
                        block_db_size=None, block_wal_size=None,
                        osd_ids=[])
         monkeypatch.setattr(lvm, 'VolumeGroup', lambda x, **kw: [])
-        monkeypatch.setattr(lvm, 'VolumeGroups', lambda: [])
+        monkeypatch.setattr(lvm, 'get_vgs', lambda: [])
         bluestore.MixedType(args, [], [db_dev], [])
 
 

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
@@ -178,7 +178,9 @@ class TestMixedType(object):
         args = factory(filtered_devices=[], osds_per_device=1,
                        journal_size=None, osd_ids=[])
         devices = [ssd, hdd]
-        result = filestore.MixedType.with_auto_devices(args, devices).computed['osds'][0]
+
+        result = filestore.MixedType.with_auto_devices(args, devices).\
+            computed['osds'][0]
         assert result['journal']['path'] == 'vg: fast'
         assert result['journal']['percentage'] == 71
         assert result['journal']['human_readable_size'] == '5.00 GB'
@@ -195,9 +197,10 @@ class TestMixedType(object):
         hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, rotational=True, sys_api=dict(size=6073740000))
 
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(filtered_devices=[], osds_per_device=1,
-                       journal_size=None, osd_ids=[])
+        args = factory(filtered_devices=[], osds_per_device=1, osd_ids=[],
+                       journal_size=None)
         devices = [ssd1, ssd2, hdd]
+
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType.with_auto_devices(args, devices)
             assert 'Could not find a common VG between devices' in str(error.value)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
@@ -1,4 +1,5 @@
 import pytest
+from ceph_volume.api import lvm as api
 from ceph_volume.devices import lvm
 from mock.mock import patch, Mock
 
@@ -119,13 +120,13 @@ class TestGetJournalLV(object):
 
     @pytest.mark.parametrize('arg', ['', '///', None, '/dev/sda1'])
     def test_no_journal_on_invalid_path(self, monkeypatch, arg):
-        monkeypatch.setattr(lvm.prepare.api, 'get_lv', lambda **kw: False)
+        monkeypatch.setattr(api, '_get_lv', lambda **kw: False)
         prepare = lvm.prepare.Prepare([])
         assert prepare.get_lv(arg) is None
 
     def test_no_journal_lv_found(self, monkeypatch):
         # patch it with 0 so we know we are getting to get_lv
-        monkeypatch.setattr(lvm.prepare.api, 'get_lv', lambda **kw: 0)
+        monkeypatch.setattr(api, '_get_lv', lambda **kw: 0)
         prepare = lvm.prepare.Prepare([])
         assert prepare.get_lv('vg/lv') == 0
 

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
@@ -1,5 +1,4 @@
 import pytest
-from ceph_volume.api import lvm as api
 from ceph_volume.devices import lvm
 from mock.mock import patch, Mock
 
@@ -115,21 +114,6 @@ class TestPrepare(object):
             prepare.safe_prepare()
             expected = 'skipping {}, it is already prepared'.format('/dev/sdfoo')
             assert expected in str(error.value)
-
-class TestGetJournalLV(object):
-
-    @pytest.mark.parametrize('arg', ['', '///', None, '/dev/sda1'])
-    def test_no_journal_on_invalid_path(self, monkeypatch, arg):
-        monkeypatch.setattr(api, '_get_lv', lambda **kw: False)
-        prepare = lvm.prepare.Prepare([])
-        assert prepare.get_lv(arg) is None
-
-    def test_no_journal_lv_found(self, monkeypatch):
-        # patch it with 0 so we know we are getting to get_lv
-        monkeypatch.setattr(api, '_get_lv', lambda **kw: 0)
-        prepare = lvm.prepare.Prepare([])
-        assert prepare.get_lv('vg/lv') == 0
-
 
 class TestActivate(object):
 

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -46,11 +46,13 @@ class TestDevice(object):
         assert disk.is_lv
 
     def test_vgs_is_empty(self, device_info, pvolumes, pvolumes_empty, monkeypatch):
-        BarPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000", pv_tags={})
+        BarPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000",
+                                 pv_tags={})
         pvolumes.append(BarPVolume)
-        monkeypatch.setattr(api, 'PVolumes', lambda populate=True: pvolumes if populate else pvolumes_empty)
         lsblk = {"TYPE": "disk"}
         device_info(lsblk=lsblk)
+        monkeypatch.setattr(api, 'get_pvs', lambda **kwargs: {})
+
         disk = device.Device("/dev/nvme0n1")
         assert disk.vgs == []
 
@@ -267,13 +269,23 @@ class TestDevice(object):
         assert not disk.available_raw
 
     @pytest.mark.parametrize("ceph_type", ["data", "block"])
-    def test_used_by_ceph(self, device_info, pvolumes, pvolumes_empty, monkeypatch, ceph_type):
-        FooPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000", lv_uuid="0000", pv_tags={}, vg_name="vg")
-        pvolumes.append(FooPVolume)
-        monkeypatch.setattr(api, 'PVolumes', lambda populate=True: pvolumes if populate else pvolumes_empty)
+    def test_used_by_ceph(self, device_info, volumes, pvolumes, pvolumes_empty,
+                          monkeypatch, ceph_type):
         data = {"/dev/sda": {"foo": "bar"}}
         lsblk = {"TYPE": "part"}
-        lv_data = {"lv_path": "vg/lv", "vg_name": "vg", "lv_uuid": "0000", "tags": {"ceph.osd_id": 0, "ceph.type": ceph_type}}
+        FooPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000",
+                                 lv_uuid="0000", pv_tags={}, vg_name="vg")
+        pvolumes.append(FooPVolume)
+        lv_data = {"lv_name": "lv", "lv_path": "vg/lv", "vg_name": "vg",
+                   "lv_uuid": "0000", "lv_tags":
+                   "ceph.osd_id=0,ceph.type="+ceph_type}
+        lv = api.Volume(**lv_data)
+        volumes.append(lv)
+        monkeypatch.setattr(api, 'get_pvs', lambda **kwargs:
+                            deepcopy(pvolumes))
+        monkeypatch.setattr(api, 'get_lvs', lambda **kwargs:
+                            deepcopy(volumes))
+
         device_info(devices=data, lsblk=lsblk, lv=lv_data)
         vg = api.VolumeGroup(vg_name='foo/bar', vg_free_count=6,
                              vg_extent_size=1073741824)
@@ -284,10 +296,12 @@ class TestDevice(object):
     def test_not_used_by_ceph(self, device_info, pvolumes, pvolumes_empty, monkeypatch):
         FooPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000", lv_uuid="0000", pv_tags={}, vg_name="vg")
         pvolumes.append(FooPVolume)
-        monkeypatch.setattr(api, 'PVolumes', lambda populate=True: pvolumes if populate else pvolumes_empty)
         data = {"/dev/sda": {"foo": "bar"}}
         lsblk = {"TYPE": "part"}
         lv_data = {"lv_path": "vg/lv", "vg_name": "vg", "lv_uuid": "0000", "tags": {"ceph.osd_id": 0, "ceph.type": "journal"}}
+        monkeypatch.setattr(api, 'get_pvs', lambda **kwargs:
+                            deepcopy(pvolumes))
+
         device_info(devices=data, lsblk=lsblk, lv=lv_data)
         disk = device.Device("/dev/sda")
         assert not disk.used_by_ceph

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -1,25 +1,38 @@
 import pytest
+from copy import deepcopy
 from ceph_volume.util import device
 from ceph_volume.api import lvm as api
 
 
 class TestDevice(object):
 
-    def test_sys_api(self, device_info):
+    def test_sys_api(self, volumes, monkeypatch, device_info):
+        volume = api.Volume(lv_name='lv', lv_uuid='y', vg_name='vg',
+                            lv_tags={}, lv_path='/dev/VolGroup/lv')
+        volumes.append(volume)
+        monkeypatch.setattr(api, 'get_lvs', lambda **kwargs:
+                            deepcopy(volumes))
+
         data = {"/dev/sda": {"foo": "bar"}}
         device_info(devices=data)
         disk = device.Device("/dev/sda")
         assert disk.sys_api
         assert "foo" in disk.sys_api
 
-    def test_lvm_size(self, device_info):
+    def test_lvm_size(self, volumes, monkeypatch, device_info):
+        volume = api.Volume(lv_name='lv', lv_uuid='y', vg_name='vg',
+                            lv_tags={}, lv_path='/dev/VolGroup/lv')
+        volumes.append(volume)
+        monkeypatch.setattr(api, 'get_lvs', lambda **kwargs:
+                            deepcopy(volumes))
+
         # 5GB in size
         data = {"/dev/sda": {"size": "5368709120"}}
         device_info(devices=data)
         disk = device.Device("/dev/sda")
         assert disk.lvm_size.gb == 4
 
-    def test_lvm_size_rounds_down(self, device_info):
+    def test_lvm_size_rounds_down(self, device_info, volumes):
         # 5.5GB in size
         data = {"/dev/sda": {"size": "5905580032"}}
         device_info(devices=data)

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -130,8 +130,14 @@ class Device(object):
                     self.sys_api = part
                     break
 
-        # start with lvm since it can use an absolute or relative path
-        lv = lvm.get_lv_from_argument(self.path)
+        # if the path is not absolute, we have 'vg/lv', let's use LV name
+        # to get the LV.
+        if self.path[0] == '/':
+            lv = lvm.get_first_lv(filters={'lv_path': self.path})
+        else:
+            vgname, lvname = self.path.split('/')
+            lv = lvm.get_first_lv(filters={'lv_name': lvname,
+                                           'vg_name': vgname})
         if lv:
             self.lv_api = lv
             self.lvs = [lv]

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -252,7 +252,6 @@ class Device(object):
                     # actually unused (not 100% sure) and can simply be removed
                     self.vg_name = vgs[0]
                     self._is_lvm_member = True
-
                     self.lvs.extend(lvm.get_device_lvs(path))
         return self._is_lvm_member
 


### PR DESCRIPTION
Use get_lvs, get_vgs and get_pvs instead. The hallmark difference
between usage of these methods and container classes is that these methods
use option -S to filter LVM devs. See lvs -S --help for more details on
these filters.

Changes to api/lvm.py will be merged separately; see PR #32231. Only
devices/lvm/listing.py is an exception in this PR since refactoring on this
file happens on a separate PR (see #31700).

These containers classes will be removed from api/lvm.py on a separate PR
after this and related PR merges.

Note: not using these container classes means LVM devs would no more be
cached by ceph-volume.

Backports #32493.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>