### PR TITLE
octopus: pybind/mgr/pg_autoscaler/module.py: do not update event if ev.pg_num== ev.pg_num_target

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -407,7 +407,7 @@ class PgAutoscaler(MgrModule):
         for pool_id in list(self._event):
             ev = self._event[pool_id]
             pool_data = pools.get(pool_id)
-            if pool_data is None or pool_data['pg_num'] == pool_data['pg_num_target']:
+            if pool_data is None or pool_data['pg_num'] == pool_data['pg_num_target'] or ev.pg_num == ev.pg_num_target:
                 # pool is gone or we've reached our target
                 self.remote('progress', 'complete', ev.ev_id)
                 del self._event[pool_id]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46489

---

backport of https://github.com/ceph/ceph/pull/35654
parent tracker: https://tracker.ceph.com/issues/46487

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh