### PR TITLE
rgw: optimize bucket creation by storing bucket count for user

### DIFF
--- a/src/cls/user/cls_user_client.cc
+++ b/src/cls/user/cls_user_client.cc
@@ -27,6 +27,16 @@ void cls_user_set_buckets(librados::ObjectWriteOperation& op, list<cls_user_buck
   op.exec("user", "set_buckets_info", in);
 }
 
+void cls_user_init_bucket_count(librados::ObjectWriteOperation& op, int calculated_bucket_count, int current_bucket_count)
+{
+  bufferlist in;
+  cls_user_init_bucket_count_op call;
+  call.calculated_bucket_count = calculated_bucket_count;
+  call.current_bucket_count = current_bucket_count;
+  encode(call, in);
+  op.exec("user", "init_bucket_count", in);
+}
+
 void cls_user_complete_stats_sync(librados::ObjectWriteOperation& op)
 {
   bufferlist in;

--- a/src/cls/user/cls_user_client.h
+++ b/src/cls/user/cls_user_client.h
@@ -18,7 +18,12 @@ public:
  * user objclass
  */
 
-void cls_user_set_buckets(librados::ObjectWriteOperation& op, std::list<cls_user_bucket_entry>& entries, bool add);
+void cls_user_set_buckets(librados::ObjectWriteOperation& op,
+			  std::list<cls_user_bucket_entry>& entries,
+			  bool add);
+void cls_user_init_bucket_count(librados::ObjectWriteOperation& op,
+				int calculated_bucket_count,
+				int current_bucket_count);
 void cls_user_complete_stats_sync(librados::ObjectWriteOperation& op);
 void cls_user_remove_bucket(librados::ObjectWriteOperation& op,  const cls_user_bucket& bucket);
 void cls_user_bucket_list(librados::ObjectReadOperation& op,

--- a/src/cls/user/cls_user_ops.cc
+++ b/src/cls/user/cls_user_ops.cc
@@ -30,6 +30,21 @@ void cls_user_set_buckets_op::generate_test_instances(list<cls_user_set_buckets_
   ls.push_back(op);
 }
 
+void cls_user_init_bucket_count_op::dump(Formatter *f) const
+{
+  encode_json("calculated_bucket_count", calculated_bucket_count, f);
+  encode_json("current_bucket_count", current_bucket_count, f);
+}
+
+void cls_user_init_bucket_count_op::generate_test_instances(list<cls_user_init_bucket_count_op*>& ls)
+{
+  ls.push_back(new cls_user_init_bucket_count_op);
+  cls_user_init_bucket_count_op *op = new cls_user_init_bucket_count_op;
+  op->calculated_bucket_count = 123;
+  op->current_bucket_count = -1;
+  ls.push_back(op);
+}
+
 void cls_user_remove_bucket_op::dump(Formatter *f) const
 {
   encode_json("bucket", bucket, f);

--- a/src/cls/user/cls_user_ops.h
+++ b/src/cls/user/cls_user_ops.h
@@ -34,6 +34,31 @@ struct cls_user_set_buckets_op {
 };
 WRITE_CLASS_ENCODER(cls_user_set_buckets_op)
 
+struct cls_user_init_bucket_count_op {
+  int calculated_bucket_count;
+  int current_bucket_count;
+
+  cls_user_init_bucket_count_op() : calculated_bucket_count(0) {}
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(calculated_bucket_count, bl);
+    encode(current_bucket_count, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(calculated_bucket_count, bl);
+    decode(current_bucket_count, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_user_init_bucket_count_op*>& ls);
+};
+WRITE_CLASS_ENCODER(cls_user_init_bucket_count_op)
+
 struct cls_user_remove_bucket_op {
   cls_user_bucket bucket;
 

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -2865,6 +2865,22 @@ int RGWUserCtl::reset_stats(const rgw_user& user)
   });
 }
 
+int RGWUserCtl::get_user_buckets_header(const rgw_user& user,
+					cls_user_header& header)
+{
+  return be_handler->call([&](RGWSI_MetaBackend_Handler::Op *op) {
+    return svc.user->get_user_buckets_header(op->ctx(), user, header);
+  });
+}
+
+int RGWUserCtl::init_user_bucket_count(const rgw_user& user,
+				      const int bucket_count)
+{
+  return be_handler->call([&](RGWSI_MetaBackend_Handler::Op *op) {
+    return svc.user->init_user_bucket_count(op->ctx(), user, bucket_count);
+  });
+}
+
 int RGWUserCtl::read_stats(const rgw_user& user, RGWStorageStats *stats,
 			   ceph::real_time *last_stats_sync,
 			   ceph::real_time *last_stats_update)

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -968,6 +968,10 @@ public:
                          const RGWBucketEnt& ent);
   int complete_flush_stats(const rgw_user& user);
   int reset_stats(const rgw_user& user);
+  int get_user_buckets_header(const rgw_user& user,
+			      cls_user_header& header);
+  int init_user_bucket_count(const rgw_user& user,
+			    const int bucket_count);
   int read_stats(const rgw_user& user, RGWStorageStats *stats,
 		 ceph::real_time *last_stats_sync = nullptr,     /* last time a full stats sync completed */
 		 ceph::real_time *last_stats_update = nullptr);   /* last time a stats update was done */

--- a/src/rgw/services/svc_user.h
+++ b/src/rgw/services/svc_user.h
@@ -105,6 +105,14 @@ public:
 				   const rgw_user& user) = 0;
   virtual int reset_bucket_stats(RGWSI_MetaBackend::Context *ctx,
 				 const rgw_user& user) = 0;
+
+  virtual int get_user_buckets_header(RGWSI_MetaBackend::Context *ctx,
+				      const rgw_user& user,
+				      cls_user_header& header) = 0;
+  virtual int init_user_bucket_count(RGWSI_MetaBackend::Context *ctx,
+				    const rgw_user& user,
+				    const int bucket_count) = 0;
+
   virtual int read_stats(RGWSI_MetaBackend::Context *ctx,
 			 const rgw_user& user, RGWStorageStats *stats,
 			 ceph::real_time *last_stats_sync,         /* last time a full stats sync completed */

--- a/src/rgw/services/svc_user_rados.h
+++ b/src/rgw/services/svc_user_rados.h
@@ -119,6 +119,14 @@ public:
     return be_handler;
   }
 
+  int get_user_buckets_header(RGWSI_MetaBackend::Context *ctx,
+			      const rgw_user& user,
+			      cls_user_header& header) override;
+			      
+  int init_user_bucket_count(RGWSI_MetaBackend::Context *ctx,
+			    const rgw_user& user,
+			    const int bucket_count) override;
+
   int read_user_info(RGWSI_MetaBackend::Context *ctx,
                      const rgw_user& user,
                      RGWUserInfo *info,


### PR DESCRIPTION
Fixes : https://tracker.ceph.com/issues/46447

Signed-off-by: Prashant Dhange <pdhange@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
