### PR TITLE
osdc/Striper: add get_file_offset function

### DIFF
--- a/src/osdc/Striper.h
+++ b/src/osdc/Striper.h
@@ -73,6 +73,9 @@
 
     static uint64_t get_num_objects(const file_layout_t& layout,
 				    uint64_t size);
+
+    static uint64_t get_file_offset(CephContext *cct,
+            const file_layout_t *layout, uint64_t objectno, uint64_t off);
     /*
      * helper to assemble a striped result
      */

--- a/src/test/test_striper.cc
+++ b/src/test/test_striper.cc
@@ -70,3 +70,18 @@ TEST(Striper, GetNumObj)
   numobjs = Striper::get_num_objects(l, size);
   ASSERT_EQ(6u, numobjs);
 }
+
+TEST(Striper, GetFileOffset)
+{
+  file_layout_t l;
+
+  l.object_size = 262144;
+  l.stripe_unit = 4096;
+  l.stripe_count = 3;
+
+  uint64_t object_no = 100;
+  uint64_t object_off = 200000;
+  uint64_t file_offset = Striper::get_file_offset(
+          g_ceph_context, &l, object_no, object_off);
+  ASSERT_EQ(26549568u, file_offset);
+}


### PR DESCRIPTION
This change was suggested by @dillaman to tweak a different PR regarding a new librbd encryption feature:
https://github.com/ceph/ceph/pull/35947#discussion_r451896061

We are adding a new get_file_offset static method to Striper, that does a simple O(1) translation from (object_no, object_off) tuple to file_offset.
This is useful for the encryption object dispatch layer which calls an encryption mode (e.g. AES-XTS) that requires as input the sector address (== the file offset) being encrypted. Since in the object dispatch layers the translation from file offset to object extents already occurred, we need to translate back to file offset.