### PR TITLE
mgr/dashboard: Fix regression on table error handling

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -36,7 +36,7 @@ const BASE_URL = 'hosts';
   providers: [{ provide: URLBuilderService, useValue: new URLBuilderService(BASE_URL) }]
 })
 export class HostsComponent extends ListWithDetails implements OnInit {
-  @ViewChild(TableComponent, { static: true })
+  @ViewChild(TableComponent)
   table: TableComponent;
   @ViewChild('servicesTpl', { static: true })
   public servicesTpl: TemplateRef<any>;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -12,7 +12,6 @@ import { ConfirmationModalComponent } from '../../../../shared/components/confir
 import { CriticalConfirmationModalComponent } from '../../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
 import { FormModalComponent } from '../../../../shared/components/form-modal/form-modal.component';
 import { ActionLabelsI18n, URLVerbs } from '../../../../shared/constants/app.constants';
-import { TableComponent } from '../../../../shared/datatable/table/table.component';
 import { CellTemplate } from '../../../../shared/enum/cell-template.enum';
 import { Icons } from '../../../../shared/enum/icons.enum';
 import { NotificationType } from '../../../../shared/enum/notification-type.enum';
@@ -50,8 +49,6 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
   markOsdConfirmationTpl: TemplateRef<any>;
   @ViewChild('criticalConfirmationTpl', { static: true })
   criticalConfirmationTpl: TemplateRef<any>;
-  @ViewChild(TableComponent, { static: true })
-  tableComponent: TableComponent;
   @ViewChild('reweightBodyTpl')
   reweightBodyTpl: TemplateRef<any>;
   @ViewChild('safeToDestroyBodyTpl')

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -18,7 +18,7 @@ import { AuthStorageService } from '../../../shared/services/auth-storage.servic
   styleUrls: ['./services.component.scss']
 })
 export class ServicesComponent extends ListWithDetails implements OnChanges, OnInit {
-  @ViewChild(TableComponent)
+  @ViewChild(TableComponent, { static: true })
   table: TableComponent;
 
   @Input() hostname: string;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
@@ -40,7 +40,7 @@ const BASE_URL = 'pool';
   styleUrls: ['./pool-list.component.scss']
 })
 export class PoolListComponent extends ListWithDetails implements OnInit {
-  @ViewChild(TableComponent, { static: true })
+  @ViewChild(TableComponent)
   table: TableComponent;
   @ViewChild('poolUsageTpl', { static: true })
   poolUsageTpl: TemplateRef<any>;


### PR DESCRIPTION
The regression was introduced by #35290 through the use of the new tab module
the pools and host listing got wrapped into the new usage, however they needed
to use the table as Viewchild and the table was static before, but it's now
dynamic. This resulted in an empty variable that wasn't filled with the
right table object. The calling of the ".reset()" was not possible
during an error case and produced an error in console trying to access
"reset" of undefined, by not calling "reset" the table get's stuck with an
rotating reload symbol.

Fixes: https://tracker.ceph.com/issues/46660
Signed-off-by: Stephan Müller <smueller@suse.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
