### PR TITLE
nautilus: mds: do not defer incoming mgrmap when mds is laggy

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1056,6 +1056,17 @@ bool MDSDaemon::ms_get_authorizer(int dest_type, AuthAuthorizer **authorizer)
 /*
  * high priority messages we always process
  */
+
+#define ALLOW_MESSAGES_FROM(peers)                                      \
+  do {                                                                  \
+    if (m->get_connection() && (m->get_connection()->get_peer_type() & (peers)) == 0) { \
+      dout(0) << __FILE__ << "." << __LINE__ << ": filtered out request, peer=" \
+              << m->get_connection()->get_peer_type() << " allowing="   \
+              << #peers << " message=" << *m << dendl;                  \
+      return true;                                                      \
+    }                                                                   \
+  } while (0)
+
 bool MDSDaemon::handle_core_message(const Message::const_ref &m)
 {
   switch (m->get_type()) {

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1030,6 +1030,10 @@ bool MDSRank::_dispatch(const Message::const_ref &m, bool new_msg)
   if (is_stale_message(m)) {
     return true;
   }
+  // do not proceed if this message cannot be handled
+  if (!is_valid_message(m)) {
+    return false;
+  }
 
   if (beacon.is_laggy()) {
     dout(5) << " laggy, deferring " << *m << dendl;
@@ -1038,10 +1042,7 @@ bool MDSRank::_dispatch(const Message::const_ref &m, bool new_msg)
     dout(5) << " there are deferred messages, deferring " << *m << dendl;
     waiting_for_nolaggy.push_back(m);
   } else {
-    if (!handle_deferrable_message(m)) {
-      return false;
-    }
-
+    handle_message(m);
     heartbeat_reset();
   }
 
@@ -1158,10 +1159,45 @@ void MDSRank::update_mlogger()
   }
 }
 
+// message types that the mds can handle
+bool MDSRank::is_valid_message(const Message::const_ref &m) {
+  int port = m->get_type() & 0xff00;
+  int type = m->get_type();
+
+  if (port == MDS_PORT_CACHE ||
+      port == MDS_PORT_MIGRATOR ||
+      type == CEPH_MSG_CLIENT_SESSION ||
+      type == CEPH_MSG_CLIENT_RECONNECT ||
+      type == CEPH_MSG_CLIENT_RECLAIM ||
+      type == CEPH_MSG_CLIENT_REQUEST ||
+      type == MSG_MDS_SLAVE_REQUEST ||
+      type == MSG_MDS_HEARTBEAT ||
+      type == MSG_MDS_TABLE_REQUEST ||
+      type == MSG_MDS_LOCK ||
+      type == MSG_MDS_INODEFILECAPS ||
+      type == CEPH_MSG_CLIENT_CAPS ||
+      type == CEPH_MSG_CLIENT_CAPRELEASE ||
+      type == CEPH_MSG_CLIENT_LEASE) {
+    return true;
+  }
+
+  return false;
+}
+
 /*
  * lower priority messages we defer if we seem laggy
  */
-bool MDSRank::handle_deferrable_message(const Message::const_ref &m)
+
+#define ALLOW_MESSAGES_FROM(peers)                                      \
+  do {                                                                  \
+    if (m->get_connection() && (m->get_connection()->get_peer_type() & (peers)) == 0) { \
+      dout(0) << __FILE__ << "." << __LINE__ << ": filtered out request, peer=" << m->get_connection()->get_peer_type() \
+              << " allowing=" << #peers << " message=" << *m << dendl;  \
+      return;                                                           \
+    }                                                                   \
+  } while (0)
+
+void MDSRank::handle_message(const Message::const_ref &m)
 {
   int port = m->get_type() & 0xff00;
 
@@ -1225,11 +1261,9 @@ bool MDSRank::handle_deferrable_message(const Message::const_ref &m)
       break;
 
     default:
-      return false;
+      derr << "unrecogonized message " << *m << dendl;
     }
   }
-
-  return true;
 }
 
 /**
@@ -1265,9 +1299,8 @@ void MDSRank::_advance_queues()
 
     if (!is_stale_message(old)) {
       dout(7) << " processing laggy deferred " << *old << dendl;
-      if (!handle_deferrable_message(old)) {
-        dout(0) << "unrecognized message " << *old << dendl;
-      }
+      ceph_assert(is_valid_message(old));
+      handle_message(old);
     }
 
     heartbeat_reset();

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1261,7 +1261,7 @@ void MDSRank::handle_message(const Message::const_ref &m)
       break;
 
     default:
-      derr << "unrecogonized message " << *m << dendl;
+      derr << "unrecognized message " << *m << dendl;
     }
   }
 }

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -266,7 +266,8 @@ class MDSRank {
     void inc_dispatch_depth() { ++dispatch_depth; }
     void dec_dispatch_depth() { --dispatch_depth; }
     void retry_dispatch(const Message::const_ref &m);
-    bool handle_deferrable_message(const Message::const_ref &m);
+    bool is_valid_message(const Message::const_ref &m);
+    void handle_message(const Message::const_ref &m);
     void _advance_queues();
     bool _dispatch(const Message::const_ref &m, bool new_msg);
 
@@ -667,16 +668,6 @@ public:
       Context *respawn_hook_,
       Context *suicide_hook_);
 };
-
-// This utility for MDS and MDSRank dispatchers.
-#define ALLOW_MESSAGES_FROM(peers) \
-do { \
-  if (m->get_connection() && (m->get_connection()->get_peer_type() & (peers)) == 0) { \
-    dout(0) << __FILE__ << "." << __LINE__ << ": filtered out request, peer=" << m->get_connection()->get_peer_type() \
-           << " allowing=" << #peers << " message=" << *m << dendl; \
-    return true; \
-  } \
-} while (0)
 
 #endif // MDS_RANK_H_
 


### PR DESCRIPTION
backport trackers: https://tracker.ceph.com/issues/46151

---

backport of https://github.com/ceph/ceph/pull/34024

parent trackers: https://tracker.ceph.com/issues/44638

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh