### PR TITLE
octopus: tests: unittest_lockdep: skip lockdep test if CEPH_DEBUG_MUTEX is not defined

### DIFF
--- a/src/test/common/test_lockdep.cc
+++ b/src/test/common/test_lockdep.cc
@@ -16,7 +16,7 @@ class lockdep : public ::testing::Test
 {
 protected:
   void SetUp() override {
-#ifdef CEPH_DEBUG_MUTEX
+#ifndef CEPH_DEBUG_MUTEX
     GTEST_SKIP() << "WARNING: CEPH_DEBUG_MUTEX is not defined, lockdep will not work";
 #endif
     CephInitParameters params(CEPH_ENTITY_TYPE_CLIENT);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46307

---

backport of https://github.com/ceph/ceph/pull/35856
parent tracker: https://tracker.ceph.com/issues/46267

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh