### PR TITLE
librbd: add read extents with version to object dispatch interface

### DIFF
--- a/src/librbd/cache/ObjectCacherObjectDispatch.h
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.h
@@ -42,10 +42,10 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      librados::snap_t snap_id, int op_flags,
-      const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      io::Extents* extent_map, int* object_dispatch_flags,
+      uint64_t object_no, const io::Extents &extents, librados::snap_t snap_id,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      ceph::bufferlist* read_data, io::Extents* extent_map,
+      uint64_t* version, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 

--- a/src/librbd/cache/ObjectCacherWriteback.cc
+++ b/src/librbd/cache/ObjectCacherWriteback.cc
@@ -137,8 +137,8 @@ void ObjectCacherWriteback::read(const object_t& oid, uint64_t object_no,
     aio_comp, off, len, {{0, len}});
 
   auto req = io::ObjectDispatchSpec::create_read(
-    m_ictx, io::OBJECT_DISPATCH_LAYER_CACHE, object_no, off, len, snapid,
-    op_flags, trace, &req_comp->bl, &req_comp->extent_map, req_comp);
+    m_ictx, io::OBJECT_DISPATCH_LAYER_CACHE, object_no, {{off, len}}, snapid,
+    op_flags, trace, &req_comp->bl, &req_comp->extent_map, nullptr, req_comp);
   req->send();
 }
 

--- a/src/librbd/cache/ParentCacheObjectDispatch.h
+++ b/src/librbd/cache/ParentCacheObjectDispatch.h
@@ -40,10 +40,10 @@ public:
   }
 
   bool read(
-      uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      librados::snap_t snap_id, int op_flags,
-      const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      io::Extents* extent_map, int* object_dispatch_flags,
+      uint64_t object_no, const io::Extents &extents, librados::snap_t snap_id,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      ceph::bufferlist* read_data, io::Extents* extent_map,
+      uint64_t* version, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 

--- a/src/librbd/cache/WriteAroundObjectDispatch.cc
+++ b/src/librbd/cache/WriteAroundObjectDispatch.cc
@@ -57,11 +57,12 @@ void WriteAroundObjectDispatch<I>::shut_down(Context* on_finish) {
 
 template <typename I>
 bool WriteAroundObjectDispatch<I>::read(
-    uint64_t object_no, uint64_t object_off, uint64_t object_len,
-    librados::snap_t snap_id, int op_flags, const ZTracer::Trace &parent_trace,
-    ceph::bufferlist* read_data, io::Extents* extent_map,
+    uint64_t object_no, const io::Extents &extents, librados::snap_t snap_id,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    ceph::bufferlist* read_data, io::Extents* extent_map, uint64_t* version,
     int* object_dispatch_flags, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
+  auto [object_off, object_len] = extents.front();
   return dispatch_unoptimized_io(object_no, object_off, object_len,
                                  dispatch_result, on_dispatched);
 }

--- a/src/librbd/cache/WriteAroundObjectDispatch.h
+++ b/src/librbd/cache/WriteAroundObjectDispatch.h
@@ -42,10 +42,10 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      librados::snap_t snap_id, int op_flags,
-      const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      io::Extents* extent_map, int* object_dispatch_flags,
+      uint64_t object_no, const io::Extents &extents, librados::snap_t snap_id,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      ceph::bufferlist* read_data, io::Extents* extent_map,
+      uint64_t* version, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -101,8 +101,8 @@ void readahead(I *ictx, const Extents& image_extents) {
                                              object_extent.length);
       auto req = io::ObjectDispatchSpec::create_read(
         ictx, io::OBJECT_DISPATCH_LAYER_NONE, object_extent.object_no,
-        object_extent.offset, object_extent.length, snap_id, 0, {},
-        &req_comp->read_data, &req_comp->extent_map, req_comp);
+        {{object_extent.offset, object_extent.length}}, snap_id, 0, {},
+        &req_comp->read_data, &req_comp->extent_map, nullptr, req_comp);
       req->send();
     }
 
@@ -405,9 +405,9 @@ void ImageReadRequest<I>::send_request() {
     auto req_comp = new io::ReadResult::C_ObjectReadRequest(
       aio_comp, oe.offset, oe.length, std::move(oe.buffer_extents));
     auto req = ObjectDispatchSpec::create_read(
-      &image_ctx, OBJECT_DISPATCH_LAYER_NONE, oe.object_no, oe.offset,
-      oe.length, snap_id, m_op_flags, this->m_trace, &req_comp->bl,
-      &req_comp->extent_map, req_comp);
+      &image_ctx, OBJECT_DISPATCH_LAYER_NONE, oe.object_no,
+      {{oe.offset, oe.length}}, snap_id, m_op_flags, this->m_trace,
+      &req_comp->bl, &req_comp->extent_map, nullptr, req_comp);
     req->send();
   }
 

--- a/src/librbd/io/ObjectDispatch.cc
+++ b/src/librbd/io/ObjectDispatch.cc
@@ -33,20 +33,18 @@ void ObjectDispatch<I>::shut_down(Context* on_finish) {
 
 template <typename I>
 bool ObjectDispatch<I>::read(
-    uint64_t object_no, uint64_t object_off, uint64_t object_len,
-    librados::snap_t snap_id, int op_flags, const ZTracer::Trace &parent_trace,
-    ceph::bufferlist* read_data, Extents* extent_map,
+    uint64_t object_no, const Extents &extents, librados::snap_t snap_id,
+    int op_flags, const ZTracer::Trace &parent_trace,
+    ceph::bufferlist* read_data, Extents* extent_map, uint64_t* version,
     int* object_dispatch_flags, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
-                 << object_off << "~" << object_len << dendl;
+  ldout(cct, 20) << "object_no=" << object_no << " " << extents << dendl;
 
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
-  auto req = new ObjectReadRequest<I>(m_image_ctx, object_no, object_off,
-                                      object_len, snap_id, op_flags,
-                                      parent_trace, read_data, extent_map,
-                                      on_dispatched);
+  auto req = new ObjectReadRequest<I>(m_image_ctx, object_no, extents, snap_id,
+                                      op_flags, parent_trace, read_data,
+                                      extent_map, version, on_dispatched);
   req->send();
   return true;
 }

--- a/src/librbd/io/ObjectDispatch.h
+++ b/src/librbd/io/ObjectDispatch.h
@@ -34,10 +34,10 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      librados::snap_t snap_id, int op_flags,
-      const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      Extents* extent_map, int* object_dispatch_flags,
+      uint64_t object_no, const Extents &extents, librados::snap_t snap_id,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      ceph::bufferlist* read_data, Extents* extent_map,
+      uint64_t* version, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 

--- a/src/librbd/io/ObjectDispatchInterface.h
+++ b/src/librbd/io/ObjectDispatchInterface.h
@@ -34,9 +34,9 @@ struct ObjectDispatchInterface {
   virtual void shut_down(Context* on_finish) = 0;
 
   virtual bool read(
-      uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      librados::snap_t snap_id, int op_flags,const ZTracer::Trace &parent_trace,
-      ceph::bufferlist* read_data, Extents* extent_map,
+      uint64_t object_no, const Extents &extents,
+      librados::snap_t snap_id, int op_flags, const ZTracer::Trace &parent_trace,
+      ceph::bufferlist* read_data, Extents* extent_map, uint64_t* version,
       int* object_dispatch_flags, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) = 0;
 

--- a/src/librbd/io/ObjectDispatcher.cc
+++ b/src/librbd/io/ObjectDispatcher.cc
@@ -107,9 +107,9 @@ struct ObjectDispatcher<I>::SendVisitor : public boost::static_visitor<bool> {
 
   bool operator()(ObjectDispatchSpec::ReadRequest& read) const {
     return object_dispatch->read(
-      read.object_no, read.object_off, read.object_len, read.snap_id,
+      read.object_no, read.extents, read.snap_id,
       object_dispatch_spec->op_flags, object_dispatch_spec->parent_trace,
-      read.read_data, read.extent_map,
+      read.read_data, read.extent_map, read.version,
       &object_dispatch_spec->object_dispatch_flags,
       &object_dispatch_spec->dispatch_result,
       &object_dispatch_spec->dispatcher_ctx.on_finish,

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.h
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.h
@@ -50,10 +50,10 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      librados::snap_t snap_id, int op_flags,
-      const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      Extents* extent_map, int* object_dispatch_flags,
+      uint64_t object_no, const Extents &extents, librados::snap_t snap_id,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      ceph::bufferlist* read_data, Extents* extent_map,
+      uint64_t* version, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 

--- a/src/librbd/io/Utils.h
+++ b/src/librbd/io/Utils.h
@@ -30,10 +30,9 @@ bool assemble_write_same_extent(const LightweightObjectExtent &object_extent,
                                 bool force_write);
 
 template <typename ImageCtxT = librbd::ImageCtx>
-void read_parent(ImageCtxT *image_ctx, uint64_t object_no, uint64_t off,
-                 uint64_t len, librados::snap_t snap_id,
-                 const ZTracer::Trace &trace, ceph::bufferlist* data,
-                 Context* on_finish);
+void read_parent(ImageCtxT *image_ctx, uint64_t object_no, const Extents &extents,
+                 librados::snap_t snap_id, const ZTracer::Trace &trace,
+                 ceph::bufferlist* data, Context* on_finish);
 
 } // namespace util
 } // namespace io

--- a/src/librbd/journal/ObjectDispatch.h
+++ b/src/librbd/journal/ObjectDispatch.h
@@ -38,10 +38,10 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      librados::snap_t snap_id, int op_flags,
-      const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      io::Extents* extent_map, int* object_dispatch_flags,
+      uint64_t object_no, const io::Extents &extents, librados::snap_t snap_id,
+      int op_flags, const ZTracer::Trace &parent_trace,
+      ceph::bufferlist* read_data, io::Extents* extent_map,
+      uint64_t* version, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) {
     return false;

--- a/src/test/librbd/io/test_mock_SimpleSchedulerObjectDispatch.cc
+++ b/src/test/librbd/io/test_mock_SimpleSchedulerObjectDispatch.cc
@@ -132,8 +132,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Read) {
   C_SaferCond cond;
   Context *on_finish = &cond;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.read(
-      0, 0, 4096, CEPH_NOSNAP, 0, {}, nullptr, nullptr, nullptr, nullptr,
-      &on_finish, nullptr));
+      0, {{0, 4096}}, CEPH_NOSNAP, 0, {}, nullptr, nullptr, nullptr, nullptr,
+      nullptr, &on_finish, nullptr));
   ASSERT_EQ(on_finish, &cond); // not modified
   on_finish->complete(0);
   ASSERT_EQ(0, cond.wait());

--- a/src/test/librbd/mock/io/MockObjectDispatch.h
+++ b/src/test/librbd/mock/io/MockObjectDispatch.h
@@ -25,17 +25,17 @@ public:
   MOCK_METHOD1(shut_down, void(Context*));
 
   MOCK_METHOD8(execute_read,
-               bool(uint64_t, uint64_t, uint64_t, librados::snap_t,
-                    ceph::bufferlist*, Extents*, DispatchResult*, Context*));
+               bool(uint64_t, const Extents&, librados::snap_t,
+                    ceph::bufferlist*, Extents*, uint64_t*,
+                    DispatchResult*, Context*));
   bool read(
-      uint64_t object_no, uint64_t object_off, uint64_t object_len,
-      librados::snap_t snap_id, int op_flags,
-      const ZTracer::Trace& parent_trace, ceph::bufferlist* read_data,
-      Extents* extent_map, int* dispatch_flags,
-      DispatchResult* dispatch_result, Context** on_finish,
-      Context* on_dispatched) {
-    return execute_read(object_no, object_off, object_len, snap_id, read_data,
-                        extent_map, dispatch_result, on_dispatched);
+      uint64_t object_no, const Extents& extents, librados::snap_t snap_id,
+      int op_flags, const ZTracer::Trace& parent_trace,
+      ceph::bufferlist* read_data, Extents* extent_map, uint64_t* version,
+      int* dispatch_flags, DispatchResult* dispatch_result,
+      Context** on_finish, Context* on_dispatched) {
+    return execute_read(object_no, extents, snap_id, read_data, extent_map,
+                        version, dispatch_result, on_dispatched);
   }
 
   MOCK_METHOD9(execute_discard,


### PR DESCRIPTION
This new object dispatch API function reads several object extents (instead of a single extent currently supprted by `read`).
Additionally, the rados version for that read can be returned.
This is required by the planned crypto layer to support unaligned (relative to the crypto segment size) writes.
Writing of unaligned data with encryption requires a read-modify-write procedure as follows:
1. Possibly reading + decrypting the head and tail of the extent to be written.
2. Updating the plaintext data with the data to be written.
3. Re-encrypting and writing with a checked write (using the version returned in (1)).

This new API is to support (1) above.

The only real implementation for this is in the CORE layer.
We could possibly add support for that in the CACHE layer, but this will require storing the read versions in the cache. We decide to skip this optimization for now.

@dillaman tagging you here in case you miss this. Thanks!