### PR TITLE
run-make-check.sh: fix the log message

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -59,7 +59,7 @@ function main() {
         cmake_opts+=" -DWITH_SEASTAR=ON"
     fi
     configure $cmake_opts $@
-    build tests && echo "make check: successful run on $(git rev-parse HEAD)"
+    build tests && echo "make check: successful build on $(git rev-parse HEAD)"
     run
 }
 


### PR DESCRIPTION
With 5e9a1d95c9f7 ("run-make-check.sh: extract run-make.sh"), this log
message is actively confusing.  At this point we just have the binaries,
no tests have run yet (and if -N is passed through CHECK_MAKEOPTS, none
will).

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>