### PR TITLE
librbd: fix parent cache initialization failures

### DIFF
--- a/src/librbd/asio/ContextWQ.cc
+++ b/src/librbd/asio/ContextWQ.cc
@@ -4,8 +4,6 @@
 #include "librbd/asio/ContextWQ.h"
 #include "include/Context.h"
 #include "common/Cond.h"
-#include <boost/asio/bind_executor.hpp>
-#include <boost/asio/post.hpp>
 
 namespace librbd {
 namespace asio {
@@ -29,23 +27,7 @@ void ContextWQ::drain_handler(Context* ctx) {
 
   // new items might be queued while we are trying to drain, so we
   // might need to post the handler multiple times
-  boost::asio::post(m_io_context, boost::asio::bind_executor(
-    m_strand, [this, ctx]() { drain_handler(ctx); }));
-}
-
-void ContextWQ::queue(Context *ctx, int r) {
-  ++m_queued_ops;
-
-  // ensure all legacy ContextWQ users are dispatched sequentially for backwards
-  // compatibility (i.e. might not be concurrent thread-safe)
-  boost::asio::post(m_io_context, boost::asio::bind_executor(
-    m_strand,
-    [this, ctx, r]() {
-      ctx->complete(r);
-
-      ceph_assert(m_queued_ops > 0);
-      --m_queued_ops;
-    }));
+  boost::asio::post(m_strand, [this, ctx]() { drain_handler(ctx); });
 }
 
 } // namespace asio

--- a/src/librbd/asio/ContextWQ.h
+++ b/src/librbd/asio/ContextWQ.h
@@ -4,11 +4,11 @@
 #ifndef CEPH_LIBRBD_ASIO_CONTEXT_WQ_H
 #define CEPH_LIBRBD_ASIO_CONTEXT_WQ_H
 
+#include "include/Context.h"
 #include <atomic>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/io_context_strand.hpp>
-
-struct Context;
+#include <boost/asio/post.hpp>
 
 namespace librbd {
 namespace asio {
@@ -18,7 +18,19 @@ public:
   explicit ContextWQ(boost::asio::io_context& io_context);
 
   void drain();
-  void queue(Context *ctx, int r = 0);
+
+  void queue(Context *ctx, int r = 0) {
+    ++m_queued_ops;
+
+    // ensure all legacy ContextWQ users are dispatched sequentially for
+    // backwards compatibility (i.e. might not be concurrent thread-safe)
+    boost::asio::post(m_strand, [this, ctx, r]() {
+      ctx->complete(r);
+
+      ceph_assert(m_queued_ops > 0);
+      --m_queued_ops;
+    });
+  }
 
 private:
   boost::asio::io_context& m_io_context;

--- a/src/librbd/cache/ParentCacheObjectDispatch.h
+++ b/src/librbd/cache/ParentCacheObjectDispatch.h
@@ -5,8 +5,9 @@
 #define CEPH_LIBRBD_CACHE_PARENT_CACHER_OBJECT_DISPATCH_H
 
 #include "librbd/io/ObjectDispatchInterface.h"
-#include "tools/immutable_object_cache/CacheClient.h"
+#include "common/ceph_mutex.h"
 #include "librbd/cache/TypeTraits.h"
+#include "tools/immutable_object_cache/CacheClient.h"
 #include "tools/immutable_object_cache/Types.h"
 
 namespace librbd {
@@ -104,10 +105,6 @@ public:
       uint64_t journal_tid, uint64_t new_journal_tid) {
   }
 
-  bool get_state() {
-    return m_initialized;
-  }
-
   ImageCtxT* get_image_ctx() {
     return m_image_ctx;
   }
@@ -127,12 +124,13 @@ private:
          io::DispatchResult* dispatch_result,
          Context* on_dispatched);
   int handle_register_client(bool reg);
-  int create_cache_session(Context* on_finish, bool is_reconnect);
+  void create_cache_session(Context* on_finish, bool is_reconnect);
 
   ImageCtxT* m_image_ctx;
-  CacheClient *m_cache_client;
-  bool m_initialized;
-  std::atomic<bool> m_connecting;
+
+  ceph::mutex m_lock;
+  CacheClient *m_cache_client = nullptr;
+  bool m_connecting = false;
 };
 
 } // namespace cache

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -51,7 +51,7 @@ set(unittest_librbd_srcs
   test_mock_TrashWatcher.cc
   test_mock_Watcher.cc
   cache/test_mock_WriteAroundObjectDispatch.cc
-  cache/test_mock_ParentImageCache.cc
+  cache/test_mock_ParentCacheObjectDispatch.cc
   deep_copy/test_mock_ImageCopyRequest.cc
   deep_copy/test_mock_MetadataCopyRequest.cc
   deep_copy/test_mock_ObjectCopyRequest.cc

--- a/src/test/librbd/cache/test_mock_ParentCacheObjectDispatch.cc
+++ b/src/test/librbd/cache/test_mock_ParentCacheObjectDispatch.cc
@@ -54,7 +54,7 @@ using ::testing::Return;
 using ::testing::WithArg;
 using ::testing::WithArgs;
 
-class TestMockParentImageCache : public TestMockFixture {
+class TestMockParentCacheObjectDispatch : public TestMockFixture {
 public :
   typedef cache::ParentCacheObjectDispatch<librbd::MockParentImageCacheImageCtx> MockParentImageCache;
 
@@ -142,7 +142,7 @@ public :
   }
 };
 
-TEST_F(TestMockParentImageCache, test_initialization_success) {
+TEST_F(TestMockParentCacheObjectDispatch, test_initialization_success) {
   librbd::ImageCtx* ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   MockParentImageCacheImageCtx mock_image_ctx(*ictx);
@@ -161,7 +161,6 @@ TEST_F(TestMockParentImageCache, test_initialization_success) {
     ASSERT_EQ(reg, true);
   });
   expect_cache_register(*mock_parent_image_cache, ctx, 0);
-  expect_cache_session_state(*mock_parent_image_cache, true);
   expect_io_object_dispatcher_register_state(*mock_parent_image_cache, 0);
   expect_cache_close(*mock_parent_image_cache, 0);
   expect_cache_stop(*mock_parent_image_cache, 0);
@@ -171,7 +170,6 @@ TEST_F(TestMockParentImageCache, test_initialization_success) {
 
   ASSERT_EQ(mock_parent_image_cache->get_dispatch_layer(),
             io::OBJECT_DISPATCH_LAYER_PARENT_CACHE);
-  ASSERT_EQ(mock_parent_image_cache->get_state(), true);
   expect_cache_session_state(*mock_parent_image_cache, true);
   ASSERT_EQ(mock_parent_image_cache->get_cache_client()->is_session_work(), true);
 
@@ -181,7 +179,7 @@ TEST_F(TestMockParentImageCache, test_initialization_success) {
   delete mock_parent_image_cache;
 }
 
-TEST_F(TestMockParentImageCache, test_initialization_fail_at_connect) {
+TEST_F(TestMockParentCacheObjectDispatch, test_initialization_fail_at_connect) {
   librbd::ImageCtx* ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   MockParentImageCacheImageCtx mock_image_ctx(*ictx);
@@ -206,7 +204,6 @@ TEST_F(TestMockParentImageCache, test_initialization_fail_at_connect) {
   // initialization fails.
   ASSERT_EQ(mock_parent_image_cache->get_dispatch_layer(),
             io::OBJECT_DISPATCH_LAYER_PARENT_CACHE);
-  ASSERT_EQ(mock_parent_image_cache->get_state(), true);
   ASSERT_EQ(mock_parent_image_cache->get_cache_client()->is_session_work(), false);
 
   mock_parent_image_cache->get_cache_client()->close();
@@ -216,7 +213,7 @@ TEST_F(TestMockParentImageCache, test_initialization_fail_at_connect) {
 
 }
 
-TEST_F(TestMockParentImageCache, test_initialization_fail_at_register) {
+TEST_F(TestMockParentCacheObjectDispatch, test_initialization_fail_at_register) {
   librbd::ImageCtx* ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   MockParentImageCacheImageCtx mock_image_ctx(*ictx);
@@ -235,7 +232,6 @@ TEST_F(TestMockParentImageCache, test_initialization_fail_at_register) {
     ASSERT_EQ(reg, false);
   });
   expect_cache_register(*mock_parent_image_cache, ctx, -1);
-  expect_cache_session_state(*mock_parent_image_cache, true);
   expect_io_object_dispatcher_register_state(*mock_parent_image_cache, 0);
   expect_cache_close(*mock_parent_image_cache, 0);
   expect_cache_stop(*mock_parent_image_cache, 0);
@@ -245,7 +241,6 @@ TEST_F(TestMockParentImageCache, test_initialization_fail_at_register) {
 
   ASSERT_EQ(mock_parent_image_cache->get_dispatch_layer(),
             io::OBJECT_DISPATCH_LAYER_PARENT_CACHE);
-  ASSERT_EQ(mock_parent_image_cache->get_state(), true);
   expect_cache_session_state(*mock_parent_image_cache, true);
   ASSERT_EQ(mock_parent_image_cache->get_cache_client()->is_session_work(), true);
 
@@ -255,7 +250,7 @@ TEST_F(TestMockParentImageCache, test_initialization_fail_at_register) {
   delete mock_parent_image_cache;
 }
 
-TEST_F(TestMockParentImageCache, test_disble_interface) {
+TEST_F(TestMockParentCacheObjectDispatch, test_disble_interface) {
   librbd::ImageCtx* ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   MockParentImageCacheImageCtx mock_image_ctx(*ictx);
@@ -295,7 +290,7 @@ TEST_F(TestMockParentImageCache, test_disble_interface) {
 
 }
 
-TEST_F(TestMockParentImageCache, test_read) {
+TEST_F(TestMockParentCacheObjectDispatch, test_read) {
   librbd::ImageCtx* ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   MockParentImageCacheImageCtx mock_image_ctx(*ictx);
@@ -314,7 +309,6 @@ TEST_F(TestMockParentImageCache, test_read) {
     ASSERT_EQ(reg, true);
   });
   expect_cache_register(*mock_parent_image_cache, ctx, 0);
-  expect_cache_session_state(*mock_parent_image_cache, true);
   expect_io_object_dispatcher_register_state(*mock_parent_image_cache, 0);
   expect_cache_close(*mock_parent_image_cache, 0);
   expect_cache_stop(*mock_parent_image_cache, 0);
@@ -324,7 +318,6 @@ TEST_F(TestMockParentImageCache, test_read) {
 
   ASSERT_EQ(mock_parent_image_cache->get_dispatch_layer(),
             io::OBJECT_DISPATCH_LAYER_PARENT_CACHE);
-  ASSERT_EQ(mock_parent_image_cache->get_state(), true);
   expect_cache_session_state(*mock_parent_image_cache, true);
   ASSERT_EQ(mock_parent_image_cache->get_cache_client()->is_session_work(), true);
 
@@ -332,7 +325,7 @@ TEST_F(TestMockParentImageCache, test_read) {
   Context* on_finish = &cond;
 
   auto& expect = EXPECT_CALL(*(mock_parent_image_cache->get_cache_client()), is_session_work());
-  expect.WillOnce(Return(true)).WillOnce(Return(true));
+  expect.WillOnce(Return(true));
 
   expect_cache_lookup_object(*mock_parent_image_cache, on_finish);
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
