### PR TITLE
nautilus: mds: make threshold for MDS_TRIM configurable

### DIFF
--- a/doc/cephfs/health-messages.rst
+++ b/doc/cephfs/health-messages.rst
@@ -59,8 +59,8 @@ by the setting ``mds_log_max_segments``, and when the number of segments
 exceeds that setting the MDS starts writing back metadata so that it
 can remove (trim) the oldest segments.  If this writeback is happening
 too slowly, or a software bug is preventing trimming, then this health
-message may appear.  The threshold for this message to appear is for the
-number of segments to be double ``mds_log_max_segments``.
+message may appear.  The threshold for this message to appear is controlled by
+the config option ``mds_log_warn_factor``, the default is 2.0.
 
 Message: "Client *name* failing to respond to capability release"
 Code: MDS_HEALTH_CLIENT_LATE_RELEASE, MDS_HEALTH_CLIENT_LATE_RELEASE_MANY

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7848,6 +7848,12 @@ std::vector<Option> get_mds_options() {
     .set_default(128)
     .set_description("maximum number of segments which may be untrimmed"),
 
+    Option("mds_log_warn_factor", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(2.0)
+    .set_min(1.0)
+    .set_flag(Option::FLAG_RUNTIME)
+    .set_description("trigger MDS_HEALTH_TRIM warning when the mds log is longer than mds_log_max_segments * mds_log_warn_factor"),
+
     Option("mds_bal_export_pin", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description("allow setting directory export pins to particular ranks"),

--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -304,9 +304,9 @@ void Beacon::notify_health(MDSRank const *mds)
   }
 
   // Detect MDS_HEALTH_TRIM condition
-  // Arbitrary factor of 2, indicates MDS is not trimming promptly
+  // Indicates MDS is not trimming promptly
   {
-    if (mds->mdlog->get_num_segments() > (size_t)(g_conf()->mds_log_max_segments * 2)) {
+    if (mds->mdlog->get_num_segments() > (size_t)(g_conf()->mds_log_max_segments * g_conf().get_val<double>("mds_log_warn_factor"))) {
       std::ostringstream oss;
       oss << "Behind on trimming (" << mds->mdlog->get_num_segments()
         << "/" << g_conf()->mds_log_max_segments << ")";


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46474

---

backport of https://github.com/ceph/ceph/pull/35415
parent tracker: https://tracker.ceph.com/issues/45906

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh