### PR TITLE
tools/ceph_dedup_tool: fix unused variable warning

### DIFF
--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -389,7 +389,6 @@ void ChunkScrub::chunk_scrub_common()
   ObjectCursor shard_start;
   ObjectCursor shard_end;
   int ret;
-  utime_t cur_time = ceph_clock_now();
   Rados rados;
 
   ret = rados.init_with_context(g_ceph_context);

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -194,6 +194,7 @@ public:
   uint64_t get_examined_bytes() { return examined_bytes; }
   uint64_t get_total_bytes() { return total_bytes; }
   uint64_t get_total_objects() { return total_objects; }
+  void set_debug(const bool debug_) { debug = debug_; }
   friend class EstimateDedupRatio;
   friend class ChunkScrub;
 };
@@ -663,6 +664,7 @@ int estimate_dedup_ratio(const std::map < std::string, std::string > &opts,
 			     report_period, s.num_objects, max_read_size,
 			     max_seconds));
     ptr->create("estimate_thread");
+    ptr->set_debug(debug);
     estimate_threads.push_back(move(ptr));
   }
   glock.unlock();


### PR DESCRIPTION
Signed-off-by: SHU Zhenyi <shuzhenyi@live.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

This pr fix compiler warning for sec/tools/ceph_dedup_tool.cc:  
- rm unused variable cur_time
- fix ignored variable debug for class `EstimateDedupRatio`

## Checklist
- [x] Updates documentation if necessary
---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
