### PR TITLE
osd/OSD.cc: remove osd_lock for bench

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2731,7 +2731,6 @@ will start to track new ops received afterwards.";
   }
 
   else if (prefix == "bench") {
-    lock_guard l(osd_lock);
     int64_t count;
     int64_t bsize;
     int64_t osize, onum;


### PR DESCRIPTION
8987f94416f453829eae6dda08837ef5a42531c6 introduced the osd_lock for the
bench command. Taking the osd_lock in bench can lead to deadlocks, causing the
command to hang as seen in https://tracker.ceph.com/issues/43888.

Fixes: https://tracker.ceph.com/issues/43888
Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>
Signed-off-by: Neha Ojha <nojha@redhat.com>

