### PR TITLE
rgw: fix md5 not match for RGWBulkUploadOp upload when enable rgw com…

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7215,7 +7215,7 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
     ceph::bufferlist tmp;
     RGWCompressionInfo cs_info;
     cs_info.compression_type = plugin->get_type_name();
-    cs_info.orig_size = s->obj_size;
+    cs_info.orig_size = size;
     cs_info.compressor_message = compressor->get_compressor_message();
     cs_info.blocks = std::move(compressor->get_compression_blocks());
     encode(cs_info, tmp);


### PR DESCRIPTION
fix https://tracker.ceph.com/issues/46625

```
 dd if=/dev/urandom of=data/1M bs=1M count=1
 dd if=/dev/urandom of=data/2M bs=1M count=2

tar cvf data.tar data

bulkupload data.tar


# -*- coding: utf-8 -*-
import swiftclient
user = 'yly:swift'
key = 'cdEsYe5WGlRB9F48D4sjsQ5eSfRMGjSNaP4F9MAa'
endpoint = 'http://127.0.0.1:7480'
conn = swiftclient.Connection(
        user=user,
        key=key,
        authurl=endpoint+'/auth',
)
headers = {
"X-Auth-Token": conn.get_auth()[1]
}
import requests
url = "http://127.0.0.1:7480/swift/v1/testswift/?extract-archive=tar"
data = open("data.tar", "rb").read()
response = requests.put(url, headers=headers, data = data)

```
the origin_size in compression info is 0
```
 ./bin/radosgw-admin object stat --bucket testswift --object=data/1M |jq .compression
{
  "compression_type": "zlib",
  "orig_size": 0,
  "blocks": [
    {
      "old_ofs": 0,
      "new_ofs": 0,
      "len": 1048897
    }
  ]
}
```

if we use s3cmd download the compressed file, s3cmd will say MD5 not match 

