### PR TITLE
client: send request to ephemeral pined mds

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1173,6 +1173,9 @@ private:
   int _posix_acl_permission(Inode *in, const UserPerm& perms, unsigned want);
 
   mds_rank_t _get_random_up_mds() const;
+  mds_rank_t hash_into_mds_rank(inodeno_t ino);
+  Inode* get_ephemeral_dist_root(Inode *in);
+  mds_rank_t _get_ephemeral_dist_mds(Inode *in);
 
   int _ll_getattr(Inode *in, int caps, const UserPerm& perms);
   int _lookup_parent(Inode *in, const UserPerm& perms, Inode **parent=NULL);

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -155,6 +155,8 @@ struct Inode {
   frag_info_t dirstat;
   nest_info_t rstat;
 
+  bool export_ephemeral_distributed_pin = false;
+
   // special stuff
   version_t version;           // auth only
   version_t xattr_version;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3942,6 +3942,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     encode(any_i->btime, bl);
     encode(any_i->change_attr, bl);
     encode(file_i->export_pin, bl);
+    encode(file_i->export_ephemeral_distributed_pin, bl);
     encode(snap_btime, bl);
     ENCODE_FINISH(bl);
   }
@@ -3999,6 +4000,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
       encode(any_i->btime, bl);
       encode(any_i->change_attr, bl);
     }
+    encode(file_i->export_ephemeral_distributed_pin, bl);
   }
 
   return valid;

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -135,6 +135,7 @@ struct InodeStat {
   quota_info_t quota;
 
   mds_rank_t dir_pin;
+  bool export_ephemeral_distributed_pin;
 
  public:
   InodeStat() {}
@@ -190,6 +191,7 @@ struct InodeStat {
       } else {
         dir_pin = -ENODATA;
       }
+      decode(export_ephemeral_distributed_pin, p);
       if (struct_v >= 3) {
         decode(snap_btime, p);
       } // else remains zero
@@ -256,6 +258,7 @@ struct InodeStat {
         btime = utime_t();
         change_attr = 0;
       }
+      decode(export_ephemeral_distributed_pin, p);
     }
   }
   


### PR DESCRIPTION
Signed-off-by: Chencan <chen.can2@zte.com.cn>

If a directory is been set  ephemeral pined，when a client accesses the immediate children of this directory，client can choose the mds rank which is pinned to it's immediate children to send request。This can reduces the message interactions between client and mds.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
