### PR TITLE
mgr/cephadm: Add migration to keep the service names consistent

### DIFF
--- a/src/pybind/mgr/cephadm/migrations.py
+++ b/src/pybind/mgr/cephadm/migrations.py
@@ -9,7 +9,7 @@ from orchestrator import OrchestratorError
 if TYPE_CHECKING:
     from .module import CephadmOrchestrator
 
-LAST_MIGRATION = 1
+LAST_MIGRATION = 2
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +52,10 @@ class Migrations:
         if self.mgr.migration_current == 0:
             if self.migrate_0_1():
                 self.set(1)
+
+        if self.mgr.migration_current == 1:
+            if self.migrate_1_2():
+                self.set(2)
 
     def migrate_0_1(self) -> bool:
         """
@@ -124,5 +128,31 @@ class Migrations:
 
         for spec in specs:
             convert_to_explicit(spec)
+
+        return True
+
+    def migrate_1_2(self) -> bool:
+        """
+        After 15.2.4, we unified some service IDs: MONs, MGRs etc no longer have a service id.
+        Which means, the service names changed:
+
+        mon.foo -> mon
+        mgr.foo -> mgr
+
+        This fixes the data structure consistency
+        """
+        bad_specs = {}
+        for name, spec in self.mgr.spec_store.specs.items():
+            if name != spec.service_name():
+                bad_specs[name] = (spec.service_name(), spec)
+
+        for old, (new, old_spec) in bad_specs.items():
+            if new not in self.mgr.spec_store.specs:
+                spec = old_spec
+            else:
+                spec = self.mgr.spec_store.specs[new]
+            spec.unmanaged = True
+            self.mgr.spec_store.save(spec)
+            self.mgr.spec_store.rm(old)
 
         return True

--- a/src/pybind/mgr/cephadm/tests/test_migration.py
+++ b/src/pybind/mgr/cephadm/tests/test_migration.py
@@ -2,13 +2,12 @@ from datetime import datetime
 
 from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, HostPlacementSpec
 from cephadm import CephadmOrchestrator
-from cephadm.tests.fixtures import _run_cephadm, cephadm_module, wait, match_glob, with_host
-from orchestrator import ServiceDescription
+from cephadm.tests.fixtures import _run_cephadm, cephadm_module, wait, with_host
 from tests import mock
 
 @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
 @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _,__,___: None)
-def test_service_ls(cephadm_module: CephadmOrchestrator):
+def test_migrate_scheduler(cephadm_module: CephadmOrchestrator):
     with with_host(cephadm_module, 'host1'):
         with with_host(cephadm_module, 'host2'):
 
@@ -44,7 +43,3 @@ def test_service_ls(cephadm_module: CephadmOrchestrator):
             out = [o.spec.placement for o in wait(cephadm_module, cephadm_module.describe_service())]
             assert out == [PlacementSpec(count=2, hosts=[HostPlacementSpec(hostname='host1', network='', name=''), HostPlacementSpec(hostname='host2', network='', name='')])]
 
-
-
-#            assert_rm_service(cephadm_module, 'rgw.r.z')
-#            assert_rm_daemon(cephadm_module, 'mds.name', 'test')

--- a/src/pybind/mgr/cephadm/tests/test_migration.py
+++ b/src/pybind/mgr/cephadm/tests/test_migration.py
@@ -1,7 +1,9 @@
+import json
 from datetime import datetime
 
 from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, HostPlacementSpec
 from cephadm import CephadmOrchestrator
+from cephadm.inventory import SPEC_STORE_PREFIX, DATEFMT
 from cephadm.tests.fixtures import _run_cephadm, cephadm_module, wait, with_host
 from tests import mock
 
@@ -38,8 +40,105 @@ def test_migrate_scheduler(cephadm_module: CephadmOrchestrator):
             cephadm_module.cache.last_daemon_update['host2'] = datetime.now()
 
             cephadm_module.migration.migrate()
-            assert cephadm_module.migration_current == 1
+            assert cephadm_module.migration_current == 2
 
             out = [o.spec.placement for o in wait(cephadm_module, cephadm_module.describe_service())]
             assert out == [PlacementSpec(count=2, hosts=[HostPlacementSpec(hostname='host1', network='', name=''), HostPlacementSpec(hostname='host2', network='', name='')])]
+
+
+@mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
+def test_migrate_service_id_mon_one(cephadm_module: CephadmOrchestrator):
+    with with_host(cephadm_module, 'host1'):
+        cephadm_module.set_store(SPEC_STORE_PREFIX + 'mon.wrong',
+            json.dumps({
+                'spec': {
+                    'service_type': 'mon',
+                    'service_id': 'wrong',
+                    'placement': {
+                        'hosts': ['host1']
+                    }
+                },
+                'created': datetime.utcnow().strftime(DATEFMT),
+            }, sort_keys=True),
+        )
+
+        cephadm_module.spec_store.load()
+
+        assert len(cephadm_module.spec_store.specs) == 1
+        assert cephadm_module.spec_store.specs['mon.wrong'].service_name() == 'mon'
+
+        cephadm_module.migration_current = 1
+        cephadm_module.migration.migrate()
+        assert cephadm_module.migration_current == 2
+
+        assert len(cephadm_module.spec_store.specs) == 1
+        assert cephadm_module.spec_store.specs['mon'] == ServiceSpec(
+            service_type='mon',
+            unmanaged=True,
+            placement=PlacementSpec(hosts=['host1'])
+        )
+
+@mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
+def test_migrate_service_id_mon_two(cephadm_module: CephadmOrchestrator):
+    with with_host(cephadm_module, 'host1'):
+        cephadm_module.set_store(SPEC_STORE_PREFIX + 'mon',
+            json.dumps({
+                'spec': {
+                    'service_type': 'mon',
+                    'placement': {
+                        'count': 5,
+                    }
+                },
+                'created': datetime.utcnow().strftime(DATEFMT),
+            }, sort_keys=True),
+        )
+        cephadm_module.set_store(SPEC_STORE_PREFIX + 'mon.wrong',
+            json.dumps({
+                'spec': {
+                    'service_type': 'mon',
+                    'service_id': 'wrong',
+                    'placement': {
+                        'hosts': ['host1']
+                    }
+                },
+                'created': datetime.utcnow().strftime(DATEFMT),
+            }, sort_keys=True),
+        )
+
+        cephadm_module.spec_store.load()
+
+        assert len(cephadm_module.spec_store.specs) == 2
+        assert cephadm_module.spec_store.specs['mon.wrong'].service_name() == 'mon'
+        assert cephadm_module.spec_store.specs['mon'].service_name() == 'mon'
+
+        cephadm_module.migration_current = 1
+        cephadm_module.migration.migrate()
+        assert cephadm_module.migration_current == 2
+
+        assert len(cephadm_module.spec_store.specs) == 1
+        assert cephadm_module.spec_store.specs['mon'] == ServiceSpec(
+            service_type='mon',
+            unmanaged=True,
+            placement=PlacementSpec(count=5)
+        )
+
+@mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
+def test_migrate_service_id_mds_one(cephadm_module: CephadmOrchestrator):
+    with with_host(cephadm_module, 'host1'):
+        cephadm_module.set_store(SPEC_STORE_PREFIX + 'mds',
+            json.dumps({
+                'spec': {
+                    'service_type': 'mds',
+                    'placement': {
+                        'hosts': ['host1']
+                    }
+                },
+                'created': datetime.utcnow().strftime(DATEFMT),
+            }, sort_keys=True),
+        )
+
+        cephadm_module.spec_store.load()
+
+        # there is nothing to migrate, as the spec is gone now.
+        assert len(cephadm_module.spec_store.specs) == 0
 


### PR DESCRIPTION
mgr/cephadm: Add migratoin to keep the service names consistent

After 15.2.4, we unified some service IDs: MONs, MGRs etc no longer have a service id.
Which means, the service names changed:

mon.foo -> mon
mgr.foo -> mgr

This fixes the data structure consistency

This is a follow up on #35839 Especially https://github.com/ceph/ceph/pull/35839#discussion_r459281853

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
