### PR TITLE
ceph-volume: add libstoragemgmt support

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/test_inventory.py
+++ b/src/ceph-volume/ceph_volume/tests/test_inventory.py
@@ -59,6 +59,52 @@ def device_sys_api_keys(device_info):
     report = Devices().json_report()[0]
     return list(report['sys_api'].keys())
 
+@pytest.fixture
+def device_data(device_info):
+    device_info(
+        devices={
+            # example output of disk.get_devices()
+            '/dev/sdb': {
+                'human_readable_size': '1.82 TB',
+                'locked': 0,
+                'model': 'PERC H700',
+                'nr_requests': '128',
+                'partitions': {},
+                'path': '/dev/sdb',
+                'removable': '0',
+                'rev': '2.10',
+                'ro': '0',
+                'rotational': '1',
+                'sas_address': '',
+                'sas_device_handle': '',
+                'scheduler_mode': 'cfq',
+                'sectors': 0,
+                'sectorsize': '512',
+                'size': 1999844147200.0,
+                'support_discard': '',
+                'vendor': 'DELL',
+            }
+        }
+    )
+
+    dev = Devices().devices[0]
+    dev.lsm_data = {
+        "serialNum": 'S2X9NX0H935283',
+        "transport": 'SAS',
+        "mediaType": 'HDD',
+        "rpm": 10000,
+        "linkSpeed": 6000,
+        "health": 'Good',
+        "ledSupport": {
+            "IDENTsupport": 'Supported',
+            "IDENTstatus": 'Off',
+            "FAILsupport": 'Supported',
+            "FAILstatus": 'Off',
+        },
+        "errors": [],
+    }
+    return dev.json_report()
+
 
 class TestInventory(object):
 
@@ -69,6 +115,7 @@ class TestInventory(object):
         'available',
         'lvs',
         'device_id',
+        'lsm_data',
     ]
 
     expected_sys_api_keys = [
@@ -92,6 +139,17 @@ class TestInventory(object):
         'vendor',
     ]
 
+    expected_lsm_keys = [
+        'serialNum',
+        'transport',
+        'mediaType',
+        'rpm',
+        'linkSpeed',
+        'health',
+        'ledSupport',
+        'errors',
+    ]
+
     def test_json_inventory_keys_unexpected(self, device_report_keys):
         for k in device_report_keys:
             assert k in self.expected_keys, "unexpected key {} in report".format(k)
@@ -107,4 +165,17 @@ class TestInventory(object):
     def test_sys_api_keys_missing(self, device_sys_api_keys):
         for k in self.expected_sys_api_keys:
             assert k in device_sys_api_keys, "expected key {} in sys_api field".format(k)
+
+    def test_lsm_data_type_unexpected(self, device_data):
+        assert isinstance(device_data['lsm_data'], dict), "lsm_data field must be of type dict"
+
+    def test_lsm_data_keys_unexpected(self, device_data):
+        for k in device_data['lsm_data'].keys():
+            assert k in self.expected_lsm_keys, "unexpected key {} in lsm_data field".format(k)
+
+    def test_lsm_data_keys_missing(self, device_data):
+        lsm_keys = device_data['lsm_data'].keys()
+        assert lsm_keys
+        for k in self.expected_lsm_keys:
+            assert k in lsm_keys, "expected key {} in lsm_data field".format(k)
 

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -112,11 +112,11 @@ class Device(object):
         '''
         devName = self.path.split('/')[-1]
         if not os.path.exists('/sys/block/{}'.format(devName)):
-            return dict()
+            return {}
 
         lsm_disk = LSMDisk(self.path)
         if not lsm_disk.lsm_available:
-            return dict()
+            return {}
 
         lsm_json = lsm_disk.json_report()
         

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -110,17 +110,12 @@ class Device(object):
         json returned will provide LSM attributes, and any associated errors that
         lsm encountered when probing the device.
         '''
-        devName = self.path.split('/')[-1]
-        if not os.path.exists('/sys/block/{}'.format(devName)):
+        if not self.exists or not self.is_device:
             return {}
 
         lsm_disk = LSMDisk(self.path)
-        if not lsm_disk.lsm_available:
-            return {}
-
-        lsm_json = lsm_disk.json_report()
         
-        return lsm_json
+        return  lsm_disk.json_report()
 
     def __lt__(self, other):
         '''

--- a/src/ceph-volume/ceph_volume/util/lsmdisk.py
+++ b/src/ceph-volume/ceph_volume/util/lsmdisk.py
@@ -7,8 +7,8 @@ a critical component of ceph-volume.
 import logging
 
 try:
-    import lsm
-    from lsm._local_disk import LocalDisk, LsmError
+    from lsm import LocalDisk, LsmError
+    from lsm import Disk as lsm_Disk
 except ImportError:
     lsm_available = False
 else:
@@ -36,7 +36,7 @@ class LSMDisk:
     @property
     def errors(self):
         """show any errors that the LSM interaction has encountered (str)"""
-        return ",".join(self.error_list)
+        return ", ".join(self.error_list)
 
     def _query_lsm(self, func, path):
         """Common method used to call the LSM functions, returning the function's result or None"""
@@ -49,7 +49,7 @@ class LSMDisk:
         try:
             output = method(path)
         except LsmError as err:
-            # logger.exception("LSM Error: {}".format(err._msg))
+            logger.error("LSM Error: {}".format(err._msg))
             self.error_list.add(err._msg)
             return None
         else:
@@ -59,9 +59,8 @@ class LSMDisk:
     def led_status(self):
         """Fetch LED status, store in the LSMDisk object and return current status (int)"""
         if self.led_bits is None:
-            bitfield = self._query_lsm('led_status_get', self.dev_path) or 1
-            self.led_bits = bitfield
-            return bitfield
+            self.led_bits = self._query_lsm('led_status_get', self.dev_path) or 1
+            return self.led_bits
         else:
             return self.led_bits
 
@@ -71,11 +70,11 @@ class LSMDisk:
         led_state = self.led_status
         if led_state == 1:
             return "Unsupported"
-        if led_state & lsm.Disk.LED_STATUS_IDENT_ON == lsm.Disk.LED_STATUS_IDENT_ON:
+        if led_state & lsm_Disk.LED_STATUS_IDENT_ON == lsm_Disk.LED_STATUS_IDENT_ON:
             return "On"
-        elif led_state & lsm.Disk.LED_STATUS_IDENT_OFF == lsm.Disk.LED_STATUS_IDENT_OFF:
+        elif led_state & lsm_Disk.LED_STATUS_IDENT_OFF == lsm_Disk.LED_STATUS_IDENT_OFF:
             return "Off"
-        elif led_state & lsm.Disk.LED_STATUS_IDENT_UNKNOWN == lsm.Disk.LED_STATUS_IDENT_UNKNOWN:
+        elif led_state & lsm_Disk.LED_STATUS_IDENT_UNKNOWN == lsm_Disk.LED_STATUS_IDENT_UNKNOWN:
             return "Unknown"
         
         return "Unsupported"
@@ -86,11 +85,11 @@ class LSMDisk:
         led_state = self.led_status
         if led_state == 1:
             return "Unsupported"
-        if led_state & lsm.Disk.LED_STATUS_FAULT_ON == lsm.Disk.LED_STATUS_FAULT_ON:
+        if led_state & lsm_Disk.LED_STATUS_FAULT_ON == lsm_Disk.LED_STATUS_FAULT_ON:
             return "On"
-        elif led_state & lsm.Disk.LED_STATUS_FAULT_OFF == lsm.Disk.LED_STATUS_FAULT_OFF:
+        elif led_state & lsm_Disk.LED_STATUS_FAULT_OFF == lsm_Disk.LED_STATUS_FAULT_OFF:
             return "Off"
-        elif led_state & lsm.Disk.LED_STATUS_FAULT_UNKNOWN == lsm.Disk.LED_STATUS_FAULT_UNKNOWN:
+        elif led_state & lsm_Disk.LED_STATUS_FAULT_UNKNOWN == lsm_Disk.LED_STATUS_FAULT_UNKNOWN:
             return "Unknown"
         
         return "Unsupported"
@@ -103,9 +102,9 @@ class LSMDisk:
             return "Unknown"
 
         ident_states = (
-            lsm.Disk.LED_STATUS_IDENT_ON + 
-            lsm.Disk.LED_STATUS_IDENT_OFF + 
-            lsm.Disk.LED_STATUS_IDENT_UNKNOWN
+            lsm_Disk.LED_STATUS_IDENT_ON + 
+            lsm_Disk.LED_STATUS_IDENT_OFF + 
+            lsm_Disk.LED_STATUS_IDENT_UNKNOWN
         )
 
         if (led_state & ident_states) == 0:
@@ -121,9 +120,9 @@ class LSMDisk:
             return "Unknown"
 
         fail_states = (
-            lsm.Disk.LED_STATUS_FAULT_ON + 
-            lsm.Disk.LED_STATUS_FAULT_OFF + 
-            lsm.Disk.LED_STATUS_FAULT_UNKNOWN
+            lsm_Disk.LED_STATUS_FAULT_ON + 
+            lsm_Disk.LED_STATUS_FAULT_OFF + 
+            lsm_Disk.LED_STATUS_FAULT_UNKNOWN
         )
 
         if led_state & fail_states == 0:
@@ -152,18 +151,18 @@ class LSMDisk:
 
         if _link_type is not None:
             _transport_map = {
-                lsm.Disk.LINK_TYPE_UNKNOWN: "Unavailable",
-                lsm.Disk.LINK_TYPE_FC: "Fibre Channel",
-                lsm.Disk.LINK_TYPE_SSA: "IBM SSA",
-                lsm.Disk.LINK_TYPE_SBP: "Serial Bus",
-                lsm.Disk.LINK_TYPE_SRP: "SCSI RDMA",
-                lsm.Disk.LINK_TYPE_ISCSI: "iSCSI",
-                lsm.Disk.LINK_TYPE_SAS: "SAS",
-                lsm.Disk.LINK_TYPE_ADT: "ADT (Tape)",
-                lsm.Disk.LINK_TYPE_ATA: "ATA/SATA",
-                lsm.Disk.LINK_TYPE_USB: "USB",
-                lsm.Disk.LINK_TYPE_SOP: "SCSI over PCI-E",
-                lsm.Disk.LINK_TYPE_PCIE: "PCI-E",
+                lsm_Disk.LINK_TYPE_UNKNOWN: "Unavailable",
+                lsm_Disk.LINK_TYPE_FC: "Fibre Channel",
+                lsm_Disk.LINK_TYPE_SSA: "IBM SSA",
+                lsm_Disk.LINK_TYPE_SBP: "Serial Bus",
+                lsm_Disk.LINK_TYPE_SRP: "SCSI RDMA",
+                lsm_Disk.LINK_TYPE_ISCSI: "iSCSI",
+                lsm_Disk.LINK_TYPE_SAS: "SAS",
+                lsm_Disk.LINK_TYPE_ADT: "ADT (Tape)",
+                lsm_Disk.LINK_TYPE_ATA: "ATA/SATA",
+                lsm_Disk.LINK_TYPE_USB: "USB",
+                lsm_Disk.LINK_TYPE_SOP: "SCSI over PCI-E",
+                lsm_Disk.LINK_TYPE_PCIE: "PCI-E",
             }
             return _transport_map.get(_link_type, "Unknown")
         else:
@@ -200,4 +199,4 @@ class LSMDisk:
                 "errors": list(self.error_list)
             }
         else:
-            return dict()
+            return {}

--- a/src/ceph-volume/ceph_volume/util/lsmdisk.py
+++ b/src/ceph-volume/ceph_volume/util/lsmdisk.py
@@ -1,0 +1,203 @@
+""" 
+This module handles the interaction with libstoragemgmt for local disk 
+devices. Interaction may fail with LSM for a number of issues, but the
+intent here is to make this a soft fail, since LSM related data is not
+a critical component of ceph-volume.
+"""
+import logging
+
+try:
+    import lsm
+    from lsm._local_disk import LocalDisk, LsmError
+except ImportError:
+    lsm_available = False
+else:
+    lsm_available = True
+
+logger = logging.getLogger(__name__)
+
+
+class LSMDisk:
+    def __init__(self, dev_path):
+        self.dev_path = dev_path
+        self.error_list = set()
+
+        if lsm_available:
+            self.lsm_available = True
+            self.disk = LocalDisk()
+        else:
+            self.lsm_available = False
+            self.error_list.add("libstoragemgmt (lsm module) is unavailable")
+            logger.info("LSM information is unavailable: libstoragemgmt is not installed")
+            self.disk = None
+
+        self.led_bits = None
+
+    @property
+    def errors(self):
+        """show any errors that the LSM interaction has encountered (str)"""
+        return ",".join(self.error_list)
+
+    def _query_lsm(self, func, path):
+        """Common method used to call the LSM functions, returning the function's result or None"""
+
+        # if disk is None, lsm is unavailable so all calls should return None
+        if self.disk is None:
+            return None
+        
+        method = getattr(self.disk, func)
+        try:
+            output = method(path)
+        except LsmError as err:
+            # logger.exception("LSM Error: {}".format(err._msg))
+            self.error_list.add(err._msg)
+            return None
+        else:
+            return output
+
+    @property
+    def led_status(self):
+        """Fetch LED status, store in the LSMDisk object and return current status (int)"""
+        if self.led_bits is None:
+            bitfield = self._query_lsm('led_status_get', self.dev_path) or 1
+            self.led_bits = bitfield
+            return bitfield
+        else:
+            return self.led_bits
+
+    @property
+    def led_ident_state(self):
+        """Query a disks IDENT LED state to discover when it is On, Off or Unknown (str)"""
+        led_state = self.led_status
+        if led_state == 1:
+            return "Unsupported"
+        if led_state & lsm.Disk.LED_STATUS_IDENT_ON == lsm.Disk.LED_STATUS_IDENT_ON:
+            return "On"
+        elif led_state & lsm.Disk.LED_STATUS_IDENT_OFF == lsm.Disk.LED_STATUS_IDENT_OFF:
+            return "Off"
+        elif led_state & lsm.Disk.LED_STATUS_IDENT_UNKNOWN == lsm.Disk.LED_STATUS_IDENT_UNKNOWN:
+            return "Unknown"
+        
+        return "Unsupported"
+
+    @property
+    def led_fault_state(self):
+        """Query a disks FAULT LED state to discover when it is On, Off or Unknown (str)"""
+        led_state = self.led_status
+        if led_state == 1:
+            return "Unsupported"
+        if led_state & lsm.Disk.LED_STATUS_FAULT_ON == lsm.Disk.LED_STATUS_FAULT_ON:
+            return "On"
+        elif led_state & lsm.Disk.LED_STATUS_FAULT_OFF == lsm.Disk.LED_STATUS_FAULT_OFF:
+            return "Off"
+        elif led_state & lsm.Disk.LED_STATUS_FAULT_UNKNOWN == lsm.Disk.LED_STATUS_FAULT_UNKNOWN:
+            return "Unknown"
+        
+        return "Unsupported"
+
+    @property
+    def led_ident_support(self):
+        """Query the LED state to determine IDENT support: Unknown, Supported, Unsupported (str)"""
+        led_state = self.led_status
+        if led_state == 1:
+            return "Unknown"
+
+        ident_states = (
+            lsm.Disk.LED_STATUS_IDENT_ON + 
+            lsm.Disk.LED_STATUS_IDENT_OFF + 
+            lsm.Disk.LED_STATUS_IDENT_UNKNOWN
+        )
+
+        if (led_state & ident_states) == 0:
+            return "Unsupported"
+        
+        return "Supported"
+
+    @property
+    def led_fault_support(self):
+        """Query the LED state to determine FAULT support: Unknown, Supported, Unsupported (str)"""
+        led_state = self.led_status
+        if led_state == 1:
+            return "Unknown"
+
+        fail_states = (
+            lsm.Disk.LED_STATUS_FAULT_ON + 
+            lsm.Disk.LED_STATUS_FAULT_OFF + 
+            lsm.Disk.LED_STATUS_FAULT_UNKNOWN
+        )
+
+        if led_state & fail_states == 0:
+            return "Unsupported"
+
+        return "Supported"
+
+    @property
+    def health(self):
+        """Determine the health of the disk from LSM : Unknown, Fail, Warn or Good (str)"""
+        health_map = {
+           -1: "Unknown",
+            0: "Fail",
+            1: "Warn",
+            2: "Good",
+        }
+        _health_int = self._query_lsm('health_status_get', self.dev_path)
+        if _health_int is None:
+            _health_int = -1
+        return health_map.get(_health_int, "Unknown")
+
+    @property
+    def transport(self):
+        """Translate a disks link type to a human readable format (str)"""
+        _link_type = self._query_lsm('link_type_get', self.dev_path)
+
+        if _link_type is not None:
+            _transport_map = {
+                lsm.Disk.LINK_TYPE_UNKNOWN: "Unavailable",
+                lsm.Disk.LINK_TYPE_FC: "Fibre Channel",
+                lsm.Disk.LINK_TYPE_SSA: "IBM SSA",
+                lsm.Disk.LINK_TYPE_SBP: "Serial Bus",
+                lsm.Disk.LINK_TYPE_SRP: "SCSI RDMA",
+                lsm.Disk.LINK_TYPE_ISCSI: "iSCSI",
+                lsm.Disk.LINK_TYPE_SAS: "SAS",
+                lsm.Disk.LINK_TYPE_ADT: "ADT (Tape)",
+                lsm.Disk.LINK_TYPE_ATA: "ATA/SATA",
+                lsm.Disk.LINK_TYPE_USB: "USB",
+                lsm.Disk.LINK_TYPE_SOP: "SCSI over PCI-E",
+                lsm.Disk.LINK_TYPE_PCIE: "PCI-E",
+            }
+            return _transport_map.get(_link_type, "Unknown")
+        else:
+            return "Unknown"
+
+    @property
+    def media_type(self):
+        """Use the rpm value to determine the type of disk media: Flash or HDD (str)"""
+        _rpm = self._query_lsm('rpm_get', self.dev_path)
+        if _rpm is not None:
+            if _rpm == 0:
+                return "Flash"
+            elif _rpm > 1:
+                return "HDD"
+
+        return "Unknown"
+
+    def json_report(self):
+        """Return the LSM related metadata for the current local disk (dict)"""
+        if self.lsm_available:
+            return {
+                "serialNum": self._query_lsm('serial_num_get', self.dev_path) or "Unknown",
+                "transport": self.transport,
+                "mediaType": self.media_type,
+                "rpm": self._query_lsm('rpm_get', self.dev_path) or "Unknown",
+                "linkSpeed": self._query_lsm('link_speed_get', self.dev_path) or "Unknown",
+                "health": self.health,
+                "ledSupport": {
+                    "IDENTsupport": self.led_ident_support,
+                    "IDENTstatus": self.led_ident_state,
+                    "FAILsupport": self.led_fault_support,
+                    "FAILstatus": self.led_fault_state,
+                },
+                "errors": list(self.error_list)
+            }
+        else:
+            return dict()

--- a/src/ceph-volume/ceph_volume/util/lsmdisk.py
+++ b/src/ceph-volume/ceph_volume/util/lsmdisk.py
@@ -13,6 +13,7 @@ except ImportError:
     lsm_available = False
     transport_map = {}
     health_map = {}
+    lsm_Disk = None
 else:
     lsm_available = True
     transport_map = {


### PR DESCRIPTION
Initial support for libstoragemgmt integration to
provide additional metadata to the device inventory.

LSM provides health, rpm, linkspeed, linktype as well as
visibility of the disks's LED status indicators (specifically
the IDENT and FAULT lights)

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>