### PR TITLE
mgr/dashboard: Fix bugs in a unit test and i18n translation

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.spec.ts
@@ -36,7 +36,7 @@ describe('RgwBucketListComponent', () => {
   });
 
   beforeEach(() => {
-    rgwBucketService = TestBed.get(RgwBucketService);
+    rgwBucketService = TestBed.inject(RgwBucketService);
     rgwBucketServiceListSpy = spyOn(rgwBucketService, 'list');
     rgwBucketServiceListSpy.and.returnValue(of(null));
     fixture = TestBed.createComponent(RgwBucketListComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/telemetry-notification/telemetry-notification.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/telemetry-notification/telemetry-notification.component.ts
@@ -61,8 +61,7 @@ export class TelemetryNotificationComponent implements OnInit, OnDestroy {
       NotificationType.success,
       this.i18n('Telemetry activation reminder muted'),
       this.i18n(
-        'You can activate the module on the Telemetry configuration ' +
-          'page (<b>Dashboard Settings</b> -> <b>Telemetry configuration</b>) at any time.'
+        'You can activate the module on the Telemetry configuration page (<b>Dashboard Settings</b> -> <b>Telemetry configuration</b>) at any time.'
       )
     );
   }


### PR DESCRIPTION
* SKIP: Unknown argument type: 'BinaryExpression' NodeObject { ... text: 'You can activate the module on the Telemetry configuration '
```
> ceph-dashboard@0.0.0 i18n:extract /home/jenkins-build/build/workspace/ceph-pull-requests/src/pybind/mgr/dashboard/frontend
> ng xi18n --output-path locale --progress=false && ngx-extractor -i 'src/**/*.ts' -f xlf -o src/locale/messages.xlf -l en-US

SKIP: Unknown argument type: 'BinaryExpression' NodeObject {
  pos: 2316,
  end: 2480,
  flags: 0,
  modifierFlagsCache: 0,
  transformFlags: 0,
  parent: undefined,
  kind: 209,
  left: TokenObject {
    pos: 2316,
    end: 2386,
    flags: 0,
    modifierFlagsCache: 0,
    transformFlags: 0,
    parent: undefined,
    kind: 10,
    text: 'You can activate the module on the Telemetry configuration '
  },
  operatorToken: TokenObject {
    pos: 2386,
    end: 2388,
    flags: 0,
    modifierFlagsCache: 0,
    transformFlags: 0,
    parent: undefined,
    kind: 39
  },
  right: TokenObject {
    pos: 2388,
    end: 2480,
    flags: 0,
    modifierFlagsCache: 0,
    transformFlags: 0,
    parent: undefined,
    kind: 10,
    text: 'page (<b>Dashboard Settings</b> -> <b>Telemetry configuration</b>) at any time.'
  },
  _children: [
    TokenObject {
      pos: 2316,
      end: 2386,
      flags: 0,
      modifierFlagsCache: 0,
      transformFlags: 0,
      parent: undefined,
      kind: 10,
      text: 'You can activate the module on the Telemetry configuration '
    },
    TokenObject {
      pos: 2386,
      end: 2388,
      flags: 0,
      modifierFlagsCache: 0,
      transformFlags: 0,
      parent: undefined,
      kind: 39
    },
    TokenObject {
      pos: 2388,
      end: 2480,
      flags: 0,
      modifierFlagsCache: 0,
      transformFlags: 0,
      parent: undefined,
      kind: 10,
      text: 'page (<b>Dashboard Settings</b> -> <b>Telemetry configuration</b>) at any time.'
    }
  ]
}
```
* WARNING: /ceph/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.spec.ts:39:32 - get is deprecated: from v9.0.0 use TestBed.inject

Fixes: https://tracker.ceph.com/issues/46371

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
