### PR TITLE
librbd:  global and pool-level config overrides require image refresh to apply

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7639,6 +7639,11 @@ static std::vector<Option> get_rbd_options() {
     .set_default("")
     .set_description("comma-delimited list of librbd plugins to enable"),
 
+    Option("rbd_config_pool_override_update_timestamp", Option::TYPE_UINT,
+           Option::LEVEL_DEV)
+    .set_default(0)
+    .set_description("timestamp of last update to pool-level config overrides"),
+
   });
 }
 

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -9,6 +9,7 @@ set(librbd_internal_srcs
   AsioEngine.cc
   AsyncObjectThrottle.cc
   AsyncRequest.cc
+  ConfigWatcher.cc
   DeepCopyRequest.cc
   ExclusiveLock.cc
   ImageCtx.cc

--- a/src/librbd/ConfigWatcher.cc
+++ b/src/librbd/ConfigWatcher.cc
@@ -1,0 +1,116 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/ConfigWatcher.h"
+#include "common/config_obs.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/api/Config.h"
+#include <deque>
+#include <string>
+#include <vector>
+#include <boost/algorithm/string/predicate.hpp>
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::ConfigWatcher: " \
+                           << __func__ << ": "
+
+namespace librbd {
+
+template <typename I>
+struct ConfigWatcher<I>::Observer : public md_config_obs_t {
+  ConfigWatcher<I>* m_config_watcher;
+
+  std::deque<std::string> m_config_key_strs;
+  mutable std::vector<const char*> m_config_keys;
+
+  Observer(CephContext* cct, ConfigWatcher<I>* config_watcher)
+    : m_config_watcher(config_watcher) {
+    const std::string rbd_key_prefix("rbd_");
+    auto& schema = cct->_conf.get_schema();
+    for (auto& pair : schema) {
+      // watch all "rbd_" keys for simplicity
+      if (!boost::starts_with(pair.first, rbd_key_prefix)) {
+        continue;
+      }
+
+      m_config_key_strs.emplace_back(pair.first);
+    }
+
+    m_config_keys.reserve(m_config_key_strs.size());
+    for (auto& key : m_config_key_strs) {
+      m_config_keys.emplace_back(key.c_str());
+    }
+    m_config_keys.emplace_back(nullptr);
+  }
+
+  const char** get_tracked_conf_keys() const override {
+    ceph_assert(!m_config_keys.empty());
+    return &m_config_keys[0];
+  }
+
+  void handle_conf_change(const ConfigProxy& conf,
+                          const std::set <std::string> &changed) override {
+    m_config_watcher->handle_global_config_change(changed);
+  }
+};
+
+template <typename I>
+ConfigWatcher<I>::ConfigWatcher(I& image_ctx)
+  : m_image_ctx(image_ctx) {
+}
+
+template <typename I>
+ConfigWatcher<I>::~ConfigWatcher() {
+  ceph_assert(m_observer == nullptr);
+}
+
+template <typename I>
+void ConfigWatcher<I>::init() {
+  auto cct = m_image_ctx.cct;
+  ldout(cct, 10) << dendl;
+
+  m_observer = new Observer(cct, this);
+  cct->_conf.add_observer(m_observer);
+}
+
+template <typename I>
+void ConfigWatcher<I>::shut_down() {
+  auto cct = m_image_ctx.cct;
+  ldout(cct, 10) << dendl;
+
+  ceph_assert(m_observer != nullptr);
+  cct->_conf.remove_observer(m_observer);
+
+  delete m_observer;
+  m_observer = nullptr;
+}
+
+template <typename I>
+void ConfigWatcher<I>::handle_global_config_change(
+    std::set<std::string> changed_keys) {
+
+  {
+    // ignore any global changes that are being overridden
+    std::shared_lock image_locker{m_image_ctx.image_lock};
+    for (auto& key : m_image_ctx.config_overrides) {
+      changed_keys.erase(key);
+    }
+  }
+  if (changed_keys.empty()) {
+    return;
+  }
+
+  auto cct = m_image_ctx.cct;
+  ldout(cct, 10) << "changed_keys=" << changed_keys << dendl;
+
+  // refresh the image to pick up any global config overrides
+  m_image_ctx.state->handle_update_notification();
+}
+
+} // namespace librbd
+
+template class librbd::ConfigWatcher<librbd::ImageCtx>;

--- a/src/librbd/ConfigWatcher.h
+++ b/src/librbd/ConfigWatcher.h
@@ -1,0 +1,47 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_CONFIG_WATCHER_H
+#define CEPH_LIBRBD_CONFIG_WATCHER_H
+
+#include <set>
+#include <string>
+
+struct Context;
+
+namespace librbd {
+
+struct ImageCtx;
+
+template <typename ImageCtxT>
+class ConfigWatcher {
+public:
+  static ConfigWatcher* create(ImageCtxT& image_ctx) {
+    return new ConfigWatcher(image_ctx);
+  }
+
+  ConfigWatcher(ImageCtxT& image_ctx);
+  ~ConfigWatcher();
+
+  ConfigWatcher(const ConfigWatcher&) = delete;
+  ConfigWatcher& operator=(const ConfigWatcher&) = delete;
+
+  void init();
+  void shut_down();
+
+private:
+  struct Observer;
+
+  ImageCtxT& m_image_ctx;
+
+  Observer* m_observer = nullptr;
+
+  void handle_global_config_change(std::set<std::string> changed);
+
+};
+
+} // namespace librbd
+
+extern template class librbd::ConfigWatcher<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_CONFIG_WATCHER_H

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -147,6 +147,7 @@ librados::IoCtx duplicate_io_ctx(librados::IoCtx& io_ctx) {
   }
 
   ImageCtx::~ImageCtx() {
+    ceph_assert(config_watcher == nullptr);
     ceph_assert(image_watcher == NULL);
     ceph_assert(exclusive_lock == NULL);
     ceph_assert(object_map == NULL);

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -724,6 +724,8 @@ librados::IoCtx duplicate_io_ctx(librados::IoCtx& io_ctx) {
                                 bool thread_safe) {
     ldout(cct, 20) << __func__ << dendl;
 
+    std::unique_lock image_locker(image_lock);
+
     // reset settings back to global defaults
     for (auto& key : config_overrides) {
       std::string value;
@@ -761,6 +763,8 @@ librados::IoCtx duplicate_io_ctx(librados::IoCtx& io_ctx) {
         }
       }
     }
+
+    image_locker.unlock();
 
 #define ASSIGN_OPTION(param, type)              \
     param = config.get_val<type>("rbd_"#param)

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -46,6 +46,7 @@ class RADOS;
 namespace librbd {
 
   struct AsioEngine;
+  template <typename> class ConfigWatcher;
   template <typename> class ExclusiveLock;
   template <typename> class ImageState;
   template <typename> class ImageWatcher;
@@ -122,6 +123,7 @@ namespace librbd {
     librados::IoCtx data_ctx;
     librados::IoCtx md_ctx;
 
+    ConfigWatcher<ImageCtx> *config_watcher = nullptr;
     ImageWatcher<ImageCtx> *image_watcher;
     Journal<ImageCtx> *journal;
 

--- a/src/librbd/api/Config.cc
+++ b/src/librbd/api/Config.cc
@@ -36,7 +36,8 @@ static std::set<std::string_view> EXCLUDE_OPTIONS {
     "rbd_tracing",
     "rbd_validate_names",
     "rbd_validate_pool",
-    "rbd_mirror_pool_replayers_refresh_interval"
+    "rbd_mirror_pool_replayers_refresh_interval",
+    "rbd_config_pool_override_update_timestamp"
   };
 static std::set<std::string_view> EXCLUDE_IMAGE_OPTIONS {
     "rbd_default_clone_format",

--- a/src/librbd/image/CloseRequest.cc
+++ b/src/librbd/image/CloseRequest.cc
@@ -4,6 +4,7 @@
 #include "librbd/image/CloseRequest.h"
 #include "common/dout.h"
 #include "common/errno.h"
+#include "librbd/ConfigWatcher.h"
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
@@ -35,6 +36,13 @@ CloseRequest<I>::CloseRequest(I *image_ctx, Context *on_finish)
 
 template <typename I>
 void CloseRequest<I>::send() {
+  if (m_image_ctx->config_watcher != nullptr) {
+    m_image_ctx->config_watcher->shut_down();
+
+    delete m_image_ctx->config_watcher;
+    m_image_ctx->config_watcher = nullptr;
+  }
+
   send_block_image_watcher();
 }
 

--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -5,6 +5,7 @@
 #include "common/dout.h"
 #include "common/errno.h"
 #include "cls/rbd/cls_rbd_client.h"
+#include "librbd/ConfigWatcher.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/PluginRegistry.h"
 #include "librbd/Utils.h"
@@ -500,6 +501,9 @@ void OpenRequest<I>::send_refresh() {
 
   CephContext *cct = m_image_ctx->cct;
   ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_image_ctx->config_watcher = ConfigWatcher<I>::create(*m_image_ctx);
+  m_image_ctx->config_watcher->init();
 
   using klass = OpenRequest<I>;
   RefreshRequest<I> *req = RefreshRequest<I>::create(

--- a/src/test/librados_test_stub/TestRadosClient.cc
+++ b/src/test/librados_test_stub/TestRadosClient.cc
@@ -208,6 +208,8 @@ int TestRadosClient::mon_command(const std::vector<std::string>& cmd,
       return 0;
     } else if ((*j_it)->get_data() == "config-key rm") {
       return 0;
+    } else if ((*j_it)->get_data() == "config set") {
+      return 0;
     } else if ((*j_it)->get_data() == "df") {
       std::stringstream str;
       str << R"({"pools": [)";

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(rbd_test_mock PUBLIC
 set(unittest_librbd_srcs
   test_main.cc
   test_mock_fixture.cc
+  test_mock_ConfigWatcher.cc
   test_mock_DeepCopyRequest.cc
   test_mock_ExclusiveLock.cc
   test_mock_Journal.cc

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -329,6 +329,7 @@ struct MockImageCtx {
   bool cache;
 
   ConfigProxy config;
+  std::set<std::string> config_overrides;
 };
 
 } // namespace librbd

--- a/src/test/librbd/mock/MockImageState.h
+++ b/src/test/librbd/mock/MockImageState.h
@@ -30,6 +30,8 @@ struct MockImageState {
 
   MOCK_METHOD2(register_update_watcher, int(UpdateWatchCtx *, uint64_t *));
   MOCK_METHOD2(unregister_update_watcher, void(uint64_t, Context *));
+
+  MOCK_METHOD0(handle_update_notification, void());
 };
 
 } // namespace librbd

--- a/src/test/librbd/test_mock_ConfigWatcher.cc
+++ b/src/test/librbd/test_mock_ConfigWatcher.cc
@@ -1,0 +1,100 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "include/rbd_types.h"
+#include "common/ceph_mutex.h"
+#include "librbd/ConfigWatcher.h"
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include <list>
+
+namespace librbd {
+namespace {
+
+struct MockTestImageCtx : public MockImageCtx {
+  MockTestImageCtx(ImageCtx &image_ctx) : MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+} // namespace librbd
+
+#include "librbd/ConfigWatcher.cc"
+
+namespace librbd {
+
+using ::testing::Invoke;
+
+class TestMockConfigWatcher : public TestMockFixture {
+public:
+  typedef ConfigWatcher<MockTestImageCtx> MockConfigWatcher;
+
+  librbd::ImageCtx *m_image_ctx;
+
+  ceph::mutex m_lock = ceph::make_mutex("m_lock");
+  ceph::condition_variable m_cv;
+  bool m_refreshed = false;
+
+  void SetUp() override {
+    TestMockFixture::SetUp();
+
+    ASSERT_EQ(0, open_image(m_image_name, &m_image_ctx));
+  }
+
+  void expect_update_notification(MockTestImageCtx& mock_image_ctx) {
+    EXPECT_CALL(*mock_image_ctx.state, handle_update_notification())
+      .WillOnce(Invoke([this]() {
+          std::unique_lock locker{m_lock};
+          m_refreshed = true;
+          m_cv.notify_all();
+        }));
+  }
+
+  void wait_for_update_notification() {
+    std::unique_lock locker{m_lock};
+    m_cv.wait(locker, [this] {
+        if (m_refreshed) {
+          m_refreshed = false;
+          return true;
+        }
+        return false;
+      });
+  }
+};
+
+TEST_F(TestMockConfigWatcher, GlobalConfig) {
+  MockTestImageCtx mock_image_ctx(*m_image_ctx);
+
+  MockConfigWatcher mock_config_watcher(mock_image_ctx);
+  mock_config_watcher.init();
+
+  expect_update_notification(mock_image_ctx);
+  mock_image_ctx.cct->_conf.set_val("rbd_cache", "false");
+  mock_image_ctx.cct->_conf.set_val("rbd_cache", "true");
+  mock_image_ctx.cct->_conf.apply_changes(nullptr);
+  wait_for_update_notification();
+
+  mock_config_watcher.shut_down();
+}
+
+TEST_F(TestMockConfigWatcher, IgnoreOverriddenGlobalConfig) {
+  MockTestImageCtx mock_image_ctx(*m_image_ctx);
+
+  MockConfigWatcher mock_config_watcher(mock_image_ctx);
+  mock_config_watcher.init();
+
+  EXPECT_CALL(*mock_image_ctx.state, handle_update_notification())
+    .Times(0);
+  mock_image_ctx.config_overrides.insert("rbd_cache");
+  mock_image_ctx.cct->_conf.set_val("rbd_cache", "false");
+  mock_image_ctx.cct->_conf.set_val("rbd_cache", "true");
+  mock_image_ctx.cct->_conf.apply_changes(nullptr);
+
+  mock_config_watcher.shut_down();
+
+  ASSERT_FALSE(m_refreshed);
+}
+
+} // namespace librbd


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
