### PR TITLE
cephadm: Fix ipv6 network regex to support routes with expiry

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3267,7 +3267,7 @@ def _list_ipv6_networks():
 
 def _parse_ipv6_route(routes, ips):
     r = {}  # type: Dict[str,List[str]]
-    route_p = re.compile(r'^(\S+) dev (\S+) proto (\S+) metric (\S+) pref (\S+)$')
+    route_p = re.compile(r'^(\S+) dev (\S+) proto (\S+) metric (\S+) .*pref (\S+)$')
     ip_p = re.compile(r'^\s+inet6 (\S+)/(.*)scope (.*)$')
     for line in routes.splitlines():
         m = route_p.findall(line)

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -99,6 +99,7 @@ default via 10.3.64.1 dev eno1 proto static metric 100
 ::1 dev lo proto kernel metric 256 pref medium
 fdbc:7574:21fe:9200::/64 dev wlp2s0 proto ra metric 600 pref medium
 fdd8:591e:4969:6363::/64 dev wlp2s0 proto ra metric 600 pref medium
+fde4:8dba:82e1::/64 dev eth1 proto kernel metric 256 expires 1844sec pref medium
 fe80::/64 dev tun0 proto kernel metric 256 pref medium
 fe80::/64 dev wlp2s0 proto kernel metric 600 pref medium
 default dev tun0 proto static metric 50 pref medium
@@ -127,6 +128,10 @@ default via fe80::2480:28ec:5097:3fe2 dev wlp2s0 proto ra metric 20600 pref medi
        valid_lft 6745sec preferred_lft 0sec
     inet6 fe80::1111:2222:3333:4444/64 scope link noprefixroute 
        valid_lft forever preferred_lft forever
+    inet6 fde4:8dba:82e1:0:ec4a:e402:e9df:b357/64 scope global temporary dynamic
+       valid_lft 1074sec preferred_lft 1074sec
+    inet6 fde4:8dba:82e1:0:5054:ff:fe72:61af/64 scope global dynamic mngtmpaddr
+       valid_lft 1074sec preferred_lft 1074sec
 12: tun0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1500 state UNKNOWN qlen 100
     inet6 fe80::cafe:cafe:cafe:cafe/64 scope link stable-privacy 
        valid_lft forever preferred_lft forever
@@ -141,6 +146,8 @@ default via fe80::2480:28ec:5097:3fe2 dev wlp2s0 proto ra metric 20600 pref medi
                                              "fdd8:591e:4969:6363:103a:abcd:af1f:57f3",
                                              "fdd8:591e:4969:6363:a128:1234:2bdd:1b6f",
                                              "fdd8:591e:4969:6363:d581:4321:380b:3905"],
+                "fde4:8dba:82e1::/64": ["fde4:8dba:82e1:0:ec4a:e402:e9df:b357",
+                                        "fde4:8dba:82e1:0:5054:ff:fe72:61af"],
                 "fe80::/64": ["fe80::1111:2222:3333:4444",
                               "fe80::cafe:cafe:cafe:cafe"]
             }


### PR DESCRIPTION
The regex I previously added didn't take into account ipv6 networks that
had an expiry, this patch updates the regex and includes an ipv6 route
version in the test.

Signed-off-by: Matthew Oliver <moliver@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
