### PR TITLE
rgw: fix vector index warning

### DIFF
--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -54,7 +54,7 @@ public:
 class RGWPutObj_ETagVerifier_MPU : public RGWPutObj_ETagVerifier
 {
   std::vector<uint64_t> part_ofs;
-  int cur_part_index{0}, next_part_index{1};
+  uint64_t cur_part_index{0}, next_part_index{1};
   MD5 mpu_etag_hash;
  
   void process_end_of_MPU_part();


### PR DESCRIPTION
src/rgw/rgw_etag_verifier.cc: In member function ‘virtual int RGWPutObj_ETagVerifier_MPU::process(ceph::bufferlist&&, uint64_t)’:
src/rgw/rgw_etag_verifier.cc:58:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<long unsigned int>::size_type
   58 |   if (next_part_index == part_ofs.size()) {
      |       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
src/rgw/rgw_etag_verifier.cc:76:25: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<long unsigned int>::size_type
   76 |     if (next_part_index == part_ofs.size())
      |         ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~

Signed-off-by: Changcheng Liu <changcheng.liu@aliyun.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
