### PR TITLE
octopus: cephfs: client: release the client_lock before copying data in read

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9130,7 +9130,7 @@ int Client::uninline_data(Inode *in, Context *onfinish)
 
 int Client::read(int fd, char *buf, loff_t size, loff_t offset)
 {
-  std::lock_guard lock(client_lock);
+  std::unique_lock lock(client_lock);
   tout(cct) << "read" << std::endl;
   tout(cct) << fd << std::endl;
   tout(cct) << size << std::endl;
@@ -9152,6 +9152,7 @@ int Client::read(int fd, char *buf, loff_t size, loff_t offset)
   int r = _read(f, offset, size, &bl);
   ldout(cct, 3) << "read(" << fd << ", " << (void*)buf << ", " << size << ", " << offset << ") = " << r << dendl;
   if (r >= 0) {
+    lock.unlock();
     bl.begin().copy(bl.length(), buf);
     r = bl.length();
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46469

---

backport of https://github.com/ceph/ceph/pull/35410
parent tracker: https://tracker.ceph.com/issues/46025

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh