### PR TITLE
crimson/net: enable on-wire-encryt and v2.1 support

### DIFF
--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -160,6 +160,7 @@ set(crimson_mon_srcs
   mon/MonClient.cc
   ${PROJECT_SOURCE_DIR}/src/mon/MonSub.cc)
 set(crimson_net_srcs
+  ${PROJECT_SOURCE_DIR}/src/msg/async/crypto_onwire.cc
   ${PROJECT_SOURCE_DIR}/src/msg/async/frames_v2.cc
   net/Errors.cc
   net/Messenger.cc

--- a/src/crimson/mgr/client.cc
+++ b/src/crimson/mgr/client.cc
@@ -103,7 +103,20 @@ seastar::future<> Client::reconnect()
   auto a_while = std::chrono::duration_cast<seastar::steady_clock_type::duration>(
     retry_interval);
   return seastar::sleep(a_while).then([this] {
-    auto peer = mgrmap.get_active_addrs().front();
+    auto peer = [&] {
+      auto& mgr_addrs = mgrmap.get_active_addrs();
+      if (msgr.get_myaddr().is_legacy()) {
+        return mgr_addrs.legacy_addr();
+      } else {
+        return mgr_addrs.msgr2_addr();
+      }
+    }();
+    if (peer == entity_addr_t{}) {
+      // crimson msgr only uses the first bound addr
+      logger().error("mgr.{} does not have an addr compatible with me",
+                     mgrmap.get_active_name());
+      return;
+    }
     conn = msgr.connect(peer, CEPH_ENTITY_TYPE_MGR);
   });
 }

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -56,15 +56,15 @@ seastar::logger& logger() {
   return crimson::get_logger(ceph_subsys_ms);
 }
 
-void abort_in_fault() {
+[[noreturn]] void abort_in_fault() {
   throw std::system_error(make_error_code(crimson::net::error::negotiation_failure));
 }
 
-void abort_protocol() {
+[[noreturn]] void abort_protocol() {
   throw std::system_error(make_error_code(crimson::net::error::protocol_aborted));
 }
 
-void abort_in_close(crimson::net::ProtocolV2& proto, bool dispatch_reset) {
+[[noreturn]] void abort_in_close(crimson::net::ProtocolV2& proto, bool dispatch_reset) {
   proto.close(dispatch_reset);
   abort_protocol();
 }

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -22,8 +22,6 @@
 #include "Interceptor.h"
 #endif
 
-#define CRIMSON_MSGR2_SUPPORTED_FEATURES	(0ull)
-
 using namespace ceph::msgr::v2;
 using crimson::common::local_conf;
 
@@ -397,7 +395,7 @@ ProtocolV2::banner_exchange(bool is_connect)
 {
   // 1. prepare and send banner
   bufferlist banner_payload;
-  encode((uint64_t)CRIMSON_MSGR2_SUPPORTED_FEATURES, banner_payload, 0);
+  encode((uint64_t)CEPH_MSGR2_SUPPORTED_FEATURES, banner_payload, 0);
   encode((uint64_t)CEPH_MSGR2_REQUIRED_FEATURES, banner_payload, 0);
 
   bufferlist bl;
@@ -408,7 +406,7 @@ ProtocolV2::banner_exchange(bool is_connect)
   logger().debug("{} SEND({}) banner: len_payload={}, supported={}, "
                  "required={}, banner=\"{}\"",
                  conn, bl.length(), len_payload,
-                 CRIMSON_MSGR2_SUPPORTED_FEATURES, CEPH_MSGR2_REQUIRED_FEATURES,
+                 CEPH_MSGR2_SUPPORTED_FEATURES, CEPH_MSGR2_REQUIRED_FEATURES,
                  CEPH_BANNER_V2_PREFIX);
   INTERCEPT_CUSTOM(custom_bp_t::BANNER_WRITE, bp_type_t::WRITE);
   return write_flush(std::move(bl)).then([this] {
@@ -463,7 +461,7 @@ ProtocolV2::banner_exchange(bool is_connect)
                      peer_supported_features, peer_required_features);
 
       // Check feature bit compatibility
-      uint64_t supported_features = CRIMSON_MSGR2_SUPPORTED_FEATURES;
+      uint64_t supported_features = CEPH_MSGR2_SUPPORTED_FEATURES;
       uint64_t required_features = CEPH_MSGR2_REQUIRED_FEATURES;
       if ((required_features & peer_supported_features) != required_features) {
         logger().error("{} peer does not support all required features"

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1065,6 +1065,8 @@ ProtocolV2::reuse_connection(
                                     client_cookie,
                                     conn.get_peer_name(),
                                     connection_features,
+                                    tx_frame_asm.get_is_rev1(),
+                                    rx_frame_asm.get_is_rev1(),
                                     conn_seq,
                                     msg_seq);
 #ifdef UNIT_TESTS_BUILT
@@ -1684,6 +1686,8 @@ void ProtocolV2::trigger_replacing(bool reconnect,
                                    uint64_t new_client_cookie,
                                    entity_name_t new_peer_name,
                                    uint64_t new_conn_features,
+                                   bool tx_is_rev1,
+                                   bool rx_is_rev1,
                                    uint64_t new_connect_seq,
                                    uint64_t new_msg_seq)
 {
@@ -1700,6 +1704,7 @@ void ProtocolV2::trigger_replacing(bool reconnect,
                   new_socket = std::move(new_socket),
                   new_auth_meta = std::move(new_auth_meta),
                   new_rxtx = std::move(new_rxtx),
+                  tx_is_rev1, rx_is_rev1,
                   new_client_cookie, new_peer_name,
                   new_conn_features, new_peer_global_seq,
                   new_connect_seq, new_msg_seq] () mutable {
@@ -1714,6 +1719,7 @@ void ProtocolV2::trigger_replacing(bool reconnect,
              new_socket = std::move(new_socket),
              new_auth_meta = std::move(new_auth_meta),
              new_rxtx = std::move(new_rxtx),
+             tx_is_rev1, rx_is_rev1,
              new_client_cookie, new_peer_name,
              new_conn_features, new_peer_global_seq,
              new_connect_seq, new_msg_seq] () mutable {
@@ -1749,6 +1755,8 @@ void ProtocolV2::trigger_replacing(bool reconnect,
           conn.set_peer_id(new_peer_name.num());
         }
         connection_features = new_conn_features;
+        tx_frame_asm.set_is_rev1(tx_is_rev1);
+        rx_frame_asm.set_is_rev1(rx_is_rev1);
         return send_server_ident();
       }
     }).then([this, reconnect] {

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -482,6 +482,9 @@ ProtocolV2::banner_exchange(bool is_connect)
       if (this->peer_required_features == 0) {
         this->connection_features = msgr2_required;
       }
+      const bool is_rev1 = HAVE_MSGR2_FEATURE(peer_supported_features, REVISION_1);
+      tx_frame_asm.set_is_rev1(is_rev1);
+      rx_frame_asm.set_is_rev1(is_rev1);
 
       auto hello = HelloFrame::Encode(messenger.get_mytype(),
                                       conn.target_addr);

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -294,13 +294,9 @@ seastar::future<> ProtocolV2::read_frame_payload()
       return read_exactly(onwire_len).then([this] (auto tmp_bl) {
         logger().trace("{} RECV({}) frame segment[{}]",
                        conn, tmp_bl.size(), rx_segments_data.size());
-        bufferlist data;
-        data.append(buffer::create(std::move(tmp_bl)));
-        if (session_stream_handlers.rx) {
-          // TODO
-          ceph_assert(false);
-        }
-        rx_segments_data.emplace_back(std::move(data));
+        bufferlist segment;
+        segment.append(buffer::create(std::move(tmp_bl)));
+        rx_segments_data.emplace_back(std::move(segment));
       });
     }
   ).then([this] {

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -122,9 +122,8 @@ class ProtocolV2 final : public Protocol {
   seastar::future<> write_flush(bufferlist&& buf);
 
   ceph::crypto::onwire::rxtx_t session_stream_handlers;
-  boost::container::static_vector<ceph::msgr::v2::segment_t,
-				  ceph::msgr::v2::MAX_NUM_SEGMENTS> rx_segments_desc;
-  ceph::msgr::v2::FrameAssembler tx_frame_asm;
+  ceph::msgr::v2::FrameAssembler tx_frame_asm{&session_stream_handlers, false};
+  ceph::msgr::v2::FrameAssembler rx_frame_asm{&session_stream_handlers, false};
   ceph::msgr::v2::segment_bls_t rx_segments_data;
 
   size_t get_current_msg_size() const;

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -202,6 +202,8 @@ class ProtocolV2 final : public Protocol {
                          uint64_t new_client_cookie,
                          entity_name_t new_peer_name,
                          uint64_t new_conn_features,
+                         bool tx_is_rev1,
+                         bool rx_is_rev1,
                          // reconnect
                          uint64_t new_connect_seq,
                          uint64_t new_msg_seq);

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -124,6 +124,7 @@ class ProtocolV2 final : public Protocol {
   ceph::crypto::onwire::rxtx_t session_stream_handlers;
   ceph::msgr::v2::FrameAssembler tx_frame_asm{&session_stream_handlers, false};
   ceph::msgr::v2::FrameAssembler rx_frame_asm{&session_stream_handlers, false};
+  ceph::bufferlist rx_preamble;
   ceph::msgr::v2::segment_bls_t rx_segments_data;
 
   size_t get_current_msg_size() const;

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -119,10 +119,10 @@ seastar::future<> AlienStore::umount()
   });
 }
 
-seastar::future<> AlienStore::mkfs(uuid_d new_osd_fsid)
+seastar::future<> AlienStore::mkfs(uuid_d osd_fsid)
 {
   logger().debug("{}", __func__);
-  osd_fsid = new_osd_fsid;
+  store->set_fsid(osd_fsid);
   return tp->submit([this] {
     return store->mkfs();
   }).then([] (int r) {
@@ -405,7 +405,7 @@ AlienStore::read_meta(const std::string& key)
 uuid_d AlienStore::get_fsid() const
 {
   logger().debug("{}", __func__);
-  return osd_fsid;
+  return store->get_fsid();
 }
 
 seastar::future<store_statfs_t> AlienStore::stat() const

--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -117,7 +117,6 @@ private:
   mutable std::unique_ptr<crimson::os::ThreadPool> tp;
   const std::string path;
   uint64_t used_bytes = 0;
-  uuid_d osd_fsid;
   std::unique_ptr<ObjectStore> store;
   std::unique_ptr<CephContext> cct;
   seastar::gate transaction_gate;

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(crimson-osd
   ${PROJECT_SOURCE_DIR}/src/objclass/class_api.cc
   ${PROJECT_SOURCE_DIR}/src/osd/ClassHandler.cc
   ${PROJECT_SOURCE_DIR}/src/osd/osd_op_util.cc
+  ${PROJECT_SOURCE_DIR}/src/osd/OSDCap.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PeeringState.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PGPeeringEvent.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PGStateUtils.cc

--- a/src/messages/MOSDBoot.h
+++ b/src/messages/MOSDBoot.h
@@ -38,7 +38,7 @@ private:
     : PaxosServiceMessage{MSG_OSD_BOOT, 0, HEAD_VERSION, COMPAT_VERSION},
       boot_epoch(0), osd_features(0)
   { }
-  MOSDBoot(OSDSuperblock& s, epoch_t e, epoch_t be,
+  MOSDBoot(const OSDSuperblock& s, epoch_t e, epoch_t be,
 	   const entity_addrvec_t& hb_back_addr_ref,
 	   const entity_addrvec_t& hb_front_addr_ref,
            const entity_addrvec_t& cluster_addr_ref,

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -259,7 +259,7 @@ public:
 
   epoch_t get_epoch() const { return epoch; }
   epoch_t get_last_failure_osd_epoch() const { return last_failure_osd_epoch; }
-  entity_addrvec_t get_active_addrs() const { return active_addrs; }
+  const entity_addrvec_t& get_active_addrs() const { return active_addrs; }
   uint64_t get_active_gid() const { return active_gid; }
   bool get_available() const { return available; }
   const std::string &get_active_name() const { return active_name; }

--- a/src/msg/async/crypto_onwire.cc
+++ b/src/msg/async/crypto_onwire.cc
@@ -68,8 +68,8 @@ public:
   }
 
   ~AES128GCM_OnWireTxHandler() override {
-    ::ceph::crypto::zeroize_for_security(&nonce, sizeof(nonce));
-    ::ceph::crypto::zeroize_for_security(&initial_nonce, sizeof(initial_nonce));
+    ::TOPNSPC::crypto::zeroize_for_security(&nonce, sizeof(nonce));
+    ::TOPNSPC::crypto::zeroize_for_security(&initial_nonce, sizeof(initial_nonce));
   }
 
   void reset_tx_handler(const uint32_t* first, const uint32_t* last) override;
@@ -189,7 +189,7 @@ public:
   }
 
   ~AES128GCM_OnWireRxHandler() override {
-    ::ceph::crypto::zeroize_for_security(&nonce, sizeof(nonce));
+    ::TOPNSPC::crypto::zeroize_for_security(&nonce, sizeof(nonce));
   }
 
   std::uint32_t get_extra_size_at_final() override {

--- a/src/msg/async/crypto_onwire.cc
+++ b/src/msg/async/crypto_onwire.cc
@@ -162,7 +162,6 @@ ceph::bufferlist AES128GCM_OnWireTxHandler::authenticated_encrypt_final()
 
 // RX PART
 class AES128GCM_OnWireRxHandler : public ceph::crypto::onwire::RxHandler {
-  CephContext* const cct;
   std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)> ectx;
   nonce_t nonce;
   bool new_nonce_format;  // 64-bit counter?
@@ -173,8 +172,7 @@ public:
 			    const key_t& key,
 			    const nonce_t& nonce,
 			    bool new_nonce_format)
-    : cct(cct),
-      ectx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free),
+    : ectx(EVP_CIPHER_CTX_new(), EVP_CIPHER_CTX_free),
       nonce(nonce), new_nonce_format(new_nonce_format) {
     ceph_assert_always(ectx);
     ceph_assert_always(key.size() * CHAR_BIT == 128);

--- a/src/stop.sh
+++ b/src/stop.sh
@@ -161,7 +161,7 @@ if [ $stop_all -eq 1 ]; then
         do_killcephadm
     fi
 
-    for p in ceph-mon ceph-mds $ceph_osd ceph-mgr radosgw lt-radosgw apache2 ganesha.nfsd ; do
+    for p in $ceph_osd ceph-mon ceph-mds ceph-mgr radosgw lt-radosgw apache2 ganesha.nfsd ; do
         for try in 0 1 1 1 1 ; do
             if ! pkill -u $MYUID $p ; then
                 break


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
