### PR TITLE
octopus: cephfs: client: fix setxattr for 0 size value (NULL value)

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11565,6 +11565,12 @@ int Client::_setxattr(Inode *in, const char *name, const void *value,
     return -EROFS;
   }
 
+  if (size == 0) {
+    value = "";
+  } else if (value == NULL) {
+      return -EINVAL;
+  }
+
   bool posix_acl_xattr = false;
   if (acl_type == POSIX_ACL)
     posix_acl_xattr = !strncmp(name, "system.", 7);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46410

---

backport of https://github.com/ceph/ceph/pull/35725
parent tracker: https://tracker.ceph.com/issues/46084

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh