### PR TITLE
octopus: rgw: orphan list teuthology test & fully-qualified domain issue

### DIFF
--- a/qa/workunits/rgw/test_rgw_orphan_list.sh
+++ b/qa/workunits/rgw/test_rgw_orphan_list.sh
@@ -17,6 +17,13 @@ awscli_dir=${HOME}/awscli_temp
 export PATH=${PATH}:${awscli_dir}
 
 rgw_host=$(hostname --fqdn)
+if echo "$rgw_host" | grep -q '\.' ; then
+    :
+else
+    host_domain=".front.sepia.ceph.com"
+    echo "WARNING: rgw hostname -- $rgw_host -- does not appear to be fully qualified; PUNTING and appending $host_domain"
+    rgw_host="${rgw_host}${host_domain}"
+fi
 rgw_port=80
 
 echo "Fully Qualified Domain Name: $rgw_host"

--- a/src/rgw/rgw-orphan-list
+++ b/src/rgw/rgw-orphan-list
@@ -28,13 +28,14 @@ error_out() {
 }
 
 prompt_pool() {
-    echo "Available pools:"
+    # note: all prompts go to stderr so stdout contains just the result
+    >&2 echo "Available pools:"
     rados lspools >"$temp_file" 2>"$lspools_err"
     if [ "$?" -ne 0 ] ;then
 	error_out "rados lspools" "$lspools_err"
     fi
-    sed 's/^/    /' $temp_file # list pools and indent
-    printf "Which pool do you want to search for orphans? "
+    >&2 sed 's/^/    /' "$temp_file" # list pools and indent
+    >&2 printf "Which pool do you want to search for orphans? "
     local mypool
     read mypool
     echo $mypool
@@ -76,9 +77,12 @@ if [ "${PIPESTATUS[0]}" -gt 1 ] ;then
     error_out "ceph-diff-sorted"
 fi
 
-found="$(wc -l < $delta_out)"
-possible="$(wc -l < $rados_out)"
-percentage=$(expr 100 \* $found / $possible)
+found=$(wc -l < "$delta_out")
+possible=$(wc -l < "$rados_out")
+percentage=0
+if [ $possible -ne 0 ] ;then
+    percentage=$(expr 100 \* $found / $possible)
+fi
 
 echo "$found potential orphans found out of a possible $possible (${percentage}%)."
 echo "The results can be found in ${delta_out}."


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/46459
* https://tracker.ceph.com/issues/46462

---

backport of

* https://github.com/ceph/ceph/pull/35966
* https://github.com/ceph/ceph/pull/35979

parent trackers:

* https://tracker.ceph.com/issues/46404
* https://tracker.ceph.com/issues/46422

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh