### PR TITLE
nautilus: tests: Revert "Revert "qa/suites/rados/mgr/tasks/module_selftest: whitelist …

### DIFF
--- a/qa/suites/rados/mgr/tasks/module_selftest.yaml
+++ b/qa/suites/rados/mgr/tasks/module_selftest.yaml
@@ -19,6 +19,7 @@ tasks:
         - \(MGR_ZABBIX_
         - foo bar
         - Failed to open Telegraf
+        - evicting unresponsive client
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_module_selftest


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46200

---

backport of https://github.com/ceph/ceph/pull/35532
parent tracker: https://tracker.ceph.com/issues/43943

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh