### PR TITLE
octopus: mgr/dashboard: add API team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,15 @@
 /monitoring/prometheus                          @ceph/dashboard
 /doc/mgr/dashboard.rst                          @ceph/dashboard
 
+# Dashboard API team
+/src/pybind/mgr/dashboard/controllers                  @ceph/api
+/src/pybind/mgr/dashboard/frontend/src/app/shared/api  @ceph/api
+/src/pybind/mgr/dashboard/run-backend-api-tests.sh     @ceph/api
+/qa/suites/rados/dashboard                             @ceph/api
+/qa/tasks/mgr/test_dashboard.py                        @ceph/api
+/qa/tasks/mgr/dashboard                                @ceph/api
+/qa/tasks/mgr/test_module_selftest.py                  @ceph/api
+
 # For Orchestrator related PRs
 /src/cephadm                                    @ceph/orchestrators
 /src/pybind/mgr/orchestrator                    @ceph/orchestrators


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46576

---

backport of https://github.com/ceph/ceph/pull/35249
parent tracker: https://tracker.ceph.com/issues/45705

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh