### PR TITLE
nautilus: qa/suites/rados/perf: run on ubuntu only

### DIFF
--- a/qa/suites/rados/perf/distros/ubuntu_16.04.yaml
+++ b/qa/suites/rados/perf/distros/ubuntu_16.04.yaml
@@ -1,0 +1,1 @@
+../../../../distros/supported-all-distro/ubuntu_16.04.yaml

--- a/qa/suites/rados/perf/distros/ubuntu_latest.yaml
+++ b/qa/suites/rados/perf/distros/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+../../../../distros/supported-all-distro/ubuntu_latest.yaml

--- a/qa/suites/rados/perf/supported-random-distro$
+++ b/qa/suites/rados/perf/supported-random-distro$
@@ -1,1 +1,0 @@
-../basic/supported-random-distro$


### PR DESCRIPTION
This change is specific to nautilus since fio tests have been failing
on centos and rhel 7.8 due to dependency issues.

Signed-off-by: Neha Ojha <nojha@redhat.com>
