### PR TITLE
[RFC] mgr/cephadm: provide a way to query the registry for new tags

### DIFF
--- a/qa/tasks/cephadm_cases/test_cli.py
+++ b/qa/tasks/cephadm_cases/test_cli.py
@@ -12,6 +12,9 @@ class TestCephadmCLI(MgrTestCase):
     def _orch_cmd(self, *args):
         return self._cmd("orch", *args)
 
+    def _cephadm_cmd(self, *args):
+        return self._cmd("cephadm", *args)
+
     def setUp(self):
         super(TestCephadmCLI, self).setUp()
 
@@ -43,3 +46,6 @@ class TestCephadmCLI(MgrTestCase):
         self.wait_for_health('CEPHADM_PAUSED', 30)
         self._orch_cmd('resume')
         self.wait_for_health_clear(30)
+
+    def test_query_latest_version(self):
+        self._cephadm_cmd('upgrade', 'query-latest-version')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -23,6 +23,7 @@ from ceph.deployment import inventory
 from ceph.deployment.drive_group import DriveGroupSpec
 from ceph.deployment.service_spec import \
     NFSServiceSpec, ServiceSpec, PlacementSpec, assert_valid_host
+from cephadm.registry import get_latest_container_image_tag
 from cephadm.services.cephadmservice import CephadmDaemonSpec
 
 from mgr_module import MgrModule, HandleCommandResult
@@ -2352,6 +2353,12 @@ you may want to run:
     @trivial_completion
     def upgrade_stop(self):
         return self.upgrade.upgrade_stop()
+
+    @orchestrator._cli_read_command(
+        'cephadm upgrade query-latest-version',
+        desc='Query the container registry for the latest minor release available')
+    def query_latest_version(self):
+        return HandleCommandResult(stdout=get_latest_container_image_tag(self))
 
     @trivial_completion
     def remove_osds(self, osd_ids: List[str],

--- a/src/pybind/mgr/cephadm/registry.py
+++ b/src/pybind/mgr/cephadm/registry.py
@@ -1,0 +1,102 @@
+import json
+from typing import List, Dict, Tuple, TYPE_CHECKING, Set
+
+import requests
+from pkg_resources import parse_version
+from requests import Response, RequestException
+
+from orchestrator import OrchestratorError
+
+if TYPE_CHECKING:
+    from cephadm.module import CephadmOrchestrator
+
+
+class Registry:
+
+    def __init__(self, url: str):
+        self._url: str = url
+
+    @property
+    def api_domain(self) -> str:
+        if self._url == 'docker.io':
+            return 'registry-1.docker.io'
+        return self._url
+
+    def get_token(self, response: Response) -> str:
+        realm, params = self.parse_www_authenticate(response.headers['Www-Authenticate'])
+        r = requests.get(realm, params=params)
+        r.raise_for_status()
+        ret = r.json()
+        if 'access_token' in ret:
+            return ret['access_token']
+        if 'token' in ret:
+            return ret['token']
+        raise ValueError(f'Unknown token reply {ret}')
+
+    def parse_www_authenticate(self, text: str) -> Tuple[str, Dict[str, str]]:
+        # 'Www-Authenticate': 'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:ceph/ceph:pull"'
+
+        r: Dict[str, str] = {}
+        for token in text.split(','):
+            key, value = token.split('=', 1)
+            r[key] = value.strip('"')
+        realm = r.pop('Bearer realm')
+        return realm, r
+
+    def get_tags(self, image) -> List[str]:
+        url = f'https://{self.api_domain}/v2/{image}/tags/list'
+        r = requests.get(url, headers={'Accept': 'application/json'})
+
+        token = self.get_token(r)
+        r = requests.get(url, headers={'Accept': 'application/json', 'Authorization': f'Bearer {token}'})
+
+        r.raise_for_status()
+        return r.json()['tags']
+
+def get_latest_container_image_tag(mgr: "CephadmOrchestrator") -> str:
+
+    from mgr_module import MonCommandFailed
+
+    try:
+        ret, out, err = mgr.check_mon_command({
+            'prefix': 'mgr versions',
+        })
+        j = json.loads(out)
+    except (MonCommandFailed, ValueError) as e:
+        raise OrchestratorError(f'Unable to get list of versions: `ceph mgr versions` failed: {e}')
+
+    versions = [v.split(' ')[2] for v in j.keys() if v.startswith('ceph version ')]
+    major: List[int] = [int(v.split('.')[0]) for v in versions if '.' in v]
+
+    if not major:
+        raise OrchestratorError('Unable to get list of versions: `ceph mgr versions` failed')
+
+    latest_major = str(max(major))
+
+    reg_name, image = mgr.container_image_base.split('/', 1)
+
+    try:
+        raw_tags = Registry(reg_name).get_tags(image)
+    except RequestException as e:
+        raise OrchestratorError(f'Unable to get list of versions for {mgr.container_image_base}: {e}')
+
+    tags = set()
+    for tag in raw_tags:
+        if tag.startswith('v'):
+            tag = tag[1:]
+        if not tag.startswith(f'{latest_major}.'):
+            continue
+        tags.add(tag)
+
+    if not tags:
+        raise OrchestratorError(f'Unable to get list of versions for {mgr.container_image_base}: empty list\n{raw_tags}')
+
+    latest = sorted(tags, key=parse_version, reverse=True)
+
+    return latest[0]
+
+
+
+
+
+

--- a/src/pybind/mgr/cephadm/tests/test_registry.py
+++ b/src/pybind/mgr/cephadm/tests/test_registry.py
@@ -1,0 +1,14 @@
+import pytest
+
+from cephadm.registry import Registry
+
+
+def test_parse_www_authendicate():
+    r = Registry('docker.io').parse_www_authenticate('Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:ceph/ceph:pull"')
+    assert r == ('https://auth.docker.io/token', {'scope': 'repository:ceph/ceph:pull', 'service': 'registry.docker.io'})
+
+
+@pytest.mark.skip('todo: mock network requests')
+def test_docker_io():
+    tags = Registry('docker.io').get_tags('ceph/ceph')
+    assert len(tags) > 1


### PR DESCRIPTION
This provides something like:

```
$ ceph cephadm upgrade query-latest-version                                                                                                              
15.2.4-20200630
```

which is obviously only a proof of concept. 

I could easily add a `--latest` flag to `ceph orch upgrade start`, but that doesn't properly solve day 1.

Any ideas? @ricardoasmarques @smithfarm ?

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
