### PR TITLE
rgw: rgw-orphan-list -- fix interaction, quoting, and percentage calc

### DIFF
--- a/src/rgw/rgw-orphan-list
+++ b/src/rgw/rgw-orphan-list
@@ -28,13 +28,14 @@ error_out() {
 }
 
 prompt_pool() {
-    echo "Available pools:"
+    # note: all prompts go to stderr so stdout contains just the result
+    >&2 echo "Available pools:"
     rados lspools >"$temp_file" 2>"$lspools_err"
     if [ "$?" -ne 0 ] ;then
 	error_out "rados lspools" "$lspools_err"
     fi
-    sed 's/^/    /' $temp_file # list pools and indent
-    printf "Which pool do you want to search for orphans? "
+    >&2 sed 's/^/    /' "$temp_file" # list pools and indent
+    >&2 printf "Which pool do you want to search for orphans? "
     local mypool
     read mypool
     echo $mypool
@@ -76,9 +77,12 @@ if [ "${PIPESTATUS[0]}" -gt 1 ] ;then
     error_out "ceph-diff-sorted"
 fi
 
-found="$(wc -l < $delta_out)"
-possible="$(wc -l < $rados_out)"
-percentage=$(expr 100 \* $found / $possible)
+found=$(wc -l < "$delta_out")
+possible=$(wc -l < "$rados_out")
+percentage=0
+if [ $possible -ne 0 ] ;then
+    percentage=$(expr 100 \* $found / $possible)
+fi
 
 echo "$found potential orphans found out of a possible $possible (${percentage}%)."
 echo "The results can be found in ${delta_out}."


### PR DESCRIPTION
The interactive mode wasn't working due to prompts going to stdout
instead of stderr. If a space should appear in temporary file, it will
generate a shell error, so quoting was added. Furthermore if there are
no objects found in a pool, a divide by zero error will be
generated. This commit addresses these issues.

Fixes: https://tracker.ceph.com/issues/46404