### PR TITLE
octopus: osd: wakeup all threads of shard rather than one thread.

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10711,7 +10711,7 @@ void OSD::ShardedOpWQ::_enqueue(OpSchedulerItem&& item) {
 
   if (empty) {
     std::lock_guard l{sdata->sdata_wait_lock};
-    sdata->sdata_cond.notify_one();
+    sdata->sdata_cond.notify_all();
   }
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46086

---

backport of https://github.com/ceph/ceph/pull/34363
parent tracker: https://tracker.ceph.com/issues/46053

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh