### PR TITLE
crimson: connect to v2 address if myaddr.is_any()

### DIFF
--- a/src/crimson/mgr/client.cc
+++ b/src/crimson/mgr/client.cc
@@ -105,10 +105,11 @@ seastar::future<> Client::reconnect()
   return seastar::sleep(a_while).then([this] {
     auto peer = [&] {
       auto& mgr_addrs = mgrmap.get_active_addrs();
-      if (msgr.get_myaddr().is_legacy()) {
-        return mgr_addrs.legacy_addr();
-      } else {
+      if (msgr.get_myaddr().is_any() ||
+          msgr.get_myaddr().is_msgr2()) {
         return mgr_addrs.msgr2_addr();
+      } else {
+        return mgr_addrs.legacy_addr();
       }
     }();
     if (peer == entity_addr_t{}) {

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -959,10 +959,11 @@ seastar::future<> Client::reopen_session(int rank)
 #warning fixme
     auto peer = [&] {
       auto& mon_addrs = monmap.get_addrs(rank);
-      if (msgr.get_myaddr().is_legacy()) {
-        return mon_addrs.legacy_addr();
-      } else {
+      if (msgr.get_myaddr().is_any() ||
+          msgr.get_myaddr().is_msgr2()) {
         return mon_addrs.msgr2_addr();
+      } else {
+        return mon_addrs.legacy_addr();
       }
     }();
     if (peer == entity_addr_t{}) {


### PR DESCRIPTION
if myaddr is any, both v1 and v2 would work for me.
this change addresses the regression introduced by 1dfe1801.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
