### PR TITLE
octopus: rgw: cls/rgw_gc: Fixing the iterator used to access urgent data map

### DIFF
--- a/src/cls/rgw_gc/cls_rgw_gc.cc
+++ b/src/cls/rgw_gc/cls_rgw_gc.cc
@@ -426,7 +426,7 @@ static int cls_rgw_gc_queue_update_entry(cls_method_context_t hctx, bufferlist *
       } //end - catch
       auto xattr_iter = xattr_urgent_data_map.find(op.info.tag);
       if (xattr_iter != xattr_urgent_data_map.end()) {
-        it->second = op.info.time;
+        xattr_iter->second = op.info.time;
         tag_found = true;
         //write the updated map back
         bufferlist bl_map;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45913

---

backport of https://github.com/ceph/ceph/pull/34969
parent tracker: https://tracker.ceph.com/issues/45503

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh