### PR TITLE
librbd: use task finisher thread for image open/close callbacks

### DIFF
--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -246,9 +246,6 @@ namespace librbd {
                             bool read_only) {
       return new ImageCtx(image_name, image_id, snap_id, p, read_only);
     }
-    void destroy() {
-      delete this;
-    }
 
     /**
      * Either image_name or image_id must be set.

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -251,7 +251,6 @@ int group_snap_remove_by_record(librados::IoCtx& group_ioctx,
     r = on_finishes[i]->wait();
     delete on_finishes[i];
     if (r < 0) {
-      delete ictxs[i];
       ictxs[i] = nullptr;
       ret_code = r;
     }
@@ -359,7 +358,6 @@ int group_snap_rollback_by_record(librados::IoCtx& group_ioctx,
     r = on_finishes[i]->wait();
     delete on_finishes[i];
     if (r < 0) {
-      delete ictxs[i];
       ictxs[i] = nullptr;
       ret_code = r;
     }
@@ -973,7 +971,6 @@ int Group<I>::snap_create(librados::IoCtx& group_ioctx,
     r = on_finishes[i]->wait();
     delete on_finishes[i];
     if (r < 0) {
-      delete ictxs[i];
       ictxs[i] = nullptr;
       ret_code = r;
     }

--- a/src/librbd/deep_copy/ImageCopyRequest.cc
+++ b/src/librbd/deep_copy/ImageCopyRequest.cc
@@ -7,8 +7,6 @@
 #include "librbd/Utils.h"
 #include "librbd/deep_copy/Handler.h"
 #include "librbd/deep_copy/Utils.h"
-#include "librbd/image/CloseRequest.h"
-#include "librbd/image/OpenRequest.h"
 #include "librbd/object_map/DiffRequest.h"
 #include "osdc/Striper.h"
 

--- a/src/librbd/image/CloseRequest.cc
+++ b/src/librbd/image/CloseRequest.cc
@@ -297,7 +297,6 @@ void CloseRequest<I>::handle_close_parent(int r) {
   CephContext *cct = m_image_ctx->cct;
   ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
 
-  delete m_image_ctx->parent;
   m_image_ctx->parent = nullptr;
   save_result(r);
   if (r < 0) {

--- a/src/librbd/image/DetachChildRequest.cc
+++ b/src/librbd/image/DetachChildRequest.cc
@@ -184,7 +184,6 @@ void DetachChildRequest<I>::handle_clone_v2_open_parent(int r) {
   if (r < 0) {
     ldout(cct, 5) << "failed to open parent for read/write: "
                   << cpp_strerror(r) << dendl;
-    m_parent_image_ctx->destroy();
     m_parent_image_ctx = nullptr;
     finish(0);
     return;
@@ -339,7 +338,6 @@ void DetachChildRequest<I>::handle_clone_v2_close_parent(int r) {
                   << dendl;
   }
 
-  m_parent_image_ctx->destroy();
   m_parent_image_ctx = nullptr;
   finish(0);
 }

--- a/src/librbd/image/RefreshParentRequest.cc
+++ b/src/librbd/image/RefreshParentRequest.cc
@@ -6,10 +6,9 @@
 #include "common/dout.h"
 #include "common/errno.h"
 #include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
 #include "librbd/Utils.h"
 #include "librbd/asio/ContextWQ.h"
-#include "librbd/image/CloseRequest.h"
-#include "librbd/image/OpenRequest.h"
 #include "librbd/io/ObjectDispatcherInterface.h"
 
 #define dout_subsys ceph_subsys_rbd
@@ -140,12 +139,11 @@ void RefreshParentRequest<I>::send_open_parent() {
     m_parent_image_ctx->set_read_flag(librados::OPERATION_LOCALIZE_READS);
   }
 
-  using klass = RefreshParentRequest<I>;
-  Context *ctx = create_async_context_callback(
+  auto ctx = create_async_context_callback(
     m_child_image_ctx, create_context_callback<
-      klass, &klass::handle_open_parent, false>(this));
-  OpenRequest<I> *req = OpenRequest<I>::create(m_parent_image_ctx, flags, ctx);
-  req->send();
+      RefreshParentRequest<I>,
+      &RefreshParentRequest<I>::handle_open_parent, false>(this));
+  m_parent_image_ctx->state->open(flags, ctx);
 }
 
 template <typename I>
@@ -159,7 +157,6 @@ Context *RefreshParentRequest<I>::handle_open_parent(int *result) {
                << dendl;
 
     // image already closed by open state machine
-    delete m_parent_image_ctx;
     m_parent_image_ctx = nullptr;
   }
 
@@ -173,12 +170,11 @@ void RefreshParentRequest<I>::send_close_parent() {
   CephContext *cct = m_child_image_ctx.cct;
   ldout(cct, 10) << this << " " << __func__ << dendl;
 
-  using klass = RefreshParentRequest<I>;
-  Context *ctx = create_async_context_callback(
+  auto ctx = create_async_context_callback(
     m_child_image_ctx, create_context_callback<
-      klass, &klass::handle_close_parent, false>(this));
-  CloseRequest<I> *req = CloseRequest<I>::create(m_parent_image_ctx, ctx);
-  req->send();
+      RefreshParentRequest<I>,
+      &RefreshParentRequest<I>::handle_close_parent, false>(this));
+  m_parent_image_ctx->state->close(ctx);
 }
 
 template <typename I>
@@ -186,7 +182,6 @@ Context *RefreshParentRequest<I>::handle_close_parent(int *result) {
   CephContext *cct = m_child_image_ctx.cct;
   ldout(cct, 10) << this << " " << __func__ << " r=" << *result << dendl;
 
-  delete m_parent_image_ctx;
   m_parent_image_ctx = nullptr;
 
   if (*result < 0) {

--- a/src/librbd/image/RemoveRequest.cc
+++ b/src/librbd/image/RemoveRequest.cc
@@ -85,7 +85,6 @@ void RemoveRequest<I>::handle_open_image(int r) {
   ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r < 0) {
-    m_image_ctx->destroy();
     m_image_ctx = nullptr;
 
     if (r != -ENOENT) {
@@ -251,7 +250,6 @@ void RemoveRequest<I>::handle_send_close_image(int r) {
                  << cpp_strerror(r) << dendl;
   }
 
-  m_image_ctx->destroy();
   m_image_ctx = nullptr;
   if (m_ret_val < 0) {
     r = m_ret_val;

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -127,7 +127,7 @@ struct C_AioCompletion : public Context {
   }
 
   void finish(int r) override {
-    ldout(cct, 20) << "C_AioComplete::finish: r=" << r << dendl;
+    ldout(cct, 20) << "C_AioCompletion::finish: r=" << r << dendl;
     if (r < 0) {
       aio_comp->fail(r);
     } else {
@@ -145,7 +145,7 @@ struct C_OpenComplete : public C_AioCompletion {
       ictx(ictx), ictxp(ictxp) {
   }
   void finish(int r) override {
-    ldout(ictx->cct, 20) << "C_OpenComplete::finish: r=" << r << dendl;
+    ldout(cct, 20) << "C_OpenComplete::finish: r=" << r << dendl;
     if (r < 0) {
       *ictxp = nullptr;
     } else {
@@ -168,7 +168,6 @@ struct C_OpenAfterCloseComplete : public Context {
   void finish(int r) override {
     ldout(ictx->cct, 20) << "C_OpenAfterCloseComplete::finish: r=" << r
 			 << dendl;
-    delete reinterpret_cast<librbd::ImageCtx*>(*ictxp);
     *ictxp = nullptr;
 
     ictx->state->open(0, new C_OpenComplete(ictx, comp, ictxp));

--- a/src/librbd/mirror/EnableRequest.cc
+++ b/src/librbd/mirror/EnableRequest.cc
@@ -173,7 +173,6 @@ void EnableRequest<I>::handle_open_image(int r) {
 
   if (r < 0) {
     lderr(m_cct) << "failed to open image: " << cpp_strerror(r) << dendl;
-    m_image_ctx->destroy();
     m_image_ctx = nullptr;
     finish(r);
     return;
@@ -237,7 +236,6 @@ template <typename I>
 void EnableRequest<I>::handle_close_image(int r) {
   ldout(m_cct, 10) << "r=" << r << dendl;
 
-  m_image_ctx->destroy();
   m_image_ctx = nullptr;
 
   if (r < 0) {

--- a/src/librbd/trash/RemoveRequest.cc
+++ b/src/librbd/trash/RemoveRequest.cc
@@ -91,7 +91,6 @@ void RemoveRequest<I>::handle_close_image(int r) {
     ldout(m_cct, 5) << "failed to close image:" << cpp_strerror(r) << dendl;
   }
 
-  m_image_ctx->destroy();
   m_image_ctx = nullptr;
   finish(m_ret_val);
 }

--- a/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
@@ -11,8 +11,6 @@
 #include "librbd/deep_copy/Handler.h"
 #include "librbd/deep_copy/ImageCopyRequest.h"
 #include "librbd/deep_copy/ObjectCopyRequest.h"
-#include "librbd/image/CloseRequest.h"
-#include "librbd/image/OpenRequest.h"
 #include "librbd/object_map/DiffRequest.h"
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
 #include "test/librbd/mock/MockImageCtx.h"
@@ -82,49 +80,6 @@ struct ObjectCopyRequest<librbd::MockTestImageCtx> {
 ObjectCopyRequest<librbd::MockTestImageCtx>* ObjectCopyRequest<librbd::MockTestImageCtx>::s_instance = nullptr;
 
 } // namespace deep_copy
-
-namespace image {
-
-template <>
-struct CloseRequest<MockTestImageCtx> {
-  Context* on_finish = nullptr;
-  static CloseRequest* s_instance;
-  static CloseRequest* create(MockTestImageCtx *image_ctx, Context *on_finish) {
-    ceph_assert(s_instance != nullptr);
-    s_instance->on_finish = on_finish;
-    return s_instance;
-  }
-
-  MOCK_METHOD0(send, void());
-
-  CloseRequest() {
-    s_instance = this;
-  }
-};
-
-CloseRequest<MockTestImageCtx>* CloseRequest<MockTestImageCtx>::s_instance = nullptr;
-
-template <>
-struct OpenRequest<MockTestImageCtx> {
-  Context* on_finish = nullptr;
-  static OpenRequest* s_instance;
-  static OpenRequest* create(MockTestImageCtx *image_ctx,
-                             bool skip_open_parent, Context *on_finish) {
-    ceph_assert(s_instance != nullptr);
-    s_instance->on_finish = on_finish;
-    return s_instance;
-  }
-
-  MOCK_METHOD0(send, void());
-
-  OpenRequest() {
-    s_instance = this;
-  }
-};
-
-OpenRequest<MockTestImageCtx>* OpenRequest<MockTestImageCtx>::s_instance = nullptr;
-
-} // namespace image
 
 namespace object_map {
 

--- a/src/test/librbd/image/test_mock_CloneRequest.cc
+++ b/src/test/librbd/image/test_mock_CloneRequest.cc
@@ -291,9 +291,6 @@ public:
       .WillOnce(WithArg<1>(Invoke([this, r](Context* ctx) {
                              image_ctx->op_work_queue->queue(ctx, r);
                            })));
-    if (r < 0) {
-      EXPECT_CALL(mock_image_ctx, destroy());
-    }
   }
 
   void expect_attach_parent(MockAttachParentRequest& mock_request, int r) {
@@ -352,7 +349,6 @@ public:
       .WillOnce(Invoke([this, r](Context* ctx) {
                   image_ctx->op_work_queue->queue(ctx, r);
                 }));
-    EXPECT_CALL(mock_image_ctx, destroy());
   }
 
   void expect_remove(MockRemoveRequest& mock_remove_request, int r) {

--- a/src/test/librbd/image/test_mock_DetachChildRequest.cc
+++ b/src/test/librbd/image/test_mock_DetachChildRequest.cc
@@ -174,7 +174,6 @@ public:
       .WillOnce(Invoke([this, r](Context* ctx) {
                   image_ctx->op_work_queue->queue(ctx, r);
                 }));
-    EXPECT_CALL(mock_image_ctx, destroy());
   }
 
   void expect_snap_remove(MockImageCtx &mock_image_ctx,
@@ -373,7 +372,6 @@ TEST_F(TestMockImageDetachChildRequest, TrashedSnapshotOpenParentError) {
                       {234, {cls::rbd::TrashSnapshotNamespace{}},
                        "snap1", 123, {}, 0}, 0);
   expect_open(mock_image_ctx, -EPERM);
-  EXPECT_CALL(mock_image_ctx, destroy());
 
   C_SaferCond ctx;
   auto req = MockDetachChildRequest::create(mock_image_ctx, &ctx);

--- a/src/test/librbd/image/test_mock_RemoveRequest.cc
+++ b/src/test/librbd/image/test_mock_RemoveRequest.cc
@@ -245,9 +245,6 @@ public:
       .WillOnce(Invoke([r](bool open_parent, Context *on_ready) {
 		  on_ready->complete(r);
                 }));
-    if (r < 0) {
-      EXPECT_CALL(mock_image_ctx, destroy());
-    }
   }
 
   void expect_state_close(MockTestImageCtx &mock_image_ctx) {
@@ -255,7 +252,6 @@ public:
       .WillOnce(Invoke([](Context *on_ready) {
                   on_ready->complete(0);
                 }));
-    EXPECT_CALL(mock_image_ctx, destroy());
   }
 
   void expect_wq_queue(ContextWQ &wq, int r) {

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -40,7 +40,6 @@ struct MockImageCtx {
     ceph_assert(s_instance != nullptr);
     return s_instance;
   }
-  MOCK_METHOD0(destroy, void());
 
   MockImageCtx(librbd::ImageCtx &image_ctx)
     : image_ctx(&image_ctx),

--- a/src/test/librbd/operation/test_mock_ResizeRequest.cc
+++ b/src/test/librbd/operation/test_mock_ResizeRequest.cc
@@ -160,7 +160,13 @@ public:
       .WillOnce(Invoke([&mock_image_ctx, &mock_io_image_dispatch_spec, r]() {
                   auto aio_comp = mock_io_image_dispatch_spec.s_instance->aio_comp;
                   auto ctx = new LambdaContext([aio_comp](int r) {
-                    aio_comp->fail(r);
+                    if (r < 0) {
+                      aio_comp->fail(r);
+                    } else {
+                      aio_comp->set_request_count(1);
+                      aio_comp->add_request();
+                      aio_comp->complete_request(r);
+                    }
                   });
                   mock_image_ctx.image_ctx->op_work_queue->queue(ctx, r);
                 }));

--- a/src/test/librbd/trash/test_mock_RemoveRequest.cc
+++ b/src/test/librbd/trash/test_mock_RemoveRequest.cc
@@ -122,7 +122,6 @@ struct TestMockTrashRemoveRequest : public TestMockFixture {
       .WillOnce(Invoke([r](Context *on_finish) {
                   on_finish->complete(r);
                 }));
-    EXPECT_CALL(mock_image_ctx, destroy());
   }
 
   void expect_remove_image(MockImageRemoveRequest& mock_image_remove_request,

--- a/src/test/rbd_mirror/image_deleter/test_mock_SnapshotPurgeRequest.cc
+++ b/src/test/rbd_mirror/image_deleter/test_mock_SnapshotPurgeRequest.cc
@@ -152,10 +152,6 @@ public:
                 }));
   }
 
-  void expect_destroy(librbd::MockTestImageCtx& mock_image_ctx) {
-    EXPECT_CALL(mock_image_ctx, destroy());
-  }
-
   librbd::ImageCtx *m_local_image_ctx;
 };
 
@@ -198,7 +194,6 @@ TEST_F(TestMockImageDeleterSnapshotPurgeRequest, SuccessJournal) {
                      0);
 
   expect_close(mock_image_ctx, 0);
-  expect_destroy(mock_image_ctx);
 
   C_SaferCond ctx;
   auto req = MockSnapshotPurgeRequest::create(m_local_io_ctx, mock_image_ctx.id,
@@ -240,7 +235,6 @@ TEST_F(TestMockImageDeleterSnapshotPurgeRequest, SuccessSnapshot) {
                      0);
 
   expect_close(mock_image_ctx, 0);
-  expect_destroy(mock_image_ctx);
 
   C_SaferCond ctx;
   auto req = MockSnapshotPurgeRequest::create(m_local_io_ctx, mock_image_ctx.id,
@@ -264,7 +258,6 @@ TEST_F(TestMockImageDeleterSnapshotPurgeRequest, OpenError) {
   InSequence seq;
   expect_set_journal_policy(mock_image_ctx);
   expect_open(mock_image_ctx, -EPERM);
-  expect_destroy(mock_image_ctx);
 
   C_SaferCond ctx;
   auto req = MockSnapshotPurgeRequest::create(m_local_io_ctx, mock_image_ctx.id,
@@ -290,7 +283,6 @@ TEST_F(TestMockImageDeleterSnapshotPurgeRequest, AcquireLockError) {
   expect_open(mock_image_ctx, 0);
   expect_acquire_lock(mock_image_ctx, -EPERM);
   expect_close(mock_image_ctx, -EINVAL);
-  expect_destroy(mock_image_ctx);
 
   C_SaferCond ctx;
   auto req = MockSnapshotPurgeRequest::create(m_local_io_ctx, mock_image_ctx.id,
@@ -324,7 +316,6 @@ TEST_F(TestMockImageDeleterSnapshotPurgeRequest, SnapUnprotectBusy) {
                         "snap1", -EBUSY);
 
   expect_close(mock_image_ctx, -EINVAL);
-  expect_destroy(mock_image_ctx);
 
   C_SaferCond ctx;
   auto req = MockSnapshotPurgeRequest::create(m_local_io_ctx, mock_image_ctx.id,
@@ -358,7 +349,6 @@ TEST_F(TestMockImageDeleterSnapshotPurgeRequest, SnapUnprotectError) {
                         "snap1", -EPERM);
 
   expect_close(mock_image_ctx, -EINVAL);
-  expect_destroy(mock_image_ctx);
 
   C_SaferCond ctx;
   auto req = MockSnapshotPurgeRequest::create(m_local_io_ctx, mock_image_ctx.id,
@@ -393,7 +383,6 @@ TEST_F(TestMockImageDeleterSnapshotPurgeRequest, SnapRemoveError) {
                      -EINVAL);
 
   expect_close(mock_image_ctx, -EPERM);
-  expect_destroy(mock_image_ctx);
 
   C_SaferCond ctx;
   auto req = MockSnapshotPurgeRequest::create(m_local_io_ctx, mock_image_ctx.id,
@@ -428,7 +417,6 @@ TEST_F(TestMockImageDeleterSnapshotPurgeRequest, CloseError) {
                      0);
 
   expect_close(mock_image_ctx, -EINVAL);
-  expect_destroy(mock_image_ctx);
 
   C_SaferCond ctx;
   auto req = MockSnapshotPurgeRequest::create(m_local_io_ctx, mock_image_ctx.id,

--- a/src/test/rbd_mirror/image_deleter/test_mock_TrashMoveRequest.cc
+++ b/src/test/rbd_mirror/image_deleter/test_mock_TrashMoveRequest.cc
@@ -260,10 +260,6 @@ public:
                 }));
   }
 
-  void expect_destroy(librbd::MockTestImageCtx& mock_image_ctx) {
-    EXPECT_CALL(mock_image_ctx, destroy());
-  }
-
   void expect_mirror_image_set(const std::string& image_id,
                                const cls::rbd::MirrorImage& mirror_image,
                                int r) {
@@ -362,7 +358,6 @@ TEST_F(TestMockImageDeleterTrashMoveRequest, SuccessJournal) {
   expect_mirror_image_remove(m_local_io_ctx, 0);
 
   expect_close(mock_image_ctx, 0);
-  expect_destroy(mock_image_ctx);
 
   MockTrashWatcher mock_trash_watcher;
   expect_notify_image_added(mock_trash_watcher, "image id");
@@ -404,7 +399,6 @@ TEST_F(TestMockImageDeleterTrashMoveRequest, SuccessSnapshot) {
   expect_mirror_image_remove(m_local_io_ctx, 0);
 
   expect_close(mock_image_ctx, 0);
-  expect_destroy(mock_image_ctx);
 
   MockTrashWatcher mock_trash_watcher;
   expect_notify_image_added(mock_trash_watcher, "image id");
@@ -581,7 +575,6 @@ TEST_F(TestMockImageDeleterTrashMoveRequest, OpenImageError) {
 
   expect_set_journal_policy(mock_image_ctx);
   expect_open(mock_image_ctx, -EINVAL);
-  expect_destroy(mock_image_ctx);
 
   C_SaferCond ctx;
   auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
@@ -620,7 +613,6 @@ TEST_F(TestMockImageDeleterTrashMoveRequest, ResetJournalError) {
   expect_journal_reset(mock_journal_reset_request, -EINVAL);
 
   expect_close(mock_image_ctx, 0);
-  expect_destroy(mock_image_ctx);
 
   C_SaferCond ctx;
   auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
@@ -662,7 +654,6 @@ TEST_F(TestMockImageDeleterTrashMoveRequest, AcquireLockError) {
   expect_acquire_lock(mock_image_ctx, -EINVAL);
 
   expect_close(mock_image_ctx, 0);
-  expect_destroy(mock_image_ctx);
 
   C_SaferCond ctx;
   auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
@@ -708,7 +699,6 @@ TEST_F(TestMockImageDeleterTrashMoveRequest, TrashMoveError) {
                     {}, -EINVAL);
 
   expect_close(mock_image_ctx, 0);
-  expect_destroy(mock_image_ctx);
 
   C_SaferCond ctx;
   auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
@@ -755,7 +745,6 @@ TEST_F(TestMockImageDeleterTrashMoveRequest, RemoveMirrorImageError) {
   expect_mirror_image_remove(m_local_io_ctx, -EINVAL);
 
   expect_close(mock_image_ctx, 0);
-  expect_destroy(mock_image_ctx);
 
   MockTrashWatcher mock_trash_watcher;
   expect_notify_image_added(mock_trash_watcher, "image id");
@@ -805,7 +794,6 @@ TEST_F(TestMockImageDeleterTrashMoveRequest, CloseImageError) {
   expect_mirror_image_remove(m_local_io_ctx, 0);
 
   expect_close(mock_image_ctx, -EINVAL);
-  expect_destroy(mock_image_ctx);
 
   MockTrashWatcher mock_trash_watcher;
   expect_notify_image_added(mock_trash_watcher, "image id");
@@ -856,7 +844,6 @@ TEST_F(TestMockImageDeleterTrashMoveRequest, DelayedDelation) {
 
   expect_mirror_image_remove(m_local_io_ctx, 0);
   expect_close(mock_image_ctx, 0);
-  expect_destroy(mock_image_ctx);
 
   MockTrashWatcher mock_trash_watcher;
   expect_notify_image_added(mock_trash_watcher, "image id");

--- a/src/tools/rbd_mirror/image_deleter/SnapshotPurgeRequest.cc
+++ b/src/tools/rbd_mirror/image_deleter/SnapshotPurgeRequest.cc
@@ -55,7 +55,6 @@ void SnapshotPurgeRequest<I>::handle_open_image(int r) {
   if (r < 0) {
     derr << "failed to open image '" << m_image_id << "': " << cpp_strerror(r)
          << dendl;
-    m_image_ctx->destroy();
     m_image_ctx = nullptr;
 
     finish(r);
@@ -264,7 +263,6 @@ template <typename I>
 void SnapshotPurgeRequest<I>::handle_close_image(int r) {
   dout(10) << "r=" << r << dendl;
 
-  m_image_ctx->destroy();
   m_image_ctx = nullptr;
 
   if (r < 0) {

--- a/src/tools/rbd_mirror/image_deleter/TrashMoveRequest.cc
+++ b/src/tools/rbd_mirror/image_deleter/TrashMoveRequest.cc
@@ -183,7 +183,6 @@ void TrashMoveRequest<I>::handle_open_image(int r) {
 
   if (r < 0) {
     derr << "failed to open image: " << cpp_strerror(r) << dendl;
-    m_image_ctx->destroy();
     m_image_ctx = nullptr;
     finish(r);
     return;
@@ -355,7 +354,6 @@ template <typename I>
 void TrashMoveRequest<I>::handle_close_image(int r) {
   dout(10) << "r=" << r << dendl;
 
-  m_image_ctx->destroy();
   m_image_ctx = nullptr;
 
   if (r < 0) {

--- a/src/tools/rbd_mirror/image_replayer/CloseImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/CloseImageRequest.cc
@@ -48,7 +48,6 @@ void CloseImageRequest<I>::handle_close_image(int r) {
          << dendl;
   }
 
-  delete *m_image_ctx;
   *m_image_ctx = nullptr;
 
   m_on_finish->complete(0);

--- a/src/tools/rbd_mirror/image_replayer/OpenImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/OpenImageRequest.cc
@@ -58,7 +58,6 @@ void OpenImageRequest<I>::handle_open_image(int r) {
   if (r < 0) {
     derr << ": failed to open image '" << m_image_id << "': "
          << cpp_strerror(r) << dendl;
-    (*m_image_ctx)->destroy();
     *m_image_ctx = nullptr;
   }
 

--- a/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
@@ -149,7 +149,6 @@ void OpenLocalImageRequest<I>::handle_open_image(int r) {
       derr << ": failed to open image '" << m_local_image_id << "': "
            << cpp_strerror(r) << dendl;
     }
-    (*m_local_image_ctx)->destroy();
     *m_local_image_ctx = nullptr;
     finish(r);
     return;


### PR DESCRIPTION
There was a potential race condition with utilizing the AsioEngine
to deliver asynchronous image open and close callbacks. This left
the potential for the io_context thread to attempt to destroy itself.

This commit changes the behavior of the image open and close callbacks
to always delete the ImageCtx (now matches the synchronous API behavior)
and it always invokes the callback in Finisher thread whose lifetime is
tied to the CephContext.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
