### PR TITLE
doc/rados: remove a redundant "a" from a sentence

### DIFF
--- a/doc/rados/index.rst
+++ b/doc/rados/index.rst
@@ -33,7 +33,7 @@ on ``ceph-deploy.``
 
 	</td><td><h3>Operations</h3>
 
-Once you have a deployed a Ceph Storage Cluster, you may begin operating 
+Once you have deployed a Ceph Storage Cluster, you may begin operating 
 your cluster.
 
 .. toctree::


### PR DESCRIPTION
This commit changes the (not quite) sentence "Once
you have a deployed a Ceph Storage Cluster, you may
begin operating your cluster." to "Once you have
deployed a Ceph Storage Cluster, you may begin
operating your cluster."

Fixes: https://tracker.ceph.com/issues/46554
Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
