### PR TITLE
os/filestore: sort objects using escaped strings

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5103,6 +5103,10 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
+    Option("filestore_bluestore_list_order", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(true)
+    .set_description("List objects in the same order as BlueStore"),
+
     Option("journal_dio", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(true)
     .set_description(""),

--- a/src/os/filestore/HashIndex.h
+++ b/src/os/filestore/HashIndex.h
@@ -402,17 +402,19 @@ private:
     return str;
   }
 
-  struct CmpPairBitwise {
-    bool operator()(const std::pair<std::string, ghobject_t>& l,
-		    const std::pair<std::string, ghobject_t>& r) const
-    {
-      if (l.first < r.first)
-	return true;
-      if (l.first > r.first)
-	return false;
-      if (cmp(l.second, r.second) < 0)
-	return true;
-      return false;
+  struct ObjectKey {
+    const std::string hash_prefix;
+    const std::string key;
+
+    ObjectKey(const std::string &hash_prefix, const std::string &key) :
+      hash_prefix(hash_prefix), key(key) {
+    }
+
+    bool operator<(const ObjectKey &rhs) const {
+      if (hash_prefix != rhs.hash_prefix) {
+        return hash_prefix < rhs.hash_prefix;
+      }
+      return key < rhs.key;
     }
   };
 
@@ -427,7 +429,7 @@ private:
     const std::vector<std::string> &path,             /// [in] Path to list
     const ghobject_t *next_object,          /// [in] list > *next_object
     std::set<std::string, CmpHexdigitStringBitwise> *hash_prefixes, /// [out] prefixes in dir
-    std::set<std::pair<std::string, ghobject_t>, CmpPairBitwise> *objects /// [out] objects
+    std::map<ObjectKey, ghobject_t> *objects /// [out] objects
     );
 
   /// List objects in collection in ghobject_t order


### PR DESCRIPTION
Similarly how the bluestore does. And we want this to have the same
order of object listing for bluestore and filestore osds in a mixed
cluster.

Fixes: https://tracker.ceph.com/issues/43174
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
