### PR TITLE
octopus: common:  ignore SIGHUP prior to fork

### DIFF
--- a/src/common/Preforker.h
+++ b/src/common/Preforker.h
@@ -3,6 +3,7 @@
 #ifndef CEPH_COMMON_PREFORKER_H
 #define CEPH_COMMON_PREFORKER_H
 
+#include <signal.h>
 #include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>

--- a/src/common/Preforker.h
+++ b/src/common/Preforker.h
@@ -45,6 +45,17 @@ public:
       return (errno = e, -1);
     }
 
+    struct sigaction sa;
+    sa.sa_handler = SIG_IGN;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    if (sigaction(SIGHUP, &sa, nullptr) != 0) {
+      int e = errno;
+      oss << "[" << getpid() << "]: unable to ignore SIGHUP: " << cpp_strerror(e);
+      err = oss.str();
+      return (errno = e, -1);
+    }
+
     forked = true;
 
     childpid = fork();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46591

---

backport of

* https://github.com/ceph/ceph/pull/35844
* #36194

parent tracker: https://tracker.ceph.com/issues/46269

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh

---

To Do:

- [x] https://github.com/ceph/ceph/pull/36194 merged into master
- [x] https://github.com/ceph/ceph/pull/36194 cherry-picked into this PR