### PR TITLE
rgw: throw error when more than one prefix in RGWPutLC::execute()

### DIFF
--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -139,7 +139,16 @@ void LCFilter_S3::decode_xml(XMLObj *obj)
     single_cond = true;
   }
 
-  RGWXMLDecoder::decode_xml("Prefix", prefix, o);
+  {
+    auto prefix_iter = o->find("Prefix");
+    auto prefix_val = prefix_iter.get_next();
+    if(prefix_val) {
+      decode_xml_obj(prefix, prefix_val);
+      if(prefix_iter.get_next()){
+        throw RGWXMLDecoder::err("Bad filter: there should not be more than one prefix!");
+      }
+    }
+  }
   if (!prefix.empty())
     num_conditions++;
   auto tags_iter = o->find("Tag");


### PR DESCRIPTION
backport tracker:  https://tracker.ceph.com/issues/46702
Signed-off-by: Shengming Zhang <zhangsm01@inspur.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
