### PR TITLE
pybind/mgr: remove coverage from tox.ini

### DIFF
--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -12,7 +12,7 @@ deps =
     cython
     -rrequirements.txt
 commands =
-    pytest --cov --cov-append --cov-report= --doctest-modules {posargs: \
+    pytest --doctest-modules {posargs: \
         mgr_util.py \
         tests/ \
         cephadm/ \


### PR DESCRIPTION
This considerably speeds up tox when running very few tests:

* tox run with `--cov`: 6-10 seconds
* tox run without : ~3.5 seconds

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

An example run with cov:

```
$ time ../../script/run_tox.sh --tox-envs=py3,mypy mgr -- cephadm/tests/test_registry.py | ts '[%Y-%m-%d %H:%M:%S]'
[2020-07-24 15:08:25] Requirement already satisfied: tox in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (3.14.3)
[2020-07-24 15:08:25] Requirement already satisfied: importlib-metadata<2,>=0.12; python_version < "3.8" in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (1.3.0)
[2020-07-24 15:08:25] Requirement already satisfied: pluggy<1,>=0.12.0 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (0.13.1)
[2020-07-24 15:08:25] Requirement already satisfied: toml>=0.9.4 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (0.10.0)
[2020-07-24 15:08:25] Requirement already satisfied: virtualenv>=16.0.0 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (16.7.9)
[2020-07-24 15:08:25] Requirement already satisfied: packaging>=14 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (20.0)
[2020-07-24 15:08:25] Requirement already satisfied: py<2,>=1.4.17 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (1.8.1)
[2020-07-24 15:08:25] Requirement already satisfied: six<2,>=1.0.0 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (1.13.0)
[2020-07-24 15:08:25] Requirement already satisfied: filelock<4,>=3.0.0 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (3.0.12)
[2020-07-24 15:08:25] Requirement already satisfied: zipp>=0.5 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from importlib-metadata<2,>=0.12; python_version < "3.8"->tox) (0.6.0)
[2020-07-24 15:08:25] Requirement already satisfied: pyparsing>=2.0.2 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from packaging>=14->tox) (2.4.6)
[2020-07-24 15:08:25] Requirement already satisfied: more-itertools in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from zipp>=0.5->importlib-metadata<2,>=0.12; python_version < "3.8"->tox) (8.0.2)
WARNING: You are using pip version 19.3.1; however, version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.                                                                                                                                                                                            
[2020-07-24 15:08:26] py3 installed: -f /home/sebastian/Repos/ceph/src/pybind/mgr/wheelhouse,apipkg==1.5,attrs==19.3.0,cachetools==4.1.1,-e git+git@github.com:sebastian-philipp/ceph.git@88e1c0a012b9fd8b7204bb571d9e4f47bcfac03c#egg=ceph&subdirectory=src/python-common,certifi==2020.6.20,cffi==1.14.0,chardet==3.0.4,coverage==5.2,cryptography==3.0,Cython==0.29.21,execnet==1.7.1,google-auth==1.19.2,idna==2.10,importlib-metadata==1.7.0,Jinja2==2.11.2,jsonpatch==1.26,jsonpointer==2.0,kubernetes==11.0.0,MarkupSafe==1.1.1,more-itertools==8.4.0,oauthlib==3.1.0,packaging==20.4,pluggy==0.13.1,prettytable==0.7.2,py==1.9.0,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycparser==2.20,pyfakefs==4.1.0,pyOpenSSL==19.1.0,pyparsing==2.4.7,pytest==5.4.3,pytest-cov==2.7.1,python-dateutil==2.8.1,PyYAML==5.3.1,remoto==1.2.0,requests==2.24.0,requests-mock==1.8.0,requests-oauthlib==1.3.0,rsa==4.6,six==1.15.0,urllib3==1.25.9,wcwidth==0.2.5,websocket-client==0.57.0,zipp==3.1.0
[2020-07-24 15:08:26] py3 run-test-pre: PYTHONHASHSEED='2845004225'
[2020-07-24 15:08:26] py3 run-test: commands[0] | pytest --cov --cov-append --cov-report= --doctest-modules cephadm/tests/test_registry.py
[2020-07-24 15:08:26] ============================= test session starts ==============================
[2020-07-24 15:08:26] platform linux -- Python 3.6.9, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
[2020-07-24 15:08:26] cachedir: .tox/py3/.pytest_cache
[2020-07-24 15:08:26] rootdir: /home/sebastian/Repos/ceph/src/pybind/mgr
[2020-07-24 15:08:26] plugins: requests-mock-1.8.0, pyfakefs-4.1.0, cov-2.7.1
[2020-07-24 15:08:26] collected 2 items
[2020-07-24 15:08:26] 
[2020-07-24 15:08:29] cephadm/tests/test_registry.py .s                                        [100%]
[2020-07-24 15:08:29] 
[2020-07-24 15:08:29] 
[2020-07-24 15:08:29] 
[2020-07-24 15:08:29] ========================= 1 passed, 1 skipped in 2.60s =========================
[2020-07-24 15:08:29] mypy installed: -f /home/sebastian/Repos/ceph/src/pybind/mgr/wheelhouse,apipkg==1.5,attrs==19.3.0,cachetools==4.1.1,-e git+git@github.com:sebastian-philipp/ceph.git@88e1c0a012b9fd8b7204bb571d9e4f47bcfac03c#egg=ceph&subdirectory=src/python-common,certifi==2020.6.20,cffi==1.14.0,chardet==3.0.4,coverage==5.2,cryptography==3.0,Cython==0.29.21,execnet==1.7.1,google-auth==1.19.2,idna==2.10,importlib-metadata==1.7.0,Jinja2==2.11.2,jsonpatch==1.26,jsonpointer==2.0,kubernetes==11.0.0,MarkupSafe==1.1.1,more-itertools==8.4.0,mypy==0.782,mypy-extensions==0.4.3,oauthlib==3.1.0,packaging==20.4,pluggy==0.13.1,prettytable==0.7.2,py==1.9.0,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycparser==2.20,pyfakefs==4.1.0,pyOpenSSL==19.1.0,pyparsing==2.4.7,pytest==5.4.3,pytest-cov==2.7.1,python-dateutil==2.8.1,PyYAML==5.3.1,remoto==1.2.0,requests==2.24.0,requests-mock==1.8.0,requests-oauthlib==1.3.0,rsa==4.6,six==1.15.0,typed-ast==1.4.1,typing-extensions==3.7.4.2,urllib3==1.25.9,wcwidth==0.2.5,websocket-client==0.57.0,zipp==3.1.0
[2020-07-24 15:08:29] mypy run-test-pre: PYTHONHASHSEED='2845004225'
[2020-07-24 15:08:29] mypy run-test: commands[0] | mypy --config-file=../../mypy.ini cephadm/module.py mgr_module.py dashboard/module.py prometheus/module.py mgr_util.py orchestrator/__init__.py progress/module.py rook/module.py osd_support/module.py test_orchestrator/module.py volumes/__init__.py
[2020-07-24 15:08:29] Success: no issues found in 11 source files
[2020-07-24 15:08:29] ___________________________________ summary ____________________________________
[2020-07-24 15:08:29]   py3: commands succeeded
[2020-07-24 15:08:29]   mypy: commands succeeded
[2020-07-24 15:08:29]   congratulations :)
../../script/run_tox.sh --tox-envs=py3,mypy mgr --   5,53s user 0,75s system 99% cpu 6,297 total
ts '[%Y-%m-%d %H:%M:%S]'  0,04s user 0,01s system 0% cpu 6,297 total
```

And without:

```
$ time ../../script/run_tox.sh --tox-envs=py3,mypy mgr -- cephadm/tests/test_registry.py | ts '[%Y-%m-%d %H:%M:%S]'
[2020-07-24 15:08:53] Requirement already satisfied: tox in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (3.14.3)
[2020-07-24 15:08:53] Requirement already satisfied: py<2,>=1.4.17 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (1.8.1)
[2020-07-24 15:08:53] Requirement already satisfied: packaging>=14 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (20.0)
[2020-07-24 15:08:53] Requirement already satisfied: six<2,>=1.0.0 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (1.13.0)
[2020-07-24 15:08:53] Requirement already satisfied: toml>=0.9.4 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (0.10.0)
[2020-07-24 15:08:53] Requirement already satisfied: filelock<4,>=3.0.0 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (3.0.12)
[2020-07-24 15:08:53] Requirement already satisfied: virtualenv>=16.0.0 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (16.7.9)
[2020-07-24 15:08:53] Requirement already satisfied: pluggy<1,>=0.12.0 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (0.13.1)
[2020-07-24 15:08:53] Requirement already satisfied: importlib-metadata<2,>=0.12; python_version < "3.8" in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from tox) (1.3.0)
[2020-07-24 15:08:53] Requirement already satisfied: pyparsing>=2.0.2 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from packaging>=14->tox) (2.4.6)
[2020-07-24 15:08:53] Requirement already satisfied: zipp>=0.5 in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from importlib-metadata<2,>=0.12; python_version < "3.8"->tox) (0.6.0)
[2020-07-24 15:08:53] Requirement already satisfied: more-itertools in /home/sebastian/Repos/ceph/build/mgr/lib/python3.6/site-packages (from zipp>=0.5->importlib-metadata<2,>=0.12; python_version < "3.8"->tox) (8.0.2)
WARNING: You are using pip version 19.3.1; however, version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.                                                                                                                                                                                            
[2020-07-24 15:08:54] py3 installed: -f /home/sebastian/Repos/ceph/src/pybind/mgr/wheelhouse,apipkg==1.5,attrs==19.3.0,cachetools==4.1.1,-e git+git@github.com:sebastian-philipp/ceph.git@88e1c0a012b9fd8b7204bb571d9e4f47bcfac03c#egg=ceph&subdirectory=src/python-common,certifi==2020.6.20,cffi==1.14.0,chardet==3.0.4,coverage==5.2,cryptography==3.0,Cython==0.29.21,execnet==1.7.1,google-auth==1.19.2,idna==2.10,importlib-metadata==1.7.0,Jinja2==2.11.2,jsonpatch==1.26,jsonpointer==2.0,kubernetes==11.0.0,MarkupSafe==1.1.1,more-itertools==8.4.0,oauthlib==3.1.0,packaging==20.4,pluggy==0.13.1,prettytable==0.7.2,py==1.9.0,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycparser==2.20,pyfakefs==4.1.0,pyOpenSSL==19.1.0,pyparsing==2.4.7,pytest==5.4.3,pytest-cov==2.7.1,python-dateutil==2.8.1,PyYAML==5.3.1,remoto==1.2.0,requests==2.24.0,requests-mock==1.8.0,requests-oauthlib==1.3.0,rsa==4.6,six==1.15.0,urllib3==1.25.9,wcwidth==0.2.5,websocket-client==0.57.0,zipp==3.1.0
[2020-07-24 15:08:54] py3 run-test-pre: PYTHONHASHSEED='3759226863'
[2020-07-24 15:08:54] py3 run-test: commands[0] | pytest --doctest-modules cephadm/tests/test_registry.py
[2020-07-24 15:08:54] ============================= test session starts ==============================
[2020-07-24 15:08:54] platform linux -- Python 3.6.9, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
[2020-07-24 15:08:54] cachedir: .tox/py3/.pytest_cache
[2020-07-24 15:08:54] rootdir: /home/sebastian/Repos/ceph/src/pybind/mgr
[2020-07-24 15:08:54] plugins: requests-mock-1.8.0, pyfakefs-4.1.0, cov-2.7.1
[2020-07-24 15:08:54] collected 2 items
[2020-07-24 15:08:54] 
[2020-07-24 15:08:54] cephadm/tests/test_registry.py .s                                        [100%]
[2020-07-24 15:08:54] 
[2020-07-24 15:08:54] ========================= 1 passed, 1 skipped in 0.13s =========================
[2020-07-24 15:08:55] mypy installed: -f /home/sebastian/Repos/ceph/src/pybind/mgr/wheelhouse,apipkg==1.5,attrs==19.3.0,cachetools==4.1.1,-e git+git@github.com:sebastian-philipp/ceph.git@88e1c0a012b9fd8b7204bb571d9e4f47bcfac03c#egg=ceph&subdirectory=src/python-common,certifi==2020.6.20,cffi==1.14.0,chardet==3.0.4,coverage==5.2,cryptography==3.0,Cython==0.29.21,execnet==1.7.1,google-auth==1.19.2,idna==2.10,importlib-metadata==1.7.0,Jinja2==2.11.2,jsonpatch==1.26,jsonpointer==2.0,kubernetes==11.0.0,MarkupSafe==1.1.1,more-itertools==8.4.0,mypy==0.782,mypy-extensions==0.4.3,oauthlib==3.1.0,packaging==20.4,pluggy==0.13.1,prettytable==0.7.2,py==1.9.0,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycparser==2.20,pyfakefs==4.1.0,pyOpenSSL==19.1.0,pyparsing==2.4.7,pytest==5.4.3,pytest-cov==2.7.1,python-dateutil==2.8.1,PyYAML==5.3.1,remoto==1.2.0,requests==2.24.0,requests-mock==1.8.0,requests-oauthlib==1.3.0,rsa==4.6,six==1.15.0,typed-ast==1.4.1,typing-extensions==3.7.4.2,urllib3==1.25.9,wcwidth==0.2.5,websocket-client==0.57.0,zipp==3.1.0
[2020-07-24 15:08:55] mypy run-test-pre: PYTHONHASHSEED='3759226863'
[2020-07-24 15:08:55] mypy run-test: commands[0] | mypy --config-file=../../mypy.ini cephadm/module.py mgr_module.py dashboard/module.py prometheus/module.py mgr_util.py orchestrator/__init__.py progress/module.py rook/module.py osd_support/module.py test_orchestrator/module.py volumes/__init__.py
[2020-07-24 15:08:55] Success: no issues found in 11 source files
[2020-07-24 15:08:55] ___________________________________ summary ____________________________________
[2020-07-24 15:08:55]   py3: commands succeeded
[2020-07-24 15:08:55]   mypy: commands succeeded
[2020-07-24 15:08:55]   congratulations :)
../../script/run_tox.sh --tox-envs=py3,mypy mgr --   3,02s user 0,77s system 99% cpu 3,791 total
ts '[%Y-%m-%d %H:%M:%S]'  0,05s user 0,01s system 1% cpu 3,790 total
```

note that the coverage report is not used right now.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
