### PR TITLE
ec: drop stubs of {encode,decode}_chunks() from ErasureCode.

### DIFF
--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -203,12 +203,6 @@ int ErasureCode::encode(const set<int> &want_to_encode,
   return 0;
 }
 
-int ErasureCode::encode_chunks(const set<int> &want_to_encode,
-                               map<int, bufferlist> *encoded)
-{
-  ceph_abort_msg("ErasureCode::encode_chunks not implemented");
-}
- 
 int ErasureCode::_decode(const set<int> &want_to_read,
 			 const map<int, bufferlist> &chunks,
 			 map<int, bufferlist> *decoded)
@@ -252,13 +246,6 @@ int ErasureCode::decode(const set<int> &want_to_read,
                         map<int, bufferlist> *decoded, int chunk_size)
 {
   return _decode(want_to_read, chunks, decoded);
-}
-
-int ErasureCode::decode_chunks(const set<int> &want_to_read,
-                               const map<int, bufferlist> &chunks,
-                               map<int, bufferlist> *decoded)
-{
-  ceph_abort_msg("ErasureCode::decode_chunks not implemented");
 }
 
 int ErasureCode::parse(const ErasureCodeProfile &profile,

--- a/src/erasure-code/ErasureCode.h
+++ b/src/erasure-code/ErasureCode.h
@@ -79,9 +79,6 @@ namespace ceph {
                        const bufferlist &in,
                        std::map<int, bufferlist> *encoded) override;
 
-    int encode_chunks(const std::set<int> &want_to_encode,
-                              std::map<int, bufferlist> *encoded) override;
-
     int decode(const std::set<int> &want_to_read,
                 const std::map<int, bufferlist> &chunks,
                 std::map<int, bufferlist> *decoded, int chunk_size) override;
@@ -89,10 +86,6 @@ namespace ceph {
     virtual int _decode(const std::set<int> &want_to_read,
 			const std::map<int, bufferlist> &chunks,
 			std::map<int, bufferlist> *decoded);
-
-    int decode_chunks(const std::set<int> &want_to_read,
-                              const std::map<int, bufferlist> &chunks,
-                              std::map<int, bufferlist> *decoded) override;
 
     const std::vector<int> &get_chunk_mapping() const override;
 

--- a/src/test/erasure-code/TestErasureCode.cc
+++ b/src/test/erasure-code/TestErasureCode.cc
@@ -47,6 +47,12 @@ public:
     encode_chunks_encoded = *encoded;
     return 0;
   }
+  int decode_chunks(const set<int> &want_to_read,
+                    const map<int, bufferlist> &chunks,
+                    map<int, bufferlist> *decoded) override {
+    ceph_abort_msg("ErasureCode::decode_chunks not implemented");
+  }
+
   int create_rule(const string &name,
 		  CrushWrapper &crush,
 		  ostream *ss) const override { return 0; }


### PR DESCRIPTION
`decode_chunks()` was needed only because of the ec unit testing.
Move its implementation there.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
