### PR TITLE
nautilus: mgr/alert: can't set inventory_cache_timeout/service_cache_timeout from CLI

### DIFF
--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -21,7 +21,7 @@ class Alerts(MgrModule):
     MODULE_OPTIONS = [
         {
             'name': 'interval',
-            'type': 'seconds',
+            'type': 'secs',
             'default': 60,
             'desc': 'How frequently to reexamine health status',
             'runtime': True,

--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -29,6 +29,7 @@ class Alerts(MgrModule):
         # smtp
         {
             'name': 'smtp_host',
+            'default': '',
             'desc': 'SMTP server',
             'runtime': True,
         },
@@ -155,6 +156,8 @@ class Alerts(MgrModule):
             if r:
                 for code, alert in r.items():
                     checks[code] = alert
+        else:
+            self.log.warn('Alert is not sent because smtp_host is not configured')
         self.set_health_checks(checks)
 
     def serve(self):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45228

84daea2cb36c426f6777bbe31615bdef3c3e3cea has been dropped since it is irrelevant for nautilus

---

backport of https://github.com/ceph/ceph/pull/32316
parent tracker: https://tracker.ceph.com/issues/43363

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh