### PR TITLE
mgr/cephadm: clean-up service module type checking

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1799,7 +1799,7 @@ you may want to run:
             'rgw': self.rgw_service.config,
             'nfs': self.nfs_service.config,
             'iscsi': self.iscsi_service.config,
-        }.get(service_type)
+        }.get(service_type)  # type: ignore
 
     def _apply_service(self, spec: ServiceSpec) -> bool:
         """

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1794,12 +1794,13 @@ you may want to run:
         return "Removed {} from host '{}'".format(name, host)
 
     def _config_fn(self, service_type) -> Optional[Callable[[ServiceSpec], None]]:
-        return {
+        fn = {
             'mds': self.mds_service.config,
             'rgw': self.rgw_service.config,
             'nfs': self.nfs_service.config,
             'iscsi': self.iscsi_service.config,
-        }.get(service_type)  # type: ignore
+        }.get(service_type)
+        return cast(Callable[[ServiceSpec], None], fn)
 
     def _apply_service(self, spec: ServiceSpec) -> bool:
         """

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -109,7 +109,7 @@ class CephadmService(metaclass=ABCMeta):
     def get_active_daemon(self, daemon_descrs: List[DaemonDescription]) -> DaemonDescription:
         raise NotImplementedError()
 
-    def _inventory_get_addr(self, hostname: str):
+    def _inventory_get_addr(self, hostname: str) -> str:
         """Get a host's address with its hostname."""
         return self.mgr.inventory.get_addr(hostname)
 
@@ -248,7 +248,7 @@ class MonService(CephadmService):
                 'who': 'mon',
                 'key': 'public_network',
             })
-            network = network.strip() # type: ignore
+            network = network.strip() if network else network
             if not network:
                 raise OrchestratorError('Must set public_network config option or specify a CIDR network, ceph addrvec, or plain IP')
             if '/' not in network:
@@ -260,8 +260,7 @@ class MonService(CephadmService):
 
         return self.mgr._create_daemon(daemon_spec)
 
-    def _check_safe_to_destroy(self, mon_id):
-        # type: (str) -> None
+    def _check_safe_to_destroy(self, mon_id: str) -> None:
         ret, out, err = self.mgr.check_mon_command({
             'prefix': 'quorum_status',
         })

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -218,7 +218,7 @@ class CephadmService(metaclass=ABCMeta):
 class MonService(CephadmService):
     TYPE = 'mon'
 
-    def create(self, daemon_spec: CephadmDaemonSpec):
+    def create(self, daemon_spec: CephadmDaemonSpec) -> str:
         """
         Create a new monitor on the given host.
         """
@@ -297,7 +297,7 @@ class MonService(CephadmService):
 class MgrService(CephadmService):
     TYPE = 'mgr'
 
-    def create(self, daemon_spec: CephadmDaemonSpec):
+    def create(self, daemon_spec: CephadmDaemonSpec) -> str:
         """
         Create a new manager instance on a host.
         """
@@ -329,7 +329,7 @@ class MdsService(CephadmService):
             'value': spec.service_id,
         })
 
-    def create(self, daemon_spec: CephadmDaemonSpec):
+    def create(self, daemon_spec: CephadmDaemonSpec) -> str:
         mds_id, host = daemon_spec.daemon_id, daemon_spec.host
 
         # get mgr. key
@@ -403,7 +403,7 @@ class RgwService(CephadmService):
             spec.service_name(), spec.placement.pretty_str()))
         self.mgr.spec_store.save(spec)
 
-    def create(self, daemon_spec: CephadmDaemonSpec):
+    def create(self, daemon_spec: CephadmDaemonSpec) -> str:
         rgw_id, host = daemon_spec.daemon_id, daemon_spec.host
         ret, keyring, err = self.mgr.check_mon_command({
             'prefix': 'auth get-or-create',
@@ -421,9 +421,8 @@ class RgwService(CephadmService):
 class RbdMirrorService(CephadmService):
     TYPE = 'rbd-mirror'
 
-    def create(self, daemon_spec: CephadmDaemonSpec):
+    def create(self, daemon_spec: CephadmDaemonSpec) -> str:
         daemon_id, host = daemon_spec.daemon_id, daemon_spec.host
-
         ret, keyring, err = self.mgr.check_mon_command({
             'prefix': 'auth get-or-create',
             'entity': 'client.rbd-mirror.' + daemon_id,
@@ -439,9 +438,8 @@ class RbdMirrorService(CephadmService):
 class CrashService(CephadmService):
     TYPE = 'crash'
 
-    def create(self, daemon_spec: CephadmDaemonSpec):
+    def create(self, daemon_spec: CephadmDaemonSpec) -> str:
         daemon_id, host = daemon_spec.daemon_id, daemon_spec.host
-
         ret, keyring, err = self.mgr.check_mon_command({
             'prefix': 'auth get-or-create',
             'entity': 'client.crash.' + host,

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -222,6 +222,7 @@ class MonService(CephadmService):
         """
         Create a new monitor on the given host.
         """
+        assert self.TYPE == daemon_spec.daemon_type
         name, host, network = daemon_spec.daemon_id, daemon_spec.host, daemon_spec.network
 
         # get mon. key
@@ -300,7 +301,9 @@ class MgrService(CephadmService):
         """
         Create a new manager instance on a host.
         """
+        assert self.TYPE == daemon_spec.daemon_type
         mgr_id, host = daemon_spec.daemon_id, daemon_spec.host
+
         # get mgr. key
         ret, keyring, err = self.mgr.check_mon_command({
             'prefix': 'auth get-or-create',
@@ -319,8 +322,10 @@ class MdsService(CephadmService):
     TYPE = 'mds'
 
     def config(self, spec: ServiceSpec) -> None:
-        # ensure mds_join_fs is set for these daemons
+        assert self.TYPE == spec.service_type
         assert spec.service_id
+
+        # ensure mds_join_fs is set for these daemons
         ret, out, err = self.mgr.check_mon_command({
             'prefix': 'config set',
             'who': 'mds.' + spec.service_id,
@@ -329,6 +334,7 @@ class MdsService(CephadmService):
         })
 
     def create(self, daemon_spec: CephadmDaemonSpec) -> str:
+        assert self.TYPE == daemon_spec.daemon_type
         mds_id, host = daemon_spec.daemon_id, daemon_spec.host
 
         # get mgr. key
@@ -348,6 +354,8 @@ class RgwService(CephadmService):
     TYPE = 'rgw'
 
     def config(self, spec: RGWSpec) -> None:
+        assert self.TYPE == spec.service_type
+
         # ensure rgw_realm and rgw_zone is set for these daemons
         ret, out, err = self.mgr.check_mon_command({
             'prefix': 'config set',
@@ -403,7 +411,9 @@ class RgwService(CephadmService):
         self.mgr.spec_store.save(spec)
 
     def create(self, daemon_spec: CephadmDaemonSpec) -> str:
+        assert self.TYPE == daemon_spec.daemon_type
         rgw_id, host = daemon_spec.daemon_id, daemon_spec.host
+
         ret, keyring, err = self.mgr.check_mon_command({
             'prefix': 'auth get-or-create',
             'entity': f"{utils.name_to_config_section('rgw')}.{rgw_id}",
@@ -421,7 +431,9 @@ class RbdMirrorService(CephadmService):
     TYPE = 'rbd-mirror'
 
     def create(self, daemon_spec: CephadmDaemonSpec) -> str:
+        assert self.TYPE == daemon_spec.daemon_type
         daemon_id, host = daemon_spec.daemon_id, daemon_spec.host
+
         ret, keyring, err = self.mgr.check_mon_command({
             'prefix': 'auth get-or-create',
             'entity': 'client.rbd-mirror.' + daemon_id,
@@ -438,7 +450,9 @@ class CrashService(CephadmService):
     TYPE = 'crash'
 
     def create(self, daemon_spec: CephadmDaemonSpec) -> str:
+        assert self.TYPE == daemon_spec.daemon_type
         daemon_id, host = daemon_spec.daemon_id, daemon_spec.host
+
         ret, keyring, err = self.mgr.check_mon_command({
             'prefix': 'auth get-or-create',
             'entity': 'client.crash.' + host,

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -319,7 +319,7 @@ class MgrService(CephadmService):
 class MdsService(CephadmService):
     TYPE = 'mds'
 
-    def config(self, spec: ServiceSpec):
+    def config(self, spec: ServiceSpec) -> None:
         # ensure mds_join_fs is set for these daemons
         assert spec.service_id
         ret, out, err = self.mgr.check_mon_command({
@@ -348,7 +348,7 @@ class MdsService(CephadmService):
 class RgwService(CephadmService):
     TYPE = 'rgw'
 
-    def config(self, spec: RGWSpec):
+    def config(self, spec: RGWSpec) -> None:
         # ensure rgw_realm and rgw_zone is set for these daemons
         ret, out, err = self.mgr.check_mon_command({
             'prefix': 'config set',

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -16,6 +16,7 @@ class IscsiService(CephadmService):
     TYPE = 'iscsi'
 
     def config(self, spec: IscsiServiceSpec) -> None:
+        assert self.TYPE == spec.service_type
         self.mgr._check_pool_exists(spec.pool, spec.service_name())
 
         logger.info('Saving service %s spec with placement %s' % (
@@ -23,10 +24,12 @@ class IscsiService(CephadmService):
         self.mgr.spec_store.save(spec)
 
     def create(self, daemon_spec: CephadmDaemonSpec[IscsiServiceSpec]) -> str:
+        assert self.TYPE == daemon_spec.daemon_type
+        assert daemon_spec.spec
+
         spec = daemon_spec.spec
-        if spec is None:
-            raise OrchestratorError(f'Unable to deploy {daemon_spec.name()}: Service not found.')
         igw_id = daemon_spec.daemon_id
+
         ret, keyring, err = self.mgr.check_mon_command({
             'prefix': 'auth get-or-create',
             'entity': utils.name_to_auth_entity('iscsi', igw_id),

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class IscsiService(CephadmService):
     TYPE = 'iscsi'
 
-    def config(self, spec: IscsiServiceSpec):
+    def config(self, spec: IscsiServiceSpec) -> None:
         self.mgr._check_pool_exists(spec.pool, spec.service_name())
 
         logger.info('Saving service %s spec with placement %s' % (

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -12,7 +12,7 @@ class GrafanaService(CephadmService):
     TYPE = 'grafana'
     DEFAULT_SERVICE_PORT = 3000
 
-    def create(self, daemon_spec: CephadmDaemonSpec):
+    def create(self, daemon_spec: CephadmDaemonSpec) -> str:
         return self.mgr._create_daemon(daemon_spec)
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:
@@ -75,7 +75,7 @@ class AlertmanagerService(CephadmService):
     TYPE = 'alertmanager'
     DEFAULT_SERVICE_PORT = 9093
 
-    def create(self, daemon_spec: CephadmDaemonSpec):
+    def create(self, daemon_spec: CephadmDaemonSpec) -> str:
         return self.mgr._create_daemon(daemon_spec)
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:
@@ -142,7 +142,7 @@ class PrometheusService(CephadmService):
     TYPE = 'prometheus'
     DEFAULT_SERVICE_PORT = 9095
 
-    def create(self, daemon_spec: CephadmDaemonSpec):
+    def create(self, daemon_spec: CephadmDaemonSpec) -> str:
         return self.mgr._create_daemon(daemon_spec)
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:
@@ -229,7 +229,7 @@ class PrometheusService(CephadmService):
 class NodeExporterService(CephadmService):
     TYPE = 'node-exporter'
 
-    def create(self, daemon_spec: CephadmDaemonSpec):
+    def create(self, daemon_spec: CephadmDaemonSpec) -> str:
         return self.mgr._create_daemon(daemon_spec)
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -13,9 +13,11 @@ class GrafanaService(CephadmService):
     DEFAULT_SERVICE_PORT = 3000
 
     def create(self, daemon_spec: CephadmDaemonSpec) -> str:
+        assert self.TYPE == daemon_spec.daemon_type
         return self.mgr._create_daemon(daemon_spec)
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:
+        assert self.TYPE == daemon_spec.daemon_type
         deps = []  # type: List[str]
 
         prom_services = []  # type: List[str]
@@ -76,9 +78,11 @@ class AlertmanagerService(CephadmService):
     DEFAULT_SERVICE_PORT = 9093
 
     def create(self, daemon_spec: CephadmDaemonSpec) -> str:
+        assert self.TYPE == daemon_spec.daemon_type
         return self.mgr._create_daemon(daemon_spec)
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:
+        assert self.TYPE == daemon_spec.daemon_type
         deps = [] # type: List[str]
 
         # dashboard(s)
@@ -143,9 +147,11 @@ class PrometheusService(CephadmService):
     DEFAULT_SERVICE_PORT = 9095
 
     def create(self, daemon_spec: CephadmDaemonSpec) -> str:
+        assert self.TYPE == daemon_spec.daemon_type
         return self.mgr._create_daemon(daemon_spec)
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:
+        assert self.TYPE == daemon_spec.daemon_type
         deps = []  # type: List[str]
 
         # scrape mgrs
@@ -230,7 +236,9 @@ class NodeExporterService(CephadmService):
     TYPE = 'node-exporter'
 
     def create(self, daemon_spec: CephadmDaemonSpec) -> str:
+        assert self.TYPE == daemon_spec.daemon_type
         return self.mgr._create_daemon(daemon_spec)
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:
+        assert self.TYPE == daemon_spec.daemon_type
         return {}, []

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -21,6 +21,8 @@ class NFSService(CephadmService):
     TYPE = 'nfs'
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:
+        assert self.TYPE == daemon_spec.daemon_type
+
         daemon_type = daemon_spec.daemon_type
         daemon_id = daemon_spec.daemon_id
         host = daemon_spec.host
@@ -67,15 +69,21 @@ class NFSService(CephadmService):
         return cephadm_config, deps
 
     def config(self, spec: NFSServiceSpec) -> None:
+        assert self.TYPE == spec.service_type
         self.mgr._check_pool_exists(spec.pool, spec.service_name())
+
         logger.info('Saving service %s spec with placement %s' % (
             spec.service_name(), spec.placement.pretty_str()))
         self.mgr.spec_store.save(spec)
 
     def create(self, daemon_spec: CephadmDaemonSpec[NFSServiceSpec]) -> str:
+        assert self.TYPE == daemon_spec.daemon_type
+        assert daemon_spec.spec
+
         daemon_id = daemon_spec.daemon_id
         host = daemon_spec.host
         spec = daemon_spec.spec
+
         logger.info('Create daemon %s on host %s with spec %s' % (
             daemon_id, host, spec))
         return self.mgr._create_daemon(daemon_spec)

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -66,7 +66,7 @@ class NFSService(CephadmService):
 
         return cephadm_config, deps
 
-    def config(self, spec):
+    def config(self, spec: NFSServiceSpec) -> None:
         self.mgr._check_pool_exists(spec.pool, spec.service_name())
         logger.info('Saving service %s spec with placement %s' % (
             spec.service_name(), spec.placement.pretty_str()))

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -72,7 +72,7 @@ class NFSService(CephadmService):
             spec.service_name(), spec.placement.pretty_str()))
         self.mgr.spec_store.save(spec)
 
-    def create(self, daemon_spec: CephadmDaemonSpec[NFSServiceSpec]):
+    def create(self, daemon_spec: CephadmDaemonSpec[NFSServiceSpec]) -> str:
         daemon_id = daemon_spec.daemon_id
         host = daemon_spec.host
         spec = daemon_spec.spec

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -118,20 +118,16 @@ class NFSGanesha(object):
         self.daemon_id = daemon_id
         self.spec = spec
 
-    def get_daemon_name(self):
-        # type: () -> str
+    def get_daemon_name(self) -> str:
         return '%s.%s' % (self.spec.service_type, self.daemon_id)
 
-    def get_rados_user(self):
-        # type: () -> str
+    def get_rados_user(self) -> str:
         return '%s.%s' % (self.spec.service_type, self.daemon_id)
 
-    def get_keyring_entity(self):
-        # type: () -> str
+    def get_keyring_entity(self) -> str:
         return utils.name_to_config_section(self.get_rados_user())
 
-    def get_or_create_keyring(self, entity=None):
-        # type: (Optional[str]) -> str
+    def get_or_create_keyring(self, entity: Optional[str] = None) -> str:
         if not entity:
             entity = self.get_keyring_entity()
 
@@ -147,8 +143,7 @@ class NFSGanesha(object):
                             % (entity, ret, err))
         return keyring
 
-    def update_keyring_caps(self, entity=None):
-        # type: (Optional[str]) -> None
+    def update_keyring_caps(self, entity: Optional[str] = None) -> None:
         if not entity:
             entity = self.get_keyring_entity()
 
@@ -169,8 +164,7 @@ class NFSGanesha(object):
                     'Unable to update keyring caps %s: %s %s' \
                             % (entity, ret, err))
 
-    def create_rados_config_obj(self, clobber=False):
-        # type: (Optional[bool]) -> None
+    def create_rados_config_obj(self, clobber: Optional[bool] = False) -> None:
         obj = self.spec.rados_config_name()
 
         with self.mgr.rados.open_ioctx(self.spec.pool) as ioctx:
@@ -191,8 +185,7 @@ class NFSGanesha(object):
                 logger.info('Creating rados config object: %s' % obj)
                 ioctx.write_full(obj, ''.encode('utf-8'))
 
-    def get_ganesha_conf(self):
-        # type: () -> str
+    def get_ganesha_conf(self) -> str:
         context = dict(user=self.get_rados_user(),
                        nodeid=self.get_daemon_name(),
                        pool=self.spec.pool,
@@ -200,8 +193,7 @@ class NFSGanesha(object):
                        url=self.spec.rados_config_location())
         return self.mgr.template.render('services/nfs/ganesha.conf.j2', context)
 
-    def get_cephadm_config(self):
-        # type: () -> Dict
+    def get_cephadm_config(self) -> Dict[str, Any]:
         config = {'pool' : self.spec.pool} # type: Dict
         if self.spec.namespace:
             config['namespace'] = self.spec.namespace


### PR DESCRIPTION

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
