### PR TITLE
ceph-volume: support for mpath devices

### DIFF
--- a/doc/ceph-volume/lvm/prepare.rst
+++ b/doc/ceph-volume/lvm/prepare.rst
@@ -253,28 +253,20 @@ work for both bluestore and filestore OSDs::
 
 ``multipath`` support
 ---------------------
-Devices that come from ``multipath`` are not supported as-is. The tool will
-refuse to consume a raw multipath device and will report a message like::
+``multipath`` devices are support if ``lvm`` is configured properly.
 
-    -->  RuntimeError: Cannot use device (/dev/mapper/<name>). A vg/lv path or an existing device is needed
+**Leave it to LVM**
 
-The reason for not supporting multipath is that depending on the type of the
-multipath setup, if using an active/passive array as the underlying physical
-devices, filters are required in ``lvm.conf`` to exclude the disks that are part of
-those underlying devices.
+Most Linux distributions should ship their LVM2 package with
+``multipath_component_detection = 1`` in the default configuration. With this
+setting ``LVM`` ignores any device that is a multipath component and
+``ceph-volume`` will accordingly not touch these devices.
 
-It is unfeasible for ceph-volume to understand what type of configuration is
-needed for LVM to be able to work in various different multipath scenarios. The
-functionality to create the LV for you is merely a (naive) convenience,
-anything that involves different settings or configuration must be provided by
-a config management system which can then provide VGs and LVs for ceph-volume
-to consume.
+**Using filters**
 
-This situation will only arise when trying to use the ceph-volume functionality
-that creates a volume group and logical volume from a device. If a multipath
-device is already a logical volume it *should* work, given that the LVM
-configuration is done correctly to avoid issues.
-
+Should this setting be unavailable, a correct ``filter`` expression must be
+provided in ``lvm.conf``. ``ceph-volume`` must not be able to use both the
+multipath device and its multipath components.
 
 Storing metadata
 ----------------

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -330,7 +330,7 @@ def is_device(dev):
     # use lsblk first, fall back to using stat
     TYPE = lsblk(dev).get('TYPE')
     if TYPE:
-        return TYPE == 'disk'
+        return TYPE in ['disk', 'mpath']
 
     # fallback to stat
     return _stat_is_device(os.lstat(dev).st_mode)
@@ -747,7 +747,7 @@ def get_devices(_sys_block_path='/sys/block'):
     for block in block_devs:
         devname = os.path.basename(block[0])
         diskname = block[1]
-        if block[2] != 'disk':
+        if block[2] not in ['disk', 'mpath']:
             continue
         sysdir = os.path.join(_sys_block_path, devname)
         metadata = {}


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajerski@suse.com>

Fixes: https://tracker.ceph.com/issues/45094

This relies on lvm.conf having `multipath_component_detection = 1` With this a mapper device for the mpath components is created and the components are locked. Thus such a device can simply be used ceph-volume without further issues.

Imho documenting that this setting must be present would be enough, as most distro package have this in their default configuration.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
