### PR TITLE
octopus: selinux: allow ceph_t amqp_port_t:tcp_socket

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -13,6 +13,8 @@ require {
 	type urandom_device_t;
 	type setfiles_t;
 	type nvme_device_t;
+	type amqp_port_t;
+	type soundd_port_t;
 	class sock_file unlink;
 	class tcp_socket name_connect_t;
 	class lnk_file { create getattr read unlink };

--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -87,6 +87,8 @@ corenet_tcp_sendrecv_cyphesis_port(ceph_t)
 
 allow ceph_t commplex_main_port_t:tcp_socket name_connect;
 allow ceph_t http_cache_port_t:tcp_socket name_connect;
+allow ceph_t amqp_port_t:tcp_socket name_connect;
+allow ceph_t soundd_port_t:tcp_socket name_connect;
 
 corecmd_exec_bin(ceph_t)
 corecmd_exec_shell(ceph_t)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46457

---

backport of

* https://github.com/ceph/ceph/pull/35983
* https://github.com/ceph/ceph/pull/36003

parent tracker: https://tracker.ceph.com/issues/46424

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh