### PR TITLE
test/librados_test_stub: handle exclusive create

### DIFF
--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -108,6 +108,13 @@ int TestMemIoCtxImpl::create(const std::string& oid, bool exclusive,
   }
 
   std::unique_lock l{m_pool->file_lock};
+  if (exclusive) {
+    TestMemCluster::SharedFile file = get_file(oid, false, CEPH_NOSNAP, {});
+    if (file != NULL && file->exists) {
+      return -EEXIST;
+    }
+  }
+
   get_file(oid, true, CEPH_NOSNAP, snapc);
   return 0;
 }

--- a/src/test/librbd/image/test_mock_ValidatePoolRequest.cc
+++ b/src/test/librbd/image/test_mock_ValidatePoolRequest.cc
@@ -39,6 +39,7 @@ public:
 
   void SetUp() override {
     TestMockFixture::SetUp();
+    m_ioctx.remove(RBD_INFO);
     ASSERT_EQ(0, open_image(m_image_name, &image_ctx));
   }
 


### PR DESCRIPTION
The exclusive boolean of the create method was unused so far.
This commit adds the proper handling by checking if an object already exists, and returning EEXISTS appropriately.

This will be used for testing an upcoming librbd PR that will add exclusive create support for ObjectDispatchInterface::write.