### PR TITLE
librbd: don't resend async_complete if watcher is unregistered

### DIFF
--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -159,12 +159,13 @@ void ImageWatcher<I>::handle_async_complete(const AsyncRequestId &request,
 			   << cpp_strerror(ret_val) << dendl;
     if (ret_val == -ETIMEDOUT && !is_unregistered()) {
       schedule_async_complete(request, r);
+      m_async_op_tracker.finish_op();
+      return;
     }
-  } else {
-    std::unique_lock async_request_locker{m_async_request_lock};
-    m_async_pending.erase(request);
   }
 
+  std::unique_lock async_request_locker{m_async_request_lock};
+  m_async_pending.erase(request);
   m_async_op_tracker.finish_op();
 }
 

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -5,6 +5,7 @@
 #define CEPH_LIBRBD_IMAGE_WATCHER_H
 
 #include "cls/rbd/cls_rbd_types.h"
+#include "common/AsyncOpTracker.h"
 #include "common/ceph_mutex.h"
 #include "include/Context.h"
 #include "include/rbd/librbd.hpp"
@@ -170,6 +171,8 @@ private:
 
   ceph::mutex m_owner_client_id_lock;
   watch_notify::ClientId m_owner_client_id;
+
+  AsyncOpTracker m_async_op_tracker;
 
   void handle_register_watch(int r);
 


### PR DESCRIPTION
Also wait for pending async_complete after unregistering the
watcher.

Fixes: https://tracker.ceph.com/issues/45268
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
