### PR TITLE
include/interval_set: use template as the 2nd template parameter

### DIFF
--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -20,10 +20,11 @@ class StupidAllocator : public Allocator {
   int64_t num_free;     ///< total bytes in freelist
   int64_t block_size;
 
-  typedef mempool::bluestore_alloc::pool_allocator<
-    std::pair<const uint64_t,uint64_t>> allocator_t;
-  typedef btree::btree_map<uint64_t,uint64_t,std::less<uint64_t>,allocator_t> interval_set_map_t;
-  typedef interval_set<uint64_t,interval_set_map_t> interval_set_t;
+  template <typename K, typename V> using allocator_t =
+    mempool::bluestore_alloc::pool_allocator<std::pair<const K, V>>;
+  template <typename K, typename V> using btree_map_t =
+    btree::btree_map<K, V, std::less<K>, allocator_t<K, V>>;
+  using interval_set_t = interval_set<uint64_t, btree_map_t>;
   std::vector<interval_set_t> free;  ///< leading-edge copy
 
   uint64_t last_alloc = 0;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -142,7 +142,7 @@ void dump(ceph::Formatter* f, const osd_alerts_t& alerts);
 
 typedef interval_set<
   snapid_t,
-  mempool::osdmap::flat_map<snapid_t,snapid_t>> snap_interval_set_t;
+  mempool::osdmap::flat_map> snap_interval_set_t;
 
 
 /**

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -239,7 +239,7 @@ add_executable(unittest_interval_set
   test_interval_set.cc
 )
 add_ceph_unittest(unittest_interval_set)
-target_link_libraries(unittest_interval_set ceph-common)
+target_link_libraries(unittest_interval_set ceph-common GTest::Main)
 
 # unittest_weighted_priority_queue
 add_executable(unittest_weighted_priority_queue

--- a/src/test/common/test_interval_set.cc
+++ b/src/test/common/test_interval_set.cc
@@ -32,10 +32,8 @@ class IntervalSetTest : public ::testing::Test {
 
 typedef ::testing::Types<
   interval_set<IntervalValueType>,
-  interval_set<IntervalValueType,
-	       btree::btree_map<IntervalValueType,IntervalValueType>>,
-  interval_set<IntervalValueType,
-	       boost::container::flat_map<IntervalValueType,IntervalValueType>>
+  interval_set<IntervalValueType, btree::btree_map>,
+  interval_set<IntervalValueType, boost::container::flat_map>
   > IntervalSetTypes;
 
 TYPED_TEST_SUITE(IntervalSetTest, IntervalSetTypes);


### PR DESCRIPTION
to avoid repeating the unit for the interval in the internal map's
parameter.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
