### PR TITLE
octopus: mgr/dashboard: Use right size in pool form

### DIFF
--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -415,4 +415,5 @@ class PoolTest(DashboardTestCase):
             'erasure_code_profiles': JList(JObj({}, allow_unknown=True)),
             'used_rules': JObj({}, allow_unknown=True),
             'used_profiles': JObj({}, allow_unknown=True),
+            'nodes': JList(JObj({}, allow_unknown=True)),
         }))

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -262,4 +262,5 @@ class PoolUi(Pool):
             "erasure_code_profiles": profiles,
             "used_rules": used_rules,
             "used_profiles": used_profiles,
+            'nodes': mgr.get('osd_map_tree')['nodes']
         }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.spec.ts
@@ -11,7 +11,8 @@ import {
   configureTestBed,
   FixtureHelper,
   FormHelper,
-  i18nProviders
+  i18nProviders,
+  Mocks
 } from '../../../../testing/unit-test-helper';
 import { CrushRuleService } from '../../../shared/api/crush-rule.service';
 import { CrushNode } from '../../../shared/models/crush-node';
@@ -27,31 +28,6 @@ describe('CrushRuleFormComponent', () => {
   let formHelper: FormHelper;
   let fixtureHelper: FixtureHelper;
   let data: { names: string[]; nodes: CrushNode[] };
-
-  // Object contains mock functions
-  const mock = {
-    node: (
-      name: string,
-      id: number,
-      type: string,
-      type_id: number,
-      children?: number[],
-      device_class?: string
-    ): CrushNode => {
-      return { name, type, type_id, id, children, device_class };
-    },
-    rule: (
-      name: string,
-      root: string,
-      failure_domain: string,
-      device_class?: string
-    ): CrushRuleConfig => ({
-      name,
-      root,
-      failure_domain,
-      device_class
-    })
-  };
 
   // Object contains functions to get something
   const get = {
@@ -125,25 +101,7 @@ describe('CrushRuleFormComponent', () => {
        * ----> ssd-rack
        * ------> 2x osd-rack with ssd
        */
-      nodes: [
-        // Root node
-        mock.node('default', -1, 'root', 11, [-2, -3]),
-        // SSD host
-        mock.node('ssd-host', -2, 'host', 1, [1, 0, 2]),
-        mock.node('osd.0', 0, 'osd', 0, undefined, 'ssd'),
-        mock.node('osd.1', 1, 'osd', 0, undefined, 'ssd'),
-        mock.node('osd.2', 2, 'osd', 0, undefined, 'ssd'),
-        // SSD and HDD mixed devices host
-        mock.node('mix-host', -3, 'host', 1, [-4, -5]),
-        // HDD rack
-        mock.node('hdd-rack', -4, 'rack', 3, [3, 4]),
-        mock.node('osd2.0', 3, 'osd-rack', 0, undefined, 'hdd'),
-        mock.node('osd2.1', 4, 'osd-rack', 0, undefined, 'hdd'),
-        // SSD rack
-        mock.node('ssd-rack', -5, 'rack', 3, [5, 6]),
-        mock.node('osd2.0', 5, 'osd-rack', 0, undefined, 'ssd'),
-        mock.node('osd2.1', 6, 'osd-rack', 0, undefined, 'ssd')
-      ]
+      nodes: Mocks.getCrushMap()
     };
     spyOn(crushRuleService, 'getInfo').and.callFake(() => of(data));
     fixture.detectChanges();
@@ -254,12 +212,12 @@ describe('CrushRuleFormComponent', () => {
     });
 
     it('creates a rule with only required fields', () => {
-      assert.creation(mock.rule('default-rule', 'default', 'osd-rack'));
+      assert.creation(Mocks.getCrushRuleConfig('default-rule', 'default', 'osd-rack'));
     });
 
     it('creates a rule with all fields', () => {
       assert.valuesOnRootChange('ssd-host', 'osd', 'ssd');
-      assert.creation(mock.rule('ssd-host-rule', 'ssd-host', 'osd', 'ssd'));
+      assert.creation(Mocks.getCrushRuleConfig('ssd-host-rule', 'ssd-host', 'osd', 'ssd'));
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.spec.ts
@@ -12,10 +12,10 @@ import {
   configureTestBed,
   FixtureHelper,
   FormHelper,
-  i18nProviders
+  i18nProviders,
+  Mocks
 } from '../../../../testing/unit-test-helper';
 import { ErasureCodeProfileService } from '../../../shared/api/erasure-code-profile.service';
-import { CrushNode } from '../../../shared/models/crush-node';
 import { ErasureCodeProfile } from '../../../shared/models/erasure-code-profile';
 import { TaskWrapperService } from '../../../shared/services/task-wrapper.service';
 import { PoolModule } from '../pool.module';
@@ -28,20 +28,6 @@ describe('ErasureCodeProfileFormModalComponent', () => {
   let formHelper: FormHelper;
   let fixtureHelper: FixtureHelper;
   let data: {};
-
-  // Object contains mock functions
-  const mock = {
-    node: (
-      name: string,
-      id: number,
-      type: string,
-      type_id: number,
-      children?: number[],
-      device_class?: string
-    ): CrushNode => {
-      return { name, type, type_id, id, children, device_class };
-    }
-  };
 
   configureTestBed({
     imports: [
@@ -70,34 +56,34 @@ describe('ErasureCodeProfileFormModalComponent', () => {
        * ----> 3x osd with ssd
        * --> mix-host
        * ----> hdd-rack
-       * ------> 2x osd-rack with hdd
+       * ------> 5x osd-rack with hdd
        * ----> ssd-rack
-       * ------> 2x osd-rack with ssd
+       * ------> 5x osd-rack with ssd
        */
       nodes: [
         // Root node
-        mock.node('default', -1, 'root', 11, [-2, -3]),
+        Mocks.getCrushNode('default', -1, 'root', 11, [-2, -3]),
         // SSD host
-        mock.node('ssd-host', -2, 'host', 1, [1, 0, 2]),
-        mock.node('osd.0', 0, 'osd', 0, undefined, 'ssd'),
-        mock.node('osd.1', 1, 'osd', 0, undefined, 'ssd'),
-        mock.node('osd.2', 2, 'osd', 0, undefined, 'ssd'),
+        Mocks.getCrushNode('ssd-host', -2, 'host', 1, [1, 0, 2]),
+        Mocks.getCrushNode('osd.0', 0, 'osd', 0, undefined, 'ssd'),
+        Mocks.getCrushNode('osd.1', 1, 'osd', 0, undefined, 'ssd'),
+        Mocks.getCrushNode('osd.2', 2, 'osd', 0, undefined, 'ssd'),
         // SSD and HDD mixed devices host
-        mock.node('mix-host', -3, 'host', 1, [-4, -5]),
+        Mocks.getCrushNode('mix-host', -3, 'host', 1, [-4, -5]),
         // HDD rack
-        mock.node('hdd-rack', -4, 'rack', 3, [3, 4, 5, 6, 7]),
-        mock.node('osd2.0', 3, 'osd-rack', 0, undefined, 'hdd'),
-        mock.node('osd2.1', 4, 'osd-rack', 0, undefined, 'hdd'),
-        mock.node('osd2.2', 5, 'osd-rack', 0, undefined, 'hdd'),
-        mock.node('osd2.3', 6, 'osd-rack', 0, undefined, 'hdd'),
-        mock.node('osd2.4', 7, 'osd-rack', 0, undefined, 'hdd'),
+        Mocks.getCrushNode('hdd-rack', -4, 'rack', 3, [3, 4, 5, 6, 7]),
+        Mocks.getCrushNode('osd2.0', 3, 'osd-rack', 0, undefined, 'hdd'),
+        Mocks.getCrushNode('osd2.1', 4, 'osd-rack', 0, undefined, 'hdd'),
+        Mocks.getCrushNode('osd2.2', 5, 'osd-rack', 0, undefined, 'hdd'),
+        Mocks.getCrushNode('osd2.3', 6, 'osd-rack', 0, undefined, 'hdd'),
+        Mocks.getCrushNode('osd2.4', 7, 'osd-rack', 0, undefined, 'hdd'),
         // SSD rack
-        mock.node('ssd-rack', -5, 'rack', 3, [8, 9, 10, 11, 12]),
-        mock.node('osd3.0', 8, 'osd-rack', 0, undefined, 'ssd'),
-        mock.node('osd3.1', 9, 'osd-rack', 0, undefined, 'ssd'),
-        mock.node('osd3.2', 10, 'osd-rack', 0, undefined, 'ssd'),
-        mock.node('osd3.3', 11, 'osd-rack', 0, undefined, 'ssd'),
-        mock.node('osd3.4', 12, 'osd-rack', 0, undefined, 'ssd')
+        Mocks.getCrushNode('ssd-rack', -5, 'rack', 3, [8, 9, 10, 11, 12]),
+        Mocks.getCrushNode('osd3.0', 8, 'osd-rack', 0, undefined, 'ssd'),
+        Mocks.getCrushNode('osd3.1', 9, 'osd-rack', 0, undefined, 'ssd'),
+        Mocks.getCrushNode('osd3.2', 10, 'osd-rack', 0, undefined, 'ssd'),
+        Mocks.getCrushNode('osd3.3', 11, 'osd-rack', 0, undefined, 'ssd'),
+        Mocks.getCrushNode('osd3.4', 12, 'osd-rack', 0, undefined, 'ssd')
       ]
     };
     spyOn(ecpService, 'getInfo').and.callFake(() => of(data));

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -145,7 +145,7 @@
               <span class="invalid-feedback"
                     *ngIf="form.showError('size', formDir)"
                     i18n>The size specified is out of range. A value from
-                {{ getMinSize() }} to {{ getMaxSize() }} is valid.</span>
+                {{ getMinSize() }} to {{ getMaxSize() }} is usable.</span>
             </div>
           </div>
 
@@ -346,7 +346,8 @@
                     <tab i18n-heading
                          heading="Crush rule"
                          class="crush-rule-info">
-                      <cd-table-key-value [renderObjects]="true"
+                      <cd-table-key-value [renderObjects]="false"
+                                          [hideKeys]="['steps', 'ruleset', 'type', 'rule_name']"
                                           [data]="form.getValue('crushRule')"
                                           [autoReload]="false">
                       </cd-table-key-value>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -254,6 +254,7 @@
                        heading="Profile"
                        class="ecp-info">
                     <cd-table-key-value [renderObjects]="true"
+                                        [hideKeys]="['name']"
                                         [data]="form.getValue('erasureProfile')"
                                         [autoReload]="false">
                     </cd-table-key-value>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -18,6 +18,7 @@ import {
   FixtureHelper,
   FormHelper,
   i18nProviders,
+  Mocks,
   modalServiceShow
 } from '../../../../testing/unit-test-helper';
 import { NotFoundComponent } from '../../../core/not-found/not-found.component';
@@ -27,7 +28,6 @@ import { PoolService } from '../../../shared/api/pool.service';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
 import { SelectBadgesComponent } from '../../../shared/components/select-badges/select-badges.component';
 import { CdFormGroup } from '../../../shared/forms/cd-form-group';
-import { CrushRule } from '../../../shared/models/crush-rule';
 import { ErasureCodeProfile } from '../../../shared/models/erasure-code-profile';
 import { Permission } from '../../../shared/models/permissions';
 import { PoolFormInfo } from '../../../shared/models/pool-form-info';
@@ -38,7 +38,7 @@ import { PoolModule } from '../pool.module';
 import { PoolFormComponent } from './pool-form.component';
 
 describe('PoolFormComponent', () => {
-  const OSDS = 8;
+  let OSDS = 15;
   let formHelper: FormHelper;
   let fixtureHelper: FixtureHelper;
   let component: PoolFormComponent;
@@ -63,44 +63,6 @@ describe('PoolFormComponent', () => {
       setPgNum(form.getValue('pgNum') + jump);
     }
     expect(form.getValue('pgNum')).toBe(returnValue);
-  };
-
-  const createCrushRule = ({
-    id = 0,
-    name = 'somePoolName',
-    min = 1,
-    max = 10,
-    type = 'replicated'
-  }: {
-    max?: number;
-    min?: number;
-    id?: number;
-    name?: string;
-    type?: string;
-  }) => {
-    const typeNumber = type === 'erasure' ? 3 : 1;
-    const rule = new CrushRule();
-    rule.max_size = max;
-    rule.min_size = min;
-    rule.rule_id = id;
-    rule.ruleset = typeNumber;
-    rule.rule_name = name;
-    rule.steps = [
-      {
-        item_name: 'default',
-        item: -1,
-        op: 'take'
-      },
-      {
-        num: 0,
-        type: 'osd',
-        op: 'choose_firstn'
-      },
-      {
-        op: 'emit'
-      }
-    ];
-    return rule;
   };
 
   const expectValidSubmit = (
@@ -136,12 +98,12 @@ describe('PoolFormComponent', () => {
       compression_algorithms: ['snappy'],
       compression_modes: ['none', 'passive'],
       crush_rules_replicated: [
-        createCrushRule({ id: 0, min: 2, max: 4, name: 'rep1', type: 'replicated' }),
-        createCrushRule({ id: 1, min: 3, max: 18, name: 'rep2', type: 'replicated' }),
-        createCrushRule({ id: 2, min: 1, max: 9, name: 'used_rule', type: 'replicated' })
+        Mocks.getCrushRule({ id: 0, min: 2, max: 4, name: 'rep1', type: 'replicated' }),
+        Mocks.getCrushRule({ id: 1, min: 3, max: 18, name: 'rep2', type: 'replicated' }),
+        Mocks.getCrushRule({ id: 2, min: 1, max: 9, name: 'used_rule', type: 'replicated' })
       ],
       crush_rules_erasure: [
-        createCrushRule({ id: 3, min: 1, max: 1, name: 'ecp1', type: 'erasure' })
+        Mocks.getCrushRule({ id: 3, min: 1, max: 1, name: 'ecp1', type: 'erasure' })
       ],
       erasure_code_profiles: [ecp1],
       pg_autoscale_default_mode: 'off',
@@ -151,7 +113,8 @@ describe('PoolFormComponent', () => {
       },
       used_profiles: {
         ecp1: ['some.other.pool.uses.it']
-      }
+      },
+      nodes: Mocks.generateSimpleCrushMap(3, 5)
     };
   };
 
@@ -331,15 +294,20 @@ describe('PoolFormComponent', () => {
     });
 
     it('validates size', () => {
+      component.info.nodes = Mocks.getCrushMap();
       formHelper.setValue('poolType', 'replicated');
       formHelper.expectValid('size');
-      formHelper.setValue('crushRule', {
-        min_size: 2,
-        max_size: 6
-      });
+      formHelper.setValue('crushRule', Mocks.getCrushRule({ min: 2, max: 6 })); // 3 OSDs usable
       formHelper.expectErrorChange('size', 1, 'min');
-      formHelper.expectErrorChange('size', 8, 'max');
-      formHelper.expectValidChange('size', 6);
+      formHelper.expectErrorChange('size', 4, 'max'); // More than usable
+      formHelper.expectValidChange('size', 3);
+
+      formHelper.setValue(
+        'crushRule',
+        Mocks.getCrushRule({ min: 1, max: 2, failureDomain: 'osd-rack' }) // 4 OSDs usable
+      );
+      formHelper.expectErrorChange('size', 4, 'max'); // More than rule allows
+      formHelper.expectValidChange('size', 2);
     });
 
     it('validates compression mode default value', () => {
@@ -453,9 +421,6 @@ describe('PoolFormComponent', () => {
   describe('pool type changes', () => {
     beforeEach(() => {
       component.ngOnInit();
-      createCrushRule({ id: 3, min: 1, max: 1, name: 'ep1', type: 'erasure' });
-      createCrushRule({ id: 0, min: 2, max: 4, name: 'rep1', type: 'replicated' });
-      createCrushRule({ id: 1, min: 3, max: 18, name: 'rep2', type: 'replicated' });
     });
 
     it('should have a default replicated size of 3', () => {
@@ -514,7 +479,7 @@ describe('PoolFormComponent', () => {
 
       it('disables rule field if only one rule exists which is used in the disabled field', () => {
         infoReturn.crush_rules_replicated = [
-          createCrushRule({ id: 0, min: 2, max: 4, name: 'rep1', type: 'replicated' })
+          Mocks.getCrushRule({ id: 0, min: 2, max: 4, name: 'rep1', type: 'replicated' })
         ];
         setUpPoolComponent();
         formHelper.setValue('poolType', 'replicated');
@@ -544,10 +509,7 @@ describe('PoolFormComponent', () => {
 
   describe('getMaxSize and getMinSize', () => {
     const setCrushRule = ({ min, max }: { min?: number; max?: number }) => {
-      formHelper.setValue('crushRule', {
-        min_size: min,
-        max_size: max
-      });
+      formHelper.setValue('crushRule', Mocks.getCrushRule({ min, max }));
     };
 
     it('returns 0 if osd count is 0', () => {
@@ -568,22 +530,30 @@ describe('PoolFormComponent', () => {
       expect(component.getMaxSize()).toBe(6);
     });
 
-    it('returns 1 as minimum and the osd count as maximum if no crush rule is available', () => {
+    it('returns 1 as minimum and 3 as maximum if no crush rule is available', () => {
       expect(component.getMinSize()).toBe(1);
-      expect(component.getMaxSize()).toBe(OSDS);
+      expect(component.getMaxSize()).toBe(3);
     });
 
     it('returns the osd count as maximum if the rule maximum exceeds it', () => {
       setCrushRule({ max: 100 });
-      expect(component.getMaxSize()).toBe(OSDS);
+      expect(component.getMaxSize()).toBe(15);
     });
 
     it('should return the osd count as minimum if its lower the the rule minimum', () => {
-      setCrushRule({ min: 10 });
-      expect(component.getMinSize()).toBe(10);
+      setCrushRule({ min: 20 });
+      expect(component.getMinSize()).toBe(20);
       const control = form.get('crushRule');
       expect(control.invalid).toBe(true);
       formHelper.expectError(control, 'tooFewOsds');
+    });
+
+    it('should get the right maximum if the device type is defined', () => {
+      formHelper.setValue(
+        'crushRule',
+        Mocks.getCrushRule({ min: 1, max: 5, itemName: 'default~ssd' })
+      );
+      expect(form.getValue('crushRule').usable_size).toBe(5);
     });
   });
 
@@ -710,6 +680,7 @@ describe('PoolFormComponent', () => {
 
     describe('pgCalc', () => {
       const PGS = 1;
+      OSDS = 8;
 
       const getValidCase = () => ({
         type: 'replicated',
@@ -816,7 +787,7 @@ describe('PoolFormComponent', () => {
           }
         };
       });
-      infoReturn.crush_rules_replicated.push(createCrushRule({ id: 8, name }));
+      infoReturn.crush_rules_replicated.push(Mocks.getCrushRule({ id: 8, name }));
       component.addCrushRule();
       expect(form.getValue('crushRule').rule_name).toBe(name);
     });
@@ -1329,7 +1300,7 @@ describe('PoolFormComponent', () => {
       pool.quota_max_bytes = 1024 * 1024 * 1024;
       pool.quota_max_objects = 3000;
 
-      createCrushRule({ name: 'someRule' });
+      Mocks.getCrushRule({ name: 'someRule' });
       spyOn(poolService, 'get').and.callFake(() => of(pool));
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -12,6 +12,7 @@ import { Observable, Subscription } from 'rxjs';
 import { CrushRuleService } from '../../../shared/api/crush-rule.service';
 import { ErasureCodeProfileService } from '../../../shared/api/erasure-code-profile.service';
 import { PoolService } from '../../../shared/api/pool.service';
+import { CrushNodeSelectionClass } from '../../../shared/classes/crush.node.selection.class';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
 import { SelectOption } from '../../../shared/components/select/select-option.model';
 import { ActionLabelsI18n, URLVerbs } from '../../../shared/constants/app.constants';
@@ -336,6 +337,7 @@ export class PoolFormComponent implements OnInit {
       if (!rule) {
         return;
       }
+      this.setCorrectMaxSize(rule);
       this.crushRuleIsUsedBy(rule.rule_name);
       this.replicatedRuleChange();
       this.pgCalc();
@@ -427,17 +429,16 @@ export class PoolFormComponent implements OnInit {
   }
 
   getMaxSize(): number {
-    if (!this.info || this.info.osd_count < 1) {
+    const rule = this.form.getValue('crushRule');
+    if (!this.info) {
       return 0;
     }
-    const osds: number = this.info.osd_count;
-    if (this.form.getValue('crushRule')) {
-      const max: number = this.form.get('crushRule').value.max_size;
-      if (max < osds) {
-        return max;
-      }
+    if (!rule) {
+      const osds = this.info.osd_count;
+      const defaultSize = 3;
+      return Math.min(osds, defaultSize);
     }
-    return osds;
+    return rule.usable_size;
   }
 
   private pgCalc() {
@@ -456,6 +457,19 @@ export class PoolFormComponent implements OnInit {
     if (!this.externalPgChange) {
       this.externalPgChange = oldValue !== newValue;
     }
+  }
+
+  private setCorrectMaxSize(rule: CrushRule = this.form.getValue('crushRule')) {
+    if (!rule) {
+      return;
+    }
+    const domains = CrushNodeSelectionClass.searchFailureDomains(
+      this.info.nodes,
+      rule.steps[0].item_name
+    );
+    const currentDomain = domains[rule.steps[1].type];
+    const usable = currentDomain ? currentDomain.length : rule.max_size;
+    rule.usable_size = Math.min(usable, rule.max_size);
   }
 
   private replicatedPgCalc(pgs: number): number {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.spec.ts
@@ -1,11 +1,13 @@
 import { FormControl } from '@angular/forms';
 
+import * as _ from 'lodash';
+
 import { configureTestBed, Mocks } from '../../../testing/unit-test-helper';
 import { CrushNode } from '../models/crush-node';
 import { CrushNodeSelectionClass } from './crush.node.selection.class';
 
 describe('CrushNodeSelectionService', () => {
-  const nodes = Mocks.getCrushNodes()
+  const nodes = Mocks.getCrushMap();
 
   let service: CrushNodeSelectionClass;
   let controls: {
@@ -22,15 +24,6 @@ describe('CrushNodeSelectionService', () => {
 
   // Expects that are used frequently
   const assert = {
-    failureDomains: (nodes: CrushNode[], types: string[]) => {
-      const expectation = {};
-      types.forEach((type) => (expectation[type] = nodes.filter((node) => node.type === type)));
-      const keys = service.failureDomainKeys;
-      expect(keys).toEqual(types);
-      keys.forEach((key) => {
-        expect(service.failureDomains[key].length).toBe(expectation[key].length);
-      });
-    },
     formFieldValues: (root: CrushNode, failureDomain: string, device: string) => {
       expect(controls.root.value).toEqual(root);
       expect(controls.failure.value).toBe(failureDomain);
@@ -44,6 +37,19 @@ describe('CrushNodeSelectionService', () => {
       const node = get.nodeByName(rootName);
       controls.root.setValue(node);
       assert.formFieldValues(node, expectedFailureDomain, expectedDevice);
+    },
+    failureDomainNodes: (
+      failureDomains: { [failureDomain: string]: CrushNode[] },
+      expected: { [failureDomains: string]: string[] | CrushNode[] }
+    ) => {
+      expect(Object.keys(failureDomains)).toEqual(Object.keys(expected));
+      Object.keys(failureDomains).forEach((key) => {
+        if (_.isString(expected[key][0])) {
+          expect(failureDomains[key]).toEqual(get.nodesByNames(expected[key] as string[]));
+        } else {
+          expect(failureDomains[key]).toEqual(expected[key]);
+        }
+      });
     }
   };
 
@@ -77,23 +83,31 @@ describe('CrushNodeSelectionService', () => {
     });
 
     it('has the following lists after init', () => {
-      assert.failureDomains(nodes, ['host', 'osd', 'osd-rack', 'rack']); // Not root as root only exist once
+      assert.failureDomainNodes(service.failureDomains, {
+        host: ['ssd-host', 'mix-host'],
+        osd: ['osd.1', 'osd.0', 'osd.2'],
+        rack: ['hdd-rack', 'ssd-rack'],
+        'osd-rack': ['osd2.0', 'osd2.1', 'osd3.0', 'osd3.1']
+      });
       expect(service.devices).toEqual(['hdd', 'ssd']);
     });
 
     it('has the following lists after selection of ssd-host', () => {
       controls.root.setValue(get.nodeByName('ssd-host'));
-      assert.failureDomains(get.nodesByNames(['osd.0', 'osd.1', 'osd.2']), ['osd']); // Not host as it only exist once
+      assert.failureDomainNodes(service.failureDomains, {
+        // Not host as it only exist once
+        osd: ['osd.1', 'osd.0', 'osd.2']
+      });
       expect(service.devices).toEqual(['ssd']);
     });
 
     it('has the following lists after selection of mix-host', () => {
       controls.root.setValue(get.nodeByName('mix-host'));
       expect(service.devices).toEqual(['hdd', 'ssd']);
-      assert.failureDomains(
-        get.nodesByNames(['hdd-rack', 'ssd-rack', 'osd2.0', 'osd2.1', 'osd3.0', 'osd3.1']),
-        ['osd-rack', 'rack']
-      );
+      assert.failureDomainNodes(service.failureDomains, {
+        rack: ['hdd-rack', 'ssd-rack'],
+        'osd-rack': ['osd2.0', 'osd2.1', 'osd3.0', 'osd3.1']
+      });
     });
   });
 
@@ -145,6 +159,62 @@ describe('CrushNodeSelectionService', () => {
     it('should show 3 OSDs when selecting "ssd-host"', () => {
       assert.valuesOnRootChange('ssd-host', 'osd', 'ssd');
       expect(service.deviceCount).toBe(3);
+    });
+  });
+
+  describe('search tree', () => {
+    it('returns the following list after searching for mix-host', () => {
+      const subNodes = CrushNodeSelectionClass.search(nodes, 'mix-host');
+      expect(subNodes).toEqual(
+        get.nodesByNames([
+          'mix-host',
+          'hdd-rack',
+          'osd2.0',
+          'osd2.1',
+          'ssd-rack',
+          'osd3.0',
+          'osd3.1'
+        ])
+      );
+    });
+
+    it('returns the following list after searching for mix-host with SSDs', () => {
+      const subNodes = CrushNodeSelectionClass.search(nodes, 'mix-host~ssd');
+      expect(subNodes.map((n) => n.name)).toEqual(['mix-host', 'ssd-rack', 'osd3.0', 'osd3.1']);
+    });
+
+    it('returns an empty array if node can not be found', () => {
+      expect(CrushNodeSelectionClass.search(nodes, 'not-there')).toEqual([]);
+    });
+
+    it('returns the following list after searching for mix-host failure domains', () => {
+      const subNodes = CrushNodeSelectionClass.search(nodes, 'mix-host');
+      assert.failureDomainNodes(CrushNodeSelectionClass.getFailureDomains(subNodes), {
+        host: ['mix-host'],
+        rack: ['hdd-rack', 'ssd-rack'],
+        'osd-rack': ['osd2.0', 'osd2.1', 'osd3.0', 'osd3.1']
+      });
+    });
+
+    it('returns the following list after searching for mix-host failure domains for a specific type', () => {
+      const subNodes = CrushNodeSelectionClass.search(nodes, 'mix-host~hdd');
+      const hddHost = _.cloneDeep(get.nodesByNames(['mix-host'])[0]);
+      hddHost.children = [-4];
+      assert.failureDomainNodes(CrushNodeSelectionClass.getFailureDomains(subNodes), {
+        host: [hddHost],
+        rack: ['hdd-rack'],
+        'osd-rack': ['osd2.0', 'osd2.1']
+      });
+      const ssdHost = _.cloneDeep(get.nodesByNames(['mix-host'])[0]);
+      ssdHost.children = [-5];
+      assert.failureDomainNodes(
+        CrushNodeSelectionClass.searchFailureDomains(nodes, 'mix-host~ssd'),
+        {
+          host: [ssdHost],
+          rack: ['ssd-rack'],
+          'osd-rack': ['osd3.0', 'osd3.1']
+        }
+      );
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.spec.ts
@@ -1,79 +1,22 @@
 import { FormControl } from '@angular/forms';
 
-import { configureTestBed } from '../../../testing/unit-test-helper';
+import { configureTestBed, Mocks } from '../../../testing/unit-test-helper';
 import { CrushNode } from '../models/crush-node';
-import { CrushRuleConfig } from '../models/crush-rule';
 import { CrushNodeSelectionClass } from './crush.node.selection.class';
 
 describe('CrushNodeSelectionService', () => {
-  let service: CrushNodeSelectionClass;
+  const nodes = Mocks.getCrushNodes()
 
+  let service: CrushNodeSelectionClass;
   let controls: {
     root: FormControl;
     failure: FormControl;
     device: FormControl;
   };
 
-  // Object contains mock functions
-  const mock = {
-    node: (
-      name: string,
-      id: number,
-      type: string,
-      type_id: number,
-      children?: number[],
-      device_class?: string
-    ): CrushNode => {
-      return { name, type, type_id, id, children, device_class };
-    },
-    rule: (
-      name: string,
-      root: string,
-      failure_domain: string,
-      device_class?: string
-    ): CrushRuleConfig => ({
-      name,
-      root,
-      failure_domain,
-      device_class
-    }),
-    nodes: [] as CrushNode[]
-  };
-
-  /**
-   * Create the following test crush map:
-   * > default
-   * --> ssd-host
-   * ----> 3x osd with ssd
-   * --> mix-host
-   * ----> hdd-rack
-   * ------> 2x osd-rack with hdd
-   * ----> ssd-rack
-   * ------> 2x osd-rack with ssd
-   */
-  mock.nodes = [
-    // Root node
-    mock.node('default', -1, 'root', 11, [-2, -3]),
-    // SSD host
-    mock.node('ssd-host', -2, 'host', 1, [1, 0, 2]),
-    mock.node('osd.0', 0, 'osd', 0, undefined, 'ssd'),
-    mock.node('osd.1', 1, 'osd', 0, undefined, 'ssd'),
-    mock.node('osd.2', 2, 'osd', 0, undefined, 'ssd'),
-    // SSD and HDD mixed devices host
-    mock.node('mix-host', -3, 'host', 1, [-4, -5]),
-    // HDD rack
-    mock.node('hdd-rack', -4, 'rack', 3, [3, 4]),
-    mock.node('osd2.0', 3, 'osd-rack', 0, undefined, 'hdd'),
-    mock.node('osd2.1', 4, 'osd-rack', 0, undefined, 'hdd'),
-    // SSD rack
-    mock.node('ssd-rack', -5, 'rack', 3, [5, 6]),
-    mock.node('osd2.0', 5, 'osd-rack', 0, undefined, 'ssd'),
-    mock.node('osd2.1', 6, 'osd-rack', 0, undefined, 'ssd')
-  ];
-
   // Object contains functions to get something
   const get = {
-    nodeByName: (name: string): CrushNode => mock.nodes.find((node) => node.name === name),
+    nodeByName: (name: string): CrushNode => nodes.find((node) => node.name === name),
     nodesByNames: (names: string[]): CrushNode[] => names.map(get.nodeByName)
   };
 
@@ -117,12 +60,12 @@ describe('CrushNodeSelectionService', () => {
     // Normally this should be extended by the class using it
     service = new CrushNodeSelectionClass();
     // Therefore to get it working correctly use "this" instead of "service"
-    service.initCrushNodeSelection(mock.nodes, controls.root, controls.failure, controls.device);
+    service.initCrushNodeSelection(nodes, controls.root, controls.failure, controls.device);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
-    expect(mock.nodes.length).toBe(12);
+    expect(nodes.length).toBe(12);
   });
 
   describe('lists', () => {
@@ -134,7 +77,7 @@ describe('CrushNodeSelectionService', () => {
     });
 
     it('has the following lists after init', () => {
-      assert.failureDomains(mock.nodes, ['host', 'osd', 'osd-rack', 'rack']); // Not root as root only exist once
+      assert.failureDomains(nodes, ['host', 'osd', 'osd-rack', 'rack']); // Not root as root only exist once
       expect(service.devices).toEqual(['hdd', 'ssd']);
     });
 
@@ -148,7 +91,7 @@ describe('CrushNodeSelectionService', () => {
       controls.root.setValue(get.nodeByName('mix-host'));
       expect(service.devices).toEqual(['hdd', 'ssd']);
       assert.failureDomains(
-        get.nodesByNames(['hdd-rack', 'ssd-rack', 'osd2.0', 'osd2.1', 'osd2.0', 'osd2.1']),
+        get.nodesByNames(['hdd-rack', 'ssd-rack', 'osd2.0', 'osd2.1', 'osd3.0', 'osd3.1']),
         ['osd-rack', 'rack']
       );
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/crush-rule.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/crush-rule.ts
@@ -2,6 +2,7 @@ import { CrushStep } from './crush-step';
 
 export class CrushRule {
   max_size: number;
+  usable_size?: number;
   min_size: number;
   rule_id: number;
   rule_name: string;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/pool-form-info.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/pool-form-info.ts
@@ -1,3 +1,4 @@
+import { CrushNode } from './crush-node';
 import { CrushRule } from './crush-rule';
 import { ErasureCodeProfile } from './erasure-code-profile';
 
@@ -15,4 +16,5 @@ export class PoolFormInfo {
   erasure_code_profiles: ErasureCodeProfile[];
   used_rules: { [rule_name: string]: string[] };
   used_profiles: { [profile_name: string]: string[] };
+  nodes: CrushNode[];
 }

--- a/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
@@ -11,6 +11,8 @@ import { Icons } from '../app/shared/enum/icons.enum';
 import { CdFormGroup } from '../app/shared/forms/cd-form-group';
 import { CdTableAction } from '../app/shared/models/cd-table-action';
 import { CdTableSelection } from '../app/shared/models/cd-table-selection';
+import { CrushNode } from '../app/shared/models/crush-node';
+import { CrushRule, CrushRuleConfig } from '../app/shared/models/crush-rule';
 import { Permission } from '../app/shared/models/permissions';
 import {
   AlertmanagerAlert,
@@ -392,5 +394,170 @@ export class IscsiHelper {
     formHelper.expectValidChange(fieldName, 'thisIsCorrect');
     formHelper.expectErrorChange(fieldName, '##?badChars?##', 'pattern');
     formHelper.expectErrorChange(fieldName, 'thisPasswordIsWayTooBig', 'pattern');
+  }
+}
+
+export class Mocks {
+  static getCrushNode(
+    name: string,
+    id: number,
+    type: string,
+    type_id: number,
+    children?: number[],
+    device_class?: string
+  ): CrushNode {
+    return { name, type, type_id, id, children, device_class };
+  }
+
+  /**
+   * Create the following test crush map:
+   * > default
+   * --> ssd-host
+   * ----> 3x osd with ssd
+   * --> mix-host
+   * ----> hdd-rack
+   * ------> 2x osd-rack with hdd
+   * ----> ssd-rack
+   * ------> 2x osd-rack with ssd
+   */
+  static getCrushMap(): CrushNode[] {
+    return [
+      // Root node
+      this.getCrushNode('default', -1, 'root', 11, [-2, -3]),
+      // SSD host
+      this.getCrushNode('ssd-host', -2, 'host', 1, [1, 0, 2]),
+      this.getCrushNode('osd.0', 0, 'osd', 0, undefined, 'ssd'),
+      this.getCrushNode('osd.1', 1, 'osd', 0, undefined, 'ssd'),
+      this.getCrushNode('osd.2', 2, 'osd', 0, undefined, 'ssd'),
+      // SSD and HDD mixed devices host
+      this.getCrushNode('mix-host', -3, 'host', 1, [-4, -5]),
+      // HDD rack
+      this.getCrushNode('hdd-rack', -4, 'rack', 3, [3, 4]),
+      this.getCrushNode('osd2.0', 3, 'osd-rack', 0, undefined, 'hdd'),
+      this.getCrushNode('osd2.1', 4, 'osd-rack', 0, undefined, 'hdd'),
+      // SSD rack
+      this.getCrushNode('ssd-rack', -5, 'rack', 3, [5, 6]),
+      this.getCrushNode('osd3.0', 5, 'osd-rack', 0, undefined, 'ssd'),
+      this.getCrushNode('osd3.1', 6, 'osd-rack', 0, undefined, 'ssd')
+    ];
+  }
+
+  /**
+   * Generates an simple crush map with multiple hosts that have OSDs with either ssd or hdd OSDs.
+   * Hosts with zero or even numbers at the end have SSD OSDs the other hosts have hdd OSDs.
+   *
+   * Host names follow the following naming convention:
+   * host.$index
+   * $index represents a number count started at 0 (like an index within an array) (same for OSDs)
+   *
+   * OSD names follow the following naming convention:
+   * osd.$hostIndex.$osdIndex
+   *
+   * The following crush map will be generated with the set defaults:
+   * > default
+   * --> host.0 (has only ssd OSDs)
+   * ----> osd.0.0
+   * ----> osd.0.1
+   * ----> osd.0.2
+   * ----> osd.0.3
+   * --> host.1 (has only hdd OSDs)
+   * ----> osd.1.0
+   * ----> osd.1.1
+   * ----> osd.1.2
+   * ----> osd.1.3
+   */
+  static generateSimpleCrushMap(hosts: number = 2, osds: number = 4): CrushNode[] {
+    const nodes = [];
+    const createOsdLeafs = (hostSuffix: number): number[] => {
+      let osdId = 0;
+      const osdIds = [];
+      const osdsInUse = hostSuffix * osds;
+      for (let o = 0; o < osds; o++) {
+        osdIds.push(osdId);
+        nodes.push(
+          this.getCrushNode(
+            `osd.${hostSuffix}.${osdId}`,
+            osdId + osdsInUse,
+            'osd',
+            0,
+            undefined,
+            hostSuffix % 2 === 0 ? 'ssd' : 'hdd'
+          )
+        );
+        osdId++;
+      }
+      return osdIds;
+    };
+    const createHostBuckets = (): number[] => {
+      let hostId = -2;
+      const hostIds = [];
+      for (let h = 0; h < hosts; h++) {
+        const hostSuffix = hostId * -1 - 2;
+        hostIds.push(hostId);
+        nodes.push(
+          this.getCrushNode(`host.${hostSuffix}`, hostId, 'host', 1, createOsdLeafs(hostSuffix))
+        );
+        hostId--;
+      }
+      return hostIds;
+    };
+    nodes.push(this.getCrushNode('default', -1, 'root', 11, createHostBuckets()));
+    return nodes;
+  }
+
+  static getCrushRuleConfig(
+    name: string,
+    root: string,
+    failure_domain: string,
+    device_class?: string
+  ): CrushRuleConfig {
+    return {
+      name,
+      root,
+      failure_domain,
+      device_class
+    };
+  }
+
+  static getCrushRule({
+    id = 0,
+    name = 'somePoolName',
+    min = 1,
+    max = 10,
+    type = 'replicated',
+    failureDomain = 'osd',
+    itemName = 'default' // This string also sets the device type - "default~ssd" <- ssd usage only
+  }: {
+    max?: number;
+    min?: number;
+    id?: number;
+    name?: string;
+    type?: string;
+    failureDomain?: string;
+    itemName?: string;
+  }): CrushRule {
+    const typeNumber = type === 'erasure' ? 3 : 1;
+    const rule = new CrushRule();
+    rule.max_size = max;
+    rule.min_size = min;
+    rule.rule_id = id;
+    rule.ruleset = typeNumber;
+    rule.rule_name = name;
+    rule.steps = [
+      {
+        item_name: itemName,
+        item: -1,
+        op: 'take'
+      },
+      {
+        num: 0,
+        type: failureDomain,
+        op: 'choose_firstn'
+      },
+      {
+        op: 'emit'
+      }
+    ];
+    return rule;
   }
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45889

---

backport of https://github.com/ceph/ceph/pull/35051
parent tracker: https://tracker.ceph.com/issues/44620

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh