### PR TITLE
cephadm: use src/mypy.ini instead

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -732,8 +732,8 @@ class FileLock(object):
         #   https://stackoverflow.com/questions/17708885/flock-removing-locked-file-without-race-condition
         fd = self._lock_file_fd
         self._lock_file_fd = None
-        fcntl.flock(fd, fcntl.LOCK_UN)
-        os.close(fd)
+        fcntl.flock(fd, fcntl.LOCK_UN)  # type: ignore
+        os.close(fd)  # type: ignore
         return None
 
 
@@ -1112,7 +1112,7 @@ def infer_fsid(func):
             logger.debug('Using specified fsid: %s' % args.fsid)
             return func()
 
-        fsids = set()
+        fsids_set = set()
         daemon_list = list_daemons(detail=False)
         for daemon in daemon_list:
             if not is_fsid(daemon['fsid']):
@@ -1120,11 +1120,11 @@ def infer_fsid(func):
                 continue
             elif 'name' not in args or not args.name:
                 # args.name not specified
-                fsids.add(daemon['fsid'])
+                fsids_set.add(daemon['fsid'])
             elif daemon['name'] == args.name:
                 # args.name is a match
-                fsids.add(daemon['fsid'])
-        fsids = sorted(fsids)
+                fsids_set.add(daemon['fsid'])
+        fsids = sorted(fsids_set)
 
         if not fsids:
             # some commands do not always require an fsid
@@ -1300,7 +1300,7 @@ def make_var_run(fsid, uid, gid):
 
 
 def copy_tree(src, dst, uid=None, gid=None):
-    # type: (List[str], str, int, int) -> None
+    # type: (List[str], str, Optional[int], Optional[int]) -> None
     """
     Copy a directory tree from src to dst
     """
@@ -1325,7 +1325,7 @@ def copy_tree(src, dst, uid=None, gid=None):
 
 
 def copy_files(src, dst, uid=None, gid=None):
-    # type: (List[str], str, int, int) -> None
+    # type: (List[str], str, Optional[int], Optional[int]) -> None
     """
     Copy a files from src to dst
     """
@@ -1345,7 +1345,7 @@ def copy_files(src, dst, uid=None, gid=None):
 
 
 def move_files(src, dst, uid=None, gid=None):
-    # type: (List[str], str, int, int) -> None
+    # type: (List[str], str, Optional[int], Optional[int]) -> None
     """
     Move files from src to dst
     """
@@ -1486,7 +1486,7 @@ def check_units(units, enabler=None):
 
 
 def get_legacy_config_fsid(cluster, legacy_dir=None):
-    # type: (str, str) -> Optional[str]
+    # type: (str, Optional[str]) -> Optional[str]
     config_file = '/etc/ceph/%s.conf' % cluster
     if legacy_dir is not None:
         config_file = os.path.abspath(legacy_dir + config_file)
@@ -1499,7 +1499,7 @@ def get_legacy_config_fsid(cluster, legacy_dir=None):
 
 
 def get_legacy_daemon_fsid(cluster, daemon_type, daemon_id, legacy_dir=None):
-    # type: (str, str, Union[int, str], str) -> Optional[str]
+    # type: (str, str, Union[int, str], Optional[str]) -> Optional[str]
     fsid = None
     if daemon_type == 'osd':
         try:

--- a/src/cephadm/mypy.ini
+++ b/src/cephadm/mypy.ini
@@ -1,2 +1,0 @@
-[mypy]
-ignore_missing_imports = False

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -13,4 +13,4 @@ commands=pytest {posargs}
 [testenv:mypy]
 basepython = python3
 deps = mypy==0.782
-commands = mypy {posargs:cephadm}
+commands = mypy --config-file ../mypy.ini {posargs:cephadm}


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

Right now, this fails with 

```
cephadm: note: In member "_release" of class "FileLock":
cephadm:735: error: Argument 1 to "flock" has incompatible type "Optional[Any]"; expected "Union[int, HasFileno]"
cephadm:736: error: Argument 1 to "close" has incompatible type "Optional[Any]"; expected "int"
cephadm: note: In function "_infer_fsid":
cephadm:1127: error: Incompatible types in assignment (expression has type "List[str]", variable has type "Set[str]")
cephadm:1133: error: Value of type "Set[str]" is not indexable
cephadm:1134: error: Value of type "Set[str]" is not indexable
cephadm: note: In function "make_data_dir":
cephadm:1277: error: Incompatible default for argument "uid" (default has type "None", argument has type "int")
cephadm:1277: error: Incompatible default for argument "gid" (default has type "None", argument has type "int")
cephadm: note: In function "make_log_dir":
cephadm:1287: error: Incompatible default for argument "uid" (default has type "None", argument has type "int")
cephadm:1287: error: Incompatible default for argument "gid" (default has type "None", argument has type "int")
cephadm: note: In function "copy_tree":
cephadm:1302: error: Incompatible default for argument "uid" (default has type "None", argument has type "int")
cephadm:1302: error: Incompatible default for argument "gid" (default has type "None", argument has type "int")
cephadm: note: In function "copy_files":
cephadm:1327: error: Incompatible default for argument "uid" (default has type "None", argument has type "int")
cephadm:1327: error: Incompatible default for argument "gid" (default has type "None", argument has type "int")
cephadm: note: In function "move_files":
cephadm:1347: error: Incompatible default for argument "uid" (default has type "None", argument has type "int")
cephadm:1347: error: Incompatible default for argument "gid" (default has type "None", argument has type "int")
cephadm: note: In function "get_legacy_config_fsid":
cephadm:1488: error: Incompatible default for argument "legacy_dir" (default has type "None", argument has type "str")
cephadm: note: In function "get_legacy_daemon_fsid":
cephadm:1501: error: Incompatible default for argument "legacy_dir" (default has type "None", argument has type "str")
cephadm: note: In function "list_daemons":
cephadm:3357: error: Argument "legacy_dir" to "get_legacy_daemon_fsid" has incompatible type "Optional[str]"; expected "str"
Found 18 errors in 1 file (checked 1 source file)
ERROR: InvocationError: '/home/sebastian/Repos/ceph/src/cephadm/.tox/mypy/bin/mypy --config-file ../mypy.ini cephadm'
```

but I know that existing open PRs will fix a few issues.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
