### PR TITLE
doc: Add a missing step to the build guide.

### DIFF
--- a/doc/install/build-ceph.rst
+++ b/doc/install/build-ceph.rst
@@ -67,9 +67,9 @@ Debian/Ubuntu or ``rpmbuild`` for the RPM Package Manager.
 Advanced Package Tool (APT)
 ---------------------------
 
-To create ``.deb`` packages for Debian/Ubuntu, ensure that you have cloned the 
-`Ceph`_ repository, installed the `Build Prerequisites`_ and installed 
-``debhelper``::
+To create ``.deb`` packages for Debian/Ubuntu, ensure that you have cloned the
+`Ceph`_ repository, installed the `Build Prerequisites`_, run do_cmake.sh, and
+installed ``debhelper``::
 
 	sudo apt-get install debhelper
 
@@ -84,8 +84,8 @@ RPM Package Manager
 -------------------
 
 To create ``.rpm`` packages, ensure that you have cloned the `Ceph`_ repository,
-installed the `Build Prerequisites`_ and installed ``rpm-build`` and 
-``rpmdevtools``::
+installed the `Build Prerequisites`_ , run do_cmake.sh, and installed
+``rpm-build`` and ``rpmdevtools``::
 
 	yum install rpm-build rpmdevtools
 


### PR DESCRIPTION
Current writing fails to note that you do need to run do_cmake.sh when building
packages.

Signed-off-by: Abutalib Aghayev <agayev@cs.cmu.edu>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
