### PR TITLE
doc/dev/crimson: remove redundant options

### DIFF
--- a/doc/dev/crimson.rst
+++ b/doc/dev/crimson.rst
@@ -88,7 +88,7 @@ So, a typical command to start a single-crimson-node cluster is::
 
   MGR=1 MON=1 OSD=1 MDS=0 RGW=0 ../src/vstart.sh -n -x --without-dashboard --memstore \
     --crimson --nodaemon --redirect-output \
-    --osd-args "--memory 4G --smp 1 --cpuset 0"
+    --osd-args "--memory 4G"
 
 Where we assign 4 GiB memory, a single thread running on core-0 to crimson-osd.
 Please refer ``crimson-osd --help-seastar`` for more Seastar specific command

--- a/doc/dev/crimson.rst
+++ b/doc/dev/crimson.rst
@@ -148,19 +148,19 @@ When a seastar application crashes, it leaves us a serial of addresses, like::
 
   Segmentation fault.
   Backtrace:
-  0x00000000108254aa
-  0x00000000107f74b9
-  0x00000000105366cc
-  0x000000001053682c
-  0x00000000105d2c2e
-  0x0000000010629b96
-  0x0000000010629c31
-  0x00002a02ebd8272f
-  0x00000000105d93ee
-  0x00000000103eff59
-  0x000000000d9c1d0a
-  /lib/x86_64-linux-gnu/libc.so.6+0x000000000002409a
-  0x000000000d833ac9
+    0x00000000108254aa
+    0x00000000107f74b9
+    0x00000000105366cc
+    0x000000001053682c
+    0x00000000105d2c2e
+    0x0000000010629b96
+    0x0000000010629c31
+    0x00002a02ebd8272f
+    0x00000000105d93ee
+    0x00000000103eff59
+    0x000000000d9c1d0a
+    /lib/x86_64-linux-gnu/libc.so.6+0x000000000002409a
+    0x000000000d833ac9
   Segmentation fault
 
 ``seastar-addr2line`` offered by Seastar can be used to decipher these
@@ -170,18 +170,18 @@ so we need to copy and paste the above addresses, then send the EOF by inputting
 
   $ ../src/seastar/scripts/seastar-addr2line -e bin/crimson-osd
 
-  0x00000000108254aa
-  0x00000000107f74b9
-  0x00000000105366cc
-  0x000000001053682c
-  0x00000000105d2c2e
-  0x0000000010629b96
-  0x0000000010629c31
-  0x00002a02ebd8272f
-  0x00000000105d93ee
-  0x00000000103eff59
-  0x000000000d9c1d0a
-  0x00000000108254aa
+    0x00000000108254aa
+    0x00000000107f74b9
+    0x00000000105366cc
+    0x000000001053682c
+    0x00000000105d2c2e
+    0x0000000010629b96
+    0x0000000010629c31
+    0x00002a02ebd8272f
+    0x00000000105d93ee
+    0x00000000103eff59
+    0x000000000d9c1d0a
+    0x00000000108254aa
   [Backtrace #0]
   seastar::backtrace_buffer::append_backtrace() at /home/kefu/dev/ceph/build/../src/seastar/src/core/reactor.cc:1136
   seastar::print_with_backtrace(seastar::backtrace_buffer&) at /home/kefu/dev/ceph/build/../src/seastar/src/core/reactor.cc:1157
@@ -193,3 +193,13 @@ so we need to copy and paste the above addresses, then send the EOF by inputting
   seastar::smp::configure(boost::program_options::variables_map, seastar::reactor_config) at /home/kefu/dev/ceph/build/../src/seastar/src/core/reactor.cc:5418
   seastar::app_template::run_deprecated(int, char**, std::function<void ()>&&) at /home/kefu/dev/ceph/build/../src/seastar/src/core/app-template.cc:173 (discriminator 5)
   main at /home/kefu/dev/ceph/build/../src/crimson/osd/main.cc:131 (discriminator 1)
+
+Please note, ``seastar-addr2line`` is able to extract the addresses from
+the input, so you can also paste the log messages like::
+
+  2020-07-22T11:37:04.500 INFO:teuthology.orchestra.run.smithi061.stderr:Backtrace:
+  2020-07-22T11:37:04.500 INFO:teuthology.orchestra.run.smithi061.stderr:  0x0000000000e78dbc
+  2020-07-22T11:37:04.501 INFO:teuthology.orchestra.run.smithi061.stderr:  0x0000000000e3e7f0
+  2020-07-22T11:37:04.501 INFO:teuthology.orchestra.run.smithi061.stderr:  0x0000000000e3e8b8
+  2020-07-22T11:37:04.501 INFO:teuthology.orchestra.run.smithi061.stderr:  0x0000000000e3e985
+  2020-07-22T11:37:04.501 INFO:teuthology.orchestra.run.smithi061.stderr:  /lib64/libpthread.so.0+0x0000000000012dbf


### PR DESCRIPTION
`--smp` and `--cpuset` have been passed to crimson-osd by vstart.sh, so
no need to pass them when launching vstart.sh

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
