### PR TITLE
mgr/cephadm: add `orch ok-to-stop` commands

### DIFF
--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -161,8 +161,10 @@ data_devices:
         self._orch_cmd("apply", "nfs", "service_name", "2")
 
     def test_error(self):
-        ret = self._orch_cmd_result("host", "add", "raise_no_support")
-        self.assertEqual(ret, errno.ENOENT)
+        ret = self._orch_cmd_result("host", "add", "raise_validation_error")
+        self.assertEqual(ret, errno.EINVAL)
+        ret = self._orch_cmd_result("host", "add", "raise_error")
+        self.assertEqual(ret, errno.EINVAL)
         ret = self._orch_cmd_result("host", "add", "raise_bug")
         self.assertEqual(ret, errno.EINVAL)
         ret = self._orch_cmd_result("host", "add", "raise_not_implemented")

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1903,8 +1903,12 @@ you may want to run:
             r = True
 
         # remove any?
-        while remove_daemon_hosts and not self.cephadm_services[daemon_type].ok_to_stop(
-                [d.daemon_id for d in remove_daemon_hosts]):
+        def _ok_to_stop(remove_daemon_hosts: Set[orchestrator.DaemonDescription]) -> bool:
+            daemon_ids = [d.daemon_id for d in remove_daemon_hosts]
+            r = self.cephadm_services[daemon_type].ok_to_stop(daemon_ids)
+            return not r.retval
+
+        while remove_daemon_hosts and not _ok_to_stop(remove_daemon_hosts):
             # let's find a subset that is ok-to-stop
             remove_daemon_hosts.pop()
         for d in remove_daemon_hosts:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1143,6 +1143,29 @@ you may want to run:
         self.log.info('Removed label %s to host %s' % (label, host))
         return 'Removed label %s from host %s' % (label, host)
 
+    @trivial_completion
+    def host_ok_to_stop(self, hostname: str):
+        if hostname not in self.cache.get_hosts():
+            raise OrchestratorError(f'Cannot find host "{hostname}"')
+
+        daemons = self.cache.get_daemons()
+        daemon_map = defaultdict(lambda: [])
+        for dd in daemons:
+            if dd.hostname == hostname:
+                daemon_map[dd.daemon_type].append(dd.daemon_id)
+
+        for daemon_type,daemon_ids in daemon_map.items():
+            r = self.cephadm_services[daemon_type].ok_to_stop(daemon_ids)
+            if r.retval:
+                self.log.error(f'It is NOT safe to stop host {hostname}')
+                raise orchestrator.OrchestratorError(
+                        r.stderr,
+                        errno=r.retval)
+
+        msg = f'It is presumed safe to stop host {hostname}'
+        self.log.info(msg)
+        return msg
+
     def update_osdspec_previews(self, search_host: str = ''):
         # Set global 'pending' flag for host
         self.cache.loading_osdspec_preview.add(search_host)

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -126,14 +126,13 @@ class CephadmUpgrade:
             if not self.upgrade_state or self.upgrade_state.get('paused'):
                 return False
 
-            ok = self.mgr.cephadm_services[s.daemon_type].ok_to_stop([s.daemon_id])
+            r = self.mgr.cephadm_services[s.daemon_type].ok_to_stop([s.daemon_id])
 
-            if ok:
-                logger.info('Upgrade: It is presumed safe to stop %s.%s' %
-                              (s.daemon_type, s.daemon_id))
+            if not r.retval:
+                logger.info(f'Upgrade: {r.stdout}')
                 return True
-            logger.info('Upgrade: It is NOT safe to stop %s.%s' %
-                          (s.daemon_type, s.daemon_id))
+            logger.error('Upgrade: {r.stderr}')
+
             time.sleep(15)
             tries -= 1
         return False

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -845,6 +845,14 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def host_ok_to_stop(self, hostname:str) -> Completion:
+        """
+        Check if the specified host can be safely stopped without reducing availability
+
+        :param host: hostname
+        """
+        raise NotImplementedError()
+
     def get_inventory(self, host_filter=None, refresh=False):
         # type: (Optional[InventoryFilter], bool) -> Completion
         """

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -47,8 +47,12 @@ class OrchestratorError(Exception):
 
     It's not intended for programming errors or orchestrator internal errors.
     """
-    def __init__(self, msg, event_kind_subject: Optional[Tuple[str, str]]=None):
+    def __init__(self,
+                 msg: str,
+                 errno: int = -errno.EINVAL,
+                 event_kind_subject: Optional[Tuple[str, str]] = None):
         super(Exception, self).__init__(msg)
+        self.errno = errno
         # See OrchestratorEvent.subject
         self.event_subject = event_kind_subject
 
@@ -58,7 +62,7 @@ class NoOrchestrator(OrchestratorError):
     No orchestrator in configured.
     """
     def __init__(self, msg="No orchestrator configured (try `ceph orch set backend`)"):
-        super(NoOrchestrator, self).__init__(msg)
+        super(NoOrchestrator, self).__init__(msg, errno=-errno.ENOENT)
 
 
 class OrchestratorValidationError(OrchestratorError):
@@ -82,8 +86,10 @@ def handle_exception(prefix, cmd_args, desc, perm, func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except (OrchestratorError, ImportError, ServiceSpecValidationError) as e:
+        except (OrchestratorError, ServiceSpecValidationError) as e:
             # Do not print Traceback for expected errors.
+            return HandleCommandResult(e.errno, stderr=str(e))
+        except ImportError as e:
             return HandleCommandResult(-errno.ENOENT, stderr=str(e))
         except NotImplementedError:
             msg = 'This Orchestrator does not support `{}`'.format(prefix)

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -348,6 +348,16 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
+    @_cli_write_command(
+        'orch host ok-to-stop',
+        'name=hostname,type=CephString',
+        desc='Check if the specified host can be safely stopped without reducing availability')
+    def _host_ok_to_stop(self, hostname: str):
+        completion = self.host_ok_to_stop(hostname)
+        self._orchestrator_wait([completion])
+        raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
     @_cli_read_command(
         'orch device ls',
         "name=hostname,type=CephString,n=N,req=false "

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -353,8 +353,10 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
     def add_host(self, spec):
         # type: (orchestrator.HostSpec) -> None
         host = spec.hostname
-        if host == 'raise_no_support':
+        if host == 'raise_validation_error':
             raise orchestrator.OrchestratorValidationError("MON count must be either 1, 3 or 5")
+        if host == 'raise_error':
+            raise orchestrator.OrchestratorError("host address is empty")
         if host == 'raise_bug':
             raise ZeroDivisionError()
         if host == 'raise_not_implemented':

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1,3 +1,4 @@
+import errno
 import fnmatch
 import re
 from collections import namedtuple, OrderedDict
@@ -14,9 +15,11 @@ class ServiceSpecValidationError(Exception):
     Defining an exception here is a bit problematic, cause you cannot properly catch it,
     if it was raised in a different mgr module.
     """
-
-    def __init__(self, msg):
+    def __init__(self,
+                 msg: str,
+                 errno: int = -errno.EINVAL):
         super(ServiceSpecValidationError, self).__init__(msg)
+        self.errno = errno
 
 
 def assert_valid_host(name):


### PR DESCRIPTION
Adds a per daemon ok-to-stop command:
```
$ ceph orch ok-to-stop osd 0 1 2
Error EBUSY: It is NOT safe to stop ['osd.0', 'osd.1', 'osd.2']: 65 PGs are already too degraded, would become too degraded or might become unavailable
```

Also adds a per host ok-to-stop command:
```
$ ceph orch host ok-to-stop host1
It is presumed safe to stop host host1
```

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
