### PR TITLE
test/librados_test_stub: use std::bind

### DIFF
--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -20,9 +20,9 @@
 #include "objclass/objclass.h"
 #include "osd/osd_types.h"
 #include <arpa/inet.h>
-#include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <deque>
+#include <functional>
 #include <list>
 #include <vector>
 #include "include/ceph_assert.h"
@@ -343,6 +343,8 @@ extern "C" int rados_wait_for_latest_osdmap(rados_t cluster) {
   return client->wait_for_latest_osdmap();
 }
 
+using namespace std::placeholders;
+
 namespace librados {
 
 AioCompletion::~AioCompletion()
@@ -511,7 +513,7 @@ void IoCtx::close() {
 int IoCtx::create(const std::string& oid, bool exclusive) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::create, _1, _2, exclusive,
+    oid, std::bind(&TestIoCtxImpl::create, _1, _2, exclusive,
                      ctx->get_snap_context()));
 }
 
@@ -525,7 +527,7 @@ int IoCtx::exec(const std::string& oid, const char *cls, const char *method,
                 bufferlist& inbl, bufferlist& outbl) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::exec, _1, _2,
+    oid, std::bind(&TestIoCtxImpl::exec, _1, _2,
                      librados_test_stub::get_class_handler(), cls,
                      method, inbl, &outbl, ctx->get_snap_read(),
                      ctx->get_snap_context()));
@@ -562,14 +564,14 @@ std::string IoCtx::get_pool_name() {
 int IoCtx::list_snaps(const std::string& o, snap_set_t *out_snaps) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    o, boost::bind(&TestIoCtxImpl::list_snaps, _1, _2, out_snaps));
+    o, std::bind(&TestIoCtxImpl::list_snaps, _1, _2, out_snaps));
 }
 
 int IoCtx::list_watchers(const std::string& o,
                          std::list<obj_watch_t> *out_watchers) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    o, boost::bind(&TestIoCtxImpl::list_watchers, _1, _2, out_watchers));
+    o, std::bind(&TestIoCtxImpl::list_watchers, _1, _2, out_watchers));
 }
 
 int IoCtx::notify(const std::string& o, uint64_t ver, bufferlist& bl) {
@@ -595,7 +597,7 @@ int IoCtx::omap_get_vals(const std::string& oid,
                          std::map<std::string, bufferlist> *out_vals) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::omap_get_vals, _1, _2, start_after, "",
+    oid, std::bind(&TestIoCtxImpl::omap_get_vals, _1, _2, start_after, "",
                      max_return, out_vals));
 }
 
@@ -616,14 +618,14 @@ int IoCtx::read(const std::string& oid, bufferlist& bl, size_t len,
                 uint64_t off) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::read, _1, _2, len, off, &bl,
+    oid, std::bind(&TestIoCtxImpl::read, _1, _2, len, off, &bl,
                      ctx->get_snap_read()));
 }
 
 int IoCtx::remove(const std::string& oid) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::remove, _1, _2, ctx->get_snap_context()));
+    oid, std::bind(&TestIoCtxImpl::remove, _1, _2, ctx->get_snap_context()));
 }
 
 int IoCtx::selfmanaged_snap_create(uint64_t *snapid) {
@@ -667,26 +669,26 @@ int IoCtx::sparse_read(const std::string& oid, std::map<uint64_t,uint64_t>& m,
                        bufferlist& bl, size_t len, uint64_t off) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, &m, &bl,
+    oid, std::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, &m, &bl,
                      ctx->get_snap_read()));
 }
 
 int IoCtx::stat(const std::string& oid, uint64_t *psize, time_t *pmtime) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::stat, _1, _2, psize, pmtime));
+    oid, std::bind(&TestIoCtxImpl::stat, _1, _2, psize, pmtime));
 }
 
 int IoCtx::tmap_update(const std::string& oid, bufferlist& cmdbl) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::tmap_update, _1, _2, cmdbl));
+    oid, std::bind(&TestIoCtxImpl::tmap_update, _1, _2, cmdbl));
 }
 
 int IoCtx::trunc(const std::string& oid, uint64_t off) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::truncate, _1, _2, off,
+    oid, std::bind(&TestIoCtxImpl::truncate, _1, _2, off,
                      ctx->get_snap_context()));
 }
 
@@ -716,14 +718,14 @@ int IoCtx::write(const std::string& oid, bufferlist& bl, size_t len,
                  uint64_t off) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::write, _1, _2, bl, len, off,
+    oid, std::bind(&TestIoCtxImpl::write, _1, _2, bl, len, off,
                      ctx->get_snap_context()));
 }
 
 int IoCtx::write_full(const std::string& oid, bufferlist& bl) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::write_full, _1, _2, bl,
+    oid, std::bind(&TestIoCtxImpl::write_full, _1, _2, bl,
                      ctx->get_snap_context()));
 }
 
@@ -731,14 +733,14 @@ int IoCtx::writesame(const std::string& oid, bufferlist& bl, size_t len,
                      uint64_t off) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::writesame, _1, _2, bl, len, off,
+    oid, std::bind(&TestIoCtxImpl::writesame, _1, _2, bl, len, off,
                      ctx->get_snap_context()));
 }
 
 int IoCtx::cmpext(const std::string& oid, uint64_t off, bufferlist& cmp_bl) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
-    oid, boost::bind(&TestIoCtxImpl::cmpext, _1, _2, off, cmp_bl,
+    oid, std::bind(&TestIoCtxImpl::cmpext, _1, _2, off, cmp_bl,
                      ctx->get_snap_read()));
 }
 
@@ -810,13 +812,13 @@ ObjectOperation::~ObjectOperation() {
 
 void ObjectOperation::assert_exists() {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::assert_exists, _1, _2, _4));
+  o->ops.push_back(std::bind(&TestIoCtxImpl::assert_exists, _1, _2, _4));
 }
 
 void ObjectOperation::exec(const char *cls, const char *method,
                            bufferlist& inbl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::exec, _1, _2,
+  o->ops.push_back(std::bind(&TestIoCtxImpl::exec, _1, _2,
 			       librados_test_stub::get_class_handler(), cls,
 			       method, inbl, _3, _4, _5));
 }
@@ -832,11 +834,11 @@ size_t ObjectOperation::size() {
 void ObjectOperation::cmpext(uint64_t off, const bufferlist& cmp_bl,
                              int *prval) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  ObjectOperationTestImpl op = boost::bind(&TestIoCtxImpl::cmpext, _1, _2, off,
+  ObjectOperationTestImpl op = std::bind(&TestIoCtxImpl::cmpext, _1, _2, off,
                                            cmp_bl, _4);
   if (prval != NULL) {
-    op = boost::bind(save_operation_result,
-                     boost::bind(op, _1, _2, _3, _4, _5), prval);
+    op = std::bind(save_operation_result,
+                     std::bind(op, _1, _2, _3, _4, _5), prval);
   }
   o->ops.push_back(op);
 }
@@ -844,11 +846,11 @@ void ObjectOperation::cmpext(uint64_t off, const bufferlist& cmp_bl,
 void ObjectReadOperation::list_snaps(snap_set_t *out_snaps, int *prval) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
 
-  ObjectOperationTestImpl op = boost::bind(&TestIoCtxImpl::list_snaps, _1, _2,
+  ObjectOperationTestImpl op = std::bind(&TestIoCtxImpl::list_snaps, _1, _2,
                                            out_snaps);
   if (prval != NULL) {
-    op = boost::bind(save_operation_result,
-                     boost::bind(op, _1, _2, _3, _4, _5), prval);
+    op = std::bind(save_operation_result,
+                     std::bind(op, _1, _2, _3, _4, _5), prval);
   }
   o->ops.push_back(op);
 }
@@ -857,11 +859,11 @@ void ObjectReadOperation::list_watchers(std::list<obj_watch_t> *out_watchers,
                                         int *prval) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
 
-  ObjectOperationTestImpl op = boost::bind(&TestIoCtxImpl::list_watchers, _1,
+  ObjectOperationTestImpl op = std::bind(&TestIoCtxImpl::list_watchers, _1,
                                            _2, out_watchers);
   if (prval != NULL) {
-    op = boost::bind(save_operation_result,
-                     boost::bind(op, _1, _2, _3, _4, _5), prval);
+    op = std::bind(save_operation_result,
+                     std::bind(op, _1, _2, _3, _4, _5), prval);
   }
   o->ops.push_back(op);
 }
@@ -872,14 +874,14 @@ void ObjectReadOperation::read(size_t off, uint64_t len, bufferlist *pbl,
 
   ObjectOperationTestImpl op;
   if (pbl != NULL) {
-    op = boost::bind(&TestIoCtxImpl::read, _1, _2, len, off, pbl, _4);
+    op = std::bind(&TestIoCtxImpl::read, _1, _2, len, off, pbl, _4);
   } else {
-    op = boost::bind(&TestIoCtxImpl::read, _1, _2, len, off, _3, _4);
+    op = std::bind(&TestIoCtxImpl::read, _1, _2, len, off, _3, _4);
   }
 
   if (prval != NULL) {
-    op = boost::bind(save_operation_result,
-                     boost::bind(op, _1, _2, _3, _4, _5), prval);
+    op = std::bind(save_operation_result,
+                     std::bind(op, _1, _2, _3, _4, _5), prval);
   }
   o->ops.push_back(op);
 }
@@ -891,14 +893,14 @@ void ObjectReadOperation::sparse_read(uint64_t off, uint64_t len,
 
   ObjectOperationTestImpl op;
   if (pbl != NULL) {
-    op = boost::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, m, pbl, _4);
+    op = std::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, m, pbl, _4);
   } else {
-    op = boost::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, m, _3, _4);
+    op = std::bind(&TestIoCtxImpl::sparse_read, _1, _2, off, len, m, _3, _4);
   }
 
   if (prval != NULL) {
-    op = boost::bind(save_operation_result,
-                     boost::bind(op, _1, _2, _3, _4, _5), prval);
+    op = std::bind(save_operation_result,
+                     std::bind(op, _1, _2, _3, _4, _5), prval);
   }
   o->ops.push_back(op);
 }
@@ -906,46 +908,46 @@ void ObjectReadOperation::sparse_read(uint64_t off, uint64_t len,
 void ObjectReadOperation::stat(uint64_t *psize, time_t *pmtime, int *prval) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
 
-  ObjectOperationTestImpl op = boost::bind(&TestIoCtxImpl::stat, _1, _2,
+  ObjectOperationTestImpl op = std::bind(&TestIoCtxImpl::stat, _1, _2,
                                            psize, pmtime);
 
   if (prval != NULL) {
-    op = boost::bind(save_operation_result,
-                     boost::bind(op, _1, _2, _3, _4, _5), prval);
+    op = std::bind(save_operation_result,
+                     std::bind(op, _1, _2, _3, _4, _5), prval);
   }
   o->ops.push_back(op);
 }
 
 void ObjectWriteOperation::append(const bufferlist &bl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::append, _1, _2, bl, _5));
+  o->ops.push_back(std::bind(&TestIoCtxImpl::append, _1, _2, bl, _5));
 }
 
 void ObjectWriteOperation::create(bool exclusive) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::create, _1, _2, exclusive, _5));
+  o->ops.push_back(std::bind(&TestIoCtxImpl::create, _1, _2, exclusive, _5));
 }
 
 void ObjectWriteOperation::omap_set(const std::map<std::string, bufferlist> &map) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::omap_set, _1, _2, boost::ref(map)));
+  o->ops.push_back(std::bind(&TestIoCtxImpl::omap_set, _1, _2, boost::ref(map)));
 }
 
 void ObjectWriteOperation::remove() {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::remove, _1, _2, _5));
+  o->ops.push_back(std::bind(&TestIoCtxImpl::remove, _1, _2, _5));
 }
 
 void ObjectWriteOperation::selfmanaged_snap_rollback(uint64_t snapid) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::selfmanaged_snap_rollback,
+  o->ops.push_back(std::bind(&TestIoCtxImpl::selfmanaged_snap_rollback,
 			       _1, _2, snapid));
 }
 
 void ObjectWriteOperation::set_alloc_hint(uint64_t expected_object_size,
                                           uint64_t expected_write_size) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::set_alloc_hint, _1, _2,
+  o->ops.push_back(std::bind(&TestIoCtxImpl::set_alloc_hint, _1, _2,
 			       expected_object_size, expected_write_size, 0,
                                _5));
 }
@@ -954,43 +956,43 @@ void ObjectWriteOperation::set_alloc_hint2(uint64_t expected_object_size,
                                            uint64_t expected_write_size,
                                            uint32_t flags) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::set_alloc_hint, _1, _2,
+  o->ops.push_back(std::bind(&TestIoCtxImpl::set_alloc_hint, _1, _2,
 			       expected_object_size, expected_write_size, flags,
                                _5));
 }
 
 void ObjectWriteOperation::tmap_update(const bufferlist& cmdbl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::tmap_update, _1, _2,
+  o->ops.push_back(std::bind(&TestIoCtxImpl::tmap_update, _1, _2,
                                cmdbl));
 }
 
 void ObjectWriteOperation::truncate(uint64_t off) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::truncate, _1, _2, off, _5));
+  o->ops.push_back(std::bind(&TestIoCtxImpl::truncate, _1, _2, off, _5));
 }
 
 void ObjectWriteOperation::write(uint64_t off, const bufferlist& bl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::write, _1, _2, bl, bl.length(),
+  o->ops.push_back(std::bind(&TestIoCtxImpl::write, _1, _2, bl, bl.length(),
 			       off, _5));
 }
 
 void ObjectWriteOperation::write_full(const bufferlist& bl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::write_full, _1, _2, bl, _5));
+  o->ops.push_back(std::bind(&TestIoCtxImpl::write_full, _1, _2, bl, _5));
 }
 
 void ObjectWriteOperation::writesame(uint64_t off, uint64_t len,
                                      const bufferlist& bl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::writesame, _1, _2, bl, len,
+  o->ops.push_back(std::bind(&TestIoCtxImpl::writesame, _1, _2, bl, len,
 			       off, _5));
 }
 
 void ObjectWriteOperation::zero(uint64_t off, uint64_t len) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
-  o->ops.push_back(boost::bind(&TestIoCtxImpl::zero, _1, _2, off, len, _5));
+  o->ops.push_back(std::bind(&TestIoCtxImpl::zero, _1, _2, off, len, _5));
 }
 
 Rados::Rados() : client(NULL) {

--- a/src/test/librados_test_stub/TestIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestIoCtxImpl.cc
@@ -10,7 +10,7 @@
 #include "common/Finisher.h"
 #include "common/valgrind.h"
 #include "objclass/objclass.h"
-#include <boost/bind.hpp>
+#include <functional>
 #include <errno.h>
 
 namespace librados {
@@ -109,7 +109,7 @@ int TestIoCtxImpl::aio_operate(const std::string& oid, TestObjectOperationImpl &
   // TODO flags for now
   ops.get();
   m_pending_ops++;
-  m_client->add_aio_operation(oid, true, boost::bind(
+  m_client->add_aio_operation(oid, true, std::bind(
     &TestIoCtxImpl::execute_aio_operations, this, oid, &ops,
     reinterpret_cast<bufferlist*>(0), m_snap_seq,
     snap_context != NULL ? *snap_context : m_snapc), c);
@@ -123,7 +123,7 @@ int TestIoCtxImpl::aio_operate_read(const std::string& oid,
   // TODO ignoring flags for now
   ops.get();
   m_pending_ops++;
-  m_client->add_aio_operation(oid, true, boost::bind(
+  m_client->add_aio_operation(oid, true, std::bind(
     &TestIoCtxImpl::execute_aio_operations, this, oid, &ops, pbl, snap_id,
     m_snapc), c);
   return 0;
@@ -209,7 +209,7 @@ int TestIoCtxImpl::operate(const std::string& oid,
 
   ops.get();
   m_pending_ops++;
-  m_client->add_aio_operation(oid, false, boost::bind(
+  m_client->add_aio_operation(oid, false, std::bind(
     &TestIoCtxImpl::execute_aio_operations, this, oid, &ops,
     reinterpret_cast<bufferlist*>(0), m_snap_seq, m_snapc), comp);
 
@@ -226,7 +226,7 @@ int TestIoCtxImpl::operate_read(const std::string& oid,
 
   ops.get();
   m_pending_ops++;
-  m_client->add_aio_operation(oid, false, boost::bind(
+  m_client->add_aio_operation(oid, false, std::bind(
     &TestIoCtxImpl::execute_aio_operations, this, oid, &ops, pbl,
     m_snap_seq, m_snapc), comp);
 
@@ -240,14 +240,14 @@ void TestIoCtxImpl::aio_selfmanaged_snap_create(uint64_t *snapid,
                                                 AioCompletionImpl *c) {
   m_client->add_aio_operation(
     "", true,
-    boost::bind(&TestIoCtxImpl::selfmanaged_snap_create, this, snapid), c);
+    std::bind(&TestIoCtxImpl::selfmanaged_snap_create, this, snapid), c);
 }
 
 void TestIoCtxImpl::aio_selfmanaged_snap_remove(uint64_t snapid,
                                                 AioCompletionImpl *c) {
   m_client->add_aio_operation(
     "", true,
-    boost::bind(&TestIoCtxImpl::selfmanaged_snap_remove, this, snapid), c);
+    std::bind(&TestIoCtxImpl::selfmanaged_snap_remove, this, snapid), c);
 }
 
 int TestIoCtxImpl::selfmanaged_snap_set_write_ctx(snap_t seq,

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -6,8 +6,8 @@
 #include "common/Clock.h"
 #include "common/RWLock.h"
 #include "include/err.h"
+#include <functional>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/bind.hpp>
 #include <errno.h>
 #include <include/compat.h>
 
@@ -59,8 +59,8 @@ TestIoCtxImpl *TestMemIoCtxImpl::clone() {
 
 int TestMemIoCtxImpl::aio_remove(const std::string& oid, AioCompletionImpl *c, int flags) {
   m_client->add_aio_operation(oid, true,
-                              boost::bind(&TestMemIoCtxImpl::remove, this, oid,
-                                          get_snap_context()),
+                              std::bind(&TestMemIoCtxImpl::remove, this, oid,
+					get_snap_context()),
                               c);
   return 0;
 }

--- a/src/test/librados_test_stub/TestRadosClient.cc
+++ b/src/test/librados_test_stub/TestRadosClient.cc
@@ -8,12 +8,12 @@
 #include "common/ceph_json.h"
 #include "common/Finisher.h"
 #include "common/async/context_pool.h"
-#include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/thread.hpp>
 #include <errno.h>
 
 #include <atomic>
+#include <functional>
 #include <sstream>
 
 static int get_concurrency() {
@@ -30,6 +30,8 @@ static int get_concurrency() {
   }
   return concurrency;
 }
+
+using namespace std::placeholders;
 
 namespace librados {
 
@@ -82,7 +84,7 @@ public:
     int ret = m_callback();
     if (m_comp != NULL) {
       if (m_finisher != NULL) {
-        m_finisher->queue(new LambdaContext(boost::bind(
+        m_finisher->queue(new LambdaContext(std::bind(
           &finish_aio_completion, m_comp, ret)));
       } else {
         finish_aio_completion(m_comp, ret);
@@ -252,7 +254,7 @@ void TestRadosClient::add_aio_operation(const std::string& oid,
 struct WaitForFlush {
   int flushed() {
     if (--count == 0) {
-      aio_finisher->queue(new LambdaContext(boost::bind(
+      aio_finisher->queue(new LambdaContext(std::bind(
         &finish_aio_completion, c, 0)));
       delete this;
     }
@@ -281,7 +283,7 @@ void TestRadosClient::flush_aio_operations(AioCompletionImpl *c) {
 
   for (size_t i = 0; i < m_finishers.size(); ++i) {
     AioFunctionContext *ctx = new AioFunctionContext(
-      boost::bind(&WaitForFlush::flushed, wait_for_flush),
+      std::bind(&WaitForFlush::flushed, wait_for_flush),
       nullptr, nullptr);
     m_finishers[i]->queue(ctx);
   }
@@ -289,7 +291,7 @@ void TestRadosClient::flush_aio_operations(AioCompletionImpl *c) {
 
 int TestRadosClient::aio_watch_flush(AioCompletionImpl *c) {
   c->get();
-  Context *ctx = new LambdaContext(boost::bind(
+  Context *ctx = new LambdaContext(std::bind(
     &TestRadosClient::finish_aio_completion, this, c, _1));
   get_watch_notify()->aio_flush(this, ctx);
   return 0;


### PR DESCRIPTION
replace boost::bind() with std::bind(), the use of the Boost
placeholders in the default namespace is deprecated. let's take
this opportunity to use its counterpart in standard library

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
