### PR TITLE
nautilus: rgw: Add support wildcard subuser for bucket policy

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -602,7 +602,11 @@ bool rgw::auth::LocalApplier::is_identity(const idset_t& ids) const {
       if (id.get_id() == user_info.user_id.id) {
         return true;
       }
-      if (subuser != NO_SUBUSER) {
+      std::string wildcard_subuser = user_info.user_id.id;
+      wildcard_subuser.append(":*");
+      if (wildcard_subuser == id.get_id()) {
+        return true;
+      } else if (subuser != NO_SUBUSER) {
         std::string user = user_info.user_id.id;
         user.append(":");
         user.append(subuser);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45930

---

backport of https://github.com/ceph/ceph/pull/33762
parent tracker: https://tracker.ceph.com/issues/44452

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh