### PR TITLE
octopus: librbd: new 'write_zeroes' API methods to suppliment the `discard` APIs

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -47,6 +47,7 @@ extern "C" {
 #define LIBRBD_SUPPORTS_IOVEC 1
 #define LIBRBD_SUPPORTS_WATCH 0
 #define LIBRBD_SUPPORTS_WRITESAME 1
+#define LIBRBD_SUPPORTS_WRITE_ZEROES 1
 
 #if __GNUC__ >= 4
   #define CEPH_RBD_API          __attribute__ ((visibility ("default")))
@@ -1094,10 +1095,15 @@ CEPH_RBD_API ssize_t rbd_write2(rbd_image_t image, uint64_t ofs, size_t len,
                                 const char *buf, int op_flags);
 CEPH_RBD_API int rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len);
 CEPH_RBD_API ssize_t rbd_writesame(rbd_image_t image, uint64_t ofs, size_t len,
-                                   const char *buf, size_t data_len, int op_flags);
+                                   const char *buf, size_t data_len,
+                                   int op_flags);
+CEPH_RBD_API ssize_t rbd_write_zeroes(rbd_image_t image, uint64_t ofs,
+                                      uint64_t len, int zero_flags,
+                                      int op_flags);
 CEPH_RBD_API ssize_t rbd_compare_and_write(rbd_image_t image, uint64_t ofs,
                                            size_t len, const char *cmp_buf,
-                                           const char *buf, uint64_t *mismatch_off,
+                                           const char *buf,
+                                           uint64_t *mismatch_off,
                                            int op_flags);
 
 CEPH_RBD_API int rbd_aio_write(rbd_image_t image, uint64_t off, size_t len,
@@ -1125,10 +1131,15 @@ CEPH_RBD_API int rbd_aio_discard(rbd_image_t image, uint64_t off, uint64_t len,
 CEPH_RBD_API int rbd_aio_writesame(rbd_image_t image, uint64_t off, size_t len,
                                    const char *buf, size_t data_len,
                                    rbd_completion_t c, int op_flags);
+CEPH_RBD_API int rbd_aio_write_zeroes(rbd_image_t image, uint64_t off,
+                                      size_t len, rbd_completion_t c,
+                                      int zero_flags, int op_flags);
 CEPH_RBD_API ssize_t rbd_aio_compare_and_write(rbd_image_t image,
                                                uint64_t off, size_t len,
-                                               const char *cmp_buf, const char *buf,
-                                               rbd_completion_t c, uint64_t *mismatch_off,
+                                               const char *cmp_buf,
+                                               const char *buf,
+                                               rbd_completion_t c,
+                                               uint64_t *mismatch_off,
                                                int op_flags);
 
 CEPH_RBD_API int rbd_aio_create_completion(void *cb_arg,

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -664,8 +664,11 @@ public:
   ssize_t write(uint64_t ofs, size_t len, ceph::bufferlist& bl);
   /* @param op_flags see librados.h constants beginning with LIBRADOS_OP_FLAG */
   ssize_t write2(uint64_t ofs, size_t len, ceph::bufferlist& bl, int op_flags);
+
   int discard(uint64_t ofs, uint64_t len);
   ssize_t writesame(uint64_t ofs, size_t len, ceph::bufferlist &bl, int op_flags);
+  ssize_t write_zeroes(uint64_t ofs, size_t len, int zero_flags, int op_flags);
+
   ssize_t compare_and_write(uint64_t ofs, size_t len, ceph::bufferlist &cmp_bl,
                             ceph::bufferlist& bl, uint64_t *mismatch_off, int op_flags);
 
@@ -673,11 +676,17 @@ public:
   /* @param op_flags see librados.h constants beginning with LIBRADOS_OP_FLAG */
   int aio_write2(uint64_t off, size_t len, ceph::bufferlist& bl,
 		  RBD::AioCompletion *c, int op_flags);
+
+  int aio_discard(uint64_t off, uint64_t len, RBD::AioCompletion *c);
   int aio_writesame(uint64_t off, size_t len, ceph::bufferlist& bl,
                     RBD::AioCompletion *c, int op_flags);
+  int aio_write_zeroes(uint64_t ofs, size_t len, RBD::AioCompletion *c,
+                       int zero_flags, int op_flags);
+
   int aio_compare_and_write(uint64_t off, size_t len, ceph::bufferlist& cmp_bl,
                             ceph::bufferlist& bl, RBD::AioCompletion *c,
                             uint64_t *mismatch_off, int op_flags);
+
   /**
    * read async from image
    *
@@ -699,7 +708,6 @@ public:
   /* @param op_flags see librados.h constants beginning with LIBRADOS_OP_FLAG */
   int aio_read2(uint64_t off, size_t len, ceph::bufferlist& bl,
 		  RBD::AioCompletion *c, int op_flags);
-  int aio_discard(uint64_t off, uint64_t len, RBD::AioCompletion *c);
 
   int flush();
   /**

--- a/src/librbd/io/ImageRequestWQ.h
+++ b/src/librbd/io/ImageRequestWQ.h
@@ -38,6 +38,8 @@ public:
   ssize_t discard(uint64_t off, uint64_t len,
                   uint32_t discard_granularity_bytes);
   ssize_t writesame(uint64_t off, uint64_t len, bufferlist &&bl, int op_flags);
+  ssize_t write_zeroes(uint64_t off, uint64_t len, int zero_flags,
+                       int op_flags);
   ssize_t compare_and_write(uint64_t off, uint64_t len,
                             bufferlist &&cmp_bl, bufferlist &&bl,
                             uint64_t *mismatch_off, int op_flags);
@@ -52,6 +54,8 @@ public:
   void aio_flush(AioCompletion *c, bool native_async=true);
   void aio_writesame(AioCompletion *c, uint64_t off, uint64_t len,
                      bufferlist &&bl, int op_flags, bool native_async=true);
+  void aio_write_zeroes(AioCompletion *c, uint64_t off, uint64_t len,
+                        int zero_flags, int op_flags, bool native_async);
   void aio_compare_and_write(AioCompletion *c, uint64_t off,
                              uint64_t len, bufferlist &&cmp_bl,
                              bufferlist &&bl, uint64_t *mismatch_off,

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2540,8 +2540,8 @@ namespace librbd {
     }
 
     bool discard_zero = ictx->config.get_val<bool>("rbd_discard_on_zeroed_write_same");
-    if (discard_zero && mem_is_zero(bl.c_str(), bl.length())) {
-      int r = ictx->io_work_queue->discard(ofs, len, 0);
+    if (discard_zero && bl.is_zero()) {
+      int r = ictx->io_work_queue->write_zeroes(ofs, len, 0U, op_flags);
       tracepoint(librbd, writesame_exit, r);
       return r;
     }
@@ -2549,6 +2549,13 @@ namespace librbd {
     int r = ictx->io_work_queue->writesame(ofs, len, bufferlist{bl}, op_flags);
     tracepoint(librbd, writesame_exit, r);
     return r;
+  }
+
+  ssize_t Image::write_zeroes(uint64_t ofs, size_t len, int zero_flags,
+                              int op_flags)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    return ictx->io_work_queue->write_zeroes(ofs, len, zero_flags, op_flags);
   }
 
   ssize_t Image::compare_and_write(uint64_t ofs, size_t len,
@@ -2678,8 +2685,9 @@ namespace librbd {
     }
 
     bool discard_zero = ictx->config.get_val<bool>("rbd_discard_on_zeroed_write_same");
-    if (discard_zero && mem_is_zero(bl.c_str(), bl.length())) {
-      ictx->io_work_queue->aio_discard(get_aio_completion(c), off, len, 0);
+    if (discard_zero && bl.is_zero()) {
+      ictx->io_work_queue->aio_write_zeroes(get_aio_completion(c), off, len, 0U,
+                                            op_flags, true);
       tracepoint(librbd, aio_writesame_exit, 0);
       return 0;
     }
@@ -2687,6 +2695,15 @@ namespace librbd {
     ictx->io_work_queue->aio_writesame(get_aio_completion(c), off, len,
                                        bufferlist{bl}, op_flags);
     tracepoint(librbd, aio_writesame_exit, 0);
+    return 0;
+  }
+
+  int Image::aio_write_zeroes(uint64_t off, size_t len, RBD::AioCompletion *c,
+                              int zero_flags, int op_flags)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    ictx->io_work_queue->aio_write_zeroes(
+      get_aio_completion(c), off, len, zero_flags, op_flags, true);
     return 0;
   }
 
@@ -5861,7 +5878,7 @@ extern "C" ssize_t rbd_writesame(rbd_image_t image, uint64_t ofs, size_t len,
 
   bool discard_zero = ictx->config.get_val<bool>("rbd_discard_on_zeroed_write_same");
   if (discard_zero && mem_is_zero(buf, data_len)) {
-    int r = ictx->io_work_queue->discard(ofs, len, 0);
+    int r = ictx->io_work_queue->write_zeroes(ofs, len, 0, op_flags);
     tracepoint(librbd, writesame_exit, r);
     return r;
   }
@@ -5871,6 +5888,13 @@ extern "C" ssize_t rbd_writesame(rbd_image_t image, uint64_t ofs, size_t len,
   int r = ictx->io_work_queue->writesame(ofs, len, std::move(bl), op_flags);
   tracepoint(librbd, writesame_exit, r);
   return r;
+}
+
+extern "C" ssize_t rbd_write_zeroes(rbd_image_t image, uint64_t ofs, size_t len,
+                                    int zero_flags, int op_flags)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  return ictx->io_work_queue->write_zeroes(ofs, len, zero_flags, op_flags);
 }
 
 extern "C" ssize_t rbd_compare_and_write(rbd_image_t image,
@@ -6085,7 +6109,8 @@ extern "C" int rbd_aio_writesame(rbd_image_t image, uint64_t off, size_t len,
 
   bool discard_zero = ictx->config.get_val<bool>("rbd_discard_on_zeroed_write_same");
   if (discard_zero && mem_is_zero(buf, data_len)) {
-    ictx->io_work_queue->aio_discard(get_aio_completion(comp), off, len, 0);
+    ictx->io_work_queue->aio_write_zeroes(get_aio_completion(comp), off, len, 0,
+                                          op_flags, true);
     tracepoint(librbd, aio_writesame_exit, 0);
     return 0;
   }
@@ -6096,6 +6121,18 @@ extern "C" int rbd_aio_writesame(rbd_image_t image, uint64_t off, size_t len,
   ictx->io_work_queue->aio_writesame(aio_completion, off, len, std::move(bl),
                                      op_flags);
   tracepoint(librbd, aio_writesame_exit, 0);
+  return 0;
+}
+
+extern "C" int rbd_aio_write_zeroes(rbd_image_t image, uint64_t off, size_t len,
+                                    rbd_completion_t c, int zero_flags,
+                                    int op_flags)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
+
+  ictx->io_work_queue->aio_write_zeroes(
+    get_aio_completion(comp), off, len, zero_flags, op_flags, true);
   return 0;
 }
 

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -500,6 +500,8 @@ cdef extern from "rbd/librbd.h" nogil:
     ssize_t rbd_write2(rbd_image_t image, uint64_t ofs, size_t len,
                        const char *buf, int op_flags)
     int rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len)
+    int rbd_write_zeroes(rbd_image_t image, uint64_t ofs, uint64_t len,
+                         int zero_flags, int op_flags)
     int rbd_copy3(rbd_image_t src, rados_ioctx_t dest_io_ctx,
                   const char *destname, rbd_image_options_t dest_opts)
     int rbd_deep_copy(rbd_image_t src, rados_ioctx_t dest_io_ctx,
@@ -622,6 +624,8 @@ cdef extern from "rbd/librbd.h" nogil:
                       char *buf, rbd_completion_t c, int op_flags)
     int rbd_aio_discard(rbd_image_t image, uint64_t off, uint64_t len,
                         rbd_completion_t c)
+    int rbd_aio_write_zeroes(rbd_image_t image, uint64_t off, uint64_t len,
+                             rbd_completion_t c, int zero_flags, int op_flags)
 
     int rbd_aio_create_completion(void *cb_arg, rbd_callback_t complete_cb,
                                   rbd_completion_t *c)
@@ -4404,6 +4408,23 @@ written." % (self.name, ret, length))
             raise make_ex(ret, msg)
 
     @requires_not_closed
+    def write_zeroes(self, offset, length, zero_flags = 0):
+        """
+        Zero the range from the image. By default it will attempt to
+        discard/unmap as much space as possible but any unaligned
+        extent segments will still be zeroed.
+        """
+        cdef:
+            uint64_t _offset = offset, _length = length
+            int _zero_flags = zero_flags
+        with nogil:
+            ret = rbd_write_zeroes(self.image, _offset, _length,
+                                   _zero_flags, 0)
+        if ret < 0:
+            msg = 'error zeroing region %d~%d' % (offset, length)
+            raise make_ex(ret, msg)
+
+    @requires_not_closed
     def flush(self):
         """
         Block until all writes are fully flushed if caching is enabled.
@@ -5081,6 +5102,34 @@ written." % (self.name, ret, length))
             if ret < 0:
                 raise make_ex(ret, 'error discarding %s %ld~%ld' %
                               (self.name, offset, _length))
+        except:
+            completion.__unpersist()
+            raise
+
+        return completion
+
+    @requires_not_closed
+    def aio_write_zeroes(self, offset, length, oncomplete, zero_flags = 0):
+        """
+        Asynchronously Zero the range from the image. By default it will attempt
+        to discard/unmap as much space as possible but any unaligned extent
+        segments will still be zeroed.
+        """
+        cdef:
+            uint64_t _offset = offset
+            size_t _length = length
+            int _zero_flags = zero_flags
+            Completion completion
+
+        completion = self.__get_completion(oncomplete)
+        try:
+            completion.__persist()
+            with nogil:
+                ret = rbd_aio_write_zeroes(self.image, _offset, _length,
+                                           completion.rbd_comp, _zero_flags, 0)
+            if ret < 0:
+                raise make_ex(ret, 'error zeroing %s %ld~%ld' %
+                              (self.name, offset, length))
         except:
             completion.__unpersist()
             raise

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -8175,6 +8175,65 @@ TEST_F(TestLibRBD, SnapRemoveWithChildMissing)
   rados_ioctx_destroy(ioctx1);
 }
 
+TEST_F(TestLibRBD, WriteZeroes) {
+  librbd::RBD rbd;
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+  std::string name = get_temp_image_name();
+  int order = 0;
+  uint64_t size = 2 << 20;
+  ASSERT_EQ(0, create_image_pp(rbd, ioctx, name.c_str(), size, &order));
+
+  librbd::Image image;
+  ASSERT_EQ(0, rbd.open(ioctx, image, name.c_str(), NULL));
+
+  // 1s from [0, 256) / length 256
+  char data[256];
+  memset(data, 1, sizeof(data));
+  bufferlist bl;
+  bl.append(data, 256);
+  ASSERT_EQ(256, image.write(0, 256, bl));
+
+  interval_set<uint64_t> diff;
+  ASSERT_EQ(0, image.diff_iterate2(nullptr, 0, size, false, false,
+                                   iterate_cb, (void *)&diff));
+  auto expected_diff = interval_set<uint64_t>{{{0, 256}}};
+  ASSERT_EQ(expected_diff, diff);
+
+  // writes zero passed the current end extents.
+  // Now 1s from [0, 192) / length 192
+  ASSERT_EQ(size - 192,
+            image.write_zeroes(192, size - 192, 0U, 0));
+  diff.clear();
+  ASSERT_EQ(0, image.diff_iterate2(nullptr, 0, size, false, false,
+                                   iterate_cb, (void *)&diff));
+  expected_diff = interval_set<uint64_t>{{{0, 192}}};
+  ASSERT_EQ(expected_diff, diff);
+
+  // zero an existing extent and truncate some off the end
+  // Now 1s from [64, 192) / length 192
+  ASSERT_EQ(64, image.write_zeroes(0, 64, 0U, 0));
+
+  diff.clear();
+  ASSERT_EQ(0, image.diff_iterate2(nullptr, 0, size, false, false,
+                                   iterate_cb, (void *)&diff));
+  expected_diff = interval_set<uint64_t>{{{0, 192}}};
+  ASSERT_EQ(expected_diff, diff);
+
+  bufferlist expected_bl;
+  expected_bl.append_zero(64);
+  bufferlist sub_bl;
+  sub_bl.substr_of(bl, 0, 128);
+  expected_bl.claim_append(sub_bl);
+  expected_bl.append_zero(size - 192);
+
+  bufferlist read_bl;
+  EXPECT_EQ(size, image.read(0, size, read_bl));
+  EXPECT_EQ(expected_bl, read_bl);
+
+  ASSERT_EQ(0, image.close());
+}
+
 // poorman's ceph_assert()
 namespace ceph {
   void __ceph_assert_fail(const char *assertion, const char *file, int line,

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -601,6 +601,12 @@ class TestImage(object):
         self.image.write(data, 0, LIBRADOS_OP_FLAG_FADVISE_DONTNEED)
         self.image.write(data, 0, LIBRADOS_OP_FLAG_FADVISE_NOCACHE)
 
+    def test_write_zeroes(self):
+        data = rand_data(256)
+        self.image.write(data, 0)
+        self.image.write_zeroes(0, 256)
+        eq(self.image.read(256, 256), b'\0' * 256)
+
     def test_read(self):
         data = self.image.read(0, 20)
         eq(data, b'\0' * 20)
@@ -1186,6 +1192,20 @@ class TestImage(object):
         data = rand_data(256)
         self.image.write(data, 0)
         comp = self.image.aio_discard(0, 256, cb)
+        comp.wait_for_complete_and_cb()
+        eq(retval[0], 0)
+        eq(comp.get_return_value(), 0)
+        eq(sys.getrefcount(comp), 2)
+        eq(self.image.read(256, 256), b'\0' * 256)
+
+    def test_aio_write_zeroes(self):
+        retval = [None]
+        def cb(comp):
+            retval[0] = comp.get_return_value()
+
+        data = rand_data(256)
+        self.image.write(data, 0)
+        comp = self.image.aio_write_zeroes(0, 256, cb)
         comp.wait_for_complete_and_cb()
         eq(retval[0], 0)
         eq(comp.get_return_value(), 0)

--- a/src/tools/rbd/action/Import.cc
+++ b/src/tools/rbd/action/Import.cc
@@ -80,9 +80,9 @@ struct ImportDiffContext {
 class C_ImportDiff : public Context {
 public:
   C_ImportDiff(ImportDiffContext *idiffctx, bufferlist data, uint64_t offset,
-               uint64_t length, bool discard)
+               uint64_t length, bool write_zeroes)
     : m_idiffctx(idiffctx), m_data(data), m_offset(offset), m_length(length),
-      m_discard(discard) {
+      m_write_zeroes(write_zeroes) {
     // use block offset (stdin) or import file position to report
     // progress.
     if (m_idiffctx->fd == STDIN_FILENO) {
@@ -103,11 +103,14 @@ public:
       new librbd::RBD::AioCompletion(ctx, &utils::aio_context_callback);
 
     int r;
-    if (m_discard) {
-      r = m_idiffctx->image->aio_discard(m_offset, m_length, aio_completion);
+    if (m_write_zeroes) {
+      r = m_idiffctx->image->aio_write_zeroes(m_offset, m_length,
+                                              aio_completion, 0U,
+                                              LIBRADOS_OP_FLAG_FADVISE_NOCACHE);
     } else {
       r = m_idiffctx->image->aio_write2(m_offset, m_length, m_data,
-                                        aio_completion, LIBRADOS_OP_FLAG_FADVISE_NOCACHE);
+                                        aio_completion,
+                                        LIBRADOS_OP_FLAG_FADVISE_NOCACHE);
     }
 
     if (r < 0) {
@@ -129,7 +132,7 @@ private:
   bufferlist m_data;
   uint64_t m_offset;
   uint64_t m_length;
-  bool m_discard;
+  bool m_write_zeroes;
   uint64_t m_prog_offset;
 };
 
@@ -233,7 +236,8 @@ static int do_image_resize(ImportDiffContext *idiffctx)
   return 0;
 }
 
-static int do_image_io(ImportDiffContext *idiffctx, bool discard, size_t sparse_size)
+static int do_image_io(ImportDiffContext *idiffctx, bool write_zeroes,
+                       size_t sparse_size)
 {
   int r;
   char buf[16];
@@ -251,7 +255,7 @@ static int do_image_io(ImportDiffContext *idiffctx, bool discard, size_t sparse_
   decode(image_offset, p);
   decode(buffer_length, p);
 
-  if (!discard) {
+  if (!write_zeroes) {
     bufferptr bp = buffer::create(buffer_length);
     r = safe_read_exact(idiffctx->fd, bp.c_str(), buffer_length);
     if (r < 0) {
@@ -391,14 +395,6 @@ int do_import_diff_fd(librados::Rados &rados, librbd::Image &image, int fd,
                            utils::RBD_DIFF_BANNER_V2));
   if (r < 0) {
     return r;
-  }
-
-  std::string skip_partial_discard;
-  r = rados.conf_get("rbd_skip_partial_discard", skip_partial_discard);
-  if (r < 0 || skip_partial_discard != "false") {
-    dout(1) << "disabling sparse import" << dendl;
-    sparse_size = 0;
-    r = 0;
   }
 
   // begin image import


### PR DESCRIPTION
https://tracker.ceph.com/issues/46674