### PR TITLE
ceph.spec.in: BUILD_WITH_INSTALL_RPATH on SUSE distros

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1175,6 +1175,9 @@ ${CMAKE} .. \
     -DCMAKE_VERBOSE_MAKEFILE=ON \
 %endif
     -DBOOST_J=$CEPH_SMP_NCPUS \
+%if 0%{?suse_version}
+    -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+%endif
     -DWITH_GRAFANA=ON
 
 %if %{with cmake_verbose_logging}


### PR DESCRIPTION
by default, cmake builds with the rpath of build tree, and edit the
rpath when installing the binaries. if the length of the rpath of build
tree is longer than that of the rpath of the installation, cmake stuffs
the rpath with some bogus data. it seems that the linker on openSUSE
leap is more picky at seeing those rpaths and strips them off from the
binaries. cmake fails when trying to change the rpath when installing
binaries, like:

[ 1486s] CMake Error at src/librbd/cmake_install.cmake:70 (file):
[ 1486s]   file RPATH_CHANGE could not write new RPATH:
[ 1486s]
[ 1486s]     /usr/lib64/ceph
[ 1486s]
[ 1486s]   to the file:
[ 1486s]
[ 1486s]     /home/abuild/rpmbuild/BUILDROOT/ceph-16.0.0-3506.ga86c764613a.x86_64/usr/lib64/ceph/librbd/libceph_librbd_parent_cache.so.1.0.0
[ 1486s]
[ 1486s]   No valid ELF RPATH or RUNPATH entry exists in the file;

to avoid this issue, in this change,

CMAKE_BUILD_WITH_INSTALL_RPATH is enabled, when building packages on
SUSE distros to build the packages with the install rpath, so there is no
need to edit the binary anymore.

see also
https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_WITH_INSTALL_RPATH.html
and
http://llvm.1065342.n5.nabble.com/llvm-trunk-build-failed-in-cmake-install-cmake-on-ARM-platform-td65895.html#a65910

Fixes: https://tracker.ceph.com/issues/46553
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
