### PR TITLE
common/bl: don't access raw::data nor raw::len directly. Use getters instead.

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -279,7 +279,7 @@ static ceph::spinlock debug_lock;
 
   ceph::unique_leakable_ptr<buffer::raw> buffer::copy(const char *c, unsigned len) {
     auto r = buffer::create_aligned(len, sizeof(size_t));
-    memcpy(r->data, c, len);
+    memcpy(r->get_data(), c, len);
     return r;
   }
 
@@ -288,7 +288,7 @@ static ceph::spinlock debug_lock;
   }
   ceph::unique_leakable_ptr<buffer::raw> buffer::create(unsigned len, char c) {
     auto ret = buffer::create_aligned(len, sizeof(size_t));
-    memset(ret->data, c, len);
+    memset(ret->get_data(), c, len);
     return ret;
   }
   ceph::unique_leakable_ptr<buffer::raw>
@@ -539,7 +539,7 @@ static ceph::spinlock debug_lock;
     return _raw->get_data()[_off + n];
   }
 
-  const char *buffer::ptr::raw_c_str() const { ceph_assert(_raw); return _raw->data; }
+  const char *buffer::ptr::raw_c_str() const { ceph_assert(_raw); return _raw->get_data(); }
   unsigned buffer::ptr::raw_length() const { ceph_assert(_raw); return _raw->len; }
   int buffer::ptr::raw_nref() const { ceph_assert(_raw); return _raw->nref; }
 
@@ -547,7 +547,7 @@ static ceph::spinlock debug_lock;
     ceph_assert(_raw);
     if (o+l > _len)
         throw end_of_buffer();
-    char* src =  _raw->data + _off + o;
+    char* src =  _raw->get_data() + _off + o;
     maybe_inline_memcpy(dest, src, l, 8);
   }
 
@@ -580,7 +580,7 @@ static ceph::spinlock debug_lock;
   {
     ceph_assert(_raw);
     ceph_assert(1 <= unused_tail_length());
-    char* ptr = _raw->data + _off + _len;
+    char* ptr = _raw->get_data() + _off + _len;
     *ptr = c;
     _len++;
     return _len + _off;
@@ -590,7 +590,7 @@ static ceph::spinlock debug_lock;
   {
     ceph_assert(_raw);
     ceph_assert(l <= unused_tail_length());
-    char* c = _raw->data + _off + _len;
+    char* c = _raw->get_data() + _off + _len;
     maybe_inline_memcpy(c, p, l, 32);
     _len += l;
     return _len + _off;
@@ -600,7 +600,7 @@ static ceph::spinlock debug_lock;
   {
     ceph_assert(_raw);
     ceph_assert(l <= unused_tail_length());
-    char* c = _raw->data + _off + _len;
+    char* c = _raw->get_data() + _off + _len;
     // FIPS zeroization audit 20191115: this memset is not security related.
     memset(c, 0, l);
     _len += l;
@@ -612,7 +612,7 @@ static ceph::spinlock debug_lock;
     ceph_assert(_raw);
     ceph_assert(o <= _len);
     ceph_assert(o+l <= _len);
-    char* dest = _raw->data + _off + o;
+    char* dest = _raw->get_data() + _off + o;
     if (crc_reset)
         _raw->invalidate_crc();
     maybe_inline_memcpy(dest, src, l, 64);
@@ -2179,7 +2179,7 @@ buffer::ptr_node* buffer::ptr_node::cloner::operator()(
 }
 
 std::ostream& buffer::operator<<(std::ostream& out, const buffer::raw &r) {
-  return out << "buffer::raw(" << (void*)r.data << " len " << r.len << " nref " << r.nref.load() << ")";
+  return out << "buffer::raw(" << (void*)r.get_data() << " len " << r.len << " nref " << r.nref.load() << ")";
 }
 
 std::ostream& buffer::operator<<(std::ostream& out, const buffer::ptr& bp) {

--- a/src/include/buffer_raw.h
+++ b/src/include/buffer_raw.h
@@ -34,8 +34,8 @@ inline namespace v15_2_0 {
 			 alignof(ptr_node)>::type bptr_storage;
   protected:
     char *data;
-  public:
     unsigned len;
+  public:
     ceph::atomic<unsigned> nref { 0 };
     int mempool;
 
@@ -88,6 +88,9 @@ private:
 public:
     char *get_data() const {
       return data;
+    }
+    unsigned get_len() const {
+      return len;
     }
     virtual raw* clone_empty() = 0;
     ceph::unique_leakable_ptr<raw> clone() {

--- a/src/include/buffer_raw.h
+++ b/src/include/buffer_raw.h
@@ -32,7 +32,9 @@ inline namespace v15_2_0 {
     // embedded slots. This would allow to avoid the "if" in dtor of ptr_node.
     std::aligned_storage<sizeof(ptr_node),
 			 alignof(ptr_node)>::type bptr_storage;
+  protected:
     char *data;
+  public:
     unsigned len;
     ceph::atomic<unsigned> nref { 0 };
     int mempool;
@@ -84,7 +86,7 @@ private:
     raw(const raw &other) = delete;
     const raw& operator=(const raw &other) = delete;
 public:
-    char *get_data() {
+    char *get_data() const {
       return data;
     }
     virtual raw* clone_empty() = 0;


### PR DESCRIPTION
This clean-up is useful especially in debugging as it brings additional points for canary verification (see https://github.com/ceph/ceph/pull/35873).

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
