### PR TITLE
mgr/diskprediction_local: Fix array size error

### DIFF
--- a/src/pybind/mgr/diskprediction_local/module.py
+++ b/src/pybind/mgr/diskprediction_local/module.py
@@ -218,7 +218,7 @@ class Module(MgrModule):
         else:
             self.log.error('unable to predict device due to health data records less than 6 days')
 
-        if predict_datas:
+        if len(predict_datas) >= 6:
             predicted_result = obj_predictor.predict(predict_datas)
         return predicted_result
 


### PR DESCRIPTION
The disk predictor assumes that it has at least 6 days worth of data to work
with, and the code ensures that `health_data` contains at least 6 elements.

However, it then gets fitlered down into a `predict_datas` array that can
contain less than 6 elements in some cases.

This commit ensures that `predict_datas` contains 6 elements or more before
passing it on to the disk predictor.

Fixes: https://tracker.ceph.com/issues/46549
Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
