### PR TITLE
rgw/sts: adding code for federated user as owner in case of STS.

### DIFF
--- a/doc/radosgw/STS.rst
+++ b/doc/radosgw/STS.rst
@@ -71,6 +71,10 @@ is of the form::
 
 The app_id in the condition above must match the 'aud' field of the incoming token.
 
+A shadow user is created corresponding to every federated user. The user id is derived from the 'sub' field of the incoming web token.
+The user is created in a separate namespace - 'oidc' such that the user id doesn't clash with any other user ids in rgw. The format of the user id
+is - <tenant>$<user-namespace>$<sub> where user-namespace is 'oidc' for users that authenticate with oidc providers.
+
 STS Configuration
 =================
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -279,6 +279,7 @@ void usage()
   cout << "  subscription ack           ack (remove) an events in a pubsub subscription\n";
   cout << "options:\n";
   cout << "   --tenant=<tenant>         tenant name\n";
+  cout << "   --user_ns=<namespace>     namespace of user (oidc in case of users authenticated with oidc provider)\n";
   cout << "   --uid=<id>                user id\n";
   cout << "   --new-uid=<id>            new user id\n";
   cout << "   --subuser=<name>          subuser name\n";
@@ -3025,6 +3026,7 @@ int main(int argc, const char **argv)
 
   rgw_user user_id;
   string tenant;
+  string user_ns;
   rgw_user new_user_id;
   std::string access_key, secret_key, user_email, display_name;
   std::string bucket_name, pool_name, object;
@@ -3230,6 +3232,8 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "--tenant", (char*)NULL)) {
       tenant = val;
       opt_tenant = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--user_ns", (char*)NULL)) {
+      user_ns = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--access-key", (char*)NULL)) {
       access_key = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--subuser", (char*)NULL)) {
@@ -3707,6 +3711,11 @@ int main(int argc, const char **argv)
         return EINVAL;
       }
       user_id.tenant = tenant;
+    }
+    if (user_ns.empty()) {
+      user_ns = user_id.ns;
+    } else {
+      user_id.ns = user_ns;
     }
 
     if (!new_user_id.empty() && !tenant.empty()) {

--- a/src/rgw/rgw_auth_filters.h
+++ b/src/rgw/rgw_auth_filters.h
@@ -105,6 +105,10 @@ public:
     get_decoratee().to_str(out);
   }
 
+  string get_role_tenant() const override {     /* in/out */
+    return get_decoratee().get_role_tenant();
+  }
+
   void load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo& user_info) const override {  /* out */
     return get_decoratee().load_acct_info(dpp, user_info);
   }

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -14,36 +14,49 @@ class cls_user_bucket;
 struct rgw_user {
   std::string tenant;
   std::string id;
+  std::string ns;
 
   rgw_user() {}
   explicit rgw_user(const std::string& s) {
     from_str(s);
   }
-  rgw_user(const std::string& tenant, const std::string& id)
+  rgw_user(const std::string& tenant, const std::string& id, const std::string& ns="")
     : tenant(tenant),
-      id(id) {
+      id(id),
+      ns(ns) {
   }
-  rgw_user(std::string&& tenant, std::string&& id)
+  rgw_user(std::string&& tenant, std::string&& id, std::string&& ns="")
     : tenant(std::move(tenant)),
-      id(std::move(id)) {
+      id(std::move(id)),
+      ns(std::move(ns)) {
   }
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(tenant, bl);
     encode(id, bl);
+    encode(ns, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(tenant, bl);
     decode(id, bl);
+    if (struct_v >= 2) {
+      decode(ns, bl);
+    }
     DECODE_FINISH(bl);
   }
 
   void to_str(std::string& str) const {
     if (!tenant.empty()) {
-      str = tenant + '$' + id;
+      if (!ns.empty()) {
+        str = tenant + '$' + ns + '$' + id;
+      } else {
+        str = tenant + '$' + id;
+      }
+    } else if (!ns.empty()) {
+      str = '$' + ns + '$' + id;
     } else {
       str = id;
     }
@@ -52,6 +65,7 @@ struct rgw_user {
   void clear() {
     tenant.clear();
     id.clear();
+    ns.clear();
   }
 
   bool empty() const {
@@ -68,9 +82,19 @@ struct rgw_user {
     size_t pos = str.find('$');
     if (pos != std::string::npos) {
       tenant = str.substr(0, pos);
-      id = str.substr(pos + 1);
+      string_view sv = str;
+      string_view ns_id = sv.substr(pos + 1);
+      size_t ns_pos = ns_id.find('$');
+      if (ns_pos != std::string::npos) {
+        ns = string(ns_id.substr(0, ns_pos));
+        id = string(ns_id.substr(ns_pos + 1));
+      } else {
+        ns.clear();
+        id = string(ns_id);
+      }
     } else {
       tenant.clear();
+      ns.clear();
       id = str;
     }
   }
@@ -84,7 +108,10 @@ struct rgw_user {
     int r = tenant.compare(u.tenant);
     if (r != 0)
       return r;
-
+    r = ns.compare(u.ns);
+    if (r != 0) {
+      return r;
+    }
     return id.compare(u.id);
   }
   int compare(const std::string& str) const {
@@ -102,6 +129,11 @@ struct rgw_user {
     if (tenant < rhs.tenant) {
       return true;
     } else if (tenant > rhs.tenant) {
+      return false;
+    }
+    if (ns < rhs.ns) {
+      return true;
+    } else if (ns > rhs.ns) {
       return false;
     }
     return (id < rhs.id);

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2035,7 +2035,7 @@ RGWBucketInfo::~RGWBucketInfo()
 }
 
 void RGWBucketInfo::encode(bufferlist& bl) const {
-  ENCODE_START(22, 4, bl);
+  ENCODE_START(23, 4, bl);
   encode(bucket, bl);
   encode(owner.id, bl);
   encode(flags, bl);
@@ -2068,11 +2068,12 @@ void RGWBucketInfo::encode(bufferlist& bl) const {
     encode(*sync_policy, bl);
   }
   encode(layout, bl);
+  encode(owner.ns, bl);
   ENCODE_FINISH(bl);
 }
 
 void RGWBucketInfo::decode(bufferlist::const_iterator& bl) {
-  DECODE_START_LEGACY_COMPAT_LEN_32(22, 4, 4, bl);
+  DECODE_START_LEGACY_COMPAT_LEN_32(23, 4, 4, bl);
   decode(bucket, bl);
   if (struct_v >= 2) {
     string s;
@@ -2146,7 +2147,9 @@ void RGWBucketInfo::decode(bufferlist::const_iterator& bl) {
   if (struct_v >= 22) {
     decode(layout, bl);
   }
-  
+  if (struct_v >= 23) {
+    decode(owner.ns, bl);
+  }
   DECODE_FINISH(bl);
 }
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4644,6 +4644,10 @@ int RGWHandler_REST_S3::postauth_init()
   rgw_parse_url_bucket(t->url_bucket, s->user->get_tenant(),
 		      s->bucket_tenant, s->bucket_name);
 
+  if (s->auth.identity->get_identity_type() == TYPE_ROLE) {
+    s->bucket_tenant = s->auth.identity->get_role_tenant();
+  }
+
   dout(10) << "s->object=" << s->object
            << " s->bucket=" << rgw_make_bucket_entry_name(s->bucket_tenant, s->bucket_name) << dendl;
 

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -30,6 +30,8 @@ class WebTokenEngine : public rgw::auth::Engine {
 
   boost::optional<RGWOIDCProvider> get_provider(const string& role_arn, const string& iss) const;
 
+  std::string get_role_tenant(const string& role_arn) const;
+
   boost::optional<WebTokenEngine::token_t>
   get_from_jwt(const DoutPrefixProvider* dpp, const std::string& token, const req_state* const s) const;
 
@@ -78,9 +80,10 @@ class DefaultStrategy : public rgw::auth::Strategy,
   aplptr_t create_apl_web_identity( CephContext* cct,
                                     const req_state* s,
                                     const string& role_session,
+                                    const string& role_tenant,
                                     const rgw::web_idp::WebTokenClaims& token) const override {
     auto apl = rgw::auth::add_sysreq(cct, ctl, s,
-      rgw::auth::WebIdentityApplier(cct, ctl, role_session, token));
+      rgw::auth::WebIdentityApplier(cct, ctl, role_session, role_tenant, token));
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }
 

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -105,7 +105,7 @@ int Credentials::generateCredentials(CephContext* cct,
   if (user)
     token.user = *user;
   else {
-    rgw_user u({}, {});
+    rgw_user u({}, {}, {});
     token.user = u;
   }
 

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -174,6 +174,7 @@
     subscription ack           ack (remove) an events in a pubsub subscription
   options:
      --tenant=<tenant>         tenant name
+     --user_ns=<namespace>     namespace of user (oidc in case of users authenticated with oidc provider)
      --uid=<id>                user id
      --new-uid=<id>            new user id
      --subuser=<name>          subuser name


### PR DESCRIPTION
A new user under the namespace 'oidc' is created for every federated
user in case of AssumeRoleWithWebIdentity.

In case of AssumeRole, the user that needs cross account access becomes
the owner.

In both cases buckets are created in the tenant that the role belongs to.

Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
