### PR TITLE
mds/MDSRank: fix typo in "unrecognized"

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1257,7 +1257,7 @@ void MDSRank::handle_message(const cref_t<Message> &m)
       break;
 
     default:
-      derr << "unrecogonized message " << *m << dendl;
+      derr << "unrecognized message " << *m << dendl;
     }
   }
 }


### PR DESCRIPTION
Fixes: beb12fa25315153e1a06a0104883de89776438a6
Signed-off-by: Nathan Cutler <ncutler@suse.com>
