### PR TITLE
octopus: rgw: lc: add lifecycle perf counters

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -3771,13 +3771,14 @@ static int rgw_cls_lc_list_entries(cls_method_context_t hctx, bufferlist *in,
       /* try backward compat */
       pair<string, int> oe;
       try {
+	iter = it->second.begin();
 	decode(oe, iter);
 	entry = {oe.first, 0 /* start */, uint32_t(oe.second)};
       } catch(buffer::error& err) {
 	CLS_LOG(
 	  1, "ERROR: rgw_cls_lc_list_entries(): failed to decode entry\n");
+	return -EIO;
       }
-      return -EIO;
     }
    op_ret.entries.push_back(entry);
   }

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -939,7 +939,7 @@ int cls_rgw_lc_list(IoCtx& io_ctx, const string& oid,
 	    [](const cls_rgw_lc_entry& a, const cls_rgw_lc_entry& b)
 	      { return a.bucket < b.bucket; });
   entries = std::move(ret.entries);
- return r;
+  return r;
 }
 
 void cls_rgw_reshard_add(librados::ObjectWriteOperation& op, const cls_rgw_reshard_entry& entry)

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -839,7 +839,8 @@ int cls_rgw_lc_put_head(IoCtx& io_ctx, const string& oid, cls_rgw_lc_obj_head& h
   return r;
 }
 
-int cls_rgw_lc_get_next_entry(IoCtx& io_ctx, const string& oid, string& marker, pair<string, int>& entry)
+int cls_rgw_lc_get_next_entry(IoCtx& io_ctx, const string& oid, string& marker,
+			      cls_rgw_lc_entry& entry)
 {
   bufferlist in, out;
   cls_rgw_lc_get_next_entry_op call;
@@ -861,7 +862,8 @@ int cls_rgw_lc_get_next_entry(IoCtx& io_ctx, const string& oid, string& marker, 
  return r;
 }
 
-int cls_rgw_lc_rm_entry(IoCtx& io_ctx, const string& oid, const pair<string, int>& entry)
+int cls_rgw_lc_rm_entry(IoCtx& io_ctx, const string& oid,
+			const cls_rgw_lc_entry& entry)
 {
   bufferlist in, out;
   cls_rgw_lc_rm_entry_op call;
@@ -871,7 +873,8 @@ int cls_rgw_lc_rm_entry(IoCtx& io_ctx, const string& oid, const pair<string, int
  return r;
 }
 
-int cls_rgw_lc_set_entry(IoCtx& io_ctx, const string& oid, const pair<string, int>& entry)
+int cls_rgw_lc_set_entry(IoCtx& io_ctx, const string& oid,
+			 const cls_rgw_lc_entry& entry)
 {
   bufferlist in, out;
   cls_rgw_lc_set_entry_op call;
@@ -881,7 +884,8 @@ int cls_rgw_lc_set_entry(IoCtx& io_ctx, const string& oid, const pair<string, in
   return r;
 }
 
-int cls_rgw_lc_get_entry(IoCtx& io_ctx, const string& oid, const std::string& marker, rgw_lc_entry_t& entry)
+int cls_rgw_lc_get_entry(IoCtx& io_ctx, const string& oid,
+			 const std::string& marker, cls_rgw_lc_entry& entry)
 {
   bufferlist in, out;
   cls_rgw_lc_get_entry_op call{marker};;
@@ -907,7 +911,7 @@ int cls_rgw_lc_get_entry(IoCtx& io_ctx, const string& oid, const std::string& ma
 int cls_rgw_lc_list(IoCtx& io_ctx, const string& oid,
                     const string& marker,
                     uint32_t max_entries,
-                    map<string, int>& entries)
+                    vector<cls_rgw_lc_entry>& entries)
 {
   bufferlist in, out;
   cls_rgw_lc_list_entries_op op;
@@ -930,8 +934,11 @@ int cls_rgw_lc_list(IoCtx& io_ctx, const string& oid,
   } catch (buffer::error& err) {
     return -EIO;
   }
-  entries.insert(ret.entries.begin(),ret.entries.end());
 
+  std::sort(std::begin(ret.entries), std::end(ret.entries),
+	    [](const cls_rgw_lc_entry& a, const cls_rgw_lc_entry& b)
+	      { return a.bucket < b.bucket; });
+  entries = std::move(ret.entries);
  return r;
 }
 

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -607,14 +607,14 @@ int cls_rgw_gc_list(librados::IoCtx& io_ctx, string& oid, string& marker, uint32
 #ifndef CLS_CLIENT_HIDE_IOCTX
 int cls_rgw_lc_get_head(librados::IoCtx& io_ctx, const string& oid, cls_rgw_lc_obj_head& head);
 int cls_rgw_lc_put_head(librados::IoCtx& io_ctx, const string& oid, cls_rgw_lc_obj_head& head);
-int cls_rgw_lc_get_next_entry(librados::IoCtx& io_ctx, const string& oid, string& marker, pair<string, int>& entry);
-int cls_rgw_lc_rm_entry(librados::IoCtx& io_ctx, const string& oid, const pair<string, int>& entry);
-int cls_rgw_lc_set_entry(librados::IoCtx& io_ctx, const string& oid, const pair<string, int>& entry);
-int cls_rgw_lc_get_entry(librados::IoCtx& io_ctx, const string& oid, const std::string& marker, rgw_lc_entry_t& entry);
+int cls_rgw_lc_get_next_entry(librados::IoCtx& io_ctx, const string& oid, string& marker, cls_rgw_lc_entry& entry);
+int cls_rgw_lc_rm_entry(librados::IoCtx& io_ctx, const string& oid, const cls_rgw_lc_entry& entry);
+int cls_rgw_lc_set_entry(librados::IoCtx& io_ctx, const string& oid, const cls_rgw_lc_entry& entry);
+int cls_rgw_lc_get_entry(librados::IoCtx& io_ctx, const string& oid, const std::string& marker, cls_rgw_lc_entry& entry);
 int cls_rgw_lc_list(librados::IoCtx& io_ctx, const string& oid,
                     const string& marker,
                     uint32_t max_entries,
-                    map<string, int>& entries);
+                    vector<cls_rgw_lc_entry>& entries);
 #endif
 
 /* resharding */

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1194,14 +1194,14 @@ struct cls_rgw_lc_list_entries_op {
   cls_rgw_lc_list_entries_op() {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(marker, bl);
     encode(max_entries, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     compat_v = struct_v;
     decode(marker, bl);
     decode(max_entries, bl);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1043,7 +1043,7 @@ struct cls_rgw_lc_get_next_entry_ret {
 
   void decode(bufferlist::const_iterator& bl) {
     DECODE_START(2, bl);
-    if (struct_v < 1) {
+    if (struct_v < 2) {
       std::pair<std::string, int> oe;
       decode(oe, bl);
       entry = {oe.first, 0 /* start */, uint32_t(oe.second)};
@@ -1109,7 +1109,7 @@ struct cls_rgw_lc_rm_entry_op {
 
   void decode(bufferlist::const_iterator& bl) {
     DECODE_START(2, bl);
-    if (struct_v < 1) {
+    if (struct_v < 2) {
       std::pair<std::string, int> oe;
       decode(oe, bl);
       entry = {oe.first, 0 /* start */, uint32_t(oe.second)};
@@ -1133,7 +1133,7 @@ struct cls_rgw_lc_set_entry_op {
 
   void decode(bufferlist::const_iterator& bl) {
     DECODE_START(2, bl);
-    if (struct_v < 1) {
+    if (struct_v < 2) {
       std::pair<std::string, int> oe;
       decode(oe, bl);
       entry = {oe.first, 0 /* start */, uint32_t(oe.second)};

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -1214,6 +1214,37 @@ struct cls_rgw_lc_obj_head
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_obj_head)
 
+struct cls_rgw_lc_entry {
+  std::string bucket;
+  uint64_t start_time; // if in_progress
+  uint32_t status;
+
+  cls_rgw_lc_entry()
+    : start_time(0), status(0) {}
+
+  cls_rgw_lc_entry(const cls_rgw_lc_entry& rhs) = default;
+
+  cls_rgw_lc_entry(const std::string& b, uint64_t t, uint32_t s)
+    : bucket(b), start_time(t), status(s) {};
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(bucket, bl);
+    encode(start_time, bl);
+    encode(status, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(bucket, bl);
+    decode(start_time, bl);
+    decode(status, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_rgw_lc_entry);
+
 struct cls_rgw_reshard_entry
 {
   ceph::real_time time;

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1276,6 +1276,11 @@ OPTION(rgw_enable_quota_threads, OPT_BOOL)
 OPTION(rgw_enable_gc_threads, OPT_BOOL)
 OPTION(rgw_enable_lc_threads, OPT_BOOL)
 
+/* overrides for librgw/nfs */
+OPTION(rgw_nfs_run_gc_threads, OPT_BOOL)
+OPTION(rgw_nfs_run_lc_threads, OPT_BOOL)
+OPTION(rgw_nfs_run_quota_threads, OPT_BOOL)
+OPTION(rgw_nfs_run_sync_thread, OPT_BOOL)
 
 OPTION(rgw_data, OPT_STR)
 OPTION(rgw_enable_apis, OPT_STR)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5931,6 +5931,22 @@ std::vector<Option> get_rgw_options() {
     .set_long_description("use fast S3 attrs from bucket index (assumes NFS "
 			  "mounts are immutable)"),
 
+    Option("rgw_nfs_run_gc_threads", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("run GC threads in librgw (default off)"),
+
+    Option("rgw_nfs_run_lc_threads", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("run lifecycle threads in librgw (default off)"),
+
+    Option("rgw_nfs_run_quota_threads", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("run quota threads in librgw (default off)"),
+
+    Option("rgw_nfs_run_sync_thread", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("run sync thread in librgw (default off)"),
+
     Option("rgw_rados_pool_autoscale_bias", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(4.0)
     .set_min_max(0.01, 100000.0)

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -508,11 +508,27 @@ namespace rgw {
     rgw::curl::setup_curl(boost::none);
     rgw_http_client_init(g_ceph_context);
 
+    auto run_gc =
+      g_conf()->rgw_enable_gc_threads &&
+      g_conf()->rgw_nfs_run_gc_threads;
+
+    auto run_lc =
+      g_conf()->rgw_enable_lc_threads &&
+      g_conf()->rgw_nfs_run_lc_threads;
+
+    auto run_quota =
+      g_conf()->rgw_enable_quota_threads &&
+      g_conf()->rgw_nfs_run_quota_threads;
+
+    auto run_sync =
+      g_conf()->rgw_run_sync_thread &&
+      g_conf()->rgw_nfs_run_sync_thread;
+
     store = RGWStoreManager::get_storage(g_ceph_context,
-					 g_conf()->rgw_enable_gc_threads,
-					 g_conf()->rgw_enable_lc_threads,
-					 g_conf()->rgw_enable_quota_threads,
-					 g_conf()->rgw_run_sync_thread,
+					 run_gc,
+					 run_lc,
+					 run_quota,
+					 run_sync,
 					 g_conf().get_val<bool>("rgw_dynamic_resharding"));
 
     if (!store) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7226,13 +7226,14 @@ next:
     formatter->open_array_section("lifecycle_list");
     vector<cls_rgw_lc_entry> bucket_lc_map;
     string marker;
+    int index{0};
 #define MAX_LC_LIST_ENTRIES 100
     if (max_entries < 0) {
       max_entries = MAX_LC_LIST_ENTRIES;
     }
     do {
       int ret = store->getRados()->list_lc_progress(marker, max_entries,
-						    bucket_lc_map);
+						    bucket_lc_map, index);
       if (ret < 0) {
         cerr << "ERROR: failed to list objs: " << cpp_strerror(-ret)
 	     << std::endl;
@@ -7252,7 +7253,6 @@ next:
         formatter->dump_string("status", lc_status);
         formatter->close_section(); // objs
         formatter->flush(cout);
-        marker = entry.bucket;
       }
     } while (!bucket_lc_map.empty());
 

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -431,6 +431,7 @@ public:
       store(_store), bucket_info(_bucket_info),
       target(store->getRados(), bucket_info), list_op(&target) {
     list_op.params.list_versions = bucket_info.versioned();
+    list_op.params.allow_unordered = true;
     delay_ms = store->ctx()->_conf.get_val<int64_t>("rgw_lc_thread_delay");
   }
 

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -585,10 +585,6 @@ static int remove_expired_obj(lc_op_ctx& oc, bool remove_indeed)
   del_op.params.obj_owner = obj_owner;
   del_op.params.unmod_since = meta.mtime;
 
-  if (perfcounter) {
-    perfcounter->inc(l_rgw_lc_remove_expired, 1);
-  }
-
   return del_op.delete_obj(null_yield);
 } /* remove_expired_obj */
 
@@ -842,20 +838,26 @@ int RGWLC::handle_multipart_expiration(
 	return;
       }
       RGWObjectCtx rctx(store);
-      ret = abort_multipart_upload(store, cct, &rctx, bucket_info, mp_obj);
-      if (ret < 0 && ret != -ERR_NO_SUCH_UPLOAD) {
-	ldpp_dout(wk->get_lc(), 0)
-	  << "ERROR: abort_multipart_upload failed, ret=" << ret
-	  << wq->thr_name()
-	  << ", meta:" << obj.key
-	  << dendl;
-      } else if (ret == -ERR_NO_SUCH_UPLOAD) {
-	ldpp_dout(wk->get_lc(), 5)
-	  << "ERROR: abort_multipart_upload failed, ret=" << ret
-	  << wq->thr_name()
-	  << ", meta:" << obj.key
-	  << dendl;
-      }
+      int ret = abort_multipart_upload(store, cct, &rctx, bucket_info, mp_obj);
+      if (ret == 0) {
+        if (perfcounter) {
+          perfcounter->inc(l_rgw_lc_abort_mpu, 1);
+        }
+      } else {
+	if (ret == -ERR_NO_SUCH_UPLOAD) {
+	  ldpp_dout(wk->get_lc(), 5)
+	    << "ERROR: abort_multipart_upload failed, ret=" << ret
+	    << wq->thr_name()
+	    << ", meta:" << obj.key
+	    << dendl;
+	} else {
+	  ldpp_dout(wk->get_lc(), 0)
+	    << "ERROR: abort_multipart_upload failed, ret=" << ret
+	    << wq->thr_name()
+	    << ", meta:" << obj.key
+	    << dendl;
+	}
+      } /* abort failed */
     } /* expired */
   };
 
@@ -1087,6 +1089,9 @@ public:
 			 << oc.wq->thr_name() << dendl;
 	return r;
       }
+      if (perfcounter) {
+        perfcounter->inc(l_rgw_lc_expire_current, 1);
+      }
       ldout(oc.cct, 2) << "DELETED:" << oc.bucket_info.bucket << ":" << o.key
 		       << " " << oc.wq->thr_name() << dendl;
     }
@@ -1132,6 +1137,9 @@ public:
 		       << " " << oc.wq->thr_name() << dendl;
       return r;
     }
+    if (perfcounter) {
+      perfcounter->inc(l_rgw_lc_expire_noncurrent, 1);
+    }
     ldout(oc.cct, 2) << "DELETED:" << oc.bucket_info.bucket << ":" << o.key
 		     << " (non-current expiration) "
 		     << oc.wq->thr_name() << dendl;
@@ -1173,6 +1181,9 @@ public:
 		       << " " << oc.wq->thr_name()
 		       << dendl;
       return r;
+    }
+    if (perfcounter) {
+      perfcounter->inc(l_rgw_lc_expire_dm, 1);
     }
     ldout(oc.cct, 2) << "DELETED:" << oc.bucket_info.bucket << ":" << o.key
 		     << " (delete marker expiration) "
@@ -1282,6 +1293,15 @@ protected:
 public:
   LCOpAction_CurrentTransition(const transition_action& _transition)
     : LCOpAction_Transition(_transition) {}
+    int process(lc_op_ctx& oc) {
+      int r = LCOpAction_Transition::process(oc);
+      if (r == 0) {
+        if (perfcounter) {
+          perfcounter->inc(l_rgw_lc_transition_current, 1);
+        }
+      }
+      return r;
+    }
 };
 
 class LCOpAction_NonCurrentTransition : public LCOpAction_Transition {
@@ -1298,6 +1318,15 @@ public:
 				  const transition_action& _transition)
     : LCOpAction_Transition(_transition)
     {}
+    int process(lc_op_ctx& oc) {
+      int r = LCOpAction_Transition::process(oc);
+      if (r == 0) {
+        if (perfcounter) {
+          perfcounter->inc(l_rgw_lc_transition_noncurrent, 1);
+        }
+      }
+      return r;
+    }
 };
 
 void LCOpRule::build()
@@ -1899,7 +1928,8 @@ void RGWLifecycleConfiguration::generate_test_instances(
   o.push_back(new RGWLifecycleConfiguration);
 }
 
-void get_lc_oid(CephContext *cct, const string& shard_id, string *oid)
+static inline void get_lc_oid(CephContext *cct,
+			      const string& shard_id, string *oid)
 {
   int max_objs =
     (cct->_conf->rgw_lc_max_objs > HASH_PRIME ? HASH_PRIME :

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -214,7 +214,7 @@ void *RGWLC::LCWorker::entry() {
     utime_t start = ceph_clock_now();
     if (should_work(start)) {
       ldpp_dout(dpp, 2) << "life cycle: start" << dendl;
-      int r = lc->process(this);
+      int r = lc->process(this, false /* once */);
       if (r < 0) {
         ldpp_dout(dpp, 0) << "ERROR: do life cycle process() returned error r="
 			  << r << dendl;
@@ -1549,7 +1549,7 @@ static inline vector<int> random_sequence(uint32_t n)
   return v;
 }
 
-int RGWLC::process(LCWorker* worker)
+int RGWLC::process(LCWorker* worker, bool once = false)
 {
   int max_secs = cct->_conf->rgw_lc_lock_max_time;
 
@@ -1557,7 +1557,7 @@ int RGWLC::process(LCWorker* worker)
    * that might be running in parallel */
   vector<int> shard_seq = random_sequence(max_objs);
   for (auto index : shard_seq) {
-    int ret = process(index, max_secs, worker);
+    int ret = process(index, max_secs, worker, once);
     if (ret < 0)
       return ret;
   }
@@ -1591,7 +1591,8 @@ time_t RGWLC::thread_stop_at()
   return time(nullptr) + interval;
 }
 
-int RGWLC::process(int index, int max_lock_secs, LCWorker* worker)
+int RGWLC::process(int index, int max_lock_secs, LCWorker* worker,
+  bool once = false)
 {
   dout(5) << "RGWLC::process(): ENTER: "
 	  << "index: " << index << " worker ix: " << worker->ix
@@ -1704,11 +1705,13 @@ int RGWLC::process(int index, int max_lock_secs, LCWorker* worker)
     l.unlock(&store->getRados()->lc_pool_ctx, obj_names[index]);
     ret = bucket_lc_process(entry.bucket, worker, thread_stop_at());
     bucket_lc_post(index, max_lock_secs, entry, ret, worker);
-  } while(1);
+  } while(1 && !once);
+
+  return 0;
 
 exit:
-    l.unlock(&store->getRados()->lc_pool_ctx, obj_names[index]);
-    return 0;
+  l.unlock(&store->getRados()->lc_pool_ctx, obj_names[index]);
+  return 0;
 }
 
 void RGWLC::start_processor()
@@ -1812,7 +1815,6 @@ int RGWLC::LCWorker::schedule_next_start_time(utime_t &start, utime_t& now)
 
 RGWLC::LCWorker::~LCWorker()
 {
-  workpool->drain();
   delete workpool;
 } /* ~LCWorker */
 

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -775,6 +775,12 @@ public:
       ix(0)
     {}
 
+  ~WorkPool() {
+    for (auto& wq : wqs) {
+      wq.join();
+    }
+  }
+
   void setf(WorkQ::work_f _f) {
     for (auto& wq : wqs) {
       wq.setf(_f);

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -431,7 +431,6 @@ public:
       store(_store), bucket_info(_bucket_info),
       target(store->getRados(), bucket_info), list_op(&target) {
     list_op.params.list_versions = bucket_info.versioned();
-    list_op.params.allow_unordered = true;
     delay_ms = store->ctx()->_conf.get_val<int64_t>("rgw_lc_thread_delay");
   }
 
@@ -500,6 +499,7 @@ public:
        * only happen if is_truncated is false */
       return boost::none;
     }
+
     return ((obj_iter + 1)->key.name);
   }
 
@@ -509,7 +509,7 @@ struct op_env {
 
   using LCWorker = RGWLC::LCWorker;
 
-  lc_op& op;
+  lc_op op;
   rgw::sal::RGWRadosStore *store;
   LCWorker* worker;
   RGWBucketInfo& bucket_info;
@@ -526,12 +526,14 @@ class WorkQ;
 
 struct lc_op_ctx {
   CephContext *cct;
-  op_env& env;
-  rgw_bucket_dir_entry& o;
+  op_env env;
+  rgw_bucket_dir_entry o;
+  boost::optional<std::string> next_key_name;
+  ceph::real_time dm_effective_mtime;
 
   rgw::sal::RGWRadosStore *store;
   RGWBucketInfo& bucket_info;
-  lc_op& op;
+  lc_op& op; // ok--refers to expanded env.op
   LCObjsLister& ol;
 
   rgw_obj obj;
@@ -540,11 +542,19 @@ struct lc_op_ctx {
   WorkQ* wq;
 
   lc_op_ctx(op_env& env, rgw_bucket_dir_entry& o,
+	    boost::optional<std::string> next_key_name,
+	    ceph::real_time dem,
 	    const DoutPrefixProvider *dpp, WorkQ* wq)
-    : cct(env.store->ctx()), env(env), o(o),
+    : cct(env.store->ctx()), env(env), o(o), next_key_name(next_key_name),
       store(env.store), bucket_info(env.bucket_info), op(env.op), ol(env.ol),
       obj(env.bucket_info.bucket, o.key), rctx(env.store), dpp(dpp), wq(wq)
     {}
+
+  bool next_has_same_name(const std::string& key_name) {
+    return (next_key_name && key_name.compare(
+	      boost::get<std::string>(next_key_name)) == 0);
+  }
+
 }; /* lc_op_ctx */
 
 static int remove_expired_obj(lc_op_ctx& oc, bool remove_indeed)
@@ -582,19 +592,12 @@ static int remove_expired_obj(lc_op_ctx& oc, bool remove_indeed)
 } /* remove_expired_obj */
 
 class LCOpAction {
-protected:
-  boost::optional<std::string> next_key_name;
 public:
   virtual ~LCOpAction() {}
 
-  bool next_has_same_name(const std::string& key_name) {
-    return (next_key_name && key_name.compare(
-	      boost::get<std::string>(next_key_name)) == 0);
-  }
-
   virtual bool check(lc_op_ctx& oc, ceph::real_time *exp_time) {
     return false;
-  };
+  }
 
   /* called after check(). Check should tell us whether this action
    * is applicable. If there are multiple actions, we'll end up executing
@@ -614,6 +617,8 @@ public:
   virtual int process(lc_op_ctx& oc) {
     return 0;
   }
+
+  friend class LCOpRule;
 }; /* LCOpAction */
 
 class LCOpFilter {
@@ -627,15 +632,22 @@ virtual ~LCOpFilter() {}
 class LCOpRule {
   friend class LCOpAction;
 
-  op_env& env;
+  op_env env;
+  boost::optional<std::string> next_key_name;
+  ceph::real_time dm_effective_mtime;
 
-  std::vector<unique_ptr<LCOpFilter> > filters;
-  std::vector<unique_ptr<LCOpAction> > actions;
+  std::vector<shared_ptr<LCOpFilter> > filters; // n.b., sharing ovhd
+  std::vector<shared_ptr<LCOpAction> > actions;
 
 public:
   LCOpRule(op_env& _env) : env(_env) {}
 
+  boost::optional<std::string> get_next_key_name() {
+    return next_key_name;
+  }
+
   void build();
+  void update();
   int process(rgw_bucket_dir_entry& o, const DoutPrefixProvider *dpp,
 	      WorkQ* wq);
 }; /* LCOpRule */
@@ -643,9 +655,9 @@ public:
 using WorkItem =
   boost::variant<void*,
 		 /* out-of-line delete */
-		 std::tuple<LCOpRule&, rgw_bucket_dir_entry>,
+		 std::tuple<LCOpRule, rgw_bucket_dir_entry>,
 		 /* uncompleted MPU expiration */
-		 std::tuple<const lc_op&, rgw_bucket_dir_entry>,
+		 std::tuple<lc_op, rgw_bucket_dir_entry>,
 		 rgw_bucket_dir_entry>;
 
 class WorkQ : public Thread
@@ -814,7 +826,7 @@ int RGWLC::handle_multipart_expiration(
   list_op.params.filter = &mp_filter;
 
   auto pf = [&](RGWLC::LCWorker* wk, WorkQ* wq, WorkItem& wi) {
-    auto wt = boost::get<std::tuple<const lc_op&, rgw_bucket_dir_entry>>(wi);
+    auto wt = boost::get<std::tuple<lc_op, rgw_bucket_dir_entry>>(wi);
     auto& [rule, obj] = wt;
     RGWMPObj mp_obj;
     if (obj_has_expired(cct, obj.meta.mtime, rule.mp_expiration)) {
@@ -868,7 +880,7 @@ int RGWLC::handle_multipart_expiration(
       }
 
       for (auto obj_iter = objs.begin(); obj_iter != objs.end(); ++obj_iter) {
-	std::tuple<const lc_op&, rgw_bucket_dir_entry> t1 =
+	std::tuple<lc_op, rgw_bucket_dir_entry> t1 =
 	  {prefix_iter->second, *obj_iter};
 	worker->workpool->enqueue(WorkItem{t1});
 	if (going_down()) {
@@ -993,9 +1005,7 @@ public:
 
 class LCOpAction_CurrentExpiration : public LCOpAction {
 public:
-  LCOpAction_CurrentExpiration(op_env& env) {
-    next_key_name = env.ol.next_key_name();
-  }
+  LCOpAction_CurrentExpiration(op_env& env) {}
 
   bool check(lc_op_ctx& oc, ceph::real_time *exp_time) override {
     auto& o = oc.o;
@@ -1006,9 +1016,17 @@ public:
       return false;
     }
     if (o.is_delete_marker()) {
-      if (next_has_same_name(o.key.name)) {
+      std::string nkn;
+      if (oc.next_key_name) nkn = *oc.next_key_name;
+      if (oc.next_has_same_name(o.key.name)) {
+	ldout(oc.cct, 7) << __func__ << "(): dm-check SAME: key=" << o.key
+		       << " next_key_name: %%" << nkn << "%% "
+		       << oc.wq->thr_name() << dendl;
 	return false;
       } else {
+	ldout(oc.cct, 7) << __func__ << "(): dm-check DELE: key=" << o.key
+			 << " next_key_name: %%" << nkn << "%% "
+			 << oc.wq->thr_name() << dendl;
         *exp_time = real_clock::now();
         return true;
       }
@@ -1042,18 +1060,29 @@ public:
     int r;
     if (o.is_delete_marker()) {
       r = remove_expired_obj(oc, true);
-    } else {
-      r = remove_expired_obj(oc, !oc.bucket_info.versioned());
-    }
-    if (r < 0) {
-      ldout(oc.cct, 0) << "ERROR: remove_expired_obj " 
-		       << oc.bucket_info.bucket << ":" << o.key 
-		       << " " << cpp_strerror(r) << " "
-		       << oc.wq->thr_name() << dendl;
+      if (r < 0) {
+	ldout(oc.cct, 0) << "ERROR: current is-dm remove_expired_obj "
+			 << oc.bucket_info.bucket << ":" << o.key
+			 << " " << cpp_strerror(r) << " "
+			 << oc.wq->thr_name() << dendl;
       return r;
+      }
+      ldout(oc.cct, 2) << "DELETED: current is-dm "
+		       << oc.bucket_info.bucket << ":" << o.key
+		       << " " << oc.wq->thr_name() << dendl;
+    } else {
+      /* ! o.is_delete_marker() */
+      r = remove_expired_obj(oc, !oc.bucket_info.versioned());
+      if (r < 0) {
+	ldout(oc.cct, 0) << "ERROR: remove_expired_obj "
+			 << oc.bucket_info.bucket << ":" << o.key
+			 << " " << cpp_strerror(r) << " "
+			 << oc.wq->thr_name() << dendl;
+	return r;
+      }
+      ldout(oc.cct, 2) << "DELETED:" << oc.bucket_info.bucket << ":" << o.key
+		       << " " << oc.wq->thr_name() << dendl;
     }
-    ldout(oc.cct, 2) << "DELETED:" << oc.bucket_info.bucket << ":" << o.key
-		     << " " << oc.wq->thr_name() << dendl;
     return 0;
   }
 };
@@ -1105,9 +1134,7 @@ public:
 
 class LCOpAction_DMExpiration : public LCOpAction {
 public:
-  LCOpAction_DMExpiration(op_env& env) {
-    next_key_name = env.ol.next_key_name();
-  }
+  LCOpAction_DMExpiration(op_env& env) {}
 
   bool check(lc_op_ctx& oc, ceph::real_time *exp_time) override {
     auto& o = oc.o;
@@ -1117,7 +1144,7 @@ public:
 			<< oc.wq->thr_name() << dendl;
       return false;
     }
-    if (next_has_same_name(o.key.name)) {
+    if (oc.next_has_same_name(o.key.name)) {
       ldout(oc.cct, 20) << __func__ << "(): key=" << o.key
 			<< ": next is same object, skipping "
 			<< oc.wq->thr_name() << dendl;
@@ -1252,20 +1279,17 @@ public:
 
 class LCOpAction_NonCurrentTransition : public LCOpAction_Transition {
 protected:
-  ceph::real_time effective_mtime;
-
   bool check_current_state(bool is_current) override {
     return !is_current;
   }
 
   ceph::real_time get_effective_mtime(lc_op_ctx& oc) override {
-    return effective_mtime;
+    return oc.dm_effective_mtime;
   }
 public:
   LCOpAction_NonCurrentTransition(op_env& env,
 				  const transition_action& _transition)
-    : LCOpAction_Transition(_transition),
-      effective_mtime(env.ol.get_prev_obj().meta.mtime)
+    : LCOpAction_Transition(_transition)
     {}
 };
 
@@ -1297,13 +1321,18 @@ void LCOpRule::build()
   }
 }
 
+void LCOpRule::update()
+{
+  next_key_name = env.ol.next_key_name();
+  dm_effective_mtime = env.ol.get_prev_obj().meta.mtime;
+}
+
 int LCOpRule::process(rgw_bucket_dir_entry& o,
 		      const DoutPrefixProvider *dpp,
 		      WorkQ* wq)
 {
-  lc_op_ctx ctx(env, o, dpp, wq);
-
-  unique_ptr<LCOpAction> *selected = nullptr;
+  lc_op_ctx ctx(env, o, next_key_name, dm_effective_mtime, dpp, wq);
+  shared_ptr<LCOpAction> *selected = nullptr; // n.b., req'd by sharing
   real_time exp;
 
   for (auto& a : actions) {
@@ -1414,8 +1443,9 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
 
   auto pf = [](RGWLC::LCWorker* wk, WorkQ* wq, WorkItem& wi) {
     auto wt =
-      boost::get<std::tuple<LCOpRule&, rgw_bucket_dir_entry>>(wi);
+      boost::get<std::tuple<LCOpRule, rgw_bucket_dir_entry>>(wi);
     auto& [op_rule, o] = wt;
+
     ldpp_dout(wk->get_lc(), 20)
       << __func__ << "(): key=" << o.key << wq->thr_name() 
       << dendl;
@@ -1476,7 +1506,8 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
     orule.build(); // why can't ctor do it?
     rgw_bucket_dir_entry* o{nullptr};
     for (; ol.get_obj(&o /* , fetch_barrier */); ol.next()) {
-      std::tuple<LCOpRule&, rgw_bucket_dir_entry> t1 = {orule, *o};
+      orule.update();
+      std::tuple<LCOpRule, rgw_bucket_dir_entry> t1 = {orule, *o};
       worker->workpool->enqueue(WorkItem{t1});
     }
     worker->workpool->drain();
@@ -1866,7 +1897,7 @@ void get_lc_oid(CephContext *cct, const string& shard_id, string *oid)
   int max_objs =
     (cct->_conf->rgw_lc_max_objs > HASH_PRIME ? HASH_PRIME :
      cct->_conf->rgw_lc_max_objs);
-  /* XXXX oh noes!!! */
+  /* n.b. review hash algo */
   int index = ceph_str_hash_linux(shard_id.c_str(),
 				  shard_id.size()) % HASH_PRIME % max_objs;
   *oid = lc_oid_prefix;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -473,6 +473,7 @@ public:
     WorkPool* workpool{nullptr};
 
   public:
+
     using lock_guard = std::lock_guard<std::mutex>;
     using unique_lock = std::unique_lock<std::mutex>;
 

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -508,7 +508,8 @@ public:
   int list_lc_progress(const string& marker, uint32_t max_entries,
 		       vector<cls_rgw_lc_entry>&);
   int bucket_lc_prepare(int index, LCWorker* worker);
-  int bucket_lc_process(string& shard_id, LCWorker* worker, time_t stop_at);
+  int bucket_lc_process(string& shard_id, LCWorker* worker, time_t stop_at,
+			bool once);
   int bucket_lc_post(int index, int max_lock_sec,
 		     cls_rgw_lc_entry& entry, int& result, LCWorker* worker);
   bool going_down();
@@ -528,8 +529,7 @@ public:
 
   int handle_multipart_expiration(RGWRados::Bucket *target,
 				  const multimap<string, lc_op>& prefix_map,
-				  LCWorker* worker,
-				  time_t stop_at);
+				  LCWorker* worker, time_t stop_at, bool once);
 };
 
 namespace rgw::lc {

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -505,8 +505,8 @@ public:
   bool if_already_run_today(time_t start_date);
   bool expired_session(time_t started);
   time_t thread_stop_at();
-  int list_lc_progress(const string& marker, uint32_t max_entries,
-		       vector<cls_rgw_lc_entry>&);
+  int list_lc_progress(string& marker, uint32_t max_entries,
+		       vector<cls_rgw_lc_entry>&, int& index);
   int bucket_lc_prepare(int index, LCWorker* worker);
   int bucket_lc_process(string& shard_id, LCWorker* worker, time_t stop_at,
 			bool once);

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -500,8 +500,8 @@ public:
   void initialize(CephContext *_cct, rgw::sal::RGWRadosStore *_store);
   void finalize();
 
-  int process(LCWorker* worker);
-  int process(int index, int max_secs, LCWorker* worker);
+  int process(LCWorker* worker, bool once);
+  int process(int index, int max_secs, LCWorker* worker, bool once);
   bool if_already_run_today(time_t start_date);
   bool expired_session(time_t started);
   time_t thread_stop_at();

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -467,6 +467,7 @@ public:
     const DoutPrefixProvider *dpp;
     CephContext *cct;
     RGWLC *lc;
+    int ix;
     ceph::mutex lock = ceph::make_mutex("LCWorker");
     ceph::condition_variable cond;
     WorkPool* workpool{nullptr};
@@ -497,10 +498,12 @@ public:
   int process(LCWorker* worker);
   int process(int index, int max_secs, LCWorker* worker);
   bool if_already_run_today(time_t& start_date);
-  int list_lc_progress(const string& marker, uint32_t max_entries, map<string, int> *progress_map);
+  int list_lc_progress(const string& marker, uint32_t max_entries,
+		       vector<cls_rgw_lc_entry>&);
   int bucket_lc_prepare(int index, LCWorker* worker);
   int bucket_lc_process(string& shard_id, LCWorker* worker);
-  int bucket_lc_post(int index, int max_lock_sec, pair<string, int >& entry, int& result, LCWorker* worker);
+  int bucket_lc_post(int index, int max_lock_sec,
+		     cls_rgw_lc_entry& entry, int& result, LCWorker* worker);
   bool going_down();
   void start_processor();
   void stop_processor();

--- a/src/rgw/rgw_perf_counters.cc
+++ b/src/rgw/rgw_perf_counters.cc
@@ -35,7 +35,20 @@ int rgw_perf_start(CephContext *cct)
   plb.add_u64_counter(l_rgw_keystone_token_cache_miss, "keystone_token_cache_miss", "Keystone token cache miss");
 
   plb.add_u64_counter(l_rgw_gc_retire, "gc_retire_object", "GC object retires");
-  plb.add_u64_counter(l_rgw_lc_remove_expired, "lc_remove_expired", "LC removed objects");
+
+  plb.add_u64_counter(l_rgw_lc_expire_current, "lc_expire_current",
+		      "Lifecycle current expiration");
+  plb.add_u64_counter(l_rgw_lc_expire_noncurrent, "lc_expire_noncurrent",
+		      "Lifecycle non-current expiration");
+  plb.add_u64_counter(l_rgw_lc_expire_dm, "lc_expire_dm",
+		      "Lifecycle delete-marker expiration");
+  plb.add_u64_counter(l_rgw_lc_transition_current, "lc_transition_current",
+		      "Lifecycle current transition");
+  plb.add_u64_counter(l_rgw_lc_transition_noncurrent,
+		      "lc_transition_noncurrent",
+		      "Lifecycle non-current transition");
+  plb.add_u64_counter(l_rgw_lc_abort_mpu, "lc_abort_mpu",
+		      "Lifecycle abort multipart upload");
 
   plb.add_u64_counter(l_rgw_pubsub_event_triggered, "pubsub_event_triggered", "Pubsub events with at least one topic");
   plb.add_u64_counter(l_rgw_pubsub_event_lost, "pubsub_event_lost", "Pubsub events lost");

--- a/src/rgw/rgw_perf_counters.h
+++ b/src/rgw/rgw_perf_counters.h
@@ -32,7 +32,13 @@ enum {
   l_rgw_keystone_token_cache_miss,
 
   l_rgw_gc_retire,
-  l_rgw_lc_remove_expired,
+
+  l_rgw_lc_expire_current,
+  l_rgw_lc_expire_noncurrent,
+  l_rgw_lc_expire_dm,
+  l_rgw_lc_transition_current,
+  l_rgw_lc_transition_noncurrent,
+  l_rgw_lc_abort_mpu,
 
   l_rgw_pubsub_event_triggered,
   l_rgw_pubsub_event_lost,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8035,7 +8035,8 @@ int RGWRados::process_gc(bool expired_only)
   return gc->process(expired_only);
 }
 
-int RGWRados::list_lc_progress(const string& marker, uint32_t max_entries, map<string, int> *progress_map)
+int RGWRados::list_lc_progress(const string& marker, uint32_t max_entries,
+			       vector<cls_rgw_lc_entry>& progress_map)
 {
   return lc->list_lc_progress(marker, max_entries, progress_map);
 }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8035,10 +8035,11 @@ int RGWRados::process_gc(bool expired_only)
   return gc->process(expired_only);
 }
 
-int RGWRados::list_lc_progress(const string& marker, uint32_t max_entries,
-			       vector<cls_rgw_lc_entry>& progress_map)
+int RGWRados::list_lc_progress(string& marker, uint32_t max_entries,
+			       vector<cls_rgw_lc_entry>& progress_map,
+			       int& index)
 {
-  return lc->list_lc_progress(marker, max_entries, progress_map);
+  return lc->list_lc_progress(marker, max_entries, progress_map, index);
 }
 
 int RGWRados::process_lc()

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8043,7 +8043,12 @@ int RGWRados::list_lc_progress(const string& marker, uint32_t max_entries,
 
 int RGWRados::process_lc()
 {
-  return lc->process(nullptr);
+  RGWLC lc;
+  lc.initialize(cct, this->store);
+  RGWLC::LCWorker worker(&lc, cct, &lc, 0);
+  auto ret = lc.process(&worker, true /* once */);
+  lc.stop_processor(); // sets down_flag, but returns immediately
+  return ret;
 }
 
 bool RGWRados::process_expire_objects()

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1444,9 +1444,9 @@ public:
   int defer_gc(void *ctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y);
 
   int process_lc();
-  int list_lc_progress(const string& marker, uint32_t max_entries,
-		       vector<cls_rgw_lc_entry>& progress_map);
-  
+  int list_lc_progress(string& marker, uint32_t max_entries,
+		       vector<cls_rgw_lc_entry>& progress_map, int& index);
+
   int bucket_check_index(RGWBucketInfo& bucket_info,
                          map<RGWObjCategory, RGWStorageStats> *existing_stats,
                          map<RGWObjCategory, RGWStorageStats> *calculated_stats);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1444,7 +1444,8 @@ public:
   int defer_gc(void *ctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y);
 
   int process_lc();
-  int list_lc_progress(const string& marker, uint32_t max_entries, map<string, int> *progress_map);
+  int list_lc_progress(const string& marker, uint32_t max_entries,
+		       vector<cls_rgw_lc_entry>& progress_map);
   
   int bucket_check_index(RGWBucketInfo& bucket_info,
                          map<RGWObjCategory, RGWStorageStats> *existing_stats,


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/45645 (missing 11 commits from https://github.com/ceph/ceph/pull/35431)
* https://tracker.ceph.com/issues/45922
* https://tracker.ceph.com/issues/46873
* https://tracker.ceph.com/issues/46874

---

backport of

* https://github.com/ceph/ceph/pull/32927 (missing 11 commits from https://github.com/ceph/ceph/pull/35431)
* https://github.com/ceph/ceph/pull/35203
* https://github.com/ceph/ceph/pull/36246
* https://github.com/ceph/ceph/pull/36474

parent trackers:

* https://tracker.ceph.com/issues/43841
* https://tracker.ceph.com/issues/45667
* https://tracker.ceph.com/issues/46677
* https://tracker.ceph.com/issues/46838

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh
