### PR TITLE
mgr/cephadm: revamp ceph.conf distribution scheduling 

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -253,6 +253,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     def __init__(self, *args, **kwargs):
         super(CephadmOrchestrator, self).__init__(*args, **kwargs)
         self._cluster_fsid = self.get('mon_map')['fsid']
+        self.last_monmap: Optional[datetime.datetime] = None
 
         # for serve()
         self.run = True
@@ -289,6 +290,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         self._cons = {}  # type: Dict[str, Tuple[remoto.backends.BaseConnection,remoto.backends.LegacyModuleExecute]]
 
+
+        self.notify('mon_map', None)
         self.config_notify()
 
         path = self.get_ceph_option('cephadm_path')
@@ -539,35 +542,28 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         TODO: this method should be moved into mgr_module.py
         """
-        module_options_changed: List[str] = []
         for opt in self.MODULE_OPTIONS:
-            old_val = getattr(self, opt['name'], None)
-            new_val = self.get_module_option(opt['name'])
             setattr(self,
                     opt['name'],  # type: ignore
-                    new_val)  # type: ignore
+                    self.get_module_option(opt['name']))  # type: ignore
             self.log.debug(' mgr option %s = %s',
                            opt['name'], getattr(self, opt['name']))  # type: ignore
-            if old_val != new_val:
-                module_options_changed.append(opt['name'])
         for opt in self.NATIVE_OPTIONS:
             setattr(self,
                     opt,  # type: ignore
                     self.get_ceph_option(opt))
             self.log.debug(' native option %s = %s', opt, getattr(self, opt))  # type: ignore
 
-        for what in module_options_changed:
-            self.config_notify_one(what)
-
         self.event.set()
-
-    def config_notify_one(self, what):
-        if what == 'manage_etc_ceph_ceph_conf' and self.manage_etc_ceph_ceph_conf:
-            self.cache.distribute_new_etc_ceph_ceph_conf()
 
     def notify(self, notify_type, notify_id):
         if notify_type == "mon_map":
-            self.cache.distribute_new_etc_ceph_ceph_conf()
+            # get monmap mtime so we can refresh configs when mons change
+            monmap = self.get('mon_map')
+            self.last_monmap = datetime.datetime.strptime(
+                monmap['modified'], CEPH_DATEFMT)
+            if self.last_monmap and self.last_monmap > datetime.datetime.utcnow():
+                self.last_monmap = None  # just in case clocks are skewed
 
     def pause(self):
         if not self.paused:
@@ -1413,7 +1409,8 @@ you may want to run:
                 )
                 if code:
                     return f'failed to create /etc/ceph/ceph.conf on {host}: {err}'
-                self.cache.remove_host_needs_new_etc_ceph_ceph_conf(host)
+                self.cache.update_last_etc_ceph_ceph_conf(host)
+                self.cache.save_host(host)
         except OrchestratorError as e:
             return f'failed to create /etc/ceph/ceph.conf on {host}: {str(e)}'
         return None
@@ -2036,12 +2033,6 @@ you may want to run:
                                     f'service {service_name}')
 
     def _check_daemons(self):
-        # get monmap mtime so we can refresh configs when mons change
-        monmap = self.get('mon_map')
-        last_monmap: Optional[datetime.datetime] = datetime.datetime.strptime(
-            monmap['modified'], CEPH_DATEFMT)
-        if last_monmap and last_monmap > datetime.datetime.utcnow():
-            last_monmap = None   # just in case clocks are skewed
 
         daemons = self.cache.get_daemons()
         daemons_post: Dict[str, List[orchestrator.DaemonDescription]] = defaultdict(list)
@@ -2078,8 +2069,8 @@ you may want to run:
                 self.log.info('Reconfiguring %s (dependencies changed)...' % (
                     dd.name()))
                 reconfig = True
-            elif last_monmap and \
-               last_monmap > last_config and \
+            elif self.last_monmap and \
+                    self.last_monmap > last_config and \
                dd.daemon_type in CEPH_TYPES:
                 self.log.info('Reconfiguring %s (monmap changed)...' % dd.name())
                 reconfig = True

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -22,7 +22,8 @@ from ceph.deployment.inventory import Devices, Device
 from orchestrator import ServiceDescription, DaemonDescription, InventoryHost, \
     HostSpec, OrchestratorError
 from tests import mock
-from .fixtures import cephadm_module, wait, _run_cephadm, mon_command, match_glob, with_host
+from .fixtures import cephadm_module, wait, _run_cephadm, mon_command, match_glob, with_host, \
+    with_cephadm_module
 from cephadm.module import CephadmOrchestrator, CEPH_DATEFMT
 
 """
@@ -662,7 +663,11 @@ class TestCephadm(object):
 
             cephadm_module.notify('mon_map', mock.MagicMock())
             assert cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')
-        
+
+    def test_etc_ceph_init(self):
+        with with_cephadm_module({'manage_etc_ceph_ceph_conf': True}) as m:
+            assert m.manage_etc_ceph_ceph_conf == True
+
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm")
     def test_registry_login(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         def check_registry_credentials(url, username, password):

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -165,13 +165,13 @@ class TestCephadm(object):
             )
         ])
     ))
-    #@mock.patch("mgr_module.MgrModule._ceph_get")
-    @mock.patch("ceph_module.BaseMgrModule._ceph_get")
-    def test_daemon_action(self, _ceph_get, cephadm_module: CephadmOrchestrator):
+    def test_daemon_action(self, cephadm_module: CephadmOrchestrator):
+
         cephadm_module.service_cache_timeout = 10
         with with_host(cephadm_module, 'test'):
             c = cephadm_module.list_daemons(refresh=True)
             wait(cephadm_module, c)
+            assert len(c.result) == 1
             c = cephadm_module.daemon_action('redeploy', 'rgw', 'myrgw.foobar')
             assert wait(cephadm_module, c) == ["Deployed rgw.myrgw.foobar on host 'test'"]
 
@@ -179,8 +179,12 @@ class TestCephadm(object):
                 c = cephadm_module.daemon_action(what, 'rgw', 'myrgw.foobar')
                 assert wait(cephadm_module, c) == [what + " rgw.myrgw.foobar from host 'test'"]
 
-            now = datetime.datetime.utcnow().strftime(CEPH_DATEFMT)
-            _ceph_get.return_value = {'modified': now}
+            # Make sure, _check_daemons does a redeploy due to monmap change:
+            cephadm_module._store['_ceph_get/mon_map'] = {
+                'modified': datetime.datetime.utcnow().strftime(CEPH_DATEFMT),
+                'fsid': 'foobar',
+            }
+            cephadm_module.notify('mon_map', None)
 
             cephadm_module._check_daemons()
 
@@ -644,9 +648,11 @@ class TestCephadm(object):
 
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
     @mock.patch("remoto.process.check")
-    def test_etc_ceph(self, _check, _get_connection, cephadm_module: CephadmOrchestrator):
+    def test_etc_ceph(self, _check, _get_connection, cephadm_module):
         _get_connection.return_value = mock.Mock(), mock.Mock()
         _check.return_value = '{}', '', 0
+
+        assert cephadm_module.manage_etc_ceph_ceph_conf is False
 
         with with_host(cephadm_module, 'test'):
             assert not cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')
@@ -661,12 +667,26 @@ class TestCephadm(object):
 
             assert not cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')
 
+            cephadm_module.cache.last_etc_ceph_ceph_conf = {}
+            cephadm_module.cache.load()
+
+            assert not cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')
+
+            # Make sure, _check_daemons does a redeploy due to monmap change:
+            cephadm_module._store['_ceph_get/mon_map'] = {
+                'modified': datetime.datetime.utcnow().strftime(CEPH_DATEFMT),
+                'fsid': 'foobar',
+            }
             cephadm_module.notify('mon_map', mock.MagicMock())
             assert cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')
+            cephadm_module.cache.last_etc_ceph_ceph_conf = {}
+            cephadm_module.cache.load()
+            assert cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')
+
 
     def test_etc_ceph_init(self):
         with with_cephadm_module({'manage_etc_ceph_ceph_conf': True}) as m:
-            assert m.manage_etc_ceph_ceph_conf == True
+            assert m.manage_etc_ceph_ceph_conf is True
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm")
     def test_registry_login(self, _run_cephadm, cephadm_module: CephadmOrchestrator):

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -19,6 +19,14 @@ if 'UNITTEST' in os.environ:
     M_classes = set()
 
     class M(object):
+        """
+        Note that:
+
+        * self.set_store() populates self._store
+        * self.set_module_option() populates self._store[module_name]
+        * self.get(thing) comes from self._store['_ceph_get' + thing]
+
+        """
         def _ceph_get_store(self, k):
             if not hasattr(self, '_store'):
                 self._store = {}
@@ -57,8 +65,10 @@ if 'UNITTEST' in os.environ:
         def _ceph_set_module_option(self, module, key, val):
             return self._ceph_set_store(f'{module}/{key}', val)
 
-        def _ceph_get(self, *args):
-            return mock.MagicMock()
+        def _ceph_get(self, data_name):
+            if not hasattr(self, '_store'):
+                self._store = {}
+            return self._store.get(f'_ceph_get/{data_name}', mock.MagicMock())
 
 
         def __init__(self, *args):

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -20,9 +20,13 @@ if 'UNITTEST' in os.environ:
 
     class M(object):
         def _ceph_get_store(self, k):
+            if not hasattr(self, '_store'):
+                self._store = {}
             return self._store.get(k, None)
 
         def _ceph_set_store(self, k, v):
+            if not hasattr(self, '_store'):
+                self._store = {}
             if v is None:
                 if k in self._store:
                     del self._store[k]
@@ -30,6 +34,8 @@ if 'UNITTEST' in os.environ:
                 self._store[k] = v
 
         def _ceph_get_store_prefix(self, prefix):
+            if not hasattr(self, '_store'):
+                self._store = {}
             return {
                 k: v for k, v in self._store.items()
                 if k.startswith(prefix)
@@ -56,7 +62,9 @@ if 'UNITTEST' in os.environ:
 
 
         def __init__(self, *args):
-            self._store = {}
+            if not hasattr(self, '_store'):
+                self._store = {}
+
 
             if self.__class__.__name__ not in M_classes:
                 # call those only once. 


### PR DESCRIPTION
Fixes

```
Traceback (most recent call last):
  File "mgr/cephadm/module.py", line 271, in __init__
    self.config_notify()
  File "mgr/cephadm/module.py", line 525, in config_notify
    self.config_notify_one(what)
  File "mgr/cephadm/module.py", line 531, in config_notify_one
    self.cache.distribute_new_etc_ceph_ceph_conf()
AttributeError: 'CephadmOrchestrator' object has no attribute 'cache'
```

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
