### PR TITLE
mgr/dashboard: use host ip instead of host name

### DIFF
--- a/src/pybind/mgr/dashboard/run-backend-rook-api-request.sh
+++ b/src/pybind/mgr/dashboard/run-backend-rook-api-request.sh
@@ -7,12 +7,12 @@
 CURR_DIR=`pwd`
 K8S_NAMESPACE='rook-ceph'
 
-HOST=$(kubectl get pods -n $K8S_NAMESPACE -l "app=rook-ceph-mgr" -o json | jq .items[0].spec.nodeName | sed s/\"//g)
-if [ "$HOST" = "minikube" ]; then
-	HOST=$(minikube ip)
+HOST_IP=$(kubectl get pods -n $K8S_NAMESPACE -l "app=rook-ceph-mgr" -o json | jq .items[0].status.hostIP | sed s/\"//g)
+if [ "$HOST_IP" = "minikube" ]; then
+	HOST_IP=$(minikube ip)
 fi
 PORT=$(kubectl get service -n $K8S_NAMESPACE rook-ceph-mgr-dashboard -o yaml | grep nodePort: | awk '{print $2}')
-API_URL="https://${HOST}:${PORT}"
+API_URL="https://${HOST_IP}:${PORT}"
 
 #
 # Rook automagically sets up an "admin" account with a random PW and stuffs


### PR DESCRIPTION
mgr/dashboard: use host ip instead of host name

using host ip instead of host name, the api url can always reachable.

Signed-off-by: Liu Chaoyang <chaoyanglius@gmail.com>