### PR TITLE
octopus: rgw: add quota enforcement to CopyObj

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5243,6 +5243,24 @@ void RGWCopyObj::execute()
 
   encode_delete_at_attr(delete_at, attrs);
 
+  if (!s->system_request) { // no quota enforcement for system requests
+    // get src object size (cached in obj_ctx from verify_permission())
+    RGWObjState* astate = nullptr;
+    op_ret = store->getRados()->get_obj_state(s->obj_ctx, src_bucket_info, src_obj,
+                                              &astate, true, s->yield, false);
+    if (op_ret < 0) {
+      return;
+    }
+    // enforce quota against the destination bucket owner
+    op_ret = store->getRados()->check_quota(dest_bucket_info.owner,
+                                            dest_bucket_info.bucket,
+                                            user_quota, bucket_quota,
+                                            astate->accounted_size);
+    if (op_ret < 0) {
+      return;
+    }
+  }
+
   bool high_precision_time = (s->system_request);
 
   /* Handle object versioning of Swift API. In case of copying to remote this


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45926

---

backport of https://github.com/ceph/ceph/pull/35073
parent tracker: https://tracker.ceph.com/issues/45382

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh