### PR TITLE
python-common/drivegroups: implement option to change filter_logic

### DIFF
--- a/doc/cephadm/drivegroups.rst
+++ b/doc/cephadm/drivegroups.rst
@@ -44,6 +44,15 @@ Since we want to have more complex setups, there are more filters than just the 
 Filters
 =======
 
+.. note::
+   Filters are applied using a `AND` gate by default. This essentially means that a drive needs to fulfill all filter
+   criteria in order to get selected.
+   If you wish to change this behavior you can adjust this behavior by setting
+
+    `filter_logic: OR`  # valid arguments are `AND`, `OR`
+
+   in the OSD Specification.
+
 You can assign disks to certain groups by their attributes using filters.
 
 The attributes are based off of ceph-volume's disk query. You can retrieve the information

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -102,6 +102,7 @@ def test_spec_octopus(spec_json):
             spec = j_c.pop('spec')
             j_c.update(spec)
         j_c.pop('objectstore', None)
+        j_c.pop('filter_logic', None)
         return j_c
     assert spec_json == convert_to_old_style_json(spec.to_json())
 

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -143,7 +143,7 @@ class DriveGroupSpec(ServiceSpec):
         "db_slots", "wal_slots", "block_db_size", "placement", "service_id", "service_type",
         "data_devices", "db_devices", "wal_devices", "journal_devices",
         "data_directories", "osds_per_device", "objectstore", "osd_id_claims",
-        "journal_size", "unmanaged"
+        "journal_size", "unmanaged", "filter_logic"
     ]
 
     def __init__(self,
@@ -165,6 +165,7 @@ class DriveGroupSpec(ServiceSpec):
                  journal_size=None,  # type: Optional[int]
                  service_type=None,  # type: Optional[str]
                  unmanaged=False,  # type: bool
+                 filter_logic='AND'  # type: str
                  ):
         assert service_type is None or service_type == 'osd'
         super(DriveGroupSpec, self).__init__('osd', service_id=service_id,
@@ -214,6 +215,10 @@ class DriveGroupSpec(ServiceSpec):
         #: Optional: mapping of host -> List of osd_ids that should be replaced
         #: See :ref:`orchestrator-osd-replace`
         self.osd_id_claims = osd_id_claims or dict()
+
+        #: The logic gate we use to match disks with filters.
+        #: defaults to 'AND'
+        self.filter_logic = filter_logic.upper()
 
     @classmethod
     def _from_json_impl(cls, json_drive_group):
@@ -295,6 +300,9 @@ class DriveGroupSpec(ServiceSpec):
             raise DriveGroupValidationError('block_wal_size must be of type int')
         if self.block_db_size is not None and type(self.block_db_size) != int:
             raise DriveGroupValidationError('block_db_size must be of type int')
+
+        if self.filter_logic not in ['AND', 'OR']:
+            raise DriveGroupValidationError('filter_logic must be either <AND> or <OR>')
 
     def __repr__(self):
         keys = [

--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -134,11 +134,19 @@ class DriveSelection(object):
             if disk in devices:
                 continue
 
-            if not all(m.compare(disk) for m in FilterGenerator(device_filter)):
-                logger.debug(
-                    "Ignoring disk {}. Filter did not match".format(
-                        disk.path))
-                continue
+            if self.spec.filter_logic == 'AND':
+                if not all(m.compare(disk) for m in FilterGenerator(device_filter)):
+                    logger.debug(
+                        "Ignoring disk {}. Not all filter did match the disk".format(
+                            disk.path))
+                    continue
+
+            if self.spec.filter_logic == 'OR':
+                if not any(m.compare(disk) for m in FilterGenerator(device_filter)):
+                    logger.debug(
+                        "Ignoring disk {}. No filter matched the disk".format(
+                            disk.path))
+                    continue
 
             logger.debug('Adding disk {}'.format(disk.path))
             devices.append(disk)

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -151,6 +151,7 @@ spec:
     model: MC-55-44-XZ
   db_devices:
     model: SSD-123-foo
+  filter_logic: AND
   objectstore: bluestore
   wal_devices:
     model: NVME-QQQQ-987

--- a/src/python-common/ceph/tests/utils.py
+++ b/src/python-common/ceph/tests/utils.py
@@ -8,12 +8,14 @@ except ImportError:
 
 def _mk_device(rotational=True,
                locked=False,
-               size="394.27 GB"):
+               size="394.27 GB",
+               vendor='Vendor',
+               model='Model'):
     return [Device(
         path='??',
         sys_api={
             "rotational": '1' if rotational else '0',
-            "vendor": "Vendor",
+            "vendor": vendor,
             "human_readable_size": size,
             "partitions": {},
             "locked": int(locked),
@@ -21,7 +23,7 @@ def _mk_device(rotational=True,
             "removable": "0",
             "path": "??",
             "support_discard": "",
-            "model": "Model",
+            "model": model,
             "ro": "0",
             "nr_requests": "128",
             "size": 423347879936  # ignore coversion from human_readable_size


### PR DESCRIPTION
Filters are applied to disks using an AND gate by default. In some
scenarios you can only achieve the desired behavior when using an OR
gate without expanding the available filters.

This patch allows to switch between `AND` and `OR` gates.

Fixes: https://tracker.ceph.com/issues/45263

TODO:

- [x] update docs 

Signed-off-by: Joshua Schmid <jschmid@suse.de>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst



-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
