### PR TITLE
octopus: rgw: orphan-list timestamp fix

### DIFF
--- a/src/rgw/rgw-orphan-list
+++ b/src/rgw/rgw-orphan-list
@@ -8,7 +8,7 @@ export LANG=C
 
 out_dir="."
 temp_file=/tmp/temp.$$
-timestamp=$(date -u +%Y%m%d%k%M)
+timestamp=$(date -u +%Y%m%d%H%M)
 lspools_err="${out_dir}/lspools-${timestamp}.error"
 rados_out="${out_dir}/rados-${timestamp}.intermediate"
 rados_err="${out_dir}/rados-${timestamp}.error"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46343

---

backport of https://github.com/ceph/ceph/pull/35736
parent tracker: https://tracker.ceph.com/issues/46161

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh