### PR TITLE
pybind/cephfs: fix custom exception raised by cephfs.pyx

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -318,6 +318,10 @@ class ObjectNotEmpty(OSError):
 class NotDirectory(OSError):
     pass
 
+class DiskQuotaExceeded(OSError):
+    pass
+
+
 IF UNAME_SYSNAME == "FreeBSD":
     cdef errno_to_exception =  {
         errno.EPERM      : PermissionError,
@@ -331,6 +335,7 @@ IF UNAME_SYSNAME == "FreeBSD":
         errno.ERANGE     : OutOfRange,
         errno.EWOULDBLOCK: WouldBlock,
         errno.ENOTEMPTY  : ObjectNotEmpty,
+        errno.EDQUOT     : DiskQuotaExceeded,
     }
 ELSE:
     cdef errno_to_exception =  {
@@ -345,7 +350,8 @@ ELSE:
         errno.ERANGE     : OutOfRange,
         errno.EWOULDBLOCK: WouldBlock,
         errno.ENOTEMPTY  : ObjectNotEmpty,
-        errno.ENOTDIR    : NotDirectory
+        errno.ENOTDIR    : NotDirectory,
+        errno.EDQUOT     : DiskQuotaExceeded,
     }
 
 

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -357,7 +357,7 @@ ELSE:
 
 cdef make_ex(ret, msg):
     """
-    Translate a librados return code into an exception.
+    Translate a libcephfs return code into an exception.
 
     :param ret: the return code
     :type ret: int
@@ -369,7 +369,7 @@ cdef make_ex(ret, msg):
     if ret in errno_to_exception:
         return errno_to_exception[ret](ret, msg)
     else:
-        return Error(msg + ': {} [Errno {:d}]'.format(os.strerror(ret), ret))
+        return OSError(ret, msg)
 
 
 class DirEntry(namedtuple('DirEntry',

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -776,3 +776,12 @@ def test_get_pool():
     s=os.popen(get_rep_cnt_cmd).read().strip('\n')
     size=int(s.split(" ")[-1])
     assert_equal(cephfs.get_pool_replication(dp_dict["pool_id"]), size)
+
+@with_setup(setup_test)
+def test_disk_quota_exceeeded_error():
+    cephfs.mkdir("/dir-1", 0o755)
+    cephfs.setxattr("/dir-1", "ceph.quota.max_bytes", b"5", 0)
+    fd = cephfs.open(b'/dir-1/file-1', 'w', 0o755)
+    assert_raises(libcephfs.DiskQuotaExceeded, cephfs.write, fd, b"abcdeghiklmnopqrstuvwxyz", 0)
+    cephfs.close(fd)
+    cephfs.unlink(b"/dir-1/file-1")


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46360
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
