### PR TITLE
nautilus: rgw: Modify the error message of PutBucketAcls when the bucket does not exist

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -215,7 +215,7 @@ int rgw_link_bucket(RGWRados* const store,
 
   if (update_entrypoint) {
     ret = store->get_bucket_entrypoint_info(obj_ctx, tenant_name, bucket_name, ep, &ot, NULL, &attrs);
-    if (ret < 0 && ret != -ENOENT) {
+    if (ret < 0 && ret != -ERR_NO_SUCH_BUCKET) {
       ldout(store->ctx(), 0) << "ERROR: store->get_bucket_entrypoint_info() returned: "
                              << cpp_strerror(-ret) << dendl;
     }
@@ -276,7 +276,7 @@ int rgw_unlink_bucket(RGWRados *store, const rgw_user& user_id, const string& te
   map<string, bufferlist> attrs;
   RGWSysObjectCtx obj_ctx = store->svc.sysobj->init_obj_ctx();
   ret = store->get_bucket_entrypoint_info(obj_ctx, tenant_name, bucket_name, ep, &ot, NULL, &attrs);
-  if (ret == -ENOENT)
+  if (ret == -ERR_NO_SUCH_BUCKET)
     return 0;
   if (ret < 0)
     return ret;
@@ -2581,11 +2581,11 @@ public:
     string tenant_name, bucket_name;
     parse_bucket(entry, &tenant_name, &bucket_name);
     int ret = store->get_bucket_entrypoint_info(obj_ctx, tenant_name, bucket_name, old_be, &old_ot, &orig_mtime, &attrs);
-    if (ret < 0 && ret != -ENOENT)
+    if (ret < 0 && ret != -ERR_NO_SUCH_BUCKET)
       return ret;
 
     // are we actually going to perform this put, or is it too old?
-    if (ret != -ENOENT &&
+    if (ret != -ERR_NO_SUCH_BUCKET &&
         !check_versions(old_ot.read_version, orig_mtime,
 			objv_tracker.write_version, mtime, sync_type)) {
       return STATUS_NO_APPLY;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8274,6 +8274,9 @@ int RGWRados::get_bucket_entrypoint_info(RGWSysObjectCtx& obj_ctx,
 			       bucket_entry, bl, objv_tracker, pmtime, pattrs,
 			       cache_info, refresh_version);
   if (ret < 0) {
+    if (ret == -ENOENT) {
+      return -ERR_NO_SUCH_BUCKET;
+    }
     return ret;
   }
 


### PR DESCRIPTION
rgw:Modify the error message of PutBucketAcls when the bucket does not exist

When the bucket does not exist, the "NoSuchKey" error will be thrown after executing PutBucketAcls, but the more accurate error should be "NoSuchBucket", so we modified the "RGWRados::get_bucket_entrypoint_info" function and corrected the error code.

Signed-off-by: wangyingbin <wangyingbin@inspur.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
