### PR TITLE
tools/ceph-dencoder: add get_struct_v,get_struct_compat commands

### DIFF
--- a/src/tools/ceph-dencoder/ceph_dencoder.cc
+++ b/src/tools/ceph-dencoder/ceph_dencoder.cc
@@ -42,6 +42,8 @@ void usage(ostream &out)
   out << "  encode              encode in-memory object\n";
   out << "  dump_json           dump in-memory object as json (to stdout)\n";
   out << "  hexdump             print encoded data in hex\n";
+  out << "  get_struct_v        print version of the encoded object\n";
+  out << "  get_struct_compat   print the oldest version of decoder that can decode the encoded object\n";
   out << "\n";
   out << "  copy                copy object (via operator=)\n";
   out << "  copy_ctor           copy object (via copy ctor)\n";
@@ -154,6 +156,10 @@ int main(int argc, const char **argv)
 
     } else if (*i == string("hexdump")) {
       encbl.hexdump(cout);
+    } else if (*i == string("get_struct_v")) {
+      std::cout << den->get_struct_v(encbl, 0) << std::endl;
+    } else if (*i == string("get_struct_compat")) {
+      std::cout << den->get_struct_v(encbl, sizeof(uint8_t)) << std::endl;
     } else if (*i == string("import")) {
       ++i;
       if (i == args.end()) {

--- a/src/tools/ceph-dencoder/denc_registry.h
+++ b/src/tools/ceph-dencoder/denc_registry.h
@@ -27,6 +27,12 @@ struct Dencoder {
   virtual int num_generated() = 0;
   virtual std::string select_generated(unsigned n) = 0;
   virtual bool is_deterministic() = 0;
+  unsigned get_struct_v(bufferlist bl, uint64_t seek) const {
+    auto p = bl.cbegin(seek);
+    uint8_t struct_v = 0;
+    ceph::decode(struct_v, p);
+    return struct_v;
+  }
   //virtual void print(ostream& out) = 0;
 };
 


### PR DESCRIPTION
for understanding the current encoding version and the lower bound of
supported decoders.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
