### PR TITLE
mds/CInode: Optimize only pinned by subtrees check

### DIFF
--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -579,6 +579,9 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     get_subtree_dirfrags(v);
     return v;
   }
+  int get_num_subtree_roots() const {
+    return num_subtree_roots;
+  }
 
   CDir *get_or_open_dirfrag(MDCache *mdcache, frag_t fg);
   CDir *add_dirfrag(CDir *dir);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6837,9 +6837,9 @@ std::pair<bool, uint64_t> MDCache::trim(uint64_t count)
       }
     } else if (!diri->is_auth() && dir->get_num_ref() <= 1) {
       // only subtree pin
-      auto&& ls = diri->get_subtree_dirfrags();
-      if (diri->get_num_ref() > (int)ls.size()) // only pinned by subtrees
+      if (diri->get_num_ref() > diri->get_num_subtree_roots()) {
         continue;
+      }
 
       // don't trim subtree root if its auth MDS is recovering.
       // This simplify the cache rejoin code.


### PR DESCRIPTION
In master while running a many-client delete workload against a single directory with many files, a profile of the mds shows significant time spent in trim in one of the ms_dispatch threads iterating over dirfrags:

```
Thread: 19 (ms_dispatch) - 1000 samples
 
+ 100.00% clone
  + 100.00% start_thread
    + 100.00% execute_native_thread_routine
      + 100.00% MDCache::<lambda()>::operator()(void) const
        + 96.00% MDCache::trim
        | + 91.50% CInode::get_subtree_dirfrags
        | | + 91.50% CInode::get_subtree_dirfrags
        | |   + 55.50% CDir::is_subtree_root
        | |   | + 55.50% std::operator!=<int, int>
        | |   |   + 55.50% std::operator==<int, int>
        | |   + 29.40% compact_map_base<frag_t, CDir*, std::map<frag_t, CDir*, std::less<frag_t>, mempool::pool_allocator<(mempool::pool_index_t)26, std::pair<frag_t const, CDir*> > > >::const_iterator_base<std::_Rb_tree_const_iterator<std::pair<frag_t const, CDir*> > >::operator++
        | |   | + 29.40% std::_Rb_tree_const_iterator<std::pair<frag_t const, CDir*> >::operator++
        | |   |   + 26.70% std::_Rb_tree_increment(std::_Rb_tree_node_base*)
        | |   |   + 1.10% std::_Rb_tree_increment(std::_Rb_tree_node_base const*)
        | |   |   + 0.20% std::_Rb_tree_increment(std::_Rb_tree_node_base const*)@plt
        | |   + 3.20% std::vector<CDir*, std::allocator<CDir*> >::push_back
        | |   + 3.00% compact_map_base<frag_t, CDir*, std::map<frag_t, CDir*, std::less<frag_t>, mempool::pool_allocator<(mempool::pool_index_t)26, std::pair<frag_t const, CDir*> > > >::const_iterator_base<std::_Rb_tree_const_iterator<std::pair<frag_t const, CDir*> > >::operator!=
        | + 4.40% MDCache::trim_lru
        | + 0.10% std::_Rb_tree_iterator<std::pair<CDir* const, std::set<CDir*, std::less<CDir*>, std::allocator<CDir*> > > >::operator++
        + 3.00% MDCache::trim_client_leases
        + 0.70% TCMallocImplementation::ReleaseToSystem(unsigned long)
        + 0.30% std::condition_variable::wait_for<unsigned long, std::ratio<1l, 1000000000l> >
```

This PR instead adds a new function in the CInode to check the number of refs directly against the existing num_subtree_roots counter instead of iterating over the entire dirfrag space grabbing the entries and then counting them via get_subtree_dirfrags.  A second run of a similar workload appears to show a significant reduction in the overhead of trim as a result.  Memory usage by the MDS processes appears to grow/shrink as expected.

```
Thread: 19 (ms_dispatch) - 1000 samples 

+ 100.00% clone
  + 100.00% start_thread
    + 100.00% execute_native_thread_routine
      + 100.00% MDCache::<lambda()>::operator()(void) const
        + 78.10% std::condition_variable::wait_for<unsigned long, std::ratio<1l, 1000000000l> >
        | + 78.10% std::condition_variable::wait_until<std::chrono::duration<long, std::ratio<1l, 1000000000l> > >
        |   + 78.10% std::condition_variable::__wait_until_impl<std::chrono::duration<long, std::ratio<1l, 1000000000l> > >
        |     + 78.10% __gthread_cond_timedwait
        |       + 78.10% pthread_cond_timedwait@@GLIBC_2.3.2
        + 8.20% std::scoped_lock<std::mutex>::scoped_lock
        | + 8.20% std::mutex::lock
        |   + 8.20% __gthread_mutex_lock
        |     + 8.20% pthread_mutex_lock
        |       + 8.20% __lll_lock_wait
        + 5.30% MDCache::trim
        | + 2.90% std::_Rb_tree_iterator<std::pair<CDir* const, std::set<CDir*, std::less<CDir*>, std::allocator<CDir*> > > >::operator++
        | + 0.30% MDSMap::get_mds_set
        | + 0.30% MDCache::send_expire_messages
        | + 0.20% MDCache::trim_lru
        + 4.20% MDCache::check_memory_usage
        + 3.20% TCMallocImplementation::ReleaseToSystem(unsigned long)
        + 0.80% Server::recall_client_state
        + 0.10% ceph::common::ConfigProxy::get_val<std::chrono::duration<long, std::ratio<1l, 1l> > >
        + 0.10% MDCache::trim_client_leases
```

Signed-off-by: Mark Nelson <mnelson@redhat.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
