### PR TITLE
librbd: ensure image cannot be closed until in-flight IO callbacks complete

### DIFF
--- a/src/librbd/io/AioCompletion.cc
+++ b/src/librbd/io/AioCompletion.cc
@@ -118,10 +118,6 @@ void AioCompletion::complete() {
     image_dispatcher_ctx->complete(rval);
   }
 
-  // note: possible for image to be closed after op marked finished
-  if (async_op.started()) {
-    async_op.finish_op();
-  }
   tracepoint(librbd, aio_complete_exit);
 }
 
@@ -274,8 +270,15 @@ void AioCompletion::complete_event_socket() {
 void AioCompletion::notify_callbacks_complete() {
   state = AIO_STATE_COMPLETE;
 
-  std::unique_lock<std::mutex> locker(lock);
-  cond.notify_all();
+  {
+    std::unique_lock<std::mutex> locker(lock);
+    cond.notify_all();
+  }
+
+  // note: possible for image to be closed after op marked finished
+  if (async_op.started()) {
+    async_op.finish_op();
+  }
 }
 
 } // namespace io

--- a/src/librbd/io/AioCompletion.cc
+++ b/src/librbd/io/AioCompletion.cc
@@ -114,10 +114,6 @@ void AioCompletion::complete() {
     notify_callbacks_complete();
   }
 
-  if (image_dispatcher_ctx != nullptr) {
-    image_dispatcher_ctx->complete(rval);
-  }
-
   tracepoint(librbd, aio_complete_exit);
 }
 
@@ -273,6 +269,10 @@ void AioCompletion::notify_callbacks_complete() {
   {
     std::unique_lock<std::mutex> locker(lock);
     cond.notify_all();
+  }
+
+  if (image_dispatcher_ctx != nullptr) {
+    image_dispatcher_ctx->complete(rval);
   }
 
   // note: possible for image to be closed after op marked finished


### PR DESCRIPTION
If a librbd client attempts to close the image while it still has in-flight IO
pending, it's possible for the AsyncOperation tracker which prevents the image
from being closed to be completed before the actual AioCompletion callback
fires. This can result in the now destructed ImageCtx being de-referenced by
the AioCompletion.

Fixes: https://tracker.ceph.com/issues/46737
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
