### PR TITLE
mgr/dashboard: Display cluster status in favicon

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/favicon.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/favicon.service.ts
@@ -52,7 +52,7 @@ export class FaviconService implements OnDestroy {
       context.save();
       context.globalCompositeOperation = 'destination-out';
       context.beginPath();
-      context.arc(canvas.width - radius, radius, radius + 1, 0, 2 * Math.PI);
+      context.arc(canvas.width - radius, radius, radius + 2, 0, 2 * Math.PI);
       context.fill();
       context.restore();
 


### PR DESCRIPTION
Use radius of 2px like on GitHub to increase visibility of the status circle.

GitHub:
![Bildschirmfoto vom 2020-07-17 13-19-09](https://user-images.githubusercontent.com/1897962/87781021-2c926b00-c830-11ea-9ebb-58a2bef88043.png)

Before:
![Bildschirmfoto vom 2020-07-17 13-47-11](https://user-images.githubusercontent.com/1897962/87783095-1090c880-c834-11ea-9114-9621bac36a92.png)

After:
![Bildschirmfoto vom 2020-07-17 13-18-48](https://user-images.githubusercontent.com/1897962/87781026-2f8d5b80-c830-11ea-8458-84f04bc4842a.png)

Follow up of PR https://github.com/ceph/ceph/pull/36000.

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
