### PR TITLE
mgr/prometheus: Fix prometheus rbd stats

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -793,8 +793,8 @@ class Module(MgrModule):
         pools_refreshed = False
         if pools:
             next_refresh = self.rbd_stats['pools_refresh_time'] + \
-                self.get_localized_module_option(
-                'rbd_stats_pools_refresh_interval', 300)
+                float(self.get_localized_module_option(
+                'rbd_stats_pools_refresh_interval', 300))
             if rbd_stats_pools != pools or time.time() >= next_refresh:
                 self.refresh_rbd_stats_pools(pools)
                 pools_refreshed = True


### PR DESCRIPTION
The prometheus fails when it is trying to get the rbd stats when you set
the 'rbd_stats_pools_refresh_interval' as that returns a string. We need
to convert this value to float to fix this.

Signed-off-by: Boris Ranto <branto@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
