### PR TITLE
octopus: common: log: fix timestap precision of log can't set to millisecond.

### DIFF
--- a/src/log/Entry.h
+++ b/src/log/Entry.h
@@ -41,7 +41,6 @@ public:
   pthread_t m_thread;
   short m_prio, m_subsys;
 
-private:
   static log_clock& clock() {
     static log_clock clock;
     return clock;

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -62,9 +62,9 @@ Log::~Log()
 void Log::set_coarse_timestamps(bool coarse) {
   std::scoped_lock lock(m_flush_mutex);
   if (coarse)
-    clock.coarsen();
+    Entry::clock().coarsen();
   else
-    clock.refine();
+    Entry::clock().refine();
 }
 
 void Log::set_flush_on_exit()

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -33,7 +33,6 @@ class Log : private Thread
   static const std::size_t DEFAULT_MAX_RECENT = 10000;
 
   Log **m_indirect_this;
-  log_clock clock;
 
   const SubsystemMap *m_subs;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46015

---

backport of https://github.com/ceph/ceph/pull/33720
parent tracker: https://tracker.ceph.com/issues/44409

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh