### PR TITLE
unittest_cdc: fix test on big-endian hosts

### DIFF
--- a/src/test/common/test_cdc.cc
+++ b/src/test/common/test_cdc.cc
@@ -27,7 +27,7 @@ void generate_buffer(int size, bufferlist *outbl, int seed = 0)
     p.set_length(l);
     char *b = p.c_str();
     for (size_t i = 0; i < l / sizeof(uint64_t); ++i) {
-      ((uint64_t*)b)[i] = engine();
+      ((ceph_le64 *)b)[i] = init_le64(engine());
     }
     outbl->append(p);
   }


### PR DESCRIPTION
The specific_result test hardcodes a particular output.  However,
the input buffer used by the test is currently initialized to a
different byte string depending host the host byte order, which
makes the expected result not match on big-endian hosts.

Fixed by always initializing the input buffer to the same string.

Signed-off-by: Ulrich Weigand <ulrich.weigand@de.ibm.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
