### PR TITLE
mgr: add types to MODULE_OPTIONS

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -29,7 +29,7 @@ from ceph.deployment.service_spec import \
 from cephadm.serve import CephadmServe
 from cephadm.services.cephadmservice import CephadmDaemonSpec
 
-from mgr_module import MgrModule, HandleCommandResult
+from mgr_module import MgrModule, HandleCommandResult, Option
 from mgr_util import create_self_signed_cert, verify_tls, ServerConfigException
 import secrets
 import orchestrator
@@ -137,161 +137,161 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
     instance = None
     NATIVE_OPTIONS = []  # type: List[Any]
-    MODULE_OPTIONS: List[dict] = [
-        {
-            'name': 'ssh_config_file',
-            'type': 'str',
-            'default': None,
-            'desc': 'customized SSH config file to connect to managed hosts',
-        },
-        {
-            'name': 'device_cache_timeout',
-            'type': 'secs',
-            'default': 30 * 60,
-            'desc': 'seconds to cache device inventory',
-        },
-        {
-            'name': 'daemon_cache_timeout',
-            'type': 'secs',
-            'default': 10 * 60,
-            'desc': 'seconds to cache service (daemon) inventory',
-        },
-        {
-            'name': 'facts_cache_timeout',
-            'type': 'secs',
-            'default': 1 * 60,
-            'desc': 'seconds to cache host facts data',
-        },
-        {
-            'name': 'host_check_interval',
-            'type': 'secs',
-            'default': 10 * 60,
-            'desc': 'how frequently to perform a host check',
-        },
-        {
-            'name': 'mode',
-            'type': 'str',
-            'enum_allowed': ['root', 'cephadm-package'],
-            'default': 'root',
-            'desc': 'mode for remote execution of cephadm',
-        },
-        {
-            'name': 'container_image_base',
-            'default': 'docker.io/ceph/ceph',
-            'desc': 'Container image name, without the tag',
-            'runtime': True,
-        },
-        {
-            'name': 'container_image_prometheus',
-            'default': 'docker.io/prom/prometheus:v2.18.1',
-            'desc': 'Prometheus container image',
-        },
-        {
-            'name': 'container_image_grafana',
-            'default': 'docker.io/ceph/ceph-grafana:6.6.2',
-            'desc': 'Prometheus container image',
-        },
-        {
-            'name': 'container_image_alertmanager',
-            'default': 'docker.io/prom/alertmanager:v0.20.0',
-            'desc': 'Prometheus container image',
-        },
-        {
-            'name': 'container_image_node_exporter',
-            'default': 'docker.io/prom/node-exporter:v0.18.1',
-            'desc': 'Prometheus container image',
-        },
-        {
-            'name': 'warn_on_stray_hosts',
-            'type': 'bool',
-            'default': True,
-            'desc': 'raise a health warning if daemons are detected on a host '
-                    'that is not managed by cephadm',
-        },
-        {
-            'name': 'warn_on_stray_daemons',
-            'type': 'bool',
-            'default': True,
-            'desc': 'raise a health warning if daemons are detected '
-                    'that are not managed by cephadm',
-        },
-        {
-            'name': 'warn_on_failed_host_check',
-            'type': 'bool',
-            'default': True,
-            'desc': 'raise a health warning if the host check fails',
-        },
-        {
-            'name': 'log_to_cluster',
-            'type': 'bool',
-            'default': True,
-            'desc': 'log to the "cephadm" cluster log channel"',
-        },
-        {
-            'name': 'allow_ptrace',
-            'type': 'bool',
-            'default': False,
-            'desc': 'allow SYS_PTRACE capability on ceph containers',
-            'long_desc': 'The SYS_PTRACE capability is needed to attach to a '
-                         'process with gdb or strace.  Enabling this options '
-                         'can allow debugging daemons that encounter problems '
-                         'at runtime.',
-        },
-        {
-            'name': 'container_init',
-            'type': 'bool',
-            'default': False,
-            'desc': 'Run podman/docker with `--init`',
-        },
-        {
-            'name': 'prometheus_alerts_path',
-            'type': 'str',
-            'default': '/etc/prometheus/ceph/ceph_default_alerts.yml',
-            'desc': 'location of alerts to include in prometheus deployments',
-        },
-        {
-            'name': 'migration_current',
-            'type': 'int',
-            'default': None,
-            'desc': 'internal - do not modify',
+    MODULE_OPTIONS = [
+        Option(
+            'ssh_config_file',
+            type='str',
+            default=None,
+            desc='customized SSH config file to connect to managed hosts',
+        ),
+        Option(
+            'device_cache_timeout',
+            type='secs',
+            default=30 * 60,
+            desc='seconds to cache device inventory',
+        ),
+        Option(
+            'daemon_cache_timeout',
+            type='secs',
+            default=10 * 60,
+            desc='seconds to cache service (daemon) inventory',
+        ),
+        Option(
+            'facts_cache_timeout',
+            type='secs',
+            default=1 * 60,
+            desc='seconds to cache host facts data',
+        ),
+        Option(
+            'host_check_interval',
+            type='secs',
+            default=10 * 60,
+            desc='how frequently to perform a host check',
+        ),
+        Option(
+            'mode',
+            type='str',
+            enum_allowed=['root', 'cephadm-package'],
+            default='root',
+            desc='mode for remote execution of cephadm',
+        ),
+        Option(
+            'container_image_base',
+            default='docker.io/ceph/ceph',
+            desc='Container image name, without the tag',
+            runtime=True,
+        ),
+        Option(
+            'container_image_prometheus',
+            default='docker.io/prom/prometheus:v2.18.1',
+            desc='Prometheus container image',
+        ),
+        Option(
+            'container_image_grafana',
+            default='docker.io/ceph/ceph-grafana:6.6.2',
+            desc='Prometheus container image',
+        ),
+        Option(
+            'container_image_alertmanager',
+            default='docker.io/prom/alertmanager:v0.20.0',
+            desc='Prometheus container image',
+        ),
+        Option(
+            'container_image_node_exporter',
+            default='docker.io/prom/node-exporter:v0.18.1',
+            desc='Prometheus container image',
+        ),
+        Option(
+            'warn_on_stray_hosts',
+            type='bool',
+            default=True,
+            desc='raise a health warning if daemons are detected on a host '
+            'that is not managed by cephadm',
+        ),
+        Option(
+            'warn_on_stray_daemons',
+            type='bool',
+            default=True,
+            desc='raise a health warning if daemons are detected '
+            'that are not managed by cephadm',
+        ),
+        Option(
+            'warn_on_failed_host_check',
+            type='bool',
+            default=True,
+            desc='raise a health warning if the host check fails',
+        ),
+        Option(
+            'log_to_cluster',
+            type='bool',
+            default=True,
+            desc='log to the "cephadm" cluster log channel"',
+        ),
+        Option(
+            'allow_ptrace',
+            type='bool',
+            default=False,
+            desc='allow SYS_PTRACE capability on ceph containers',
+            long_desc='The SYS_PTRACE capability is needed to attach to a '
+            'process with gdb or strace.  Enabling this options '
+            'can allow debugging daemons that encounter problems '
+            'at runtime.',
+        ),
+        Option(
+            'container_init',
+            type='bool',
+            default=False,
+            desc='Run podman/docker with `--init`'
+        ),
+        Option(
+            'prometheus_alerts_path',
+            type='str',
+            default='/etc/prometheus/ceph/ceph_default_alerts.yml',
+            desc='location of alerts to include in prometheus deployments',
+        ),
+        Option(
+            'migration_current',
+            type='int',
+            default=None,
+            desc='internal - do not modify',
             # used to track track spec and other data migrations.
-        },
-        {
-            'name': 'config_dashboard',
-            'type': 'bool',
-            'default': True,
-            'desc': 'manage configs like API endpoints in Dashboard.'
-        },
-        {
-            'name': 'manage_etc_ceph_ceph_conf',
-            'type': 'bool',
-            'default': False,
-            'desc': 'Manage and own /etc/ceph/ceph.conf on the hosts.',
-        },
-        {
-            'name': 'registry_url',
-            'type': 'str',
-            'default': None,
-            'desc': 'Custom repository url'
-        },
-        {
-            'name': 'registry_username',
-            'type': 'str',
-            'default': None,
-            'desc': 'Custom repository username'
-        },
-        {
-            'name': 'registry_password',
-            'type': 'str',
-            'default': None,
-            'desc': 'Custom repository password'
-        },
-        {
-            'name': 'use_repo_digest',
-            'type': 'bool',
-            'default': False,
-            'desc': 'Automatically convert image tags to image digest. Make sure all daemons use the same image',
-        }
+        ),
+        Option(
+            'config_dashboard',
+            type='bool',
+            default=True,
+            desc='manage configs like API endpoints in Dashboard.'
+        ),
+        Option(
+            'manage_etc_ceph_ceph_conf',
+            type='bool',
+            default=False,
+            desc='Manage and own /etc/ceph/ceph.conf on the hosts.',
+        ),
+        Option(
+            'registry_url',
+            type='str',
+            default=None,
+            desc='Custom repository url'
+        ),
+        Option(
+            'registry_username',
+            type='str',
+            default=None,
+            desc='Custom repository username'
+        ),
+        Option(
+            'registry_password',
+            type='str',
+            default=None,
+            desc='Custom repository password'
+        ),
+        Option(
+            'use_repo_digest',
+            type='bool',
+            default=False,
+            desc='Automatically convert image tags to image digest. Make sure all daemons use the same image',
+        ),
     ]
 
     def __init__(self, *args: Any, **kwargs: Any):

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1,10 +1,15 @@
 import ceph_module  # noqa
 
-try:
-    from typing import Set, Tuple, Iterator, Any, Dict, Optional, Callable, List
-except ImportError:
-    # just for type checking
-    pass
+from typing import Set, Tuple, Iterator, Any, Dict, Optional, Callable, List, \
+    Union, TYPE_CHECKING, NamedTuple
+if TYPE_CHECKING:
+    import sys
+    if sys.version_info >= (3, 8):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
+
+
 import logging
 import errno
 import json
@@ -354,27 +359,37 @@ def CLIWriteCommand(prefix, args="", desc=""):
 def _get_localized_key(prefix, key):
     return '{}/{}'.format(prefix, key)
 
+"""
+MODULE_OPTIONS types and Option Class
+"""
+if TYPE_CHECKING:
+    OptionTypeLabel = Literal[
+        'uint', 'int', 'str', 'float', 'bool', 'addr', 'addrvec', 'uuid', 'size', 'secs']
 
-class Option(dict):
+
+# common/options.h: value_t
+OptionValue = Optional[Union[bool, int, float, str]]
+
+
+class Option(Dict):
     """
     Helper class to declare options for MODULE_OPTIONS list.
-
-    Caveat: it uses argument names matching Python keywords (type, min, max),
-    so any further processing should happen in a separate method.
-
-    TODO: type validation.
+    TODO: Replace with typing.TypedDict when in python_version >= 3.8
     """
 
     def __init__(
-            self, name,
-            default=None,
-            type='str',
-            desc=None, longdesc=None,
-            min=None, max=None,
-            enum_allowed=None,
-            see_also=None,
-            tags=None,
-            runtime=False,
+            self,
+            name: str,
+            default: OptionValue=None,
+            type: 'OptionTypeLabel'='str',
+            desc: Optional[str]=None,
+            long_desc: Optional[str]=None,
+            min: OptionValue=None,
+            max: OptionValue=None,
+            enum_allowed: Optional[List[str]]=None,
+            tags: Optional[List[str]]=None,
+            see_also: Optional[List[str]]=None,
+            runtime: bool=False,
     ):
         super(Option, self).__init__(
             (k, v) for k, v in vars().items()
@@ -600,7 +615,7 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule, MgrModuleLoggingMixin):
     from their active peer), and to configuration settings (read only).
     """
 
-    MODULE_OPTIONS = []  # type: List[Dict[str, Any]]
+    MODULE_OPTIONS: List[Option] = []
     MODULE_OPTION_DEFAULTS = {}  # type: Dict[str, Any]
 
     def __init__(self, module_name, capsule):
@@ -663,13 +678,11 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule, MgrModuleLoggingMixin):
     def get_mgr_id(self):
         return self._ceph_get_mgr_id()
 
-    def get_module_option(self, key, default=None):
+    def get_module_option(self, key: str, default: OptionValue=None) -> OptionValue:
         """
         Retrieve the value of a persistent configuration setting
 
-        :param str key:
         :param default: the default value of the config if it is not found
-        :return: str
         """
         r = self._ceph_get_module_option(key)
         if r is None:
@@ -692,7 +705,7 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule, MgrModuleLoggingMixin):
     def get_active_uri(self):
         return self._ceph_get_active_uri()
 
-    def get_localized_module_option(self, key, default=None):
+    def get_localized_module_option(self, key: str, default: OptionValue=None) -> OptionValue:
         r = self._ceph_get_module_option(key, self.get_mgr_id())
         if r is None:
             return self.MODULE_OPTION_DEFAULTS.get(key, default)
@@ -702,7 +715,7 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule, MgrModuleLoggingMixin):
 
 class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
     COMMANDS = []  # type: List[Any]
-    MODULE_OPTIONS = []  # type: List[dict]
+    MODULE_OPTIONS: List[Option] = []
     MODULE_OPTION_DEFAULTS = {}  # type: Dict[str, Any]
 
     # Priority definitions for perf counters
@@ -1248,28 +1261,23 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         else:
             return r
 
-    def get_module_option(self, key, default=None):
+    def get_module_option(self, key: str, default: OptionValue=None) -> OptionValue:
         """
         Retrieve the value of a persistent configuration setting
-
-        :param str key:
-        :param str default:
-        :return: str
         """
         self._validate_module_option(key)
         return self._get_module_option(key, default)
 
-    def get_module_option_ex(self, module, key, default=None):
+    def get_module_option_ex(self, module: str, key: str, default: OptionValue=None) -> OptionValue:
         """
         Retrieve the value of a persistent configuration setting
         for the specified module.
 
-        :param str module: The name of the module, e.g. 'dashboard'
+        :param module: The name of the module, e.g. 'dashboard'
             or 'telemetry'.
-        :param str key: The configuration key, e.g. 'server_addr'.
-        :param str,None default: The default value to use when the
+        :param key: The configuration key, e.g. 'server_addr'.
+        :param default: The default value to use when the
             returned value is ``None``. Defaults to ``None``.
-        :return: str,int,bool,float,None
         """
         if module == self.module_name:
             self._validate_module_option(key)
@@ -1289,12 +1297,9 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
     def _set_localized(self, key, val, setter):
         return setter(_get_localized_key(self.get_mgr_id(), key), val)
 
-    def get_localized_module_option(self, key, default=None):
+    def get_localized_module_option(self, key: str, default: OptionValue=None) -> OptionValue:
         """
         Retrieve localized configuration for this ceph-mgr instance
-        :param str key:
-        :param str default:
-        :return: str
         """
         self._validate_module_option(key)
         return self._get_module_option(key, default, self.get_mgr_id())

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -13,7 +13,7 @@ from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection
 from ceph.deployment.service_spec import PlacementSpec, ServiceSpec
 
 from mgr_util import format_bytes, to_pretty_timedelta, format_dimless
-from mgr_module import MgrModule, HandleCommandResult
+from mgr_module import MgrModule, HandleCommandResult, Option
 
 from ._interface import OrchestratorClientMixin, DeviceLightLoc, _cli_read_command, \
     raise_if_exception, _cli_write_command, TrivialReadCompletion, OrchestratorError, \
@@ -135,15 +135,14 @@ def preview_table_services(data):
 class OrchestratorCli(OrchestratorClientMixin, MgrModule,
                       metaclass=CLICommandMeta):
     MODULE_OPTIONS = [
-        {
-            'name': 'orchestrator',
-            'type': 'str',
-            'default': None,
-            'desc': 'Orchestrator backend',
-            'enum_allowed': ['cephadm', 'rook',
-                             'test_orchestrator'],
-            'runtime': True,
-        },
+        Option(
+            'orchestrator',
+            type='str',
+            default=None,
+            desc='Orchestrator backend',
+            enum_allowed=['cephadm', 'rook', 'test_orchestrator'],
+            runtime=True,
+        )
     ]
     NATIVE_OPTIONS = []  # type: List[dict]
 
@@ -633,38 +632,38 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
 usage:
   ceph orch apply osd -i <json_file/yaml_file> [--dry-run]
   ceph orch apply osd --all-available-devices [--dry-run] [--unmanaged]
-  
+
 Restrictions:
-  
+
   Mutexes:
   * -i, --all-available-devices
   * -i, --unmanaged (this would overwrite the osdspec loaded from a file)
-  
+
   Parameters:
-  
+
   * --unmanaged
      Only works with --all-available-devices.
-  
+
 Description:
-  
+
   * -i
     An inbuf object like a file or a json/yaml blob containing a valid OSDSpec
-    
+
   * --all-available-devices
     The most simple OSDSpec there is. Takes all as 'available' marked devices
     and creates standalone OSDs on them.
-    
+
   * --unmanaged
     Set a the unmanaged flag for all--available-devices (default is False)
-    
+
 Examples:
 
    # ceph orch apply osd -i <file.yml|json>
-   
+
    Applies one or more OSDSpecs found in <file>
-   
+
    # ceph orch osd apply --all-available-devices --unmanaged=true
-   
+
    Creates and applies simple OSDSpec with the unmanaged flag set to <true>
 """
 

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -30,7 +30,7 @@ except ImportError:
     client = None
     config = None
 
-from mgr_module import MgrModule
+from mgr_module import MgrModule, Option
 import orchestrator
 
 from .rook_cluster import RookCluster
@@ -98,9 +98,9 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
     Right now, we are calling the k8s API synchronously.
     """
 
-    MODULE_OPTIONS = [
+    MODULE_OPTIONS: List[Option] = [
         # TODO: configure k8s API addr instead of assuming local
-    ]  # type: List[Dict[str, Any]]
+    ]
 
     def process(self, completions):
         # type: (List[RookCompletion]) -> None

--- a/src/pybind/mgr/snap_schedule/module.py
+++ b/src/pybind/mgr/snap_schedule/module.py
@@ -7,20 +7,20 @@ import errno
 import json
 import sqlite3
 from .fs.schedule_client import SnapSchedClient
-from mgr_module import MgrModule, CLIReadCommand, CLIWriteCommand
+from mgr_module import MgrModule, CLIReadCommand, CLIWriteCommand, Option
 from mgr_util import CephfsConnectionException
 from threading import Event
 
 
 class Module(MgrModule):
     MODULE_OPTIONS = [
-        {
-            'name':    'allow_m_granularity',
-            'type':    'bool',
-            'default': False,
-            'desc':    'allow minute scheduled snapshots',
-            'runtime': True,
-        },
+        Option(
+            'allow_m_granularity',
+            type='bool',
+            default=False,
+            desc='allow minute scheduled snapshots',
+            runtime=True,
+        ),
     ]
 
     def __init__(self, *args, **kwargs):

--- a/src/pybind/mgr/stats/module.py
+++ b/src/pybind/mgr/stats/module.py
@@ -5,7 +5,7 @@ performance stats for ceph filesystem (for now...)
 import json
 from typing import List, Dict
 
-from mgr_module import MgrModule
+from mgr_module import MgrModule, Option
 
 from .fs.perf_stats import FSPerfStats
 
@@ -20,7 +20,7 @@ class Module(MgrModule):
             "perm": "r"
         },
     ]
-    MODULE_OPTIONS = [] # type: List[Dict]
+    MODULE_OPTIONS: List[Option] = []
 
     def __init__(self, *args, **kwargs):
         super(Module, self).__init__(*args, **kwargs)

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -4,7 +4,7 @@ import logging
 import traceback
 import threading
 
-from mgr_module import MgrModule
+from mgr_module import MgrModule, Option
 import orchestrator
 
 from .fs.volume import VolumeClient
@@ -396,12 +396,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     ]
 
     MODULE_OPTIONS = [
-        {
-            'name': 'max_concurrent_clones',
-            'type': 'int',
-            'default': 4,
-            'desc': 'Number of asynchronous cloner threads',
-        }
+        Option(
+            'max_concurrent_clones',
+            type='int',
+            default=4,
+            desc='Number of asynchronous cloner threads',
+        )
     ]
 
     def __init__(self, *args, **kwargs):

--- a/src/python-common/requirements.txt
+++ b/src/python-common/requirements.txt
@@ -4,3 +4,4 @@ mypy==0.790; python_version >= '3'
 pytest-mypy; python_version >= '3'
 pytest >= 2.1.3; python_version >= '3'
 pyyaml
+typing-extensions; python_version < '3.8'


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46577
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
