### PR TITLE
mgr/cephadm: allow to map existing daemons to osdspecs

### DIFF
--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -124,13 +124,14 @@ class OSDService(CephadmService):
         for host in matching_hosts:
             inventory_for_host = _find_inv_for_host(host, self.mgr.cache.devices)
             logger.debug(f"Found inventory for host {inventory_for_host}")
-            drive_selection = DriveSelection(drive_group, inventory_for_host)
+            drive_selection = DriveSelection(drive_group, inventory_for_host,
+                                             self.mgr.cache.get_daemons_with_volatile_status())
             logger.debug(f"Found drive selection {drive_selection}")
             host_ds_map.append((host, drive_selection))
         return host_ds_map
 
-    def driveselection_to_ceph_volume(self,
-                                      drive_selection: DriveSelection,
+    @staticmethod
+    def driveselection_to_ceph_volume(drive_selection: DriveSelection,
                                       osd_id_claims: Optional[List[str]] = None,
                                       preview: bool = False) -> Optional[str]:
         logger.debug(f"Translating DriveGroup <{drive_selection.spec}> to ceph-volume command")

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -124,8 +124,13 @@ class OSDService(CephadmService):
         for host in matching_hosts:
             inventory_for_host = _find_inv_for_host(host, self.mgr.cache.devices)
             logger.debug(f"Found inventory for host {inventory_for_host}")
+
+            # List of Daemons on that host
+            dd_for_spec = self.mgr.cache.get_daemons_by_service(drive_group.service_name())
+            dd_for_spec_and_host = [dd for dd in dd_for_spec if dd.hostname == host]
+
             drive_selection = DriveSelection(drive_group, inventory_for_host,
-                                             self.mgr.cache.get_daemons_with_volatile_status())
+                                             existing_daemons=len(dd_for_spec_and_host))
             logger.debug(f"Found drive selection {drive_selection}")
             host_ds_map.append((host, drive_selection))
         return host_ds_map

--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -1,7 +1,7 @@
 import logging
 
 try:
-    from typing import List, Optional
+    from typing import List, Optional, Iterator, Tuple, Dict
 except ImportError:
     pass
 
@@ -17,9 +17,12 @@ class DriveSelection(object):
     def __init__(self,
                  spec,  # type: DriveGroupSpec
                  disks,  # type: List[Device]
+                 daemons=None,  # type: Iterator[Tuple[str, Dict[str, "DaemonDescription"]]]
                  ):
         self.disks = disks.copy()
         self.spec = spec
+        self.daemons = daemons
+        self.osds_for_spec = self.find_osds_in_spec()
 
         if self.spec.data_devices.paths:  # type: ignore
             # re: type: ignore there is *always* a path attribute assigned to DeviceSelection
@@ -33,6 +36,17 @@ class DriveSelection(object):
             self._wal = self.assign_devices(self.spec.wal_devices)
             self._db = self.assign_devices(self.spec.db_devices)
             self._journal = self.assign_devices(self.spec.journal_devices)
+
+    def find_osds_in_spec(self) -> List["DaemonDescription"]:
+        osds: List["DaemonDescription"] = []
+        if not self.daemons:
+            return osds
+        for host, dm in self.daemons:
+            for name, dd in dm.items():
+                if dd.daemon_type == 'osd':
+                    if dd.osdspec_affinity == self.spec.service_id:
+                        osds.append(dd)
+        return osds
 
     def data_devices(self):
         # type: () -> List[Device]
@@ -50,8 +64,7 @@ class DriveSelection(object):
         # type: () -> List[Device]
         return self._journal
 
-    @staticmethod
-    def _limit_reached(device_filter, len_devices,
+    def _limit_reached(self, device_filter, len_devices,
                        disk_path):
         # type: (DeviceSelection, int, str) -> bool
         """ Check for the <limit> property and apply logic


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

with https://tracker.ceph.com/issues/44755 finally being handled, this enables us to implement the `limit` key in osdspecs/drivegroups properly.

Fixes: https://tracker.ceph.com/issues/44888


**Depends on**

- [x] #36388 
- [x] #36541

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
