### PR TITLE
selinux: allow ceph_t amqp_port_t:tcp_socket

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -88,6 +88,8 @@ corenet_tcp_sendrecv_cyphesis_port(ceph_t)
 
 allow ceph_t commplex_main_port_t:tcp_socket name_connect;
 allow ceph_t http_cache_port_t:tcp_socket name_connect;
+allow ceph_t amqp_port_t:tcp_socket name_connect;
+allow ceph_t soundd_port_t:tcp_socket name_connect;
 
 corecmd_exec_bin(ceph_t)
 corecmd_exec_shell(ceph_t)


### PR DESCRIPTION
allow ceph_t amqp_port_t:tcp_socket name_connect;
allow ceph_t soundd_port_t:tcp_socket name_connect;

Required for running RabbitMQ

(soundd_port_t) for running RabbitMQ on port 8000

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1854083
Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
