### PR TITLE
mgr/dashboard: Use same required field message accross the UI

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.html
@@ -37,7 +37,7 @@
                        placeholder="192.168.0.10, 192.168.1.0/8">
                 <span class="invalid-feedback">
                   <span *ngIf="showError(index, 'addresses', formDir, 'required')"
-                        i18n>Required field</span>
+                        i18n>This field is required.</span>
 
                   <span *ngIf="showError(index, 'addresses', formDir, 'pattern')">
                     <ng-container i18n>Must contain one or more comma-separated values</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -35,7 +35,7 @@
             </select>
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('cluster_id', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
           </div>
         </div>
 
@@ -105,7 +105,7 @@
               </select>
               <span class="invalid-feedback"
                     *ngIf="nfsForm.showError('name', formDir, 'required')"
-                    i18n>Required field</span>
+                    i18n>This field is required.</span>
             </div>
           </div>
 
@@ -135,7 +135,7 @@
               </select>
               <span class="invalid-feedback"
                     *ngIf="nfsForm.showError('rgw_user_id', formDir, 'required')"
-                    i18n>Required field</span>
+                    i18n>This field is required.</span>
             </div>
           </div>
 
@@ -164,7 +164,7 @@
               </select>
               <span class="invalid-feedback"
                     *ngIf="nfsForm.showError('user_id', formDir, 'required')"
-                    i18n>Required field</span>
+                    i18n>This field is required.</span>
             </div>
           </div>
 
@@ -194,7 +194,7 @@
               </select>
               <span class="invalid-feedback"
                     *ngIf="nfsForm.showError('fs_name', formDir, 'required')"
-                    i18n>Required field</span>
+                    i18n>This field is required.</span>
             </div>
           </div>
         </div>
@@ -230,7 +230,7 @@
 
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('sec_label_xattr', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
           </div>
         </div>
 
@@ -251,7 +251,7 @@
                    (blur)="pathChangeHandler()">
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('path', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
 
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('path', formDir, 'pattern')"
@@ -280,7 +280,7 @@
 
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('path', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
 
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('path', formDir, 'pattern')"
@@ -321,7 +321,7 @@
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('protocolNfsv3', formDir, 'required') ||
                   nfsForm.showError('protocolNfsv4', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
           </div>
         </div>
 
@@ -367,7 +367,7 @@
                    formControlName="pseudo">
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('pseudo', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('pseudo', formDir, 'pattern')"
                   i18n>Pseudo needs to start with a '/' and can't contain any of the following: &gt;, &lt;, |, &, ( or ).</span>
@@ -410,7 +410,7 @@
                  target="_blank"> documentation</a> for details before enabling write access.</span>
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('access_type', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
           </div>
         </div>
 
@@ -439,7 +439,7 @@
             </select>
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('squash', formDir,'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
           </div>
         </div>
 
@@ -472,7 +472,7 @@
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('transportUDP', formDir, 'required') ||
                   nfsForm.showError('transportTCP', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
             <hr>
           </div>
         </div>


### PR DESCRIPTION
Some pages use the message 'Required field', but 99% use 'This field is required'. Use the latter everywhere.

Fixes: https://tracker.ceph.com/issues/46395

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
