### PR TITLE
rgw: ordered list map efficiency

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8533,10 +8533,16 @@ int RGWRados::cls_bucket_list_ordered(const DoutPrefixProvider *dpp,
       ldpp_dout(dpp, 10) << "RGWRados::" << __func__ << ": got " <<
 	dirent.key << dendl;
 
-      m[name] = std::move(dirent);
-      last_entry_visited = &(m[name]);
-      ++count;
-    } else { // r == -ENOENT
+      auto [it, inserted] = m.insert_or_assign(name, std::move(dirent));
+      last_entry_visited = &it->second;
+      if (inserted) {
+	++count;
+      } else {
+	ldpp_dout(dpp, 0) << "WARNING: RGWRados::" << __func__ <<
+	  ": reassigned map value at \"" << name <<
+	  "\", which should not happen" << dendl;
+      }
+    } else {
       ldpp_dout(dpp, 10) << "RGWRados::" << __func__ << ": skipping " <<
 	dirent.key.name << "[" << dirent.key.instance << "]" << dendl;
       last_entry_visited = &tracker.dir_entry();


### PR DESCRIPTION
Adding an object to the result map required two "find" operations back-to-back, each of which was O(log n). By using std::map's insert function and getting an iterator, we can avoid the second find. Recovers and logs a warning when unexpected happens.

This is a small enhancement, so I don't expect backports, therefore no tracker.