### PR TITLE
crimson/net: do not reset need_addr before learning it

### DIFF
--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -199,13 +199,13 @@ seastar::future<> SocketMessenger::learned_addr(const entity_addr_t &peer_addr_f
     }
     return seastar::now();
   }
-  need_addr = false;
 
   if (get_myaddr().get_type() == entity_addr_t::TYPE_NONE) {
     // Not bound
     entity_addr_t addr = peer_addr_for_me;
     addr.set_type(entity_addr_t::TYPE_ANY);
     addr.set_port(0);
+    need_addr = false;
     return set_myaddrs(entity_addrvec_t{addr}
     ).then([this, &conn, peer_addr_for_me] {
       logger().info("{} learned myaddr={} (unbound) from {}",
@@ -230,6 +230,7 @@ seastar::future<> SocketMessenger::learned_addr(const entity_addr_t &peer_addr_f
       entity_addr_t addr = peer_addr_for_me;
       addr.set_type(get_myaddr().get_type());
       addr.set_port(get_myaddr().get_port());
+      need_addr = false;
       return set_myaddrs(entity_addrvec_t{addr}
       ).then([this, &conn, peer_addr_for_me] {
         logger().info("{} learned myaddr={} (blank IP) from {}",
@@ -241,6 +242,7 @@ seastar::future<> SocketMessenger::learned_addr(const entity_addr_t &peer_addr_f
       throw std::system_error(
           make_error_code(crimson::net::error::bad_peer_address));
     } else {
+      need_addr = false;
       return seastar::now();
     }
   }


### PR DESCRIPTION
because we don't bind both v1 and v2 addresses, when monitor returns a
v1 peer address, as the client side, crimson-osd just drops the
connection. but this failed attempt to learn the myaddr resets
`need_addr`. and this prevents crimson-osd from learning the v2 address
returned by monitor.

in this change, we reset need_addr only after it is learned from the
peer.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
