### PR TITLE
mgr/orch: Add some more type annotations

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -34,8 +34,7 @@ TODOs:
 
 
 def assert_rm_service(cephadm, srv_name):
-    assert wait(cephadm, cephadm.remove_service(srv_name)) == [
-        f'Removed service {srv_name}']
+    assert wait(cephadm, cephadm.remove_service(srv_name)) == f'Removed service {srv_name}'
     cephadm._apply_all_services()
 
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -565,9 +565,9 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
             spec = service.spec
             spec.unmanaged = unmanaged_flag
             specs.append(spec)
-        completion = self.apply(cast(List[GenericSpec], specs))
-        self._orchestrator_wait([completion])
-        raise_if_exception(completion)
+        apply_completion = self.apply(cast(List[GenericSpec], specs))
+        self._orchestrator_wait([apply_completion])
+        raise_if_exception(apply_completion)
         if specs:
             return HandleCommandResult(stdout=f"Changed <unmanaged> flag to <{unmanaged_flag}> for "
                                               f"{[spec.service_name() for spec in specs]}")
@@ -1181,10 +1181,10 @@ Usage:
         raise_if_exception(completion)
         out = completion.result_str()
         if dry_run:
-            completion = self.plan([spec])
-            self._orchestrator_wait([completion])
-            raise_if_exception(completion)
-            data = completion.result
+            completion_plan = self.plan([spec])
+            self._orchestrator_wait([completion_plan])
+            raise_if_exception(completion_plan)
+            data = completion_plan.result
             if format == 'plain':
                 out = preview_table_services(data)
             else:
@@ -1233,10 +1233,10 @@ Usage:
         raise_if_exception(completion)
         out = completion.result_str()
         if dry_run:
-            completion = self.plan([spec])
-            self._orchestrator_wait([completion])
-            raise_if_exception(completion)
-            data = completion.result
+            completion_plan = self.plan([spec])
+            self._orchestrator_wait([completion_plan])
+            raise_if_exception(completion_plan)
+            data = completion_plan.result
             if format == 'plain':
                 out = preview_table_services(data)
             else:
@@ -1279,10 +1279,10 @@ Usage:
         raise_if_exception(completion)
         out = completion.result_str()
         if dry_run:
-            completion = self.plan([spec])
-            self._orchestrator_wait([completion])
-            raise_if_exception(completion)
-            data = completion.result
+            completion_plan = self.plan([spec])
+            self._orchestrator_wait([completion_plan])
+            raise_if_exception(completion_plan)
+            data = completion_plan.result
             if format == 'plain':
                 out = preview_table_services(data)
             else:
@@ -1329,10 +1329,10 @@ Usage:
         raise_if_exception(completion)
         out = completion.result_str()
         if dry_run:
-            completion = self.plan([spec])
-            self._orchestrator_wait([completion])
-            raise_if_exception(completion)
-            data = completion.result
+            completion_plan = self.plan([spec])
+            self._orchestrator_wait([completion_plan])
+            raise_if_exception(completion_plan)
+            data = completion_plan.result
             if format == 'plain':
                 out = preview_table_services(data)
             else:


### PR DESCRIPTION
Made `orch.Completion` a generic type

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
