### PR TITLE
mgr/prometheus: introduce metric for collection time

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -777,6 +777,8 @@ class Module(MgrModule):
                 ))
 
             osd_dev_node = None
+            osd_wal_dev_node = ''
+            osd_db_dev_node = ''
             if obj_store == "filestore":
                 # collect filestore backend device
                 osd_dev_node = osd_metadata.get(

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -2,7 +2,6 @@ import cherrypy
 from collections import defaultdict
 from distutils.version import StrictVersion
 import json
-from collections import defaultdict
 import errno
 import math
 import os

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -2,6 +2,7 @@ import cherrypy
 from collections import defaultdict
 from distutils.version import StrictVersion
 import json
+from collections import defaultdict
 import errno
 import math
 import os
@@ -182,6 +183,24 @@ class Metric(object):
                 value=floatstr(value),
             )
         return expfmt
+
+
+class MetricCounter(Metric):
+    def __init__(self, name, desc, labels=None):
+        super(MetricCounter, self).__init__('counter', name, desc, labels)
+        self.value = defaultdict(lambda: 0)
+
+    def clear(self):
+        pass  # Skip calls to clear as we want to keep the counters here.
+
+    def set(self, value, labelvalues=None):
+        msg = 'This method must not be used for instances of MetricCounter class'
+        raise NotImplementedError(msg)
+
+    def add(self, value, labelvalues=None):
+        # labelvalues must be a tuple
+        labelvalues = labelvalues or ('',)
+        self.value[labelvalues] += value
 
 
 class MetricCollectionThread(threading.Thread):
@@ -1104,6 +1123,32 @@ class Module(MgrModule):
 
         self.metrics.update(new_metrics)
 
+    def get_collect_time_metrics(self):
+        if 'prometheus_collect_duration_seconds_sum' not in self.metrics:
+            self.metrics['prometheus_collect_duration_seconds_sum'] = MetricCounter(
+                'prometheus_collect_duration_seconds_sum',
+                'The sum of seconds took to collect all metrics of this exporter',
+                ('method',),
+            )
+        if 'prometheus_collect_duration_seconds_count' not in self.metrics:
+            self.metrics['prometheus_collect_duration_seconds_count'] = MetricCounter(
+                'prometheus_collect_duration_seconds_count',
+                'The amount of metrics gathered for this exporter',
+                ('method',),
+            )
+
+        # Collect all timing data and make it available as metric, excluding the
+        # `collect` method because it has not finished at this point and hence
+        # there's no `_execution_duration` attribute to be found. The
+        # `_execution_duration` attribute is added by the `profile_method`
+        # decorator.
+        for method_name, method in Module.__dict__.items():
+            if hasattr(method, '_execution_duration'):
+                self.metrics['prometheus_collect_duration_seconds_sum'].add(
+                    method._execution_duration, (method_name, ))
+                self.metrics['prometheus_collect_duration_seconds_count'].add(
+                    1, (method_name, ))
+
     @profile_method(True)
     def collect(self):
         # Clear the metrics before scraping
@@ -1169,6 +1214,8 @@ class Module(MgrModule):
 
         self.add_fixed_name_metrics()
         self.get_rbd_stats()
+
+        self.get_collect_time_metrics()
 
         # Return formatted metrics and clear no longer used data
         _metrics = [m.str_expfmt() for m in self.metrics.values()]


### PR DESCRIPTION
Introduces metric `prometheus_collect_duration_seconds` summary (`_sum` and `_count`) for the time it
takes the Prometheus manager module to collect all the metrics.

```
# HELP ceph_prometheus_collect_duration_seconds_sum The sum of seconds took to collect all metrics of this exporter
# TYPE ceph_prometheus_collect_duration_seconds_sum counter
ceph_prometheus_collect_duration_seconds_sum{method="get_health"} 0.014837503433227539
ceph_prometheus_collect_duration_seconds_sum{method="get_pool_stats"} 0.015115976333618164
ceph_prometheus_collect_duration_seconds_sum{method="get_df"} 0.024508237838745117
ceph_prometheus_collect_duration_seconds_sum{method="get_fs"} 0.03028130531311035
ceph_prometheus_collect_duration_seconds_sum{method="get_quorum_status"} 0.030310869216918945
ceph_prometheus_collect_duration_seconds_sum{method="get_mgr_status"} 0.2740020751953125
ceph_prometheus_collect_duration_seconds_sum{method="get_pg_status"} 0.019570589065551758
ceph_prometheus_collect_duration_seconds_sum{method="get_osd_stats"} 0.01889801025390625
ceph_prometheus_collect_duration_seconds_sum{method="get_metadata_and_osd_status"} 0.21236467361450195
ceph_prometheus_collect_duration_seconds_sum{method="get_num_objects"} 0.012030839920043945
ceph_prometheus_collect_duration_seconds_sum{method="get_rbd_stats"} 0.011925935745239258
# HELP ceph_prometheus_collect_duration_seconds_count The amount of metrics gathered for this exporter
# TYPE ceph_prometheus_collect_duration_seconds_count counter
ceph_prometheus_collect_duration_seconds_count{method="get_health"} 107.0
ceph_prometheus_collect_duration_seconds_count{method="get_pool_stats"} 107.0
ceph_prometheus_collect_duration_seconds_count{method="get_df"} 107.0
ceph_prometheus_collect_duration_seconds_count{method="get_fs"} 107.0
ceph_prometheus_collect_duration_seconds_count{method="get_quorum_status"} 107.0
ceph_prometheus_collect_duration_seconds_count{method="get_mgr_status"} 107.0
ceph_prometheus_collect_duration_seconds_count{method="get_pg_status"} 107.0
ceph_prometheus_collect_duration_seconds_count{method="get_osd_stats"} 107.0
ceph_prometheus_collect_duration_seconds_count{method="get_metadata_and_osd_status"} 107.0
ceph_prometheus_collect_duration_seconds_count{method="get_num_objects"} 107.0
ceph_prometheus_collect_duration_seconds_count{method="get_rbd_stats"} 107.0
```

Fixes: https://tracker.ceph.com/issues/46703


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
