### PR TITLE
mds: reduce memory usage of open file table prefetch

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1037,6 +1037,8 @@ void Client::update_dentry_lease(Dentry *dn, LeaseStat *dlease, utime_t from, Me
     }
   }
   dn->cap_shared_gen = dn->dir->parent_inode->shared_gen;
+  if (dlease->mask & CEPH_LEASE_PRIMARY_LINK)
+    dn->mark_primary();
 }
 
 
@@ -2825,7 +2827,7 @@ void Client::send_reconnect(MetaSession *session)
 	       << " wants " << ccap_string(in->caps_wanted())
 	       << dendl;
       filepath path;
-      in->make_long_path(path);
+      in->make_short_path(path);
       ldout(cct, 10) << "    path " << path << dendl;
 
       bufferlist flockbl;

--- a/src/client/Dentry.h
+++ b/src/client/Dentry.h
@@ -64,6 +64,10 @@ public:
     inode.reset();
     dir->num_null_dentries++;
   }
+  void mark_primary() {
+    if (inode && inode->dentries.front() != this)
+      inode->dentries.push_front(&inode_xlist_link);
+  }
   void detach(void) {
     ceph_assert(!inode);
     auto p = dir->dentries.find(name);

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -95,9 +95,19 @@ void Inode::make_long_path(filepath& p)
     dn->dir->parent_inode->make_long_path(p);
     p.push_dentry(dn->name);
   } else if (snapdir_parent) {
-    snapdir_parent->make_nosnap_relative_path(p);
-    string empty;
-    p.push_dentry(empty);
+    make_nosnap_relative_path(p);
+  } else
+    p = filepath(ino);
+}
+
+void Inode::make_short_path(filepath& p)
+{
+  if (!dentries.empty()) {
+    Dentry *dn = get_first_parent();
+    ceph_assert(dn->dir && dn->dir->parent_inode);
+    p = filepath(dn->name, dn->dir->parent_inode->ino);
+  } else if (snapdir_parent) {
+    make_nosnap_relative_path(p);
   } else
     p = filepath(ino);
 }

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -238,6 +238,7 @@ struct Inode {
   }
 
   void make_long_path(filepath& p);
+  void make_short_path(filepath& p);
   void make_nosnap_relative_path(filepath& p);
 
   void get();

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8144,6 +8144,11 @@ std::vector<Option> get_mds_options() {
     .set_default(10.0)
     .set_description("rate of decay for export targets communicated to clients"),
 
+    Option("mds_oft_prefetch_dirfrags", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description("prefetch dirfrags recorded in open file table on startup")
+    .set_flag(Option::FLAG_STARTUP),
+
     Option("mds_replay_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(1.0)
     .set_description("time in seconds between replay of updates to journal by standby replay MDS"),

--- a/src/mds/Anchor.cc
+++ b/src/mds/Anchor.cc
@@ -18,21 +18,24 @@
 
 void Anchor::encode(bufferlist &bl) const
 {
-  ENCODE_START(1, 1, bl);
+  ENCODE_START(2, 1, bl);
   encode(ino, bl);
   encode(dirino, bl);
   encode(d_name, bl);
   encode(d_type, bl);
+  encode(frags, bl);
   ENCODE_FINISH(bl);
 }
 
 void Anchor::decode(bufferlist::const_iterator &bl)
 {
-  DECODE_START(1, bl);
+  DECODE_START(2, bl);
   decode(ino, bl);
   decode(dirino, bl);
   decode(d_name, bl);
   decode(d_type, bl);
+  if (struct_v >= 2)
+    decode(frags, bl);
   DECODE_FINISH(bl);
 }
 

--- a/src/mds/Anchor.h
+++ b/src/mds/Anchor.h
@@ -36,15 +36,17 @@ public:
   void decode(bufferlist::const_iterator &bl);
   void dump(Formatter *f) const;
   static void generate_test_instances(std::list<Anchor*>& ls);
-  bool operator==(const Anchor &r) {
+  bool operator==(const Anchor &r) const {
     return ino == r.ino && dirino == r.dirino &&
-    d_name == r.d_name && d_type == r.d_type;
+	   d_name == r.d_name && d_type == r.d_type &&
+	   frags == r.frags;
   }
 
   inodeno_t ino;	// anchored ino
   inodeno_t dirino;
   std::string d_name;
   __u8 d_type = 0;
+  std::set<frag_t> frags;
 
   int omap_idx = -1;	// stored in which omap object
 };

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3344,9 +3344,9 @@ void CInode::set_mds_caps_wanted(mempool::mds_co::compact_map<int32_t,int32_t>& 
   mds_caps_wanted.swap(m);
   if (old_empty != (bool)mds_caps_wanted.empty()) {
     if (old_empty)
-      adjust_num_caps_wanted(1);
+      adjust_num_caps_notable(1);
     else
-      adjust_num_caps_wanted(-1);
+      adjust_num_caps_notable(-1);
   }
 }
 
@@ -3356,23 +3356,23 @@ void CInode::set_mds_caps_wanted(mds_rank_t mds, int32_t wanted)
   if (wanted) {
     mds_caps_wanted[mds] = wanted;
     if (old_empty)
-      adjust_num_caps_wanted(1);
+      adjust_num_caps_notable(1);
   } else if (!old_empty) {
     mds_caps_wanted.erase(mds);
     if (mds_caps_wanted.empty())
-      adjust_num_caps_wanted(-1);
+      adjust_num_caps_notable(-1);
   }
 }
 
-void CInode::adjust_num_caps_wanted(int d)
+void CInode::adjust_num_caps_notable(int d)
 {
-  if (!num_caps_wanted && d > 0)
+  if (!num_caps_notable && d > 0)
     mdcache->open_file_table.add_inode(this);
-  else if (num_caps_wanted > 0 && num_caps_wanted == -d)
+  else if (num_caps_notable > 0 && num_caps_notable == -d)
     mdcache->open_file_table.remove_inode(this);
 
-  num_caps_wanted +=d;
-  ceph_assert(num_caps_wanted >= 0);
+  num_caps_notable +=d;
+  ceph_assert(num_caps_notable >= 0);
 }
 
 Capability *CInode::add_client_cap(client_t client, Session *session,
@@ -3419,8 +3419,8 @@ void CInode::remove_client_cap(client_t client)
   if (client == loner_cap)
     loner_cap = -1;
 
-  if (cap->wanted())
-    adjust_num_caps_wanted(-1);
+  if (cap->is_wanted_notable())
+    adjust_num_caps_notable(-1);
 
   client_caps.erase(it);
   if (client_caps.empty()) {

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -400,7 +400,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     close_snaprealm();
     clear_file_locks();
     ceph_assert(num_projected_srnodes == 0);
-    ceph_assert(num_caps_wanted == 0);
+    ceph_assert(num_caps_notable == 0);
     ceph_assert(num_subtree_roots == 0);
     ceph_assert(num_exporting_dirs == 0);
     ceph_assert(batch_ops.empty());
@@ -904,8 +904,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     }
   }
 
-  int get_num_caps_wanted() const { return num_caps_wanted; }
-  void adjust_num_caps_wanted(int d);
+  int get_num_caps_notable() const { return num_caps_notable; }
+  void adjust_num_caps_notable(int d);
 
   Capability *add_client_cap(client_t client, Session *session,
 			     SnapRealm *conrealm=nullptr, bool new_inode=false);
@@ -1207,7 +1207,7 @@ protected:
   mempool_cap_map client_caps; // client -> caps
   mempool::mds_co::compact_map<int32_t, int32_t> mds_caps_wanted;     // [auth] mds -> caps wanted
   int replica_caps_wanted = 0; // [replica] what i've requested from auth
-  int num_caps_wanted = 0;
+  int num_caps_notable = 0;
 
   ceph_lock_state_t *fcntl_locks = nullptr;
   ceph_lock_state_t *flock_locks = nullptr;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -358,6 +358,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static const int STATE_DELAYEDEXPORTPIN	= (1<<19);
   static const int STATE_DISTEPHEMERALPIN       = (1<<20);
   static const int STATE_RANDEPHEMERALPIN       = (1<<21);
+  static const int STATE_CLIENTWRITEABLE	= (1<<22);
+
   // orphan inode needs notification of releasing reference
   static const int STATE_ORPHAN =	STATE_NOTIFYREF;
 
@@ -931,6 +933,11 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   bool is_any_caps_wanted() const;
   int get_caps_wanted(int *ploner = 0, int *pother = 0, int shift = 0, int mask = -1) const;
   bool issued_caps_need_gather(SimpleLock *lock);
+
+  // client writeable
+  bool is_clientwriteable() const { return state & STATE_CLIENTWRITEABLE; }
+  void mark_clientwriteable();
+  void clear_clientwriteable();
 
   // -- authority --
   mds_authority_t authority() const override;

--- a/src/mds/Capability.cc
+++ b/src/mds/Capability.cc
@@ -212,15 +212,12 @@ void Capability::maybe_clear_notable()
 void Capability::set_wanted(int w) {
   CInode *in = get_inode();
   if (in) {
-    if (!_wanted && w) {
-      in->adjust_num_caps_wanted(1);
-    } else if (_wanted && !w) {
-      in->adjust_num_caps_wanted(-1);
-    }
     if (!is_wanted_notable(_wanted) && is_wanted_notable(w)) {
+      in->adjust_num_caps_notable(1);
       if (!is_notable())
 	mark_notable();
     } else if (is_wanted_notable(_wanted) && !is_wanted_notable(w)) {
+      in->adjust_num_caps_notable(-1);
       maybe_clear_notable();
     }
   }

--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -253,6 +253,9 @@ public:
   static bool is_wanted_notable(int wanted) {
     return wanted & (CEPH_CAP_ANY_WR|CEPH_CAP_FILE_WR|CEPH_CAP_FILE_RD);
   }
+  bool is_wanted_notable() const {
+    return is_wanted_notable(wanted());
+  }
   bool is_notable() const { return state & STATE_NOTABLE; }
 
   bool is_stale() const;

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -5416,6 +5416,9 @@ void Locker::file_eval(ScatterLock *lock, bool *need_issue)
 	    << " on " << *lock->get_parent() << dendl;
     simple_sync(lock, need_issue);
   }
+  else if (in->state_test(CInode::STATE_NEEDSRECOVER)) {
+    mds->mdcache->queue_file_recover(in);
+  }
 }
 
 

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2686,9 +2686,7 @@ uint64_t Locker::calc_new_max_size(const CInode::inode_const_ptr &pi, uint64_t s
   return round_up_to(new_max, pi->get_layout_size_increment());
 }
 
-void Locker::calc_new_client_ranges(CInode *in, uint64_t size, bool update,
-				    CInode::mempool_inode::client_range_map *new_ranges,
-				    bool *max_increased)
+bool Locker::check_client_ranges(CInode *in, uint64_t size)
 {
   const auto& latest = in->get_projected_inode();
   uint64_t ms;
@@ -2699,31 +2697,73 @@ void Locker::calc_new_client_ranges(CInode *in, uint64_t size, bool update,
     ms = 0;
   }
 
-  // increase ranges as appropriate.
-  // shrink to 0 if no WR|BUFFER caps issued.
+  auto it = latest->client_ranges.begin();
   for (auto &p : in->client_caps) {
     if ((p.second.issued() | p.second.wanted()) & CEPH_CAP_ANY_FILE_WR) {
-      client_writeable_range_t& nr = (*new_ranges)[p.first];
-      nr.range.first = 0;
-      auto it = latest->client_ranges.find(p.first);
-      if (it != latest->client_ranges.end()) {
-	const client_writeable_range_t& oldr = it->second;
-	if (ms > oldr.range.last)
-	  *max_increased = true;
-	nr.range.last = std::max(ms, oldr.range.last);
-	nr.follows = oldr.follows;
-      } else {
-	*max_increased = true;
-	nr.range.last = ms;
-	nr.follows = in->first - 1;
-      }
-      if (update)
-	p.second.mark_clientwriteable();
-    } else {
-      if (update)
-	p.second.clear_clientwriteable();
+      if (it == latest->client_ranges.end())
+	return true;
+      if (it->first != p.first)
+	return true;
+      if (ms > it->second.range.last)
+	return true;
+      ++it;
     }
   }
+  return it != latest->client_ranges.end();
+}
+
+bool Locker::calc_new_client_ranges(CInode *in, uint64_t size, bool *max_increased)
+{
+  const auto& latest = in->get_projected_inode();
+  uint64_t ms;
+  if (latest->has_layout()) {
+    ms = calc_new_max_size(latest, size);
+  } else {
+    // Layout-less directories like ~mds0/, have zero size
+    ms = 0;
+  }
+
+  auto pi = in->_get_projected_inode();
+  bool updated = false;
+
+  // increase ranges as appropriate.
+  // shrink to 0 if no WR|BUFFER caps issued.
+  auto it = pi->client_ranges.begin();
+  for (auto &p : in->client_caps) {
+    if ((p.second.issued() | p.second.wanted()) & CEPH_CAP_ANY_FILE_WR) {
+      while (it != pi->client_ranges.end() && it->first < p.first) {
+	it = pi->client_ranges.erase(it);
+	updated = true;
+      }
+
+      if (it != pi->client_ranges.end() && it->first == p.first) {
+	if (ms > it->second.range.last) {
+	  it->second.range.last = ms;
+	  updated = true;
+	  if (max_increased)
+	    *max_increased = true;
+	}
+      } else {
+	it = pi->client_ranges.emplace_hint(it, std::piecewise_construct,
+					    std::forward_as_tuple(p.first),
+					    std::forward_as_tuple());
+	it->second.range.last = ms;
+	it->second.follows = in->first - 1;
+	updated = true;
+	if (max_increased)
+	  *max_increased = true;
+      }
+      p.second.mark_clientwriteable();
+      ++it;
+    } else {
+      p.second.clear_clientwriteable();
+    }
+  }
+  while (it != pi->client_ranges.end()) {
+    it = pi->client_ranges.erase(it);
+    updated = true;
+  }
+  return updated;
 }
 
 bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
@@ -2734,11 +2774,8 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
   ceph_assert(in->is_file());
 
   const auto& latest = in->get_projected_inode();
-  CInode::mempool_inode::client_range_map new_ranges;
   uint64_t size = latest->size;
   bool update_size = new_size > 0;
-  bool update_max = false;
-  bool max_increased = false;
 
   if (update_size) {
     new_size = size = std::max(size, new_size);
@@ -2747,28 +2784,8 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
       update_size = false;
   }
 
-  int can_update = 1;
-  if (in->is_frozen()) {
-    can_update = -1;
-  } else if (!force_wrlock && !in->filelock.can_wrlock(in->get_loner())) {
-    // lock?
-    if (in->filelock.is_stable()) {
-      if (in->get_target_loner() >= 0)
-	file_excl(&in->filelock);
-      else
-	simple_lock(&in->filelock);
-    }
-    if (!in->filelock.can_wrlock(in->get_loner()))
-      can_update = -2;
-  }
-
-  calc_new_client_ranges(in, std::max(new_max_size, size), can_update > 0,
-			 &new_ranges, &max_increased);
-
-  if (max_increased || latest->client_ranges != new_ranges)
-    update_max = true;
-
-  if (!update_size && !update_max) {
+  bool new_ranges = check_client_ranges(in, std::max(new_max_size, size));
+  if (!update_size && !new_ranges) {
     dout(20) << "check_inode_max_size no-op on " << *in << dendl;
     return false;
   }
@@ -2777,16 +2794,25 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
 	   << " update_size " << update_size
 	   << " on " << *in << dendl;
 
-  if (can_update < 0) {
-    auto cms = new C_MDL_CheckMaxSize(this, in, new_max_size, new_size, new_mtime);
-    if (can_update == -1) {
-      dout(10) << "check_inode_max_size frozen, waiting on " << *in << dendl;
-      in->add_waiter(CInode::WAIT_UNFREEZE, cms);
-    } else {
-      in->filelock.add_waiter(SimpleLock::WAIT_STABLE, cms);
-      dout(10) << "check_inode_max_size can't wrlock, waiting on " << *in << dendl;
-    }
+  if (in->is_frozen()) {
+    dout(10) << "check_inode_max_size frozen, waiting on " << *in << dendl;
+    in->add_waiter(CInode::WAIT_UNFREEZE,
+		   new C_MDL_CheckMaxSize(this, in, new_max_size, new_size, new_mtime));
     return false;
+  } else if (!force_wrlock && !in->filelock.can_wrlock(in->get_loner())) {
+    // lock?
+    if (in->filelock.is_stable()) {
+      if (in->get_target_loner() >= 0)
+	file_excl(&in->filelock);
+      else
+	simple_lock(&in->filelock);
+    }
+    if (!in->filelock.can_wrlock(in->get_loner())) {
+      dout(10) << "check_inode_max_size can't wrlock, waiting on " << *in << dendl;
+      in->filelock.add_waiter(SimpleLock::WAIT_STABLE,
+			      new C_MDL_CheckMaxSize(this, in, new_max_size, new_size, new_mtime));
+      return false;
+    }
   }
 
   MutationRef mut(new MutationImpl());
@@ -2795,9 +2821,12 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
   auto pi = in->project_inode(mut);
   pi.inode->version = in->pre_dirty();
 
-  if (update_max) {
-    dout(10) << "check_inode_max_size client_ranges " << pi.inode->client_ranges << " -> " << new_ranges << dendl;
-    pi.inode->client_ranges = new_ranges;
+  bool max_increased = false;
+  if (new_ranges &&
+      calc_new_client_ranges(in, std::max(new_max_size, size), &max_increased)) {
+    dout(10) << "check_inode_max_size client_ranges "
+	     << in->get_previous_projected_inode()->client_ranges
+	     <<  " -> " << pi.inode->client_ranges << dendl;
   }
 
   if (update_size) {

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -174,9 +174,9 @@ public:
 
   void request_inode_file_caps(CInode *in);
 
-  void calc_new_client_ranges(CInode *in, uint64_t size, bool update,
-			      CInode::mempool_inode::client_range_map* new_ranges,
-			      bool *max_increased);
+  bool check_client_ranges(CInode *in, uint64_t size);
+  bool calc_new_client_ranges(CInode *in, uint64_t size,
+			      bool *max_increased=nullptr);
   bool check_inode_max_size(CInode *in, bool force_wrlock=false,
                             uint64_t newmax=0, uint64_t newsize=0,
 			    utime_t mtime=utime_t());

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -834,7 +834,9 @@ class MDCache {
 
   void kick_open_ino_peers(mds_rank_t who);
   void open_ino(inodeno_t ino, int64_t pool, MDSContext *fin,
-		bool want_replica=true, bool want_xlocked=false);
+		bool want_replica=true, bool want_xlocked=false,
+		vector<inode_backpointer_t> *ancestors_hint=nullptr,
+		mds_rank_t auth_hint=MDS_RANK_NONE);
 
   void find_ino_peers(inodeno_t ino, MDSContext *c,
 		      mds_rank_t hint=MDS_RANK_NONE, bool path_locked=false);

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -1726,6 +1726,8 @@ void Migrator::finish_export_inode(CInode *in, mds_rank_t peer,
 
   in->clear_dirty_parent();
 
+  in->clear_clientwriteable();
+
   in->clear_file_locks();
 
   // waiters
@@ -2868,6 +2870,7 @@ void Migrator::import_reverse(CDir *dir)
 
 	in->clear_dirty_parent();
 
+	in->clear_clientwriteable();
 	in->state_clear(CInode::STATE_NEEDSRECOVER);
 
 	in->authlock.clear_gather();
@@ -3228,6 +3231,9 @@ void Migrator::decode_import_inode(CDentry *dn, bufferlist::const_iterator& blp,
 
   if (in->get_inode()->is_dirty_rstat())
     in->mark_dirty_rstat();
+
+  if (!in->get_inode()->client_ranges.empty())
+    in->mark_clientwriteable();
   
   // clear if dirtyscattered, since we're going to journal this
   //  but not until we _actually_ finish the import...

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -2868,6 +2868,8 @@ void Migrator::import_reverse(CDir *dir)
 
 	in->clear_dirty_parent();
 
+	in->state_clear(CInode::STATE_NEEDSRECOVER);
+
 	in->authlock.clear_gather();
 	in->linklock.clear_gather();
 	in->dirfragtreelock.clear_gather();
@@ -2906,6 +2908,8 @@ void Migrator::import_reverse(CDir *dir)
 	}
 	if (cap->is_importing())
 	  in->remove_client_cap(q->first);
+	else
+	  cap->clear_clientwriteable();
       }
       in->put(CInode::PIN_IMPORTINGCAPS);
     }
@@ -3278,6 +3282,10 @@ void Migrator::finish_import_inode_caps(CInode *in, mds_rank_t peer, bool auth_c
 					const map<client_t,Capability::Export> &export_map,
 					map<client_t,Capability::Import> &import_map)
 {
+  const auto& client_ranges = in->get_projected_inode()->client_ranges;
+  auto r = client_ranges.cbegin();
+  bool needs_recover = false;
+
   for (auto& it : export_map) {
     dout(10) << "for client." << it.first << " on " << *in << dendl;
 
@@ -3297,6 +3305,17 @@ void Migrator::finish_import_inode_caps(CInode *in, mds_rank_t peer, bool auth_c
 	cap->mark_importing();
     }
 
+    if (auth_cap) {
+      while (r != client_ranges.cend() && r->first < it.first) {
+	needs_recover = true;
+	++r;
+      }
+      if (r != client_ranges.cend() && r->first == it.first) {
+	cap->mark_clientwriteable();
+	++r;
+      }
+    }
+
     // Always ask exporter mds to send cap export messages for auth caps.
     // For non-auth caps, ask exporter mds to send cap export messages to
     // clients who haven't opened sessions. The cap export messages will
@@ -3314,6 +3333,13 @@ void Migrator::finish_import_inode_caps(CInode *in, mds_rank_t peer, bool auth_c
 				  it.second.seq, it.second.mseq - 1, peer,
 				  auth_cap ? CEPH_CAP_FLAG_AUTH : CEPH_CAP_FLAG_RELEASE);
     }
+  }
+
+  if (auth_cap) {
+    if (r != client_ranges.cend())
+      needs_recover = true;
+    if (needs_recover)
+      in->state_set(CInode::STATE_NEEDSRECOVER);
   }
 
   if (peer >= 0) {

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -1028,8 +1028,13 @@ void OpenFileTable::_open_ino_finish(inodeno_t ino, int r)
   num_opening_inodes--;
   if (num_opening_inodes == 0) {
     if (prefetch_state == DIR_INODES)  {
-      prefetch_state = DIRFRAGS;
-      _prefetch_dirfrags();
+      if (g_conf().get_val<bool>("mds_oft_prefetch_dirfrags")) {
+	prefetch_state = DIRFRAGS;
+	_prefetch_dirfrags();
+      } else {
+	prefetch_state = FILE_INODES;
+	_prefetch_inodes();
+      }
     } else if (prefetch_state == FILE_INODES) {
       prefetch_state = DONE;
       logseg_destroyed_inos.clear();

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -84,8 +84,8 @@ protected:
   void _journal_finish(int r, uint64_t log_seq, MDSContext *fin,
 		       std::map<unsigned, std::vector<ObjectOperation> >& ops);
 
-  void get_ref(CInode *in);
-  void put_ref(CInode *in);
+  void get_ref(CInode *in, frag_t fg=-1U);
+  void put_ref(CInode *in, frag_t fg=-1U);
 
   object_t get_object_name(unsigned idx) const;
 
@@ -95,7 +95,6 @@ protected:
     journal_state = JOURNAL_NONE;
     loaded_journals.clear();
     loaded_anchor_map.clear();
-    loaded_dirfrags.clear();
   }
   void _load_finish(int op_r, int header_r, int values_r,
 		    unsigned idx, bool first, bool more,
@@ -115,7 +114,6 @@ protected:
   std::vector<unsigned> omap_num_items;
 
   map<inodeno_t, OpenedAnchor> anchor_map;
-  set<dirfrag_t> dirfrags;
 
   std::map<inodeno_t, int> dirty_items; // ino -> dirty state
 
@@ -131,7 +129,6 @@ protected:
 
   std::vector<std::map<std::string, bufferlist> > loaded_journals;
   map<inodeno_t, RecoveredAnchor> loaded_anchor_map;
-  set<dirfrag_t> loaded_dirfrags;
   MDSContext::vec waiting_for_load;
   bool load_done = false;
 

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -50,9 +50,6 @@ public:
     waiting_for_load.push_back(c);
   }
 
-  bool get_ancestors(inodeno_t ino, vector<inode_backpointer_t>& ancestors,
-		     mds_rank_t& auth_hint);
-
   bool prefetch_inodes();
   bool is_prefetched() const { return prefetch_state == DONE; }
   void wait_for_prefetch(MDSContext *c) {
@@ -105,6 +102,10 @@ protected:
   void _open_ino_finish(inodeno_t ino, int r);
   void _prefetch_inodes();
   void _prefetch_dirfrags();
+
+  void _get_ancestors(const Anchor& parent,
+		      vector<inode_backpointer_t>& ancestors,
+		      mds_rank_t& auth_hint);
 
   MDSRank *mds;
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4395,6 +4395,7 @@ void Server::handle_client_openc(MDRequestRef& mdr)
     _inode->client_ranges[client].range.first = 0;
     _inode->client_ranges[client].range.last = _inode->layout.stripe_unit;
     _inode->client_ranges[client].follows = follows;
+    newi->mark_clientwriteable();
     cap->mark_clientwriteable();
   }
   
@@ -5058,6 +5059,7 @@ void Server::do_open_truncate(MDRequestRef& mdr, int cmode)
     pi.inode->client_ranges[client].range.last = pi.inode->get_layout_size_increment();
     pi.inode->client_ranges[client].follows = realm->get_newest_seq();
     changed_ranges = true;
+    in->mark_clientwriteable();
     cap->mark_clientwriteable();
   }
   
@@ -6030,6 +6032,7 @@ void Server::handle_client_mknod(MDRequestRef& mdr)
       _inode->client_ranges[client].range.first = 0;
       _inode->client_ranges[client].range.last = _inode->layout.stripe_unit;
       _inode->client_ranges[client].follows = follows;
+      newi->mark_clientwriteable();
       cap->mark_clientwriteable();
     }
   }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4995,12 +4995,9 @@ void Server::handle_client_setattr(MDRequestRef& mdr)
     pi.inode->mtime = mdr->get_op_stamp();
 
     // adjust client's max_size?
-    CInode::mempool_inode::client_range_map new_ranges;
-    bool max_increased = false;
-    mds->locker->calc_new_client_ranges(cur, pi.inode->size, true, &new_ranges, &max_increased);
-    if (pi.inode->client_ranges != new_ranges) {
-      dout(10) << " client_ranges " << pi.inode->client_ranges << " -> " << new_ranges << dendl;
-      pi.inode->client_ranges = new_ranges;
+    if (mds->locker->calc_new_client_ranges(cur, pi.inode->size)) {
+      dout(10) << " client_ranges "  << cur->get_previous_projected_inode()->client_ranges
+	       << " -> " << pi.inode->client_ranges << dendl;
       changed_ranges = true;
     }
   }

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -188,6 +188,8 @@ void StrayManager::_purge_stray_purged(
     pi.inode->truncate_size = 0;
     pi.inode->truncate_from = 0;
     pi.inode->version = in->pre_dirty();
+    pi.inode->client_ranges.clear();
+    in->clear_clientwriteable();
 
     CDir *dir = dn->get_dir();
     auto pf = dir->project_fnode(mut);

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -494,6 +494,11 @@ struct inode_t {
 
   bool is_dirty_rstat() const { return !(rstat == accounted_rstat); }
 
+  uint64_t get_client_range(client_t client) const {
+    auto it = client_ranges.find(client);
+    return it != client_ranges.end() ? it->second.range.last : 0;
+  }
+
   uint64_t get_max_size() const {
     uint64_t max = 0;
       for (std::map<client_t,client_writeable_range_t>::const_iterator p = client_ranges.begin();


### PR DESCRIPTION
- Add an option that disables dirfrags prefetch. Dirfrags prefetch is the main cause of memory usage issue.
- Also modify client to encode inode's parent/d_name in cap_reconnect_t ,  which can eliminate the bad effect of disabling dirfrags prefetch.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
