### PR TITLE
mgr/orch: allow for multiline OrchestratorEvent message

### DIFF
--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1604,7 +1604,7 @@ class OrchestratorEvent:
     """
     INFO = 'INFO'
     ERROR = 'ERROR'
-    regex_v1 = re.compile(r'^([^ ]+) ([^:]+):([^ ]+) \[([^\]]+)\] "(.*)"$')
+    regex_v1 = re.compile(r'^([^ ]+) ([^:]+):([^ ]+) \[([^\]]+)\] "((?:.|\n)*)"$', re.MULTILINE)
 
     def __init__(self, created: Union[str, datetime.datetime], kind, subject, level, message):
         if isinstance(created, str):
@@ -1633,7 +1633,6 @@ class OrchestratorEvent:
         created = self.created.strftime(DATEFMT)
         return f'{created} {self.kind_subject()} [{self.level}] "{self.message}"'
 
-
     @classmethod
     @handle_type_error
     def from_json(cls, data) -> "OrchestratorEvent":
@@ -1648,6 +1647,13 @@ class OrchestratorEvent:
         if match:
             return cls(*match.groups())
         raise ValueError(f'Unable to match: "{data}"')
+
+    def __eq__(self, other):
+        if not isinstance(other, OrchestratorEvent):
+            return False
+
+        return self.created == other.created and self.kind == other.kind \
+            and self.subject == other.subject and self.message == other.message
 
 
 def _mk_orch_methods(cls):

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import datetime
 import json
 
 import pytest
@@ -279,3 +280,12 @@ events:
 
         j = json.loads(to_format(object, 'json', False, cls))
         assert to_format(cls.from_json(j), 'yaml', False, cls) == y
+
+
+def test_event_multiline():
+    from .._interface import OrchestratorEvent
+    e = OrchestratorEvent(datetime.datetime.utcnow(), 'service', 'subject', 'ERROR', 'message')
+    assert OrchestratorEvent.from_json(e.to_json()) == e
+
+    e = OrchestratorEvent(datetime.datetime.utcnow(), 'service', 'subject', 'ERROR', 'multiline\nmessage')
+    assert OrchestratorEvent.from_json(e.to_json()) == e


### PR DESCRIPTION
Multi-line OrchestratorEvent messages break the output of the ls command:
```
$ ceph orch ls mon --format yaml
Error EINVAL: Traceback (most recent call last):
  File "/usr/share/ceph/mgr/mgr_module.py", line 1171, in _handle_command
    return self.handle_command(inbuf, cmd)
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 131, in handle_command
    return dispatch[cmd['prefix']].call(self, cmd, inbuf)
  File "/usr/share/ceph/mgr/mgr_module.py", line 311, in call
    return self.func(mgr, **kwargs)
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 93, in <lambda>
    wrapper_copy = lambda *l_args, **l_kwargs: wrapper(*l_args, **l_kwargs)
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 84, in wrapper
    return func(*args, **kwargs)
  File "/usr/share/ceph/mgr/orchestrator/module.py", line 452, in _list_services
    return HandleCommandResult(stdout=to_format(services, format, many=True, cls=ServiceDescription))
  File "/usr/share/ceph/mgr/orchestrator/module.py", line 52, in to_format
    copy = [cls.from_json(o) for o in flat] if many else cls.from_json(flat)
  File "/usr/share/ceph/mgr/orchestrator/module.py", line 52, in <listcomp>
    copy = [cls.from_json(o) for o in flat] if many else cls.from_json(flat)
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 1211, in inner
    return method(cls, *args, **kwargs)
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 1489, in from_json
    events = [OrchestratorEvent.from_json(e) for e in event_strs]
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 1489, in <listcomp>
    events = [OrchestratorEvent.from_json(e) for e in event_strs]
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 1211, in inner
    return method(cls, *args, **kwargs)
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 1649, in from_json
    raise ValueError(f'Unable to match: "{data}"')
ValueError: Unable to match: "2020-07-28T19:32:27.463735 service:mon [ERROR] "Failed to apply: cephadm exited with an error code: 1, stderr:INFO:cephadm:Deploy daemon mon.host3 ...
INFO:cephadm:Non-zero exit code 1 from /usr/bin/podman run --rm --net=host --ipc=host -e CONTAINER_IMAGE=docker.io/ceph/daemon-base@sha256:481a818ec6ca7b5712670c8a0eaaceb64d5ce8390cd931a540d937043d3baed0 -e NODE_NAME=host3 -v /var/log/ceph/a5fb8148-4d79-44ef-b578-2d46db934808:/var/log/ceph:z -v /var/lib/ceph/a5fb8148-4d79-44ef-b578-2d46db934808/mon.host3:/var/lib/ceph/mon/ceph-host3:z -v /tmp/ceph-tmp_buqrhay:/tmp/keyring:z -v /tmp/ceph-tmps_evysk3:/tmp/config:z --entrypoint /usr/bin/ceph-mon docker.io/ceph/daemon-base@sha256:481a818ec6ca7b5712670c8a0eaaceb64d5ce8390cd931a540d937043d3baed0 --mkfs -i host3 --fsid a5fb8148-4d79-44ef-b578-2d46db934808 -c /tmp/config --keyring /tmp/keyring --setuser ceph --setgroup ceph --default-log-to-file=false --default-log-to-stderr=true --default-log-stderr-prefix="debug " --default-mon-cluster-log-to-file=false --default-mon-cluster-log-to-stderr=true
INFO:cephadm:/usr/bin/ceph-mon:stderr "debug "2020-07-28T19:32:15.661+0000 7fa83bbb8700  0 set uid:gid to 167:167 (ceph:ceph)
INFO:cephadm:/usr/bin/ceph-mon:stderr "debug "2020-07-28T19:32:15.661+0000 7fa83bbb8700 -1 unable to find any IP address in networks '192.168.0.1/24' interfaces ''
Traceback (most recent call last):
  File "<stdin>", line 5048, in <module>
  File "<stdin>", line 1216, in _default_image
  File "<stdin>", line 3000, in command_deploy
  File "<stdin>", line 1879, in deploy_daemon
  File "<stdin>", line 2374, in run
  File "<stdin>", line 877, in call_throws
RuntimeError: Failed command: /usr/bin/podman run --rm --net=host --ipc=host -e CONTAINER_IMAGE=docker.io/ceph/daemon-base@sha256:481a818ec6ca7b5712670c8a0eaaceb64d5ce8390cd931a540d937043d3baed0 -e NODE_NAME=host3 -v /var/log/ceph/a5fb8148-4d79-44ef-b578-2d46db934808:/var/log/ceph:z -v /var/lib/ceph/a5fb8148-4d79-44ef-b578-2d46db934808/mon.host3:/var/lib/ceph/mon/ceph-host3:z -v /tmp/ceph-tmp_buqrhay:/tmp/keyring:z -v /tmp/ceph-tmps_evysk3:/tmp/config:z --entrypoint /usr/bin/ceph-mon docker.io/ceph/daemon-base@sha256:481a818ec6ca7b5712670c8a0eaaceb64d5ce8390cd931a540d937043d3baed0 --mkfs -i host3 --fsid a5fb8148-4d79-44ef-b578-2d46db934808 -c /tmp/config --keyring /tmp/keyring --setuser ceph --setgroup ceph --default-log-to-file=false --default-log-to-stderr=true --default-log-stderr-prefix="debug " --default-mon-cluster-log-to-file=false --default-mon-cluster-log-to-stderr=true""
```




Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
