### PR TITLE
nautilus: mgr/dashboard: support RBD mirroring bootstrap create/import

### DIFF
--- a/qa/suites/rados/dashboard/tasks/dashboard.yaml
+++ b/qa/suites/rados/dashboard/tasks/dashboard.yaml
@@ -42,6 +42,7 @@ tasks:
         - tasks.mgr.dashboard.test_rgw
         - tasks.mgr.dashboard.test_rbd
         - tasks.mgr.dashboard.test_pool
+        - tasks.mgr.dashboard.test_rbd_mirroring
         - tasks.mgr.dashboard.test_requests
         - tasks.mgr.dashboard.test_role
         - tasks.mgr.dashboard.test_settings

--- a/qa/tasks/mgr/dashboard/test_rbd_mirroring.py
+++ b/qa/tasks/mgr/dashboard/test_rbd_mirroring.py
@@ -140,9 +140,12 @@ class RbdMirroringTest(DashboardTestCase):
         expected_peer = {
             'uuid': uuid,
             'cluster_name': 'remote',
+            'site_name': 'remote',
             'client_id': 'admin',
             'mon_host': '',
-            'key': ''
+            'key': '',
+            'direction': 'rx-tx',
+            'fsid': ''
         }
         peer = self.get_peer('rbd', uuid)
         self.assertEqual(expected_peer, peer)

--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -420,6 +420,14 @@ class RbdMirroringPoolPeer(RESTController):
         peer['client_id'] = peer['client_name'].split('.', 1)[-1]
         del peer['client_name']
 
+        # convert direction enum to string
+        directions = {
+            rbd.RBD_MIRROR_PEER_DIRECTION_RX: 'rx',
+            rbd.RBD_MIRROR_PEER_DIRECTION_TX: 'tx',
+            rbd.RBD_MIRROR_PEER_DIRECTION_RX_TX: 'rx-tx'
+        }
+        peer['direction'] = directions[peer.get('direction', rbd.RBD_MIRROR_PEER_DIRECTION_RX)]
+
         try:
             attributes = rbd.RBD().mirror_peer_get_attributes(ioctx, peer_uuid)
         except rbd.ImageNotFound:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43205

---

backport of https://github.com/ceph/ceph/pull/31062
parent tracker: https://tracker.ceph.com/issues/42355

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh