### PR TITLE
octopus: mgr/dashboard: Allow to edit iSCSI target with active session 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../../testing/unit-test-helper';
 import { IscsiService } from '../../../shared/api/iscsi.service';
 import { TableActionsComponent } from '../../../shared/datatable/table-actions/table-actions.component';
+import { CdTableAction } from '../../../shared/models/cd-table-action';
 import { ExecutingTask } from '../../../shared/models/executing-task';
 import { SummaryService } from '../../../shared/services/summary.service';
 import { TaskListService } from '../../../shared/services/task-list.service';
@@ -169,6 +170,102 @@ describe('IscsiTargetListComponent', () => {
       addTask('iscsi/target/delete', 'iqn.b');
       expect(component.targets.length).toBe(3);
       expectItemTasks(component.targets[1], 'Deleting');
+    });
+  });
+
+  describe('handling of actions', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    let action: CdTableAction;
+
+    const getAction = (name: string): CdTableAction => {
+      return component.tableActions.find((tableAction) => tableAction.name === name);
+    };
+
+    describe('edit', () => {
+      beforeEach(() => {
+        action = getAction('Edit');
+      });
+
+      it('should be disabled if no gateways', () => {
+        component.selection.selected = [
+          {
+            id: '-1'
+          }
+        ];
+        expect(action.disable(undefined)).toBeTruthy();
+        expect(action.disableDesc(undefined)).toBe('Unavailable gateway(s)');
+      });
+
+      it('should be enabled if active sessions', () => {
+        component.selection.selected = [
+          {
+            id: '-1',
+            info: {
+              num_sessions: 1
+            }
+          }
+        ];
+        expect(action.disable(undefined)).toBeFalsy();
+        expect(action.disableDesc(undefined)).toBeUndefined();
+      });
+
+      it('should be enabled if no active sessions', () => {
+        component.selection.selected = [
+          {
+            id: '-1',
+            info: {
+              num_sessions: 0
+            }
+          }
+        ];
+        expect(action.disable(undefined)).toBeFalsy();
+        expect(action.disableDesc(undefined)).toBeUndefined();
+      });
+    });
+
+    describe('delete', () => {
+      beforeEach(() => {
+        action = getAction('Delete');
+      });
+
+      it('should be disabled if no gateways', () => {
+        component.selection.selected = [
+          {
+            id: '-1'
+          }
+        ];
+        expect(action.disable(undefined)).toBeTruthy();
+        expect(action.disableDesc(undefined)).toBe('Unavailable gateway(s)');
+      });
+
+      it('should be disabled if active sessions', () => {
+        component.selection.selected = [
+          {
+            id: '-1',
+            info: {
+              num_sessions: 1
+            }
+          }
+        ];
+        expect(action.disable(undefined)).toBeTruthy();
+        expect(action.disableDesc(undefined)).toBe('Target has active sessions');
+      });
+
+      it('should be enabled if no active sessions', () => {
+        component.selection.selected = [
+          {
+            id: '-1',
+            info: {
+              num_sessions: 0
+            }
+          }
+        ];
+        expect(action.disable(undefined)).toBeFalsy();
+        expect(action.disableDesc(undefined)).toBeUndefined();
+      });
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
@@ -85,7 +85,7 @@ export class IscsiTargetListComponent extends ListWithDetails implements OnInit,
         icon: Icons.edit,
         routerLink: () => `/block/iscsi/targets/edit/${this.selection.first().target_iqn}`,
         name: this.actionLabels.EDIT,
-        disable: () => !this.selection.first() || !_.isUndefined(this.getDeleteDisableDesc()),
+        disable: () => !this.selection.first() || !_.isUndefined(this.getEditDisableDesc()),
         disableDesc: () => this.getEditDisableDesc()
       },
       {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46436

---

backport of https://github.com/ceph/ceph/pull/35963
parent tracker: https://tracker.ceph.com/issues/46383

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh