### PR TITLE
crimson: do not capture unused variables

### DIFF
--- a/src/crimson/osd/backfill_state.cc
+++ b/src/crimson/osd/backfill_state.cc
@@ -128,7 +128,7 @@ void BackfillState::Enqueuing::maybe_update_range()
                    pg().get_projected_last_update());
     logger().debug("{}: scanning pg log first", __func__);
     peering_state().get_pg_log().get_log().scan_log_after(primary_bi.version,
-      [&, this](const pg_log_entry_t& e) {
+      [&](const pg_log_entry_t& e) {
         logger().debug("maybe_update_range(lambda): updating from version {}",
                        e.version);
         if (e.soid >= primary_bi.begin && e.soid <  primary_bi.end) {
@@ -198,7 +198,7 @@ bool BackfillState::Enqueuing::should_rescan_replicas(
 {
   const auto& targets = peering_state().get_backfill_targets();
   return std::any_of(std::begin(targets), std::end(targets),
-    [&, this] (const auto& bt) {
+    [&] (const auto& bt) {
       return ReplicasScanning::replica_needs_scan(peer_backfill_info.at(bt),
                                                   backfill_info);
     });
@@ -218,7 +218,7 @@ void BackfillState::Enqueuing::trim_backfilled_object_from_intervals(
   std::map<pg_shard_t, BackfillInterval>& peer_backfill_info)
 {
   std::for_each(std::begin(result.pbi_targets), std::end(result.pbi_targets),
-    [this, &peer_backfill_info] (const auto& bt) {
+    [&peer_backfill_info] (const auto& bt) {
       peer_backfill_info.at(bt).pop_front();
     });
   last_backfill_started = std::move(result.new_last_backfill_started);

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1055,7 +1055,7 @@ seastar::future<> OSD::send_incremental_map(crimson::net::Connection* conn,
     });
   } else {
     return load_map_bl(osdmap->get_epoch())
-    .then([this, conn, first](auto&& bl) mutable {
+    .then([this, conn](auto&& bl) mutable {
       auto m = make_message<MOSDMap>(monc->get_fsid(),
 	  osdmap->get_encoding_features());
       m->oldest_map = superblock.oldest_map;


### PR DESCRIPTION
this change silences warnings like:

mson/osd/backfill_state.cc:131:11: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
      [&, this](const pg_log_entry_t& e) {
        ~~^~~~

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
