### PR TITLE
[DNM] osd: write success when quorum osds committed

### DIFF
--- a/src/include/Context.h
+++ b/src/include/Context.h
@@ -95,6 +95,9 @@ class Context {
  public:
   Context() {}
   virtual ~Context() {}       // we want a virtual destructor!!!
+  virtual void quorum_complete(int r) {
+    finish(r);
+  }
   virtual void complete(int r) {
     finish(r);
     delete this;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10543,15 +10543,28 @@ class C_OSD_RepopCommit : public Context {
 public:
   C_OSD_RepopCommit(PrimaryLogPG *pg, PrimaryLogPG::RepGather *repop)
     : pg(pg), repop(repop) {}
-  void finish(int) override {
-    pg->repop_all_committed(repop.get());
+  void finish(int r) override {
+    if (r)
+      pg->repop_quorum_committed(repop.get());
+    else
+      pg->repop_all_committed(repop.get());
   }
 };
 
+void PrimaryLogPG::repop_quorum_committed(RepGather *repop)
+{
+  dout(10) << __func__ << ": repop tid " << repop->rep_tid
+           << " quorum committed " << dendl;
+
+  repop->quorum_committed = true;
+  if (!repop->rep_aborted)
+    eval_repop(repop);
+}
+
 void PrimaryLogPG::repop_all_committed(RepGather *repop)
 {
-  dout(10) << __func__ << ": repop tid " << repop->rep_tid << " all committed "
-	   << dendl;
+  dout(10) << __func__ << ": repop tid " << repop->rep_tid
+           << " all committed " << dendl;
   repop->all_committed = true;
   if (!repop->rep_aborted) {
     if (repop->v != eversion_t()) {
@@ -10581,20 +10594,42 @@ void PrimaryLogPG::op_applied(const eversion_t &applied_version)
 
 void PrimaryLogPG::eval_repop(RepGather *repop)
 {
-  dout(10) << "eval_repop " << *repop
-    << (repop->op && repop->op->get_req<MOSDOp>() ? "" : " (no op)") << dendl;
+  dout(10) << __func__ << " " << *repop
+           << (repop->op && repop->op->get_req<MOSDOp>() ? "" : " (no op)")
+           << dendl;
+
+  if (repop->quorum_committed != repop->all_committed) {
+    dout(10) << " commit: " << *repop << dendl;
+    for (auto p = repop->on_committed.begin();
+         p != repop->on_committed.end();
+         repop->on_committed.erase(p++)) {
+      (*p)();
+    }
+
+    auto it = waiting_for_ondisk.find(repop->v);
+    if (it != waiting_for_ondisk.end()) {
+      dout(10) << __func__ << " waiting_for_ondisk " << waiting_for_ondisk.begin()->first
+               << " repop->v " << repop->v << dendl;
+      if (waiting_for_ondisk.begin()->first == repop->v) {
+        for (auto& i : it->second) {
+          int return_code = repop->r;
+          if (return_code >= 0) {
+            return_code = std::get<2>(i);
+          }
+          osd->reply_op_error(std::get<0>(i), return_code, repop->v,
+                              std::get<1>(i), std::get<3>(i));
+        }
+        waiting_for_ondisk.erase(it);
+      }
+    }
+  }
 
   // ondisk?
   if (repop->all_committed) {
-    dout(10) << " commit: " << *repop << dendl;
-    for (auto p = repop->on_committed.begin();
-	 p != repop->on_committed.end();
-	 repop->on_committed.erase(p++)) {
-      (*p)();
-    }
-    // send dup commits, in order
     auto it = waiting_for_ondisk.find(repop->v);
     if (it != waiting_for_ondisk.end()) {
+      dout(10) << __func__ << " waiting_for_ondisk " << waiting_for_ondisk.begin()->first
+               << " repop->v " << repop->v << dendl;
       ceph_assert(waiting_for_ondisk.begin()->first == repop->v);
       for (auto& i : it->second) {
         int return_code = repop->r;
@@ -14670,7 +14705,7 @@ bool PrimaryLogPG::already_complete(eversion_t v)
 	       << " (*i)->v past v" << dendl;
       break;
     }
-    if (!(*i)->all_committed) {
+    if (!((*i)->quorum_committed || (*i)->all_committed)) {
       dout(20) << __func__ << ": " << **i
 	       << " not committed, returning false"
 	       << dendl;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -781,6 +781,7 @@ public:
     ceph_tid_t rep_tid;
 
     bool rep_aborted;
+    bool quorum_committed;
     bool all_committed;
     
     utime_t   start;
@@ -802,6 +803,7 @@ public:
       nref(1),
       rep_tid(rt), 
       rep_aborted(false),
+      quorum_committed(false),
       all_committed(false),
       pg_local_last_complete(lc),
       lock_manager(std::move(c->lock_manager)),
@@ -822,6 +824,7 @@ public:
       r(r),
       rep_tid(rt),
       rep_aborted(false),
+      quorum_committed(false),
       all_committed(false),
       pg_local_last_complete(lc),
       lock_manager(std::move(manager)) {
@@ -951,6 +954,7 @@ protected:
   xlist<RepGather*> repop_queue;
 
   friend class C_OSD_RepopCommit;
+  void repop_quorum_committed(RepGather *repop);
   void repop_all_committed(RepGather *repop);
   void eval_repop(RepGather*);
   void issue_repop(RepGather *repop, OpContext *ctx);
@@ -1991,7 +1995,8 @@ inline ostream& operator<<(ostream& out, const PrimaryLogPG::RepGather& repop)
   out << "repgather(" << &repop
       << " " << repop.v
       << " rep_tid=" << repop.rep_tid 
-      << " committed?=" << repop.all_committed
+      << " quorum_committed?=" << repop.quorum_committed
+      << " all_committed?=" << repop.all_committed
       << " r=" << repop.r
       << ")";
   return out;

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -16,6 +16,7 @@
 #define REPBACKEND_H
 
 #include "PGBackend.h"
+#include "global/global_context.h"
 
 struct C_ReplicatedBackend_OnPullComplete;
 class ReplicatedBackend : public PGBackend {
@@ -336,9 +337,11 @@ private:
   struct InProgressOp : public RefCountedObject {
     ceph_tid_t tid;
     std::set<pg_shard_t> waiting_for_commit;
+    size_t tolerated_uncommit_size;
     Context *on_commit;
     OpRequestRef op;
     eversion_t v;
+    bool primary_committed;
     bool done() const {
       return waiting_for_commit.empty();
     }
@@ -347,7 +350,12 @@ private:
     InProgressOp(ceph_tid_t tid, Context *on_commit, OpRequestRef op, eversion_t v)
       :
 	tid(tid), on_commit(on_commit),
-	op(op), v(v) {}
+	op(op), v(v), primary_committed(false) {
+    auto pool_size = g_conf().get_val<uint64_t>("osd_pool_default_size");
+    auto min_size = g_conf().get_osd_pool_default_min_size(pool_size);
+    tolerated_uncommit_size = pool_size - (pool_size / 2 + 1);
+    tolerated_uncommit_size = std::min(tolerated_uncommit_size, static_cast<size_t>(min_size));
+  }
   };
   std::map<ceph_tid_t, ceph::ref_t<InProgressOp>> in_progress_ops;
 public:


### PR DESCRIPTION
This pr improves availability a little by responsing client writing when quorum osds committed.

Signed-off-by: SHU Zhenyi <shuzhenyi@live.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
