### PR TITLE
pybind/mgr/balancer: use "==" and "!=" for comparing str

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -470,7 +470,7 @@ class Module(MgrModule):
             return (0, '', '')
         elif command['prefix'] == 'balancer pool ls':
             pool_ids = self.get_module_option('pool_ids')
-            if pool_ids is '':
+            if pool_ids == '':
                 return (0, '', '')
             pool_ids = pool_ids.split(',')
             pool_ids = [int(p) for p in pool_ids]
@@ -496,7 +496,7 @@ class Module(MgrModule):
             to_add = [str(pool_id_by_name[p]) for p in raw_names if p in pool_id_by_name]
             existing = self.get_module_option('pool_ids')
             final = to_add
-            if existing is not '':
+            if existing != '':
                 existing = existing.split(',')
                 final = set(to_add) | set(existing)
             self.set_module_option('pool_ids', ','.join(final))
@@ -504,7 +504,7 @@ class Module(MgrModule):
         elif command['prefix'] == 'balancer pool rm':
             raw_names = command['pools']
             existing = self.get_module_option('pool_ids')
-            if existing is '': # for idempotence
+            if existing == '': # for idempotence
                 return (0, '', '')
             existing = existing.split(',')
             osdmap = self.get_osdmap()
@@ -664,7 +664,7 @@ class Module(MgrModule):
                 osdmap = self.get_osdmap()
                 allow = self.get_module_option('pool_ids')
                 final = []
-                if allow is not '':
+                if allow != '':
                     allow = allow.split(',')
                     valid = [str(p['pool']) for p in osdmap.dump().get('pools', [])]
                     final = set(allow) & set(valid)


### PR DESCRIPTION
to silence warnings like:

balancer/module.py:473: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if pool_ids is '':

Fixes: https://tracker.ceph.com/issues/46406
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
