### PR TITLE
selinux: add amqp and soundd types to ceph.te

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -14,6 +14,8 @@ require {
 	type setfiles_t;
 	type nvme_device_t;
 	type targetd_etc_rw_t;
+	type amqp_port_t;
+	type soundd_port_t;
 	class sock_file unlink;
 	class tcp_socket name_connect_t;
 	class lnk_file { create getattr read unlink };


### PR DESCRIPTION
The previous PR (https://github.com/ceph/ceph/pull/35983) that merged did not build downstream on Nautilus (14.2.8).

It looks like we're missing the appropriate types in the "require" section.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1854083

Signed-off-by: Thomas Serlin <tserlin@redhat.com>
