### PR TITLE
cephadm: Update error message on host failure

### DIFF
--- a/doc/cephadm/adoption.rst
+++ b/doc/cephadm/adoption.rst
@@ -75,11 +75,11 @@ Adoption process
 #. Generate an SSH key::
 
      # ceph cephadm generate-key
-     # ceph cephadm get-pub-key > ceph.pub
+     # ceph cephadm get-pub-key > ~/ceph.pub
 
 #. Install the cluster SSH key on each host in the cluster::
 
-     # ssh-copy-id -f -i ceph.pub root@<host>
+     # ssh-copy-id -f -i ~/ceph.pub root@<host>
 
    .. note::
      It is also possible to import an existing ssh key. See

--- a/doc/cephadm/troubleshooting.rst
+++ b/doc/cephadm/troubleshooting.rst
@@ -110,44 +110,44 @@ ssh errors
 
 Error message::
 
-  xxxxxx.gateway_bootstrap.HostNotFound: -F /tmp/cephadm-conf-kbqvkrkw root@10.10.1.2
-  raise OrchestratorError('Failed to connect to %s (%s).  Check that the host is reachable and accepts  connections using the cephadm SSH key' % (host, addr)) from
-  orchestrator._interface.OrchestratorError: Failed to connect to 10.10.1.2 (10.10.1.2).  Check that the host is reachable and accepts connections using the cephadm SSH key
+  execnet.gateway_bootstrap.HostNotFound: -F /tmp/cephadm-conf-73z09u6g -i /tmp/cephadm-identity-ky7ahp_5 root@10.10.1.2
+  ...
+  raise OrchestratorError(msg) from e
+  orchestrator._interface.OrchestratorError: Failed to connect to 10.10.1.2 (10.10.1.2).
+  Please make sure that the host is reachable and accepts connections using the cephadm SSH key
+  ...
 
 Things users can do:
 
 1. Ensure cephadm has an SSH identity key::
-      
-     [root@mon1~]# cephadm shell -- ceph config-key get mgr/cephadm/ssh_identity_key > key
+
+     [root@mon1~]# cephadm shell -- ceph config-key get mgr/cephadm/ssh_identity_key > ~/cephadm_private_key
      INFO:cephadm:Inferring fsid f8edc08a-7f17-11ea-8707-000c2915dd98
      INFO:cephadm:Using recent ceph image docker.io/ceph/ceph:v15 obtained 'mgr/cephadm/ssh_identity_key'
-     [root@mon1 ~] # chmod 0600 key
+     [root@mon1 ~] # chmod 0600 ~/cephadm_private_key
 
  If this fails, cephadm doesn't have a key. Fix this by running the following command::
-   
+
      [root@mon1 ~]# cephadm shell -- ceph cephadm generate-ssh-key
 
  or::
-   
-     [root@mon1 ~]# cat key | cephadm shell -- ceph cephadm set-ssk-key -i -
+
+     [root@mon1 ~]# cat ~/cephadm_private_key | cephadm shell -- ceph cephadm set-ssk-key -i -
 
 2. Ensure that the ssh config is correct::
-   
+
      [root@mon1 ~]# cephadm shell -- ceph cephadm get-ssh-config > config
 
 3. Verify that we can connect to the host::
-    
-     [root@mon1 ~]# ssh -F config -i key root@mon1
 
-
-
+     [root@mon1 ~]# ssh -F config -i ~/cephadm_private_key root@mon1
 
 Verifying that the Public Key is Listed in the authorized_keys file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 To verify that the public key is in the authorized_keys file, run the following commands::
 
-     [root@mon1 ~]# cephadm shell -- ceph config-key get mgr/cephadm/ssh_identity_pub > key.pub
-     [root@mon1 ~]# grep "`cat key.pub`"  /root/.ssh/authorized_keys
+     [root@mon1 ~]# cephadm shell -- ceph cephadm get-pub-key > ~/ceph.pub
+     [root@mon1 ~]# grep "`cat ~/ceph.pub`"  /root/.ssh/authorized_keys
 
 Failed to infer CIDR network error
 ----------------------------------

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1045,12 +1045,16 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
             user = self.ssh_user if self.mode == 'root' else 'cephadm'
             msg = f'''Failed to connect to {host} ({addr}).
-Check that the host is reachable and accepts connections using the cephadm SSH key
+Please make sure that the host is reachable and accepts connections using the cephadm SSH key
 
-you may want to run:
+To add the cephadm SSH key to the host:
+> ceph cephadm get-pub-key > ~/ceph.pub
+> ssh-copy-id -f -i ~/ceph.pub {user}@{host}
+
+To check that the host is reachable:
 > ceph cephadm get-ssh-config > ssh_config
-> ceph config-key get mgr/cephadm/ssh_identity_key > key
-> ssh -F ssh_config -i key {user}@{host}'''
+> ceph config-key get mgr/cephadm/ssh_identity_key > ~/cephadm_private_key
+> ssh -F ssh_config -i ~/cephadm_private_key {user}@{host}'''
             raise OrchestratorError(msg) from e
         except Exception as ex:
             self.log.exception(ex)


### PR DESCRIPTION
Now the error message explains how to add the ssh key to the not
reachable host

Fixes: https://tracker.ceph.com/issues/46551
Signed-off-by: Stephan Müller <smueller@suse.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
