### PR TITLE
cephadm: Make Vagrantfile more flexible

### DIFF
--- a/src/pybind/mgr/cephadm/HACKING.rst
+++ b/src/pybind/mgr/cephadm/HACKING.rst
@@ -37,10 +37,13 @@ From within the `src/pybind/mgr/cephadm` directory.
 
    # vagrant up
 
-This will spawn three machines.
-mon0, mgr0, osd0
+This will spawn three machines by default.
+mon0, mgr0 and osd0 with 2 additional disks.
 
-NUM_DAEMONS can be used to increase the number of VMs created. (defaults to 1)
+You can change that by passing `MONS` (default: 1), `MGRS` (default: 1), `OSDS` (default: 1) and
+`DISKS` (default: 2) environment variables to overwrite the defaults. In order to not always have
+to set the environment variables you can now create as JSON see `./vagrant.config.example.json`
+for details.
 
 If will also come with the necessary packages preinstalled as well as your ~/.ssh/id_rsa.pub key
 injected. (to users root and vagrant; the cephadm-orchestrator currently connects as root)
@@ -48,7 +51,8 @@ injected. (to users root and vagrant; the cephadm-orchestrator currently connect
 
 2) Update the ssh-config
 
-The cephadm orchestrator needs to understand how to connect to the new node. Most likely the VM isn't reachable with the default settings used:
+The cephadm orchestrator needs to understand how to connect to the new node. Most likely the VM
+isn't reachable with the default settings used:
 
 ```
 Host *
@@ -82,12 +86,32 @@ Add the newly created host(s) to the inventory.
 
 4) Verify the inventory
 
+You should see the hostname in the list.
+
 ::
 
    # ceph orch host ls
 
 
-You should see the hostname in the list.
+5) Verify the devices
+
+To verify all disks are set and in good shape look if all devices have been spawned
+and can be found
+
+::
+
+   # ceph orch device ls
+
+
+6) Make a snapshot of all your VMs!
+
+To not go the long way again the next time snapshot your VMs in order to revert them back
+if they are dirty.
+
+In `this repository <https://github.com/Devp00l/vagrant-helper-scripts>`_ you can find two
+scripts that will help you with doing a snapshot and reverting it, without having to manual
+snapshot and revert each VM individually.
+
 
 Understanding ``AsyncCompletion``
 =================================

--- a/src/pybind/mgr/cephadm/Vagrantfile
+++ b/src/pybind/mgr/cephadm/Vagrantfile
@@ -1,24 +1,51 @@
 # vi: set ft=ruby :
+#
+# In order to reduce the need of recreating all vagrant boxes everytime they
+# get dirty, snaptshot them and revert the snapshot of them instead.
+# Two helpful scripts to do this easily can be found here:
+# https://github.com/Devp00l/vagrant-helper-scripts
 
-NUM_DAEMONS = ENV["NUM_DAEMONS"] ? ENV["NUM_DAEMONS"].to_i : 1
+require 'json'
+configFileName = 'vagrant.config.json'
+CONFIG = File.file?(configFileName) && JSON.parse(File.read(File.join(File.dirname(__FILE__), configFileName)))
+
+def getConfig(name, default)
+  down = name.downcase
+  up = name.upcase
+  CONFIG && CONFIG[down] ? CONFIG[down] : (ENV[up] ? ENV[up].to_i : default)
+end
+
+OSDS = getConfig('OSDS', 1)
+MGRS = getConfig('MGRS', 1)
+MONS = getConfig('MONS', 1)
+DISKS = getConfig('DISKS', 2)
+
+# Activate only for test purpose as it changes the output of each vagrant command link to get the ssh_config.
+# puts "Your setup:","OSDs: #{OSDS}","MGRs: #{MGRS}","MONs: #{MONS}","Disks per OSD: #{DISKS}"
 
 Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.network "private_network", type: "dhcp"
   config.vm.box = "centos/7"
 
-  (0..NUM_DAEMONS - 1).each do |i|
+  (0..MONS - 1).each do |i|
     config.vm.define "mon#{i}" do |mon|
       mon.vm.hostname = "mon#{i}"
     end
+  end
+  (0..MGRS - 1).each do |i|
     config.vm.define "mgr#{i}" do |mgr|
       mgr.vm.hostname = "mgr#{i}"
     end
+  end
+  (0..OSDS - 1).each do |i|
     config.vm.define "osd#{i}" do |osd|
       osd.vm.hostname = "osd#{i}"
       osd.vm.provider :libvirt do |libvirt|
-        libvirt.storage :file, :size => '20G'
-        libvirt.storage :file, :size => '20G'
+        (0..DISKS - 1).each do |d|
+          # In ruby value.chr makes ASCII char from value
+          libvirt.storage :file, :size => '20G', :device => "vd#{(98+d).chr}#{i}"
+        end
       end
     end
   end
@@ -35,6 +62,5 @@ Vagrant.configure("2") do |config|
     sudo rpm --import 'https://download.ceph.com/keys/release.asc'
     curl -L https://shaman.ceph.com/api/repos/ceph/master/latest/centos/7/repo/ | sudo tee /etc/yum.repos.d/shaman.repo
     sudo yum install -y python36 podman ceph
-    sudo ln -s /usr/bin/python36 /usr/bin/python3 || true
   SHELL
 end

--- a/src/pybind/mgr/cephadm/vagrant.config.example.json
+++ b/src/pybind/mgr/cephadm/vagrant.config.example.json
@@ -1,0 +1,13 @@
+/**
+ * To use a permenant config copy this file to "vagrant.config.json",
+ * edit it and remove this comment beacuase comments are not allowed
+ * in a valid JSON file.
+ */
+
+{
+  "mgrs": 1,
+  "mons": 1,
+  "osds": 1,
+  "disks": 2
+}
+


### PR DESCRIPTION
Now you can use a JSON or pass multiple variable to vagrant in order to
configure the outcome of VMs you get. Similar to vstart.sh you can use
OSDS, MGRS and MONS as arguments to pass. As OSDS behave a bit different
in this scenario you can also specify the amount of extra disks and OSD
VM has.

Fixes: https://tracker.ceph.com/issues/46376
Signed-off-by: Stephan Müller <smueller@suse.com>


---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
