### PR TITLE
octopus: rgw: add check for index entry's existing when adding bucket stats during bucket reshard.

### DIFF
--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -327,6 +327,7 @@ bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key,
       {
         rgw_bucket_dir_entry entry;
         decode(entry, iter);
+        account = (account && entry.exists);
         *key = entry.key;
         *category = entry.meta.category;
         accounted_stats->num_entries++;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46005

---

backport of https://github.com/ceph/ceph/pull/29062
parent tracker: https://tracker.ceph.com/issues/45970

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh