### PR TITLE
cephadm: deploying of monitoring images partially broken

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -128,7 +128,7 @@ class Monitoring(object):
 
     components = {
         "prometheus": {
-            "image": "prom/prometheus:latest",
+            "image": "docker.io/prom/prometheus:v2.18.1",
             "cpus": '2',
             "memory": '4GB',
             "args": [
@@ -141,7 +141,7 @@ class Monitoring(object):
             ],
         },
         "node-exporter": {
-            "image": "prom/node-exporter",
+            "image": "docker.io/prom/node-exporter:v0.18.1",
             "cpus": "1",
             "memory": "1GB",
             "args": [
@@ -149,7 +149,7 @@ class Monitoring(object):
             ],
         },
         "grafana": {
-            "image": "ceph/ceph-grafana:latest",
+            "image": "docker.io/ceph/ceph-grafana:6.6.2",
             "cpus": "2",
             "memory": "4GB",
             "args": [],
@@ -161,7 +161,7 @@ class Monitoring(object):
             ],
         },
         "alertmanager": {
-            "image": "prom/alertmanager",
+            "image": "docker.io/prom/alertmanager:v0.20.0",
             "cpus": "2",
             "memory": "2GB",
             "args": [],

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -151,22 +151,22 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         },
         {
             'name': 'container_image_prometheus',
-            'default': 'prom/prometheus:v2.18.1',
+            'default': 'docker.io/prom/prometheus:v2.18.1',
             'desc': 'Prometheus container image',
         },
         {
             'name': 'container_image_grafana',
-            'default': 'ceph/ceph-grafana:6.6.2',
+            'default': 'docker.io/ceph/ceph-grafana:6.6.2',
             'desc': 'Prometheus container image',
         },
         {
             'name': 'container_image_alertmanager',
-            'default': 'prom/alertmanager:v0.20.0',
+            'default': 'docker.io/prom/alertmanager:v0.20.0',
             'desc': 'Prometheus container image',
         },
         {
             'name': 'container_image_node_exporter',
-            'default': 'prom/node-exporter:v0.18.1',
+            'default': 'docker.io/prom/node-exporter:v0.18.1',
             'desc': 'Prometheus container image',
         },
         {
@@ -441,7 +441,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         The main loop of cephadm.
 
         A command handler will typically change the declarative state
-        of cephadm. This loop will then attempt to apply this new state. 
+        of cephadm. This loop will then attempt to apply this new state.
         """
         self.log.debug("serve starting")
         while self.run:


### PR DESCRIPTION
Deployment of monitoring images has been broken in the context of
ceph-salt. Due to the removal of the registries in
/etc/containers/registries.conf, all images need to be provided
qualified.

Fixes: https://tracker.ceph.com/issues/46726

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
