### PR TITLE
nautilus: tests: qa/tasks/cephfs/cephfs_test_case.py: skip cleaning the core dumps when in program case

### DIFF
--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -267,6 +267,10 @@ class CephFSTestCase(CephTestCase):
         if core_dir:  # Non-default core_pattern with a directory in it
             # We have seen a core_pattern that looks like it's from teuthology's coredump
             # task, so proceed to clear out the core file
+            if core_dir[0] == '|':
+                log.info("Piped core dumps to program {0}, skip cleaning".format(core_dir[1:]))
+                return;
+
             log.info("Clearing core from directory: {0}".format(core_dir))
 
             # Verify that we see the expected single coredump


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46310

---

backport of https://github.com/ceph/ceph/pull/35038
parent tracker: https://tracker.ceph.com/issues/45530

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh