### PR TITLE
octopus:  rgw: lc: fix Segmentation Fault when the tag of the object was not found

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -841,6 +841,8 @@ static inline bool has_all_tags(const lc_op& rule_action,
   for (const auto& tag : object_tags.get_tags()) {
     const auto& rule_tags = rule_action.obj_tags->get_tags();
     const auto& iter = rule_tags.find(tag.first);
+    if(iter == rule_tags.end())
+        continue;
     if(iter->second == tag.second)
     {
       tag_count++;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46511

---

backport of https://github.com/ceph/ceph/pull/36055
parent tracker: https://tracker.ceph.com/issues/46485

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh