### PR TITLE
mgr/cephadm: fix call to cephadm for daemon restarts etc

### DIFF
--- a/qa/tasks/cephadm_cases/test_cli.py
+++ b/qa/tasks/cephadm_cases/test_cli.py
@@ -43,3 +43,10 @@ class TestCephadmCLI(MgrTestCase):
         self.wait_for_health('CEPHADM_PAUSED', 30)
         self._orch_cmd('resume')
         self.wait_for_health_clear(30)
+
+    def test_daemon_restart(self):
+        self._orch_cmd('daemon', 'stop', 'osd.0')
+        self.wait_for_health('OSD_DOWN', 30)
+        self._orch_cmd('daemon', 'start', 'osd.0')
+        self.wait_for_health_clear(30)
+        self._orch_cmd('daemon', 'restart', 'osd.0')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1571,7 +1571,7 @@ you may want to run:
         for a in actions[action]:
             try:
                 out, err, code = self._run_cephadm(
-                    daemon_spec.daemon_type, name, 'unit',
+                    host, name, 'unit',
                     ['--name', name, a])
             except Exception:
                 self.log.exception(f'`{host}: cephadm unit {name} {a}` failed')


### PR DESCRIPTION
The call currently passes the daemon_type as the first
parameter - but the function expects the hostname. This
results in failures when attempting daemon restarts through
the ceph orch daemon <action> <daemon_id> command.

Fixes: https://tracker.ceph.com/issues/46740

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>
