### PR TITLE
octopus: cephfs: client: fix snap directory atime

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10748,6 +10748,7 @@ Inode *Client::open_snapdir(Inode *diri)
     in->mtime = diri->mtime;
     in->ctime = diri->ctime;
     in->btime = diri->btime;
+    in->atime = diri->atime;
     in->size = diri->size;
     in->change_attr = diri->change_attr;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46186

---

backport of https://github.com/ceph/ceph/pull/33879
parent tracker: https://tracker.ceph.com/issues/46070

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh