### PR TITLE
kv: replace compat_mkdir with fs::create_directory

### DIFF
--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -293,9 +293,6 @@ int lchown(const char *path, uid_t owner, gid_t group);
 #ifdef __cplusplus
 }
 
-// Windows' mkdir doesn't accept a mode argument.
-#define compat_mkdir(pathname, mode) mkdir(pathname)
-
 #endif
 
 // O_CLOEXEC is not defined on Windows. Since handles aren't inherited
@@ -307,8 +304,6 @@ int lchown(const char *path, uid_t owner, gid_t group);
 #else
 
 #define SOCKOPT_VAL_TYPE void*
-
-#define compat_mkdir(pathname, mode) mkdir(pathname, mode)
 
 #endif /* WIN32 */
 


### PR DESCRIPTION
so no need to use a wrapper maintained by ourselves.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
