### PR TITLE
doc/rbd: Fix switched `accessMode` claim supports

### DIFF
--- a/doc/rbd/rbd-kubernetes.rst
+++ b/doc/rbd/rbd-kubernetes.rst
@@ -207,9 +207,9 @@ provision a `PersistentVolume`, which would be backed by a Ceph block image.
 An optional `volumeMode` can be included to select between a mounted file system
 (default) or raw block device-based volume.
 
-Using `ceph-csi`, specifying `Filesystem` for `volumeMode` can support both
-`ReadWriteOnce` and `ReadOnlyMany` `accessMode` claims, and specifying `Block`
-for `volumeMode` can support `ReadWriteOnce`, `ReadWriteMany`, and
+Using `ceph-csi`, specifying `Filesystem` for `volumeMode` can support all
+`ReadWriteOnce`, `ReadOnlyMany`, and `ReadWriteMany` `accessMode` claims, and
+specifying `Block` for `volumeMode` can support only `ReadWriteOnce`, and
 `ReadOnlyMany` `accessMode` claims.
 
 For example, to create a block-based `PersistentVolumeClaim` that utilizes


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
