### PR TITLE
nautilus: mds: do not submit omap_rm_keys if the dir is the basedir of merge.

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2224,10 +2224,11 @@ void CDir::_omap_commit(int op_prio)
   };
 
   if (state_test(CDir::STATE_FRAGMENTING)) {
+    assert(committed_version == 0);
     for (auto p = items.begin(); p != items.end(); ) {
       CDentry *dn = p->second;
       ++p;
-      if (!dn->is_dirty() && dn->get_linkage()->is_null())
+      if (dn->get_linkage()->is_null())
 	continue;
       write_one(dn);
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46521

---

backport of https://github.com/ceph/ceph/pull/35848
parent tracker: https://tracker.ceph.com/issues/46273

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh