### PR TITLE
nautilus: client: release the client_lock before copying data in read

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9074,7 +9074,7 @@ int Client::uninline_data(Inode *in, Context *onfinish)
 
 int Client::read(int fd, char *buf, loff_t size, loff_t offset)
 {
-  std::lock_guard lock(client_lock);
+  std::unique_lock lock(client_lock);
   tout(cct) << "read" << std::endl;
   tout(cct) << fd << std::endl;
   tout(cct) << size << std::endl;
@@ -9096,6 +9096,7 @@ int Client::read(int fd, char *buf, loff_t size, loff_t offset)
   int r = _read(f, offset, size, &bl);
   ldout(cct, 3) << "read(" << fd << ", " << (void*)buf << ", " << size << ", " << offset << ") = " << r << dendl;
   if (r >= 0) {
+    lock.unlock();
     bl.copy(0, bl.length(), buf);
     r = bl.length();
   }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46470
