### PR TITLE
rgw: orphan list teuthology test & fully-qualified domain issue

### DIFF
--- a/qa/workunits/rgw/test_rgw_orphan_list.sh
+++ b/qa/workunits/rgw/test_rgw_orphan_list.sh
@@ -17,6 +17,13 @@ awscli_dir=${HOME}/awscli_temp
 export PATH=${PATH}:${awscli_dir}
 
 rgw_host=$(hostname --fqdn)
+if echo "$rgw_host" | grep -q '\.' ; then
+    :
+else
+    host_domain=".front.sepia.ceph.com"
+    echo "WARNING: rgw hostname -- $rgw_host -- does not appear to be fully qualified; PUNTING and appending $host_domain"
+    rgw_host="${rgw_host}${host_domain}"
+fi
 rgw_port=80
 
 echo "Fully Qualified Domain Name: $rgw_host"


### PR DESCRIPTION
Sometimes when teuthology machines are provisioned, the command
`hostname --fqdn` does not provide a fully qualified domain name but
instead just the hostname (e.g., smithi149 instead of
smithi149.front.sepia.ceph.com). This prevents the teuthology test for
rgw-orphan-list from running successfully [for example, the hostname
was for some reason mis-interpreted as the bucket name in the
request].

This commit checks whether the hostname derived from `hostname --fqdn`
contains any '.'s and if it does not, it will append
".front.sepia.ceph.com" to the hostname. This is a hack, but until
teuthology machines are configured appropriately it seems to be a
reasonable work-around.

(Note: this is labeled as a "feature" rather than a "bug" since it's a hack/work-around to an apparent bug in another system.)

Fixes: https://tracker.ceph.com/issues/46422