### PR TITLE
octopus: mgr/progress: Skip pg_summary update if _events dict is empty.

### DIFF
--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -533,6 +533,10 @@ class Module(MgrModule):
             ))
             self._osdmap_changed(old_osdmap, self._latest_osdmap)
         elif notify_type == "pg_summary":
+            # if there are no events we will skip this here to avoid 
+            # expensive get calls
+            if len(self._events) == 0:
+                return
             data = self.get("pg_stats")
             ready = self.get("pg_ready")
             for ev_id in list(self._events):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46514

---

backport of https://github.com/ceph/ceph/pull/35973
parent tracker: https://tracker.ceph.com/issues/46416

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh