### PR TITLE
octopus: test: osd-backfill-stats.sh use nobackfill to avoid races in remainin…

### DIFF
--- a/qa/standalone/osd/osd-backfill-stats.sh
+++ b/qa/standalone/osd/osd-backfill-stats.sh
@@ -152,8 +152,10 @@ function TEST_backfill_sizeup() {
 	rados -p $poolname put obj$i /dev/null
     done
 
+    ceph osd set nobackfill
     ceph osd pool set $poolname size 3
-    sleep 15
+    sleep 2
+    ceph osd unset nobackfill
 
     wait_for_clean || return 1
 
@@ -202,9 +204,11 @@ function TEST_backfill_sizeup_out() {
     # Remember primary during the backfill
     local primary=$(get_primary $poolname obj1)
 
+    ceph osd set nobackfill
     ceph osd out osd.$primary
     ceph osd pool set $poolname size 3
-    sleep 15
+    sleep 2
+    ceph osd unset nobackfill
 
     wait_for_clean || return 1
 
@@ -249,8 +253,10 @@ function TEST_backfill_out() {
     # Remember primary during the backfill
     local primary=$(get_primary $poolname obj1)
 
+    ceph osd set nobackfill
     ceph osd out osd.$(get_not_primary $poolname obj1)
-    sleep 15
+    sleep 2
+    ceph osd unset nobackfill
 
     wait_for_clean || return 1
 
@@ -296,10 +302,12 @@ function TEST_backfill_down_out() {
     local primary=$(get_primary $poolname obj1)
     local otherosd=$(get_not_primary $poolname obj1)
 
+    ceph osd set nobackfill
     kill $(cat $dir/osd.${otherosd}.pid)
     ceph osd down osd.${otherosd}
     ceph osd out osd.${otherosd}
-    sleep 15
+    sleep 2
+    ceph osd unset nobackfill
 
     wait_for_clean || return 1
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46016

---

backport of https://github.com/ceph/ceph/pull/35425
parent tracker: https://tracker.ceph.com/issues/44314

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh