### PR TITLE
client: add asok command to get caps

### DIFF
--- a/qa/suites/fs/functional/tasks/caps.yaml
+++ b/qa/suites/fs/functional/tasks/caps.yaml
@@ -1,0 +1,18 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - bad backtrace
+      - object missing on disk
+      - error reading table object
+      - error reading sessionmap
+      - unmatched fragstat
+      - unmatched rstat
+      - was unreadable, recreating it now
+      - Scrub error on inode
+      - Metadata damage detected
+      - inconsistent rstat on inode
+      - Error recovering journal
+tasks:
+  - cephfs_test_runner:
+      modules:
+        - tasks.cephfs.test_caps

--- a/qa/tasks/cephfs/test_caps.py
+++ b/qa/tasks/cephfs/test_caps.py
@@ -1,0 +1,49 @@
+import os
+from tasks.cephfs.cephfs_test_case import CephFSTestCase
+
+
+class TestCaps(CephFSTestCase):
+    CLIENTS_REQUIRED = 2
+
+    def test_file_lazy_io_caps(self):
+
+        """
+        Validates the grant of lazy_io cap request on multiple clients.
+
+        This capability means the clients could perform lazy io. LazyIO
+        relaxes POSIX semantics. Buffered reads/writes are allowed even
+        when a file is opened by multiple applications on multiple clients.
+        Applications are responsible for managing cache coherency themselves
+        """
+        mount_b_file_path = os.path.join(self.mount_b.mountpoint, "file_Fl")
+        mount_a_file_path = os.path.join(self.mount_a.mountpoint, "file_Fl")
+        self.mount_a.run_shell(["touch", mount_a_file_path])
+
+        # Usually the caps pAsLsXsFscr/0xd55 are given. Verify Fl caps are
+        # given.
+        mount_a_caps = self.mount_a.getfattr(mount_a_file_path, "ceph.caps")
+        self.assertNotIn("l", mount_a_caps)
+
+        mount_b_caps = self.mount_b.getfattr(mount_b_file_path, "ceph.caps")
+        self.assertNotIn("l", mount_b_caps)
+
+        # Request for Fl(32768) on client mount_a
+        self.mount_a.admin_socket(['get_caps', '/file_Fl', "32768"])
+        mount_a_caps = self.mount_a.getfattr(mount_a_file_path, "ceph.caps")
+        # Verify Fl is not granted
+        self.assertIn("l", mount_a_caps)
+
+        # Client mount_b caps are unchanged
+        mount_b_caps_1 = self.mount_b.getfattr(mount_b_file_path, "ceph.caps")
+        self.assertEqual(mount_b_caps, mount_b_caps_1)
+
+        # Request for Fl (32768) on client mount_b
+        self.mount_b.admin_socket(['get_caps', '/file_Fl', "32768"])
+        # Verify Fl is not granted
+        mount_b_caps = self.mount_b.getfattr(mount_b_file_path, "ceph.caps")
+        self.assertIn("l", mount_b_caps)
+
+        # Verify Fl is still retained on mount_a
+        mount_a_caps = self.mount_a.getfattr(mount_a_file_path, "ceph.caps")
+        # Verify Fl is not granted
+        self.assertIn("l", mount_a_caps)

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -923,6 +923,7 @@ protected:
 
   void dump_mds_requests(Formatter *f);
   void dump_mds_sessions(Formatter *f, bool cap_dump=false);
+  void get_caps_asok_interface(std::string relpath, int mask, Formatter *f);
 
   int make_request(MetaRequest *req, const UserPerm& perms,
 		   InodeRef *ptarget = 0, bool *pcreated = 0,


### PR DESCRIPTION
Idea is to avoid using UNIX commands or libcephfs
calls to implicitly acquire the caps we want.
Instead, use this asok command that explicitly
tries to acquire caps for an inode.

This is a first step to creating a test suite for
cap acquisition/revoke behavior with the MDS.

Fixes: https://tracker.ceph.com/issues/44279
Signed-off-by: Kotresh HR <khiremat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
