### PR TITLE
mds/MDSRank: fix naked return statement in ALLOW_MESSAGES_FROM

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1189,7 +1189,7 @@ bool MDSRank::is_valid_message(const cref_t<Message> &m) {
     if (m->get_connection() && (m->get_connection()->get_peer_type() & (peers)) == 0) { \
       dout(0) << __FILE__ << "." << __LINE__ << ": filtered out request, peer=" << m->get_connection()->get_peer_type() \
               << " allowing=" << #peers << " message=" << *m << dendl;  \
-      return;                                                           \
+      return true;                                                      \
     }                                                                   \
   } while (0)
 


### PR DESCRIPTION
Fixes: beb12fa25315153e1a06a0104883de89776438a6
Fixes: https://tracker.ceph.com/issues/46612
Signed-off-by: Nathan Cutler <ncutler@suse.com>
