### PR TITLE
cmake: enlist libceph-common as json_spirit's depedency.

### DIFF
--- a/src/json_spirit/CMakeLists.txt
+++ b/src/json_spirit/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_library(json_spirit STATIC
   json_spirit_reader.cpp
   json_spirit_writer.cpp)
-target_link_libraries(json_spirit common_utf8)
+target_link_libraries(json_spirit common_utf8 common)


### PR DESCRIPTION
Before the commit the library was using symbols, like `ceph_assert` (see ddfcec5f8756bb66c68ef6b18bf9dd3ea046838d), from `common` but without enlisting the dependency. This was the reason for a FTBFS:

```
[ 57%] Linking CXX executable ../../bin/ceph_scratchtool
cd /work/ceph-2/build/src/tools && /usr/bin/cmake -E cmake_link_script CMakeFiles/ceph_scratchtool.dir/link.txt --verbose=1
/usr/bin/c++  -O2 -g -DNDEBUG   -rdynamic CMakeFiles/ceph_scratchtool.dir/scratchtool.c.o  -o ../../bin/ceph_scratchtool -Wl,-rpath,/work/ceph-2/build/lib: ../../lib/librados.so.2.0.0 ../../lib/libglobal.a ../../lib/libceph-common.so.2 ../../lib/libjson_spirit.a ../../lib/libcommon_utf8.a ../../lib/liberasure_code.a ../../lib/libcrc32.a ../../lib/libarch.a ../../boost/lib/libboost_thread.a ../../boost/lib/libboost_chrono.a ../../boost/lib/libboost_atomic.a ../../boost/lib/libboost_system.a ../../boost/lib/libboost_random.a ../../boost/lib/libboost_program_options.a ../../boost/lib/libboost_date_time.a ../../boost/lib/libboost_iostreams.a ../../boost/lib/libboost_regex.a ../../lib/libfmt.a -lstdc++fs /usr/lib/x86_64-linux-gnu/libblkid.so /usr/lib/x86_64-linux-gnu/libcrypto.so -lpthread /usr/lib/x86_64-linux-gnu/libudev.so /usr/lib/libibverbs.so /usr/lib/x86_64-linux-gnu/librdmacm.so /usr/lib/x86_64-linux-gnu/libz.so -ldl /usr/lib/x86_64-linux-gnu/librt.so -lresolv
/usr/bin/ld: ../../lib/librados.so.2.0.0: undefined reference to symbol '_ZN4ceph18__ceph_assert_failERKNS_11assert_dataE'
../../lib/libceph-common.so.2: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
src/tools/CMakeFiles/ceph_scratchtool.dir/build.make:108: recipe for target 'bin/ceph_scratchtool' failed
```

```
$ nm ../../lib/libjson_spirit.a | grep _ZN4ceph18__ceph_assert_failERKNS_11assert_dataE
                 U _ZN4ceph18__ceph_assert_failERKNS_11assert_dataE
                 U _ZN4ceph18__ceph_assert_failERKNS_11assert_dataE
```

This commit fixes that.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
