### PR TITLE
octopus: mon/MDSMonitor: copy MDS info which may be removed

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2039,7 +2039,7 @@ bool MDSMonitor::check_health(FSMap& fsmap, bool* propose_osdmap)
   }
 
   for (const auto& gid : to_remove) {
-    auto& info = fsmap.get_info_gid(gid);
+    auto info = fsmap.get_info_gid(gid);
     const mds_info_t* rep_info = nullptr;
     if (info.rank >= 0) {
       auto fscid = fsmap.gid_fscid(gid);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46286

---

backport of https://github.com/ceph/ceph/pull/35784
parent tracker: https://tracker.ceph.com/issues/46216

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh