### PR TITLE
octopus: mds: do not defer incoming mgrmap when mds is laggy

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -904,6 +904,17 @@ bool MDSDaemon::ms_dispatch2(const ref_t<Message> &m)
 /*
  * high priority messages we always process
  */
+
+#define ALLOW_MESSAGES_FROM(peers)                                      \
+  do {                                                                  \
+    if (m->get_connection() && (m->get_connection()->get_peer_type() & (peers)) == 0) { \
+      dout(0) << __FILE__ << "." << __LINE__ << ": filtered out request, peer=" \
+              << m->get_connection()->get_peer_type() << " allowing="   \
+              << #peers << " message=" << *m << dendl;                  \
+      return true;                                                      \
+    }                                                                   \
+  } while (0)
+
 bool MDSDaemon::handle_core_message(const cref_t<Message> &m)
 {
   switch (m->get_type()) {

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -421,7 +421,8 @@ class MDSRank {
     void inc_dispatch_depth() { ++dispatch_depth; }
     void dec_dispatch_depth() { --dispatch_depth; }
     void retry_dispatch(const cref_t<Message> &m);
-    bool handle_deferrable_message(const cref_t<Message> &m);
+    bool is_valid_message(const cref_t<Message> &m);
+    void handle_message(const cref_t<Message> &m);
     void _advance_queues();
     bool _dispatch(const cref_t<Message> &m, bool new_msg);
     bool is_stale_message(const cref_t<Message> &m) const;
@@ -652,16 +653,6 @@ public:
   // Call into me from MDS::ms_dispatch
   bool ms_dispatch(const cref_t<Message> &m);
 };
-
-// This utility for MDS and MDSRank dispatchers.
-#define ALLOW_MESSAGES_FROM(peers) \
-do { \
-  if (m->get_connection() && (m->get_connection()->get_peer_type() & (peers)) == 0) { \
-    dout(0) << __FILE__ << "." << __LINE__ << ": filtered out request, peer=" << m->get_connection()->get_peer_type() \
-           << " allowing=" << #peers << " message=" << *m << dendl; \
-    return true; \
-  } \
-} while (0)
 
 #endif // MDS_RANK_H_
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46152

---

backport of https://github.com/ceph/ceph/pull/34024
parent tracker: https://tracker.ceph.com/issues/44638

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh