### PR TITLE
mgr/dashboard: Block the import of async from @angular/core/testing

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/app.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app.component.spec.ts
@@ -1,18 +1,17 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { configureTestBed } from '../testing/unit-test-helper';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   let component: AppComponent;
   let fixture: ComponentFixture<AppComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [AppComponent],
-      imports: [RouterTestingModule]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [AppComponent],
+    imports: [RouterTestingModule]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AppComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -53,7 +53,7 @@ describe('HostsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render hosts list even with not permission mapped services', async(() => {
+  it('should render hosts list even with not permission mapped services', () => {
     const hostname = 'ceph.dev';
     const payload = [
       {
@@ -79,7 +79,7 @@ describe('HostsComponent', () => {
 
     hostListSpy.and.callFake(() => of(payload));
 
-    fixture.whenStable().then(() => {
+    return fixture.whenStable().then(() => {
       fixture.detectChanges();
 
       const spans = fixture.debugElement.nativeElement.querySelectorAll(
@@ -87,7 +87,7 @@ describe('HostsComponent', () => {
       );
       expect(spans[0].textContent).toBe(hostname);
     });
-  }));
+  });
 
   describe('getEditDisableDesc', () => {
     it('should return message (not managed by Orchestrator)', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/device-list/device-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/device-list/device-list.component.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { i18nProviders } from '../../../../testing/unit-test-helper';
+import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
 import { DeviceListComponent } from './device-list.component';
 
@@ -9,13 +9,11 @@ describe('DeviceListComponent', () => {
   let component: DeviceListComponent;
   let fixture: ComponentFixture<DeviceListComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [DeviceListComponent],
-      imports: [SharedModule, HttpClientTestingModule],
-      providers: [i18nProviders]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [DeviceListComponent],
+    imports: [SharedModule, HttpClientTestingModule],
+    providers: [i18nProviders]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DeviceListComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/blank-layout/blank-layout.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/blank-layout/blank-layout.component.spec.ts
@@ -1,18 +1,17 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { BlankLayoutComponent } from './blank-layout.component';
 
 describe('DefaultLayoutComponent', () => {
   let component: BlankLayoutComponent;
   let fixture: ComponentFixture<BlankLayoutComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [BlankLayoutComponent],
-      imports: [RouterTestingModule]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [BlankLayoutComponent],
+    imports: [RouterTestingModule]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(BlankLayoutComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/login-layout/login-layout.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/login-layout/login-layout.component.spec.ts
@@ -1,8 +1,9 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
 import { LoginLayoutComponent } from './login-layout.component';
 
@@ -10,12 +11,10 @@ describe('LoginLayoutComponent', () => {
   let component: LoginLayoutComponent;
   let fixture: ComponentFixture<LoginLayoutComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [LoginLayoutComponent],
-      imports: [BrowserAnimationsModule, HttpClientTestingModule, RouterTestingModule, SharedModule]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [LoginLayoutComponent],
+    imports: [BrowserAnimationsModule, HttpClientTestingModule, RouterTestingModule, SharedModule]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LoginLayoutComponent);

--- a/src/pybind/mgr/dashboard/frontend/tslint.json
+++ b/src/pybind/mgr/dashboard/frontend/tslint.json
@@ -12,7 +12,7 @@
     },
     "eofline": true,
     "forin": true,
-    "import-blacklist": [true, "rxjs/Rx"],
+    "import-blacklist": [true, "rxjs/Rx", {"@angular/core/testing": ["async"]}],
     "import-spacing": true,
     "indent": [true, "spaces"],
     "interface-over-type-literal": true,


### PR DESCRIPTION
We no longer need this and it was causing unexpected results in some tests.

Fixes: https://tracker.ceph.com/issues/46500

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
