### PR TITLE
octopus: mds/MDSRank: fix typo in "unrecognized"

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1235,7 +1235,7 @@ void MDSRank::handle_message(const cref_t<Message> &m)
       break;
 
     default:
-      derr << "unrecogonized message " << *m << dendl;
+      derr << "unrecognized message " << *m << dendl;
     }
   }
 }


### PR DESCRIPTION
Fixes: beb12fa25315153e1a06a0104883de89776438a6
Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit 6e96081dae543b3356799767dd94d9f73dc5b275)
