### PR TITLE
mgr/dashboard: Fix language selector

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/angular.json
+++ b/src/pybind/mgr/dashboard/frontend/angular.json
@@ -28,6 +28,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "i18nLocale": "en",
             "aot": true,
             "i18nMissingTranslation": "ignore",
             "outputPath": "dist",

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/language-selector/language-selector.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/language-selector/language-selector.component.html
@@ -4,7 +4,7 @@
   <a ngbDropdownToggle
      i18n-title
      title="Select a Language">
-    {{ supportedLanguages[selectedLanguage] }}
+    {{ allLanguages[selectedLanguage] }}
   </a>
   <div ngbDropdownMenu>
     <ng-container *ngFor="let lang of supportedLanguages | keyvalue">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/language-selector/language-selector.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/language-selector/language-selector.component.html
@@ -1,6 +1,5 @@
 <div ngbDropdown
-     placement="bottom-right"
-     *ngIf="isDropdown">
+     placement="bottom-right">
   <a ngbDropdownToggle
      i18n-title
      title="Select a Language">
@@ -15,11 +14,3 @@
     </ng-container>
   </div>
 </div>
-
-<select *ngIf="!isDropdown"
-        (change)="changeLanguage($event.target.value)"
-        [(ngModel)]="selectedLanguage"
-        class="form-control custom-select">
-  <option *ngFor="let lang of supportedLanguages | keyvalue"
-          [value]="lang.key">{{ lang.value }}</option>
-</select>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/language-selector/language-selector.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/language-selector/language-selector.component.ts
@@ -14,6 +14,7 @@ export class LanguageSelectorComponent implements OnInit {
   @Input()
   isDropdown = true;
 
+  allLanguages = SupportedLanguages;
   supportedLanguages: Record<string, any> = {};
   selectedLanguage: string;
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/language-selector/language-selector.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/language-selector/language-selector.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 import * as _ from 'lodash';
 
@@ -11,9 +11,6 @@ import { SupportedLanguages } from './supported-languages.enum';
   styleUrls: ['./language-selector.component.scss']
 })
 export class LanguageSelectorComponent implements OnInit {
-  @Input()
-  isDropdown = true;
-
   allLanguages = SupportedLanguages;
   supportedLanguages: Record<string, any> = {};
   selectedLanguage: string;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
Fixes: https://tracker.ceph.com/issues/45762

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
