### PR TITLE
test/librados_test_stub: add version tracking of objects

### DIFF
--- a/src/test/librados_test_stub/TestMemCluster.cc
+++ b/src/test/librados_test_stub/TestMemCluster.cc
@@ -7,12 +7,13 @@
 namespace librados {
 
 TestMemCluster::File::File()
-  : snap_id(), exists(true) {
+  : objver(0), snap_id(), exists(true) {
 }
 
 TestMemCluster::File::File(const File &rhs)
   : data(rhs.data),
     mtime(rhs.mtime),
+    objver(rhs.objver),
     snap_id(rhs.snap_id),
     exists(rhs.exists) {
 }

--- a/src/test/librados_test_stub/TestMemCluster.h
+++ b/src/test/librados_test_stub/TestMemCluster.h
@@ -35,6 +35,7 @@ public:
 
     bufferlist data;
     time_t mtime;
+    uint64_t objver;
 
     uint64_t snap_id;
     std::vector<uint64_t> snaps;

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -816,6 +816,8 @@ TestMemCluster::SharedFile TestMemIoCtxImpl::get_file(
       file->mtime = ceph_clock_now().sec();
       m_pool->files[{get_namespace(), oid}].push_back(file);
     }
+
+    file->objver++;
     return file;
   }
 


### PR DESCRIPTION
True RADOS objects have a uint64_t objver associated, increasing upon each write.
This commit adds the same for librados_test_stub objects.

This will be used for testing an upcoming librbd PR that will add assert_version support for ObjectDispatchInterface::write.

BTW, is it just me or should TestMemCluster::file.mtime be updated upon each write (like objver), and not just when a new object clone is created?