### PR TITLE
mgr/dashboard: fix navigation sidebar elements alignment

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.scss
@@ -184,6 +184,7 @@ $sidebar-width: 200px;
         display: block;
         font-size: 1.1em;
         padding: 10px;
+        padding-left: 27px;
 
         text-decoration: none;
 
@@ -225,7 +226,7 @@ $sidebar-width: 200px;
   ul ul a {
     background: lighten(bd.$color-navbar-bg, 10);
     font-size: 0.9em !important;
-    padding-left: 30px !important;
+    padding-left: 40px !important;
   }
 
   .cd-navbar-primary a:focus {


### PR DESCRIPTION
Currently the navigation sidebar elements are not aligned properly with the three bars for opening and closing the sidebar. This PR address that minor cleanup.

![navbarupstream](https://user-images.githubusercontent.com/53651462/87909210-71fba600-ca85-11ea-8ac7-f50da14efda1.png)


Fixes: https://tracker.ceph.com/issues/46621

Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
