### PR TITLE
doc: cephfs: improve documentation of "ceph nfs cluster create" and "ceph fs volume create" commands

### DIFF
--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -20,7 +20,7 @@ Create NFS Ganesha Cluster
     $ ceph nfs cluster create <type> <clusterid> [<placement>]
 
 This creates a common recovery pool for all NFS Ganesha daemons, new user based on
-cluster_id, and a common NFS Ganesha config rados object. It can also bring up
+cluster_id, and a common NFS Ganesha config RADOS object. It can also bring up
 NFS Ganesha daemons using the enabled ceph-mgr orchestrator module (see
 :doc:`/mgr/orchestrator`), e.g. cephadm.
 
@@ -111,7 +111,7 @@ Create CephFS Export
 
     $ ceph nfs export create cephfs <fsname> <clusterid> <binding> [--readonly] [--path=/path/in/cephfs]
 
-This creates export rados objects containing the export block.
+This creates export RADOS objects containing the export block.
 
 <fsname> is the name of the FS volume used by the NFS Ganesha cluster that will
 serve this export.

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -111,8 +111,14 @@ Create CephFS Export
 
     $ ceph nfs export create cephfs <fsname> <clusterid> <binding> [--readonly] [--path=/path/in/cephfs]
 
-It creates export rados objects containing the export block. Here binding is
-the pseudo root name and type is export type.
+This creates export rados objects containing the export block.
+
+<fsname> is the name of the FS volume used by the NFS Ganesha cluster that will
+serve this export.
+
+<clusterid> is the NFS Ganesha cluster ID.
+
+<binding> is the pseudo root path (must be an absolute path).
 
 Delete CephFS Export
 ====================
@@ -121,7 +127,11 @@ Delete CephFS Export
 
     $ ceph nfs export delete <clusterid> <binding>
 
-It deletes an export in cluster based on pseudo root name (binding).
+It deletes an export in an NFS Ganesha cluster.
+
+<clusterid> is the NFS Ganesha cluster ID.
+
+<binding> is the pseudo root path (must be an absolute path).
 
 List CephFS Export
 ==================

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -113,14 +113,14 @@ Create CephFS Export
 
     $ ceph nfs export create cephfs <fsname> <clusterid> <binding> [--readonly] [--path=/path/in/cephfs]
 
-This creates export RADOS objects containing the export block.
+This creates export RADOS objects containing the export block, where
 
-<fsname> is the name of the FS volume used by the NFS Ganesha cluster that will
+``fsname`` is the name of the FS volume used by the NFS Ganesha cluster that will
 serve this export.
 
-<clusterid> is the NFS Ganesha cluster ID.
+``clusterid`` is the NFS Ganesha cluster ID.
 
-<binding> is the pseudo root path (must be an absolute path).
+``binding`` is the pseudo root path (must be an absolute path).
 
 Delete CephFS Export
 ====================
@@ -129,21 +129,24 @@ Delete CephFS Export
 
     $ ceph nfs export delete <clusterid> <binding>
 
-It deletes an export in an NFS Ganesha cluster.
+This deletes an export in an NFS Ganesha cluster, where:
 
-<clusterid> is the NFS Ganesha cluster ID.
+``clusterid`` is the NFS Ganesha cluster ID.
 
-<binding> is the pseudo root path (must be an absolute path).
+``binding`` is the pseudo root path (must be an absolute path).
 
-List CephFS Export
-==================
+List CephFS Exports
+===================
 
 .. code:: bash
 
     $ ceph nfs export ls <clusterid> [--detailed]
 
-It lists export for a cluster. With detailed option enabled it shows entire
-export block.
+It lists exports for a cluster, where:
+
+``clusterid`` is the NFS Ganesha cluster ID.
+
+With the ``--detailed`` option enabled it shows entire export block.
 
 Get CephFS Export
 =================
@@ -152,18 +155,25 @@ Get CephFS Export
 
     $ ceph nfs export get <clusterid> <binding>
 
-It displays export block for a cluster based on pseudo root name (binding).
+This displays export block for a cluster based on pseudo root name (binding),
+where:
+
+``clusterid`` is the NFS Ganesha cluster ID.
+
+``binding`` is the pseudo root path (must be an absolute path).
 
 Configuring NFS Ganesha to export CephFS with vstart
 ====================================================
 
-1) Using cephadm
+1) Using ``cephadm``
 
     .. code:: bash
 
         $ MDS=1 MON=1 OSD=3 NFS=1 ../src/vstart.sh -n -d --cephadm
 
-    It can deploy only single NFS Ganesha daemon with vstart on default NFS Ganesha port.
+    This will deploy a single NFS Ganesha daemon using ``vstart.sh``, where:
+
+    The daemon will listen on the default NFS Ganesha port.
 
 2) Using test orchestrator
 
@@ -171,10 +181,12 @@ Configuring NFS Ganesha to export CephFS with vstart
 
        $ MDS=1 MON=1 OSD=3 NFS=1 ../src/vstart.sh -n -d
 
-    It can deploy multiple NFS Ganesha daemons on random port. But this requires
-    NFS Ganesha packages to be installed.
+    This will deploy multiple NFS Ganesha daemons, each listening on a random
+    port, where:
 
-NFS: It is the number of NFS Ganesha clusters to be created.
+    ``NFS`` is the number of NFS Ganesha clusters to be created.
+
+    NOTE: NFS Ganesha packages must be pre-installed for this to work.
 
 Mount
 =====

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -17,15 +17,37 @@ Create NFS Ganesha Cluster
 
 .. code:: bash
 
-    $ ceph nfs cluster create <type=cephfs> <clusterid> [<placement>]
+    $ ceph nfs cluster create <type> <clusterid> [<placement>]
 
 This creates a common recovery pool for all Ganesha daemons, new user based on
-cluster_id and common ganesha config rados object.
+cluster_id, and a common ganesha config rados object. It can also bring up NFS
+Ganesha daemons using the enabled ceph-mgr orchestrator module (see
+:doc:`/mgr/orchestrator`), e.g. cephadm.
 
-Here type is export type and placement specifies the size of cluster and hosts.
-For more details on placement specification refer the `orchestrator doc
-<https://docs.ceph.com/docs/master/mgr/orchestrator/#placement-specification>`_.
-Currently only CephFS export type is supported.
+<type> signifies the export type, which corresponds to the NFS Ganesha file
+system abstraction layer (FSAL). Permissible values are "cephfs" or "rgw", but
+currently only "cephfs" is supported.
+
+<clusterid> is an arbitrary string by which this NFS Ganesha cluster will be
+known.
+
+<placement> is an optional string signifying which hosts should have NFS Ganesha
+daemon containers running on them and, optionally, the total number of NFS
+Ganesha daemons the cluster (should you want to have more than one NFS Ganesha
+daemon running per node). For example, the following placement string means
+"deploy NFS Ganesha daemons on nodes host1 and host2 (one daemon per host):
+
+    "host1,host2"
+
+and this placement specification says to deploy two NFS Ganesha daemons each
+on nodes host1 and host2 (for a total of four NFS Ganesha daemons in the
+cluster):
+
+    "4 host1,host2"
+
+For more details on placement specification refer to the `orchestrator doc
+<https://docs.ceph.com/docs/master/mgr/orchestrator/#placement-specification>`_
+but keep in mind that specifying the placement via a YAML file is not supported.
 
 Update NFS Ganesha Cluster
 ==========================

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -19,9 +19,9 @@ Create NFS Ganesha Cluster
 
     $ ceph nfs cluster create <type> <clusterid> [<placement>]
 
-This creates a common recovery pool for all Ganesha daemons, new user based on
-cluster_id, and a common ganesha config rados object. It can also bring up NFS
-Ganesha daemons using the enabled ceph-mgr orchestrator module (see
+This creates a common recovery pool for all NFS Ganesha daemons, new user based on
+cluster_id, and a common NFS Ganesha config rados object. It can also bring up
+NFS Ganesha daemons using the enabled ceph-mgr orchestrator module (see
 :doc:`/mgr/orchestrator`), e.g. cephadm.
 
 <type> signifies the export type, which corresponds to the NFS Ganesha file
@@ -85,8 +85,8 @@ Show NFS Ganesha Cluster Information
 
 This displays ip and port of deployed cluster.
 
-Set Customized Ganesha Configuration
-====================================
+Set Customized NFS Ganesha Configuration
+========================================
 
 .. code:: bash
 
@@ -95,8 +95,8 @@ Set Customized Ganesha Configuration
 With this the nfs cluster will use the specified config and it will have
 precedence over default config blocks.
 
-Reset Ganesha Configuration
-===========================
+Reset NFS Ganesha Configuration
+===============================
 
 .. code:: bash
 
@@ -152,7 +152,7 @@ Get CephFS Export
 
 It displays export block for a cluster based on pseudo root name (binding).
 
-Configuring NFS-Ganesha to export CephFS with vstart
+Configuring NFS Ganesha to export CephFS with vstart
 ====================================================
 
 1) Using cephadm
@@ -161,7 +161,7 @@ Configuring NFS-Ganesha to export CephFS with vstart
 
         $ MDS=1 MON=1 OSD=3 NFS=1 ../src/vstart.sh -n -d --cephadm
 
-    It can deploy only single ganesha daemon with vstart on default ganesha port.
+    It can deploy only single NFS Ganesha daemon with vstart on default NFS Ganesha port.
 
 2) Using test orchestrator
 
@@ -169,15 +169,15 @@ Configuring NFS-Ganesha to export CephFS with vstart
 
        $ MDS=1 MON=1 OSD=3 NFS=1 ../src/vstart.sh -n -d
 
-    It can deploy multiple ganesha daemons on random port. But this requires
-    ganesha packages to be installed.
+    It can deploy multiple NFS Ganesha daemons on random port. But this requires
+    NFS Ganesha packages to be installed.
 
-NFS: It is the number of NFS-Ganesha clusters to be created.
+NFS: It is the number of NFS Ganesha clusters to be created.
 
 Mount
 =====
 
-After the exports are successfully created and Ganesha daemons are no longer in
+After the exports are successfully created and NFS Ganesha daemons are no longer in
 grace period. The exports can be mounted by
 
 .. code:: bash

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -20,9 +20,11 @@ Create NFS Ganesha Cluster
     $ ceph nfs cluster create <type> <clusterid> [<placement>]
 
 This creates a common recovery pool for all NFS Ganesha daemons, new user based on
-cluster_id, and a common NFS Ganesha config RADOS object. It can also bring up
-NFS Ganesha daemons using the enabled ceph-mgr orchestrator module (see
-:doc:`/mgr/orchestrator`), e.g. cephadm.
+cluster_id, and a common NFS Ganesha config RADOS object.
+
+NOTE: Since this command also brings up NFS Ganesha daemons using a ceph-mgr
+orchestrator module (see :doc:`/mgr/orchestrator`) such as "mgr/cephadm", at
+least one such module must be enabled for it to work.
 
 <type> signifies the export type, which corresponds to the NFS Ganesha file
 system abstraction layer (FSAL). Permissible values are "cephfs" or "rgw", but

--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -45,9 +45,29 @@ Create a volume using::
 
     $ ceph fs volume create <vol_name> [<placement>]
 
-This creates a CephFS file system and its data and metadata pools. It also tries
-to create MDSes for the filesystem using the enabled ceph-mgr orchestrator
-module  (see :doc:`/mgr/orchestrator`) , e.g., rook.
+This creates a CephFS file system and its data and metadata pools. It can also
+try to create MDSes for the filesystem using the enabled ceph-mgr orchestrator
+module (see :doc:`/mgr/orchestrator`), e.g. rook.
+
+<vol_name> is the volume name (an arbitrary string), and
+
+<placement> is an optional string signifying which hosts should have NFS Ganesha
+daemon containers running on them and, optionally, the total number of NFS
+Ganesha daemons the cluster (should you want to have more than one NFS Ganesha
+daemon running per node). For example, the following placement string means
+"deploy NFS Ganesha daemons on nodes host1 and host2 (one daemon per host):
+
+    "host1,host2"
+
+and this placement specification says to deploy two NFS Ganesha daemons each
+on nodes host1 and host2 (for a total of four NFS Ganesha daemons in the
+cluster):
+
+    "4 host1,host2"
+
+For more details on placement specification refer to the `orchestrator doc
+<https://docs.ceph.com/docs/master/mgr/orchestrator/#placement-specification>`_
+but keep in mind that specifying the placement via a YAML file is not supported.
 
 Remove a volume using::
 


### PR DESCRIPTION
When a reader sees "ceph nfs create <type=cephfs>" it's not
clear that this means they should type "ceph nfs create cephfs".

I also took this opportunity to clarify the command description
based on my testing and discussions with the CephFS developers.

Fixes: https://tracker.ceph.com/issues/46559
Signed-off-by: Nathan Cutler <ncutler@suse.com>
