### PR TITLE
mgr/rook: Fix error creating OSDs

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -493,8 +493,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         def execute(all_hosts_):
             # type: (List[orchestrator.HostSpec]) -> orchestrator.Completion
-            all_hosts = [h.hostname for h in all_hosts_]
-            matching_hosts = drive_group.placement.filter_matching_hosts(lambda label=None, as_hostspec=None: all_hosts)
+            matching_hosts = drive_group.placement.filter_matching_hosts(lambda label=None, as_hostspec=None: all_hosts_)
 
             assert len(matching_hosts) == 1
 


### PR DESCRIPTION
Fix broken Rook Integration tests when creating new OSDs (probably introduced in [34860](https://github.com/ceph/ceph/pull/34860) )

The error can be seen in:
[Rook Integration test for Rook ceph orchestrator log](https://jenkins.rook.io/blue/rest/organizations/jenkins/pipelines/rook/pipelines/rook/branches/master/runs/2046/nodes/63/steps/121/log/?start=0) 


Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>
