### PR TITLE
octopus: mgr/dashboard: Use same required field message accross the UI

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.html
@@ -37,7 +37,7 @@
                        placeholder="192.168.0.10, 192.168.1.0/8">
                 <span class="invalid-feedback">
                   <span *ngIf="showError(index, 'addresses', formDir, 'required')"
-                        i18n>Required field</span>
+                        i18n>This field is required.</span>
 
                   <span *ngIf="showError(index, 'addresses', formDir, 'pattern')">
                     <ng-container i18n>Must contain one or more comma-separated values</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -34,7 +34,7 @@
             </select>
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('cluster_id', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
           </div>
         </div>
 
@@ -104,7 +104,7 @@
               </select>
               <span class="invalid-feedback"
                     *ngIf="nfsForm.showError('name', formDir, 'required')"
-                    i18n>Required field</span>
+                    i18n>This field is required.</span>
             </div>
           </div>
 
@@ -134,7 +134,7 @@
               </select>
               <span class="invalid-feedback"
                     *ngIf="nfsForm.showError('rgw_user_id', formDir, 'required')"
-                    i18n>Required field</span>
+                    i18n>This field is required.</span>
             </div>
           </div>
 
@@ -163,7 +163,7 @@
               </select>
               <span class="invalid-feedback"
                     *ngIf="nfsForm.showError('user_id', formDir, 'required')"
-                    i18n>Required field</span>
+                    i18n>This field is required.</span>
             </div>
           </div>
 
@@ -193,7 +193,7 @@
               </select>
               <span class="invalid-feedback"
                     *ngIf="nfsForm.showError('fs_name', formDir, 'required')"
-                    i18n>Required field</span>
+                    i18n>This field is required.</span>
             </div>
           </div>
         </div>
@@ -229,7 +229,7 @@
 
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('sec_label_xattr', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
           </div>
         </div>
 
@@ -250,7 +250,7 @@
                    (blur)="pathChangeHandler()">
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('path', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
 
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('path', formDir, 'pattern')"
@@ -279,7 +279,7 @@
 
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('path', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
 
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('path', formDir, 'pattern')"
@@ -320,7 +320,7 @@
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('protocolNfsv3', formDir, 'required') ||
                   nfsForm.showError('protocolNfsv4', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
           </div>
         </div>
 
@@ -366,7 +366,7 @@
                    formControlName="pseudo">
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('pseudo', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('pseudo', formDir, 'pattern')"
                   i18n>Pseudo needs to start with a '/' and can't contain any of the following: &gt;, &lt;, |, &, ( or ).</span>
@@ -409,7 +409,7 @@
                  target="_blank"> documentation</a> for details before enabling write access.</span>
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('access_type', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
           </div>
         </div>
 
@@ -438,7 +438,7 @@
             </select>
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('squash', formDir,'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
           </div>
         </div>
 
@@ -471,7 +471,7 @@
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('transportUDP', formDir, 'required') ||
                   nfsForm.showError('transportTCP', formDir, 'required')"
-                  i18n>Required field</span>
+                  i18n>This field is required.</span>
             <hr>
           </div>
         </div>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46590

---

backport of https://github.com/ceph/ceph/pull/35960
parent tracker: https://tracker.ceph.com/issues/46395

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh