### PR TITLE
crimson: seastore  add extentmap tree

### DIFF
--- a/src/crimson/os/seastore/CMakeLists.txt
+++ b/src/crimson/os/seastore/CMakeLists.txt
@@ -13,6 +13,9 @@ add_library(crimson-seastore
   onode_manager/simple-fltree/onode_block.cc
   onode_manager/simple-fltree/onode_delta.cc
   onode_manager/simple-fltree/onode_node.cc
+  extentmap_manager.cc
+  extentmap_manager/btree/extentmap_btree_node_impl.cc
+  extentmap_manager/btree/btree_extentmap_manager.cc
   seastore.cc
   ../../../test/crimson/seastore/test_block.cc
 	)

--- a/src/crimson/os/seastore/extentmap_manager.cc
+++ b/src/crimson/os/seastore/extentmap_manager.cc
@@ -1,0 +1,40 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "crimson/os/seastore/transaction_manager.h"
+#include "crimson/os/seastore/extentmap_manager.h"
+#include "crimson/os/seastore/extentmap_manager/btree/btree_extentmap_manager.h"
+namespace crimson::os::seastore::extentmap_manager {
+
+ExtentMapManagerRef create_extentmap_manager(
+  TransactionManager *trans_manager) {
+  return ExtentMapManagerRef(new BtreeExtentMapManager(trans_manager));
+}
+ExtentMapManagerRef create_extentmap_manager(
+  TransactionManager *trans_manager, extmap_root_ref exroot) {
+  return ExtentMapManagerRef(new BtreeExtentMapManager(trans_manager, exroot));
+}
+
+}
+
+namespace crimson::os::seastore {
+
+std::ostream &operator<<(std::ostream &out, const Extent &rhs)
+{
+  return out << "LBAPin(" << rhs.logical_offset << "~" << rhs.length
+	     << "->" << rhs.laddr;
+}
+
+std::ostream &operator<<(std::ostream &out, const extent_map_list_t &rhs)
+{
+  bool first = true;
+  out << '[';
+  for (auto &i: rhs) {
+    out << (first ? "" : ",") << *i;
+    first = false;
+  }
+  return out << ']';
+}
+
+}
+

--- a/src/crimson/os/seastore/extentmap_manager.h
+++ b/src/crimson/os/seastore/extentmap_manager.h
@@ -1,0 +1,149 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <iostream>
+
+#include <boost/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+
+#include <seastar/core/future.hh>
+
+#include "common/Formatter.h"
+#include "include/ceph_assert.h"
+#include "include/buffer_fwd.h"
+
+#include "crimson/osd/exceptions.h"
+#include "crimson/os/seastore/seastore_types.h"
+#include "crimson/os/seastore/transaction_manager.h"
+
+#define PAGE_SIZE 4096
+#define EXTMAP_BLOCK_SIZE 4096
+
+namespace crimson::os::seastore {
+
+struct lext_map_val_t {
+  laddr_t laddr;
+  extent_len_t lextent_offset = 0;
+  extent_len_t length = 0;
+  // other stuff: checksum,  refcount
+  lext_map_val_t(
+    laddr_t laddr,
+    extent_len_t lextent_offset,
+    extent_len_t length)
+    : laddr(laddr), lextent_offset(lextent_offset), length(length) {}
+
+};
+class Extent
+{
+public:
+  objaddr_t logical_offset = 0;  //offset in object
+  laddr_t laddr;     // lextent start address aligned with block size.
+  extent_len_t lextent_offset = 0;
+  extent_len_t length = 0;
+  /// ctor for lookup only
+  explicit Extent(objaddr_t lo) : logical_offset(lo) { }
+  /// ctor for delayed initialization (see decode_some())
+
+  Extent(
+    objaddr_t lo,
+    laddr_t laddr,
+    extent_len_t offset,
+    extent_len_t length)
+    : logical_offset(lo), laddr(laddr), lextent_offset(offset), length(length) {}
+
+  void dump(ceph::Formatter* f) const;
+    // comparators for intrusive_set
+    friend bool operator<(const Extent &a, const Extent &b) {
+      return a.logical_offset < b.logical_offset;
+    }
+    friend bool operator>(const Extent &a, const Extent &b) {
+      return a.logical_offset > b.logical_offset;
+    }
+    friend bool operator==(const Extent &a, const Extent &b) {
+      return a.logical_offset == b.logical_offset;
+    }
+
+  ~Extent() {}
+};
+
+using ExtentRef = std::unique_ptr<Extent>;
+using extent_map_list_t = std::list<ExtentRef>;
+
+struct extmap_root_t {
+  depth_t depth = 0;
+  laddr_t extmap_root_laddr;
+  extmap_root_t(depth_t dep, laddr_t laddr)
+  : depth(dep),
+    extmap_root_laddr(laddr) {}
+};
+
+using extmap_root_ref = std::shared_ptr<extmap_root_t>;
+
+/**
+ * Abstract interface for managing the object inner offset to logical addr mapping
+ * each onode has an extentmap tree.
+ */
+class ExtentMapManager {
+public:
+  using alloc_extmap_root_ertr = TransactionManager::alloc_extent_ertr;
+  using alloc_extmap_root_ret = alloc_extmap_root_ertr::future<>;
+  virtual alloc_extmap_root_ret alloc_extmap_root(Transaction &t) = 0;
+
+  using seek_lextent_ertr = TransactionManager::read_extent_ertr;
+  using seek_lextent_ret = seek_lextent_ertr::future<extent_map_list_t>;
+  //seek to the first lextent including or after offset
+  virtual seek_lextent_ret
+    seek_lextent(Transaction &t, objaddr_t lo, extent_len_t len) = 0;
+
+  //add a new Extent
+  using add_lextent_ertr = TransactionManager::read_extent_ertr;
+  using add_lextent_ret = add_lextent_ertr::future<ExtentRef>;
+  virtual add_lextent_ret
+    add_lextent(Transaction &t, objaddr_t lo, lext_map_val_t val) = 0;
+
+  // remove (and delete) an Extent
+  using rm_lextent_ertr = TransactionManager::read_extent_ertr;
+  using rm_lextent_ret = rm_lextent_ertr::future<bool>;
+  virtual rm_lextent_ret rm_lextent(Transaction &t, objaddr_t lo, lext_map_val_t val) = 0;
+
+  //punch a logical hole.  add lextents to deref to target list.
+  using punch_lextent_ertr = TransactionManager::read_extent_ertr;
+  using punch_lextent_ret = punch_lextent_ertr::future<extent_map_list_t>;
+  virtual punch_lextent_ret punch_lextent(Transaction &t, objaddr_t lo, extent_len_t len) = 0;
+
+  //put new lextent into lextent_map overwriting existing ones if
+  //any and update references accordingly
+  using set_lextent_ertr = TransactionManager::read_extent_ertr;
+  using set_lextent_ret = set_lextent_ertr::future<ExtentRef>;
+  virtual set_lextent_ret set_lextent(Transaction &t, objaddr_t lo, lext_map_val_t val) = 0;
+
+  //find a hole in mapping
+  using find_hole_ertr = TransactionManager::read_extent_ertr;
+  using find_hole_ret = find_hole_ertr::future<ExtentRef>;
+  virtual find_hole_ret find_hole(Transaction &t, objaddr_t lo, extent_len_t len) = 0;
+
+  using has_any_ertr = TransactionManager::read_extent_ertr;
+  using has_any_ret = has_any_ertr::future<bool>;
+  virtual has_any_ret has_any_lextents(Transaction &t, objaddr_t lo, extent_len_t length) = 0;
+
+  /// consolidate adjacent lextents in extent_map
+  using compress_ertr = TransactionManager::read_extent_ertr;;
+  using compress_ret =  compress_ertr::future<int>;
+  virtual compress_ret compress_extent_map(Transaction &t, objaddr_t lo, extent_len_t length) = 0;
+
+  virtual ~ExtentMapManager() {}
+};
+using ExtentMapManagerRef = std::unique_ptr<ExtentMapManager>;
+
+namespace extentmap_manager {
+ExtentMapManagerRef create_extentmap_manager(
+  TransactionManager *trans_manager);
+
+ExtentMapManagerRef create_extentmap_manager(
+  TransactionManager *trans_manager, extmap_root_ref exroot);
+
+}
+
+}

--- a/src/crimson/os/seastore/extentmap_manager/btree/btree_extentmap_manager.cc
+++ b/src/crimson/os/seastore/extentmap_manager/btree/btree_extentmap_manager.cc
@@ -1,0 +1,180 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#include <sys/mman.h>
+#include <string.h>
+
+#include "crimson/common/log.h"
+
+#include "include/buffer.h"
+#include "crimson/os/seastore/extentmap_manager/btree/btree_extentmap_manager.h"
+#include "crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node_impl.h"
+
+namespace {
+  seastar::logger& logger() {
+    return crimson::get_logger(ceph_subsys_filestore);
+  }
+}
+
+namespace crimson::os::seastore::extentmap_manager {
+
+BtreeExtentMapManager::BtreeExtentMapManager(
+  TransactionManager *tm)
+  : tm(tm) {}
+
+BtreeExtentMapManager::BtreeExtentMapManager(
+  TransactionManager *tm,  extmap_root_ref extmap_root)
+  : tm(tm),
+    extmap_root(extmap_root) {}
+
+
+BtreeExtentMapManager::alloc_extmap_root_ret
+BtreeExtentMapManager::alloc_extmap_root(Transaction &t)
+{
+
+  logger().debug("BtreeExtentMapManager::alloc_extmap_root");
+  if (extmap_root)
+    return alloc_extmap_root_ertr::now();
+
+  return tm->alloc_extent<ExtMapLeafNode>(t, L_ADDR_MIN, EXTMAP_BLOCK_SIZE)
+    .safe_then([this](auto&& root_extent) {
+      root_extent->set_tm(tm);
+      root_extent->set_size(0);
+      root_extent->set_depth(0);
+      extmap_root = std::make_shared<extmap_root_t>(0, root_extent->get_laddr());
+      return alloc_extmap_root_ertr::now();
+  });
+}
+
+BtreeExtentMapManager::get_root_ret
+BtreeExtentMapManager::get_extmap_root(Transaction &t)
+{
+  assert(extmap_root != NULL);
+  laddr_t laddr = extmap_root->extmap_root_laddr;
+  return extmap_load_extent(tm, t, laddr, extmap_root->depth);
+}
+
+BtreeExtentMapManager::seek_lextent_ret
+BtreeExtentMapManager::seek_lextent(Transaction &t, uint32_t lo,
+		                    uint32_t len)
+{
+  logger().debug("seek_lextent: {}, {}", lo, len);
+  return get_extmap_root(t).safe_then([this, &t, lo, len](auto&& extent) {
+    return extent->seek_lextent(t, lo, len);
+  }).safe_then([](auto &&e) {
+     // logger().debug("seek_lextent: found_lextent {}", e);
+      return seek_lextent_ret(
+        seek_lextent_ertr::ready_future_marker{},
+	std::move(e));
+  });
+
+}
+
+BtreeExtentMapManager::add_lextent_ret
+BtreeExtentMapManager::add_lextent(Transaction &t, uint32_t lo,
+                                   lext_map_val_t val)
+{
+  logger().debug("add_lextent: {}, {}, {}, {}", lo, val.laddr, val.lextent_offset, val.length);
+  return get_extmap_root(t).safe_then([this, &t, lo, val](auto &&root) {
+    return insert_lextent(t, root, lo, val);
+  }).safe_then([](auto ret) {
+  //    logger().debug("add_lextent:  {}", ret);
+      return add_lextent_ret(
+        add_lextent_ertr::ready_future_marker{},
+        std::move(ret));
+  });
+
+}
+
+BtreeExtentMapManager::insert_lextent_ret
+BtreeExtentMapManager::insert_lextent(Transaction &t, ExtMapNodeRef root,
+                    uint32_t logical_offset, lext_map_val_t val)
+{
+  auto split = insert_lextent_ertr::make_ready_future<ExtMapNodeRef>(root);
+  if (root->at_max_capacity()) {
+      logger().debug("BtreeExtentMapManager::splitting root {}", *root);
+    split =  root->extmap_alloc_extent<ExtMapInnerNode>(t, EXTMAP_BLOCK_SIZE)
+        .safe_then([this, root, &t, logical_offset](auto&& nroot) {
+        nroot->set_depth(root->depth + 1);
+	nroot->journal_insert(nroot->begin(), OBJ_ADDR_MIN,
+			      root->get_laddr(), nullptr);
+        extmap_root->extmap_root_laddr = nroot->get_laddr();
+        extmap_root->depth = root->depth + 1;
+        return nroot->split_entry(t, logical_offset, nroot->begin(), root);
+      });
+  }
+  return split.safe_then([this, &t, logical_offset, val](ExtMapNodeRef node) {
+    return node->insert(t, logical_offset, val);
+  });
+}
+
+BtreeExtentMapManager::has_any_ret
+BtreeExtentMapManager::has_any_lextents(Transaction &t, uint32_t lo, uint32_t len)
+{
+  return seek_lextent(t, lo, len).safe_then([this, lo, len](auto&& extents) {
+    if (extents.empty())
+      return has_any_ertr::make_ready_future<bool>(false);
+
+    auto &ext = *extents.begin();
+    if (ext->logical_offset >= lo + len)
+      return has_any_ertr::make_ready_future<bool>(false);
+
+    return has_any_ertr::make_ready_future<bool>(true);
+
+  });
+}
+
+BtreeExtentMapManager::rm_lextent_ret
+BtreeExtentMapManager::rm_lextent(Transaction &t, uint32_t lo, lext_map_val_t val)
+{
+
+  logger().debug("rm_lextent: {}, {}, {}, {}", lo, val.laddr, val.lextent_offset, val.length);
+  return get_extmap_root(t).safe_then([this, &t, lo, val](auto extent) {
+    return extent->rm_lextent(t, lo, val);
+  }).safe_then([](auto ret) {
+    logger().debug("rm_lextent: {}", ret);
+    return rm_lextent_ret(
+      rm_lextent_ertr::ready_future_marker{},
+      ret);
+  });
+}
+
+BtreeExtentMapManager::punch_lextent_ret
+BtreeExtentMapManager::punch_lextent(Transaction &t, uint32_t lo, uint32_t len)
+{
+  logger().debug("punch_lextent: {}, {}", lo, len);
+  return get_extmap_root(t).safe_then([this, &t, lo, len](auto extent) {
+    return extent->punch_lextent(t, lo, len);
+  }).safe_then([](auto &&ret) {
+  //  logger().debug("punch_lextent: {}", ret);
+    return punch_lextent_ret(
+      punch_lextent_ertr::ready_future_marker{},
+      std::move(ret));
+  });
+
+}
+
+BtreeExtentMapManager::find_hole_ret
+BtreeExtentMapManager::find_hole(Transaction &t, uint32_t lo, uint32_t len)
+{
+  logger().debug("find_lextent: {}, {}", lo, len);
+  return get_extmap_root(t).safe_then([this, &t, lo, len](auto extent) {
+    return extent->find_hole(t, lo, len);
+  }).safe_then([](auto &&ret) {
+  //  logger().debug("find_lextent: {}", ret);
+    return find_hole_ret(
+      find_hole_ertr::ready_future_marker{},
+      std::move(ret));
+  });
+
+}
+
+BtreeExtentMapManager::set_lextent_ret
+BtreeExtentMapManager::set_lextent(Transaction &t, uint32_t lo, lext_map_val_t val)
+{
+  return punch_lextent(t, lo, val.length).safe_then([this, &t, lo, val](auto &&extent) {
+    return add_lextent(t, lo, val);
+  });
+
+}
+
+}

--- a/src/crimson/os/seastore/extentmap_manager/btree/btree_extentmap_manager.h
+++ b/src/crimson/os/seastore/extentmap_manager/btree/btree_extentmap_manager.h
@@ -1,0 +1,82 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <iostream>
+
+#include <boost/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+#include <seastar/core/future.hh>
+
+#include "include/ceph_assert.h"
+#include "include/buffer_fwd.h"
+#include "crimson/osd/exceptions.h"
+
+#include "crimson/os/seastore/extentmap_manager.h"
+#include "crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node.h"
+#include "crimson/os/seastore/seastore_types.h"
+#include "crimson/os/seastore/transaction_manager.h"
+
+namespace crimson::os::seastore::extentmap_manager {
+/**
+ * BtreeExtentMapManager
+ *
+ * Uses a btree to track :
+ * objaddr_t -> laddr_t mapping for each onode extentmap
+ *
+ */
+
+class BtreeExtentMapManager : public ExtentMapManager {
+  TransactionManager *tm = nullptr;
+  extmap_root_ref extmap_root = nullptr;
+
+  using get_root_ertr = TransactionManager::read_extent_ertr;
+  using get_root_ret = get_root_ertr::future<ExtMapNodeRef>;
+  get_root_ret get_extmap_root(Transaction &t);
+
+  using insert_lextent_ertr = TransactionManager::read_extent_ertr;
+  using insert_lextent_ret = insert_lextent_ertr::future<ExtentRef>;
+  insert_lextent_ret insert_lextent(Transaction &t,
+                                    ExtMapNodeRef extent, uint32_t lo,
+				    lext_map_val_t val);
+
+public:
+  explicit BtreeExtentMapManager(
+    TransactionManager *tm, extmap_root_ref extmap_root);
+
+  explicit BtreeExtentMapManager(TransactionManager *tm);
+
+  alloc_extmap_root_ret alloc_extmap_root(Transaction &t) final;
+
+  //seek to the first lextent including or after offset
+  seek_lextent_ret seek_lextent(Transaction &t, uint32_t lo, uint32_t len) final;
+
+  add_lextent_ret add_lextent(Transaction &t, uint32_t lo, lext_map_val_t val) final;
+
+  /// remove (and delete) an Extent
+  rm_lextent_ret rm_lextent(Transaction &t, uint32_t lo, lext_map_val_t val) final;
+
+  punch_lextent_ret punch_lextent(Transaction &t, uint32_t lo, uint32_t len) final;
+
+  set_lextent_ret
+    set_lextent(Transaction &t, uint32_t lo, lext_map_val_t val) final;
+
+  find_hole_ret find_hole(Transaction &t, uint32_t lo, uint32_t len) final;
+
+  has_any_ret
+    has_any_lextents(Transaction &t, uint32_t offset, uint32_t length)final;
+
+  /// consolidate adjacent lextents in extent_map
+  compress_ret
+    compress_extent_map(Transaction &t, uint32_t offset, uint32_t length) final
+    {//TODO
+      return compress_ertr::make_ready_future<int>(0);
+    }
+
+};
+using BtreeExtentMapManagerRef = std::unique_ptr<BtreeExtentMapManager>;
+
+}
+
+

--- a/src/crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node.h
+++ b/src/crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node.h
@@ -1,0 +1,93 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+
+#pragma once
+
+#include "crimson/common/log.h"
+#include "crimson/os/seastore/seastore_types.h"
+#include "crimson/os/seastore/transaction_manager.h"
+#include "crimson/os/seastore/extentmap_manager.h"
+
+namespace crimson::os::seastore::extentmap_manager{
+
+struct ExtMapNode : LogicalCachedExtent {
+  TransactionManager* tm = nullptr;
+  using ExtMapNodeRef = TCachedExtentRef<ExtMapNode>;
+  depth_t depth = 0;
+
+  ExtMapNode(ceph::bufferptr &&ptr) : LogicalCachedExtent(std::move(ptr)) {}
+  ExtMapNode(const ExtMapNode &other)
+  : LogicalCachedExtent(other),
+    tm(other.tm),
+    depth(other.depth) {}
+
+  void set_depth(depth_t _depth) { depth = _depth; }
+  void set_tm(TransactionManager* _tm) { tm = _tm; }
+
+  LogicalCachedExtentRef make_duplicate(Transaction& t,
+	  LogicalCachedExtentRef ref) {
+    return tm->get_mutable_extent(t, ref);
+  };
+
+  using seek_lextent_ertr = ExtentMapManager::seek_lextent_ertr;
+  using seek_lextent_ret = ExtentMapManager::seek_lextent_ret;
+  virtual seek_lextent_ret seek_lextent(Transaction &t,
+		                        objaddr_t lo, extent_len_t len) = 0;
+  using insert_ertr = TransactionManager::read_extent_ertr;
+  using insert_ret = insert_ertr::future<ExtentRef>;
+  virtual insert_ret insert(Transaction &t, objaddr_t lo, lext_map_val_t val) = 0;
+
+  using punch_lextent_ertr = ExtentMapManager::punch_lextent_ertr;
+  using punch_lextent_ret = ExtentMapManager::punch_lextent_ret;
+  virtual punch_lextent_ret punch_lextent(Transaction &t, objaddr_t lo, extent_len_t len) = 0;
+
+  using find_hole_ertr = TransactionManager::read_extent_ertr;
+  using find_hole_ret = find_hole_ertr::future<ExtentRef>;
+  virtual find_hole_ret find_hole(Transaction &t, objaddr_t lo, extent_len_t len) = 0;
+
+  using rm_lextent_ertr = TransactionManager::read_extent_ertr;
+  using rm_lextent_ret = rm_lextent_ertr::future<bool>;
+  virtual rm_lextent_ret rm_lextent(Transaction &t, objaddr_t lo, lext_map_val_t val) = 0;
+
+  using split_children_ertr = TransactionManager::alloc_extent_ertr;
+  using split_children_ret = split_children_ertr::future
+	  <std::tuple<ExtMapNodeRef, ExtMapNodeRef, uint32_t>>;
+  virtual split_children_ret make_split_children(Transaction &t) = 0;
+
+  using full_merge_ertr = TransactionManager::alloc_extent_ertr;
+  using full_merge_ret = full_merge_ertr::future<ExtMapNodeRef>;
+  virtual full_merge_ret make_full_merge(Transaction &t, ExtMapNodeRef right) = 0;
+
+  using make_balanced_ertr = TransactionManager::alloc_extent_ertr;
+  using make_balanced_ret = make_balanced_ertr::future
+	  <std::tuple<ExtMapNodeRef, ExtMapNodeRef, uint32_t>>;
+  virtual make_balanced_ret
+    make_balanced(Transaction &t, ExtMapNodeRef right, bool prefer_left) = 0;
+
+  virtual bool at_max_capacity() const = 0;
+  virtual bool at_min_capacity() const = 0;
+  virtual ~ExtMapNode() = default;
+
+  using alloc_ertr = TransactionManager::alloc_extent_ertr;
+  template<class T>
+  alloc_ertr::future<TCachedExtentRef<T>>
+  extmap_alloc_extent(Transaction& txn, extent_len_t len) {
+    return tm->alloc_extent<T>(txn, L_ADDR_MIN, len).safe_then(
+      [this](auto&& extent) {
+      extent->set_tm(tm);
+      return alloc_ertr::make_ready_future<TCachedExtentRef<T>>(std::move(extent));
+    });
+  }
+
+
+};
+
+using ExtMapNodeRef = ExtMapNode::ExtMapNodeRef;
+
+TransactionManager::read_extent_ertr::future<ExtMapNodeRef>
+extmap_load_extent(TransactionManager* tm, Transaction& txn, laddr_t laddr, depth_t depth);
+
+}
+
+

--- a/src/crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node_impl.cc
@@ -1,0 +1,604 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <sys/mman.h>
+#include <string.h>
+
+#include <memory>
+#include <string.h>
+
+#include "include/buffer.h"
+#include "include/byteorder.h"
+#include "crimson/os/seastore/transaction_manager.h"
+#include "crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node.h"
+#include "crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node_impl.h"
+
+#include "test/crimson/seastore/test_block.h"   //for temporary
+namespace {
+  seastar::logger& logger() {
+    return crimson::get_logger(ceph_subsys_filestore);
+  }
+}
+
+namespace crimson::os::seastore::extentmap_manager {
+
+std::ostream &ExtMapInnerNode::print_detail(std::ostream &out) const
+{
+  return out << ", size=" << get_size()
+	     << ", depth=" << depth;
+}
+ExtMapInnerNode::seek_lextent_ret
+ExtMapInnerNode::seek_lextent(Transaction &t, objaddr_t lo, extent_len_t len)
+{
+  auto [begin, end] = bound(lo, lo + len);
+  auto result_up = std::make_unique<extent_map_list_t>();
+  auto &result = *result_up;
+  return crimson::do_for_each(
+    std::move(begin),
+    std::move(end),
+    [this, &t, &result, lo, len](const auto &val) mutable {
+      return extmap_load_extent(tm, t, val.get_val(), depth - 1).safe_then(
+	  [&t, &result, lo, len](auto extent) mutable {
+	    // TODO: add backrefs to ensure cache residence of parents
+	    return extent->seek_lextent(t, lo, len).safe_then(
+		[&t, &result, lo, len](auto item_list) mutable {
+		  result.splice(result.end(), item_list,
+				item_list.begin(), item_list.end());
+            });
+      });
+  }).safe_then([result=std::move(result_up)] {
+    return seek_lextent_ret(
+           seek_lextent_ertr::ready_future_marker{},
+           std::move(*result));
+  });
+}
+
+ExtMapInnerNode::insert_ret
+ExtMapInnerNode::insert(Transaction &t, objaddr_t lo, lext_map_val_t val)
+{
+  auto insertion_pt = get_containing_child(lo);
+  return extmap_load_extent(tm, t, insertion_pt->get_val(), depth-1).safe_then(
+    [this, insertion_pt, &t, lo, val=std::move(val)](auto extent) mutable {
+      return extent->at_max_capacity() ?
+        split_entry(t, lo, insertion_pt, extent) :
+        insert_ertr::make_ready_future<ExtMapNodeRef>(std::move(extent));
+    }).safe_then([this, &t, lo, val=std::move(val)](ExtMapNodeRef extent) mutable {
+      return extent->insert(t, lo, val);
+    });
+}
+
+ExtMapInnerNode::punch_lextent_ret
+ExtMapInnerNode::punch_lextent(Transaction &t, objaddr_t lo, extent_len_t len)
+{
+  auto result_up = std::make_unique<extent_map_list_t>();
+  auto &result = *result_up;
+  auto [begin, end] = bound(lo, lo + len);
+  logger().debug("ExtMapInnerNode::punch_lextent {} {}", lo, len);
+  return crimson::do_for_each(
+    std::move(begin),
+    std::move(end),
+    [this, &t, &result, lo, len](auto &punch_pt) mutable {
+    return extmap_load_extent(tm, t, punch_pt->get_val(), depth-1).safe_then(
+      [this, &result, punch_pt, &t, lo, len](auto extent) mutable {
+      return extent->at_max_capacity() ?
+        split_entry(t, lo, punch_pt, extent) :
+        punch_lextent_ertr::make_ready_future<ExtMapNodeRef>(std::move(extent));
+    }).safe_then([this, &result, &t, lo, len](ExtMapNodeRef extent) mutable {
+      return extent->punch_lextent(t, lo, len).safe_then(
+        [&result](auto item_list) mutable {
+        result.splice(result.end(), item_list, item_list.begin(), item_list.end());
+      });
+    });
+  }).safe_then([result=std::move(result_up)] {
+    return punch_lextent_ret(
+           punch_lextent_ertr::ready_future_marker{},
+           std::move(*result));
+  });
+
+}
+
+ExtMapInnerNode::rm_lextent_ret
+ExtMapInnerNode::rm_lextent(Transaction &t, objaddr_t lo, lext_map_val_t val)
+{
+  auto rm_pt = get_containing_child(lo);
+  return extmap_load_extent(tm, t, rm_pt->get_val(), depth-1).safe_then(
+    [this, rm_pt, &t, lo, val=std::move(val)](auto extent) mutable {
+    if (extent->at_min_capacity()) {
+      return merge_entry(t, lo, get_containing_child(lo), extent);
+    } else {
+      return merge_entry_ertr::make_ready_future<ExtMapNodeRef>(std::move(extent));
+    }
+  }).safe_then([this, &t, lo, val](ExtMapNodeRef extent) mutable {
+    return extent->rm_lextent(t, lo, val);
+  });
+}
+
+ExtMapInnerNode::find_hole_ret
+ExtMapInnerNode::find_hole(Transaction &t, objaddr_t lo, extent_len_t len)
+{
+  logger().debug("ExtMapInnerNode::find_hole for logic_offset={}, len={}, *this={}",
+    lo, len, *this);
+  auto bounds = bound(lo, lo + len);
+  return seastar::do_with(
+    bounds.first,
+    bounds.second,
+    lext_map_val_t{L_ADDR_NULL, 0, 0},
+    [this, &t, lo, len](auto &i, auto &e, auto &ret) {
+      return crimson::do_until(
+	[this, &t, &i, &e, &ret, lo, len] {
+	  if (i == e + 1) {
+	    return find_hole_ertr::make_ready_future<ExtentRef>(
+			    std::make_unique<Extent>(lo, L_ADDR_NULL, 0, 0));
+	  }
+	  return extmap_load_extent(tm, t, i->get_val(), depth-1)
+	    .safe_then([this, &t, &i, lo, len](auto extent) mutable {
+	    logger().debug(
+	      "ExtMapInnerNode::find_hole in {} for lo {} len {} ",
+	      *extent, lo, len);
+	    return extent->find_hole(t, lo, len);
+	  }).safe_then([lo, &i, &ret](auto ext_map) mutable {
+	    i++;
+	    if (ext_map->laddr != L_ADDR_NULL) {
+	      ret.laddr = ext_map->laddr;
+	      ret.lextent_offset = ext_map->lextent_offset;
+	      ret.length = ext_map->length;
+	    }
+	    return find_hole_ertr::make_ready_future<ExtentRef>(
+	           std::make_unique<Extent>(lo, ret.laddr,
+				   ret.lextent_offset, ret.length));
+	  });
+        }).safe_then([lo, &ret]() {
+          return find_hole_ertr::make_ready_future<ExtentRef>(
+                 std::make_unique<Extent>(lo, ret.laddr,
+                                 ret.lextent_offset, ret.length));
+	});
+    });
+}
+
+ExtMapInnerNode::split_children_ret
+ExtMapInnerNode::make_split_children(Transaction &t)
+{
+  return extmap_alloc_extent<ExtMapInnerNode>(t, EXTMAP_BLOCK_SIZE)
+    .safe_then([this, &t] (auto &&left) {
+      return extmap_alloc_extent<ExtMapInnerNode>(t,  EXTMAP_BLOCK_SIZE)
+        .safe_then([this, left = std::move(left)] (auto &&right) {
+          return split_children_ret(
+            split_children_ertr::ready_future_marker{},
+            std::make_tuple(left, right, split_into(*left, *right)));
+      });
+  });
+}
+
+ExtMapInnerNode::full_merge_ret
+ExtMapInnerNode::make_full_merge(Transaction &t, ExtMapNodeRef right)
+{
+  return extmap_alloc_extent<ExtMapInnerNode>(t, EXTMAP_BLOCK_SIZE)
+    .safe_then([this, right] (auto &&replacement) {
+      replacement->merge_from(*this, *right->cast<ExtMapInnerNode>());
+      return full_merge_ret(
+        full_merge_ertr::ready_future_marker{},
+        std::move(replacement));
+  });
+}
+
+ExtMapInnerNode::make_balanced_ret
+ExtMapInnerNode::make_balanced(Transaction &t,
+                 ExtMapNodeRef _right, bool prefer_left)
+{
+  ceph_assert(_right->get_type() == type);
+  return extmap_alloc_extent<ExtMapInnerNode>(t,  EXTMAP_BLOCK_SIZE)
+    .safe_then([this, &t, _right, prefer_left] (auto &&replacement_left){
+      return extmap_alloc_extent<ExtMapInnerNode>(t, EXTMAP_BLOCK_SIZE)
+        .safe_then([this, _right, prefer_left,
+	replacement_left = std::move(replacement_left)]
+                   (auto &&replacement_right) {
+          auto &right = *_right->cast<ExtMapInnerNode>();
+          return make_balanced_ret(
+            make_balanced_ertr::ready_future_marker{},
+            std::make_tuple(replacement_left, replacement_right,
+            balance_into_new_nodes(*this, right, prefer_left,
+                                   *replacement_left, *replacement_right)));
+      });
+  });
+}
+ExtMapInnerNode::split_entry_ret
+ExtMapInnerNode::split_entry(Transaction &t, objaddr_t lo,
+  internal_iterator_t iter, ExtMapNodeRef entry)
+{
+  if (!is_pending()) {
+    auto mut = make_duplicate(t, this)->cast<ExtMapInnerNode>();
+    auto mut_iter = mut->iter_idx(iter->get_offset());
+    return mut->split_entry(t, lo, mut_iter, entry);
+  }
+  ceph_assert(!at_max_capacity());
+  return entry->make_split_children(t)
+    .safe_then([this, &t, lo, iter, entry] (auto tuple){
+    auto [left, right, pivot] = tuple;
+    journal_update(iter, left->get_laddr(), maybe_get_delta_buffer());
+    journal_insert(iter + 1, pivot, right->get_laddr(), maybe_get_delta_buffer());
+    //retire extent
+    return tm->dec_ref(t, entry->get_laddr())
+      .safe_then([this, lo, left = std::move(left), right = std::move(right), pivot]
+      (auto ret) {
+      logger().debug(
+        "ExtMapInnerNode::split_entry *this {} left {} right {}",
+        *this, *left, *right);
+
+      return split_entry_ertr::make_ready_future<ExtMapNodeRef>(
+             pivot > lo ? left : right);
+    });
+  });
+}
+
+ExtMapInnerNode::merge_entry_ret
+ExtMapInnerNode::merge_entry(Transaction &t, objaddr_t lo,
+  internal_iterator_t iter, ExtMapNodeRef entry)
+{
+  if (!is_pending()) {
+    auto mut = make_duplicate(t, this)->cast<ExtMapInnerNode>();
+    auto mut_iter = mut->iter_idx(iter->get_offset());
+    return mut->merge_entry(t, lo, mut_iter, entry);
+  }
+  logger().debug("ExtMapInnerNode: merge_entry: {}, {}", *this, *entry);
+  auto is_left = (iter + 1) == end();
+  auto donor_iter = is_left ? iter - 1 : iter + 1;
+  return extmap_load_extent(tm, t, donor_iter->get_val(), depth-1)
+    .safe_then([this, &t, lo, iter, entry, donor_iter, is_left]
+      (auto &&donor) mutable {
+    auto [l, r] = is_left ?
+      std::make_pair(donor, entry) : std::make_pair(entry, donor);
+    auto [liter, riter] = is_left ?
+      std::make_pair(donor_iter, iter) : std::make_pair(iter, donor_iter);
+    if (donor->at_min_capacity()) {
+      return l->make_full_merge(t, r)
+        .safe_then([this, &t, lo, iter, entry, donor_iter, is_left, l, r, liter, riter]
+	(auto &&replacement){
+        journal_update(liter, replacement->get_laddr(), maybe_get_delta_buffer());
+        journal_remove(riter, maybe_get_delta_buffer());
+
+        //retire extent
+        return tm->dec_ref(t, l->get_laddr())
+          .safe_then([this, r, replacement, &t] (auto ret) {
+	  return tm->dec_ref(t, r->get_laddr())
+            .safe_then([replacement] (auto ret) {
+            return merge_entry_ertr::make_ready_future<ExtMapNodeRef>(replacement);
+          });
+	});
+      });
+    } else {
+      logger().debug("ExtMapInnerNode::merge_entry balanced l {} r {}",
+	*l, *r);
+      return l->make_balanced(t, r, !is_left)
+	.safe_then([this, &t, lo, iter, entry, donor_iter, is_left, l, r, liter, riter]
+	(auto tuple) {
+	auto [replacement_l, replacement_r, pivot] = tuple;
+        journal_update(liter, replacement_l->get_laddr(), maybe_get_delta_buffer());
+        journal_replace(riter, pivot, replacement_r->get_laddr(),
+                maybe_get_delta_buffer());
+
+
+        // retire extent
+        return tm->dec_ref(t, l->get_laddr())
+          .safe_then([this, &t, lo, r, pivot, replacement_l, replacement_r] (auto ret) {
+          return tm->dec_ref(t, r->get_laddr())
+            .safe_then([lo, pivot, replacement_l, replacement_r] (auto ret) {
+            return merge_entry_ertr::make_ready_future<ExtMapNodeRef>(
+               lo >= pivot ? replacement_r : replacement_l);
+          });
+        });
+      });
+    }
+  });
+}
+
+
+ExtMapInnerNode::internal_iterator_t
+ExtMapInnerNode::get_containing_child(objaddr_t lo)
+{
+  // TODO: binary search
+  for (auto i = begin(); i != end(); ++i) {
+    if (i.contains(lo))
+      return i;
+  }
+  ceph_assert(0 == "invalid");
+  return end();
+}
+
+std::ostream &ExtMapLeafNode::print_detail(std::ostream &out) const
+{
+  return out << ", size=" << get_size()
+	     << ", depth=" << depth;
+}
+
+ExtMapLeafNode::seek_lextent_ret
+ExtMapLeafNode::seek_lextent(Transaction &t, objaddr_t lo, extent_len_t len)
+{
+  logger().debug(
+    "ExtMapLeafNode::seek_lextent {}~{}", lo, len);
+  auto ret = extent_map_list_t();
+  auto [from, to] = get_leaf_entries(lo, len);
+  if (from == to && to != end())
+    ++to;
+  for (; from != to; ++from) {
+    auto val = (*from).get_val();
+    ret.emplace_back(
+      std::make_unique<Extent>(
+	(*from).get_key(),
+	val.laddr,
+	val.lextent_offset,
+	val.length));
+    logger().debug("ExtMapLeafNode::seek_lextent find {}~{}", lo, val.laddr);
+  }
+  return seek_lextent_ertr::make_ready_future<extent_map_list_t>(
+    std::move(ret));
+}
+
+ExtMapLeafNode::insert_ret
+ExtMapLeafNode::insert(Transaction &t, objaddr_t lo, lext_map_val_t val)
+{
+  ceph_assert(!at_max_capacity());
+  if (!is_pending()) {
+    auto mut = make_duplicate(t, this)->cast<ExtMapLeafNode>();
+    return mut->insert(t, lo, val);
+  }
+  auto insert_pt = lower_bound(lo);
+  journal_insert(insert_pt, lo, val, maybe_get_delta_buffer());
+
+  logger().debug(
+    "ExtMapLeafNode::insert: inserted {}->{} {} {}",
+    insert_pt.get_key(),
+    insert_pt.get_val().laddr,
+    insert_pt.get_val().lextent_offset,
+    insert_pt.get_val().length);
+  return insert_ertr::make_ready_future<ExtentRef>(
+    std::make_unique<Extent>(lo, val.laddr, val.lextent_offset, val.length));
+}
+
+ExtMapLeafNode::punch_lextent_ret
+ExtMapLeafNode::punch_lextent(Transaction &t, objaddr_t lo, extent_len_t len)
+{
+  if (!is_pending()) {
+    auto mut = make_duplicate(t, this)->cast<ExtMapLeafNode>();
+    return mut->punch_lextent(t, lo, len);
+  }
+  auto result_up = std::make_unique<extent_map_list_t>();
+  auto &ret = *result_up;
+  auto deflist = std::list<laddr_t>();
+  auto [punch_pt, punch_end] = get_leaf_entries(lo, len);
+  objaddr_t loend = lo + len;
+  for (; punch_pt != punch_end; ++punch_pt) {
+    if (punch_pt->get_key() >= loend)
+      break;
+    logger().debug("ExtMapLeafNode::punch_lextent {} {}", lo, len);
+    auto val = (*punch_pt).get_val();
+    if ( punch_pt->get_key() < lo) {
+      if (punch_pt->get_key() + val.length > loend) {
+        //split and deref middle
+        logger().debug("ExtMapLeafNode::punch_middle {} {}", lo, len);
+	uint32_t front = lo - punch_pt->get_key();
+	ret.emplace_back(
+	  std::make_unique<Extent>(
+            lo,
+	    val.laddr,
+	    val.lextent_offset + front,
+	    len));
+	lext_map_val_t upval(val.laddr, val.lextent_offset, front);
+        journal_update(punch_pt, upval, maybe_get_delta_buffer());
+        lext_map_val_t inval(val.laddr, val.lextent_offset + front + len,
+	                     val.length - front -len);
+        journal_insert(punch_pt + 1, loend, inval, maybe_get_delta_buffer());
+        break;
+      } else {
+        // deref tail
+        logger().debug("ExtMapLeafNode::punch_tail {} {}", lo, len);
+	ceph_assert(punch_pt->get_key() + val.length > lo);
+	uint32_t keep = lo - punch_pt->get_key();
+	ret.emplace_back(
+          std::make_unique<Extent>(
+            lo,
+            val.laddr,
+            val.lextent_offset + keep,
+            val.length - keep));
+        lext_map_val_t upval(val.laddr, val.lextent_offset, keep);
+	journal_update(punch_pt, upval, maybe_get_delta_buffer());
+	continue;
+      }
+    }
+    if (punch_pt->get_key() + punch_pt->get_val().length <= loend){
+      //deref whole lextent
+      logger().debug("ExtMapLeafNode::punch_whole {} {}", lo, len);
+      ret.emplace_back(
+        std::make_unique<Extent>(
+          punch_pt->get_key(),
+          val.laddr,
+          val.lextent_offset,
+          val.length));
+      journal_remove(punch_pt, maybe_get_delta_buffer());
+      deflist.push_back(val.laddr);
+      continue;
+    }
+    // deref head
+    logger().debug("ExtMapLeafNode::punch_head {} {}", lo, len);
+    uint32_t keep = punch_pt->get_key() + val.length - loend;
+    ret.emplace_back(
+      std::make_unique<Extent>(
+        punch_pt->get_key(),
+        val.laddr,
+        val.lextent_offset,
+        val.length - keep));
+    lext_map_val_t inval(val.laddr, val.lextent_offset + val.length -keep, keep);
+    journal_insert(punch_pt + 1, loend, inval, maybe_get_delta_buffer());
+    journal_remove(punch_pt, maybe_get_delta_buffer());
+    break;
+  }
+  return crimson::do_for_each(deflist.begin(), deflist.end(), [this, &t, &ret]
+	 (const auto &laddr) {
+    return tm->dec_ref(t, laddr).safe_then([](auto i) {
+      return punch_lextent_ertr::now();
+    });
+  }).safe_then ([this, ret = std::move(result_up)] {
+    return punch_lextent_ertr::make_ready_future<extent_map_list_t>(std::move(*ret));
+  });
+}
+
+ExtMapLeafNode::rm_lextent_ret
+ExtMapLeafNode::rm_lextent(Transaction &t, objaddr_t lo, lext_map_val_t val)
+{
+  if(!is_pending()) {
+    auto mut =  make_duplicate(t, this)->cast<ExtMapLeafNode>();
+    return mut->rm_lextent(t, lo, val);
+  }
+
+  auto [rm_pt, rm_end] = get_leaf_entries(lo, val.length);
+  if(lo == rm_pt->get_key() && val.laddr == rm_pt->get_val().laddr && val.length == rm_pt->get_val().length){
+    journal_remove(rm_pt, maybe_get_delta_buffer());
+    logger().debug(
+      "ExtMapLeafNode::rm_lextent: removed {}->{} {} {}",
+      rm_pt.get_key(),
+      rm_pt.get_val().laddr,
+      rm_pt.get_val().lextent_offset,
+      rm_pt.get_val().length);
+      return rm_lextent_ertr::make_ready_future<bool>(true);
+  } else {
+    return rm_lextent_ertr::make_ready_future<bool>(false);
+  }
+}
+
+ExtMapLeafNode::find_hole_ret
+ExtMapLeafNode::find_hole(Transaction &t, objaddr_t lo, extent_len_t len)
+{
+  logger().debug("ExtMapLeafNode::find_hole lo={}, len={}, *this={}",
+                 lo, len, *this);
+  auto [start, end] = bound(lo, lo + len);
+
+  //cross at least one mapping
+  if (start != end && start++ != end)
+    return find_hole_ertr::make_ready_future<ExtentRef>(
+		    std::make_unique<Extent>(lo, L_ADDR_NULL, 0, 0));
+  //overlap at start tail
+  if (start != end && lo < (start->get_key() + start->get_val().length))
+    return find_hole_ertr::make_ready_future<ExtentRef>(
+                    std::make_unique<Extent>(lo, L_ADDR_NULL, 0, 0));
+  //overlap at start head
+  if (start != end && start->get_key() >= lo)
+    return find_hole_ertr::make_ready_future<ExtentRef>(
+                    std::make_unique<Extent>(lo, L_ADDR_NULL, 0, 0));
+
+  if (start != begin())
+    start = start - 1;
+
+  return tm->read_extents<TestBlock>(t, start->get_val().laddr,
+    start->get_val().length).safe_then([this, start, end, &t, lo, len]
+    (auto &&extents) mutable {
+    [[maybe_unused]] auto [addr, extref] = extents.front();
+    auto lextent_end = start.get_key()- start.get_val().lextent_offset + extref->get_length();
+    if (lextent_end <= lo)
+      start = start + 1;
+
+    return tm->read_extents<TestBlock>(t, start.get_val().laddr,
+      start.get_val().length).safe_then([this, start, end, &t, lo, len] (auto &&extents){
+      [[maybe_unused]] auto [addr, extref] = extents.front();
+      auto keyl = start.get_key();
+      auto vall = start.get_val();
+      auto lextent_endl = keyl- vall.lextent_offset + extref->get_length();
+      auto keyr = end.get_key();
+      auto valr = end.get_val();
+
+
+      laddr_t laddr = L_ADDR_NULL;
+      uint32_t lextent_offset = 0;
+
+      if (start != end && vall.laddr == valr.laddr) {  //find hole in middle of one extent
+	laddr = vall.laddr;
+	lextent_offset = lo- keyl + vall.lextent_offset;
+      } else if ((lo + len) <= lextent_endl){  //find hole in begin extent
+        laddr = vall.laddr;
+	lextent_offset = lo - keyl + vall.lextent_offset;
+      } else if (keyr - valr.lextent_offset <= lo) {   //find hole in end extent
+        laddr = valr.laddr;
+	lextent_offset = valr.lextent_offset - (keyr-lo);
+      }
+      return find_hole_ertr::make_ready_future<ExtentRef>
+	      (std::make_unique<Extent>(lo, laddr, lextent_offset, len));
+    });
+  });
+}
+
+ExtMapLeafNode::split_children_ret
+ExtMapLeafNode::make_split_children(Transaction &t)
+{
+  return extmap_alloc_extent<ExtMapLeafNode>(t, EXTMAP_BLOCK_SIZE)
+    .safe_then([this, &t] (auto &&left) {
+      return extmap_alloc_extent<ExtMapLeafNode>(t, EXTMAP_BLOCK_SIZE)
+        .safe_then([this, &t, left = std::move(left)] (auto &&right){
+           return split_children_ret(
+             split_children_ertr::ready_future_marker{},
+	     std::make_tuple(left, right, split_into(*left, *right)));
+      });
+  });
+}
+ExtMapLeafNode::full_merge_ret
+ExtMapLeafNode::make_full_merge(Transaction &t, ExtMapNodeRef right)
+{
+  return extmap_alloc_extent<ExtMapLeafNode>(t, EXTMAP_BLOCK_SIZE)
+    .safe_then([this, &t, right] (auto &&replacement) {
+      replacement->merge_from(*this, *right->cast<ExtMapLeafNode>());
+      return full_merge_ret(
+	full_merge_ertr::ready_future_marker{},
+	std::move(replacement));
+  });
+}
+ExtMapLeafNode::make_balanced_ret
+ExtMapLeafNode::make_balanced(Transaction &t,
+                              ExtMapNodeRef _right, bool prefer_left)
+{
+  ceph_assert(_right->get_type() == type);
+  return extmap_alloc_extent<ExtMapLeafNode>(t, EXTMAP_BLOCK_SIZE)
+    .safe_then([this, &t, _right, prefer_left] (auto &&replacement_left) {
+      return extmap_alloc_extent<ExtMapLeafNode>(t, EXTMAP_BLOCK_SIZE)
+        .safe_then([this, _right, prefer_left,
+          replacement_left = std::move(replacement_left)] (auto &&replacement_right){
+          auto &right = *_right->cast<ExtMapLeafNode>();
+          return make_balanced_ret(
+                 make_balanced_ertr::ready_future_marker{},
+                 std::make_tuple(replacement_left, replacement_right,
+                     balance_into_new_nodes(*this, right, prefer_left,
+                       *replacement_left, *replacement_right)));
+    });
+  });
+}
+
+
+std::pair<ExtMapLeafNode::internal_iterator_t, ExtMapLeafNode::internal_iterator_t>
+ExtMapLeafNode::get_leaf_entries(objaddr_t addr, extent_len_t len)
+{
+  return bound(addr, addr + len);
+}
+
+
+TransactionManager::read_extent_ertr::future<ExtMapNodeRef>
+extmap_load_extent(TransactionManager* tm, Transaction& txn, laddr_t laddr, depth_t depth)
+{
+  if (depth > 0) {
+    return tm->read_extents<ExtMapInnerNode>(txn, laddr, EXTMAP_BLOCK_SIZE).safe_then(
+      [tm, depth](auto&& extents) {
+      assert(extents.size() == 1);
+      [[maybe_unused]] auto [laddr, e] = extents.front();
+      e->set_depth(depth);
+      e->set_tm(tm);
+      return TransactionManager::read_extent_ertr::make_ready_future<ExtMapNodeRef>(std::move(e));
+    });
+  } else {
+    return tm->read_extents<ExtMapLeafNode>(txn, laddr, EXTMAP_BLOCK_SIZE).safe_then(
+      [tm, depth](auto&& extents) {
+      assert(extents.size() == 1);
+      [[maybe_unused]] auto [laddr, e] = extents.front();
+      e->set_depth(depth);
+      e->set_tm(tm);
+      return TransactionManager::read_extent_ertr::make_ready_future<ExtMapNodeRef>(std::move(e));
+    });
+  }
+}
+
+}
+

--- a/src/crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node_impl.h
+++ b/src/crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node_impl.h
@@ -1,0 +1,264 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+#include <sys/mman.h>
+#include <string.h>
+
+#include "include/buffer.h"
+
+#include "crimson/common/fixed_kv_node_layout.h"
+#include "crimson/common/errorator.h"
+#include "crimson/os/seastore/extentmap_manager.h"
+#include "crimson/os/seastore/seastore_types.h"
+#include "crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node.h"
+
+namespace crimson::os::seastore::extentmap_manager {
+
+/**
+ * ExtMapInnerlNode
+ *
+ * Abstracts operations on and layout of internal nodes for the
+ * Extentmap Tree.
+ *
+ * Layout (4k):
+ *   num_entries: uint16_t           2b
+ *   (padding)  :                    14b
+ *   keys       : objaddr_t[340]     (340*4)b
+ *   values     : laddr_t[340]       (340*8)b
+ *                                    = 4096
+ */
+constexpr size_t INNER_NODE_CAPACITY = 340;
+
+struct ExtMapInnerNode
+  : ExtMapNode,
+    common::FixedKVNodeLayout<
+      INNER_NODE_CAPACITY,
+      objaddr_t, ceph_le32,
+      laddr_t, laddr_le_t> {
+  using internal_iterator_t = const_iterator;
+  template <typename... T>
+  ExtMapInnerNode(T&&... t) :
+    ExtMapNode(std::forward<T>(t)...),
+    FixedKVNodeLayout(get_bptr().c_str()) {}
+
+  static constexpr extent_types_t type = extent_types_t::EXTMAP_INNER;
+
+  CachedExtentRef duplicate_for_write() final {
+    assert(delta_buffer.empty());
+    return CachedExtentRef(new ExtMapInnerNode(*this));
+ };
+
+  delta_buffer_t delta_buffer;
+  delta_buffer_t *maybe_get_delta_buffer() {
+    return is_mutation_pending() ? &delta_buffer : nullptr;
+  }
+
+  seek_lextent_ret seek_lextent(Transaction &t, objaddr_t lo, extent_len_t len) final;
+
+  insert_ret insert(Transaction &transaction,
+                    objaddr_t lo, lext_map_val_t val) final;
+
+  rm_lextent_ret rm_lextent(Transaction &t, objaddr_t lo, lext_map_val_t val) final;
+
+  punch_lextent_ret punch_lextent(Transaction &t, objaddr_t lo, extent_len_t len) final;
+
+  find_hole_ret find_hole(Transaction &t, objaddr_t lo, extent_len_t len) final;
+
+  split_children_ret make_split_children(Transaction &t) final;
+
+  full_merge_ret
+  make_full_merge(Transaction &t, ExtMapNodeRef right) final;
+
+  make_balanced_ret
+  make_balanced(Transaction &t, ExtMapNodeRef _right, bool prefer_left) final;
+
+  std::ostream &print_detail(std::ostream &out) const final;
+
+  extent_types_t get_type() const final {
+    return type;
+  }
+
+  ceph::bufferlist get_delta() final {
+    assert(!delta_buffer.empty());
+    ceph::buffer::ptr bptr(delta_buffer.get_bytes());
+    delta_buffer.copy_out(bptr.c_str(), bptr.length());
+    ceph::bufferlist bl;
+    bl.push_back(bptr);
+    return bl;
+  }
+
+  void apply_delta(const ceph::bufferlist &_bl) final {
+    assert(_bl.length());
+    ceph::bufferlist bl = _bl;
+    bl.rebuild();
+    delta_buffer_t buffer;
+    buffer.copy_in(bl.front().c_str(), bl.front().length());
+    buffer.replay(*this);
+  }
+
+  bool at_max_capacity() const final {
+    return get_size() == get_capacity();
+  }
+
+  bool at_min_capacity() const {
+    return get_size() == get_capacity() / 2;
+  }
+
+// should make it common
+  std::pair<internal_iterator_t, internal_iterator_t> bound(
+    objaddr_t l, objaddr_t r) {
+    auto retl = begin();
+    for (; retl != end(); ++retl) {
+      if (retl->get_next_key_or_max() > l)
+        break;
+    }
+    auto retr = retl;
+    for (; retr != end(); ++retr) {
+      if (retr->get_key() >= r)
+        break;
+    }
+    return std::make_pair(retl, retr);
+  }
+
+  using split_entry_ertr = TransactionManager::read_extent_ertr;
+  using split_entry_ret = split_entry_ertr::future<ExtMapNodeRef>;
+  split_entry_ret split_entry(Transaction &t, objaddr_t lo,
+                              internal_iterator_t, ExtMapNodeRef entry);
+
+  using merge_entry_ertr = TransactionManager::read_extent_ertr;
+  using merge_entry_ret = merge_entry_ertr::future<ExtMapNodeRef>;
+  merge_entry_ret merge_entry(Transaction &t, objaddr_t lo,
+              internal_iterator_t iter, ExtMapNodeRef entry);
+
+  internal_iterator_t get_containing_child(objaddr_t lo);
+
+};
+
+/**
+ * ExtMapLeafNode
+ *
+ * Abstracts operations on and layout of leaf nodes for the
+ * ExtentMap Tree.
+ *
+ * Layout (4k):
+ *   num_entries: uint16_t               2b
+ *   (padding)  :                        14b
+ *   keys       : objaddr_t[204]         (204*4)b
+ *   values     : lext_map_val_t[204] (204*16)b
+ *                                       = 4096
+ */
+constexpr size_t LEAF_NODE_CAPACITY = 204;
+struct lext_map_val_le_t {
+  laddr_le_t laddr = init_laddr_le_t(0);
+  ceph_le32 lextent_offset = init_le32(0);
+  ceph_le32 length = init_le32(0);
+
+  lext_map_val_le_t() = default;
+  lext_map_val_le_t(const lext_map_val_le_t &) = default;
+  explicit lext_map_val_le_t(const lext_map_val_t &val)
+    : laddr(init_laddr_le_t(val.laddr)),
+      lextent_offset(init_le32(val.lextent_offset)),
+      length(init_le32(val.length)) {}
+
+  operator lext_map_val_t() const {
+    return lext_map_val_t{laddr, lextent_offset, length};
+  }
+};
+
+struct ExtMapLeafNode
+  : ExtMapNode,
+    common::FixedKVNodeLayout<
+      LEAF_NODE_CAPACITY,
+      objaddr_t, ceph_le32,
+      lext_map_val_t, lext_map_val_le_t> {
+ using internal_iterator_t = const_iterator;
+  template <typename... T>
+  ExtMapLeafNode(T&&... t) :
+    ExtMapNode(std::forward<T>(t)...),
+    FixedKVNodeLayout(get_bptr().c_str()) {}
+
+  static constexpr extent_types_t type = extent_types_t::EXTMAP_LEAF;
+
+  CachedExtentRef duplicate_for_write() final {
+    assert(delta_buffer.empty());
+    return CachedExtentRef(new ExtMapLeafNode(*this));
+  };
+
+  delta_buffer_t delta_buffer;
+  delta_buffer_t *maybe_get_delta_buffer() {
+    return is_mutation_pending() ? &delta_buffer : nullptr;
+  }
+
+  seek_lextent_ret seek_lextent(Transaction &t, objaddr_t lo, extent_len_t len) final;
+
+  insert_ret insert(Transaction &transaction, objaddr_t lo, lext_map_val_t val) final;
+
+  punch_lextent_ret punch_lextent(Transaction &t, objaddr_t lo, extent_len_t len) final;
+
+  rm_lextent_ret rm_lextent(Transaction &t, objaddr_t lo, lext_map_val_t val) final;
+
+  find_hole_ret find_hole(Transaction &t, objaddr_t lo, extent_len_t len) final;
+
+  split_children_ret make_split_children(Transaction &t) final;
+
+  full_merge_ret make_full_merge(Transaction &t, ExtMapNodeRef right) final;
+
+  make_balanced_ret make_balanced(Transaction &t,
+		    ExtMapNodeRef _right, bool prefer_left) final;
+
+  extent_types_t get_type() const final {
+    return type;
+  }
+
+  ceph::bufferlist get_delta() final {
+    assert(!delta_buffer.empty());
+    ceph::buffer::ptr bptr(delta_buffer.get_bytes());
+    delta_buffer.copy_out(bptr.c_str(), bptr.length());
+    ceph::bufferlist bl;
+    bl.push_back(bptr);
+    return bl;
+  }
+
+  void apply_delta(const ceph::bufferlist &_bl) final {
+    assert(_bl.length());
+    ceph::bufferlist bl = _bl;
+    bl.rebuild();
+    delta_buffer_t buffer;
+    buffer.copy_in(bl.front().c_str(), bl.front().length());
+    buffer.replay(*this);
+  }
+
+  std::ostream &print_detail(std::ostream &out) const final;
+
+  bool at_max_capacity() const final {
+    return get_size() == get_capacity();
+  }
+
+  bool at_min_capacity() const final {
+    return get_size() == get_capacity()/2;
+  }
+
+  std::pair<internal_iterator_t, internal_iterator_t> bound(
+    objaddr_t l, objaddr_t r) {
+    auto retl = begin();
+    for (; retl != end(); ++retl) {
+      if (retl->get_key() >= l || (retl->get_key() + retl->get_val().length) > l)
+        break;
+    }
+    auto retr = retl;
+    for (; retr != end(); ++retr) {
+      if (retr->get_key() >= r)
+        break;
+    }
+    return std::make_pair(retl, retr);
+  }
+
+  std::pair<internal_iterator_t, internal_iterator_t>
+  get_leaf_entries(objaddr_t lo, extent_len_t len);
+
+};
+using ExtentMapLeafNodeRef = TCachedExtentRef<ExtMapLeafNode>;
+
+}
+

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.cc
@@ -200,8 +200,15 @@ LBAInternalNode::split_entry(
   ceph_assert(!at_max_capacity());
   auto [left, right, pivot] = entry->make_split_children(c, t);
 
-  journal_update(iter, left->get_paddr(), maybe_get_delta_buffer());
-  journal_insert(iter + 1, pivot, right->get_paddr(), maybe_get_delta_buffer());
+  journal_update(
+    iter,
+    maybe_generate_relative(left->get_paddr()),
+    maybe_get_delta_buffer());
+  journal_insert(
+    iter + 1,
+    pivot,
+    maybe_generate_relative(right->get_paddr()),
+    maybe_get_delta_buffer());
 
   c.retire_extent(t, entry);
 
@@ -251,7 +258,10 @@ LBAInternalNode::merge_entry(
 	t,
 	r);
 
-      journal_update(liter, replacement->get_paddr(), maybe_get_delta_buffer());
+      journal_update(
+	liter,
+	maybe_generate_relative(replacement->get_paddr()),
+	maybe_get_delta_buffer());
       journal_remove(riter, maybe_get_delta_buffer());
 
       c.retire_extent(t, l);
@@ -271,12 +281,12 @@ LBAInternalNode::merge_entry(
 
       journal_update(
 	liter,
-	replacement_l->get_paddr(),
+	maybe_generate_relative(replacement_l->get_paddr()),
 	maybe_get_delta_buffer());
       journal_replace(
 	riter,
 	pivot,
-	replacement_r->get_paddr(),
+	maybe_generate_relative(replacement_r->get_paddr()),
 	maybe_get_delta_buffer());
 
       c.retire_extent(t, l);

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -167,6 +167,8 @@ struct paddr_le_t {
 
 std::ostream &operator<<(std::ostream &out, const paddr_t &rhs);
 
+using objaddr_t = uint32_t;
+constexpr uint32_t OBJ_ADDR_MIN = std::numeric_limits<uint32_t>::min();
 // logical addr, see LBAManager, TransactionManager
 using laddr_t = uint64_t;
 constexpr laddr_t L_ADDR_MIN = std::numeric_limits<laddr_t>::min();
@@ -175,7 +177,28 @@ constexpr laddr_t L_ADDR_NULL = std::numeric_limits<laddr_t>::max();
 constexpr laddr_t L_ADDR_ROOT = std::numeric_limits<laddr_t>::max() - 1;
 constexpr laddr_t L_ADDR_LBAT = std::numeric_limits<laddr_t>::max() - 2;
 
-using laddr_le_t = ceph_le64;
+struct laddr_le_t {
+private:
+  laddr_t laddr;
+public:
+  laddr_le_t() = default;
+  laddr_le_t& operator=(laddr_t nv){
+    laddr = nv;
+    return *this;
+  }
+
+  laddr_le_t(const laddr_t &addr)
+  : laddr(addr) {}
+
+  operator laddr_t() const {
+    return laddr;
+  }
+};
+inline laddr_le_t init_laddr_le_t(laddr_t addr) {
+  laddr_le_t v;
+  v = addr;
+  return v;
+}
 
 // logical offset, see LBAManager, TransactionManager
 using extent_len_t = uint32_t;
@@ -212,6 +235,8 @@ enum class extent_types_t : uint8_t {
   LADDR_INTERNAL = 1,
   LADDR_LEAF = 2,
   ONODE_BLOCK = 3,
+  EXTMAP_INNER = 4,
+  EXTMAP_LEAF = 5,
 
   // Test Block Types
   TEST_BLOCK = 0xF0,

--- a/src/test/crimson/seastore/CMakeLists.txt
+++ b/src/test/crimson/seastore/CMakeLists.txt
@@ -36,4 +36,13 @@ target_link_libraries(
   crimson::gtest
   crimson-seastore)
 
+add_executable(unittest_extmap_manager
+  test_extmap_manager.cc
+  ../gtest_seastar.cc)
+add_ceph_unittest(unittest_extmap_manager)
+target_link_libraries(
+  unittest_extmap_manager
+  ${CMAKE_DL_LIBS}
+  crimson-seastore)
+
 add_subdirectory(onode_tree)

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -10,6 +10,8 @@
 #include "crimson/os/seastore/segment_manager.h"
 #include "crimson/os/seastore/lba_manager/btree/btree_lba_manager.h"
 
+#include "test/crimson/seastore/test_block.h"
+
 namespace {
   [[maybe_unused]] seastar::logger& logger() {
     return crimson::get_logger(ceph_subsys_test);
@@ -116,10 +118,12 @@ struct btree_lba_manager_test :
   };
 
   auto create_transaction() {
-    return test_transaction_t{
+    auto t = test_transaction_t{
       lba_manager->create_transaction(),
       test_lba_mappings
     };
+    cache.alloc_new_extent<TestBlock>(*t.t, TestBlock::SIZE);
+    return t;
   }
 
   void submit_test_transaction(test_transaction_t t) {

--- a/src/test/crimson/seastore/test_extmap_manager.cc
+++ b/src/test/crimson/seastore/test_extmap_manager.cc
@@ -1,0 +1,547 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/crimson/gtest_seastar.h"
+
+#include "crimson/os/seastore/cache.h"
+#include "crimson/os/seastore/transaction_manager.h"
+#include "crimson/os/seastore/segment_manager.h"
+#include "crimson/os/seastore/extentmap_manager.h"
+
+#include "test/crimson/seastore/test_block.h"
+
+using namespace crimson;
+using namespace crimson::os;
+using namespace crimson::os::seastore;
+
+namespace {
+  [[maybe_unused]] seastar::logger& logger() {
+    return crimson::get_logger(ceph_subsys_test);
+  }
+}
+
+
+struct extentmap_manager_test_t : public seastar_test_suite_t {
+  std::unique_ptr<SegmentManager> segment_manager;
+  Journal journal;
+  Cache cache;
+  LBAManagerRef lba_manager;
+  TransactionManager tm;
+  ExtentMapManagerRef extmap_manager;
+
+  extentmap_manager_test_t()
+    : segment_manager(create_ephemeral(segment_manager::DEFAULT_TEST_EPHEMERAL)),
+      journal(*segment_manager),
+      cache(*segment_manager),
+      lba_manager(
+	lba_manager::create_lba_manager(*segment_manager, cache)),
+      tm(*segment_manager, journal, cache, *lba_manager),
+      extmap_manager(
+        extentmap_manager::create_extentmap_manager(&tm)) {}
+
+  seastar::future<> set_up_fut() final {
+    return segment_manager->init().safe_then([this] {
+      return tm.mkfs();
+    }).safe_then([this] {
+      return tm.mount();
+    }).handle_error(
+      crimson::ct_error::all_same_way([] {
+	ASSERT_FALSE("Unable to mount");
+      })
+    );
+  }
+
+  seastar::future<> tear_down_fut() final {
+    return tm.close(
+    ).handle_error(
+      crimson::ct_error::all_same_way([] {
+	ASSERT_FALSE("Unable to close");
+      })
+    );
+  }
+
+  using test_extmap_t = std::map<uint32_t, lext_map_val_t>;
+  test_extmap_t test_ext_mappings;
+  test_extmap_t temp_mappings;
+
+  TestBlockRef alloc_extent(
+    Transaction &t,
+    extent_len_t len,
+    char contents) {
+    auto extent = tm.alloc_extent<TestBlock>(
+      t,
+      L_ADDR_MIN,
+      len).unsafe_get0();
+    extent->set_contents(contents);
+    EXPECT_EQ(len, extent->get_length());
+    return extent;
+  }
+
+  ExtentRef insert_extent(
+    Transaction &t,
+    uint32_t lo,
+    lext_map_val_t val) {
+    auto extent = extmap_manager->add_lextent(t, lo, val).unsafe_get0();
+    EXPECT_EQ(lo, extent->logical_offset);
+    EXPECT_EQ(val.laddr, extent->laddr);
+    EXPECT_EQ(val.lextent_offset, extent->lextent_offset);
+    EXPECT_EQ(val.length, extent->length);
+    test_ext_mappings.emplace(std::make_pair(extent->logical_offset,
+      lext_map_val_t{extent->laddr, extent->lextent_offset, extent->length}));
+    return extent;
+  }
+
+  extent_map_list_t find_extent(
+    Transaction &t,
+    uint32_t lo,
+    uint32_t len) {
+    auto extent = extmap_manager->seek_lextent(t, lo, len).unsafe_get0();
+    EXPECT_EQ(lo, extent.front()->logical_offset);
+    EXPECT_EQ(len, extent.front()->length);
+    return extent;
+  }
+  extent_map_list_t findno_extent(
+    Transaction &t,
+    uint32_t lo,
+    uint32_t len) {
+    auto extent = extmap_manager->seek_lextent(t, lo, len).unsafe_get0();
+    EXPECT_EQ(extent.empty(), true);
+    return extent;
+  }
+  extent_map_list_t find_any(
+    Transaction &t,
+    uint32_t lo,
+    uint32_t len) {
+    auto extent = extmap_manager->seek_lextent(t, lo, len).unsafe_get0();
+    EXPECT_EQ(extent.size(), 1);
+    return extent;
+  }
+
+  bool rm_extent(
+    Transaction &t,
+    uint32_t lo,
+    lext_map_val_t val ) {
+    auto ret = extmap_manager->rm_lextent(t, lo, val).unsafe_get0();
+    EXPECT_EQ(ret, true);
+    test_ext_mappings.erase(test_ext_mappings.find(lo));
+    return ret;
+  }
+
+  extent_map_list_t punch_extent(
+    Transaction &t,
+    uint32_t lo,
+    uint32_t offset,
+    uint32_t flag,
+    uint32_t len) {
+    auto extent = extmap_manager->punch_lextent(t, lo + offset, len).unsafe_get0();
+    if (extent.empty())
+      return extent;
+
+    auto it = test_ext_mappings.find(lo);
+    auto key = it->first;
+    auto val = it->second;
+    if (it != test_ext_mappings.end())
+      test_ext_mappings.erase(it);
+    if (flag == 0) {
+      test_ext_mappings.insert(std::make_pair(lo +offset +len,
+			       lext_map_val_t{val.laddr, len, val.length-len}));
+      EXPECT_EQ(lo + offset, extent.front()->logical_offset);
+      EXPECT_EQ(len, extent.front()->length);
+    }
+    if (flag == 1){
+      test_ext_mappings.insert(std::make_pair(key, lext_map_val_t{val.laddr, 0, offset}));
+      test_ext_mappings.insert(std::make_pair(lo + offset + len,
+		       lext_map_val_t{val.laddr, offset + len, val.length-offset-len}));
+      EXPECT_EQ(lo + offset, extent.front()->logical_offset);
+      EXPECT_EQ(len, extent.front()->length);
+    }
+    if (flag == 2){
+      test_ext_mappings.insert(std::make_pair(key,
+			       lext_map_val_t{val.laddr, 0, val.length-len}));
+      EXPECT_EQ(lo + offset , extent.front()->logical_offset);
+      EXPECT_EQ(len, extent.front()->length);
+    }
+    return extent;
+  }
+  ExtentRef set_extent(
+    Transaction &t,
+    uint32_t lo,
+    lext_map_val_t val,
+    ExtentRef &&olde) {
+    auto extent = extmap_manager->set_lextent(t, lo, val).unsafe_get0();
+    EXPECT_EQ(lo, extent->logical_offset);
+    EXPECT_EQ(val.length, extent->length);
+
+    auto it = test_ext_mappings.find(olde->logical_offset);
+    if (it != test_ext_mappings.end())
+      test_ext_mappings.erase(it);
+    if (lo > olde->logical_offset && (lo+val.length) < (olde->logical_offset + olde->length) ){
+      test_ext_mappings.insert(std::make_pair(olde->logical_offset,
+	lext_map_val_t{olde->laddr, olde->lextent_offset,
+                       val.lextent_offset - olde->lextent_offset}));
+      test_ext_mappings.insert(std::make_pair(lo + val.length,
+        lext_map_val_t{olde->laddr, val.lextent_offset+val.length,
+        olde->length-val.length-(val.lextent_offset - olde->lextent_offset)}));
+
+    }
+    return extent;
+}
+  void check_mappings(Transaction &t) {
+    for (auto &&i: test_ext_mappings){
+      auto ret_list = find_extent(t, i.first, i.second.length);
+      EXPECT_EQ(ret_list.size(), 1);
+      auto &ret = *ret_list.begin();
+      EXPECT_EQ(i.second.laddr, ret->laddr);
+      EXPECT_EQ(i.second.lextent_offset, ret->lextent_offset);
+      EXPECT_EQ(i.second.length, ret->length);
+    }
+  }
+
+  void check_mappings() {
+    auto t = tm.create_transaction();
+    check_mappings(*t);
+  }
+
+};
+
+TEST_F(extentmap_manager_test_t, basic)
+{
+  run_async([this] {
+    uint32_t len = 4096;
+    uint32_t lo = 0x1 * len;
+    {
+      auto t = tm.create_transaction();
+      logger().debug("first transaction");
+      [[maybe_unused]] auto ret = extmap_manager->alloc_extmap_root(*t).unsafe_get();
+      [[maybe_unused]] auto extent = alloc_extent(*t, len, 'a');
+      [[maybe_unused]] auto addref = insert_extent(*t, lo, {extent->get_laddr(), 0, len});
+      [[maybe_unused]] auto seekref = find_extent(*t, lo, len);
+      tm.submit_transaction(std::move(t)).unsafe_get();
+
+      auto t2 = tm.create_transaction();
+      logger().debug("second transaction");
+      [[maybe_unused]] auto seekref2 = find_extent(*t2, lo, len);
+      [[maybe_unused]] auto seekref5 = find_any(*t2, 0, len);
+      [[maybe_unused]] auto rmret = rm_extent(*t2, lo, {extent->get_laddr(), 0, len});
+      [[maybe_unused]] auto decref = tm.dec_ref(*t2, extent->get_laddr()).unsafe_get();
+      [[maybe_unused]] auto seekref3 = findno_extent(*t2, lo, len);
+      tm.submit_transaction(std::move(t2)).unsafe_get();
+
+      auto t3 = tm.create_transaction();
+      logger().debug("third transaction");
+      [[maybe_unused]] auto seekref4 = findno_extent(*t3, lo, len);
+      tm.submit_transaction(std::move(t3)).unsafe_get();
+
+    }
+  });
+}
+
+TEST_F(extentmap_manager_test_t, force_split)
+{
+  run_async([this] {
+    {
+      auto t = tm.create_transaction();
+      [[maybe_unused]] auto ret = extmap_manager->alloc_extmap_root(*t).unsafe_get();
+      tm.submit_transaction(std::move(t)).unsafe_get();
+    }
+    uint32_t len = 4096;
+    uint32_t lo = 0;
+    for (unsigned i = 0; i < 40; i++) {
+      auto t = tm.create_transaction();
+      logger().debug("opened transaction");
+      for (unsigned j = 0; j < 10; ++j) {
+        auto extent = alloc_extent(*t, len, 'a');
+        [[maybe_unused]] auto addref = insert_extent(*t, lo, {extent->get_laddr(), 0, len});
+        lo += len;
+        if ((i % 20 == 0) && (j == 5)) {
+          check_mappings(*t);
+        }
+      }
+      logger().debug("force split submit transaction i = {}", i);
+      tm.submit_transaction(std::move(t)).unsafe_get();
+      check_mappings();
+    }
+  });
+
+}
+
+TEST_F(extentmap_manager_test_t, force_split_merge)
+{
+  run_async([this] {
+    {
+      auto t = tm.create_transaction();
+      [[maybe_unused]] auto ret = extmap_manager->alloc_extmap_root(*t).unsafe_get();
+      tm.submit_transaction(std::move(t)).unsafe_get();
+    }
+    uint32_t len = 4096;
+    uint32_t lo = 0;
+    for (unsigned i = 0; i < 80; i++) {
+      auto t = tm.create_transaction();
+      logger().debug("opened split_merge transaction");
+      for (unsigned j = 0; j < 5; ++j) {
+        auto extent = alloc_extent(*t, len, 'a');
+        [[maybe_unused]] auto addref = insert_extent(*t, lo, {extent->get_laddr(), 0, len});
+        lo += len;
+	if ((i % 10 == 0) && (j == 3)) {
+	  check_mappings(*t);
+	}
+      }
+      logger().debug("submitting transaction");
+      tm.submit_transaction(std::move(t)).unsafe_get();
+      if (i % 50 == 0) {
+	check_mappings();
+      }
+    }
+    auto t = tm.create_transaction();
+    int i = 0;
+    for (auto &e: test_ext_mappings) {
+      if (i % 3 != 0) {
+	auto val = e;
+	[[maybe_unused]] auto rmref= rm_extent(*t, e.first, e.second);
+        [[maybe_unused]] auto decref = tm.dec_ref(*t, val.second.laddr).unsafe_get();
+      }
+
+      if (i % 10 == 0) {
+        logger().debug("submitting transaction i= {}", i);
+	tm.submit_transaction(std::move(t)).unsafe_get();
+	t = tm.create_transaction();
+      }
+      if (i % 100 == 0) {
+        logger().debug("check_mappings  i= {}", i);
+	check_mappings(*t);
+	check_mappings();
+      }
+      i++;
+    }
+    logger().debug("finally submitting transaction ");
+    tm.submit_transaction(std::move(t)).unsafe_get();
+  });
+}
+
+TEST_F(extentmap_manager_test_t, force_split_balanced)
+{
+  run_async([this] {
+    {
+      auto t = tm.create_transaction();
+      [[maybe_unused]] auto ret = extmap_manager->alloc_extmap_root(*t).unsafe_get();
+      tm.submit_transaction(std::move(t)).unsafe_get();
+    }
+    uint32_t len = 4096;
+    uint32_t lo = 0;
+    for (unsigned i = 0; i < 50; i++) {
+      auto t = tm.create_transaction();
+      logger().debug("opened split_merge transaction");
+      for (unsigned j = 0; j < 5; ++j) {
+        auto extent = alloc_extent(*t, len, 'a');
+        [[maybe_unused]] auto addref = insert_extent(*t, lo, {extent->get_laddr(), 0, len});
+        lo += len;
+        if ((i % 10 == 0) && (j == 3)) {
+          check_mappings(*t);
+        }
+      }
+      logger().debug("submitting transaction");
+      tm.submit_transaction(std::move(t)).unsafe_get();
+      if (i % 50 == 0) {
+        check_mappings();
+      }
+    }
+    auto t = tm.create_transaction();
+    int i = 0;
+    for (auto &e: test_ext_mappings) {
+      if (i < 100) {
+        auto val = e;
+        [[maybe_unused]] auto rmref= rm_extent(*t, e.first, e.second);
+        [[maybe_unused]] auto decref = tm.dec_ref(*t, val.second.laddr).unsafe_get();
+      }
+
+      if (i % 10 == 0) {
+      logger().debug("submitting transaction i= {}", i);
+        tm.submit_transaction(std::move(t)).unsafe_get();
+        t = tm.create_transaction();
+      }
+      if (i % 50 == 0) {
+      logger().debug("check_mappings  i= {}", i);
+        check_mappings(*t);
+        check_mappings();
+      }
+      i++;
+      if (i == 100)
+	break;
+    }
+    logger().debug("finally submitting transaction ");
+    tm.submit_transaction(std::move(t)).unsafe_get();
+    check_mappings();
+  });
+}
+
+TEST_F(extentmap_manager_test_t, force_split_punch)
+{
+  run_async([this] {
+    {
+      auto t = tm.create_transaction();
+      [[maybe_unused]] auto ret = extmap_manager->alloc_extmap_root(*t).unsafe_get();
+      tm.submit_transaction(std::move(t)).unsafe_get();
+    }
+    uint32_t len = 4096;
+    uint32_t lo = 0;
+    for (unsigned i = 0; i < 50; i++) {
+      auto t = tm.create_transaction();
+      logger().debug("opened split_merge transaction");
+      for (unsigned j = 0; j < 5; ++j) {
+        auto extent = alloc_extent(*t, 3*len, 'a');
+        [[maybe_unused]] auto addref = insert_extent(*t, lo, {extent->get_laddr(), 0, 3*len});
+        lo += 3*len;
+        if ((i % 10 == 0) && (j == 3)) {
+          check_mappings(*t);
+        }
+      }
+      logger().debug("submitting transaction");
+      tm.submit_transaction(std::move(t)).unsafe_get();
+      if (i % 10 == 0) {
+        check_mappings();
+      }
+    }
+    temp_mappings.insert(test_ext_mappings.begin(), test_ext_mappings.end());
+
+    auto t = tm.create_transaction();
+    int i = 1;
+    for (auto &e: temp_mappings) {
+      if (i < 50 && i % 3 == 0) {
+        [[maybe_unused]] auto punchref= punch_extent(*t, e.first, 0, 0, len);
+        i++;
+	continue;
+      }
+
+      if (i < 100 && i %3 == 0) {
+        [[maybe_unused]] auto punchref= punch_extent(*t, e.first, len, 1, len);
+        i++;
+	continue;
+      }
+
+      if (i < 150 && i % 3 == 0) {
+        [[maybe_unused]] auto punchref= punch_extent(*t, e.first, 2*len, 2, len);
+        i++;
+	continue;
+      }
+
+      if(i < 200 && i % 3  == 0) {
+        [[maybe_unused]] auto punchref= punch_extent(*t, e.first, 0, 3, 3*len);
+        i++;
+        continue;
+      }
+
+      if (i % 50 == 0) {
+        logger().debug("submitting transaction i= {}", i);
+        tm.submit_transaction(std::move(t)).unsafe_get();
+        t = tm.create_transaction();
+      }
+      i++;
+    }
+    logger().debug("finally submitting transaction ");
+    tm.submit_transaction(std::move(t)).unsafe_get();
+    check_mappings();
+  });
+}
+
+TEST_F(extentmap_manager_test_t, withoffset_and_punch)
+{
+  run_async([this] {
+    {
+      auto t = tm.create_transaction();
+      [[maybe_unused]] auto ret = extmap_manager->alloc_extmap_root(*t).unsafe_get();
+      tm.submit_transaction(std::move(t)).unsafe_get();
+     }
+
+     uint32_t len = 0x800;
+     uint32_t lo = 0x600;
+     auto t = tm.create_transaction();
+     auto lextent_offset = lo % PAGE_SIZE;
+     auto logical_len = lextent_offset + len;
+     auto alloc_len = (logical_len +PAGE_SIZE -1) &~(PAGE_SIZE - 1);
+     auto extent = alloc_extent(*t, alloc_len, 'a');
+     [[maybe_unused]] auto addref = insert_extent(*t, lo, {extent->get_laddr(), lextent_offset, len});
+     tm.submit_transaction(std::move(t)).unsafe_get();
+
+     len = 0x200;
+     lo = 0x700;
+     lextent_offset = lo % PAGE_SIZE;
+     t = tm.create_transaction();
+     auto extlist = find_any(*t, lo, len);
+     auto &extref = *extlist.begin();
+     EXPECT_EQ(lo, extref->logical_offset+0x100);
+     EXPECT_EQ(extref->length, 0x800);
+     auto extentnew = alloc_extent(*t, PAGE_SIZE, 'a');
+     [[maybe_unused]] auto setref = set_extent(*t, lo, {extentnew->get_laddr(),lextent_offset,len}, std::move(extref));
+     tm.submit_transaction(std::move(t)).unsafe_get();
+     check_mappings();
+
+   });
+}
+
+TEST_F(extentmap_manager_test_t, split_and_findhole)
+{
+  run_async([this] {
+    {
+      auto t = tm.create_transaction();
+      [[maybe_unused]] auto ret = extmap_manager->alloc_extmap_root(*t).unsafe_get();
+      tm.submit_transaction(std::move(t)).unsafe_get();
+     }
+
+    uint32_t len = 0x200;
+    uint32_t lo = 0x0;
+    uint32_t off = 0x0;
+    for (unsigned i = 0; i < 50; i++) {
+      auto t = tm.create_transaction();
+      logger().debug("opened split transaction");
+      for (unsigned j = 0; j < 6; ++j) {
+        auto extent = alloc_extent(*t, PAGE_SIZE, 'a');
+	if (j % 3 == 0)
+          [[maybe_unused]] auto addref0 = insert_extent(*t, lo, {extent->get_laddr(), 0, len});
+        if (j % 3 == 1)
+          [[maybe_unused]] auto addref1 = insert_extent(*t, lo + 0x700, {extent->get_laddr(), 0x700, len});
+        if (j %3 == 2) {
+          [[maybe_unused]] auto addref2 = insert_extent(*t, lo, {extent->get_laddr(), 0, len});
+          [[maybe_unused]] auto addref3 = insert_extent(*t, lo + 0x700, {extent->get_laddr(), 0x700, len});
+        }
+
+	lo += PAGE_SIZE;
+        if ((i % 10 == 0) && (j == 3)) {
+          check_mappings(*t);
+        }
+      }
+      logger().debug("submitting transaction");
+      tm.submit_transaction(std::move(t)).unsafe_get();
+      if (i % 40 == 0) {
+        check_mappings();
+      }
+    }
+
+    int i = 0;
+    lo = 0x0;
+    bool skip = false;
+    auto t = tm.create_transaction();
+    for (auto &e: test_ext_mappings) {
+      if (skip) {
+        skip = false;
+        continue;
+      }
+      if (i % 3 == 0) off = 0x200;
+      if (i % 3 == 1) off = 0x500;
+      if (i %3 == 2) off = 0x300;
+      auto extref = extmap_manager->find_hole(*t, lo + off, len).unsafe_get0();
+      EXPECT_EQ(extref->laddr, e.second.laddr);
+      if (i % 3 == 0){
+	EXPECT_EQ(extref->logical_offset, e.first + off);
+      }
+      if (i % 3 == 1){
+	EXPECT_EQ(extref->logical_offset, e.first -e.second.lextent_offset + off);
+      }
+      if (i %3 == 2){
+	skip = true;
+        EXPECT_EQ(extref->logical_offset, e.first + off);
+      }
+      lo += PAGE_SIZE;
+      i++;
+    }
+  });
+}

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -324,3 +324,21 @@ TEST_F(transaction_manager_test_t, inc_dec_ref)
     }
   });
 }
+
+TEST_F(transaction_manager_test_t, cause_lba_split)
+{
+  constexpr laddr_t SIZE = 4096;
+  run_async([this] {
+    for (unsigned i = 0; i < 200; ++i) {
+      auto t = create_transaction();
+      auto extent = alloc_extent(
+	t,
+	i * SIZE,
+	SIZE,
+	(char)(i & 0xFF));
+      ASSERT_EQ(i * SIZE, extent->get_laddr());
+      submit_transaction(std::move(t));
+    }
+    check_mappings();
+  });
+}


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
