### PR TITLE
octopus: client: introduce timeout for client shutdown

### DIFF
--- a/qa/tasks/cephfs/test_client_recovery.py
+++ b/qa/tasks/cephfs/test_client_recovery.py
@@ -636,7 +636,7 @@ class TestClientRecovery(CephFSTestCase):
         self.mount_a.umount_wait()
 
         if isinstance(self.mount_a, FuseMount):
-            self.skipTest("Not implemented in FUSE client yet")
+            self.mount_a.mount(mount_options=['--client_reconnect_stale=1', '--fuse_disable_pagecache=1'])
         else:
             try:
                 self.mount_a.mount(mount_options=['recover_session=clean'])

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2075,6 +2075,7 @@ void Client::_closed_mds_session(MetaSession *s, bool rejected)
   mount_cond.notify_all();
   remove_session_caps(s);
   kick_requests_closed(s);
+  mds_ranks_closing.erase(s->mds_num);
   if (s->state == MetaSession::STATE_CLOSED)
     mds_sessions.erase(s->mds_num);
 }
@@ -6025,13 +6026,27 @@ void Client::_close_sessions()
     for (auto &p : mds_sessions) {
       if (p.second.state != MetaSession::STATE_CLOSING) {
 	_close_mds_session(&p.second);
+	mds_ranks_closing.insert(p.first);
       }
     }
 
     // wait for sessions to close
-    ldout(cct, 2) << "waiting for " << mds_sessions.size() << " mds sessions to close" << dendl;
+    double timo = cct->_conf.get_val<std::chrono::seconds>("client_shutdown_timeout").count();
+    ldout(cct, 2) << "waiting for " << mds_ranks_closing.size() << " mds session(s) to close (timeout: "
+                  << timo << "s)" << dendl;
     std::unique_lock l{client_lock, std::adopt_lock};
-    mount_cond.wait(l);
+    if (!timo) {
+      mount_cond.wait(l);
+    } else if (!mount_cond.wait_for(l, ceph::make_timespan(timo), [this] { return mds_ranks_closing.empty(); })) {
+      ldout(cct, 1) << mds_ranks_closing.size() << " mds(s) did not respond to session close -- timing out." << dendl;
+      while (!mds_ranks_closing.empty()) {
+        auto session = mds_sessions.at(*mds_ranks_closing.begin());
+        // this prunes entry from mds_sessions and mds_ranks_closing
+        _closed_mds_session(&session, -ETIMEDOUT);
+      }
+    }
+
+    mds_ranks_closing.clear();
     l.release();
   }
 }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9755,9 +9755,11 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
 		       in->truncate_size, in->truncate_seq,
 		       &onfinish);
     client_lock.unlock();
-    onfinish.wait();
+    r = onfinish.wait();
     client_lock.lock();
     _sync_write_commit(in);
+    if (r < 0)
+      goto done;
   }
 
   // if we get here, write was successful, update client metadata

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3222,8 +3222,10 @@ void Client::put_cap_ref(Inode *in, int cap)
   }
 }
 
-int Client::get_caps(Inode *in, int need, int want, int *phave, loff_t endoff)
+int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
 {
+  Inode *in = fh->inode.get();
+
   int r = check_pool_perm(in, need);
   if (r < 0)
     return r;
@@ -3236,6 +3238,9 @@ int Client::get_caps(Inode *in, int need, int want, int *phave, loff_t endoff)
 		     << dendl;
       return -EBADF;
     }
+
+    if ((in->flags & I_ERROR_FILELOCK) && fh->has_any_filelocks())
+      return -EIO;
 
     int implemented;
     int have = in->caps_issued(&implemented);
@@ -8907,7 +8912,8 @@ int Client::_open(Inode *in, int flags, mode_t mode, Fh **fhp,
       if (cmode & CEPH_FILE_MODE_RD)
         need |= CEPH_CAP_FILE_RD;
 
-      result = get_caps(in, need, want, &have, -1);
+      Fh fh(in, flags, cmode, perms);
+      result = get_caps(&fh, need, want, &have, -1);
       if (result < 0) {
 	ldout(cct, 8) << "Unable to get caps after open of inode " << *in <<
 			  " . Denying open: " <<
@@ -9238,7 +9244,7 @@ retry:
     want = CEPH_CAP_FILE_CACHE | CEPH_CAP_FILE_LAZYIO;
   else
     want = CEPH_CAP_FILE_CACHE;
-  r = get_caps(in, CEPH_CAP_FILE_RD, want, &have, -1);
+  r = get_caps(f, CEPH_CAP_FILE_RD, want, &have, -1);
   if (r < 0) {
     goto done;
   }
@@ -9668,7 +9674,7 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
     want = CEPH_CAP_FILE_BUFFER | CEPH_CAP_FILE_LAZYIO;
   else
     want = CEPH_CAP_FILE_BUFFER;
-  int r = get_caps(in, CEPH_CAP_FILE_WR|CEPH_CAP_AUTH_SHARED, want, &have, endoff);
+  int r = get_caps(f, CEPH_CAP_FILE_WR|CEPH_CAP_AUTH_SHARED, want, &have, endoff);
   if (r < 0)
     return r;
 
@@ -13616,7 +13622,7 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
   }
 
   int have;
-  int r = get_caps(in, CEPH_CAP_FILE_WR, CEPH_CAP_FILE_BUFFER, &have, -1);
+  int r = get_caps(fh, CEPH_CAP_FILE_WR, CEPH_CAP_FILE_BUFFER, &have, -1);
   if (r < 0)
     return r;
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13384,7 +13384,10 @@ int Client::ll_read(Fh *fh, loff_t off, loff_t len, bufferlist *bl)
 
   /* We can't return bytes written larger than INT_MAX, clamp len to that */
   len = std::min(len, (loff_t)INT_MAX);
-  return _read(fh, off, len, bl);
+  int r = _read(fh, off, len, bl);
+  ldout(cct, 3) << "ll_read " << fh << " " << off << "~" << len << " = " << r
+		<< dendl;
+  return r;
 }
 
 int Client::ll_read_block(Inode *in, uint64_t blockid,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1212,6 +1212,7 @@ private:
 
   // mds sessions
   map<mds_rank_t, MetaSession> mds_sessions;  // mds -> push seq
+  std::set<mds_rank_t> mds_ranks_closing;  // mds ranks currently tearing down sessions
   std::list<ceph::condition_variable*> waiting_for_mdsmap;
 
   // FSMap, for when using mds_command

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -627,7 +627,7 @@ public:
 		      inodeno_t realm, int flags, const UserPerm& perms);
   void remove_cap(Cap *cap, bool queue_release);
   void remove_all_caps(Inode *in);
-  void remove_session_caps(MetaSession *session);
+  void remove_session_caps(MetaSession *session, int err);
   int mark_caps_flushing(Inode *in, ceph_tid_t *ptid);
   void adjust_session_flushing_caps(Inode *in, MetaSession *old_s, MetaSession *new_s);
   void flush_caps_sync();
@@ -766,7 +766,7 @@ protected:
   MetaSession *_get_or_open_mds_session(mds_rank_t mds);
   MetaSession *_open_mds_session(mds_rank_t mds);
   void _close_mds_session(MetaSession *s);
-  void _closed_mds_session(MetaSession *s, bool rejected=false);
+  void _closed_mds_session(MetaSession *s, int err=0, bool rejected=false);
   bool _any_stale_sessions() const;
   void _kick_stale_sessions();
   void handle_client_session(const MConstRef<MClientSession>& m);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1264,6 +1264,8 @@ private:
   ceph::unordered_map<inodeno_t,SnapRealm*> snap_realms;
   std::map<std::string, std::string> metadata;
 
+  utime_t last_auto_reconnect;
+
   // trace generation
   ofstream traceout;
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -766,7 +766,7 @@ protected:
   MetaSession *_get_or_open_mds_session(mds_rank_t mds);
   MetaSession *_open_mds_session(mds_rank_t mds);
   void _close_mds_session(MetaSession *s);
-  void _closed_mds_session(MetaSession *s);
+  void _closed_mds_session(MetaSession *s, bool rejected=false);
   bool _any_stale_sessions() const;
   void _kick_stale_sessions();
   void handle_client_session(const MConstRef<MClientSession>& m);
@@ -1243,12 +1243,6 @@ private:
   interval_set<ino_t> free_faked_inos;
   ino_t last_used_faked_ino;
   ino_t last_used_faked_root;
-
-  // When an MDS has sent us a REJECT, remember that and don't
-  // contact it again.  Remember which inst rejected us, so that
-  // when we talk to another inst with the same rank we can
-  // try again.
-  std::map<mds_rank_t, entity_addrvec_t> rejected_by_mds;
 
   int local_osd = -ENXIO;
   epoch_t local_osd_epoch = 0;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -634,7 +634,7 @@ public:
   void kick_flushing_caps(Inode *in, MetaSession *session);
   void kick_flushing_caps(MetaSession *session);
   void early_kick_flushing_caps(MetaSession *session);
-  int get_caps(Inode *in, int need, int want, int *have, loff_t endoff);
+  int get_caps(Fh *fh, int need, int want, int *have, loff_t endoff);
   int get_caps_used(Inode *in);
 
   void maybe_update_snaprealm(SnapRealm *realm, snapid_t snap_created, snapid_t snap_highwater,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1233,6 +1233,7 @@ private:
   ceph::unordered_map<int, Fh*> fd_map;
   set<Fh*> ll_unclosed_fh_set;
   ceph::unordered_set<dir_result_t*> opened_dirs;
+  uint64_t fd_gen = 1;
 
   bool   initialized = false;
   bool   mounted = false;

--- a/src/client/Fh.cc
+++ b/src/client/Fh.cc
@@ -18,9 +18,9 @@
 
 #include "Fh.h"
 
-Fh::Fh(InodeRef in, int flags, int cmode, const UserPerm &perms) :
-    inode(in), _ref(1), pos(0), mds(0), mode(cmode), flags(flags), pos_locked(false),
-    actor_perms(perms), readahead()
+Fh::Fh(InodeRef in, int flags, int cmode, uint64_t _gen, const UserPerm &perms) :
+    inode(in), _ref(1), pos(0), mds(0), mode(cmode), gen(_gen), flags(flags),
+    pos_locked(false), actor_perms(perms), readahead()
 {
   inode->add_fh(this);
 }

--- a/src/client/Fh.h
+++ b/src/client/Fh.h
@@ -30,6 +30,12 @@ struct Fh {
   std::unique_ptr<ceph_lock_state_t> fcntl_locks;
   std::unique_ptr<ceph_lock_state_t> flock_locks;
 
+  bool has_any_filelocks() {
+    return
+      (fcntl_locks && !fcntl_locks->empty()) ||
+      (flock_locks && !flock_locks->empty());
+  }
+
   // IO error encountered by any writeback on this Inode while
   // this Fh existed (i.e. an fsync on another Fh will still show
   // up as an async_err here because it could have been the same

--- a/src/client/Fh.h
+++ b/src/client/Fh.h
@@ -17,6 +17,7 @@ struct Fh {
   loff_t    pos;
   int       mds;        // have to talk to mds we opened with (for now)
   int       mode;       // the mode i opened the file with
+  uint64_t  gen;
 
   int flags;
   bool pos_locked;           // pos is currently in use
@@ -50,7 +51,7 @@ struct Fh {
   }
 
   Fh() = delete;
-  Fh(InodeRef in, int flags, int cmode, const UserPerm &perms);
+  Fh(InodeRef in, int flags, int cmode, uint64_t gen, const UserPerm &perms);
   ~Fh();
 
   void get() { ++_ref; }

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -109,11 +109,12 @@ struct CapSnap {
 };
 
 // inode flags
-#define I_COMPLETE	1
-#define I_DIR_ORDERED	2
-#define I_CAP_DROPPED	4
-#define I_SNAPDIR_OPEN	8
-#define I_KICK_FLUSH	16
+#define I_COMPLETE		(1 << 0)
+#define I_DIR_ORDERED		(1 << 1)
+#define I_SNAPDIR_OPEN		(1 << 2)
+#define I_KICK_FLUSH		(1 << 3)
+#define I_CAP_DROPPED		(1 << 4)
+#define I_ERROR_FILELOCK	(1 << 5)
 
 struct Inode {
   Client *client;
@@ -257,6 +258,12 @@ struct Inode {
   // file locks
   std::unique_ptr<ceph_lock_state_t> fcntl_locks;
   std::unique_ptr<ceph_lock_state_t> flock_locks;
+
+  bool has_any_filelocks() {
+    return
+      (fcntl_locks && !fcntl_locks->empty()) ||
+      (flock_locks && !flock_locks->empty());
+  }
 
   list<Delegation> delegations;
 

--- a/src/client/MetaSession.h
+++ b/src/client/MetaSession.h
@@ -33,6 +33,7 @@ struct MetaSession {
     STATE_CLOSING,
     STATE_CLOSED,
     STATE_STALE,
+    STATE_REJECTED,
   } state;
 
   enum {

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -347,7 +347,6 @@ OPTION(client_trace, OPT_STR)
 OPTION(client_readahead_min, OPT_LONGLONG)  // readahead at _least_ this much.
 OPTION(client_readahead_max_bytes, OPT_LONGLONG)  // default unlimited
 OPTION(client_readahead_max_periods, OPT_LONGLONG)  // as multiple of file layout period (object size * num stripes)
-OPTION(client_reconnect_stale, OPT_BOOL)  // automatically reconnect stale session
 OPTION(client_snapdir, OPT_STR)
 OPTION(client_mount_uid, OPT_INT)
 OPTION(client_mount_gid, OPT_INT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8444,6 +8444,14 @@ std::vector<Option> get_mds_client_options() {
     Option("debug_allow_any_pool_priority", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .set_description("Allow any pool priority to be set to test conversion to new range"),
+
+    Option("client_shutdown_timeout", Option::TYPE_SECS, Option::LEVEL_ADVANCED)
+    .set_flag(Option::FLAG_RUNTIME)
+    .set_default(30)
+    .set_min(0)
+    .set_description("timeout for shutting down CephFS")
+    .set_long_description("Timeout for shutting down CephFS via unmount or shutdown.")
+    .add_tag("client")
   });
 }
 

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -416,6 +416,8 @@ public:
    */
   virtual int bind(const entity_addr_t& bind_addr) = 0;
 
+  virtual int bindv(const entity_addrvec_t& addrs);
+
   /**
    * This function performs a full restart of the Messenger component,
    * whatever that means.  Other entities who connect to this
@@ -432,10 +434,15 @@ public:
    * is true.
    * @param bind_addr The address to bind to.
    * @return 0 on success, or -1 on error, or -errno if
+   * we can be more specific about the failure.
    */
   virtual int client_bind(const entity_addr_t& bind_addr) = 0;
 
-  virtual int bindv(const entity_addrvec_t& addrs);
+  /**
+   * reset the 'client' Messenger. Mark all the existing Connections down
+   * and update 'nonce'.
+   */
+  virtual int client_reset() = 0;
 
 
   virtual bool should_use_msgr2() {

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -503,6 +503,24 @@ void AsyncMessenger::_finish_bind(const entity_addrvec_t& bind_addrs,
   did_bind = true;
 }
 
+int AsyncMessenger::client_reset()
+{
+  mark_down_all();
+
+  std::scoped_lock l{lock};
+  // adjust the nonce; we want our entity_addr_t to be truly unique.
+  nonce += 1000000;
+  ldout(cct, 10) << __func__ << " new nonce " << nonce << dendl;
+
+  entity_addrvec_t newaddrs = *my_addrs;
+  for (auto& a : newaddrs.v) {
+    a.set_nonce(nonce);
+  }
+  set_myaddrs(newaddrs);
+  _init_local_connection();
+  return 0;
+}
+
 int AsyncMessenger::start()
 {
   std::scoped_lock l{lock};

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -116,9 +116,11 @@ public:
 
   int bind(const entity_addr_t& bind_addr) override;
   int rebind(const set<int>& avoid_ports) override;
+  int bindv(const entity_addrvec_t& bind_addrs) override;
+
   int client_bind(const entity_addr_t& bind_addr) override;
 
-  int bindv(const entity_addrvec_t& bind_addrs) override;
+  int client_reset() override;
 
   bool should_use_msgr2() override;
 


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/46389
* https://tracker.ceph.com/issues/46402

---

backport of

* https://github.com/ceph/ceph/pull/31480
* https://github.com/ceph/ceph/pull/35496

parent trackers:

* https://tracker.ceph.com/issues/20
* https://tracker.ceph.com/issues/44276

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh