### PR TITLE
nautilus: mgr/DaemonServer.cc: make 'config show' on fsid work

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1835,6 +1835,12 @@ bool DaemonServer::_handle_command(
     std::lock_guard l(daemon->lock);
 
     if (cmd_getval(g_ceph_context, cmdctx->cmdmap, "key", name)) {
+      // handle special options
+      if (name == "fsid") {
+       cmdctx->odata.append(stringify(monc->get_fsid()) + "\n");
+       cmdctx->reply(r, ss);
+       return true;
+      }
       auto p = daemon->config.find(name);
       if (p != daemon->config.end() &&
 	  !p->second.empty()) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46184

---

backport of https://github.com/ceph/ceph/pull/35662
parent tracker: https://tracker.ceph.com/issues/46123

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh