### PR TITLE
qa/cephfs: set omit_sudo to False for wait_until_mounted() in fuse_mount.py

### DIFF
--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -241,13 +241,15 @@ class FuseMount(CephFSMount):
 
         self.mounted = True
 
-        # Now that we're mounted, set permissions so that the rest of the test will have
-        # unrestricted access to the filesystem mount.
+        # Now that we're mounted, set permissions so that the rest of the test
+        # will have unrestricted access to the filesystem mount.
         for retry in range(10):
             try:
                 stderr = StringIO()
-                self.client_remote.run(args=['sudo', 'chmod', '1777', self.mountpoint],
-                                       timeout=(15*60), cwd=self.test_dir, stderr=stderr)
+                self.client_remote.run(args=['sudo', 'chmod', '1777',
+                                             self.mountpoint],
+                                       timeout=(15*60), cwd=self.test_dir,
+                                       stderr=stderr, omit_sudo=False)
                 break
             except run.CommandFailedError:
                 stderr = stderr.getvalue()


### PR DESCRIPTION
This isn't critical at all to vstart_runner.py runs but this patch must
dramatically reduce the time it takes in case the command fails with
"permission denied" due to lack of superuser privileges since in this
case the command is re-run 9 more times, each separated by a sleep for
5 seconds.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>