### PR TITLE
doc/releases: add "octopus" column to Release Timeline

### DIFF
--- a/doc/releases/general.rst
+++ b/doc/releases/general.rst
@@ -119,7 +119,7 @@ Detailed information on all releases, past and present, can be found at :ref:`ce
 Release timeline
 ----------------
 
-.. ceph_timeline:: releases.yml development nautilus mimic luminous kraken jewel infernalis hammer giant firefly emperor
+.. ceph_timeline:: releases.yml development octopus nautilus mimic luminous kraken jewel infernalis hammer giant firefly
 
 .. _Octopus: ../octopus
 .. _15.2.4: ../octopus#v15-2-4-octopus


### PR DESCRIPTION
Octopus has been out for awhile. I suppose this should have been done
earlier, but "better late than never".

Signed-off-by: Nathan Cutler <ncutler@suse.com>